### PR TITLE
RFR: Introduce HTTP runner for invoking HTTP actions

### DIFF
--- a/contrib/examples/actions/http-google-action.json
+++ b/contrib/examples/actions/http-google-action.json
@@ -1,0 +1,8 @@
+{
+    "name": "remote-http-google-action",
+    "runner_type": "http-runner",
+    "description": "Action that returns results for google search.",
+    "enabled": true,
+    "entry_point":null,
+    "parameters": {"method":null,"timeout":null,"auth":null,"headers":null,"params":null}
+}

--- a/st2actioncontroller/st2actioncontroller/model/__init__.py
+++ b/st2actioncontroller/st2actioncontroller/model/__init__.py
@@ -43,7 +43,17 @@ def register_action_types():
                                            'user': None,
                                            'cmd': None,
                                            'remotedir': None},
-                     'runner_module': 'st2actionrunner.runners.fabricrunner'}]
+                     'runner_module': 'st2actionrunner.runners.fabricrunner'},
+
+                    {'name': 'http-runner',
+                     'description': 'A HTTP client for running HTTP actions.',
+                     'enabled': True,
+                     'runner_parameters': {'url': None,
+                                           'headers': None,
+                                           'cookies': None,
+                                           'proxy': None,
+                                           'redirects': None},
+                     'runner_module': 'st2actionrunner.runners.httprunner'}]
 
     LOG.debug('Registering actiontypes')
 
@@ -93,7 +103,7 @@ def register_actions():
                 model.runner_type = get_actiontype_by_name(str(content['runner_type']))
             except StackStormDBObjectNotFoundError:
                 LOG.exception('Failed to register action %s as runner %s was not found',
-                               model.name, str(content['runner_type']))
+                              model.name, str(content['runner_type']))
                 continue
             model.parameters = dict(content['parameters'])
             model = Action.add_or_update(model)

--- a/st2actionrunnercontroller/st2actionrunner/runners/httprunner.py
+++ b/st2actionrunnercontroller/st2actionrunner/runners/httprunner.py
@@ -1,0 +1,119 @@
+import requests
+import uuid
+
+from oslo.config import cfg
+
+from st2actionrunner.runners import ActionRunner
+from st2common import log as logging
+
+LOG = logging.getLogger(__name__)
+
+
+# Lookup constants for runner params
+RUNNER_ON_BEHALF_USER = 'user'
+RUNNER_URL = 'url'
+RUNNER_HEADERS = 'headers'  # Debatable whether this should be action params.
+RUNNER_COOKIES = 'cookies'
+RUNNER_ALLOW_REDIRECTS = 'allow_redirects'
+RUNNER_PROXIES = 'proxies'
+
+
+# Lookup constants for action params
+ACTION_AUTH = 'auth'
+ACTION_BODY = 'body'
+ACTION_TIMEOUT = 'timeout'
+ACTION_METHOD = 'method'
+ACTION_QUERY_PARAMS = 'params'
+
+
+def get_runner():
+    return HttpRunner(str(uuid.uuid4()))
+
+
+class HttpRunner(ActionRunner):
+    def __init__(self, id):
+        super(HttpRunner, self).__init__()
+        self._on_behalf_user = cfg.CONF.fabric_runner.user
+        self._timeout = 60
+
+    def pre_run(self):
+        LOG.debug('Entering HttpRunner.pre_run() for liveaction_id="%s"', self.liveaction_id)
+        LOG.debug('    runner_parameters = %s', self.runner_parameters)
+        self._on_behalf_user = self.runner_parameters.get(RUNNER_ON_BEHALF_USER,
+                                                          self._on_behalf_user)
+        self._url = self.runner_parameters.get(RUNNER_URL, None)
+        self._headers = self.runner_parameters.get(RUNNER_HEADERS, {})
+        self._cookies = self.runner_parameters.get(RUNNER_COOKIES, None)
+        self._redirects = self.runner_parameters.get(RUNNER_ALLOW_REDIRECTS, False)
+        self._proxies = self.runner_parameters.get(RUNNER_PROXIES, None)
+        return
+
+    def run(self, action_parameters):
+        client = self._get_http_client(action_parameters)
+        LOG.debug('action_parameters = %s', action_parameters)
+        try:
+            output = client.run()
+        except Exception:
+            raise
+        self.container_service.report_result(output)
+        return output is not None
+
+    def post_run(self):
+        pass
+
+    def _get_http_client(self, action_parameters):
+        # XXX: Action context should be passed in and we need to add x-headers here.
+        body = action_parameters.get(ACTION_BODY, None)
+        timeout = float(action_parameters.get(ACTION_TIMEOUT, None))
+        method = action_parameters.get(ACTION_METHOD, 'GET')
+        params = action_parameters.get(ACTION_QUERY_PARAMS, None)
+        auth = action_parameters.get('ACTION_AUTH', {})
+        return HTTPClient(url=self._url, method=method, body=body, params=params,
+                          headers=self._headers, cookies=self._cookies, auth=auth,
+                          timeout=timeout, allow_redirects=self._redirects,
+                          proxies=self._proxies)
+
+
+class HTTPClient(object):
+    def __init__(self, url=None, method='GET', body='', params=None, headers=None, cookies=None,
+                 auth=None, timeout=60, allow_redirects=True, proxies=None):
+        if url is None:
+            raise Exception('URL must be specified.')
+        self.url = url
+        if method is None:
+            raise Exception('Method must be specified.')
+        self.method = method
+        self.headers = headers
+        self.body = body
+        self.params = params
+        self.headers = headers
+        self.cookies = cookies
+        self.auth = auth
+        self.timeout = timeout
+        self.allow_redirects = allow_redirects
+        self.proxies = proxies
+
+    def run(self):
+        results = {}
+        try:
+            resp = requests.request(
+                self.method,
+                self.url,
+                params=self.params,
+                data=self.body,
+                headers=self.headers,
+                cookies=self.cookies,
+                auth=self.auth,
+                timeout=self.timeout,
+                allow_redirects=self.allow_redirects,
+                proxies=self.proxies
+            )
+            results['status_code'] = resp.status_code
+            results['body'] = resp.text
+            results['headers'] = dict(resp.headers)
+            return results
+        except Exception as e:
+            LOG.exception('Exception making request to remote URL: %s, %s', self.url, e)
+            raise
+        finally:
+            resp.close()


