### PR TITLE
[STORM-194] Add action fields to ActionDB

### DIFF
--- a/st2actioncontroller/st2actioncontroller/controllers/actions.py
+++ b/st2actioncontroller/st2actioncontroller/controllers/actions.py
@@ -86,6 +86,13 @@ class ActionsController(RestController):
 
         LOG.info('POST /actions/ with action data=%s', action)
 
+        if action.enabled is wstypes.Unset:
+            # Default enabled flag to True
+            LOG.debug('POST /actions/ incoming action data has enabled field unset. Defaulting enabled to True.')
+            action.enabled = True
+        else:
+            action.enabled = bool(action.enabled)
+
         action_api = ActionAPI.to_model(action)
         LOG.debug('/actions/ POST verified ActionAPI object=%s', action_api)
         # TODO: POST operations should only add to DB.

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -24,10 +24,10 @@ class ActionAPI(StormBaseAPI):
                    the action.
     """
 
-    """
-    enabled = wstypes.bool
-    repo_path = wstypes.text
+    enabled = bool
+    artifact_path = wstypes.text
     entry_point = wstypes.text
+    """
     runner_type = wstypes.text
     parameter_names = wstypes.ArrayType(wstypes.text)
     """
@@ -35,18 +35,22 @@ class ActionAPI(StormBaseAPI):
     @classmethod
     def from_model(kls, model):
         action = StormBaseAPI.from_model(kls, model)
-        """
         action.enabled = bool(model.enabled)
-        action.repo_path = model.repo_path
+        action.artifact_path = model.artifact_path
         action.entry_point = model.entry_point
+        """
         action.parameter_names = [str(n) for n in model.parameter_names]
         """
         return action
 
     @classmethod
-    def to_model(kls, model):
-        action = StormBaseAPI.to_model(ActionDB, model)
-        return action
+    def to_model(kls, action):
+        model = StormBaseAPI.to_model(ActionDB, action)
+        model.enabled = bool(action.enabled)
+        model.artifact_path = str(action.artifact_path)
+        model.entry_point = str(action.entry_point)
+        
+        return model
 
 
 ACTIONEXEC_STATUS_INIT = 'initializing'
@@ -67,7 +71,6 @@ class ActionExecutionAPI(StormFoundationAPI):
 
     # Correct parameters...
     status = wstypes.Enum(str, *ACTIONEXEC_STATUSES)
-#    status = wstypes.Enum(str, ACTIONEXEC_STATUS_INIT, ACTIONEXEC_STATUS_RUNNING)
     action_name = wstypes.text
     runner_parameters = wstypes.DictType(str, str)
     action_parameters = wstypes.DictType(str, str)

--- a/st2common/st2common/models/db/action.py
+++ b/st2common/st2common/models/db/action.py
@@ -24,13 +24,13 @@ class ActionDB(StormBaseDB):
                    the action.
     """
 
-    """
-    enabled = me.fields.BooleanField(required=True, default=True,
+    enabled = me.BooleanField(required=True, default=True,
                           help_text=u'Flag indicating whether the action is enabled.')
-    repo_path = me.fields.StringField(required=True,
+    artifact_path = me.StringField(required=True,
                           help_text=u'Path to action content relative to repository base.')
-    entry_point = me.fields.StringField(required=True,
+    entry_point = me.StringField(required=True,
                           help_text=u'Action entrypoint.')
+    """
     runner_type = me.fields.StringField(required=True,
                           help_text=u'Execution environment to use when invoking the action.')
     parameter_names = me.fields.ListField(required=True,
@@ -52,7 +52,7 @@ class ActionExecutionDB(StormFoundationDB):
     """
 
     # TODO: Can status be an enum at the Mongo layer?
-    status = me.StringField(
+    status = me.StringField(required=True,
                 help_text=u'The current status of the ActionExecution.')
     action_name = me.StringField(
                 help_text=u'The action executed by this instance.')


### PR DESCRIPTION
- Extend Action API model to accept artifact_path, enabled, and entry_point fields.
- Extend Action DB model to accept the same fields.
- Implement handling of enabled flag in POST handler to make "enabled"
  an optional field.
