### PR TITLE
Fix timer

### DIFF
--- a/st2reactor/st2reactor/timer/base.py
+++ b/st2reactor/st2reactor/timer/base.py
@@ -51,6 +51,7 @@ class St2Timer(object):
 
     def start(self):
         self._register_timer_trigger_types()
+        self._trigger_watcher.start()
         self._scheduler.start()
 
     def cleanup(self):

--- a/st2reactor/tests/unit/test_timer.py
+++ b/st2reactor/tests/unit/test_timer.py
@@ -21,10 +21,10 @@ from st2common.persistence.reactor import Trigger
 from st2common.models.db.reactor import TriggerDB
 from st2common.models.system.common import ResourceReference
 from st2common.constants.triggers import TIMER_TRIGGER_TYPES
-from st2tests.base import DbTestCase
+from st2tests.base import CleanDbTestCase
 
 
-class St2TimerTestCase(DbTestCase):
+class St2TimerTestCase(CleanDbTestCase):
     def setUp(self):
         self.setUpClass()
 
@@ -55,7 +55,7 @@ class St2TimerTestCase(DbTestCase):
         timer._scheduler = Mock()
         timer._trigger_watcher.run = Mock()
 
-        # Verify there are no Trigger and TriggerType in the db when we start
+        # Verify there are no Trigger and TriggerType in the db wh:w
         self.assertItemsEqual(Trigger.get_all(), [])
         self.assertItemsEqual(TriggerType.get_all(), [])
 

--- a/st2reactor/tests/unit/test_timer.py
+++ b/st2reactor/tests/unit/test_timer.py
@@ -25,9 +25,6 @@ from st2tests.base import CleanDbTestCase
 
 
 class St2TimerTestCase(CleanDbTestCase):
-    def setUp(self):
-        self.setUpClass()
-
     def test_trigger_types_are_registered_on_start(self):
         timer = St2Timer()
         timer._scheduler = Mock()

--- a/st2reactor/tests/unit/test_timer.py
+++ b/st2reactor/tests/unit/test_timer.py
@@ -1,0 +1,76 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mock import Mock
+
+from st2reactor.timer.base import St2Timer
+from st2common.persistence.reactor import TriggerType
+from st2common.persistence.reactor import Trigger
+from st2common.models.db.reactor import TriggerDB
+from st2common.models.system.common import ResourceReference
+from st2common.constants.triggers import TIMER_TRIGGER_TYPES
+from st2tests.base import DbTestCase
+
+
+class St2TimerTestCase(DbTestCase):
+    def setUp(self):
+        self.setUpClass()
+
+    def test_trigger_types_are_registered_on_start(self):
+        timer = St2Timer()
+        timer._scheduler = Mock()
+
+        # Verify there are no TriggerType in the db when we start
+        self.assertItemsEqual(TriggerType.get_all(), [])
+
+        timer.start()
+
+        # Verify TriggerType objects have been created
+        trigger_type_dbs = TriggerType.get_all()
+        self.assertEqual(len(trigger_type_dbs), len(TIMER_TRIGGER_TYPES))
+
+        timer_trigger_type_refs = TIMER_TRIGGER_TYPES.keys()
+
+        for trigger_type in trigger_type_dbs:
+            ref = ResourceReference(pack=trigger_type.pack, name=trigger_type.name).ref
+            self.assertTrue(ref in timer_trigger_type_refs)
+
+    def test_existing_rules_are_loaded_on_start(self):
+        # Assert that we dispatch message for every existing Trigger object
+        St2Timer._handle_create_trigger = Mock()
+
+        timer = St2Timer()
+        timer._scheduler = Mock()
+        timer._trigger_watcher.run = Mock()
+
+        # Verify there are no Trigger and TriggerType in the db when we start
+        self.assertItemsEqual(Trigger.get_all(), [])
+        self.assertItemsEqual(TriggerType.get_all(), [])
+
+        # Add a dummy timer Trigger object
+        type = TIMER_TRIGGER_TYPES.keys()[0]
+        parameters = {'unit': 'seconds', 'delta': 1000}
+        trigger_db = TriggerDB(name='test_trigger_1', pack='dummy', type=type,
+                               parameters=parameters)
+        trigger_db = Trigger.add_or_update(trigger_db)
+
+        # Verify object has been added
+        self.assertEqual(len(Trigger.get_all()), 1)
+
+        timer.start()
+        timer._trigger_watcher._load_thread.wait()
+
+        # Verify handlers are called
+        timer._handle_create_trigger.assert_called_with(trigger_db)

--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -27,6 +27,12 @@ import st2common.models.db.datastore as datastore_model
 import st2common.models.db.actionrunner as actionrunner_model
 import st2common.models.db.history as history_model
 
+__all__ = [
+    'EventletTestCase',
+    'DbTestCase',
+    'CleanDbTestCase'
+]
+
 
 ALL_MODELS = []
 ALL_MODELS.extend(reactor_model.MODELS)
@@ -91,6 +97,17 @@ class DbTestCase(TestCase):
         global ALL_MODELS
         for model in ALL_MODELS:
             model.drop_collection()
+
+
+class CleanDbTestCase(DbTestCase):
+    """
+    Class which ensures database is re-created for every test method.
+
+    This way each test method starts with a clean database.
+    """
+
+    def setUp(self):
+        self.setUpClass()
 
 
 def get_fixtures_path():

--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -100,6 +100,12 @@ class BaseDbTestCase(TestCase):
 
 
 class DbTestCase(BaseDbTestCase):
+    """
+    This class drops and re-creates the database once per TestCase run.
+
+    This means database is only dropped once before all the tests from this class run. This means
+    data is persited between different tests in this class.
+    """
     db_connection = None
 
     @classmethod
@@ -114,9 +120,10 @@ class DbTestCase(BaseDbTestCase):
 
 class CleanDbTestCase(BaseDbTestCase):
     """
-    Class which ensures database is re-created for every test method.
+    Class which ensures database is re-created before running each test method.
 
-    This way each test method starts with a clean database.
+    This means each test inside this class is self-sustained and starts with a clean (empty)
+    database.
     """
 
     def setUp(self):

--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -43,6 +43,10 @@ ALL_MODELS.extend(history_model.MODELS)
 
 
 class EventletTestCase(TestCase):
+    """
+    Base test class which performs eventlet monkey patching before the tests run
+    and un-patching after the tests have finished running.
+    """
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Add missing start call and associated regression tests.

Previously, start was not called so timer triggers were not loaded from the DB.