### PR TITLE
[STORM-200] Implement checks for disabled action objects

### DIFF
--- a/st2actioncontroller/st2actioncontroller/controllers/actionexecutions.py
+++ b/st2actioncontroller/st2actioncontroller/controllers/actionexecutions.py
@@ -170,6 +170,12 @@ class ActionExecutionsController(RestController):
                          'lookup failure.')
                 actionexecution.action = action_dict
 
+        # If the Action is disabled, abort the POST call.
+        if not action_db.enabled:
+            LOG.error('POST /actionexecutions/ Unable to create Action Execution for a disabled '
+                      'Action. Action is: %s', action_db)
+            abort(httplib.FORBIDDEN)
+
         # Initialize empty results data
         """
         actionexecution.exit_code = None

--- a/st2actionrunnercontroller/st2actionrunnercontroller/controllers/liveactions.py
+++ b/st2actionrunnercontroller/st2actionrunnercontroller/controllers/liveactions.py
@@ -118,6 +118,12 @@ class LiveActionsController(RestController):
         LOG.info('POST /liveactions/ obtained Action object from database. '
                  'Object is %s', action_db)
 
+        # If the Action is disabled, abort the POST call.
+        if not action_db.enabled:
+            LOG.error('POST /actionexecutions/ Unable to create Live Action for a disabled '
+                      'Action. Action is: %s', action_db)
+            abort(httplib.FORBIDDEN)
+
         try:
             actiontype_db = get_actiontype_by_name(action_db.runner_type)
         except StackStormDBObjectNotFoundError, e:


### PR DESCRIPTION
- If an action object is disabled, clients should not be able to create ActionExecution or LiveAction objects.
