### PR TITLE
SSL support in CLI

### DIFF
--- a/st2auth/conf/apache.sample.conf
+++ b/st2auth/conf/apache.sample.conf
@@ -1,8 +1,14 @@
 <VirtualHost *:9100>
 
+    ServerName myhost.mydomain.com:9100
+
     WSGIScriptAlias / /path/to/st2auth/st2auth/wsgi.py
     WSGIDaemonProcess st2auth user=stanley group=stanley processes=2 threads=25 python-path=/path/to/st2auth:/path/to/st2common:/path/to/virtualenv/local/lib/python2.7/site-packages
     WSGIProcessGroup st2auth
+
+    SSLEngine on
+    SSLCertificateFile /etc/apache2/ssl/mycert.crt
+    SSLCertificateKeyFile /etc/apache2/ssl/mycert.key
 
     AddExternalAuth pwauth /usr/sbin/pwauth
     SetExternalAuthMethod pwauth pipe

--- a/st2client/st2client/client.py
+++ b/st2client/st2client/client.py
@@ -11,35 +11,46 @@ class Client(object):
 
     def __init__(self, *args, **kwargs):
 
-        # If API endpoints not provided, then try to get it from environment.
+        # Get CLI options. If not given, then try to get it from the environment.
         self.endpoints = dict()
-        self.endpoints['base'] = os.environ.get(
-            'ST2_BASE_URL', kwargs.get('base_url', 'http://localhost'))
+        self.endpoints['base'] = kwargs.get('base_url')
+        if not self.endpoints['base']:
+            self.endpoints['base'] = os.environ.get(
+                'ST2_BASE_URL', 'http://localhost')
+
         self.endpoints['auth'] = kwargs.get('auth_url')
         if not self.endpoints['auth']:
+            base_https_url = self.endpoints['base'].replace('http://', 'https://')
             self.endpoints['auth'] = os.environ.get(
-                'ST2_AUTH_URL', '%s:%s' % (self.endpoints['base'], 9100))
+                'ST2_AUTH_URL', '%s:%s' % (base_https_url, 9100))
+
         self.endpoints['api'] = kwargs.get('api_url')
         if not self.endpoints['api']:
             self.endpoints['api'] = os.environ.get(
                 'ST2_API_URL', '%s:%s' % (self.endpoints['base'], 9101))
 
+        self.cacert = kwargs.get('cacert')
+        if not self.cacert:
+            self.cacert = os.environ.get('ST2_CACERT', None)
+        if self.cacert and not os.path.isfile(self.cacert):
+            raise ValueError('CA cert file "%s" does not exist.' % self.cacert)
+
         # Instantiate resource managers and assign appropriate API endpoint.
         self.managers = dict()
         self.managers['Token'] = models.ResourceManager(
-            models.Token, self.endpoints['auth'])
+            models.Token, self.endpoints['auth'], cacert=self.cacert)
         self.managers['RunnerType'] = models.ResourceManager(
-            models.RunnerType, self.endpoints['api'])
+            models.RunnerType, self.endpoints['api'], cacert=self.cacert)
         self.managers['Action'] = models.ResourceManager(
-            models.Action, self.endpoints['api'])
+            models.Action, self.endpoints['api'], cacert=self.cacert)
         self.managers['ActionExecution'] = models.ResourceManager(
-            models.ActionExecution, self.endpoints['api'])
+            models.ActionExecution, self.endpoints['api'], cacert=self.cacert)
         self.managers['Rule'] = models.ResourceManager(
-            models.Rule, self.endpoints['api'])
+            models.Rule, self.endpoints['api'], cacert=self.cacert)
         self.managers['Trigger'] = models.ResourceManager(
-            models.Trigger, self.endpoints['api'])
+            models.Trigger, self.endpoints['api'], cacert=self.cacert)
         self.managers['KeyValuePair'] = models.ResourceManager(
-            models.KeyValuePair, self.endpoints['api'])
+            models.KeyValuePair, self.endpoints['api'], cacert=self.cacert)
 
     @property
     def tokens(self):

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -63,11 +63,9 @@ class Resource(object):
 
 class ResourceManager(object):
 
-    def __init__(self, resource, endpoint, read_only=False):
-        self.endpoint = endpoint
+    def __init__(self, resource, endpoint, cacert=None):
         self.resource = resource
-        self.read_only = read_only
-        self.client = httpclient.HTTPClient(self.endpoint)
+        self.client = httpclient.HTTPClient(endpoint, cacert=cacert)
 
     @staticmethod
     def handle_error(response):
@@ -88,7 +86,6 @@ class ResourceManager(object):
             limit = None
         if limit:
             url += '/?limit=%s' % limit
-        LOG.info('GET %s/%s' % (self.endpoint, url))
         response = self.client.get(url, **kwargs)
         if response.status_code != 200:
             self.handle_error(response)
@@ -97,7 +94,6 @@ class ResourceManager(object):
 
     def get_by_id(self, id, **kwargs):
         url = '/%s/%s' % (self.resource.get_plural_name().lower(), id)
