### PR TITLE
Add support to action run command to inherit all the environment variables

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,9 @@ Docs: http://docks.stackstorm.com/latest
   ``core.local``, ``core.local_sudo`` (bug-fix)
 * Allow user to override authentication information (username, password, private key) on per
   action basis for all the remote runner actions. (new-feature)
+* Allow user to pass ``--inherit-env`` flag to the ``st2 action run`` command which causes all
+  the environment variables accessible to the CLI to be sent as ``env`` parameter to the action
+  being executed. (new-feature)
 
 v0.7 - January 16, 2015
 -----------------------

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -131,3 +131,35 @@ Example:
 .. sourcecode:: bash
 
     st2 run core.remote hosts=<host> username=<username> @private_key=/home/myuser/.ssh/id_rsa cmd=<cmd>
+
+Inheriting all the environment variables which are accessible to the CLI and passing them to runner as env parameter
+--------------------------------------------------------------------------------------------------------------------
+
+Local, remote and Python runner support ``env`` parameter. This parameter tells
+the runner which environment variables should be accessible to the action which
+is being executed.
+
+User can specify environment variables manually using ``env`` parameter exactly
+the same way as other parameters.
+
+For example:
+
+.. sourcecode:: bash
+
+    st2 run core.remote hosts=localhost env="key1=val1,key2=val2" cmd="echo ponies \${key1} \${key2}
+
+In addition to that, user can pass ``-e`` / ``--inherit-env`` flag to the
+``action run`` command.
+
+This flag will cause the command to inherit all the environment variables which
+are accessible to the CLI and send them as an ``env`` parameter to the action.
+
+Keep in mind that some global shell login variables such as ``PWD``, ``PATH``
+and others are ignored and not inherited. Full list of ignored variables can
+be found in `action.py file <https://github.com/StackStorm/st2/blob/master/st2client/st2client/commands/action.py>`_.
+
+For example:
+
+.. sourcecode:: bash
+
+    st2 run --inherit-env core.remote cmd=...


### PR DESCRIPTION
This pull request allows user to easily send all the environment variables which are accessible to the CLI as ``env`` parameter to the action being executed.

Keep in mind that some common environment variables which are set in a login shell such as ``PWD``, ``PATH`` and others are ignored. The feature is there to make it easier for user to send user-defined environment variables (e.g. different credentials, path to credential files, etc.) and not the ones which are defined by login script / shell. On top of that, sending some of those variables (e.g. ``PATH``, ``PYTHONPATH``, etc.) could interfere and break the action itself.

See #1034 for more information.