### PR TITLE
Add iequal operator for performing case-insensitive equality check on the text criteria values

### DIFF
--- a/st2common/st2common/operators.py
+++ b/st2common/st2common/operators.py
@@ -20,6 +20,8 @@ from datetime import datetime
 # operator impls
 equals = lambda v1, v2: v1 == v2
 
+iequals = lambda v1, v2: v1.lower() == v2.lower()
+
 less_than = lambda v1, v2: v1 < v2
 
 greater_than = lambda v1, v2: v1 > v2
@@ -63,6 +65,8 @@ def timediff_gt(diff_target, period):
 MATCH_REGEX = 'matchregex'
 EQUALS_SHORT = 'eq'
 EQUALS_LONG = 'equals'
+IEQUALS_SHORT = 'ieq'
+IEQUALS_LONG = 'iequals'
 LESS_THAN_SHORT = 'lt'
 LESS_THAN_LONG = 'lessthan'
 GREATER_THAN_SHORT = 'gt'
@@ -77,6 +81,8 @@ operators = {
     MATCH_REGEX: match_regex,
     EQUALS_SHORT: equals,
     EQUALS_LONG: equals,
+    IEQUALS_SHORT: iequals,
+    IEQUALS_LONG: iequals,
     LESS_THAN_SHORT: less_than,
     LESS_THAN_LONG: less_than,
     GREATER_THAN_SHORT: greater_than,

--- a/st2common/tests/unit/test_operators.py
+++ b/st2common/tests/unit/test_operators.py
@@ -47,6 +47,16 @@ class OperatorTest(unittest2.TestCase):
         op = operators.get_operator('equals')
         self.assertFalse(op('1', '2'), 'Passed equals.')
 
+    def test_iequals(self):
+        op = operators.get_operator('iequals')
+        self.assertTrue(op('ABC', 'ABC'), 'Failed iequals.')
+        self.assertTrue(op('ABC', 'abc'), 'Failed iequals.')
+        self.assertTrue(op('AbC', 'aBc'), 'Failed iequals.')
+
+    def test_iequals_fail(self):
+        op = operators.get_operator('iequals')
+        self.assertFalse(op('ABC', 'BCA'), 'Failed iequals.')
+
     def test_lt(self):
         op = operators.get_operator('lessthan')
         self.assertTrue(op(1, 2), 'Failed lessthan.')


### PR DESCRIPTION
Note - this operator only works when both values are string.
