### PR TITLE
Update gitpython dependency to the newest version to avoid AttributeError exception

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,5 @@ requests
 setuptools
 six
 git+https://github.com/StackStorm/fabric.git@stanley-patched
-gitpython==0.3.2RC1
+gitpython==0.3.2.1
 python-json-logger


### PR DESCRIPTION
Encounter this bug in production yesterday when testing the Twitter sensor.

```
|                 |         "twitter": "Success."                                |
|                 |     },                                                       |
|                 |     "exit_code": 0,                                          |
|                 |     "stderr": "Exception AttributeError: "'NoneType' object  |
|                 | has no attribute 'debug'" in <bound method                   |
|                 | ThreadPool.__del__ of <async.pool.ThreadPool object at       |
|                 | 0x7f6765e6a188>> ignored                                     |
|                 | ",                                                           |
|                 |     "stdout": ""                                             |
|                 | }                                            

|                 |     "result": {                                              |
|                 |         "twitter": "Success."                                |
|                 |     },                                                       |
|                 |     "exit_code": 0,                                          |
|                 |     "stderr": "Exception AttributeError: "'NoneType' object  |
|                 | has no attribute 'debug'" in <bound method                   |
|                 | ThreadPool.__del__ of <async.pool.ThreadPool object at       |
|                 | 0x7f6d8522c188>> ignored                                     |
|                 | ",                                                           |
|                 |     "stdout": ""       
```

The issue seems to be caused by a bug in gitpython dependency which has been fixed in a new version - https://github.com/msiemens/PyGitUp/issues/18
