### PR TITLE
RFR: Handle rabbitmq connection closes with retries

### DIFF
--- a/st2common/st2common/transport/publishers.py
+++ b/st2common/st2common/transport/publishers.py
@@ -1,21 +1,33 @@
 from kombu import Connection
 from kombu.pools import producers
 
+from st2common import log as logging
+
 CREATE_RK = 'create'
 UPDATE_RK = 'update'
 DELETE_RK = 'delete'
 
+LOG = logging.getLogger(__name__)
+
 
 class PoolPublisher(object):
     def __init__(self, url):
-        self.pool = Connection(url).Pool(10)
+        self.pool = Connection(url).Pool(limit=10, preload=1)
+
+    def errback(self, exc, interval):
+        LOG.error('Rabbitmq connection error: %r', exc, exc_info=True)
 
     def publish(self, payload, exchange, routing_key=''):
         # pickling the payload for now. Better serialization mechanism is essential.
         with self.pool.acquire(block=True) as connection:
             with producers[connection].acquire(block=True) as producer:
-                producer.publish(payload, exchange=exchange, routing_key=routing_key,
-                                 serializer='pickle')
+                try:
+                    publish = connection.ensure(producer, producer.publish, errback=self.errback,
+                                                max_retries=3)
+                    publish(payload, exchange=exchange, routing_key=routing_key,
+                            serializer='pickle')
+                except:
+                    LOG.exception('Connections to rabbitmq cannot be re-established.')
 
 
 class CUDPublisher(object):


### PR DESCRIPTION
  Refer: https://github.com/celery/kombu/commit/1c5f0ecf9f79e0c3f8f689057541295d3bf7a336#diff-9fa13492ded708799168a1c48c81584cR104
- Fabric uses multiprocessing for running tasks in parallel. Kombu
  wants to reset connections on multiprocessing forks. So you
  see abrupt rabbitmq channel closes. There also seems to be
  a bug in connection status not being synced to channel
  status in Kombu.
- Fix: Add retries to publish loop and call ensure_connection
  to make sure connection can be re-established. This is needed
  anyways. It just happens to be a work around for the above bug.

For the future, if you want to debug, here is a script that'll help you dump messages from queue on rabbitmq:
https://gist.github.com/lakshmi-kannan/78ffbdc2529cb3df2e70
