### PR TITLE
patch __invoke_action to fix tests

### DIFF
--- a/st2reactor/tests/test_enforce.py
+++ b/st2reactor/tests/test_enforce.py
@@ -5,7 +5,7 @@ import unittest2
 from st2common.persistence.reactor import Rule, RuleEnforcement
 from st2common.models.db.reactor import TriggerDB, TriggerInstanceDB, \
     RuleDB, ActionExecutionSpecDB
-from st2common.models.db.action import ActionDB
+from st2common.models.db.action import ActionDB, ActionExecutionDB
 from st2reactor.ruleenforcement.enforce import RuleEnforcer
 
 MOCK_TRIGGER = TriggerDB()
@@ -21,6 +21,10 @@ MOCK_TRIGGER_INSTANCE.occurrence_time = datetime.datetime.now()
 MOCK_ACTION = ActionDB()
 MOCK_ACTION.id = 'action-test-1.id'
 MOCK_ACTION.name = 'action-test-1.name'
+
+MOCK_ACTION_EXECUTION = ActionExecutionDB()
+MOCK_ACTION_EXECUTION.id = 'actionexec-test-1.id'
+MOCK_ACTION_EXECUTION.name = 'actionexec-test-1.name'
 
 MOCK_RULE_1 = RuleDB()
 MOCK_RULE_1.id = 'rule-test-1'
@@ -44,6 +48,8 @@ class EnforceTest(unittest2.TestCase):
     @mock.patch.object(Rule, 'query', mock.MagicMock(
         return_value=[MOCK_RULE_1]))
     @mock.patch.object(RuleEnforcement, 'add_or_update')
+    @mock.patch.object(RuleEnforcer, '_RuleEnforcer__invoke_action', mock.MagicMock(
+        return_value=MOCK_ACTION_EXECUTION))
     def test_single_ruleenforcement_creation(self, mock_ruleenforcement_add):
         enforcer = RuleEnforcer(MOCK_TRIGGER_INSTANCE)
         enforcer.enforce()
@@ -53,6 +59,8 @@ class EnforceTest(unittest2.TestCase):
     @mock.patch.object(Rule, 'query', mock.MagicMock(
         return_value=[MOCK_RULE_1, MOCK_RULE_2]))
     @mock.patch.object(RuleEnforcement, 'add_or_update')
+    @mock.patch.object(RuleEnforcer, '_RuleEnforcer__invoke_action', mock.MagicMock(
+        return_value=MOCK_ACTION_EXECUTION))
     def test_multiple_ruleenforcement_creation(
             self, mock_ruleenforcement_add):
         enforcer = RuleEnforcer(MOCK_TRIGGER_INSTANCE)


### PR DESCRIPTION
- __invoke_action calls out to remote ep /actionexecutions. This is not
  running in the CI environment and should not be required for units. Patching
  and providing default impl to workaround the issue.
- in local env the endpoint was being serverd therefor did not see failures
  until it hit CI.

closes : STORM-169
