### PR TITLE
Use restart to start the mysql service

### DIFF
--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -140,9 +140,9 @@ setup_mongo() {
 
 setup_mysql() {
   if [[ "$TYPE" == "debs" ]]; then
-    service mysql start
+    service mysql restart
   elif [[ "$TYPE" == "rpms" ]]; then
-    service mysqld start
+    service mysqld restart
   fi
   mysqladmin -u root password StackStorm
   mysql -uroot -pStackStorm -e "DROP DATABASE IF EXISTS mistral"


### PR DESCRIPTION
Ubuntu starts mysql post install whereas Fedora does not. If use
"service mysql start", Ubuntu throws an exception about job is already
running.
