### PR TITLE
Fix: Split out bot tests and python tests as two targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,12 +118,15 @@ web:
 	bower install --config.cwd=$(WEB_DIR) --config.directory=components
 	gulp --cwd $(WEB_DIR) build
 
-.PHONY: stormbot
-stormbot:
+.PHONY: botrqmnts
+botrqmnts:
 	npm install --prefix $(STORMBOT_DIR)
 
 .PHONY: tests
-tests: requirements stormbot
+tests: pytests bottests
+
+.PHONY: pytests
+pytests: requirements
 	@echo
 	@echo "====================tests===================="
 	@echo
@@ -133,6 +136,9 @@ tests: requirements stormbot
 		echo "==========================================================="; \
 		. $(VIRTUALENV_DIR)/bin/activate; nosetests -s -v $$component || exit 1; \
 	done
+
+.PHONY: bottests
+bottests: botrqmnts
 	npm test ../$(STORMBOT_DIR)
 
 .PHONY: install


### PR DESCRIPTION
## This affects your muscle memory and everyday life.
## I split out tests into pytests and bottests. `make tests` still runs both.

To just run python tests, do make pytests. 
To just run bot tests, do make bottests *There are two 't's. Sigh.  
