### PR TITLE
Rename mistral workbook/workflow if name is not equal to action ref

### DIFF
--- a/contrib/examples/actions/mistral-basic-rename.json
+++ b/contrib/examples/actions/mistral-basic-rename.json
@@ -1,10 +1,10 @@
 {
-    "name": "mistral-workbook-basic",
+    "name": "mistral-basic-rename",
     "pack": "examples",
     "runner_type": "mistral-v2",
-    "description": "Run a local linux command",
+    "description": "Example of auto-renaming the workflow before saving the definition to Mistral.",
     "enabled": true,
-    "entry_point":"mistral-workbook-basic.yaml",
+    "entry_point":"mistral-basic-rename.yaml",
     "parameters": {
         "cmd": {
             "type": "string",

--- a/contrib/examples/actions/mistral-basic-rename.yaml
+++ b/contrib/examples/actions/mistral-basic-rename.yaml
@@ -1,0 +1,12 @@
+version: '2.0'
+
+whatever:
+    type: direct
+    input:
+        - cmd
+    tasks:
+        run-cmd:
+            action: core.local cmd={$.cmd}
+            publish:
+                stdout: $.stdout
+                stderr: $.stderr

--- a/contrib/examples/actions/mistral-workbook-basic-rename.json
+++ b/contrib/examples/actions/mistral-workbook-basic-rename.json
@@ -1,0 +1,14 @@
+{
+    "name": "mistral-workbook-basic-rename",
+    "pack": "examples",
+    "runner_type": "mistral-v2",
+    "description": "Example of auto-renaming the workbook before saving the definition to Mistral.",
+    "enabled": true,
+    "entry_point":"mistral-workbook-basic-rename.yaml",
+    "parameters": {
+        "cmd": {
+            "type": "string",
+            "required": true
+        }
+    }
+}

--- a/contrib/examples/actions/mistral-workbook-basic-rename.yaml
+++ b/contrib/examples/actions/mistral-workbook-basic-rename.yaml
@@ -1,0 +1,16 @@
+name: 'whatever'
+version: '2.0'
+description: 'Basic mistral workbook example'
+workflows:
+    demo:
+        type: direct
+        input:
+            - cmd
+        tasks:
+            run-cmd:
+                action: core.local
+                input:
+                    cmd: $.cmd
+                publish:
+                    stdout: $.stdout
+                    stderr: $.stderr

--- a/st2actions/st2actions/runners/mistral/utils.py
+++ b/st2actions/st2actions/runners/mistral/utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import json
 import re
 
@@ -127,8 +128,11 @@ def _transform_action(spec, action_key, input_key):
 
 
 def transform_definition(definition):
-    spec = yaml.safe_load(definition)
+    # If definition is a dictionary, there is no need to load from YAML.
+    is_dict = isinstance(definition, dict)
+    spec = copy.deepcopy(definition) if is_dict else yaml.safe_load(definition)
 
+    # Check version
     if 'version' not in spec:
         raise Exception('Unknown version. Only version 2.0 is supported.')
 
@@ -153,4 +157,5 @@ def transform_definition(definition):
                 for task_name, task_spec in six.iteritems(value.get('tasks')):
                     _transform_action(task_spec, 'action', 'input')
 
-    return yaml.safe_dump(spec, default_flow_style=False)
+    # Return the same type as original input.
+    return (spec if is_dict else yaml.safe_dump(spec, default_flow_style=False))

--- a/st2actions/st2actions/runners/mistral/v2.py
+++ b/st2actions/st2actions/runners/mistral/v2.py
@@ -45,6 +45,18 @@ class MistralRunner(AsyncActionRunner):
     def pre_run(self):
         pass
 
+    @staticmethod
+    def _check_and_rename_definition(action_ref, def_dict):
+        # If workbook, change the value of the "name" key.
+        if 'workflows' in def_dict:
+            if def_dict.get('name') != action_ref:
+                def_dict['name'] = action_ref
+        # If workflow, change the key name of the workflow.
+        else:
+            workflow_name = [k for k, v in six.iteritems(def_dict) if k != 'version'][0]
+            if workflow_name != action_ref:
+                def_dict[action_ref] = def_dict.pop(workflow_name)
+
     def _save_workbook(self, name, def_yaml):
         # If the workbook is not found, the mistral client throws a generic API exception.
         try:
@@ -130,6 +142,7 @@ class MistralRunner(AsyncActionRunner):
 
         action_ref = '%s.%s' % (self.action.pack, self.action.name)
         def_dict_xformed = utils.transform_definition(def_dict)
+        self._check_and_rename_definition(action_ref, def_dict_xformed)
         def_yaml_xformed = yaml.safe_dump(def_dict_xformed, default_flow_style=False)
 
         # Save workbook/workflow definition.

--- a/st2actions/tests/unit/test_mistral_dsl_transform.py
+++ b/st2actions/tests/unit/test_mistral_dsl_transform.py
@@ -85,17 +85,31 @@ class DSLTransformTestCase(DbTestCase):
         def_yaml = yaml.safe_dump(def_dict)
         self.assertRaises(Exception, utils.transform_definition, def_yaml)
 
-    def test_transform_workbook_dsl(self):
+    def test_transform_workbook_dsl_yaml(self):
         def_yaml = _read_file_content(WB_PRE_XFORM_PATH)
         new_def = utils.transform_definition(def_yaml)
         actual = yaml.safe_load(new_def)
         expected = copy.deepcopy(WB_POST_XFORM_DEF)
         self.assertDictEqual(actual, expected)
 
-    def test_transform_workflow_dsl(self):
+    def test_transform_workbook_dsl_dict(self):
+        def_yaml = _read_file_content(WB_PRE_XFORM_PATH)
+        def_dict = yaml.safe_load(def_yaml)
+        actual = utils.transform_definition(def_dict)
+        expected = copy.deepcopy(WB_POST_XFORM_DEF)
+        self.assertDictEqual(actual, expected)
+
+    def test_transform_workflow_dsl_yaml(self):
         def_yaml = _read_file_content(WF_PRE_XFORM_PATH)
         new_def = utils.transform_definition(def_yaml)
         actual = yaml.safe_load(new_def)
+        expected = copy.deepcopy(WF_POST_XFORM_DEF)
+        self.assertDictEqual(actual, expected)
+
+    def test_transform_workflow_dsl_dict(self):
+        def_yaml = _read_file_content(WF_PRE_XFORM_PATH)
+        def_dict = yaml.safe_load(def_yaml)
+        actual = utils.transform_definition(def_dict)
         expected = copy.deepcopy(WF_POST_XFORM_DEF)
         self.assertDictEqual(actual, expected)
 

--- a/st2tests/integration/mistral/test_wiring.py
+++ b/st2tests/integration/mistral/test_wiring.py
@@ -66,8 +66,19 @@ class TestWorkflowExecution(unittest2.TestCase):
         execution = self._wait_for_completion(execution)
         self._assert_success(execution)
 
+    def test_basic_workflow_rename_to_action_ref(self):
+        execution = self._execute_workflow('examples.mistral-basic-rename', {'cmd': 'date'})
+        execution = self._wait_for_completion(execution)
+        self._assert_success(execution)
+
     def test_basic_workbook(self):
         execution = self._execute_workflow('examples.mistral-workbook-basic', {'cmd': 'date'})
+        execution = self._wait_for_completion(execution)
+        self._assert_success(execution)
+
+    def test_basic_workbook_rename_to_action_ref(self):
+        execution = self._execute_workflow(
+            'examples.mistral-workbook-basic-rename', {'cmd': 'date'})
         execution = self._wait_for_completion(execution)
         self._assert_success(execution)
 

--- a/st2tests/st2tests/fixtures/generic/actions/workbook_v2_rename.json
+++ b/st2tests/st2tests/fixtures/generic/actions/workbook_v2_rename.json
@@ -1,0 +1,18 @@
+{
+    "name": "workbook_v2_rename",
+    "pack": "generic",
+    "runner_type": "mistral-v2",
+    "description": "Say hi to friend!",
+    "enabled": true,
+    "entry_point":"workbook_v2.yaml",
+    "parameters": {
+        "count": {
+            "type": "string",
+            "default": "3"
+        },
+        "friend": {
+            "type": "string",
+            "required": true
+        }
+    }
+}

--- a/st2tests/st2tests/fixtures/generic/actions/workflow_v2_rename.json
+++ b/st2tests/st2tests/fixtures/generic/actions/workflow_v2_rename.json
@@ -1,0 +1,18 @@
+{
+    "name": "workflow_v2_rename",
+    "pack": "generic",
+    "runner_type": "mistral-v2",
+    "description": "Say hi to friend!",
+    "enabled": true,
+    "entry_point":"workflow_v2.yaml",
+    "parameters": {
+        "count": {
+            "type": "string",
+            "default": "3"
+        },
+        "friend": {
+            "type": "string",
+            "required": true
+        }
+    }
+}

--- a/st2tests/st2tests/fixtures/generic/workflows/workflow_v2.yaml
+++ b/st2tests/st2tests/fixtures/generic/workflows/workflow_v2.yaml
@@ -1,6 +1,6 @@
 version: '2.0'
 
-examples.mistral-basic:
+generic.workflow_v2:
   type: direct
   input:
     - count

--- a/st2tests/st2tests/fixtures/generic/workflows/workflow_v2_many_workflows.yaml
+++ b/st2tests/st2tests/fixtures/generic/workflows/workflow_v2_many_workflows.yaml
@@ -1,6 +1,6 @@
 version: '2.0'
 
-main1:
+generic.workflow_v2.main1:
   type: direct
   input:
     - count
@@ -21,7 +21,7 @@ main1:
       publish:
         towhom: $.stdout
 
-main2:
+generic.workflow_v2.main2:
   type: direct
   input:
     - count


### PR DESCRIPTION
If name of the mistral workbook or workflow is not the same as the action ref, rename it before sending the definition to mistral.