### PR TITLE
All named_args which contain spaces are to be quoted.

### DIFF
--- a/contrib/examples/actions/remote-fibonacci.json
+++ b/contrib/examples/actions/remote-fibonacci.json
@@ -4,5 +4,5 @@
     "description": "Action that returns fibonacci numbers in a range.",
     "enabled": true,
     "entry_point": "python_fibonacci/fibonacci.py",
-    "parameters": {"args": null}
+    "parameters": {}
 }

--- a/st2actioncontroller/st2actioncontroller/model/__init__.py
+++ b/st2actioncontroller/st2actioncontroller/model/__init__.py
@@ -74,8 +74,13 @@ def register_action_types():
 def register_actions():
     actions = glob.glob(cfg.CONF.actions.modules_path + '/*.json')
     for action in actions:
+        LOG.debug('Loading action from %s', action)
         with open(action, 'r') as fd:
-            content = json.load(fd)
+            try:
+                content = json.load(fd)
+            except:
+                LOG.exception('Unable to load action from %s.', action)
+                continue
             try:
                 model = Action.get_by_name(str(content['name']))
             except:
@@ -92,6 +97,7 @@ def register_actions():
                 continue
             model.parameters = dict(content['parameters'])
             model = Action.add_or_update(model)
+            LOG.debug('Added action %s from %s.', model.name, action)
 
 
 def init_model():

--- a/st2common/st2common/models/system/action.py
+++ b/st2common/st2common/models/system/action.py
@@ -107,31 +107,29 @@ class RemoteScriptAction(RemoteAction):
         if self.named_args is not None:
             for (arg, value) in self.named_args.items():
                 if value is None or len(value) < 1:
+                    LOG.debug('Ignoring named arg %s as its value is %s.', arg, value)
                     continue
-                if ' ' in value:
-                    command_parts.append('%s=\'%s\'' % (arg,value))
-                else:
-                    command_parts.append('%s=%s' % (arg,value))
+                command_parts.append('%s=%s' % (arg, pipes.quote(value)))
         # add the positional args
         command_parts.append(self.positional_args)
         return ' '.join(command_parts)
 
     def __str__(self):
-            str_rep = []
-            str_rep.append('%s@%s(name: %s' % (self.__class__.__name__, id(self), self.name))
-            str_rep.append('id: %s' % self.id)
-            str_rep.append('local_script: %s' % self.script_local_path_abs)
-            str_rep.append('remote_dir: %s' % self.remote_dir)
-            str_rep.append('named_args: %s' % self.named_args)
-            str_rep.append('positional_args: %s' % self.positional_args)
-            str_rep.append('command: %s' % self.command)
-            str_rep.append('user: %s' % self.user)
-            str_rep.append('on_behalf_user: %s' % self.on_behalf_user)
-            str_rep.append('sudo: %s' % self.sudo)
-            str_rep.append('parallel: %s' % self.parallel)
-            str_rep.append('hosts: %s)' % self.hosts)
+        str_rep = []
+        str_rep.append('%s@%s(name: %s' % (self.__class__.__name__, id(self), self.name))
+        str_rep.append('id: %s' % self.id)
+        str_rep.append('local_script: %s' % self.script_local_path_abs)
+        str_rep.append('remote_dir: %s' % self.remote_dir)
+        str_rep.append('named_args: %s' % self.named_args)
+        str_rep.append('positional_args: %s' % self.positional_args)
+        str_rep.append('command: %s' % self.command)
+        str_rep.append('user: %s' % self.user)
+        str_rep.append('on_behalf_user: %s' % self.on_behalf_user)
+        str_rep.append('sudo: %s' % self.sudo)
+        str_rep.append('parallel: %s' % self.parallel)
+        str_rep.append('hosts: %s)' % self.hosts)
 
-            return ', '.join(str_rep)
+        return ', '.join(str_rep)
 
 
 class ParamikoSSHCommandAction(SSHCommandAction):


### PR DESCRIPTION
- name="a b c" or name=a\ b\ c are handled by pipes.quote to generate
  name="a b b" for the remote cli.
- improved error handling and logging in register_actions()
