### PR TITLE
RFR: Add: Ability to specfiy a ssh key file for fabric

### DIFF
--- a/conf/stanley.conf
+++ b/conf/stanley.conf
@@ -52,5 +52,5 @@ modules_path = /opt/stackstorm/actions
 
 [fabric_runner]
 user = stanley
-ssh_key_filename = /home/vagrant/.ssh/stanley_rsa
+ssh_key_file = /home/vagrant/.ssh/stanley_rsa
 remote_dir = /tmp

--- a/st2actionrunnercontroller/st2actionrunner/runners/fabricrunner.py
+++ b/st2actionrunnercontroller/st2actionrunner/runners/fabricrunner.py
@@ -18,7 +18,7 @@ LOG = logging.getLogger(__name__)
 # XXX: Note fabric env is a global singleton.
 env.parallel = True  # By default, execute things in parallel. Uses multiprocessing under the hood.
 env.user = cfg.CONF.fabric_runner.user
-ssh_key_file = cfg.CONF.fabric_runner.ssh_key_filename
+ssh_key_file = cfg.CONF.fabric_runner.ssh_key_file
 if ssh_key_file is not None and os.path.exists(ssh_key_file):
     env.key_filename = ssh_key_file
 env.timeout = 60  # Timeout for commands. 1 minute.

--- a/st2actionrunnercontroller/st2actionrunnercontroller/config.py
+++ b/st2actionrunnercontroller/st2actionrunnercontroller/config.py
@@ -61,7 +61,7 @@ fabric_runner_opts = [
     cfg.StrOpt('user',
                default='stanley',
                help='User for running remote tasks via the FabricRunner.'),
-    cfg.StrOpt('ssh_key_filename',
+    cfg.StrOpt('ssh_key_file',
                default='/home/vagrant/.ssh/stanley_rsa',
                help='SSH private key for running remote tasks via the FabricRunner.'),
     cfg.StrOpt('remote_dir',


### PR DESCRIPTION
Example:

```
(virtualenv)vagrant@vagrant-fedora20 ~/onebox-stanley/st2actionrunnercontroller/st2actionrunner/runners (STORM-341/fabric_ssh_key_file●)$ ssh stanley@54.191.85.86
Permission denied (publickey,gssapi-keyex,gssapi-with-mic).
(virtualenv)vagrant@vagrant-fedora20 ~/onebox-stanley/st2actionrunnercontroller/st2actionrunner/runners (STORM-341/fabric_ssh_key_file●)$ python fabricrunner.py
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!! NORMAL CMD !!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
FabricRemoteAction@14019152(name: UNAME, id: action_exec_id47318278-38b8-466e-abd2-5bc0c82ca48f, command: uname -a, user: stanley, on_behalf_user: narcissist, sudo: False, parallel: True, hosts: ['54.191.85.86', '54.191.17.38', '54.200.102.55'])
[54.191.85.86] Executing task 'UNAME'
[54.191.17.38] Executing task 'UNAME'
[54.200.102.55] Executing task 'UNAME'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!! RESULTS !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
{'54.191.17.38': {'failed': False, 'stderr': '', 'return_code': 0, 'succeeded': True, 'stdout': 'Linux st2stage001.stackstorm.net 3.11.10-301.fc20.x86_64 #1 SMP Thu Dec 5 14:01:17 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux'}, '54.200.102.55': {'failed': False, 'stderr': '', 'return_code': 0, 'succeeded': True, 'stdout': 'Linux ops001.stackstorm.net 3.11.10-301.fc20.x86_64 #1 SMP Thu Dec 5 14:01:17 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux'}, '54.191.85.86': {'failed': False, 'stderr': '', 'return_code': 0, 'succeeded': True, 'stdout': 'Linux st2stage002.stackstorm.net 3.11.10-301.fc20.x86_64 #1 SMP Thu Dec 5 14:01:17 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux'}}
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!! SUDO CMD !!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
[54.191.85.86] Executing task 'UNAME'
[54.191.17.38] Executing task 'UNAME'
[54.200.102.55] Executing task 'UNAME'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!! RESULTS !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
{'54.191.17.38': {'failed': False, 'stderr': '', 'return_code': 0, 'succeeded': True, 'stdout': 'Linux st2stage001.stackstorm.net 3.11.10-301.fc20.x86_64 #1 SMP Thu Dec 5 14:01:17 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux'}, '54.200.102.55': {'failed': False, 'stderr': '', 'return_code': 0, 'succeeded': True, 'stdout': 'Linux ops001.stackstorm.net 3.11.10-301.fc20.x86_64 #1 SMP Thu Dec 5 14:01:17 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux'}, '54.191.85.86': {'failed': False, 'stderr': '', 'return_code': 0, 'succeeded': True, 'stdout': 'Linux st2stage002.stackstorm.net 3.11.10-301.fc20.x86_64 #1 SMP Thu Dec 5 14:01:17 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux'}}
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!! SCRIPT DAWG !!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
[54.191.85.86] Executing task 'UNAME'
[54.191.85.86] put: /tmp/ls-script.sh -> /tmp/ls-script.sh
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!! RESULTS !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
{'54.191.85.86': {'failed': False, 'stderr': '', 'return_code': 0, 'succeeded': True, 'stdout': 'total 125M\n-rwxrwxr-x 1 lakshmi lakshmi   19 Jul 23 16:26 uname-script.sh\n-rw-r--r-- 1 root    root     86M Jul 24 11:10 st2reactor.log\ndrwxrwxr-x 2 phool   phool   2.3M Jul 24 14:41 actionrunner\ndrwx------ 3 root    root    4.0K Jul 28 08:56 systemd-ntpd.service-X9qyBgZ\nsrwxrwxrwx 1 mongodb mongodb    0 Jul 28 20:34 mongodb-27017.sock\n-rw-r--r-- 1 root    root     37M Jul 30 15:44 st2_startup.log\n-rwxrwxr-x 1 stanley stanley   12 Jul 30 15:44 ls-script.sh'}}
(virtualenv)vagrant@vagrant-fedora20 ~/onebox-stanley/st2actionrunnercontroller/st2actionrunner/runners (STORM-341/fabric_ssh_key_file●)$
```
