### PR TITLE
register_content to pass appropriate flags.

### DIFF
--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -304,7 +304,7 @@ deploy_deb() {
 
 register_content() {
   echo "########## Registering all content ##########"
-  $PYTHON ${PYTHONPACK}/st2common/bin/registercontent.py --config-file ${STANCONF}
+  $PYTHON ${PYTHONPACK}/st2common/bin/registercontent.py --register-sensors --register-actions--config-file ${STANCONF}
 }
 
 create_user

--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -304,7 +304,7 @@ deploy_deb() {
 
 register_content() {
   echo "########## Registering all content ##########"
-  $PYTHON ${PYTHONPACK}/st2common/bin/registercontent.py --register-sensors --register-actions--config-file ${STANCONF}
+  $PYTHON ${PYTHONPACK}/st2common/bin/registercontent.py --register-sensors --register-actions --config-file ${STANCONF}
 }
 
 create_user


### PR DESCRIPTION
A change was made in https://github.com/StackStorm/st2/commit/239d6f453f937f51328e7c9f35a8076f81910ea2 than needs to be moved to the st2_deploy.sh command. Repairs actions not properly registering on first-install, needing to run `st2ctl reload` to repair.

/cc @Kami @DoriftoShoes 