### PR TITLE
Fix: Rule refers to trigger as a string reference

### DIFF
--- a/st2actions/tests/test_history.py
+++ b/st2actions/tests/test_history.py
@@ -124,7 +124,7 @@ class TestActionExecutionHistoryWorker(DbTestCase):
             TriggerTypeAPI.to_model(TriggerTypeAPI(**docs['trigger_type'])))
         trigger = Trigger.add_or_update(TriggerAPI.to_model(TriggerAPI(**docs['trigger'])))
         rule = RuleAPI.to_model(RuleAPI(**docs['rule']))
-        rule.trigger = reference.get_ref_from_model(trigger)
+        rule.trigger = reference.get_str_resource_ref_from_model(trigger)
         rule = Rule.add_or_update(rule)
         trigger_instance = TriggerInstance.add_or_update(
             TriggerInstanceAPI.to_model(TriggerInstanceAPI(**docs['trigger_instance'])))

--- a/st2api/st2api/controllers/rules.py
+++ b/st2api/st2api/controllers/rules.py
@@ -66,7 +66,7 @@ class RuleController(RestController):
             trigger_api = self._get_trigger_api_from_rule(rule)
             trigger_db = TriggerService.create_trigger_db(trigger_api)
 
-            rule_db.trigger = reference.get_ref_from_model(trigger_db)
+            rule_db.trigger = reference.get_str_resource_ref_from_model(trigger_db)
             LOG.debug('/rules/ POST verified RuleAPI and formulated RuleDB=%s', rule_db)
             rule_db = Rule.add_or_update(rule_db)
         except (ValidationError, ValueError) as e:
@@ -104,7 +104,7 @@ class RuleController(RestController):
             rule_db.id = rule_id
 
             trigger_db = TriggerService.create_trigger_db(TriggerAPI(**rule.trigger))
-            rule_db.trigger = reference.get_ref_from_model(trigger_db)
+            rule_db.trigger = reference.get_str_resource_ref_from_model(trigger_db)
 
             rule_db = Rule.add_or_update(rule_db)
 

--- a/st2common/st2common/models/api/reactor.py
+++ b/st2common/st2common/models/api/reactor.py
@@ -260,8 +260,8 @@ class RuleAPI(BaseAPI):
     @classmethod
     def from_model(cls, model):
         rule = cls._from_model(model)
-        rule['trigger'] = vars(TriggerAPI.from_model(reference.get_model_from_ref(Trigger,
-                                                                                  model.trigger)))
+        trigger_db = reference.get_model_by_resource_ref(Trigger, model.trigger)
+        rule['trigger'] = vars(TriggerAPI.from_model(trigger_db))
         del rule['trigger']['id']
         del rule['trigger']['name']
         for oldkey, value in six.iteritems(rule['criteria']):

