### PR TITLE
Rename "ref" attribute on the ActionExecution model to "action".

### DIFF
--- a/st2actions/st2actions/container/actionsensor.py
+++ b/st2actions/st2actions/container/actionsensor.py
@@ -82,7 +82,7 @@ def post_trigger(action_execution):
                 'execution_id': str(action_execution.id),
                 'status': action_execution.status,
                 'start_timestamp': str(action_execution.start_timestamp),
-                'action_name': action_execution.ref,
+                'action_name': action_execution.action,
                 'parameters': action_execution.parameters,
                 'result': action_execution.result
             }

--- a/st2actions/st2actions/container/base.py
+++ b/st2actions/st2actions/container/base.py
@@ -45,7 +45,7 @@ class RunnerContainer(object):
         return runner
 
     def dispatch(self, actionexec_db):
-        action_ref = ResourceReference.from_string_reference(ref=actionexec_db.ref)
+        action_ref = ResourceReference.from_string_reference(ref=actionexec_db.action)
         (action_db, _) = get_action_by_dict(
             {'name': action_ref.name, 'pack': action_ref.pack})
         runnertype_db = get_runnertype_by_name(action_db.runner_type['name'])

--- a/st2actions/st2actions/history.py
+++ b/st2actions/st2actions/history.py
@@ -60,7 +60,7 @@ class Historian(ConsumerMixin):
         try:
             history_id = bson.ObjectId()
             execution = ActionExecution.get_by_id(str(body.id))
-            action_ref = ResourceReference.from_string_reference(ref=execution.ref)
+            action_ref = ResourceReference.from_string_reference(ref=execution.action)
             action_db, _ = action_utils.get_action_by_dict(
                 {'name': action_ref.name,
                  'pack': action_ref.pack})

--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -144,7 +144,7 @@ class ActionChainRunner(ActionRunner):
 
     @staticmethod
     def _run_action(action_ref, parent_execution_id, params, wait_for_completion=True):
-        execution = ActionExecutionDB(ref=action_ref)
+        execution = ActionExecutionDB(action=action_ref)
         execution.parameters = ActionChainRunner._cast_params(action_ref, params)
         execution.context = {'parent': str(parent_execution_id)}
         execution = action_service.schedule(execution)

--- a/st2actions/tests/fixtures/history/rule.json
+++ b/st2actions/tests/fixtures/history/rule.json
@@ -13,7 +13,7 @@
         }
     },
     "action": {
-        "ref": "core.local",
+        "action": "core.local",
         "parameters": {
             "cmd": "echo \"{{trigger}}\" >> /tmp/st2.persons.out"
         }

--- a/st2actions/tests/test_history.py
+++ b/st2actions/tests/test_history.py
@@ -71,7 +71,7 @@ class TestActionExecutionHistoryWorker(DbTestCase):
 
     def test_basic_execution(self):
         action_ref = ResourceReference(name='local', pack='core')
-        execution = ActionExecutionDB(ref=action_ref.ref, parameters={'cmd': 'uname -a'})
+        execution = ActionExecutionDB(action=action_ref.ref, parameters={'cmd': 'uname -a'})
         execution = action_service.schedule(execution)
         execution = ActionExecution.get_by_id(str(execution.id))
         self.assertEqual(execution.status, ACTIONEXEC_STATUS_SUCCEEDED)
@@ -94,7 +94,7 @@ class TestActionExecutionHistoryWorker(DbTestCase):
 
     def test_chained_executions(self):
         action_ref = ResourceReference(name='chain', pack='core')
-        execution = ActionExecutionDB(ref=action_ref.ref)
+        execution = ActionExecutionDB(action=action_ref.ref)
         execution = action_service.schedule(execution)
         execution = ActionExecution.get_by_id(str(execution.id))
         self.assertEqual(execution.status, ACTIONEXEC_STATUS_SUCCEEDED)
@@ -143,7 +143,7 @@ class TestActionExecutionHistoryWorker(DbTestCase):
         self.assertDictEqual(history.trigger_instance,
                              vars(TriggerInstanceAPI.from_model(trigger_instance)))
         self.assertDictEqual(history.rule, vars(RuleAPI.from_model(rule)))
-        action_ref = ResourceReference.from_string_reference(ref=execution.ref)
+        action_ref = ResourceReference.from_string_reference(ref=execution.action)
         action, _ = action_utils.get_action_by_dict(
             {'name': action_ref.name, 'pack': action_ref.pack})
         self.assertDictEqual(history.action, vars(ActionAPI.from_model(action)))

--- a/st2actions/tests/test_mistral_v1.py
+++ b/st2actions/tests/test_mistral_v1.py
@@ -65,7 +65,7 @@ class TestMistralRunner(DbTestCase):
         mock.MagicMock(return_value=EXECUTION))
     def test_launch_workflow(self):
         MistralRunner.entry_point = mock.PropertyMock(return_value=WORKFLOW_YAML)
