### PR TITLE
Try to json load mistral task result/input/output

### DIFF
--- a/st2actions/st2actions/query/mistral/v2.py
+++ b/st2actions/st2actions/query/mistral/v2.py
@@ -101,6 +101,11 @@ class MistralResultsQuerier(Querier):
         resp = requests.get(url)
         result = resp.json()
         tasks = result.get('tasks', [])
+
+        for task in tasks:
+            for attr in ['result', 'input', 'output']:
+                task[attr] = jsonify.try_loads(task.get(attr, None))
+
         return tasks
 
 


### PR DESCRIPTION
Mistral API stores task result, input, and output as text. Modify the
mistral query module for results tracker to try converting the text to
json.