### PR TITLE
Add sort to REST API for action execution history

### DIFF
--- a/st2api/st2api/controllers/history.py
+++ b/st2api/st2api/controllers/history.py
@@ -12,6 +12,7 @@ LOG = logging.getLogger(__name__)
 class ActionExecutionController(resource.ResourceController):
     model = ActionExecutionHistoryAPI
     access = ActionExecutionHistory
+
     supported_filters = {
         'action': 'action__name',
         'parent': 'parent',
@@ -21,6 +22,10 @@ class ActionExecutionController(resource.ResourceController):
         'trigger': 'trigger__name',
         'trigger_type': 'trigger_type__name',
         'user': 'execution__context__user'
+    }
+
+    options = {
+        'sort': ['-execution__start_timestamp']
     }
 
 

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -26,6 +26,9 @@ class ResourceController(rest.RestController):
     model = abc.abstractproperty
     access = abc.abstractproperty
     supported_filters = abc.abstractproperty
+    options = {
+        'sort': []
+    }
 
     def __init__(self):
         self.supported_filters = copy.deepcopy(self.__class__.supported_filters)
@@ -33,6 +36,12 @@ class ResourceController(rest.RestController):
 
     @jsexpose()
     def get_all(self, **kwargs):
+        sort = kwargs.get('sort').split(',') if kwargs.get('sort') else []
+        for i in range(len(sort)):
+            sort.pop(i)
+            direction = '-' if sort[i].startswith('-') else ''
+            sort.insert(i, direction + self.supported_filters[sort[i]])
+        kwargs['sort'] = sort if sort else copy.copy(self.options.get('sort'))
         filters = {v: kwargs[k] for k, v in six.iteritems(self.supported_filters) if kwargs.get(k)}
         instances = self.access.query(**filters)
         return [self.model.from_model(instance) for instance in instances]

--- a/st2api/tests/controllers/test_history.py
+++ b/st2api/tests/controllers/test_history.py
@@ -10,7 +10,7 @@ from tests import FunctionalTest
 from tests.fixtures import history as fixture
 from st2api.controllers.history import ActionExecutionController
 from st2common.persistence.history import ActionExecutionHistory
-from st2common.models.api.history import ActionExecutionHistoryAPI
+from st2common.models.api.history import ActionExecutionHistoryAPI, DATE_FORMAT
 
 
 class TestActionExecutionHistory(FunctionalTest):
@@ -163,9 +163,26 @@ class TestActionExecutionHistory(FunctionalTest):
         self.assertEqual(response.status_int, 200)
         self.assertIsInstance(response.json, list)
         self.assertEqual(len(response.json), 10)
+        dt1 = response.json[0]['execution']['start_timestamp']
+        dt2 = response.json[9]['execution']['start_timestamp']
+        self.assertLess(datetime.datetime.strptime(dt1, DATE_FORMAT),
+                        datetime.datetime.strptime(dt2, DATE_FORMAT))
 
         dt_range = '20141225T000019..20141225T000010'
         response = self.app.get('/history/executions?timestamp=%s' % dt_range)
         self.assertEqual(response.status_int, 200)
         self.assertIsInstance(response.json, list)
         self.assertEqual(len(response.json), 10)
+        dt1 = response.json[0]['execution']['start_timestamp']
+        dt2 = response.json[9]['execution']['start_timestamp']
+        self.assertLess(datetime.datetime.strptime(dt2, DATE_FORMAT),
+                        datetime.datetime.strptime(dt1, DATE_FORMAT))
+
+    def test_default_sort(self):
+        response = self.app.get('/history/executions')
+        self.assertEqual(response.status_int, 200)
+        self.assertIsInstance(response.json, list)
+        dt1 = response.json[0]['execution']['start_timestamp']
+        dt2 = response.json[len(response.json) - 1]['execution']['start_timestamp']
+        self.assertLess(datetime.datetime.strptime(dt2, DATE_FORMAT),
+                        datetime.datetime.strptime(dt1, DATE_FORMAT))

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -38,11 +38,23 @@ def process_datetime_ranges(func):
             values = v.split('..')
             dt1 = datetime.datetime.strptime(values[0].ljust(21, '0'), pattern)
             dt2 = datetime.datetime.strptime(values[1].ljust(21, '0'), pattern)
+            order_by_list = kwargs.get('order_by', [])
             k__gte = '%s__gte' % k
             k__lte = '%s__lte' % k
-            query = {k__gte: dt1, k__lte: dt2} if dt1 < dt2 else {k__gte: dt2, k__lte: dt1}
+            if dt1 < dt2:
+                query = {k__gte: dt1, k__lte: dt2}
+                sort_key, reverse_sort_key = k, '-' + k
+            else:
+                query = {k__gte: dt2, k__lte: dt1}
+                sort_key, reverse_sort_key = '-' + k, k
             del kwargs[k]
             kwargs.update(query)
+            if reverse_sort_key in order_by_list:
+                idx = order_by_list.index(reverse_sort_key)
+                order_by_list.pop(idx)
+                order_by_list.insert(idx, sort_key)
+            elif sort_key not in order_by_list:
+                kwargs['order_by'] = [sort_key] + order_by_list
         return func(*args, **kwargs)
     return decorate
 


### PR DESCRIPTION
The default sort order for the history records is by descending order of
the execution start_timestamp.
http://localhost:9101/history/executions

The placement of the datetimes in a range query determine the sort order automatically.
http://localhost:9101/history/executions?timestamp=20141225T000010..20141225T000019
http://localhost:9101/history/executions?timestamp=20141225T000019..20141225T000010

The sort order can be overridden by a query param named "sort".
http://localhost:9101/history/executions?sort=action,timestamp

The sort direction can be changed to descending by prepending '-'.
http://localhost:9101/history/executions?sort=action,-timestamp
