### PR TITLE
Fix mistral to handle JSON text with single quotes

### DIFF
--- a/st2actions/st2actions/handlers/mistral.py
+++ b/st2actions/st2actions/handlers/mistral.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import ast
 import json
 import requests
 
@@ -41,7 +42,11 @@ class MistralCallbackHandler(handlers.ActionExecutionCallbackHandler):
     def callback(url, context, status, result):
         try:
             method = 'PUT'
-            output = json.dumps(result) if isinstance(result, dict) else str(result)
+            if isinstance(result, basestring) and len(result) > 0 and result[0] in ['{', '[']:
+                value = ast.literal_eval(result)
+                if type(value) in [dict, list]:
+                    result = value
+            output = json.dumps(result) if type(result) in [dict, list] else str(result)
             v1 = 'v1' in url
             output_key = 'output' if v1 else 'result'
             data = {'state': STATUS_MAP[status], output_key: output}

--- a/st2actions/tests/test_mistral_v1.py
+++ b/st2actions/tests/test_mistral_v1.py
@@ -34,6 +34,7 @@ import st2actions.bootstrap.runnersregistrar as runners_registrar
 from st2actions import worker
 from st2actions.runners.mistral.v1 import MistralRunner
 from st2actions.runners.fabricrunner import FabricRunner
+from st2actions.handlers.mistral import MistralCallbackHandler
 from st2common.transport.publishers import CUDPublisher
 from st2common.services import action as action_service
 from st2common.models.db.action import ActionExecutionDB
@@ -125,6 +126,43 @@ class TestMistralRunner(DbTestCase):
         execution = action_service.schedule(execution)
         execution = ActionExecution.get_by_id(str(execution.id))
         self.assertEqual(execution.status, ACTIONEXEC_STATUS_RUNNING)
+
+    @mock.patch.object(
+        requests, 'request',
+        mock.MagicMock(return_value=http.FakeResponse({}, 200, 'OK')))
+    def test_callback_handler_with_result_as_text(self):
+        MistralCallbackHandler.callback('http://localhost:8989/v1/tasks/12345', {},
+                                        ACTIONEXEC_STATUS_SUCCEEDED, '<html></html>')
+
+    @mock.patch.object(
+        requests, 'request',
+        mock.MagicMock(return_value=http.FakeResponse({}, 200, 'OK')))
+    def test_callback_handler_with_result_as_dict(self):
+        MistralCallbackHandler.callback('http://localhost:8989/v1/tasks/12345', {},
+                                        ACTIONEXEC_STATUS_SUCCEEDED, {'a': 1})
+
+    @mock.patch.object(
+        requests, 'request',
+        mock.MagicMock(return_value=http.FakeResponse({}, 200, 'OK')))
+    def test_callback_handler_with_result_as_json_str(self):
+        MistralCallbackHandler.callback('http://localhost:8989/v1/tasks/12345', {},
+                                        ACTIONEXEC_STATUS_SUCCEEDED, '{"a": 1}')
+        MistralCallbackHandler.callback('http://localhost:8989/v1/tasks/12345', {},
+                                        ACTIONEXEC_STATUS_SUCCEEDED, "{'a': 1}")
+
+    @mock.patch.object(
+        requests, 'request',
+        mock.MagicMock(return_value=http.FakeResponse({}, 200, 'OK')))
+    def test_callback_handler_with_result_as_list(self):
+        MistralCallbackHandler.callback('http://localhost:8989/v1/tasks/12345', {},
+                                        ACTIONEXEC_STATUS_SUCCEEDED, ["a", "b", "c"])
+
+    @mock.patch.object(
+        requests, 'request',
+        mock.MagicMock(return_value=http.FakeResponse({}, 200, 'OK')))
+    def test_callback_handler_with_result_as_list_str(self):
+        MistralCallbackHandler.callback('http://localhost:8989/v1/tasks/12345', {},
+                                        ACTIONEXEC_STATUS_SUCCEEDED, '["a", "b", "c"]')
 
     @mock.patch.object(
         requests, 'request',

--- a/st2actions/tests/test_mistral_v2.py
+++ b/st2actions/tests/test_mistral_v2.py
@@ -34,6 +34,7 @@ import st2actions.bootstrap.runnersregistrar as runners_registrar
 from st2actions import worker
 from st2actions.runners.mistral.v2 import MistralRunner
 from st2actions.runners.fabricrunner import FabricRunner
+from st2actions.handlers.mistral import MistralCallbackHandler
 from st2common.transport.publishers import CUDPublisher
 from st2common.services import action as action_service
 from st2common.models.db.action import ActionExecutionDB
@@ -113,6 +114,43 @@ class TestMistralRunner(DbTestCase):
         execution = action_service.schedule(execution)
         execution = ActionExecution.get_by_id(str(execution.id))
         self.assertEqual(execution.status, ACTIONEXEC_STATUS_RUNNING)
+
+    @mock.patch.object(
+        requests, 'request',
+        mock.MagicMock(return_value=http.FakeResponse({}, 200, 'OK')))
+    def test_callback_handler_with_result_as_text(self):
+        MistralCallbackHandler.callback('http://localhost:8989/v2/tasks/12345', {},
+                                        ACTIONEXEC_STATUS_SUCCEEDED, '<html></html>')
+
+    @mock.patch.object(
+        requests, 'request',
+        mock.MagicMock(return_value=http.FakeResponse({}, 200, 'OK')))
+    def test_callback_handler_with_result_as_dict(self):
+        MistralCallbackHandler.callback('http://localhost:8989/v2/tasks/12345', {},
+                                        ACTIONEXEC_STATUS_SUCCEEDED, {'a': 1})
+
+    @mock.patch.object(
+        requests, 'request',
+        mock.MagicMock(return_value=http.FakeResponse({}, 200, 'OK')))
+    def test_callback_handler_with_result_as_json_str(self):
+        MistralCallbackHandler.callback('http://localhost:8989/v2/tasks/12345', {},
+                                        ACTIONEXEC_STATUS_SUCCEEDED, '{"a": 1}')
+        MistralCallbackHandler.callback('http://localhost:8989/v2/tasks/12345', {},
+                                        ACTIONEXEC_STATUS_SUCCEEDED, "{'a': 1}")
+
+    @mock.patch.object(
+        requests, 'request',
+        mock.MagicMock(return_value=http.FakeResponse({}, 200, 'OK')))
+    def test_callback_handler_with_result_as_list(self):
+        MistralCallbackHandler.callback('http://localhost:8989/v2/tasks/12345', {},
+                                        ACTIONEXEC_STATUS_SUCCEEDED, ["a", "b", "c"])
+
+    @mock.patch.object(
+        requests, 'request',
+        mock.MagicMock(return_value=http.FakeResponse({}, 200, 'OK')))
+    def test_callback_handler_with_result_as_list_str(self):
+        MistralCallbackHandler.callback('http://localhost:8989/v2/tasks/12345', {},
+                                        ACTIONEXEC_STATUS_SUCCEEDED, '["a", "b", "c"]')
 
     @mock.patch.object(
         requests, 'request',


### PR DESCRIPTION
If result is JSON text in str type and uses single quotes, mistral throws error on converting the result back to JSON. Add a literal_eval to gracefully handle the JSON text.
