### PR TITLE
Fix missing content pack on action update

### DIFF
--- a/st2api/st2api/controllers/actions.py
+++ b/st2api/st2api/controllers/actions.py
@@ -123,6 +123,8 @@ class ActionsController(resource.ResourceController):
     @jsexpose(str, body=ActionAPI)
     def put(self, action_id, action):
         action_db = ActionsController._get_by_id(action_id)
+        if not getattr(action, 'content_pack', None):
+            action.content_pack = action_db.content_pack
 
         try:
             action_validator.validate_action(action)

--- a/st2api/tests/controllers/test_actions.py
+++ b/st2api/tests/controllers/test_actions.py
@@ -258,11 +258,15 @@ class TestActionController(FunctionalTest):
         body = json.loads(post_resp.body)
         action['id'] = body['id']
         action['description'] = 'some other test description'
+        content_pack = action['content_pack']
+        del action['content_pack']
+        self.assertNotIn('content_pack', action)
         put_resp = self.__do_put(action['id'], action)
         self.assertEqual(put_resp.status_int, 200)
         self.assertIn('description', put_resp.body)
         body = json.loads(put_resp.body)
         self.assertEqual(body['description'], action['description'])
+        self.assertEqual(body['content_pack'], content_pack)
         self.__do_delete(self.__get_action_id(post_resp))
 
     def test_post_invalid_runner_type(self):


### PR DESCRIPTION
The action content_pack is auto-assigned to default if not provided on create. This is inconsistent on update as the API throws exception on the same action metadata file. So if content_pack is not provided on update, the content_pack currently assigned to the action in the database is used.
