### PR TITLE
Fix: Do not print progress indicator if json output is requested

### DIFF
--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -120,7 +120,8 @@ class ActionRunCommand(resource.ResourceCommand):
             while execution.status == act.ACTIONEXEC_STATUS_SCHEDULED \
                     or execution.status == act.ACTIONEXEC_STATUS_RUNNING:
                 time.sleep(1)
-                sys.stdout.write('.')
+                if not args.json:
+                    sys.stdout.write('.')
                 execution = action_exec_mgr.get_by_id(execution.id, **kwargs)
 
             sys.stdout.write('\n')
@@ -173,7 +174,7 @@ class ActionRunCommand(resource.ResourceCommand):
                     if set(parameters.keys()) - set(required):
                         print('Optional Parameters:')
                         [self.print_param(name, parameters.get(name))
-                        for name in sorted(parameters) if name not in required]
+                            for name in sorted(parameters) if name not in required]
                 except resource.ResourceNotFoundError:
                     print('Action "%s" is not found.' % args.name_or_id)
                 except Exception as e:


### PR DESCRIPTION
With this PR, you'll be able to output the cli output to CLI json parsers like jq.

```
(virtualenv)~/stanley git:fix_json_output_cli ❯❯❯ st2 run http url="https://www.google.com/" --json  | python -m json.tool
```

```
(virtualenv)~/stanley git:fix_json_output_cli ❯❯❯ st2 run http url="https://www.google.com/" --json  | python -m json.tool | jq '.["result"]'                                                                                                          ✭ ✱ ◼
{
  "status_code": 200,
  "headers": {
    "x-xss-protection": "1; mode=block",
    "x-frame-options": "SAMEORIGIN",
    "cache-control": "private, max-age=0",
    "content-type": "text/html; charset=ISO-8859-1",
    "date": "Mon, 29 Sep 2014 22:28:13 GMT",
    "expires": "-1",
    "p3p": "CP=\"This is not a P3P policy! See http://www.google.com/support/accounts/bin/answer.py?hl=en&answer=151657 for more info.\"",
    "server": "gws",
    "set-cookie": "PREF=ID=5325f04ee5e91d4c:FF=0:TM=1412029693:LM=1412029693:S=9QvecWnz89kKu83s; expires=Wed, 28-Sep-2016 22:28:13 GMT; path=/; domain=.google.com, NID=67=bv0uijmmU-XMvpOLQr4hi1cnVhD8X3Y_pngsycZcrysUPB65QEC8aKGtjXDBHLp3pJDXBUHnV3PTPqugL2L9SfnGNshPoRJDGjh6El2nMFEB6aTdrwpCOK70Dvjc7WCc; expires=Tue, 31-Mar-2015 22:28:13 GMT; path=/; domain=.google.com; HttpOnly",
    "transfer-encoding": "chunked"
  },
  "body": ""
}
```
