### PR TITLE
NotUniqueErrors are logged at warn instead of error.

### DIFF
--- a/st2actioncontroller/st2actioncontroller/controllers/actions.py
+++ b/st2actioncontroller/st2actioncontroller/controllers/actions.py
@@ -116,8 +116,8 @@ class ActionsController(RestController):
             action_db = Action.add_or_update(action_model)
         except NotUniqueError as e:
             # If an existing DB object conflicts with new object then raise error.
-            LOG.exception('/actions/ POST unable to save ActionDB object "%s" due to uniqueness '
-                          'conflict. %s', action_model, e)
+            LOG.warn('/actions/ POST unable to save ActionDB object "%s" due to uniqueness '
+                     'conflict. %s', action_model, str(e))
             abort(httplib.CONFLICT, str(e))
         except Exception as e:
             LOG.exception('/actions/ POST unable to save ActionDB object "%s". %s',

--- a/st2reactorcontroller/st2reactorcontroller/controllers/rules.py
+++ b/st2reactorcontroller/st2reactorcontroller/controllers/rules.py
@@ -77,7 +77,8 @@ class RuleController(RestController):
             abort(httplib.BAD_REQUEST, str(e))
             return
         except NotUniqueError as e:
-            LOG.exception('Rule creation of %s failed with uniqueness conflict.', rule)
+            LOG.warn('Rule creation of %s failed with uniqueness conflict. Exception %s',
+                     rule, str(e))
             abort(httplib.CONFLICT, str(e))
             return
 

--- a/st2reactorcontroller/st2reactorcontroller/controllers/triggers.py
+++ b/st2reactorcontroller/st2reactorcontroller/controllers/triggers.py
@@ -193,7 +193,8 @@ class TriggerController(RestController):
             LOG.exception('Validation failed for trigger data=%s.', trigger)
             abort(httplib.BAD_REQUEST, str(e))
         except NotUniqueError as e:
-            LOG.exception('Trigger creation of %s failed with uniqueness conflict.', trigger)
+            LOG.warn('Trigger creation of %s failed with uniqueness conflict. Exception %s',
+                     trigger, str(e))
             abort(httplib.CONFLICT, str(e))
 
         LOG.audit('Trigger created. Trigger=%s', trigger_db)


### PR DESCRIPTION
- It is quite possible for clients to retry creation of entities.
  Marking these as warn to reduce severity as it is ignorable.
