### PR TITLE
Add username and password options to mongodb

### DIFF
--- a/st2actions/st2actions/cmd/actionrunner.py
+++ b/st2actions/st2actions/cmd/actionrunner.py
@@ -29,8 +29,10 @@ def _setup():
     logging.setup(cfg.CONF.actionrunner.logging)
     # 3. all other setup which requires config to be parsed and logging to
     # be correctly setup.
-    db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host,
-             cfg.CONF.database.port)
+    username = cfg.CONF.database.username if hasattr(cfg.CONF.database, 'username') else None
+    password = cfg.CONF.database.password if hasattr(cfg.CONF.database, 'password') else None
+    db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
+             username=username, password=password)
 
 
 def _run_worker():

--- a/st2actions/st2actions/cmd/history.py
+++ b/st2actions/st2actions/cmd/history.py
@@ -30,7 +30,10 @@ def _setup():
     logging.setup(cfg.CONF.history.logging)
 
     # All other setup which requires config to be parsed and logging to be correctly setup.
-    db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port)
+    username = cfg.CONF.database.username if hasattr(cfg.CONF.database, 'username') else None
+    password = cfg.CONF.database.password if hasattr(cfg.CONF.database, 'password') else None
+    db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
+             username=username, password=password)
 
 
 def _teardown():

--- a/st2api/st2api/cmd/api.py
+++ b/st2api/st2api/cmd/api.py
@@ -31,8 +31,10 @@ def _setup():
 
     # 3. all other setup which requires config to be parsed and logging to
     # be correctly setup.
-    db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host,
-             cfg.CONF.database.port)
+    username = cfg.CONF.database.username if hasattr(cfg.CONF.database, 'username') else None
+    password = cfg.CONF.database.password if hasattr(cfg.CONF.database, 'password') else None
+    db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
+             username=username, password=password)
 
 
 def _run_server():

--- a/st2auth/st2auth/wsgi.py
+++ b/st2auth/st2auth/wsgi.py
@@ -7,9 +7,10 @@ from st2common.models import db
 
 cfg.CONF(args=['--config-file', '/etc/stanley/stanley.conf'])
 
-db.db_setup(cfg.CONF.database.db_name,
-            cfg.CONF.database.host,
-            cfg.CONF.database.port)
+username = cfg.CONF.database.username if hasattr(cfg.CONF.database, 'username') else None
+password = cfg.CONF.database.password if hasattr(cfg.CONF.database, 'password') else None
+db.db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
+            username=username, password=password)
 
 pecan_config = {
     'app': {

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -45,7 +45,9 @@ def register_opts(ignore_errors=False):
     db_opts = [
         cfg.StrOpt('host', default='0.0.0.0', help='host of db server'),
         cfg.IntOpt('port', default=27017, help='port of db server'),
-        cfg.StrOpt('db_name', default='st2', help='name of database')
+        cfg.StrOpt('db_name', default='st2', help='name of database'),
+        cfg.StrOpt('username', help='username for db login'),
+        cfg.StrOpt('password', help='password for db login'),
     ]
     _do_register_opts(db_opts, 'database', ignore_errors)
 

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -74,8 +74,10 @@ def _setup():
 
     # 3. all other setup which requires config to be parsed and logging to
     # be correctly setup.
-    db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host,
-             cfg.CONF.database.port)
+    username = cfg.CONF.database.username if hasattr(cfg.CONF.database, 'username') else None
+    password = cfg.CONF.database.password if hasattr(cfg.CONF.database, 'password') else None
+    db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
+             username=username, password=password)
 
 
 def _teardown():

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -8,9 +8,12 @@ from st2common import log as logging
 LOG = logging.getLogger(__name__)
 
 
-def db_setup(db_name, db_host, db_port):
-    LOG.info('Connecting to database "%s" @ "%s:%s"' % (db_name, db_host, db_port))
-    return mongoengine.connection.connect(db_name, host=db_host, port=db_port, tz_aware=True)
+def db_setup(db_name, db_host, db_port, username=None, password=None):
+    LOG.info('Connecting to database "%s" @ "%s:%s" as user "%s".' %
+             (db_name, db_host, db_port, str(username)))
+    return mongoengine.connection.connect(db_name, host=db_host,
+                                          port=db_port, tz_aware=True,
+                                          username=username, password=password)
 
 
 def db_teardown():

--- a/st2reactor/st2reactor/cmd/sensormanager.py
+++ b/st2reactor/st2reactor/cmd/sensormanager.py
@@ -26,8 +26,10 @@ def _setup():
 
     # 3. all other setup which requires config to be parsed and logging to
     # be correctly setup.
-    db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host,
-             cfg.CONF.database.port)
+    username = cfg.CONF.database.username if hasattr(cfg.CONF.database, 'username') else None
+    password = cfg.CONF.database.password if hasattr(cfg.CONF.database, 'password') else None
+    db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
+             username=username, password=password)
 
 
 def _teardown():

--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -50,8 +50,11 @@ class DbTestCase(TestCase):
     @classmethod
     def setUpClass(cls):
         st2tests.config.parse_args()
-        DbTestCase.db_connection = db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host,
-                                            cfg.CONF.database.port)
+        username = cfg.CONF.database.username if hasattr(cfg.CONF.database, 'username') else None
+        password = cfg.CONF.database.password if hasattr(cfg.CONF.database, 'password') else None
+        DbTestCase.db_connection = db_setup(
+            cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
+            username=username, password=password)
         cls.drop_collections()
         DbTestCase.db_connection.drop_database(cfg.CONF.database.db_name)
 


### PR DESCRIPTION
Add database username and password options in the configuration file. mongoengine builds the connection string to pymongo. mongoengine requires username and password to be provided explicitly via the connection object.
