### PR TITLE
Allow user to override authentication information for remote runner actions on per action basis

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,8 @@ Docs: http://docks.stackstorm.com/latest
   ``x-auth-token`` query string parameter. (new-feature)
 * Allow actions without parameters. (bug-fix)
 * Fix a bug with rule matching not working for any triggers with parameters. (bug-fix)
+* Require ``cmd`` parameter for the following actions: ``core.remote``, ``core.remote_sudo``,
+  ``core.local``, ``core.local_sudo`` (bug-fix)
 
 v0.7 - January 16, 2015
 -----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,8 @@ Docs: http://docks.stackstorm.com/latest
 * Fix a bug with rule matching not working for any triggers with parameters. (bug-fix)
 * Require ``cmd`` parameter for the following actions: ``core.remote``, ``core.remote_sudo``,
   ``core.local``, ``core.local_sudo`` (bug-fix)
+* Allow user to override authentication information (username, password, private key) on per
+  action basis for all the remote runner actions. (new-feature)
 
 v0.7 - January 16, 2015
 -----------------------

--- a/contrib/core/actions/local.json
+++ b/contrib/core/actions/local.json
@@ -7,6 +7,11 @@
     "parameters": {
         "sudo": {
             "immutable": true
+        },
+        "cmd": {
+            "description": "Arbitrary Linux command to be executed on the remote host(s).",
+            "type": "string",
+            "required": true
         }
     }
 }

--- a/contrib/core/actions/local_sudo.json
+++ b/contrib/core/actions/local_sudo.json
@@ -8,6 +8,11 @@
         "sudo": {
             "immutable": true,
             "default": true
+        },
+        "cmd": {
+            "description": "Arbitrary Linux command to be executed on the remote host(s).",
+            "type": "string",
+            "required": true
         }
     }
 }

--- a/contrib/core/actions/remote.json
+++ b/contrib/core/actions/remote.json
@@ -7,6 +7,11 @@
     "parameters": {
         "sudo": {
             "immutable": true
+        },
+        "cmd": {
+            "description": "Arbitrary Linux command to be executed on the remote host(s).",
+            "type": "string",
+            "required": true
         }
     }
 }

