### PR TITLE
Allow user to provide environment variables by passing "env" parameter to the runners

### DIFF
--- a/docs/source/actions.rst
+++ b/docs/source/actions.rst
@@ -128,10 +128,13 @@ When configuring the metadata, there exists several built-in parameters that
 can be used and overwritten to change the default functionality of the
 various runners.
 
-* ``args`` - (``run-local``/``run-remote``) By default, |st2| will assemble arguments based on whether a user defines named or positional arguments. Adjusts the format of arguments passed to ``cmd``
-* ``cmd``  - (``run-local``/``run-remote``) Configure the command to be run on the target system
-* ``cwd``  - (``run-local``/``run-remote``) Configure the directory where remote commands will be executed from.
-* ``dir``  - (``run-local``/``run-remote``) Configure the directory where scripts are copied from a pack to the target machine prior to execution
+* ``args`` - (``run-local``, ``run-remote``) By default, |st2| will assemble arguments based on whether a user defines named or positional arguments. Adjusts the format of arguments passed to ``cmd``
+* ``cmd``  - (``run-local``, ``run-remote``) Configure the command to be run on the target system
+* ``cwd``  - (``run-local``, ``run-remote``) Configure the directory where remote commands will be executed from.
+* ``env``  - (``run-local``, ``run-local-script``, ``run-remote``,
+  ``run-remote-script``, ``run-python``) Environment variables which will be
+  available to the executed command / script.
+* ``dir``  - (``run-local``, ``run-remote``) Configure the directory where scripts are copied from a pack to the target machine prior to execution
 
 Converting existing scripts into actions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/actions.rst
+++ b/docs/source/actions.rst
@@ -128,13 +128,19 @@ When configuring the metadata, there exists several built-in parameters that
 can be used and overwritten to change the default functionality of the
 various runners.
 
-* ``args`` - (``run-local``, ``run-remote``) By default, |st2| will assemble arguments based on whether a user defines named or positional arguments. Adjusts the format of arguments passed to ``cmd``
-* ``cmd``  - (``run-local``, ``run-remote``) Configure the command to be run on the target system
-* ``cwd``  - (``run-local``, ``run-remote``) Configure the directory where remote commands will be executed from.
+* ``args`` - (``run-local``, ``run-remote``) By default, |st2| will assemble
+  arguments based on whether a user defines named or positional arguments.
+  Adjusts the format of arguments passed to ``cmd``.
+* ``cmd``  - (``run-local``, ``run-remote``) Configure the command to be run
+  on the target system.
+* ``cwd``  - (``run-local``, ``run-remote``) Configure the directory where
+  remote commands will be executed from.
 * ``env``  - (``run-local``, ``run-local-script``, ``run-remote``,
   ``run-remote-script``, ``run-python``) Environment variables which will be
   available to the executed command / script.
-* ``dir``  - (``run-local``, ``run-remote``) Configure the directory where scripts are copied from a pack to the target machine prior to execution
+* ``dir``  - (``run-local``, ``run-remote``) Configure the directory where
+  scripts are copied from a pack to the target machine prior to execution.
+  Defaults to ``/tmp``.
 
 Converting existing scripts into actions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/st2actions/st2actions/bootstrap/runnersregistrar.py
+++ b/st2actions/st2actions/bootstrap/runnersregistrar.py
@@ -120,6 +120,11 @@ def register_runner_types():
                     'description': 'Working directory where the script will be executed in',
                     'type': 'string'
                 },