-        execution = ActionExecutionDB(ref='core.workflow-v1', parameters={'friend': 'Rocky'})
+        execution = ActionExecutionDB(action='core.workflow-v1', parameters={'friend': 'Rocky'})
         execution = action_service.schedule(execution)
         execution = ActionExecution.get_by_id(str(execution.id))
         self.assertEqual(execution.status, ACTIONEXEC_STATUS_RUNNING)
@@ -84,7 +84,7 @@ class TestMistralRunner(DbTestCase):
         mock.MagicMock(return_value=EXECUTION))
     def test_launch_workflow_when_definition_changed(self):
         MistralRunner.entry_point = mock.PropertyMock(return_value=WORKFLOW_YAML)
-        execution = ActionExecutionDB(ref='core.workflow-v1', parameters={'friend': 'Rocky'})
+        execution = ActionExecutionDB(action='core.workflow-v1', parameters={'friend': 'Rocky'})
         execution = action_service.schedule(execution)
         execution = ActionExecution.get_by_id(str(execution.id))
         self.assertEqual(execution.status, ACTIONEXEC_STATUS_RUNNING)
@@ -106,7 +106,7 @@ class TestMistralRunner(DbTestCase):
         mock.MagicMock(return_value=EXECUTION))
     def test_launch_workflow_when_workbook_not_exists(self):
         MistralRunner.entry_point = mock.PropertyMock(return_value=WORKFLOW_YAML)
-        execution = ActionExecutionDB(ref='core.workflow-v1', parameters={'friend': 'Rocky'})
+        execution = ActionExecutionDB(action='core.workflow-v1', parameters={'friend': 'Rocky'})
         execution = action_service.schedule(execution)
         execution = ActionExecution.get_by_id(str(execution.id))
         self.assertEqual(execution.status, ACTIONEXEC_STATUS_RUNNING)
@@ -116,7 +116,7 @@ class TestMistralRunner(DbTestCase):
         mock.MagicMock(return_value=http.FakeResponse({}, 200, 'OK')))
     def test_callback(self):
         execution = ActionExecutionDB(
-            ref='core.local', parameters={'cmd': 'uname -a'},
+            action='core.local', parameters={'cmd': 'uname -a'},
             callback={'source': 'mistral', 'url': 'http://localhost:8989/v1/tasks/12345'})
         execution = action_service.schedule(execution)
         execution = ActionExecution.get_by_id(str(execution.id))

--- a/st2actions/tests/test_mistral_v2.py
+++ b/st2actions/tests/test_mistral_v2.py
@@ -63,7 +63,7 @@ class TestMistralRunner(DbTestCase):
         mock.MagicMock(return_value=EXECUTION))
     def test_launch_workflow(self):
         MistralRunner.entry_point = mock.PropertyMock(return_value=WORKFLOW_YAML)
-        execution = ActionExecutionDB(ref='core.workflow-v2', parameters={'friend': 'Rocky'})
+        execution = ActionExecutionDB(action='core.workflow-v2', parameters={'friend': 'Rocky'})
         execution = action_service.schedule(execution)
         execution = ActionExecution.get_by_id(str(execution.id))
         self.assertEqual(execution.status, ACTIONEXEC_STATUS_RUNNING)
@@ -79,7 +79,7 @@ class TestMistralRunner(DbTestCase):
         mock.MagicMock(return_value=EXECUTION))
     def test_launch_workflow_when_definition_changed(self):
         MistralRunner.entry_point = mock.PropertyMock(return_value=WORKFLOW_YAML)
-        execution = ActionExecutionDB(ref='core.workflow-v2', parameters={'friend': 'Rocky'})
+        execution = ActionExecutionDB(action='core.workflow-v2', parameters={'friend': 'Rocky'})
         execution = action_service.schedule(execution)
         execution = ActionExecution.get_by_id(str(execution.id))
         self.assertEqual(execution.status, ACTIONEXEC_STATUS_RUNNING)
@@ -94,7 +94,7 @@ class TestMistralRunner(DbTestCase):
         executions.ExecutionManager, 'create',
         mock.MagicMock(return_value=EXECUTION))
     def test_launch_workflow_when_workbook_not_exists(self):
-        execution = ActionExecutionDB(ref='core.workflow-v2', parameters={'friend': 'Rocky'})
+        execution = ActionExecutionDB(action='core.workflow-v2', parameters={'friend': 'Rocky'})
         execution = action_service.schedule(execution)
         execution = ActionExecution.get_by_id(str(execution.id))
         self.assertEqual(execution.status, ACTIONEXEC_STATUS_RUNNING)
