### PR TITLE
Add workflow output to execution result and update mistral task

### DIFF
--- a/contrib/examples/actions/mistral-basic.yaml
+++ b/contrib/examples/actions/mistral-basic.yaml
@@ -4,6 +4,8 @@ examples.mistral-basic:
     type: direct
     input:
         - cmd
+    output:
+        stdout: $.stdout
     tasks:
         run-cmd:
             action: core.local cmd={$.cmd}

--- a/contrib/examples/actions/mistral-workbook-basic.yaml
+++ b/contrib/examples/actions/mistral-workbook-basic.yaml
@@ -6,6 +6,8 @@ workflows:
         type: direct
         input:
             - cmd
+        output:
+            stdout: $.stdout
         tasks:
             run-cmd:
                 action: core.local

--- a/contrib/examples/actions/mistral-workbook-complex.yaml
+++ b/contrib/examples/actions/mistral-workbook-complex.yaml
@@ -9,6 +9,9 @@ workflows:
             - vm_name
             - cpu_cores
             - memory_mb
+        output:
+            vm_id: $.vm_id
+            vm_state: $.vm_state 
         task-defaults:
           on-error:
             - fail
@@ -66,8 +69,8 @@ workflows:
             add_disk:
                 action: core.local
                 input:
-                    cmd: "sleep 1; printf '{$.vm_id}'"
+                    cmd: "sleep 1; printf 'configured'"
             edit_cpu_mem:
                 action: core.local
                 input:
-                    cmd: "sleep 1; printf '{\"vm_id\": \"{$.vm_id}\", \"cpu\": {$.cpu_cores}, \"memory\": {$.memory_mb}}'"
+                    cmd: "sleep 1; printf 'configured'"

--- a/contrib/examples/actions/mistral-workbook-subflows.json
+++ b/contrib/examples/actions/mistral-workbook-subflows.json
@@ -1,0 +1,18 @@
+{
+    "name": "mistral-workbook-subflows",
+    "pack": "examples",
+    "runner_type": "mistral-v2",
+    "description": "Test the output for a series of mistral-basic workflows.",
+    "enabled": true,
+    "entry_point":"mistral-workbook-subflows.yaml",
+    "parameters": {
+        "subject": {
+            "type": "string",
+            "default": "StackStorm"
+        },
+        "adjective": {
+            "type": "string",
+            "default": "awesome"
+        }
+    }
+}

--- a/contrib/examples/actions/mistral-workbook-subflows.yaml
+++ b/contrib/examples/actions/mistral-workbook-subflows.yaml
@@ -1,0 +1,30 @@
+version: "2.0"
+name: "examples.mistral-workbook-subflows"
+
+workflows:
+
+    main:
+        type: direct
+        input:
+            - subject
+            - adjective
+        output:
+            tagline: "{$.printed_subject} is {$.printed_adjective}!"
+        task-defaults:
+          on-error:
+            - fail
+        tasks:
+            print_subject:
+                action: examples.mistral-basic
+                input:
+                    cmd: "printf '{$.subject}'"
+                publish:
+                    printed_subject: $.stdout
+                on-success:
+                    - print_adjective
+            print_adjective:
+                action: examples.mistral-basic
+                input:
+                    cmd: "printf '{$.adjective}'"
+                publish:
+                    printed_adjective: $.stdout

--- a/st2actions/st2actions/handlers/mistral.py
+++ b/st2actions/st2actions/handlers/mistral.py
@@ -40,17 +40,29 @@ class MistralCallbackHandler(handlers.ActionExecutionCallbackHandler):
 
     @staticmethod
     def callback(url, context, status, result):
+        if status not in [action.ACTIONEXEC_STATUS_SUCCEEDED, action.ACTIONEXEC_STATUS_FAILED]:
+            return
+
         try:
             method = 'PUT'
+            headers = {'content-type': 'application/json'}
+
             if isinstance(result, basestring) and len(result) > 0 and result[0] in ['{', '[']:
                 value = ast.literal_eval(result)
                 if type(value) in [dict, list]:
                     result = value
+
+            if isinstance(result, dict):
+                # Remove the list of tasks created by the results
+                # tracker before sending the output.
+                result.pop('tasks', None)
+
             output = json.dumps(result) if type(result) in [dict, list] else str(result)
+
             v1 = 'v1' in url
             output_key = 'output' if v1 else 'result'
             data = {'state': STATUS_MAP[status], output_key: output}
-            headers = {'content-type': 'application/json'}
+            LOG.info('Sending callback to %s with data %s.', url, data)
             response = requests.request(method, url, data=json.dumps(data), headers=headers)
             if response.status_code != 200:
                 response.raise_for_status()

--- a/st2actions/st2actions/query/mistral/v2.py
+++ b/st2actions/st2actions/query/mistral/v2.py
@@ -4,6 +4,7 @@ from oslo.config import cfg
 import requests
 
 from st2actions.query.base import Querier
+from st2common.util import jsonify
 from st2common import log as logging
 from st2common.constants.action import (ACTIONEXEC_STATUS_SUCCEEDED, ACTIONEXEC_STATUS_FAILED,
                                         ACTIONEXEC_STATUS_RUNNING)
