### PR TITLE
Sync persistence and db access interfaces

### DIFF
--- a/st2common/st2common/persistence/__init__.py
+++ b/st2common/st2common/persistence/__init__.py
@@ -3,6 +3,7 @@ import six
 
 from st2common import log as logging
 
+
 LOG = logging.getLogger(__name__)
 
 
@@ -28,13 +29,20 @@ class Access(object):
         return kls._get_impl().get_by_id(value)
 
     @classmethod
+    def get(kls, *args, **kwargs):
+        return kls._get_impl().get(*args, **kwargs)
+
+    @classmethod
     def get_all(kls, *args, **kwargs):
         return kls._get_impl().get_all(*args, **kwargs)
 
     @classmethod
-    def query(kls, order_by=[], limit=None, **query_args):
-        return kls._get_impl().query(order_by=order_by,
-                                     limit=limit, **query_args)
+    def count(kls, *args, **kwargs):
+        return kls._get_impl().count(*args, **kwargs)
+
+    @classmethod
+    def query(kls, *args, **kwargs):
+        return kls._get_impl().query(*args, **kwargs)
 
     @classmethod
     def add_or_update(kls, model_object, publish=True):

--- a/st2common/tests/test_persistence.py
+++ b/st2common/tests/test_persistence.py
@@ -5,6 +5,7 @@ import mongoengine
 
 from st2tests import DbTestCase
 from st2common.models import db
+from st2common import persistence
 from st2common.models.db import stormbase
 
 
@@ -13,16 +14,24 @@ class FakeModelDB(stormbase.StormBaseDB):
     index = mongoengine.IntField(min_value=0)
 
 
-class TestAccessLayer(DbTestCase):
+class FakeModel(persistence.Access):
+    impl = db.MongoDBAccess(FakeModelDB)
+
+    @classmethod
+    def _get_impl(cls):
+        return cls.impl
+
+
+class TestPersistence(DbTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestAccessLayer, cls).setUpClass()
-        cls.access = db.MongoDBAccess(FakeModelDB)
+        super(TestPersistence, cls).setUpClass()
+        cls.access = FakeModel()
 
     def tearDown(self):
         FakeModelDB.drop_collection()
-        super(TestAccessLayer, self).tearDown()
+        super(TestPersistence, self).tearDown()
 
     def test_crud(self):
         obj1 = FakeModelDB(name=uuid.uuid4().hex, context={'a': 1})


### PR DESCRIPTION
Refactor persistence Access class to have the same set of query
interfaces as the MongoDBAccess. Add tests for persistence on top of db access.