--- a/st2common/st2common/models/db/reactor.py
+++ b/st2common/st2common/models/db/reactor.py
@@ -86,7 +86,7 @@ class RuleDB(StormBaseDB):
         status: enabled or disabled. If disabled occurrence of the trigger
         does not lead to execution of a action and vice-versa.
     """
-    trigger = me.DictField()
+    trigger = me.StringField()
     criteria = me.DictField()
     action = me.EmbeddedDocumentField(ActionExecutionSpecDB)
     enabled = me.BooleanField(required=True, default=True,

--- a/st2common/st2common/util/reference.py
+++ b/st2common/st2common/util/reference.py
@@ -40,3 +40,33 @@ def get_model_by_resource_ref(db_api, ref):
     ref_obj = ResourceReference.from_string_reference(ref=ref)
     result = db_api.query(name=ref_obj.name, content_pack=ref_obj.pack).first()
     return result
+
+
+def get_resource_ref_from_model(model):
+    """
+    Return a ResourceReference given db_model.
+
+    :param model: DB model that contains name and content_pack.
+    :type model: ``object``
+
+    :return: ResourceReference.
+    """
+    try:
+        name = model.name
+        pack = model.content_pack
+    except AttributeError:
+        raise Exception('Cannot build ResourceReference for model: %s. Name or pack missing.',
+                        model)
+    return ResourceReference(name=name, pack=pack)
+
+
+def get_str_resource_ref_from_model(model):
+    """
+    Return a resource reference as string given db_model.
+
+    :param model: DB model that contains name and content_pack.
+    :type model: ``object``
+
+    :return: String representation of ResourceReference.
+    """
+    return get_resource_ref_from_model(model).ref

--- a/st2common/tests/test_db.py
+++ b/st2common/tests/test_db.py
@@ -117,7 +117,7 @@ class ReactorModelTest(DbTestCase):
         runnertype = ActionModelTest._create_save_runnertype()
         action = ActionModelTest._create_save_action(runnertype)
         saved = ReactorModelTest._create_save_rule(trigger, action)
-        retrievedrules = Rule.query(trigger=reference.get_ref_from_model(trigger))
+        retrievedrules = Rule.query(trigger=reference.get_str_resource_ref_from_model(trigger))
         self.assertEqual(1, len(retrievedrules), 'No rules found.')
         for retrievedrule in retrievedrules:
             self.assertEqual(saved.id, retrievedrule.id, 'Incorrect rule returned.')
@@ -129,7 +129,7 @@ class ReactorModelTest(DbTestCase):
         runnertype = ActionModelTest._create_save_runnertype()
         action = ActionModelTest._create_save_action(runnertype)
         saved = ReactorModelTest._create_save_rule(trigger, action)
-        retrievedrules = Rule.query(trigger=reference.get_ref_from_model(trigger),
+        retrievedrules = Rule.query(trigger=reference.get_str_resource_ref_from_model(trigger),
                                     enabled=True)
         self.assertEqual(1, len(retrievedrules), 'Error looking up enabled rules.')
         for retrievedrule in retrievedrules:
@@ -143,7 +143,7 @@ class ReactorModelTest(DbTestCase):
         runnertype = ActionModelTest._create_save_runnertype()
         action = ActionModelTest._create_save_action(runnertype)
         saved = ReactorModelTest._create_save_rule(trigger, action, False)
-        retrievedrules = Rule.query(trigger=reference.get_ref_from_model(trigger),
+        retrievedrules = Rule.query(trigger=reference.get_str_resource_ref_from_model(trigger),
                                     enabled=False)
         self.assertEqual(1, len(retrievedrules), 'Error looking up enabled rules.')
         for retrievedrule in retrievedrules:
@@ -194,7 +194,7 @@ class ReactorModelTest(DbTestCase):
         created.name = 'rule-1'
         created.description = ''
         created.enabled = enabled
-        created.trigger = reference.get_ref_from_model(trigger)
+        created.trigger = reference.get_str_resource_ref_from_model(trigger)
         created.criteria = {}
         created.action = ActionExecutionSpecDB()
         action_ref = ResourceReference(pack=action.content_pack, name=action.name).ref

--- a/st2reactor/st2reactor/bootstrap/rulesregistrar.py
+++ b/st2reactor/st2reactor/bootstrap/rulesregistrar.py
@@ -39,7 +39,7 @@ def _register_rules_from_pack(pack, rules):
                 except ValueError:
                     LOG.info('Rule %s not found. Creating new one.', rule)
 
-                rule_db.trigger = reference.get_ref_from_model(trigger_db)
+                rule_db.trigger = reference.get_str_resource_ref_from_model(trigger_db)
 
                 try:
                     rule_db = Rule.add_or_update(rule_db)

--- a/st2reactor/st2reactor/rules/enforcer.py
+++ b/st2reactor/st2reactor/rules/enforcer.py
@@ -23,9 +23,11 @@ class RuleEnforcer(object):
         LOG.info('Invoking action %s for trigger_instance %s with data %s.',
                  self.rule.action.ref, self.trigger_instance.id,
                  json.dumps(data))
-        context = {'trigger_instance': reference.get_ref_from_model(self.trigger_instance),
-                   'rule': reference.get_ref_from_model(self.rule),
-                   'user': get_system_username()}
+        context = {
+            'trigger_instance': reference.get_ref_from_model(self.trigger_instance),
+            'rule': reference.get_ref_from_model(self.rule),
+            'user': get_system_username()
+        }
 
         action_execution = RuleEnforcer._invoke_action(self.rule.action, data, context)
         if not action_execution:

--- a/st2reactor/st2reactor/rules/engine.py
+++ b/st2reactor/st2reactor/rules/engine.py
@@ -22,7 +22,7 @@ class RulesEngine(object):
         return self.get_rules_for_trigger_from_db(trigger)
 
     def get_rules_for_trigger_from_db(self, trigger):
-        rules = Rule.query(trigger__id=trigger['id'], enabled=True)
+        rules = Rule.query(trigger=trigger.type, enabled=True)
         LOG.info('Found %d rules defined for trigger %s', len(rules), trigger['name'])
         return rules
 

--- a/st2reactor/tests/test_enforce.py
+++ b/st2reactor/tests/test_enforce.py
@@ -14,6 +14,7 @@ import st2tests.config as tests_config
 MOCK_TRIGGER = TriggerDB()
 MOCK_TRIGGER.id = 'trigger-test.id'
 MOCK_TRIGGER.name = 'trigger-test.name'
+MOCK_TRIGGER.content_pack = 'dummypack1'
 
 MOCK_TRIGGER_INSTANCE = TriggerInstanceDB()
 MOCK_TRIGGER_INSTANCE.id = 'triggerinstance-test'
@@ -32,7 +33,7 @@ MOCK_ACTION_EXECUTION.status = 'scheduled'
 
 MOCK_RULE_1 = RuleDB()
 MOCK_RULE_1.id = 'rule-test-1'
-MOCK_RULE_1.trigger = reference.get_ref_from_model(MOCK_TRIGGER)
+MOCK_RULE_1.trigger = reference.get_str_resource_ref_from_model(MOCK_TRIGGER)
 MOCK_RULE_1.criteria = {}
 MOCK_RULE_1.action = ActionExecutionSpecDB()
 MOCK_RULE_1.action.action = reference.get_ref_from_model(MOCK_ACTION)
@@ -40,7 +41,7 @@ MOCK_RULE_1.enabled = True
 
 MOCK_RULE_2 = RuleDB()
 MOCK_RULE_2.id = 'rule-test-2'
-MOCK_RULE_2.trigger = reference.get_ref_from_model(MOCK_TRIGGER)
+MOCK_RULE_2.trigger = reference.get_str_resource_ref_from_model(MOCK_TRIGGER)
 MOCK_RULE_2.criteria = {}
 MOCK_RULE_2.action = ActionExecutionSpecDB()
 MOCK_RULE_2.action.action = reference.get_ref_from_model(MOCK_ACTION)

--- a/st2reactor/tests/test_filter.py
+++ b/st2reactor/tests/test_filter.py
@@ -29,19 +29,20 @@ MOCK_ACTION.name = 'action-test-1.name'
 MOCK_RULE_1 = RuleDB()
 MOCK_RULE_1.id = bson.ObjectId()
 MOCK_RULE_1.name = "some1"
-MOCK_RULE_1.trigger = reference.get_ref_from_model(MOCK_TRIGGER)
+MOCK_RULE_1.trigger = reference.get_str_resource_ref_from_model(MOCK_TRIGGER)
 MOCK_RULE_1.criteria = {}
 MOCK_RULE_1.action = ActionExecutionSpecDB(ref="somepack.someaction")
 
 MOCK_RULE_2 = RuleDB()
 MOCK_RULE_2.id = bson.ObjectId()
 MOCK_RULE_1.name = "some2"
-MOCK_RULE_2.trigger = reference.get_ref_from_model(MOCK_TRIGGER)
+MOCK_RULE_2.trigger = reference.get_str_resource_ref_from_model(MOCK_TRIGGER)
 MOCK_RULE_2.criteria = {}
 MOCK_RULE_2.action = ActionExecutionSpecDB(name="somepack.someaction")
 
 
-@mock.patch.object(reference, 'get_model_from_ref', mock.MagicMock(return_value=MOCK_TRIGGER))
+@mock.patch.object(reference, 'get_model_by_resource_ref',
+                   mock.MagicMock(return_value=MOCK_TRIGGER))
 class FilterTest(DbTestCase):
     def test_empty_criteria(self):
         rule = MOCK_RULE_1

--- a/st2reactor/tests/test_rule_engine.py
+++ b/st2reactor/tests/test_rule_engine.py
@@ -132,7 +132,7 @@ class RuleEngineTest(DbTestCase):
         rule_db = RuleAPI.to_model(rule_api)
         trigger_api = TriggerAPI(**rule_api.trigger)
         trigger_db = TriggerService.create_trigger_db(trigger_api)
-        trigger_ref = reference.get_ref_from_model(trigger_db)
+        trigger_ref = reference.get_str_resource_ref_from_model(trigger_db)
         rule_db.trigger = trigger_ref
         rule_db = Rule.add_or_update(rule_db)
         rules.append(rule_db)
@@ -220,7 +220,7 @@ class RuleEngineTest(DbTestCase):
         rule_db = RuleAPI.to_model(rule_api)
         trigger_api = TriggerAPI(**rule_api.trigger)
         trigger_db = TriggerService.create_trigger_db(trigger_api)
-        trigger_ref = reference.get_ref_from_model(trigger_db)
+        trigger_ref = reference.get_str_resource_ref_from_model(trigger_db)
         rule_db.trigger = trigger_ref
         rule_db = Rule.add_or_update(rule_db)
         rules.append(rule_db)

--- a/st2reactor/tests/test_rule_matcher.py
+++ b/st2reactor/tests/test_rule_matcher.py
@@ -73,7 +73,7 @@ class RuleMatcherTest(DbTestCase):
         rule_db = RuleAPI.to_model(rule_api)
         trigger_api = TriggerAPI(**rule_api.trigger)
         trigger_db = TriggerService.create_trigger_db(trigger_api)
-        trigger_ref = reference.get_ref_from_model(trigger_db)
+        trigger_ref = reference.get_str_resource_ref_from_model(trigger_db)
         rule_db.trigger = trigger_ref
         rule_db = Rule.add_or_update(rule_db)
         rules.append(rule_db)


### PR DESCRIPTION
## TODO

There are still some places referring to things by a dict of name or id. 

st2reactor/st2reactor/rules/enforcer.py
27:            'trigger_instance': reference.get_ref_from_model(self.trigger_instance),
28:            'rule': reference.get_ref_from_model(self.rule),
(virtualenv)~/stanley git:STORM-717/string_refs_bro ❯❯❯

I am not sure what's the right approach there. TriggerInstance doesn't have name/pack. Rule doesn't have pack.
