### PR TITLE
Change log level for syslog handler

### DIFF
--- a/st2actions/conf/syslog.conf
+++ b/st2actions/conf/syslog.conf
@@ -13,7 +13,7 @@ handlers=syslogHandler
 
 [handler_syslogHandler]
 class=handlers.SysLogHandler
-level=AUDIT
+level=DEBUG
 formatter=syslogVerboseFormatter
 args=(('localhost', handlers.SYSLOG_UDP_PORT), handlers.SysLogHandler.LOG_LOCAL7)
 

--- a/st2actions/conf/syslog.history.conf
+++ b/st2actions/conf/syslog.history.conf
@@ -13,7 +13,7 @@ handlers=syslogHandler
 
 [handler_syslogHandler]
 class=handlers.SysLogHandler
-level=AUDIT
+level=DEBUG
 formatter=syslogVerboseFormatter
 args=(('localhost', handlers.SYSLOG_UDP_PORT), handlers.SysLogHandler.LOG_LOCAL7)
 

--- a/st2api/conf/syslog.conf
+++ b/st2api/conf/syslog.conf
@@ -13,7 +13,7 @@ handlers=syslogHandler
 
 [handler_syslogHandler]
 class=handlers.SysLogHandler
-level=AUDIT
+level=DEBUG
 formatter=syslogVerboseFormatter
 args=(('localhost', handlers.SYSLOG_UDP_PORT), handlers.SysLogHandler.LOG_LOCAL7)
 

--- a/st2auth/conf/syslog.conf
+++ b/st2auth/conf/syslog.conf
@@ -13,7 +13,7 @@ handlers=syslogHandler
 
 [handler_syslogHandler]
 class=handlers.SysLogHandler
-level=AUDIT
+level=DEBUG
 formatter=syslogVerboseFormatter
 args=(('localhost', handlers.SYSLOG_UDP_PORT), handlers.SysLogHandler.LOG_LOCAL7)
 

--- a/st2reactor/conf/syslog.conf
+++ b/st2reactor/conf/syslog.conf
@@ -13,7 +13,7 @@ handlers=syslogHandler
 
 [handler_syslogHandler]
 class=handlers.SysLogHandler
-level=AUDIT
+level=DEBUG
 formatter=syslogVerboseFormatter
 args=(('localhost', handlers.SYSLOG_UDP_PORT), handlers.SysLogHandler.LOG_LOCAL7)
 


### PR DESCRIPTION
We want DEBUG level logging for the syslog handler since we split the audit log into a separate file from within the rsyslog config.
