### PR TITLE
Resource create/update should be able to handle yaml

### DIFF
--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -1,3 +1,4 @@
 prettytable
+pyyaml
 requests
 six

--- a/st2client/tests/test_auth.py
+++ b/st2client/tests/test_auth.py
@@ -162,7 +162,7 @@ class TestAuthToken(base.BaseCLITestCase):
         url = 'http://localhost:9101/rules'
         data = {'name': RULE['name'], 'description': RULE['description']}
 
-        fd, path = tempfile.mkstemp()
+        fd, path = tempfile.mkstemp(suffix='.json')
         try:
             with open(path, 'a') as f:
                 f.write(json.dumps(data, indent=4))
@@ -199,7 +199,7 @@ class TestAuthToken(base.BaseCLITestCase):
         put_url = 'http://localhost:9101/rules/%s' % RULE['id']
         data = {'name': RULE['name'], 'description': RULE['description']}
 
-        fd, path = tempfile.mkstemp()
+        fd, path = tempfile.mkstemp(suffix='.json')
         try:
             with open(path, 'a') as f:
                 f.write(json.dumps(data, indent=4))

--- a/st2client/tests/test_commands.py
+++ b/st2client/tests/test_commands.py
@@ -119,7 +119,7 @@ class TestResourceCommand(unittest2.TestCase):
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(base.RESOURCES[0]), 200, 'OK')))
     def test_command_create(self):
         instance = base.FakeResource(name='abc')
-        fd, path = tempfile.mkstemp()
+        fd, path = tempfile.mkstemp(suffix='.json')
         try:
             with open(path, 'a') as f:
                 f.write(json.dumps(instance.serialize(), indent=4))
@@ -139,7 +139,7 @@ class TestResourceCommand(unittest2.TestCase):
         mock.MagicMock(return_value=base.FakeResponse('', 500, 'INTERNAL SERVER ERROR')))
     def test_command_create_failed(self):
         instance = base.FakeResource(name='abc')
-        fd, path = tempfile.mkstemp()
+        fd, path = tempfile.mkstemp(suffix='.json')
         try:
             with open(path, 'a') as f:
                 f.write(json.dumps(instance.serialize(), indent=4))
@@ -159,7 +159,7 @@ class TestResourceCommand(unittest2.TestCase):
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(base.RESOURCES[0]), 200, 'OK')))
     def test_command_update(self):
         instance = base.FakeResource(id='123', name='abc')
-        fd, path = tempfile.mkstemp()
+        fd, path = tempfile.mkstemp(suffix='.json')
         try:
             with open(path, 'a') as f:
                 f.write(json.dumps(instance.serialize(), indent=4))
@@ -183,7 +183,7 @@ class TestResourceCommand(unittest2.TestCase):
         mock.MagicMock(return_value=base.FakeResponse('', 500, 'INTERNAL SERVER ERROR')))
     def test_command_update_failed(self):
         instance = base.FakeResource(id='123', name='abc')
-        fd, path = tempfile.mkstemp()
+        fd, path = tempfile.mkstemp(suffix='.json')
         try:
             with open(path, 'a') as f:
                 f.write(json.dumps(instance.serialize(), indent=4))
@@ -201,7 +201,7 @@ class TestResourceCommand(unittest2.TestCase):
         mock.MagicMock(return_value=base.FakeResponse(json.dumps([base.RESOURCES[0]]), 200, 'OK')))
     def test_command_update_id_mismatch(self):
         instance = base.FakeResource(id='789', name='abc')
-        fd, path = tempfile.mkstemp()
+        fd, path = tempfile.mkstemp(suffix='.json')
         try:
             with open(path, 'a') as f:
                 f.write(json.dumps(instance.serialize(), indent=4))


### PR DESCRIPTION
Fixes: https://github.com/StackStorm/st2/issues/822
## What?

CLI commands should be able to take in YAML files and be able to create resources. 
## Pending

There is a -j option which prints the resources in JSON. Since we support only JSON in APIs, I decided not to support a -y option for printing YAML. However, this leads to an inconsistency.
If we decide to support a -y option, I'll open another PR. 
## Example:

```
(virtualenv)~/s/c/e/rules git:master ❯❯❯ st2 rule create sample_rule_with_webhook.yaml                                                                                                                                                                                                                    ⏎ ✭ ✱ ◼
+-------------+---------------------------------------------------------+
| Property    | Value                                                   |
+-------------+---------------------------------------------------------+
| id          | 5474e81d0640fd21f1d73192                                |
| name        | examples.webhook_file                                   |
| description | Sample rule dumping webhook payload to a file.          |
| action      | {                                                       |
|             |     "ref": "core.local",                                |
|             |     "parameters": {                                     |
|             |         "cmd": "echo \"{{trigger.body}}\" >>            |
|             | /tmp/st2.webhook_sample.out"                            |
|             |     }                                                   |
|             | }                                                       |
| criteria    | {                                                       |
|             |     "trigger.body.name": {                              |
|             |         "pattern": "st2",                               |
|             |         "type": "equals"                                |
|             |     }                                                   |
|             | }                                                       |
| enabled     | True                                                    |
| trigger     | {                                                       |
|             |     "type": "core.st2.webhook",                         |
|             |     "parameters": {                                     |
|             |         "url": "sample"                                 |
|             |     },                                                  |
|             |     "pack": "core"                                      |
|             | }                                                       |
+-------------+---------------------------------------------------------+
```

Now get the rule via CLI. 

```
(virtualenv)~/s/c/e/rules git:master ❯❯❯ st2 rule get examples.webhook_file                                                                                                                                                                                                                                 ✭ ✱ ◼
+-------------+---------------------------------------------------------+
| Property    | Value                                                   |
+-------------+---------------------------------------------------------+
| id          | 5474e81d0640fd21f1d73192                                |
| name        | examples.webhook_file                                   |
| description | Sample rule dumping webhook payload to a file.          |
| action      | {                                                       |
|             |     "ref": "core.local",                                |
|             |     "parameters": {                                     |
|             |         "cmd": "echo \"{{trigger.body}}\" >>            |
|             | /tmp/st2.webhook_sample.out"                            |
|             |     }                                                   |
|             | }                                                       |
| criteria    | {                                                       |
|             |     "trigger.body.name": {                              |
|             |         "pattern": "st2",                               |
|             |         "type": "equals"                                |
|             |     }                                                   |
|             | }                                                       |
| enabled     | True                                                    |
| trigger     | {                                                       |
|             |     "type": "core.st2.webhook",                         |
|             |     "parameters": {                                     |
|             |         "url": "sample"                                 |
|             |     },                                                  |
|             |     "pack": "core"                                      |
|             | }                                                       |
+-------------+---------------------------------------------------------+
(virtualenv)~/s/c/e/rules git:master ❯❯❯
```
