### PR TITLE
[STORM-467] Escape '.' and '$' as they are reserved characters in mongo.

### DIFF
--- a/conf/stanley.conf
+++ b/conf/stanley.conf
@@ -39,7 +39,7 @@ modules_path = /opt/stackstorm/actions
 
 [ssh_runner]
 user = stanley
-ssh_key_file = /home/vagrant/.ssh/stanley_rsa
+ssh_key_file = /vagrant/.ssh/stanley_rsa
 remote_dir = /tmp
 
 [st2_webhook_sensor]

--- a/st2common/st2common/models/db/action.py
+++ b/st2common/st2common/models/db/action.py
@@ -3,7 +3,7 @@ import mongoengine as me
 
 from st2common import log as logging
 from st2common.models.db import MongoDBAccess
-from st2common.models.db.stormbase import (StormFoundationDB, StormBaseDB)
+from st2common.models.db.stormbase import StormFoundationDB, StormBaseDB, EscapedDynamicField
 
 
 __all__ = ['RunnerTypeDB',
@@ -93,8 +93,8 @@ class ActionExecutionDB(StormFoundationDB):
     parameters = me.DictField(
         default={},
         help_text='The key-value pairs passed as to the action runner &  execution.')
-    result = me.DynamicField(
-        default='',
+    result = EscapedDynamicField(
+        default={},
         help_text='Action defined result.')
     context = me.DictField(
         default={},

--- a/st2common/st2common/models/db/stormbase.py
+++ b/st2common/st2common/models/db/stormbase.py
@@ -1,4 +1,5 @@
 import mongoengine as me
+from st2common.util import mongoescape
 
 
 class StormFoundationDB(me.Document):
@@ -52,3 +53,14 @@ class StormBaseDB(StormFoundationDB):
     meta = {
         'abstract': True
     }
+
+
+class EscapedDynamicField(me.DynamicField):
+
+    def to_mongo(self, value):
+        value = mongoescape.escape_chars(value)
+        return super(EscapedDynamicField, self).to_mongo(value)
+
+    def to_python(self, value):
+        value = super(EscapedDynamicField, self).to_python(value)
+        return mongoescape.unescape_chars(value)

--- a/st2common/st2common/util/mongoescape.py
+++ b/st2common/st2common/util/mongoescape.py
@@ -1,0 +1,37 @@
+import six
+
+# http://docs.mongodb.org/manual/faq/developers/#faq-dollar-sign-escaping
+UNESCAPED = ['.', '$']
+ESCAPED = [u'\uFF0E', u'\uFF04']
+ESCAPE_TRANSLATION = dict(zip(UNESCAPED, ESCAPED))
+UNESCAPE_TRANSLATION = dict(zip(ESCAPED, UNESCAPED))
+
+
+def _translate_chars(field, translation):
+    # Only translate the fields of a dict
+    if not isinstance(field, dict):
+        return field
+    work_items = [(k, v, field) for k, v in six.iteritems(field)]
+    while len(work_items) > 0:
+        work_item = work_items.pop(0)
+        oldkey = work_item[0]
+        value = work_item[1]
+        work_field = work_item[2]
+        newkey = oldkey
+        for t_k, t_v in six.iteritems(translation):
+            newkey = newkey.replace(t_k, t_v)
+        if newkey != oldkey:
+            work_field[newkey] = value
+            del work_field[oldkey]
+        if isinstance(value, dict):
+            nested_work_items = [(k, v, value) for k, v in six.iteritems(value)]
+            work_items.extend(nested_work_items)
+    return field
+
+
+def escape_chars(field):
+    return _translate_chars(field, ESCAPE_TRANSLATION)
+
+
+def unescape_chars(field):
+    return _translate_chars(field, UNESCAPE_TRANSLATION)

--- a/st2common/tests/test_mongoescape.py
+++ b/st2common/tests/test_mongoescape.py
@@ -1,0 +1,27 @@
+import unittest
+
+from st2common.util import mongoescape
+
+
+class TestMongoEscape(unittest.TestCase):
+
+    def test_unnested(self):
+        field = {'k1.k1.k1': 'v1', 'k2$': 'v2', '$k3.': 'v3'}
+        escaped = mongoescape.escape_chars(field)
+        self.assertEqual(escaped, {u'k1\uff0ek1\uff0ek1': 'v1',
+                                   u'k2\uff04': 'v2',
+                                   u'\uff04k3\uff0e': 'v3'}, 'Escaping failed.')
+        unescaped = mongoescape.unescape_chars(escaped)
+        self.assertEqual(unescaped, field, 'Unescaping failed.')
+
+    def test_nested(self):
+        nested_field = {'nk1.nk1.nk1': 'v1', 'nk2$': 'v2', '$nk3.': 'v3'}
+        field = {'k1.k1.k1': nested_field, 'k2$': 'v2', '$k3.': 'v3'}
+        escaped = mongoescape.escape_chars(field)
+        self.assertEqual(escaped, {u'k1\uff0ek1\uff0ek1': {u'\uff04nk3\uff0e': 'v3',
+                                                           u'nk1\uff0enk1\uff0enk1': 'v1',
+                                                           u'nk2\uff04': 'v2'},
+                                   u'k2\uff04': 'v2',
+                                   u'\uff04k3\uff0e': 'v3'}, 'un-escaping failed.')
+        unescaped = mongoescape.unescape_chars(escaped)
+        self.assertEqual(unescaped, field, 'Unescaping failed.')


### PR DESCRIPTION
- The result field of ActionExecution is a DynamicField and the key of any
  dict supplied as part of a result could be a reserved characted which must
  by escaped.
- Created a new field type EscapedDynamicField and a utility to escape and
  unescape reserved chars.
