### PR TITLE
Throw better exception if a rule object is missing corresponding Trigger object

### DIFF
--- a/st2common/st2common/models/api/rule.py
+++ b/st2common/st2common/models/api/rule.py
@@ -123,6 +123,10 @@ class RuleAPI(BaseAPI):
     def from_model(cls, model):
         rule = cls._from_model(model)
         trigger_db = reference.get_model_by_resource_ref(Trigger, model.trigger)
+
+        if not trigger_db:
+            raise ValueError('Missing TriggerDB object for rule %s' % (rule['id']))
+
         rule['trigger'] = vars(TriggerAPI.from_model(trigger_db))
         del rule['trigger']['id']
         del rule['trigger']['name']


### PR DESCRIPTION
If for some reason a rule references a trigger for which `TriggerDB` object doesn't exist, we should explicitly throw this so it's easier to debug.

Before that, cryptic "to_mongo" error was thrown which made it harder to debug and track down the root cause.

```
tomaz@st2master001:~$ st2 rule list
ERROR: 500 Server Error: Internal Server Error
MESSAGE: 'NoneType' object has no attribute 'to_mongo'
```
