### PR TITLE
Fix "listener has no attribute shutdown"

### DIFF
--- a/st2api/st2api/listener.py
+++ b/st2api/st2api/listener.py
@@ -98,6 +98,9 @@ class Listener(ConsumerMixin):
         finally:
             self.queues.remove(queue)
 
+    def shutdown(self):
+        pass
+
 
 def listen(listener):
     try:


### PR DESCRIPTION
We don't actually need shutdown methode there, but for consistency I still added
it (all the other worker classes written by us also have it).