### PR TITLE
Fix api-mock build issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ PYTHON_TARGET := 2.7
 REQUIREMENTS := requirements.txt test-requirements.txt
 
 .PHONY: all
-all: requirements tests
+all: requirements web tests
 
 # Target for debugging Makefile variable assembly
 .PHONY: play
@@ -89,8 +89,6 @@ $(VIRTUALENV_DIR)/bin/activate:
 .PHONY: web
 web:
 	npm install --prefix $(WEB_DIR)
-	# Temporary fix for STORM-38. Should be removed when api-mock will update their npm package.
-	npm install --prefix $(WEB_DIR)/node_modules/api-mock/
 	bower install --config.cwd=$(WEB_DIR) --config.directory=components
 	gulp --cwd $(WEB_DIR) build
 

--- a/web/README.md
+++ b/web/README.md
@@ -31,18 +31,3 @@ and finally run build system to fetch the font, compile css and so on
 At that point you should be able to point your browser to [host]:3000 and see the the page.
 
 It should be noted that `make all` is calling `gulp build` which neither starts a server to serve the page nor mocks the API. If you intend not only to build this thing, but also preview it, you would have to call `gulp mockapi serve` or `gulp serve` or set up your own web server. Calling just `gulp` both mocks and serves so it's better suited for development, but will not pass CI.
-
-There is also a temporary problem with api-mock package that preventing it from compiling properly. Pull request have already been merged, but we need to wait for maintainer to update npm package. On my local environment I was able to solve it by installing package manually:
-
-    $ cd stanley/web/node_modules/api-mock
-    $ npm install
-
-But for some reason, in dev environment package is fetching incomplete so you would probably have to git clone it manually:
-
-    $ cd stanley/web/node_modules
-    $ rm -R api-mock
-    $ git clone git://github.com/enykeev/api-mock.git -b bug/contexts api-mock
-    $ cd api-mock
-    $ npm install
-
-This problem should disappear when maintainer would finally update npm package. For now, sorry for the inconvinience.

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "api-mock": "git://github.com/enykeev/api-mock.git#bug/contexts",
+    "api-mock": "https://s3-us-west-1.amazonaws.com/stackstorm.com/thirdparty/api-mock-0.0.10.tgz",
     "chai": "^1.9.1",
     "event-stream": "^3.1.5",
     "fontello-update": "^0.6.0",


### PR DESCRIPTION
Replaced the link to forked repository with tarball. Added `web` stage back to `make all`.

Closes: STORM-155
