### PR TITLE
[STORM-175] Basic CLI - Clean up resource naming in help text

### DIFF
--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -116,7 +116,7 @@ class ActionExecutionCancelCommand(resource.ResourceCommand):
 
     def __init__(self, resource, manager, subparsers):
         super(ActionExecutionCancelCommand, self).__init__(
-            'cancel', 'Cancels an %s.' % resource.__name__.lower(),
+            'cancel', 'Cancels an %s.' % resource.get_display_name().lower(),
             resource, manager, subparsers)
         self.parser.add_argument('execution-id',
                                  help='ID of the action execution.')

--- a/st2client/st2client/models/action.py
+++ b/st2client/st2client/models/action.py
@@ -7,7 +7,9 @@ LOG = logging.getLogger(__name__)
 
 
 class ActionType(models.Resource):
+    _display_name = 'Action Type'
     _plural = 'ActionTypes'
+    _plural_display_name = 'Action Types'
 
 
 class Action(models.Resource):
@@ -15,4 +17,7 @@ class Action(models.Resource):
 
 
 class ActionExecution(models.Resource):
+    _alias = 'Execution'
+    _display_name = 'Action Execution'
     _plural = 'ActionExecutions'
+    _plural_display_name = 'Action Executions'

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -38,7 +38,7 @@ def main(argv=sys.argv[1:]):
         client.actions,
         'TODO: Put description of action here.',
         subparsers)
-    commands['actionexecution'] = action.ActionExecutionBranch(
+    commands['execution'] = action.ActionExecutionBranch(
         client.executions,
         'TODO: Put description of action execution here.',
         subparsers)


### PR DESCRIPTION
Implemented alias, display name, and their plural forms in the model
definition to print more readable help text.