--- a/contrib/core/actions/remote_sudo.json
+++ b/contrib/core/actions/remote_sudo.json
@@ -8,6 +8,11 @@
         "sudo": {
             "immutable": true,
             "default": true
+        },
+        "cmd": {
+            "description": "Arbitrary Linux command to be executed on the remote host(s).",
+            "type": "string",
+            "required": true
         }
     }
 }

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -1,0 +1,133 @@
+StackStorm CLI 101
+==================
+
+StackStorm command line client (CLI) allows you talk to and operate StackStorm
+deployment using the command line interface. It talks to the StackStorm
+installation using the public API.
+
+Installation
+------------
+
+If you installed StackStorm using packages or a deployment script, the CLI
+should already be available. On the other hand, if you used the run from
+sources method, see :ref:`setup-st2-cli` section for information how to
+install and set up the client.
+
+Using debug mode
+----------------
+
+The command line tools accepts ``--debug`` flag. When this flag is provided,
+debug mode will be enabled. Debug mode consists of the following:
+
+* On error / exception, full stack trace and client settings (api url, auth
+  url, proxy information, etc.) are printed to the console.
+* Curl command for each request is printed to the console. This makes it easy
+  to reproduce actions performed by the CLI using curl.
+* Raw API responses are printed to the console.
+
+For example:
+
+.. sourcecode:: bash
+
+    st2 --debug action list --pack=core
+
+Example output (no error):
+
+.. sourcecode:: bash
+
+    st2 --debug action list --pack=core
+    # -------- begin 140702450464272 request ----------
+    curl -X GET -H  'Connection: keep-alive' -H  'Accept-Encoding: gzip, deflate' -H  'Accept: */*' -H  'User-Agent: python-requests/2.5.1 CPython/2.7.6 Linux/3.13.0-36-generic' 'http://localhost:9101/v1/actions?pack=core'
+    # -------- begin 140702450464272 response ----------
+    [
+        {
+            "runner_type": "http-runner",
+            "name": "http",
+            "parameters": {
+            ...
+
+Example output (error):
+
+.. sourcecode:: bash
+
+    st2 --debug action list --pack=core
+    ERROR: ('Connection aborted.', error(111, 'Connection refused'))
+
+    Client settings:
+    ----------------
+    ST2_BASE_URL: http://localhost
+    ST2_AUTH_URL: https://localhost:9100
+    ST2_API_URL: http://localhost:9101/v1
+
+    Proxy settings:
+    ---------------
+    HTTP_PROXY:
+    HTTPS_PROXY:
+
+    Traceback (most recent call last):
+      File "./st2client/st2client/shell.py", line 175, in run
+        args.func(args)
+      File "/data/stanley/st2client/st2client/commands/resource.py", line 218, in run_and_print
+        instances = self.run(args, **kwargs)
+      File "/data/stanley/st2client/st2client/commands/resource.py", line 37, in decorate
+        return func(*args, **kwargs)
+        ...
+
+Escaping shell variables when using core.local and core.remote actions
+----------------------------------------------------------------------
+
+When you use local and remote actions (e.g. ``core.local``, ``core.remote``,
+etc.), you need to wrap ``cmd`` parameter value in a single quote or escape the
+variables, otherwise the shell variables will be expanded locally which is
+something you usually don't want.
+
+Example (using single quotes):
+
+.. sourcecode:: bash
+
+    st2 run core.local env='{"key1": "val1", "key2": "val2"}' cmd='echo "ponies ${key1} ${key2}"'
+
+Example (escaping the variables):
+
+.. sourcecode:: bash
+
+    st2 run core.remote hosts=localhost env='{"key1": "val1", "key2": "val2"}' cmd="echo ponies \${key1} \${key2}
+
+Specifying parameters which type is "object"
+--------------------------------------------
+
+When running an action using ``st2 run`` command, you can specify value of
+parameters which type is ``object`` using two different approaches:
+
+1. Using JSON
+
+For complex objects, you should use JSON notation. For example:
+
+.. sourcecode:: bash
+
+    st2 run core.remote hosts=localhost env='{"key1": "val1", "key2": "val2"}' cmd="echo ponies \${key1} \${key2}
+
+2. Using a string of comma-delimited ``key=value`` pairs
+
+For simple objects (such as specifying a dictionary where both keys and values
+are simple strings), you should use this notation.
+
+.. sourcecode:: bash
+
+    st2 run core.remote hosts=localhost env="key1=val1,key2=val2" cmd="echo ponies \${key1} \${key2}
+
+Reading parameter value from a file
+-----------------------------------
+
+CLI also supports special ``@parameter`` notation which makes it read parameter
+value from a file.
+
+An example of when this might be useful is when you are using a http runner
+actions or when you want to read information such a private SSH key content
+from a file.
+
+Example:
+
+.. sourcecode:: bash
+
+    st2 run core.remote hosts=<host> username=<username> @private_key=/home/myuser/.ssh/id_rsa cmd=<cmd>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,6 +18,7 @@ Contents:
     datastore
     workflows
     history
+    cli
     resources/index
     reference/index
     changelog

--- a/docs/source/install/sources.rst
+++ b/docs/source/install/sources.rst
@@ -114,6 +114,8 @@ output.
 |st2| can now be operated using the REST API, |st2| CLI, and the
 st2client python client library.
 
+.. _setup-st2-cli:
+
 Setup |st2| CLI
 ~~~~~~~~~~~~~~~
 

--- a/st2actions/st2actions/bootstrap/actionsregistrar.py
+++ b/st2actions/st2actions/bootstrap/actionsregistrar.py
@@ -58,6 +58,7 @@ class ActionsRegistrar(ResourceRegistrar):
         """
         Register all the actions from the provided pack.
         """
+        pack_dir = pack_dir[:-1] if pack_dir.endswith('/') else pack_dir
         _, pack = os.path.split(pack_dir)
         actions_dir = self._pack_loader.get_content_from_pack(pack_dir=pack_dir,
                                                               content_type='actions')

--- a/st2actions/st2actions/bootstrap/runnersregistrar.py
+++ b/st2actions/st2actions/bootstrap/runnersregistrar.py
@@ -121,6 +121,24 @@ def register_runner_types():
                     'type': 'string',
                     'required': True
                 },
+                'username': {
+                    'description': 'Username used to log-in. If not provided, '
+                                   'default username from config is used.',
+                    'type': 'string',
+                    'required': False
+                },
+                'password': {
+                    'description': 'Password used to log in. If not provided, ',
+                                   'private key from the config file is used.'
+                    'type': 'string',
+                    'required': False
+                },
+                'private_key': {
+                    'description': 'Private key used to log in. If not provided, ',
+                                   'private key from the config file is used.'
+                    'type': 'string',
+                    'required': False
+                },
                 'cmd': {
                     'description': 'Arbitrary Linux command to be executed on the '
                                    'remote host(s).',
@@ -178,6 +196,24 @@ def register_runner_types():
                                    'where the remote command will be executed.',
                     'type': 'string',
                     'required': True
+                },
+                'username': {
+                    'description': 'Username used to log-in. If not provided, '
+                                   'default username from config is used.',
+                    'type': 'string',
+                    'required': False
+                },
+                'password': {
+                    'description': 'Password used to log in. If not provided, ',
+                                   'private key from the config file is used.'
+                    'type': 'string',
+                    'required': False
+                },
+                'private_key': {
+                    'description': 'Private key used to log in. If not provided, ',
+                                   'private key from the config file is used.'
+                    'type': 'string',
+                    'required': False
                 },
                 'parallel': {
                     'description': 'Default to parallel execution.',

--- a/st2actions/st2actions/bootstrap/runnersregistrar.py
+++ b/st2actions/st2actions/bootstrap/runnersregistrar.py
@@ -122,20 +122,20 @@ def register_runner_types():
                     'required': True
                 },
                 'username': {
-                    'description': 'Username used to log-in. If not provided, '
-                                   'default username from config is used.',
+                    'description': ('Username used to log-in. If not provided, '
+                                    'default username from config is used.'),
                     'type': 'string',
                     'required': False
                 },
                 'password': {
-                    'description': 'Password used to log in. If not provided, ',
-                                   'private key from the config file is used.'
+                    'description': ('Password used to log in. If not provided, '
+                                    'private key from the config file is used.'),
                     'type': 'string',
                     'required': False
                 },
                 'private_key': {
-                    'description': 'Private key used to log in. If not provided, ',
-                                   'private key from the config file is used.'
+                    'description': ('Private key used to log in. If not provided, '
+                                    'private key from the config file is used.'),
                     'type': 'string',
                     'required': False
                 },
@@ -198,20 +198,20 @@ def register_runner_types():
                     'required': True
                 },
                 'username': {
-                    'description': 'Username used to log-in. If not provided, '
-                                   'default username from config is used.',
+                    'description': ('Username used to log-in. If not provided, '
+                                    'default username from config is used.'),
                     'type': 'string',
                     'required': False
                 },
                 'password': {
-                    'description': 'Password used to log in. If not provided, ',
-                                   'private key from the config file is used.'
+                    'description': ('Password used to log in. If not provided, '
+                                    'private key from the config file is used.'),
                     'type': 'string',
                     'required': False
                 },
                 'private_key': {
-                    'description': 'Private key used to log in. If not provided, ',
-                                   'private key from the config file is used.'
+                    'description': ('Private key used to log in. If not provided, '
+                                    'private key from the config file is used.'),
                     'type': 'string',
                     'required': False
                 },

--- a/st2actions/st2actions/runners/fabricrunner.py
+++ b/st2actions/st2actions/runners/fabricrunner.py
@@ -54,6 +54,9 @@ env.abort_exception = FabricExecutionFailureException
 
 # constants to lookup in runner_parameters.
 RUNNER_HOSTS = 'hosts'
+RUNNER_USERNAME = 'username'
+RUNNER_PASSWORD = 'password'
+RUNNER_PRIVATE_KEY = 'private_key'
 RUNNER_PARALLEL = 'parallel'
 RUNNER_SUDO = 'sudo'
 RUNNER_ON_BEHALF_USER = 'user'
@@ -76,7 +79,9 @@ class FabricRunner(ActionRunner, ShellRunnerMixin):
         self._parallel = True
         self._sudo = False
         self._on_behalf_user = None
-        self._user = None
+        self._username = None
+        self._password = None
+        self._private_key = None
         self._kwarg_op = '--'
 
     def pre_run(self):
@@ -88,11 +93,14 @@ class FabricRunner(ActionRunner, ShellRunnerMixin):
         if len(self._hosts) < 1:
             raise ActionRunnerPreRunError('No hosts specified to run action for action %s.',
                                           self.action_execution_id)
+        self._username = self.runner_parameters.get(RUNNER_USERNAME, cfg.CONF.system_user.user)
+        self._username = self._username or cfg.CONF.system_user.user
+        self._password = self.runner_parameters.get(RUNNER_PASSWORD, None)
+        self._private_key = self.runner_parameters.get(RUNNER_PRIVATE_KEY, None)
         self._parallel = self.runner_parameters.get(RUNNER_PARALLEL, True)
         self._sudo = self.runner_parameters.get(RUNNER_SUDO, False)
         self._sudo = self._sudo if self._sudo else False
         self._on_behalf_user = self.context.get(RUNNER_ON_BEHALF_USER, env.user)
-        self._user = cfg.CONF.system_user.user
         self._cwd = self.runner_parameters.get(RUNNER_CWD, None)
         self._env = self.runner_parameters.get(RUNNER_ENV, {})
         self._kwarg_op = self.runner_parameters.get(RUNNER_KWARG_OP, '--')
@@ -134,7 +142,9 @@ class FabricRunner(ActionRunner, ShellRunnerMixin):
                                   command,
                                   env_vars=env_vars,
                                   on_behalf_user=self._on_behalf_user,
-                                  user=self._user,
+                                  user=self._username,
+                                  password=self._password,
+                                  private_key=self._private_key,
                                   hosts=self._hosts,
                                   parallel=self._parallel,
                                   sudo=self._sudo,
@@ -157,7 +167,9 @@ class FabricRunner(ActionRunner, ShellRunnerMixin):
                                         positional_args=pos_args,
                                         env_vars=env_vars,
                                         on_behalf_user=self._on_behalf_user,
-                                        user=self._user,
+                                        user=self._username,
+                                        password=self._password,
+                                        private_key=self._private_key,
                                         remote_dir=remote_dir,
                                         hosts=self._hosts,
                                         parallel=self._parallel,

--- a/st2actions/st2actions/runners/localrunner.py
+++ b/st2actions/st2actions/runners/localrunner.py
@@ -74,6 +74,7 @@ class LocalShellRunner(ActionRunner, ShellRunnerMixin):
         self._user = cfg.CONF.system_user.user
         self._cwd = self.runner_parameters.get(RUNNER_CWD, None)
         self._env = self.runner_parameters.get(RUNNER_ENV, {})
+        self._env = self._env or {}
         self._kwarg_op = self.runner_parameters.get(RUNNER_KWARG_OP, DEFAULT_KWARG_OP)
         self._timeout = self.runner_parameters.get(RUNNER_TIMEOUT, DEFAULT_ACTION_TIMEOUT)
 

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -37,6 +37,20 @@ LOG = logging.getLogger(__name__)
 ACTIONEXEC_STATUS_SCHEDULED = 'scheduled'
 ACTIONEXEC_STATUS_RUNNING = 'running'
 
+PARAMETERS_TO_MASK = [
+    'password',
+    'private_key'
+]
+
+
+def format_parameters(value):
+    # Mask sensitive parameters
+    for param_name, _ in value.items():
+        if param_name in PARAMETERS_TO_MASK:
+            value[param_name] = '********'
+
+    return value
+
 
 class ActionBranch(resource.ResourceBranch):
 
@@ -79,6 +93,11 @@ class ActionDeleteCommand(resource.ContentPackResourceDeleteCommand):
 class ActionRunCommand(resource.ResourceCommand):
     attribute_display_order = ['id', 'ref', 'context', 'parameters', 'status',
                                'start_timestamp', 'result']
+    attribute_transform_functions = {
+        'start_timestamp': format_isodate,
+        'end_timestamp': format_isodate,
+        'parameters': format_parameters
+    }
 
     def __init__(self, resource, *args, **kwargs):
 
@@ -342,11 +361,13 @@ class ActionRunCommand(resource.ResourceCommand):
     def run_and_print(self, args, **kwargs):
         if self.print_help(args, **kwargs):
             return
+
         # Execute the action.
         instance = self.run(args, **kwargs)
         self.print_output(instance, table.PropertyValueTable,
                           attributes=['all'], json=args.json,
-                          attribute_display_order=self.attribute_display_order)
+                          attribute_display_order=self.attribute_display_order,
+                          attribute_transform_functions=self.attribute_transform_functions)
         if args.async:
             self.print_output('To get the results, execute: \n'
                               '    $ st2 execution get %s' % instance.id,
@@ -416,7 +437,8 @@ class ActionExecutionListCommand(resource.ResourceCommand):
                           'end_timestamp']
     attribute_transform_functions = {
         'start_timestamp': format_isodate,
-        'end_timestamp': format_isodate
+        'end_timestamp': format_isodate,
+        'parameters': format_parameters
     }
 
     def __init__(self, resource, *args, **kwargs):
