### PR TITLE
Fix: Do not preload connections

### DIFF
--- a/st2common/st2common/transport/publishers.py
+++ b/st2common/st2common/transport/publishers.py
@@ -12,7 +12,7 @@ LOG = logging.getLogger(__name__)
 
 class PoolPublisher(object):
     def __init__(self, url):
-        self.pool = Connection(url).Pool(limit=10, preload=1)
+        self.pool = Connection(url).Pool(limit=10)
 
     def errback(self, exc, interval):
         LOG.error('Rabbitmq connection error: %r', exc, exc_info=True)


### PR DESCRIPTION
Even though pre-loading connections is better for production, for tests this is not good. I don't see a good way to fix it. Until we find a way, let pre-loading be disabled. 
