### PR TITLE
* Split sensors doc into triggers and sensors doc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ If installed from sources, you need to setup the CLI client into the virtualenv:
 	setup.py
 	st2 --help
 
-Some examples of using CLI:
+Some examples of using CLI: (See [Terminology](#Terminology) section.)
 
 	st2 action list
 	st2 run {action} {parameters}
@@ -38,8 +38,15 @@ Some examples of using CLI:
 
 **TODO:**  add sample command to run action
 
+## Terminology
+1. Trigger - An external event that is mapped to a stanley input. It is the stanley invocation point.
+2. Action - An activity that happens as a response to the external event.
+3. Rule - A specification to invoke an "action" on a "trigger" selectively based on some criteria.
+4. Sensors - An adapter to convert an external event to a form stanley understands. This is usually a piece of python code. 
 
 ## Adding a Rule
+Writing a rule is a means to associate triggers to actions. Let us see an example. 
+
 Create a rule JSON definition. See an example at [Stanley/contrib/examples/rules/sample-rule.json](../contrib/examples/rules/sample-rule.json) for the rule structure. Look at [../contrib/sandbox/packages/](../contrib/sandbox/packages/) for more sample rules.
 
 **TODO:** draw a sample with here with comments on required and optional fields.
@@ -48,13 +55,20 @@ Deploy the rule:
 
 	st2 rule create path/to/rule.json
 
+## Triggers
+Stanley comes bundled with two kinds of triggers viz.
 
-## Creating sensors
+1. Timers.
+2. Webhooks.
+
+Timers are used when you want to execute an action based on a schedule. Webhooks are used when you want to POST a JSON payload to an active endpoint and kickoff actions based on the payload. Note you can selectively invoke
+actions by writing a suitable criteria in the rule. 
+
+For purposes of demo, these triggers are implemented as stock sensors in the system. To see them up, look at [triggers](triggers.md) section.
+
+## Creating custom sensors
 See [sensors.md](sensors.md)
 
 ## Creating Custom Actions
 See [actions.md](actions.md)
-
-## Creating Custom Sensors
-See [sensors.md](sensors.md)
 

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -1,0 +1,82 @@
+Creating triggers should be done via the API. Unfortunately, this API isn't complete. So until that happens, you'll need to go through these manual steps
+to setup timers and webhooks.
+
+## Configuring timers
+
+1. Edit [config file](../st2reactor/st2reactor/contrib/sensors/st2_timer_sensor.yaml) and add a new named timer trigger. For example,
+    timer.mytimer:
+    type: interval
+    timezone: utc
+    time:
+        delta: 30
+        unit: seconds
+
+2. Use these named timer triggers in your rule [Refer rule section],
+
+        ./rule.json:
+        { "name": "mytimerrule",
+        "trigger": {
+            "name": "timer.mytimer"
+        ...
+   Note that you are referring to the trigger by name "timer.mytimer" which was
+   supplied in the config. Stanley basically registered the trigger for you under the hood.
+
+3. Reboot stanley to pick the config and the rule:
+   ```
+    ${SRC_ROOT}/tools/launch.sh stop
+    ${SRC_ROOT}/tools/launch.sh start
+   ```
+Note: You cannot emit custom payloads on a pre-defined timer. For this, you'd need to write your own sensor. See [sensors](sesnors.md) section.
+
+## Configuring Webhooks
+
+1. Edit [config file](../st2reactor/st2reactor/contrib/sensors/st2_generic_webhook_sensor.yaml) and add a string there. This string will serve both as a name of the webhook trigger and a subpath to the url. For example, call it "mywebhook". 
+This will spin up an endpoint ```http://{host}:6001/webhooks/generic/mywebhook```.
+
+2. Register the webhook trigger, named "mywebhook".
+   Create a json file mywebhooktrigger.json (file name can be anything)
+
+        ./mywebhooktrigger.json
+        {
+            "name": "mywebhook",
+            "description": "call it yourname.webhooktrigger",
+            "payload_schema": {}
+        }
+    Use st2 cli to register this trigger.
+    $st2 trigger create -j mywebhooktrigger.json
+    Note: In this case, stanley did not auto register the trigger type for you. Since you can specify the payload schema for the webhook if you know,
+    this manual step is required now.
+
+3. Create a rule.json for that trigger:
+   
+        ./rule.json:
+        { "name": "mywebhookrule",
+            "trigger": {
+            "name": "webhooks.mywebhook"
+
+4. Reboot Stanley: 
+    ```
+      ${SRC_ROOT}/tools/launch.sh stop  
+      ${SRC_ROOT}/tools/launch.sh start
+    ```
+5. Use curl or [httpie](https://github.com/jakubroztocil/httpie) to POST aribitrary payload to the endpoint. An example using httpie is shown below.
+```
+http POST http://{host}:6001/webhooks/generic/mywebhook < payload.json
+```
+  Example payload:
+  ```json
+    { 
+      "foo": "bar",
+      "baz": 1
+    }
+  ```
+
+## API status
+* Partially complete. [Look out for alpha.]
+* You can create simple triggers without parameters using the API.
+
+## CLI status
+* Mirrors APIs. Try out:
+```
+st2 trigger list|create|get|delete
+```


### PR DESCRIPTION
- Moved out timers and webhooks into triggers doc.
- Cleaned up sensors doc.
- Formatting changes and hyperlink improvements.