@@ -460,7 +482,8 @@ class ActionExecutionGetCommand(resource.ResourceCommand):
     display_attributes = ['all']
     attribute_transform_functions = {
         'start_timestamp': format_isodate,
-        'end_timestamp': format_isodate
+        'end_timestamp': format_isodate,
+        'parameters': format_parameters
     }
 
     def __init__(self, resource, *args, **kwargs):

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -181,6 +181,9 @@ class ActionRunCommand(resource.ResourceCommand):
         execution = models.ActionExecution()
         execution.action = action_ref
         execution.parameters = dict()
+
+        action_ref_or_id = args.ref_or_id
+
         for idx in range(len(args.parameters)):
             arg = args.parameters[idx]
             if '=' in arg:
@@ -200,8 +203,13 @@ class ActionRunCommand(resource.ResourceCommand):
                         file_path = os.path.normpath(pjoin(os.getcwd(), v))
                         file_name = os.path.basename(file_path)
                         content = read_file(file_path=file_path)
-                        execution.parameters['_file_name'] = file_name
-                        execution.parameters['file_content'] = content
+
+                        if action_ref_or_id == 'core.http':
+                            # Special case for http runner
+                            execution.parameters['_file_name'] = file_name
+                            execution.parameters['file_content'] = content
+                        else:
+                            execution.parameters[k] = content
                     else:
                         execution.parameters[k] = normalize(k, v)
                 except Exception as e:

