### PR TITLE
[STORM 275] Create launch script for development

### DIFF
--- a/conf/stanley.conf
+++ b/conf/stanley.conf
@@ -27,10 +27,10 @@ modules_path = st2reactor/st2reactor/sensor/samples
 actionexecution_base_url = http://0.0.0.0:9101/actionexecutions
 
 [action_controller_logging]
-config_file = /etc/st2actioncontroller/logging.conf
+config_file = st2actioncontroller/conf/logging.conf
 
 [actionrunner_controller_logging]
-config_file = /etc/st2actionrunnercontroller/logging.conf
+config_file = st2actionrunnercontroller/conf/logging.conf
 
 [datastore_logging]
 config_file = st2datastore/conf/logging.conf

--- a/devel/scripts/launch.sh
+++ b/devel/scripts/launch.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+if [ "$#" -ne 1 ] || ([ ${1} != "start" ] && [ ${1} != "stop" ]) ; then
+  echo "Usage: $0 [start|stop]" >&2
+  exit 1
+fi
+
+if [[ ${1} == "start" ]]; then
+
+    echo "Starting all Stanley servers..."
+
+    # Install screen if it is not installed
+    if ! yum list installed | grep -qw screen; then
+        echo "Installing the screen program..."
+        sudo yum install screen
+    fi
+
+    # Determine where the stanley repo is located. Some assumption is made here
+    # that this script is located under stanley/devel/scripts.
+
+    COMMAND_PATH=${0%/*}
+    CURRENT_DIR=`pwd`
+
+    if [[ (${COMMAND_PATH} == /*) ]] ;
+    then
+        ST2_REPO=${COMMAND_PATH}/../..
+    else
+        ST2_REPO=${CURRENT_DIR}/${COMMAND_PATH}/../..
+    fi
+
+    # Change working directory to the root of the repo.
+    ST2_REPO=`realpath ${ST2_REPO}`
+    echo "Changing working directory to ${ST2_REPO}..."
+    cd ${ST2_REPO}
+
+    # Run the reactor API server
+    echo 'Starting screen session st2-reactor...'
+    screen -d -m -S st2-reactor ./virtualenv/bin/python \
+        ./st2reactorcontroller/bin/reactor_controller \
+        --config-file ./conf/stanley.conf
+
+    # Run the action runner API server
+    echo 'Starting screen session st2-actionrunner...'
+    screen -d -m -S st2-actionrunner ./virtualenv/bin/python \
+        ./st2actionrunnercontroller/bin/actionrunner_controller \
+        --config-file ./conf/stanley.conf
+
+    # Run the action API server
+    echo 'Starting screen session st2-action...'
+    screen -d -m -S st2-action ./virtualenv/bin/python \
+        ./st2actioncontroller/bin/action_controller \
+        --config-file ./conf/stanley.conf 
+
+    # Run the datastore API server
+    echo 'Starting screen session st2-datastore...'
+    screen -d -m -S st2-datastore ./virtualenv/bin/python \
+        ./st2datastore/bin/datastore_controller \
+        --config-file ./conf/stanley.conf
+
+elif [[ ${1} == "stop" ]]; then
+
+    echo "Stopping all Stanley servers..."
+
+    # Stop the datastore API server
+    echo "Terminating the screen session for st2-datastore..."
+    screen -X -S st2-datastore quit
+
+    # Stop the action API server
+    echo "Terminating the screen session for st2-action..."
+    screen -X -S st2-action quit
+
+    # Stop the reactor API server
+    echo "Terminating the screen session for st2-reactor..."
+    screen -X -S st2-reactor quit
+
+    # Stop the action runner API server
+    echo "Terminating the screen session for st2-actionrunner..."
+    screen -X -S st2-actionrunner quit
+
+fi


### PR DESCRIPTION
Created a launch script for development environment that starts/stops all API servers in detached screen sessions. The launch script will automatically install screen if it's not installed. The script will also reasonably try to determine where the stanley repo is located assuming this script has not been relocated and separated from the stanley repo.

Assuming /home/vagrant/stanley is the directory where the stanley repo is clone. The following are example usages.

cd ~/stanley/devel/scripts
./launch.sh start
./launch.sh stop
cd ~/stanley
./devel/scripts/launch.sh start
./devel/scripts/launch.sh stop
cd ~
~/stanley/devel/scripts/launch.sh start
~/stanley/devel/scripts/launch.sh stop
cd /
/home/vagrant/stanley/devel/scripts/launch.sh start
/home/vagrant/stanley/devel/scripts/launch.sh stop
