### PR TITLE
Use patched version of Fabric for fabricrunner

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ prettytable
 pyyaml
 apscheduler>=3.0.0rc1
 python-dateutil
-Fabric
 paramiko
+git+https://github.com/StackStorm/fabric.git@stanley-patched


### PR DESCRIPTION
```
Eventlet monkey patching of select pretty much blows Fabric.
Related: https://github.com/StackStorm/fabric/pull/1
Related: https://github.com/StackStorm/fabric/pull/2
This PR switches to using a forked version of Fabric
with the above fixes.
```

```
+-------------------+---------------------------------------------------------+
| Property          | Value                                                   |
+-------------------+---------------------------------------------------------+
| action            | {                                                       |
|                   |     "name": "remote-action-sysuser",                    |
|                   |     "id": "53d048a3b185977edbbc3a17"                    |
|                   | }                                                       |
| action_parameters | {}                                                      |
| id                | 53d1975fb185970abf82b1b0                                |
| result            | {"54.191.17.38": {"failed": false, "stderr": "",        |
|                   | "return_code": 0, "succeeded": true, "stdout": "total   |
|                   | 0"}, "54.191.85.86": {"failed": false, "stderr": "",    |
|                   | "return_code": 0, "succeeded": true, "stdout": "total   |
|                   | 12\ndrwxrwxr-x 3 stanley 1006 4096 Jun 22 18:53         |
|                   | packages\ndrwxrwxr-x 8 stanley 1006 4096 Jun 22 18:53   |
|                   | rpmbuild\ndrwxrwxr-x 3 stanley 1006 4096 Jun 22 18:53   |
|                   | workspace"}}                                            |
| runner_parameters | {                                                       |
|                   |     "hosts": "54.191.85.86, 54.191.17.38",              |
|                   |     "command": "ls -l",                                 |
|                   |     "user": "manas"                                     |
|                   | }                                                       |
| start_timestamp   | 2014-07-24T16:31:43.457000                              |
| status            | complete                                                |
| uri               | None                                                    |
+-------------------+---------------------------------------------------------+

(virtualenv)vagrant@vagrant-fedora20 ~/onebox-stanley (master●)$
```
