### PR TITLE
Fix broken tests

### DIFF
--- a/st2common/tests/test_db.py
+++ b/st2common/tests/test_db.py
@@ -134,6 +134,17 @@ class ReactorModelTest(unittest2.TestCase):
                              'Incorrect rule returned.')
         ReactorModelTest._delete([saved, trigger, action, triggersource])
 
+    def test_trigger_lookup(self):
+        triggersource = ReactorModelTest._create_save_triggersource()
+        saved = ReactorModelTest._create_save_trigger(triggersource)
+        retrievedtriggers = Trigger.query(name=saved.name)
+        print len(retrievedtriggers)
+        self.assertEqual(1, len(retrievedtriggers), 'No triggers found.')
+        for retrievedtrigger in retrievedtriggers:
+            self.assertEqual(saved.id, retrievedtrigger.id,
+                             'Incorrect trigger returned.')
+        ReactorModelTest._delete([saved, triggersource])
+
     @staticmethod
     def _create_save_triggersource():
         created = TriggerSourceDB()

--- a/st2reactor/tests/test_containerservice.py
+++ b/st2reactor/tests/test_containerservice.py
@@ -4,18 +4,18 @@ import tests
 import unittest2
 import st2reactor.adapter.containerservice
 from st2common.persistence.reactor import Trigger, TriggerInstance
+from st2common.models.db.reactor import TriggerDB, TriggerInstanceDB
 
-MOCK_TRIGGER = {
-    'id': 'trigger-test.id',
-    'name': 'trigger-test.name'
-}
-MOCK_TRIGGER_INSTANCE = {
-    'id': 'triggerinstance-test',
-    'name': 'trigger-test.name',
-    'trigger': MOCK_TRIGGER,
-    'payload': {},
-    'occurrence_time': datetime.datetime.now()
-}
+MOCK_TRIGGER = TriggerDB()
+MOCK_TRIGGER.id = 'trigger-test.id'
+MOCK_TRIGGER.name = 'trigger-test.name'
+
+MOCK_TRIGGER_INSTANCE = TriggerInstanceDB()
+MOCK_TRIGGER_INSTANCE.id = 'triggerinstance-test'
+MOCK_TRIGGER_INSTANCE.name = 'triggerinstance-test.name'
+MOCK_TRIGGER_INSTANCE.trigger = MOCK_TRIGGER
+MOCK_TRIGGER_INSTANCE.payload = {}
+MOCK_TRIGGER_INSTANCE.occurrence_time = datetime.datetime.now()
 
 
 class ContainerServiceTest(unittest2.TestCase):
@@ -23,7 +23,7 @@ class ContainerServiceTest(unittest2.TestCase):
         tests.parse_args()
 
     @mock.patch.object(Trigger, 'query', mock.MagicMock(
-        return_value=MOCK_TRIGGER))
+        return_value=[MOCK_TRIGGER]))
     @mock.patch.object(TriggerInstance, 'add_or_update', mock.MagicMock(
         return_value=MOCK_TRIGGER_INSTANCE))
     @mock.patch('st2reactor.adapter.containerservice.DISPATCH_HANDLER')
@@ -33,6 +33,8 @@ class ContainerServiceTest(unittest2.TestCase):
         mock_dispatch_handler.assert_called_once_with([MOCK_TRIGGER_INSTANCE])
 
 
+    @mock.patch.object(Trigger, 'query', mock.MagicMock(
+        return_value=[MOCK_TRIGGER]))
     @mock.patch.object(Trigger, 'add_or_update')
     def test_add_trigger(self, mock_add_handler):
         mock_add_handler.return_value = MOCK_TRIGGER

--- a/st2reactor/tests/test_enforce.py
+++ b/st2reactor/tests/test_enforce.py
@@ -4,6 +4,7 @@ import tests
 import unittest2
 from st2common.persistence.reactor import Rule, RuleEnforcement
 from st2common.models.db.reactor import TriggerDB, TriggerInstanceDB, RuleDB
+from st2common.models.db.action import ActionDB
 from st2reactor.ruleenforcement.enforce import RuleEnforcer
 
 MOCK_TRIGGER = TriggerDB()
@@ -15,15 +16,19 @@ MOCK_TRIGGER_INSTANCE.trigger = MOCK_TRIGGER
 MOCK_TRIGGER_INSTANCE.payload = {}
 MOCK_TRIGGER_INSTANCE.occurrence_time = datetime.datetime.now()
 
+MOCK_ACTION = ActionDB()
+MOCK_ACTION.id = 'action-test-1.id'
+MOCK_ACTION.name = 'action-test-1.name'
+
 MOCK_RULE_1 = RuleDB()
 MOCK_RULE_1.id = 'rule-test-1'
 MOCK_RULE_1.trigger = MOCK_TRIGGER
-MOCK_RULE_1.staction = None
+MOCK_RULE_1.action = MOCK_ACTION
 
 MOCK_RULE_2 = RuleDB()
 MOCK_RULE_2.id = 'rule-test-2'
 MOCK_RULE_2.trigger = MOCK_TRIGGER
-MOCK_RULE_2.staction = None
+MOCK_RULE_2.action = MOCK_ACTION
 
 
 class EnforceTest(unittest2.TestCase):
@@ -52,8 +57,8 @@ class EnforceTest(unittest2.TestCase):
     @mock.patch.object(Rule, 'query', mock.MagicMock(
         return_value=[MOCK_RULE_1, MOCK_RULE_2]))
     @mock.patch.object(RuleEnforcement, 'add_or_update', mock.MagicMock())
-    @mock.patch.object(RuleEnforcer, '_RuleEnforcer__invoke_staction')
-    def test_staction_execution(self, mock_ruleenforcer_invokestaction):
+    @mock.patch.object(RuleEnforcer, '_RuleEnforcer__invoke_action')
+    def test_action_execution(self, mock_ruleenforcer_invokestaction):
         enforcer = RuleEnforcer(MOCK_TRIGGER_INSTANCE)
         enforcer.enforce()
         self.assertEqual(mock_ruleenforcer_invokestaction.call_count, 2,


### PR DESCRIPTION
- Add a trigger lookup test to test_db
- Fixed failing test_containerservice and test_enforce tests. The breakage was
  due to code changes which did not have corresponding changes in the test. These
  real failures were masked by test bootstraping issues.
