### PR TITLE
Allow user to register resources from a specific pack

### DIFF
--- a/st2actions/st2actions/bootstrap/actionsregistrar.py
+++ b/st2actions/st2actions/bootstrap/actionsregistrar.py
@@ -124,11 +124,18 @@ class ActionsRegistrar(ResourceRegistrar):
                 continue
 
 
-def register_actions(packs_base_paths=None):
+def register_actions(packs_base_paths=None, pack_dir=None):
     if packs_base_paths:
         assert(isinstance(packs_base_paths, list))
 
     if not packs_base_paths:
         packs_base_paths = content_utils.get_packs_base_paths()
 
-    return ActionsRegistrar().register_actions_from_packs(base_dirs=packs_base_paths)
+    registrar = ActionsRegistrar()
+
+    if pack_dir:
+        result = registrar.register_actions_from_pack(pack_dir=pack_dir)
+    else:
+        result = registrar.register_actions_from_packs(base_dirs=packs_base_paths)
+
+    return result

--- a/st2actions/st2actions/bootstrap/actionsregistrar.py
+++ b/st2actions/st2actions/bootstrap/actionsregistrar.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 
 import six
 
@@ -38,6 +39,10 @@ class ActionsRegistrar(ResourceRegistrar):
     ALLOWED_EXTENSIONS = ALLOWED_EXTS
 
     def register_actions_from_packs(self, base_dirs):
+        """
+        Discover all the packs in the provided directory and register actions from all of the
+        discovered packs.
+        """
         content = self._pack_loader.get_content(base_dirs=base_dirs,
                                                 content_type='actions')
 
@@ -48,6 +53,25 @@ class ActionsRegistrar(ResourceRegistrar):
                 self._register_actions_from_pack(pack=pack, actions=actions)
             except:
                 LOG.exception('Failed registering all actions from pack: %s', actions_dir)
+
+    def register_actions_from_pack(self, pack_dir):
+        """
+        Register all the actions from the provided pack.
+        """
+        _, pack = os.path.split(pack_dir)
+        actions_dir = self._pack_loader.get_content_from_pack(pack_dir=pack_dir,
+                                                              content_type='actions')
+
+        if not actions_dir:
+            return None
+
+        LOG.debug('Registering actions from pack %s:, dir: %s', pack, actions_dir)
+
+        try:
+            actions = self._get_actions_from_pack(actions_dir=actions_dir)
+            self._register_actions_from_pack(pack=pack, actions=actions)
+        except:
+            LOG.exception('Failed registering all actions from pack: %s', actions_dir)
 
     def _get_actions_from_pack(self, actions_dir):
         actions = self._get_resources_from_pack(resources_dir=actions_dir)

--- a/st2common/st2common/bootstrap/base.py
+++ b/st2common/st2common/bootstrap/base.py
@@ -16,6 +16,7 @@
 import glob
 
 from st2common.content.loader import MetaLoader
+from st2common.content.loader import ContentPackLoader
 
 __all__ = [
     'ResourceRegistrar'
@@ -27,6 +28,7 @@ class ResourceRegistrar(object):
 
     def __init__(self):
         self._meta_loader = MetaLoader()
+        self._pack_loader = ContentPackLoader()
 
     def _get_resources_from_pack(self, resources_dir):
         resources = []

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -31,7 +31,8 @@ def register_opts():
         cfg.BoolOpt('all', default=False, help='Register sensors, actions and rules.'),
         cfg.BoolOpt('sensors', default=False, help='Register sensors.'),
         cfg.BoolOpt('actions', default=False, help='Register actions.'),
-        cfg.BoolOpt('rules', default=False, help='Register rules.')
+        cfg.BoolOpt('rules', default=False, help='Register rules.'),
+        cfg.StrOpt('pack', default=None, help='Directory to the pack to register content from.')
     ]
     try:
         cfg.CONF.register_cli_opts(content_opts, group='register')
