### PR TITLE
Fix: action object must be passed in as a dict

### DIFF
--- a/st2reactor/st2reactor/rules/enforcer.py
+++ b/st2reactor/st2reactor/rules/enforcer.py
@@ -38,8 +38,8 @@ class RuleEnforcer(object):
                       self.trigger_instance.id, self.rule)
 
     @staticmethod
-    def __invoke_action(action, action_args):
-        payload = json.dumps({'action': action,
+    def __invoke_action(action_name, action_args):
+        payload = json.dumps({'action': {'name': action_name},
                               'parameters': action_args})
         r = requests.post(cfg.CONF.reactor.actionexecution_base_url,
                           data=payload,


### PR DESCRIPTION
POST /actionexecutions/ expects payload like
{
action: {
name: foo
}
parameters: {
}
}

action needs to be a dict. 
