### PR TITLE
Add query support for null filter

### DIFF
--- a/st2api/tests/controllers/test_history.py
+++ b/st2api/tests/controllers/test_history.py
@@ -126,6 +126,17 @@ class TestActionExecutionHistory(FunctionalTest):
         ids = [item['id'] for item in response.json]
         self.assertListEqual(sorted(ids), sorted(ref.children))
 
+    def test_parentless(self):
+        refs = {k: v for k, v in six.iteritems(self.refs) if not getattr(v, 'parent', None)}
+        self.assertTrue(refs)
+        self.assertNotEqual(len(refs), self.num_records)
+        response = self.app.get('/history/executions?parent=null')
+        self.assertEqual(response.status_int, 200)
+        self.assertIsInstance(response.json, list)
+        self.assertEqual(len(response.json), len(refs))
+        ids = [item['id'] for item in response.json]
+        self.assertListEqual(sorted(ids), sorted(refs.keys()))
+
     def test_pagination(self):
         retrieved = []
         page_size = 10

--- a/st2common/tests/test_persistence.py
+++ b/st2common/tests/test_persistence.py
@@ -103,6 +103,22 @@ class TestPersistence(DbTestCase):
         self.assertEqual(obj1.name, objs[0].name)
         self.assertDictEqual(obj1.context, objs[0].context)
 
+    def test_null_filter(self):
+        obj1 = FakeModelDB(name=uuid.uuid4().hex)
+        obj1 = self.access.add_or_update(obj1)
+
+        objs = self.access.query(index='null')
+        self.assertEqual(len(objs), 1)
+        self.assertEqual(obj1.id, objs[0].id)
+        self.assertEqual(obj1.name, objs[0].name)
+        self.assertIsNone(getattr(obj1, 'index', None))
+
+        objs = self.access.query(index=None)
+        self.assertEqual(len(objs), 1)
+        self.assertEqual(obj1.id, objs[0].id)
+        self.assertEqual(obj1.name, objs[0].name)
+        self.assertIsNone(getattr(obj1, 'index', None))
+
     def test_pagination(self):
         count = 100
         page_size = 25


### PR DESCRIPTION
Support queries to filter parameter by null value. The following example
returns all action execution history with no parents.

Example:
http://localhost:9101/history/executions?parent=null