@@ -104,7 +104,7 @@ class TestMistralRunner(DbTestCase):
         mock.MagicMock(return_value=http.FakeResponse({}, 200, 'OK')))
     def test_callback(self):
         execution = ActionExecutionDB(
-            ref='core.local', parameters={'cmd': 'uname -a'},
+            action='core.local', parameters={'cmd': 'uname -a'},
             callback={'source': 'mistral', 'url': 'http://localhost:8989/v2/tasks/12345'})
         execution = action_service.schedule(execution)
         execution = ActionExecution.get_by_id(str(execution.id))

--- a/st2actions/tests/test_param_utils.py
+++ b/st2actions/tests/test_param_utils.py
@@ -257,8 +257,8 @@ class ParamsUtilsTest(TestCase):
         actionexec_db = ActionExecutionDB()
         actionexec_db.status = 'initializing'
         actionexec_db.start_timestamp = datetime.datetime.utcnow()
-        actionexec_db.ref = ResourceReference(name=ParamsUtilsTest.action_db.name,
-                                              pack=ParamsUtilsTest.action_db.pack).ref
+        actionexec_db.action = ResourceReference(name=ParamsUtilsTest.action_db.name,
+                                                 pack=ParamsUtilsTest.action_db.pack).ref
         actionexec_db.parameters = params
         return actionexec_db
 

--- a/st2actions/tests/test_runner_container.py
+++ b/st2actions/tests/test_runner_container.py
@@ -94,7 +94,7 @@ class RunnerContainerTest(DbTestCase):
         actionexec_db = ActionExecutionDB()
         actionexec_db.status = 'initializing'
         actionexec_db.start_timestamp = datetime.datetime.utcnow()
