### PR TITLE
Fix: launchdev to use right config; lines to fit 100 char width

### DIFF
--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -29,7 +29,7 @@ function st2start(){
     cd ${ST2_REPO}
 
     if [ -z "$ST2_CONF" ]; then
-        ST2_CONF=${ST2_REPO}/st2tests/conf/stanley.conf
+        ST2_CONF=${ST2_REPO}/conf/stanley.conf
     fi
     echo "Using st2 config file: $ST2_CONF"
 
@@ -38,7 +38,8 @@ function st2start(){
         exit 1
     fi
 
-    CONTENT_PACKS_BASE_DIR=$(grep 'content_packs_base_path' ${ST2_CONF} | awk 'BEGIN {FS=" = "}; {print $2}')
+    CONTENT_PACKS_BASE_DIR=$(grep 'content_packs_base_path' ${ST2_CONF} \
+        | awk 'BEGIN {FS=" = "}; {print $2}')
     if [ -z $CONTENT_PACKS_BASE_DIR ]; then
         CONTENT_PACKS_BASE_DIR="/opt/stackstorm"
     fi
@@ -74,7 +75,9 @@ function st2start(){
     for i in $(seq 1 $runner_count)
     do
         # a screen for every runner
-        screen -S st2-actionrunner -X screen -t runner-$i ./virtualenv/bin/python ./st2actions/bin/actionrunner --config-file $ST2_CONF
+        screen -S st2-actionrunner -X screen -t runner-$i ./virtualenv/bin/python \
+            ./st2actions/bin/actionrunner \
+            --config-file $ST2_CONF
     done
 
     # Run the st2 API server


### PR DESCRIPTION
```
Changing working directory to /home/lakshmi/stanley...
Using st2 config file: /home/lakshmi/stanley/conf/stanley.conf
Using conent packs base dir: /opt/stackstorm/
Killing existing st2 screen sessions...
Starting screen session st2-actionrunner...
Starting screen session st2-api...
Starting screen session st2-reactor...

There are screens on:
    31554.st2-reactor   (09/29/2014 10:11:54 PM)    (Detached)
    31552.st2-api   (09/29/2014 10:11:54 PM)    (Detached)
    31546.st2-actionrunner  (09/29/2014 10:11:54 PM)    (Detached)
3 Sockets in /var/run/screen/S-lakshmi.
```

```
(virtualenv)~/stanley git:fix_launchdev_conf ❯❯❯ ssh -i st2tests/conf/vagrant.privkey.insecure localhost                                                                                                                                                 ✭ ◼
Welcome to Ubuntu 14.04.1 LTS (GNU/Linux 3.13.0-34-generic x86_64)
```
