### PR TITLE
Make flake8 checks optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ nosetests.xml
 .idea
 .DS_Store
 ._*
+screenlog.*
 
 # Generated documentation
 docs/html

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ flake8: requirements
 	@echo
 	@echo "====================flake===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate; flake8 --config ./.flake8 $(COMPONENTS)
+	. $(VIRTUALENV_DIR)/bin/activate; flake8 --config ./.flake8 $(COMPONENTS) || exit 0
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
The failing of flake tests prevents later parts of Makefile from being executed. While it might make sense later, when we fix all the issues in code, right now it gets in a way of testing other things out.
