### PR TITLE
RFR : [STORM-283] separate out system sensor path and user sensor path

### DIFF
--- a/conf/stanley.conf
+++ b/conf/stanley.conf
@@ -15,13 +15,13 @@ config_file = st2reactorcontroller/conf/logging.conf
 [reactor_controller_api]
 # Host and port to bind the API server to
 host = 0.0.0.0
-port = 9102 
+port = 9102
 
 [reactor_pecan]
 #auth_enable = True
 
 [sensors]
-modules_path = st2reactor/st2reactor/sensor/samples
+modules_path = /opt/stackstorm/repo/sensors
 
 [reactor]
 actionexecution_base_url = http://0.0.0.0:9101/actionexecutions

--- a/st2reactor/st2reactor/cmd/sensorcontainer.py
+++ b/st2reactor/st2reactor/cmd/sensorcontainer.py
@@ -56,7 +56,7 @@ def _load_sensor_modules(path):
     if not os.path.isdir(path):
         raise Exception('Directory containing sensors must be provided.')
 
-    LOG.info('Loading sensor modules from path: %s' % path)
+    LOG.info('Loading sensor modules from path: %s', path)
 
     plugins = []
     for (dirpath, dirnames, filenames) in os.walk(path):
@@ -66,7 +66,7 @@ def _load_sensor_modules(path):
         files = [f for f in files if not re.match(excludes, f)]
         plugins.extend(files)
         break
-    LOG.info('Found %d sensor modules in path.' % len(plugins))
+    LOG.info('Found %d sensor modules in path.', len(plugins))
 
     plugins_dict = defaultdict(list)
     for plugin in plugins:
@@ -151,7 +151,9 @@ def main():
     if _is_single_sensor_mode():
         return _run_sensor(cfg.CONF.sensor_path)
     else:
-        sensors_dict = _load_sensor_modules(os.path.realpath(cfg.CONF.sensors.modules_path))
+        sensors_dict = _load_sensor_modules(os.path.realpath(cfg.CONF.sensors.system_path))
+        user_sensor_dict = _load_sensor_modules(os.path.realpath(cfg.CONF.sensors.modules_path))
+        sensors_dict.update(user_sensor_dict)
         LOG.info('Found %d sensors.', len(sensors_dict))
         exit_code = _run_sensors(sensors_dict)
         _teardown()

--- a/st2reactor/st2reactor/config.py
+++ b/st2reactor/st2reactor/config.py
@@ -27,6 +27,8 @@ sensors_opts = [
     cfg.StrOpt('modules_path', default='/var/lib/stanley/sensors/modules/',
         help='path to load sensor modules from'),
     cfg.StrOpt('scripts_path', default='/var/lib/stanley/sensors/scripts',
+        help='path to load sensor scripts from'),
+    cfg.StrOpt('system_path', default='st2reactor/st2reactor/sensor/samples',
         help='path to load sensor scripts from')
 ]
 CONF.register_opts(sensors_opts, group='sensors')


### PR DESCRIPTION
- separate path allow for user to not have to know about system sensors.
- system sensors are loaded prior to any user defined sensors.
- config for system path is not highlighted in the conf file and should
  be treated as an internal configuration.
