### PR TITLE
RFR: Revert "Simplified timer sensor"

### DIFF
--- a/st2common/st2common/models/api/reactor.py
+++ b/st2common/st2common/models/api/reactor.py
@@ -32,18 +32,18 @@ def get_model_from_ref(db_api, ref):
 
 
 class TriggerAPI(StormBaseAPI):
-    payload_schema = wstypes.DictType(str, str)
+    payload_info = wstypes.ArrayType(str)
 
     @classmethod
     def from_model(kls, model):
         trigger = StormBaseAPI.from_model(kls, model)
-        trigger.payload_schema = model.payload_schema
+        trigger.payload_info = model.payload_info
         return trigger
 
     @classmethod
     def to_model(kls, trigger):
         model = StormBaseAPI.to_model(TriggerDB, trigger)
-        model.payload_schema = trigger.payload_schema
+        model.payload_info = trigger.payload_info
         return model
 
 

--- a/st2common/st2common/models/db/reactor.py
+++ b/st2common/st2common/models/db/reactor.py
@@ -3,17 +3,31 @@ from st2common.models.db import MongoDBAccess
 from st2common.models.db.stormbase import StormBaseDB, StormFoundationDB
 
 
+class TriggerSourceDB(StormBaseDB):
+    """Source of a trigger. Typically an external system or service that
+    generates events which must be adapted to a trigger using the provided
+    adapter.
+    Attribute:
+        url: url of the source
+        auth_token: token used by an adapter to authenticate with the
+        adapter_file_uri: uri of the adapter which will translate an event
+        specific to the source to a corresponding trigger.
+    """
+    url = me.URLField()
+    auth_token = me.StringField()
+    adapter_file_uri = me.StringField()
+
+
 class TriggerDB(StormBaseDB):
     """Description of a specific kind/type of a trigger. The name is expected
        uniquely identify a trigger in the namespace of all triggers provided
        by a specific trigger_source.
     Attribute:
         trigger_source: Source that owns this trigger type.
-        payload_schema: Meta information of the expected payload.
-        parameters_schema: Meta information of the expected parameters.
+        payload_info: Meta information of the expected payload.
     """
-    payload_schema = me.DictField()
-    parameters_schema = me.DictField()
+    trigger_source = me.ReferenceField(TriggerSourceDB.__name__)
+    payload_info = me.ListField()
 
 
 class TriggerInstanceDB(StormFoundationDB):
@@ -66,6 +80,7 @@ class RuleEnforcementDB(StormFoundationDB):
 
 
 # specialized access objects
+triggersource_access = MongoDBAccess(TriggerSourceDB)
 trigger_access = MongoDBAccess(TriggerDB)
 triggerinstance_access = MongoDBAccess(TriggerInstanceDB)
 rule_access = MongoDBAccess(RuleDB)

--- a/st2common/st2common/persistence/reactor.py
+++ b/st2common/st2common/persistence/reactor.py
@@ -1,6 +1,15 @@
 from st2common.persistence import Access
-from st2common.models.db.reactor import trigger_access, triggerinstance_access, rule_access, \
+from st2common.models.db.reactor import triggersource_access, \
+    trigger_access, triggerinstance_access, rule_access, \
     ruleenforcement_access
+
+
+class TriggerSource(Access):
+    IMPL = triggersource_access
+
+    @classmethod
+    def _get_impl(kls):
+        return kls.IMPL
 
 
 class Trigger(Access):

--- a/st2reactor/st2reactor/container/utils.py
+++ b/st2reactor/st2reactor/container/utils.py
@@ -20,19 +20,16 @@ def create_trigger_instance(trigger_name, payload, occurrence_time):
     return TriggerInstance.add_or_update(trigger_instance)
 
 
-def __create_trigger_type(name, description='', payload_schema={}, parameters_schema={}):
+def __create_trigger_type(name, description=None, payload_info=None):
     triggers = Trigger.query(name=name)
+    trigger_type = TriggerDB()
     if len(triggers) > 0:
         trigger_type = triggers[0]
