### PR TITLE
remove st2api dependency on st2actions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,6 +50,8 @@ Docs: http://docks.stackstorm.com/latest
 * Add ``rule_tester`` tool which allows users to test rules in an offline mode without any services
   running (new-feature)
 * Fix a bug where trigger objects weren't created for triggers with different parameters. (bug-fix)
+* st2api only requires st2common and dependencies defined in requirements to be available on the
+  pythonpath thus making it possible to run st2api standalone.
 
 v0.6.0 - December 8, 2014
 -------------------------

--- a/st2actions/st2actions/container/service.py
+++ b/st2actions/st2actions/container/service.py
@@ -13,10 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import pipes
-
-from st2common.constants.action import LIBS_DIR as ACTION_LIBS_DIR
 from st2common.content import utils
 from st2common import log as logging
 
@@ -54,22 +50,11 @@ class RunnerContainerService(object):
 
     @staticmethod
     def get_entry_point_abs_path(pack=None, entry_point=None):
-        if entry_point is not None and len(entry_point) > 0:
-            if os.path.isabs(entry_point):
-                return entry_point
-            return os.path.join(utils.get_packs_base_path(),
-                                pipes.quote(pack), 'actions', pipes.quote(entry_point))
-        else:
-            return None
+        return utils.get_entry_point_abs_path(pack, entry_point)
 
     @staticmethod
     def get_action_libs_abs_path(pack=None, entry_point=None):
-        entry_point_abs_path = RunnerContainerService.get_entry_point_abs_path(
-            pack=pack, entry_point=entry_point)
-        if entry_point_abs_path is not None:
-            return os.path.join(os.path.dirname(entry_point_abs_path), ACTION_LIBS_DIR)
-        else:
-            return None
+        return utils.get_action_libs_abs_path(pack, entry_point)
 
     def __str__(self):
         result = []

--- a/st2actions/st2actions/utils/param_utils.py
+++ b/st2actions/st2actions/utils/param_utils.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import ast
-import copy
 import json
 import six
 
@@ -25,62 +24,6 @@ from st2common.util.compat import to_unicode
 
 
 LOG = logging.getLogger(__name__)
-
-
-def _merge_param_meta_values(action_meta=None, runner_meta=None):
-    runner_meta_keys = runner_meta.keys() if runner_meta else []
-    action_meta_keys = action_meta.keys() if action_meta else []
-    all_keys = set(runner_meta_keys).union(set(action_meta_keys))
-
-    merged_meta = {}
-
-    # ?? Runner immutable param's meta shouldn't be allowed to be modified by action whatsoever.
-    if runner_meta and runner_meta.get('immutable', False):
-        merged_meta = runner_meta
-
-    for key in all_keys:
-        if key in action_meta_keys and key not in runner_meta_keys:
-            merged_meta[key] = action_meta[key]
-        elif key in runner_meta_keys and key not in action_meta_keys:
-            merged_meta[key] = runner_meta[key]
-        else:
-            if key in ['immutable', 'required']:
-                merged_meta[key] = runner_meta.get(key, False) or action_meta.get(key, False)
-            else:
-                merged_meta[key] = action_meta.get(key)
-    return merged_meta
-
-
-def get_params_view(action_db=None, runner_db=None, merged_only=False):
-    runner_params = copy.deepcopy(runner_db.runner_parameters) if runner_db else {}
-    action_params = copy.deepcopy(action_db.parameters) if action_db else {}
-
-    parameters = set(runner_params.keys()).union(set(action_params.keys()))
-
-    merged_params = {}
-    for param in parameters:
-        merged_params[param] = _merge_param_meta_values(action_meta=action_params.get(param),
-                                                        runner_meta=runner_params.get(param))
-
-    if merged_only:
-        return merged_params
-
-    def is_required(param_meta):
-        return param_meta.get('required', False)
-
-    def is_immutable(param_meta):
-        return param_meta.get('immutable', False)
-
-    immutable = {param for param in parameters if is_immutable(merged_params.get(param))}
-    required = {param for param in parameters if is_required(merged_params.get(param))}
-    required = required - immutable
-    optional = parameters - required - immutable
-
-    required_params = {k: merged_params[k] for k in required}
-    optional_params = {k: merged_params[k] for k in optional}
-    immutable_params = {k: merged_params[k] for k in immutable}
-
-    return (required_params, optional_params, immutable_params)
 
 
 def _split_params(runner_parameters, action_parameters, mixed_params):

