### PR TITLE
RFR: Include conflict id in API response

### DIFF
--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -106,7 +106,7 @@ class ActionsController(resource.ContentPackResourceControler):
             # If an existing DB object conflicts with new object then raise error.
             LOG.warn('/actions/ POST unable to save ActionDB object "%s" due to uniqueness '
                      'conflict. %s', action_model, str(e))
-            abort(http_client.CONFLICT, str(e), headers={'X-st2-conflict-id': e.conflict_id})
+            abort(http_client.CONFLICT, str(e), body={'conflict-id': e.conflict_id})
             return
         except Exception as e:
             LOG.exception('/actions/ POST unable to save ActionDB object "%s". %s',

--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mongoengine import ValidationError, NotUniqueError
+from mongoengine import ValidationError
 
 from pecan import abort
 import six
@@ -27,6 +27,7 @@ from st2api.controllers.v1.actionviews import ActionViewsController
 from st2common import log as logging
 from st2common.constants.pack import DEFAULT_PACK_NAME
 from st2common.exceptions.apivalidation import ValueValidationException
+from st2common.exceptions.db import StackStormDBObjectConflictError
 from st2common.models.api.base import jsexpose
 from st2common.persistence.action import Action
 from st2common.models.api.action import ActionAPI
@@ -101,11 +102,11 @@ class ActionsController(resource.ContentPackResourceControler):
         LOG.debug('/actions/ POST verified ActionAPI object=%s', action)
         try:
             action_db = Action.add_or_update(action_model)
-        except NotUniqueError as e:
+        except StackStormDBObjectConflictError as e:
             # If an existing DB object conflicts with new object then raise error.
             LOG.warn('/actions/ POST unable to save ActionDB object "%s" due to uniqueness '
                      'conflict. %s', action_model, str(e))
-            abort(http_client.CONFLICT, str(e))
+            abort(http_client.CONFLICT, str(e), headers={'X-st2-conflict-id': e.conflict_id})
             return
         except Exception as e:
             LOG.exception('/actions/ POST unable to save ActionDB object "%s". %s',

--- a/st2api/st2api/controllers/v1/rules.py
+++ b/st2api/st2api/controllers/v1/rules.py
@@ -88,7 +88,7 @@ class RuleController(RestController):
         except StackStormDBObjectConflictError as e:
             LOG.warn('Rule creation of %s failed with uniqueness conflict. Exception %s',
                      rule, str(e))
-            abort(http_client.CONFLICT, str(e), headers={'X-st2-conflict-id': e.conflict_id})
+            abort(http_client.CONFLICT, str(e), body={'conflict-id': e.conflict_id})
             return
 
         LOG.audit('Rule created. Rule=%s', rule_db)

--- a/st2api/st2api/controllers/v1/rules.py
+++ b/st2api/st2api/controllers/v1/rules.py
@@ -13,13 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mongoengine import ValidationError, NotUniqueError
+from mongoengine import ValidationError
 from pecan import abort
 from pecan.rest import RestController
 import six
 
 from st2common import log as logging
 from st2common.exceptions.apivalidation import ValueValidationException
+from st2common.exceptions.db import StackStormDBObjectConflictError
 from st2common.models.api.rule import RuleAPI
 from st2common.models.api.base import jsexpose
 from st2common.persistence.reactor import Rule
@@ -84,10 +85,10 @@ class RuleController(RestController):
             LOG.exception('Validation failed for rule data=%s.', rule)
             abort(http_client.BAD_REQUEST, str(e))
             return
-        except NotUniqueError as e:
+        except StackStormDBObjectConflictError as e:
             LOG.warn('Rule creation of %s failed with uniqueness conflict. Exception %s',
                      rule, str(e))
-            abort(http_client.CONFLICT, str(e))
+            abort(http_client.CONFLICT, str(e), headers={'X-st2-conflict-id': e.conflict_id})
             return
 
         LOG.audit('Rule created. Rule=%s', rule_db)

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -175,7 +175,7 @@ class TriggerTypeController(resource.ContentPackResourceControler):
                 LOG.exception('Validation failed for trigger data=%s.', trigger)
                 # Not aborting as this is convenience.
                 return
-        except NotUniqueError as e:
+        except StackStormDBObjectConflictError as e:
             LOG.warn('Trigger creation of %s failed with uniqueness conflict. Exception %s',
                      trigger, str(e))
             # Not aborting as this is convenience.
@@ -245,10 +245,10 @@ class TriggerController(RestController):
             LOG.exception('Validation failed for trigger data=%s.', trigger)
             abort(http_client.BAD_REQUEST, str(e))
             return
-        except NotUniqueError as e:
+        except StackStormDBObjectConflictError as e:
             LOG.warn('Trigger creation of %s failed with uniqueness conflict. Exception %s',
                      trigger, str(e))
-            abort(http_client.CONFLICT, str(e))
+            abort(http_client.CONFLICT, str(e), body={'conflict-id': e.conflict_id})
             return
 
         LOG.audit('Trigger created. Trigger=%s', trigger_db)

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -70,7 +70,7 @@ class TriggerTypeController(resource.ContentPackResourceControler):
         except StackStormDBObjectConflictError as e:
             LOG.warn('TriggerType creation of %s failed with uniqueness conflict. Exception : %s',
                      triggertype, str(e))
-            abort(http_client.CONFLICT, str(e), headers={'X-st2-conflict-id': e.conflict_id})
+            abort(http_client.CONFLICT, str(e), body={'conflict-id': e.conflict_id})
             return
         else:
             LOG.audit('TriggerType created. TriggerType=%s', triggertype_db)

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mongoengine import ValidationError, NotUniqueError
+from mongoengine import ValidationError
 from pecan import abort
 from pecan.rest import RestController
 import six
@@ -25,6 +25,7 @@ from st2common.persistence.reactor import TriggerType, Trigger, TriggerInstance
 from st2common.services import triggers as TriggerService
 from st2api.controllers import resource
 from st2common.exceptions.apivalidation import ValueValidationException
+from st2common.exceptions.db import StackStormDBObjectConflictError
 from st2common.validators.api.misc import validate_not_part_of_system_pack
 
 http_client = six.moves.http_client
@@ -66,10 +67,10 @@ class TriggerTypeController(resource.ContentPackResourceControler):
             LOG.exception('Validation failed for triggertype data=%s.', triggertype)
             abort(http_client.BAD_REQUEST, str(e))
             return
-        except NotUniqueError as e:
+        except StackStormDBObjectConflictError as e:
             LOG.warn('TriggerType creation of %s failed with uniqueness conflict. Exception : %s',
                      triggertype, str(e))
-            abort(http_client.CONFLICT, str(e))
+            abort(http_client.CONFLICT, str(e), headers={'X-st2-conflict-id': e.conflict_id})
             return
         else:
             LOG.audit('TriggerType created. TriggerType=%s', triggertype_db)

--- a/st2api/tests/unit/controllers/v1/test_actions.py
+++ b/st2api/tests/unit/controllers/v1/test_actions.py
@@ -321,6 +321,7 @@ class TestActionController(FunctionalTest):
         post_resp = self.__do_post(ACTION_1, expect_errors=True)
         # Verify name conflict
         self.assertEqual(post_resp.status_int, 409)
+        self.assertEqual(post_resp.json['conflict-id'], action_ids[0])
 
         post_resp = self.__do_post(ACTION_10)
         action_ids.append(self.__get_action_id(post_resp))

--- a/st2api/tests/unit/controllers/v1/test_rules.py
+++ b/st2api/tests/unit/controllers/v1/test_rules.py
@@ -79,10 +79,12 @@ class TestRuleController(FunctionalTest):
 
     def test_post_duplicate(self):
         post_resp = self.__do_post(TestRuleController.RULE_1)
+        org_id = self.__get_rule_id(post_resp)
         self.assertEqual(post_resp.status_int, http_client.CREATED)
         post_resp_2 = self.__do_post(TestRuleController.RULE_1)
         self.assertEqual(post_resp_2.status_int, http_client.CONFLICT)
-        self.__do_delete(self.__get_rule_id(post_resp))
+        self.assertEqual(post_resp_2.json['conflict-id'], org_id)
+        self.__do_delete(org_id)
 
     def test_put(self):
         post_resp = self.__do_post(TestRuleController.RULE_1)

--- a/st2api/tests/unit/controllers/v1/test_triggertypes.py
+++ b/st2api/tests/unit/controllers/v1/test_triggertypes.py
@@ -92,10 +92,12 @@ class TestTriggerTypeController(FunctionalTest):
 
     def test_post_duplicate(self):
         post_resp = self.__do_post(TRIGGER_1)
+        org_id = self.__get_trigger_id(post_resp)
         self.assertEqual(post_resp.status_int, http_client.CREATED)
         post_resp_2 = self.__do_post(TRIGGER_1)
         self.assertEqual(post_resp_2.status_int, http_client.CONFLICT)
-        self.__do_delete(self.__get_trigger_id(post_resp))
+        self.assertEqual(post_resp_2.json['conflict-id'], org_id)
+        self.__do_delete(org_id)
 
     def test_put(self):
         post_resp = self.__do_post(TRIGGER_1)

--- a/st2api/tests/unit/controllers/v1/test_triggertypes.py
+++ b/st2api/tests/unit/controllers/v1/test_triggertypes.py
@@ -42,6 +42,21 @@ TRIGGER_2 = {
 
 class TestTriggerTypeController(FunctionalTest):
 
+    @classmethod
+    def setUpClass(cls):
+        # super's setUpClass does the following:
+        #  - create DB connections, sets up a fresh DB etc.
+        #  - creates all the controllers by instantiating the pecan app.
+        # The WebHookController ends up registering a TriggerType in its  __init__
+        # which is why when this test is run individually it simply falls apart.
+        # When run in a suite the pecan app creation is somehow optimized and since
+        # this is not the first test to run its all good as some other test performs
+        # the DB cleanup. This is the unfortunate story of why these two lines in this
+        # exact order are needed. There are perhaps other ways to fix the problem
+        # however this is the most localized solution for now.
+        super(TestTriggerTypeController, cls).setUpClass()
+        cls._establish_connection_and_re_create_db()
+
     def test_get_all(self):
         post_resp = self.__do_post(TRIGGER_0)
         trigger_id_0 = self.__get_trigger_id(post_resp)

--- a/st2common/st2common/exceptions/db.py
+++ b/st2common/st2common/exceptions/db.py
@@ -22,3 +22,12 @@ class StackStormDBObjectNotFoundError(StackStormBaseException):
 
 class StackStormDBObjectMalformedError(StackStormBaseException):
     pass
+
+
+class StackStormDBObjectConflictError(StackStormBaseException):
+    """
+    Exception that captures a DB object conflict error.
+    """
+    def __init__(self, message, conflict_id):
+        super(StackStormDBObjectConflictError, self).__init__(message)
+        self.conflict_id = conflict_id

--- a/st2common/st2common/models/api/base.py
+++ b/st2common/st2common/models/api/base.py
@@ -80,11 +80,20 @@ class BaseAPI(object):
         return model
 
 
-def _handle_error(status, exception):
-    LOG.error(exception, exc_info=True)
-    pecan.response.status = status
-    error = {'faultstring': exception.message}
-    return json_encode(error)
+def _handle_error(e, status_code, body=None, headers=None):
+    """
+    Encodes error into a json response and returns. This was the default
+    response to an error, HTML page, is skipped.
+    """
+    pecan.response.status = status_code
+    if headers:
+        pecan.response.headers = headers
+    # re-purposing body this way has drawbacks but the other options i.e.
+    # to envelope the body inside error_body would be awkward for clients.
+    error_body = body if body else dict()
+    assert isinstance(error_body, dict)
+    error_body['faultstring'] = e.message
+    return json_encode(error_body)
 
 
 def jsexpose(*argtypes, **opts):
@@ -128,7 +137,7 @@ def jsexpose(*argtypes, **opts):
                     try:
                         obj = body_cls(**data)
                     except jsonschema.exceptions.ValidationError as e:
-                        return _handle_error(http_client.BAD_REQUEST, e)
+                        return _handle_error(e, http_client.BAD_REQUEST)
                     more.append(obj)
 
                 args = tuple(more) + tuple(args)
@@ -152,10 +161,15 @@ def jsexpose(*argtypes, **opts):
                     else:
                         return result
                 except exc.HTTPException as e:
-                    return _handle_error(e.wsgi_response.status, e)
+                    LOG.exception('API call failed.')
+                    # Exception contains pecan.response.header + more. This is per implementation
+                    # of the WSGIHTTPException type from WebOb.
+                    return _handle_error(e, e.wsgi_response.status_code, e.wsgi_response.body,
+                                         e.headers)
 
             except Exception as e:
-                return _handle_error(http_client.INTERNAL_SERVER_ERROR, e)
+                LOG.exception('API call failed.')
+                return _handle_error(e, http_client.INTERNAL_SERVER_ERROR)
 
         pecan_json_decorate(callfunction)
 

--- a/st2common/st2common/persistence/access.py
+++ b/st2common/st2common/persistence/access.py
@@ -26,6 +26,12 @@ class User(Access):
     def _get_impl(kls):
         return kls.impl
 
+    @classmethod
+    def _get_by_object(kls, object):
+        # For User name is unique.
+        name = getattr(object, 'name', '')
+        return kls.get_by_name(name)
+
 
 class Token(Access):
     impl = MongoDBAccess(TokenDB)

--- a/st2common/st2common/persistence/access.py
+++ b/st2common/st2common/persistence/access.py
@@ -23,35 +23,35 @@ class User(Access):
     impl = MongoDBAccess(UserDB)
 
     @classmethod
-    def _get_impl(kls):
-        return kls.impl
+    def _get_impl(cls):
+        return cls.impl
 
     @classmethod
-    def _get_by_object(kls, object):
+    def _get_by_object(cls, object):
         # For User name is unique.
         name = getattr(object, 'name', '')
-        return kls.get_by_name(name)
+        return cls.get_by_name(name)
 
 
 class Token(Access):
     impl = MongoDBAccess(TokenDB)
 
     @classmethod
-    def _get_impl(kls):
-        return kls.impl
+    def _get_impl(cls):
+        return cls.impl
 
     @classmethod
-    def add_or_update(kls, model_object, publish=True):
+    def add_or_update(cls, model_object, publish=True):
         if not getattr(model_object, 'user', None):
             raise ValueError('User is not provided in the token.')
         if not getattr(model_object, 'token', None):
             raise ValueError('Token value is not set.')
         if not getattr(model_object, 'expiry', None):
             raise ValueError('Token expiry is not provided in the token.')
-        return super(Token, kls).add_or_update(model_object, publish=publish)
+        return super(Token, cls).add_or_update(model_object, publish=publish)
 
     @classmethod
-    def get(kls, value):
+    def get(cls, value):
         for model_object in TokenDB.objects(token=value):
             return model_object
         raise TokenNotFoundError()

--- a/st2common/st2common/persistence/action.py
+++ b/st2common/st2common/persistence/action.py
@@ -25,22 +25,22 @@ class RunnerType(Access):
     impl = runnertype_access
 
     @classmethod
-    def _get_impl(kls):
-        return kls.impl
+    def _get_impl(cls):
+        return cls.impl
 
     @classmethod
-    def _get_by_object(kls, object):
+    def _get_by_object(cls, object):
         # For RunnerType name is unique.
         name = getattr(object, 'name', '')
-        return kls.get_by_name(name)
+        return cls.get_by_name(name)
 
 
 class Action(Access, ContentPackResourceMixin):
     impl = action_access
 
     @classmethod
-    def _get_impl(kls):
-        return kls.impl
+    def _get_impl(cls):
+        return cls.impl
 
 
 class ActionExecution(Access):
@@ -48,15 +48,15 @@ class ActionExecution(Access):
     publisher = None
 
     @classmethod
-    def _get_impl(kls):
-        return kls.impl
+    def _get_impl(cls):
+        return cls.impl
 
     @classmethod
-    def _get_publisher(kls):
-        if not kls.publisher:
-            kls.publisher = transport.actionexecution.ActionExecutionPublisher(
+    def _get_publisher(cls):
+        if not cls.publisher:
+            cls.publisher = transport.actionexecution.ActionExecutionPublisher(
                 cfg.CONF.messaging.url)
-        return kls.publisher
+        return cls.publisher
 
 
 class ActionExecutionState(Access):
@@ -64,12 +64,12 @@ class ActionExecutionState(Access):
     publisher = None
 
     @classmethod
-    def _get_impl(kls):
-        return kls.impl
+    def _get_impl(cls):
+        return cls.impl
 
     @classmethod
-    def _get_publisher(kls):
-        if not kls.publisher:
-            kls.publisher = transport.actionexecutionstate.ActionExecutionStatePublisher(
+    def _get_publisher(cls):
+        if not cls.publisher:
+            cls.publisher = transport.actionexecutionstate.ActionExecutionStatePublisher(
                 cfg.CONF.messaging.url)
-        return kls.publisher
+        return cls.publisher

--- a/st2common/st2common/persistence/action.py
+++ b/st2common/st2common/persistence/action.py
@@ -18,7 +18,7 @@ from oslo.config import cfg
 from st2common import transport
 from st2common.models.db.action import (runnertype_access, action_access, actionexec_access)
 from st2common.models.db.action import actionexecstate_access
-from st2common.persistence.base import (Access, ContentPackResourceMixin)
+from st2common.persistence.base import (Access, ContentPackResource)
 
 
 class RunnerType(Access):
@@ -35,7 +35,7 @@ class RunnerType(Access):
         return cls.get_by_name(name)
 
 
-class Action(Access, ContentPackResourceMixin):
+class Action(ContentPackResource):
     impl = action_access
 
     @classmethod

--- a/st2common/st2common/persistence/action.py
+++ b/st2common/st2common/persistence/action.py
@@ -28,6 +28,12 @@ class RunnerType(Access):
     def _get_impl(kls):
         return kls.impl
 
+    @classmethod
+    def _get_by_object(kls, object):
+        # For RunnerType name is unique.
+        name = getattr(object, 'name', '')
+        return kls.get_by_name(name)
+
 
 class Action(Access, ContentPackResourceMixin):
     impl = action_access

--- a/st2common/st2common/persistence/actionrunner.py
+++ b/st2common/st2common/persistence/actionrunner.py
@@ -21,5 +21,5 @@ class ActionRunner(Access):
     IMPL = actionrunner_access
 
     @classmethod
-    def _get_impl(kls):
-        return kls.IMPL
+    def _get_impl(cls):
+        return cls.IMPL

--- a/st2common/st2common/persistence/base.py
+++ b/st2common/st2common/persistence/base.py
@@ -31,64 +31,64 @@ class Access(object):
 
     @classmethod
     @abc.abstractmethod
-    def _get_impl(kls):
+    def _get_impl(cls):
         pass
 
     @classmethod
     @abc.abstractmethod
-    def _get_publisher(kls):
+    def _get_publisher(cls):
         return None
 
     @classmethod
     @abc.abstractmethod
-    def _get_by_object(kls, object):
+    def _get_by_object(cls, object):
         return None
 
     @classmethod
-    def get_by_name(kls, value):
-        return kls._get_impl().get_by_name(value)
+    def get_by_name(cls, value):
+        return cls._get_impl().get_by_name(value)
 
     @classmethod
-    def get_by_id(kls, value):
-        return kls._get_impl().get_by_id(value)
+    def get_by_id(cls, value):
+        return cls._get_impl().get_by_id(value)
 
     @classmethod
-    def get(kls, *args, **kwargs):
-        return kls._get_impl().get(*args, **kwargs)
+    def get(cls, *args, **kwargs):
+        return cls._get_impl().get(*args, **kwargs)
 
     @classmethod
-    def get_all(kls, *args, **kwargs):
-        return kls._get_impl().get_all(*args, **kwargs)
+    def get_all(cls, *args, **kwargs):
+        return cls._get_impl().get_all(*args, **kwargs)
 
     @classmethod
-    def count(kls, *args, **kwargs):
-        return kls._get_impl().count(*args, **kwargs)
+    def count(cls, *args, **kwargs):
+        return cls._get_impl().count(*args, **kwargs)
 
     @classmethod
-    def query(kls, *args, **kwargs):
-        return kls._get_impl().query(*args, **kwargs)
+    def query(cls, *args, **kwargs):
+        return cls._get_impl().query(*args, **kwargs)
 
     @classmethod
-    def distinct(kls, *args, **kwargs):
-        return kls._get_impl().distinct(*args, **kwargs)
+    def distinct(cls, *args, **kwargs):
+        return cls._get_impl().distinct(*args, **kwargs)
 
     @classmethod
-    def aggregate(kls, *args, **kwargs):
-        return kls._get_impl().aggregate(*args, **kwargs)
+    def aggregate(cls, *args, **kwargs):
+        return cls._get_impl().aggregate(*args, **kwargs)
 
     @classmethod
-    def add_or_update(kls, model_object, publish=True):
+    def add_or_update(cls, model_object, publish=True):
         pre_persist_id = model_object.id
         try:
-            model_object = kls._get_impl().add_or_update(model_object)
+            model_object = cls._get_impl().add_or_update(model_object)
         except NotUniqueError as e:
             LOG.exception('Conflict while trying to save in DB.')
             # On a conflict determine the conflicting object and return its id in
             # the raised exception.
-            conflict_object = kls._get_by_object(model_object)
+            conflict_object = cls._get_by_object(model_object)
             conflict_id = str(conflict_object.id) if conflict_object else None
             raise StackStormDBObjectConflictError(str(e), conflict_id)
-        publisher = kls._get_publisher()
+        publisher = cls._get_publisher()
         try:
             if publisher and publish:
                 if str(pre_persist_id) == str(model_object.id):
@@ -100,9 +100,9 @@ class Access(object):
         return model_object
 
     @classmethod
-    def delete(kls, model_object, publish=True):
-        persisted_object = kls._get_impl().delete(model_object)
-        publisher = kls._get_publisher()
+    def delete(cls, model_object, publish=True):
+        persisted_object = cls._get_impl().delete(model_object)
+        publisher = cls._get_publisher()
         if publisher and publish:
             # using model_object.
             publisher.publish_delete(model_object)

--- a/st2common/st2common/persistence/base.py
+++ b/st2common/st2common/persistence/base.py
@@ -85,7 +85,9 @@ class Access(object):
             LOG.exception('Conflict while trying to save in DB.')
             # On a conflict determine the conflicting object and return its id in
             # the raised exception.
+            print cls
             conflict_object = cls._get_by_object(model_object)
+            print conflict_object
             conflict_id = str(conflict_object.id) if conflict_object else None
             raise StackStormDBObjectConflictError(str(e), conflict_id)
         publisher = cls._get_publisher()
@@ -109,7 +111,8 @@ class Access(object):
         return persisted_object
 
 
-class ContentPackResourceMixin(object):
+class ContentPackResource(Access):
+
     @classmethod
     def get_by_ref(cls, ref):
         if not ref:

--- a/st2common/st2common/persistence/base.py
+++ b/st2common/st2common/persistence/base.py
@@ -85,9 +85,7 @@ class Access(object):
             LOG.exception('Conflict while trying to save in DB.')
             # On a conflict determine the conflicting object and return its id in
             # the raised exception.
-            print cls
             conflict_object = cls._get_by_object(model_object)
-            print conflict_object
             conflict_id = str(conflict_object.id) if conflict_object else None
             raise StackStormDBObjectConflictError(str(e), conflict_id)
         publisher = cls._get_publisher()

--- a/st2common/st2common/persistence/datastore.py
+++ b/st2common/st2common/persistence/datastore.py
@@ -23,3 +23,9 @@ class KeyValuePair(Access):
     @classmethod
     def _get_impl(cls):
         return cls.IMPL
+
+    @classmethod
+    def _get_by_object(kls, object):
+        # For KeyValuePair name is unique.
+        name = getattr(object, 'name', '')
+        return kls.get_by_name(name)

--- a/st2common/st2common/persistence/datastore.py
+++ b/st2common/st2common/persistence/datastore.py
@@ -25,7 +25,7 @@ class KeyValuePair(Access):
         return cls.IMPL
 
     @classmethod
-    def _get_by_object(kls, object):
+    def _get_by_object(cls, object):
         # For KeyValuePair name is unique.
         name = getattr(object, 'name', '')
-        return kls.get_by_name(name)
+        return cls.get_by_name(name)

--- a/st2common/st2common/persistence/history.py
+++ b/st2common/st2common/persistence/history.py
@@ -26,12 +26,12 @@ class ActionExecutionHistory(Access):
     publisher = None
 
     @classmethod
-    def _get_impl(kls):
-        return kls.impl
+    def _get_impl(cls):
+        return cls.impl
 
     @classmethod
-    def _get_publisher(kls):
-        if not kls.publisher:
-            kls.publisher = transport.history.HistoryPublisher(
+    def _get_publisher(cls):
+        if not cls.publisher:
+            cls.publisher = transport.history.HistoryPublisher(
                 cfg.CONF.messaging.url)
-        return kls.publisher
+        return cls.publisher

--- a/st2common/st2common/persistence/reactor.py
+++ b/st2common/st2common/persistence/reactor.py
@@ -26,16 +26,16 @@ class SensorType(Access, ContentPackResourceMixin):
     impl = sensor_type_access
 
     @classmethod
-    def _get_impl(kls):
-        return kls.impl
+    def _get_impl(cls):
+        return cls.impl
 
 
 class TriggerType(Access, ContentPackResourceMixin):
     impl = triggertype_access
 
     @classmethod
-    def _get_impl(kls):
-        return kls.impl
+    def _get_impl(cls):
+        return cls.impl
 
 
 class Trigger(Access, ContentPackResourceMixin):
@@ -43,33 +43,33 @@ class Trigger(Access, ContentPackResourceMixin):
     publisher = None
 
     @classmethod
-    def _get_impl(kls):
-        return kls.impl
+    def _get_impl(cls):
+        return cls.impl
 
     @classmethod
-    def _get_publisher(kls):
-        if not kls.publisher:
-            kls.publisher = transport.reactor.TriggerCUDPublisher(cfg.CONF.messaging.url)
-        return kls.publisher
+    def _get_publisher(cls):
+        if not cls.publisher:
+            cls.publisher = transport.reactor.TriggerCUDPublisher(cfg.CONF.messaging.url)
+        return cls.publisher
 
 
 class TriggerInstance(Access):
     impl = triggerinstance_access
 
     @classmethod
-    def _get_impl(kls):
-        return kls.impl
+    def _get_impl(cls):
+        return cls.impl
 
 
 class Rule(Access):
     impl = rule_access
 
     @classmethod
-    def _get_impl(kls):
-        return kls.impl
+    def _get_impl(cls):
+        return cls.impl
 
     @classmethod
-    def _get_by_object(kls, object):
+    def _get_by_object(cls, object):
         # For Rule name is unique.
         name = getattr(object, 'name', '')
-        return kls.get_by_name(name)
+        return cls.get_by_name(name)

--- a/st2common/st2common/persistence/reactor.py
+++ b/st2common/st2common/persistence/reactor.py
@@ -19,10 +19,10 @@ from st2common import transport
 from st2common.models.db.reactor import sensor_type_access
 from st2common.models.db.reactor import triggertype_access, trigger_access, triggerinstance_access,\
     rule_access
-from st2common.persistence.base import (Access, ContentPackResourceMixin)
+from st2common.persistence.base import (Access, ContentPackResource)
 
 
-class SensorType(Access, ContentPackResourceMixin):
+class SensorType(ContentPackResource):
     impl = sensor_type_access
 
     @classmethod
@@ -30,7 +30,7 @@ class SensorType(Access, ContentPackResourceMixin):
         return cls.impl
 
 
-class TriggerType(Access, ContentPackResourceMixin):
+class TriggerType(ContentPackResource):
     impl = triggertype_access
 
     @classmethod
@@ -38,7 +38,7 @@ class TriggerType(Access, ContentPackResourceMixin):
         return cls.impl
 
 
-class Trigger(Access, ContentPackResourceMixin):
+class Trigger(ContentPackResource):
     impl = trigger_access
     publisher = None
 

--- a/st2common/st2common/persistence/reactor.py
+++ b/st2common/st2common/persistence/reactor.py
@@ -67,3 +67,9 @@ class Rule(Access):
     @classmethod
     def _get_impl(kls):
         return kls.impl
+
+    @classmethod
+    def _get_by_object(kls, object):
+        # For Rule name is unique.
+        name = getattr(object, 'name', '')
+        return kls.get_by_name(name)


### PR DESCRIPTION
- On conflict identify the conflict object at the persistence layer.
- In process of trying to localize the uniqueness identification changes ended up having to change ContentPackResourceMixin to ContentPackResource i.e. subclass from Access.
- Changes to how errors are handled in the API. This way headers, original body etc are preserved.
- Updated all API sites to move from NotUniqueError to StackStormDBObjectConflictError and include the conflict-id as part of the abort call.
- Minor change from kls -> cls as per typical python norms.