### PR TITLE
Fix: Don't copy plugins to /tmp folder

### DIFF
--- a/st2common/tests/test_loader.py
+++ b/st2common/tests/test_loader.py
@@ -15,7 +15,7 @@ SRC_ROOT = '{}/{}'.format(os.path.abspath(os.path.dirname(__file__)),
 
 
 class LoaderTest(unittest2.TestCase):
-    sys_path = 0
+    sys_path = None
 
     @six.add_metaclass(abc.ABCMeta)
     class DummyPlugin(object):


### PR DESCRIPTION
We were copying plugins from test/resources folder to /tmp before running the loader tests. In OS X, /tmp is a symlink to /private/tmp. This messed up sys.path validation. 

We have reached a consensus that there is no good reason to make this copy. This PR fixes things so we don't copy the plugins to /tmp. 

Here's output on running the test in OS X:

```
(virtualenv)lakshmi@Lakshmis-MacBook-Pro ~/src/storm/kandra (STORM-139/dont_copy_to_tmp)$ nosetests -v st2common/tests/test_loader.py
test_module_load_from_file (tests.test_loader.LoaderTest) ... ok
test_module_load_from_file_fail (tests.test_loader.LoaderTest) ... ok
test_syspath_unchanged_load_multiple_plugins (tests.test_loader.LoaderTest) ... ok

----------------------------------------------------------------------
Ran 3 tests in 0.004s

OK
(virtualenv)lakshmi@Lakshmis-MacBook-Pro ~/src/storm/kandra (STORM-139/dont_copy_to_tmp)$ ls -lthr /tmp
lrwxr-xr-x@ 1 root  wheel    11B Oct 23  2013 /tmp -> private/tmp
(virtualenv)lakshmi@Lakshmis-MacBook-Pro ~/src/storm/kandra (STORM-139/dont_copy_to_tmp)$
```

Here's output on VM:

```
----------------------------------------------------------------------
Ran 3 tests in 0.026s

OK
(virtualenv)vagrant@vagrant-fedora20 ~/kandra (STORM-139/dont_copy_to_tmp●)$ nosetests -v st2common/tests/test_loader.py
```
