### PR TITLE
Fix: Cleanup FunctionalTests

### DIFF
--- a/st2actioncontroller/tests/base.py
+++ b/st2actioncontroller/tests/base.py
@@ -1,14 +1,12 @@
 import tests.config
 from pecan.testing import load_test_app
-from st2tests import DbTestCase
 from oslo.config import cfg
+
 from st2actioncontroller import model
+from st2tests import DbTestCase
 
 
 class FunctionalTest(DbTestCase):
-
-    db_connection = None
-
     @classmethod
     def setUpClass(cls):
         super(FunctionalTest, cls).setUpClass()

--- a/st2actionrunnercontroller/tests/base.py
+++ b/st2actionrunnercontroller/tests/base.py
@@ -1,13 +1,11 @@
 import tests.config
 from pecan.testing import load_test_app
-from st2tests import DbTestCase
 from oslo.config import cfg
+
+from st2tests import DbTestCase
 
 
 class FunctionalTest(DbTestCase):
-
-    db_connection = None
-
     @classmethod
     def setUpClass(cls):
         super(FunctionalTest, cls).setUpClass()

--- a/st2datastore/tests/base.py
+++ b/st2datastore/tests/base.py
@@ -1,22 +1,15 @@
 import tests.config
 from pecan.testing import load_test_app
-from unittest import TestCase
 from oslo.config import cfg
 
-from st2common.models.db import db_setup, db_teardown
+from st2tests import DbTestCase
 
 
-class FunctionalTest(TestCase):
-
-    db_connection = None
-
+class FunctionalTest(DbTestCase):
     @classmethod
     def setUpClass(cls):
+        super(FunctionalTest, cls).setUpClass()
         tests.config.parse_args()
-        FunctionalTest.db_connection = db_setup(cfg.CONF.database.db_name,
-                                                cfg.CONF.database.host,
-                                                cfg.CONF.database.port)
-
         opts = cfg.CONF.datastore_pecan
         cfg_dict = {
             'app': {
@@ -32,9 +25,4 @@ class FunctionalTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        FunctionalTest.__do_db_teardown()
-
-    @staticmethod
-    def __do_db_teardown():
-        FunctionalTest.db_connection.drop_database(cfg.CONF.database.db_name)
-        db_teardown()
+        super(FunctionalTest, cls).tearDownClass()

--- a/st2reactorcontroller/tests/base.py
+++ b/st2reactorcontroller/tests/base.py
@@ -2,13 +2,9 @@ import tests.config
 from pecan.testing import load_test_app
 from st2tests import DbTestCase
 from oslo.config import cfg
-from st2common.models.db import db_setup, db_teardown
 
 
 class FunctionalTest(DbTestCase):
-
-    db_connection = None
-
     @classmethod
     def setUpClass(cls):
         super(FunctionalTest, cls).setUpClass()

--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -44,3 +44,4 @@ class DbTestCase(TestCase):
     def tearDownClass(cls):
         DbTestCase.db_connection.drop_database(cfg.CONF.database.db_name)
         db_teardown()
+        DbTestCase.db_connection = None


### PR DESCRIPTION
FunctionalTest also had a db_connection property. Possibly some left over from some refactoring. This might explain some of the weirdness we were seeing this morning. 
