### PR TITLE
[STORM-45] Move bootstrap to st2reactor module

### DIFF
--- a/st2reactor/bin/adapter_container
+++ b/st2reactor/bin/adapter_container
@@ -3,12 +3,9 @@
 #
 #   kandra adapter_container
 #
-
 import os
 import sys
-import logging
-import logging.config
-from oslo.config import cfg
+from st2reactor import main
 
 DEVEL = True
 
@@ -19,42 +16,6 @@ if DEVEL:
     '''
     python_lib_dir = os.path.abspath(os.path.dirname(sys.argv[0]) + '/..')
     sys.path.append(python_lib_dir)
-
-from st2reactor import config
-from st2reactor.adapter import container
-from st2reactor.adapter.adapters import FixedRunAdapter
-from st2common.models.db import setup as db_setup
-from st2common.models.db import setup as db_teardown
-LOG = logging.getLogger('st2reactor.bin.adapter_container')
-
-
-def __setup():
-    # 1. parse config.
-    config.parse_args()
-    # 2. setup logging.
-    logging.config.fileConfig(cfg.CONF.reactor_logging.config_file,
-                              defaults=None,
-                              disable_existing_loggers=False)
-    # 3. all other setup which requires config to be parsed and logging to
-    # be correctly setup.
-    db_setup()
-
-
-def __teardown():
-    db_teardown()
-
-
-def main():
-    __setup()
-
-    LOG.info('AdapterContainer process[{}] started.'.format(os.getpid()))
-    adapter_container = container.AdapterContainer([FixedRunAdapter,
-                                                    FixedRunAdapter])
-    exit_code = adapter_container.main()
-    LOG.info('AdapterContainer process[{}] exit with code {}.'.format(
-        os.getpid(), exit_code))
-    __teardown()
-    sys.exit(exit_code)
 
 if __name__ == '__main__':
     main()

--- a/st2reactor/st2reactor/__init__.py
+++ b/st2reactor/st2reactor/__init__.py
@@ -1,0 +1,41 @@
+import os
+import logging
+import logging.config
+from oslo.config import cfg
+from st2reactor import config
+from st2reactor.adapter import container
+from st2reactor.adapter.adapters import FixedRunAdapter
+from st2common.models.db import setup as db_setup
+from st2common.models.db import teardown as db_teardown
+
+
+LOG = logging.getLogger('st2reactor.bin.adapter_container')
+
+
+def __setup():
+    # 1. parse config.
+    config.parse_args()
+    # 2. setup logging.
+    logging.config.fileConfig(cfg.CONF.reactor_logging.config_file,
+                              defaults=None,
+                              disable_existing_loggers=False)
+    # 3. all other setup which requires config to be parsed and logging to
+    # be correctly setup.
+    db_setup()
+
+
+def __teardown():
+    db_teardown()
+
+
+def main():
+    __setup()
+
+    LOG.info('AdapterContainer process[{}] started.'.format(os.getpid()))
+    adapter_container = container.AdapterContainer([FixedRunAdapter,
+                                                    FixedRunAdapter])
+    exit_code = adapter_container.main()
+    LOG.info('AdapterContainer process[{}] exit with code {}.'.format(
+        os.getpid(), exit_code))
+    __teardown()
+    return exit_code

--- a/st2reactor/st2reactor/adapter/adapters.py
+++ b/st2reactor/st2reactor/adapter/adapters.py
@@ -7,6 +7,7 @@ from st2reactor.adapter import AdapterBase
 
 LOG = logging.getLogger('st2reactor.adapter.adapters')
 
+
 class FixedRunAdapter(AdapterBase):
     def __init__(self, iterations=10):
         self.__iterations = iterations
@@ -16,7 +17,7 @@ class FixedRunAdapter(AdapterBase):
         while self.__iterations > count:
             count += 1
             LOG.info("[{0}] iter: {1}".format(thread.get_ident(), count))
-            eventlet.sleep(random.randint(1,100)*0.01)
+            eventlet.sleep(random.randint(1, 100)*0.01)
 
     def stop(self):
         pass


### PR DESCRIPTION
- adapter_container is starting to do more than expected.
- moved all db init, adapter load and container start code to the st2reactor module.
- validated the startup script.
