### PR TITLE
Fix a bug with rule matching not working for any trigger with parameters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Docs: http://docks.stackstorm.com/latest
 * Allow user to provide authentication token either inside headers (``X-Auth-Token``) or via
   ``x-auth-token`` query string parameter. (new-feature)
 * Allow actions without parameters. (bug-fix)
+* Fix a bug with rule matching not working for any triggers with parameters. (bug-fix)
 
 v0.7 - January 16, 2015
 -----------------------

--- a/st2common/st2common/services/triggers.py
+++ b/st2common/st2common/services/triggers.py
@@ -36,8 +36,7 @@ LOG = logging.getLogger(__name__)
 
 def get_trigger_db_given_type_and_params(type=None, parameters=None):
     try:
-        if not parameters:
-            parameters = {}
+        parameters = parameters or {}
         return Trigger.query(type=type,
                              parameters=parameters).first()
     except ValueError as e:

--- a/st2reactor/st2reactor/container/utils.py
+++ b/st2reactor/st2reactor/container/utils.py
@@ -44,7 +44,10 @@ def create_trigger_instance(trigger, payload, occurrence_time):
     if isinstance(trigger, six.string_types):
         trigger_db = TriggerService.get_trigger_db_by_ref(trigger)
     else:
-        trigger_db = TriggerService.get_trigger_db_given_type_and_params(trigger)
+        type = trigger.get('type', None)
+        parameters = trigger.get('parameters', {})
+        trigger_db = TriggerService.get_trigger_db_given_type_and_params(type=type,
+                                                                         parameters=parameters)
 
     if trigger_db is None:
         LOG.info('No trigger in db for %s', trigger)

--- a/st2reactor/tests/unit/test_rule_engine.py
+++ b/st2reactor/tests/unit/test_rule_engine.py
@@ -58,6 +58,17 @@ class RuleEngineTest(DbTestCase):
         for instance in instances:
             rules_engine.handle_trigger_instance(instance)
 
+    def test_create_trigger_instance_for_trigger_with_params(self):
+        trigger = {'type': 'dummy_pack_1.st2.test.trigger4', 'parameters': {'url': 'sample'}}
+        payload = {'k1': 't1_p_v', 'k2': 'v2', 'k3': 'v3'}
+        occurrence_time = datetime.datetime.now()
+        trigger_instance = container_utils.create_trigger_instance(trigger=trigger,
+                                                                   payload=payload,
+                                                                   occurrence_time=occurrence_time)
+        self.assertTrue(trigger_instance)
+        self.assertEqual(trigger_instance.trigger, trigger['type'])
+        self.assertEqual(trigger_instance.payload, payload)
+
     def test_get_matching_rules_filters_disabled_rules(self):
         trigger_instance = container_utils.create_trigger_instance(
             'dummy_pack_1.st2.test.trigger1',
@@ -85,7 +96,7 @@ class RuleEngineTest(DbTestCase):
 
     @classmethod
     def _setup_sample_triggers(self, names=['st2.test.trigger1', 'st2.test.trigger2',
-                                            'st2.test.trigger3']):
+                                            'st2.test.trigger3', 'st2.test.trigger4']):
         trigger_dbs = []
         for name in names:
             trigtype = None
@@ -108,7 +119,12 @@ class RuleEngineTest(DbTestCase):
             created.pack = 'dummy_pack_1'
             created.description = ''
             created.type = trigtype.get_reference().ref
-            created.parameters = {}
+
+            if name in ['st2.test.trigger4']:
+                created.parameters = {'url': 'sample'}
+            else:
+                created.parameters = {}
+
             created = Trigger.add_or_update(created)
             trigger_dbs.append(created)
 


### PR DESCRIPTION
This was a regression introduced in v0.7.

Also, for the love of a flying spaghetti monster, in the future, please use keyword args everywhere. It's easy and cheap and it makes issues like this a lot easier to spot during code reviews.

Spotted by cleavoy on IRC.