@@ -39,42 +40,68 @@ class MistralResultsQuerier(Querier):
         if not exec_id:
             raise Exception('Mistral execution id invalid in query_context %s.' %
                             str(query_context))
-        url = self._get_execution_status_url(exec_id)
-        resp = requests.get(url)
-        try:
-            status = self._get_workflow_status(resp.json())
-        except:
-            LOG.exception('Exception trying to get workflow status for query context: %s.' +
-                          ' Will skip query.', query_context)
-            raise
-        url = self._get_execution_results_url(exec_id)
-        resp = requests.get(url)
-        LOG.debug('Mistral query results: %s' % resp.json())
-        return (status, resp.json())
 
-    def _get_execution_results_url(self, exec_id):
+        try:
+            status, output = self._get_workflow_result(exec_id)
+            if output and 'tasks' in output:
+                LOG.warn('Key conflict with tasks in the workflow output.')
+        except:
+            LOG.exception('Exception trying to get workflow status and output for '
+                          'query context: %s. Will skip query.', query_context)
+            raise
+
+        result = output or {}
+        result['tasks'] = self._get_workflow_tasks(exec_id)
+
+        LOG.debug('Mistral query results: %s' % result)
+
+        return (status, result)
+
+    def _get_execution_tasks_url(self, exec_id):
         return self._base_url + 'executions/' + exec_id + '/tasks'
 
-    def _get_execution_status_url(self, exec_id):
+    def _get_execution_url(self, exec_id):
         return self._base_url + 'executions/' + exec_id
 
-    def _get_workflow_status(self, execution_obj):
+    def _get_workflow_result(self, exec_id):
         """
-        Returns st2 status given mistral status.
+        Returns the workflow status and output. Mistral workflow status will be converted
+        to st2 action status.
 
-        :param execution_obj: Object representing the results of API call v2/executions/${id}/tasks
-        :type execution_obj: ``object``
+        :param exec_id: Mistral execution ID
+        :type exec_id: ``str``
 
-        :rtype: ``str``
+        :rtype: (``str``, ``dict``)
         """
-        workflow_state = execution_obj.get('state', None)
+        url = self._get_execution_url(exec_id)
+        resp = requests.get(url)
+        execution = resp.json()
+
+        workflow_state = execution.get('state', None)
+
         if not workflow_state:
-            raise Exception('Workflow status unknown for mistral execution id %s.'
-                            % execution_obj.get('id', None))
-        if workflow_state in DONE_STATES:
-            return DONE_STATES[workflow_state]
+            raise Exception('Workflow status unknown for mistral execution id %s.' % exec_id)
 
-        return ACTIONEXEC_STATUS_RUNNING
+        if workflow_state in DONE_STATES:
+            workflow_output = jsonify.try_loads(execution.get('output', {}))
+            return (DONE_STATES[workflow_state], workflow_output)
+
+        return (ACTIONEXEC_STATUS_RUNNING, None)
+
+    def _get_workflow_tasks(self, exec_id):
+        """
+        Returns the list of tasks for a workflow execution.
+
+        :param exec_id: Mistral execution ID
+        :type exec_id: ``str``
+
+        :rtype: ``list``
+        """
+        url = self._get_execution_tasks_url(exec_id)
+        resp = requests.get(url)
+        result = resp.json()
+        tasks = result.get('tasks', [])
+        return tasks
 
 
 def get_instance():

--- a/st2actions/st2actions/runners/__init__.py
+++ b/st2actions/st2actions/runners/__init__.py
@@ -14,12 +14,15 @@
 # limitations under the License.
 
 import abc
+import importlib
 
 import six
 
 from st2actions import handlers
 from st2common import log as logging
+from st2common.exceptions.actionrunner import ActionRunnerCreateError
 import st2common.util.action_db as action_utils
