### PR TITLE
Actually use st2-test db in reactor and common config.

### DIFF
--- a/st2common/tests/config.py
+++ b/st2common/tests/config.py
@@ -17,7 +17,7 @@ def __setup_config_opts():
         db_opts = [
             cfg.StrOpt('host', default='0.0.0.0', help='host of db server'),
             cfg.IntOpt('port', default=27017, help='port of db server'),
-            cfg.StrOpt('db_name', default='st2', help='name of database')
+            cfg.StrOpt('db_name', default='st2-test', help='name of database')
         ]
         CONF.register_opts(db_opts, group='database')
     except cfg.DuplicateOptError:

--- a/st2reactor/tests/config.py
+++ b/st2reactor/tests/config.py
@@ -17,7 +17,7 @@ def __setup_config_opts():
         db_opts = [
             cfg.StrOpt('host', default='0.0.0.0', help='host of db server'),
             cfg.IntOpt('port', default=27017, help='port of db server'),
-            cfg.StrOpt('db_name', default='st2', help='name of database')
+            cfg.StrOpt('db_name', default='st2-test', help='name of database')
         ]
         CONF.register_opts(db_opts, group='database')
     except cfg.DuplicateOptError:


### PR DESCRIPTION
- Modified configs of st2reactor and st2common to use the test db. Was missed out
  in the previous check-in.
