### PR TITLE
[STORM-378] CLI for action metadata

### DIFF
--- a/st2client/st2client/client.py
+++ b/st2client/st2client/client.py
@@ -30,6 +30,8 @@ class Client(object):
 
         # Instantiate resource managers and assign appropriate API endpoint.
         self.managers = dict()
+        self.managers['RunnerType'] = models.ResourceManager(
+            models.RunnerType, self.endpoints['action'])
         self.managers['Action'] = models.ResourceManager(
             models.Action, self.endpoints['action'])
         self.managers['ActionExecution'] = models.ResourceManager(
@@ -40,6 +42,10 @@ class Client(object):
             models.Trigger, self.endpoints['reactor'])
         self.managers['KeyValuePair'] = models.ResourceManager(
             models.KeyValuePair, self.endpoints['datastore'])
+
+    @property
+    def runners(self):
+        return self.managers['RunnerType']
 
     @property
     def actions(self):

--- a/st2client/st2client/commands/__init__.py
+++ b/st2client/st2client/commands/__init__.py
@@ -40,7 +40,7 @@ class Command(object):
         self.parser.set_defaults(func=self.run_and_print)
 
     @abc.abstractmethod
-    def run(self, args):
+    def run(self, args, **kwargs):
         """
         This method should be invoked from run_and_print. The separation of run
         is to let the core logic be testable.
@@ -48,7 +48,7 @@ class Command(object):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def run_and_print(self, args):
+    def run_and_print(self, args, **kwargs):
         """
         This method is invoked when the corresponding command is executed
         from the command line.

--- a/st2client/st2client/commands/datastore.py
+++ b/st2client/st2client/commands/datastore.py
@@ -50,12 +50,12 @@ class KeyValuePairCreateCommand(resource.ResourceCommand):
                                  action='store_true', dest='json',
                                  help='Prints output in JSON format.')
 
-    def run(self, args):
+    def run(self, args, **kwargs):
         instance = self.resource(name=args.name, value=args.value)
         return self.manager.create(instance)
 
-    def run_and_print(self, args):
-        instance = self.run(args)
+    def run_and_print(self, args, **kwargs):
+        instance = self.run(args, **kwargs)
         self.print_output(instance, table.PropertyValueTable,
                           attributes=['id', 'name', 'value'], json=args.json)
 
@@ -75,13 +75,13 @@ class KeyValuePairUpdateCommand(resource.ResourceCommand):
                                  action='store_true', dest='json',
                                  help='Prints output in JSON format.')
 
-    def run(self, args):
+    def run(self, args, **kwargs):
         instance = self.get_resource(args.name_or_id)
         instance.value = args.value
         return self.manager.update(instance)
 
-    def run_and_print(self, args):
-        instance = self.run(args)
+    def run_and_print(self, args, **kwargs):
+        instance = self.run(args, **kwargs)
         self.print_output(instance, table.PropertyValueTable,
                           attributes=['id', 'name', 'value'], json=args.json)
 
@@ -101,7 +101,7 @@ class KeyValuePairLoadCommand(resource.ResourceCommand):
                                  action='store_true', dest='json',
                                  help='Prints output in JSON format.')
 
-    def run(self, args):
+    def run(self, args, **kwargs):
         if not os.path.isfile(args.file):
             raise Exception('File "%s" does not exist.' % args.file)
         with open(args.file, 'r') as f:
@@ -120,7 +120,7 @@ class KeyValuePairLoadCommand(resource.ResourceCommand):
                     instances.append(self.manager.update(instance))
             return instances
 
-    def run_and_print(self, args):
-        instances = self.run(args)
+    def run_and_print(self, args, **kwargs):
+        instances = self.run(args, **kwargs)
         self.print_output(instances, table.MultiColumnTable,
                           attributes=['id', 'name', 'value'], json=args.json)

--- a/st2client/st2client/commands/resource.py
+++ b/st2client/st2client/commands/resource.py
@@ -107,11 +107,11 @@ class ResourceListCommand(ResourceCommand):
                                  action='store_true', dest='json',
                                  help='Prints output in JSON format.')
 
-    def run(self, args):
+    def run(self, args, **kwargs):
         return self.manager.get_all()
 
-    def run_and_print(self, args):
-        instances = self.run(args)
+    def run_and_print(self, args, **kwargs):
+        instances = self.run(args, **kwargs)
         self.print_output(instances, table.MultiColumnTable,
                           attributes=args.attr, widths=args.width,
                           json=args.json)
@@ -139,12 +139,12 @@ class ResourceGetCommand(ResourceCommand):
                                  action='store_true', dest='json',
                                  help='Prints output in JSON format.')
 
-    def run(self, args):
+    def run(self, args, **kwargs):
         return self.get_resource(args.name_or_id)
 
