### PR TITLE
RFR: Return 404 when invalid reference for GET /actions

### DIFF
--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -113,8 +113,7 @@ class ContentPackResourceControler(ResourceController):
         try:
             kwargs = self._get_filters(**kwargs)
         except InvalidResourceReferenceError:
-            msg = 'Unable to find resource by ref: %s' % kwargs.get('ref', '')
-            pecan.abort(http_client.NOT_FOUND, msg)
+            return []
         except Exception as e:
             pecan.abort(http_client.BAD_REQUEST, e.message)
 


### PR DESCRIPTION
```
(virtualenv)~/stanley git:fix_action_invalid_ref_500 ❯❯❯ http GET http://localhost:9101/actions\?ref\=http                                                                                                                      ✭ ✱ ◼
HTTP/1.1 200 OK
Access-Control-Allow-Headers: Content-Type
Access-Control-Allow-Methods: GET,POST,PUT,DELETE,OPTIONS
Access-Control-Allow-Origin: http://localhost:3000
Access-Control-Expose-Headers: Content-Type,X-Limit,X-Total-Count
Content-Length: 2
Content-Type: application/json; charset=UTF-8
Date: Tue, 28 Oct 2014 02:19:31 GMT

[]

(virtualenv)~/stanley git:fix_action_invalid_ref_500 ❯❯❯ st2 action get http                                                                                                                                                    ✭ ✱ ◼
Action "http" is not found.

(virtualenv)~/stanley git:fix_action_invalid_ref_500 ❯❯❯
```
