### PR TITLE
Programatic control over versions controller to return

### DIFF
--- a/st2api/st2api/controllers/root.py
+++ b/st2api/st2api/controllers/root.py
@@ -16,11 +16,18 @@
 from pecan import expose
 
 from st2common import __version__
+from st2common import log as logging
 import st2api.controllers.v1.root as v1_root
+
+LOG = logging.getLogger(__name__)
 
 
 class RootController(object):
-    v1 = v1_root.RootController()
+
+    def __init__(self):
+        v1 = v1_root.RootController()
+        self.controllers = {'v1': v1}
+        self.default_controller = v1
 
     @expose(generic=True, template='index.html')
     def index(self):
@@ -34,3 +41,14 @@ class RootController(object):
         data['version'] = __version__
         data['docs_url'] = docs_url
         return data
+
+    @expose()
+    def _lookup(self, *remainder):
+        version = ''
+        if len(remainder) > 0:
+            version = remainder[0]
+        versioned_controller = self.controllers.get(version, None)
+        if versioned_controller:
+            return versioned_controller, remainder[1:]
+        LOG.debug('No version specified in URL. Will use default controller.')
+        return self.default_controller, remainder


### PR DESCRIPTION
- If no version is specified the default controller is used. For now this is v1 and can change in the future. Therefore
  -- http://hostname:9101/v1/actions and http://hostname:9101/actions are the same url.

```
$ http http://localhost:9101/v1/triggers
HTTP/1.1 200 OK
Access-Control-Allow-Headers: Content-Type,Authorization,X-Auth-Token
Access-Control-Allow-Methods: GET,POST,PUT,DELETE,OPTIONS
Access-Control-Allow-Origin: http://localhost:3000
Access-Control-Expose-Headers: Content-Type,X-Limit,X-Total-Count
Connection: keep-alive
Content-Length: 205
Content-Type: application/json; charset=UTF-8
Date: Fri, 12 Dec 2014 01:00:30 GMT

[
    {
        "id": "548a2ceb0640fd34b443647b",
        "name": "st2.generic.actiontrigger",
        "pack": "core",
        "parameters": {},
        "type": "core.st2.generic.actiontrigger"
    }
]

$ http http://localhost:9101/triggers
HTTP/1.1 200 OK
Access-Control-Allow-Headers: Content-Type,Authorization,X-Auth-Token
Access-Control-Allow-Methods: GET,POST,PUT,DELETE,OPTIONS
Access-Control-Allow-Origin: http://localhost:3000
Access-Control-Expose-Headers: Content-Type,X-Limit,X-Total-Count
Connection: keep-alive
Content-Length: 205
Content-Type: application/json; charset=UTF-8
Date: Fri, 12 Dec 2014 01:00:39 GMT

[
    {
        "id": "548a2ceb0640fd34b443647b",
        "name": "st2.generic.actiontrigger",
        "pack": "core",
        "parameters": {},
        "type": "core.st2.generic.actiontrigger"
    }
]
```
