### PR TITLE
RFR: Fix: Rename mapping to parameters for action section in rule model

### DIFF
--- a/contrib/examples/rules/sample-rule.json
+++ b/contrib/examples/rules/sample-rule.json
@@ -17,9 +17,9 @@
         "type": {
             "name": "st2.test.action"
         },
-        "mapping": {
-            "ip2": "{{system.k1}}",
-            "ip1": "{{trigger.t1_p}}"
+        "parameters": {
+            "ip1": "{{trigger.t1_p}}",
+            "ip2": "{{system.k1}}"
         }
     },
 

--- a/st2common/st2common/models/api/reactor.py
+++ b/st2common/st2common/models/api/reactor.py
@@ -79,7 +79,7 @@ class RuleAPI(StormBaseAPI):
         e.g.
         "action":
         { "type": {"id": "2345678901"}
-        , "mapping":
+        , "parameters":
             { "command": "{{ system.foo }}"
             , "args": "--email {{ trigger.from }} --subject \'{{ user[stanley].ALERT_SUBJECT }}\'"}
         }
@@ -97,7 +97,7 @@ class RuleAPI(StormBaseAPI):
         rule.trigger = model.trigger
         rule.criteria = dict(model.criteria)
         rule.action = {'type': model.action.action,
-                       'mapping': dict(model.action.data_mapping)}
+                       'parameters': dict(model.action.parameters)}
         rule.enabled = model.enabled
         return rule
 
@@ -110,8 +110,8 @@ class RuleAPI(StormBaseAPI):
         model.action = ActionExecutionSpecDB()
         if 'type' in rule.action:
             model.action.action = rule.action['type']
-        if 'mapping' in rule.action:
-            model.action.data_mapping = rule.action['mapping']
+        if 'parameters' in rule.action:
+            model.action.parameters = rule.action['parameters']
         model.enabled = rule.enabled
         return model
 

--- a/st2common/st2common/models/db/reactor.py
+++ b/st2common/st2common/models/db/reactor.py
@@ -44,7 +44,7 @@ class TriggerInstanceDB(StormFoundationDB):
 
 class ActionExecutionSpecDB(me.EmbeddedDocument):
     action = me.DictField()
-    data_mapping = me.DictField()
+    parameters = me.DictField()
 
 
 class RuleDB(StormBaseDB):

--- a/st2common/tests/test_db.py
+++ b/st2common/tests/test_db.py
@@ -201,7 +201,7 @@ class ReactorModelTest(DbTestCase):
         created.criteria = {}
         created.action = ActionExecutionSpecDB()
         created.action.action = reference.get_ref_from_model(action)
-        created.action.data_mapping = {}
+        created.action.parameters = {}
         return Rule.add_or_update(created)
 
     @staticmethod

--- a/st2reactor/st2reactor/rules/enforcer.py
+++ b/st2reactor/st2reactor/rules/enforcer.py
@@ -22,7 +22,7 @@ class RuleEnforcer(object):
         rule_enforcement = RuleEnforcementDB()
         rule_enforcement.trigger_instance = reference.get_ref_from_model(self.trigger_instance)
         rule_enforcement.rule = reference.get_ref_from_model(self.rule)
-        data = self.data_transformer(self.rule.action.data_mapping)
+        data = self.data_transformer(self.rule.action.parameters)
         LOG.info('Invoking action %s for trigger_instance %s with data %s.',
                  RuleEnforcer.__get_action_name(self.rule.action), self.trigger_instance.id,
                  json.dumps(data))

--- a/st2reactorcontroller/tests/controllers/test_rules.py
+++ b/st2reactorcontroller/tests/controllers/test_rules.py
@@ -43,7 +43,7 @@ RULE_1 = {
         'type': {
             'name': 'st2.test.action'
         },
-        'mapping': {
+        'parameters': {
             'ip2': '{{rule.k1}}',
             'ip1': '{{trigger.t1_p}}'
         }


### PR DESCRIPTION
I'll base my next rule PR off this one and merge them in one go. 