@@ -48,7 +49,7 @@ def register_sensors():
         # Importing here to reduce scope of dependency. This way even if st2reactor
         # is not installed bootstrap continues.
         import st2reactor.bootstrap.sensorsregistrar as sensors_registrar
-        sensors_registrar.register_sensors()
+        sensors_registrar.register_sensors(pack_dir=cfg.CONF.register.pack)
     except Exception as e:
         LOG.warning('Failed to register sensors: %s', e, exc_info=True)
 
@@ -72,7 +73,7 @@ def register_actions():
             # Importing here to reduce scope of dependency. This way even if st2action
             # is not installed bootstrap continues.
             import st2actions.bootstrap.actionsregistrar as actions_registrar
-            actions_registrar.register_actions()
+            actions_registrar.register_actions(pack_dir=cfg.CONF.register.pack)
         except Exception as e:
             LOG.warning('Failed to register actions: %s', e, exc_info=True)
 
@@ -86,7 +87,7 @@ def register_rules():
         # Importing here to reduce scope of dependency. This way even if st2reactor
         # is not installed bootstrap continues.
         import st2reactor.bootstrap.rulesregistrar as rules_registrar
-        rules_registrar.register_rules()
+        rules_registrar.register_rules(pack_dir=cfg.CONF.register.pack)
     except Exception as e:
         LOG.warning('Failed to register rules: %s', e, exc_info=True)
 

--- a/st2common/st2common/content/loader.py
+++ b/st2common/st2common/content/loader.py
@@ -127,17 +127,17 @@ class ContentPackLoader(object):
 
     def _get_sensors(self, pack_dir):
         if 'sensors' not in os.listdir(pack_dir):
-            raise ValueError('No sensors found.')
+            raise ValueError('No sensors found in "%s".' % (pack_dir))
         return os.path.join(pack_dir, 'sensors')
 
     def _get_actions(self, pack_dir):
         if 'actions' not in os.listdir(pack_dir):
-            raise ValueError('No actions found.')
+            raise ValueError('No actions found in "%s".' % (pack_dir))
         return os.path.join(pack_dir, 'actions')
 
     def _get_rules(self, pack_dir):
         if 'rules' not in os.listdir(pack_dir):
-            raise ValueError('No rules found.')
+            raise ValueError('No rules found in "%s".' % (pack_dir))
         return os.path.join(pack_dir, 'rules')
 
 

--- a/st2common/tests/unit/test_content_loader.py
+++ b/st2common/tests/unit/test_content_loader.py
@@ -61,3 +61,26 @@ class ContentLoaderTest(unittest2.TestCase):
                         '"%s/packs/", ignoring content from '
                         '"%s/packs2/"' % (RESOURCES_DIR, RESOURCES_DIR))
         LOG.warning.assert_called_once_with(expected_msg)
+
+    def test_get_content_from_pack_success(self):
+        loader = ContentPackLoader()
+        pack_path = os.path.join(RESOURCES_DIR, 'packs/pack1')
+
+        sensors = loader.get_content_from_pack(pack_dir=pack_path, content_type='sensors')
+        self.assertTrue(sensors.endswith('packs/pack1/sensors'))
+
+    def test_get_content_from_pack_directory_doesnt_exist(self):
+        loader = ContentPackLoader()
+        pack_path = os.path.join(RESOURCES_DIR, 'packs/pack100')
+
+        message_regex = 'Directory .*? doesn\'t exist'
+        self.assertRaisesRegexp(ValueError, message_regex, loader.get_content_from_pack,
+                                pack_dir=pack_path, content_type='sensors')
+
+    def test_get_content_from_pack_no_sensors(self):
+        loader = ContentPackLoader()
+        pack_path = os.path.join(RESOURCES_DIR, 'packs/pack2')
+
+        message_regex = 'No sensors found'
+        self.assertRaisesRegexp(ValueError, message_regex, loader.get_content_from_pack,
+                                pack_dir=pack_path, content_type='sensors')

