### PR TITLE
Update st2auth to return configured public URL to API endpoint on successful auth

### DIFF
--- a/conf/st2.conf
+++ b/conf/st2.conf
@@ -27,6 +27,9 @@ enable = False
 mode = proxy
 logging = st2auth/conf/logging.conf
 
+# Base URL to the API endpoint excluding the version (e.g. http://myhost.net:9101/)
+api_url =
+
 [system]
 base_path = /opt/stackstorm
 

--- a/docs/source/install/deploy.rst
+++ b/docs/source/install/deploy.rst
@@ -46,6 +46,21 @@ Install st2auth. The configuration file for st2auth should be located at /etc/st
     [auth]
     token_ttl = 2592000
 
+Configuring the API endpoint URL
+--------------------------------
+
+Authentication service also acts as a service catalog. It returns a URL to the API endpoint on
+successful authentication. This information is used by clients such as command line tool and web
+ui.
+
+For this to work, you need to configure ``api_url`` setting in the config file. The setting needs
+to contain a public base URL to the API endpoint (excluding the API version).
+
+For example ::
+
+    [auth]
+    api_url = http://myhost.net:9101/
+
 Follow the example below and create /etc/apache2/sites-available/st2-auth.conf. The following configures st2auth to authenticate users who belong to the st2ops group, with PAM via apache.
 
 .. literalinclude:: ../../../st2auth/conf/apache.sample.conf

--- a/st2auth/st2auth/config.py
+++ b/st2auth/st2auth/config.py
@@ -52,6 +52,9 @@ def _register_app_opts():
         cfg.StrOpt('backend_kwargs', default=None,
                    help='JSON serialized arguments which are passed to the authentication backend'
                         ' in a standalone mode.'),
+        cfg.StrOpt('api_url', default=None,
+                   help='Base URL to the API endpoint excluding the version')
+
     ]
     cfg.CONF.register_cli_opts(auth_opts, group='auth')
 

--- a/st2auth/st2auth/controllers/access.py
+++ b/st2auth/st2auth/controllers/access.py
@@ -24,7 +24,6 @@ from st2common.models.api.base import jsexpose
 from st2common.models.api.access import TokenAPI
 from st2common.services.access import create_token
 from st2common import log as logging
-from st2common.util.api import get_full_api_url
 from st2auth.backends import get_backend_instance
 
 
@@ -100,7 +99,7 @@ class TokenController(rest.RestController):
         pecan.abort(status_code, message)
 
     def _process_successful_response(self, token):
-        api_url = get_full_api_url()
+        api_url = cfg.CONF.auth.api_url
         pecan.response.headers['X-API-URL'] = api_url
         return token
 

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -111,6 +111,7 @@ def _register_auth_opts():
         cfg.StrOpt('mode', default='proxy'),
         cfg.StrOpt('logging', default='conf/logging.conf'),
         cfg.IntOpt('token_ttl', default=86400, help='Access token ttl in seconds.'),
+        cfg.StrOpt('api_url', default='http://localhost:9101/'),
         cfg.BoolOpt('debug', default=True)
     ]
     _register_opts(auth_opts, group='auth')


### PR DESCRIPTION
As discussed a while ago.

Service catalog functionality will become even more important in the future where we support the scale out story and user can run API and other services on multiple servers potentially running in different regions.

This still needs corresponding webui changes - /cc @enykeev 