### PR TITLE
Use jsonpath library to walk dict hierarchy.

### DIFF
--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -3,3 +3,4 @@ pyyaml
 requests
 six
 python-dateutil
+jsonpath-rw

--- a/st2client/st2client/utils/jsutil.py
+++ b/st2client/st2client/utils/jsutil.py
@@ -25,7 +25,7 @@ def get_value(doc, key):
     matches = jsonpath_expr.find(doc)
     value = None if len(matches) < 1 else matches[0].value
     if isinstance(value, dict):
-        value = json.dumps(value, indent=4)
+        value = json.dumps(value, indent=4, sort_keys=True)
     return value
 
 

--- a/st2client/st2client/utils/jsutil.py
+++ b/st2client/st2client/utils/jsutil.py
@@ -13,21 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+
+from jsonpath_rw import parse
+
 
 def get_value(doc, key):
     if not key or not isinstance(doc, dict):
         raise ValueError()
-    if '.' not in key:
-        if key not in doc:
-            return None
-        return doc[key]
-    else:
-        name = key[:key.index('.')]
-        value = doc[name] if name else None
-        attr = key[key.index('.') + 1:]
-        if not isinstance(value, dict):
-            return None
-        return get_value(value, attr)
+    jsonpath_expr = parse(key)
+    matches = jsonpath_expr.find(doc)
+    value = None if len(matches) < 1 else matches[0].value
+    if isinstance(value, dict):
+        value = json.dumps(value, indent=4)
+    return value
 
 
 def get_kvps(doc, keys):

--- a/st2client/tests/unit/test_formatters.py
+++ b/st2client/tests/unit/test_formatters.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import six
 import os
 import sys
 import mock
@@ -94,8 +95,8 @@ class TestExecutionResultFormatter(unittest2.TestCase):
     def test_execution_get_default_in_json(self):
         argv = ['execution', 'get', ACTION_EXECUTION['id'], '-j']
         content = self._get_execution(argv)
-        self.assertDictEqual(json.loads(content),
-                             jsutil.get_kvps(ACTION_EXECUTION, ['status', 'result']))
+        self.assertEqual(json.loads(content),
+                         jsutil.get_kvps(ACTION_EXECUTION, ['status', 'result']))
 
     def test_execution_get_detail(self):
         argv = ['execution', 'get', ACTION_EXECUTION['id'], '-d']
@@ -105,7 +106,13 @@ class TestExecutionResultFormatter(unittest2.TestCase):
     def test_execution_get_detail_in_json(self):
         argv = ['execution', 'get', ACTION_EXECUTION['id'], '-d', '-j']
         content = self._get_execution(argv)
-        self.assertDictEqual(json.loads(content), ACTION_EXECUTION)
+        content_dict = json.loads(content)
+        # Sufficient to check if output contains all expected keys. The entire result will not
+        # match as content will contain characters which improve rendering.
+        for k in six.iterkeys(ACTION_EXECUTION):
+            if k in content:
+                continue
+            self.assertTrue(False, 'Missing key %s. %s != %s' % (k, ACTION_EXECUTION, content_dict))
 
     def test_execution_get_result_by_key(self):
         argv = ['execution', 'get', ACTION_EXECUTION['id'], '-k', 'localhost.stdout']

--- a/st2client/tests/unit/test_util_json.py
+++ b/st2client/tests/unit/test_util_json.py
@@ -43,7 +43,8 @@ class TestGetValue(unittest2.TestCase):
         self.assertEqual(jsutil.get_value(DOC, 'a01'), 1)
         self.assertEqual(jsutil.get_value(DOC, 'c01.c11'), 3)
         self.assertEqual(jsutil.get_value(DOC, 'c01.c13.c22'), 6)
-        self.assertDictEqual(jsutil.get_value(DOC, 'c01.c13'), {'c21': 5, 'c22': 6})
+        self.assertEqual(jsutil.get_value(DOC, 'c01.c13'), json.dumps({'c21': 5, 'c22': 6},
+                                                                      indent=4, sort_keys=True))
         self.assertListEqual(jsutil.get_value(DOC, 'c01.c14'), [7, 8, 9])
 
     def test_dot_notation_with_val_error(self):
@@ -61,14 +62,19 @@ class TestGetValue(unittest2.TestCase):
 class TestGetKeyValuePairs(unittest2.TestCase):
 
     def test_select_kvps(self):
