### PR TITLE
RFR: Fix test_duplicate_action_insert 

### DIFF
--- a/st2actioncontroller/st2actioncontroller/controllers/actions.py
+++ b/st2actioncontroller/st2actioncontroller/controllers/actions.py
@@ -102,8 +102,8 @@ class ActionsController(RestController):
             action_db = Action.add_or_update(action_model)
         except (NotUniqueError) as e:
             # If an existing DB object conflicts with new object then raise error.
-            LOG.exception('/actions/ POST unable to save ActionDB object "%s" due to uniqueness '
-                          'conflict. Exception was: %s', action_model)
+            LOG.exception('/actions/ POST unable to save ActionDB object "%s" due to uniqueness ' +
+                          'conflict.', action_model)
             abort(httplib.CONFLICT)
 
         LOG.debug('/actions/ POST saved ActionDB object=%s', action_db)

--- a/st2actioncontroller/tests/controllers/test_actionexecutions.py
+++ b/st2actioncontroller/tests/controllers/test_actionexecutions.py
@@ -1,6 +1,9 @@
 import copy
+try:
+    import simplejson as json
+except ImportError:
+    import json
 import mock
-from nose.tools import nottest
 from tests import FunctionalTest
 
 from st2actioncontroller.controllers.actionexecutions import ActionExecutionsController

--- a/st2actioncontroller/tests/controllers/test_actions.py
+++ b/st2actioncontroller/tests/controllers/test_actions.py
@@ -1,6 +1,5 @@
 from tests import FunctionalTest
 import json
-import unittest2
 
 
 SHELL_RUNNER_ARGS = {'hosts': 'localhost',
@@ -157,13 +156,13 @@ class TestActionController(FunctionalTest):
         self.assertNotEquals(data['id'], ACTION_7['id'])
         self.__do_delete(self.__get_action_id(post_resp))
 
-    @unittest2.skip('/actions is accepting dups!')
     def test_post_name_duplicate(self):
         action_ids = []
 
         post_resp = self.__do_post(ACTION_1)
         self.assertEquals(post_resp.status_int, 201)
-
+        action_in_db = Action.get_by_name(ACTION_1.get('name'))
+        self.assertTrue(action_in_db is not None, 'Action must be in db.')
         action_ids.append(self.__get_action_id(post_resp))
 
         post_resp = self.__do_post(ACTION_1)

--- a/st2common/st2common/models/db/action.py
+++ b/st2common/st2common/models/db/action.py
@@ -93,3 +93,5 @@ class ActionExecutionDB(StormFoundationDB):
 runnertype_access = MongoDBAccess(RunnerTypeDB)
 action_access = MongoDBAccess(ActionDB)
 actionexec_access = MongoDBAccess(ActionExecutionDB)
+
+MODELS = [RunnerTypeDB, ActionDB, ActionExecutionDB]

--- a/st2common/st2common/models/db/actionrunner.py
+++ b/st2common/st2common/models/db/actionrunner.py
@@ -36,3 +36,5 @@ class ActionRunnerDB(StormFoundationDB):
 # specialized access objects
 liveaction_access = MongoDBAccess(LiveActionDB)
 actionrunner_access = MongoDBAccess(ActionRunnerDB)
+
+MODELS = [LiveActionDB, ActionRunnerDB]

--- a/st2common/st2common/models/db/datastore.py
+++ b/st2common/st2common/models/db/datastore.py
@@ -14,3 +14,5 @@ class KeyValuePairDB(stormbase.StormBaseDB):
 
 # specialized access objects
 keyvaluepair_access = MongoDBAccess(KeyValuePairDB)
+
+MODELS = [KeyValuePairDB]

--- a/st2common/st2common/models/db/reactor.py
+++ b/st2common/st2common/models/db/reactor.py
@@ -83,3 +83,6 @@ trigger_access = MongoDBAccess(TriggerDB)
 triggerinstance_access = MongoDBAccess(TriggerInstanceDB)
 rule_access = MongoDBAccess(RuleDB)
 ruleenforcement_access = MongoDBAccess(RuleEnforcementDB)
+
+MODELS = [TriggerTypeDB, TriggerDB, TriggerInstanceDB, RuleDB,
+          RuleEnforcementDB]

--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -5,6 +5,16 @@ import st2tests.config
 from unittest2 import TestCase
 from oslo.config import cfg
 from st2common.models.db import db_setup, db_teardown
+import st2common.models.db.reactor as reactor_model
+import st2common.models.db.action as action_model
+import st2common.models.db.datastore as datastore_model
+import st2common.models.db.actionrunner as actionrunner_model
+
+ALL_MODELS = []
+ALL_MODELS.extend(reactor_model.MODELS)
+ALL_MODELS.extend(action_model.MODELS)
+ALL_MODELS.extend(datastore_model.MODELS)
+ALL_MODELS.extend(actionrunner_model.MODELS)
 
 
 class EventletTestCase(TestCase):
@@ -42,6 +52,17 @@ class DbTestCase(TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        cls.drop_collections()
         DbTestCase.db_connection.drop_database(cfg.CONF.database.db_name)
         db_teardown()
         DbTestCase.db_connection = None
+
+    @classmethod
+    def drop_collections(cls):
+        # XXX: Explicitly drop all the collection. Otherwise, artifacts are left over in
+        # subsequent tests.
+        # See: https://github.com/MongoEngine/mongoengine/issues/566
+        # See: https://github.com/MongoEngine/mongoengine/issues/565
+        global ALL_MODELS
+        for model in ALL_MODELS:
+            model.drop_collection()


### PR DESCRIPTION
With this PR, we are also dropping collections after every test case. Otherwise, artifacts from db are carried over. 

Tests pass now. We need to watch out for mongoengine fixes for https://github.com/MongoEngine/mongoengine/issues/566

There goes 2 days. 
