### PR TITLE
[STORM-272] Support default values for action arguments

### DIFF
--- a/devel/scripts/create_actions.sh
+++ b/devel/scripts/create_actions.sh
@@ -4,10 +4,10 @@ ACTION_URL=http://localhost:9101
 ACTIONRUNNER_URL=http://localhost:9501
 
 # Internal dummy
-curl -i -H 'Content-Type: application/json' -X POST -d '{"name": "dummyaction", "runner_type": "internaldummy-builtin", "description": "Action that executes an arbitrary Linux command.", "enabled": true, "artifact_paths": [], "uri": null, "entry_point": "", "parameters": {}}' ${ACTION_URL}/actions
+curl -i -H 'Content-Type: application/json' -X POST -d '{"name": "dummyaction-builtin", "runner_type": "internaldummy-builtin", "description": "Action that executes an arbitrary Linux command.", "enabled": true, "artifact_paths": [], "uri": null, "entry_point": "", "parameters": {}}' ${ACTION_URL}/actions
 
 # Internal dummy plugin
-curl -i -H 'Content-Type: application/json' -X POST -d '{"name": "dummypluginaction", "runner_type": "internaldummy", "description": "Action that executes an arbitrary Linux command.", "enabled": true, "artifact_paths": [], "uri": null, "entry_point": "", "parameters": {}}' ${ACTION_URL}/actions
+curl -i -H 'Content-Type: application/json' -X POST -d '{"name": "dummyaction", "runner_type": "internaldummy", "description": "Action that executes an arbitrary Linux command.", "enabled": true, "artifact_paths": [], "uri": null, "entry_point": "", "parameters": {}}' ${ACTION_URL}/actions
 
 # Echo action
 curl -i -H 'Content-Type: application/json' -X POST -d '{"name": "echo-script", "runner_type": "shell", "description": "An echo action.", "enabled": true, "uri": null, "entry_point": "actions/bash_echo/bash_echo.sh", "artifact_paths": ["actions/bash_echo"], "parameters": {}}' ${ACTION_URL}/actions

--- a/st2actionrunnercontroller/st2actionrunnercontroller/controllers/actiontypes.py
+++ b/st2actionrunnercontroller/st2actionrunnercontroller/controllers/actiontypes.py
@@ -17,14 +17,14 @@ from st2actionrunner.container import get_runner_container
 LOG = logging.getLogger(__name__)
 
 
-ACTION_TYPES = {'internaldummy': {'name': 'internaldummy',
-                                  'description': ('An internal action type for '
+ACTION_TYPES = {'internaldummy-builtin': {'name': 'internaldummy-builtin',
+                                  'description': ('An built-in, internal action type for '
                                                   'development only.'),
                                   'enabled': True,
                                   'runner_parameters': {'command': None},
                                   'runner_module': 'no.such.module',
                                   },
-                'internaldummy-plugin': {'name': 'internaldummy-plugin',
+                'internaldummy': {'name': 'internaldummy',
                                          'description': ('An internal action type for '
                                                          'development only. Implemented '
                                                          'using a plugin.'),


### PR DESCRIPTION
- Update action objects created by development support script.
- Update names for internaldummy action runners. ("internaldummy" is now the plugin implementation because that version is more "real-world".)
