### PR TITLE
[STORM-378] Action metadata

### DIFF
--- a/contrib/examples/actions/ping-google.json
+++ b/contrib/examples/actions/ping-google.json
@@ -1,8 +1,0 @@
-{
-    "name": "ping-google",
-    "runner_type": "shell",
-    "description": "A ping host action.",
-    "enabled": true,
-    "entry_point": "bash_ping/bash_ping.sh",
-    "parameters": {"args": "8.8.8.8", "count": null}
-}

--- a/contrib/examples/actions/ping.json
+++ b/contrib/examples/actions/ping.json
@@ -4,5 +4,9 @@
     "description": "A ping host action.",
     "enabled": true,
     "entry_point": "bash_ping/bash_ping.sh",
-    "parameters": {"count": null}
+    "parameters": {
+        "count": {
+            "type": "integer"
+        }
+    }
 }

--- a/contrib/examples/actions/remote-random-exit.json
+++ b/contrib/examples/actions/remote-random-exit.json
@@ -4,5 +4,9 @@
     "description": "Action that returns a randomly generated exit code remotely."
     "enabled": true,
     "entry_point": "bash_random/random2.sh",
-    "parameters": {"count":null}
+    "parameters": {
+        "count": {
+            "type": "integer"
+        }
+    }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ apscheduler>=3.0.0rc1
 python-dateutil
 paramiko
 git+https://github.com/StackStorm/fabric.git@stanley-patched
+jsonschema>=2.3.0

--- a/st2actionrunnercontroller/st2actionrunner/container/__init__.py
+++ b/st2actionrunnercontroller/st2actionrunner/container/__init__.py
@@ -90,13 +90,15 @@ class RunnerContainer():
         actionexec_runner_parameters, actionexec_action_parameters = RunnerContainer._split_params(
             runnertype_db, action_db, actionexec_db)
 
-        runner_parameters = runnertype_db.runner_parameters
+        runner_parameters = dict([(k, v['default'])
+                                  for k, v in runnertype_db.runner_parameters.iteritems()
+                                  if 'default' in v and v['default']])
         runner_parameters.update(actionexec_runner_parameters)
 
         # Create action parameters by merging default values with dynamic values
-        action_parameters = {}
-        action_action_parameters = dict(action_db.parameters)
-        action_parameters.update(action_action_parameters)
+        action_parameters = dict([(k, v['default'])
+                                  for k, v in action_db.parameters.iteritems()
+                                  if 'default' in v and v['default']])
         action_parameters.update(actionexec_action_parameters)
 
         runner.set_liveaction_id(liveaction_id)

--- a/st2actionrunnercontroller/st2actionrunner/runners/fabricrunner.py
+++ b/st2actionrunnercontroller/st2actionrunner/runners/fabricrunner.py
@@ -53,10 +53,8 @@ class FabricRunner(ActionRunner):
         if len(self._hosts) < 1:
             raise ActionRunnerPreRunError('No hosts specified to run action for liveaction %s.',
                                           self.liveaction_id)
-        parallel = self.runner_parameters.get(RUNNER_PARALLEL, 'true')
-        self._parallel = True if parallel is None else parallel.lower() == 'true'
-        sudo = self.runner_parameters.get(RUNNER_SUDO, 'false')
-        self._sudo = False if sudo is None else sudo.lower() == 'true'
+        self._parallel = self.runner_parameters.get(RUNNER_PARALLEL, True)
+        self._sudo = self.runner_parameters.get(RUNNER_SUDO, False)
         self._on_behalf_user = self.runner_parameters.get(RUNNER_ON_BEHALF_USER, env.user)
         self._user = cfg.CONF.fabric_runner.user
 

--- a/st2actionrunnercontroller/st2actionrunnercontroller/controllers/liveactions.py
+++ b/st2actionrunnercontroller/st2actionrunnercontroller/controllers/liveactions.py
@@ -12,7 +12,7 @@ from st2common.models.api.action import ACTIONEXEC_STATUS_RUNNING, ACTIONEXEC_ST
 from st2common.models.api.actionrunner import LiveActionAPI
 from st2common.persistence.actionrunner import LiveAction
 from st2common.util.action_db import (get_actionexec_by_id, get_action_by_dict,
-                                      update_actionexecution_status)
+                                      update_actionexecution_status, get_runnertype_by_name)
 from st2common.util.actionrunner_db import (get_liveaction_by_id,
                                             get_liveactions_by_actionexec_id)
 
