### PR TITLE
Add "Changelog" section to the documentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,10 @@
+Changelog
+=========
+
+in development
+--------------
+
+v0.5.0 - November 3rd, 2014
+---------------------------
+
+* Initial public release

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,0 +1,1 @@
+.. include:: ../../CHANGELOG.rst

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,6 +19,7 @@ Contents:
     history
     resources/index
     reference/index
+    changelog
     roadmap
 
 Indices and tables


### PR DESCRIPTION
We should populate the "in development" section as the pull requests are being merged in so it's always up to date.

This way, users can just check this document to see what's coming in the future and what's new in master instead of needing to browse through the commits.

The same document should also serve as an official change log document (before we prepare and cut a release we should just go over it and clean it up as needed).
