### PR TITLE
Reverting key path change

### DIFF
--- a/conf/st2.conf
+++ b/conf/st2.conf
@@ -27,7 +27,7 @@ facility = local7
 
 [system_user]
 user = stanley
-ssh_key_file = /home/vagrant/.ssh/stanley_rsa
+ssh_key_file = /vagrant/.ssh/stanley_rsa
 
 [messaging]
 url = amqp://guest:guest@localhost:5672//


### PR DESCRIPTION
Part of the packaging and deployment process looks for this specific line and changes it to point to the home directory of the stanley user.  We can change this down the road if we really need to but it requires packaging updates.
