### PR TITLE
[STORM-299] Clean up old stuffs

### DIFF
--- a/st2actionrunnercontroller/st2actionrunner/utils.py
+++ b/st2actionrunnercontroller/st2actionrunner/utils.py
@@ -1,2 +1,0 @@
-def get_action_artifact_repo_path():
-    return '/vagrant/code/stanley/content/devel/actions'


### PR DESCRIPTION
Remove utils.py. The function "get_action_artifact_repo_path" is not in
use.
