### PR TITLE
[STORM-285] Ability to register trigger types

### DIFF
--- a/st2common/st2common/models/api/reactor.py
+++ b/st2common/st2common/models/api/reactor.py
@@ -2,7 +2,7 @@ import datetime
 from wsme import types as wstypes
 
 from st2common.models.api.stormbase import StormBaseAPI, StormFoundationAPI
-from st2common.models.db.reactor import RuleDB, ActionExecutionSpecDB
+from st2common.models.db.reactor import RuleDB, ActionExecutionSpecDB, TriggerDB
 from st2common.persistence.reactor import Trigger
 from st2common.persistence.action import Action
 
@@ -39,6 +39,12 @@ class TriggerAPI(StormBaseAPI):
         trigger = StormBaseAPI.from_model(kls, model)
         trigger.payload_info = model.payload_info
         return trigger
+
+    @classmethod
+    def to_model(kls, trigger):
+        model = StormBaseAPI.to_model(TriggerDB, trigger)
+        model.payload_info = trigger.payload_info
+        return model
 
 
 class TriggerInstanceAPI(StormFoundationAPI):

--- a/st2reactorcontroller/st2reactorcontroller/controllers/triggers.py
+++ b/st2reactorcontroller/st2reactorcontroller/controllers/triggers.py
@@ -1,6 +1,6 @@
 import httplib
 import wsmeext.pecan as wsme_pecan
-from mongoengine import ValidationError
+from mongoengine import ValidationError, NotUniqueError
 from pecan import abort
 from pecan.rest import RestController
 from st2common import log as logging
@@ -17,7 +17,7 @@ class TriggerController(RestController):
         the lifecycle of Triggers in the system.
     """
     @wsme_pecan.wsexpose(TriggerAPI, wstypes.text)
-    def get_one(self, id):
+    def get_one(self, trigger_id):
 
         """
             List triggers by id.
