### PR TITLE
Reduction in logging

### DIFF
--- a/st2actioncontroller/st2actioncontroller/controllers/actionexecutions.py
+++ b/st2actioncontroller/st2actioncontroller/controllers/actionexecutions.py
@@ -78,10 +78,7 @@ class ActionExecutionsController(RestController):
 
         custom_headers = self._create_custom_headers()
         payload = self._create_liveaction_data(actionexec_id)
-        LOG.info('Payload for /liveactions/ POST: data="%s" custom_headers="%s"',
-                 payload, custom_headers)
-        LOG.info('Issuing /liveactions/ POST for ActionExecution with id ="%s"', actionexec_id)
-
+        LOG.info('Issuing /liveactions/ POST data=%s custom_headers=%s', payload, custom_headers)
         request_error = False
         result = None
         try:
@@ -192,11 +189,7 @@ class ActionExecutionsController(RestController):
             LOG.error('POST /actionexecutions/ Action for "%s" cannot be found.',
                       actionexecution.action)
             abort(httplib.NOT_FOUND, 'Unable to find action.')
-        else:
-            if action_dict != dict(actionexecution.action):
-                LOG.info('POST /actionexecutions/ Action identity dict updated to remove '
-                         'lookup failure.')
-                actionexecution.action = action_dict
+        actionexecution.action = action_dict
 
         # If the Action is disabled, abort the POST call.
         if not action_db.enabled:
@@ -222,17 +215,9 @@ class ActionExecutionsController(RestController):
         # Set initial value for ActionExecution status.
         # Not using update_actionexecution_status to allow other initialization to
         # be done before saving to DB.
-        LOG.debug('Setting actionexecution status to "%s"', ACTIONEXEC_STATUS_INIT)
         actionexecution.status = ACTIONEXEC_STATUS_INIT
-
-        LOG.info('POST /actionexecutions/ with actionexec data=%s', actionexecution)
-        actionexec_api = ActionExecutionAPI.to_model(actionexecution)
-        LOG.debug('/actionexecutions/ POST verified ActionExecutionAPI object=%s',
-                  actionexec_api)
-
-        actionexec_db = ActionExecution.add_or_update(actionexec_api)
-        LOG.debug('/actionexecutions/ POST saved ActionExecution object=%s', actionexec_db)
-
+        actionexec_db = ActionExecutionAPI.to_model(actionexecution)
+        actionexec_db = ActionExecution.add_or_update(actionexec_db)
         LOG.audit('ActionExecution created. ActionExecution=%s. ', actionexec_db)
 
         actionexec_id = actionexec_db.id

--- a/st2actioncontroller/st2actioncontroller/model/__init__.py
+++ b/st2actioncontroller/st2actioncontroller/model/__init__.py
@@ -128,26 +128,25 @@ def register_runner_types():
         }
     ]
 
-    LOG.debug('Registering runnertypes')
+    LOG.info('Start : register default RunnerTypes.')
 
     for runnertype in RUNNER_TYPES:
         try:
             runnertype_db = get_runnertype_by_name(runnertype['name'])
             if runnertype_db:
+                LOG.info('RunnerType name=%s exists.', runnertype['name'])
                 continue
         except StackStormDBObjectNotFoundError:
-            LOG.debug('RunnerType "%s" does not exist in DB.', runnertype['name'])
+            pass
 
         runnertype_api = RunnerTypeAPI(**runnertype)
-        LOG.debug('RunnerType after field population: %s', runnertype_api)
         try:
             runnertype_db = RunnerType.add_or_update(RunnerTypeAPI.to_model(runnertype_api))
-            LOG.debug('created runnertype name=%s in DB. Object: %s',
-                      runnertype['name'], runnertype_db)
-        except Exception as e:
-            LOG.exception('Unable to register runner type %s. %s', runnertype['name'], e)
+            LOG.audit('RunnerType created. RunnerType %s', runnertype_db)
+        except Exception:
+            LOG.exception('Unable to register runner type %s.', runnertype['name'])
 
-    LOG.debug('Registering runnertypes complete.')
+    LOG.info('End : register default RunnerTypes.')
 
 
 def register_actions():
@@ -179,9 +178,9 @@ def register_actions():
                 continue
             try:
                 model = Action.add_or_update(model)
-                LOG.debug('Added action %s from %s.', model.name, action)
-            except Exception as e:
-                LOG.exception('Failed to register action %s. %s', model.name, e)
+                LOG.audit('Action created. Action %s from %s.', model, action)
+            except Exception:
+                LOG.exception('Failed to create action %s.', model.name)
 
 
 def init_model():

--- a/st2actionrunnercontroller/conf/logging.conf
+++ b/st2actionrunnercontroller/conf/logging.conf
@@ -13,13 +13,13 @@ handlers=consoleHandler, fileHandler, auditHandler
 
 [handler_consoleHandler]
 class=StreamHandler
-level=DEBUG
+level=INFO
 formatter=simpleFormatter
 args=(sys.stdout,)
 
 [handler_fileHandler]
 class=FileHandler
-level=DEBUG
+level=INFO
 formatter=verboseFormatter
 args=("logs/st2actionrunnercontroller.log",)
 

