### PR TITLE
RFR: Rename 'adapter' to 'sensor'

### DIFF
--- a/st2reactor/README.md
+++ b/st2reactor/README.md
@@ -2,4 +2,4 @@ reactor
 =======
 
 ### To start reactor container
-python bin/adapter_container --config-file ../conf/kandra.conf
+python bin/sensor_container --config-file ../conf/kandra.conf

--- a/st2reactor/bin/sensor_container
+++ b/st2reactor/bin/sensor_container
@@ -1,7 +1,7 @@
 #!/usr/bin/env python2.7
 
 #
-#   kandra adapter_container
+#   kandra sensor_container
 #
 import os
 import sys

--- a/st2reactor/st2reactor/__init__.py
+++ b/st2reactor/st2reactor/__init__.py
@@ -7,11 +7,11 @@ import logging.config
 from oslo.config import cfg
 from st2common.models.db import db_setup
 from st2common.models.db import db_teardown
-from st2reactor.adapter import container
-from st2reactor.adapter.adapters import FixedRunAdapter, \
-    DummyTriggerGeneratorAdapter
+from st2reactor.sensor import container
+from st2reactor.sensor.sensors import FixedRunSensor, \
+    DummyTriggerGeneratorSensor
 
-LOG = logging.getLogger('st2reactor.bin.adapter_container')
+LOG = logging.getLogger('st2reactor.bin.sensor_container')
 
 
 def __setup():
@@ -34,11 +34,11 @@ def __teardown():
 def main():
     __setup()
 
