### PR TITLE
Clean up cached packages in st2_deploy script

### DIFF
--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -257,6 +257,13 @@ download_pkgs() {
     elif [[ "$TYPE" == "rpms" ]]; then
       PACKAGE="${pkg}-${VER}-${RELEASE}.noarch.rpm"
     fi
+
+    # Clean up a bit if older versions exist
+    old_package=$(ls *${pkg}* 2> /dev/null | wc -l)
+    if [ "${old_package}" != "0" ]; then
+      rm -f *${pkg}*
+    fi
+
     curl -sS -k -O https://ops.stackstorm.net/releases/st2/${VER}/${TYPE}/${BUILD}/${PACKAGE}
   done
   popd


### PR DESCRIPTION
This fix attempts to clean up any cached old packages. Fixes
a bug where the install may attempt to install multiple versions
of the st2 packages during an install.

Fixes: https://stackstorm.atlassian.net/browse/STORM-867

/cc @DoriftoShoes @dzimine 
