### PR TITLE
Add user context to action execution

### DIFF
--- a/st2api/tests/base.py
+++ b/st2api/tests/base.py
@@ -56,4 +56,8 @@ class AuthMiddlewareTest(DbTestCase):
             }
         }
 
+        # TODO(manas) : register action types here for now. RunnerType registration can be moved
+        # to posting to /runnertypes but that implies implementing POST.
+        runners_registrar.register_runner_types()
+
         cls.app = TestApp(auth.AuthMiddleware(load_app(cfg_dict)))

--- a/st2api/tests/controllers/test_actionexecutions.py
+++ b/st2api/tests/controllers/test_actionexecutions.py
@@ -1,14 +1,20 @@
+import uuid
 import copy
+import datetime
+
+import bson
+import mock
 from six.moves import filter
 try:
     import simplejson as json
 except ImportError:
     import json
-import mock
 
 from st2api.controllers.actions import ActionsController
+from st2common.models.db.access import TokenDB
+from st2common.persistence.access import Token
 from st2common.transport.publishers import PoolPublisher
-from tests import FunctionalTest
+from tests import FunctionalTest, AuthMiddlewareTest
 
 
 ACTION_1 = {
@@ -108,20 +114,21 @@ class FakeResponse(object):
 
 
 @mock.patch.object(PoolPublisher, 'publish', mock.MagicMock())
-class TestActionExecutionsController(FunctionalTest):
+class TestActionExecutionController(FunctionalTest):
 
     @classmethod
-    @mock.patch.object(ActionsController, '_is_valid_content_pack', mock.MagicMock(
-        return_value=True))
+    @mock.patch.object(
+        ActionsController, '_is_valid_content_pack',
+        mock.MagicMock(return_value=True))
     def setUpClass(cls):
-        super(TestActionExecutionsController, cls).setUpClass()
-        cls.action1 = copy.copy(ACTION_1)
+        super(TestActionExecutionController, cls).setUpClass()
+        cls.action1 = copy.deepcopy(ACTION_1)
         post_resp = cls.app.post_json('/actions', cls.action1)
         cls.action1['id'] = post_resp.json['id']
-        cls.action2 = copy.copy(ACTION_2)
+        cls.action2 = copy.deepcopy(ACTION_2)
         post_resp = cls.app.post_json('/actions', cls.action2)
         cls.action2['id'] = post_resp.json['id']
-        cls.action3 = copy.copy(ACTION_3)
+        cls.action3 = copy.deepcopy(ACTION_3)
         post_resp = cls.app.post_json('/actions', cls.action3)
         cls.action3['id'] = post_resp.json['id']
 
@@ -129,45 +136,46 @@ class TestActionExecutionsController(FunctionalTest):
     def tearDownClass(cls):
         cls.app.delete('/actions/%s' % cls.action1['id'])
         cls.app.delete('/actions/%s' % cls.action2['id'])
-        super(TestActionExecutionsController, cls).tearDownClass()
+        cls.app.delete('/actions/%s' % cls.action3['id'])
+        super(TestActionExecutionController, cls).tearDownClass()
 
     def test_get_one(self):
-        post_resp = self.__do_post(ACTION_EXECUTION_1)
-        actionexecution_id = self.__get_actionexecution_id(post_resp)
-        get_resp = self.__do_get_one(actionexecution_id)
-        self.assertEquals(get_resp.status_int, 200)
-        self.assertEquals(self.__get_actionexecution_id(get_resp), actionexecution_id)
+        post_resp = self._do_post(ACTION_EXECUTION_1)
+        actionexecution_id = self._get_actionexecution_id(post_resp)
+        get_resp = self._do_get_one(actionexecution_id)
+        self.assertEqual(get_resp.status_int, 200)
+        self.assertEqual(self._get_actionexecution_id(get_resp), actionexecution_id)
 
     def test_get_all(self):
-        self.__get_actionexecution_id(self.__do_post(ACTION_EXECUTION_1))
-        self.__get_actionexecution_id(self.__do_post(ACTION_EXECUTION_2))
+        self._get_actionexecution_id(self._do_post(ACTION_EXECUTION_1))
+        self._get_actionexecution_id(self._do_post(ACTION_EXECUTION_2))
         resp = self.app.get('/actionexecutions')
         self.assertEqual(resp.status_int, 200)
-        self.assertEquals(len(resp.json), 2,
-                          '/actionexecutions did not return all '
-                          'actionexecutions.')
+        self.assertEqual(len(resp.json), 2,
+                         '/actionexecutions did not return all '
+                         'actionexecutions.')
 
     def test_get_query(self):
-        actionexecution_1_id = self.__get_actionexecution_id(self.__do_post(ACTION_EXECUTION_1))
-        actionexecution_2_id = self.__get_actionexecution_id(self.__do_post(ACTION_EXECUTION_2))
+        actionexecution_1_id = self._get_actionexecution_id(self._do_post(ACTION_EXECUTION_1))
+        actionexecution_2_id = self._get_actionexecution_id(self._do_post(ACTION_EXECUTION_2))
 
         resp = self.app.get('/actionexecutions?action_name=%s' %
                             ACTION_EXECUTION_1['action']['name'])
         self.assertEqual(resp.status_int, 200)
         matching_execution = filter(lambda ae: ae['id'] == actionexecution_1_id, resp.json)
-        self.assertEquals(len(list(matching_execution)), 1,
-                          '/actionexecutions did not return correct actionexecution.')
+        self.assertEqual(len(list(matching_execution)), 1,
+                         '/actionexecutions did not return correct actionexecution.')
 
         resp = self.app.get('/actionexecutions?action_id=%s' %
                             self.action2['id'])
         self.assertEqual(resp.status_int, 200)
         matching_execution = filter(lambda ae: ae['id'] == actionexecution_2_id, resp.json)
-        self.assertEquals(len(list(matching_execution)), 1,
-                          '/actionexecutions did not return correct actionexecution.')
+        self.assertEqual(len(list(matching_execution)), 1,
+                         '/actionexecutions did not return correct actionexecution.')
 
     def test_get_query_with_limit(self):
-        self.__get_actionexecution_id(self.__do_post(ACTION_EXECUTION_1))
-        self.__get_actionexecution_id(self.__do_post(ACTION_EXECUTION_1))
+        self._get_actionexecution_id(self._do_post(ACTION_EXECUTION_1))
+        self._get_actionexecution_id(self._do_post(ACTION_EXECUTION_1))
 
         resp = self.app.get('/actionexecutions')
         self.assertEqual(resp.status_int, 200)
@@ -201,40 +209,106 @@ class TestActionExecutionsController(FunctionalTest):
         self.assertEqual(resp.status_int, 404)
 
     def test_post_delete(self):
-        post_resp = self.__do_post(ACTION_EXECUTION_1)
-        self.assertEquals(post_resp.status_int, 201)
+        post_resp = self._do_post(ACTION_EXECUTION_1)
+        self.assertEqual(post_resp.status_int, 201)
 
     def test_post_parameter_validation_failed(self):
-        execution = copy.copy(ACTION_EXECUTION_1)
+        execution = copy.deepcopy(ACTION_EXECUTION_1)
 
         # Runner type does not expects additional properties.
         execution['parameters']['foo'] = 'bar'
-        post_resp = self.__do_post(execution, expect_errors=True)
-        self.assertEquals(post_resp.status_int, 400)
+        post_resp = self._do_post(execution, expect_errors=True)
+        self.assertEqual(post_resp.status_int, 400)
 
         # Runner type expects parameter "hosts".
         execution['parameters'] = {}
-        post_resp = self.__do_post(execution, expect_errors=True)
-        self.assertEquals(post_resp.status_int, 400)
+        post_resp = self._do_post(execution, expect_errors=True)
+        self.assertEqual(post_resp.status_int, 400)
 
         # Runner type expects parameters "cmd" to be str.
         execution['parameters'] = {"hosts": "localhost", "cmd": 1000}
-        post_resp = self.__do_post(execution, expect_errors=True)
-        self.assertEquals(post_resp.status_int, 400)
+        post_resp = self._do_post(execution, expect_errors=True)
+        self.assertEqual(post_resp.status_int, 400)
 
         # Runner type permits parameters with no metadata.
-        execution = copy.copy(ACTION_EXECUTION_3)
-        post_resp = self.__do_post(execution, expect_errors=False)
-        self.assertEquals(post_resp.status_int, 201)
+        execution = copy.deepcopy(ACTION_EXECUTION_3)
+        post_resp = self._do_post(execution, expect_errors=False)
+        self.assertEqual(post_resp.status_int, 201)
+
+    def test_post_with_st2_context_in_headers(self):
+        resp = self._do_post(copy.deepcopy(ACTION_EXECUTION_1))
+        self.assertEqual(resp.status_int, 201)
+        context = {'parent': str(resp.json['id'])}
+        headers = {'content-type': 'application/json', 'st2-context': json.dumps(context)}
+        resp = self._do_post(copy.deepcopy(ACTION_EXECUTION_1), headers=headers)
+        self.assertEqual(resp.status_int, 201)
+        self.assertNotIn('user', resp.json)
+        self.assertDictEqual(resp.json['context'], context)
 
     @staticmethod
-    def __get_actionexecution_id(resp):
+    def _get_actionexecution_id(resp):
         return resp.json['id']
 
-    def __do_get_one(self, actionexecution_id, expect_errors=False):
-        return self.app.get('/actionexecutions/%s' % actionexecution_id,
-                            expect_errors=expect_errors)
+    def _do_get_one(self, actionexecution_id, *args, **kwargs):
+        return self.app.get('/actionexecutions/%s' % actionexecution_id, *args, **kwargs)
 
-    def __do_post(self, actionexecution, expect_errors=False):
-        return self.app.post_json('/actionexecutions', actionexecution,
-                                  expect_errors=expect_errors)
+    def _do_post(self, actionexecution, *args, **kwargs):
+        return self.app.post_json('/actionexecutions', actionexecution, *args, **kwargs)
+
+
+EXPIRY = datetime.datetime.now() + datetime.timedelta(seconds=300)
+SYS_TOKEN = TokenDB(id=bson.ObjectId(), user='system', token=uuid.uuid4().hex, expiry=EXPIRY)
+USR_TOKEN = TokenDB(id=bson.ObjectId(), user='stanley', token=uuid.uuid4().hex, expiry=EXPIRY)
+
+
+def mock_get_token(*args, **kwargs):
+    if args[0] == SYS_TOKEN.token:
+        return SYS_TOKEN
+    return USR_TOKEN
+
+
+@mock.patch.object(PoolPublisher, 'publish', mock.MagicMock())
+class TestActionExecutionControllerAuthEnabled(AuthMiddlewareTest):
+
+    @classmethod
+    @mock.patch.object(
+        Token, 'get',
+        mock.MagicMock(side_effect=mock_get_token))
+    @mock.patch.object(
+        ActionsController, '_is_valid_content_pack',
+        mock.MagicMock(return_value=True))
+    def setUpClass(cls):
+        super(TestActionExecutionControllerAuthEnabled, cls).setUpClass()
+        cls.action = copy.deepcopy(ACTION_1)
+        headers = {'content-type': 'application/json', 'X-Auth-Token': str(SYS_TOKEN.token)}
+        post_resp = cls.app.post_json('/actions', cls.action, headers=headers)
+        cls.action['id'] = post_resp.json['id']
+
+    @classmethod
+    @mock.patch.object(
+        Token, 'get',
+        mock.MagicMock(side_effect=mock_get_token))
+    def tearDownClass(cls):
+        headers = {'content-type': 'application/json', 'X-Auth-Token': str(SYS_TOKEN.token)}
+        cls.app.delete('/actions/%s' % cls.action['id'], headers=headers)
+        super(TestActionExecutionControllerAuthEnabled, cls).tearDownClass()
+
+    def _do_post(self, actionexecution, *args, **kwargs):
+        return self.app.post_json('/actionexecutions', actionexecution, *args, **kwargs)
+
+    @mock.patch.object(
+        Token, 'get',
+        mock.MagicMock(side_effect=mock_get_token))
+    def test_post_with_st2_context_in_headers(self):
+        headers = {'content-type': 'application/json', 'X-Auth-Token': str(USR_TOKEN.token)}
+        resp = self._do_post(copy.deepcopy(ACTION_EXECUTION_1), headers=headers)
+        self.assertEqual(resp.status_int, 201)
+        self.assertEqual(resp.json['user'], 'stanley')
+        context = {'parent': str(resp.json['id'])}
+        headers = {'content-type': 'application/json',
+                   'X-Auth-Token': str(SYS_TOKEN.token),
+                   'st2-context': json.dumps(context)}
+        resp = self._do_post(copy.deepcopy(ACTION_EXECUTION_1), headers=headers)
+        self.assertEqual(resp.status_int, 201)
+        self.assertEqual(resp.json['user'], 'stanley')
+        self.assertDictEqual(resp.json['context'], context)

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -209,7 +209,7 @@ class ActionExecutionBranch(resource.ResourceBranch):
 
 class ActionExecutionListCommand(resource.ResourceCommand):
 
-    display_attributes = ['id', 'action.name', 'status', 'start_timestamp']
+    display_attributes = ['id', 'action.name', 'user', 'status', 'start_timestamp']
 
     def __init__(self, resource, *args, **kwargs):
         super(ActionExecutionListCommand, self).__init__(

--- a/st2common/st2common/models/api/access.py
+++ b/st2common/st2common/models/api/access.py
@@ -8,6 +8,9 @@ from st2common import log as logging
 LOG = logging.getLogger(__name__)
 
 
+SYSTEM_USERNAME = 'system'
+
+
 class UserAPI(BaseAPI):
     model = UserDB
     schema = {

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -262,6 +262,9 @@ class ActionExecutionAPI(BaseAPI):
             },
             "callback": {
                 "type": "object"
+            },
+            "user": {
+                "type": "string"
             }
         },
         "required": ["action"],
@@ -287,4 +290,5 @@ class ActionExecutionAPI(BaseAPI):
         model.context = getattr(execution, 'context', dict())
         model.callback = getattr(execution, 'callback', dict())
         model.result = getattr(execution, 'result', None)
+        model.user = getattr(execution, 'user', None)
         return model

--- a/st2common/st2common/models/db/action.py
+++ b/st2common/st2common/models/db/action.py
@@ -105,6 +105,8 @@ class ActionExecutionDB(StormFoundationDB):
     callback = me.DictField(
         default={},
         help_text='Callback information for the on completion of action execution.')
+    user = me.StringField(
+        help_text='The user that invoked this action execution.')
 
 
 # specialized access objects

--- a/st2reactor/st2reactor/rules/enforcer.py
+++ b/st2reactor/st2reactor/rules/enforcer.py
@@ -7,6 +7,7 @@ from st2common.models.db.reactor import RuleEnforcementDB
 from st2common.persistence.reactor import RuleEnforcement
 from st2common.services import action as action_service
 from st2common.models.api.action import ActionExecutionAPI, ACTIONEXEC_STATUS_SCHEDULED
+from st2common.models.api.access import SYSTEM_USERNAME
 
 
 LOG = logging.getLogger('st2reactor.ruleenforcement.enforce')
@@ -40,6 +41,7 @@ class RuleEnforcer(object):
 
     @staticmethod
     def _invoke_action(action_name, action_args):
-        execution = ActionExecutionAPI(action={'name': action_name}, parameters=action_args)
+        action = {'name': action_name}
+        execution = ActionExecutionAPI(action=action, parameters=action_args, user=SYSTEM_USERNAME)
         execution = action_service.schedule(execution)
         return {'id': execution.id} if execution.status == ACTIONEXEC_STATUS_SCHEDULED else None


### PR DESCRIPTION
Add user attribute to ActionExecution model. For subtasks in a workflow
action, the user context will inherit from the parent workflow action.
Update execution list in CLI to include user column.