@@ -136,7 +136,7 @@ class LiveActionsController(RestController):
             # TODO: Is there a more appropriate status code?
             abort(httplib.BAD_REQUEST)
 
-        runnertype_db = action_db.runner_type
+        runnertype_db = get_runnertype_by_name(action_db.runner_type['name'])
 
         #  Got Action object (2)
         LOG.info('POST /liveactions/ obtained Action object from database. '

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -1,0 +1,10 @@
+from oslo.config import cfg
+
+
+schema_opts = [
+    cfg.IntOpt('version', default=4, help='Version of JSON schema to use.'),
+    cfg.StrOpt('draft', default='http://json-schema.org/draft-04/schema#',
+               help='URL to the JSON schema draft.')
+]
+
+cfg.CONF.register_opts(schema_opts, group='schema')

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -1,9 +1,13 @@
 import datetime
 import json
+
+import jsonschema
 from wsme import wsattr
 from wsme import types as wstypes
 
+from st2common import util
 from st2common import log as logging
+from st2common.models.base import BaseAPI
 from st2common.models.api.stormbase import (StormFoundationAPI, StormBaseAPI)
 from st2common.models.db.action import (RunnerTypeDB, ActionDB, ActionExecutionDB)
 
@@ -15,127 +19,173 @@ __all__ = ['ActionAPI',
 LOG = logging.getLogger(__name__)
 
 
-class RunnerTypeAPI(StormBaseAPI):
+class RunnerTypeAPI(BaseAPI):
     """
-        The representation of an RunnerType in the system. An RunnerType
-        has a one-to-one mapping to a particular ActionRunner implementation.
-
-        Attributes:
-            id: See StormBaseAPI
-            name: See StormBaseAPI
-            description: See StormBaseAPI
-
-            enabled: Boolean value indicating whether the runner for this type
-                     is enabled.
-            runner_module: The python module that implements the action runner
-                           for this type.
-            runner_parameters: The names for the parameter that are required by the
-                               action runner. Any values in this dictionary are
-                               default values for the parameters.
+    The representation of an RunnerType in the system. An RunnerType
+    has a one-to-one mapping to a particular ActionRunner implementation.
     """
-    enabled = bool
-    runner_parameters = wstypes.DictType(str, str)
-    runner_module = wstypes.text
+
+    schema = {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "title": "Runner",
+        "description": "A handler for a specific type of actions.",
+        "type": "object",
+        "properties": {
+            "id": {
+                "description": "The unique identifier for the action runner.",
+                "type": "string",
+                "default": None
+            },
+            "name": {
+                "description": "The name of the action runner.",
+                "type": "string"
+            },
+            "description": {
+                "description": "The description of the action runner.",
+                "type": "string"
+            },
+            "enabled": {
+                "description": "Enable or disable the action runner.",
+                "type": "boolean",
+                "default": True
+            },
+            "runner_module": {
+                "description": "The python module that implements the "
+                               "action runner for this type.",
+                "type": "string",
+            },
+            "runner_parameters": {
+                "description": "Input parameters for the action runner.",
+                "type": "object",
+                "patternProperties": {
+                    "^\w+$": util.schema.get_draft_schema()
+                }
+            },
+            "required_parameters": {
+                "description": "List of required parameters.",
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "required": ["name", "runner_module"],
+        "additionalProperties": False
+    }
+
+    def __init__(self, **kw):
+        jsonschema.validate(kw, self.schema)
+        for key, value in kw.items():
+            setattr(self, key, value)
+        if not hasattr(self, 'runner_parameters'):
+            setattr(self, 'runner_parameters', dict())
+        if not hasattr(self, 'required_parameters'):
+            setattr(self, 'required_parameters', list())
 
     @classmethod
-    def from_model(kls, model):
+    def from_model(cls, model):
         LOG.debug('entering RctionTypeAPI.from_model() Input object: %s', model)
-
-        runnertype = StormBaseAPI.from_model(kls, model)
-        runnertype.enabled = bool(model.enabled)
-        runnertype.runner_module = str(model.runner_module)
-        runnertype.runner_parameters = dict(model.runner_parameters)
-
+        runnertype = model.to_mongo()
+        runnertype['id'] = str(runnertype['_id'])
+        del runnertype['_id']
         LOG.debug('exiting RunnerTypeAPI.from_model() Result object: %s', runnertype)
-        return runnertype
+        return cls(**runnertype)
 
     @classmethod
-    def to_model(kls, runnertype):
+    def to_model(cls, runnertype):
         LOG.debug('entering RunnerTypeAPI.to_model() Input object: %s', runnertype)
-
         model = StormBaseAPI.to_model(RunnerTypeDB, runnertype)
         model.enabled = bool(runnertype.enabled)
         model.runner_module = str(runnertype.runner_module)
-        model.runner_parameters = dict(runnertype.runner_parameters)
-
+        model.runner_parameters = getattr(runnertype, 'runner_parameters', dict())
+        model.required_parameters = getattr(runnertype, 'required_parameters', list())
         LOG.debug('exiting RunnerTypeAPI.to_model() Result object: %s', model)
         return model
 
-    # TODO: Write generic str function for API and DB model base classes
-    def __str__(self):
-        result = []
-        result.append('RunnerTypeAPI@')
-        result.append(str(id(self)))
-        result.append('(')
-        result.append('id="%s", ' % self.id)
-        result.append('name="%s", ' % self.name)
-        result.append('description="%s", ' % self.description)
-        result.append('enabled="%s", ' % self.enabled)
-        result.append('runner_module="%s", ' % str(self.runner_module))
-        result.append('runner_parameters="%s", ' % str(self.runner_parameters))
-        result.append('uri="%s")' % self.uri)
-        return ''.join(result)
 
+class ActionAPI(BaseAPI):
+    """The system entity that represents a Stack Action/Automation in the system."""
 
-class ActionAPI(StormBaseAPI):
-    """The system entity that represents a Stack Action/Automation in
-       the system.
-    Attribute:
-        enabled: flag indicating whether this action is enabled in the system.
-        repo_path: relative path to the action artifact. Relative to the root
-                   of the repo.
-        run_type: string identifying which actionrunner is used to execute the action.
-        parameter_names: flat list of strings required as key names when running
-                   the action.
-    """
+    schema = {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "title": "Action",
+        "description": "An activity that happens as a response to the external event.",
+        "type": "object",
+        "properties": {
+            "id": {
+                "description": "The unique identifier for the action.",
+                "type": "string"
+            },
+            "name": {
+                "description": "The name of the action.",
+                "type": "string"
+            },
+            "description": {
+                "description": "The description of the action.",
+                "type": "string"
+            },
+            "enabled": {
+                "description": "Enable or disable the action from invocation.",
+                "type": "boolean",
+                "default": True
+            },
+            "runner_type": {
+                "description": "The type of runner that executes the action.",
+                "type": "string",
+            },
+            "entry_point": {
+                "description": "The entry point for the action.",
+                "type": "string"
+            },
+            "parameters": {
+                "description": "Input parameters for the action.",
+                "type": "object",
+                "patternProperties": {
+                    "^\w+$": util.schema.get_draft_schema()
+                }
+            },
+            "required_parameters": {
+                "description": "List of required parameters.",
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "required": ["name", "runner_type"],
+        "additionalProperties": False
+    }
 
-    enabled = bool
-    entry_point = wstypes.text
-    runner_type = wstypes.text
-    # TODO: Support default parameter values
-    parameters = wstypes.DictType(str, str)
+    def __init__(self, **kw):
+        jsonschema.validate(kw, self.schema)
+        for key, value in kw.items():
+            setattr(self, key, value)
+        if not hasattr(self, 'parameters'):
+            setattr(self, 'parameters', dict())
+        if not hasattr(self, 'required_parameters'):
+            setattr(self, 'required_parameters', list())
 
     @classmethod
-    def from_model(kls, model):
+    def from_model(cls, model):
         LOG.debug('entering ActionAPI.from_model() Input object: %s', model)
-
-        action = StormBaseAPI.from_model(kls, model)
-        action.enabled = bool(model.enabled)
-        action.entry_point = str(model.entry_point)
-        action.runner_type = str(model.runner_type.name)
-        action.parameters = dict(model.runner_type.runner_parameters)
-        action.parameters.update(model.parameters)
+        action = model.to_mongo()
+        action['id'] = str(action['_id'])
+        action['runner_type'] = action['runner_type']['name']
+        del action['_id']
         LOG.debug('exiting ActionAPI.from_model() Result object: %s', action)
-        return action
+        return cls(**action)
 
     @classmethod
-    def to_model(kls, action, runnertype_db):
+    def to_model(cls, action):
         LOG.debug('entering ActionAPI.to_model() Input object: %s', action)
-
         model = StormBaseAPI.to_model(ActionDB, action)
         model.enabled = bool(action.enabled)
         model.entry_point = str(action.entry_point)
-        model.runner_type = runnertype_db
-        model.parameters = dict(action.parameters)
-
+        model.runner_type = {'name': str(action.runner_type)}
+        model.parameters = getattr(action, 'parameters', dict())
+        model.required_parameters = getattr(action, 'required_parameters', list())
         LOG.debug('exiting ActionAPI.to_model() Result object: %s', model)
         return model
-
-    def __str__(self):
-        # Note: List append followed by list comprehension is fastest way to build a string.
-        result = []
-        result.append('ActionAPI@')
-        result.append(str(id(self)))
-        result.append('(')
-        result.append('id="%s", ' % self.id)
-        result.append('name="%s", ' % self.name)
-        result.append('description="%s", ' % self.description)
-        result.append('enabled="%s",' % self.enabled)
-        result.append('entry_point="%s",' % self.entry_point)
-        result.append('runner_type="%s",' % self.runner_type)
-        result.append('parameters="%s",' % str(self.parameters))
-        result.append('uri="%s")' % self.uri)
-        return ''.join(result)
 
 
 ACTIONEXEC_STATUS_INIT = 'initializing'
@@ -152,51 +202,95 @@ ACTION_NAME = 'name'
 ACTION_ID = 'id'
 
 
-class ActionExecutionAPI(StormFoundationAPI):
-    """The system entity that represents the execution of a Stack Action/Automation in
-       the system.
-    Attribute:
-       ...
+class ActionExecutionAPI(BaseAPI):
+    """The system entity that represents the execution of a Stack Action/Automation
+    in the system.
     """
-    status = wstypes.Enum(str, *ACTIONEXEC_STATUSES)
-    start_timestamp = datetime.datetime
-    action = wsattr(wstypes.DictType(str, str), mandatory=True)
-    parameters = wsattr(wstypes.DictType(str, str), default={})
-    result = wsattr(str, default='')
+
+    schema = {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "title": "ActionExecution",
+        "description": "An execution of an action.",
+        "type": "object",
+        "properties": {
+            "id": {
+                "description": "The unique identifier for the action execution.",
+                "type": "string"
+            },
+            "status": {
+                "description": "The current status of the action execution.",
+                "enum": ACTIONEXEC_STATUSES
+            },
+            "start_timestamp": {
+                "description": "The start time when the action is executed.",
+                "type": "string",
+                "pattern": "^\d{4}-\d{2}-\d{2}[ ]\d{2}:\d{2}:\d{2}.\d{6}$"
+            },
+            "action": {
+                "description": "The action to be executed.",
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "description": "The unique identifier for the action.",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "The name of the action.",
+                        "type": "string"
+                    }
+                }
+            },
+            "parameters": {
+                "description": "Input parameters for the action.",
+                "type": "object",
+                "patternProperties": {
+                    "^\w+$": {
+                        "anyOf": [
+                            {"type": "array"},
+                            {"type": "boolean"},
+                            {"type": "integer"},
+                            {"type": "number"},
+                            {"type": "object"},
+                            {"type": "string"}
+                        ]
+                    }
+                }
+            },
+            "result": {
+                "type": "string"
+            }
+        },
+        "required": ["action"],
+        "additionalProperties": False
+    }
+
+    def __init__(self, **kw):
+        start_timestamp = kw.pop('start_timestamp') if 'start_timestamp' in kw else None
+        super(ActionExecutionAPI, self).__init__(**kw)
+        if start_timestamp and not isinstance(start_timestamp, datetime.datetime):
+            start_timestamp = datetime.datetime.strptime(start_timestamp,
+                                                         '%Y-%m-%d %H:%M:%S.%f')
+        if start_timestamp:
+            self.start_timestamp = start_timestamp
 
     @classmethod
-    def from_model(kls, model):
+    def from_model(cls, model):
         LOG.debug('entering ActionExecutionAPI.from_model() Input object: %s', model)
-        actionexec = StormFoundationAPI.from_model(kls, model)
-        actionexec.action = dict(model.action)
-        actionexec.status = str(model.status)
-        actionexec.start_timestamp = model.start_timestamp
-        actionexec.parameters = dict(model.parameters)
-        actionexec.result = model.result
-        LOG.debug('exiting ActionExecutionAPI.from_model() Result object: %s', actionexec)
-        return actionexec
+        execution = model.to_mongo()
+        execution['id'] = str(execution['_id'])
+        del execution['_id']
+        result = cls(**execution)
+        LOG.debug('exiting ActionExecutionAPI.from_model() Result object: %s', result)
+        return result
 
     @classmethod
-    def to_model(kls, actionexec):
-        LOG.debug('entering ActionExecutionAPI.to_model() Input object: %s', actionexec)
-        model = StormFoundationAPI.to_model(ActionExecutionDB, actionexec)
-        model.status = str(actionexec.status)
-        model.start_timestamp = actionexec.start_timestamp
-        model.action = actionexec.action
-        model.parameters = dict(actionexec.parameters)
-        model.result = actionexec.result
+    def to_model(cls, execution):
+        LOG.debug('entering ActionExecutionAPI.to_model() Input object: %s', execution)
+        model = StormFoundationAPI.to_model(ActionExecutionDB, execution)
+        model.status = str(execution.status)
+        model.start_timestamp = execution.start_timestamp
+        model.action = execution.action
+        model.parameters = dict(execution.parameters)
+        setattr(model, 'result', getattr(execution, 'result', None))
         LOG.debug('exiting ActionExecutionAPI.to_model() Result object: %s', model)
         return model
-
-    def __str__(self):
-        result = []
-        result.append('ActionExecutionAPI@')
-        result.append(str(id(self)))
-        result.append('(')
-        result.append('id="%s", ' % self.id)
-        result.append('status="%s", ' % self.status)
-        result.append('action="%s", ' % self.action)
-        result.append('parameters="%s", ' % self.parameters)
-        result.append('result=%s, ' % json.dumps(self.result))
-        result.append('uri="%s")' % self.uri)
-        return ''.join(result)

--- a/st2common/st2common/models/api/stormbase.py
+++ b/st2common/st2common/models/api/stormbase.py
@@ -53,12 +53,12 @@ class StormBaseAPI(StormFoundationAPI):
     def from_model(kls, model):
         api_instance = StormFoundationAPI.from_model(kls, model)
         api_instance.name = model.name
-        api_instance.description = model.description
+        setattr(api_instance, 'description', getattr(model, 'description', None))
         return api_instance
 
     @staticmethod
     def to_model(kls, api_instance):
         model = StormFoundationAPI.to_model(kls, api_instance)
         model.name = api_instance.name
-        model.description = api_instance.description
+        setattr(model, 'description', getattr(api_instance, 'description', None))
         return model

--- a/st2common/st2common/models/db/action.py
+++ b/st2common/st2common/models/db/action.py
@@ -1,9 +1,12 @@
 import datetime
 import mongoengine as me
 
+from oslo.config import cfg
+
 from st2common import log as logging
 from st2common.models.db import MongoDBAccess
 from st2common.models.db.stormbase import (StormFoundationDB, StormBaseDB)
+
 
 __all__ = ['RunnerTypeDB',
            'ActionDB',
@@ -22,45 +25,49 @@ class RunnerTypeDB(StormBaseDB):
         id: See StormBaseAPI
         name: See StormBaseAPI
         description: See StormBaseAPI
-
-        enabled: Boolean value indicating whether the runner for this type
-                 is enabled.
-        runner_parameter_names: The names required by the action runner to
-                                function.
-        runner_module: The python module that implements the action runner
-                       for this type.
+        enabled: A flag indicating whether the runner for this type is enabled.
+        runner_module: The python module that implements the action runner for this type.
+        runner_parameters: The specification for parameters for the action runner.
+        required_parameters: The list of parameters required by the action runner.
     """
 
-    enabled = me.BooleanField(required=True, default=True,
-                              help_text=(u'Flag indicating whether the action runner ' +
-                                         u'represented by this runnertype is enabled.'))
-    runner_parameters = me.DictField(required=True, default={},
-                                     help_text=(u'The parameter names required by the action ' +
-                                                u'runner. Default values are optional.'))
-    runner_module = me.StringField(required=True,
-                                   help_text=u'Implementation of the action runner.')
+    enabled = me.BooleanField(
+        required=True, default=True,
+        help_text='A flag indicating whether the runner for this type is enabled.')
+    runner_module = me.StringField(
+        required=True,
+        help_text='The python module that implements the action runner for this type.')
+    runner_parameters = me.DictField(
+        help_text='The specification for parameters for the action runner.')
+    required_parameters = me.ListField(
+        help_text='The list of parameters required by the action runner.')
 
 
 class ActionDB(StormBaseDB):
-    """The system entity that represents a Stack Action/Automation in
-       the system.
+    """
+    The system entity that represents a Stack Action/Automation in the system.
+
     Attribute:
-        enabled: flag indicating whether this action is enabled in the system.
-        repo_path: relative path to the action artifact. Relative to the root
-                   of the repo.
-        run_type: string identifying which actionrunner is used to execute the action.
-        parameter_names: flat list of strings required as key names when running
-                   the action.
+        enabled: A flag indicating whether this action is enabled in the system.
+        entry_point: The entry point to the action.
+        runner_type: The actionrunner is used to execute the action.
+        parameters: The specification for parameters for the action.
+        required_parameters: The list of parameters required by the action.
     """
 
-    enabled = me.BooleanField(required=True, default=True,
-                              help_text='Flag indicating whether the action is enabled.')
-    entry_point = me.StringField(required=True,
-                                 help_text='Action entrypoint.')
-    runner_type = me.ReferenceField(RunnerTypeDB, required=True,
-                                    help_text='Execution environment to use.')
-    parameters = me.DictField(default={},
-                              help_text='Action parameters with optional default values.')
+    enabled = me.BooleanField(
+        required=True, default=True,
+        help_text='A flag indicating whether the action is enabled.')
+    entry_point = me.StringField(
+        required=True,
+        help_text='The entry point to the action.')
+    runner_type = me.DictField(
+        required=True, default={},
+        help_text='The action runner to use for executing the action.')
+    parameters = me.DictField(
+        help_text='The specification for parameters for the action.')
+    required_parameters = me.ListField(
+        help_text='The list of parameters required by the action.')
 
 
 class ActionExecutionDB(StormFoundationDB):
@@ -76,17 +83,21 @@ class ActionExecutionDB(StormFoundationDB):
     """
 
     # TODO: Can status be an enum at the Mongo layer?
-    status = me.StringField(required=True,
-                            help_text='The current status of the ActionExecution.')
-    start_timestamp = me.DateTimeField(default=datetime.datetime.now(),
-                                       help_text=(u'The timestamp when the ActionExecution ' +
-                                                  u' was created.'))
-    action = me.DictField(required=True,
-                          help_text='The action executed by this instance.')
-    parameters = me.DictField(default={},
-                              help_text=(u'The key-value pairs passed as to the action runner & ' +
-                                         u' execution.'))
-    result = me.StringField(default='', help_text='Action defined result.')
+    status = me.StringField(
+        required=True,
+        help_text='The current status of the ActionExecution.')
+    start_timestamp = me.DateTimeField(
+        default=datetime.datetime.now(),
+        help_text='The timestamp when the ActionExecution was created.')
+    action = me.DictField(
+        required=True,
+        help_text='The action executed by this instance.')
+    parameters = me.DictField(
+        default={},
+        help_text='The key-value pairs passed as to the action runner &  execution.')
+    result = me.StringField(
+        default='',
+        help_text='Action defined result.')
 
 
 # specialized access objects

--- a/st2common/st2common/util/__init__.py
+++ b/st2common/st2common/util/__init__.py
@@ -1,0 +1,5 @@
+from st2common.util import http
+from st2common.util import loader
+from st2common.util import reference
+from st2common.util import schema
+from st2common.util import ssh

--- a/st2common/st2common/util/schema.py
+++ b/st2common/st2common/util/schema.py
@@ -1,0 +1,192 @@
+import jsonschema
+from oslo.config import cfg
+
+
+cfg.CONF.import_opt('version', 'st2common.config', group='schema')
+cfg.CONF.import_opt('draft', 'st2common.config', group='schema')
+
+
+# https://github.com/json-schema/json-schema/blob/master/draft-04/schema
+# The source material is licensed under the AFL or BSD license.
+draft4_schema = {
+    "id": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Core schema meta-schema",
+    "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#" }
+        },
+        "positiveInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "positiveIntegerDefault0": {
+            "allOf": [ { "$ref": "#/definitions/positiveInteger" }, { "default": 0 } ]
+        },
+        "simpleTypes": {
+            "enum": [ "array", "boolean", "integer", "null", "number", "object", "string" ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1,
+            "uniqueItems": True
+        }
+    },
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string",
+            "format": "uri"
+        },
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": {},
+        "multipleOf": {
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": True
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "boolean",
+            "default": False
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "boolean",
+            "default": False
+        },
+        "maxLength": { "$ref": "#/definitions/positiveInteger" },
+        "minLength": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "additionalItems": {
+            "anyOf": [
+                { "type": "boolean" },
+                { "$ref": "#" }
+            ],
+            "default": {}
+        },
+        "items": {
+            "anyOf": [
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
+            ],
+            "default": {}
+        },
+        "maxItems": { "$ref": "#/definitions/positiveInteger" },
+        "minItems": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": False
+        },
+        "maxProperties": { "$ref": "#/definitions/positiveInteger" },
+        "minProperties": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "required": { "$ref": "#/definitions/stringArray" },
+        "additionalProperties": {
+            "anyOf": [
+                { "type": "boolean" },
+                { "$ref": "#" }
+            ],
+            "default": {}
+        },
+        "definitions": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#" },
+                    { "$ref": "#/definitions/stringArray" }
+                ]
+            }
+        },
+        "enum": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": True
+        },
+        "type": {
+            "anyOf": [
+                { "$ref": "#/definitions/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": True
+                }
+            ]
+        },
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" }
+    },
+    "dependencies": {
+        "exclusiveMaximum": [ "maximum" ],
+        "exclusiveMinimum": [ "minimum" ]
+    },
+    "default": {}
+}
+
+
+def get_draft_schema():
+    return draft4_schema
+
+
+def get_validator():
+    return jsonschema.Draft4Validator
+
+
+def get_parameter_schema(model):
+    # Dynamically construct JSON schema from the parameters metadata.
+    schema = {"$schema": cfg.CONF.schema.draft}
+    from st2common.util.action_db import get_runnertype_by_name
+    runner_type = get_runnertype_by_name(model.runner_type['name'])
+    runner_params = [(k, v) for k, v in runner_type.runner_parameters.iteritems() if v]
+    params = [(k, v) for k, v in model.parameters.iteritems() if v]
+    required = list(set(runner_type.required_parameters + model.required_parameters))
+    properties = runner_params + params
+    if properties:
+        schema['title'] = model.name
+        schema['description'] = model.description
+        schema['type'] = 'object'
+        schema['properties'] = dict()
+        schema['required'] = required
+        schema['additionalProperties'] = False
+        for p in properties:
+            name = p[0]
+            metadata = p[1]
+            if name not in schema['properties']:
+                schema['properties'][name] = metadata
+    return schema

