### PR TITLE
[STORM-292] Refactor help commands in CLI to be consistent

### DIFF
--- a/st2client/st2client/commands/__init__.py
+++ b/st2client/st2client/commands/__init__.py
@@ -19,8 +19,7 @@ class Branch(object):
         self.parent_parser = parent_parser
         self.parser = subparsers.add_parser(self.name,
                                             description=self.description,
-                                            help=self.description,
-                                            add_help=False)
+                                            help=self.description)
         self.commands = dict()
 
 
@@ -28,7 +27,8 @@ class Branch(object):
 class Command(object):
     """Represents a commandlet in the command tree."""
 
-    def __init__(self, name, description, app, subparsers, parent_parser=None):
+    def __init__(self, name, description, app, subparsers,
+                 parent_parser=None, add_help=True):
         self.name = name
         self.description = description
         self.app = app
@@ -36,7 +36,7 @@ class Command(object):
         self.parser = subparsers.add_parser(self.name,
                                             description=self.description,
                                             help=self.description,
-                                            add_help=False)
+                                            add_help=add_help)
         self.parser.set_defaults(func=self.run_and_print)
 
     @abc.abstractmethod

--- a/st2client/st2client/commands/resource.py
+++ b/st2client/st2client/commands/resource.py
@@ -35,8 +35,6 @@ class ResourceBranch(commands.Branch):
                   self.resource.get_plural_display_name().lower()))
 
         # Resolves if commands need to be overridden.
-        if 'help' not in commands:
-            commands['help'] = ResourceHelpCommand
         if 'list' not in commands:
             commands['list'] = ResourceListCommand
         if 'get' not in commands:
@@ -50,7 +48,6 @@ class ResourceBranch(commands.Branch):
 
         # Instantiate commands.
         args = [self.resource, self.app, self.subparsers]
-        self.commands['help'] = commands['help'](self.commands, *args)
         self.commands['list'] = commands['list'](*args)
         self.commands['get'] = commands['get'](*args)
         if not read_only:
@@ -77,40 +74,6 @@ class ResourceCommand(commands.Command):
     def print_not_found(self, name):
         print ('%s "%s" cannot be found.' %
                (self.resource.get_display_name(), name))
-
-
-class ResourceHelpCommand(ResourceCommand):
-
-    def __init__(self, commands, resource, *args, **kwargs):
-        super(ResourceHelpCommand, self).__init__(resource, 'help',
-            'Print usage for the given command.',
-            *args, **kwargs)
-
-        # If parent parser is the top level parser, set the command argument to
-        # optional so that running "prog help" will return the program's help
-        # message instead of throwing the "too few arguments" error.
-        nargs = '?' if self.parent_parser and self.parent_parser.prog else None
-        self.parser.add_argument('command', nargs=nargs,
-                                 help='Name of the command.')
-
-        # Registers this help command in the command list so "prog help help"
-        # will return the help message for this help command.
-        self.commands = commands
-        self.commands['help'] = self
-
-    def run(self, args):
-        pass
-
-    def run_and_print(self, args):
-        if args.command:
-            command = self.commands[args.command]
-            command.parser.print_help()
-        else:
-            if self.parent_parser and self.parent_parser.prog:
-                self.parent_parser.print_help()
-            else:
-                self.parser.print_help()
-        print
 
 
 class ResourceListCommand(ResourceCommand):

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -27,8 +27,7 @@ class Shell(object):
 
         # Set up the main parser.
         self.parser = argparse.ArgumentParser(
-            description='TODO: Add description for the CLI here.',
-            add_help=False)
+            description='TODO: Add description for the CLI here.')
 
         # Set up general program options.
         self.parser.add_argument(
@@ -67,9 +66,6 @@ class Shell(object):
         # Set up list of commands and subcommands.
         self.subparsers = self.parser.add_subparsers()
         self.commands = dict()
-        self.commands['help'] = resource.ResourceHelpCommand(
-            self.commands, None, self, self.subparsers,
-            parent_parser=self.parser)
         self.commands['action'] = action.ActionBranch(
             'TODO: Put description of action here.',
             self, self.subparsers)

--- a/st2client/tests/test_shell.py
+++ b/st2client/tests/test_shell.py
@@ -46,6 +46,8 @@ class TestShell(unittest2.TestCase):
             ['action', 'create', '/tmp/action.json'],
             ['action', 'update', '123', '/tmp/action.json'],
             ['action', 'delete', 'abc'],
+            ['action', 'execute', '-h'],
+            ['action', 'execute', 'abc', '-h'],
             ['action', 'execute', 'abc', '-r', 'command="uname =a"']
         ]
         self._validate_parser(args_list)


### PR DESCRIPTION
Normalize help commands in CLI to "-h" or "--help" optional args.

Example:
st2 -h
st2 --help
st2 trigger -h
st2 rule update -h
st2 action execute -h
st2 action execute ssh -h

CLOSES: STORM-292