-        self.assertDictEqual(jsutil.get_kvps(DOC, ['a01']), {'a01': 1})
-        self.assertDictEqual(jsutil.get_kvps(DOC, ['c01.c11']), {'c01': {'c11': 3}})
-        self.assertDictEqual(jsutil.get_kvps(DOC, ['c01.c13.c22']), {'c01': {'c13': {'c22': 6}}})
-        self.assertDictEqual(jsutil.get_kvps(DOC, ['c01.c13']),
-                             {'c01': {'c13': {'c21': 5, 'c22': 6}}})
-        self.assertDictEqual(jsutil.get_kvps(DOC, ['c01.c14']), {'c01': {'c14': [7, 8, 9]}})
-        self.assertDictEqual(jsutil.get_kvps(DOC, ['a01', 'c01.c11', 'c01.c13.c21']),
-                             {'a01': 1, 'c01': {'c11': 3, 'c13': {'c21': 5}}})
+        self.assertEqual(jsutil.get_kvps(DOC, ['a01']),
+                         {'a01': 1})
+        self.assertEqual(jsutil.get_kvps(DOC, ['c01.c11']),
+                         {'c01': {'c11': 3}})
+        self.assertEqual(jsutil.get_kvps(DOC, ['c01.c13.c22']),
+                         {'c01': {'c13': {'c22': 6}}})
+        self.assertEqual(jsutil.get_kvps(DOC, ['c01.c13']),
+                         {'c01': {'c13': json.dumps({'c21': 5, 'c22': 6},
+                                                    indent=4, sort_keys=True)}})
+        self.assertEqual(jsutil.get_kvps(DOC, ['c01.c14']),
+                         {'c01': {'c14': [7, 8, 9]}})
+        self.assertEqual(jsutil.get_kvps(DOC, ['a01', 'c01.c11', 'c01.c13.c21']),
+                         {'a01': 1, 'c01': {'c11': 3, 'c13': {'c21': 5}}})
 
     def test_select_kvps_with_val_error(self):
         self.assertRaises(ValueError, jsutil.get_kvps, DOC, [None])
@@ -76,9 +82,9 @@ class TestGetKeyValuePairs(unittest2.TestCase):
         self.assertRaises(ValueError, jsutil.get_kvps, json.dumps(DOC), ['a01'])
 
     def test_select_kvps_with_key_error(self):
-        self.assertDictEqual(jsutil.get_kvps(DOC, ['d01']), {})
-        self.assertDictEqual(jsutil.get_kvps(DOC, ['a01.a11']), {})
-        self.assertDictEqual(jsutil.get_kvps(DOC, ['c01.c11.c21.c31']), {})
-        self.assertDictEqual(jsutil.get_kvps(DOC, ['c01.c14.c31']), {})
-        self.assertDictEqual(jsutil.get_kvps(DOC, ['a01', 'c01.c11', 'c01.c13.c23']),
-                             {'a01': 1, 'c01': {'c11': 3}})
+        self.assertEqual(jsutil.get_kvps(DOC, ['d01']), {})
+        self.assertEqual(jsutil.get_kvps(DOC, ['a01.a11']), {})
+        self.assertEqual(jsutil.get_kvps(DOC, ['c01.c11.c21.c31']), {})
+        self.assertEqual(jsutil.get_kvps(DOC, ['c01.c14.c31']), {})
+        self.assertEqual(jsutil.get_kvps(DOC, ['a01', 'c01.c11', 'c01.c13.c23']),
+                         {'a01': 1, 'c01': {'c11': 3}})


### PR DESCRIPTION
- Benefit of using this library is that some more key options open up.
- Subtle fix in the return of jsutil to improve rendering of dict values.


=== Output ===
* Without -k
```
$ st2 execution get 54822ea10640fd1b449fc5e7
STATUS: succeeded
RESULT:
{
    "localhost": {
        "failed": false,
        "stderr": "",
        "return_code": 0,
        "succeeded": true,
        "stdout": "PING google.com (74.125.239.136) 56(84) bytes of data.
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=1 ttl=63 time=6.47 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=2 ttl=63 time=80.2 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=3 ttl=63 time=7.08 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=4 ttl=63 time=6.25 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=5 ttl=63 time=6.39 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=6 ttl=63 time=9.17 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=7 ttl=63 time=6.99 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=8 ttl=63 time=11.5 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=9 ttl=63 time=7.41 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=10 ttl=63 time=8.08 ms

--- google.com ping statistics ---
10 packets transmitted, 10 received, 0% packet loss, time 9016ms
rtt min/avg/max/mdev = 6.254/14.971/80.280/21.823 ms"
    }
}
```

* with -k and dict value
```
$ st2 execution get 54822ea10640fd1b449fc5e7 -k localhost
{
    "failed": false,
    "stderr": "",
    "return_code": 0,
    "succeeded": true,
    "stdout": "PING google.com (74.125.239.136) 56(84) bytes of data.
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=1 ttl=63 time=6.47 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=2 ttl=63 time=80.2 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=3 ttl=63 time=7.08 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=4 ttl=63 time=6.25 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=5 ttl=63 time=6.39 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=6 ttl=63 time=9.17 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=7 ttl=63 time=6.99 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=8 ttl=63 time=11.5 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=9 ttl=63 time=7.41 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=10 ttl=63 time=8.08 ms

--- google.com ping statistics ---
10 packets transmitted, 10 received, 0% packet loss, time 9016ms
rtt min/avg/max/mdev = 6.254/14.971/80.280/21.823 ms"
}
```

* with -k and string value
```
$ st2 execution get 54822ea10640fd1b449fc5e7 -k localhost.stdout
PING google.com (74.125.239.136) 56(84) bytes of data.
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=1 ttl=63 time=6.47 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=2 ttl=63 time=80.2 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=3 ttl=63 time=7.08 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=4 ttl=63 time=6.25 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=5 ttl=63 time=6.39 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=6 ttl=63 time=9.17 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=7 ttl=63 time=6.99 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=8 ttl=63 time=11.5 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=9 ttl=63 time=7.41 ms
64 bytes from nuq05s02-in-f8.1e100.net (74.125.239.136): icmp_seq=10 ttl=63 time=8.08 ms

--- google.com ping statistics ---
10 packets transmitted, 10 received, 0% packet loss, time 9016ms
rtt min/avg/max/mdev = 6.254/14.971/80.280/21.823 ms
```