### PR TITLE
Display a better error message if a resource with a provided id / name doesn't exist

### DIFF
--- a/st2client/st2client/commands/resource.py
+++ b/st2client/st2client/commands/resource.py
@@ -107,7 +107,9 @@ class ResourceCommand(commands.Command):
             except:
                 pass
         if not instance:
-            raise ResourceNotFoundError()
+            message = ('Resource with id or name "%s" doesn\'t exist.' %
+                       (name_or_id))
+            raise ResourceNotFoundError(message)
         return instance
 
     @abc.abstractmethod


### PR DESCRIPTION
Minor thing I spotted while playing with the CLI.

If you pass in an invalid / inexistent resource id which results in "not found" exception in the API, empty error message is returned to the user.

I've updated the code to include a message when `ResourceNotFound` exception is thrown.

Before change:

``` bash
python /data/stanley/st2client/st2client/shell.py run ee
ERROR: 

```

After change:

``` bash
python /data/stanley/st2client/st2client/shell.py run ee
ERROR: Resource with id or name "ee" doesn't exist

```
