### PR TITLE
RFR: Add: A generic webhook sensor using flask

### DIFF
--- a/st2reactor/st2reactor/sensor/samples/st2_generic_webhook_sensor.py
+++ b/st2reactor/st2reactor/sensor/samples/st2_generic_webhook_sensor.py
@@ -1,0 +1,78 @@
+from functools import wraps
+import httplib
+
+from flask import (jsonify, request, Flask)
+
+'''
+Dectorators for request validations.
+'''
+
+
+def validate_json(f):
+    @wraps(f)
+    def wrapper(*args, **kw):
+        try:
+            request.json
+        except Exception:
+            msg = 'Content-Type must be application/json.'
+            return jsonify({'error': msg}), httplib.BAD_REQUEST
+        return f(*args, **kw)
+    return wrapper
+
+
+class St2GenericWebhooksSensor(object):
+    def __init__(self, container_service):
+        self._container_service = container_service
+        self._log = self._container_service.get_logger(self.__class__.__name__)
+        self._port = 6001
+        self._app = Flask(__name__)
+
+    def setup(self):
+        # XXX: The list of URLs need to be picked from config file.
+        self._setup_flask_app(urls=['/webhooks/generic/st2webhooks'])
+
+    def start(self):
+        self._app.run(port=self._port)
+
+    def stop(self):
+        # If Flask is using the default Werkzeug server, then call shutdown on it.
+        func = request.environ.get('werkzeug.server.shutdown')
+        if func is None:
+            raise RuntimeError('Not running with the Werkzeug Server')
+        func()
+
+    def get_trigger_types(self):
+        return []
+
+    @validate_json
+    def _handle_webhook(self, name):
+        webhook_body = request.get_json()
+        # Generate trigger instances and send them.
+        triggers = self._to_triggers(webhook_body)
+
+        try:
+            self._container_service.dispatch(triggers)
+        except Exception as e:
+            self._log.exception('Exception %s handling webhook', e)
+            status = httplib.INTERNAL_SERVER_ERROR
+            return jsonify({'error': str(e)}), status
+
+        return jsonify({}), httplib.ACCEPTED
+
+    '''
+    Flask app specific stuff.
+    '''
+    def _setup_flask_app(self, urls=[]):
+        for url in urls:
+            self._app.add_url_rule('/webhooks/generic/<path:name>',
+                                   'generic-webhook-' + url,
+                                   self._handle_webhook, methods=['POST'])
+
+    def _to_triggers(self, webhook_body):
+        triggers = []
+
+        # XXX: if there is schema mismatch among entries, we ignore.
+        for item in webhook_body:
+            triggers.append(item)
+
+        return triggers


### PR DESCRIPTION
I started with an initial implementation. I'll add ability to dynamically add routes to this sensor. For now, I hard coded the list of URLs to listen for quick testing. 

Server logs:

```
(virtualenv)vagrant@vagrant-fedora20 /vagrant/src/stanley (master●)$ st2reactor/bin/sensor_container --config-file=conf/stanley.conf --sensor-path=./st2reactor/st2reactor/sensor/samples/st2_generic_webhook_sensor.py
2014-07-08 17:45:56,575 INFO [-] Database details - dbname:st2, host:0.0.0.0, port:27017
2014-07-08 17:45:56,643 INFO [-] Running in sensor testing mode.
2014-07-08 17:45:57,067 INFO [-] Setting up container to run 1 sensors.
2014-07-08 17:45:57,099 WARNING [-] No trigger type registered by sensor <class 'st2_generic_webhook_sensor.St2GenericWebhooksSensor'> in file ./st2reactor/st2reactor/sensor/samples/st2_generic_webhook_sensor.py
2014-07-08 17:45:57,099 INFO [-] SensorContainer process[4537] started.
2014-07-08 17:45:57,101 INFO [-] Container setup to run 1 sensors.
2014-07-08 17:45:57,101 INFO [-] Running sensor St2GenericWebhooksSensor
2014-07-08 17:45:57,197 INFO [-]  * Running on http://127.0.0.1:6001/
2014-07-08 17:45:59,854 INFO [-] 127.0.0.1 - - [08/Jul/2014 17:45:59] "POST /webhooks/generic/st2webhooks HTTP/1.1" 202 -
2014-07-08 17:45:59,857 INFO [-] No trigger with name None found.
2014-07-08 17:45:59,858 INFO [-] No trigger with name foo found.
```

Client logs:

```
vagrant@vagrant-fedora20 /vagrant/src/stanley (master●)$ http POST http://127.0.0.1:6001/webhooks/generic/st2webhooks < sample-webhook.json
HTTP/1.0 202 ACCEPTED
Content-Length: 2
Content-Type: application/json
Date: Wed, 09 Jul 2014 00:45:59 GMT
Server: Werkzeug/0.9.6 Python/2.7.5

{}

vagrant@vagrant-fedora20 /vagrant/src/stanley (master●)$
```
