### PR TITLE
Exit when any component test fails.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ tests: requirements
 		echo "==========================================================="; \
 		echo "Running tests in" $$component; \
 		echo "==========================================================="; \
-		. $(VIRTUALENV_DIR)/bin/activate; nosetests -v $$component; \
+		. $(VIRTUALENV_DIR)/bin/activate; nosetests -v $$component || exit 1; \
 	done
 
 .PHONY: install


### PR DESCRIPTION
- When a component test fails exiting make so that CI can pick up the failure.
