### PR TITLE
[STORM-27] move access classses to st2common.persistence

### DIFF
--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -14,3 +14,35 @@ def setup(db_name=cfg.CONF.database.db_name, db_host=cfg.CONF.database.host,
 
 def teardown():
     disconnect()
+
+
+class MongoDBAccess(object):
+    """
+    Db Object Access class. Provides general implementation which should be
+    specialized for a model type.
+    """
+    def __init__(self, model_kls):
+        self._model_kls = model_kls
+
+    def get_by_name(self, value):
+        for model_object in self._model_kls.objects(name=value):
+            return model_object
+        raise ValueError('{} with name "{}" does not exist.'.format(
+            self._model_kls.__name__, value))
+
+    def get_by_id(self, value):
+        for model_object in self._model_kls.objects(id=value):
+            return model_object
+        raise ValueError('{} with id "{}" does not exist.'.format(
+            self._model_kls.__name__, value))
+
+    def get_all(self):
+        return self._model_kls.objects()
+
+    @staticmethod
+    def add_or_update(model_object):
+        return model_object.save()
+
+    @staticmethod
+    def delete(model_object):
+        model_object.delete()

--- a/st2common/st2common/models/db/reactor.py
+++ b/st2common/st2common/models/db/reactor.py
@@ -1,4 +1,5 @@
 import mongoengine as me
+from st2common.models.db import MongoDBAccess
 from st2common.models.db.stormbase import BaseDB
 from st2common.models.db.stactioncontroller import StactionDB
 
@@ -73,37 +74,6 @@ class RuleEnforcementDB(BaseDB):
     trigger_instance = me.ReferenceField(TriggerInstanceDB.__name__)
     staction_execution = me.ReferenceField(StactionDB.__name__)
 
-
-class MongoDBAccess(object):
-    """
-    Db Object Access class. Provides general implementation which should be
-    specialized for a model type.
-    """
-    def __init__(self, model_kls):
-        self._model_kls = model_kls
-
-    def get_by_name(self, value):
-        for model_object in self._model_kls.objects(name=value):
-            return model_object
-        raise ValueError('{} with name "{}" does not exist.'.format(
-            self._model_kls.__name__, value))
-
-    def get_by_id(self, value):
-        for model_object in self._model_kls.objects(id=value):
-            return model_object
-        raise ValueError('{} with id "{}" does not exist.'.format(
-            self._model_kls.__name__, value))
-
-    def get_all(self):
-        return self._model_kls.objects()
-
-    @staticmethod
-    def add_or_update(model_object):
-        return model_object.save()
-
-    @staticmethod
-    def delete(model_object):
-        model_object.delete()
 
 # specialized access objects
 triggersource_access = MongoDBAccess(TriggerSourceDB)

--- a/st2common/st2common/models/db/stactioncontroller.py
+++ b/st2common/st2common/models/db/stactioncontroller.py
@@ -1,5 +1,6 @@
 import mongoengine as me
 
+from st2common.models.db import MongoDBAccess
 from st2common.models.db.stormbase import BaseDB
 
 class StactionDB(BaseDB):
@@ -21,3 +22,7 @@ class StactionDB(BaseDB):
     repo_path = me.StringField(required=True)
     run_type = me.StringField()
     parameter_names = me.ListField()
+
+
+# specialized access objects
+staction_access = MongoDBAccess(StactionDB)

--- a/st2common/st2common/persistence/__init__.py
+++ b/st2common/st2common/persistence/__init__.py
@@ -1,8 +1,6 @@
 import abc
 import six
 
-import st2common.models.db.stactioncontroller as stactioncontrollerDB
-
 @six.add_metaclass(abc.ABCMeta)
 class Access(object):
 
@@ -30,11 +28,3 @@ class Access(object):
     @classmethod
     def delete(cls, model_object):
         return cls._get_impl().delete(model_object)
-
-
-class Staction(Access):
-    IMPL = staction_access
-
-    @classmethod
-    def _get_impl(cls):
-        return cls.IMPL

--- a/st2common/st2common/persistence/reactor.py
+++ b/st2common/st2common/persistence/reactor.py
@@ -1,37 +1,7 @@
-import abc
-import six
-
+from st2common.persistence import Access
 from st2common.models.db.reactor import triggersource_access, \
     trigger_access, triggerinstance_access, rule_access, \
     ruleenforcement_access
-
-@six.add_metaclass(abc.ABCMeta)
-class Access(object):
-
-    @classmethod
-    @abc.abstractmethod
-    def _get_impl(cls):
-        """ """
-
-    @classmethod
-    def get_by_name(cls, value):
-        return cls._get_impl().get_by_name(value)
-
-    @classmethod
-    def get_by_id(cls, value):
-        return cls._get_impl().get_by_id(value)
-
-    @classmethod
-    def get_all(cls):
-        return cls._get_impl().get_all()
-
-    @classmethod
-    def add_or_update(cls, model_object):
-        return cls._get_impl().add_or_update(model_object)
-
-    @classmethod
-    def delete(cls, model_object):
-        return cls._get_impl().delete(model_object)
 
 
 class TriggerSource(Access):

--- a/st2common/st2common/persistence/stactioncontroller.py
+++ b/st2common/st2common/persistence/stactioncontroller.py
@@ -1,0 +1,10 @@
+from st2common.persistence import Access
+from st2common.models.db.stactioncontroller import staction_access
+
+
+class Staction(Access):
+    IMPL = staction_access
+
+    @classmethod
+    def _get_impl(cls):
+        return cls.IMPL

--- a/st2common/tests/test_db.py
+++ b/st2common/tests/test_db.py
@@ -29,7 +29,7 @@ class DbConnectionTest(unittest2.TestCase):
 
 from st2common.models.db.reactor import TriggerDB, TriggerInstanceDB, \
     TriggerSourceDB, RuleEnforcementDB, RuleDB
-from st2common.models.api.reactor import Trigger, TriggerInstance, \
+from st2common.persistence.reactor import Trigger, TriggerInstance, \
     TriggerSource, RuleEnforcement, Rule
 
 


### PR DESCRIPTION
- moved access classes to the persistence package.
- factored out all base classes like Access and MongoDBAccess to root of the package.
- update persistence/stactioncontroller.py to follow pattern.
