### PR TITLE
RFR: Return tuple instead of list of parameters

### DIFF
--- a/st2actions/st2actions/utils/param_utils.py
+++ b/st2actions/st2actions/utils/param_utils.py
@@ -53,4 +53,4 @@ def get_params_view(action_db=None, runner_db=None, merged_only=False):
     optional_params = {k: merged_params[k] for k in optional}
     immutable_params = {k: merged_params[k] for k in immutable}
 
-    return required_params, optional_params, immutable_params
+    return (required_params, optional_params, immutable_params)


### PR DESCRIPTION
- Fix: get_params_view to return a tuple when asking for a split
  view so the function return value can be caught in one variable.