-        LOG.info('Found existing trigger id: %s with name: %s. Will update '
+        LOG.info('Found existing trigger id:%s with name:%s. Will update '
                  'trigger.', trigger_type.id, name)
-
-    trigger_type = TriggerDB()
     trigger_type.name = name
     trigger_type.description = description
-    trigger_type.payload_schema = payload_schema
-    trigger_type.parameters_schema = parameters_schema
-
+    trigger_type.payload_info = payload_info
     return Trigger.add_or_update(trigger_type)
 
 
@@ -48,7 +45,10 @@ def __validate_trigger_type(trigger_type):
 
 
 def __add_trigger_type(trigger_type):
-    __create_trigger_type(**trigger_type)
+    __create_trigger_type(
+        trigger_type['name'],
+        trigger_type['description'] if 'description' in trigger_type else '',
+        trigger_type['payload_info'] if 'payload_info' in trigger_type else [])
 
 
 def add_trigger_types(trigger_types):

--- a/st2reactor/st2reactor/contrib/sensors/st2_timer_sensor.py
+++ b/st2reactor/st2reactor/contrib/sensors/st2_timer_sensor.py
@@ -6,141 +6,11 @@ from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.date import DateTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 import apscheduler.util as aps_utils
+# from apscheduler.executors.pool import ThreadPoolExecutor
 import dateutil.parser as date_parser
 from dateutil.tz import tzutc
-import jsonschema
+from pytz import utc
 import yaml
-
-
-PROPERTIES_SCHEMA = {
-    "oneOf": [{
-        "type": "object",
-        "properties": {
-            "type": {
-                "enum": ["cron"]
-            },
-            "timezone": {
-                "type": "string"
-            },
-            "time": {
-                "type": "object",
-                "properties": {
-                    "year": {
-                        "type": "integer"
-                    },
-                    "month": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "maximum": 12
-                    },
-                    "day": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "maximum": 31
-                    },
-                    "week": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "maximum": 53
-                    },
-                    "day_of_week": {
-                        "type": "integer",
-                        "minimum": 0,
-                        "maximum": 6
-                    },
-                    "hour": {
-                        "type": "integer",
-                        "minimum": 0,
-                        "maximum": 23
-                    },
-                    "minute": {
-                        "type": "integer",
-                        "minimum": 0,
-                        "maximum": 59
-                    },
-                    "second": {
-                        "type": "integer",
-                        "minimum": 0,
-                        "maximum": 59
-                    }
-                }
-            }
-        },
-        "required": [
-            "type",
-            "time"
-        ],
-        "additionalProperties": False
-    }, {
-        "type": "object",
-        "properties": {
-            "type": {
-                "enum": ["interval"]
-            },
-            "timezone": {
-                "type": "string"
-            },
-            "time": {
-                "type": "object",
-                "properties": {
-                    "units": {
-                        "enum": ["weeks", "days", "hours", "minutes", "seconds"]
-                    },
-                    "delta": {
-                        "type": "integer"
-                    }
-                }
-            }
-        },
-        "required": [
-            "type",
-            "time"
-        ],
-        "additionalProperties": False
-    }, {
-        "type": "object",
-        "properties": {
-            "type": {
-                "enum": ["date"]
-            },
-            "timezone": {
-                "type": "string"
-            },
-            "time": {
-                "type": "object",
-                "properties": {
-                    "date": {
-                        "type": "string",
-                        "format": "date-time"
-                    }
-                }
-            }
-        },
-        "required": [
-            "type",
-            "time"
-        ],
-        "additionalProperties": False
-    }]
-}
-
-PAYLOAD_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "executed_at": {
-            "type": "string",
-            "format": "date-time",
-            "default": "2014-07-30 05:04:24.578325"
-        },
-        "schedule": {
-            "type": "object",
-            "default": {
-                "delta": 30,
-                "units": "seconds"
-            }
-        }
-    }
-}
 
 
 class St2TimerSensor(object):
@@ -158,12 +28,15 @@ class St2TimerSensor(object):
             raise Exception('Config file %s not found.' % self._config_file)
         with open(self._config_file) as f:
             self._config = yaml.safe_load(f)
+        self._valid_time_types = set(['interval', 'cron', 'date'])
+        self._valid_interval_units = set(['seconds', 'minutes', 'hours', 'days', 'weeks'])
+        self._valid_cron_types = set(['year', 'month', 'day', 'week', 'day_of_week', 'hour',
+                                      'minute', 'second'])
         self._jobs = {}
 
     def setup(self):
         if self._config is not None:
-            for parameters in self._config:
-                self.add(parameters)
+            self._add_jobs_to_scheduler(self._config)
 
     def start(self):
         self._scheduler.start()
@@ -171,90 +44,116 @@ class St2TimerSensor(object):
     def stop(self):
         self._scheduler.shutdown(wait=True)
 
-    def add(self, parameters):
-        self._add_job_to_scheduler(parameters)
-
     def get_trigger_types(self):
