### PR TITLE
[STORM-73] Use Audit level for logging

### DIFF
--- a/st2actioncontroller/conf/logging.conf
+++ b/st2actioncontroller/conf/logging.conf
@@ -2,14 +2,14 @@
 keys=root
 
 [handlers]
-keys=consoleHandler, fileHandler
+keys=consoleHandler, fileHandler, auditHandler
 
 [formatters]
 keys=verboseFormatter, simpleFormatter
 
 [logger_root]
 level=DEBUG
-handlers=consoleHandler, fileHandler
+handlers=consoleHandler, fileHandler, auditHandler
 
 [handler_consoleHandler]
 class=StreamHandler
@@ -22,6 +22,12 @@ class=FileHandler
 level=DEBUG
 formatter=verboseFormatter
 args=("/tmp/st2actioncontroller.log",)
+
+[handler_auditHandler]
+class=FileHandler
+level=AUDIT
+formatter=verboseFormatter
+args=("/tmp/st2actioncontroller.audit.log",)
 
 [formatter_verboseFormatter]
 format=%(asctime)s %(thread)s %(levelname)s %(module)s [-] %(message)s

--- a/st2actioncontroller/st2actioncontroller/__init__.py
+++ b/st2actioncontroller/st2actioncontroller/__init__.py
@@ -3,11 +3,11 @@ from st2actioncontroller import config
 config.parse_args()
 
 import eventlet
-import logging
 import os
 import sys
 
 from oslo.config import cfg
+from st2common import log as logging
 from st2common.models.db import db_setup
 from st2common.models.db import db_teardown
 from st2actioncontroller import app
@@ -26,9 +26,7 @@ LOG = logging.getLogger(__name__)
 
 def __setup():
     # 1. setup logging.
-    logging.config.fileConfig(cfg.CONF.action_controller_logging.config_file,
-                              defaults=None,
-                              disable_existing_loggers=False)
+    logging.setup(cfg.CONF.action_controller_logging.config_file)
 
     # 2. all other setup which requires config to be parsed and logging to
     # be correctly setup.

--- a/st2actioncontroller/st2actioncontroller/app.py
+++ b/st2actioncontroller/st2actioncontroller/app.py
@@ -1,7 +1,7 @@
-import logging
 from oslo.config import cfg
 import pecan
 
+from st2common import log as logging
 from st2actioncontroller import model
 from st2actioncontroller.version import version_string
 

--- a/st2actioncontroller/st2actioncontroller/controllers/actionexecutions.py
+++ b/st2actioncontroller/st2actioncontroller/controllers/actionexecutions.py
@@ -1,5 +1,4 @@
 import httplib
-import logging
 from pecan import (abort, expose, response)
 from pecan.rest import RestController
 
@@ -11,6 +10,7 @@ from mongoengine import ValidationError
 from wsme import types as wstypes
 import wsmeext.pecan as wsme_pecan
 
+from st2common import log as logging
 from st2common.persistence.action import ActionExecution
 from st2common.models.api.action import ActionExecutionAPI
 

--- a/st2actioncontroller/st2actioncontroller/controllers/actions.py
+++ b/st2actioncontroller/st2actioncontroller/controllers/actions.py
@@ -1,5 +1,4 @@
 import httplib
-import logging
 from pecan import (abort, response)
 from pecan.rest import RestController
 
@@ -11,6 +10,7 @@ from mongoengine import ValidationError
 from wsme import types as wstypes
 import wsmeext.pecan as wsme_pecan
 
+from st2common import log as logging
 from st2common.persistence.action import Action
 from st2common.models.api.action import ActionAPI
 

--- a/st2actioncontroller/st2actioncontroller/controllers/root.py
+++ b/st2actioncontroller/st2actioncontroller/controllers/root.py
@@ -1,10 +1,10 @@
 import httplib
-import logging
 from pecan import expose, redirect
 from webob.exc import status_map
 
 from wsmeext.pecan import wsexpose
 
+from st2common import log as logging
 from st2actioncontroller.controllers.actions import ActionsController
 from st2actioncontroller.controllers.actionexecutions import ActionExecutionsController
 