-        actionexec_db.ref = ResourceReference(
+        actionexec_db.action = ResourceReference(
             name=RunnerContainerTest.action_db.name,
             pack=RunnerContainerTest.action_db.pack).ref
         actionexec_db.parameters = params
@@ -105,7 +105,7 @@ class RunnerContainerTest(DbTestCase):
         actionexec_db = ActionExecutionDB()
         actionexec_db.status = 'initializing'
         actionexec_db.start_timestamp = datetime.datetime.now()
-        actionexec_db.ref = ResourceReference(
+        actionexec_db.action = ResourceReference(
             name=RunnerContainerTest.failingaction_db.name,
             pack=RunnerContainerTest.failingaction_db.pack).ref
         actionexec_db.parameters = params

--- a/st2api/st2api/controllers/actionexecutions.py
+++ b/st2api/st2api/controllers/actionexecutions.py
@@ -28,11 +28,11 @@ class ActionExecutionsController(ResourceController):
     access = ActionExecution
 
     supported_filters = {
-        'action': 'ref'
+        'action': 'action'
     }
 
     query_options = {
-        'sort': ['ref']
+        'sort': ['action']
     }
 
     def _get_action_executions(self, **kw):

--- a/st2api/tests/controllers/test_actionexecutions.py
+++ b/st2api/tests/controllers/test_actionexecutions.py
@@ -79,7 +79,7 @@ ACTION_3 = {
 }
 
 ACTION_EXECUTION_1 = {
-    'ref': 'sixpack.st2.dummy.action1',
+    'action': 'sixpack.st2.dummy.action1',
     'parameters': {
         'hosts': 'localhost',
         'cmd': 'uname -a'
@@ -87,7 +87,7 @@ ACTION_EXECUTION_1 = {
 }
 
 ACTION_EXECUTION_2 = {
-    'ref': 'familypack.st2.dummy.action2',
+    'action': 'familypack.st2.dummy.action2',
     'parameters': {
         'hosts': 'localhost',
         'cmd': 'ls -l'
@@ -95,7 +95,7 @@ ACTION_EXECUTION_2 = {
 }
 
 ACTION_EXECUTION_3 = {
-    'ref': 'wolfpack.st2.dummy.action3',
+    'action': 'wolfpack.st2.dummy.action3',
     'parameters': {
         'hosts': 'localhost',
         'cmd': 'ls -l',
@@ -163,7 +163,7 @@ class TestActionExecutionController(FunctionalTest):
     def test_get_query(self):
         actionexecution_1_id = self._get_actionexecution_id(self._do_post(ACTION_EXECUTION_1))
 
-        resp = self.app.get('/actionexecutions?action=%s' % ACTION_EXECUTION_1['ref'])
+        resp = self.app.get('/actionexecutions?action=%s' % ACTION_EXECUTION_1['action'])
         self.assertEqual(resp.status_int, 200)
         matching_execution = filter(lambda ae: ae['id'] == actionexecution_1_id, resp.json)
         self.assertEqual(len(list(matching_execution)), 1,
@@ -185,17 +185,17 @@ class TestActionExecutionController(FunctionalTest):
         self.assertEqual(resp.status_int, 200)
         self.assertTrue(len(resp.json) > 1)
 
-        resp = self.app.get('/actionexecutions?action=%s' % ACTION_EXECUTION_1['ref'])
+        resp = self.app.get('/actionexecutions?action=%s' % ACTION_EXECUTION_1['action'])
         self.assertEqual(resp.status_int, 200)
         self.assertTrue(len(resp.json) > 1)
 
         resp = self.app.get('/actionexecutions?action=%s&limit=1' %
-                            ACTION_EXECUTION_1['ref'])
+                            ACTION_EXECUTION_1['action'])
         self.assertEqual(resp.status_int, 200)
         self.assertEqual(len(resp.json), 1)
 
         resp = self.app.get('/actionexecutions?action=%s&limit=0' %
-                            ACTION_EXECUTION_1['ref'])
+                            ACTION_EXECUTION_1['action'])
         self.assertEqual(resp.status_int, 200)
         self.assertTrue(len(resp.json) > 1)
 
@@ -256,7 +256,7 @@ class TestActionExecutionController(FunctionalTest):
     def test_update_execution_with_minimum_data(self):
         response = self._do_post(ACTION_EXECUTION_1)
         self.assertEqual(response.status_int, 201)
-        execution = {'ref': response.json['ref'],
+        execution = {'action': response.json['action'],
                      'status': 'succeeded', 'result': True}
         response = self._do_put(response.json['id'], execution)
         self.assertEqual(response.status_int, 200)

--- a/st2api/tests/controllers/test_rules.py
+++ b/st2api/tests/controllers/test_rules.py
@@ -45,7 +45,7 @@ RULE_1 = {
         }
     },
     'action': {
-        'ref': 'sixpack.st2.test.action',
+        'action': 'sixpack.st2.test.action',
         'parameters': {
             'ip2': '{{rule.k1}}',
             'ip1': '{{trigger.t1_p}}'

--- a/st2api/tests/fixtures/history/executions.json
+++ b/st2api/tests/fixtures/history/executions.json
@@ -8,7 +8,7 @@
         "context": {
             "user": "system"
         },
-        "ref": "core.chain"
+        "action": "core.chain"
     },
     "task1": {
         "status": "succeeded",
@@ -32,7 +32,7 @@
         "context": {
             "user": "system"
         },
-        "ref": "core.local"
+        "action": "core.local"
     },
     "task2": {
         "status": "succeeded",
@@ -56,6 +56,6 @@
         "context": {
             "user": "system"
         },
-        "ref": "core.local"
+        "action": "core.local"
     }
 }

--- a/st2api/tests/fixtures/history/rule.json
+++ b/st2api/tests/fixtures/history/rule.json
@@ -13,7 +13,7 @@
         }
     },
     "action": {
-        "ref": "core.local",
+        "action": "core.local",
         "parameters": {
             "cmd": "echo \"{{trigger}}\" >> /tmp/st2.persons.out"
         }

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -129,7 +129,7 @@ class ActionRunCommand(resource.ResourceCommand):
 
         action_ref = '.'.join([action.pack, action.name])
         execution = models.ActionExecution()
-        execution.ref = action_ref
+        execution.action = action_ref
         execution.parameters = dict()
         for idx in range(len(args.parameters)):
             arg = args.parameters[idx]

--- a/st2client/tests/test_action.py
+++ b/st2client/tests/test_action.py
@@ -59,7 +59,7 @@ ACTION2 = {
 }
 
 ACTION_EXECUTION = {
-    'ref': 'mockety.mock',
+    'action': 'mockety.mock',
     'status': 'complete'
 }
 
@@ -112,7 +112,7 @@ class ActionCommandTestCase(unittest2.TestCase):
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(ACTION_EXECUTION), 200, 'OK')))
     def test_runner_param_bool_conversion(self):
         self.shell.run(['run', 'mockety.mock1', 'bool=false'])
-        expected = {'ref': 'mockety.mock1', 'parameters': {'bool': False}}
+        expected = {'action': 'mockety.mock1', 'parameters': {'bool': False}}
         httpclient.HTTPClient.post.assert_called_with('/actionexecutions', expected)
 
     @mock.patch.object(
@@ -126,7 +126,7 @@ class ActionCommandTestCase(unittest2.TestCase):
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(ACTION_EXECUTION), 200, 'OK')))
     def test_runner_param_integer_conversion(self):
         self.shell.run(['run', 'mockety.mock1', 'int=30'])
-        expected = {'ref': 'mockety.mock1', 'parameters': {'int': 30}}
+        expected = {'action': 'mockety.mock1', 'parameters': {'int': 30}}
         httpclient.HTTPClient.post.assert_called_with('/actionexecutions', expected)
 
     @mock.patch.object(
@@ -140,7 +140,7 @@ class ActionCommandTestCase(unittest2.TestCase):
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(ACTION_EXECUTION), 200, 'OK')))
     def test_runner_param_float_conversion(self):
         self.shell.run(['run', 'mockety.mock1', 'float=3.01'])
