### PR TITLE
[STORM-422] Make cmd param in shell runner optional

### DIFF
--- a/st2actioncontroller/st2actioncontroller/controllers/actionexecutions.py
+++ b/st2actioncontroller/st2actioncontroller/controllers/actionexecutions.py
@@ -185,6 +185,7 @@ class ActionExecutionsController(RestController):
             setattr(actionexecution, 'runner_parameters', {})
 
         (action_db, action_dict) = get_action_by_dict(actionexecution.action)
+        LOG.debug('POST /actionexecutions/ Action=%s', action_db)
 
         if not action_db:
             LOG.error('POST /actionexecutions/ Action for "%s" cannot be found.',
@@ -200,6 +201,7 @@ class ActionExecutionsController(RestController):
 
         # Assign default parameters
         runnertype = get_runnertype_by_name(action_db.runner_type['name'])
+        LOG.debug('POST /actionexecutions/ Runner=%s', runnertype)
         for key, metadata in runnertype.runner_parameters.iteritems():
             if key not in actionexecution.parameters and 'default' in metadata:
                 if metadata.get('default') is not None:
@@ -208,10 +210,12 @@ class ActionExecutionsController(RestController):
         # Validate action parameters
         schema = util.schema.get_parameter_schema(action_db)
         try:
+            LOG.debug('POST /actionexecutions/ Validation for parameters=%s & schema=%s',
+                      actionexecution.parameters, schema)
             jsonschema.validate(actionexecution.parameters, schema)
+            LOG.debug('POST /actionexecutions/ Parameter validation passed.')
         except jsonschema.ValidationError as e:
-            LOG.error('POST /actionexecutions/ Validation failed on input parameters. '
-                      'Parameters: %s; Action is: %s' % (actionexecution.parameters, action_db))
+            LOG.error('POST /actionexecutions/ Parameter validation failed. %s', actionexecution)
             abort(httplib.BAD_REQUEST, str(e))
 
         # Set initial value for ActionExecution status.

--- a/st2actioncontroller/st2actioncontroller/model/__init__.py
+++ b/st2actioncontroller/st2actioncontroller/model/__init__.py
@@ -55,7 +55,6 @@ def register_runner_types():
                     'type': 'string'
                 }
             },
-            'required_parameters': ['cmd'],
             'runner_module': 'st2actionrunner.runners.fabricrunner'
         },
         {
@@ -95,7 +94,7 @@ def register_runner_types():
                     'type': 'string'
                 }
             },
-            'required_parameters': ['hosts', 'cmd'],
+            'required_parameters': ['hosts'],
             'runner_module': 'st2actionrunner.runners.fabricrunner'
         },
         {

--- a/st2actioncontroller/tests/controllers/test_actionexecutions.py
+++ b/st2actioncontroller/tests/controllers/test_actionexecutions.py
@@ -13,7 +13,7 @@ ACTION_1 = {
     'description': 'test description',
     'enabled': True,
     'entry_point': '/tmp/test/action1.sh',
-    'runner_type': 'run-local',
+    'runner_type': 'run-remote',
     'parameters': {
         'a': {
             'type': 'string',
@@ -31,7 +31,7 @@ ACTION_2 = {
     'description': 'another test description',
     'enabled': True,
     'entry_point': '/tmp/test/action2.sh',
-    'runner_type': 'run-local',
+    'runner_type': 'run-remote',
     'parameters': {
         'c': {
             'type': 'object',
@@ -53,7 +53,7 @@ ACTION_3 = {
     'description': 'another test description',
     'enabled': True,
     'entry_point': '/tmp/test/action3.sh',
-    'runner_type': 'run-local',
+    'runner_type': 'run-remote',
     'parameters': {
         'e': {},
         'f': {}
@@ -63,6 +63,7 @@ ACTION_3 = {
 ACTION_EXECUTION_1 = {
     'action': {'name': 'st2.dummy.action1'},
     'parameters': {
+        'hosts': 'localhost',
         'cmd': 'uname -a'
     }
 }
@@ -70,6 +71,7 @@ ACTION_EXECUTION_1 = {
 ACTION_EXECUTION_2 = {
     'action': {'name': 'st2.dummy.action2'},
     'parameters': {
+        'hosts': 'localhost',
         'cmd': 'ls -l'
     }
 }
@@ -77,6 +79,7 @@ ACTION_EXECUTION_2 = {
 ACTION_EXECUTION_3 = {
     'action': {'name': 'st2.dummy.action3'},
     'parameters': {
+        'hosts': 'localhost',
         'cmd': 'ls -l',
         'e': 'abcde',
         'f': 12345
@@ -238,13 +241,13 @@ class TestActionExecutionsController(FunctionalTest):
         post_resp = self.__do_post(execution, expect_errors=True)
         self.assertEquals(post_resp.status_int, 400)
 
-        # Runner type expects parameter "cmd".
+        # Runner type expects parameter "hosts".
         execution['parameters'] = {}
         post_resp = self.__do_post(execution, expect_errors=True)
         self.assertEquals(post_resp.status_int, 400)
 
         # Runner type expects parameters "cmd" to be str.
-        execution['parameters'] = {"cmd": 1000}
+        execution['parameters'] = {"hosts": "localhost", "cmd": 1000}
         post_resp = self.__do_post(execution, expect_errors=True)
         self.assertEquals(post_resp.status_int, 400)
 

--- a/st2common/st2common/util/schema.py
+++ b/st2common/st2common/util/schema.py
@@ -194,6 +194,7 @@ def get_parameter_schema(model):
         schema['description'] = model.description
         schema['type'] = 'object'
         schema['properties'] = properties
-        schema['required'] = required
+        if required:
+            schema['required'] = required
         schema['additionalProperties'] = False
     return schema


### PR DESCRIPTION
Modify the run-local and run-remote runner to have cmd as optional
parameters. There are use cases where shell script do not take
positional arguments.

Closes: STORM-422
