### PR TITLE
[STORM-408] Fix no json could be decoded error on st2 run

### DIFF
--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -89,7 +89,10 @@ class ActionRunCommand(resource.ResourceCommand):
 
             sys.stdout.write('\n')
 
-            execution.result = json.loads(execution.result)
+            try:
+                execution.result = json.loads(execution.result)
+            except:
+                pass
 
         return execution
 


### PR DESCRIPTION
On action failure, result may be empty and cannot be loaded as JSON.

Closes: STORM-408
