### PR TITLE
STORM-553

### DIFF
--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -14,6 +14,7 @@ from st2common.util import action_db as action_db_util
 
 
 LOG = logging.getLogger(__name__)
+RESULTS_KEY = '__results'
 
 
 class ActionChain(object):
@@ -112,6 +113,7 @@ class ActionChainRunner(ActionRunner):
         context = {}
         context.update(original_parameters)
         context.update(results)
+        context.update({RESULTS_KEY: results})
         env = jinja2.Environment(undefined=jinja2.StrictUndefined)
         rendered_params = {}
         for k, v in six.iteritems(action_node.params):

--- a/st2actions/tests/fixtures/actionchains/chain_dep_result_input.json
+++ b/st2actions/tests/fixtures/actionchains/chain_dep_result_input.json
@@ -1,0 +1,22 @@
+{
+    "chain": [
+        {
+            "name": "c1",
+            "action": "a1",
+            "params": {"p1": "{{s1}}"},
+            "on-success": "c2"
+        },
+        {
+            "name": "c2",
+            "action": "a2",
+            "params": {"p1": "{{c1.o1}}"},
+            "on-success": "c3"
+        },
+        {
+            "name": "c3",
+            "action": "a3",
+            "params": {"out": "{{__results}}"}
+        }
+    ],
+    "default": "c1"
+}


### PR DESCRIPTION
- Use '__results' in the jinja template to access the full results.