--- a/st2common/tests/test_watcher.py
+++ b/st2common/tests/test_watcher.py
@@ -77,7 +77,7 @@ class WatcherTest(DbTestCase):
 
         watcher.watch(func, ExampleDB, watch.INSERT)
 
-        eventlet.sleep(0)
+        eventlet.sleep(1)
 
         doc = self._create_and_save_test_document()
         self._delete_test_document(doc)

--- a/st2reactorcontroller/tests/controllers/test_rules.py
+++ b/st2reactorcontroller/tests/controllers/test_rules.py
@@ -57,7 +57,7 @@ class TestRuleController(FunctionalTest):
         RUNNER_TYPE.id = None
         RunnerType.add_or_update(RUNNER_TYPE)
         ACTION.id = None
-        ACTION.runner_type = RUNNER_TYPE
+        ACTION.runner_type = {'name': RUNNER_TYPE.name}
         Action.add_or_update(ACTION)
         TRIGGER.id = None
         Trigger.add_or_update(TRIGGER)


### PR DESCRIPTION
Refactor action and runner type parameters to include metadata.
- Each parameter in the dictionary is expected to comform to jsonschema.
- The parameters are dynamically composed into a single schema document.
- The input parameters from execution are validated.
- The action, runner type, and action execution controllers uses jsonschema instead of wsme.
- The runner_type field in ActionDB is now a DictField and no longer a MongoDB object reference.
