### PR TITLE
Use eventlet.wsgi server rather than wsgiref server.

### DIFF
--- a/st2actioncontroller/st2actioncontroller/cmd/actioncontroller.py
+++ b/st2actioncontroller/st2actioncontroller/cmd/actioncontroller.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 from oslo.config import cfg
-from wsgiref import simple_server
+from eventlet import wsgi
 
 from st2common import log as logging
 from st2common.models.db import db_setup
@@ -62,12 +62,10 @@ def __run_server():
     host = cfg.CONF.action_controller_api.host
     port = cfg.CONF.action_controller_api.port
 
-    server = simple_server.make_server(host, port, app.setup_app())
-
     LOG.info("action API is serving on http://%s:%s (PID=%s)",
              host, port, os.getpid())
 
-    server.serve_forever()
+    wsgi.server(eventlet.listen((host, port)), app.setup_app())
 
 
 def __teardown():

--- a/st2actionrunnercontroller/st2actionrunnercontroller/cmd/actionrunnercontroller.py
+++ b/st2actionrunnercontroller/st2actionrunnercontroller/cmd/actionrunnercontroller.py
@@ -3,12 +3,13 @@ import os
 import sys
 
 from oslo.config import cfg
+from eventlet import wsgi
+
 from st2common import log as logging
 from st2common.models.db import db_setup
 from st2common.models.db import db_teardown
 from st2actionrunnercontroller import config
 from st2actionrunnercontroller import app
-from wsgiref import simple_server
 
 
 eventlet.monkey_patch(
@@ -37,12 +38,10 @@ def __run_server():
     host = cfg.CONF.actionrunner_controller_api.host
     port = cfg.CONF.actionrunner_controller_api.port
 
-    server = simple_server.make_server(host, port, app.setup_app())
-
     LOG.info("actionrunner API is serving on http://%s:%s (PID=%s)",
              host, port, os.getpid())
 
-    server.serve_forever()
+    wsgi.server(eventlet.listen((host, port)), app.setup_app())
 
 
 def __teardown():

--- a/st2datastore/st2datastore/cmd/datastore.py
+++ b/st2datastore/st2datastore/cmd/datastore.py
@@ -3,12 +3,13 @@ import os
 import sys
 
 from oslo.config import cfg
+from eventlet import wsgi
+
 from st2common import log as logging
 from st2common.models.db import db_setup
 from st2common.models.db import db_teardown
 from st2datastore import app
 from st2datastore import config
-from wsgiref import simple_server
 
 
 eventlet.monkey_patch(
@@ -39,12 +40,10 @@ def __run_server():
     host = cfg.CONF.datastore_api.host
     port = cfg.CONF.datastore_api.port
 
-    server = simple_server.make_server(host, port, app.setup_app())
-
     LOG.info("Datastore API is serving on http://%s:%s (PID=%s)",
              host, port, os.getpid())
 
-    server.serve_forever()
+    wsgi.server(eventlet.listen((host, port)), app.setup_app())
 
 
 def __teardown():

--- a/st2reactorcontroller/st2reactorcontroller/cmd/reactorcontroller.py
+++ b/st2reactorcontroller/st2reactorcontroller/cmd/reactorcontroller.py
@@ -3,12 +3,13 @@ import os
 import sys
 
 from oslo.config import cfg
+from eventlet import wsgi
+
 from st2common import log as logging
 from st2common.models.db import db_setup
 from st2common.models.db import db_teardown
 from st2reactorcontroller import app
 from st2reactorcontroller import config
-from wsgiref import simple_server
 
 
 eventlet.monkey_patch(
@@ -43,12 +44,10 @@ def __run_server():
     host = cfg.CONF.reactor_controller_api.host
     port = cfg.CONF.reactor_controller_api.port
 
-    server = simple_server.make_server(host, port, app.setup_app())
-
     LOG.info("reactor API is serving on http://%s:%s (PID=%s)",
              host, port, os.getpid())
 
-    server.serve_forever()
+    wsgi.server(eventlet.listen((host, port)), app.setup_app())
 
 
 def __teardown():


### PR DESCRIPTION
- Using eventlet.wsgi allows multiple client connections to be handled
  simultaneously.
