### PR TITLE
Integrate reactor with actionexecution_controller

### DIFF
--- a/conf/stanley.conf
+++ b/conf/stanley.conf
@@ -21,7 +21,7 @@ port = 9102
 #auth_enable = True
 
 [sensors]
-modules_path = st2reactor/sensor/samples
+modules_path = st2reactor/st2reactor/sensor/samples
 
 [reactor]
 actionexecution_base_url = http://0.0.0.0:9101/actionexecutions

--- a/st2actioncontroller/st2actioncontroller/controllers/actionexecutions.py
+++ b/st2actioncontroller/st2actioncontroller/controllers/actionexecutions.py
@@ -79,11 +79,6 @@ class ActionExecutionsController(RestController):
 
         LOG.info('POST /actionexecutions/ with actionexec data=%s', actionexecution)
 
-        if ACTION_ID not in actionexecution.action:
-            LOG.error('Action can only be accessed by ID in the current implementation.'
-                      'Aborting POST.')
-            abort(httplib.NOT_IMPLEMENTED)
-
         (action_db,action_dict) = get_action_for_dict(actionexecution.action)
         if not action_db:
             LOG.error('POST /actionexecutions/ Action for "%s" cannot be found.', actionexecution.action)

--- a/st2reactor/st2reactor/ruleenforcement/enforce.py
+++ b/st2reactor/st2reactor/ruleenforcement/enforce.py
@@ -59,7 +59,9 @@ class RuleEnforcer(object):
 
     @staticmethod
     def __invoke_action(action, action_args):
-        payload = json.dumps({'target': action.name, 'name': '', 'description': ''})
+        payload = json.dumps({'action': {'name': action.name},
+                              'runner_parameters': {},
+                              'action_parameters': action_args})
         r = requests.post(cfg.CONF.reactor.actionexecution_base_url,
                           data=payload,
                           headers=HTTP_AE_POST_HEADER)


### PR DESCRIPTION
- Update actionexecution payload sent out by reactor.
- Removed check to Make sure actionexecution do not require action to
  identified by id.
- Update config to run st2reactor from stanley root folder.
