### PR TITLE
Support local actions that output more than 65535 chars

### DIFF
--- a/st2actions/st2actions/runners/localrunner.py
+++ b/st2actions/st2actions/runners/localrunner.py
@@ -13,8 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import eventlet
 import os
 import pwd
+import shlex
 import uuid
 
 from oslo.config import cfg
@@ -35,7 +37,7 @@ __all__ = [
 
 LOG = logging.getLogger(__name__)
 
-DEFAULT_ACTION_TIMEOUT = 60
+DEFAULT_ACTION_TIMEOUT = 10
 LOGGED_USER_USERNAME = pwd.getpwuid(os.getuid())[0]
 
 # constants to lookup in runner_parameters.
@@ -106,21 +108,40 @@ class LocalShellRunner(ActionRunner, ShellRunnerMixin):
             args = 'chmod +x %s ; %s' % (script_local_path_abs, args)
 
         env = os.environ.copy()
+        # Make sure os.setsid is called on each spawned process so that all processes
+        # are in the same group.
         process = subprocess.Popen(args=args, stdin=None, stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE, shell=True, env=env)
+                                   stderr=subprocess.PIPE, shell=True, env=env,
+                                   preexec_fn=os.setsid)
 
-        try:
-            exit_code = process.wait(timeout=self._timeout)
-        except subprocess.TimeoutExpired:
-            # Action has timed out, kill the process and propagate the error
-            # Note: process.kill() will set the returncode to -9 so we don't
-            # need to explicitly set it to some non-zero value
-            process.kill()
-            error = 'Action failed to complete in %s seconds' % (self._timeout)
-        else:
-            error = None
+        error_holder = {}
+
+        def on_timeout_expired(timeout):
+            try:
+                process.wait(timeout=self._timeout)
+            except subprocess.TimeoutExpired:
+                # Set the error prior to kill the process else the error is not picked up due
+                # to eventlet scheduling.
+                error_holder['error'] = 'Action failed to complete in %s seconds' % (self._timeout)
+                # Action has timed out, kill the process and propagate the error. The process
+                # is started as sudo -u {{system_user}} -- bash -c {{command}}. Introduction of the
+                # bash means that multiple independent processes are spawned without them being
+                # children of the process we have access to and this requires use of pkill.
+                # Ideally os.killpg should have done the trick but for some reason that failed.
+                # Note: pkill will set the returncode to 143 so we don't need to explicitly set
+                # it to some non-zero value.
+                try:
+                    killcommand = shlex.split('sudo pkill -TERM -s %s' % process.pid)
+                    subprocess.call(killcommand)
+                except:
+                    LOG.exception('Unable to pkill.')
+
+        timeout_expiry = eventlet.spawn(on_timeout_expired, self._timeout)
 
         stdout, stderr = process.communicate()
+        LOG.info('Process terminated %s.', process.pid)
+        timeout_expiry.cancel()
+        error = error_holder.get('error', None)
         exit_code = process.returncode
         succeeded = (exit_code == 0)
 

