### PR TITLE
Add version badge to Docs

### DIFF
--- a/docs/source/_themes/sphinx_rtd_theme/versions.html
+++ b/docs/source/_themes/sphinx_rtd_theme/versions.html
@@ -1,8 +1,6 @@
-{% if READTHEDOCS %}
 {# Add rst-badge after rst-versions for small badge style. #}
-  <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
+  <div class="rst-versions rst-badge" data-toggle="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
-      <span class="fa fa-book"> Read the Docs</span>
       v: {{ current_version }}
       <span class="fa fa-caret-down"></span>
     </span>
@@ -13,25 +11,7 @@
           <dd><a href="{{ url }}">{{ slug }}</a></dd>
         {% endfor %}
       </dl>
-      <dl>
-        <dt>Downloads</dt>
-        {% for type, url in downloads %}
-          <dd><a href="{{ url }}">{{ type }}</a></dd>
-        {% endfor %}
-      </dl>
-      <dl>
-        <dt>On Read the Docs</dt>
-          <dd>
-            <a href="//{{ PRODUCTION_DOMAIN }}/projects/{{ slug }}/?fromdocs={{ slug }}">Project Home</a>
-          </dd>
-          <dd>
-            <a href="//{{ PRODUCTION_DOMAIN }}/builds/{{ slug }}/?fromdocs={{ slug }}">Builds</a>
-          </dd>
-      </dl>
-      <hr/>
-      Free document hosting provided by <a href="http://www.readthedocs.org">Read the Docs</a>.
-
     </div>
   </div>
-{% endif %}
+
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,7 +57,7 @@ copyright = u'2014, StackStorm Inc'
 # The short X.Y version.
 version = '0.5'
 # The full version, including alpha/beta/rc tags.
-release = '0.5.1'
+release = '0.5.2'
 
 # extlink configurator sphinx.ext.extlinks
 extlinks = {
@@ -216,6 +216,12 @@ html_context = {
     'conf_py_path': '/docs/source/',
     'display_github': True,
     'source_suffix': source_suffix,
+    'versions': [
+            ( release, ''),
+            ('0.5.1','0.5.1'),
+            ('0.5.0','0.5.0'),        
+        ],
+    'current_version': release
 }
 
 


### PR DESCRIPTION
Figured how to show the badge with the current theme. 

The `current version` is taken from `release` variable,
but the previous versions are hardcoded, need to be
updated manually every big release for now.

![screen shot 2014-12-02 at 8 26 42 pm](https://cloud.githubusercontent.com/assets/1294734/5275864/a19828f4-7a61-11e4-99b6-7053c0edd41a.png)
