### PR TITLE
[STORM-330] Remove actiontypes from stacktion.coffee

### DIFF
--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -103,8 +103,8 @@ class ActionAPI(StormBaseAPI):
         action.enabled = bool(model.enabled)
         action.entry_point = str(model.entry_point)
         action.runner_type = str(model.runner_type.name)
-        action.parameters = dict(model.parameters)
-        action.parameters.update(model.runner_type.runner_parameters)
+        action.parameters = dict(model.runner_type.runner_parameters)
+        action.parameters.update(model.parameters)
         LOG.debug('exiting ActionAPI.from_model() Result object: %s', action)
         return action
 


### PR DESCRIPTION
- runner_parameters are rolled up into the action.parameters therefore
  eliminating the need to lookup actiontypes.
- Also, rearragnged copy order of values into action.parameters.
- renamed rvsp to rsvp in stacktion.coffee.
