### PR TITLE
Raise exception if workbook/workflow name is not equal to action_ref

### DIFF
--- a/contrib/examples/actions/mistral-workbook-basic.json
+++ b/contrib/examples/actions/mistral-workbook-basic.json
@@ -6,11 +6,6 @@
     "enabled": true,
     "entry_point":"mistral-workbook-basic.yaml",
     "parameters": {
-        "workflow": {
-            "type": "string",
-            "default": "examples.mistral-workbook-basic.demo",
-            "immutable": true
-        },
         "cmd": {
             "type": "string",
             "required": true

--- a/st2actions/st2actions/runners/mistral/utils.py
+++ b/st2actions/st2actions/runners/mistral/utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import json
 import re
 
@@ -127,8 +128,11 @@ def _transform_action(spec, action_key, input_key):
 
 
 def transform_definition(definition):
-    spec = yaml.safe_load(definition)
+    # If definition is a dictionary, there is no need to load from YAML.
+    is_dict = isinstance(definition, dict)
+    spec = copy.deepcopy(definition) if is_dict else yaml.safe_load(definition)
 
+    # Check version
     if 'version' not in spec:
         raise Exception('Unknown version. Only version 2.0 is supported.')
 
@@ -153,4 +157,5 @@ def transform_definition(definition):
                 for task_name, task_spec in six.iteritems(value.get('tasks')):
                     _transform_action(task_spec, 'action', 'input')
 
-    return yaml.safe_dump(spec, default_flow_style=False)
+    # Return the same type as original input.
+    return (spec if is_dict else yaml.safe_dump(spec, default_flow_style=False))

--- a/st2actions/st2actions/runners/mistral/v2.py
+++ b/st2actions/st2actions/runners/mistral/v2.py
@@ -45,6 +45,20 @@ class MistralRunner(AsyncActionRunner):
     def pre_run(self):
         pass
 
+    @staticmethod
+    def _check_name(action_ref, is_workbook, def_dict):
+        # If workbook, change the value of the "name" key.
+        if is_workbook:
+            if def_dict.get('name') != action_ref:
+                raise Exception('Name of the workbook must be the same as the '
+                                'fully qualified action name "%s".' % action_ref)
+        # If workflow, change the key name of the workflow.
+        else:
+            workflow_name = [k for k, v in six.iteritems(def_dict) if k != 'version'][0]
+            if workflow_name != action_ref:
+                raise Exception('Name of the workflow must be the same as the '
+                                'fully qualified action name "%s".' % action_ref)
+
     def _save_workbook(self, name, def_yaml):
         # If the workbook is not found, the mistral client throws a generic API exception.
         try:
@@ -129,6 +143,7 @@ class MistralRunner(AsyncActionRunner):
                                 'Multiple workflows is not supported.')
 
         action_ref = '%s.%s' % (self.action.pack, self.action.name)
+        self._check_name(action_ref, is_workbook, def_dict)
         def_dict_xformed = utils.transform_definition(def_dict)
         def_yaml_xformed = yaml.safe_dump(def_dict_xformed, default_flow_style=False)
 

--- a/st2actions/tests/unit/test_mistral_dsl_transform.py
+++ b/st2actions/tests/unit/test_mistral_dsl_transform.py
@@ -85,17 +85,31 @@ class DSLTransformTestCase(DbTestCase):
         def_yaml = yaml.safe_dump(def_dict)
         self.assertRaises(Exception, utils.transform_definition, def_yaml)
 
-    def test_transform_workbook_dsl(self):
+    def test_transform_workbook_dsl_yaml(self):
         def_yaml = _read_file_content(WB_PRE_XFORM_PATH)
         new_def = utils.transform_definition(def_yaml)
         actual = yaml.safe_load(new_def)
         expected = copy.deepcopy(WB_POST_XFORM_DEF)
         self.assertDictEqual(actual, expected)
 
-    def test_transform_workflow_dsl(self):
+    def test_transform_workbook_dsl_dict(self):
+        def_yaml = _read_file_content(WB_PRE_XFORM_PATH)
+        def_dict = yaml.safe_load(def_yaml)
+        actual = utils.transform_definition(def_dict)
+        expected = copy.deepcopy(WB_POST_XFORM_DEF)
+        self.assertDictEqual(actual, expected)
+
+    def test_transform_workflow_dsl_yaml(self):
         def_yaml = _read_file_content(WF_PRE_XFORM_PATH)
         new_def = utils.transform_definition(def_yaml)
         actual = yaml.safe_load(new_def)
+        expected = copy.deepcopy(WF_POST_XFORM_DEF)
+        self.assertDictEqual(actual, expected)
+
+    def test_transform_workflow_dsl_dict(self):
+        def_yaml = _read_file_content(WF_PRE_XFORM_PATH)
+        def_dict = yaml.safe_load(def_yaml)
+        actual = utils.transform_definition(def_dict)
         expected = copy.deepcopy(WF_POST_XFORM_DEF)
         self.assertDictEqual(actual, expected)
 

--- a/st2tests/st2tests/fixtures/generic/actions/workbook_v2_name_mismatch.json
+++ b/st2tests/st2tests/fixtures/generic/actions/workbook_v2_name_mismatch.json
@@ -1,0 +1,18 @@
+{
+    "name": "workbook_v2_name_mismatch",
+    "pack": "generic",
+    "runner_type": "mistral-v2",
+    "description": "Say hi to friend!",
+    "enabled": true,
+    "entry_point":"workbook_v2.yaml",
+    "parameters": {
+        "count": {
+            "type": "string",
+            "default": "3"
+        },
+        "friend": {
+            "type": "string",
+            "required": true
+        }
+    }
+}

--- a/st2tests/st2tests/fixtures/generic/actions/workflow_v2_name_mismatch.json
+++ b/st2tests/st2tests/fixtures/generic/actions/workflow_v2_name_mismatch.json
@@ -1,0 +1,18 @@
+{
+    "name": "workflow_v2_name_mismatch",
+    "pack": "generic",
+    "runner_type": "mistral-v2",
+    "description": "Say hi to friend!",
+    "enabled": true,
+    "entry_point":"workflow_v2.yaml",
+    "parameters": {
+        "count": {
+            "type": "string",
+            "default": "3"
+        },
+        "friend": {
+            "type": "string",
+            "required": true
+        }
+    }
+}

--- a/st2tests/st2tests/fixtures/generic/workflows/workflow_v2.yaml
+++ b/st2tests/st2tests/fixtures/generic/workflows/workflow_v2.yaml
@@ -1,6 +1,6 @@
 version: '2.0'
 
-examples.mistral-basic:
+generic.workflow_v2:
   type: direct
   input:
     - count

--- a/st2tests/st2tests/fixtures/generic/workflows/workflow_v2_many_workflows.yaml
+++ b/st2tests/st2tests/fixtures/generic/workflows/workflow_v2_many_workflows.yaml
@@ -1,6 +1,6 @@
 version: '2.0'
 
-main1:
+generic.workflow_v2.main1:
   type: direct
   input:
     - count
@@ -21,7 +21,7 @@ main1:
       publish:
         towhom: $.stdout
 
-main2:
+generic.workflow_v2.main2:
   type: direct
   input:
     - count


### PR DESCRIPTION
If name of the mistral workbook or workflow is not the same as the action ref, raise an exception.