### PR TITLE
RFR: Rename DB setup and teardown methods; Remove keyword args to read from cfg.CONF

### DIFF
--- a/st2actioncontroller/st2actioncontroller/__init__.py
+++ b/st2actioncontroller/st2actioncontroller/__init__.py
@@ -8,8 +8,8 @@ import os
 import sys
 
 from oslo.config import cfg
-from st2common.models.db import setup as db_setup
-from st2common.models.db import teardown as db_teardown
+from st2common.models.db import db_setup
+from st2common.models.db import db_teardown
 from st2actioncontroller import app
 from wsgiref import simple_server
 
@@ -32,7 +32,8 @@ def __setup():
 
     # 2. all other setup which requires config to be parsed and logging to
     # be correctly setup.
-    db_setup()
+    db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host,
+             cfg.CONF.database.port)
 
 
 def __run_server():

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -5,14 +5,13 @@ from oslo.config import cfg
 LOG = logging.getLogger('st2common.models.db')
 
 
-def setup(db_name=cfg.CONF.database.db_name, db_host=cfg.CONF.database.host,
-          db_port=cfg.CONF.database.port):
+def db_setup(db_name, db_host, db_port):
     LOG.info('Database details - dbname:{}, host:{}, port:{}'.format(
         db_name, db_host, db_port))
     connect(db_name, host=db_host, port=db_port)
 
 
-def teardown():
+def db_teardown():
     disconnect()
 
 

--- a/st2common/tests/test_db.py
+++ b/st2common/tests/test_db.py
@@ -3,7 +3,7 @@ import tests
 import unittest2
 import mongoengine.connection
 from oslo.config import cfg
-from st2common.models.db import setup, teardown
+from st2common.models.db import db_setup, db_teardown
 
 SKIP_DELETE = False
 
@@ -13,11 +13,12 @@ class DbConnectionTest(unittest2.TestCase):
     @classmethod
     def setUpClass(cls):
         tests.parse_args()
-        setup()
+        db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host,
+                 cfg.CONF.database.port)
 
     @classmethod
     def tearDownClass(cls):
-        teardown()
+        db_teardown()
 
     def test_check_connect(self):
         """
@@ -41,11 +42,12 @@ class ReactorModelTest(unittest2.TestCase):
     @classmethod
     def setUpClass(cls):
         tests.parse_args()
-        setup()
+        db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host,
+                 cfg.CONF.database.port)
 
     @classmethod
     def tearDownClass(cls):
-        teardown()
+        db_teardown()
 
     def test_triggersource_crud(self):
         saved = ReactorModelTest._create_save_triggersource()
@@ -197,11 +199,12 @@ class ActionModelTest(unittest2.TestCase):
     @classmethod
     def setUpClass(cls):
         tests.parse_args()
-        setup()
+        db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host,
+                 cfg.CONF.database.port)
 
     @classmethod
     def tearDownClass(cls):
-        teardown()
+        db_teardown()
 
     def test_action_crud(self):
         saved = ActionModelTest._create_save_action()

--- a/st2reactor/st2reactor/__init__.py
+++ b/st2reactor/st2reactor/__init__.py
@@ -1,14 +1,12 @@
-# setup config before anything else.
 from st2reactor import config
-config.parse_args()
 
 import os
 import logging
 import logging.config
 
 from oslo.config import cfg
-from st2common.models.db import setup as db_setup
-from st2common.models.db import teardown as db_teardown
+from st2common.models.db import db_setup
+from st2common.models.db import db_teardown
 from st2reactor.adapter import container
 from st2reactor.adapter.adapters import FixedRunAdapter, \
     DummyTriggerGeneratorAdapter
@@ -17,13 +15,16 @@ LOG = logging.getLogger('st2reactor.bin.adapter_container')
 
 
 def __setup():
+    # setup config before anything else.
+    config.parse_args()
     # 1. setup logging.
     logging.config.fileConfig(cfg.CONF.reactor_logging.config_file,
                               defaults=None,
                               disable_existing_loggers=False)
     # 2. all other setup which requires config to be parsed and logging to
     # be correctly setup.
-    db_setup()
+    db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host,
+             cfg.CONF.database.port)
 
 
 def __teardown():

--- a/st2reactorcontroller/st2reactorcontroller/__init__.py
+++ b/st2reactorcontroller/st2reactorcontroller/__init__.py
@@ -8,8 +8,8 @@ import os
 import sys
 
 from oslo.config import cfg
-from st2common.models.db import setup as db_setup
-from st2common.models.db import teardown as db_teardown
+from st2common.models.db import db_setup
+from st2common.models.db import db_teardown
 from st2reactorcontroller import app
 from wsgiref import simple_server
 
@@ -32,7 +32,8 @@ def __setup():
 
     # 2. all other setup which requires config to be parsed and logging to
     # be correctly setup.
-    db_setup()
+    db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host,
+             cfg.CONF.database.port)
 
 
 def __run_server():


### PR DESCRIPTION
Tests run now for st2reactor and others. Ran the standalone binaries. ReactorController API runs fine. adapter_container exits with exit code 0. I'll look into the following error and fix it in a different PR.

~/kandra/st2actioncontroller $ python bin/action_controller --config-file=./../conf/kandra.conf
<snap>
2014-06-04 10:39:05,876 INFO [-] Creating st2actioncontroller.app as Pecan app.
2014-06-04 10:39:05,887 ERROR [-] 'module' object has no attribute 'txt'
