### PR TITLE
Run restart_component action as sudo.

### DIFF
--- a/contrib/packs/actions/restart_component.json
+++ b/contrib/packs/actions/restart_component.json
@@ -6,6 +6,7 @@
     "entry_point": "",
     "parameters": {
         "sudo": {
+            "default": true,
             "immutable": true
         },
         "cmd": {


### PR DESCRIPTION
- This way restart_component succeeds.
- The user that runs the action, typically stanley, must support passwordless sudo.
