### PR TITLE
[STORM-175] Basic CLI - Handle resource not found

### DIFF
--- a/st2client/st2client/commands/resource.py
+++ b/st2client/st2client/commands/resource.py
@@ -50,6 +50,9 @@ class ResourceCommand(commands.Command):
         self.resource = resource
         self.manager = manager
 
+    def print_not_found(self, name):
+        print '%s named "%s" is not found.' % (self.resource.__name__, name)
+
 
 class ResourceListCommand(ResourceCommand):
 
@@ -96,8 +99,11 @@ class ResourceGetCommand(ResourceCommand):
 
     def run(self, args):
         instance = self.manager.get_by_name(args.name)
-        self.print_output(instance, table.PropertyValueTable,
-                          attributes=args.attr, json=args.json)
+        if not instance:
+            self.print_not_found(args.name)
+        else:
+            self.print_output(instance, table.PropertyValueTable,
+                              attributes=args.attr, json=args.json)
 
 
 class ResourceCreateCommand(ResourceCommand):
@@ -170,4 +176,7 @@ class ResourceDeleteCommand(ResourceCommand):
 
     def run(self, args):
         instance = self.manager.get_by_name(args.name)
-        self.manager.delete(instance.id)
+        if not instance:
+            self.print_not_found(args.name)
+        else:
+            self.manager.delete(instance)

--- a/st2client/st2client/models/__init__.py
+++ b/st2client/st2client/models/__init__.py
@@ -48,6 +48,8 @@ class ResourceManager(object):
         url = '/%s/%s' % (self.resource._plural.lower(), id)
         LOG.info('GET %s/%s' % (self.endpoint, url))
         response = self.client.get(url)
+        if response.status_code == 404:
+            return None
         if response.status_code != 200:
             response.raise_for_status()
         return self.resource.deserialize(response.json())
@@ -56,6 +58,8 @@ class ResourceManager(object):
         url = '/%s/?name=%s' % (self.resource._plural.lower(), name)
         LOG.info('GET %s/%s' % (self.endpoint, url))
         response = self.client.get(url)
+        if response.status_code == 404:
+            return None
         if response.status_code != 200:
             response.raise_for_status()
         items = response.json()
@@ -81,9 +85,9 @@ class ResourceManager(object):
         instance = self.resource.deserialize(response.json())
         return instance
 
-    def delete(self, id):
-        url = '/%s/%s' % (self.resource._plural.lower(), id)
+    def delete(self, instance):
+        url = '/%s/%s' % (self.resource._plural.lower(), instance.id)
         LOG.info('DELETE %s/%s' % (self.endpoint, url))
         response = self.client.delete(url)
-        if response.status_code != 204:
+        if response.status_code not in (204, 404):
             response.raise_for_status()


### PR DESCRIPTION
Instead of throwing errors, return a message in the CLI stating the
resource is not found. In the library binding, NoneType is returned if
resoruce is not found.
