### PR TITLE
Rule supplies action_parameters instead of runner_parameters

### DIFF
--- a/st2reactor/st2reactor/ruleenforcement/enforce.py
+++ b/st2reactor/st2reactor/ruleenforcement/enforce.py
@@ -63,8 +63,8 @@ class RuleEnforcer(object):
     @staticmethod
     def __invoke_action(action, action_args):
         payload = json.dumps({'action': action,
-                              'runner_parameters': action_args,
-                              'action_parameters': {}})
+                              'runner_parameters': {},
+                              'action_parameters': action_args})
         r = requests.post(cfg.CONF.reactor.actionexecution_base_url,
                           data=payload,
                           headers=HTTP_AE_POST_HEADER)


### PR DESCRIPTION
- Rules can't distinguish between action params and runner params.
  Since shell action require the args to be used as action params
  it is better to supply args as those. Effectively, the actions
  run by internal dummy are broken.
