### PR TITLE
CLI debug mode improvements

### DIFF
--- a/st2client/st2client/client.py
+++ b/st2client/st2client/client.py
@@ -25,8 +25,9 @@ LOG = logging.getLogger(__name__)
 class Client(object):
 
     def __init__(self, *args, **kwargs):
-
         # Get CLI options. If not given, then try to get it from the environment.
+        self.debug = kwargs.get('debug', False)
+
         self.endpoints = dict()
         self.endpoints['base'] = kwargs.get('base_url')
         if not self.endpoints['base']:
@@ -55,21 +56,21 @@ class Client(object):
         # Instantiate resource managers and assign appropriate API endpoint.
         self.managers = dict()
         self.managers['Token'] = models.ResourceManager(
-            models.Token, self.endpoints['auth'], cacert=self.cacert)
+            models.Token, self.endpoints['auth'], cacert=self.cacert, debug=self.debug)
         self.managers['RunnerType'] = models.ResourceManager(
-            models.RunnerType, self.endpoints['api'], cacert=self.cacert)
+            models.RunnerType, self.endpoints['api'], cacert=self.cacert, debug=self.debug)
         self.managers['Action'] = models.ResourceManager(
-            models.Action, self.endpoints['api'], cacert=self.cacert)
+            models.Action, self.endpoints['api'], cacert=self.cacert, debug=self.debug)
         self.managers['ActionExecution'] = models.ResourceManager(
-            models.ActionExecution, self.endpoints['api'], cacert=self.cacert)
+            models.ActionExecution, self.endpoints['api'], cacert=self.cacert, debug=self.debug)
         self.managers['Rule'] = models.ResourceManager(
-            models.Rule, self.endpoints['api'], cacert=self.cacert)
+            models.Rule, self.endpoints['api'], cacert=self.cacert, debug=self.debug)
         self.managers['Sensor'] = models.ResourceManager(
-            models.Sensor, self.endpoints['api'], cacert=self.cacert)
+            models.Sensor, self.endpoints['api'], cacert=self.cacert, debug=self.debug)
         self.managers['Trigger'] = models.ResourceManager(
-            models.Trigger, self.endpoints['api'], cacert=self.cacert)
+            models.Trigger, self.endpoints['api'], cacert=self.cacert, debug=self.debug)
         self.managers['KeyValuePair'] = models.ResourceManager(
-            models.KeyValuePair, self.endpoints['api'], cacert=self.cacert)
+            models.KeyValuePair, self.endpoints['api'], cacert=self.cacert, debug=self.debug)
 
     @property
     def tokens(self):

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -109,9 +109,10 @@ class Resource(object):
 
 class ResourceManager(object):
 
-    def __init__(self, resource, endpoint, cacert=None):
+    def __init__(self, resource, endpoint, cacert=None, debug=False):
         self.resource = resource
-        self.client = httpclient.HTTPClient(endpoint, cacert=cacert)
+        self.debug = debug
+        self.client = httpclient.HTTPClient(endpoint, cacert=cacert, debug=debug)
 
     @staticmethod
     def handle_error(response):

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -150,9 +150,10 @@ class Shell(object):
             'An invocation of an action.',
             self, self.subparsers)
 
-    def get_client(self, args):
+    def get_client(self, args, debug=False):
         options = ['base_url', 'auth_url', 'api_url', 'api_version', 'cacert']
         kwargs = {opt: getattr(args, opt) for opt in options}
+        kwargs['debug'] = debug
         return Client(**kwargs)
 
     def run(self, argv):
@@ -161,7 +162,8 @@ class Shell(object):
             args = self.parser.parse_args(args=argv)
 
             # Set up client.
-            self.client = self.get_client(args)
+            debug = getattr(args, 'debug', False)
+            self.client = self.get_client(args=args, debug=debug)
 
             # Execute command.
             args.func(args)


### PR DESCRIPTION
If `--debug` mode is used, cURL request line and raw response body will also be printed the console.

```
(virtualenv)vagrant@vagrant-ubuntu-trusty-64:/data/stanley$ python ./st2client/st2client/shell.py --debug execution list
# -------- begin 140434055391696 request ----------
curl -X GET -H  'Connection: keep-alive' -H  'Accept-Encoding: gzip, deflate' -H  'Accept: */*' -H  'User-Agent: python-requests/2.5.0 CPython/2.7.6 Linux/3.13.0-36-generic' 'http://localhost:9101/v1/actionexecutions/?limit=50'
# -------- begin 140434055391696 response ----------
[
    {
        "status": "succeeded", 
        "start_timestamp": "2014-12-08T20:55:48.021000Z", 
        "parameters": {
            "cmd": "date"
        }, 
        "callback": {}, 
        "result": {
            "localhost": {
                "succeeded": true, 
                "failed": false, 
                "return_code": 0, 
                "stderr": "", 
                "stdout": "Mon Dec  8 20:56:29 UTC 2014"
            }
        }, 
        "context": {
            "user": "stanley"
        }, 
        "action": "core.local", 
        "id": "548610540640fd2ca3c1eb71", 
        "end_timestamp": "2014-12-08T20:56:29.401000Z"
    }, 
    {
        "status": "succeeded", 
        "start_timestamp": "2014-12-08T20:55:22.204000Z", 
        "parameters": {
            "cmd": "date"
        }, 
        "callback": {}, 
        "result": {
            "localhost": {
                "succeeded": true, 
                "failed": false, 
                "return_code": 0, 
                "stderr": "", 
                "stdout": "Mon Dec  8 20:55:25 UTC 2014"
            }
        }, 
        "context": {
            "user": "stanley"
        }, 
        "action": "core.local", 
        "id": "5486103a0640fd2ca3c1eb70", 
        "end_timestamp": "2014-12-08T20:55:25.792000Z"
    }
]
# -------- end 140434055391696 response ------------

+--------------------------+------------+--------------+-----------+------------------------------+------------------------------+
| id                       | action     | context.user | status    | start_timestamp              | end_timestamp                |
+--------------------------+------------+--------------+-----------+------------------------------+------------------------------+
| 5486103a0640fd2ca3c1eb70 | core.local | stanley      | succeeded | Mon, 08 Dec 2014 20:55:22    | Mon, 08 Dec 2014 20:55:25    |
|                          |            |              |           | UTC                          | UTC                          |
| 548610540640fd2ca3c1eb71 | core.local | stanley      | succeeded | Mon, 08 Dec 2014 20:55:48    | Mon, 08 Dec 2014 20:56:29    |
|                          |            |              |           | UTC                          | UTC                          |
+--------------------------+------------+--------------+-----------+------------------------------+------------------------------+
```
