### PR TITLE
Improve client debug mode

### DIFF
--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -19,6 +19,7 @@ Command-line interface to Stanley
 
 from __future__ import print_function
 
+import os
 import sys
 import argparse
 import logging
@@ -174,9 +175,31 @@ class Shell(object):
 
             debug = getattr(args, 'debug', False)
             if debug:
+                # Print client settings
+                self._print_client_settings()
+
+                # Print exception traceback
                 traceback.print_exc()
 
             return 1
+
+    def _print_client_settings(self):
+        client = self.client
+
+        if not client:
+            return
+
+        print('Client settings:')
+        print('----------------')
+        print('ST2_BASE_URL: %s' % (client.endpoints['base']))
+        print('ST2_AUTH_URL: %s' % (client.endpoints['auth']))
+        print('ST2_API_URL: %s' % (client.endpoints['api']))
+        print('')
+        print('Proxy settings:')
+        print('---------------')
+        print('HTTP_PROXY: %s' % (os.environ.get('HTTP_PROXY', '')))
+        print('HTTPS_PROXY: %s' % (os.environ.get('HTTPS_PROXY', '')))
+        print('')
 
 
 def main(argv=sys.argv[1:]):


### PR DESCRIPTION
This should help with debugging in many different scenarios.

```
python ./st2client/st2client/shell.py --debug action list
ERROR: ('Connection aborted.', error(111, 'Connection refused'))

Client settings:
----------------
ST2_BASE_URL: http://localhost
ST2_AUTH_URL: https://localhost:9100
ST2_API_URL: http://localhost:9101/v1
ST2_AUTH_TOKEN: 

Proxy settings:
---------------
HTTP_PROXY: 
HTTPS_PROXY: 

Traceback (most recent call last):
  File "./st2client/st2client/shell.py", line 170, in run
    args.func(args)
  File "/data/stanley/st2client/st2client/commands/resource.py", line 189, in run_and_print
    instances = self.run(args, **kwargs)
  File "/data/stanley/st2client/st2client/commands/resource.py", line 37, in decorate
    return func(*args, **kwargs)
  File "/data/stanley/st2client/st2client/commands/resource.py", line 210, in run
    return self.manager.get_all(**filters)
  File "/data/stanley/st2client/st2client/models/core.py", line 33, in decorate
    return func(*args, **kwargs)
  File "/data/stanley/st2client/st2client/models/core.py", line 145, in get_all
    response = self.client.get(url=url, params=params, **kwargs)
  File "/data/stanley/st2client/st2client/utils/httpclient.py", line 30, in decorate
    return func(*args, **kwargs)
  File "/data/stanley/st2client/st2client/utils/httpclient.py", line 41, in decorate
    return func(*args, **kwargs)
  File "/data/stanley/st2client/st2client/utils/httpclient.py", line 65, in get
    response = requests.get(self.root + url, **kwargs)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/requests/api.py", line 65, in get
    return request('get', url, **kwargs)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/requests/api.py", line 49, in request
    response = session.request(method=method, url=url, **kwargs)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/requests/sessions.py", line 461, in request
    resp = self.send(prep, **send_kwargs)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/requests/sessions.py", line 573, in send
    r = adapter.send(request, **kwargs)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/requests/adapters.py", line 415, in send
    raise ConnectionError(err, request=request)
ConnectionError: ('Connection aborted.', error(111, 'Connection refused'))
```