--- a/st2actionrunner/conf/logging.conf
+++ b/st2actionrunner/conf/logging.conf
@@ -2,14 +2,14 @@
 keys=root
 
 [handlers]
-keys=consoleHandler, fileHandler
+keys=consoleHandler, fileHandler, auditHandler
 
 [formatters]
 keys=verboseFormatter, simpleFormatter
 
 [logger_root]
 level=DEBUG
-handlers=consoleHandler, fileHandler
+handlers=consoleHandler, fileHandler, auditHandler
 
 [handler_consoleHandler]
 class=StreamHandler
@@ -22,6 +22,12 @@ class=FileHandler
 level=DEBUG
 formatter=verboseFormatter
 args=("/tmp/st2actionrunner.log",)
+
+[handler_auditHandler]
+class=FileHandler
+level=AUDIT
+formatter=verboseFormatter
+args=("/tmp/st2actionrunner.audit.log",)
 
 [formatter_verboseFormatter]
 format=%(asctime)s %(thread)s %(levelname)s %(module)s [-] %(message)s

--- a/st2actionrunner/st2actionrunner/__init__.py
+++ b/st2actionrunner/st2actionrunner/__init__.py
@@ -3,11 +3,11 @@ from st2actionrunner import config
 config.parse_args()
 
 import eventlet
-import logging
 import os
 import sys
 
 from oslo.config import cfg
+from st2common import log as logging
 from st2common.models.db import db_setup
 from st2common.models.db import db_teardown
 from st2actionrunner import app
@@ -28,9 +28,7 @@ LOG = logging.getLogger(__name__)
 def __setup():
     # 1. setup logging.
     print cfg.CONF.actionrunner_controller_logging.config_file
-    logging.config.fileConfig(cfg.CONF.actionrunner_controller_logging.config_file,
-                              defaults=None,
-                              disable_existing_loggers=False)
+    logging.setup(cfg.CONF.actionrunner_controller_logging.config_file)
 
     # 2. all other setup which requires config to be parsed and logging to
     # be correctly setup.

--- a/st2actionrunner/st2actionrunner/app.py
+++ b/st2actionrunner/st2actionrunner/app.py
@@ -1,7 +1,7 @@
-import logging
 from oslo.config import cfg
 import pecan
 
+from st2common import log as logging
 from st2actionrunner import model
 from st2actionrunner.version import version_string
 

--- a/st2actionrunner/st2actionrunner/controllers/actionrunners.py
+++ b/st2actionrunner/st2actionrunner/controllers/actionrunners.py
@@ -1,11 +1,11 @@
 import httplib
-import logging
 from pecan import (abort, expose, )
 from pecan.rest import RestController
 
 from wsme import types as wstypes
 from wsmeext.pecan import wsexpose
 
+from st2common import log as logging
 from st2common.persistence.action import LiveAction
 from st2common.models.api.actionrunner import ActionRunnerAPI
 

--- a/st2actionrunner/st2actionrunner/controllers/liveactions.py
+++ b/st2actionrunner/st2actionrunner/controllers/liveactions.py
@@ -1,11 +1,11 @@
 import httplib
-import logging
 from pecan import (abort, expose, )
 from pecan.rest import RestController
 
 from wsme import types as wstypes
 from wsmeext.pecan import wsexpose
 
+from st2common import log as logging
 from st2common.persistence.actionrunner import LiveAction
 from st2common.models.api.actionrunner import LiveActionAPI
 

--- a/st2actionrunner/st2actionrunner/controllers/root.py
+++ b/st2actionrunner/st2actionrunner/controllers/root.py
@@ -1,10 +1,10 @@
 import httplib
-import logging
 from pecan import expose, redirect
 from webob.exc import status_map
 
 from wsmeext.pecan import wsexpose
 
+from st2common import log as logging
 # from st2actionrunner.controllers.liveactions import LiveActionsController
 from st2actionrunner.controllers.liveactions import LiveActionsController
 

