### PR TITLE
RFR: Add fields 'position' and 'locked' for action params.

### DIFF
--- a/.agignore
+++ b/.agignore
@@ -1,1 +1,2 @@
+virtualenv
 node_modules

--- a/st2api/tests/controllers/test_actions.py
+++ b/st2api/tests/controllers/test_actions.py
@@ -32,8 +32,8 @@ ACTION_2 = {
     'entry_point': '/tmp/test/action2.py',
     'runner_type': 'run-local',
     'parameters': {
-        'c': {'type': 'string', 'default': 'C1'},
-        'd': {'type': 'string', 'default': 'D1'}
+        'c': {'type': 'string', 'default': 'C1', 'position': 0},
+        'd': {'type': 'string', 'default': 'D1', 'locked': True}
     }
 }
 
@@ -120,6 +120,20 @@ ACTION_8 = {
     }
 }
 
+# ACTION_9: Parameter dict has fields not part of JSONSchema spec.
+ACTION_9 = {
+    'name': 'st2.dummy.action9',
+    'description': 'test description',
+    'enabled': True,
+    'content_pack': 'wolfpack',
+    'entry_point': '/tmp/test/action1.sh',
+    'runner_type': 'run-local',
+    'parameters': {
+        'a': {'type': 'string', 'default': 'A1', 'dummyfield': True},  # dummyfield is invalid.
+        'b': {'type': 'string', 'default': 'B1'}
+    }
+}
+
 
 class TestActionController(FunctionalTest):
     @mock.patch.object(ActionsController, '_is_valid_content_pack', mock.MagicMock(
@@ -167,6 +181,12 @@ class TestActionController(FunctionalTest):
         post_resp = self.__do_post(ACTION_1)
         self.assertEqual(post_resp.status_int, 201)
         self.__do_delete(self.__get_action_id(post_resp))
+
+    @mock.patch.object(ActionsController, '_is_valid_content_pack', mock.MagicMock(
+        return_value=True))
+    def test_post_action_with_bad_params(self):
+        post_resp = self.__do_post(ACTION_9, expect_errors=True)
+        self.assertEqual(post_resp.status_int, 400)
 
     @mock.patch.object(ActionsController, '_is_valid_content_pack', mock.MagicMock(
         return_value=True))

--- a/st2common/st2common/util/schema.py
+++ b/st2common/st2common/util/schema.py
@@ -144,6 +144,14 @@ SCHEMA_DRAFT4 = {
                 }
             ]
         },
+        "position": {
+            "type": "number",
+            "minimum": 0
+        },
+        "locked": {
+            "type": "boolean",
+            "default": False
+        },
         "allOf": {"$ref": "#/definitions/schemaArray"},
         "anyOf": {"$ref": "#/definitions/schemaArray"},
         "oneOf": {"$ref": "#/definitions/schemaArray"},
@@ -153,7 +161,8 @@ SCHEMA_DRAFT4 = {
         "exclusiveMaximum": ["maximum"],
         "exclusiveMinimum": ["minimum"]
     },
-    "default": {}
+    "default": {},
+    'additionalProperties': False
 }
 
 


### PR DESCRIPTION
- Add: Appending fields 'position' and 'locked' to JSONSchema draft.
- Add: Test cases to catch invalid fields in action params.