--- a/st2actions/tests/unit/test_param_utils.py
+++ b/st2actions/tests/unit/test_param_utils.py
@@ -23,18 +23,25 @@ from st2common.models.system.common import ResourceReference
 from st2common.models.db.action import (ActionDB, ActionExecutionDB)
 from st2common.models.api.action import RunnerTypeAPI
 from st2common.transport.publishers import PoolPublisher
+from st2tests.fixturesloader import FixturesLoader
 from unittest2 import TestCase
+
+
+FIXTURES_PACK = 'generic'
+
+TEST_MODELS = {
+    'actions': ['action1.json'],
+    'runners': ['testrunner1.json']
+}
+
+FIXTURES = FixturesLoader().load_models(fixtures_pack=FIXTURES_PACK,
+                                        fixtures_dict=TEST_MODELS)
 
 
 @mock.patch.object(PoolPublisher, 'publish', mock.MagicMock())
 class ParamsUtilsTest(TestCase):
-    action_db = None
-    runnertype_db = None
-
-    @classmethod
-    def setUpClass(cls):
-        super(ParamsUtilsTest, cls).setUpClass()
-        ParamsUtilsTest._setup_test_models()
+    action_db = FIXTURES['actions']['action1.json']
+    runnertype_db = FIXTURES['runners']['testrunner1.json']
 
     def test_get_resolved_params(self):
         params = {
@@ -262,64 +269,3 @@ class ParamsUtilsTest(TestCase):
         actionexec_db.parameters = params
 
         return actionexec_db
-
-    @classmethod
-    def _setup_test_models(cls):
-        ParamsUtilsTest._setup_runner_models()
-        ParamsUtilsTest._setup_action_models()
-
-    @classmethod
-    def _setup_runner_models(cls):
-        test_runner = {
-            'name': 'test-runner',
-            'description': 'A test runner.',
-            'enabled': True,
-            'runner_parameters': {
-                'runnerstr': {
-                    'description': 'Foo str param.',
-                    'type': 'string',
-                    'default': 'defaultfoo'
-                },
-                'runnerint': {
-                    'description': 'Foo int param.',
-                    'type': 'number'
-                },
-                'runnerfoo': {
-                    'description': 'Some foo param.',
-                    'default': 'FOO'
-                },
-                'runnerdummy': {
-                    'description': 'Dummy param.',
-                    'type': 'string',
-                    'default': 'runnerdummy'
-                },
-                'runnerimmutable': {
-                    'description': 'Immutable param.',
-                    'type': 'string',
-                    'default': 'runnerimmutable',
-                    'immutable': True
-                }
-            },
-            'runner_module': 'tests.test_runner'
-        }
-        runnertype_api = RunnerTypeAPI(**test_runner)
-        ParamsUtilsTest.runnertype_db = RunnerTypeAPI.to_model(runnertype_api)
-
-    @classmethod
-    def _setup_action_models(cls):
-        action_db = ActionDB()
-        action_db.name = 'action-1'
-        action_db.description = 'awesomeness'
-        action_db.enabled = True
-        action_db.pack = 'wolfpack'
-        action_db.entry_point = ''
-        action_db.runner_type = {'name': 'test-runner'}
-        action_db.parameters = {
-            'actionstr': {'type': 'string', 'required': True},
-            'actionint': {'type': 'number', 'default': 10},
-            'runnerdummy': {'type': 'string', 'default': 'actiondummy', 'immutable': True},
-            'runnerfoo': {'type': 'string', 'immutable': True},
-            'runnerimmutable': {'type': 'string', 'default': 'failed_override'},
-            'actionimmutable': {'type': 'string', 'default': 'actionimmutable', 'immutable': True}
-        }
-        ParamsUtilsTest.action_db = action_db

--- a/st2actions/tests/unit/test_param_utils.py
+++ b/st2actions/tests/unit/test_param_utils.py
@@ -20,8 +20,7 @@ import mock
 import st2actions.utils.param_utils as param_utils
 from st2common.exceptions import actionrunner
 from st2common.models.system.common import ResourceReference
-from st2common.models.db.action import (ActionDB, ActionExecutionDB)
-from st2common.models.api.action import RunnerTypeAPI
+from st2common.models.db.action import ActionExecutionDB
 from st2common.transport.publishers import PoolPublisher
 from st2tests.fixturesloader import FixturesLoader
 from unittest2 import TestCase

--- a/st2actions/tests/unit/test_param_utils.py
+++ b/st2actions/tests/unit/test_param_utils.py
@@ -260,6 +260,7 @@ class ParamsUtilsTest(TestCase):
         actionexec_db.action = ResourceReference(name=ParamsUtilsTest.action_db.name,
                                                  pack=ParamsUtilsTest.action_db.pack).ref
         actionexec_db.parameters = params
+
         return actionexec_db
 
     @classmethod

--- a/st2actions/tests/unit/test_param_utils.py
+++ b/st2actions/tests/unit/test_param_utils.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import datetime
 import mock
 
@@ -36,52 +35,6 @@ class ParamsUtilsTest(TestCase):
     def setUpClass(cls):
         super(ParamsUtilsTest, cls).setUpClass()
         ParamsUtilsTest._setup_test_models()
-
-    def test_merge_action_runner_params_meta(self):
-        required, optional, immutable = param_utils.get_params_view(
-            action_db=ParamsUtilsTest.action_db,
-            runner_db=ParamsUtilsTest.runnertype_db)
-        merged = {}
-        merged.update(required)
-        merged.update(optional)
-        merged.update(immutable)
-
-        consolidated = param_utils.get_params_view(
-            action_db=ParamsUtilsTest.action_db,
-            runner_db=ParamsUtilsTest.runnertype_db,
-            merged_only=True)
-
-        # Validate that merged_only view works.
-        self.assertEqual(merged, consolidated)
-
-        # Validate required params.
-        self.assertEqual(len(required), 1, 'Required should contain only one param.')
-        self.assertTrue('actionstr' in required, 'actionstr param is a required param.')
-        self.assertTrue('actionstr' not in optional and 'actionstr' not in immutable and
-                        'actionstr' in merged)
-
-        # Validate immutable params.
-        self.assertTrue('runnerimmutable' in immutable, 'runnerimmutable should be in immutable.')
-        self.assertTrue('actionimmutable' in immutable, 'actionimmutable should be in immutable.')
-
-        # Validate optional params.
-        for opt in optional:
-            self.assertTrue(opt not in required and opt not in immutable and opt in merged,
-                            'Optional parameter %s failed validation.' % opt)
-
-    def test_merge_param_meta_values(self):
-
-        runner_meta = copy.deepcopy(ParamsUtilsTest.runnertype_db.runner_parameters['runnerdummy'])
-        action_meta = copy.deepcopy(ParamsUtilsTest.action_db.parameters['runnerdummy'])
-        merged_meta = param_utils._merge_param_meta_values(action_meta=action_meta,
-                                                           runner_meta=runner_meta)
-
-        # Description is in runner meta but not in action meta.
-        self.assertEqual(merged_meta['description'], runner_meta['description'])
-        # Default value is overridden in action.
-        self.assertEqual(merged_meta['default'], action_meta['default'])
-        # Immutability is set in action.
-        self.assertEqual(merged_meta['immutable'], action_meta['immutable'])
 
     def test_get_resolved_params(self):
         params = {

--- a/st2api/st2api/controllers/v1/actionviews.py
+++ b/st2api/st2api/controllers/v1/actionviews.py
@@ -18,10 +18,10 @@ from pecan import abort
 from pecan.rest import RestController
 import six
 
-from st2actions.container.service import RunnerContainerService
 from st2api.controllers import resource
 from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2common import log as logging
+from st2common.content import utils
 from st2common.models.api.action import ActionAPI
 from st2common.models.api.base import jsexpose
 from st2common.models.utils import action_param_utils
@@ -150,7 +150,7 @@ class EntryPointController(resource.ContentPackResourceControler):
         pack = getattr(action_db, 'pack', None)
         entry_point = getattr(action_db, 'entry_point', None)
 
-        abs_path = RunnerContainerService.get_entry_point_abs_path(pack, entry_point)
+        abs_path = utils.get_entry_point_abs_path(pack, entry_point)
 
         if not abs_path:
             raise StackStormDBObjectNotFoundError('Action ref_or_id=%s has no entry_point to output'

--- a/st2api/st2api/controllers/v1/actionviews.py
+++ b/st2api/st2api/controllers/v1/actionviews.py
@@ -18,13 +18,13 @@ from pecan import abort
 from pecan.rest import RestController
 import six
 
-import st2actions.utils.param_utils as param_utils
 from st2actions.container.service import RunnerContainerService
 from st2api.controllers import resource
 from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2common import log as logging
 from st2common.models.api.action import ActionAPI
 from st2common.models.api.base import jsexpose
+from st2common.models.utils import action_param_utils
 from st2common.persistence.action import (Action, RunnerType)
 
 http_client = six.moves.http_client
@@ -80,7 +80,7 @@ class ParametersViewController(RestController):
         LOG.info('Found action: %s, runner: %s', action_db, action_db.runner_type['name'])
         runner_db = LookupUtils._get_runner_by_name(action_db.runner_type['name'])
 
-        all_params = param_utils.get_params_view(
+        all_params = action_param_utils.get_params_view(
             action_db=action_db, runner_db=runner_db, merged_only=True)
 
         return {'parameters': all_params}

--- a/st2common/st2common/content/utils.py
+++ b/st2common/st2common/content/utils.py
@@ -17,6 +17,7 @@ import os
 import pipes
 
 from oslo.config import cfg
+from st2common.constants.action import LIBS_DIR as ACTION_LIBS_DIR
 
 __all__ = [
     'get_packs_base_path',
@@ -44,3 +45,41 @@ def get_pack_base_path(pack_name):
     pack_base_path = os.path.join(packs_base_path, pipes.quote(pack_name))
     pack_base_path = os.path.abspath(pack_base_path)
     return pack_base_path
+
+
+def get_entry_point_abs_path(pack=None, entry_point=None):
+    """
+    Return full absolute path of an action entry point in a pack.
+
+    :param pack_name: Content pack name.
+    :type pack_name: ``str``
+    :param entry_point: Action entry point.
+    :type entry_point: ``str``
+
+    :rtype: ``str``
+    """
+    if entry_point is not None and len(entry_point) > 0:
+        if os.path.isabs(entry_point):
+            return entry_point
+        return os.path.join(get_packs_base_path(),
+                            pipes.quote(pack), 'actions', pipes.quote(entry_point))
+    else:
+        return None
+
+
+def get_action_libs_abs_path(pack=None, entry_point=None):
+    """
+    Return full absolute path of libs for an action.
+
+    :param pack_name: Content pack name.
+    :type pack_name: ``str``
+    :param entry_point: Action entry point.
+    :type entry_point: ``str``
+
+    :rtype: ``str``
+    """
+    entry_point_abs_path = get_entry_point_abs_path(pack=pack, entry_point=entry_point)
+    if entry_point_abs_path is not None:
+        return os.path.join(os.path.dirname(entry_point_abs_path), ACTION_LIBS_DIR)
+    else:
+        return None

--- a/st2common/st2common/models/utils/action_param_utils.py
+++ b/st2common/st2common/models/utils/action_param_utils.py
@@ -1,0 +1,72 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+
+
+def _merge_param_meta_values(action_meta=None, runner_meta=None):
+    runner_meta_keys = runner_meta.keys() if runner_meta else []
+    action_meta_keys = action_meta.keys() if action_meta else []
+    all_keys = set(runner_meta_keys).union(set(action_meta_keys))
+
+    merged_meta = {}
+
+    # ?? Runner immutable param's meta shouldn't be allowed to be modified by action whatsoever.
+    if runner_meta and runner_meta.get('immutable', False):
+        merged_meta = runner_meta
+
+    for key in all_keys:
+        if key in action_meta_keys and key not in runner_meta_keys:
+            merged_meta[key] = action_meta[key]
+        elif key in runner_meta_keys and key not in action_meta_keys:
+            merged_meta[key] = runner_meta[key]
+        else:
+            if key in ['immutable', 'required']:
+                merged_meta[key] = runner_meta.get(key, False) or action_meta.get(key, False)
+            else:
+                merged_meta[key] = action_meta.get(key)
+    return merged_meta
+
+
+def get_params_view(action_db=None, runner_db=None, merged_only=False):
+    runner_params = copy.deepcopy(runner_db.runner_parameters) if runner_db else {}
+    action_params = copy.deepcopy(action_db.parameters) if action_db else {}
+
+    parameters = set(runner_params.keys()).union(set(action_params.keys()))
+
+    merged_params = {}
+    for param in parameters:
+        merged_params[param] = _merge_param_meta_values(action_meta=action_params.get(param),
+                                                        runner_meta=runner_params.get(param))
+
+    if merged_only:
+        return merged_params
+
+    def is_required(param_meta):
+        return param_meta.get('required', False)
+
+    def is_immutable(param_meta):
+        return param_meta.get('immutable', False)
+
+    immutable = {param for param in parameters if is_immutable(merged_params.get(param))}
+    required = {param for param in parameters if is_required(merged_params.get(param))}
+    required = required - immutable
+    optional = parameters - required - immutable
+
+    required_params = {k: merged_params[k] for k in required}
+    optional_params = {k: merged_params[k] for k in optional}
+    immutable_params = {k: merged_params[k] for k in immutable}
+
+    return (required_params, optional_params, immutable_params)

--- a/st2common/tests/unit/test_action_param_utils.py
+++ b/st2common/tests/unit/test_action_param_utils.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+
+import st2actions.utils.param_utils as param_utils
+from unittest2 import TestCase
+from st2common.models.db.action import ActionDB
+from st2common.models.api.action import RunnerTypeAPI
+
+
+class ActionParamsUtilsTest(TestCase):
+    action_db = None
+    runnertype_db = None
+
+    @classmethod
+    def setUpClass(cls):
+        super(ActionParamsUtilsTest, cls).setUpClass()
+        # TODO(manas): Use fixtures
+        ActionParamsUtilsTest._setup_test_models()
+
+    def test_merge_action_runner_params_meta(self):
+        required, optional, immutable = param_utils.get_params_view(
+            action_db=ActionParamsUtilsTest.action_db,
+            runner_db=ActionParamsUtilsTest.runnertype_db)
+        merged = {}
+        merged.update(required)
+        merged.update(optional)
+        merged.update(immutable)
+
+        consolidated = param_utils.get_params_view(
+            action_db=ActionParamsUtilsTest.action_db,
+            runner_db=ActionParamsUtilsTest.runnertype_db,
+            merged_only=True)
+
+        # Validate that merged_only view works.
+        self.assertEqual(merged, consolidated)
+
+        # Validate required params.
+        self.assertEqual(len(required), 1, 'Required should contain only one param.')
+        self.assertTrue('actionstr' in required, 'actionstr param is a required param.')
+        self.assertTrue('actionstr' not in optional and 'actionstr' not in immutable and
+                        'actionstr' in merged)
+
+        # Validate immutable params.
+        self.assertTrue('runnerimmutable' in immutable, 'runnerimmutable should be in immutable.')
+        self.assertTrue('actionimmutable' in immutable, 'actionimmutable should be in immutable.')
+
+        # Validate optional params.
+        for opt in optional:
+            self.assertTrue(opt not in required and opt not in immutable and opt in merged,
+                            'Optional parameter %s failed validation.' % opt)
+
+    def test_merge_param_meta_values(self):
+        runner_meta = copy.deepcopy(
+            ActionParamsUtilsTest.runnertype_db.runner_parameters['runnerdummy'])
+        action_meta = copy.deepcopy(ActionParamsUtilsTest.action_db.parameters['runnerdummy'])
+        merged_meta = param_utils._merge_param_meta_values(action_meta=action_meta,
+                                                           runner_meta=runner_meta)
+
+        # Description is in runner meta but not in action meta.
+        self.assertEqual(merged_meta['description'], runner_meta['description'])
+        # Default value is overridden in action.
+        self.assertEqual(merged_meta['default'], action_meta['default'])
+        # Immutability is set in action.
+        self.assertEqual(merged_meta['immutable'], action_meta['immutable'])
+
+    @classmethod
+    def _setup_test_models(cls):
+        ActionParamsUtilsTest._setup_runner_models()
+        ActionParamsUtilsTest._setup_action_models()
+
+    @classmethod
+    def _setup_runner_models(cls):
+        test_runner = {
+            'name': 'test-runner',
+            'description': 'A test runner.',
+            'enabled': True,
+            'runner_parameters': {
+                'runnerstr': {
+                    'description': 'Foo str param.',
+                    'type': 'string',
+                    'default': 'defaultfoo'
+                },
+                'runnerint': {
+                    'description': 'Foo int param.',
+                    'type': 'number'
+                },
+                'runnerfoo': {
+                    'description': 'Some foo param.',
+                    'default': 'FOO'
+                },
+                'runnerdummy': {
+                    'description': 'Dummy param.',
+                    'type': 'string',
+                    'default': 'runnerdummy'
+                },
+                'runnerimmutable': {
+                    'description': 'Immutable param.',
+                    'type': 'string',
+                    'default': 'runnerimmutable',
+                    'immutable': True
+                }
+            },
+            'runner_module': 'tests.test_runner'
+        }
+        runnertype_api = RunnerTypeAPI(**test_runner)
+        ActionParamsUtilsTest.runnertype_db = RunnerTypeAPI.to_model(runnertype_api)
+
+    @classmethod
+    def _setup_action_models(cls):
+        action_db = ActionDB()
+        action_db.name = 'action-1'
+        action_db.description = 'awesomeness'
+        action_db.enabled = True
+        action_db.pack = 'wolfpack'
+        action_db.entry_point = ''
+        action_db.runner_type = {'name': 'test-runner'}
+        action_db.parameters = {
+            'actionstr': {'type': 'string', 'required': True},
+            'actionint': {'type': 'number', 'default': 10},
+            'runnerdummy': {'type': 'string', 'default': 'actiondummy', 'immutable': True},
+            'runnerfoo': {'type': 'string', 'immutable': True},
+            'runnerimmutable': {'type': 'string', 'default': 'failed_override'},
+            'actionimmutable': {'type': 'string', 'default': 'actionimmutable', 'immutable': True}
+        }
+        ActionParamsUtilsTest.action_db = action_db

--- a/st2common/tests/unit/test_action_param_utils.py
+++ b/st2common/tests/unit/test_action_param_utils.py
@@ -17,20 +17,24 @@
 import copy
 
 from unittest2 import TestCase
-from st2common.models.api.action import RunnerTypeAPI
-from st2common.models.db.action import ActionDB
 from st2common.models.utils import action_param_utils
+from st2tests.fixturesloader import FixturesLoader
+
+
+FIXTURES_PACK = 'generic'
+
+TEST_MODELS = {
+    'actions': ['action1.json'],
+    'runners': ['testrunner1.json']
+}
+
+FIXTURES = FixturesLoader().load_models(fixtures_pack=FIXTURES_PACK,
+                                        fixtures_dict=TEST_MODELS)
 
 
 class ActionParamsUtilsTest(TestCase):
-    action_db = None
-    runnertype_db = None
-
-    @classmethod
-    def setUpClass(cls):
-        super(ActionParamsUtilsTest, cls).setUpClass()
-        # TODO(manas): Use fixtures
-        ActionParamsUtilsTest._setup_test_models()
+    action_db = FIXTURES['actions']['action1.json']
+    runnertype_db = FIXTURES['runners']['testrunner1.json']
 
     def test_merge_action_runner_params_meta(self):
         required, optional, immutable = action_param_utils.get_params_view(
@@ -77,64 +81,3 @@ class ActionParamsUtilsTest(TestCase):
         self.assertEqual(merged_meta['default'], action_meta['default'])
         # Immutability is set in action.
         self.assertEqual(merged_meta['immutable'], action_meta['immutable'])
-
-    @classmethod
-    def _setup_test_models(cls):
-        ActionParamsUtilsTest._setup_runner_models()
-        ActionParamsUtilsTest._setup_action_models()
-
-    @classmethod
-    def _setup_runner_models(cls):
-        test_runner = {
-            'name': 'test-runner',
-            'description': 'A test runner.',
-            'enabled': True,
-            'runner_parameters': {
-                'runnerstr': {
-                    'description': 'Foo str param.',
-                    'type': 'string',
-                    'default': 'defaultfoo'
-                },
-                'runnerint': {
-                    'description': 'Foo int param.',
-                    'type': 'number'
-                },
-                'runnerfoo': {
-                    'description': 'Some foo param.',
-                    'default': 'FOO'
-                },
-                'runnerdummy': {
-                    'description': 'Dummy param.',
-                    'type': 'string',
-                    'default': 'runnerdummy'
-                },
-                'runnerimmutable': {
-                    'description': 'Immutable param.',
-                    'type': 'string',
-                    'default': 'runnerimmutable',
-                    'immutable': True
-                }
-            },
-            'runner_module': 'tests.test_runner'
-        }
-        runnertype_api = RunnerTypeAPI(**test_runner)
-        ActionParamsUtilsTest.runnertype_db = RunnerTypeAPI.to_model(runnertype_api)
-
-    @classmethod
-    def _setup_action_models(cls):
-        action_db = ActionDB()
-        action_db.name = 'action-1'
-        action_db.description = 'awesomeness'
-        action_db.enabled = True
-        action_db.pack = 'wolfpack'
-        action_db.entry_point = ''
-        action_db.runner_type = {'name': 'test-runner'}
-        action_db.parameters = {
-            'actionstr': {'type': 'string', 'required': True},
-            'actionint': {'type': 'number', 'default': 10},
-            'runnerdummy': {'type': 'string', 'default': 'actiondummy', 'immutable': True},
-            'runnerfoo': {'type': 'string', 'immutable': True},
-            'runnerimmutable': {'type': 'string', 'default': 'failed_override'},
-            'actionimmutable': {'type': 'string', 'default': 'actionimmutable', 'immutable': True}
-        }
-        ActionParamsUtilsTest.action_db = action_db

--- a/st2common/tests/unit/test_action_param_utils.py
+++ b/st2common/tests/unit/test_action_param_utils.py
@@ -16,10 +16,10 @@
 
 import copy
 
-import st2actions.utils.param_utils as param_utils
 from unittest2 import TestCase
-from st2common.models.db.action import ActionDB
 from st2common.models.api.action import RunnerTypeAPI
+from st2common.models.db.action import ActionDB
+from st2common.models.utils import action_param_utils
 
 
 class ActionParamsUtilsTest(TestCase):
@@ -33,7 +33,7 @@ class ActionParamsUtilsTest(TestCase):
         ActionParamsUtilsTest._setup_test_models()
 
     def test_merge_action_runner_params_meta(self):
-        required, optional, immutable = param_utils.get_params_view(
+        required, optional, immutable = action_param_utils.get_params_view(
             action_db=ActionParamsUtilsTest.action_db,
             runner_db=ActionParamsUtilsTest.runnertype_db)
         merged = {}
@@ -41,7 +41,7 @@ class ActionParamsUtilsTest(TestCase):
         merged.update(optional)
         merged.update(immutable)
 
-        consolidated = param_utils.get_params_view(
+        consolidated = action_param_utils.get_params_view(
             action_db=ActionParamsUtilsTest.action_db,
             runner_db=ActionParamsUtilsTest.runnertype_db,
             merged_only=True)
@@ -68,8 +68,8 @@ class ActionParamsUtilsTest(TestCase):
         runner_meta = copy.deepcopy(
             ActionParamsUtilsTest.runnertype_db.runner_parameters['runnerdummy'])
         action_meta = copy.deepcopy(ActionParamsUtilsTest.action_db.parameters['runnerdummy'])
-        merged_meta = param_utils._merge_param_meta_values(action_meta=action_meta,
-                                                           runner_meta=runner_meta)
+        merged_meta = action_param_utils._merge_param_meta_values(action_meta=action_meta,
+                                                                  runner_meta=runner_meta)
 
         # Description is in runner meta but not in action meta.
         self.assertEqual(merged_meta['description'], runner_meta['description'])

--- a/st2tests/st2tests/fixtures/generic/actions/action1.json
+++ b/st2tests/st2tests/fixtures/generic/actions/action1.json
@@ -16,7 +16,13 @@
         },
         "runnerdummy": {
             "type": "string",
-            "default": "actiondummy"
+            "default": "actiondummy",
+            "immutable": true
+        },
+        "runnerfoo": {
+            "type": "string",
+            "default": "FOO",
+            "immutable": true
         },
         "runnerimmutable": {
             "type": "string",

--- a/st2tests/st2tests/fixtures/generic/runners/testrunner1.json
+++ b/st2tests/st2tests/fixtures/generic/runners/testrunner1.json
@@ -17,6 +17,10 @@
             "type": "string",
             "default": "runnerdummy"
         },
+        "runnerfoo": {
+            "description": "Some foo param.",
+            "default": "FOO"
+        },
         "runnerimmutable": {
             "description": "Immutable param.",
             "type": "string",


### PR DESCRIPTION
- all utils that st2api requires are moved to st2common.
- moved around some tests.
- migrated affected tests to using fixtures.
- verified fix by running st2api standalone.