### PR TITLE
Parameters view should be a merged view.

### DIFF
--- a/st2actions/st2actions/utils/param_utils.py
+++ b/st2actions/st2actions/utils/param_utils.py
@@ -46,11 +46,15 @@ def get_params_view(action_db=None, runner_db=None, merged_only=False):
         merged_params[param] = _merge_param_meta_values(action_meta=action_params.get(param),
                                                         runner_meta=runner_params.get(param))
 
-    if merged_only:
-        return merged_params
-
     required = set((getattr(runner_db, 'required_parameters', list()) +
                     getattr(action_db, 'required_parameters', list())))
+
+    for param in merged_params:
+        if param in required:
+            merged_params[param]['required'] = True
+
+    if merged_only:
+        return merged_params
 
     def is_immutable(param_meta):
         return param_meta.get('immutable', False)

--- a/st2api/st2api/controllers/actionviews.py
+++ b/st2api/st2api/controllers/actionviews.py
@@ -62,15 +62,10 @@ class ParametersViewController(RestController):
         LOG.info('Found action: %s, runner: %s', action_db, action_db.runner_type['name'])
         runner_db = LookupUtils._get_runner_by_name(action_db.runner_type['name'])
 
-        required, optional, immutable = param_utils.get_params_view(
-            action_db=action_db, runner_db=runner_db, merged_only=False)
+        all_params = param_utils.get_params_view(
+            action_db=action_db, runner_db=runner_db, merged_only=True)
 
-        param_types = {}
-        param_types['required'] = required
-        param_types['optional'] = optional
-        param_types['immutable'] = immutable
-
-        return {'parameters': param_types}
+        return {'parameters': all_params}
 
 
 class OverviewController(RestController):

--- a/st2api/tests/controllers/test_action_views.py
+++ b/st2api/tests/controllers/test_action_views.py
@@ -90,7 +90,4 @@ class TestParametersView(FunctionalTest):
         action_id = post_resp.json['id']
         get_resp = self.app.get('/actions/views/parameters/%s' % action_id)
         self.assertEqual(get_resp.status_int, 200)
-        self.assertTrue(get_resp.json['parameters']['required'] is not None, get_resp.json)
-        self.assertTrue(get_resp.json['parameters']['optional'] is not None, get_resp.json)
-        self.assertTrue(get_resp.json['parameters']['immutable'] is not None, get_resp.json)
         self.app.delete('/actions/%s' % action_id)


### PR DESCRIPTION
- Fix: Parameters in action overview and action parameters view should show merged parameters.

Note that required is a property on the meta for every param but this is inconsistent with how action jsons supply required params. Task:https://stackstorm.atlassian.net/browse/STORM-566. I'll fix it in a different PR. (Working on it right now). 

```
(virtualenv)~/stanley git:fix_merged_view_params ❯❯❯ http GET http://0.0.0.0:9101/actions/views/overview/543458080640fd5416626537
HTTP/1.1 200 OK
Access-Control-Allow-Headers: origin, authorization, accept
Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS
Access-Control-Allow-Origin: *
Content-Length: 1395
Content-Type: application/json; charset=UTF-8
Date: Wed, 08 Oct 2014 01:29:10 GMT

{
    "content_pack": "core",
    "description": "This sends an email",
    "enabled": true,
    "entry_point": "send_mail/send_mail",
    "id": "543458080640fd5416626537",
    "name": "send_mail_script",
    "parameters": {
        "body": {
            "description": "Body of the email.",
            "position": 2,
            "required": true,
            "type": "string"
        },
        "dir": {
            "default": "/tmp",
            "description": "The working directory where the command will be executed on the host.",
            "immutable": true,
            "type": "string"
        },
        "hosts": {
            "default": "localhost",
            "description": "Fixed to localhost as this action is run locally.",
            "immutable": true,
            "type": "string"
        },
        "kwarg_op": {
            "default": "--",
            "description": "Operator to use in front of keyword args i.e. \"--\" or \"-\".",
            "type": "string"
        },
        "parallel": {
            "default": false,
            "description": "Parallel execution is unsupported.",
            "immutable": true,
            "type": "boolean"
        },
        "subject": {
            "description": "Subject of the email.",
            "position": 1,
            "required": true,
            "type": "string"
        },
        "sudo": {
            "default": false,
            "description": "The command will be executed with sudo.",
            "immutable": true,
            "type": "boolean"
        },
        "to": {
            "description": "Recipient email address.",
            "position": 0,
            "required": true,
            "type": "string"
        },
        "user": {
            "description": "The user who is executing this command. This is for audit purposes only. The command will always execute as the user stanley.",
            "immutable": true,
            "type": "string"
        }
    },
    "runner_type": "run-local-script"
}

(virtualenv)~/stanley git:fix_merged_view_params ❯❯❯
```
