### PR TITLE
[STORM-15] Use logging instead of print

### DIFF
--- a/etc/kandra.conf
+++ b/etc/kandra.conf
@@ -1,1 +1,6 @@
 # System-wide confguration
+[reactor_logging]
+# If starting from kandra base.
+# config_file = st2reactor/etc/logging.conf
+# If starting from st2reactor base.
+config_file = etc/logging.conf

--- a/etc/logging.conf
+++ b/etc/logging.conf
@@ -1,1 +1,0 @@
-# System-wide logging configuration 

--- a/st2reactor/bin/adapter_container
+++ b/st2reactor/bin/adapter_container
@@ -6,6 +6,9 @@
 
 import os
 import sys
+import logging
+import logging.config
+from oslo.config import cfg
 
 DEVEL = True
 
@@ -16,13 +19,34 @@ if DEVEL:
     '''
     python_lib_dir = os.path.abspath(os.path.dirname(sys.argv[0]) + '/..')
     sys.path.append(python_lib_dir)
-    print sys.path
+    #print sys.path
 
+from st2reactor import config
 from st2reactor.adapter import container
 from st2reactor.adapter.adapters import FixedRunAdapter
 
+LOG = logging.getLogger('st2reactor.bin.adapter_container')
+
+
+def setup():
+    config.parse_args()
+    print cfg.CONF.reactor_logging.config_file
+    logging.config.fileConfig(cfg.CONF.reactor_logging.config_file,
+                              defaults=None,
+                              disable_existing_loggers=False)
+
+
+def main():
+    setup()
+
+    LOG.info('AdapterContainer process[{}] started.'.format(os.getpid()))
+    adapter_container = container.AdapterContainer([FixedRunAdapter,
+                                                    FixedRunAdapter])
+    exit_code = adapter_container.main()
+    LOG.info('AdapterContainer process[{}] exit with code {}.'.format(
+        os.getpid(), exit_code))
+
+    sys.exit(exit_code)
+
 if __name__ == '__main__':
-    container = container.AdapterContainer([FixedRunAdapter, FixedRunAdapter])
-    sys.exit(container.main(sys.argv))
-
-
+    main()

--- a/st2reactor/etc/logging.conf
+++ b/st2reactor/etc/logging.conf
@@ -1,0 +1,32 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=consoleHandler, fileHandler
+
+[formatters]
+keys=verboseFormatter, simpleFormatter
+
+[logger_root]
+level=DEBUG
+handlers=consoleHandler, fileHandler
+
+[handler_consoleHandler]
+class=StreamHandler
+level=INFO
+formatter=simpleFormatter
+args=(sys.stdout,)
+
+[handler_fileHandler]
+class=FileHandler
+level=INFO
+formatter=verboseFormatter
+args=("/tmp/st2reactor.log",)
+
+[formatter_verboseFormatter]
+format=%(asctime)s %(thread)s %(levelname)s %(module)s [-] %(message)s
+datefmt=
+
+[formatter_simpleFormatter]
+format=%(asctime)s %(levelname)s [-] %(message)s
+datefmt=

--- a/st2reactor/st2reactor/adapter/adapters.py
+++ b/st2reactor/st2reactor/adapter/adapters.py
@@ -1,9 +1,11 @@
 import eventlet
+import logging
 import random
 import thread
 
 from st2reactor.adapter import AdapterBase
 
+LOG = logging.getLogger('st2reactor.adapter.adapters')
 
 class FixedRunAdapter(AdapterBase):
     def __init__(self, iterations=10):
@@ -13,7 +15,7 @@ class FixedRunAdapter(AdapterBase):
         count = 0
         while self.__iterations > count:
             count += 1
-            print "[{0}] iter: {1}".format(thread.get_ident(), count)
+            LOG.info("[{0}] iter: {1}".format(thread.get_ident(), count))
             eventlet.sleep(random.randint(1,100)*0.01)
 
     def stop(self):

--- a/st2reactor/st2reactor/adapter/container.py
+++ b/st2reactor/st2reactor/adapter/container.py
@@ -1,4 +1,5 @@
 import eventlet
+import logging
 from threading import Thread
 
 # Constants
@@ -12,6 +13,8 @@ eventlet.monkey_patch(
     time=True
 )
 
+LOG = logging.getLogger('st2reactor.adapter.container')
+
 
 class AdapterContainer(object):
 
@@ -21,7 +24,7 @@ class AdapterContainer(object):
 
     def load(self):
         self.__adapters = [m() for m in self.__adapter_modules]
-        print "Created {} adapters.".format(len(self.__adapters))
+        LOG.info("Created {} adapters.".format(len(self.__adapters)))
 
     def run(self):
         worker_threads = []
@@ -29,15 +32,15 @@ class AdapterContainer(object):
             t = Thread(group=None, target=m.start)
             worker_threads.append((m.__class__.__name__, t))
             t.start()
-        print "No of threads {}".format(len(worker_threads))
+        LOG.debug("No of threads {}".format(len(worker_threads)))
         for item in worker_threads:
             module_name = item[0]
             thread = item[1]
             thread.join()
-            print "{} for module {} has exit.".format(thread.ident,
-                                                      module_name)
+            LOG.info("Thread {} running module {} has exit.".format(
+                thread.ident, module_name))
 
-    def main(self, argv=None):
+    def main(self):
         self.load()
         self.run()
         return SUCCESS_EXIT_CODE

--- a/st2reactor/st2reactor/config.py
+++ b/st2reactor/st2reactor/config.py
@@ -1,0 +1,21 @@
+from oslo.config import cfg
+
+CONF = cfg.CONF
+
+logging_opts = [
+    cfg.StrOpt('config_file', default='etc/logging.conf',
+               help='location of the logging.conf file')
+]
+CONF.register_opts(logging_opts, group='reactor_logging')
+
+use_debugger = cfg.BoolOpt(
+    'use-debugger', default=False,
+    help='Enables debugger. Note that using this option changes how the '
+         'eventlet library is used to support async IO. This could result in '
+         'failures that do not occur under normal operation.'
+)
+CONF.register_cli_opt(use_debugger)
+
+
+def parse_args(args=None):
+    CONF(args=args)


### PR DESCRIPTION
- Setup python logging for reactor.
- etc/kandra.conf is now the global config file.
- Location of the logging config file is picked from the global config.
- Going forward each component will come with its own logging configuration.
- Assumed some basic elements of logging infrastructure viz log file location, formatters etc.
- Replaced all occurences of print with LOG.

Closes: STORM-15
