### PR TITLE
Update tox.ini so we can slowly move over to tox from make

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,33 +1,61 @@
 [tox]
-envlist = py27,py34,lint,lint3
+# envlist = py26,py27,py34,flake8-py2,flake8-py3,pylint,pylint3
+envlist = py27,flake8-py2
 skipsdist = true
+skip_missing_interpreters=true
 
 [testenv]
-whitelist_externals = make
 setenv = PYTHONPATH = {toxinidir}/external
          VIRTUALENV_DIR = {envdir}
 install_command = pip install -U --force-reinstall {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
-       -e{toxinidir}/st2common
        -e{toxinidir}/st2tests
-       -e{toxinidir}/st2actionrunner
+       -e{toxinidir}/st2actions
        -e{toxinidir}/st2api
+       -e{toxinidir}/st2auth
        -e{toxinidir}/st2client
+       -e{toxinidir}/st2common
        -e{toxinidir}/st2reactor
-commands = make .pytests
+commands =
+    nosetests -sv st2actions/tests
+    nosetests -sv st2api/tests
+    nosetests -sv st2auth/tests
+    nosetests -sv st2client/tests
+    nosetests -sv st2common/tests
+    nosetests -sv st2reactor/tests
+    nosetests -sv st2tests/tests
 
 [testenv:venv]
 commands = {posargs}
 
-[testenv:lint]
+[testenv:pylint]
 setenv = VIRTUALENV_DIR = {envdir}
 basepython = python2.7
 deps = pylint
-commands = make .pylint
+commands = pylint -E --rcfile=./.pylintrc st2actions st2api st2auth st2client st2common st2reactor st2tests
 
-[testenv:lint3]
+[testenv:pylint3]
 setenv = VIRTUALENV_DIR = {envdir}
 basepython = python3.4
 deps = pylint
-commands = make .pylint
+commands = pylint -E --rcfile=./.pylintrc st2actions st2api st2auth st2client st2common st2reactor st2tests
+
+[testenv:flake8-py2]
+deps = flake8
+commands =
+    flake8 --config {toxinidir}/.flake8 st2actions st2api st2auth st2client st2common st2reactor st2tests
+
+[testenv:flake8-py3]
+basepython = py3: python3.4
+deps = flake8
+commands =
+    flake8 --config {toxinidir}/.flake8 st2actions st2api st2auth st2client st2common st2reactor st2tests
+
+[testenv:docs]
+deps = sphinx
+commands = sphinx-build -W -b html {toxinidir}/docs/source {toxinidir}/docs/build/html
+
+[testenv:livedocs]
+deps = sphinx
+commands = sphinx-autobuild -H 0.0.0.0 -b html {toxinidir}/docs/source {toxinidir}/docs/build/html


### PR DESCRIPTION
We are not compatible with python3.4 because of one of our dependencies. (gitpython -> gitdb). [Ref: https://github.com/gitpython-developers/gitdb/pull/13]

We are not compatible with 2.6 either. I am unsure how travis builds 2.6 just fine. Doesn't pass on my local box. 
