### PR TITLE
[STORM-346] Fix link in documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@ St2 Stanley
 ======
 
 ## Installing from packages
-See [Install.md](Install.md)
+See [Install.md](install.md)
 
 ## Running from sources
 Install prerequisites. See Prerequisites in [main README.md](../README.md)


### PR DESCRIPTION
Fix a dead hyperlink in documentation.
