### PR TITLE
cli json output changes

### DIFF
--- a/st2client/st2client/formatters/doc.py
+++ b/st2client/st2client/formatters/doc.py
@@ -40,4 +40,4 @@ class Json(formatters.Formatter):
                 doc = item if isinstance(item, dict) else item.__dict__
                 keys = doc.keys() if not attributes or 'all' in attributes else attributes
                 docs.append(jsutil.get_kvps(doc, keys))
-        return json.dumps(docs, indent=4)
+        return json.dumps(docs, indent=4, sort_keys=True)

--- a/st2client/st2client/utils/jsutil.py
+++ b/st2client/st2client/utils/jsutil.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
-
 from jsonpath_rw import parse
 
 
@@ -24,8 +22,6 @@ def get_value(doc, key):
     jsonpath_expr = parse(key)
     matches = jsonpath_expr.find(doc)
     value = None if len(matches) < 1 else matches[0].value
-    if isinstance(value, dict):
-        value = json.dumps(value, indent=4, sort_keys=True)
     return value
 
 

--- a/st2client/tests/unit/test_util_json.py
+++ b/st2client/tests/unit/test_util_json.py
@@ -43,8 +43,7 @@ class TestGetValue(unittest2.TestCase):
         self.assertEqual(jsutil.get_value(DOC, 'a01'), 1)
         self.assertEqual(jsutil.get_value(DOC, 'c01.c11'), 3)
         self.assertEqual(jsutil.get_value(DOC, 'c01.c13.c22'), 6)
-        self.assertEqual(jsutil.get_value(DOC, 'c01.c13'), json.dumps({'c21': 5, 'c22': 6},
-                                                                      indent=4, sort_keys=True))
+        self.assertEqual(jsutil.get_value(DOC, 'c01.c13'), {'c21': 5, 'c22': 6})
         self.assertListEqual(jsutil.get_value(DOC, 'c01.c14'), [7, 8, 9])
 
     def test_dot_notation_with_val_error(self):
@@ -69,8 +68,7 @@ class TestGetKeyValuePairs(unittest2.TestCase):
         self.assertEqual(jsutil.get_kvps(DOC, ['c01.c13.c22']),
                          {'c01': {'c13': {'c22': 6}}})
         self.assertEqual(jsutil.get_kvps(DOC, ['c01.c13']),
-                         {'c01': {'c13': json.dumps({'c21': 5, 'c22': 6},
-                                                    indent=4, sort_keys=True)}})
+                         {'c01': {'c13': {'c21': 5, 'c22': 6}}})
         self.assertEqual(jsutil.get_kvps(DOC, ['c01.c14']),
                          {'c01': {'c14': [7, 8, 9]}})
         self.assertEqual(jsutil.get_kvps(DOC, ['a01', 'c01.c11', 'c01.c13.c21']),


### PR DESCRIPTION
- mostly reverting a previous change. Since only parts are to be reverted creating new commits.
- With this the -j option does not introduce new control characters thus the output remains consumable json.