### PR TITLE
Added some hackery around the initial startup

### DIFF
--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -197,12 +197,14 @@ register_content
 echo "########## Starting St2 Services ##########"
 st2ctl restart 
 sleep 20 
-st2 run core.local date -a
+##This is a hack around a weird issue with actions getting stuck in scheduled state
+st2 run core.local date -a &> /dev/null && st2ctl restart &> /dev/null
+ACTIONEXIT=$?
 
 echo "=============================="
 echo ""
 
-if [ ! "$?" == 0 ]
+if [ ! "${ACTIONEXIT}" == 0 ]
 then
   echo "ERROR!" 
   echo "Something went wrong, st2 failed to start"


### PR DESCRIPTION
There is a weird bug where when we first start the system all actions get stuck in 'scheduled' state.  If you schedule an action, then restart st2, everything is fine.  I added a little hackery around that so that st2express users won't feel this pain.  This is a temporary fix until we figure out the root cause.
