### PR TITLE
Use StormFoundation* for TriggerInstance* and RuleEnforcement*

### DIFF
--- a/st2common/st2common/models/api/reactor.py
+++ b/st2common/st2common/models/api/reactor.py
@@ -1,7 +1,7 @@
 import datetime
 from wsme import types as wstypes
 
-from st2common.models.api.stormbase import StormBaseAPI
+from st2common.models.api.stormbase import StormBaseAPI, StormFoundationAPI
 from st2common.models.db.reactor import RuleDB, ActionExecutionSpecDB
 from st2common.persistence.reactor import Trigger
 from st2common.persistence.action import Action
@@ -41,14 +41,14 @@ class TriggerAPI(StormBaseAPI):
         return trigger
 
 
-class TriggerInstanceAPI(StormBaseAPI):
+class TriggerInstanceAPI(StormFoundationAPI):
     trigger = wstypes.text
     payload = wstypes.DictType(str, str)
     occurrence_time = datetime.datetime
 
     @classmethod
     def from_model(kls, model):
-        trigger_instance = StormBaseAPI.from_model(kls, model)
+        trigger_instance = StormFoundationAPI.from_model(kls, model)
         trigger_instance.trigger = get_id(model.trigger)
         trigger_instance.payload = dict(model.payload)
         trigger_instance.occurrence_time = model.occurrence_time
@@ -114,14 +114,14 @@ class RuleAPI(StormBaseAPI):
         return model
 
 
-class RuleEnforcementAPI(StormBaseAPI):
+class RuleEnforcementAPI(StormFoundationAPI):
     rule = wstypes.text
     trigger_instance = wstypes.text
     action_execution = wstypes.text
 
     @classmethod
     def from_model(kls, model):
-        rule_enforcement = StormBaseAPI.from_model(kls, model)
+        rule_enforcement = StormFoundationAPI.from_model(kls, model)
         rule_enforcement.rule = get_id(model.rule)
         rule_enforcement.trigger_instance = get_id(model.trigger_instance)
         rule_enforcement.action_execution = get_id(model.action_execution)

--- a/st2common/st2common/models/api/stormbase.py
+++ b/st2common/st2common/models/api/stormbase.py
@@ -49,20 +49,16 @@ class StormBaseAPI(StormFoundationAPI):
     name = wstypes.text
     description = wstypes.wsattr(wstypes.text, default='')
 
-    # TODO: delegate uri and id handling to StormFoundationAPI
-
     @staticmethod
     def from_model(kls, model):
-        api_instance = kls()
-        api_instance.id = str(model.id)
-        api_instance.uri = model.uri
+        api_instance = StormFoundationAPI.from_model(kls, model)
         api_instance.name = model.name
         api_instance.description = model.description
         return api_instance
 
     @staticmethod
     def to_model(kls, api_instance):
-        model = kls()
+        model = StormFoundationAPI.to_model(kls, api_instance)
         model.name = api_instance.name
         model.description = api_instance.description
         return model

--- a/st2common/st2common/models/db/reactor.py
+++ b/st2common/st2common/models/db/reactor.py
@@ -1,6 +1,6 @@
 import mongoengine as me
 from st2common.models.db import MongoDBAccess
-from st2common.models.db.stormbase import StormBaseDB
+from st2common.models.db.stormbase import StormBaseDB, StormFoundationDB
 from st2common.models.db.action import ActionDB, ActionExecutionDB
 
 
@@ -31,7 +31,7 @@ class TriggerDB(StormBaseDB):
     payload_info = me.ListField()
 
 
-class TriggerInstanceDB(StormBaseDB):
+class TriggerInstanceDB(StormFoundationDB):
     """An instance or occurrence of a type of Trigger.
     Attribute:
         trigger: Reference to the trigger type.
@@ -73,7 +73,7 @@ class CriterionSpecDB(me.EmbeddedDocument):
     operator = me.StringField()
 
 
-class RuleEnforcementDB(StormBaseDB):
+class RuleEnforcementDB(StormFoundationDB):
     """A record of when an enabled rule was enforced.
     Attribute:
         rule (Reference): Rule that was enforced.

--- a/st2common/tests/test_db.py
+++ b/st2common/tests/test_db.py
@@ -57,8 +57,7 @@ class ReactorModelTest(tests.DbTestCase):
         trigger = ReactorModelTest._create_save_trigger(triggersource)
         saved = ReactorModelTest._create_save_triggerinstance(trigger)
         retrieved = TriggerInstance.get_by_id(saved.id)
-        self.assertEqual(saved.name, retrieved.name,
-                         'Same triggerinstance was not returned.')
+        self.assertIsNotNone(retrieved, 'No triggerinstance created.')
         ReactorModelTest._delete([retrieved, trigger, triggersource])
         try:
             retrieved = TriggerInstance.get_by_id(saved.id)
@@ -90,8 +89,7 @@ class ReactorModelTest(tests.DbTestCase):
         saved = ReactorModelTest._create_save_ruleenforcement(triggerinstance,
                                                               rule)
         retrieved = RuleEnforcement.get_by_id(saved.id)
-        self.assertEqual(saved.name, retrieved.name,
-                         'Same rule was not returned.')
+        self.assertIsNotNone(retrieved, 'No ruleenforcement created.')
         ReactorModelTest._delete([retrieved, rule, triggerinstance, trigger,
                                   triggersource])
         try:
@@ -165,8 +163,6 @@ class ReactorModelTest(tests.DbTestCase):
     @staticmethod
     def _create_save_triggerinstance(trigger):
         created = TriggerInstanceDB()
-        created.name = 'triggerinstance-1'
-        created.description = ''
         created.trigger = trigger
         created.payload = {}
         created.occurrence_time = datetime.datetime.now()
@@ -189,8 +185,6 @@ class ReactorModelTest(tests.DbTestCase):
     def _create_save_ruleenforcement(triggerinstance, rule,
                                      actionexecution=None):
         created = RuleEnforcementDB()
-        created.name = 'ruleenforcement-1'
-        created.description = ''
         created.rule = rule
         created.trigger_instance = triggerinstance
         created.action_execution = actionexecution

--- a/st2reactor/st2reactor/container/utils.py
+++ b/st2reactor/st2reactor/container/utils.py
@@ -16,7 +16,6 @@ def create_trigger_instance(trigger_name, payload,
         LOG.info('No trigger with name {} found.', trigger_name)
         return None
     trigger_instance = TriggerInstanceDB()
-    trigger_instance.name = 'auto-generated'
     trigger_instance.trigger = trigger
     trigger_instance.payload = payload
     trigger_instance.occurrence_time = occurrence_time

--- a/st2reactor/st2reactor/ruleenforcement/enforce.py
+++ b/st2reactor/st2reactor/ruleenforcement/enforce.py
@@ -33,7 +33,6 @@ class RuleEnforcer(object):
                  self.trigger_instance.trigger.name)
         for rule in rules:
             rule_enforcement = RuleEnforcementDB()
-            rule_enforcement.name = 'auto-generated'
             rule_enforcement.trigger_instance = self.trigger_instance
             rule_enforcement.rule = rule
             data = self.data_transformer(rule.action.data_mapping, rule.rule_data)


### PR DESCRIPTION
- TriggerInstance and RuleEnforcement are system generated objects which
  do not have a name and description. Subclassing from StormFoundation to
  remove the name and description properties.
