### PR TITLE
Allow user to pass auth token via query string

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Docs: http://docks.stackstorm.com/latest
   used by the action runner service. Previous, system's default Python binary was used.
 * Fix a race-condition / bug which would occur when multiple packs are installed at the same time.
   (bug-fix)
+* Allow user to provide authentication token either inside headers (``X-Auth-Token``) or via
+  ``x-auth-token`` query string parameter. (new-feature)
 
 v0.7 - January 16, 2015
 -----------------------

--- a/docs/source/webhooks.rst
+++ b/docs/source/webhooks.rst
@@ -29,8 +29,11 @@ Authentication
 --------------
 
 All the requests to the /webhooks endpoints needs to be authenticated in the
-same way as other API requests. This means the requests need to contain
-``X-Auth-Token`` header with a valid authentication token.
+same way as other API requests. This means the request needs to contain a valid
+authentication token. This token can either be provided in ``X-Auth-Token``
+(usually used with your scripts where you can control request headers) or via
+``?x-auth-token`` query parameter (usually used with 3rd party services such as
+Github where you can only specify a URL).
 
 Using a generic st2 webhook
 ---------------------------

--- a/st2actions/st2actions/runners/httprunner.py
+++ b/st2actions/st2actions/runners/httprunner.py
@@ -15,10 +15,10 @@
 
 import copy
 import uuid
-import urlparse
 
 import requests
 from oslo.config import cfg
+from six.moves.urllib import parse as urlparse
 
 from st2actions.runners import ActionRunner
 from st2common import log as logging

--- a/st2api/st2api/controllers/v1/webhooks.py
+++ b/st2api/st2api/controllers/v1/webhooks.py
@@ -22,7 +22,8 @@ import six
 import pecan
 from pecan import abort
 from pecan.rest import RestController
-from urlparse import urljoin
+from six.moves.urllib import parse as urlparse
+urljoin = urlparse.urljoin
 
 from st2common import log as logging
 from st2common.constants.triggers import WEBHOOK_TRIGGER_TYPES

--- a/st2api/tests/unit/controllers/v1/test_auth.py
+++ b/st2api/tests/unit/controllers/v1/test_auth.py
@@ -39,9 +39,16 @@ class TestTokenValidation(AuthMiddlewareTest):
     @mock.patch.object(
         Token, 'get',
         mock.Mock(return_value=TokenDB(id=OBJ_ID, user=USER, token=TOKEN, expiry=FUTURE)))
-    def test_token_validation(self):
+    def test_token_validation_token_in_headers(self):
         response = self.app.get('/v1/actions', headers={'X-Auth-Token': TOKEN},
                                 expect_errors=False)
+        self.assertEqual(response.status_int, 200)
+
+    @mock.patch.object(
+        Token, 'get',
+        mock.Mock(return_value=TokenDB(id=OBJ_ID, user=USER, token=TOKEN, expiry=FUTURE)))
+    def test_token_validation_token_in_query_params(self):
+        response = self.app.get('/v1/actions?x-auth-token=%s' % (TOKEN), expect_errors=False)
         self.assertEqual(response.status_int, 200)
 
     @mock.patch.object(

--- a/st2common/st2common/hooks.py
+++ b/st2common/st2common/hooks.py
@@ -102,7 +102,7 @@ class AuthHook(PecanHook):
         query_string = request.query_string
         query_params = dict(urlparse.parse_qsl(query_string))
 
-        token_in_headers = headers.get('X_Auth_Token', None)
+        token_in_headers = headers.get('X-Auth-Token', None)
         token_in_query_params = query_params.get('x-auth-token', None)
         return validate_token(token_in_headers=token_in_headers,
                               token_in_query_params=token_in_query_params)

--- a/st2common/st2common/hooks.py
+++ b/st2common/st2common/hooks.py
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import urlparse
 
 import webob
 from oslo.config import cfg
 from pecan.hooks import PecanHook
+from six.moves.urllib import parse as urlparse
 
 from st2common import log as logging
 from st2common.exceptions import access as exceptions

--- a/st2common/st2common/middleware/auth.py
+++ b/st2common/st2common/middleware/auth.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import urlparse
+from six.moves.urllib import parse as urlparse
 
 from st2common.util import isotime
 from st2common.exceptions import access as exceptions

--- a/st2common/st2common/middleware/auth.py
+++ b/st2common/st2common/middleware/auth.py
@@ -73,6 +73,7 @@ class AuthMiddleware(object):
         query_string = env.get('QUERY_STRING', '')
         query_params = dict(urlparse.parse_qsl(query_string))
 
+        # Note: This is a WSGI environment variable name
         token_in_headers = env.get('HTTP_X_AUTH_TOKEN', None)
         token_in_query_params = query_params.get('x-auth-token', None)
 

--- a/st2common/st2common/util/auth.py
+++ b/st2common/st2common/util/auth.py
@@ -55,8 +55,8 @@ def validate_token(token_in_headers, token_in_query_params):
 
     if token.expiry <= isotime.add_utc_tz(datetime.datetime.utcnow()):
         # TODO: purge expired tokens
-        LOG.audit('Token "%s" has expired.' % (token_string))
+        LOG.audit('Token with id "%s" has expired.' % (token.id))
         raise exceptions.TokenExpiredError('Token has expired.')
 
-    LOG.audit('Token "%s" is validated.' % (token_string))
+    LOG.audit('Token with id "%s" is validated.' % (token.id))
     return token


### PR DESCRIPTION
This pull request allows user to also pass authentication token via `?x-auth-token` query parameter (in addition to passing the token via header).

This popped up while I worked on the webhooks documentation (#1022). Previously webhooks were unauthenticated, but now they require same authentication as other API methods. This means webhooks won't work with 3rd party services such as Github which only allow you to manipulate URL and query parameters, but not headers.

In the past @enykeev has also asked for this feature. IIRC, Server-Sent Events don't allow you to send custom headers which means we can't authenticate those requests.