### PR TITLE
Fix mistral v2 status update

### DIFF
--- a/st2actions/st2actions/handlers/mistral.py
+++ b/st2actions/st2actions/handlers/mistral.py
@@ -28,7 +28,8 @@ class MistralCallbackHandler(handlers.ActionExecutionCallbackHandler):
             method = 'PUT'
             output = json.dumps(result) if isinstance(result, dict) else str(result)
             v1 = 'v1' in url
-            data = {'state': STATUS_MAP[status], 'output': output} if v1 else {'result': output}
+            output_key = 'output' if v1 else 'result'
+            data = {'state': STATUS_MAP[status], output_key: output}
             headers = {'content-type': 'application/json'}
             response = requests.request(method, url, data=json.dumps(data), headers=headers)
             if response.status_code != 200:

--- a/st2actions/tests/test_mistral_v2.py
+++ b/st2actions/tests/test_mistral_v2.py
@@ -110,5 +110,5 @@ class TestMistralRunner(DbTestCase):
         execution = ActionExecution.get_by_id(str(execution.id))
         self.assertEqual(execution.status, ACTIONEXEC_STATUS_SUCCEEDED)
         requests.request.assert_called_with('PUT', execution.callback['url'],
-                                            data=json.dumps({'result': '{}'}),
+                                            data=json.dumps({'state': 'SUCCESS', 'result': '{}'}),
                                             headers={'content-type': 'application/json'})


### PR DESCRIPTION
The mistral v2 callback handler did not include status in the update.
