### PR TITLE
Add detail for built-in parameters to Action Metadata

### DIFF
--- a/docs/source/actions.rst
+++ b/docs/source/actions.rst
@@ -121,6 +121,18 @@ parameters (from_number, to_number, body).
 
 .. _ref-actions-converting-scripts:
 
+Built-in Parameters
+^^^^^^^^^^^^^^^^^^^
+
+When configuring the metadata, there exists several built-in parameters that
+can be used and overwritten to change the default functionality of the
+various runners.
+
+* ``args`` - (``run-local``/``run-remote``) By default, |st2| will assemble arguments based on whether a user defines named or positional arguments. Adjusts the format of arguments passed to ``cmd``
+* ``cmd``  - (``run-local``/``run-remote``) Configure the command to be run on the target system
+* ``cwd``  - (``run-local``/``run-remote``) Configure the directory where remote commands will be executed from.
+* ``dir``  - (``run-local``/``run-remote``) Configure the directory where scripts are copied from a pack to the target machine prior to execution
+
 Converting existing scripts into actions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This PR adds additional details around some of the built-in parameters, what they do, and mention that they can be overwritten.

/cc https://stackstorm.atlassian.net/browse/STORM-939