### PR TITLE
RFR: Set action status as failure on python action exceptions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,6 +50,7 @@ Docs: http://docks.stackstorm.com/latest
 * Add ``rule_tester`` tool which allows users to test rules in an offline mode without any services
   running (new-feature)
 * Fix a bug where trigger objects weren't created for triggers with different parameters. (bug-fix)
+* Exception thrown from python actions should record the action as failed. (bug-fix)
 
 v0.6.0 - December 8, 2014
 -------------------------

--- a/st2actions/st2actions/runners/python_action_wrapper.py
+++ b/st2actions/st2actions/runners/python_action_wrapper.py
@@ -54,17 +54,28 @@ class PythonActionWrapper(object):
 
     def run(self):
         action = self._get_action_instance()
-        output = action.run(**self._parameters)
+
+        stream = None
+        try:
+            # XXX: We need a way for actions to return status and result.
+            output = action.run(**self._parameters)
+            stream = sys.stdout
+            exit_code = 0
+        except Exception as e:
+            output = e
+            stream = sys.stderr
+            exit_code = 1
 
         # Print output to stdout so the parent can capture it
-        sys.stdout.write(ACTION_OUTPUT_RESULT_DELIMITER)
+        stream.write(ACTION_OUTPUT_RESULT_DELIMITER)
         print_output = None
         try:
             print_output = json.dumps(output)
         except:
             print_output = str(output)
-        sys.stdout.write(print_output + '\n')
-        sys.stdout.write(ACTION_OUTPUT_RESULT_DELIMITER)
+        stream.write(print_output + '\n')
+        stream.write(ACTION_OUTPUT_RESULT_DELIMITER)
+        sys.exit(exit_code)
 
     def _get_action_instance(self):
         actions_cls = action_loader.register_plugin(Action, self._file_path)

--- a/st2actions/st2actions/runners/python_action_wrapper.py
+++ b/st2actions/st2actions/runners/python_action_wrapper.py
@@ -13,9 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-import json
 import argparse
+import json
+import sys
+import traceback
 
 from st2common import log as logging
 from st2actions import config
@@ -62,7 +63,7 @@ class PythonActionWrapper(object):
             stream = sys.stdout
             exit_code = 0
         except Exception as e:
-            output = e
+            output = traceback.format_exc(e)
             stream = sys.stderr
             exit_code = 1
 

--- a/st2actions/st2actions/runners/pythonrunner.py
+++ b/st2actions/st2actions/runners/pythonrunner.py
@@ -148,11 +148,13 @@ class PythonRunner(ActionRunner):
         stdout, stderr = process.communicate()
         exit_code = process.returncode
 
-        if ACTION_OUTPUT_RESULT_DELIMITER in stdout:
-            split = stdout.split(ACTION_OUTPUT_RESULT_DELIMITER)
+        stream_to_process = stderr if exit_code else stdout
+
+        if ACTION_OUTPUT_RESULT_DELIMITER in stream_to_process:
+            split = stream_to_process.split(ACTION_OUTPUT_RESULT_DELIMITER)
             assert len(split) == 3
             result = split[1].strip()
-            stdout = split[0] = split[2]
+            stream_to_process = split[0] = split[2]
         else:
             result = None
 


### PR DESCRIPTION
* Print the exception to stderr and make sure exception shows in
action execution object.