### PR TITLE
Fix class reference in super call.

### DIFF
--- a/st2common/tests/test_action_db_utils.py
+++ b/st2common/tests/test_action_db_utils.py
@@ -20,7 +20,7 @@ class ActionDBUtilsTestCase(DbTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(DbTestCase, cls).setUpClass()
+        super(ActionDBUtilsTestCase, cls).setUpClass()
         ActionDBUtilsTestCase._setup_test_models()
 
     def test_get_runnertype_nonexisting(self):


### PR DESCRIPTION
Now works!

$ nosetests -sv st2common/tests/test_action_db_utils.py
test_get_action_existing (tests.test_action_db_utils.ActionDBUtilsTestCase) ... ok
test_get_action_nonexisting (tests.test_action_db_utils.ActionDBUtilsTestCase) ... ok
test_get_actionexec_existing (tests.test_action_db_utils.ActionDBUtilsTestCase) ... ok
test_get_actionexec_nonexisting (tests.test_action_db_utils.ActionDBUtilsTestCase) ... ok
test_get_args (tests.test_action_db_utils.ActionDBUtilsTestCase) ... ok
test_get_runnertype_existing (tests.test_action_db_utils.ActionDBUtilsTestCase) ... ok
test_get_runnertype_nonexisting (tests.test_action_db_utils.ActionDBUtilsTestCase) ... ok
test_update_actionexecution_status (tests.test_action_db_utils.ActionDBUtilsTestCase) ... ok
test_update_actionexecution_status_invalid (tests.test_action_db_utils.ActionDBUtilsTestCase) ... ok

---

Ran 9 tests in 0.059s