--- a/st2actionrunnercontroller/st2actionrunner/container/actionsensor.py
+++ b/st2actionrunnercontroller/st2actionrunner/container/actionsensor.py
@@ -34,7 +34,7 @@ ACTION_TRIGGER_TYPE = {
 
 
 def _do_register_trigger_type(attempt_no=0):
-    LOG.info('Attempt no %s to register %s.', attempt_no, ACTION_TRIGGER_TYPE['name'])
+    LOG.debug('Attempt no %s to register %s.', attempt_no, ACTION_TRIGGER_TYPE['name'])
     try:
         payload = json.dumps(ACTION_TRIGGER_TYPE)
         r = requests.post(TRIGGER_TYPE_ENDPOINT,
@@ -51,7 +51,6 @@ def _do_register_trigger_type(attempt_no=0):
     except requests.exceptions.ConnectionError:
         if attempt_no < MAX_ATTEMPTS:
             eventlet.spawn_after(RETRY_WAIT, _do_register_trigger_type, attempt_no + 1)
-            eventlet.sleep(0)
         else:
             LOG.exception('Exceeded max attempts to register trigger %s.',
                           ACTION_TRIGGER_TYPE['name'])

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -81,22 +81,18 @@ class RunnerTypeAPI(BaseAPI):
 
     @classmethod
     def from_model(cls, model):
-        LOG.debug('entering RctionTypeAPI.from_model() Input object: %s', model)
         runnertype = model.to_mongo()
         runnertype['id'] = str(runnertype['_id'])
         del runnertype['_id']
-        LOG.debug('exiting RunnerTypeAPI.from_model() Result object: %s', runnertype)
         return cls(**runnertype)
 
     @classmethod
     def to_model(cls, runnertype):
-        LOG.debug('entering RunnerTypeAPI.to_model() Input object: %s', runnertype)
         model = StormBaseAPI.to_model(RunnerTypeDB, runnertype)
         model.enabled = bool(runnertype.enabled)
         model.runner_module = str(runnertype.runner_module)
         model.runner_parameters = getattr(runnertype, 'runner_parameters', dict())
         model.required_parameters = getattr(runnertype, 'required_parameters', list())
-        LOG.debug('exiting RunnerTypeAPI.to_model() Result object: %s', model)
         return model
 
 
@@ -164,24 +160,20 @@ class ActionAPI(BaseAPI):
 
     @classmethod
     def from_model(cls, model):
-        LOG.debug('entering ActionAPI.from_model() Input object: %s', model)
         action = model.to_mongo()
         action['id'] = str(action['_id'])
         action['runner_type'] = action['runner_type']['name']
         del action['_id']
-        LOG.debug('exiting ActionAPI.from_model() Result object: %s', action)
         return cls(**action)
 
     @classmethod
     def to_model(cls, action):
-        LOG.debug('entering ActionAPI.to_model() Input object: %s', action)
         model = StormBaseAPI.to_model(ActionDB, action)
         model.enabled = bool(action.enabled)
         model.entry_point = str(action.entry_point)
         model.runner_type = {'name': str(action.runner_type)}
         model.parameters = getattr(action, 'parameters', dict())
         model.required_parameters = getattr(action, 'required_parameters', list())
-        LOG.debug('exiting ActionAPI.to_model() Result object: %s', model)
         return model
 
 
@@ -272,22 +264,18 @@ class ActionExecutionAPI(BaseAPI):
 
     @classmethod
     def from_model(cls, model):
-        LOG.debug('entering ActionExecutionAPI.from_model() Input object: %s', model)
         execution = model.to_mongo()
         execution['id'] = str(execution['_id'])
         del execution['_id']
         result = cls(**execution)
-        LOG.debug('exiting ActionExecutionAPI.from_model() Result object: %s', result)
         return result
 
     @classmethod
     def to_model(cls, execution):
-        LOG.debug('entering ActionExecutionAPI.to_model() Input object: %s', execution)
         model = StormFoundationAPI.to_model(ActionExecutionDB, execution)
         model.status = str(execution.status)
         model.start_timestamp = execution.start_timestamp
         model.action = execution.action
         model.parameters = dict(execution.parameters)
         setattr(model, 'result', getattr(execution, 'result', None))
-        LOG.debug('exiting ActionExecutionAPI.to_model() Result object: %s', model)
         return model

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -57,7 +57,6 @@ class MongoDBAccess(object):
 
     @staticmethod
     def add_or_update(model_object):
-        LOG.debug('MongoDBAccess.add_or_update() model_object=%s', model_object)
         return model_object.save()
 
     @staticmethod

--- a/st2common/st2common/util/action_db.py
+++ b/st2common/st2common/util/action_db.py
@@ -33,7 +33,6 @@ def get_runnertype_by_name(runnertype_name):
             Get an runnertype by name.
             On error, raise ST2ObjectNotFoundError.
         """
-        LOG.debug('Lookup for runnertype with name="%s"', runnertype_name)
         try:
             runnertypes = RunnerType.query(name=runnertype_name)
         except (ValueError, ValidationError) as e:


### PR DESCRIPTION
- Pare back the logging to make it possible to debug with supplied
  logs.
- Add in logs where necessary to help with flow.
- The only principle embodied in this change is avoid logging the same
  thing twice.
