### PR TITLE
WIP: Resolve criterion key as Jinja variable

### DIFF
--- a/contrib/examples/rules/sample-rule-with-actiontrigger.json
+++ b/contrib/examples/rules/sample-rule-with-actiontrigger.json
@@ -9,11 +9,11 @@
     },
 
     "criteria": {
-        "action_name": {
+        "trigger.action_name": {
             "pattern": "local",
             "type": "equals"
         },
-        "status": {
+        "trigger.status": {
             "pattern": "error",
             "type": "equals"
         }

--- a/contrib/examples/rules/sample-rule.json
+++ b/contrib/examples/rules/sample-rule.json
@@ -8,7 +8,7 @@
     },
 
     "criteria": {
-        "work": {
+        "trigger.work": {
             "pattern": "done",
             "type": "equals"
         }

--- a/contrib/sandbox/packages/correlation/rules/aggregate-ordered-events-rule2.json
+++ b/contrib/sandbox/packages/correlation/rules/aggregate-ordered-events-rule2.json
@@ -7,7 +7,7 @@
     },
 
     "criteria": {
-        "event_id": {
+        "trigger.event_id": {
             "pattern": 2000,
             "type": "equals"
         }

--- a/st2common/st2common/models/api/reactor.py
+++ b/st2common/st2common/models/api/reactor.py
@@ -199,6 +199,11 @@ class RuleAPI(BaseAPI):
                                                                                   model.trigger)))
         del rule['trigger']['id']
         del rule['trigger']['name']
+        for oldkey, value in rule['criteria'].iteritems():
+            newkey = oldkey.replace(u'\u2024', '.')
+            if oldkey != newkey:
+                rule['criteria'][newkey] = value
+                del rule['criteria'][oldkey]
         return cls(**rule)
 
     @classmethod
@@ -206,6 +211,11 @@ class RuleAPI(BaseAPI):
         model = StormBaseAPI.to_model(RuleDB, rule)
         model.trigger = TriggerAPI(**rule.trigger)
         model.criteria = dict(rule.criteria)
+        for oldkey, value in model.criteria.iteritems():
+            newkey = oldkey.replace('.', u'\u2024')
+            if oldkey != newkey:
+                model.criteria[newkey] = value
+                del model.criteria[oldkey]
         validator.validate_criteria(model.criteria)
         model.action = ActionExecutionSpecDB()
         model.action.name = rule.action['name']

--- a/st2reactor/tests/test_filter.py
+++ b/st2reactor/tests/test_filter.py
@@ -1,41 +1,69 @@
+import bson
+import copy
 import datetime
-import unittest2
+import mock
 from st2common.models.db.reactor import TriggerDB, TriggerInstanceDB, \
     RuleDB, ActionExecutionSpecDB
 from st2common.models.db.action import ActionDB
 from st2common.util import reference
 from st2reactor.rules.filter import RuleFilter
+from st2tests import DbTestCase
+
 
 MOCK_TRIGGER = TriggerDB()
-MOCK_TRIGGER.id = 'trigger-test.id'
+MOCK_TRIGGER.id = bson.ObjectId()
 MOCK_TRIGGER.name = 'trigger-test.name'
 
 MOCK_TRIGGER_INSTANCE = TriggerInstanceDB()
-MOCK_TRIGGER_INSTANCE.id = 'triggerinstance-test'
+MOCK_TRIGGER_INSTANCE.id = bson.ObjectId()
 MOCK_TRIGGER_INSTANCE.trigger = reference.get_ref_from_model(MOCK_TRIGGER)
-MOCK_TRIGGER_INSTANCE.payload = {'trigger.p1': 'v1'}
+MOCK_TRIGGER_INSTANCE.payload = {'p1': 'v1'}
 MOCK_TRIGGER_INSTANCE.occurrence_time = datetime.datetime.now()
 
 MOCK_ACTION = ActionDB()
-MOCK_ACTION.id = 'action-test-1.id'
+MOCK_ACTION.id = bson.ObjectId()
 MOCK_ACTION.name = 'action-test-1.name'
 
 MOCK_RULE_1 = RuleDB()
-MOCK_RULE_1.id = 'rule-test-1'
+MOCK_RULE_1.id = bson.ObjectId()
+MOCK_RULE_1.name = "some1"
 MOCK_RULE_1.trigger = reference.get_ref_from_model(MOCK_TRIGGER)
 MOCK_RULE_1.criteria = {}
-MOCK_RULE_1.action = ActionExecutionSpecDB()
+MOCK_RULE_1.action = ActionExecutionSpecDB(name="some")
 MOCK_RULE_1.action.action = reference.get_ref_from_model(MOCK_ACTION)
 
 MOCK_RULE_2 = RuleDB()
-MOCK_RULE_2.id = 'rule-test-2'
+MOCK_RULE_2.id = bson.ObjectId()
+MOCK_RULE_1.name = "some2"
 MOCK_RULE_2.trigger = reference.get_ref_from_model(MOCK_TRIGGER)
 MOCK_RULE_2.criteria = {}
-MOCK_RULE_2.action = ActionExecutionSpecDB()
+MOCK_RULE_2.action = ActionExecutionSpecDB(name="some")
 MOCK_RULE_2.action.action = reference.get_ref_from_model(MOCK_ACTION)
 
 
-class FilterTest(unittest2.TestCase):
+@mock.patch.object(reference, 'get_model_from_ref', mock.MagicMock(return_value=MOCK_TRIGGER))
+class FilterTest(DbTestCase):
+    def test_empty_criteria(self):
+        rule = MOCK_RULE_1
+        rule.criteria = {}
+        f = RuleFilter(MOCK_TRIGGER_INSTANCE, rule)
+        self.assertTrue(f.filter(), 'equals check should have failed.')
+
+    def test_empty_payload(self):
+        rule = MOCK_RULE_1
+        rule.criteria = {'trigger.p1': {'type': 'equals', 'pattern': 'v1'}}
+        trigger_instance = copy.deepcopy(MOCK_TRIGGER_INSTANCE)
+        trigger_instance.payload = None
+        f = RuleFilter(trigger_instance, rule)
+        self.assertFalse(f.filter(), 'equals check should have failed.')
+
+    def test_empty_criteria_and_empty_payload(self):
+        rule = MOCK_RULE_1
+        rule.criteria = {}
+        trigger_instance = copy.deepcopy(MOCK_TRIGGER_INSTANCE)
+        trigger_instance.payload = None
+        f = RuleFilter(trigger_instance, rule)
+        self.assertTrue(f.filter(), 'equals check should have failed.')
 
     def test_matchregex_operator_pass_criteria(self):
         rule = MOCK_RULE_1


### PR DESCRIPTION
There was a problem related to MongoDB not being able to store dots in a key, so I've temporarly replaced them with unicode representation (\u2022). Later we would either need to get rid of Mongo or came with better structure for criteria.
