### PR TITLE
Fix action reference in mistral integration

### DIFF
--- a/contrib/sandbox/packages/workflow/actions/heyheyhey.json
+++ b/contrib/sandbox/packages/workflow/actions/heyheyhey.json
@@ -1,5 +1,6 @@
 {
     "name": "heyheyhey",
+    "pack": "default",
     "runner_type": "mistral-v1",
     "description": "Say hi to friend!",
     "enabled": true,
@@ -7,7 +8,7 @@
     "parameters": {
         "workbook": {
             "type": "string",
-            "default": "heyheyhey",
+            "default": "default.heyheyhey",
             "immutable": true
         },
         "task": {
@@ -23,6 +24,7 @@
         },
         "count": {
             "type": "string",
+            "required": true,
             "default": "3"
         },
         "friend": {

--- a/contrib/sandbox/packages/workflow/actions/heyheyhey.yaml
+++ b/contrib/sandbox/packages/workflow/actions/heyheyhey.yaml
@@ -3,7 +3,7 @@ Workflow:
     say-greeting:
       action: st2.action
       parameters:
-        name: "hey"
+        name: "default.hey"
         parameters:
           cmd: $.count
       publish:
@@ -13,7 +13,7 @@ Workflow:
     say-friend:
       action: st2.action
       parameters:
-        name: "friend"
+        name: "default.friend"
         parameters:
           cmd: $.friend
       publish:
@@ -23,7 +23,7 @@ Workflow:
     greet-friend:
       action: st2.action
       parameters:
-        name: "local"
+        name: "core.local"
         parameters:
           cmd: "echo \"{$.greet}, {$.towhom}\""
       publish:

--- a/contrib/sandbox/packages/workflow/actions/heyheyhey2.json
+++ b/contrib/sandbox/packages/workflow/actions/heyheyhey2.json
@@ -1,5 +1,6 @@
 {
     "name": "heyheyhey2",
+    "pack": "default",
     "runner_type": "mistral-v2",
     "description": "Say hi to friend!",
     "enabled": true,
@@ -7,7 +8,7 @@
     "parameters": {
         "workflow": {
             "type": "string",
-            "default": "heyheyhey.heyheyhey",
+            "default": "default.heyheyhey.heyheyhey",
             "immutable": true
         },
         "context": {
@@ -18,6 +19,7 @@
         },
         "count": {
             "type": "string",
+            "required": true,
             "default": "3"
         },
         "friend": {

--- a/contrib/sandbox/packages/workflow/actions/heyheyhey2.yaml
+++ b/contrib/sandbox/packages/workflow/actions/heyheyhey2.yaml
@@ -1,4 +1,4 @@
-name: 'heyheyhey'
+name: 'default.heyheyhey'
 version: '2.0'
 
 workflows:
@@ -12,7 +12,7 @@ workflows:
       say-greeting:
         action: st2.action
         input:
-          name: "hey"
+          name: "default.hey"
           parameters:
             cmd: $.count
         publish:
@@ -24,7 +24,7 @@ workflows:
       say-friend:
         action: st2.action
         input:
-          name: "friend"
+          name: "default.friend"
           parameters:
             cmd: $.friend
         publish:

--- a/st2actions/st2actions/runners/mistral/v1.py
+++ b/st2actions/st2actions/runners/mistral/v1.py
@@ -30,18 +30,19 @@ class MistralRunner(ActionRunner):
         client = mistral.client(mistral_url='%s/v1' % self.url)
 
         # Update workbook definition.
-        workbook = next((w for w in client.workbooks.list() if w.name == self.action.name), None)
+        workbook_name = self.action.pack + '.' + self.action.name
+        workbook = next((w for w in client.workbooks.list() if w.name == workbook_name), None)
         if not workbook:
-            client.workbooks.create(self.action.name, description=self.action.description)
+            client.workbooks.create(workbook_name, description=self.action.description)
         workbook_file = self.entry_point
         with open(workbook_file, 'r') as workbook_spec:
             definition = workbook_spec.read()
             try:
-                old_definition = client.workbooks.get_definition(self.action.name)
+                old_definition = client.workbooks.get_definition(workbook_name)
             except:
                 old_definition = None
             if definition != old_definition:
-                client.workbooks.upload_definition(self.action.name, definition)
+                client.workbooks.upload_definition(workbook_name, definition)
 
         # Setup context for the workflow execution.
         context = self.runner_parameters.get('context', dict())

--- a/st2actions/st2actions/runners/mistral/v2.py
+++ b/st2actions/st2actions/runners/mistral/v2.py
@@ -30,10 +30,11 @@ class MistralRunner(ActionRunner):
         client = mistral.client(mistral_url='%s/v2' % self.url)
 
         # Update workbook definition.
+        workbook_name = self.action.pack + '.' + self.action.name
         with open(self.entry_point, 'r') as wbkfile:
             definition = wbkfile.read()
             try:
-                wbk = client.workbooks.get(self.action.name)
+                wbk = client.workbooks.get(workbook_name)
                 if wbk.definition != definition:
                     client.workbooks.update(definition)
             except:

--- a/st2actions/tests/fixtures/mistral/workflow-v1.yaml
+++ b/st2actions/tests/fixtures/mistral/workflow-v1.yaml
@@ -3,7 +3,7 @@ Workflow:
     say-greeting:
       action: st2.action
       parameters:
-        name: "hey"
+        name: "core.hey"
         parameters:
           cmd: $.count
       publish:
@@ -13,7 +13,7 @@ Workflow:
     say-friend:
       action: st2.action
       parameters:
-        name: "friend"
+        name: "core.friend"
         parameters:
           cmd: $.friend
       publish:
@@ -23,7 +23,7 @@ Workflow:
     greet-friend:
       action: st2.action
       parameters:
-        name: "local"
+        name: "core.local"
         parameters:
           cmd: "echo \"{$.greet}, {$.towhom}\""
       publish:

--- a/st2actions/tests/fixtures/mistral/workflow-v2.yaml
+++ b/st2actions/tests/fixtures/mistral/workflow-v2.yaml
@@ -12,7 +12,7 @@ workflows:
       say-greeting:
         action: st2.action
         input:
-          name: "hey"
+          name: "core.hey"
           parameters:
             cmd: $.count
         publish:
@@ -24,7 +24,7 @@ workflows:
       say-friend:
         action: st2.action
         input:
-          name: "friend"
+          name: "core.friend"
           parameters:
             cmd: $.friend
         publish:

--- a/st2actions/tests/test_mistral_v1.py
+++ b/st2actions/tests/test_mistral_v1.py
@@ -30,7 +30,7 @@ from st2common.persistence.action import Action, ActionExecution
 CHAMPION = worker.Worker(None)
 WORKFLOW_YAML = [f for f in fixture.WORKFLOW_YAMLS if 'workflow-v1.yaml' in f][0]
 WORKBOOK_SPEC = fixture.ARTIFACTS['workflows']['workflow-v1']
-WORKBOOK = workbooks.Workbook(None, {'name': 'workflow-v1'})
+WORKBOOK = workbooks.Workbook(None, {'name': 'core.workflow-v1'})
 EXECUTION = executions.Execution(None, {'id': str(uuid.uuid4()), 'state': 'RUNNING'})
 
 


### PR DESCRIPTION
Change action reference from dict to fully qualified action name. Change workbook name and reference to action name in workbook definitions to use fully qualified action name.
