### PR TITLE
[STORM-424] Fix execution error if action has no description

### DIFF
--- a/st2common/st2common/util/schema.py
+++ b/st2common/st2common/util/schema.py
@@ -191,7 +191,8 @@ def get_parameter_schema(model):
     properties.update(normalize(model.parameters))
     if properties:
         schema['title'] = model.name
-        schema['description'] = model.description
+        if model.description:
+            schema['description'] = model.description
         schema['type'] = 'object'
         schema['properties'] = properties
         if required:


### PR DESCRIPTION
The error is caused by the validation of the dynamic schema generated
for the action parameters. If there is no description in the action, the
description of the schema is assigned NoneType.
