### PR TITLE
Implement get-by-name for triggers and rules.

### DIFF
--- a/st2common/st2common/models/api/reactor.py
+++ b/st2common/st2common/models/api/reactor.py
@@ -106,7 +106,7 @@ class RuleAPI(StormBaseAPI):
         model.criteria = dict(rule.criteria)
         model.action = ActionExecutionSpecDB()
         if 'type' in rule.action:
-            model.action.type = get_model_from_ref(Action, rule.action['type'])
+            model.action.action = get_model_from_ref(Action, rule.action['type'])
         if 'mapping' in rule.action:
             model.action.data_mapping = rule.action['mapping']
         model.rule_data = rule.rule_data

--- a/st2reactorcontroller/st2reactorcontroller/controllers/triggers.py
+++ b/st2reactorcontroller/st2reactorcontroller/controllers/triggers.py
@@ -38,18 +38,26 @@ class TriggerController(RestController):
         return trigger_api
 
     @wsme_pecan.wsexpose([TriggerAPI], wstypes.text)
-    def get_all(self):
+    def get_all(self, name=None):
         """
             List all triggers.
 
             Handles requests:
                 GET /triggers/
         """
-        LOG.info('GET all /triggers/')
-        trigger_apis = [TriggerAPI.from_model(trigger_db) for
-                        trigger_db in Trigger.get_all()]
+        LOG.info('GET all /triggers/ and name=%s', name)
+        trigger_dbs = Trigger.get_all() if name is None else TriggerController.__get_by_name(name)
+        trigger_apis = [TriggerAPI.from_model(trigger_db) for trigger_db in trigger_dbs]
         LOG.debug('GET all /triggers/ client_result=%s', trigger_apis)
         return trigger_apis
+
+    @staticmethod
+    def __get_by_name(trigger_name):
+        try:
+            return [Trigger.get_by_name(trigger_name)]
+        except ValueError as e:
+            LOG.debug('Database lookup for name="%s" resulted in exception : %s.', trigger_name, e)
+            return []
 
 
 class TriggerInstanceController(RestController):


### PR DESCRIPTION
- support for /triggers/?name=triggername & /rules/?name=rulename. Get requests
  to this url respond with trigger and rule that match the criteria.
- fixed a bug in POST method of a rule where action reference was not being saved.
