### PR TITLE
[STORM-295] Provide actions complete control on the reported results.

### DIFF
--- a/st2actionrunnercontroller/st2actionrunner/container/service.py
+++ b/st2actionrunnercontroller/st2actionrunner/container/service.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 import tempfile
@@ -29,16 +30,18 @@ class RunnerContainerService():
 
     def __init__(self, container):
         self._container = container
-        self._exit_code = None
-        self._output = []
+        self._result = None
         self._payload = {}
         self._action_workingdir = None
 
-    def report_exit_code(self, code):
-        self._exit_code = code
+    def report_result(self, result):
+        self._result = result
 
-    def report_output(self, stream, output):
-        self._output.append((stream, output))
+    def get_result(self):
+        return self._result
+
+    def get_result_json(self):
+        return json.dumps(self._result)
 
     def report_payload(self, name, value):
         self._payload[name] = value
@@ -139,8 +142,7 @@ class RunnerContainerService():
         result.append(str(id(self)))
         result.append('(')
         result.append('_container="%s", ' % self._container)
-        result.append('_exit_code="%s", ' % self._exit_code)
-        result.append('_output="%s", ' % self._output)
+        result.append('_result="%s", ' % self._result)
         result.append('_payload="%s", ' % self._payload)
         result.append(')')
         return ''.join(result)

--- a/st2actionrunnercontroller/st2actionrunner/runners/internaldummy.py
+++ b/st2actionrunnercontroller/st2actionrunner/runners/internaldummy.py
@@ -72,9 +72,11 @@ class InternalDummyRunner(ActionRunner):
         LOG.debug('    [Internal Dummy Runner] command_exit: %s', command_exitcode)
         LOG.debug('    [Internal Dummy Runner] TODO: Save output to DB')
 
-        self.container_service.report_exit_code(command_exitcode)
-        self.container_service.report_output(STDOUT, command_stdout)
-        self.container_service.report_output(STDERR, command_stderr)
+        result = {'exit_code': command_exitcode,
+                  'std_out': command_stdout,
+                  'std_err': command_stderr}
+
+        self.container_service.report_result(result)
 
         return (command_exitcode, command_stdout, command_stderr)
 

--- a/st2actionrunnercontroller/st2actionrunner/runners/shellrunner.py
+++ b/st2actionrunnercontroller/st2actionrunner/runners/shellrunner.py
@@ -117,9 +117,11 @@ class ShellRunner(ActionRunner):
         LOG.debug('    [ShellRunner,liveaction_id="%s"] command_exit: %s',
                   self.liveaction_id, command_exitcode)
 
-        self.container_service.report_exit_code(command_exitcode)
-        self.container_service.report_output(STDOUT, command_stdout)
-        self.container_service.report_output(STDERR, command_stderr)
+        result = {'exit_code': command_exitcode,
+                  'std_out': command_stdout,
+                  'std_err': command_stderr}
+
+        self.container_service.report_result(result)
 
         os.chdir(old_dir)
 

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -1,4 +1,6 @@
 import datetime
+import json
+from wsme import wsattr
 from wsme import types as wstypes
 
 from st2common import log as logging
@@ -96,17 +98,12 @@ class ActionExecutionAPI(StormFoundationAPI):
     Attribute:
        ...
     """
-
-    # Correct parameters...
     status = wstypes.Enum(str, *ACTIONEXEC_STATUSES)
     start_timestamp = datetime.datetime
-    action = wstypes.DictType(str, str)
-    runner_parameters = wstypes.DictType(str, str)
-    action_parameters = wstypes.DictType(str, str)
-    # result_data = wstypes.DictType(str, wstypes.DictType(str, str))
-    exit_code = wstypes.text
-    std_out = wstypes.text
-    std_err = wstypes.text
+    action = wsattr(wstypes.DictType(str, str), mandatory=True)
+    runner_parameters = wsattr(wstypes.DictType(str, str), default={})
+    action_parameters = wsattr(wstypes.DictType(str, str), default={})
+    result = wsattr(str, default='')
 
     @classmethod
     def from_model(kls, model):
@@ -117,12 +114,7 @@ class ActionExecutionAPI(StormFoundationAPI):
         actionexec.start_timestamp = model.start_timestamp
         actionexec.runner_parameters = dict(model.runner_parameters)
         actionexec.action_parameters = dict(model.action_parameters)
-        # actionexec.result_data = dict(model.result_data)
-        # if actionexec.exit_code not in [None, Unset]:
-        #    actionexec.exit_code = int(model.exit_code)
-        actionexec.exit_code = str(model.exit_code)
-        actionexec.std_out = str(model.std_out)
-        actionexec.std_err = str(model.std_err)
+        actionexec.result = model.result
         LOG.debug('exiting ActionExecutionAPI.from_model() Result object: %s', actionexec)
         return actionexec
 
@@ -135,10 +127,7 @@ class ActionExecutionAPI(StormFoundationAPI):
         model.action = actionexec.action
         model.runner_parameters = dict(actionexec.runner_parameters)
         model.action_parameters = dict(actionexec.action_parameters)
-        # model.result_data = actionexec.result_data
-        model.exit_code = str(actionexec.exit_code)
-        model.std_out = str(actionexec.std_out)
-        model.std_err = str(actionexec.std_err)
+        model.result = actionexec.result
         LOG.debug('exiting ActionExecutionAPI.to_model() Result object: %s', model)
         return model
 
@@ -152,9 +141,6 @@ class ActionExecutionAPI(StormFoundationAPI):
         result.append('action="%s", ' % self.action)
         result.append('runner_parameters="%s", ' % self.runner_parameters)
         result.append('action_parameters="%s", ' % self.action_parameters)
-        # result.append('result_data=%s, ' % json.dumps(self.result_data))
-        result.append('exit_code="%s", ' % self.exit_code)
-        result.append('std_out="%s", ' % self.std_out)
-        result.append('std_err="%s", ' % self.std_err)
+        result.append('result=%s, ' % json.dumps(self.result))
         result.append('uri="%s")' % self.uri)
         return ''.join(result)

--- a/st2common/st2common/models/db/action.py
+++ b/st2common/st2common/models/db/action.py
@@ -51,28 +51,6 @@ class ActionDB(StormBaseDB):
         return ''.join(result)
 
 
-class ActionExecutionResultDB(me.EmbeddedDocument):
-    """
-        Result data for a single Action execution (on a single host).
-    """
-    exit_code = me.StringField(default=None,
-                           help_text='Exit code for action.')
-    std_out = me.ListField(default=[],
-                           help_text='List of stdout output strings in output order.')
-    std_err = me.ListField(default=[],
-                           help_text='List of stdout output strings in output order.')
-
-    def __str__(self):
-        result = []
-        result.append('ActionExecutionResultDB@')
-        result.append(str(id(self)))
-        result.append('(')
-        result.append('exit_code=%s' % int(self.exit_code))
-        result.append('std_out=%s' % str(self.std_out))
-        result.append('std_err=%s)' % str(self.std_err))
-        return ''.join(result)
-
-
 class ActionExecutionDB(StormFoundationDB):
     """
         The databse entity that represents a Stack Action/Automation in
