### PR TITLE
[STORM-25] 1:1 collection-model mapping

### DIFF
--- a/st2common/st2common/models/db/stormbase.py
+++ b/st2common/st2common/models/db/stormbase.py
@@ -14,6 +14,8 @@ class BaseDB(me.Document):
     # ObjectIdField should be not have any constraints like required,
     # unique etc for it to be auto-generated.
     id = me.ObjectIdField()
-    # see http://docs.mongoengine.org/guide/defining-documents
-    # .html#document-inheritance
-    meta = {'allow_inheritance': True}
+    # see http://docs.mongoengine.org/guide/defining-documents.html#
+    # abstract-classes
+    meta = {
+        'abstract': True
+    }


### PR DESCRIPTION
Marked BaseDB as abstract in its meta. See -
http://docs.mongoengine.org/guide/defining-documents.html#abstract-classes

closes : STORM-25
