### PR TITLE
ActionChainRunner stores error.

### DIFF
--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -13,13 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import uuid
-
 import ast
 import eventlet
 import jinja2
 import json
 import six
+import traceback
+import uuid
 
 from st2actions.runners import ActionRunner
 from st2common import log as logging
@@ -113,6 +113,8 @@ class ActionChainRunner(ActionRunner):
                                                            resolved_params)
             except:
                 LOG.exception('Failure in running action %s.', action_node.name)
+                # Save the traceback and error message.
+                results[action_node.name] = {'error': traceback.format_exc(10)}
             else:
                 # for now append all successful results
                 results[action_node.name] = actionexec.result

--- a/st2actions/tests/unit/test_actionchain.py
+++ b/st2actions/tests/unit/test_actionchain.py
@@ -193,7 +193,7 @@ class TestActionChainRunner(TestCase):
         chain_runner.action = ACTION_1
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
-        (status, success) = chain_runner.run({})
+        status, _ = chain_runner.run({})
         self.assertEqual(status, ACTIONEXEC_STATUS_FAILED)
         self.assertNotEqual(chain_runner.action_chain, None)
         # based on the chain the callcount is known to be 2. Not great but works.
@@ -208,10 +208,13 @@ class TestActionChainRunner(TestCase):
         chain_runner.action = ACTION_1
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
-        chain_runner.run({})
+        status, results = chain_runner.run({})
+        self.assertEqual(status, ACTIONEXEC_STATUS_FAILED)
         self.assertNotEqual(chain_runner.action_chain, None)
         # based on the chain the callcount is known to be 2. Not great but works.
         self.assertEqual(schedule.call_count, 2)
+        self.assertEqual(len([result['error'] for _, result in six.iteritems(results)]),
+                         2, 'Expected errors')
 
     @mock.patch.object(action_db_util, 'get_action_by_ref',
                        mock.MagicMock(return_value=ACTION_1))


### PR DESCRIPTION
- Error raised in in processing params etc is now bubbled up as a result of the execution.