### PR TITLE
Fix mistral DSL transformer where action has no input

### DIFF
--- a/st2actions/st2actions/runners/mistral/utils.py
+++ b/st2actions/st2actions/runners/mistral/utils.py
@@ -112,7 +112,7 @@ def _transform_action(spec, action_key, input_key):
 
     action_ref = spec.get(action_key)
 
-    if ResourceReference.is_resource_reference(action_ref):
+    if action_ref and ResourceReference.is_resource_reference(action_ref):
         ref = ResourceReference.from_string_reference(ref=action_ref)
         actions = Action.query(name=ref.name, pack=ref.pack)
         action = actions.first() if actions else None
@@ -121,10 +121,10 @@ def _transform_action(spec, action_key, input_key):
 
     if action:
         spec[action_key] = 'st2.action'
-        spec[input_key] = {
-            'ref': action_ref,
-            'parameters': spec[input_key]
-        }
+        action_input = spec.get(input_key)
+        spec[input_key] = {'ref': action_ref}
+        if action_input:
+            spec[input_key]['parameters'] = action_input
 
 
 def transform_definition(definition):

--- a/st2tests/st2tests/fixtures/generic/workflows/wf_post_xform.yaml
+++ b/st2tests/st2tests/fixtures/generic/workflows/wf_post_xform.yaml
@@ -5,7 +5,7 @@ demo:
     input:
         - cmd
     tasks:
-        run-cmd:
+        task_with_input:
             action: st2.action
             input:
                 ref: core.local
@@ -14,3 +14,7 @@ demo:
             publish:
                 stdout: $.stdout
                 stderr: $.stderr
+        task_with_no_input:
+            action: st2.action
+            input:
+                ref: core.local

--- a/st2tests/st2tests/fixtures/generic/workflows/wf_pre_xform.yaml
+++ b/st2tests/st2tests/fixtures/generic/workflows/wf_pre_xform.yaml
@@ -5,10 +5,12 @@ demo:
     input:
         - cmd
     tasks:
-        run-cmd:
+        task_with_input:
             action: core.local
             input:
                 cmd: $.cmd
             publish:
                 stdout: $.stdout
                 stderr: $.stderr
+        task_with_no_input:
+            action: core.local


### PR DESCRIPTION
If there is no action input, do not add the parameters key.