### PR TITLE
[STORM-340] cli st2 run args parsing

### DIFF
--- a/st2client/st2client/commands/resource.py
+++ b/st2client/st2client/commands/resource.py
@@ -78,7 +78,10 @@ class ResourceCommand(commands.Command):
     def get_resource(self, name_or_id):
         instance = self.manager.get_by_name(name_or_id)
         if not instance:
-            instance = self.manager.get_by_id(name_or_id)
+            try:
+                instance = self.manager.get_by_id(name_or_id)
+            except:
+                pass
         if not instance:
             raise ResourceNotFoundError()
         return instance

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -86,7 +86,7 @@ class Shell(object):
         self.commands['action'] = action.ActionBranch(
             'TODO: Put description of action here.',
             self, self.subparsers)
-        self.commands['run'] = action.ActionExecuteCommand(
+        self.commands['run'] = action.ActionRunCommand(
             models.Action, self, self.subparsers,
             name='run', add_help=False)
         self.commands['execution'] = action.ActionExecutionBranch(

--- a/st2client/tests/test_shell.py
+++ b/st2client/tests/test_shell.py
@@ -137,7 +137,8 @@ class TestShell(unittest2.TestCase):
         args_list = [
             ['run', '-h'],
             ['run', 'abc', '-h'],
-            ['run', 'abc', '-p', 'command="uname =a"']
+            ['run', 'remote', 'hosts=192.168.1.1', 'user=st2', 'cmd="ls -l"'],
+            ['run', 'remote-fib', 'hosts=192.168.1.1', '3', '8']
         ]
         self._validate_parser(args_list, is_subcommand=False)
 


### PR DESCRIPTION
Refactor st2 run to parse command as positional arguments.

Examples:
st2 run remote hosts=vm1.stackstorm.net user=stanley -- ls -l
st2 run remote hosts=vm1.stackstorm.net user=stanley cmd="ls -l"
st2 run remote-fib hosts=vm1.stackstorm.net 3 8
st2 run remote-fib hosts=vm1.stackstorm.net cmd="3 8"