@@ -26,13 +26,7 @@ class TriggerController(RestController):
                 GET /triggers/1
         """
         LOG.info('GET /triggers/ with id=%s', id)
-
-        try:
-            trigger_db = Trigger.get_by_id(id)
-        except (ValueError, ValidationError):
-            LOG.exception('Database lookup for id="%s" resulted in exception.', id)
-            abort(httplib.NOT_FOUND)
-
+        trigger_db = TriggerController.__get_by_id(trigger_id)
         trigger_api = TriggerAPI.from_model(trigger_db)
         LOG.debug('GET /triggers/ with id=%s, client_result=%s', id, trigger_api)
         return trigger_api
@@ -50,6 +44,80 @@ class TriggerController(RestController):
         trigger_apis = [TriggerAPI.from_model(trigger_db) for trigger_db in trigger_dbs]
         LOG.debug('GET all /triggers/ client_result=%s', trigger_apis)
         return trigger_apis
+
+    @wsme_pecan.wsexpose(TriggerAPI, body=TriggerAPI, status_code=httplib.CREATED)
+    def post(self, trigger):
+        """
+            Create a new trigger.
+
+            Handles requests:
+                POST /triggers/
+        """
+        LOG.info('POST /triggers/ with trigger data=%s', trigger)
+
+        try:
+            trigger_db = TriggerAPI.to_model(trigger)
+            LOG.debug('/triggers/ POST verified TriggerAPI and formulated TriggerDB=%s', trigger_db)
+            trigger_db = Trigger.add_or_update(trigger_db)
+        except (ValidationError, ValueError) as e:
+            LOG.exception('Validation failed for trigger data=%s.', trigger)
+            abort(httplib.BAD_REQUEST, str(e))
+        except NotUniqueError as e:
+            LOG.exception('Trigger creation of %s failed with uniqueness conflict.', trigger)
+            abort(httplib.CONFLICT, str(e))
+
+        LOG.debug('/triggers/ POST saved TriggerDB object=%s', trigger_db)
+        trigger_api = TriggerAPI.from_model(trigger_db)
+        LOG.debug('POST /triggers/ client_result=%s', trigger_api)
+
+        return trigger_api
+
+    @wsme_pecan.wsexpose(TriggerAPI, wstypes.text, body=TriggerAPI, status_code=httplib.OK)
+    def put(self, trigger_id, trigger):
+        LOG.info('PUT /triggers/ with trigger id=%s and data=%s', trigger_id, trigger)
+        trigger_db = TriggerController.__get_by_id(trigger_id)
+        LOG.debug('PUT /triggers/ lookup with id=%s found object: %s', trigger_id, trigger_db)
+
+        try:
+            if trigger.id is not None and trigger.id is not '' and trigger.id != trigger_id:
+                LOG.warning('Discarding mismatched id=%s found in payload and using uri_id=%s.',
+                            trigger.id, trigger_id)
+            trigger_db = TriggerAPI.to_model(trigger)
+            trigger_db.id = trigger_id
+            trigger_db = Trigger.add_or_update(trigger_db)
+            LOG.debug('/triggers/ PUT updated TriggerDB object=%s', trigger_db)
+        except (ValidationError, ValueError) as e:
+            LOG.exception('Validation failed for trigger data=%s', trigger)
+            abort(httplib.BAD_REQUEST, str(e))
+
+        trigger_api = TriggerAPI.from_model(trigger_db)
+        LOG.debug('PUT /triggers/ client_result=%s', trigger_api)
+
+        return trigger_api
+
+    @wsme_pecan.wsexpose(None, wstypes.text, status_code=httplib.NO_CONTENT)
+    def delete(self, trigger_id):
+        """
+            Delete a trigger.
+
+            Handles requests:
+                DELETE /triggers/1
+        """
+        LOG.info('DELETE /triggers/ with id=%s', trigger_id)
+        trigger_db = TriggerController.__get_by_id(trigger_id)
+        LOG.debug('DELETE /triggers/ lookup with id=%s found object: %s', trigger_id, trigger_db)
+        try:
+            Trigger.delete(trigger_db)
+        except Exception:
+            LOG.exception('Database delete encountered exception during delete of id="%s". ', trigger_id)
+
+    @staticmethod
+    def __get_by_id(trigger_id):
+        try:
+            return Trigger.get_by_id(trigger_id)
+        except (ValueError, ValidationError):
+            LOG.exception('Database lookup for id="%s" resulted in exception.', trigger_id)
+            abort(httplib.NOT_FOUND)
 
     @staticmethod
     def __get_by_name(trigger_name):

--- a/st2reactorcontroller/tests/controllers/test_triggers.py
+++ b/st2reactorcontroller/tests/controllers/test_triggers.py
@@ -1,30 +1,92 @@
+import httplib
+import unittest2
 from st2common.persistence.reactor import Trigger
 from st2common.models.db import reactor
 from tests import FunctionalTest
 
-TRIGGER = reactor.TriggerDB()
-TRIGGER.name = 'st2.test.trigger1'
-TRIGGER.description = ''
-TRIGGER.payload_info = ['tp1', 'tp2', 'tp3']
-TRIGGER.trigger_source = None
+TRIGGER_0 = {
+    'name': 'st2.test.trigger0',
+    'description': 'test trigger',
+    'payload_info': ['tp1', 'tp2', 'tp3']
+}
+TRIGGER_1 = {
+    'name': 'st2.test.trigger1',
+    'description': 'test trigger',
+    'payload_info': ['tp1', 'tp2', 'tp3']
+}
 
 
 class TestTriggerController(FunctionalTest):
 
-    def setUp(self):
-        # assigning id to none guarantees that it is assigned a new id before evey test.
-        TRIGGER.id = None
-        Trigger.add_or_update(TRIGGER)
-
-    def tearDown(self):
-        Trigger.delete(TRIGGER)
-
     def test_get_all(self):
+        post_resp = self.__do_post(TRIGGER_0)
+        trigger_id_0 = self.__get_trigger_id(post_resp)
+        post_resp = self.__do_post(TRIGGER_1)
+        trigger_id_1 = self.__get_trigger_id(post_resp)
         resp = self.app.get('/triggers')
-        self.assertEqual(resp.status_int, 200)
+        self.assertEqual(resp.status_int, httplib.OK)
+        self.assertEqual(len(resp.json), 2, 'Get all failure.')
+        self.__do_delete(trigger_id_0)
+        self.__do_delete(trigger_id_1)
 
     def test_get_one(self):
-        resp = self.app.get('/triggers')
-        trigger_id = resp.json[0]['id']
-        get_one_resp = self.app.get('/triggers/%s' % trigger_id)
-        self.assertEqual(get_one_resp.status_int, 200)
+        post_resp = self.__do_post(TRIGGER_1)
+        trigger_id = self.__get_trigger_id(post_resp)
+        get_resp = self.__do_get_one(trigger_id)
+        self.assertEquals(get_resp.status_int, httplib.OK)
+        self.assertEquals(self.__get_trigger_id(get_resp), trigger_id)
+        self.__do_delete(trigger_id)
+
+    def test_get_one_fail(self):
+        resp = self.__do_get_one('1')
+        self.assertEqual(resp.status_int, httplib.NOT_FOUND)
+
+    def test_post(self):
+        post_resp = self.__do_post(TRIGGER_1)
+        self.assertEquals(post_resp.status_int, httplib.CREATED)
+        self.__do_delete(self.__get_trigger_id(post_resp))
+
+    @unittest2.skip('/triggers is accepting dups!')
+    def test_post_duplicate(self):
+        post_resp = self.__do_post(TRIGGER_1)
+        self.assertEquals(post_resp.status_int, httplib.CREATED)
+        post_resp_2 = self.__do_post(TRIGGER_1)
+        self.assertEquals(post_resp_2.status_int, httplib.CONFLICT)
+        self.__do_delete(self.__get_trigger_id(post_resp))
+
+    def test_put(self):
+        post_resp = self.__do_post(TRIGGER_1)
+        update_input = post_resp.json
+        update_input['description'] = 'updated description.'
+        put_resp = self.__do_put(self.__get_trigger_id(post_resp), update_input)
+        self.assertEquals(put_resp.status_int, httplib.OK)
+        self.__do_delete(self.__get_trigger_id(put_resp))
+
+    def test_put_fail(self):
+        post_resp = self.__do_post(TRIGGER_1)
+        update_input = post_resp.json
+        # If the id in the URL is incorrect the update will fail since id in the body is ignored.
+        put_resp = self.__do_put(1, update_input)
+        self.assertEquals(put_resp.status_int, httplib.NOT_FOUND)
+        self.__do_delete(self.__get_trigger_id(post_resp))
+
+    def test_delete(self):
+        post_resp = self.__do_post(TRIGGER_1)
+        del_resp = self.__do_delete(self.__get_trigger_id(post_resp))
+        self.assertEquals(del_resp.status_int, httplib.NO_CONTENT)
+
+    @staticmethod
+    def __get_trigger_id(resp):
+        return resp.json['id']
+
+    def __do_get_one(self, trigger_id):
+        return self.app.get('/triggers/%s' % trigger_id, expect_errors=True)
+
+    def __do_post(self, trigger):
+        return self.app.post_json('/triggers', trigger, expect_errors=True)
+
+    def __do_put(self, trigger_id, trigger):
+        return self.app.put_json('/triggers/%s' % trigger_id, trigger, expect_errors=True)
+
+    def __do_delete(self, trigger_id):
+        return self.app.delete('/triggers/%s' % trigger_id)


### PR DESCRIPTION
- Before posting triggers via the stanley webhook sensor post on
  /triggers to register corresponding trigger type.
-  Now the /triggers endpoint exposes full CRUD operation on triggers.
