### PR TITLE
Implement repr to BaseAPI

### DIFF
--- a/st2common/st2common/models/base.py
+++ b/st2common/st2common/models/base.py
@@ -45,11 +45,17 @@ class BaseAPI(object):
         for key, value in kw.items():
             setattr(self, key, value)
 
+    def __repr__(self):
+        name = type(self).__name__
+        attrs = ', '.join("'%s':%r" % item for item in vars(self).iteritems())
+        # The format here is so that eval can be applied.
+        return "%s(**{%s})" % (name, attrs)
+
     def __str__(self):
         name = type(self).__name__
         attrs = ', '.join("%s=%r" % item for item in vars(self).iteritems())
 
-        return "%s [%s]" % (name, attrs)
+        return "%s[%s]" % (name, attrs)
 
     def __json__(self):
         return vars(self)


### PR DESCRIPTION
- repr is used to represent an object when a container collection is
  tested.
- picking peculiar repr formatting so that eval works correctly.
