### PR TITLE
RFR: Fix typo in wstypes argument for DELETE API in action controller. 

### DIFF
--- a/st2actioncontroller/st2actioncontroller/controllers/actionexecutions.py
+++ b/st2actioncontroller/st2actioncontroller/controllers/actionexecutions.py
@@ -68,7 +68,7 @@ class StactionExecutionsController(RestController):
         """
         return {"dummy": "put"}
 
-    @wsexpose(None, wstypes.txt)
+    @wsexpose(None, wstypes.text)
     def delete(self, id):
         """
             Delete a actionexecution.


### PR DESCRIPTION
Verified there are no more typos.

lakshmi@Lakshmis-MacBook-Pro ~/vm/kandra/st2actioncontroller (master●●)$ grep -RI "wstypes.txt" *
lakshmi@Lakshmis-MacBook-Pro ~/vm/kandra/st2actioncontroller (master●●)$

~/kandra/st2actioncontroller $ python bin/action_controller --config-file=./../conf/kandra.conf
2014-06-04 11:28:24,641 INFO [-] Database details - dbname:kandra, host:0.0.0.0, port:27017
2014-06-04 11:28:24,646 INFO [-] Kandra Action Controller v0.1.0 [0]
2014-06-04 11:28:24,647 INFO [-] Creating st2actioncontroller.app as Pecan app.
2014-06-04 11:28:24,657 INFO [-] st2actioncontroller.app app created.
2014-06-04 11:28:24,942 INFO [-] action API is serving on http://0.0.0.0:9101 (PID=3876)
