### PR TITLE
Perform eventlet monkey patching in the sensor wrapper

### DIFF
--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -14,10 +14,12 @@
 # limitations under the License.
 
 import os
+import sys
 import json
 import atexit
 import argparse
 
+import eventlet
 from oslo.config import cfg
 from st2client.client import Client
 
@@ -37,6 +39,13 @@ from st2client.models.datastore import KeyValuePair
 __all__ = [
     'SensorWrapper'
 ]
+
+eventlet.monkey_patch(
+    os=True,
+    select=True,
+    socket=True,
+    thread=False if '--use-debugger' in sys.argv else True,
+    time=True)
 
 
 class SensorService(object):


### PR DESCRIPTION
Currently we explicitly perform it in the sensors, but with this change, we don't need to do this anymore.

Originally, the idea was not to perform it in the wrapper and the sensors who need it must explicitly opt-in (in general blocking is not an issue here since sensors run in a separate process).

And if this ever becomes a problem, we can also make it opt-in (or opt-out) via sensor metadata or via base-class.