-        return [{
-            'name': 'st2.timer',
-            'payload_schema': PAYLOAD_SCHEMA,
-            'parameters_schema': PROPERTIES_SCHEMA
-        }]
+        trigger_types = []
+        for name, value in self._config.iteritems():
+            trigger_type = {}
+            trigger_type['name'] = name
+            trigger_type['payload'] = {}  # For now, let's say payload is empty.
+            trigger_types.append(trigger_type)
+        return trigger_types
 
-    def _add_job_to_scheduler(self, parameters):
-        try:
-            jsonschema.validate(parameters, PROPERTIES_SCHEMA)
-        except Exception as e:
-            self._log.error('Exception scheduling timer: %s, %s', parameters, e, exc_info=True)
+    def _add_jobs_to_scheduler(self, jobs):
+        for name, value in jobs.iteritems():
+            try:
+                self._validate_job_spec(name, value)
+            except Exception as e:
+                self._log.error('Exception scheduling timer: %s, %s', name, e, exc_info=True)
+                continue
 
-        time_type = parameters.get('type')
-        # time_spec = parameters.get('time')
-        # time_zone = aps_utils.astimezone(parameters.get('timezone'))
+            time_type = value.get('type')
+            time_spec = value.get('time')
+            time_zone = aps_utils.astimezone(value.get('timezone'))
 
-        if time_type == 'interval':
-            self._add_interval_job(parameters)
-        elif time_type == 'cron':
-            self._add_cron_job(parameters)
-        elif time_type == 'date':
-            self._add_date_job(parameters)
+            if time_type == 'interval':
+                self._add_interval_job(name, time_spec, time_zone)
+            elif time_type == 'cron':
+                self._add_cron_job(name, time_spec, time_zone)
+            elif time_type == 'date':
+                self._add_date_job(name, time_spec, time_zone)
 
-    def _add_interval_job(self, parameters):
-        time_spec = parameters.get('time')
-        time_zone = aps_utils.astimezone(parameters.get('timezone'))
+    def _add_interval_job(self, name, time_spec, time_zone=utc):
+        interval_trigger = self._validate_interval_spec(name, time_spec, time_zone)
+        self._add_job(name, time_spec, interval_trigger)
 
-        unit = time_spec.get('unit', None)
-        value = time_spec.get('delta', None)
-
-        interval_trigger = IntervalTrigger(**{unit: value, 'timezone': time_zone})
-        self._add_job(parameters, interval_trigger)
-
-    def _add_date_job(self, parameters):
-        time_spec = parameters.get('time')
-        time_zone = aps_utils.astimezone(parameters.get('timezone'))
-
-        dat = date_parser.parse(time_spec.get('date', None))  # Raises an exception if date string isn't a valid one.
-        date_trigger = DateTrigger(dat, timezone=time_zone)
-
+    def _add_date_job(self, name, time_spec, time_zone=utc):
+        date_trigger = self._validate_date_spec(name, time_spec, time_zone)
         if datetime.now(tzutc()) < date_trigger.run_date:
-            self._add_job(parameters, date_trigger)
+            self._add_job(name, time_spec, date_trigger, time_zone)
         else:
-            self._log.warning('Not scheduling expired timer: %s : %s', parameters, date_trigger.run_date)
+            self._log.warning('Not scheduling expired timer: %s : %s', name, date_trigger.run_date)
 
-    def _add_cron_job(self, parameters):
-        time_spec = parameters.get('time')
-        time_zone = aps_utils.astimezone(parameters.get('timezone'))
+    def _add_cron_job(self, name, time_spec, time_zone=utc):
+        cron_trigger = self._validate_cron_spec(name, time_spec, time_zone)
+        self._add_job(name, time_spec, cron_trigger)
 
-        cron = time_spec
-        cron['timezone'] = time_zone
-
-        cron_trigger = CronTrigger(**cron)
-        self._add_job(parameters, cron_trigger)
-
-    def _add_job(self, parameters, trigger, replace=True):
-        def hashify(d):
-            return frozenset(
-                (k, hashify(v)) if type(v) is dict else (k, v) for (k, v) in d.iteritems()
-            )
-
+    def _add_job(self, name, time_spec, trigger, replace=True):
         try:
             job = self._scheduler.add_job(self._emit_trigger_instance,
                                           trigger=trigger,
-                                          args=[parameters],
+                                          args=[name, time_spec],
                                           replace_existing=replace)
             self._log.info('Job %s scheduled.', job.id)