@@ -82,7 +60,7 @@ class ActionExecutionDB(StormFoundationDB):
             status: the most recently observed status of the execution.
                     One of "starting", "running", "completed", "error".
             result: an embedded document structure that holds the
-                    output and exit status code from the stack action.
+                    output and exit status code from the action.
     """
 
     # TODO: Can status be an enum at the Mongo layer?
@@ -96,22 +74,7 @@ class ActionExecutionDB(StormFoundationDB):
                 help_text='The key-value pairs passed as parameters to the action runner.')
     action_parameters = me.DictField(default={},
                 help_text='The key-value pairs passed as parameters to the execution.')
-
-    # TODO: Move result data to dict of embedded documents.... to support multiple action
-    #       targets.
-    # result_data = me.ListField( me.EmbeddedDocumentField(ActionExecutionResultDB),
-    #                           help_text='Output from action. Key values are hostnames.')
-    # result_data = me.EmbeddedDocumentField(ActionExecutionResultDB, default=ActionExecutionResultDB(),
-    #             help_text='Output from action. Key values are hostnames.')
-
-    exit_code = me.StringField(default='',
-                           help_text='Exit code for action.')
-    # std_out = me.ListField(default=[],
-    std_out = me.StringField(default='',
-                           help_text='List of stdout output strings in output order.')
-    # std_err = me.ListField(default=[],
-    std_err = me.StringField(default='',
-                           help_text='List of stdout output strings in output order.')
+    result = me.StringField(default='', help_text='Action defined result.')
 
     # TODO: Write generic str function for API and DB model base classes
     def __str__(self):
@@ -119,16 +82,14 @@ class ActionExecutionDB(StormFoundationDB):
         result.append('ActionExecutionDB@')
         result.append(str(id(self)))
         result.append('(')
-        result.append('id="%s", ' % self.id)
+        result.append('id=%s, ' % self.id)
         result.append('action=%s, ' % str(self.action))
         result.append('status=%s, ' % str(self.status))
         result.append('start_timestamp=%s, ' % str(self.start_timestamp))
         result.append('runner_parameters=%s, ' % str(self.runner_parameters))
         result.append('action_parameters=%s, ' % str(self.action_parameters))
-        result.append('exit_code=%s, ' % str(self.exit_code))
-        result.append('std_out=%s, ' % str(self.std_out))
-        result.append('std_err=%s, ' % str(self.std_err))
-        result.append('uri="%s")' % self.uri)
+        result.append('result=%s, ' % self.result)
+        result.append(')')
         return ''.join(result)
 
 

--- a/st2common/st2common/models/db/actionrunner.py
+++ b/st2common/st2common/models/db/actionrunner.py
@@ -7,9 +7,7 @@ from st2common.models.db.stormbase import (StormFoundationDB, StormBaseDB)
 
 __all__ = ['LiveActionDB',
            'ActionRunnerDB',
-           'ActionTypeDB',
-           'ActionExecutionResultDB',
-           ]
+           'ActionTypeDB']
 
 
 LOG = logging.getLogger(__name__)
@@ -87,16 +85,6 @@ class ActionRunnerDB(StormFoundationDB):
         Attributes:
     """
     pass
-
-
-class ActionExecutionResultDB(me.EmbeddedDocument):
-    """
-    TODO: fill-in
-    Not sure if I will need this to be persisted.
-    """
-    exit_code = me.IntField()
-    std_out = me.StringField()
-    std_err = me.StringField()
 
 
 # specialized access objects


### PR DESCRIPTION
- Current design expect that every action will be able to report
  exit_code, std_out and std_err. This imposes restrictions on an
  actions design.
- Results are very action & action runner specific e.g. an action which
  runs on multiple hosts cannot fit the result with maximum fidelity in
  the same exit_code, std_out and std_err format.
- The downside of opening up the result to complete action control is
  that it is no longer possible to provide any extra system services
  without making an assumption of the output format.
- Result is stored in the DB as json representation of the object. This
  simplifies some pecan issues and avoid repeated marshalling of result.
