### PR TITLE
Use X.Y version in docs on v0.7

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -221,10 +221,10 @@ html_context = {
     'source_suffix': source_suffix,
     'versions': [
         ('latest', 'http://docs.stackstorm.com/latest'),
-        (release, 'http://docs.stackstorm.com/%s' % release),
+        (version, 'http://docs.stackstorm.com/%s' % version),
         ('0.6.0', 'http://docs.stackstorm.com/0.6.0')
     ],
-    'current_version': release
+    'current_version': version
 }
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -221,8 +221,8 @@ html_context = {
     'source_suffix': source_suffix,
     'versions': [
         ('latest', 'http://docs.stackstorm.com/latest'),
-        ('0.6.0', 'http://docs.stackstorm.com/0.6.0'),
-        ('0.5.1', 'http://docs.stackstorm.com/0.5.1'),
+        (release, 'http://docs.stackstorm.com/%s' % release),
+        ('0.6.0', 'http://docs.stackstorm.com/0.6.0')
     ],
     'current_version': release
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -222,6 +222,8 @@ html_context = {
     'versions': [
         ('latest', 'http://docs.stackstorm.com/latest'),
         (version, 'http://docs.stackstorm.com/%s' % version),
+        # TODO(dzimine): get "prev stable version" from somewhere (?)
+        ('0.7', 'http://docs.stackstorm.com/0.7')
         ('0.6.0', 'http://docs.stackstorm.com/0.6.0')
     ],
     'current_version': version


### PR DESCRIPTION
Here is the fix. Does the job but it is still wrong: 

We need to refer the docs by 'X.Y' version, not by 'X.Y.Z' build release. 
To do this: change s3, and change the doc publishing jobs.