-        LOG.info('GET %s/%s' % (self.endpoint, url))
         response = self.client.get(url, **kwargs)
         if response.status_code == 404:
             return None
@@ -136,7 +132,6 @@ class ResourceManager(object):
 
     def create(self, instance, **kwargs):
         url = '/%s' % self.resource.get_plural_name().lower()
-        LOG.info('POST %s/%s' % (self.endpoint, url))
         response = self.client.post(url, instance.serialize(), **kwargs)
         if response.status_code != 200:
             self.handle_error(response)
@@ -145,7 +140,6 @@ class ResourceManager(object):
 
     def update(self, instance, **kwargs):
         url = '/%s/%s' % (self.resource.get_plural_name().lower(), instance.id)
-        LOG.info('PUT %s/%s' % (self.endpoint, url))
         response = self.client.put(url, instance.serialize(), **kwargs)
         if response.status_code != 200:
             self.handle_error(response)
@@ -154,7 +148,6 @@ class ResourceManager(object):
 
     def delete(self, instance, **kwargs):
         url = '/%s/%s' % (self.resource.get_plural_name().lower(), instance.id)
-        LOG.info('DELETE %s/%s' % (self.endpoint, url))
         response = self.client.delete(url, **kwargs)
         if response.status_code not in (204, 404):
             self.handle_error(response)

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -34,7 +34,7 @@ class Shell(object):
         self.parser.add_argument(
             '--url',
             action='store',
-            dest='url',
+            dest='base_url',
             default=None,
             help='Base URL for the API servers. Assumes all servers uses the '
                  'same base URL and default ports are used. Get ST2_BASE_URL'
@@ -57,6 +57,16 @@ class Shell(object):
             default=None,
             help='URL for the API server. Get ST2_API_URL'
                  'from the environment variables by default.'
+        )
+
+        self.parser.add_argument(
+            '--cacert',
+            action='store',
+            dest='cacert',
+            default=None,
+            help='Path to the CA cert bundle for the SSL endpoints. '
+                 'Get ST2_CACERT from the environment variables by default. '
+                 'If this is not provided, then SSL cert will not be verified.'
         )
 
         # Set up list of commands and subcommands.
@@ -97,14 +107,9 @@ class Shell(object):
             self, self.subparsers)
 
     def get_client(self, args):
-        endpoints = dict()
-        if args.url:
-            endpoints['base_url'] = args.url
-        if args.auth_url:
-            endpoints['auth_url'] = args.auth_url
-        if args.api_url:
-            endpoints['api_url'] = args.api_url
-        return Client(**endpoints)
+        options = ['base_url', 'auth_url', 'api_url', 'cacert']
+        kwargs = {opt: getattr(args, opt) for opt in options}
+        return Client(**kwargs)
 
     def run(self, argv):
         try:

--- a/st2client/st2client/utils/httpclient.py
+++ b/st2client/st2client/utils/httpclient.py
@@ -6,6 +6,15 @@ import logging
 LOG = logging.getLogger(__name__)
 
 
+def add_ssl_verify_to_kwargs(func):
+    def decorate(*args, **kwargs):
+        if isinstance(args[0], HTTPClient) and 'https' in getattr(args[0], 'root', ''):
+            cacert = getattr(args[0], 'cacert', None)
+            kwargs['verify'] = cacert if cacert else False
+        return func(*args, **kwargs)
+    return decorate
+
+
 def add_auth_token_to_headers(func):
     def decorate(*args, **kwargs):
         token = kwargs.pop('token', None)
@@ -29,28 +38,34 @@ def add_json_content_type_to_headers(func):
 
 class HTTPClient(object):
 
-    def __init__(self, root):
+    def __init__(self, root, cacert=None):
         self.root = root
+        self.cacert = cacert
 
+    @add_ssl_verify_to_kwargs
     @add_auth_token_to_headers
     def get(self, url, **kwargs):
         return requests.get(self.root + url, **kwargs)
 
+    @add_ssl_verify_to_kwargs
     @add_auth_token_to_headers
     @add_json_content_type_to_headers
     def post(self, url, data, **kwargs):
         return requests.post(self.root + url, json.dumps(data), **kwargs)
 
+    @add_ssl_verify_to_kwargs
     @add_auth_token_to_headers
     @add_json_content_type_to_headers
     def put(self, url, data, **kwargs):
         return requests.put(self.root + url, json.dumps(data), **kwargs)
 
+    @add_ssl_verify_to_kwargs
     @add_auth_token_to_headers
     @add_json_content_type_to_headers
     def patch(self, url, data, **kwargs):
         return requests.patch(self.root + url, data, **kwargs)
 
+    @add_ssl_verify_to_kwargs
     @add_auth_token_to_headers
     def delete(self, url, **kwargs):
         return requests.delete(self.root + url, **kwargs)

