### PR TITLE
Make stream return headers immediately

### DIFF
--- a/st2api/st2api/controllers/v1/stream.py
+++ b/st2api/st2api/controllers/v1/stream.py
@@ -27,6 +27,9 @@ LOG = logging.getLogger(__name__)
 
 
 def format(gen):
+    # Yield initial state so client would receive the headers the moment it connects to the stream
+    yield '\n'
+
     message = '''event: %s\ndata: %s\n\n'''
 
     for pack in gen:


### PR DESCRIPTION
Before that change, stream endpoint didn't return anything until either heartbeat or the first event happens. During that time, client wasn't been able say for sure whether connection has been established successfully or there is a problem with CORS or authorization.

Sending an empty message right after the connection has been established initiates the response sequence and triggers the webserver to respond with headers.
