### PR TITLE
[RFR/No merge]Include the raw result of stdout and stderr in stdout_raw and stderr_raw.

### DIFF
--- a/st2actions/st2actions/runners/localrunner.py
+++ b/st2actions/st2actions/runners/localrunner.py
@@ -153,7 +153,9 @@ class LocalShellRunner(ActionRunner, ShellRunnerMixin):
             'succeeded': succeeded,
             'return_code': exit_code,
             'stdout': stdout,
-            'stderr': stderr
+            'stdout_raw': stdout,
+            'stderr': stderr,
+            'stderr_raw': stderr
         }
 
         if error:

--- a/st2common/st2common/models/system/action.py
+++ b/st2common/st2common/models/system/action.py
@@ -342,7 +342,9 @@ class FabricRemoteAction(RemoteAction):
         else:
             result = {
                 'stdout': output.stdout,
+                'stdout_raw': output.stdout,
                 'stderr': output.stderr,
+                'stderr_raw': output.stderr,
                 'return_code': output.return_code,
                 'succeeded': output.succeeded,
                 'failed': output.failed
@@ -360,7 +362,9 @@ class FabricRemoteAction(RemoteAction):
         else:
             result = {
                 'stdout': output.stdout,
+                'stdout_raw': output.stdout,
                 'stderr': output.stderr,
+                'stderr_raw': output.stderr,
                 'return_code': output.return_code,
                 'succeeded': output.succeeded,
                 'failed': output.failed


### PR DESCRIPTION
* output of `core.local cmd="date"`
```
 st2 execution get 54c72f6b0640fd24cfc343f1 -d -j
{
    "action": "core.local",
    "callback": {},
    "context": {
        "user": "stanley"
    },
    "end_timestamp": "2015-01-27T06:25:47.670000Z",
    "id": "54c72f6b0640fd24cfc343f1",
    "parameters": {
        "cmd": "date"
    },
    "result": {
        "failed": false,
        "return_code": 0,
        "stderr": "",
        "stderr_raw": "",
        "stdout": "Tue Jan 27 06:25:47 UTC 2015\n",
        "stdout_raw": "Tue Jan 27 06:25:47 UTC 2015\n",
        "succeeded": true
    },
    "start_timestamp": "2015-01-27T06:25:47.619000Z",
    "status": "succeeded"
}
```

* output of `core.local cmd="echo 1"`
```
$ st2 execution get 54c7301d0640fd24cfc343f3 -dj
{
    "action": "core.local",
    "callback": {},
    "context": {
        "user": "stanley"
    },
    "end_timestamp": "2015-01-27T06:28:45.374000Z",
    "id": "54c7301d0640fd24cfc343f3",
    "parameters": {
        "cmd": "echo 1"
    },
    "result": {
        "failed": false,
        "return_code": 0,
        "stderr": "",
        "stderr_raw": "",
        "stdout": 1,
        "stdout_raw": "1\n",
        "succeeded": true
    },
    "start_timestamp": "2015-01-27T06:28:45.320000Z",
    "status": "succeeded"
}
```