--- a/st2client/st2client/formatters/table.py
+++ b/st2client/st2client/formatters/table.py
@@ -100,9 +100,9 @@ class MultiColumnTable(formatters.Formatter):
                     values.append(value)
                 else:
                     value = cls._get_simple_field_value(entry, field_name)
-                    transfor_function = attribute_transform_functions.get(field_name,
+                    transform_function = attribute_transform_functions.get(field_name,
                                                                           lambda value: value)
-                    value = transfor_function(value=value)
+                    value = transform_function(value=value)
                     value = strutil.unescape(value)
                     values.append(value)
             table.add_row(values)
@@ -168,14 +168,18 @@ class PropertyValueTable(formatters.Formatter):
         table.padding_width = 1
         table.align = 'l'
         table.valign = 't'
+
         for attribute in attributes:
             value = cls._get_attribute_value(subject, attribute)
+
+            transform_function = attribute_transform_functions.get(attribute,
+                                                                  lambda value: value)
+            value = transform_function(value=value)
+
             if type(value) is dict or type(value) is list:
                 value = json.dumps(value, indent=4)
+
             value = strutil.unescape(value)
-            transfor_function = attribute_transform_functions.get(attribute,
-                                                                  lambda value: value)
-            value = transfor_function(value=value)
             table.add_row([attribute, value])
         return table
 

--- a/st2common/st2common/models/system/action.py
+++ b/st2common/st2common/models/system/action.py
@@ -19,6 +19,7 @@ import pipes
 import six
 import sys
 import traceback
+import tempfile
 
 from fabric.api import (put, run, sudo)
 from fabric.context_managers import shell_env
@@ -232,11 +233,14 @@ class SSHCommandAction(ShellCommandAction):
 
 class RemoteAction(SSHCommandAction):
     def __init__(self, name, action_exec_id, command, env_vars=None, on_behalf_user=None,
-                 user=None, hosts=None, parallel=True, sudo=False, timeout=None, cwd=None):
+                 user=None, password=None, private_key=None, hosts=None, parallel=True, sudo=False,
+                 timeout=None, cwd=None):
         super(RemoteAction, self).__init__(name=name, action_exec_id=action_exec_id,
                                            command=command, env_vars=env_vars, user=user,
                                            hosts=hosts, parallel=parallel, sudo=sudo,
                                            timeout=timeout, cwd=cwd)