--- a/st2common/st2common/log.py
+++ b/st2common/st2common/log.py
@@ -1,0 +1,37 @@
+
+import logging
+import logging.config
+import six
+from six import moves
+
+
+logging.AUDIT = logging.CRITICAL + 10
+logging.addLevelName(logging.AUDIT, 'AUDIT')
+
+
+_loggers = {}
+
+
+def setup(config_file):
+    """Configure logging from file.
+    """
+    try:
+        logging.config.fileConfig(config_file,
+                                  defaults=None,
+                                  disable_existing_loggers=False)
+    except moves.configparser.Error as exc:
+        raise Exception(six.text_type(exc))
+
+
+def getLogger(name, extra=None):
+    if name not in _loggers:
+        _loggers[name] = AuditLoggerAdapter(logging.getLogger(name), extra)
+    return _loggers[name]
+
+
+class AuditLoggerAdapter(logging.LoggerAdapter):
+    """Logger adapter to write message with the audit log level.
+    """
+
+    def audit(self, msg, *args, **kwargs):
+        self.log(logging.AUDIT, msg, *args, **kwargs)

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -1,5 +1,6 @@
-import logging
+from st2common import log as logging
 from mongoengine.connection import connect, disconnect
+
 
 LOG = logging.getLogger('st2common.models.db')
 

--- a/st2common/st2common/util/loader.py
+++ b/st2common/st2common/util/loader.py
@@ -1,8 +1,10 @@
 import importlib
 import inspect
-import logging
 import os
 import sys
+
+from st2common import log as logging
+
 
 LOG = logging.getLogger(__name__)
 PYTHON_EXTENSIONS = ('.py')

--- a/st2common/tests/resources/logging.conf
+++ b/st2common/tests/resources/logging.conf
@@ -1,0 +1,28 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=fileHandler, auditHandler
+
+[formatters]
+keys=simpleFormatter
+
+[logger_root]
+level=DEBUG
+handlers=fileHandler, auditHandler
+
+[handler_fileHandler]
+class=FileHandler
+level=INFO
+formatter=simpleFormatter
+args=("{0}",)
+
+[handler_auditHandler]
+class=FileHandler
+level=AUDIT
+formatter=simpleFormatter
+args=("{1}",)
+
+[formatter_simpleFormatter]
+format=%(message)s
+datefmt=

--- a/st2common/tests/test_logger.py
+++ b/st2common/tests/test_logger.py
@@ -1,0 +1,72 @@
+
+import unittest
+import os
+import uuid
+import tempfile
+
+from st2common import log as logging
+
+
+CONFIG_FILE_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                                'resources/logging.conf')
+
+
+class TestLogger(unittest.TestCase):
+
+    def setUp(self):
+        super(TestLogger, self).setUp()
+        self.config_text = open(CONFIG_FILE_PATH).read()
+        self.cfg_fd, self.cfg_path = tempfile.mkstemp()
+        self.info_log_fd, self.info_log_path = tempfile.mkstemp()
+        self.audit_log_fd, self.audit_log_path = tempfile.mkstemp()
+        with open(self.cfg_path, 'a') as f:
+            f.write(self.config_text.format(self.info_log_path,
+                                            self.audit_log_path))
+
+    def tearDown(self):
+        self._remove_tempfile(self.cfg_fd, self.cfg_path)
+        self._remove_tempfile(self.info_log_fd, self.info_log_path)
+        self._remove_tempfile(self.audit_log_fd, self.audit_log_path)
+        super(TestLogger, self).tearDown()
+
+    def _remove_tempfile(self, fd, path):
+        os.close(fd)
+        os.unlink(path)
+
+    def test_logger_setup_failure(self):
+        config_file = '/tmp/abc123'
+        self.assertFalse(os.path.exists(config_file))
+        self.assertRaises(Exception, logging.setup, config_file)
+
+    def test_log_info(self):
+        """Test that INFO log entry does not go to the audit log."""
+        logging.setup(self.cfg_path)
+        log = logging.getLogger(__name__)
+        msg = uuid.uuid4().hex
+        log.info(msg)
+        info_log_entries = open(self.info_log_path).read()
+        self.assertIn(msg, info_log_entries)
+        audit_log_entries = open(self.audit_log_path).read()
+        self.assertNotIn(msg, audit_log_entries)
+
+    def test_log_critical(self):
+        """Test that CRITICAL log entry does not go to the audit log."""
+        logging.setup(self.cfg_path)
+        log = logging.getLogger(__name__)
+        msg = uuid.uuid4().hex
+        log.critical(msg)
+        info_log_entries = open(self.info_log_path).read()
+        self.assertIn(msg, info_log_entries)
+        audit_log_entries = open(self.audit_log_path).read()
+        self.assertNotIn(msg, audit_log_entries)
+
+    def test_log_audit(self):
+        """Test that AUDIT log entry goes to the audit log."""
+        logging.setup(self.cfg_path)
+        log = logging.getLogger(__name__)
+        msg = uuid.uuid4().hex
+        log.audit(msg)
+        info_log_entries = open(self.info_log_path).read()
+        self.assertIn(msg, info_log_entries)
+        audit_log_entries = open(self.audit_log_path).read()
+        self.assertIn(msg, audit_log_entries)

