### PR TITLE
RFR: Better validation of stanley webhook payloads

### DIFF
--- a/st2reactor/st2reactor/sensor/samples/st2_webhook_sensor.py
+++ b/st2reactor/st2reactor/sensor/samples/st2_webhook_sensor.py
@@ -100,7 +100,7 @@ class St2WebhookSensor(object):
             try:
                 self.__container_service.dispatch(triggers)
             except Exception as e:
-                self.__log.error('Exception %s handling webhook %s', e, trigger['name'])
+                self.__log.exception('Exception %s handling webhook %s', e, trigger['name'])
                 status = httplib.INTERNAL_SERVER_ERROR
                 data = {'error': str(e)}
 


### PR DESCRIPTION
```
vagrant@vagrant-fedora20 /vagrant/src/stanley (STORM-232/eventid_optional_field●●)$ http --verbose http://127.0.0.1:6000/webhooks/st2 < sample-webhook.json
POST /webhooks/st2 HTTP/1.1
Accept: application/json
Accept-Encoding: gzip, deflate
Content-Length: 37
Content-Type: application/json; charset=utf-8
Host: 127.0.0.1:6000
User-Agent: HTTPie/0.8.0

{
    "name": "foo",
    "payload": {}
}

HTTP/1.0 202 ACCEPTED
Content-Length: 2
Content-Type: application/json
Date: Thu, 26 Jun 2014 17:07:47 GMT
Server: Werkzeug/0.9.6 Python/2.7.5

{}

vagrant@vagrant-fedora20 /vagrant/src/stanley (STORM-232/eventid_optional_field●●)$ http --verbose http://127.0.0.1:6000/webhooks/st2 < sample-webhook-nullpayload.json
POST /webhooks/st2 HTTP/1.1
Accept: application/json
Accept-Encoding: gzip, deflate
Content-Length: 39
Content-Type: application/json; charset=utf-8
Host: 127.0.0.1:6000
User-Agent: HTTPie/0.8.0

{
    "name": "foo",
    "payload": null
}

HTTP/1.0 202 ACCEPTED
Content-Length: 2
Content-Type: application/json

▽
Date: Thu, 26 Jun 2014 17:07:49 GMT
Server: Werkzeug/0.9.6 Python/2.7.5

{}

vagrant@vagrant-fedora20 /vagrant/src/stanley (STORM-232/eventid_optional_field●●)$ http --verbose http://127.0.0.1:6000/webhooks/st2 < sample-webhook-emptyname.json
POST /webhooks/st2 HTTP/1.1
Accept: application/json
Accept-Encoding: gzip, deflate
Content-Length: 38
Content-Type: application/json; charset=utf-8
Host: 127.0.0.1:6000
User-Agent: HTTPie/0.8.0

{
    "name": null,
    "payload": null
}

HTTP/1.0 400 BAD REQUEST
Content-Length: 52
Content-Type: application/json
Date: Thu, 26 Jun 2014 17:07:55 GMT
Server: Werkzeug/0.9.6 Python/2.7.5

{
    "error": "\"name\" field has to be non-empty."
}

vagrant@vagrant-fedora20 /vagrant/src/stanley (STORM-232/eventid_optional_field●●)$
```