+        self.password = password
+        self.private_key = private_key
         self.on_behalf_user = on_behalf_user  # Used for audit purposes.
         self.timeout = timeout
 
@@ -260,13 +264,15 @@ class RemoteAction(SSHCommandAction):
 class RemoteScriptAction(ShellScriptAction):
     def __init__(self, name, action_exec_id, script_local_path_abs, script_local_libs_path_abs,
                  named_args=None, positional_args=None, env_vars=None, on_behalf_user=None,
-                 user=None, remote_dir=None, hosts=None, parallel=True, sudo=False, timeout=None,
-                 cwd=None):
+                 user=None, password=None, private_key=None, remote_dir=None, hosts=None,
+                 parallel=True, sudo=False, timeout=None, cwd=None):
         super(RemoteScriptAction, self).__init__(name=name, action_exec_id=action_exec_id,
                                                  script_local_path_abs=script_local_path_abs,
+                                                 user=user, password=password,
+                                                 private_key=private_key,
                                                  named_args=named_args,
                                                  positional_args=positional_args, env_vars=env_vars,
-                                                 user=user, sudo=sudo, timeout=timeout, cwd=cwd)
+                                                 sudo=sudo, timeout=timeout, cwd=cwd)
         self.script_local_libs_path_abs = script_local_libs_path_abs
         self.script_local_dir, self.script_name = os.path.split(self.script_local_path_abs)
         self.remote_dir = remote_dir if remote_dir is not None else '/tmp'
