### PR TITLE
Fix: Sort action executions by timestamp

### DIFF
--- a/st2api/st2api/controllers/actionexecutions.py
+++ b/st2api/st2api/controllers/actionexecutions.py
@@ -32,12 +32,11 @@ class ActionExecutionsController(ResourceController):
     }
 
     query_options = {
-        'sort': ['action']
+        'sort': ['-start_timestamp', 'action']
     }
 
     def _get_action_executions(self, **kw):
         kw['limit'] = int(kw.get('limit', 50))
-        kw['order_by'] = kw.get('order_by', '-start_timestamp')
 
         LOG.debug('Retrieving all action executions with filters=%s', kw)
         return super(ActionExecutionsController, self)._get_all(**kw)

--- a/st2api/tests/controllers/test_actionexecutions.py
+++ b/st2api/tests/controllers/test_actionexecutions.py
@@ -155,6 +155,11 @@ class TestActionExecutionController(FunctionalTest):
         self._get_actionexecution_id(self._do_post(ACTION_EXECUTION_1))
         self._get_actionexecution_id(self._do_post(ACTION_EXECUTION_2))
         resp = self.app.get('/actionexecutions')
+        body = resp.json
+        # Assert executions are sorted by timestamp.
+        for i in range(len(body) - 1):
+            self.assertTrue(isotime.parse(body[i]['start_timestamp']) >=
+                            isotime.parse(body[i + 1]['start_timestamp']))
         self.assertEqual(resp.status_int, 200)
         self.assertEqual(len(resp.json), 2,
                          '/actionexecutions did not return all '


### PR DESCRIPTION
```
(virtualenv)~/stanley git:STORM-780/action_execution_sort ❯❯❯ st2 execution list                             ✭ ✱ ◼
+--------------------------+------------+--------------+-----------+-----------------------------+
| id                       | action     | context.user | status    | start_timestamp             |
+--------------------------+------------+--------------+-----------+-----------------------------+
| 5452ab320640fd411a3f4df2 | core.local |              | succeeded | 2014-10-30T21:18:42.921000Z |
| 5452ab2e0640fd411a3f4df1 | core.local |              | succeeded | 2014-10-30T21:18:38.253000Z |
| 5452ab260640fd411a3f4df0 | core.local |              | succeeded | 2014-10-30T21:18:30.140000Z |
| 5452ab220640fd411a3f4def | core.local |              | succeeded | 2014-10-30T21:18:26.700000Z |
+--------------------------+------------+--------------+-----------+-----------------------------+
(virtualenv)~/stanley git:STORM-780/action_execution_sort ❯❯❯ st2 execution list -n 1                        ✭ ✱ ◼
+--------------------------+------------+--------------+-----------+-----------------------------+
| id                       | action     | context.user | status    | start_timestamp             |
+--------------------------+------------+--------------+-----------+-----------------------------+
| 5452ab320640fd411a3f4df2 | core.local |              | succeeded | 2014-10-30T21:18:42.921000Z |
+--------------------------+------------+--------------+-----------+-----------------------------+
(virtualenv)~/stanley git:STORM-780/action_execution_sort ❯❯❯
```
