### PR TITLE
[storm-114] Name test target to tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,6 @@ $(VIRTUALENV_DIR)/bin/activate:
 	echo 'end' >> $(VIRTUALENV_DIR)/bin/activate.fish
 	touch $(VIRTUALENV_DIR)/bin/activate.fish
 
-.PHONY: test
-test: requirements
+.PHONY: tests
+tests: requirements
 	. $(VIRTUALENV_DIR)/bin/activate; nosetests -v $(COMPONENTS_TEST)


### PR DESCRIPTION
- renaming to 'tests' to fix an inadvertent change.
- validated that 'make tests' and 'make all' also execute the tests.