--- a/st2reactor/conf/logging.conf
+++ b/st2reactor/conf/logging.conf
@@ -2,14 +2,14 @@
 keys=root
 
 [handlers]
-keys=consoleHandler, fileHandler
+keys=consoleHandler, fileHandler, auditHandler
 
 [formatters]
 keys=verboseFormatter, simpleFormatter
 
 [logger_root]
 level=DEBUG
-handlers=consoleHandler, fileHandler
+handlers=consoleHandler, fileHandler, auditHandler
 
 [handler_consoleHandler]
 class=StreamHandler
@@ -22,6 +22,12 @@ class=FileHandler
 level=INFO
 formatter=verboseFormatter
 args=("/tmp/st2reactor.log",)
+
+[handler_auditHandler]
+class=FileHandler
+level=AUDIT
+formatter=verboseFormatter
+args=("/tmp/st2reactor.audit.log",)
 
 [formatter_verboseFormatter]
 format=%(asctime)s %(thread)s %(levelname)s %(module)s [-] %(message)s

--- a/st2reactor/st2reactor/__init__.py
+++ b/st2reactor/st2reactor/__init__.py
@@ -2,11 +2,10 @@ from st2reactor import config
 
 import fnmatch
 import os
-import logging
-import logging.config
 import re
 
 from oslo.config import cfg
+from st2common import log as logging
 from st2common.models.db import db_setup
 from st2common.models.db import db_teardown
 import st2common.util.loader as sensors_loader
@@ -14,6 +13,7 @@ from st2reactor.container.base import SensorContainer
 from st2reactor.sensor.base import Sensor
 from st2reactor.sensor.samples.demo import FixedRunSensor, \
     DummyTriggerGeneratorSensor
+
 
 LOG = logging.getLogger('st2reactor.bin.sensor_container')
 
@@ -59,9 +59,7 @@ def __setup():
     # setup config before anything else.
     config.parse_args()
     # 1. setup logging.
-    logging.config.fileConfig(cfg.CONF.reactor_logging.config_file,
-                              defaults=None,
-                              disable_existing_loggers=False)
+    logging.setup(cfg.CONF.reactor_logging.config_file)
     # 2. all other setup which requires config to be parsed and logging to
     # be correctly setup.
     db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host,

--- a/st2reactor/st2reactor/container/base.py
+++ b/st2reactor/st2reactor/container/base.py
@@ -1,7 +1,9 @@
 import eventlet
-import logging
 import sys
 from threading import Thread
+
+from st2common import log as logging
+
 
 # Constants
 SUCCESS_EXIT_CODE = 0

--- a/st2reactor/st2reactor/container/utils.py
+++ b/st2reactor/st2reactor/container/utils.py
@@ -1,9 +1,10 @@
 import datetime
-import logging
-import st2reactor.ruleenforcement.enforce
 
+import st2reactor.ruleenforcement.enforce
+from st2common import log as logging
 from st2common.persistence.reactor import Trigger, TriggerInstance
 from st2common.models.db.reactor import TriggerDB, TriggerInstanceDB
+
 
 LOG = logging.getLogger('st2reactor.sensor.dispatcher')
 DISPATCH_HANDLER = st2reactor.ruleenforcement.enforce.handle_trigger_instances

