### PR TITLE
Query string fixes

### DIFF
--- a/st2api/st2api/controllers/v1/rules.py
+++ b/st2api/st2api/controllers/v1/rules.py
@@ -15,13 +15,13 @@
 
 from mongoengine import ValidationError
 from pecan import abort
-from pecan.rest import RestController
 import six
 
 from st2common import log as logging
 from st2common.exceptions.apivalidation import ValueValidationException
 from st2common.exceptions.db import StackStormDBObjectConflictError
 from st2common.exceptions.triggers import TriggerDoesNotExistException
+from st2api.controllers import resource
 from st2common.models.api.rule import RuleAPI
 from st2common.models.api.base import jsexpose
 from st2common.persistence.reactor import Rule
@@ -31,38 +31,21 @@ http_client = six.moves.http_client
 LOG = logging.getLogger(__name__)
 
 
-class RuleController(RestController):
+class RuleController(resource.ContentPackResourceControler):
     """
         Implements the RESTful web endpoint that handles
         the lifecycle of Rules in the system.
     """
-    @jsexpose(str)
-    def get_one(self, id):
-        """
-            List rule by id.
 
-            Handle:
-                GET /rules/1
-        """
-        LOG.info('GET /rules/ with id=%s', id)
-        rule_db = RuleController.__get_by_id(id)
-        rule_api = RuleAPI.from_model(rule_db)
-        LOG.debug('GET /rules/ with id=%s, client_result=%s', id, rule_api)
-        return rule_api
+    model = RuleAPI
+    access = Rule
+    supported_filters = {
+        'name': 'name'
+    }
 
-    @jsexpose(str)
-    def get_all(self, **kw):
-        """
-            List all rules.
-
-            Handles requests:
-                GET /rules/
-        """
-        LOG.info('GET all /rules/ with filters=%s', kw)
-        rule_dbs = Rule.get_all(**kw)
-        rule_apis = [RuleAPI.from_model(rule_db) for rule_db in rule_dbs]
-        LOG.debug('GET all /rules/ client_result=%s', rule_apis)
-        return rule_apis
+    query_options = {
+        'sort': ['name']
+    }
 
     @jsexpose(body=RuleAPI, status_code=http_client.CREATED)
     def post(self, rule):

--- a/st2common/st2common/constants/auth.py
+++ b/st2common/st2common/constants/auth.py
@@ -16,13 +16,19 @@
 __all__ = [
     'VALID_MODES',
     'DEFAULT_MODE',
-    'DEFAULT_BACKEND'
+    'DEFAULT_BACKEND',
+
+    'HEADER_ATTRIBUTE_NAME',
+    'QUERY_PARAM_ATTRIBUTE_NAME'
 ]
 
 VALID_MODES = [
     'proxy',
     'standalone'
 ]
+
+HEADER_ATTRIBUTE_NAME = 'X-Auth-Token'
+QUERY_PARAM_ATTRIBUTE_NAME = 'x-auth-token'
 
 DEFAULT_MODE = 'proxy'
 

--- a/st2common/st2common/hooks.py
+++ b/st2common/st2common/hooks.py
@@ -23,6 +23,8 @@ from st2common import log as logging
 from st2common.exceptions import access as exceptions
 from st2common.util.jsonify import json_encode
 from st2common.util.auth import validate_token
+from st2common.constants.auth import HEADER_ATTRIBUTE_NAME
+from st2common.constants.auth import QUERY_PARAM_ATTRIBUTE_NAME
 
 
 LOG = logging.getLogger(__name__)
@@ -102,7 +104,7 @@ class AuthHook(PecanHook):
         query_string = request.query_string
         query_params = dict(urlparse.parse_qsl(query_string))
 
-        token_in_headers = headers.get('X-Auth-Token', None)
-        token_in_query_params = query_params.get('x-auth-token', None)
+        token_in_headers = headers.get(HEADER_ATTRIBUTE_NAME, None)
+        token_in_query_params = query_params.get(QUERY_PARAM_ATTRIBUTE_NAME, None)
         return validate_token(token_in_headers=token_in_headers,
                               token_in_query_params=token_in_query_params)

--- a/st2common/st2common/middleware/auth.py
+++ b/st2common/st2common/middleware/auth.py
@@ -19,6 +19,7 @@ from st2common.util import isotime
 from st2common.exceptions import access as exceptions
 from st2common import log as logging
 from st2common.util.auth import validate_token
+from st2common.constants.auth import QUERY_PARAM_ATTRIBUTE_NAME
 
 
 LOG = logging.getLogger(__name__)