@@ -335,8 +341,11 @@ class FabricRemoteAction(RemoteAction):
         return self._run
 
     def _run(self):
+        fabric_env_vars = self.env_vars
+        fabric_settings = self._get_settings()
+
         try:
-            with shell_env(**self.env_vars), settings(command_timeout=self.timeout, cwd=self.cwd):
+            with shell_env(**fabric_env_vars), settings(**fabric_settings):
                 output = run(self.command, combine_stderr=False, pty=False, quiet=True)
         except Exception:
             LOG.exception('Failed executing remote action.')
@@ -349,12 +358,17 @@ class FabricRemoteAction(RemoteAction):
                 'succeeded': output.succeeded,
                 'failed': output.failed
             }
+        finally:
+            self._cleanup(settings=fabric_settings)
 
         return jsonify.json_loads(result, FabricRemoteAction.KEYS_TO_TRANSFORM)
 
     def _sudo(self):
+        fabric_env_vars = self.env_vars
+        fabric_settings = self._get_settings()
+
         try:
-            with shell_env(**self.env_vars), settings(command_timeout=self.timeout, cwd=self.cwd):
+            with shell_env(**fabric_env_vars), settings(**fabric_settings):
                 output = sudo(self.command, combine_stderr=False, pty=True, quiet=True)
         except Exception:
             LOG.exception('Failed executing remote action.')
