### PR TITLE
Pwh/st2ctl

### DIFF
--- a/tools/st2ctl
+++ b/tools/st2ctl
@@ -1,6 +1,6 @@
 #!/bin/bash
 LOGFILE="/tmp/st2_startup.log"
-COMPONENTS="actionrunner st2api st2auth sensor_container history mistral"
+COMPONENTS="actionrunner st2api sensor_container history mistral"
 STANCONF="/etc/st2/st2.conf"
 PYTHON=`which python`
 if [ -z "$AR" ];


### PR DESCRIPTION
The fixes in this PR include:
- Removing st2auth since it doesn't run as it's own process.  It is a module to be used by apache or another web server.
- Added logic around mistral process supervision for Docker.  Docker upstart has been modified and our will not work with our normal deploy process.
