### PR TITLE
added nohup

### DIFF
--- a/tools/st2ctl
+++ b/tools/st2ctl
@@ -24,12 +24,12 @@ fi
 function st2start(){
   for i in `seq 1 ${AR}`
   do
-    actionrunner --config-file ${STANCONF} &>> ${LOGFILE} &
+    nohup actionrunner --config-file ${STANCONF} &>> ${LOGFILE} &
   done
-  st2api --config-file ${STANCONF} &>> ${LOGFILE} &
-  sensor_container --config-file ${STANCONF} &>> ${LOGFILE} &
-  /usr/bin/history --config-file ${STANCONF} &>> ${LOGFILE} &
-  rules_engine --config-file ${STANCONF} &>> ${LOGFILE} &
+  nohup st2api --config-file ${STANCONF} &>> ${LOGFILE} &
+  nohup sensor_container --config-file ${STANCONF} &>> ${LOGFILE} &
+  nohup /usr/bin/history --config-file ${STANCONF} &>> ${LOGFILE} &
+  nohup rules_engine --config-file ${STANCONF} &>> ${LOGFILE} &
   if [[ "${CONTAINER}" == "DOCKER" ]]
   then
     /opt/openstack/mistral/.venv/bin/python /opt/openstack/mistral/mistral/cmd/launch.py --config-file /etc/mistral/mistral.conf --log-file /var/log/mistral.log &> /dev/null &


### PR DESCRIPTION
Adding nohup to the start up line of the components.  I ran in to an issue trying to run st2ctl over st2 that seems to be a limitation of the pty setting in the fabricrunner.  This fixes the issue and has less likelihood of creating bugs with other tasks via the remote runner than makes changes to fabricrunner.