+                'env': {
+                    'description': ('Environment variables which will be available to the command'
+                                    '(e.g. key1=val1,key2=val2)'),
+                    'type': 'object'
+                },
                 'parallel': {
                     'description': 'Default to parallel execution.',
                     'type': 'boolean',
@@ -174,6 +179,11 @@ def register_runner_types():
                     'description': 'Working directory where the script will be executed in.',
                     'type': 'string',
                     'default': default_remote_dir
+                },
+                'env': {
+                    'description': ('Environment variables which will be available to the script'
+                                    '(e.g. key1=val1,key2=val2)'),
+                    'type': 'object'
                 },
                 'sudo': {
                     'description': 'The remote command will be executed with sudo.',

--- a/st2actions/st2actions/bootstrap/runnersregistrar.py
+++ b/st2actions/st2actions/bootstrap/runnersregistrar.py
@@ -306,6 +306,11 @@ def register_runner_types():
             'description': 'A runner for launching python actions.',
             'enabled': True,
             'runner_parameters': {
+                'env': {
+                    'description': ('Environment variables which will be available to the script'
+                                    '(e.g. key1=val1,key2=val2)'),
+                    'type': 'object'
+                },
                 'timeout': {
                     'description': ('Action timeout in seconds. Action will get killed if it '
                                     'doesn\'t finish in timeout seconds.'),

--- a/st2actions/st2actions/bootstrap/runnersregistrar.py
+++ b/st2actions/st2actions/bootstrap/runnersregistrar.py
@@ -52,6 +52,11 @@ def register_runner_types():
                     'description': 'Working directory where the command will be executed in',
                     'type': 'string'
                 },
+                'env': {
+                    'description': ('Environment variables which will be available to the command'
+                                    '(e.g. key1=val1,key2=val2)'),
+                    'type': 'object'
+                },
                 'sudo': {
                     'description': 'The command will be executed with sudo.',
                     'type': 'boolean',
@@ -79,6 +84,11 @@ def register_runner_types():
                 'cwd': {
                     'description': 'Working directory where the script will be executed in',
                     'type': 'string'
+                },
+                'env': {
+                    'description': ('Environment variables which will be available to the script'
+                                    '(e.g. key1=val1,key2=val2)'),
+                    'type': 'object'
                 },
                 'sudo': {
                     'description': 'The command will be executed with sudo.',

--- a/st2actions/st2actions/runners/fabricrunner.py
+++ b/st2actions/st2actions/runners/fabricrunner.py
@@ -60,6 +60,7 @@ RUNNER_ON_BEHALF_USER = 'user'
 RUNNER_REMOTE_DIR = 'dir'
 RUNNER_COMMAND = 'cmd'
 RUNNER_CWD = 'cwd'
+RUNNER_ENV = 'env'
 RUNNER_KWARG_OP = 'kwarg_op'
 RUNNER_TIMEOUT = 'timeout'
 
@@ -93,6 +94,7 @@ class FabricRunner(ActionRunner, ShellRunnerMixin):
         self._on_behalf_user = self.context.get(RUNNER_ON_BEHALF_USER, env.user)
         self._user = cfg.CONF.system_user.user
         self._cwd = self.runner_parameters.get(RUNNER_CWD, None)
+        self._env = self.runner_parameters.get(RUNNER_ENV, {})
         self._kwarg_op = self.runner_parameters.get(RUNNER_KWARG_OP, '--')
         self._timeout = self.runner_parameters.get(RUNNER_TIMEOUT, DEFAULT_ACTION_TIMEOUT)
 
@@ -164,7 +166,18 @@ class FabricRunner(ActionRunner, ShellRunnerMixin):
                                         cwd=self._cwd)
 
     def _get_env_vars(self):
-        return {'st2_auth_token': self.auth_token.token} if self.auth_token else {}
+        """
+        :rtype: ``dict``
+        """
+        env_vars = {}
+
+        if self.auth_token:
+            env_vars['st2_auth_token'] = self.auth_token.token
+
+        if self._env:
+            env_vars.update(self._env)
+
+        return env_vars
 
     @staticmethod
     def _get_result_status(result, allow_partial_failure):

--- a/st2actions/st2actions/runners/localrunner.py
+++ b/st2actions/st2actions/runners/localrunner.py
@@ -46,6 +46,7 @@ RUNNER_SUDO = 'sudo'
 RUNNER_ON_BEHALF_USER = 'user'
 RUNNER_COMMAND = 'cmd'
 RUNNER_CWD = 'cwd'
+RUNNER_ENV = 'env'
 RUNNER_KWARG_OP = 'kwarg_op'
 RUNNER_TIMEOUT = 'timeout'
 
@@ -72,11 +73,14 @@ class LocalShellRunner(ActionRunner, ShellRunnerMixin):
         self._on_behalf_user = self.context.get(RUNNER_ON_BEHALF_USER, LOGGED_USER_USERNAME)
         self._user = cfg.CONF.system_user.user
         self._cwd = self.runner_parameters.get(RUNNER_CWD, None)
+        self._env = self.runner_parameters.get(RUNNER_ENV, {})
         self._kwarg_op = self.runner_parameters.get(RUNNER_KWARG_OP, DEFAULT_KWARG_OP)
         self._timeout = self.runner_parameters.get(RUNNER_TIMEOUT, DEFAULT_ACTION_TIMEOUT)
 
     def run(self, action_parameters):
         LOG.debug('    action_parameters = %s', action_parameters)
+
+        env_vars = self._env
 
         if not self.entry_point:
             script_action = False
@@ -85,7 +89,7 @@ class LocalShellRunner(ActionRunner, ShellRunnerMixin):
                                         action_exec_id=str(self.action_execution_id),
                                         command=command,
                                         user=self._user,
-                                        env_vars={},
+                                        env_vars=env_vars,
                                         sudo=self._sudo,
                                         timeout=self._timeout)
         else:
@@ -100,7 +104,7 @@ class LocalShellRunner(ActionRunner, ShellRunnerMixin):
                                        named_args=named_args,
                                        positional_args=positional_args,
                                        user=self._user,
-                                       env_vars={},
+                                       env_vars=env_vars,
                                        sudo=self._sudo,
                                        timeout=self._timeout,
                                        cwd=self._cwd)
@@ -112,6 +116,10 @@ class LocalShellRunner(ActionRunner, ShellRunnerMixin):
             args = 'chmod +x %s ; %s' % (script_local_path_abs, args)
 
         env = os.environ.copy()
+
+        # Include user provided env vars (if any)
+        env.update(env_vars)
+
         # Make sure os.setsid is called on each spawned process so that all processes
         # are in the same group.
         process = subprocess.Popen(args=args, stdin=None, stdout=subprocess.PIPE,

--- a/st2actions/st2actions/runners/pythonrunner.py
+++ b/st2actions/st2actions/runners/pythonrunner.py
@@ -39,6 +39,7 @@ LOG = logging.getLogger(__name__)
 DEFAULT_ACTION_TIMEOUT = 10 * 60
 
 # constants to lookup in runner_parameters.
+RUNNER_ENV = 'env'
 RUNNER_TIMEOUT = 'timeout'
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -103,6 +104,7 @@ class PythonRunner(ActionRunner):
         # TODO :This is awful, but the way "runner_parameters" and other variables get
         # assigned on the runner instance is even worse. Those arguments should
         # be passed to the constructor.
+        self._env = self.runner_parameters.get(RUNNER_ENV, {})
         self._timeout = self.runner_parameters.get(RUNNER_TIMEOUT, self._timeout)
 
     def run(self, action_parameters):
@@ -131,6 +133,10 @@ class PythonRunner(ActionRunner):
         env = os.environ.copy()
         env['PYTHONPATH'] = get_sandbox_python_path(inherit_from_parent=True,
                                                     inherit_parent_virtualenv=True)
+
+        # Include user provided environment variables (if any)
+        user_env_vars = self._get_env_vars()
+        env.update(user_env_vars)
 
         # Note: We are using eventlet friendly implementation of subprocess
         # which uses GreenPipe so it doesn't block
@@ -177,3 +183,28 @@ class PythonRunner(ActionRunner):
         status = ACTIONEXEC_STATUS_SUCCEEDED if exit_code == 0 else ACTIONEXEC_STATUS_FAILED
         LOG.debug('Action output : %s. exit_code : %s. status : %s', str(output), exit_code, status)
         return (status, output)
+
+    def _get_env_vars(self):
+        """
+        Return sanitized environment variables which will be used when launching
+        a subprocess.
+
+        :rtype: ``dict``
+        """
+        # Don't allow user to override PYTHONPATH since this would break things
+        blacklisted_vars = ['pythonpath']
+        env_vars = {}
+
+        if self._env:
+            env_vars.update(self._env)
+
+        # Remove "blacklisted" environment variables
+        to_delete = []
+        for key, value in env_vars.items():
+            if key.lower() in blacklisted_vars:
+                to_delete.append(key)
+
+        for key in to_delete:
+            del env_vars[key]
+
+        return env_vars

--- a/st2actions/tests/unit/test_fabricrunner.py
+++ b/st2actions/tests/unit/test_fabricrunner.py
@@ -19,9 +19,25 @@ tests_config.parse_args()
 
 from unittest2 import TestCase
 
+from st2actions.runners.fabricrunner import get_runner
 from st2actions.runners.fabricrunner import FabricRunner
 from st2common.constants.action import ACTIONEXEC_STATUS_SUCCEEDED, ACTIONEXEC_STATUS_FAILED
 from st2common.models.system.action import RemoteScriptAction
+
+
+class FabricRunnerTestCase(TestCase):
+    def test_get_env_vars(self):
+        env_vars = {'key1': 'val1', 'key2': 'val2'}
+
+        runner = get_runner()
+        runner.runner_parameters = {'hosts': 'localhost', 'env': env_vars}
+        # This is awful, context is just set at some point, no idea when and
+        # where MOVE IT TO CONSTRUCTOR!11
+        runner.context = {}
+        runner.pre_run()
+
+        actual_env_vars = runner._get_env_vars()
+        self.assertEqual(actual_env_vars, env_vars)
 
 
 class TestFabricRunnerResultStatus(TestCase):

--- a/st2actions/tests/unit/test_pythonrunner.py
+++ b/st2actions/tests/unit/test_pythonrunner.py
@@ -19,7 +19,6 @@ from unittest2 import TestCase
 import mock
 
 from st2actions.runners import pythonrunner
-from st2actions.runners.pythonrunner import subprocess
 from st2actions.container import service
 from st2common.constants.action import ACTIONEXEC_STATUS_SUCCEEDED, ACTIONEXEC_STATUS_FAILED
 from st2common.constants.pack import SYSTEM_PACK_NAME

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -137,12 +137,31 @@ class ActionRunCommand(resource.ResourceCommand):
 
             return content
 
+        def transform_object(value):
+            # Also support simple key1=val1,key2=val2 syntax
+            if value.startswith('{'):
+                # Assume it's JSON
+                result = value = json.loads(value)
+            else:
+                pairs = value.split(',')
+
+                result = {}
+                for pair in pairs:
+                    split = pair.split('=', 1)
+
+                    if len(split) != 2:
+                        continue
+
+                    key, value = split
+                    result[key] = value
+            return result
+
         transformer = {
             'array': (lambda cs_x: [v.strip() for v in cs_x.split(',')]),
             'boolean': (lambda x: ast.literal_eval(x.capitalize())),
             'integer': int,
             'number': float,
-            'object': json.loads,
+            'object': transform_object,
             'string': str
         }
 

--- a/st2common/st2common/models/system/action.py
+++ b/st2common/st2common/models/system/action.py
@@ -57,15 +57,17 @@ class ShellCommandAction(object):
         self.cwd = cwd
 
     def get_full_command_string(self):
+        # Note: We pass -E to sudo because we want to preserve user provided
+        # environment variables
         if self.sudo:
             command = pipes.quote(self.command)
-            command = 'sudo -- bash -c %s' % (command)
+            command = 'sudo -E -- bash -c %s' % (command)
         else:
             if self.user and self.user != LOGGED_USER_USERNAME:
                 # Need to use sudo to run as a different user
                 user = pipes.quote(self.user)
                 command = pipes.quote(self.command)
-                command = 'sudo -u %s -- bash -c %s' % (user, command)
+                command = 'sudo -E -u %s -- bash -c %s' % (user, command)
             else:
                 command = self.command
 
@@ -125,7 +127,7 @@ class ShellScriptAction(ShellCommandAction):
             else:
                 command = pipes.quote(self.script_local_path_abs)
 
-            command = 'sudo -- bash -c %s' % (command)
+            command = 'sudo -E -- bash -c %s' % (command)
         else:
             if self.user and self.user != LOGGED_USER_USERNAME:
                 # Need to use sudo to run as a different user
@@ -136,7 +138,7 @@ class ShellScriptAction(ShellCommandAction):
                 else:
                     command = pipes.quote(self.script_local_path_abs)
 
-                command = 'sudo -u %s -- bash -c %s' % (user, command)
+                command = 'sudo -E -u %s -- bash -c %s' % (user, command)
             else:
                 script_path = pipes.quote(self.script_local_path_abs)
 

--- a/st2common/tests/fixtures/localrunner/escaping_test_command_2.txt
+++ b/st2common/tests/fixtures/localrunner/escaping_test_command_2.txt
@@ -1,1 +1,1 @@
-sudo -- bash -c '/tmp/foo.sh key3='"'"'date ; whoami'"'"' key2='"'"'value "bar" foo'"'"' key1='"'"'value foo bar'"'"' key4='"'"'"date ; whoami"'"'"''
+sudo -E -- bash -c '/tmp/foo.sh key3='"'"'date ; whoami'"'"' key2='"'"'value "bar" foo'"'"' key1='"'"'value foo bar'"'"' key4='"'"'"date ; whoami"'"'"''

--- a/st2common/tests/unit/test_shell_action_system_model.py
+++ b/st2common/tests/unit/test_shell_action_system_model.py
@@ -52,7 +52,7 @@ class ShellCommandActionTestCase(unittest2.TestCase):
         kwargs['user'] = 'mauser'
         action = ShellCommandAction(**kwargs)
         command = action.get_full_command_string()
-        self.assertEqual(command, 'sudo -u mauser -- bash -c \'ls -la\'')
+        self.assertEqual(command, 'sudo -E -u mauser -- bash -c \'ls -la\'')
 
         # sudo is used, it doesn't matter what user is specified since the
         # command should run as root
@@ -61,7 +61,7 @@ class ShellCommandActionTestCase(unittest2.TestCase):
         kwargs['user'] = 'mauser'
         action = ShellCommandAction(**kwargs)
         command = action.get_full_command_string()
-        self.assertEqual(command, 'sudo -- bash -c \'ls -la\'')
+        self.assertEqual(command, 'sudo -E -- bash -c \'ls -la\'')
 
 
 class ShellScriptActionTestCase(unittest2.TestCase):
@@ -99,7 +99,7 @@ class ShellScriptActionTestCase(unittest2.TestCase):
         kwargs['user'] = 'mauser'
         action = ShellScriptAction(**kwargs)
         command = action.get_full_command_string()
-        self.assertEqual(command, 'sudo -u mauser -- bash -c /tmp/foo.sh')
+        self.assertEqual(command, 'sudo -E -u mauser -- bash -c /tmp/foo.sh')
 
         # sudo is used, it doesn't matter what user is specified since the
         # command should run as root
@@ -108,7 +108,7 @@ class ShellScriptActionTestCase(unittest2.TestCase):
         kwargs['user'] = 'mauser'
         action = ShellScriptAction(**kwargs)
         command = action.get_full_command_string()
-        self.assertEqual(command, 'sudo -- bash -c /tmp/foo.sh')
+        self.assertEqual(command, 'sudo -E -- bash -c /tmp/foo.sh')
 
     def test_command_construction_with_parameters(self):
         # same user, named args, no positional args
@@ -129,7 +129,7 @@ class ShellScriptActionTestCase(unittest2.TestCase):
         kwargs['positional_args'] = ''
         action = ShellScriptAction(**kwargs)
         command = action.get_full_command_string()
-        expected = 'sudo -u mauser -- bash -c \'/tmp/foo.sh key2=value2 key1=value1\''
+        expected = 'sudo -E -u mauser -- bash -c \'/tmp/foo.sh key2=value2 key1=value1\''
         self.assertEqual(command, expected)
 
         # same user, positional args, no named args
@@ -150,7 +150,7 @@ class ShellScriptActionTestCase(unittest2.TestCase):
         kwargs['positional_args'] = 'ein zwei drei'
         action = ShellScriptAction(**kwargs)
         command = action.get_full_command_string()
-        expected = 'sudo -u mauser -- bash -c \'/tmp/foo.sh ein zwei drei\''
+        expected = 'sudo -E -u mauser -- bash -c \'/tmp/foo.sh ein zwei drei\''
         self.assertEqual(command, expected)
 
         # same user, positional and named args
@@ -171,7 +171,7 @@ class ShellScriptActionTestCase(unittest2.TestCase):
         kwargs['positional_args'] = 'ein zwei drei'
         action = ShellScriptAction(**kwargs)
         command = action.get_full_command_string()
-        expected = ('sudo -u mauser -- bash -c \'/tmp/foo.sh key2=value2 '
+        expected = ('sudo -E -u mauser -- bash -c \'/tmp/foo.sh key2=value2 '
                     'key1=value1 ein zwei drei\'')
         self.assertEqual(command, expected)
 


### PR DESCRIPTION
This change allows user to specify environment variables which are accessible to the command / scripts executed by the following runners: `run-local`, `run-local-script`, `run-remote`, `run-remote-script`, `run-python`.

In addition to that, I've added a change which makes specifying simple objects via CLI easier:

Existing approach (using JSON):

```bash
st2 run core.remote hosts=localhost env='{"key1": "val1", "key2": "val2"}' cmd='echo "ponies ${key1} ${key2}"'
```

New approach (using comma delimited string of `key=value` pairs):

```bash
st1 run core.local env="key1=foo1333,key2=foo244" cmd='echo "ponies ${key1} ${key2}"'
```

Existing approach is still supported for more complicated objects where key=value pair syntax is not sufficient.