### PR TITLE
Hack to fix st2_deploy.sh

### DIFF
--- a/st2client/Makefile
+++ b/st2client/Makefile
@@ -19,5 +19,5 @@ rpm:
 deb:
 	python setup.py --command-packages=stdeb.command bdist_deb
 	mkdir -p ~/debbuild
-	cp deb_dist/python-$(COMPONENTS)_$(VER)-1_all.deb ~/debbuild/$(COMPONENTS)_$(VER)-$(RELEASE)_all.deb
+	cp deb_dist/python-$(COMPONENTS)_$(VER)-1_all.deb ~/debbuild/$(COMPONENTS)_$(VER)-$(RELEASE)_amd64.deb
 	rm -Rf dist deb_dist $(COMPONENTS)-$(VER).tar.gz $(COMPONENTS).egg-info ChangeLog AUTHORS build


### PR DESCRIPTION
This is a quick hack to keep the st2_deploy.sh script working.  I'll look into making the script more dynamic but this will fix it for now.
