### PR TITLE
RFR: New trigger should be created for each rule with different trigger parameters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,6 +49,7 @@ Docs: http://docks.stackstorm.com/latest
 * Action models now use ContentPackResourceMixin so we can get them by ref. (refactor)
 * Add ``rule_tester`` tool which allows users to test rules in an offline mode without any services
   running (new-feature)
+* Fix a bug where trigger objects weren't created for triggers with different parameters. (bug-fix)
 
 v0.6.0 - December 8, 2014
 -------------------------

--- a/st2common/st2common/models/api/rule.py
+++ b/st2common/st2common/models/api/rule.py
@@ -103,6 +103,10 @@ class RuleAPI(BaseAPI):
                     'parameters': {
                         'type': 'object',
                         'default': {}
+                    },
+                    'ref': {
+                        'type': 'string',
+                        'required': False
                     }
                 },
                 'additionalProperties': True

--- a/st2common/st2common/services/triggers.py
+++ b/st2common/st2common/services/triggers.py
@@ -101,13 +101,22 @@ def get_trigger_type_db(ref):
 
 def _get_trigger_api_given_rule(rule):
     trigger = rule.trigger
-    triggertype_ref = ResourceReference.from_string_reference(trigger.get('type'))
     trigger_dict = {}
-
-    trigger_dict['name'] = triggertype_ref.name
-    trigger_dict['pack'] = triggertype_ref.pack
+    triggertype_ref = ResourceReference.from_string_reference(trigger.get('type'))
+    trigger_dict['pack'] = trigger_dict.get('pack', triggertype_ref.pack)
     trigger_dict['type'] = triggertype_ref.ref
-    trigger_dict['parameters'] = rule.trigger.get('parameters', {})
+
+    trigger_ref_str = trigger.get('ref', None)
+    if trigger_ref_str:
+        trigger_ref = ResourceReference.from_string_reference(trigger_ref_str)
+        trigger_dict['name'] = trigger_ref.name
+        trigger_dict['pack'] = trigger_ref.pack
+        if triggertype_ref and trigger_ref.pack != triggertype_ref.pack:
+            raise Exception('Invalid definition for trigger in rule. ' +
+                            'Packs mismatch for trigger (%s) and trigger type (%s).' %
+                            (trigger_ref.pack, triggertype_ref.pack))
+    else:
+        trigger_dict['parameters'] = rule.trigger.get('parameters', {})
 
     trigger_api = TriggerAPI(**trigger_dict)
 

--- a/st2common/tests/unit/test_trigger_services.py
+++ b/st2common/tests/unit/test_trigger_services.py
@@ -1,0 +1,69 @@
+import copy
+
+from st2common.models.api.rule import RuleAPI
+from st2common.models.system.common import ResourceReference
+from st2common.persistence.reactor import Trigger
+import st2common.services.triggers as trigger_service
+
+from st2tests.base import CleanDbTestCase
+from st2tests.fixturesloader import FixturesLoader
+
+
+class TriggerServiceTests(CleanDbTestCase):
+
+    def test_create_trigger_db_from_rule(self):
+        test_fixtures = {
+            'rules': ['cron_timer_rule_1.json', 'cron_timer_rule_3.json']
+        }
+        loader = FixturesLoader()
+        fixtures = loader.load_fixtures(fixtures_pack='generic', fixtures_dict=test_fixtures)
+        rules = fixtures['rules']
+
+        trigger_db_ret_1 = trigger_service.create_trigger_db_from_rule(
+            RuleAPI(**rules['cron_timer_rule_1.json']))
+        self.assertTrue(trigger_db_ret_1 is not None)
+        trigger_db = Trigger.get_by_id(trigger_db_ret_1.id)
+        self.assertDictEqual(trigger_db.parameters,
+                             rules['cron_timer_rule_1.json']['trigger']['parameters'])
+
+        trigger_db_ret_2 = trigger_service.create_trigger_db_from_rule(
+            RuleAPI(**rules['cron_timer_rule_3.json']))
+        self.assertTrue(trigger_db_ret_2 is not None)
+        self.assertTrue(trigger_db_ret_2.id != trigger_db_ret_1.id)
+
+    def test_create_trigger_db_from_rule_duplicate(self):
+        test_fixtures = {
+            'rules': ['cron_timer_rule_1.json', 'cron_timer_rule_2.json']
+        }
+        loader = FixturesLoader()
+        fixtures = loader.load_fixtures(fixtures_pack='generic', fixtures_dict=test_fixtures)
+        rules = fixtures['rules']
+
+        trigger_db_ret_1 = trigger_service.create_trigger_db_from_rule(
+            RuleAPI(**rules['cron_timer_rule_1.json']))
+        self.assertTrue(trigger_db_ret_1 is not None)
+        trigger_db_ret_2 = trigger_service.create_trigger_db_from_rule(
+            RuleAPI(**rules['cron_timer_rule_2.json']))
+        self.assertTrue(trigger_db_ret_2 is not None)
+        self.assertEqual(trigger_db_ret_1, trigger_db_ret_2, 'Should reuse same trigger.')
+        trigger_db = Trigger.get_by_id(trigger_db_ret_1.id)
+        self.assertDictEqual(trigger_db.parameters,
+                             rules['cron_timer_rule_1.json']['trigger']['parameters'])
+
+    def test_create_trigger_db_from_rule_use_ref_for_trigger(self):
+        test_fixtures = {
+            'rules': ['cron_timer_rule_1.json']
+        }
+        loader = FixturesLoader()
+        fixtures = loader.load_fixtures(fixtures_pack='generic', fixtures_dict=test_fixtures)
+        rules = fixtures['rules']
+        rule_api = RuleAPI(**rules['cron_timer_rule_1.json'])
+        trigger_db_ret_1 = trigger_service.create_trigger_db_from_rule(rule_api)
+        self.assertTrue(trigger_db_ret_1 is not None)
+        rule_api2 = copy.copy(rule_api)
+        ref = ResourceReference.to_string_reference(name=trigger_db_ret_1.name,
+                                                    pack=trigger_db_ret_1.pack)
+        rule_api2.trigger = {'ref': ref, 'type': trigger_db_ret_1.type}
+        trigger_db_ret_2 = trigger_service.create_trigger_db_from_rule(rule_api2)
+        self.assertTrue(trigger_db_ret_2 is not None)
+        self.assertTrue(trigger_db_ret_2.id == trigger_db_ret_1.id)