-    LOG.info('AdapterContainer process[{}] started.'.format(os.getpid()))
-    adapter_container = container.AdapterContainer(
-        [FixedRunAdapter, DummyTriggerGeneratorAdapter])
-    exit_code = adapter_container.main()
-    LOG.info('AdapterContainer process[{}] exit with code {}.'.format(
+    LOG.info('SensorContainer process[{}] started.'.format(os.getpid()))
+    sensor_container = container.SensorContainer(
+        [FixedRunSensor, DummyTriggerGeneratorSensor])
+    exit_code = sensor_container.main()
+    LOG.info('SensorContainer process[{}] exit with code {}.'.format(
         os.getpid(), exit_code))
     __teardown()
     return exit_code

--- a/st2reactor/st2reactor/sensor/__init__.py
+++ b/st2reactor/st2reactor/sensor/__init__.py
@@ -3,7 +3,7 @@ import six
 
 
 @six.add_metaclass(abc.ABCMeta)
-class AdapterBase(object):
+class Sensor(object):
     """
     """
 

--- a/st2reactor/st2reactor/sensor/container.py
+++ b/st2reactor/st2reactor/sensor/container.py
@@ -13,22 +13,22 @@ eventlet.monkey_patch(
     time=True
 )
 
-LOG = logging.getLogger('st2reactor.adapter.container')
+LOG = logging.getLogger('st2reactor.sensor.container')
 
 
-class AdapterContainer(object):
+class SensorContainer(object):
 
-    def __init__(self, adapter_modules=[]):
-        self.__adapter_modules = adapter_modules
-        self.__adapters = []
+    def __init__(self, sensor_modules=[]):
+        self.__sensor_modules = sensor_modules
+        self.__sensors = []
 
     def load(self):
-        self.__adapters = [m() for m in self.__adapter_modules]
-        LOG.info("Created {} adapters.".format(len(self.__adapters)))
+        self.__sensors = [m() for m in self.__sensor_modules]
+        LOG.info("Created {} sensors.".format(len(self.__sensors)))
 
     def run(self):
         worker_threads = []
-        for m in self.__adapters:
+        for m in self.__sensors:
             t = Thread(group=None, target=m.start)
             worker_threads.append((m.__class__.__name__, t))
             t.start()

--- a/st2reactor/st2reactor/sensor/containerservice.py
+++ b/st2reactor/st2reactor/sensor/containerservice.py
@@ -5,7 +5,7 @@ import st2reactor.ruleenforcement.enforce
 from st2common.persistence.reactor import Trigger, TriggerInstance
 from st2common.models.db.reactor import TriggerDB, TriggerInstanceDB
 
-LOG = logging.getLogger('st2reactor.adapter.dispatcher')
+LOG = logging.getLogger('st2reactor.sensor.dispatcher')
 DISPATCH_HANDLER = st2reactor.ruleenforcement.enforce.handle_trigger_instances
 
 

--- a/st2reactor/st2reactor/sensor/sensors.py
+++ b/st2reactor/st2reactor/sensor/sensors.py
@@ -3,12 +3,12 @@ import logging
 import random
 import thread
 
-from st2reactor.adapter import AdapterBase
+from st2reactor.sensor import Sensor
 
-LOG = logging.getLogger('st2reactor.adapter.adapters')
+LOG = logging.getLogger('st2reactor.sensor.sensors')
 
 
-class FixedRunAdapter(AdapterBase):
+class FixedRunSensor(Sensor):
     def __init__(self, iterations=10):
         self.__iterations = iterations
 
@@ -23,16 +23,16 @@ class FixedRunAdapter(AdapterBase):
         pass
 
 
-from st2reactor.adapter.containerservice import add_trigger_types, \
+from st2reactor.sensor.containerservice import add_trigger_types, \
     dispatch_triggers
 
 
-class DummyTriggerGeneratorAdapter(AdapterBase):
+class DummyTriggerGeneratorSensor(Sensor):
     def __init__(self, iterations=10):
         self.__iterations = iterations
 
     def start(self):
-        DummyTriggerGeneratorAdapter.__add_triggers()
+        DummyTriggerGeneratorSensor.__add_triggers()
         self.__dispatch_trigger_instances()
 
     def stop(self):
@@ -42,7 +42,7 @@ class DummyTriggerGeneratorAdapter(AdapterBase):
         count = 0
         while self.__iterations > count:
             count += 1
-            LOG.info("[{0}] of adapter {1} iter: {2}".format(
+            LOG.info("[{0}] of sensor {1} iter: {2}".format(
                 thread.get_ident(), self.__class__.__name__, count))
             dispatch_triggers([
                 {'name': 'st2.dummy.t1', 'payload': {'t1_p': 't1_p_v'}},

--- a/st2reactor/tests/test_container.py
+++ b/st2reactor/tests/test_container.py
@@ -1,19 +1,19 @@
 import unittest2
-from st2reactor.adapter.container import AdapterContainer
-from st2reactor.adapter import AdapterBase
+from st2reactor.sensor.container import SensorContainer
+from st2reactor.sensor import Sensor
 
 
 class ContainerTest(unittest2.TestCase):
 
     def test_load(self):
         """
-        Verify the correct no of adapters are created.
+        Verify the correct no of sensors are created.
         """
-        class LoadTestAdapter(AdapterBase):
+        class LoadTestSensor(Sensor):
             init_count = 0
 
             def __init__(self):
-                LoadTestAdapter.init_count += 1
+                LoadTestSensor.init_count += 1
 
             def start(self):
                 pass
@@ -21,47 +21,47 @@ class ContainerTest(unittest2.TestCase):
             def stop(self):
                 pass
 
-        adapter_modules = [LoadTestAdapter, LoadTestAdapter]
-        container = AdapterContainer(adapter_modules)
+        sensor_modules = [LoadTestSensor, LoadTestSensor]
+        container = SensorContainer(sensor_modules)
         container.load()
-        self.assertEqual(LoadTestAdapter.init_count, len(adapter_modules),
-                         'Insufficient adapters instantiated.')
+        self.assertEqual(LoadTestSensor.init_count, len(sensor_modules),
+                         'Insufficient sensors instantiated.')
 
-    def test_adapter_start(self):
+    def test_sensor_start(self):
         """
-        Verify start of adapters is called.
+        Verify start of sensors is called.
         """
-        class RunTestAdapter(AdapterBase):
+        class RunTestSensor(Sensor):
             start_call_count = 0
 
             def start(self):
-                RunTestAdapter.start_call_count += 1
+                RunTestSensor.start_call_count += 1
 
             def stop(self):
                 pass
 
-        adapter_modules = [RunTestAdapter, RunTestAdapter]
-        container = AdapterContainer(adapter_modules)
+        sensor_modules = [RunTestSensor, RunTestSensor]
+        container = SensorContainer(sensor_modules)
         container.load()
         container.run()
-        self.assertEqual(RunTestAdapter.start_call_count, len(adapter_modules),
-                         'Not all AdapterBase.start called.')
+        self.assertEqual(RunTestSensor.start_call_count, len(sensor_modules),
+                         'Not all Sensor.start called.')
 
-    def test_adapter_start_no_load(self):
+    def test_sensor_start_no_load(self):
         """
-        Verify start of adapters is not called without load.
+        Verify start of sensors is not called without load.
         """
-        class RunTestAdapter(AdapterBase):
+        class RunTestSensor(Sensor):
             start_call_count = 0
 
             def start(self):
-                RunTestAdapter.start_call_count += 1
+                RunTestSensor.start_call_count += 1
 
             def stop(self):
                 pass
 
-        adapter_modules = [RunTestAdapter, RunTestAdapter]
-        container = AdapterContainer(adapter_modules)
+        sensor_modules = [RunTestSensor, RunTestSensor]
+        container = SensorContainer(sensor_modules)
         container.run()
-        self.assertEqual(RunTestAdapter.start_call_count, 0,
-                         'AdapterBase.start should not be called.')
+        self.assertEqual(RunTestSensor.start_call_count, 0,
+                         'Sensor.start should not be called.')

--- a/st2reactor/tests/test_containerservice.py
+++ b/st2reactor/tests/test_containerservice.py
@@ -2,7 +2,7 @@ import datetime
 import mock
 import tests
 import unittest2
-import st2reactor.adapter.containerservice
+import st2reactor.sensor.containerservice
 from st2common.persistence.reactor import Trigger, TriggerInstance
 from st2common.models.db.reactor import TriggerDB, TriggerInstanceDB
 
@@ -26,9 +26,9 @@ class ContainerServiceTest(unittest2.TestCase):
         return_value=[MOCK_TRIGGER]))
     @mock.patch.object(TriggerInstance, 'add_or_update', mock.MagicMock(
         return_value=MOCK_TRIGGER_INSTANCE))
-    @mock.patch('st2reactor.adapter.containerservice.DISPATCH_HANDLER')
+    @mock.patch('st2reactor.sensor.containerservice.DISPATCH_HANDLER')
     def test_validate_dispatch(self, mock_dispatch_handler):
-        st2reactor.adapter.containerservice.dispatch_trigger(
+        st2reactor.sensor.containerservice.dispatch_trigger(
             MOCK_TRIGGER_INSTANCE)
         mock_dispatch_handler.assert_called_once_with([MOCK_TRIGGER_INSTANCE])
 
@@ -37,5 +37,5 @@ class ContainerServiceTest(unittest2.TestCase):
     @mock.patch.object(Trigger, 'add_or_update')
     def test_add_trigger(self, mock_add_handler):
         mock_add_handler.return_value = MOCK_TRIGGER
-        st2reactor.adapter.containerservice.add_trigger_type(MOCK_TRIGGER)
+        st2reactor.sensor.containerservice.add_trigger_type(MOCK_TRIGGER)
         self.assertTrue(mock_add_handler.called, 'trigger not added.')


### PR DESCRIPTION
I am just renaming adapter to sensor so we are consistent in discussions and code. 

Also, renamed AdapterBase to Sensor (not SensorBase). 

lakshmi@Lakshmis-MacBook-Pro ~/vm/kandra/st2reactor (STORM-41/dynamic_adapter_loading●)$ grep -RI "adapter" *
lakshmi@Lakshmis-MacBook-Pro ~/vm/kandra/st2reactor (STORM-41/dynamic_adapter_loading●)$
