### PR TITLE
Add: .travis.yml file for enabling travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+script: make tests
+services:
+  - mongodb
+  - rabbitmq


### PR DESCRIPTION
I think it's now time to bring back Travis. Ref: https://github.com/StackStorm/st2/pull/332.
