### PR TITLE
Move action execution user into context field

### DIFF
--- a/conf/stanley.conf
+++ b/conf/stanley.conf
@@ -17,7 +17,7 @@ logging = st2actions/conf/logging.conf
 host = 0.0.0.0
 port = 9100
 debug = False
-enable = False
+enable = True
 logging = st2auth/conf/logging.conf
 
 [messaging]

--- a/st2api/st2api/controllers/actionexecutions.py
+++ b/st2api/st2api/controllers/actionexecutions.py
@@ -97,20 +97,24 @@ class ActionExecutionsController(RestController):
     @jsexpose(body=ActionExecutionAPI, status_code=http_client.CREATED)
     def post(self, execution):
         try:
+            # Initialize execution context if it does not exist.
+            if not hasattr(execution, 'context'):
+                execution.context = dict()
+
             # Retrieve user context from the request header.
-            execution.user = pecan.request.headers.get('X-User-Name')
+            execution.context['user'] = pecan.request.headers.get('X-User-Name')
 
             # Retrieve other st2 context from request header.
             if ('st2-context' in pecan.request.headers and pecan.request.headers['st2-context']):
                 context = pecan.request.headers['st2-context'].replace("'", "\"")
-                execution.context = json.loads(context)
+                execution.context.update(json.loads(context))
 
             # Use the user context from the parent action execution. Subtasks in a workflow
             # action can be invoked by a system user and so we want to use the user context
             # from the original workflow action.
             if getattr(execution, 'context', None) and 'parent' in execution.context:
                 parent = ActionExecution.get_by_id(execution.context['parent'])
-                execution.user = parent.user
+                execution.context['user'] = getattr(parent, 'context', dict()).get('user')
 
             # Schedule the action execution.
             return action_service.schedule(execution)

--- a/st2api/tests/controllers/test_actionexecutions.py
+++ b/st2api/tests/controllers/test_actionexecutions.py
@@ -238,11 +238,11 @@ class TestActionExecutionController(FunctionalTest):
     def test_post_with_st2_context_in_headers(self):
         resp = self._do_post(copy.deepcopy(ACTION_EXECUTION_1))
         self.assertEqual(resp.status_int, 201)
-        context = {'parent': str(resp.json['id'])}
+        context = {'parent': str(resp.json['id']), 'user': None}
         headers = {'content-type': 'application/json', 'st2-context': json.dumps(context)}
         resp = self._do_post(copy.deepcopy(ACTION_EXECUTION_1), headers=headers)
         self.assertEqual(resp.status_int, 201)
-        self.assertNotIn('user', resp.json)
+        self.assertIsNone(resp.json['context']['user'])
         self.assertDictEqual(resp.json['context'], context)
 
     @staticmethod
@@ -303,12 +303,12 @@ class TestActionExecutionControllerAuthEnabled(AuthMiddlewareTest):
         headers = {'content-type': 'application/json', 'X-Auth-Token': str(USR_TOKEN.token)}
         resp = self._do_post(copy.deepcopy(ACTION_EXECUTION_1), headers=headers)
         self.assertEqual(resp.status_int, 201)
-        self.assertEqual(resp.json['user'], 'stanley')
+        self.assertEqual(resp.json['context']['user'], 'stanley')
         context = {'parent': str(resp.json['id'])}
         headers = {'content-type': 'application/json',
                    'X-Auth-Token': str(SYS_TOKEN.token),
                    'st2-context': json.dumps(context)}
         resp = self._do_post(copy.deepcopy(ACTION_EXECUTION_1), headers=headers)
         self.assertEqual(resp.status_int, 201)
-        self.assertEqual(resp.json['user'], 'stanley')
-        self.assertDictEqual(resp.json['context'], context)
+        self.assertEqual(resp.json['context']['user'], 'stanley')
+        self.assertEqual(resp.json['context']['parent'], context['parent'])

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -209,7 +209,7 @@ class ActionExecutionBranch(resource.ResourceBranch):
 
 class ActionExecutionListCommand(resource.ResourceCommand):
 
