### PR TITLE
Make "timeout" fabric runner argument user-configurble

### DIFF
--- a/st2actions/st2actions/bootstrap/runnersregistrar.py
+++ b/st2actions/st2actions/bootstrap/runnersregistrar.py
@@ -26,6 +26,10 @@ LOG = logging.getLogger(__name__)
 
 
 def register_runner_types():
+    # Note: We need to do import here because config needs to be parsed for this
+    # import to work
+    from st2actions.runners import fabricrunner
+
     try:
         default_remote_dir = cfg.CONF.ssh_runner.remote_dir
     except:
@@ -69,6 +73,12 @@ def register_runner_types():
                     'description': 'Operator to use in front of keyword args i.e. "--" or "-".',
                     'type': 'string',
                     'default': '--'
+                },
+                'timeout': {
+                    'description': ('Action timeout in seconds. Action will get killed if it '
+                                    'doesn\'t finish in timeout seconds.'),
+                    'type': 'integer',
+                    'default': fabricrunner.DEFAULT_ACTION_TIMEOUT
                 }
             },
             'runner_module': 'st2actions.runners.fabricrunner'
@@ -105,6 +115,12 @@ def register_runner_types():
                     'description': 'Operator to use in front of keyword args i.e. "--" or "-".',
                     'type': 'string',
                     'default': '--'
+                },
+                'timeout': {
+                    'description': ('Action timeout in seconds. Action will get killed if it '
+                                    'doesn\'t finish in timeout seconds.'),
+                    'type': 'integer',
+                    'default': fabricrunner.DEFAULT_ACTION_TIMEOUT
                 }
             },
             'runner_module': 'st2actions.runners.fabricrunner'
@@ -146,6 +162,12 @@ def register_runner_types():
                     'description': 'Operator to use in front of keyword args i.e. "--" or "-".',
                     'type': 'string',
                     'default': '--'
+                },
+                'timeout': {
+                    'description': ('Action timeout in seconds. Action will get killed if it '
+                                    'doesn\'t finish in timeout seconds.'),
+                    'type': 'integer',
+                    'default': fabricrunner.DEFAULT_ACTION_TIMEOUT
                 }
             },
             'runner_module': 'st2actions.runners.fabricrunner'
@@ -182,6 +204,12 @@ def register_runner_types():
                     'description': 'Operator to use in front of keyword args i.e. "--" or "-".',
                     'type': 'string',
                     'default': '--'
+                },
+                'timeout': {
+                    'description': ('Action timeout in seconds. Action will get killed if it '
+                                    'doesn\'t finish in timeout seconds.'),
+                    'type': 'integer',
+                    'default': fabricrunner.DEFAULT_ACTION_TIMEOUT
                 }
             },
             'runner_module': 'st2actions.runners.fabricrunner'


### PR DESCRIPTION
This pull requests makes `timeout` argument for all the fabric runner actions (run-local, run-remote, run-remote-script, etc.) user-configurable.

Note: There is a known issue with timeout exception reporting (the same issue existed before this change). In parallel mode, fabric won't correctly report underlying `CommandTimeout` exception which means, that the error which is returned to the user is not friendly and doesn't indicate a timeout.

I've added a fix for this in https://github.com/fabric/fabric/pull/1228 which I will soon merge into our fork.