-    def run_and_print(self, args):
+    def run_and_print(self, args, **kwargs):
         try:
-            instance = self.run(args)
+            instance = self.run(args, **kwargs)
             self.print_output(instance, table.PropertyValueTable,
                               attributes=args.attr, json=args.json)
         except ResourceNotFoundError as e:
@@ -165,7 +165,7 @@ class ResourceCreateCommand(ResourceCommand):
                                  action='store_true', dest='json',
                                  help='Prints output in JSON format.')
 
-    def run(self, args):
+    def run(self, args, **kwargs):
         if not os.path.isfile(args.file):
             raise Exception('File "%s" does not exist.' % args.file)
         with open(args.file, 'r') as f:
@@ -173,8 +173,8 @@ class ResourceCreateCommand(ResourceCommand):
             instance = self.resource.deserialize(data)
             return self.manager.create(instance)
 
-    def run_and_print(self, args):
-        instance = self.run(args)
+    def run_and_print(self, args, **kwargs):
+        instance = self.run(args, **kwargs)
         self.print_output(instance, table.PropertyValueTable,
                           attributes=['all'], json=args.json)
 
@@ -197,7 +197,7 @@ class ResourceUpdateCommand(ResourceCommand):
                                  action='store_true', dest='json',
                                  help='Prints output in JSON format.')
 
-    def run(self, args):
+    def run(self, args, **kwargs):
         if not os.path.isfile(args.file):
             raise Exception('File "%s" does not exist.' % args.file)
         instance = self.get_resource(args.name_or_id)
@@ -214,8 +214,8 @@ class ResourceUpdateCommand(ResourceCommand):
                                     self.resource.get_display_name().lower())
             return self.manager.update(modified_instance)
 
-    def run_and_print(self, args):
-        instance = self.run(args)
+    def run_and_print(self, args, **kwargs):
+        instance = self.run(args, **kwargs)
         self.print_output(instance, table.PropertyValueTable,
                           attributes=['all'], json=args.json)
 
@@ -232,12 +232,12 @@ class ResourceDeleteCommand(ResourceCommand):
                                  help=('Name or ID of the %s.' %
                                        resource.get_display_name().lower()))
 
-    def run(self, args):
+    def run(self, args, **kwargs):
         instance = self.get_resource(args.name_or_id)
         self.manager.delete(instance)
 
-    def run_and_print(self, args):
+    def run_and_print(self, args, **kwargs):
         try:
-            instance = self.run(args)
+            instance = self.run(args, **kwargs)
         except ResourceNotFoundError as e:
             self.print_not_found(args.name)

--- a/st2client/st2client/models/action.py
+++ b/st2client/st2client/models/action.py
@@ -7,9 +7,10 @@ LOG = logging.getLogger(__name__)
 
 
 class RunnerType(core.Resource):
-    _display_name = 'Runner Type'
+    _alias = 'Runner'
+    _display_name = 'Runner'
     _plural = 'RunnerTypes'
-    _plural_display_name = 'Runner Types'
+    _plural_display_name = 'Runners'
 
 
 class Action(core.Resource):

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -90,9 +90,12 @@ class Shell(object):
         self.commands['action'] = action.ActionBranch(
             'An activity that happens as a response to the external event.',
             self, self.subparsers)
+        self.commands['runner'] = resource.ResourceBranch(
+            models.RunnerType,
+            'Runner is a type of handler for a specific class of actions.',
+            self, self.subparsers, read_only=True)
         self.commands['run'] = action.ActionRunCommand(
-            models.Action, self, self.subparsers,
-            name='run', add_help=False)
+            models.Action, self, self.subparsers, name='run', add_help=False)
         self.commands['execution'] = action.ActionExecutionBranch(
             'An invocation of an action.',
             self, self.subparsers)
@@ -118,7 +121,7 @@ class Shell(object):
             self.client = self.get_client(args)
 
             # Execute command.
-            args.func(args)
+            args.func(args, argv=argv)
 
             return 0
         except Exception as e:

--- a/st2client/tests/test_shell.py
+++ b/st2client/tests/test_shell.py
@@ -120,6 +120,13 @@ class TestShell(unittest2.TestCase):
         ]
         self._validate_parser(args_list)
 
+    def test_runner(self):
+        args_list = [
+            ['runner', 'list'],
+            ['runner', 'get', 'abc']
+        ]
+        self._validate_parser(args_list)
+
     def test_action(self):
         args_list = [
             ['action', 'list'],


### PR DESCRIPTION
Refactor the help message for action to display metadata. The runner
parameters is not displayed on action get so not to confuse user. The
runner parameters is displayed in action help message. Runner type get
and list are also implemented.

Examples:
st2 run local -h
st2 action execute local -h