-    display_attributes = ['id', 'action.name', 'user', 'status', 'start_timestamp']
+    display_attributes = ['id', 'action.name', 'context.user', 'status', 'start_timestamp']
 
     def __init__(self, resource, *args, **kwargs):
         super(ActionExecutionListCommand, self).__init__(

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -262,9 +262,6 @@ class ActionExecutionAPI(BaseAPI):
             },
             "callback": {
                 "type": "object"
-            },
-            "user": {
-                "type": "string"
             }
         },
         "required": ["action"],
@@ -290,5 +287,4 @@ class ActionExecutionAPI(BaseAPI):
         model.context = getattr(execution, 'context', dict())
         model.callback = getattr(execution, 'callback', dict())
         model.result = getattr(execution, 'result', None)
-        model.user = getattr(execution, 'user', None)
         return model

--- a/st2common/st2common/models/db/action.py
+++ b/st2common/st2common/models/db/action.py
@@ -105,8 +105,6 @@ class ActionExecutionDB(StormFoundationDB):
     callback = me.DictField(
         default={},
         help_text='Callback information for the on completion of action execution.')
-    user = me.StringField(
-        help_text='The user that invoked this action execution.')
 
 
 # specialized access objects

--- a/st2common/tests/services/test_action.py
+++ b/st2common/tests/services/test_action.py
@@ -60,12 +60,13 @@ class TestActionExecutionService(DbTestCase):
         super(TestActionExecutionService, cls).tearDownClass()
 
     def test_schedule(self):
+        context = {'user': USERNAME}
         parameters = {'hosts': 'localhost', 'cmd': 'uname -a'}
-        execution = ActionExecutionAPI(action=ACTION_REF, parameters=parameters, user=USERNAME)
+        execution = ActionExecutionAPI(action=ACTION_REF, context=context, parameters=parameters)
         execution = action_service.schedule(execution)
         self.assertIsNotNone(execution)
         self.assertIsNotNone(execution.id)
-        self.assertEqual(execution.user, USERNAME)
+        self.assertEqual(execution.context['user'], USERNAME)
         self.assertEqual(execution.status, ACTIONEXEC_STATUS_SCHEDULED)
         self.assertIsInstance(execution.start_timestamp, datetime.datetime)
         executiondb = ActionExecution.get_by_id(execution.id)
@@ -73,7 +74,7 @@ class TestActionExecutionService(DbTestCase):
         self.assertEqual(executiondb.id, bson.ObjectId(execution.id))
         action = {'id': str(self.actiondb.id), 'name': self.actiondb.name}
         self.assertDictEqual(executiondb.action, action)
-        self.assertEqual(executiondb.user, execution.user)
+        self.assertEqual(executiondb.context['user'], execution.context['user'])
         self.assertDictEqual(executiondb.parameters, execution.parameters)
         self.assertEqual(executiondb.status, ACTIONEXEC_STATUS_SCHEDULED)
         self.assertIsInstance(executiondb.start_timestamp, datetime.datetime)

--- a/st2reactor/st2reactor/rules/enforcer.py
+++ b/st2reactor/st2reactor/rules/enforcer.py
@@ -42,6 +42,7 @@ class RuleEnforcer(object):
     @staticmethod
     def _invoke_action(action_name, action_args):
         action = {'name': action_name}
-        execution = ActionExecutionAPI(action=action, parameters=action_args, user=SYSTEM_USERNAME)
+        context = {'user': SYSTEM_USERNAME}
+        execution = ActionExecutionAPI(action=action, context=context, parameters=action_args)
         execution = action_service.schedule(execution)
         return {'id': execution.id} if execution.status == ACTIONEXEC_STATUS_SCHEDULED else None


### PR DESCRIPTION
Instead of having user as first level field in the action execution
model, move the user attribute to the context field.