-            self._jobs[hashify(parameters)] = job.id
+            self._jobs[name] = job.id
         except Exception, e:
-            self._log.error('Exception scheduling timer: %s, %s', parameters, e, exc_info=True)
+            self._log.error('Exception scheduling timer: %s, %s', name, e, exc_info=True)
 
-    def _emit_trigger_instance(self, parameters):
-        self._log.info('Timer fired at: %s. Time spec: %s', str(datetime.now()), parameters)
-
-        trigger = {
-            'name': 'st2.timer',
-            'parameters': parameters,
-            'payload': {
-                'executed_at': str(datetime.now()),
-                'schedule': parameters.get('time')
-            }
+    def _emit_trigger_instance(self, name, time_spec):
+        self._log.info('Timer: %s fired at: %s. Time spec: %s', name,
+                       str(datetime.now()), time_spec)
+        trigger = {}
+        trigger['name'] = name
+        trigger['payload'] = {
+            'executed_at': str(datetime.now()),
+            'schedule': time_spec
         }
         self._container_service.dispatch([trigger])
+
+    def _validate_job_spec(self, name, value):
+        time_type = value.get('type', None)
+        if not time_type:
+            raise Exception('No type specified for timer: %s' % name)
+        if time_type not in self._valid_time_types:
+            raise Exception('Invalid type specification for timer: %s, type: %s' %
+                            (name, time_type))
+
+        time_spec = value.get('time', None)
+        if not time_spec:
+            raise Exception('No time specified for timer: %s' % name)
+
+        time_zone = value.get('timezone', None)
+        aps_utils.astimezone(time_zone)  # Raises an exception if time zone isn't a known one.
+
+    def _validate_interval_spec(self, name, time_spec, time_zone=utc):
+        unit = time_spec.get('unit', None)
+        if not unit:
+            raise Exception('Timer: %s, Error: No unit specified for time.' % name)
+        if unit not in self._valid_interval_units:
+            raise Exception('Timer: %s, Error: Invalid unit "%s" specified for time.' %
+                (name, unit))
+        value = time_spec.get('delta', None)
+        if not value:
+            raise Exception('Timer: %s, Error: No interval specified.' % name)
+        kw = {unit: value, 'timezone': time_zone}
+        return IntervalTrigger(**kw)
+
+    def _validate_date_spec(self, name, time_spec, time_zone=utc):
+        dat = time_spec.get('date', None)
+        if not dat:
+            raise Exception('Timer: %s, Error: No date specified.')
+        dat = date_parser.parse(dat)  # Raises an exception if date string isn't a valid one.
+        date_trigger = DateTrigger(dat, timezone=time_zone)
+        self._log.info('Date = %s', date_trigger)
+        return date_trigger
+
+    def _validate_cron_spec(self, name, time_spec, time_zone=utc):
+        cron_parts = time_spec
+        cron = {}
+        for key, value in cron_parts.iteritems():
+            if key not in self._valid_cron_types:
+                raise Exception('Invalid cron entry: %s for timer: %s' % (key, name))
+
+            cron[key] = value
+        cron['timezone'] = time_zone
+        cron_trigger = CronTrigger(**cron)
+        return cron_trigger

--- a/st2reactor/st2reactor/contrib/sensors/st2_timer_sensor.yaml
+++ b/st2reactor/st2reactor/contrib/sensors/st2_timer_sensor.yaml
@@ -1,37 +1,43 @@
 # Time zones are to be specified as full names.
 # See http://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-- type: interval
-  timezone: utc
-  time:
-    delta: 30
-    unit: seconds
-- type: cron
-  timezone: utc
-  time:
-    year: 1
-    day: 1
-    hour: 0
-    minute: 0
-    second: 0
-- type: date
-  time:
-    date: '2013-08-10T20:59:50.000000Z'  # ISO 8601 format in UTC. (Preferred)
-- type: date
-  time:
-    date: '2013-08-10T20:59:50.000000+00:00'  # ISO 8601 format with offset. (OK)
-- type: date
-  timezone: America/Los_Angeles
-  time:
-    date: '2014-08-10 13:59:50.000000'  # Python str(datetime.now()) format. (Pushing it)
-- type: date
-  timezone: America/Los_Angeles
-  time:
-    date: '2014-08-10 13:59:50'  # Same format as above but no seconds. (Hate it)
-
+st2.timer.30s:
+    type: interval
+    timezone: utc
+    time:
+        delta: 30
+        unit: seconds
+st2.timer.yearly:
+    type: cron
+    timezone: utc
+    time:
+        year: 1
+        day: 1
+        hour: 0
+        minute: 0
+        second: 0
+st2.timer.pacific.dately-1:
+    type: date
+    time:
+        date: '2013-07-10T20:59:50.000000Z'  # ISO 8601 format in UTC. (Preferred)
+st2.timer.pacific.dately-2:
+    type: date
+    time:
+        date: '2013-07-10T20:59:50.000000+00:00'  # ISO 8601 format with offset. (OK)
+st2.timer.pacific.dately-3:
+    type: date
+    timezone: America/Los_Angeles
+    time:
+        date: '2014-07-10 13:59:50.000000'  # Python str(datetime.now()) format. (Pushing it)
+st2.timer.pacific.dately-4:
+    type: date
+    timezone: America/Los_Angeles
+    time:
+        date: '2014-07-10 13:59:50'  # Same format as above but no seconds. (Hate it)
 # In the following, user specifies both timezone field (TZ is America/Los_Angeles) and
 # provides date in ISO8601 (TZ in UTC).
 # Here, timezone field is completely ignored.
-- type: date
-  timezone: America/Los_Angeles
-  time:
-    date: '2013-08-10T20:59:50.000000Z'
+st2.timer.pacific.dately-2:
+    type: date
+    timezone: America/Los_Angeles
+    time:
+        date: '2013-07-10T20:59:50.000000Z'

--- a/st2reactor/tests/test_container.py
+++ b/st2reactor/tests/test_container.py
@@ -19,13 +19,9 @@ class ContainerTest(EventletTestCase):
             self.stop_call_count += 1
 
         def get_trigger_types(self):
-            return [{
-                'name': 'st2.dummy.t1',
-                'description': 'some desc',
-                'payload_schema': {
-                    'type': 'object'
-                }
-            }]
+            return [
+                {'name': 'st2.dummy.t1', 'description': 'some desc', 'payload_info': ['a', 'b']}
+            ]
 
     def test_sensor_methods_are_called(self):
         sensor_modules = [ContainerTest.RunTestSensor(), ContainerTest.RunTestSensor()]

--- a/st2reactor/tests/test_container_utils.py
+++ b/st2reactor/tests/test_container_utils.py
@@ -16,9 +16,7 @@ class ContainerUtilsTest(unittest2.TestCase):
     @mock.patch.object(Trigger, 'add_or_update')
     def test_add_trigger(self, mock_add_handler):
         mock_add_handler.return_value = MOCK_TRIGGER
-        container_utils.add_trigger_types([{
-            "name": MOCK_TRIGGER.name
-        }])
+        container_utils.add_trigger_types([MOCK_TRIGGER])
         self.assertTrue(mock_add_handler.called, 'trigger not added.')
 
     def test_add_trigger_type(self):

--- a/st2reactorcontroller/tests/controllers/test_rules.py
+++ b/st2reactorcontroller/tests/controllers/test_rules.py
@@ -24,9 +24,7 @@ ACTION.parameter_names = {'p1': None, 'p2': None, 'p3': None}
 TRIGGER = reactor.TriggerDB()
 TRIGGER.name = 'st2.test.trigger1'
 TRIGGER.description = ''
-TRIGGER.payload_schema = {
-    'type': 'object'
-}
+TRIGGER.payload_info = ['tp1', 'tp2', 'tp3']
 TRIGGER.trigger_source = None
 
 RULE_1 = {

--- a/st2reactorcontroller/tests/controllers/test_triggers.py
+++ b/st2reactorcontroller/tests/controllers/test_triggers.py
@@ -7,16 +7,12 @@ from tests import FunctionalTest
 TRIGGER_0 = {
     'name': 'st2.test.trigger0',
     'description': 'test trigger',
-    'payload_schema': {
-        'type': 'object'
-    }
+    'payload_info': ['tp1', 'tp2', 'tp3']
 }
 TRIGGER_1 = {
     'name': 'st2.test.trigger1',
     'description': 'test trigger',
-    'payload_schema': {
-        'type': 'object'
-    }
+    'payload_info': ['tp1', 'tp2', 'tp3']
 }
 
 


### PR DESCRIPTION
This reverts commit 06915928557cb34512a1c48b0e2146e0b6e57efe.

For purposes of demo, we want to revert this. I restored the branch used in the original PR https://github.com/StackStorm/stanley/pull/275

Let's work on that branch until we know we can functionally have timers working end-to-end. 

CC: @enykeev @manasdk @m4dcoder @dzimine 