@@ -75,7 +76,7 @@ class AuthMiddleware(object):
 
         # Note: This is a WSGI environment variable name
         token_in_headers = env.get('HTTP_X_AUTH_TOKEN', None)
-        token_in_query_params = query_params.get('x-auth-token', None)
+        token_in_query_params = query_params.get(QUERY_PARAM_ATTRIBUTE_NAME, None)
 
         return validate_token(token_in_headers=token_in_headers,
                               token_in_query_params=token_in_query_params)

--- a/st2common/st2common/models/api/base.py
+++ b/st2common/st2common/models/api/base.py
@@ -107,7 +107,7 @@ def jsexpose(*argtypes, **opts):
     def decorate(f):
         @functools.wraps(f)
         def callfunction(*args, **kwargs):
-            params = pecan.request.params
+            params = getattr(pecan.request, 'params', {})
 
             if QUERY_PARAM_ATTRIBUTE_NAME in params and QUERY_PARAM_ATTRIBUTE_NAME in kwargs:
                 # Remove auth token if one is provided via query params

--- a/st2common/st2common/models/api/base.py
+++ b/st2common/st2common/models/api/base.py
@@ -106,6 +106,12 @@ def jsexpose(*argtypes, **opts):
     def decorate(f):
         @functools.wraps(f)
         def callfunction(*args, **kwargs):
+            params = pecan.request.params
+
+            if 'x-auth-token' in params and 'x-auth-token' in kwargs:
+                # Remove auth token if one is provided via query params
+                del kwargs['x-auth-token']
+
             try:
                 args = list(args)
                 types = list(argtypes)

--- a/st2common/st2common/models/api/base.py
+++ b/st2common/st2common/models/api/base.py
@@ -28,6 +28,7 @@ from st2common.util import mongoescape as util_mongodb
 from st2common.util import schema as util_schema
 from st2common.util.jsonify import json_encode
 from st2common import log as logging
+from st2common.constants.auth import QUERY_PARAM_ATTRIBUTE_NAME
 
 
 LOG = logging.getLogger(__name__)
@@ -108,9 +109,9 @@ def jsexpose(*argtypes, **opts):
         def callfunction(*args, **kwargs):
             params = pecan.request.params
 
-            if 'x-auth-token' in params and 'x-auth-token' in kwargs:
+            if QUERY_PARAM_ATTRIBUTE_NAME in params and QUERY_PARAM_ATTRIBUTE_NAME in kwargs:
                 # Remove auth token if one is provided via query params
-                del kwargs['x-auth-token']
+                del kwargs[QUERY_PARAM_ATTRIBUTE_NAME]
 
             try:
                 args = list(args)


### PR DESCRIPTION
* Remove `x-auth-token` from kwargs inside jsexpose if one is provided via query parameters
* Fix query param handling in the rules controller (previously we would throw an exception if user passed in a query parameter)

```
Traceback (most recent call last):
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/eventlet/wsgi.py", line 442, in handle_one_response
    result = self.application(self.environ, start_response)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/pecan/middleware/recursive.py", line 56, in __call__
    return self.application(environ, start_response)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/pecan/core.py", line 762, in __call__
    return super(Pecan, self).__call__(environ, start_response)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/pecan/core.py", line 625, in __call__
    self.invoke_controller(controller, args, kwargs, state)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/pecan/core.py", line 531, in invoke_controller
    result = controller(*args, **kwargs)
  File "/data/stanley/st2common/st2common/models/api/base.py", line 178, in callfunction
    return _handle_error(e, http_client.INTERNAL_SERVER_ERROR)
  File "/data/stanley/st2common/st2common/models/api/base.py", line 96, in _handle_error
    return json_encode(error_body)
  File "/data/stanley/st2common/st2common/util/jsonify.py", line 32, in json_encode
    return json.dumps(obj, cls=GenericJSON, indent=indent)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/simplejson/__init__.py", line 386, in dumps
    **kw).encode(obj)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/simplejson/encoder.py", line 271, in encode
    chunks = list(chunks)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/simplejson/encoder.py", line 632, in _iterencode
    for chunk in _iterencode_dict(o, _current_indent_level):
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/simplejson/encoder.py", line 591, in _iterencode_dict
    for chunk in chunks:
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/simplejson/encoder.py", line 642, in _iterencode
    o = _default(o)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/pecan/jsonify.py", line 112, in default
    return JSONEncoder.default(self, obj)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/simplejson/encoder.py", line 246, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: LookUpError('Cannot resolve field "foo"',) is not JSON serializable
* Closing connection 0
```

Good catch by @enykeev