### PR TITLE
Docs: Quick Start v2 and Rules

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -70,6 +70,7 @@ extlinks = {
 # Use for variables substitutions
 rst_epilog = """
 .. |st2| replace:: StackStorm
+.. _st2contrib: http://www.github.com/stackstorm/st2contrib
 """
 
 # Show or hide TODOs. See http://sphinx-doc.org/ext/todo.html

--- a/docs/source/install/config.rst
+++ b/docs/source/install/config.rst
@@ -9,6 +9,8 @@ SUDO Access
 
 .. todo:: (Manas) please describe 1) we run st2 as a user, it's in config file, it needs sudo.
 
+.. _configure-ssh:
+
 Configure SSH 
 ----------------
 

--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -1,4 +1,71 @@
 Rules
 ======================================
 
-TODO: Details on rule semantics.
+StackStorm uses rule and worfklows to capture operational patterns as automations. 
+Rules map triggers to actions (or workflows), applying matching criterias and 
+mapping trigger payload to action inputs.
+
+Rule spec is defined as JSON. The following is a sample rule definition
+structure and a listing of the required and optional elements.
+
+.. code-block:: json
+
+    {
+            "name": "rule_name",                       # required
+            "description": "Rule description",         # optional
+
+            "trigger": {                               # required
+                "name": "trigger_name"
+            },
+
+            "criteria": {                              # optional
+                ...
+            },
+
+            "action": {                                # required
+                "ref": "action_name",
+                "parameters": {                        # optional
+                        ...
+                }
+            },
+
+            "enabled": true                            # required
+    }
+
+Criteria in the rule is expressed as:
+
+::
+
+    criteria: {
+         "trigger.payload_parameter_name": {
+            "pattern" : "value",
+            "type": "matchregex"
+          }
+          ...
+    }
+
+Current criteria types are: ``matchregex``, ``eq`` (or ``equals``), ``lt`` (or ``lessthan``), ``gt`` (or ``greaterthan``), ``td_lt`` (or ``timediff_lt``), ``td_gt`` (or ``timediff_gt``).  **For Developers:** The criterion are defined in :github_st2:`st2/st2common/st2common/operators.py </st2common/st2common/operators.py>`,
+if you miss some criteria - welcome to code it up and submit a patch :)
+
+.. todo:: How to operate the rules. 
+
+To deploy a rule, use CLI:
+
+.. code-block:: bash
+    
+    st2 rule create /opt/stackstorm/examples/rules/sample_rule_with_webhook.json
+    st2 rule list
+    st2 rule get examples.webhook_file
+
+By default, StackStorm doesn't load the rules deployed under ``/opt/stackstorm/``. However you can force it 
+load them with ``st2 run pacsk.load register=rules``
+place them in 
+-------------------------------
+
+.. rubric:: What's Next?
+
+* See :doc:`/start` for a simple example of creating and deploying a rule. 
+* Explore automations on `st2contrib`_ comminity repo.
+* Learn more about :doc:`sensors`. 
+
+.. include:: engage.rst


### PR DESCRIPTION
Also: 
- set _st2contrib link as a variable to access in all docs.
- use ref for proper cross-document reference - see config-ssh.
