### PR TITLE
Separate requirements.txt for st2client

### DIFF
--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -1,0 +1,4 @@
+pbr>=0.6,!=0.7,<1.0
+prettytable
+requests
+six


### PR DESCRIPTION
The st2client can be installed separately on other systems and so it
should have a separate requirements.txt.
