### PR TITLE
Fix a bug with action runners not working

### DIFF
--- a/st2actions/st2actions/container/base.py
+++ b/st2actions/st2actions/container/base.py
@@ -151,7 +151,7 @@ class RunnerContainer(object):
         runner.post_run(status, result)
         runner.container_service = None
 
-        return actionexec_db
+        return updated_actionexec_db
 
     def _update_action_execution_db(self, actionexec_id, status, result):
         actionexec_db = get_actionexec_by_id(actionexec_id)


### PR DESCRIPTION
This fixes a bug which was introduced with the recent runner refactorings.

All of the actions failed to complete successfuly and blew up with "Failed to execute action.". The problem is that we were returning actionexec_db object which didn't have the result populated yet.

```bash
2015-01-09 16:48:44,032 ERROR [-] execute_action failed. Message body : ActionExecutionDB(action="core.local", callback={}, context={'user': 'stanley'}, end_timestamp=None, id=54b0066b0640fd0bb55dee38, parameters={u'cmd': u'echo "aa"'}, result={}, start_timestamp="2015-01-09 16:48:43.969902+00:00", status="scheduled")
Traceback (most recent call last):
  File "/data/stanley/st2actions/st2actions/worker.py", line 67, in _do_process_task
    self.execute_action(body)
  File "/data/stanley/st2actions/st2actions/worker.py", line 97, in execute_action
    raise ActionRunnerException('Failed to execute action.')
ActionRunnerException: Failed to execute action.
```