### PR TITLE
[STORM-299] Action auto-registration

### DIFF
--- a/contrib/core/actions/shell-echo.json
+++ b/contrib/core/actions/shell-echo.json
@@ -4,7 +4,7 @@
     "description": "An echo action.",
     "enabled": true,
     "uri": null,
-    "entry_point": "actions/bash_echo/bash_echo.sh",
-    "artifact_paths": ["actions/bash_echo"],
+    "entry_point": "echo",
+    "artifact_paths": [],
     "parameters": {}
 }

--- a/contrib/sandbox/scripts/launch.sh
+++ b/contrib/sandbox/scripts/launch.sh
@@ -16,7 +16,7 @@ if [[ ${1} == "start" ]]; then
     fi
 
     # Determine where the stanley repo is located. Some assumption is made here
-    # that this script is located under stanley/devel/scripts.
+    # that this script is located under stanley/contrib/sandbox/scripts.
 
     COMMAND_PATH=${0%/*}
     CURRENT_DIR=`pwd`
@@ -32,6 +32,10 @@ if [[ ${1} == "start" ]]; then
     ST2_REPO=`realpath ${ST2_REPO}`
     echo "Changing working directory to ${ST2_REPO}..."
     cd ${ST2_REPO}
+
+    # Copy and overwrite the action contents
+    mkdir -p /opt/stackstorm
+    cp -Rp ./contrib/core/actions /opt/stackstorm 
 
     # activate virtualenv to set PYTHONPATH
     source ./virtualenv/bin/activate

--- a/st2actioncontroller/st2actioncontroller/cmd/actioncontroller.py
+++ b/st2actioncontroller/st2actioncontroller/cmd/actioncontroller.py
@@ -1,14 +1,19 @@
 import eventlet
 import os
 import sys
+import glob
+import json
 
 from oslo.config import cfg
+from wsgiref import simple_server
+
 from st2common import log as logging
 from st2common.models.db import db_setup
 from st2common.models.db import db_teardown
 from st2actioncontroller import config
 from st2actioncontroller import app
-from wsgiref import simple_server
+from st2common.persistence.action import Action
+from st2common.models.db.action import ActionDB
 
 
 eventlet.monkey_patch(
@@ -36,6 +41,24 @@ def __setup():
     # 4. ensure paths exist
     if not os.path.exists(cfg.CONF.actions.modules_path):
         os.makedirs(cfg.CONF.actions.modules_path)
+
+    # 5. register actions at the modules path
+    actions = glob.glob(cfg.CONF.actions.modules_path + '/*.json')    
+    for action in actions:
+        with open(action, 'r') as fd:
+            content = json.load(fd)
+            try:
+                model = Action.get_by_name(str(content['name']))
+            except:
+                model = ActionDB()
+            model.name = str(content['name'])
+            model.description = str(content['description'])
+            model.enabled = bool(content['enabled'])
+            model.artifact_paths = [str(v) for v in content['artifact_paths']]
+            model.entry_point = str(content['entry_point'])
+            model.runner_type = str(content['runner_type'])
+            model.parameters = dict(content['parameters'])
+            model = Action.add_or_update(model)
 
 def __run_server():
 


### PR DESCRIPTION
The development launch script at
stanley/contrib/sandbox/scripts/launch.py will copy and overwrite the
stanley/contrib/core/actions directory to /opt/stackstorm on start. When
the action controller is started, it will identify all the JSON files in
/opt/stackstorm/actions and auto-registers the actions. If the action
already exists in the database, it'll be overwritten.
