### PR TITLE
Make Ad Hoc triggers work end-to-end

### DIFF
--- a/contrib/examples/rules/sample-rule-with-parameters.json
+++ b/contrib/examples/rules/sample-rule-with-parameters.json
@@ -4,29 +4,25 @@
     "description": "Some test rule.",
 
     "trigger": {
-        "name": "st2.timer.30s",
+        "name": "st2.timer.5s",
         "type": "st2.timer",
         "parameters": {
             "type": "interval",
             "time": {
-                "delta": 30,
+                "delta": 5,
                 "unit": "seconds"
             }
         }
     },
 
-    "criteria": {
-        "t1_p": {
-            "pattern": "t1_p_v",
-            "type": "equals"
+    "criteria": {},
+
+    "action": {
+        "name": "local",
+        "parameters": {
+            "attr": "echo \"{{trigger.executed_at}}\""
         }
     },
 
-    "action": {
-        "name": "st2.test.action",
-        "parameters": {
-            "ip1": "{{trigger.t1_p}}",
-            "ip2": "{{system.k1}}"
-        }
-    }
+    "enabled": true
 }

--- a/st2common/st2common/models/db/reactor.py
+++ b/st2common/st2common/models/db/reactor.py
@@ -45,7 +45,7 @@ class TriggerInstanceDB(StormFoundationDB):
         payload (dict): payload specific to the occurrence.
         occurrence_time (datetime): time of occurrence of the trigger.
     """
-    trigger = me.DictField()
+    trigger = me.ReferenceField(AHTriggerDB.__name__)
     payload = me.DictField()
     occurrence_time = me.DateTimeField()
 

--- a/st2reactor/st2reactor/container/base.py
+++ b/st2reactor/st2reactor/container/base.py
@@ -2,8 +2,6 @@ import eventlet
 import sys
 
 from st2common import log as logging
-from st2common.models.db.reactor import AHTriggerDB
-from st2common.util import watch
 
 # Constants
 SUCCESS_EXIT_CODE = 0
@@ -25,7 +23,6 @@ class SensorContainer(object):
         self._pool = eventlet.GreenPool(self._pool_size)
         self._sensors = sensor_instances
         self._threads = {}
-        self._watcher = watch.get_watcher()
         LOG.info('Container setup to run %d sensors.' % len(sensor_instances))
 
     def _run_sensor(self, sensor):
@@ -83,25 +80,8 @@ class SensorContainer(object):
 
         return True
 
-    def __add_sensor_instance(self, document):
-        from pprint import pprint
-        print('\nadd:')
-        pprint(document)
-
-    def __update_sensor_instance(self, document):
-        from pprint import pprint
-        print('\nupdate:')
-        pprint(document)
-
-    def __watch(self, ns, ts, op, id, doc):
-        {
-            watch.INSERT: lambda: self.__add_sensor_instance(doc.get('o')),
-            watch.UPDATE: lambda: self.__update_sensor_instance(doc.get('o').get('$set'))
-        }.get(op, lambda: None)()
-
     def run(self):
         self._run_all_sensors()
-        self._watcher.watch(self.__watch, 'st2', AHTriggerDB._get_collection_name())
         self._pool.waitall()
         LOG.info('Container has no active sensors running.')
         return SUCCESS_EXIT_CODE

--- a/st2reactor/st2reactor/container/triggerdispatcher.py
+++ b/st2reactor/st2reactor/container/triggerdispatcher.py
@@ -12,18 +12,13 @@ class TriggerDispatcher(object):
     def __init__(self):
         self.rules_engine = RulesEngine()
 
-    def dispatch(self, triggers):
+    def dispatch(self, trigger, payload=None):
         """
         """
-        trigger_instances = []
-        for trigger in triggers:
-            ti = container_utils.create_trigger_instance(
-                trigger['name'],
-                trigger['payload'] if 'payload' in trigger else {},
-                trigger['occurrence_time'] if 'occurrence_time' in trigger else
-                datetime.datetime.now())
-            if ti is not None:
-                trigger_instances.append(ti)
+        trigger_instance = container_utils.create_trigger_instance(
+            trigger,
+            payload or {},
+            datetime.datetime.now())
 
-        if trigger_instances:
-            self.rules_engine.handle_trigger_instances(trigger_instances)
+        if trigger_instance:
+            self.rules_engine.handle_trigger_instance(trigger_instance)

--- a/st2reactor/st2reactor/container/utils.py
+++ b/st2reactor/st2reactor/container/utils.py
@@ -1,20 +1,18 @@
 from st2common import log as logging
 from st2common.exceptions.sensors import TriggerTypeRegistrationException
-from st2common.persistence.reactor import Trigger, TriggerInstance
+from st2common.persistence.reactor import Trigger, AHTrigger, TriggerInstance
 from st2common.models.db.reactor import TriggerDB, TriggerInstanceDB
-from st2common.util import reference
 
 LOG = logging.getLogger('st2reactor.sensor.container_utils')
 
 
-def create_trigger_instance(trigger_name, payload, occurrence_time):
-    triggers = Trigger.query(name=trigger_name)
-    trigger = None if len(triggers) == 0 else triggers[0]
+def create_trigger_instance(trigger, payload, occurrence_time):
+    trigger = AHTrigger.query(type=trigger['type'], parameters=trigger['parameters']).first()
     if trigger is None:
-        LOG.info('No trigger with name %s found.', trigger_name)
+        LOG.info('No trigger with name %s and parameters %s found.', trigger['type'], trigger['parameters'])
         return None
     trigger_instance = TriggerInstanceDB()
-    trigger_instance.trigger = reference.get_ref_from_model(trigger)
+    trigger_instance.trigger = trigger
     trigger_instance.payload = payload
     trigger_instance.occurrence_time = occurrence_time
     return TriggerInstance.add_or_update(trigger_instance)

--- a/st2reactor/st2reactor/contrib/sensors/st2_timer_sensor.py
+++ b/st2reactor/st2reactor/contrib/sensors/st2_timer_sensor.py
@@ -6,11 +6,141 @@ from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.date import DateTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 import apscheduler.util as aps_utils
-# from apscheduler.executors.pool import ThreadPoolExecutor
 import dateutil.parser as date_parser
 from dateutil.tz import tzutc
-from pytz import utc
+import jsonschema
 import yaml
+
+
+PROPERTIES_SCHEMA = {
+    "oneOf": [{
+        "type": "object",
+        "properties": {
+            "type": {
+                "enum": ["cron"]
+            },
+            "timezone": {
+                "type": "string"
+            },
+            "time": {
+                "type": "object",
+                "properties": {
+                    "year": {
+                        "type": "integer"
+                    },
+                    "month": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 12
+                    },
+                    "day": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 31
+                    },
+                    "week": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 53
+                    },
+                    "day_of_week": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 6
+                    },
+                    "hour": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 23
+                    },
+                    "minute": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 59
+                    },
+                    "second": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 59
+                    }
+                }
+            }
+        },
+        "required": [
+            "type",
+            "time"
+        ],
+        "additionalProperties": False
+    }, {
+        "type": "object",
+        "properties": {
+            "type": {
+                "enum": ["interval"]
+            },
+            "timezone": {
+                "type": "string"
+            },
+            "time": {
+                "type": "object",
+                "properties": {
+                    "units": {
+                        "enum": ["weeks", "days", "hours", "minutes", "seconds"]
+                    },
+                    "delta": {
+                        "type": "integer"
+                    }
+                }
+            }
+        },
+        "required": [
+            "type",
+            "time"
+        ],
+        "additionalProperties": False
+    }, {
+        "type": "object",
+        "properties": {
+            "type": {
+                "enum": ["date"]
+            },
+            "timezone": {
+                "type": "string"
+            },
+            "time": {
+                "type": "object",
+                "properties": {
+                    "date": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                }
+            }
+        },
+        "required": [
+            "type",
+            "time"
+        ],
+        "additionalProperties": False
+    }]
+}
+
+PAYLOAD_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "executed_at": {
+            "type": "string",
+            "format": "date-time",
+            "default": "2014-07-30 05:04:24.578325"
+        },
+        "schedule": {
+            "type": "object",
+            "default": {
+                "delta": 30,
+                "units": "seconds"
+            }
+        }
+    }
+}
 
 
 class St2TimerSensor(object):
@@ -22,21 +152,19 @@ class St2TimerSensor(object):
         self._container_service = container_service
         self._log = self._container_service.get_logger(self.__class__.__name__)
         self._scheduler = BlockingScheduler(timezone=self._timezone)
-        dirname, filename = os.path.split(os.path.abspath(__file__))
-        self._config_file = os.path.join(dirname, __name__ + '.yaml')
-        if not os.path.exists(self._config_file):
-            raise Exception('Config file %s not found.' % self._config_file)
-        with open(self._config_file) as f:
-            self._config = yaml.safe_load(f)
-        self._valid_time_types = set(['interval', 'cron', 'date'])
-        self._valid_interval_units = set(['seconds', 'minutes', 'hours', 'days', 'weeks'])
-        self._valid_cron_types = set(['year', 'month', 'day', 'week', 'day_of_week', 'hour',
-                                      'minute', 'second'])
+        # dirname, filename = os.path.split(os.path.abspath(__file__))
+        # self._config_file = os.path.join(dirname, __name__ + '.yaml')
+        # if not os.path.exists(self._config_file):
+        #     raise Exception('Config file %s not found.' % self._config_file)
+        # with open(self._config_file) as f:
+        #     self._config = yaml.safe_load(f)
         self._jobs = {}
 
     def setup(self):
-        if self._config is not None:
-            self._add_jobs_to_scheduler(self._config)
+        # if self._config is not None:
+        #     for parameters in self._config:
+        #         self.add(parameters)
+        pass
 
     def start(self):
         self._scheduler.start()
@@ -44,116 +172,87 @@ class St2TimerSensor(object):
     def stop(self):
         self._scheduler.shutdown(wait=True)
 
+    def add(self, trigger):
+        self._add_job_to_scheduler(trigger)
+
     def get_trigger_types(self):
-        trigger_types = []
-        for name, value in self._config.iteritems():
-            trigger_type = {}
-            trigger_type['name'] = name
-            trigger_type['payload'] = {}  # For now, let's say payload is empty.
-            trigger_types.append(trigger_type)
-        return trigger_types
+        return [{
+            'name': 'st2.timer',
+            'payload_info': (),
+            'parameters_schema': PROPERTIES_SCHEMA
+        }]
 
-    def _add_jobs_to_scheduler(self, jobs):
-        for name, value in jobs.iteritems():
-            try:
-                self._validate_job_spec(name, value)
-            except Exception as e:
-                self._log.error('Exception scheduling timer: %s, %s', name, e, exc_info=True)
-                continue
+    def _add_job_to_scheduler(self, trigger):
+        try:
+            jsonschema.validate(trigger['parameters'], PROPERTIES_SCHEMA)
+        except Exception as e:
+            self._log.error('Exception scheduling timer: %s, %s',
+                            trigger['parameters'], e, exc_info=True)
 
-            time_type = value.get('type')
-            time_spec = value.get('time')
-            time_zone = aps_utils.astimezone(value.get('timezone'))
+        time_type = trigger['parameters'].get('type')
+        # time_spec = parameters.get('time')
+        # time_zone = aps_utils.astimezone(parameters.get('timezone'))
 
-            if time_type == 'interval':
-                self._add_interval_job(name, time_spec, time_zone)
-            elif time_type == 'cron':
-                self._add_cron_job(name, time_spec, time_zone)
-            elif time_type == 'date':
-                self._add_date_job(name, time_spec, time_zone)
+        if time_type == 'interval':
+            self._add_interval_job(trigger)
+        elif time_type == 'cron':
+            self._add_cron_job(trigger)
+        elif time_type == 'date':
+            self._add_date_job(trigger)
 
-    def _add_interval_job(self, name, time_spec, time_zone=utc):
-        interval_trigger = self._validate_interval_spec(name, time_spec, time_zone)
-        self._add_job(name, time_spec, interval_trigger)
+    def _add_interval_job(self, trigger):
+        time_spec = trigger['parameters'].get('time')
+        time_zone = aps_utils.astimezone(trigger['parameters'].get('timezone'))
 
-    def _add_date_job(self, name, time_spec, time_zone=utc):
-        date_trigger = self._validate_date_spec(name, time_spec, time_zone)
+        unit = time_spec.get('unit', None)
+        value = time_spec.get('delta', None)
+
+        interval_trigger = IntervalTrigger(**{unit: value, 'timezone': time_zone})
+        self._add_job(trigger, interval_trigger)
+
+    def _add_date_job(self, trigger):
+        time_spec = trigger['parameters'].get('time')
+        time_zone = aps_utils.astimezone(trigger['parameters'].get('timezone'))
+
+        dat = date_parser.parse(time_spec.get('date', None))  # Raises an exception if date string isn't a valid one.
+        date_trigger = DateTrigger(dat, timezone=time_zone)
+
         if datetime.now(tzutc()) < date_trigger.run_date:
-            self._add_job(name, time_spec, date_trigger, time_zone)
+            self._add_job(trigger, date_trigger)
         else:
-            self._log.warning('Not scheduling expired timer: %s : %s', name, date_trigger.run_date)
+            self._log.warning('Not scheduling expired timer: %s : %s', trigger['parameters'], date_trigger.run_date)
 
-    def _add_cron_job(self, name, time_spec, time_zone=utc):
-        cron_trigger = self._validate_cron_spec(name, time_spec, time_zone)
-        self._add_job(name, time_spec, cron_trigger)
+    def _add_cron_job(self, trigger):
+        time_spec = trigger['parameters'].get('time')
+        time_zone = aps_utils.astimezone(trigger['parameters'].get('timezone'))
 
-    def _add_job(self, name, time_spec, trigger, replace=True):
+        cron = time_spec
+        cron['timezone'] = time_zone
+
+        cron_trigger = CronTrigger(**cron)
+        self._add_job(trigger, cron_trigger)
+
+    def _add_job(self, trigger, type, replace=True):
+        def hashify(d):
+            return frozenset(
+                (k, hashify(v)) if type(v) is dict else (k, v) for (k, v) in d.iteritems()
+            )
+
         try:
             job = self._scheduler.add_job(self._emit_trigger_instance,
-                                          trigger=trigger,
-                                          args=[name, time_spec],
+                                          trigger=type,
+                                          args=[trigger],
                                           replace_existing=replace)
             self._log.info('Job %s scheduled.', job.id)
-            self._jobs[name] = job.id
+            self._jobs[trigger['_id']] = job.id
         except Exception, e:
-            self._log.error('Exception scheduling timer: %s, %s', name, e, exc_info=True)
+            self._log.error('Exception scheduling timer: %s, %s', trigger['parameters'], e, exc_info=True)
 
-    def _emit_trigger_instance(self, name, time_spec):
-        self._log.info('Timer: %s fired at: %s. Time spec: %s', name,
-                       str(datetime.now()), time_spec)
-        trigger = {}
-        trigger['name'] = name
-        trigger['payload'] = {
+    def _emit_trigger_instance(self, trigger):
+        self._log.info('Timer fired at: %s. Trigger: %s', str(datetime.now()), trigger)
+
+        payload = {
             'executed_at': str(datetime.now()),
-            'schedule': time_spec
+            'schedule': trigger['parameters'].get('time')
         }
-        self._container_service.dispatch([trigger])
-
-    def _validate_job_spec(self, name, value):
-        time_type = value.get('type', None)
-        if not time_type:
-            raise Exception('No type specified for timer: %s' % name)
-        if time_type not in self._valid_time_types:
-            raise Exception('Invalid type specification for timer: %s, type: %s' %
-                            (name, time_type))
-
-        time_spec = value.get('time', None)
-        if not time_spec:
-            raise Exception('No time specified for timer: %s' % name)
-
-        time_zone = value.get('timezone', None)
-        aps_utils.astimezone(time_zone)  # Raises an exception if time zone isn't a known one.
-
-    def _validate_interval_spec(self, name, time_spec, time_zone=utc):
-        unit = time_spec.get('unit', None)
-        if not unit:
-            raise Exception('Timer: %s, Error: No unit specified for time.' % name)
-        if unit not in self._valid_interval_units:
-            raise Exception('Timer: %s, Error: Invalid unit "%s" specified for time.' %
-                (name, unit))
-        value = time_spec.get('delta', None)
-        if not value:
-            raise Exception('Timer: %s, Error: No interval specified.' % name)
-        kw = {unit: value, 'timezone': time_zone}
-        return IntervalTrigger(**kw)
-
-    def _validate_date_spec(self, name, time_spec, time_zone=utc):
-        dat = time_spec.get('date', None)
-        if not dat:
-            raise Exception('Timer: %s, Error: No date specified.')
-        dat = date_parser.parse(dat)  # Raises an exception if date string isn't a valid one.
-        date_trigger = DateTrigger(dat, timezone=time_zone)
-        self._log.info('Date = %s', date_trigger)
-        return date_trigger
-
-    def _validate_cron_spec(self, name, time_spec, time_zone=utc):
-        cron_parts = time_spec
-        cron = {}
-        for key, value in cron_parts.iteritems():
-            if key not in self._valid_cron_types:
-                raise Exception('Invalid cron entry: %s for timer: %s' % (key, name))
-
-            cron[key] = value
-        cron['timezone'] = time_zone
-        cron_trigger = CronTrigger(**cron)
-        return cron_trigger
+        self._container_service.dispatch(trigger, payload)

--- a/st2reactor/st2reactor/rules/engine.py
+++ b/st2reactor/st2reactor/rules/engine.py
@@ -1,5 +1,3 @@
-from sets import Set
-
 from st2common import log as logging
 from st2common.persistence.reactor import Rule
 from st2reactor.rules.enforcer import RuleEnforcer
@@ -9,52 +7,38 @@ LOG = logging.getLogger('st2reactor.rules.RulesEngine')
 
 
 class RulesEngine(object):
-    def handle_trigger_instances(self, trigger_instances):
-        # Find matching rules for each trigger instance.
-        matching_rules_map = self.get_matching_rules_for_triggers(trigger_instances)
+    def handle_trigger_instance(self, trigger_instance):
+        # Find matching rules for trigger instance.
+        matching_rules = self.get_matching_rules_for_trigger(trigger_instance)
 
         # Create rule enforcers.
-        enforcers = self.create_rule_enforcers(matching_rules_map)
+        enforcers = self.create_rule_enforcers(trigger_instance, matching_rules)
 
         # Enforce the rules.
         self.enforce_rules(enforcers)
 
-    def get_rules_for_triggers(self, trigger_names):
-        trigger_rules_map = {}
-        for trigger_name in trigger_names:
-            rules = self.get_rules_for_trigger_from_db(trigger_name)
-            trigger_rules_map[trigger_name] = rules
-        return trigger_rules_map
+    def get_rules_for_trigger(self, trigger):
+        return self.get_rules_for_trigger_from_db(trigger)
 
-    def get_rules_for_trigger_from_db(self, trigger_name):
-        trigger = {'name': trigger_name}
-        rules = Rule.query(trigger=trigger, enabled=True)
-        LOG.info('Found %d rules defined for trigger %s.', len(rules), trigger_name)
+    def get_rules_for_trigger_from_db(self, trigger):
+        rules = Rule.query(trigger=trigger.id, enabled=True)
+        LOG.info('Found %d rules defined for trigger %s with parameters %s',
+                 len(rules), trigger.name, trigger.parameters)
         return rules
 
-    def get_matching_rules_for_triggers(self, trigger_instances):
-        trigger_names = [trigger_instance.trigger['name'] for trigger_instance in trigger_instances]
-        trigger_names = Set(trigger_names)  # uniquify the list
-        trigger_rules_map = self.get_rules_for_triggers(trigger_names)  # Saves some queries to db.
-        matchers = [(trigger_instance, RulesMatcher(trigger_instance,
-                    trigger_rules_map[trigger_instance.trigger['name']]))
-                    for trigger_instance in trigger_instances]
+    def get_matching_rules_for_trigger(self, trigger_instance):
+        rules = self.get_rules_for_trigger(trigger_instance.trigger)  # Saves some queries to db.
+        matcher = RulesMatcher(trigger_instance, rules)
 
-        matching_rules_map = {}
-        for trigger_instance, matcher in matchers:
-            matching_rules = matcher.get_matching_rules()
-            LOG.info('Matched %s rule(s) for trigger_instance %s.', len(matching_rules),
-                     trigger_instance.trigger['name'])
-            if not matching_rules:
-                continue
-            matching_rules_map[trigger_instance] = matching_rules
-        return matching_rules_map
+        matching_rules = matcher.get_matching_rules()
+        LOG.info('Matched %s rule(s) for trigger_instance %s.', len(matching_rules),
+                 trigger_instance.trigger['name'])
+        return matching_rules
 
-    def create_rule_enforcers(self, matching_rules_map):
+    def create_rule_enforcers(self, trigger_instance, matching_rules):
         enforcers = []
-        for trigger_instance, matching_rules in matching_rules_map.iteritems():
-            for matching_rule in matching_rules:
-                enforcers.append(RuleEnforcer(trigger_instance, matching_rule))
+        for matching_rule in matching_rules:
+            enforcers.append(RuleEnforcer(trigger_instance, matching_rule))
         return enforcers
 
     def enforce_rules(self, enforcers):


### PR DESCRIPTION
I had to make a few modifications to the big picture of how RulesEngine work. I've decided to make it handle one trigger tinstance at the time (at least temporary) to avoid some complex hashing\unhashing issues in relation to trigger parameters. Personally, I think it's ok if sensor would dispatch its triggers one by one, after all we do have a queue in place for that, but if there is a valid reason to dispatch multiple events at the time, we may get back to it later.