--- a/st2client/tests/test_ssl.py
+++ b/st2client/tests/test_ssl.py
@@ -1,0 +1,107 @@
+import os
+import sys
+import json
+import mock
+import tempfile
+import requests
+import logging
+import unittest2
+
+from tests import base
+from st2client import shell
+
+
+LOG = logging.getLogger(__name__)
+
+USERNAME = 'stanley'
+PASSWORD = 'ShhhDontTell'
+HEADERS = {'content-type': 'application/json'}
+AUTH_URL = 'https://localhost:9100/tokens'
+GET_RULES_URL = 'http://localhost:9101/rules'
+
+
+class TestHttps(unittest2.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        super(TestHttps, self).__init__(*args, **kwargs)
+        self.shell = shell.Shell()
+
+    def setUp(self):
+        # Setup environment.
+        os.environ['ST2_BASE_URL'] = 'http://localhost'
+        if 'ST2_CACERT' in os.environ:
+            del os.environ['ST2_CACERT']
+
+        # Create a temp file to mock a cert file.
+        self.cacert_fd, self.cacert_path = tempfile.mkstemp()
+
+        # Redirect standard output and error to null. If not, then
+        # some of the print output from shell commands will pollute
+        # the test output.
+        sys.stdout = open(os.devnull, 'w')
+        sys.stderr = open(os.devnull, 'w')
+
+    def tearDown(self):
+        # Clean up environment.
+        if 'ST2_CACERT' in os.environ:
+            del os.environ['ST2_CACERT']
+        if 'ST2_BASE_URL' in os.environ:
+            del os.environ['ST2_BASE_URL']
+
+        # Clean up temp files.
+        os.close(self.cacert_fd)
+        os.unlink(self.cacert_path)
+
+        # Reset to original stdout and stderr.
+        sys.stdout = sys.__stdout__
+        sys.stderr = sys.__stderr__
+
+    @mock.patch.object(
+        requests, 'post',
+        mock.MagicMock(return_value=base.FakeResponse(json.dumps({}), 200, 'OK')))
+    def test_decorate_https_without_cacert(self):
+        self.shell.run(['auth', USERNAME, '-p', PASSWORD])
+        kwargs = {'verify': False, 'headers': HEADERS, 'auth': (USERNAME, PASSWORD)}
+        requests.post.assert_called_with(AUTH_URL, json.dumps({}), **kwargs)
+
+    @mock.patch.object(
+        requests, 'post',
+        mock.MagicMock(return_value=base.FakeResponse(json.dumps({}), 200, 'OK')))
+    def test_decorate_https_with_cacert_from_cli(self):
+        self.shell.run(['--cacert', self.cacert_path, 'auth', USERNAME, '-p', PASSWORD])
+        kwargs = {'verify': self.cacert_path, 'headers': HEADERS, 'auth': (USERNAME, PASSWORD)}
+        requests.post.assert_called_with(AUTH_URL, json.dumps({}), **kwargs)
+
+    @mock.patch.object(
+        requests, 'post',
+        mock.MagicMock(return_value=base.FakeResponse(json.dumps({}), 200, 'OK')))
+    def test_decorate_https_with_cacert_from_env(self):
+        os.environ['ST2_CACERT'] = self.cacert_path
+        self.shell.run(['auth', USERNAME, '-p', PASSWORD])
+        kwargs = {'verify': self.cacert_path, 'headers': HEADERS, 'auth': (USERNAME, PASSWORD)}
+        requests.post.assert_called_with(AUTH_URL, json.dumps({}), **kwargs)
+
+    @mock.patch.object(
+        requests, 'get',
+        mock.MagicMock(return_value=base.FakeResponse(json.dumps([]), 200, 'OK')))
+    def test_decorate_http_without_cacert(self):
+        self.shell.run(['rule', 'list'])
+        kwargs = {}
+        requests.get.assert_called_with(GET_RULES_URL, **kwargs)
+
+    @mock.patch.object(
+        requests, 'get',
+        mock.MagicMock(return_value=base.FakeResponse(json.dumps({}), 200, 'OK')))
+    def test_decorate_http_with_cacert_from_cli(self):
+        self.shell.run(['--cacert', self.cacert_path, 'rule', 'list'])
+        kwargs = {}
+        requests.get.assert_called_with(GET_RULES_URL, **kwargs)
+
+    @mock.patch.object(
+        requests, 'get',
+        mock.MagicMock(return_value=base.FakeResponse(json.dumps({}), 200, 'OK')))
+    def test_decorate_http_with_cacert_from_env(self):
+        os.environ['ST2_CACERT'] = self.cacert_path
+        self.shell.run(['rule', 'list'])
+        kwargs = {}
+        requests.get.assert_called_with(GET_RULES_URL, **kwargs)


### PR DESCRIPTION
By default, auth endpoint is configured to use https if not overridden
in CLI argument --auth-url or environment variable ST2_AUTH_URL. A
cacert option is added as CLI argument --cacert and environment variable
ST2_CACERT. If cacert is provided, HTTPS requests will set to verify.
The cacert option is ignored for regular HTTP requests.
