### PR TITLE
Tiny: Fix: Remove newline at EOF in st2reactor package

### DIFF
--- a/st2reactor/st2reactor/container/__init__.py
+++ b/st2reactor/st2reactor/container/__init__.py
@@ -1,4 +1,3 @@
 """
 Module that contains the reactor container
 """
-

--- a/st2reactor/st2reactor/container/containerservice.py
+++ b/st2reactor/st2reactor/container/containerservice.py
@@ -15,4 +15,3 @@ class ContainerService(object):
         Pass through implementation.
         '''
         self.__dispatcher.dispatch(triggers)
-

--- a/st2reactor/st2reactor/container/triggerdispatcher.py
+++ b/st2reactor/st2reactor/container/triggerdispatcher.py
@@ -22,4 +22,3 @@ class TriggerDispatcher(object):
             datetime.datetime.now())
             for trigger in triggers]
         rules_engine.handle_trigger_instances(trigger_instances)
-

--- a/st2reactor/st2reactor/sensor/__init__.py
+++ b/st2reactor/st2reactor/sensor/__init__.py
@@ -1,4 +1,3 @@
 """
 Module that defines the type of sensors supported
 """
-

--- a/st2reactor/st2reactor/sensor/base.py
+++ b/st2reactor/st2reactor/sensor/base.py
@@ -30,4 +30,3 @@ class Sensor(object):
         """
         """
         pass
-

--- a/st2reactor/st2reactor/sensor/samples/demo.py
+++ b/st2reactor/st2reactor/sensor/samples/demo.py
@@ -66,4 +66,3 @@ class DummyTriggerGeneratorSensor(object):
                 {'name': 'st2.dummy.t1', 'payload': {'t1_p': 't1_p_v'}},
                 {'name': 'st2.dummy.t2', 'payload': {'t2_p': 't2_p_v'}}])
             eventlet.sleep(1)
-

--- a/st2reactor/st2reactor/sensor/scriptsensor.py
+++ b/st2reactor/st2reactor/sensor/scriptsensor.py
@@ -15,4 +15,3 @@ class ScriptSensor(object):
         XXX: Haven't thought through what should go in here.
         """
         pass
-

--- a/st2reactor/tests/test_container.py
+++ b/st2reactor/tests/test_container.py
@@ -39,4 +39,3 @@ class ContainerTest(unittest2.TestCase):
         container.shutdown()
         self.assertEqual(RunTestSensor.stop_call_count, len(sensor_modules),
                          'Not all Sensor.stop called.')
-

--- a/st2reactor/tests/test_container_utils.py
+++ b/st2reactor/tests/test_container_utils.py
@@ -49,4 +49,3 @@ class ContainerServiceTest(unittest2.TestCase):
             self.assertTrue(False, 'Trigger type doesn\'t have \'name\' field. Should have thrown.')
         except Exception:
             self.assertTrue(True)
-

--- a/st2reactor/tests/test_trigger_dispatcher.py
+++ b/st2reactor/tests/test_trigger_dispatcher.py
@@ -5,7 +5,6 @@ import unittest2
 
 from st2common.models.db.reactor import TriggerDB, TriggerInstanceDB
 from st2common.persistence.reactor import Trigger, TriggerInstance
-import st2reactor.container.utils as container_utils
 from st2reactor.container.triggerdispatcher import TriggerDispatcher
 
 MOCK_TRIGGER = TriggerDB()
@@ -39,4 +38,3 @@ class TriggerDispatcherTest(unittest2.TestCase):
         dispatcher.dispatch([MOCK_TRIGGER_INSTANCE])
         self.assertEquals(TriggerDispatcherTest.TestDispatcher.called_dispatch, True,
                           "dispatch() method should have been called")
-


### PR DESCRIPTION
```
test_single_ruleenforcement_creation (tests.test_enforce.EnforceTest) ... ok
test_equals_operator_fail_criteria (tests.test_filter.FilterTest) ... ok
test_equals_operator_pass_criteria (tests.test_filter.FilterTest) ... ok
test_matchregex_operator_fail_criteria (tests.test_filter.FilterTest) ... ok
test_matchregex_operator_pass_criteria (tests.test_filter.FilterTest) ... ok
test_validate_dispatch (tests.test_trigger_dispatcher.TriggerDispatcherTest) ... ok

----------------------------------------------------------------------
Ran 30 tests in 0.136s

OK
(pull_sensors)lakshmi@vagrant-fedora20 ~/src/stanley (STORM-182/add_container_service_interface●●)$
```

make check on reactor has no warnings/errors.

```
(pull_sensors)lakshmi@vagrant-fedora20 ~/src/stanley (STORM-182/add_container_service_interface●●)$ make check | grep st2reactor
flake8 --config ./.flake8 st2common st2actioncontroller st2reactor st2actionrunnercontroller st2reactorcontroller
make: *** [flake8] Error 1
(pull_sensors)lakshmi@vagrant-fedora20 ~/src/stanley (STORM-182/add_container_service_interface●●)$
```