--- a/st2actions/st2actions/runners/localrunner.py
+++ b/st2actions/st2actions/runners/localrunner.py
@@ -38,6 +38,7 @@ __all__ = [
 LOG = logging.getLogger(__name__)
 
 DEFAULT_ACTION_TIMEOUT = 60
+DEFAULT_KWARG_OP = '--'
 LOGGED_USER_USERNAME = pwd.getpwuid(os.getuid())[0]
 
 # constants to lookup in runner_parameters.
@@ -69,7 +70,7 @@ class LocalShellRunner(ActionRunner, ShellRunnerMixin):
         self._sudo = self.runner_parameters.get(RUNNER_SUDO, False)
         self._on_behalf_user = self.context.get(RUNNER_ON_BEHALF_USER, LOGGED_USER_USERNAME)
         self._user = cfg.CONF.system_user.user
-        self._kwarg_op = self.runner_parameters.get(RUNNER_KWARG_OP, '--')
+        self._kwarg_op = self.runner_parameters.get(RUNNER_KWARG_OP, DEFAULT_KWARG_OP)
         self._timeout = self.runner_parameters.get(RUNNER_TIMEOUT, DEFAULT_ACTION_TIMEOUT)
 
     def run(self, action_parameters):

--- a/st2actions/st2actions/runners/localrunner.py
+++ b/st2actions/st2actions/runners/localrunner.py
@@ -37,7 +37,7 @@ __all__ = [
 
 LOG = logging.getLogger(__name__)
 
-DEFAULT_ACTION_TIMEOUT = 10
+DEFAULT_ACTION_TIMEOUT = 60
 LOGGED_USER_USERNAME = pwd.getpwuid(os.getuid())[0]
 
 # constants to lookup in runner_parameters.

--- a/st2actions/tests/integration/test_localrunner.py
+++ b/st2actions/tests/integration/test_localrunner.py
@@ -72,7 +72,7 @@ class TestLocalShellRunner(TestCase):
             'localrunner_pack', 'actions', 'text_gen.py')
         runner = TestLocalShellRunner._get_runner(action_db, entry_point=entry_point)
         runner.pre_run()
-        char_count = 10**6  # Note 10^7 succeeds but ends up being slow.
+        char_count = 10 ** 6  # Note 10^7 succeeds but ends up being slow.
         status, result = runner.run({'chars': char_count})
         runner.post_run(status, result)
         self.assertEquals(status, action_constants.ACTIONEXEC_STATUS_SUCCEEDED)

--- a/st2actions/tests/integration/test_localrunner.py
+++ b/st2actions/tests/integration/test_localrunner.py
@@ -1,0 +1,106 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import st2tests.config as tests_config
+tests_config.parse_args()
+
+import uuid
+
+from unittest2 import TestCase
+from st2actions.container.service import RunnerContainerService
+from st2actions.runners import localrunner
+from st2common.constants import action as action_constants
+from st2tests.fixturesloader import FixturesLoader
+
+
+class TestLocalShellRunner(TestCase):
+
+    fixtures_loader = FixturesLoader()
+
+    def test_shell_command_action_basic(self):
+        models = TestLocalShellRunner.fixtures_loader.load_models(
+            fixtures_pack='generic', fixtures_dict={'actions': ['local.json']})
+        action_db = models['actions']['local.json']
+        runner = TestLocalShellRunner._get_runner(action_db, cmd='echo 10')
+        runner.pre_run()
+        status, result = runner.run({})
+        runner.post_run(status, result)
+        self.assertEquals(status, action_constants.ACTIONEXEC_STATUS_SUCCEEDED)
+        self.assertEquals(result['stdout'], 10)
+
+    def test_shell_script_action(self):
+        models = TestLocalShellRunner.fixtures_loader.load_models(
+            fixtures_pack='localrunner_pack', fixtures_dict={'actions': ['text_gen.yml']})
+        action_db = models['actions']['text_gen.yml']
+        entry_point = TestLocalShellRunner.fixtures_loader.get_fixture_file_path_abs(
+            'localrunner_pack', 'actions', 'text_gen.py')
+        runner = TestLocalShellRunner._get_runner(action_db, entry_point=entry_point)
+        runner.pre_run()
+        status, result = runner.run({'chars': 1000})
+        runner.post_run(status, result)
+        self.assertEquals(status, action_constants.ACTIONEXEC_STATUS_SUCCEEDED)
+        self.assertEquals(len(result['stdout']), 1000 + 1)  # +1 for the newline
+
+    def test_timeout(self):
+        models = TestLocalShellRunner.fixtures_loader.load_models(
+            fixtures_pack='generic', fixtures_dict={'actions': ['local.json']})
+        action_db = models['actions']['local.json']
+        # smaller timeout == faster tests.
+        runner = TestLocalShellRunner._get_runner(action_db, cmd='sleep 10', timeout=0.01)
+        runner.pre_run()
+        status, result = runner.run({})
+        runner.post_run(status, result)
+        self.assertEquals(status, action_constants.ACTIONEXEC_STATUS_FAILED)
+
+    def test_large_stdout(self):
+        models = TestLocalShellRunner.fixtures_loader.load_models(
+            fixtures_pack='localrunner_pack', fixtures_dict={'actions': ['text_gen.yml']})
+        action_db = models['actions']['text_gen.yml']
+        entry_point = TestLocalShellRunner.fixtures_loader.get_fixture_file_path_abs(
+            'localrunner_pack', 'actions', 'text_gen.py')
+        runner = TestLocalShellRunner._get_runner(action_db, entry_point=entry_point)
+        runner.pre_run()
+        char_count = 10**6  # Note 10^7 succeeds but ends up being slow.
+        status, result = runner.run({'chars': char_count})
+        runner.post_run(status, result)
+        self.assertEquals(status, action_constants.ACTIONEXEC_STATUS_SUCCEEDED)
+        self.assertEquals(len(result['stdout']), char_count + 1)  # +1 for the newline
+
+    @staticmethod
+    def _get_runner(action_db,
+                    entry_point=None,
+                    cmd=None,
+                    on_behalf_user=None,
+                    user=None,
+                    kwarg_op=localrunner.DEFAULT_KWARG_OP,
+                    timeout=localrunner.DEFAULT_ACTION_TIMEOUT,
+                    sudo=False):
+        runner = localrunner.LocalShellRunner(uuid.uuid4().hex)
+        runner.container_service = RunnerContainerService()
+        runner.action = action_db
+        runner.action_name = action_db.name
+        runner.action_execution_id = uuid.uuid4().hex
+        runner.entry_point = entry_point
+        runner.runner_parameters = {localrunner.RUNNER_COMMAND: cmd,
+                                    localrunner.RUNNER_SUDO: sudo,
+
+                                    localrunner.RUNNER_ON_BEHALF_USER: user,
+                                    localrunner.RUNNER_KWARG_OP: kwarg_op,
+                                    localrunner.RUNNER_TIMEOUT: timeout}
+        runner.context = dict()
+        runner.callback = dict()
+        runner.libs_dir_path = None
+        runner.auth_token = None
+        return runner

--- a/st2tests/st2tests/fixtures/localrunner_pack/actions/text_gen.py
+++ b/st2tests/st2tests/fixtures/localrunner_pack/actions/text_gen.py
@@ -1,0 +1,24 @@
+#! /usr/bin/python
+
+import argparse
+import string
+import random
+
+
+def print_random_chars(chars=1000, selection=string.letters + string.digits):
+    s = []
+    for _ in range(chars - 1):
+        s.append(random.choice(selection))
+    s.append('@')
+    print(''.join(s))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--chars', type=int, metavar='N')
+    args = parser.parse_args()
+    print_random_chars(args.chars)
+
+
+if __name__ == '__main__':
+    main()

--- a/st2tests/st2tests/fixtures/localrunner_pack/actions/text_gen.yml
+++ b/st2tests/st2tests/fixtures/localrunner_pack/actions/text_gen.yml
@@ -1,0 +1,13 @@
+---
+"name": "text_gen"
+"pack": "localrunner_pack"
+"runner_type": "run-local-script"
+"description": "Action that executes an arbitrary Linux command on the localhost."
+"enabled": true
+"entry_point": "text_gen.py"
+"parameters":
+    "sudo":
+        "immutable": true
+    "chars":
+        "type": "integer"
+        "default": 1000


### PR DESCRIPTION
- Using Popen.wait() with STDOUT=subprocess.PIPE causes a deadlocal and it is
  described as a warning in the docs as well. Basically, the child process blocks
  on the buffer from being empty and the spawning process is wait for the child to
  quite prior to reading - so deadlock.
- The solution is to use Popen.communicate(). Using this works great and large
  data upto 10^6 chars can also be read. Rest of the system starts struggling but
  that is not in scope of this commit.
- Using communicate leads to challenges with kill on a timeout. The timeout is placed
  to avoid bad action from taking down the runners. The only way to cleanly handle the
  kill of all the process is to use pkill. The specific way in which the shell command
  is constructed implies that there is no child-parent relation. Therefore all procs
  are put in a single process group and the process group is killed. This requires
  use of pkill. We clearly don't plan to run this code on windows.