--- a/st2reactor/st2reactor/bootstrap/rulesregistrar.py
+++ b/st2reactor/st2reactor/bootstrap/rulesregistrar.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import six
 
 from st2common import log as logging
@@ -43,6 +45,25 @@ class RulesRegistrar(ResourceRegistrar):
                 self._register_rules_from_pack(pack, rules)
             except:
                 LOG.exception('Failed registering all rules from pack: %s', rules_dir)
+
+    def register_rules_from_pack(self, pack_dir):
+        """
+        Register all the rules from the provided pack.
+        """
+        _, pack = os.path.split(pack_dir)
+        rules_dir = self._pack_loader.get_content_from_pack(pack_dir=pack_dir,
+                                                            content_type='rules')
+
+        if not rules_dir:
+            return None
+
+        LOG.debug('Registering rules from pack %s:, dir: %s', pack, rules_dir)
+
+        try:
+            rules = self._get_rules_from_pack(rules_dir=rules_dir)
+            self._register_rules_from_pack(pack=pack, rules=rules)
+        except:
+            LOG.exception('Failed registering all rules from pack: %s', rules_dir)
 
     def _get_rules_from_pack(self, rules_dir):
         return self._get_resources_from_pack(resources_dir=rules_dir)

--- a/st2reactor/st2reactor/bootstrap/rulesregistrar.py
+++ b/st2reactor/st2reactor/bootstrap/rulesregistrar.py
@@ -88,11 +88,18 @@ class RulesRegistrar(ResourceRegistrar):
                 LOG.exception('Failed registering rule from %s.', rule)
 
 
-def register_rules(packs_base_paths=None):
+def register_rules(packs_base_paths=None, pack_dir=None):
     if packs_base_paths:
         assert(isinstance(packs_base_paths, list))
 
     if not packs_base_paths:
         packs_base_paths = content_utils.get_packs_base_paths()
 
-    return RulesRegistrar().register_rules_from_packs(base_dirs=packs_base_paths)
+    registrar = RulesRegistrar()
+
+    if pack_dir:
+        result = registrar.register_rules_from_pack(pack_dir=pack_dir)
+    else:
+        result = registrar.register_rules_from_packs(base_dirs=packs_base_paths)
+
+    return result

--- a/st2reactor/st2reactor/bootstrap/sensorsregistrar.py
+++ b/st2reactor/st2reactor/bootstrap/sensorsregistrar.py
@@ -39,17 +39,40 @@ class SensorsRegistrar(ResourceRegistrar):
     ]
 
     def register_sensors_from_packs(self, base_dirs):
+        """
+        Discover all the packs in the provided directory and register sensors from all of the
+        discovered packs.
+        """
         content = self._pack_loader.get_content(base_dirs=base_dirs,
                                                 content_type='sensors')
 
         for pack, sensors_dir in six.iteritems(content):
             try:
-                LOG.info('Registering sensors from pack: %s', pack)
+                LOG.debug('Registering sensors from pack %s:, dir: %s', pack, sensors_dir)
                 sensors = self._get_sensors_from_pack(sensors_dir)
                 self._register_sensors_from_pack(pack=pack, sensors=sensors)
             except Exception as e:
                 LOG.exception('Failed registering all sensors from pack "%s": %s', sensors_dir,
                               str(e))
+
+    def register_sensors_from_pack(self, pack_dir):
+        """
+        Register all the sensors from the provided pack.
+        """
+        _, pack = os.path.split(pack_dir)
+        sensors_dir = self._pack_loader.get_content_from_pack(pack_dir=pack_dir,
+                                                              content_type='sensors')
+
+        if not sensors_dir:
+            return None
+
+        LOG.debug('Registering sensors from pack %s:, dir: %s', pack, sensors_dir)
+
+        try:
+            sensors = self._get_sensors_from_pack(sensors_dir=sensors_dir)
+            self._register_sensors_from_pack(pack=pack, sensors=sensors)
+        except Exception as e:
+            LOG.exception('Failed registering all sensors from pack "%s": %s', sensors_dir, str(e))
 
     def _get_sensors_from_pack(self, sensors_dir):
         return self._get_resources_from_pack(resources_dir=sensors_dir)

