### PR TITLE
Default Python binary used by Python runner actions to be the one used by action runner

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,10 @@ Docs: http://docks.stackstorm.com/latest
 * Default values of the parameter of an Action can be system values stored in kv-store. (new-feature)
 * Allow users to specify additional paths where StackStorm looks for integration packs using
   ``packs_base_paths`` setting. (new-feature)
+* Allow user to specify which Python binary to use for the Python runner actions using
+  ``actionrunner.python_binary`` setting (new-feature)
+* Default Python binary which is used by Python runner actions to be the Python binary which is
+  used by the action runner service. Previous, system's default Python binary was used.
 
 v0.7 - January 16, 2015
 -----------------------

--- a/contrib/packs/actions/pack_mgmt/setup_virtualenv.py
+++ b/contrib/packs/actions/pack_mgmt/setup_virtualenv.py
@@ -98,9 +98,15 @@ class SetupVirtualEnvironmentAction(Action):
                           (pack_name, virtualenv_path))
 
     def _create_virtualenv(self, virtualenv_path):
-        self.logger.debug('Creating virtualenv in "%s"' % (virtualenv_path))
+        python_binary = cfg.CONF.actionrunner.python_binary
 
-        cmd = ['virtualenv', '--system-site-packages', virtualenv_path]
+        if not os.path.isfile(python_binary):
+            raise Exception('Python binary "%s" doesn\'t exist' % (python_binary))
+
+        self.logger.debug('Creating virtualenv in "%s" using Python binary "%s"' %
+                          (virtualenv_path, python_binary))
+
+        cmd = ['virtualenv', '-p', python_binary, '--system-site-packages', virtualenv_path]
         exit_code, _, stderr = run_command(cmd=cmd)
 
         if exit_code != 0:

--- a/st2actions/st2actions/config.py
+++ b/st2actions/st2actions/config.py
@@ -17,6 +17,8 @@
 Configuration options registration and useful routines.
 """
 
+import sys
+
 from oslo.config import cfg
 
 import st2common.config as common_config
@@ -27,7 +29,9 @@ CONF = cfg.CONF
 
 logging_opts = [
     cfg.StrOpt('logging', default='conf/logging.conf',
-               help='location of the logging.conf file')
+               help='location of the logging.conf file'),
+    cfg.StrOpt('python_binary', default=sys.executable,
+               help='Python binary which will be used by Python actions.')
 ]
 CONF.register_opts(logging_opts, group='actionrunner')
 

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -53,8 +53,8 @@ def register_opts(ignore_errors=False):
     _do_register_opts(schema_opts, 'schema', ignore_errors)
 
     system_opts = [
-        cfg.StrOpt('base_path', default='/opt/stackstorm/',
-                   help='Base path to all st2 artifacts.'),
+        cfg.StrOpt('base_path', default='/opt/stackstorm',
+                   help='Base path to all st2 artifacts.')
     ]
     _do_register_opts(system_opts, 'system', ignore_errors)
 


### PR DESCRIPTION
This change makes Python binary which is used in virtual environments by Python runner actions configurable.

Previously we used system's default Python binary, but now we used the same binary which is used to run action runner (which is better anyway, good catch @phool).