### PR TITLE
Tiny: Fix: 'from' imports in sensor file should not be treated as sensors

### DIFF
--- a/st2common/st2common/util/loader.py
+++ b/st2common/st2common/util/loader.py
@@ -29,7 +29,8 @@ def __get_plugin_module(plugin_file_path):
 
 
 def __get_classes_in_module(module):
-    return [kls for name, kls in inspect.getmembers(module, inspect.isclass)]
+    return [kls for name, kls in inspect.getmembers(module,
+        lambda member: inspect.isclass(member) and member.__module__ == module.__name__)]
 
 
 def __get_plugin_classes(module_name):


### PR DESCRIPTION
See gist for the problem:
https://gist.github.com/lakshmi-kannan/2577927b79e5010896f1

Before fix:

```
In [11]: inspect.getmembers(modl, inspect.isclass)
Out[11]: [('JIRA', jira.client.JIRA), ('JIRASensor', jira_sensor.JIRASensor)]
```

After fix:

```
In [10]: inspect.getmembers(modl, lambda member: inspect.isclass(member) and member.__module__ == modl.__name__)
Out[10]: [('JIRASensor', jira_sensor.JIRASensor)]
```