@@ -367,6 +381,8 @@ class FabricRemoteAction(RemoteAction):
                 'succeeded': output.succeeded,
                 'failed': output.failed
             }
+        finally:
+            self._cleanup(settings=fabric_settings)
 
         # XXX: For sudo, fabric requires to set pty=True. This basically combines stdout and
         # stderr into a single stdout stream. So if the command fails, we explictly set stderr
@@ -376,6 +392,69 @@ class FabricRemoteAction(RemoteAction):
             result['stdout'] = ''
 
         return jsonify.json_loads(result, FabricRemoteAction.KEYS_TO_TRANSFORM)
+
+    def _cleanup(self, settings):
+        """
+        Clean function which is ran after executing a fabric command.
+
+        :param settings: Fabric settings.
+        """
+        temporary_key_file_path = settings.get('key_filename', None)
+
+        if temporary_key_file_path:
+            self._remove_private_key_file(file_path=temporary_key_file_path)
+
+    def _get_settings(self):
+        """
+        Retrieve settings used for the fabric command execution.
+        """
+        settings = {
+            'user': self.user,
+            'command_timeout': self.timeout,
+            'cwd': self.cwd
+        }
+
+        if self.password:
+            settings['password'] = self.password
+
+        if self.private_key:
+            # Fabric doesn't support passing key as string so we need to write
+            # it to a temporary file
+            key_file_path = self._write_private_key(private_key_material=self.private_key)
+            settings['key_filename'] = key_file_path
+
+        return settings
+
+    def _get_env_vars(self):
+        """
+        Retrieve environment variables used for the fabric command execution.
+        """
+        env_vars = self.env_vars or {}
+        return env_vars
+
+    def _write_private_key(self, private_key_material):
+        """
+        Write private key to a temporary file and return path to the file.
+        """
+        _, key_file_path = tempfile.mkstemp()
+        with open(key_file_path, 'w') as fp:
+            fp.write(private_key_material)
+
+        return key_file_path
+
+    def _remove_private_key_file(self, file_path):
+        """
+        Remove private key file if temporary private key is used to log in.
+        """
+        if not file_path or '/tmp' not in file_path:
+            return False
+
+        try:
+            os.remove(file_path)
+        except Exception:
+            pass
+
+        return True
 
 
 class FabricRemoteScriptAction(RemoteScriptAction, FabricRemoteAction):

--- a/st2common/st2common/models/system/action.py
+++ b/st2common/st2common/models/system/action.py
@@ -268,8 +268,7 @@ class RemoteScriptAction(ShellScriptAction):
                  parallel=True, sudo=False, timeout=None, cwd=None):
         super(RemoteScriptAction, self).__init__(name=name, action_exec_id=action_exec_id,
                                                  script_local_path_abs=script_local_path_abs,
-                                                 user=user, password=password,
-                                                 private_key=private_key,
+                                                 user=user,
                                                  named_args=named_args,
                                                  positional_args=positional_args, env_vars=env_vars,
                                                  sudo=sudo, timeout=timeout, cwd=cwd)
@@ -278,6 +277,8 @@ class RemoteScriptAction(ShellScriptAction):
         self.remote_dir = remote_dir if remote_dir is not None else '/tmp'
         self.remote_libs_path_abs = os.path.join(self.remote_dir, ACTION_LIBS_DIR)
         self.on_behalf_user = on_behalf_user
+        self.password = password
+        self.private_key = private_key
         self.remote_script = os.path.join(self.remote_dir, pipes.quote(self.script_name))
         self.hosts = hosts
         self.parallel = parallel

--- a/st2common/tests/unit/test_action_system_models.py
+++ b/st2common/tests/unit/test_action_system_models.py
@@ -111,3 +111,27 @@ class FabricRemoteActionTestCase(unittest2.TestCase):
         self.assertEqual(remote_action.get_on_behalf_user(), 'stan')
         self.assertEqual(remote_action.remote_dir, '/foo')
         self.assertEqual(remote_action.remote_script, '/foo/st2.py')
