### PR TITLE
Fix empty entry point python runner bug

### DIFF
--- a/st2actions/st2actions/runners/pythonrunner.py
+++ b/st2actions/st2actions/runners/pythonrunner.py
@@ -115,6 +115,9 @@ class PythonRunner(ActionRunner):
             msg = PACK_VIRTUALENV_DOESNT_EXIST % (pack, pack)
             raise Exception(msg)
 
+        if not self.entry_point:
+            raise Exception('Action "%s" is missing entry_point attribute' % (self.action.name))
+
         args = [
             python_path,
             WRAPPER_SCRIPT_PATH,

--- a/st2actions/tests/unit/test_pythonrunner.py
+++ b/st2actions/tests/unit/test_pythonrunner.py
@@ -63,11 +63,20 @@ class PythonRunnerTestCase(TestCase):
     def test_simple_action_no_file(self):
         runner = pythonrunner.get_runner()
         runner.action = self._get_mock_action_obj()
-        runner.entry_point = ''
+        runner.entry_point = 'foo.py'
         runner.container_service = service.RunnerContainerService()
         (status, result) = runner.run({})
         self.assertTrue(result is not None)
         self.assertEqual(status, ACTIONEXEC_STATUS_FAILED)
+
+    def test_simple_action_no_entry_point(self):
+        runner = pythonrunner.get_runner()
+        runner.action = self._get_mock_action_obj()
+        runner.entry_point = ''
+        runner.container_service = service.RunnerContainerService()
+
+        expected_msg = 'Action .*? is missing entry_point attribute'
+        self.assertRaisesRegexp(Exception, expected_msg, runner.run, {})
 
     def _get_mock_action_obj(self):
         """
@@ -77,4 +86,5 @@ class PythonRunnerTestCase(TestCase):
         """
         action = mock.Mock()
         action.pack = SYSTEM_PACK_NAME
+        action.entry_point = 'foo.py'
         return action


### PR DESCRIPTION
Previously a cryptic error was returned to the user.

Ideally, down the road, we would have a schema per runner type (local and remote actions without entry_point are fine, but python actions require entry_point).