### PR TITLE
Index on action and start_timestamp

### DIFF
--- a/st2common/st2common/models/db/action.py
+++ b/st2common/st2common/models/db/action.py
@@ -122,6 +122,10 @@ class ActionExecutionDB(StormFoundationDB):
         default={},
         help_text='Callback information for the on completion of action execution.')
 
+    meta = {
+        'indexes': ['-start_timestamp', 'action']
+    }
+
 
 # specialized access objects
 runnertype_access = MongoDBAccess(RunnerTypeDB)


### PR DESCRIPTION
The action and start_timestamp index is required for queries to work correctly.

From mongo CLI

```
> db.action_execution_d_b.getIndexes()
[
    {
        "v" : 1,
        "key" : {
            "_id" : 1
        },
        "ns" : "st2.action_execution_d_b",
        "name" : "_id_"
    },
    {
        "v" : 1,
        "key" : {
            "start_timestamp" : -1
        },
        "ns" : "st2.action_execution_d_b",
        "background" : false,
        "name" : "start_timestamp_-1",
        "dropDups" : false
    },
    {
        "v" : 1,
        "key" : {
            "action" : 1
        },
        "ns" : "st2.action_execution_d_b",
        "background" : false,
        "name" : "action_1",
        "dropDups" : false
    }
]
```
