### PR TITLE
[STORM-175] Basic CLI - Support for ActionExecution

### DIFF
--- a/st2client/st2client/formatters/table.py
+++ b/st2client/st2client/formatters/table.py
@@ -38,8 +38,20 @@ class MultiColumnTable(formatters.Formatter):
         table.padding_width = 1
         table.align = 'l'
         for entry in entries:
-            table.add_row([getattr(entry, field_name, '')
-                           for field_name in table.field_names])
+            # TODO: Improve getting values of nested dict.
+            values = []
+            for field_name in table.field_names:
+                if '.' in field_name:
+                    field_names = field_name.split('.')
+                    value = getattr(entry, field_names.pop(0), {})
+                    for name in field_names:
+                        value = value[name] if name in value else ''
+                        if type(value) is str:
+                            break
+                    values.append(value)
+                else:
+                    values.append(getattr(entry, field_name, '')) 
+            table.add_row(values)
         return table
 
 

--- a/st2client/st2client/models/__init__.py
+++ b/st2client/st2client/models/__init__.py
@@ -16,7 +16,7 @@ class Resource(object):
             setattr(self, k, v)
 
     def serialize(self):
-        return dict((unicode(k), v)
+        return dict((k, v)
                     for k, v in self.__dict__.iteritems()
                     if not k.startswith('_'))
 

--- a/st2client/st2client/models/action.py
+++ b/st2client/st2client/models/action.py
@@ -6,6 +6,10 @@ from st2client import models
 LOG = logging.getLogger(__name__)
 
 
+class ActionType(models.Resource):
+    _plural = 'ActionTypes'
+
+
 class Action(models.Resource):
     _plural = 'Actions'
 

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -38,6 +38,10 @@ def main(argv=sys.argv[1:]):
         client.actions,
         'TODO: Put description of action here.',
         subparsers)
+    commands['actionexecution'] = action.ActionExecutionBranch(
+        client.executions,
+        'TODO: Put description of action execution here.',
+        subparsers)
     commands['rule'] = resource.ResourceBranch(
         reactor.Rule, client.rules,
         'TODO: Put description of rule here.',

--- a/st2client/tests/test_models.py
+++ b/st2client/tests/test_models.py
@@ -1,7 +1,7 @@
 import mock
 import json
 import logging
-import unittest
+import unittest2
 
 from st2client import models
 from st2client.utils import httpclient
@@ -40,7 +40,7 @@ class FakeResponse(object):
         raise Exception(self.reason)
 
 
-class TestResourceManager(unittest.TestCase):
+class TestResourceManager(unittest2.TestCase):
 
     @mock.patch.object(
         httpclient.HTTPClient, 'get',


### PR DESCRIPTION
Support for ActionExecution is implemented. CLI allows action to be
executed manually. The list and get of action execution is included.

Example:
Assumes that an action of runner type "internaldummy" is registered per
https://stackstorm.atlassian.net/wiki/display/STORM/Demo+-+ActionRunner.

st2 action execute st2.dummy.a1 -r command="uname -a"
st2 actionexecution list
st2 actionexecution get myactionid
