### PR TITLE
[STORM-222] Implement PUT method for /rules/

### DIFF
--- a/st2common/tests/test_db.py
+++ b/st2common/tests/test_db.py
@@ -4,6 +4,7 @@ import mongoengine.connection
 from oslo.config import cfg
 
 SKIP_DELETE = False
+DUMMY_DESCRIPTION = 'Sample Description.'
 
 
 class DbConnectionTest(tests.DbTestCase):
@@ -45,6 +46,13 @@ class ReactorModelTest(tests.DbTestCase):
         retrieved = Trigger.get_by_id(saved.id)
         self.assertEqual(saved.name, retrieved.name,
                          'Same trigger was not returned.')
+        # test update
+        self.assertEqual(retrieved.description, '')
+        retrieved.description = DUMMY_DESCRIPTION
+        saved = Trigger.add_or_update(retrieved)
+        retrieved = Trigger.get_by_id(saved.id)
+        self.assertEqual(retrieved.description, DUMMY_DESCRIPTION, 'Update to trigger failed.')
+        # cleanup
         ReactorModelTest._delete([retrieved, triggersource])
         try:
             retrieved = Trigger.get_by_id(saved.id)
@@ -71,8 +79,14 @@ class ReactorModelTest(tests.DbTestCase):
         trigger = ReactorModelTest._create_save_trigger(triggersource)
         saved = ReactorModelTest._create_save_rule(trigger, action)
         retrieved = Rule.get_by_id(saved.id)
-        self.assertEqual(saved.name, retrieved.name,
-                         'Same rule was not returned.')
+        self.assertEqual(saved.name, retrieved.name, 'Same rule was not returned.')
+        # test update
+        self.assertEqual(retrieved.enabled, True)
+        retrieved.enabled = False
+        saved = Rule.add_or_update(retrieved)
+        retrieved = Rule.get_by_id(saved.id)
+        self.assertEqual(retrieved.enabled, False, 'Update to rule failed.')
+        # cleanup
         ReactorModelTest._delete([retrieved, trigger, action, triggersource])
         try:
             retrieved = Rule.get_by_id(saved.id)
@@ -210,6 +224,13 @@ class ActionModelTest(tests.DbTestCase):
         retrieved = Action.get_by_id(saved.id)
         self.assertEqual(saved.name, retrieved.name,
                          'Same TriggerSource was not returned.')
+        # test update
+        self.assertEqual(retrieved.description, '')
+        retrieved.description = DUMMY_DESCRIPTION
+        saved = Action.add_or_update(retrieved)
+        retrieved = Action.get_by_id(saved.id)
+        self.assertEqual(retrieved.description, DUMMY_DESCRIPTION, 'Update to action failed.')
+        # cleanup
         ActionModelTest._delete([retrieved])
         try:
             retrieved = Action.get_by_id(saved.id)

--- a/st2reactorcontroller/tests/controllers/test_rules.py
+++ b/st2reactorcontroller/tests/controllers/test_rules.py
@@ -80,6 +80,22 @@ class TestRuleController(FunctionalTest):
         self.assertEquals(post_resp.status_int, 201)
         self.__do_delete(self.__get_rule_id(post_resp))
 
+    def test_put(self):
+        post_resp = self.__do_post(RULE_1)
+        update_input = post_resp.json
+        update_input['enabled'] = not update_input['enabled']
+        put_resp = self.__do_put(self.__get_rule_id(post_resp), update_input)
+        self.assertEquals(put_resp.status_int, 200)
+        self.__do_delete(self.__get_rule_id(put_resp))
+
+    def test_put_fail(self):
+        post_resp = self.__do_post(RULE_1)
+        update_input = post_resp.json
+        # If the id in the URL is incorrect the update will fail since id in the body is ignored.
+        put_resp = self.__do_put(1, update_input)
+        self.assertEquals(put_resp.status_int, 404)
+        self.__do_delete(self.__get_rule_id(post_resp))
+
     def test_delete(self):
         post_resp = self.__do_post(RULE_1)
         del_resp = self.__do_delete(self.__get_rule_id(post_resp))
@@ -94,6 +110,9 @@ class TestRuleController(FunctionalTest):
 
     def __do_post(self, rule):
         return self.app.post_json('/rules', rule)
+
+    def __do_put(self, rule_id, rule):
+        return self.app.put_json('/rules/%s' % rule_id, rule, expect_errors=True)
 
     def __do_delete(self, rule_id):
         return self.app.delete('/rules/%s' % rule_id)


### PR DESCRIPTION
- Method can be used to update an existing rule objects.
- Does not lead to creation of a rule if the object specified in the url is not found.
- Ignores the id in the payload if specified and/or mismatched with the url id.
- Default fields if not specified will assume default values and leads to updates.
