### PR TITLE
RFR: Remove requirements.txt and test-requirements.txt from targets list for ...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ distclean:
 	rm -rf $(VIRTUALENV_DIR)
 
 .PHONY: requirements
-requirements: virtualenv requirements.txt test-requirements.txt
+requirements: virtualenv
 	. $(VIRTUALENV_DIR)/bin/activate ; pip install -U $(foreach req,$(REQUIREMENTS),-r $(req))
 
 .PHONY: virtualenv


### PR DESCRIPTION
...requirements target

I couldn't get 'make requirements' to work on my dev environment. It appears the requirements.txt and test-requirements.txt are targets we want to run. Those targets don't seem to exist. The error we got with these in were so weird. 

This commit might be relevant: 
https://github.com/StackStorm/kandra/commit/990d02f2aea311be34e9a1d648f8470541f918f8
