### PR TITLE
Fix rpm build

### DIFF
--- a/st2client/setup.cfg
+++ b/st2client/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 name = st2client
+version = 0.5.1
 vendor = StackStorm
 summary = CLI and Python Client Library for the StackStorm (St2) Automation Platform
 description-file = README.md


### PR DESCRIPTION
Auto-generation of the st2client.spec depends on the version number in the metadata section of setup.cfg.
