### PR TITLE
Add rule data to Jinja context

### DIFF
--- a/contrib/core/rules/person-joe.json
+++ b/contrib/core/rules/person-joe.json
@@ -13,13 +13,13 @@
         "trigger.name": {
             "pattern": "Joe",
             "type": "equals"
-         }
+        }
     },
 
     "action": {
         "name": "local",
         "parameters": {
-            "cmd": "echo \"{{trigger}}\" >> /tmp/st2.persons.out"
+            "cmd": "echo \"{{trigger}} from {{rule.trigger.type}}\" >> /tmp/st2.persons.out"
         }
     },
 

--- a/st2common/st2common/models/api/reactor.py
+++ b/st2common/st2common/models/api/reactor.py
@@ -177,6 +177,12 @@ class RuleAPI(BaseAPI):
             'trigger': {
                 'type': 'object',
                 'properties': {
+                    'id': {
+                        'type': 'string'
+                    },
+                    'name': {
+                        'type': 'string'
+                    },
                     'type': {
                         'type': 'string'
                     },
@@ -206,8 +212,6 @@ class RuleAPI(BaseAPI):
         rule = cls._from_model(model)
         rule['trigger'] = vars(TriggerAPI.from_model(reference.get_model_from_ref(Trigger,
                                                                                   model.trigger)))
-        del rule['trigger']['id']
-        del rule['trigger']['name']
         for oldkey, value in six.iteritems(rule['criteria']):
             newkey = oldkey.replace(u'\u2024', '.')
             if oldkey != newkey:

--- a/st2reactor/st2reactor/rules/datatransform.py
+++ b/st2reactor/st2reactor/rules/datatransform.py
@@ -3,19 +3,22 @@ import json
 import copy
 import jinja2
 
+from st2common.models.api.reactor import RuleAPI
 from st2common.persistence.datastore import KeyValuePair
 import six
 
 
 PAYLOAD_PREFIX = 'trigger'
-RULE_DATA_PREFIX = 'rule'
+RULE_PREFIX = 'rule'
 SYSTEM_PREFIX = 'system'
 
 
 class Jinja2BasedTransformer(object):
-    def __init__(self, payload):
-        self._payload_context = Jinja2BasedTransformer.\
-            _construct_context(PAYLOAD_PREFIX, payload, {})
+    def __init__(self, payload, rule=None):
+        context = {}
+        if rule:
+            context['rule'] = vars(RuleAPI.from_model(rule))
+        self._payload_context = self._construct_context(PAYLOAD_PREFIX, payload, context)
 
     def __call__(self, mapping):
         context = copy.copy(self._payload_context)
@@ -26,12 +29,10 @@ class Jinja2BasedTransformer(object):
             resolved_mapping[mapping_k] = template.render(context)
         return resolved_mapping
 
-    @staticmethod
-    def _construct_context(prefix, data, context):
+    def _construct_context(self, prefix, data, context):
         if data is None:
             return context
-        context = Jinja2BasedTransformer.\
-            _construct_system_context(data, context)
+        context = self._construct_system_context(data, context)
         template = jinja2.Template(json.dumps(data))
         resolved_data = json.loads(template.render(context))
         if resolved_data:
@@ -40,8 +41,7 @@ class Jinja2BasedTransformer(object):
             context[prefix].update(resolved_data)
         return context
 
-    @staticmethod
-    def _construct_system_context(data, context):
+    def _construct_system_context(self, data, context):
         """Identify the system context in the data."""
         # The following regex will look for all occurrences of "{{system.*}}",
         # "{{ system.* }}", "{{ system.*}}", and "{{system.* }}" in the data.
@@ -60,5 +60,5 @@ class Jinja2BasedTransformer(object):
         return context
 
 
-def get_transformer(payload):
-    return Jinja2BasedTransformer(payload)
+def get_transformer(payload, rule=None):
+    return Jinja2BasedTransformer(payload, rule)

--- a/st2reactor/st2reactor/rules/enforcer.py
+++ b/st2reactor/st2reactor/rules/enforcer.py
@@ -16,7 +16,7 @@ class RuleEnforcer(object):
     def __init__(self, trigger_instance, rule):
         self.trigger_instance = trigger_instance
         self.rule = rule
-        self.data_transformer = get_transformer(trigger_instance.payload)
+        self.data_transformer = get_transformer(trigger_instance.payload, self.rule)
 
     def enforce(self):
         rule_enforcement = RuleEnforcementDB()

--- a/st2reactor/st2reactor/rules/filter.py
+++ b/st2reactor/st2reactor/rules/filter.py
@@ -20,7 +20,7 @@ class RuleFilter(object):
         if criteria and not self.trigger_instance.payload:
             return False
 
-        transform = get_transformer(self.trigger_instance.payload)
+        transform = get_transformer(self.trigger_instance.payload, self.rule)
 
         for criterion_k in criteria.keys():
             criterion_v = criteria[criterion_k]

--- a/st2reactor/tests/test_data_transform.py
+++ b/st2reactor/tests/test_data_transform.py
@@ -2,14 +2,21 @@ import copy
 
 from st2tests import DbTestCase
 from st2common.models.db.datastore import KeyValuePairDB
+from st2common.models.db.reactor import RuleDB, TriggerDB
 from st2common.persistence.datastore import KeyValuePair
+from st2common.persistence.reactor import Rule, Trigger
+from st2common.util import reference
 from st2reactor.rules import datatransform
+
 
 
 PAYLOAD = {'k1': 'v1', 'k2': 'v2'}
 
 PAYLOAD_WITH_KVP = copy.copy(PAYLOAD)
 PAYLOAD_WITH_KVP.update({'k5': '{{system.k5}}'})
+
+PAYLOAD_WITH_RULE = copy.copy(PAYLOAD)
+PAYLOAD_WITH_RULE.update({'trigger_name': '{{ rule.trigger.name }}'})
 
 
 class DataTransformTest(DbTestCase):
@@ -39,3 +46,24 @@ class DataTransformTest(DbTestCase):
             KeyValuePair.delete(k5)
             KeyValuePair.delete(k6)
             KeyValuePair.delete(k7)
+
+    def test_rule_transform(self):
+        trigger = Trigger.add_or_update(TriggerDB(name='fancytrigger',
+                                                  type={'name': 'st2.trigger'},
+                                                  parameters={'data': 'some'}))
+        rule = Rule.add_or_update(RuleDB(name='fancyrule',
+                                         trigger=reference.get_ref_from_model(trigger),
+                                         action={'name': 'fancyaction'}))
+        try:
+            transformer = datatransform.get_transformer(PAYLOAD_WITH_RULE, rule)
+            mapping = {'trigger_name': '{{trigger.trigger_name}}',
+                       'trigger_id': '{{rule.trigger.id}}',
+                       'trigger_type': '{{rule.trigger.type}}'}
+            result = transformer(mapping)
+            expected = {'trigger_name': 'fancytrigger',
+                        'trigger_id': str(trigger.id),
+                        'trigger_type': 'st2.trigger'}
+            self.assertEquals(result, expected)
+        finally:
+            Rule.delete(rule)
+            Trigger.delete(trigger)

--- a/st2reactor/tests/test_enforce.py
+++ b/st2reactor/tests/test_enforce.py
@@ -1,3 +1,4 @@
+import bson
 import datetime
 import mock
 import unittest2
@@ -9,37 +10,37 @@ from st2common.util import reference
 from st2reactor.rules.enforcer import RuleEnforcer
 
 MOCK_TRIGGER = TriggerDB()
-MOCK_TRIGGER.id = 'trigger-test.id'
+MOCK_TRIGGER.id = bson.ObjectId()
 MOCK_TRIGGER.name = 'trigger-test.name'
+MOCK_TRIGGER.type = {'name': 'trigger-test'}
 
 MOCK_TRIGGER_INSTANCE = TriggerInstanceDB()
-MOCK_TRIGGER_INSTANCE.id = 'triggerinstance-test'
+MOCK_TRIGGER_INSTANCE.id = bson.ObjectId()
 MOCK_TRIGGER_INSTANCE.trigger = reference.get_ref_from_model(MOCK_TRIGGER)
 MOCK_TRIGGER_INSTANCE.payload = {}
 MOCK_TRIGGER_INSTANCE.occurrence_time = datetime.datetime.now()
 
-MOCK_ACTION = ActionDB()
-MOCK_ACTION.id = 'action-test-1.id'
+MOCK_ACTION = ActionExecutionSpecDB()
 MOCK_ACTION.name = 'action-test-1.name'
 
 MOCK_ACTION_EXECUTION = ActionExecutionDB()
-MOCK_ACTION_EXECUTION.id = 'actionexec-test-1.id'
+MOCK_ACTION_EXECUTION.id = bson.ObjectId()
 MOCK_ACTION_EXECUTION.name = 'actionexec-test-1.name'
 
 MOCK_RULE_1 = RuleDB()
-MOCK_RULE_1.id = 'rule-test-1'
+MOCK_RULE_1.id = bson.ObjectId()
+MOCK_RULE_1.name = 'rule1'
 MOCK_RULE_1.trigger = reference.get_ref_from_model(MOCK_TRIGGER)
 MOCK_RULE_1.criteria = {}
-MOCK_RULE_1.action = ActionExecutionSpecDB()
-MOCK_RULE_1.action.action = reference.get_ref_from_model(MOCK_ACTION)
+MOCK_RULE_1.action = MOCK_ACTION
 MOCK_RULE_1.enabled = True
 
 MOCK_RULE_2 = RuleDB()
-MOCK_RULE_2.id = 'rule-test-2'
+MOCK_RULE_2.id = bson.ObjectId()
+MOCK_RULE_1.name = 'rule2'
 MOCK_RULE_2.trigger = reference.get_ref_from_model(MOCK_TRIGGER)
 MOCK_RULE_2.criteria = {}
-MOCK_RULE_2.action = ActionExecutionSpecDB()
-MOCK_RULE_2.action.action = reference.get_ref_from_model(MOCK_ACTION)
+MOCK_RULE_2.action = MOCK_ACTION
 MOCK_RULE_2.enabled = True
 
 
@@ -48,6 +49,7 @@ class EnforceTest(unittest2.TestCase):
     @mock.patch.object(RuleEnforcement, 'add_or_update')
     @mock.patch.object(RuleEnforcer, '_RuleEnforcer__invoke_action', mock.MagicMock(
         return_value=reference.get_ref_from_model(MOCK_ACTION_EXECUTION)))
+    @mock.patch.object(reference, 'get_model_from_ref', mock.MagicMock(return_value=MOCK_TRIGGER))
     def test_ruleenforcement_creation(self, mock_ruleenforcement_add):
         enforcer = RuleEnforcer(MOCK_TRIGGER_INSTANCE, MOCK_RULE_1)
         enforcer.enforce()

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
        -e{toxinidir}/st2common
        -e{toxinidir}/st2tests
-       -e{toxinidir}/st2actionrunner
+       -e{toxinidir}/st2actions
        -e{toxinidir}/st2api
        -e{toxinidir}/st2client
        -e{toxinidir}/st2reactor


### PR DESCRIPTION
Now user can refer to the rule being evaluated using Jinja template {{ rule.\* }}. Instead of using this template just for rule data, I've decided to give user an access to the whole rule object. The initial idea for that template may be implemented by adding a 'data' field to the Rule itself and doesn't require any changes in evaluation logic.

STORM-242 STORM-210 #resolve
