### PR TITLE
Pin mistral client to specific version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,11 +11,11 @@ paramiko
 pecan==0.7.0
 pymongo
 python-dateutil
+python-mistralclient==0.1.1
 pyyaml
 requests
 setuptools
 six
-git+https://github.com/stackforge/python-mistralclient.git
 git+https://github.com/StackStorm/fabric.git@stanley-patched
 gitpython==0.3.2RC1
 python-json-logger

--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -243,7 +243,7 @@ setup_mistral() {
   deactivate
 
   # Setup mistral client.
-  pip install -U git+https://github.com/stackforge/python-mistralclient.git
+  pip install -U git+https://github.com/StackStorm/python-mistralclient.git@st2-0.5.1
 }
 
 download_pkgs() {
@@ -301,12 +301,12 @@ download_pkgs
 
 if [[ "$TYPE" == "debs" ]]; then
   install_apt
-  deploy_deb
   setup_mistral
+  deploy_deb
 elif [[ "$TYPE" == "rpms" ]]; then
   install_yum
-  deploy_rpm
   setup_mistral
+  deploy_rpm
 fi
 
 install_st2client() {


### PR DESCRIPTION
Current trunk of mistral client is not compatible with the st2-0.5.1 branch of mistral. The change here pin the mistral client to a specific release. Move the installation of mistral before the st2 deb packages so the st2-0.5.1 branch of python-mistralclient will already satisfy the dependencies listed in the st2 requirements.txt.
