### PR TITLE
Add: Support for sending multiple trigger instances in a webhook

### DIFF
--- a/st2reactor/st2reactor/sensor/samples/st2webhookschemas/st2webhooks.json
+++ b/st2reactor/st2reactor/sensor/samples/st2webhookschemas/st2webhooks.json
@@ -1,11 +1,16 @@
 {
   "create": {
-    "type": "object",
-    "properties": {
-      "name": {},
-      "event_id": {},
-      "payload": {}
-    },
-    "required": ["name", "payload"]
+    "type": "array",
+    "items": [
+        {
+            "type": "object",
+            "properties": {
+                "name": {},
+                "event_id": {},
+                "payload": {}
+            },
+            "required": ["name", "payload"]
+        }
+    ]
   }
 }


### PR DESCRIPTION
```
(virtualenv)vagrant@vagrant-fedora20 /vagrant/src/stanley (STORM-239/multiple_ti_per_webhook●●)$ http --verbose http://127.0.0.1:6000/webhooks/st2 < success.json
POST /webhooks/st2 HTTP/1.1
Accept: application/json
Accept-Encoding: gzip, deflate
Content-Length: 135
Content-Type: application/json; charset=utf-8
Host: 127.0.0.1:6000
User-Agent: HTTPie/0.8.0

[
    {
        "event_id": "gosh",
        "name": "foo",
        "payload": {
            "foo": "bar"
        }
    },
    {
        "name": "foo",
        "payload": {}
    }
]

HTTP/1.0 202 ACCEPTED
Content-Length: 2
Content-Type: application/json
Date: Thu, 26 Jun 2014 22:43:22 GMT
Server: Werkzeug/0.9.6 Python/2.7.5

{}

(virtualenv)vagrant@vagrant-fedora20 /vagrant/src/stanley (STORM-239/multiple_ti_per_webhook●●)$ http --verbose http://127.0.0.1:6000/webhooks/st2 < sample-webhook.json
POST /webhooks/st2 HTTP/1.1
Accept: application/json
Accept-Encoding: gzip, deflate
Content-Length: 130
Content-Type: application/json; charset=utf-8
Host: 127.0.0.1:6000
User-Agent: HTTPie/0.8.0

[
    {
        "name": null,
        "payload": {}
    },
    {
        "event_id": "gosh",
        "name": "foo",
        "payload": {
            "foo": "bar"
        }
    }
]

HTTP/1.0 400 BAD REQUEST
Content-Length: 75
Content-Type: application/json
Date: Thu, 26 Jun 2014 22:43:36 GMT
Server: Werkzeug/0.9.6 Python/2.7.5

{
    "invalid": [
        {
            "name": null,
            "payload": {}
        }
    ]
}

(virtualenv)vagrant@vagrant-fedora20 /vagrant/src/stanley (STORM-239/multiple_ti_per_webhook●●)$
```