### PR DESCRIPTION
Output:

```
$ st2 run remote-http-google-action user="lakshmi" method="GET" timeout="10" url="https://google.com"
```

```
$ st2 execution get 53e2a89eb18597755d8fc7f6
+-----------------+---------------------------------------------------------+
| Property        | Value                                                   |
+-----------------+---------------------------------------------------------+
| id              | 53e2a89eb18597755d8fc7f6                                |
| action          | {                                                       |
|                 |     "name": "remote-http-google-action",                |
|                 |     "id": "53e29e64b1859751178163e5"                    |
|                 | }                                                       |
| parameters      | {                                                       |
|                 |     "url": "https://google.com",                        |
|                 |     "user": "lakshmi",                                  |
|                 |     "timeout": "10",                                    |
|                 |     "method": "GET"                                     |
|                 | }                                                       |
| result          | {"body": "<HTML><HEAD><meta http-equiv=\"content-type\" |
|                 | content=\"text/html;charset=utf-8\">\n<TITLE>301        |
|                 | Moved</TITLE></HEAD><BODY>\n<H1>301 Moved</H1>\nThe     |
|                 | document has moved\n<A HREF=\"https://www.google.com/\" |
|                 | >here</A>.\r\n</BODY></HTML>\r\n", "status_code": 301,  |
|                 | "headers": {"alternate-protocol": "443:quic", "content- |
|                 | length": "220", "x-xss-protection": "1; mode=block",    |
|                 | "expires": "Fri, 05 Sep 2014 22:13:50 GMT", "server":   |
|                 | "gws", "location": "https://www.google.com/", "cache-   |
|                 | control": "public, max-age=2592000", "date": "Wed, 06   |
|                 | Aug 2014 22:13:50 GMT", "x-frame-options":              |
|                 | "SAMEORIGIN", "content-type": "text/html;               |
|                 | charset=UTF-8"}}                                        |
| start_timestamp | 2014-08-06T15:13:50.176000                              |
| status          | complete                                                |
| uri             | None                                                    |
+-----------------+---------------------------------------------------------+

(virtualenv)vagrant@vagrant-fedora20 ~/onebox-stanley (STORM-375/http_runner●●)$
| 53e2a2afb185976269cfea36 | remote-http-google-action | error    | 2014-08-06T14
```
