### PR TITLE
Use X.Y version in docs on v0.7

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -221,10 +221,10 @@ html_context = {
     'source_suffix': source_suffix,
     'versions': [
         ('latest', 'http://docs.stackstorm.com/latest'),
-        ('0.6.0', 'http://docs.stackstorm.com/0.6.0'),
-        ('0.5.1', 'http://docs.stackstorm.com/0.5.1'),
+        (version, 'http://docs.stackstorm.com/%s' % version),
+        ('0.6.0', 'http://docs.stackstorm.com/0.6.0')
     ],
-    'current_version': release
+    'current_version': version
 }
 
 


### PR DESCRIPTION
But for backward, refer previous build as it is, 0.6.0

![image](https://cloud.githubusercontent.com/assets/1294734/5787297/ce60e910-9dad-11e4-9c79-0c15211a513c.png)
