### PR TITLE
Refactor access service to use DB model

### DIFF
--- a/st2auth/st2auth/controllers/access.py
+++ b/st2auth/st2auth/controllers/access.py
@@ -21,4 +21,6 @@ class TokenController(rest.RestController):
             LOG.audit('Access denied to anonymous user.')
             pecan.abort(http_client.UNAUTHORIZED)
 
-        return create_token(pecan.request.remote_user, getattr(request, 'ttl', None))
+        tokendb = create_token(pecan.request.remote_user, getattr(request, 'ttl', None))
+
+        return TokenAPI.from_model(tokendb)

--- a/st2common/st2common/services/access.py
+++ b/st2common/st2common/services/access.py
@@ -4,7 +4,7 @@ import datetime
 from oslo.config import cfg
 
 from st2common.util import isotime
-from st2common.models.api.access import TokenAPI, UserAPI
+from st2common.models.db.access import TokenDB, UserDB
 from st2common.persistence.access import Token, User
 from st2common import log as logging
 
@@ -15,22 +15,25 @@ LOG = logging.getLogger(__name__)
 def create_token(username, ttl=None):
     if not ttl or ttl > cfg.CONF.auth.token_ttl:
         ttl = cfg.CONF.auth.token_ttl
+
     if username:
         try:
             User.get_by_name(username)
         except:
-            user = UserAPI(name=username)
-            User.add_or_update(UserAPI.to_model(user))
+            user = UserDB(name=username)
+            User.add_or_update(user)
             LOG.audit('Registered new user "%s".' % username)
         LOG.audit('Access granted to user "%s".' % username)
 
     token = uuid.uuid4().hex
     expiry = datetime.datetime.utcnow() + datetime.timedelta(seconds=ttl)
     expiry = isotime.add_utc_tz(expiry)
-    token = TokenAPI(user=username, token=token, expiry=isotime.format(expiry))
-    Token.add_or_update(TokenAPI.to_model(token))
+    token = TokenDB(user=username, token=token, expiry=expiry)
+    Token.add_or_update(token)
     LOG.audit('Access granted to %s with the token set to expire at "%s".' %
-              ('user "%s"' % username if username else "an anonymous user", str(expiry)))
+              ('user "%s"' % username if username else "an anonymous user",
+               isotime.format(expiry, offset=False)))
+
     return token
 
 


### PR DESCRIPTION
API model stores expiry as iso formatted string. Since other system
components can reuse the access service, the service should use and
return the DB model instead.
