### PR TITLE
Changed path to avoid Permission Denied error

### DIFF
--- a/contrib/core/actions/downloadpacks.json
+++ b/contrib/core/actions/downloadpacks.json
@@ -11,7 +11,7 @@
         },
         "repo_url": {
             "type": "string",
-            "default": "git@github.com:StackStorm/st2contrib.git",
+            "default": "https://github.com/StackStorm/st2contrib.git",
             "immutable": true
         },
         "abs_repo_base": {


### PR DESCRIPTION
With the current path it was trying to use my keys to authenticate and gave a Permission Denied error.  Switching to the https:// path fixed it.  It can be reproduced consistently on a clean st2express environment.