+
+    def test_get_settings(self):
+        # no password and private_key
+        remote_action = FabricRemoteAction(name='foo', action_exec_id='foo-id',
+                                           command='ls -lrth', on_behalf_user='stan',
+                                           parallel=True, sudo=True,
+                                           user='user')
+
+        settings = remote_action._get_settings()
+        self.assertEqual(settings['user'], 'user')
+        self.assertTrue('password' not in settings)
+        self.assertTrue('key_filename' not in settings)
+
+        # password and private_key
+        remote_action = FabricRemoteAction(name='foo', action_exec_id='foo-id',
+                                           command='ls -lrth', on_behalf_user='stan',
+                                           parallel=True, sudo=True,
+                                           user='test1', password='testpass1',
+                                           private_key='key_material')
+
+        settings = remote_action._get_settings()
+        self.assertEqual(settings['user'], 'test1')
+        self.assertEqual(settings['password'], 'testpass1')
+        self.assertTrue('/tmp/' in settings['key_filename'])

--- a/st2reactor/st2reactor/bootstrap/rulesregistrar.py
+++ b/st2reactor/st2reactor/bootstrap/rulesregistrar.py
@@ -50,6 +50,7 @@ class RulesRegistrar(ResourceRegistrar):
         """
         Register all the rules from the provided pack.
         """
+        pack_dir = pack_dir[:-1] if pack_dir.endswith('/') else pack_dir
         _, pack = os.path.split(pack_dir)
         rules_dir = self._pack_loader.get_content_from_pack(pack_dir=pack_dir,
                                                             content_type='rules')

--- a/st2reactor/st2reactor/bootstrap/sensorsregistrar.py
+++ b/st2reactor/st2reactor/bootstrap/sensorsregistrar.py
@@ -59,6 +59,7 @@ class SensorsRegistrar(ResourceRegistrar):
         """
         Register all the sensors from the provided pack.
         """
+        pack_dir = pack_dir[:-1] if pack_dir.endswith('/') else pack_dir
         _, pack = os.path.split(pack_dir)
         sensors_dir = self._pack_loader.get_content_from_pack(pack_dir=pack_dir,
                                                               content_type='sensors')


### PR DESCRIPTION
This pull request allows user to override authentication information for remote actions on per action basis.

### Reasoning

Currently, when we run remote actions, we use information from the config (username and private key) to log in to the remote server. This is fine for a common case and in an ideal world where "stanley" user account is created during a bootstrap process (e.g. using cloud-init, custom image or similar approach).

In addion to the "ideal world scenario" this approach has multiple limitations and breaks under the following scenarios:

1. You use different credentials or set of credentials for different servers or group of servers.

2. There is a "chicken and the egg" problem when bootstrapping a server using some of the cloud provider APIs.

Some of the providers return a random root password on bootstrap. This means that using the current approach will allow user to bootstrap a cloud server, but they won't be able to run additional actions on it since StackStorm will always try to use the default account to log in.

With this change, user can use a temporary password inside the work-flow to login in and create a stanley user with the provided private key. After that, we can use standard stanley user to run other actions.

This limitation / issue was initially encountered by @jfryman.

### Examples

1. Use default authentication information from the config (username and private key file)

```bash
st2 run core.remote hosts=<host> cmd=<cmd>
```

2. Use the provided username and password

```bash
st2 run core.remote hosts=<host> username=<username> password=<password> cmd=<cmd>
```

3. Use the provided username and private key material (providing key as string):

```bash
st2 run core.remote hosts=<host> username=<username> private_key=<private_key_material_string> cmd=<cmd>
```

4. Use the provided username and private key material (providing key as a path to the file):

```bash
st2 run core.remote hosts=<host> username=<username> @private_key=/path/to/key/file cmd=<cmd>
```

### TODO

- [x] Docs
- [x] Examples
- [x] Tests
- [x] Support for specifying path to the private key using @file_path syntax