### PR TITLE
RFR: Content pack should be displayed in st2 action list

### DIFF
--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -22,12 +22,19 @@ class ActionBranch(resource.ResourceBranch):
     def __init__(self, description, app, subparsers, parent_parser=None):
         super(ActionBranch, self).__init__(
             models.Action, description, app, subparsers,
-            parent_parser=parent_parser)
+            parent_parser=parent_parser,
+            commands={
+                'list': ActionListCommand
+            })
 
         # Registers extended commands
         self.commands['execute'] = ActionRunCommand(
             self.resource, self.app, self.subparsers,
             add_help=False)
+
+
+class ActionListCommand(resource.ResourceListCommand):
+    display_attributes = ['id', 'content_pack', 'name', 'description']
 
 
 class ActionRunCommand(resource.ResourceCommand):


### PR DESCRIPTION
```
(virtualenv)~/s/st2client git:master ❯❯❯ st2 action list                                                                                                                                                                                               ✭ ✱ ◼
+--------------------------+--------------+--------------+-------------------------------------------------------------------+
| id                       | content_pack | name         | description                                                       |
+--------------------------+--------------+--------------+-------------------------------------------------------------------+
| 5410dd2b0640fd0d3e518cb9 | pack1        | http         | Action that performs an http request.                             |
| 5410dd2b0640fd0d3e518cbb | pack1        | local        | Action that executes an arbitrary Linux command on the localhost. |
| 5410dd2b0640fd0d3e518cb7 | pack1        | remote       | Action to execute arbitrary linux command remotely.               |
| 5410dd2b0640fd0d3e518cba | pack1        | send_mail    | This sends an email                                               |
| 5410dd2b0640fd0d3e518cb8 | pack1        | stormbot_say | This posts a message to StormBot                                  |
+--------------------------+--------------+--------------+-------------------------------------------------------------------+
```
