### PR TITLE
RFR: context.user should be set to system user if not specified in API headers

### DIFF
--- a/st2api/st2api/controllers/actionexecutions.py
+++ b/st2api/st2api/controllers/actionexecutions.py
@@ -1,6 +1,7 @@
 import json
 
 import jsonschema
+from oslo.config import cfg
 import pecan
 from pecan import abort
 from six.moves import http_client
@@ -60,7 +61,10 @@ class ActionExecutionsController(ResourceController):
                 execution.context = dict()
 
             # Retrieve user context from the request header.
-            execution.context['user'] = pecan.request.headers.get('X-User-Name')
+            user = pecan.request.headers.get('X-User-Name')
+            if not user:
+                user = cfg.CONF.system_user.user
+            execution.context['user'] = user
 
             # Retrieve other st2 context from request header.
             if ('st2-context' in pecan.request.headers and pecan.request.headers['st2-context']):

--- a/st2api/tests/controllers/test_actionexecutions.py
+++ b/st2api/tests/controllers/test_actionexecutions.py
@@ -243,12 +243,15 @@ class TestActionExecutionController(FunctionalTest):
     def test_post_with_st2_context_in_headers(self):
         resp = self._do_post(copy.deepcopy(ACTION_EXECUTION_1))
         self.assertEqual(resp.status_int, 201)
-        context = {'parent': str(resp.json['id']), 'user': None}
+        parent_user = resp.json['context']['user']
+        parent_exec_id = str(resp.json['id'])
+        context = {'parent': parent_exec_id, 'user': None}
         headers = {'content-type': 'application/json', 'st2-context': json.dumps(context)}
         resp = self._do_post(copy.deepcopy(ACTION_EXECUTION_1), headers=headers)
         self.assertEqual(resp.status_int, 201)
-        self.assertIsNone(resp.json['context']['user'])
-        self.assertDictEqual(resp.json['context'], context)
+        self.assertEqual(resp.json['context']['user'], parent_user, 'Should use parent\'s user.')
+        expected = {'parent': parent_exec_id, 'user': parent_user}
+        self.assertDictEqual(resp.json['context'], expected)
 
     def test_update_execution(self):
         response = self._do_post(ACTION_EXECUTION_1)


### PR DESCRIPTION
```
(virtualenv)~/stanley git:STORM-801/context_user_execution ❯❯❯ st2 execution list                              ✭ ◼
+--------------------------+------------+--------------+-----------+-----------------------------+
| id                       | action     | context.user | status    | start_timestamp             |
+--------------------------+------------+--------------+-----------+-----------------------------+
| 5452bf0b0640fd725bb11114 | core.local | lakshmi      | failed    | 2014-10-30T22:43:23.012000Z |
| 5452bf070640fd725bb11113 | core.local | lakshmi      | succeeded | 2014-10-30T22:43:19.374000Z |
| 5452bf030640fd725bb11112 | core.local | lakshmi      | succeeded | 2014-10-30T22:43:15.373000Z |
+--------------------------+------------+--------------+-----------+-----------------------------+
(virtualenv)~/stanley git:STORM-801/context_user_execution ❯❯❯
```
