### PR TITLE
Implement data mappings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ six
 eventlet>=0.13.0
 pecan
 WSME
+jinja2

--- a/st2reactor/st2reactor/ruleenforcement/datatransform.py
+++ b/st2reactor/st2reactor/ruleenforcement/datatransform.py
@@ -1,9 +1,34 @@
+import copy
+import jinja2
+
+PAYLOAD_PREFIX = 'trigger'
+RULE_DATA_PREFIX = 'rule'
+
+
 class Jinja2BasedTransformer(object):
     def __init__(self, payload):
-        self.__payload = payload
+        self._payload_context = Jinja2BasedTransformer._construct_payload_context(payload)
 
-    def __call__(self, transformation):
-        return transformation
+    def __call__(self, mapping, rule_data):
+        context = self._construct_context(rule_data)
+        resolved_mapping = {}
+        for mapping_k, mapping_v in mapping.iteritems():
+            template = jinja2.Template(mapping_v)
+            resolved_mapping[mapping_k] = template.render(context)
+        return resolved_mapping
+
+    def _construct_context(self, rule_data):
+        context = copy.copy(self._payload_context)
+        if rule_data is None:
+            return context
+        context[RULE_DATA_PREFIX] = rule_data
+        return context
+
+    @staticmethod
+    def _construct_payload_context(payload):
+        if payload is None:
+            return {}
+        return {PAYLOAD_PREFIX: payload}
 
 
 def get_transformer(payload):

--- a/st2reactor/st2reactor/ruleenforcement/enforce.py
+++ b/st2reactor/st2reactor/ruleenforcement/enforce.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from st2reactor.ruleenforcement.datatransform import get_transformer
 from st2reactor.ruleenforcement.filter import get_filter
@@ -30,9 +31,10 @@ class RuleEnforcer(object):
             rule_enforcement.name = 'auto-generated'
             rule_enforcement.trigger_instance = self.trigger_instance
             rule_enforcement.rule = rule
-            data = self.data_transformer(rule.action.data_mapping)
-            LOG.info('Invoking action %s for trigger_instance %s.',
-                     RuleEnforcer.__get_action_id(rule.action), self.trigger_instance.id)
+            data = self.data_transformer(rule.action.data_mapping, rule.rule_data)
+            LOG.info('Invoking action %s for trigger_instance %s with data %s.',
+                     RuleEnforcer.__get_action_name(rule.action), self.trigger_instance.id,
+                     json.dumps(data))
             action_execution = RuleEnforcer.__invoke_action(rule.action, data)
             rule_enforcement.action_execution = action_execution
             RuleEnforcement.add_or_update(rule_enforcement)
@@ -43,10 +45,10 @@ class RuleEnforcer(object):
                       Rule.query(trigger_type=trigger_instance.trigger))
 
     @staticmethod
-    def __get_action_id(action_exec_spec):
+    def __get_action_name(action_exec_spec):
         if action_exec_spec is None or action_exec_spec.action is None:
             return ''
-        return action_exec_spec.action.id
+        return action_exec_spec.action.name
 
     @staticmethod
     def __invoke_action(action, action_args):

--- a/st2reactor/st2reactor/sensor/samples/demo.py
+++ b/st2reactor/st2reactor/sensor/samples/demo.py
@@ -49,7 +49,7 @@ class DummyTriggerGeneratorSensor(object):
     @staticmethod
     def __add_triggers():
         add_trigger_types([
-            {'name': 'st2.dummy.t1', 'description': 'some desc 1', 'payload_info': ['a', 'b']},
-            {'name': 'st2.dummy.t2', 'description': 'some desc 2', 'payload_info': ['c', 'd']},
-            {'name': 'st2.dummy.t3', 'description': 'some desc 3', 'payload_info': ['e', 'f']}
+            {'name': 'st2.dummy.t1', 'description': 'some desc 1', 'payload_info': ['t1_p']},
+            {'name': 'st2.dummy.t2', 'description': 'some desc 2', 'payload_info': ['t2_p']},
+            {'name': 'st2.dummy.t3', 'description': 'some desc 3', 'payload_info': ['t3_p']}
         ])

--- a/st2reactor/tests/test_data_transform.py
+++ b/st2reactor/tests/test_data_transform.py
@@ -1,0 +1,29 @@
+import sys
+print sys.path
+
+import unittest2
+from st2reactor.ruleenforcement import datatransform
+
+PAYLOAD = {'k1': 'v1', 'k2': 'v2'}
+RULE_DATA = {'k3': 'v3', 'k4': 'v4'}
+
+
+class DataTransformTest(unittest2.TestCase):
+
+    def test_payload_transform(self):
+        transformer = datatransform.get_transformer(PAYLOAD)
+        mapping = {'ip1': '{{trigger.k1}}-static', 'ip2': '{{trigger.k2}} static'}
+        result = transformer(mapping, None)
+        self.assertEquals(result, {'ip1': 'v1-static', 'ip2': 'v2 static'})
+
+    def test_rule_data_transform(self):
+        transformer = datatransform.get_transformer(None)
+        mapping = {'ip3': '{{rule.k3}}-static', 'ip4': '{{rule.k4}} static'}
+        result = transformer(mapping, RULE_DATA)
+        self.assertEquals(result, {'ip3': 'v3-static', 'ip4': 'v4 static'})
+
+    def test_combined_transform(self):
+        transformer = datatransform.get_transformer(PAYLOAD)
+        mapping = {'ip1': '{{trigger.k1}}-static', 'ip4': '{{rule.k4}} static'}
+        result = transformer(mapping, RULE_DATA)
+        self.assertEquals(result, {'ip1': 'v1-static', 'ip4': 'v4 static'})


### PR DESCRIPTION
- data mappings are Jinja template based.
- There is a notion of namespace for properties extracted from payload and rule_data.
  rule.\* and trigger.\* are the namespaces to reference properties.
- positive testcases for data_transform.
- modified the dummy trigger generator to dump out consistent trigger_type and
  trigger_instance(s).
