### PR TITLE
[STORM-300] Improve dev launch script

### DIFF
--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -7,25 +7,19 @@ fi
 
 if [[ ${1} == "start" ]]; then
 
-    echo "Starting all Stanley servers..."
-
-    # Install screen if it is not installed
-    if ! yum list installed | grep -qw screen; then
-        echo "Installing the screen program..."
-        sudo yum install screen
-    fi
+    echo "Starting all st2 servers..."
 
     # Determine where the stanley repo is located. Some assumption is made here
-    # that this script is located under stanley/contrib/sandbox/scripts.
+    # that this script is located under stanley/tools.
 
     COMMAND_PATH=${0%/*}
     CURRENT_DIR=`pwd`
 
     if [[ (${COMMAND_PATH} == /*) ]] ;
     then
-        ST2_REPO=${COMMAND_PATH}/../../..
+        ST2_REPO=${COMMAND_PATH}/..
     else
-        ST2_REPO=${CURRENT_DIR}/${COMMAND_PATH}/../../..
+        ST2_REPO=${CURRENT_DIR}/${COMMAND_PATH}/..
     fi
 
     # Change working directory to the root of the repo.
@@ -39,6 +33,13 @@ if [[ ${1} == "start" ]]; then
 
     # activate virtualenv to set PYTHONPATH
     source ./virtualenv/bin/activate
+
+    # Kill existing st2 screens
+    screen -ls | grep st2 &> /dev/null
+    if [ $? == 0 ]; then
+        echo 'Killing existing st2 screen sessions...'
+        screen -ls | grep st2 | cut -d. -f1 | awk '{print $1}' | xargs kill
+    fi
 
     # Run the datastore API server
     echo 'Starting screen session st2-datastore...'
@@ -70,27 +71,33 @@ if [[ ${1} == "start" ]]; then
         ./st2reactorcontroller/bin/reactor_controller \
         --config-file ./conf/stanley.conf
 
+    # Check whether screen sessions are started
+    screens=(
+        "st2-datastore"
+        "st2-action"
+        "st2-actionrunner"
+        "st2-reactor"
+        "st2-reactorcontroller"
+    )
+
+    echo
+    for s in "${screens[@]}"
+    do
+        screen -ls | grep "${s}[[:space:]]" &> /dev/null
+        if [ $? != 0 ]; then
+            echo "ERROR: Unable to start screen session for $s."
+        fi
+    done
+
+    # List screen sessions
+    screen -ls
+
 elif [[ ${1} == "stop" ]]; then
 
-    echo "Stopping all Stanley servers..."
+    screen -ls | grep st2 &> /dev/null
+    if [ $? == 0 ]; then
+        echo 'Killing existing st2 screen sessions...'
+        screen -ls | grep st2 | cut -d. -f1 | awk '{print $1}' | xargs kill
+    fi
 
-    # Stop the reactor API server
-    echo "Terminating the screen session for st2-reactorcontroller..."
-    screen -X -S st2-reactorcontroller quit
-
-    # Stop the reactor server
-    echo "Terminating the screen session for st2-reactor..."
-    screen -X -S st2-reactor quit
-
-    # Stop the action API server
-    echo "Terminating the screen session for st2-action..."
-    screen -X -S st2-action quit
-
-    # Stop the action runner API server
-    echo "Terminating the screen session for st2-actionrunner..."
-    screen -X -S st2-actionrunner quit
-
-    # Stop the datastore API server
-    echo "Terminating the screen session for st2-datastore..."
-    screen -X -S st2-datastore quit
 fi


### PR DESCRIPTION
Move the launch script from stanley/contrib/sandbox/scripts to
stanley/tools. Move the yum install for screen to bootstrap.sh in
devenv. Refactored the launch script to kill existing st2 screen
sessions before starting and check if any screen sessions did not start
properly. Refactored launch script to kill all screen sessions with prefix of st2 in session name on stop.

Closes: STORM-300