--- a/st2reactor/st2reactor/ruleenforcement/enforce.py
+++ b/st2reactor/st2reactor/ruleenforcement/enforce.py
@@ -1,9 +1,11 @@
 import json
-import logging
+
+from st2common import log as logging
 from st2reactor.ruleenforcement.datatransform import get_transformer
 from st2reactor.ruleenforcement.filter import get_filter
 from st2common.models.db.reactor import RuleEnforcementDB
 from st2common.persistence.reactor import RuleEnforcement, Rule
+
 
 LOG = logging.getLogger('st2reactor.ruleenforcement.enforce')
 

--- a/st2reactor/st2reactor/ruleenforcement/filter.py
+++ b/st2reactor/st2reactor/ruleenforcement/filter.py
@@ -1,5 +1,7 @@
-import logging
 import re
+
+from st2common import log as logging
+
 
 LOG = logging.getLogger('st2reactor.ruleenforcement.filter')
 

--- a/st2reactor/st2reactor/sensor/samples/demo.py
+++ b/st2reactor/st2reactor/sensor/samples/demo.py
@@ -1,7 +1,9 @@
 import eventlet
-import logging
 import random
 import thread
+
+from st2common import log as logging
+
 
 LOG = logging.getLogger('st2reactor.sensor.sensors')
 

--- a/st2reactorcontroller/conf/logging.conf
+++ b/st2reactorcontroller/conf/logging.conf
@@ -2,14 +2,14 @@
 keys=root
 
 [handlers]
-keys=consoleHandler, fileHandler
+keys=consoleHandler, fileHandler, auditHandler
 
 [formatters]
 keys=verboseFormatter, simpleFormatter
 
 [logger_root]
 level=DEBUG
-handlers=consoleHandler, fileHandler
+handlers=consoleHandler, fileHandler, auditHandler
 
 [handler_consoleHandler]
 class=StreamHandler
@@ -22,6 +22,12 @@ class=FileHandler
 level=INFO
 formatter=verboseFormatter
 args=("/tmp/st2reactorcontroller.log",)
+
+[handler_auditHandler]
+class=FileHandler
+level=AUDIT
+formatter=verboseFormatter
+args=("/tmp/st2reactorcontroller.audit.log",)
 
 [formatter_verboseFormatter]
 format=%(asctime)s %(thread)s %(levelname)s %(module)s [-] %(message)s

--- a/st2reactorcontroller/st2reactorcontroller/__init__.py
+++ b/st2reactorcontroller/st2reactorcontroller/__init__.py
@@ -3,11 +3,11 @@ from st2reactorcontroller import config
 config.parse_args()
 
 import eventlet
-import logging
 import os
 import sys
 
 from oslo.config import cfg
+from st2common import log as logging
 from st2common.models.db import db_setup
 from st2common.models.db import db_teardown
 from st2reactorcontroller import app
@@ -26,9 +26,7 @@ LOG = logging.getLogger(__name__)
 
 def __setup():
     # 1. setup logging.
-    logging.config.fileConfig(cfg.CONF.reactor_controller_logging.config_file,
-                              defaults=None,
-                              disable_existing_loggers=False)
+    logging.setup(cfg.CONF.reactor_controller_logging.config_file)
 
     # 2. all other setup which requires config to be parsed and logging to
     # be correctly setup.

--- a/st2reactorcontroller/st2reactorcontroller/app.py
+++ b/st2reactorcontroller/st2reactorcontroller/app.py
@@ -1,6 +1,7 @@
-import logging
 import pecan
 from oslo.config import cfg
+from st2common import log as logging
+
 
 LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
Implemented a common logger in st2common with new AUDIT level and audit
function. Included unit tests for logging info and audit messages. A
sample logging.conf is included under tests/resources that shows how to
configure audit handler and is used by the unit tests. Refactored st2 to
use the new log module.

Example: (Please note that the logging.setup only has to be invoked once
in the main program.)

```
from st2common import log as logging
logging.setup(config_file)
LOG = logging.getLogger(log_name)
LOG.audit('Anything that can go wrong will go wrong.')
```

Closes: STORM-73