-        expected = {'ref': 'mockety.mock1', 'parameters': {'float': 3.01}}
+        expected = {'action': 'mockety.mock1', 'parameters': {'float': 3.01}}
         httpclient.HTTPClient.post.assert_called_with('/actionexecutions', expected)
 
     @mock.patch.object(
@@ -154,7 +154,7 @@ class ActionCommandTestCase(unittest2.TestCase):
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(ACTION_EXECUTION), 200, 'OK')))
     def test_runner_param_json_conversion(self):
         self.shell.run(['run', 'mockety.mock1', 'json={"a":1}'])
-        expected = {'ref': 'mockety.mock1', 'parameters': {'json': {'a': 1}}}
+        expected = {'action': 'mockety.mock1', 'parameters': {'json': {'a': 1}}}
         httpclient.HTTPClient.post.assert_called_with('/actionexecutions', expected)
 
     @mock.patch.object(
@@ -168,7 +168,7 @@ class ActionCommandTestCase(unittest2.TestCase):
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(ACTION_EXECUTION), 200, 'OK')))
     def test_param_bool_conversion(self):
         self.shell.run(['run', 'mockety.mock2', 'bool=false'])
-        expected = {'ref': 'mockety.mock2', 'parameters': {'bool': False}}
+        expected = {'action': 'mockety.mock2', 'parameters': {'bool': False}}
         httpclient.HTTPClient.post.assert_called_with('/actionexecutions', expected)
 
     @mock.patch.object(
@@ -182,7 +182,7 @@ class ActionCommandTestCase(unittest2.TestCase):
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(ACTION_EXECUTION), 200, 'OK')))
     def test_param_integer_conversion(self):
         self.shell.run(['run', 'mockety.mock2', 'int=30'])
-        expected = {'ref': 'mockety.mock2', 'parameters': {'int': 30}}
+        expected = {'action': 'mockety.mock2', 'parameters': {'int': 30}}
         httpclient.HTTPClient.post.assert_called_with('/actionexecutions', expected)
 
     @mock.patch.object(
@@ -196,7 +196,7 @@ class ActionCommandTestCase(unittest2.TestCase):
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(ACTION_EXECUTION), 200, 'OK')))
     def test_param_float_conversion(self):
         self.shell.run(['run', 'mockety.mock2', 'float=3.01'])
-        expected = {'ref': 'mockety.mock2', 'parameters': {'float': 3.01}}
+        expected = {'action': 'mockety.mock2', 'parameters': {'float': 3.01}}
         httpclient.HTTPClient.post.assert_called_with('/actionexecutions', expected)
 
     @mock.patch.object(
@@ -210,7 +210,7 @@ class ActionCommandTestCase(unittest2.TestCase):
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(ACTION_EXECUTION), 200, 'OK')))
     def test_param_json_conversion(self):
         self.shell.run(['run', 'mockety.mock2', 'json={"a":1}'])
-        expected = {'ref': 'mockety.mock2', 'parameters': {'json': {'a': 1}}}
+        expected = {'action': 'mockety.mock2', 'parameters': {'json': {'a': 1}}}
         httpclient.HTTPClient.post.assert_called_with('/actionexecutions', expected)
 
     @mock.patch.object(
@@ -224,6 +224,6 @@ class ActionCommandTestCase(unittest2.TestCase):
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(ACTION_EXECUTION), 200, 'OK')))
     def test_param_value_with_equal_sign(self):
         self.shell.run(['run', 'mockety.mock2', 'key=foo=bar&ponies=unicorns'])
-        expected = {'ref': 'mockety.mock2',
+        expected = {'action': 'mockety.mock2',
                     'parameters': {'key': 'foo=bar&ponies=unicorns'}}
         httpclient.HTTPClient.post.assert_called_with('/actionexecutions', expected)

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -206,7 +206,7 @@ class ActionExecutionAPI(BaseAPI):
                 "type": "string",
                 "pattern": isotime.ISO8601_UTC_REGEX
             },
