### PR TITLE
Improve MQ transport abstractions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,9 @@ $(VIRTUALENV_DIR)/bin/activate:
 
 .PHONY: web
 web:
+	@echo
+	@echo "====================web===================="
+	@echo
 	npm install --prefix $(WEB_DIR)
 	bower install --config.cwd=$(WEB_DIR) --config.directory=components
 	gulp --cwd $(WEB_DIR) build
@@ -199,4 +202,3 @@ debs:
 	rm -Rf ~/debbuild
 	$(foreach COM,$(COMPONENTS), pushd $(COM); make deb; popd;)
 	pushd st2client && make deb && popd
-

--- a/st2actionrunner/st2actionrunner/worker.py
+++ b/st2actionrunner/st2actionrunner/worker.py
@@ -1,18 +1,17 @@
 import json
 
-from kombu import Connection, Queue
+from kombu import Connection
 from kombu.mixins import ConsumerMixin
 from oslo.config import cfg
 from st2common import log as logging
-from st2common.transport import actionexecution
+from st2common.transport import actionexecution, publishers
 from st2actionrunner.controllers import liveactions
 
 LOG = logging.getLogger(__name__)
 
 
-ACTIONRUNNER_WORK_Q = Queue('st2.actionrunner.work',
-                            actionexecution.ACTIONEXECUTION_XCHG,
-                            routing_key=actionexecution.CREATE_RK)
+ACTIONRUNNER_WORK_Q = actionexecution.get_queue('st2.actionrunner.work',
+                                                routing_key=publishers.CREATE_RK)
 
 
 class Worker(ConsumerMixin):

--- a/st2api/st2api/controllers/actionexecutions.py
+++ b/st2api/st2api/controllers/actionexecutions.py
@@ -45,7 +45,8 @@ class ActionExecutionsController(RestController):
         self._live_actions_monitor_thread = eventlet.greenthread.spawn(self._drain_live_actions)
         self._monitor_thread_empty_q_sleep_time = MONITOR_THREAD_EMPTY_Q_SLEEP_TIME
         self._monitor_thread_no_workers_sleep_time = MONITOR_THREAD_NO_WORKERS_SLEEP_TIME
-        self._publisher = transport.publishers.PoolPublisher(cfg.CONF.messaging.url)
+        self._publisher = transport.actionexecution.ActionExecutionPublisher(
+            cfg.CONF.messaging.url)
 
     def _issue_liveaction_post(self, actionexec_id):
         """
@@ -58,9 +59,7 @@ class ActionExecutionsController(RestController):
         request_error = False
         result = None
         try:
-            self._publisher.publish(json.dumps(payload),
-                                    exchange=transport.actionexecution.ACTIONEXECUTION_XCHG,
-                                    routing_key=transport.actionexecution.CREATE_RK)
+            self._publisher.publish_create(json.dumps(payload))
         except Exception:
             LOG.exception('Unable to publish to exchange.')
             request_error = True

--- a/st2common/st2common/transport/actionexecution.py
+++ b/st2common/st2common/transport/actionexecution.py
@@ -1,8 +1,17 @@
 # All Exchanges and Queues related to ActionExecution.
 
-from kombu import Exchange
-
-CREATE_RK = 'create'
+from kombu import Exchange, Queue
+from st2common.transport import publishers
 
 ACTIONEXECUTION_XCHG = Exchange('st2.actionexecution',
                                 type='topic')
+
+
+class ActionExecutionPublisher(publishers.CUDPublisher):
+
+    def __init__(self, url):
+        super(ActionExecutionPublisher, self).__init__(url, ACTIONEXECUTION_XCHG)
+
+
+def get_queue(name, routing_key):
+    return Queue(name, ACTIONEXECUTION_XCHG, routing_key=routing_key)

--- a/st2common/st2common/transport/publishers.py
+++ b/st2common/st2common/transport/publishers.py
@@ -1,6 +1,10 @@
 from kombu import Connection
 from kombu.pools import producers
 
+CREATE_RK = 'create'
+UPDATE_RK = 'update'
+DELETE_RK = 'delete'
+
 
 class PoolPublisher(object):
     def __init__(self, url):
@@ -10,3 +14,18 @@ class PoolPublisher(object):
         with self.pool.acquire(block=True) as connection:
             with producers[connection].acquire(block=True) as producer:
                 producer.publish(payload, exchange=exchange, routing_key=routing_key)
+
+
+class CUDPublisher(object):
+    def __init__(self, url, exchange):
+        self._publisher = PoolPublisher(url)
+        self._exchange = exchange
+
+    def publish_create(self, payload):
+        self._publisher.publish(payload, self._exchange, CREATE_RK)
+
+    def publish_update(self, payload):
+        self._publisher.publish(payload, self._exchange, UPDATE_RK)
+
+    def publish_delete(self, payload):
+        self._publisher.publish(payload, self._exchange, DELETE_RK)


### PR DESCRIPTION
- Introduce a CUD publisher.
- Exchange and routing key definitions are in st2common.
- Queue creation method per module like ActionExecution so to limit
  Exchange visibility.
