### PR TITLE
RFR: Configuration to redirect stderr to logs.

### DIFF
--- a/conf/st2.conf
+++ b/conf/st2.conf
@@ -38,6 +38,7 @@ protocol = udp
 
 [log]
 excludes = requests,paramiko
+redirect_stderr = False
 
 [system_user]
 user = stanley

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -96,7 +96,9 @@ def register_opts(ignore_errors=False):
 
     log_opts = [
         cfg.ListOpt('excludes', default='',
-                    help='Exclusion list of loggers to omit.')
+                    help='Exclusion list of loggers to omit.'),
+        cfg.BoolOpt('redirect_stderr', default=False,
+                   help='Controls if stderr should be redirected to the logs.')
     ]
     _do_register_opts(log_opts, 'log', ignore_errors)
 


### PR DESCRIPTION
- By default the redirection is not performed.
- Enabling the redirection helps in debugging issues where the error is written to sys.stderr and in production stderr is typically redirected to dev/null.