### PR TITLE
componenet specific testing for st2actionrunner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ COMPONENTS := $(wildcard st2*)
 
 # Components that implement a component-controlled test-runner. These components provide an
 # in-component Makefile. (Temporary fix until I can generalize the pecan unittest setup. -mar)
-COMPONENT_SPECIFIC_TESTS := st2actioncontroller st2reactorcontroller
+COMPONENT_SPECIFIC_TESTS := st2actioncontroller st2reactorcontroller st2actionrunner
 
 EXTERNAL_DIR := external
 


### PR DESCRIPTION
- st2actionrunner tests are component specific.
- st2actionrunner tests also don't work so by doing this 'make tests'
  is still functional.

closes : storm-123