--- a/st2reactor/st2reactor/bootstrap/sensorsregistrar.py
+++ b/st2reactor/st2reactor/bootstrap/sensorsregistrar.py
@@ -129,11 +129,18 @@ class SensorsRegistrar(ResourceRegistrar):
             container_utils.add_sensor_model(pack=pack, sensor=sensor_obj)
 
 
-def register_sensors(packs_base_paths=None):
+def register_sensors(packs_base_paths=None, pack_dir=None):
     if packs_base_paths:
         assert(isinstance(packs_base_paths, list))
 
     if not packs_base_paths:
         packs_base_paths = content_utils.get_packs_base_paths()
 
-    return SensorsRegistrar().register_sensors_from_packs(base_dirs=packs_base_paths)
+    registrar = SensorsRegistrar()
+
+    if pack_dir:
+        result = registrar.register_sensors_from_pack(pack_dir=pack_dir)
+    else:
+        result = registrar.register_sensors_from_packs(base_dirs=packs_base_paths)
+
+    return result

--- a/st2reactor/st2reactor/bootstrap/sensorsregistrar.py
+++ b/st2reactor/st2reactor/bootstrap/sensorsregistrar.py
@@ -19,7 +19,6 @@ import six
 
 from st2common import log as logging
 from st2common.bootstrap.base import ResourceRegistrar
-from st2common.content.loader import ContentPackLoader
 import st2reactor.container.utils as container_utils
 import st2common.content.utils as content_utils
 
@@ -38,6 +37,19 @@ class SensorsRegistrar(ResourceRegistrar):
         '.yaml',
         '.yml'
     ]
+
+    def register_sensors_from_packs(self, base_dirs):
+        content = self._pack_loader.get_content(base_dirs=base_dirs,
+                                                content_type='sensors')
+
+        for pack, sensors_dir in six.iteritems(content):
+            try:
+                LOG.info('Registering sensors from pack: %s', pack)
+                sensors = self._get_sensors_from_pack(sensors_dir)
+                self._register_sensors_from_pack(pack=pack, sensors=sensors)
+            except Exception as e:
+                LOG.exception('Failed registering all sensors from pack "%s": %s', sensors_dir,
+                              str(e))
 
     def _get_sensors_from_pack(self, sensors_dir):
         return self._get_resources_from_pack(resources_dir=sensors_dir)
@@ -92,19 +104,6 @@ class SensorsRegistrar(ResourceRegistrar):
                 'enabled': enabled
             }
             container_utils.add_sensor_model(pack=pack, sensor=sensor_obj)
-
-    def register_sensors_from_packs(self, base_dirs):
-        pack_loader = ContentPackLoader()
-        content = pack_loader.get_content(base_dirs=base_dirs, content_type='sensors')
-
-        for pack, sensors_dir in six.iteritems(content):
-            try:
-                LOG.info('Registering sensors from pack: %s', pack)
-                sensors = self._get_sensors_from_pack(sensors_dir)
-                self._register_sensors_from_pack(pack=pack, sensors=sensors)
-            except Exception as e:
-                LOG.exception('Failed registering all sensors from pack "%s": %s', sensors_dir,
-                              str(e))
 
 
 def register_sensors(packs_base_paths=None):


### PR DESCRIPTION
This branch allows user to register resources from a specific pack using register-content.py script by passing `--pack=<pack dir>` argument to the script.

Among other places, I will use this functionality in st2contrib to validate resources in a particular pack against the schema (this happens during registration).