--- a/st2reactor/tests/unit/test_sensor_and_rule_registration.py
+++ b/st2reactor/tests/unit/test_sensor_and_rule_registration.py
@@ -125,7 +125,7 @@ class RuleRegistrationTestCase(DbTestCase):
         self.assertEqual(len(trigger_dbs), 1)
 
         self.assertEqual(rule_dbs[0].name, 'sample.with_timer')
-        self.assertEqual(trigger_dbs[0].name, 'st2.IntervalTimer')
+        self.assertTrue(trigger_dbs[0].name is not None)
 
         # Verify second register call updates existing models
         registrar.register_rules_from_packs(base_dir=PACKS_DIR)

--- a/st2tests/st2tests/fixtures/generic/rules/cron_timer_rule_1.json
+++ b/st2tests/st2tests/fixtures/generic/rules/cron_timer_rule_1.json
@@ -1,0 +1,29 @@
+{
+    "name": "cron_timer_rule_1",
+    "description": "",
+    "enabled": true,
+    "trigger": {
+        "type": "core.CronTimer",
+        "parameters": {
+            "minute": 0,
+            "second": 0
+        }
+    },
+    "criteria": {
+        "t1_p": {
+            "pattern": "t1_p_v",
+            "type": "equals"
+        }
+    },
+    "action": {
+        "ref": "wolfpack.action-1",
+        "parameters": {
+            "ip2": "{{rule.k1}}",
+            "ip1": "{{trigger.t1_p}}"
+        }
+    },
+    "tags": [
+        {"name": "tag1", "value": "dont-care"},
+        {"name": "tag2", "value": "dont-care"}
+    ]
+}

--- a/st2tests/st2tests/fixtures/generic/rules/cron_timer_rule_2.json
+++ b/st2tests/st2tests/fixtures/generic/rules/cron_timer_rule_2.json
@@ -1,0 +1,29 @@
+{
+    "name": "cron_timer_rule_2",
+    "description": "",
+    "enabled": true,
+    "trigger": {
+        "type": "core.CronTimer",
+        "parameters": {
+            "minute": 0,
+            "second": 0
+        }
+    },
+    "criteria": {
+        "t1_p": {
+            "pattern": "t1_p_v",
+            "type": "equals"
+        }
+    },
+    "action": {
+        "ref": "wolfpack.action-1",
+        "parameters": {
+            "ip2": "{{rule.k1}}",
+            "ip1": "{{trigger.t1_p}}"
+        }
+    },
+    "tags": [
+        {"name": "tag1", "value": "dont-care"},
+        {"name": "tag2", "value": "dont-care"}
+    ]
+}

--- a/st2tests/st2tests/fixtures/generic/rules/cron_timer_rule_3.json
+++ b/st2tests/st2tests/fixtures/generic/rules/cron_timer_rule_3.json
@@ -1,0 +1,29 @@
+{
+    "name": "cron_timer_rule_3",
+    "description": "",
+    "enabled": true,
+    "trigger": {
+        "type": "core.CronTimer",
+        "parameters": {
+            "minute": 0,
+            "second": 1
+        }
+    },
+    "criteria": {
+        "t1_p": {
+            "pattern": "t1_p_v",
+            "type": "equals"
+        }
+    },
+    "action": {
+        "ref": "wolfpack.action-1",
+        "parameters": {
+            "ip2": "{{rule.k1}}",
+            "ip1": "{{trigger.t1_p}}"
+        }
+    },
+    "tags": [
+        {"name": "tag1", "value": "dont-care"},
+        {"name": "tag2", "value": "dont-care"}
+    ]
+}

--- a/st2tests/st2tests/fixturesloader.py
+++ b/st2tests/st2tests/fixturesloader.py
@@ -132,8 +132,7 @@ class FixturesLoader(object):
 
     def load_fixtures(self, fixtures_pack=None, fixtures_dict={}):
         """
-        Loads fixtures specified in fixtures_dict. This method must be
-        used for fixtures that don't have associated data models. We
+        Loads fixtures specified in fixtures_dict. We
         simply want to load the meta into dict objects.
 
         fixtures_dict should be of the form:


### PR DESCRIPTION
Currently, we don't create a trigger for each rule. This results in parameters
being equal for all triggers. The behavior we want is to reuse the same trigger
if the parameters are same. If they are different, we want a new trigger to be
created.

* _get_trigger_api_given_rule in st2common/services/triggers now returns the right
 trigger API object.
* Add test cases to catch the bug.
* Add fixtures.