### PR TITLE
RFR: Fix script local path set to right path

### DIFF
--- a/st2actionrunnercontroller/st2actionrunner/runners/fabricrunner.py
+++ b/st2actionrunnercontroller/st2actionrunner/runners/fabricrunner.py
@@ -104,9 +104,7 @@ class FabricRunner(ActionRunner):
             # Use the 'args' param from the action_parameters if it
             # was not provided in runner parameters.
             script_args = action_parameters[ARGS_PARAM]
-        script_local_path = os.path.join(self.container_service.get_artifact_repo_path(),
-                                         self.entry_point)
-        script_local_path_abs = os.path.abspath(script_local_path)
+        script_local_path_abs = self.container_service.get_entry_point_abs_path(self.entry_point)
         remote_dir = self.runner_parameters.get(RUNNER_REMOTE_DIR,
                                                 cfg.CONF.fabric_runner.remote_dir)
         # TODO(manas) : add support for args to a script.

--- a/st2common/st2common/models/system/action.py
+++ b/st2common/st2common/models/system/action.py
@@ -103,6 +103,21 @@ class RemoteScriptAction(RemoteAction):
         self.command = " ".join(pipes.quote(s) for s in command_parts)
         LOG.debug('RemoteScriptAction: command to run on remote box: %s', self.command)
 
+    def __str__(self):
+            str_rep = []
+            str_rep.append('%s@%s(name: %s' % (self.__class__.__name__, id(self), self.name))
+            str_rep.append('id: ' + self.id)
+            str_rep.append('local_script: ' + self.script_local_path_abs)
+            str_rep.append('remote_dir: ' + self.remote_dir)
+            str_rep.append('command: ' + self.command)
+            str_rep.append('user: ' + self.user)
+            str_rep.append('on_behalf_user: ' + self.on_behalf_user)
+            str_rep.append('sudo: ' + str(self.sudo))
+            str_rep.append('parallel: ' + str(self.parallel))
+            str_rep.append('hosts: %s)' % str(self.hosts))
+
+            return ', '.join(str_rep)
+
 
 class ParamikoSSHCommandAction(SSHCommandAction):
     pass
@@ -153,9 +168,7 @@ class FabricRemoteAction(RemoteAction):
 
 class FabricRemoteScriptAction(RemoteScriptAction, FabricRemoteAction):
     def get_fabric_task(self):
-        action_method = self._get_script_action_method()
-        return WrappedCallableTask(action_method, name=self.name, alias=self.id,
-                                   parallel=self.parallel, sudo=self.sudo)
+        return self._get_script_action_method()
 
     def _get_script_action_method(self):
         return WrappedCallableTask(self._run_script, name=self.name, alias=self.id,
@@ -187,6 +200,7 @@ class FabricRemoteScriptAction(RemoteScriptAction, FabricRemoteAction):
         }
 
         if output.failed:
+            LOG.error('Failed copying file %s to remote host.', self.script_local_path_abs)
             result['error'] = 'Failed copying file %s to %s on remote box' % (
                 self.script_local_path_abs, self.remote_path)
         return result


### PR DESCRIPTION
Output:

```
(virtualenv)vagrant@vagrant-fedora20 ~/onebox-stanley (fix_fabric_runner_script_action)$ st2 action execute remote-fib -p hosts="54.191.85.86" user='lakshmi'
+-----------------+---------------------------------------------------------+
| Property        | Value                                                   |
+-----------------+---------------------------------------------------------+
| id              | 53d80f58b1859745836e7f04                                |
| action          | {                                                       |
|                 |     "name": "remote-fib",                               |
|                 |     "id": "53d7e610b1859712b1ea538b"                    |
|                 | }                                                       |
| parameters      | {                                                       |
|                 |     "hosts": "54.191.85.86",                            |
|                 |     "user": "lakshmi"                                   |
|                 | }                                                       |
| result          | {"54.191.85.86": {"failed": true, "stderr": "Traceback  |
|                 | (most recent call last):\n  File \"/tmp/fibonacci.py\", |
|                 | line 13, in <module>\n    startNumber =                 |
|                 | int(sys.argv[1])\nIndexError: list index out of         |
|                 | range\nlist index out of range", "return_code": 1,      |
|                 | "succeeded": false, "stdout": ""}}                      |
| start_timestamp | 2014-07-29T14:17:12.517000                              |
| status          | complete                                                |
| uri             | None                                                    |
+-----------------+---------------------------------------------------------+
```