+
 
 __all__ = [
     'ActionRunner',
@@ -31,6 +34,23 @@ LOG = logging.getLogger(__name__)
 
 # constants to lookup in runner_parameters
 RUNNER_COMMAND = 'cmd'
+
+
+def get_runner(module_name):
+    """Load the module and return an instance of the runner."""
+
+    LOG.debug('Runner loading python module: %s', module_name)
+    try:
+        module = importlib.import_module(module_name, package=None)
+    except Exception as e:
+        LOG.exception('Failed to import module %s.', module_name)
+        raise ActionRunnerCreateError(e)
+
+    LOG.debug('Instance of runner module: %s', module)
+
+    runner = module.get_runner()
+    LOG.debug('Instance of runner: %s', runner)
+    return runner
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/st2actions/tests/unit/test_runner_container.py
+++ b/st2actions/tests/unit/test_runner_container.py
@@ -17,6 +17,7 @@ import datetime
 import mock
 
 from oslo.config import cfg
+from st2actions.runners import get_runner
 from st2common.exceptions.actionrunner import ActionRunnerCreateError
 from st2common.models.system.common import ResourceReference
 from st2common.models.db.action import (ActionExecutionDB, RunnerTypeDB)
@@ -31,7 +32,7 @@ from st2tests.fixturesloader import FixturesLoader
 # XXX: There is dependency on config being setup before importing
 # RunnerContainer. Do not move this until you fix config
 # dependencies.
-from st2actions.container.base import RunnerContainer, get_runner_container
+from st2actions.container.base import get_runner_container
 
 TEST_FIXTURES = {
     'runners': ['testrunner1.json', 'testfailingrunner1.json', 'testasyncrunner1.json'],
@@ -61,17 +62,15 @@ class RunnerContainerTest(DbTestCase):
 
     def test_get_runner_module(self):
         runnertype_db = RunnerContainerTest.runnertype_db
-        runner_container = RunnerContainer()
-        runner = runner_container._get_runner(runnertype_db)
+        runner = get_runner(runnertype_db.runner_module)
         self.assertTrue(runner is not None, 'TestRunner must be valid.')
 
     def test_get_runner_module_fail(self):
         runnertype_db = RunnerTypeDB()
         runnertype_db.runner_module = 'absent.module'
-        runner_container = RunnerContainer()
         runner = None
         try:
-            runner = runner_container._get_runner(runnertype_db)
+            runner = get_runner(runnertype_db.runner_module)
         except ActionRunnerCreateError:
             pass
         self.assertFalse(runner, 'TestRunner must be valid.')

--- a/st2common/st2common/util/jsonify.py
+++ b/st2common/st2common/util/jsonify.py
@@ -20,6 +20,7 @@ except ImportError:
 
 
 from pecan.jsonify import GenericJSON
+import six
 
 
 __all__ = [
@@ -61,3 +62,10 @@ def json_loads(obj, keys=None):
         except:
             pass
     return obj
+
+
+def try_loads(s):
+    try:
+        return json.loads(s) if s and isinstance(s, six.string_types) else s
+    except:
+        return s

--- a/st2common/tests/unit/test_jsonify.py
+++ b/st2common/tests/unit/test_jsonify.py
@@ -23,3 +23,14 @@ class JsonifyTests(unittest2.TestCase):
         obj = {'foo': '{"bar": "baz"}', 'yo': 'bibimbao'}
         transformed_obj = jsonify.json_loads(obj, ['yo'])
         self.assertTrue(transformed_obj['yo'] == 'bibimbao')
+
+    def test_try_loads(self):
+        # The function json.loads will fail and the function should return the original value.
+        values = ['abc', 123, True, object()]
+        for value in values:
+            self.assertEqual(jsonify.try_loads(value), value)
+
+        # The function json.loads succeed.
+        d = '{"a": 1, "b": true}'
+        expected = {'a': 1, 'b': True}
+        self.assertDictEqual(jsonify.try_loads(d), expected)

--- a/st2tests/integration/mistral/test_wiring.py
+++ b/st2tests/integration/mistral/test_wiring.py
@@ -81,6 +81,14 @@ class TestWorkflowExecution(unittest2.TestCase):
         self.assertIn('vm_id', execution.result)
         self.assertIn('vm_state', execution.result)
 
+    def test_complex_workbook_subflow_actions(self):
+        execution = self._execute_workflow(
+            'examples.mistral-workbook-subflows', {'subject': 'st2', 'adjective': 'cool'})
+        execution = self._wait_for_completion(execution)
+        self._assert_success(execution)
+        self.assertIn('tagline', execution.result)
+        self.assertEqual(execution.result['tagline'], 'st2 is cool!')
+
     def test_execution_failure(self):
         execution = self._execute_workflow('examples.mistral-basic', {'cmd': 'foo'})
         execution = self._wait_for_completion(execution)

--- a/st2tests/integration/mistral/test_wiring.py
+++ b/st2tests/integration/mistral/test_wiring.py
@@ -65,17 +65,21 @@ class TestWorkflowExecution(unittest2.TestCase):
         execution = self._execute_workflow('examples.mistral-basic', {'cmd': 'date'})
         execution = self._wait_for_completion(execution)
         self._assert_success(execution)
+        self.assertIn('stdout', execution.result)
 
     def test_basic_workbook(self):
         execution = self._execute_workflow('examples.mistral-workbook-basic', {'cmd': 'date'})
         execution = self._wait_for_completion(execution)
         self._assert_success(execution)
+        self.assertIn('stdout', execution.result)
 
     def test_complex_workbook(self):
         execution = self._execute_workflow(
             'examples.mistral-workbook-complex', {'vm_name': 'demo1'})
         execution = self._wait_for_completion(execution)
         self._assert_success(execution)
+        self.assertIn('vm_id', execution.result)
+        self.assertIn('vm_state', execution.result)
 
     def test_execution_failure(self):
         execution = self._execute_workflow('examples.mistral-basic', {'cmd': 'foo'})


### PR DESCRIPTION
Refactor mistral query module to get workflow output from mistral API and save to the execution result. Refactor Querier to invoke post run when async action is completed. In the case of mistral, the post run update the task state and output on workflow action completion. This allows stitching of multiple workflow actions.