### PR TITLE
Adding rhel-rpm Makefile targets

### DIFF
--- a/st2actions/Makefile
+++ b/st2actions/Makefile
@@ -37,6 +37,13 @@ rpm:
 	cp packaging/rpm/$(COMPONENTS).spec $(RPM_SPECS_DIR)/
 	cd $(RPM_SPECS_DIR) && rpmbuild --clean --rmsource -ba $(COMPONENTS).spec
 
+.PHONY: rhel-rpm
+rhel-rpm:
+	pushd ~ && rpmdev-setuptree && popd
+	tar --transform=s~^~$(COMPONENTS)-$(VER)/~ -czf $(RPM_SOURCES_DIR)/$(COMPONENTS).tar.gz bin conf $(COMPONENTS)
+	cp packaging/rpm/$(COMPONENTS)-rhel6.spec $(RPM_SPECS_DIR)/
+	cd $(RPM_SPECS_DIR) && rpmbuild --clean --rmsource -ba $(COMPONENTS)-rhel6.spec
+
 .PHONY: deb
 deb:
 	mkdir -p ~/debbuild

--- a/st2actions/packaging/rpm/st2actions-rhel6.spec
+++ b/st2actions/packaging/rpm/st2actions-rhel6.spec
@@ -1,0 +1,39 @@
+Summary: ST2 Actions
+Name: st2actions
+Version: 0.4.0
+Release: 1
+License: Apache
+Group: Applications/Engineering
+BuildArch: noarch
+Source: /opt/git/st2/st2actions.tar.gz
+URL: https://github.com/StackStorm/st2
+Vendor: StackStorm
+Packager: Estee Tew <st2@stackstorm.com>
+Requires:     st2common
+
+%description
+An automation plaform that needs a much better description than this.
+
+%prep
+%setup
+
+%build
+sed -i -r "s~logs~/var/log/st2~g" conf/*log*.conf
+
+%install
+
+mkdir -p %{buildroot}/etc/st2actions
+mkdir -p %{buildroot}/usr/local/lib/python2.7/site-packages
+mkdir -p %{buildroot}/usr/bin
+cp -R st2actions %{buildroot}/usr/local/lib/python2.7/site-packages/
+cp -R conf/* %{buildroot}/etc/st2actions
+install -m755 bin/actionrunner %{buildroot}/usr/bin/actionrunner
+install -m755 bin/history %{buildroot}/usr/bin/history
+install -m755 bin/st2resultstracker %{buildroot}/usr/bin/st2resultstracker
+%files
+
+/usr/local/lib/python2.7/site-packages/st2actions*
+/usr/bin/actionrunner
+/usr/bin/history
+/usr/bin/st2resultstracker
+/etc/st2actions*

--- a/st2api/Makefile
+++ b/st2api/Makefile
@@ -35,6 +35,13 @@ rpm:
 	cp packaging/rpm/$(COMPONENTS).spec $(RPM_SPECS_DIR)/
 	cd $(RPM_SPECS_DIR) && rpmbuild --clean --rmsource -ba $(COMPONENTS).spec
 
+.PHONY: rhel-rpm
+rhel-rpm:
+	pushd ~ && rpmdev-setuptree && popd
+  tar --transform=s~^~$(COMPONENTS)-$(VER)/~ -czf $(RPM_SOURCES_DIR)/$(COMPONENTS).tar.gz bin conf $(COMPONENTS)
+  cp packaging/rpm/$(COMPONENTS)-rhel6.spec $(RPM_SPECS_DIR)/
+  cd $(RPM_SPECS_DIR) && rpmbuild --clean --rmsource -ba $(COMPONENTS)-rhel6.spec
+
 .PHONY: deb
 deb:
 	mkdir -p ~/debbuild

--- a/st2api/packaging/rpm/st2api-rhel6.spec
+++ b/st2api/packaging/rpm/st2api-rhel6.spec
@@ -1,0 +1,36 @@
+Summary: ST2 API
+Name: st2api
+Version: 0.4.0
+Release: 1
+License: Apache
+Group: Applications/Engineering
+BuildArch: noarch
+Source: /opt/git/st2/st2api.tar.gz
+URL: https://github.com/StackStorm/st2
+Vendor: StackStorm
+Packager: Estee Tew <st2@stackstorm.com>
+Requires:       st2common
+
+%description
+An automation plaform that needs a much better description than this.
+
+%prep
+%setup
+
+%build
+sed -i -r "s~logs~/var/log/st2~g" conf/logging.conf
+
+%install
+
+mkdir -p %{buildroot}/etc/st2api
+mkdir -p %{buildroot}/usr/local/lib/python2.7
+mkdir -p %{buildroot}/usr/bin
+cp -R st2api %{buildroot}/usr/local/lib/python2.7/
+cp -R conf/* %{buildroot}/etc/st2api
+install -m755 bin/st2api %{buildroot}/usr/bin/st2api
+
+%files
+
+/usr/local/lib/python2.7/site-packages/st2api*
+/usr/bin/st2api
+/etc/st2api*

--- a/st2auth/Makefile
+++ b/st2auth/Makefile
@@ -35,6 +35,13 @@ rpm:
 	cp packaging/rpm/$(COMPONENTS).spec $(RPM_SPECS_DIR)/
 	cd $(RPM_SPECS_DIR) && rpmbuild --clean --rmsource -ba $(COMPONENTS).spec
 
+.PHONY: rhel-rpm
+rhel-rpm:
+  pushd ~ && rpmdev-setuptree && popd
+  tar --transform=s~^~$(COMPONENTS)-$(VER)/~ -czf $(RPM_SOURCES_DIR)/$(COMPONENTS).tar.gz bin conf $(COMPONENTS)
+  cp packaging/rpm/$(COMPONENTS)-rhel6.spec $(RPM_SPECS_DIR)/
+  cd $(RPM_SPECS_DIR) && rpmbuild --clean --rmsource -ba $(COMPONENTS)-rhel6.spec
+
 .PHONY: deb
 deb:
 	mkdir -p ~/debbuild

--- a/st2auth/packaging/rpm/st2auth-rhel6.spec
+++ b/st2auth/packaging/rpm/st2auth-rhel6.spec
@@ -1,0 +1,36 @@
+Summary: ST2 Authentication
+Name: st2auth
+Version: 0.4.0
+Release: 1
+License: Apache
+Group: Applications/Engineering
+BuildArch: noarch
+Source: /opt/git/st2/st2auth.tar.gz
+URL: https://github.com/StackStorm/st2
+Vendor: StackStorm
+Packager: Estee Tew <st2@stackstorm.com>
+Requires:       st2common
+
+%description
+An automation plaform that needs a much better description than this.
+
+%prep
+%setup
+
+%build
+sed -i -r "s~logs~/var/log/st2~g" conf/logging.conf
+
+%install
+
+mkdir -p %{buildroot}/etc/st2auth
+mkdir -p %{buildroot}/usr/local/lib/python2.7
+mkdir -p %{buildroot}/usr/bin
+cp -R st2auth %{buildroot}/usr/local/lib/python2.7/
+cp -R conf/* %{buildroot}/etc/st2auth
+install -m755 bin/st2auth %{buildroot}/usr/bin/st2auth
+
+%files
+
+/usr/local/lib/python2.7/site-packages/st2auth*
+/usr/bin/st2auth
+/etc/st2auth*

--- a/st2client/Makefile
+++ b/st2client/Makefile
@@ -1,4 +1,5 @@
 SHELL := /bin/bash
+PY27=$(which python2.7)
 RPM_ROOT=~/rpmbuild
 RPM_SOURCES_DIR := $(RPM_ROOT)/SOURCES/
 RPM_SPECS_DIR := $(RPM_ROOT)/SPECS/
@@ -9,6 +10,15 @@ COMPONENTS := st2client
 .PHONY: rpm
 rpm: 
 	python setup.py bdist_rpm
+	mkdir -p $(RPM_ROOT)/RPMS/noarch
+	cp dist/$(COMPONENTS)*noarch.rpm $(RPM_ROOT)/RPMS/noarch/$(COMPONENTS)-$(VER)-$(RELEASE).noarch.rpm
+	mkdir -p $(RPM_ROOT)/SRPMS
+	cp dist/*src.rpm $(RPM_ROOT)/SRPMS/$(COMPONENTS)-$(VER)-$(RELEASE).src.rpm
+	rm -Rf dist $(COMPONENTS).egg-info ChangeLog AUTHORS build
+
+.PHONY: rhel-rpm
+rhel-rpm:
+	$(PY27) setup.py bdist_rpm
 	mkdir -p $(RPM_ROOT)/RPMS/noarch
 	cp dist/$(COMPONENTS)*noarch.rpm $(RPM_ROOT)/RPMS/noarch/$(COMPONENTS)-$(VER)-$(RELEASE).noarch.rpm
 	mkdir -p $(RPM_ROOT)/SRPMS

--- a/st2common/Makefile
+++ b/st2common/Makefile
@@ -14,6 +14,13 @@ rpm:
 	cp packaging/rpm/$(COMPONENTS).spec $(RPM_SPECS_DIR)/
 	cd $(RPM_SPECS_DIR) && rpmbuild --clean --rmsource -ba $(COMPONENTS).spec
 
+.PHONY: rhel-rpm
+rhel-rpm:
+  pushd ~ && rpmdev-setuptree && popd
+  tar --transform=s~^~$(COMPONENTS)-$(VER)/~ -czf $(RPM_SOURCES_DIR)/$(COMPONENTS).tar.gz bin conf $(COMPONENTS)
+  cp packaging/rpm/$(COMPONENTS)-rhel6.spec $(RPM_SPECS_DIR)/
+  cd $(RPM_SPECS_DIR) && rpmbuild --clean --rmsource -ba $(COMPONENTS)-rhel6.spec
+
 .PHONY: deb
 deb:
 	mkdir -p ~/debbuild

--- a/st2common/packaging/rpm/st2common-rhel6.spec
+++ b/st2common/packaging/rpm/st2common-rhel6.spec
@@ -1,0 +1,51 @@
+Summary: ST2 Common Libraries
+Name: st2common
+Version: 0.4.0
+Release: 1
+License: Apache
+Group: Applications/Engineering
+BuildArch: noarch
+Source: /opt/git/st2/st2common.tar.gz
+URL: https://github.com/StackStorm/st2
+Vendor: StackStorm
+Packager: Estee Tew <st2@stackstorm.com>
+Requires:	python-devel
+Requires:   	python-pip
+Requires:     mongodb
+Requires:     mongodb-server
+
+%description
+An automation plaform that needs a much better description than this.
+
+%prep
+%setup
+
+%build
+sed -i -r "s~(st2.*)/conf~/etc/\1~g" st2/st2.conf
+sed -i "/packs_base_path/a system_path = /usr/local/lib/python2.7/st2reactor/contrib/sensors" st2/st2.conf
+sed -i "s~vagrant~/home/stanley~g" st2/st2.conf
+
+%install
+
+mkdir -p %{buildroot}/usr/bin
+mkdir -p %{buildroot}/usr/local/lib/python2.7
+mkdir -p %{buildroot}/var/log/st2
+mkdir -p %{buildroot}/etc/st2
+mkdir -p %{buildroot}/opt/stackstorm/packs
+mkdir -p %{buildroot}/usr/share/doc/st2
+cp -R contrib/core %{buildroot}/opt/stackstorm/packs/
+cp -R contrib/packs %{buildroot}/opt/stackstorm/packs/
+cp -R contrib/examples %{buildroot}/usr/share/doc/st2/
+cp -R docs/* %{buildroot}/usr/share/doc/st2/
+cp -R st2common %{buildroot}//usr/local/lib/python2.7/
+cp -R bin %{buildroot}//usr/local/lib/python2.7/st2common/
+install st2/st2.conf %{buildroot}/etc/st2/st2.conf
+install -m755 tools/st2ctl %{buildroot}/usr/bin/st2ctl
+
+%files
+/usr/local/lib/python2.7/st2common*
+/usr/share/doc/st2/*
+/etc/st2/*
+/opt/stackstorm/*
+/var/log/st2
+/usr/bin/st2ctl

--- a/st2reactor/Makefile
+++ b/st2reactor/Makefile
@@ -12,6 +12,13 @@ rpm:
 	cp packaging/rpm/$(COMPONENTS).spec $(RPM_SPECS_DIR)/
 	cd $(RPM_SPECS_DIR) && rpmbuild --clean --rmsource -ba $(COMPONENTS).spec
 
+.PHONY: rhel-rpm
+rhel-rpm:
+  pushd ~ && rpmdev-setuptree && popd
+  tar --transform=s~^~$(COMPONENTS)-$(VER)/~ -czf $(RPM_SOURCES_DIR)/$(COMPONENTS).tar.gz bin conf $(COMPONENTS)
+  cp packaging/rpm/$(COMPONENTS)-rhel6.spec $(RPM_SPECS_DIR)/
+  cd $(RPM_SPECS_DIR) && rpmbuild --clean --rmsource -ba $(COMPONENTS)-rhel6.spec
+
 .PHONY: deb
 deb:
 	mkdir -p ~/debbuild

--- a/st2reactor/packaging/rpm/st2reactor-rhel6.spec
+++ b/st2reactor/packaging/rpm/st2reactor-rhel6.spec
@@ -1,0 +1,38 @@
+Summary: ST2 reactor
+Name: st2reactor
+Version: 0.4.0
+Release: 1
+License: Apache
+Group: Applications/Engineering
+BuildArch: noarch
+Source: /opt/git/st2/st2reactor.tar.gz
+URL: https://github.com/StackStorm/st2
+Vendor: StackStorm
+Packager: Estee Tew <st2@stackstorm.com>
+Requires:     st2common
+
+%description
+An automation plaform that needs a much better description than this.
+
+%prep
+%setup
+
+%build
+sed -i -r "s~logs~/var/log/st2~g" conf/logging*.conf
+
+%install
+
+mkdir -p %{buildroot}/usr/local/lib/python2.7
+mkdir -p %{buildroot}/etc/st2reactor
+mkdir -p %{buildroot}/usr/bin/
+cp -R st2reactor %{buildroot}/usr/local/lib/python2.7/
+cp -R conf/* %{buildroot}/etc/st2reactor
+install -m755 bin/sensor_container %{buildroot}/usr/bin/sensor_container
+install -m755 bin/rules_engine %{buildroot}/usr/bin/rules_engine
+
+%files
+
+/usr/local/lib/python2.7/site-packages/st2reactor*
+/usr/bin/sensor_container
+/usr/bin/rules_engine
+/etc/st2reactor*


### PR DESCRIPTION
This adds spec files and Make file targets for building rhel-rpms.  We will need an RHEL6 build host in conjunction with this.