### PR TITLE
Changing syslog format

### DIFF
--- a/st2actions/conf/syslog.conf
+++ b/st2actions/conf/syslog.conf
@@ -18,5 +18,5 @@ formatter=syslogVerboseFormatter
 args=(('localhost', handlers.SYSLOG_UDP_PORT), handlers.SysLogHandler.LOG_LOCAL7)
 
 [formatter_syslogVerboseFormatter]
-format=[st2actions] %(asctime)s %(thread)s %(levelname)s %(module)s [-] %(message)s
+format=st2actions[%(process)d]: %(levelname)s %(thread)s %(module)s [-] %(message)s
 datefmt=

--- a/st2actions/conf/syslog.history.conf
+++ b/st2actions/conf/syslog.history.conf
@@ -18,5 +18,5 @@ formatter=syslogVerboseFormatter
 args=(('localhost', handlers.SYSLOG_UDP_PORT), handlers.SysLogHandler.LOG_LOCAL7)
 
 [formatter_syslogVerboseFormatter]
-format=[st2history] %(asctime)s %(thread)s %(levelname)s %(module)s [-] %(message)s
+format=st2history[%(process)d]: %(levelname)s %(thread)s %(module)s [-] %(message)s
 datefmt=

--- a/st2api/conf/syslog.conf
+++ b/st2api/conf/syslog.conf
@@ -18,5 +18,5 @@ formatter=syslogVerboseFormatter
 args=(('localhost', handlers.SYSLOG_UDP_PORT), handlers.SysLogHandler.LOG_LOCAL7)
 
 [formatter_syslogVerboseFormatter]
-format=[st2api] %(asctime)s %(thread)s %(levelname)s %(module)s [-] %(message)s
+format=st2api[%(process)d]: %(levelname)s %(thread)s [-] %(message)s
 datefmt=

--- a/st2auth/conf/syslog.conf
+++ b/st2auth/conf/syslog.conf
@@ -18,5 +18,5 @@ formatter=syslogVerboseFormatter
 args=(('localhost', handlers.SYSLOG_UDP_PORT), handlers.SysLogHandler.LOG_LOCAL7)
 
 [formatter_syslogVerboseFormatter]
-format=[st2auth] %(asctime)s %(thread)s %(levelname)s %(module)s [-] %(message)s
+format=st2auth[%(process)d]: %(levelname)s %(thread)s %(module)s [-] %(message)s
 datefmt=

--- a/st2reactor/conf/syslog.conf
+++ b/st2reactor/conf/syslog.conf
@@ -18,5 +18,5 @@ formatter=syslogVerboseFormatter
 args=(('localhost', handlers.SYSLOG_UDP_PORT), handlers.SysLogHandler.LOG_LOCAL7)
 
 [formatter_syslogVerboseFormatter]
-format=[st2reactor] %(asctime)s %(thread)s %(levelname)s %(module)s [-] %(message)s
+format=st2reactor[%(process)d]: %(levelname)s %(thread)s %(module)s [-] %(message)s
 datefmt=


### PR DESCRIPTION
The name[PID] format is standard for syslog and allows me to do property name matching easier.  The time is automatically added by syslog so that was redundant.  I changed the order of thread and level name for readability purposes.
