### PR TITLE
Add support of querying history by datetime range

### DIFF
--- a/st2api/st2api/controllers/history.py
+++ b/st2api/st2api/controllers/history.py
@@ -17,6 +17,7 @@ class ActionExecutionController(resource.ResourceController):
         'parent': 'parent',
         'rule': 'rule__name',
         'runner': 'runner__name',
+        'timestamp': 'execution__start_timestamp',
         'trigger': 'trigger__name',
         'trigger_type': 'trigger_type__name',
         'user': 'execution__context__user'

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -34,7 +34,7 @@ class ResourceController(rest.RestController):
     @jsexpose()
     def get_all(self, **kwargs):
         filters = {v: kwargs[k] for k, v in six.iteritems(self.supported_filters) if kwargs.get(k)}
-        instances = self.access.get_all(**filters)
+        instances = self.access.query(**filters)
         return [self.model.from_model(instance) for instance in instances]
 
     @jsexpose(str)


### PR DESCRIPTION
Add support to REST API to query action execution start_timestamp for a
given datetime range. Both examples below return the same set of records.

Example:
http://localhost:9101/history/executions?timestamp=20141003T061800..20141001T000000
http://localhost:9101/history/executions?timestamp=20141001T000000..20141003T061800
