### PR TITLE
[STORM-321] Include runner_parameter in action returned by /actions

### DIFF
--- a/st2actioncontroller/tests/controllers/test_actions.py
+++ b/st2actioncontroller/tests/controllers/test_actions.py
@@ -2,6 +2,9 @@ from tests import FunctionalTest
 import json
 import unittest2
 
+
+SHELL_RUNNER_ARGS = {'shell': '/usr/bin/bash', 'args': None}
+
 # ACTION_1: Good action definition.
 ACTION_1 = {
     'name': 'st2.dummy.action1',
@@ -83,6 +86,17 @@ class TestActionController(FunctionalTest):
         get_resp = self.__do_get_one(action_id)
         self.assertEquals(get_resp.status_int, 200)
         self.assertEquals(self.__get_action_id(get_resp), action_id)
+        self.__do_delete(action_id)
+
+    def test_get_one_validate_params(self):
+        post_resp = self.__do_post(ACTION_1)
+        action_id = self.__get_action_id(post_resp)
+        get_resp = self.__do_get_one(action_id)
+        self.assertEquals(get_resp.status_int, 200)
+        self.assertEquals(self.__get_action_id(get_resp), action_id)
+        expected_args = dict(SHELL_RUNNER_ARGS)
+        expected_args.update(ACTION_1['parameters'])
+        self.assertEquals(get_resp.json['parameters'], expected_args)
         self.__do_delete(action_id)
 
     def test_get_all(self):

--- a/st2actionrunnercontroller/st2actionrunnercontroller/controllers/liveactions.py
+++ b/st2actionrunnercontroller/st2actionrunnercontroller/controllers/liveactions.py
@@ -146,13 +146,6 @@ class LiveActionsController(RestController):
                       'Action. Action is: %s', action_db)
             abort(httplib.FORBIDDEN)
 
-        try:
-            actiontype_db = get_actiontype_by_name(action_db.runner_type)
-        except StackStormDBObjectNotFoundError as e:
-            LOG.error(e.message)
-            # TODO: Is there a more appropriate status code?
-            abort(httplib.BAD_REQUEST)
-
         #  Got ActionType object (3)
         LOG.info('POST /liveactions/ obtained ActionType object from database. '
                  'Object is %s', actiontype_db)
@@ -174,7 +167,8 @@ class LiveActionsController(RestController):
             raise NotImplementedError('Error: Asynchronous execution of Live Action not yet implemented')
         else:
             global runner_container
-            result = runner_container.dispatch(liveaction_db, actiontype_db, action_db, actionexec_db)
+            result = runner_container.dispatch(liveaction_db, action_db.runner_type, action_db,
+                                               actionexec_db)
             LOG.info('Runner dispatch produced result: %s', result)
 
         if not result:

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -102,19 +102,20 @@ class ActionAPI(StormBaseAPI):
         action = StormBaseAPI.from_model(kls, model)
         action.enabled = bool(model.enabled)
         action.entry_point = str(model.entry_point)
-        action.runner_type = str(model.runner_type)
+        action.runner_type = str(model.runner_type.name)
         action.parameters = dict(model.parameters)
+        action.parameters.update(model.runner_type.runner_parameters)
         LOG.debug('exiting ActionAPI.from_model() Result object: %s', action)
         return action
 
     @classmethod
-    def to_model(kls, action):
+    def to_model(kls, action, actiontype_db):
         LOG.debug('entering ActionAPI.to_model() Input object: %s', action)
 
         model = StormBaseAPI.to_model(ActionDB, action)
         model.enabled = bool(action.enabled)
         model.entry_point = str(action.entry_point)
-        model.runner_type = str(action.runner_type)
+        model.runner_type = actiontype_db
         model.parameters = dict(action.parameters)
 
         LOG.debug('exiting ActionAPI.to_model() Result object: %s', model)

--- a/st2common/st2common/models/db/action.py
+++ b/st2common/st2common/models/db/action.py
@@ -72,7 +72,7 @@ class ActionDB(StormBaseDB):
                           help_text='Flag indicating whether the action is enabled.')
     entry_point = me.StringField(required=True,
                           help_text='Action entrypoint.')
-    runner_type = me.StringField(required=True,
+    runner_type = me.ReferenceField(ActionTypeDB, required=True,
                           help_text='Execution environment to use when invoking the action.')
     parameters = me.DictField(default={},
                           help_text='Action parameters with optional default values.')
@@ -86,7 +86,7 @@ class ActionDB(StormBaseDB):
         result.append('name"%s", ' % self.name)
         result.append('enabled="%s", ' % self.enabled)
         result.append('entry_point="%s", ' % self.entry_point)
-        result.append('runner_type="%s", ' % self.runner_type)
+        result.append('runner_type="%s", ' % self.runner_type.name)
         result.append('parameters=%s, ' % str(self.parameters))
         result.append('uri="%s")' % self.uri)
         return ''.join(result)

--- a/st2reactorcontroller/tests/controllers/test_rules.py
+++ b/st2reactorcontroller/tests/controllers/test_rules.py
@@ -1,8 +1,16 @@
 import httplib
-from st2common.persistence.action import Action
+from st2common.persistence.action import Action, ActionType
 from st2common.persistence.reactor import Trigger
 from st2common.models.db import action, reactor
 from tests import FunctionalTest
+
+
+ACTION_TYPE = action.ActionTypeDB()
+ACTION_TYPE.name = 'python'
+ACTION_TYPE.description = ''
+ACTION_TYPE.enabled = True
+ACTION_TYPE.runner_parameters = {'r1': None, 'r2': None}
+ACTION_TYPE.runner_module = 'nomodule'
 
 ACTION = action.ActionDB()
 ACTION.name = 'st2.test.action1'
@@ -10,8 +18,8 @@ ACTION.description = ''
 ACTION.enabled = True
 ACTION.artifact_path = '/tmp/action.py'
 ACTION.entry_point = ''
-ACTION.runner_type = 'python'
-ACTION.parameter_names = ['p1', 'p2', 'p3']
+ACTION.runner_type = None
+ACTION.parameter_names = {'p1': None, 'p2': None, 'p3': None}
 
 TRIGGER = reactor.TriggerDB()
 TRIGGER.name = 'st2.test.trigger1'
@@ -51,13 +59,17 @@ RULE_1 = {
 class TestRuleController(FunctionalTest):
 
     def setUp(self):
+        ACTION_TYPE.id = None
+        ActionType.add_or_update(ACTION_TYPE)
         ACTION.id = None
+        ACTION.runner_type = ACTION_TYPE
         Action.add_or_update(ACTION)
         TRIGGER.id = None
         Trigger.add_or_update(TRIGGER)
 
     def tearDown(self):
         Action.delete(ACTION)
+        ActionType.delete(ACTION_TYPE)
         Trigger.delete(TRIGGER)
 
     def test_get_all(self):


### PR DESCRIPTION
- Modified ActionDB to hold a mongo reference to ActionTypeDB
- Update the API layer to include the runner_paramters when the action
  is returned.
- Update all the tests.
