### PR TITLE
[STORM-230] Lookup runnertype based on Action in ActionExecution

### DIFF
--- a/st2actioncontroller/st2actioncontroller/controllers/actionexecutions.py
+++ b/st2actioncontroller/st2actioncontroller/controllers/actionexecutions.py
@@ -128,10 +128,14 @@ class ActionExecutionsController(RestController):
                          'lookup failure.')
                 actionexecution.action = action_dict
 
+        # ActionExecution doesn't hold the runner_type data. Disable this field update.
+        #LOG.debug('Setting actionexecution runner_type to "%s"', action_db.runner_type)
+        #actionexecution.runner_type = str(action_db.runner_type)
+
         LOG.debug('Setting actionexecution status to "%s"', ACTIONEXEC_STATUS_INIT)
         actionexecution.status = str(ACTIONEXEC_STATUS_INIT)
-        LOG.info('POST /actionexecutions/ with actionexec data=%s', actionexecution)
 
+        LOG.info('POST /actionexecutions/ with actionexec data=%s', actionexecution)
         actionexec_api = ActionExecutionAPI.to_model(actionexecution)
         LOG.debug('/actionexecutions/ POST verified ActionExecutionAPI object=%s',
                   actionexec_api)

--- a/st2common/st2common/models/api/actionrunner.py
+++ b/st2common/st2common/models/api/actionrunner.py
@@ -6,6 +6,7 @@ from st2common.models.db.actionrunner import (ActionTypeDB, LiveActionDB)
 
 __all__ = ['LiveActionAPI',
            'ActionRunnerAPI',
+           'ActionTypeAPI',
            ]
 
 

--- a/st2common/st2common/models/db/actionrunner.py
+++ b/st2common/st2common/models/db/actionrunner.py
@@ -7,6 +7,8 @@ from st2common.models.db.stormbase import (StormFoundationDB, StormBaseDB)
 
 __all__ = ['LiveActionDB',
            'ActionRunnerDB',
+           'ActionTypeDB',
+           'ActionExecutionResultDB',
            ]
 
 


### PR DESCRIPTION
- Implemented, but commented out runner_type lookup in ActionExecution.
  (Currently no need to have this data in the ActionExecutionController.)
- Fixed missing entries in **all** in action and actionrunner models.
