### PR TITLE
json loads 'stdout' and 'stderr' in shell & ssh runners

### DIFF
--- a/st2actions/st2actions/runners/localrunner.py
+++ b/st2actions/st2actions/runners/localrunner.py
@@ -27,6 +27,7 @@ from st2common.models.system.action import ShellCommandAction
 from st2common.models.system.action import ShellScriptAction
 from st2common.constants.action import ACTIONEXEC_STATUS_SUCCEEDED
 from st2common.constants.action import ACTIONEXEC_STATUS_FAILED
+import st2common.util.jsonify as jsonify
 
 __all__ = [
     'get_runner'
@@ -57,6 +58,7 @@ class LocalShellRunner(ActionRunner, ShellRunnerMixin):
     Note: The user under which the action runner service is running (stanley user by default) needs
     to have pasworless sudo access set up.
     """
+    KEYS_TO_TRANSFORM = ['stdout', 'stderr']
 
     def __init__(self, runner_id):
         super(LocalShellRunner, self).__init__(runner_id=runner_id)
@@ -134,5 +136,4 @@ class LocalShellRunner(ActionRunner, ShellRunnerMixin):
             result['error'] = error
 
         status = ACTIONEXEC_STATUS_SUCCEEDED if exit_code == 0 else ACTIONEXEC_STATUS_FAILED
-        print('Returning from localshellrunner*********')
-        return (status, result)
+        return (status, jsonify.json_loads(result, LocalShellRunner.KEYS_TO_TRANSFORM))

--- a/st2common/st2common/models/system/action.py
+++ b/st2common/st2common/models/system/action.py
@@ -25,6 +25,7 @@ from fabric.tasks import WrappedCallableTask
 
 from st2common.constants.action import LIBS_DIR as ACTION_LIBS_DIR
 from st2common import log as logging
+import st2common.util.jsonify as jsonify
 
 __all__ = [
     'ShellCommandAction',
@@ -290,6 +291,8 @@ class ParamikoSSHCommandAction(SSHCommandAction):
 
 
 class FabricRemoteAction(RemoteAction):
+    KEYS_TO_TRANSFORM = ['stdout', 'stderr']
+
     def get_fabric_task(self):
         action_method = self._get_action_method()
         LOG.debug('action_method is %s', action_method)
@@ -319,7 +322,7 @@ class FabricRemoteAction(RemoteAction):
             'succeeded': output.succeeded,
             'failed': output.failed
         }
-        return result
+        return jsonify.json_loads(result, FabricRemoteAction.KEYS_TO_TRANSFORM)
 
     def _sudo(self):
         with shell_env(**self.env_vars), settings(command_timeout=self.timeout):
@@ -339,7 +342,7 @@ class FabricRemoteAction(RemoteAction):
             result['stderr'] = result['stdout']
             result['stdout'] = ''
 
-        return result
+        return jsonify.json_loads(result, FabricRemoteAction.KEYS_TO_TRANSFORM)
 
 
 class FabricRemoteScriptAction(RemoteScriptAction, FabricRemoteAction):

--- a/st2common/st2common/util/jsonify.py
+++ b/st2common/st2common/util/jsonify.py
@@ -37,6 +37,18 @@ def load_file(path):
 
 
 def json_loads(obj, keys=None):
+    """
+    Given an object, this method tries to json.loads() the value of each of the keys. If json.loads
+    fails, the original value stays in the object.
+
+    :param obj: Original object whose values should be converted to json.
+    :type obj: ``dict``
+
+    :param keys: Optional List of keys whose values should be transformed.
+    :type keys: ``list``
+
+    :rtype ``dict`` or ``None``
+    """
     if not obj:
         return None
 

--- a/st2common/st2common/util/jsonify.py
+++ b/st2common/st2common/util/jsonify.py
@@ -34,3 +34,18 @@ def json_encode(obj, indent=4):
 def load_file(path):
     with open(path, 'r') as fd:
         return json.load(fd)
+
+
+def json_loads(obj, keys=None):
+    if not obj:
+        return None
+
+    if not keys:
+        keys = obj.keys()
+
+    for key in keys:
+        try:
+            obj[key] = json.loads(obj[key])
+        except:
+            pass
+    return obj


### PR DESCRIPTION
* Add a json_loads utility method in st2common/util/jsonify.py
* Add test cases for utility method
* FabricRunner and LocalShellRunner to use utility method to transform
  stdout and stderr streams

## Sample output

```
(virtualenv)~/stanley git:STORM-931/parse_json_in_results_shell_runners ❯❯❯ st2 run core.local shit                                                                                                                             ✭ ✱ ◼
.
+-----------------+-----------------------------+
| Property        | Value                       |
+-----------------+-----------------------------+
| id              | 54aee0740640fd77c6c9f312    |
| context         | {                           |
|                 |     "user": "lakshmi"       |
|                 | }                           |
| parameters      | {                           |
|                 |     "cmd": "shit"           |
|                 | }                           |
| status          | succeeded                   |
| start_timestamp | 2015-01-08T19:54:28.122000Z |
| result          | {                           |
|                 |     "failed": false,        |
|                 |     "stderr": "",           |
|                 |     "return_code": 0,       |
|                 |     "succeeded": true,      |
|                 |     "stdout": {             |
|                 |         "foo": {            |
|                 |             "bar": "baz"    |
|                 |         }                   |
|                 |     }                       |
|                 | }                           |
| action          | core.local                  |
| callback        |                             |
| end_timestamp   | 2015-01-08T19:54:28.216000Z |
+-----------------+-----------------------------+
(virtualenv)~/stanley git:STORM-931/parse_json_in_results_shell_runners ❯❯❯
```