### PR TITLE
RFR: Support st2 webhook in webhooks controller

### DIFF
--- a/st2api/st2api/controllers/v1/webhooks.py
+++ b/st2api/st2api/controllers/v1/webhooks.py
@@ -59,7 +59,7 @@ class WebhooksController(pecan.rest.RestController):
             msg = 'Invalid JSON body: %s' % (body)
             return pecan.abort(http_client.BAD_REQUEST, msg)
 
-        if hook == 'st2':
+        if hook == 'st2' or hook == 'st2/':
             return self._handle_st2_webhook(body)
 
         if not self._is_valid_hook(hook):


### PR DESCRIPTION
Bug reported by cleavoy (https://github.com/chrisleavoy) on freenode # stackstorm. 
