### PR TITLE
Actionchain improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ Docs: http://docks.stackstorm.com/latest
   local or the remote runner (``run-local``, ``run-local-script``, ``run-remote``,
   ``run-remote-script``). (new-feature)
 * Default values of the paramter of an Action can be system values stored in kv-store.
+* vars can be defined in the ActionChain.
+* Node in an ActionChain can publish global variables.
 
 v0.7 - January 16, 2015
 -----------------------

--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -44,7 +44,7 @@ class ChainHolder(object):
         self.actionchain = actionchain.ActionChain(**chainspec)
         self.chainname = chainname
         if not self.actionchain.default:
-            default = self._get_default()
+            default = self._get_default(self.actionchain)
             self.actionchain.default = default
         LOG.debug('Using %s as default for %s.', self.actionchain.default, self.chainname)
         if not self.actionchain.default:
@@ -69,7 +69,7 @@ class ChainHolder(object):
         referenced_nodes = on_success_nodes | on_failure_nodes
         possible_default_nodes = node_names - referenced_nodes
         if possible_default_nodes:
-            return possible_default_nodes[0]
+            return possible_default_nodes.pop()
         # If no node is found assume the first node in the chain list to be default.
         return _actionchain.chain[0].name
 

--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -185,7 +185,7 @@ class ActionChainRunner(ActionRunner):
         The output variable can refer to a variable from the execution_result,
         previous_execution_results or chain_vars.
         """
-        if not action_node.output:
+        if not action_node.publish:
             return execution_result
         context = {}
         context.update({action_node.name: execution_result})
@@ -193,7 +193,7 @@ class ActionChainRunner(ActionRunner):
         context.update(chain_vars)
         context.update({RESULTS_KEY: previous_execution_results})
         context.update({SYSTEM_KV_PREFIX: KeyValueLookup()})
-        rendered_result = render_values(action_node.output, context)
+        rendered_result = render_values(action_node.publish, context)
         return rendered_result
 
     @staticmethod

--- a/st2actions/tests/unit/test_actionchain.py
+++ b/st2actions/tests/unit/test_actionchain.py
@@ -16,8 +16,6 @@
 import mock
 import six
 
-from unittest2 import TestCase
-
 from st2actions.runners import actionchainrunner as acr
 from st2actions.container.service import RunnerContainerService
 from st2common.exceptions import actionrunner as runnerexceptions
@@ -29,7 +27,6 @@ from st2common.persistence.datastore import KeyValuePair
 from st2common.services import action as action_service
 from st2common.util import action_db as action_db_util
 from st2tests import DbTestCase
-import st2tests.config as tests_config
 from st2tests.fixturesloader import FixturesLoader
 
 
@@ -80,57 +77,6 @@ CHAIN_TYPED_PARAMS = FixturesLoader().get_fixture_file_path_abs(
 CHAIN_SYSTEM_PARAMS = FixturesLoader().get_fixture_file_path_abs(
     FIXTURES_PACK, 'actionchains', 'chain_typed_system_params.json')
 
-CHAIN_EMPTY = {}
-
-
-class TestActionChain(TestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        tests_config.parse_args()
-
-    def test_chain_creation_basic(self):
-        action_chain = acr.ActionChain(CHAIN_1)
-
-        expected_node_count = 0
-        expected_link_count = 0
-        for node in CHAIN_1['chain']:
-            expected_node_count += 1
-            if 'on-success' in node:
-                expected_link_count += 1
-            if 'on-failure' in node:
-                expected_link_count += 1
-
-        self.assertEqual(len(action_chain.nodes), expected_node_count)
-
-        link_count = 0
-        for _, links in six.iteritems(action_chain.links):
-            link_count += len(links)
-        self.assertEqual(link_count, expected_link_count)
-
-        self.assertEqual(action_chain.default, CHAIN_1['default'])
-
-    def test_chain_iteration(self):
-        action_chain = acr.ActionChain(CHAIN_1)
-
-        for node in CHAIN_1['chain']:
-            if 'on-success' in node:
-                next_node = action_chain.get_next_node(node['name'], 'on-success')
-                self.assertEqual(next_node.name, node['on-success'])
-            if 'on-failure' in node:
-                next_node = action_chain.get_next_node(node['name'], 'on-failure')
-                self.assertEqual(next_node.name, node['on-failure'])
-
-        default = action_chain.get_next_node()
-        self.assertEqual(type(default), acr.ActionChain.Node)
-        self.assertEqual(default.name, CHAIN_1['default'])
-
-    def test_empty_chain(self):
-        action_chain = acr.ActionChain(CHAIN_EMPTY)
-        self.assertEqual(len(action_chain.nodes), 0)
-        self.assertEqual(len(action_chain.links), 0)
-        self.assertEqual(action_chain.default, '')
-
 
 @mock.patch.object(action_db_util, 'get_runnertype_by_name',
                    mock.MagicMock(return_value=RUNNER))
@@ -162,7 +108,7 @@ class TestActionChainRunner(DbTestCase):
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
         chain_runner.run({})
-        self.assertNotEqual(chain_runner.action_chain, None)
+        self.assertNotEqual(chain_runner.chain_holder.actionchain, None)
         # based on the chain the callcount is known to be 3. Not great but works.
         self.assertEqual(schedule.call_count, 3)
 
@@ -180,7 +126,7 @@ class TestActionChainRunner(DbTestCase):
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
         chain_runner.run({})
-        self.assertNotEqual(chain_runner.action_chain, None)
+        self.assertNotEqual(chain_runner.chain_holder.actionchain, None)
         # based on the chain the callcount is known to be 3. Not great but works.
         self.assertEqual(schedule.call_count, 3)
 
@@ -196,7 +142,7 @@ class TestActionChainRunner(DbTestCase):
         chain_runner.pre_run()
         status, _ = chain_runner.run({})
         self.assertEqual(status, ACTIONEXEC_STATUS_FAILED)
-        self.assertNotEqual(chain_runner.action_chain, None)
+        self.assertNotEqual(chain_runner.chain_holder.actionchain, None)
         # based on the chain the callcount is known to be 2. Not great but works.
         self.assertEqual(schedule.call_count, 2)
 
@@ -211,7 +157,7 @@ class TestActionChainRunner(DbTestCase):
         chain_runner.pre_run()
         status, results = chain_runner.run({})
         self.assertEqual(status, ACTIONEXEC_STATUS_FAILED)
-        self.assertNotEqual(chain_runner.action_chain, None)
+        self.assertNotEqual(chain_runner.chain_holder.actionchain, None)
         # based on the chain the callcount is known to be 2. Not great but works.
         self.assertEqual(schedule.call_count, 2)
         self.assertEqual(len([result['error'] for _, result in six.iteritems(results)]),
@@ -227,7 +173,7 @@ class TestActionChainRunner(DbTestCase):
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
         chain_runner.run({'s1': 1, 's2': 2, 's3': 3, 's4': 4})
-        self.assertNotEqual(chain_runner.action_chain, None)
+        self.assertNotEqual(chain_runner.chain_holder.actionchain, None)
         mock_args, _ = schedule.call_args
         self.assertEqual(mock_args[0].parameters, {"p1": "1"})
 
@@ -241,7 +187,7 @@ class TestActionChainRunner(DbTestCase):
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
         chain_runner.run({'s1': 1, 's2': 2, 's3': 3, 's4': 4})
-        self.assertNotEqual(chain_runner.action_chain, None)
+        self.assertNotEqual(chain_runner.chain_holder.actionchain, None)
         mock_args, _ = schedule.call_args
         self.assertEqual(mock_args[0].parameters, {"p1": "[2, 3, 4]"})
 
@@ -255,7 +201,7 @@ class TestActionChainRunner(DbTestCase):
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
         chain_runner.run({'s1': 1, 's2': 2, 's3': 3, 's4': 4})
-        self.assertNotEqual(chain_runner.action_chain, None)
+        self.assertNotEqual(chain_runner.chain_holder.actionchain, None)
         expected_value = {"p1": {"p1.3": "[3, 4]", "p1.2": "2", "p1.1": "1"}}
         mock_args, _ = schedule.call_args
         self.assertEqual(mock_args[0].parameters, expected_value)
@@ -271,7 +217,7 @@ class TestActionChainRunner(DbTestCase):
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
         chain_runner.run({'s1': 1, 's2': 2, 's3': 3, 's4': 4})
-        self.assertNotEqual(chain_runner.action_chain, None)
+        self.assertNotEqual(chain_runner.chain_holder.actionchain, None)
         expected_values = [{u'p1': u'1'},
                            {u'p1': u'1'},
                            {u'p2': u'1', u'p3': u'1', u'p1': u'1'}]
@@ -292,7 +238,7 @@ class TestActionChainRunner(DbTestCase):
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
         chain_runner.run({'s1': 1})
-        self.assertNotEqual(chain_runner.action_chain, None)
+        self.assertNotEqual(chain_runner.chain_holder.actionchain, None)
         expected_values = [{u'p1': u'1'},
                            {u'p1': u'1'},
                            {u'out': u"{u'c2': {'o1': '1'}, u'c1': {'o1': '1'}}"}]
@@ -325,7 +271,7 @@ class TestActionChainRunner(DbTestCase):
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
         chain_runner.run({'s1': 1, 's2': 'two', 's3': 3.14})
-        self.assertNotEqual(chain_runner.action_chain, None)
+        self.assertNotEqual(chain_runner.chain_holder.actionchain, None)
         expected_value = {'booltype': True,
                           'inttype': 1,
                           'numbertype': 3.14,
@@ -348,7 +294,7 @@ class TestActionChainRunner(DbTestCase):
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
         chain_runner.run({})
-        self.assertNotEqual(chain_runner.action_chain, None)
+        self.assertNotEqual(chain_runner.chain_holder.actionchain, None)
         expected_value = {'inttype': 1,
                           'strtype': 'two'}
         mock_args, _ = schedule.call_args

--- a/st2common/st2common/models/system/actionchain.py
+++ b/st2common/st2common/models/system/actionchain.py
@@ -40,7 +40,7 @@ class Node(object):
             },
             "params": {
                 "type": "object",
-                "description": "query context to be used by querier.",
+                "description": "Parameter for the execution.",
                 "default": {}
             },
             "on-success": {
@@ -84,6 +84,13 @@ class ActionChain(object):
             "default": {
                 "type": "string",
                 "description": "Ref of the action to be executed."
+            },
+            "vars": {
+                "description": "",
+                "type": "object",
+                "patternProperties": {
+                    "^\w+$": {}
+                }
             }
         },
         "additionalProperties": False

--- a/st2common/st2common/models/system/actionchain.py
+++ b/st2common/st2common/models/system/actionchain.py
@@ -55,10 +55,10 @@ class Node(object):
                                " node.",
                 "default": ""
             },
-            "output": {
+            "publish": {
                 "description": "The variables to publish from the result. Should be of the form"
                                " name.foo. o1: {{node_name.foo}} will result in creation of a"
-                               " variable node_name.o1 which is now available for reference through"
+                               " variable o1 which is now available for reference through"
                                " remainder of the chain.",
                 "type": "object",
                 "patternProperties": {

--- a/st2common/st2common/models/system/actionchain.py
+++ b/st2common/st2common/models/system/actionchain.py
@@ -59,7 +59,7 @@ class Node(object):
                 "description": "The variables to publish from the result. Should be of the form"
                                " name.foo. o1: {{node_name.foo}} will result in creation of a"
                                " variable o1 which is now available for reference through"
-                               " remainder of the chain.",
+                               " remainder of the chain as a global variable.",
                 "type": "object",
                 "patternProperties": {
                     "^\w+$": {}
@@ -86,14 +86,14 @@ class ActionChain(object):
         "type": "object",
         "properties": {
             "chain": {
-                "description": "The chains.",
+                "description": "The chain.",
                 "type": "array",
                 "items": [Node.schema],
                 "required": True
             },
             "default": {
                 "type": "string",
-                "description": "Ref of the action to be executed."
+                "description": "name of the action to be executed."
             },
             "vars": {
                 "description": "",

--- a/st2common/st2common/models/system/actionchain.py
+++ b/st2common/st2common/models/system/actionchain.py
@@ -1,0 +1,99 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import six
+
+from st2common.util import schema as util_schema
+
+VALIDATOR = util_schema.get_validator(assign_property_default=False)
+
+
+class Node(object):
+
+    schema = {
+        "title": "Node",
+        "description": "Node of an ActionChain.",
+        "type": "object",
+        "properties": {
+            "name": {
+                "description": "The name of this node.",
+                "type": "string",
+                "required": True
+            },
+            "ref": {
+                "type": "string",
+                "description": "Ref of the action to be executed.",
+                "required": True
+            },
+            "params": {
+                "type": "object",
+                "description": "query context to be used by querier.",
+                "default": {}
+            },
+            "on-success": {
+                "type": "string",
+                "description": "Name of the node to invoke on successful completion of action"
+                               " executed for this node.",
+                "default": ""
+            },
+            "on-failure": {
+                "type": "string",
+                "description": "Name of the node to invoke on failure of action executed for this"
+                               " node.",
+                "default": ""
+            }
+        },
+        "additionalProperties": False
+    }
+
+    def __init__(self, **kw):
+        for prop in six.iterkeys(self.schema.get('properties', [])):
+            value = kw.get(prop, None)
+            setattr(self, prop, value)
+
+
+class ActionChain(object):
+
+    schema = {
+        "title": "ActionChain",
+        "description": "A chain of sequentially executed actions.",
+        "type": "object",
+        "properties": {
+            "chain": {
+                "description": "The chains.",
+                "type": "array",
+                "items": [Node.schema],
+                "required": True
+            },
+            "default": {
+                "type": "string",
+                "description": "Ref of the action to be executed."
+            }
+        },
+        "additionalProperties": False
+    }
+
+    def __init__(self, **kw):
+        VALIDATOR(self.schema).validate(kw)
+
+        for prop in six.iterkeys(self.schema.get('properties', [])):
+            value = kw.get(prop, None)
+            # special handling for chain property to create the Node object
+            if prop == 'chain':
+                nodes = []
+                for node in value:
+                    nodes.append(Node(**node))
+                value = nodes
+            setattr(self, prop, value)

--- a/st2common/st2common/models/system/actionchain.py
+++ b/st2common/st2common/models/system/actionchain.py
@@ -54,6 +54,16 @@ class Node(object):
                 "description": "Name of the node to invoke on failure of action executed for this"
                                " node.",
                 "default": ""
+            },
+            "output": {
+                "description": "The variables to publish from the result. Should be of the form"
+                               " name.foo. o1: {{node_name.foo}} will result in creation of a"
+                               " variable node_name.o1 which is now available for reference through"
+                               " remainder of the chain.",
+                "type": "object",
+                "patternProperties": {
+                    "^\w+$": {}
+                }
             }
         },
         "additionalProperties": False

--- a/st2common/st2common/models/system/actionchain.py
+++ b/st2common/st2common/models/system/actionchain.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import six
+import string
 
 from st2common.util import schema as util_schema
 
@@ -61,6 +62,9 @@ class Node(object):
     def __init__(self, **kw):
         for prop in six.iterkeys(self.schema.get('properties', [])):
             value = kw.get(prop, None)
+            # having '-' in the property name lead to challenges in referencing the property.
+            # At hindsight the schema property should've been on_success rather than on-success.
+            prop = string.replace(prop, '-', '_')
             setattr(self, prop, value)
 
 

--- a/st2common/tests/unit/test_actionchain_schema.py
+++ b/st2common/tests/unit/test_actionchain_schema.py
@@ -21,13 +21,15 @@ from st2tests.fixturesloader import FixturesLoader
 
 FIXTURES_PACK = 'generic'
 TEST_FIXTURES = {
-    'actionchains': ['chain1.json', 'malformedchain.json', 'no_default_chain.json']
+    'actionchains': ['chain1.json', 'malformedchain.json', 'no_default_chain.json',
+                     'chain_with_vars.json']
 }
 FIXTURES = FixturesLoader().load_fixtures(fixtures_pack=FIXTURES_PACK,
                                           fixtures_dict=TEST_FIXTURES)
 CHAIN_1 = FIXTURES['actionchains']['chain1.json']
 MALFORMED_CHAIN = FIXTURES['actionchains']['malformedchain.json']
 NO_DEFAULT_CHAIN = FIXTURES['actionchains']['no_default_chain.json']
+CHAIN_WITH_VARS = FIXTURES['actionchains']['chain_with_vars.json']
 
 
 class ActionChainSchemaTest(unittest2.TestCase):
@@ -41,6 +43,11 @@ class ActionChainSchemaTest(unittest2.TestCase):
         chain = actionchain.ActionChain(**NO_DEFAULT_CHAIN)
         self.assertEquals(len(chain.chain), len(NO_DEFAULT_CHAIN['chain']))
         self.assertEquals(chain.default, None)
+
+    def test_actionchain_with_vars(self):
+        chain = actionchain.ActionChain(**CHAIN_WITH_VARS)
+        self.assertEquals(len(chain.chain), len(CHAIN_WITH_VARS['chain']))
+        self.assertEquals(len(chain.vars), len(CHAIN_WITH_VARS['vars']))
 
     def test_actionchain_schema_invalid(self):
         with self.assertRaises(ValidationError):

--- a/st2common/tests/unit/test_actionchain_schema.py
+++ b/st2common/tests/unit/test_actionchain_schema.py
@@ -22,7 +22,7 @@ from st2tests.fixturesloader import FixturesLoader
 FIXTURES_PACK = 'generic'
 TEST_FIXTURES = {
     'actionchains': ['chain1.json', 'malformedchain.json', 'no_default_chain.json',
-                     'chain_with_vars.json', 'chain_with_output.json']
+                     'chain_with_vars.json', 'chain_with_publish.json']
 }
 FIXTURES = FixturesLoader().load_fixtures(fixtures_pack=FIXTURES_PACK,
                                           fixtures_dict=TEST_FIXTURES)
@@ -30,7 +30,7 @@ CHAIN_1 = FIXTURES['actionchains']['chain1.json']
 MALFORMED_CHAIN = FIXTURES['actionchains']['malformedchain.json']
 NO_DEFAULT_CHAIN = FIXTURES['actionchains']['no_default_chain.json']
 CHAIN_WITH_VARS = FIXTURES['actionchains']['chain_with_vars.json']
-CHAIN_WITH_OUTPUT = FIXTURES['actionchains']['chain_with_output.json']
+CHAIN_WITH_PUBLISH = FIXTURES['actionchains']['chain_with_publish.json']
 
 
 class ActionChainSchemaTest(unittest2.TestCase):
@@ -50,10 +50,11 @@ class ActionChainSchemaTest(unittest2.TestCase):
         self.assertEquals(len(chain.chain), len(CHAIN_WITH_VARS['chain']))
         self.assertEquals(len(chain.vars), len(CHAIN_WITH_VARS['vars']))
 
-    def test_actionchain_with_output(self):
-        chain = actionchain.ActionChain(**CHAIN_WITH_OUTPUT)
-        self.assertEquals(len(chain.chain), len(CHAIN_WITH_OUTPUT['chain']))
-        self.assertEquals(len(chain.chain[0].output), len(CHAIN_WITH_OUTPUT['chain'][0]['output']))
+    def test_actionchain_with_publish(self):
+        chain = actionchain.ActionChain(**CHAIN_WITH_PUBLISH)
+        self.assertEquals(len(chain.chain), len(CHAIN_WITH_PUBLISH['chain']))
+        self.assertEquals(len(chain.chain[0].publish),
+                          len(CHAIN_WITH_PUBLISH['chain'][0]['publish']))
 
     def test_actionchain_schema_invalid(self):
         with self.assertRaises(ValidationError):

--- a/st2common/tests/unit/test_actionchain_schema.py
+++ b/st2common/tests/unit/test_actionchain_schema.py
@@ -22,7 +22,7 @@ from st2tests.fixturesloader import FixturesLoader
 FIXTURES_PACK = 'generic'
 TEST_FIXTURES = {
     'actionchains': ['chain1.json', 'malformedchain.json', 'no_default_chain.json',
-                     'chain_with_vars.json']
+                     'chain_with_vars.json', 'chain_with_output.json']
 }
 FIXTURES = FixturesLoader().load_fixtures(fixtures_pack=FIXTURES_PACK,
                                           fixtures_dict=TEST_FIXTURES)
@@ -30,6 +30,7 @@ CHAIN_1 = FIXTURES['actionchains']['chain1.json']
 MALFORMED_CHAIN = FIXTURES['actionchains']['malformedchain.json']
 NO_DEFAULT_CHAIN = FIXTURES['actionchains']['no_default_chain.json']
 CHAIN_WITH_VARS = FIXTURES['actionchains']['chain_with_vars.json']
+CHAIN_WITH_OUTPUT = FIXTURES['actionchains']['chain_with_output.json']
 
 
 class ActionChainSchemaTest(unittest2.TestCase):
@@ -48,6 +49,11 @@ class ActionChainSchemaTest(unittest2.TestCase):
         chain = actionchain.ActionChain(**CHAIN_WITH_VARS)
         self.assertEquals(len(chain.chain), len(CHAIN_WITH_VARS['chain']))
         self.assertEquals(len(chain.vars), len(CHAIN_WITH_VARS['vars']))
+
+    def test_actionchain_with_output(self):
+        chain = actionchain.ActionChain(**CHAIN_WITH_OUTPUT)
+        self.assertEquals(len(chain.chain), len(CHAIN_WITH_OUTPUT['chain']))
+        self.assertEquals(len(chain.chain[0].output), len(CHAIN_WITH_OUTPUT['chain'][0]['output']))
 
     def test_actionchain_schema_invalid(self):
         with self.assertRaises(ValidationError):

--- a/st2common/tests/unit/test_actionchain_schema.py
+++ b/st2common/tests/unit/test_actionchain_schema.py
@@ -1,0 +1,47 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest2
+
+from jsonschema.exceptions import ValidationError
+from st2common.models.system import actionchain
+from st2tests.fixturesloader import FixturesLoader
+
+FIXTURES_PACK = 'generic'
+TEST_FIXTURES = {
+    'actionchains': ['chain1.json', 'malformedchain.json', 'no_default_chain.json']
+}
+FIXTURES = FixturesLoader().load_fixtures(fixtures_pack=FIXTURES_PACK,
+                                          fixtures_dict=TEST_FIXTURES)
+CHAIN_1 = FIXTURES['actionchains']['chain1.json']
+MALFORMED_CHAIN = FIXTURES['actionchains']['malformedchain.json']
+NO_DEFAULT_CHAIN = FIXTURES['actionchains']['no_default_chain.json']
+
+
+class ActionChainSchemaTest(unittest2.TestCase):
+
+    def test_actionchain_schema_valid(self):
+        chain = actionchain.ActionChain(**CHAIN_1)
+        self.assertEquals(len(chain.chain), len(CHAIN_1['chain']))
+        self.assertEquals(chain.default, CHAIN_1['default'])
+
+    def test_actionchain_no_default(self):
+        chain = actionchain.ActionChain(**NO_DEFAULT_CHAIN)
+        self.assertEquals(len(chain.chain), len(NO_DEFAULT_CHAIN['chain']))
+        self.assertEquals(chain.default, None)
+
+    def test_actionchain_schema_invalid(self):
+        with self.assertRaises(ValidationError):
+            actionchain.ActionChain(**MALFORMED_CHAIN)

--- a/st2tests/st2tests/fixtures/generic/actionchains/chain_vars.json
+++ b/st2tests/st2tests/fixtures/generic/actionchains/chain_vars.json
@@ -1,0 +1,19 @@
+{
+    "vars": {
+        "strtype": "{{system.a}}",
+        "inttype": 1
+    },
+    "chain": [
+        {
+            "name": "c1",
+            "ref": "wolfpack.a2",
+            "params":
+            {
+                "inttype": "{{inttype}}",
+                "strtype": "{{strtype}}",
+                "booltype": true
+            }
+        }
+    ],
+    "default": "c1"
+}

--- a/st2tests/st2tests/fixtures/generic/actionchains/chain_with_output.json
+++ b/st2tests/st2tests/fixtures/generic/actionchains/chain_with_output.json
@@ -1,0 +1,23 @@
+{
+    "vars": {
+        "strtype": "{{system.a}}",
+        "inttype": 1
+    },
+    "chain": [
+        {
+            "name": "c1",
+            "ref": "wolfpack.a2",
+            "params":
+            {
+                "inttype": "{{inttype}}",
+                "strtype": "{{strtype}}",
+                "booltype": true
+            },
+            "output":
+            {
+                "o1": "{{c1.foo.bar}}"
+            }
+        }
+    ],
+    "default": "c1"
+}

--- a/st2tests/st2tests/fixtures/generic/actionchains/chain_with_output.json
+++ b/st2tests/st2tests/fixtures/generic/actionchains/chain_with_output.json
@@ -16,6 +16,17 @@
             "output":
             {
                 "o1": "{{c1.foo.bar}}"
+            },
+            "on-success": "c2"
+        },
+        {
+            "name": "c2",
+            "ref": "wolfpack.a2",
+            "params":
+            {
+                "inttype": "{{inttype}}",
+                "strtype": "{{c1.o1}}",
+                "booltype": true
             }
         }
     ],

--- a/st2tests/st2tests/fixtures/generic/actionchains/chain_with_publish.json
+++ b/st2tests/st2tests/fixtures/generic/actionchains/chain_with_publish.json
@@ -13,7 +13,7 @@
                 "strtype": "{{strtype}}",
                 "booltype": true
             },
-            "output":
+            "publish":
             {
                 "o1": "{{c1.foo.bar}}"
             },

--- a/st2tests/st2tests/fixtures/generic/actionchains/chain_with_publish.json
+++ b/st2tests/st2tests/fixtures/generic/actionchains/chain_with_publish.json
@@ -15,7 +15,7 @@
             },
             "publish":
             {
-                "o1": "{{c1.foo.bar}}"
+                "o1": "{{c1.raw_out}}"
             },
             "on-success": "c2"
         },
@@ -25,7 +25,7 @@
             "params":
             {
                 "inttype": "{{inttype}}",
-                "strtype": "{{c1.o1}}",
+                "strtype": "{{o1}}",
                 "booltype": true
             }
         }

--- a/st2tests/st2tests/fixtures/generic/actionchains/chain_with_vars.json
+++ b/st2tests/st2tests/fixtures/generic/actionchains/chain_with_vars.json
@@ -1,0 +1,34 @@
+{
+    "vars": {
+        "var1": "1",
+        "var2": 2
+    },
+    "chain": [
+        {
+            "name": "c1",
+            "ref": "wolfpack.a1",
+            "params": {"p1": "v1"},
+            "on-success": "c2",
+            "on-failure": "c4"
+        },
+        {
+            "name": "c2",
+            "ref": "wolfpack.a2",
+            "params": {"p1": "v1"},
+            "on-success": "c3",
+            "on-failure": "c4"
+        },
+        {
+            "name": "c3",
+            "ref": "wolfpack.a3",
+            "params": {},
+            "on-failure": "c4"
+        },
+        {
+            "name": "c4",
+            "ref": "wolfpack.a1",
+            "params": {}
+        }
+    ],
+    "default": "c1"
+}

--- a/st2tests/st2tests/fixtures/generic/actionchains/no_default_chain.json
+++ b/st2tests/st2tests/fixtures/generic/actionchains/no_default_chain.json
@@ -1,0 +1,29 @@
+{
+    "chain": [
+        {
+            "name": "c1",
+            "ref": "wolfpack.a1",
+            "params": {"p1": "v1"},
+            "on-success": "c2",
+            "on-failure": "c4"
+        },
+        {
+            "name": "c2",
+            "ref": "wolfpack.a2",
+            "params": {"p1": "v1"},
+            "on-success": "c3",
+            "on-failure": "c4"
+        },
+        {
+            "name": "c3",
+            "ref": "wolfpack.a3",
+            "params": {},
+            "on-failure": "c4"
+        },
+        {
+            "name": "c4",
+            "ref": "wolfpack.a1",
+            "params": {}
+        }
+    ]
+}


### PR DESCRIPTION
- Proper schema for ActionChain
- Schema validation catches malformed yaml/json
- default node is now optional
- support for vars
```
{
    "vars": {
        "strtype": "{{system.a}}",
        "inttype": 1
    },
    "chain": [
        {
            "name": "c1",
            "ref": "wolfpack.a2",
            "params":
            {
                "inttype": "{{inttype}}",
                "strtype": "{{strtype}}",
                "booltype": true
            }
        }
    ],
    "default": "c1"
}
```
- support for output variable per action_node
```
{
    "chain": [
        {
            "name": "c1",
            "ref": "wolfpack.a2",
            "params":
            {
                "inttype": "{{inttype}}",
                "strtype": "{{strtype}}",
                "booltype": true
            },
            "output":
            {
                "o1": "{{c1.foo.bar}}"
            },
            "on-success": "c2"
        },
        {
            "name": "c2",
            "ref": "wolfpack.a2",
            "params":
            {
                "strtype": "{{o1}}"
            }
        }
    ],
    "default": "c1"
}
```
Note : Full result of `c1` is still available and variables published by `c1` are in the global context.