### PR TITLE
Fix a bug / race condition occurring during concurrent pack installation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Docs: http://docks.stackstorm.com/latest
   ``actionrunner.python_binary`` setting (new-feature)
 * Default Python binary which is used by Python runner actions to be the Python binary which is
   used by the action runner service. Previous, system's default Python binary was used.
+* Fix a race-condition / bug which would occur when multiple packs are installed at the same time.
+  (bug-fix)
 
 v0.7 - January 16, 2015
 -----------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ six==1.9.0
 git+https://github.com/StackStorm/python-mistralclient.git@st2-0.5.1
 git+https://github.com/StackStorm/fabric.git@stanley-patched
 passlib>=1.6.2,<1.7
+lockfile>=0.10.2,<0.11


### PR DESCRIPTION
This should fix a bug / issue encountered by @jfryman.

> 1) During my first pass, I attempted to model in Puppet installation of individual packs one at a time (e.g.: for each pack, I executed a unique st2 action execute packs=XXX). This created a really interesting lock in the system... where all of the pack installs at the same time pounced all over each other and failed. I tried to debug this a bit, but couldn't find anything. I can pretty easily reproduce it though.