### PR TITLE
Create database indexes up-front in setup_db function before starting the app

### DIFF
--- a/st2common/st2common/models/db/access.py
+++ b/st2common/st2common/models/db/access.py
@@ -16,6 +16,11 @@
 import mongoengine as me
 from st2common.models.db import stormbase
 
+__all__ = [
+    'UserDB',
+    'TokenDB'
+]
+
 
 class UserDB(stormbase.StormFoundationDB):
     name = me.StringField(required=True, unique=True)
@@ -25,3 +30,6 @@ class TokenDB(stormbase.StormFoundationDB):
     user = me.StringField(required=True)
     token = me.StringField(required=True, unique=True)
     expiry = me.DateTimeField(required=True)
+
+
+MODELS = [UserDB, TokenDB]

--- a/st2common/st2common/models/db/action.py
+++ b/st2common/st2common/models/db/action.py
@@ -20,10 +20,11 @@ from st2common import log as logging
 from st2common.models.db import MongoDBAccess
 from st2common.models.db.stormbase import StormFoundationDB, StormBaseDB, EscapedDynamicField
 
-
-__all__ = ['RunnerTypeDB',
-           'ActionDB',
-           'ActionExecutionDB']
+__all__ = [
+    'RunnerTypeDB',
+    'ActionDB',
+    'ActionExecutionDB'
+]
 
 
 LOG = logging.getLogger(__name__)

--- a/st2common/st2common/models/db/actionrunner.py
+++ b/st2common/st2common/models/db/actionrunner.py
@@ -17,8 +17,9 @@ from st2common import log as logging
 from st2common.models.db import MongoDBAccess
 from st2common.models.db.stormbase import StormFoundationDB
 
-
-__all__ = ['ActionRunnerDB']
+__all__ = [
+    'ActionRunnerDB'
+]
 
 
 LOG = logging.getLogger(__name__)

--- a/st2common/st2common/models/db/datastore.py
+++ b/st2common/st2common/models/db/datastore.py
@@ -17,6 +17,10 @@ import mongoengine as me
 from st2common.models.db import MongoDBAccess
 from st2common.models.db import stormbase
 
+__all__ = [
+    'KeyValuePairDB'
+]
+
 
 class KeyValuePairDB(stormbase.StormBaseDB):
     """

--- a/st2common/st2common/models/db/history.py
+++ b/st2common/st2common/models/db/history.py
@@ -18,6 +18,10 @@ import mongoengine as me
 from st2common.models.db import stormbase
 from st2common import log as logging
 
+__all__ = [
+    'ActionExecutionHistoryDB'
+]
+
 
 LOG = logging.getLogger(__name__)
 

--- a/st2common/st2common/models/db/reactor.py
+++ b/st2common/st2common/models/db/reactor.py
@@ -18,6 +18,15 @@ from st2common.models.db import MongoDBAccess
 from st2common.models.db.stormbase import StormBaseDB, StormFoundationDB
 from st2common.models.db.stormbase import ContentPackResourceMixin
 
+__all__ = [
+    'SensorTypeDB',
+    'TriggerTypeDB',
+    'TriggerDB',
+    'TriggerInstanceDB',
+    'ActionExecutionSpecDB',
+    'RuleDB'
+]
+
 
 class SensorTypeDB(StormBaseDB, ContentPackResourceMixin):
     """


### PR DESCRIPTION
This branch fixes one of the issues reported in #776.
## Background

By default, mongoengine creates database indexes lazily when inserting a document in the database. This means, database could end up in a bad / corrupted state if there are multiple concurrent request trying to insert a document before an index has been created.

In our case, this showed up as duplicate entries which violate the unique constraint in the DB. The reason why this could happen is because insert happened before unique and other indexes were created.
## Proposed solution

In this branch I create all the indexes up-front in the `setup_db` function. This function is always called first before the application becomes available. This means it should now be impossible for the database to end up in a state which violates index constraints.

Note: Since we now manually create the indexes, we could also set `auto_create_index` attribute on all the models to `False` (see 6th paragraph on http://docs.mongoengine.org/apireference.html#documents).
