### PR TITLE
Utils to move between reference and db models.

### DIFF
--- a/st2common/st2common/exceptions/db.py
+++ b/st2common/st2common/exceptions/db.py
@@ -3,3 +3,6 @@ from st2common.exceptions import StackStormBaseException
 
 class StackStormDBObjectNotFoundError(StackStormBaseException):
     pass
+
+class StackStormDBObjectMalformedError(StackStormBaseException):
+    pass

--- a/st2common/st2common/util/reference.py
+++ b/st2common/st2common/util/reference.py
@@ -1,0 +1,24 @@
+from st2common.exceptions import db
+
+
+def get_ref_from_model(model):
+    if model is None:
+        raise ValueError('Model should has None value.')
+    model_id = getattr(model, 'id', None)
+    if model_id is None:
+        raise db.StackStormDBObjectMalformedError('model %s must contain id.' % str(model))
+    reference = {'id': str(model_id),
+                 'name': getattr(model, 'name', None)}
+    return reference
+
+
+def get_model_from_ref(db_api, reference):
+    if reference is None:
+        raise db.StackStormDBObjectNotFoundError('No reference supplied.')
+    model_id = reference.get('id', None)
+    if model_id is not None:
+        return db_api.get_by_id(model_id)    
+    model_name = reference.get('name', None)
+    if model_name is None:
+        raise db.StackStormDBObjectNotFoundError('Both name and id are None.')
+    return db_api.get_by_name(model_name)

--- a/st2common/tests/test_reference.py
+++ b/st2common/tests/test_reference.py
@@ -1,0 +1,78 @@
+import copy
+import mongoengine
+
+from st2common.exceptions import db
+from st2common.models.db.reactor import TriggerDB
+from st2common.persistence.reactor import Trigger
+from st2common.util import reference
+from st2tests import DbTestCase
+
+class ReferenceTest(DbTestCase):
+
+    __model = None
+    __ref = None
+
+    @classmethod
+    def setUpClass(cls):
+        super(ReferenceTest, cls).setUpClass()
+        trigger = TriggerDB()
+        trigger.name = 'trigger-1'
+        cls.__model = Trigger.add_or_update(trigger)
+        cls.__ref = {'id': str(cls.__model.id),
+                     'name': cls.__model.name}
+
+    @classmethod
+    def tearDownClass(cls):
+        Trigger.delete(cls.__model)
+        super(ReferenceTest, cls).tearDownClass()
+
+    def test_to_reference(self):
+        ref = reference.get_ref_from_model(self.__model)
+        self.assertEquals(ref, self.__ref, 'Failed to generated equivalent ref.')
+
+    def test_to_reference_no_model(self):
+        try:
+            reference.get_ref_from_model(None)
+            self.assertTrue(False, 'Exception expected.')
+        except ValueError:
+            self.assertTrue(True)
+
+    def test_to_reference_no_model_id(self):
+        try:
+            model = copy.copy(self.__model)
+            model.id = None
+            reference.get_ref_from_model(model)
+            self.assertTrue(False, 'Exception expected.')
+        except db.StackStormDBObjectMalformedError:
+            self.assertTrue(True)
+
+    def test_to_model_with_id(self):
+        model = reference.get_model_from_ref(Trigger, self.__ref)
+        self.assertEquals(model, self.__model, 'Failed to return correct model.')
+
+    def test_to_model_with_name(self):
+        ref = copy.copy(self.__ref)
+        ref['id'] = None
+        model = reference.get_model_from_ref(Trigger, ref)
+        self.assertEquals(model, self.__model, 'Failed to return correct model.')
+
+    def test_to_model_no_name_no_id(self):
+        try:
+            reference.get_model_from_ref(Trigger, {})
+            self.assertTrue(False, 'Exception expected.')
+        except db.StackStormDBObjectNotFoundError:
+            self.assertTrue(True)
+
+    def test_to_model_unknown_id(self):
+        try:
+            reference.get_model_from_ref(Trigger, {'id':'1'})
+            self.assertTrue(False, 'Exception expected.')
+        except mongoengine.ValidationError:
+            self.assertTrue(True)
+
+    def test_to_model_unknown_name(self):
+        try:
+            reference.get_model_from_ref(Trigger, {'name':'unknown'})
+            self.assertTrue(False, 'Exception expected.')
+        except ValueError:
+            self.assertTrue(True)


### PR DESCRIPTION
- Added two methods that move between reference and models.
- New exception to identify a malformed model object.
- Tests.