-            "ref": {
+            "action": {
                 "description": "Reference to the action to be executed.",
                 "type": "string"
             },
@@ -241,7 +241,7 @@ class ActionExecutionAPI(BaseAPI):
                 "type": "object"
             }
         },
-        "required": ["ref"],
+        "required": ["action"],
         "additionalProperties": False
     }
 
@@ -255,7 +255,7 @@ class ActionExecutionAPI(BaseAPI):
     @classmethod
     def to_model(cls, execution):
         model = super(cls, cls).to_model(execution)
-        model.ref = execution.ref
+        model.action = execution.action
         if getattr(execution, 'start_timestamp', None):
             model.start_timestamp = isotime.parse(execution.start_timestamp)
         model.status = getattr(execution, 'status', None)

--- a/st2common/st2common/models/api/rule.py
+++ b/st2common/st2common/models/api/rule.py
@@ -13,14 +13,14 @@ class ActionSpec(BaseAPI):
     schema = {
         'type': 'object',
         'properties': {
-            'ref': {
+            'action': {
                 'type': 'string'
             },
             'parameters': {
                 'type': 'object'
             }
         },
-        'required': ['ref'],
+        'required': ['action'],
         'additionalProperties': False
     }
 
@@ -119,7 +119,7 @@ class RuleAPI(BaseAPI):
                 del model.criteria[oldkey]
         validator.validate_criteria(model.criteria)
         model.action = ActionExecutionSpecDB()
-        model.action.ref = rule.action['ref']
+        model.action.action = rule.action['action']
         model.action.parameters = rule.action['parameters']
         model.enabled = rule.enabled
         return model

--- a/st2common/st2common/models/db/action.py
+++ b/st2common/st2common/models/db/action.py
@@ -94,7 +94,7 @@ class ActionExecutionDB(StormFoundationDB):
     start_timestamp = me.DateTimeField(
         default=datetime.datetime.utcnow,
         help_text='The timestamp when the ActionExecution was created.')
-    ref = me.StringField(
+    action = me.StringField(
         required=True,
         help_text='Reference to the action that has to be executed.')
     parameters = me.DictField(

--- a/st2common/st2common/models/db/reactor.py
+++ b/st2common/st2common/models/db/reactor.py
@@ -63,14 +63,14 @@ class TriggerInstanceDB(StormFoundationDB):
 
 
 class ActionExecutionSpecDB(me.EmbeddedDocument):
-    ref = me.StringField(required=True, unique=False)
+    action = me.StringField(required=True, unique=False)
     parameters = me.DictField()
 
     def __str__(self):
         result = []
         result.append('ActionExecutionSpecDB@')
         result.append(str(id(self)))
-        result.append('(ref="%s", ' % self.ref)
+        result.append('(action="%s", ' % self.action)
         result.append('parameters="%s")' % self.parameters)
         return ''.join(result)
 

--- a/st2common/st2common/services/action.py
+++ b/st2common/st2common/services/action.py
@@ -28,11 +28,11 @@ def schedule(execution):
         execution.context['user'] = getattr(parent, 'context', dict()).get('user')
 
     # Validate action.
-    action_db = action_utils.get_action_by_ref(execution.ref)
+    action_db = action_utils.get_action_by_ref(execution.action)
     if not action_db:
-        raise ValueError('Action "%s" cannot be found.' % execution.ref)
+        raise ValueError('Action "%s" cannot be found.' % execution.action)
     if not action_db.enabled:
-        raise ValueError('Unable to execute. Action "%s" is disabled.' % execution.ref)
+        raise ValueError('Unable to execute. Action "%s" is disabled.' % execution.action)
 
     runnertype_db = action_utils.get_runnertype_by_name(action_db.runner_type['name'])
 

--- a/st2common/tests/fixtures/history/executions.json
+++ b/st2common/tests/fixtures/history/executions.json
@@ -8,7 +8,7 @@
         "context": {
             "user": "system"
         },
-        "ref": "core.chain"
+        "action": "core.chain"
     },
     "task1": {
         "status": "succeeded",
@@ -32,7 +32,7 @@
         "context": {
             "user": "system"
         },
-        "ref": "core.local"
+        "action": "core.local"
     },
     "task2": {
         "status": "succeeded",
@@ -56,6 +56,6 @@
         "context": {
             "user": "system"
         },
-        "ref": "core.local"
+        "action": "core.local"
     }
 }

--- a/st2common/tests/fixtures/history/rule.json
+++ b/st2common/tests/fixtures/history/rule.json
@@ -13,7 +13,7 @@
         }
     },
     "action": {
-        "ref": "core.local",
+        "action": "core.local",
         "parameters": {
             "cmd": "echo \"{{trigger}}\" >> /tmp/st2.persons.out"
         }

--- a/st2common/tests/services/test_action.py
+++ b/st2common/tests/services/test_action.py
@@ -62,13 +62,13 @@ class TestActionExecutionService(DbTestCase):
     def test_schedule(self):
         context = {'user': USERNAME}
         parameters = {'hosts': 'localhost', 'cmd': 'uname -a'}
-        request = ActionExecutionDB(ref=ACTION_REF, context=context, parameters=parameters)
+        request = ActionExecutionDB(action=ACTION_REF, context=context, parameters=parameters)
         request = action_service.schedule(request)
         execution = ActionExecution.get_by_id(str(request.id))
         self.assertIsNotNone(execution)
         self.assertEqual(execution.id, request.id)
         action = '.'.join([self.actiondb.pack, self.actiondb.name])
-        actual_action = execution.ref
+        actual_action = execution.action
         self.assertEqual(actual_action, action)
         self.assertEqual(execution.context['user'], request.context['user'])
         self.assertDictEqual(execution.parameters, request.parameters)
@@ -79,20 +79,20 @@ class TestActionExecutionService(DbTestCase):
 
     def test_schedule_invalid_parameters(self):
         parameters = {'hosts': 'localhost', 'cmd': 'uname -a', 'a': 123}
-        execution = ActionExecutionDB(ref=ACTION_REF, parameters=parameters)
+        execution = ActionExecutionDB(action=ACTION_REF, parameters=parameters)
         self.assertRaises(jsonschema.ValidationError, action_service.schedule, execution)
 
     def test_schedule_nonexistent_action(self):
         parameters = {'hosts': 'localhost', 'cmd': 'uname -a'}
         action_ref = ResourceReference(name='i.action', pack='default').ref
-        execution = ActionExecutionDB(ref=action_ref, parameters=parameters)
+        execution = ActionExecutionDB(action=action_ref, parameters=parameters)
         self.assertRaises(ValueError, action_service.schedule, execution)
 
     def test_schedule_disabled_action(self):
         self.actiondb.enabled = False
         Action.add_or_update(self.actiondb)
         parameters = {'hosts': 'localhost', 'cmd': 'uname -a'}
-        execution = ActionExecutionDB(ref=ACTION_REF, parameters=parameters)
+        execution = ActionExecutionDB(action=ACTION_REF, parameters=parameters)
         self.assertRaises(ValueError, action_service.schedule, execution)
         self.actiondb.enabled = True
         Action.add_or_update(self.actiondb)

--- a/st2common/tests/test_action_db_utils.py
+++ b/st2common/tests/test_action_db_utils.py
@@ -91,7 +91,7 @@ class ActionDBUtilsTestCase(DbTestCase):
         actionexec_db = ActionExecutionDB()
         actionexec_db.status = 'initializing'
         actionexec_db.start_timestamp = datetime.datetime.utcnow()
-        actionexec_db.ref = ResourceReference(
+        actionexec_db.action = ResourceReference(
             name=ActionDBUtilsTestCase.action_db.name,
             pack=ActionDBUtilsTestCase.action_db.pack).ref
         params = {
@@ -114,7 +114,7 @@ class ActionDBUtilsTestCase(DbTestCase):
         actionexec_db = ActionExecutionDB()
         actionexec_db.status = 'initializing'
         actionexec_db.start_timestamp = datetime.datetime.utcnow()
-        actionexec_db.ref = ResourceReference(
+        actionexec_db.action = ResourceReference(
             name=ActionDBUtilsTestCase.action_db.name,
             pack=ActionDBUtilsTestCase.action_db.pack).ref
         params = {
@@ -195,7 +195,7 @@ class ActionDBUtilsTestCase(DbTestCase):
         actionexec_db = ActionExecutionDB()
         actionexec_db.status = 'initializing'
         actionexec_db.start_timestamp = datetime.datetime.utcnow()
-        actionexec_db.ref = ResourceReference(
+        actionexec_db.action = ResourceReference(
             name=ActionDBUtilsTestCase.action_db.name,
             pack=ActionDBUtilsTestCase.action_db.pack).ref
         params = {

--- a/st2common/tests/test_db.py
+++ b/st2common/tests/test_db.py
@@ -198,7 +198,7 @@ class ReactorModelTest(DbTestCase):
         created.criteria = {}
         created.action = ActionExecutionSpecDB()
         action_ref = ResourceReference(pack=action.pack, name=action.name).ref
-        created.action.ref = action_ref
+        created.action.action = action_ref
         created.action.pack = action.pack
         created.action.parameters = {}
         return Rule.add_or_update(created)

--- a/st2reactor/st2reactor/rules/enforcer.py
+++ b/st2reactor/st2reactor/rules/enforcer.py
@@ -21,7 +21,7 @@ class RuleEnforcer(object):
     def enforce(self):
         data = self.data_transformer(self.rule.action.parameters)
         LOG.info('Invoking action %s for trigger_instance %s with data %s.',
-                 self.rule.action.ref, self.trigger_instance.id,
+                 self.rule.action.action, self.trigger_instance.id,
                  json.dumps(data))
         context = {
             'trigger_instance': reference.get_ref_from_model(self.trigger_instance),
@@ -44,8 +44,8 @@ class RuleEnforcer(object):
 
     @staticmethod
     def _invoke_action(action, action_args, context=None):
-        action_ref = action['ref']
-        execution = ActionExecutionDB(ref=action_ref, context=context, parameters=action_args)
+        action_ref = action['action']
+        execution = ActionExecutionDB(action=action_ref, context=context, parameters=action_args)
         execution = action_service.schedule(execution)
         return ({'id': str(execution.id)}
                 if execution.status == ACTIONEXEC_STATUS_SCHEDULED else None)

--- a/st2reactor/tests/test_filter.py
+++ b/st2reactor/tests/test_filter.py
@@ -31,7 +31,7 @@ MOCK_RULE_1.id = bson.ObjectId()
 MOCK_RULE_1.name = "some1"
 MOCK_RULE_1.trigger = reference.get_str_resource_ref_from_model(MOCK_TRIGGER)
 MOCK_RULE_1.criteria = {}
-MOCK_RULE_1.action = ActionExecutionSpecDB(ref="somepack.someaction")
+MOCK_RULE_1.action = ActionExecutionSpecDB(action="somepack.someaction")
 
 MOCK_RULE_2 = RuleDB()
 MOCK_RULE_2.id = bson.ObjectId()

--- a/st2reactor/tests/test_rule_engine.py
+++ b/st2reactor/tests/test_rule_engine.py
@@ -120,7 +120,7 @@ class RuleEngineTest(DbTestCase):
                 }
             },
             'action': {
-                'ref': 'sixpack.st2.test.action',
+                'action': 'sixpack.st2.test.action',
                 'parameters': {
                     'ip2': '{{rule.k1}}',
                     'ip1': '{{trigger.t1_p}}'
@@ -151,7 +151,7 @@ class RuleEngineTest(DbTestCase):
                 }
             },
             'action': {
-                'ref': 'sixpack.st2.test.action',
+                'action': 'sixpack.st2.test.action',
                 'parameters': {
                     'ip2': '{{rule.k1}}',
                     'ip1': '{{trigger.t1_p}}'
@@ -179,7 +179,7 @@ class RuleEngineTest(DbTestCase):
                 }
             },
             'action': {
-                'ref': 'sixpack.st2.test.action',
+                'action': 'sixpack.st2.test.action',
                 'parameters': {
                     'ip2': '{{rule.k1}}',
                     'ip1': '{{trigger.t1_p}}'
@@ -208,7 +208,7 @@ class RuleEngineTest(DbTestCase):
                 }
             },
             'action': {
-                'ref': 'sixpack.st2.test.action',
+                'action': 'sixpack.st2.test.action',
                 'parameters': {
                     'ip2': '{{rule.k1}}',
                     'ip1': '{{trigger.t1_p}}'

--- a/st2reactor/tests/test_rule_matcher.py
+++ b/st2reactor/tests/test_rule_matcher.py
@@ -61,7 +61,7 @@ class RuleMatcherTest(DbTestCase):
                 }
             },
             'action': {
-                'ref': 'sixpack.st2.test.action',
+                'action': 'sixpack.st2.test.action',
                 'parameters': {
                     'ip2': '{{rule.k1}}',
                     'ip1': '{{trigger.t1_p}}'
@@ -92,7 +92,7 @@ class RuleMatcherTest(DbTestCase):
                 }
             },
             'action': {
-                'ref': 'sixpack.st2.test.action',
+                'action': 'sixpack.st2.test.action',
                 'parameters': {
                     'ip2': '{{rule.k1}}',
                     'ip1': '{{trigger.t1_p}}'
@@ -120,7 +120,7 @@ class RuleMatcherTest(DbTestCase):
                 }
             },
             'action': {
-                'ref': 'sixpack.st2.test.action',
+                'action': 'sixpack.st2.test.action',
                 'parameters': {
                     'ip2': '{{rule.k1}}',
                     'ip1': '{{trigger.t1_p}}'


### PR DESCRIPTION
This way it's consistent with other model and it's clear that it's a reference
to an Action and not reference to the ActionExecution.
