### PR TITLE
Add support of mistral workflow only definition

### DIFF
--- a/contrib/examples/actions/mistral-basic.json
+++ b/contrib/examples/actions/mistral-basic.json
@@ -6,11 +6,6 @@
     "enabled": true,
     "entry_point":"mistral-basic.yaml",
     "parameters": {
-        "workflow": {
-            "type": "string",
-            "default": "examples.mistral-basic.demo",
-            "immutable": true
-        },
         "cmd": {
             "type": "string",
             "required": true

--- a/contrib/examples/actions/mistral-basic.yaml
+++ b/contrib/examples/actions/mistral-basic.yaml
@@ -1,16 +1,12 @@
-name: 'examples.mistral-basic'
 version: '2.0'
-description: 'Basic mistral workflow example'
-workflows:
-    demo:
-        type: direct
-        input:
-            - cmd
-        tasks:
-            run-cmd:
-                action: core.local
-                input:
-                    cmd: $.cmd
-                publish:
-                    stdout: $.stdout
-                    stderr: $.stderr
+
+examples.mistral-basic:
+    type: direct
+    input:
+        - cmd
+    tasks:
+        run-cmd:
+            action: core.local cmd={$.cmd}
+            publish:
+                stdout: $.stdout
+                stderr: $.stderr

--- a/contrib/examples/actions/mistral-workbook-basic.json
+++ b/contrib/examples/actions/mistral-workbook-basic.json
@@ -1,0 +1,19 @@
+{
+    "name": "mistral-workbook-basic",
+    "pack": "examples",
+    "runner_type": "mistral-v2",
+    "description": "Run a local linux command",
+    "enabled": true,
+    "entry_point":"mistral-workbook-basic.yaml",
+    "parameters": {
+        "workflow": {
+            "type": "string",
+            "default": "examples.mistral-workbook-basic.demo",
+            "immutable": true
+        },
+        "cmd": {
+            "type": "string",
+            "required": true
+        }
+    }
+}

--- a/contrib/examples/actions/mistral-workbook-basic.yaml
+++ b/contrib/examples/actions/mistral-workbook-basic.yaml
@@ -1,0 +1,16 @@
+name: 'examples.mistral-workbook-basic'
+version: '2.0'
+description: 'Basic mistral workbook example'
+workflows:
+    demo:
+        type: direct
+        input:
+            - cmd
+        tasks:
+            run-cmd:
+                action: core.local
+                input:
+                    cmd: $.cmd
+                publish:
+                    stdout: $.stdout
+                    stderr: $.stderr

--- a/contrib/examples/actions/mistral-workbook-complex.json
+++ b/contrib/examples/actions/mistral-workbook-complex.json
@@ -1,14 +1,14 @@
 {
-    "name": "mistral-complex",
+    "name": "mistral-workbook-complex",
     "pack": "examples",
     "runner_type": "mistral-v2",
-    "description": "Run a series of printf commands.",
+    "description": "Run a series of simulated actions.",
     "enabled": true,
-    "entry_point":"mistral-complex.yaml",
+    "entry_point":"mistral-workbook-complex.yaml",
     "parameters": {
         "workflow": {
             "type": "string",
-            "default": "examples.mistral-complex.main",
+            "default": "examples.mistral-workbook-complex.main",
             "immutable": true
         },
         "vm_name": {

--- a/contrib/examples/actions/mistral-workbook-complex.yaml
+++ b/contrib/examples/actions/mistral-workbook-complex.yaml
@@ -1,5 +1,5 @@
 version: "2.0"
-name: "examples.mistral-complex"
+name: "examples.mistral-workbook-complex"
 
 workflows:
 

--- a/docs/source/mistral.rst
+++ b/docs/source/mistral.rst
@@ -4,31 +4,31 @@ Mistral
 
 Basic Workflow
 ++++++++++++++
-Let's start with a very basic workflow that calls a |st2| action and notifies |st2| when the workflow is done. The files used in this example is also located under /usr/share/doc/st2/examples if |st2| is already installed. The first task is named **run-cmd** that executes a shell command on the local server where st2 is installed. The run-cmd task is calling **core.local** and passing the cmd as input. **core.local** is an action that comes installed with |st2|. In the workflow, we can reference |st2| action directly. When the workflow is invoked, |st2| will translate the workflow definition appropriately before sending it to Mistral. Let's save this as mistral-basic.yaml at /opt/stackstorm/packs/examples/actions/ where |st2| is installed.
+Let's start with a very basic workflow that calls a |st2| action and notifies |st2| when the workflow is done. The files used in this example is also located under /usr/share/doc/st2/examples if |st2| is already installed. The first task is named **run-cmd** that executes a shell command on the local server where st2 is installed. The run-cmd task is calling **core.local** and passing the cmd as input. **core.local** is an action that comes installed with |st2|. In the workflow, we can reference |st2| action directly. When the workflow is invoked, |st2| will translate the workflow definition appropriately before sending it to Mistral. Let's save this as mistral-workbook-basic.yaml at /opt/stackstorm/packs/examples/actions/ where |st2| is installed.
 
-.. literalinclude:: /../../contrib/examples/actions/mistral-basic.yaml
+.. literalinclude:: /../../contrib/examples/actions/mistral-workbook-basic.yaml
 
-The following is the corresponding |st2| action metadata for example above. The |st2| pack for this workflow action is named "examples". Please note that the workbook is named fully qualified as "<pack>.<action>" in the workbook definition above. The |st2| action runner is "mistral-v2". The entry point for the |st2| action refers to the YAML file of the workbook definition. Under the parameters section, we added an immutable parameter that specifies which workflow in the workbook to execute and a second parameter that takes the command to execute. Let's save this metadata as mistral-basic.json at /opt/stackstorm/packs/examples/actions/.
+The following is the corresponding |st2| action metadata for example above. The |st2| pack for this workflow action is named "examples". Please note that the workbook is named fully qualified as "<pack>.<action>" in the workbook definition above. The |st2| action runner is "mistral-v2". The entry point for the |st2| action refers to the YAML file of the workbook definition. Under the parameters section, we added an immutable parameter that specifies which workflow in the workbook to execute and a second parameter that takes the command to execute. Let's save this metadata as mistral-workbook-basic.json at /opt/stackstorm/packs/examples/actions/.
 
-.. literalinclude:: /../../contrib/examples/actions/mistral-basic.json
+.. literalinclude:: /../../contrib/examples/actions/mistral-workbook-basic.json
 
-Next, run the following |st2| command to create this workflow action. This will register the workflow as examples.mistral-basic in |st2|. ::
+Next, run the following |st2| command to create this workflow action. This will register the workflow as examples.mistral-workbook-basic in |st2|. ::
 
-    st2 action create /opt/stackstorm/packs/examples/actions/mistral-basic.json
+    st2 action create /opt/stackstorm/packs/examples/actions/mistral-workbook-basic.json
 
 
 To execute the workflow, run the following command where -a tells the command to return and not wait for the workflow to complete. ::
 
-    st2 run examples.mistral-basic cmd=date -a
+    st2 run examples.mistral-workbook-basic cmd=date -a
 
-If the workflow completed successfully, both the workflow **examples.mistral-basic** and the action **core.local** would have a **succeeded** status in the |st2| action execution list. ::
+If the workflow completed successfully, both the workflow **examples.mistral-workbook-basic** and the action **core.local** would have a **succeeded** status in the |st2| action execution list. ::
 
-    +--------------------------+------------------------+--------------+-----------+-----------------------------+
-    | id                       | action                 | context.user | status    | start_timestamp             |
-    +--------------------------+------------------------+--------------+-----------+-----------------------------+
-    | 545169bf9c99383e585e2934 | examples.mistral-basic |              | succeeded | 2014-11-03T10:00:11.808000Z |
-    | 545169c09c99383e585e2935 | core.local             |              | succeeded | 2014-11-03T10:00:12.084000Z |
-    +--------------------------+------------------------+--------------+-----------+-----------------------------+
+    +--------------------------+---------------------------------+--------------+-----------+-----------------------------+
+    | id                       | action                          | context.user | status    | start_timestamp             |
+    +--------------------------+---------------------------------+--------------+-----------+-----------------------------+
+    | 545169bf9c99383e585e2934 | examples.mistral-workbook-basic | stanley      | succeeded | 2014-11-03T10:00:11.808000Z |
+    | 545169c09c99383e585e2935 | core.local                      | stanley      | succeeded | 2014-11-03T10:00:12.084000Z |
+    +--------------------------+---------------------------------+--------------+-----------+-----------------------------+
 
 Stitching a more Complex Workflow
 +++++++++++++++++++++++++++++++++

--- a/st2tests/integration/mistral/test_wiring.py
+++ b/st2tests/integration/mistral/test_wiring.py
@@ -66,12 +66,18 @@ class TestWorkflowExecution(unittest2.TestCase):
         execution = self._wait_for_completion(execution)
         self._assert_success(execution)
 
-    def test_complex_workflow(self):
-        execution = self._execute_workflow('examples.mistral-complex', {'vm_name': 'demo1'})
+    def test_basic_workbook(self):
+        execution = self._execute_workflow('examples.mistral-workbook-basic', {'cmd': 'date'})
         execution = self._wait_for_completion(execution)
         self._assert_success(execution)
 
-    def test_workflow_failure(self):
+    def test_complex_workbook(self):
+        execution = self._execute_workflow(
+            'examples.mistral-workbook-complex', {'vm_name': 'demo1'})
+        execution = self._wait_for_completion(execution)
+        self._assert_success(execution)
+
+    def test_execution_failure(self):
         execution = self._execute_workflow('examples.mistral-basic', {'cmd': 'foo'})
         execution = self._wait_for_completion(execution)
         self._assert_failure(execution)

--- a/st2tests/st2tests/fixtures/generic/actions/workflow_v2.json
+++ b/st2tests/st2tests/fixtures/generic/actions/workflow_v2.json
@@ -1,0 +1,18 @@
+{
+    "name": "workflow_v2",
+    "pack": "generic",
+    "runner_type": "mistral-v2",
+    "description": "Say hi to friend!",
+    "enabled": true,
+    "entry_point":"workflow_v2.yaml",
+    "parameters": {
+        "count": {
+            "type": "string",
+            "default": "3"
+        },
+        "friend": {
+            "type": "string",
+            "required": true
+        }
+    }
+}

--- a/st2tests/st2tests/fixtures/generic/actions/workflow_v2_many_workflows.json
+++ b/st2tests/st2tests/fixtures/generic/actions/workflow_v2_many_workflows.json
@@ -1,0 +1,18 @@
+{
+    "name": "workflow_v2_many_workflows",
+    "pack": "generic",
+    "runner_type": "mistral-v2",
+    "description": "Say hi to friend!",
+    "enabled": true,
+    "entry_point":"workflow_v2_many_workflows.yaml",
+    "parameters": {
+        "count": {
+            "type": "string",
+            "default": "3"
+        },
+        "friend": {
+            "type": "string",
+            "required": true
+        }
+    }
+}

--- a/st2tests/st2tests/fixtures/generic/workflows/workflow_v2.yaml
+++ b/st2tests/st2tests/fixtures/generic/workflows/workflow_v2.yaml
@@ -1,0 +1,22 @@
+version: '2.0'
+
+examples.mistral-basic:
+  type: direct
+  input:
+    - count
+    - friend
+  tasks:
+    say-greeting:
+      action: core.hey
+      input:
+        cmd: $.count
+      publish:
+        greet: $.stdout
+      on-success:
+        - say-friend
+    say-friend:
+      action: core.friend
+      input:
+        cmd: $.friend
+      publish:
+        towhom: $.stdout

--- a/st2tests/st2tests/fixtures/generic/workflows/workflow_v2_many_workflows.yaml
+++ b/st2tests/st2tests/fixtures/generic/workflows/workflow_v2_many_workflows.yaml
@@ -1,0 +1,43 @@
+version: '2.0'
+
+main1:
+  type: direct
+  input:
+    - count
+    - friend
+  tasks:
+    say-greeting:
+      action: core.hey
+      input:
+        cmd: $.count
+      publish:
+        greet: $.stdout
+      on-success:
+        - say-friend
+    say-friend:
+      action: core.friend
+      input:
+        cmd: $.friend
+      publish:
+        towhom: $.stdout
+
+main2:
+  type: direct
+  input:
+    - count
+    - friend
+  tasks:
+    say-greeting:
+      action: core.hey
+      input:
+        cmd: $.count
+      publish:
+        greet: $.stdout
+      on-success:
+        - say-friend
+    say-friend:
+      action: core.friend
+      input:
+        cmd: $.friend
+      publish:
+        towhom: $.stdout


### PR DESCRIPTION
Add support of mistral workflow only (non-workbook) definition. Definition
with multiple workflows is not supported because the default workflow to
launch would be ambiguous.