### PR TITLE
RFR: Add pylint checking to Makefile

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,18 @@
+[MESSAGES CONTROL]
+# C0111 Missing docstring 
+# I0011 Warning locally suppressed using disable-msg
+# I0012 Warning locally suppressed using disable-msg
+# W0704 Except doesn't do anything Used when an except clause does nothing but "pass" and there is no "else" clause
+# W0142 Used * or * magic* Used when a function or method is called using *args or **kwargs to dispatch arguments.
+# W0212 Access to a protected member %s of a client class
+# W0232 Class has no __init__ method Used when a class has no __init__ method, neither its parent classes.
+# W0613 Unused argument %r Used when a function or method argument is not used.
+# W0702 No exception's type specified Used when an except clause doesn't specify exceptions type to catch.
+# R0201 Method could be a function
+# W0614 Unused import XYZ from wildcard import
+# R0914 Too many local variables
+# R0912 Too many branches
+# R0915 Too many statements
+# R0913 Too many arguments
+# R0904 Too many public methods
+disable=C0111,I0011,I0012,W0704,W0142,W0212,W0232,W0613,W0702,R0201,W0614,R0914,R0912,R0915,R0913,R0904,R0801

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ play:
 
 
 .PHONY: check
-check: flake8 checklogs
+check: requirements flake8 checklogs
 
 .PHONY: checklogs
 checklogs:
@@ -56,12 +56,23 @@ docs:
 	@echo
 	doxygen $(DOXYGEN_CONFIG)
 
+.PHONY: pylint
+pylint: requirements .pylint
+
+.PHONY: .pylint
+.pylint:
+	@echo
+	@echo "================== pylint ===================="
+	@echo
+	@for component in $(COMPONENTS); do\
+		echo "==========================================================="; \
+		echo "Running pylint on" $$component; \
+		echo "==========================================================="; \
+		. $(VIRTUALENV_DIR)/bin/activate; pylint --rcfile=./.pylintrc $$component/$$component; \
+	done
+
 .PHONY: flake8
-flake8: requirements
-	@echo
-	@echo "====================flake===================="
-	@echo
-	. $(VIRTUALENV_DIR)/bin/activate; flake8 --config ./.flake8 $(COMPONENTS)
+flake8: requirements .flake8
 
 .PHONY: .flake8
 .flake8:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
-flake8
 ipython
 mock>=1.0
 nose
-pep8
 unittest2
+flake8
+pylint


### PR DESCRIPTION
- Add - pylint requirement in test-requirements
- Add - pylint target in Makefile
- Fix - Cleanup flake8 targets in Makefile

pylint is not added to make check target as this will break the build now.
We have to get to a state where pylint won't show errors and then enable it
in make check.
