### PR TITLE
Cast params prior to rule execution

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,8 @@ Docs: http://docks.stackstorm.com/latest
 * Allow user to pass ``--inherit-env`` flag to the ``st2 action run`` command which causes all
   the environment variables accessible to the CLI to be sent as ``env`` parameter to the action
   being executed. (new-feature)
+* Cast params of an execution before scheduling in the RulesEngine. This allows non-string
+  parameters in an action. (new-feature)
 
 v0.7 - January 16, 2015
 -----------------------

--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ast
 import eventlet
 import jinja2
 import json
@@ -30,6 +29,7 @@ from st2common.content.loader import MetaLoader
 from st2common.exceptions import actionrunner as runnerexceptions
 from st2common.models.db.action import ActionExecutionDB
 from st2common.models.system import actionchain
+from st2common.models.utils import action_param_utils
 from st2common.services import action as action_service
 from st2common.services.keyvalues import KeyValueLookup
 from st2common.util import action_db as action_db_util
@@ -242,7 +242,8 @@ class ActionChainRunner(ActionRunner):
     @staticmethod
     def _run_action(action_node, parent_execution_id, params, wait_for_completion=True):
         execution = ActionExecutionDB(action=action_node.ref)
-        execution.parameters = ActionChainRunner._cast_params(action_node.ref, params)
+        execution.parameters = action_param_utils.cast_params(action_ref=action_node.ref,
+                                                              params=params)
         execution.context = {
             'parent': str(parent_execution_id),
             'chain': vars(action_node)
@@ -287,53 +288,6 @@ class ActionChainRunner(ActionRunner):
             result['result'] = action_exec_db.result
 
         return result
-
-    @staticmethod
-    def _cast_params(action_ref, params):
-        def cast_object(x):
-            if isinstance(x, str) or isinstance(x, unicode):
-                try:
-                    return json.loads(x)
-                except:
-                    return ast.literal_eval(x)
-            else:
-                return x
-
-        casts = {
-            'array': (lambda x: ast.literal_eval(x) if isinstance(x, str) or isinstance(x, unicode)
-                      else x),
-            'boolean': (lambda x: ast.literal_eval(x.capitalize())
-                        if isinstance(x, str) or isinstance(x, unicode) else x),
-            'integer': int,
-            'number': float,
-            'object': cast_object,
-            'string': str
-        }
-
-        action_db = action_db_util.get_action_by_ref(action_ref)
-        action_parameters_schema = action_db.parameters
-        runnertype_db = action_db_util.get_runnertype_by_name(action_db.runner_type['name'])
-        runner_parameters_schema = runnertype_db.runner_parameters
-        # combine into 1 list of parameter schemas
-        parameters_schema = {}
-        if runner_parameters_schema:
-            parameters_schema.update(runner_parameters_schema)
-        if action_parameters_schema:
-            parameters_schema.update(action_parameters_schema)
-        # cast each param individually
-        for k, v in six.iteritems(params):
-            parameter_schema = parameters_schema.get(k, None)
-            if not parameter_schema:
-                continue
-            parameter_type = parameter_schema.get('type', None)
-            if not parameter_type:
-                continue
-            cast = casts.get(parameter_type, None)
-            LOG.debug('Casting param: %s of type %s to type: %s', v, type(v), parameter_type)
-            if not cast:
-                continue
-            params[k] = cast(v)
-        return params
 
 
 def get_runner():

--- a/st2actions/st2actions/utils/param_utils.py
+++ b/st2actions/st2actions/utils/param_utils.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ast
 import copy
 import json
 import six

--- a/st2actions/st2actions/utils/param_utils.py
+++ b/st2actions/st2actions/utils/param_utils.py
@@ -23,6 +23,7 @@ from st2common import log as logging
 from st2common.constants.system import SYSTEM_KV_PREFIX
 from st2common.exceptions import actionrunner
 from st2common.services.keyvalues import KeyValueLookup
+from st2common.util.casts import get_cast
 from st2common.util.compat import to_unicode
 
 
@@ -228,18 +229,6 @@ def _do_render_params(renderable_params, context):
 
 
 def _cast_params(rendered, parameter_schemas):
-    casts = {
-        'array': (lambda x: json.loads(x) if isinstance(x, str) or isinstance(x, unicode)
-                  else x),
-        'boolean': (lambda x: ast.literal_eval(x.capitalize())
-                    if isinstance(x, str) or isinstance(x, unicode) else x),
-        'integer': int,
-        'number': float,
-        'object': (lambda x: json.loads(x) if isinstance(x, str) or isinstance(x, unicode)
-                   else x),
-        'string': to_unicode
-    }
-
     casted_params = {}
     for k, v in six.iteritems(rendered):
         # Add uncasted first and then override with casted param. Not all params will end up
@@ -255,7 +244,7 @@ def _cast_params(rendered, parameter_schemas):
         parameter_type = parameter_schema.get('type', None)
         if not parameter_type:
             continue
-        cast = casts.get(parameter_type, None)
+        cast = get_cast(cast_type=parameter_type)
         if not cast:
             continue
         casted_params[k] = cast(v)

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -20,9 +20,17 @@ from oslo.config import cfg
 from st2common.constants.system import VERSION_STRING
 
 
-def _do_register_opts(opts, group, ignore_errors):
+def do_register_opts(opts, group=None, ignore_errors=False):
     try:
         cfg.CONF.register_opts(opts, group=group)
+    except:
+        if not ignore_errors:
+            raise
+
+
+def do_register_cli_opts(opt, ignore_errors=False):
+    try:
+        cfg.CONF.register_cli_opt(opt)
     except:
         if not ignore_errors:
             raise
@@ -33,7 +41,7 @@ def register_opts(ignore_errors=False):
         cfg.BoolOpt('enable', default=True, help='Enable authentication middleware.'),
         cfg.IntOpt('token_ttl', default=86400, help='Access token ttl in seconds.')
     ]
-    _do_register_opts(auth_opts, 'auth', ignore_errors)
+    do_register_opts(auth_opts, 'auth', ignore_errors)
 
     system_user_opts = [
         cfg.StrOpt('user',
@@ -43,20 +51,20 @@ def register_opts(ignore_errors=False):
                    default='/home/vagrant/.ssh/stanley_rsa',
                    help='SSH private key for the system user.')
     ]
-    _do_register_opts(system_user_opts, 'system_user', ignore_errors)
+    do_register_opts(system_user_opts, 'system_user', ignore_errors)
 
     schema_opts = [
         cfg.IntOpt('version', default=4, help='Version of JSON schema to use.'),
         cfg.StrOpt('draft', default='http://json-schema.org/draft-04/schema#',
                    help='URL to the JSON schema draft.')
     ]
-    _do_register_opts(schema_opts, 'schema', ignore_errors)
+    do_register_opts(schema_opts, 'schema', ignore_errors)
 
     system_opts = [
         cfg.StrOpt('base_path', default='/opt/stackstorm',
                    help='Base path to all st2 artifacts.')
     ]
-    _do_register_opts(system_opts, 'system', ignore_errors)
+    do_register_opts(system_opts, 'system', ignore_errors)
 
     system_packs_base_path = os.path.join(cfg.CONF.system.base_path, 'packs')
     content_opts = [
@@ -65,7 +73,7 @@ def register_opts(ignore_errors=False):
         cfg.StrOpt('packs_base_paths', default=None,
                    help='Paths which will be searched for integration packs.')
     ]
-    _do_register_opts(content_opts, 'content', ignore_errors)
+    do_register_opts(content_opts, 'content', ignore_errors)
 
     db_opts = [
         cfg.StrOpt('host', default='0.0.0.0', help='host of db server'),
@@ -74,13 +82,13 @@ def register_opts(ignore_errors=False):
         cfg.StrOpt('username', help='username for db login'),
         cfg.StrOpt('password', help='password for db login'),
     ]
-    _do_register_opts(db_opts, 'database', ignore_errors)
+    do_register_opts(db_opts, 'database', ignore_errors)
 
     messaging_opts = [
         cfg.StrOpt('url', default='amqp://guest:guest@localhost:5672//',
                    help='URL of the messaging server.')
     ]
-    _do_register_opts(messaging_opts, 'messaging', ignore_errors)
+    do_register_opts(messaging_opts, 'messaging', ignore_errors)
 
     syslog_opts = [
         cfg.StrOpt('host', default='localhost',
@@ -92,7 +100,7 @@ def register_opts(ignore_errors=False):
         cfg.StrOpt('protocol', default='udp',
                    help='Transport protocol to use (udp / tcp).')
     ]
-    _do_register_opts(syslog_opts, 'syslog', ignore_errors)
+    do_register_opts(syslog_opts, 'syslog', ignore_errors)
 
     log_opts = [
         cfg.ListOpt('excludes', default='',
@@ -100,14 +108,14 @@ def register_opts(ignore_errors=False):
         cfg.BoolOpt('redirect_stderr', default=False,
                     help='Controls if stderr should be redirected to the logs.')
     ]
-    _do_register_opts(log_opts, 'log', ignore_errors)
+    do_register_opts(log_opts, 'log', ignore_errors)
 
     # Common API options
     api_opts = [
         cfg.StrOpt('host', default='0.0.0.0', help='StackStorm API server host'),
         cfg.IntOpt('port', default=9101, help='StackStorm API server port')
     ]
-    cfg.CONF.register_opts(api_opts, group='api')
+    do_register_opts(api_opts, 'api', ignore_errors)
 
     use_debugger = cfg.BoolOpt(
         'use-debugger', default=True,
@@ -115,7 +123,11 @@ def register_opts(ignore_errors=False):
              'eventlet library is used to support async IO. This could result in '
              'failures that do not occur under normal operation.'
     )
-    cfg.CONF.register_cli_opt(use_debugger)
+    try:
+        cfg.CONF.register_cli_opt(use_debugger)
+    except:
+        if not ignore_errors:
+            raise
 
 
 def parse_args(args=None):

--- a/st2common/st2common/models/utils/action_param_utils.py
+++ b/st2common/st2common/models/utils/action_param_utils.py
@@ -117,13 +117,17 @@ def cast_params(action_ref, params):
     for k, v in six.iteritems(params):
         parameter_schema = parameters_schema.get(k, None)
         if not parameter_schema:
+            LOG.debug('Will skip cast of param[name: %s, value: %s]. No schema.', k, v)
             continue
         parameter_type = parameter_schema.get('type', None)
         if not parameter_type:
+            LOG.debug('Will skip cast of param[name: %s, value: %s]. No type.', k, v)
             continue
         cast = casts.get(parameter_type, None)
-        LOG.debug('Casting param: %s of type %s to type: %s', v, type(v), parameter_type)
         if not cast:
+            LOG.debug('Will skip cast of param[name: %s, value: %s]. No cast for %s.', k, v,
+                      parameter_type)
             continue
+        LOG.debug('Casting param: %s of type %s to type: %s', v, type(v), parameter_type)
         params[k] = cast(v)
     return params

--- a/st2common/st2common/util/casts.py
+++ b/st2common/st2common/util/casts.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+import json
+
+from st2common.util.compat import to_unicode
+
+
+def _cast_object(x):
+    if isinstance(x, str) or isinstance(x, unicode):
+        try:
+            return json.loads(x)
+        except:
+            return ast.literal_eval(x)
+    else:
+        return x
+
+
+# These types as they appear in json schema.
+CASTS = {
+    'array': (lambda x: ast.literal_eval(x) if isinstance(x, str) or isinstance(x, unicode)
+              else x),
+    'boolean': (lambda x: ast.literal_eval(x.capitalize())
+                if isinstance(x, str) or isinstance(x, unicode) else x),
+    'integer': int,
+    'number': float,
+    'object': _cast_object,
+    'string': to_unicode
+}
+
+
+def get_cast(cast_type):
+    """
+    Determines the callable which will perform the cast given a string representation
+    of the type.
+
+    :param cast_type: Type of the cast to perform.
+    :type cast_type: ``str``
+
+    :rtype: ``callable``
+    """
+    return CASTS.get(cast_type, None)

--- a/st2reactor/st2reactor/rules/enforcer.py
+++ b/st2reactor/st2reactor/rules/enforcer.py
@@ -20,6 +20,7 @@ from st2common.util import reference
 from st2reactor.rules.datatransform import get_transformer
 from st2common.services import action as action_service
 from st2common.models.db.action import ActionExecutionDB
+from st2common.models.utils import action_param_utils
 from st2common.constants.action import ACTIONEXEC_STATUS_SCHEDULED
 from st2common.models.api.access import get_system_username
 
@@ -58,9 +59,11 @@ class RuleEnforcer(object):
         return actionexecution_db
 
     @staticmethod
-    def _invoke_action(action, action_args, context=None):
+    def _invoke_action(action, params, context=None):
         action_ref = action['ref']
-        execution = ActionExecutionDB(action=action_ref, context=context, parameters=action_args)
+        # prior to shipping off the params cast them to the right type.
+        params = action_param_utils.cast_params(action_ref, params)
+        execution = ActionExecutionDB(action=action_ref, context=context, parameters=params)
         execution = action_service.schedule(execution)
         return ({'id': str(execution.id)}
                 if execution.status == ACTIONEXEC_STATUS_SCHEDULED else None)

--- a/st2reactor/st2reactor/sensor/config.py
+++ b/st2reactor/st2reactor/sensor/config.py
@@ -21,41 +21,43 @@ from st2common.constants.system import VERSION_STRING
 CONF = cfg.CONF
 
 
-def _register_common_opts():
-    st2cfg.register_opts()
+def _register_common_opts(ignore_errors=False):
+    st2cfg.register_opts(ignore_errors=True)
 
 
-def _register_sensor_container_opts():
+def _register_sensor_container_opts(ignore_errors=False):
     logging_opts = [
         cfg.StrOpt('logging', default='conf/logging.sensorcontainer.conf',
                    help='location of the logging.conf file')
     ]
-    CONF.register_opts(logging_opts, group='sensorcontainer')
+    st2cfg.do_register_opts(logging_opts, group='sensorcontainer', ignore_errors=ignore_errors)
 
     sensor_test_opt = cfg.StrOpt('sensor-name', help='Only run sensor with the provided name.')
-    CONF.register_cli_opt(sensor_test_opt)
+    st2cfg.do_register_cli_opts(sensor_test_opt, ignore_errors=ignore_errors)
 
     st2_webhook_opts = [
         cfg.StrOpt('host', default='0.0.0.0', help='Host for the st2 webhook endpoint.'),
         cfg.IntOpt('port', default='6000', help='Port for the st2 webhook endpoint.'),
         cfg.StrOpt('url', default='/webhooks/st2/', help='URL of the st2 webhook endpoint.')
     ]
-    CONF.register_opts(st2_webhook_opts, group='st2_webhook_sensor')
+    st2cfg.do_register_opts(st2_webhook_opts, group='st2_webhook_sensor',
+                            ignore_errors=ignore_errors)
 
     generic_webhook_opts = [
         cfg.StrOpt('host', default='0.0.0.0', help='Host for the generic webhook endpoint.'),
         cfg.IntOpt('port', default='6001', help='Port for the generic webhook endpoint.'),
         cfg.StrOpt('url', default='/webhooks/generic/', help='URL of the st2 webhook endpoint.')
     ]
-    CONF.register_opts(generic_webhook_opts, group='generic_webhook_sensor')
+    st2cfg.do_register_opts(generic_webhook_opts, group='generic_webhook_sensor',
+                            ignore_errors=ignore_errors)
 
 
-def register_opts():
-    _register_common_opts()
-    _register_sensor_container_opts()
+def register_opts(ignore_errors=False):
+    _register_common_opts(ignore_errors=ignore_errors)
+    _register_sensor_container_opts(ignore_errors=ignore_errors)
 
 
-register_opts()
+register_opts(ignore_errors=True)
 
 
 def parse_args(args=None):

--- a/st2reactor/st2reactor/sensor/config.py
+++ b/st2reactor/st2reactor/sensor/config.py
@@ -22,7 +22,7 @@ CONF = cfg.CONF
 
 
 def _register_common_opts(ignore_errors=False):
-    st2cfg.register_opts(ignore_errors=True)
+    st2cfg.register_opts(ignore_errors=ignore_errors)
 
 
 def _register_sensor_container_opts(ignore_errors=False):

--- a/st2reactor/tests/unit/test_enforce.py
+++ b/st2reactor/tests/unit/test_enforce.py
@@ -16,62 +16,62 @@
 import datetime
 
 import mock
-import unittest2
 
-from st2common.models.db.reactor import TriggerDB, TriggerInstanceDB, \
+import st2tests.config
+st2tests.config.parse_args()
+
+from st2common.models.db.reactor import TriggerInstanceDB, \
     RuleDB, ActionExecutionSpecDB
-from st2common.models.db.action import ActionDB, ActionExecutionDB
+from st2common.models.db.action import ActionExecutionDB
 import st2common.services.action as action_service
 from st2common.util import reference
 from st2reactor.rules.enforcer import RuleEnforcer
-import st2tests.config as tests_config
 
-MOCK_TRIGGER = TriggerDB()
-MOCK_TRIGGER.id = 'trigger-test.id'
-MOCK_TRIGGER.name = 'trigger-test.name'
-MOCK_TRIGGER.pack = 'dummypack1'
+from st2tests import DbTestCase
+from st2tests.fixturesloader import FixturesLoader
+
+
+PACK = 'generic'
+FIXTURES_1 = {
+    'runners': ['testrunner1.json'],
+    'actions': ['action1.json'],
+    'triggertypes': ['triggertype1.json'],
+    'triggers': ['trigger1.json']
+}
+FIXTURES_2 = {
+    'rules': ['rule1.json']
+}
 
 MOCK_TRIGGER_INSTANCE = TriggerInstanceDB()
 MOCK_TRIGGER_INSTANCE.id = 'triggerinstance-test'
-MOCK_TRIGGER_INSTANCE.trigger = reference.get_ref_from_model(MOCK_TRIGGER)
-MOCK_TRIGGER_INSTANCE.payload = {}
+MOCK_TRIGGER_INSTANCE.payload = {'t1_p': 't1_p_v'}
 MOCK_TRIGGER_INSTANCE.occurrence_time = datetime.datetime.utcnow()
-
-MOCK_ACTION = ActionDB()
-MOCK_ACTION.id = 'action-test-1.id'
-MOCK_ACTION.name = 'action-test-1.name'
 
 MOCK_ACTION_EXECUTION = ActionExecutionDB()
 MOCK_ACTION_EXECUTION.id = 'actionexec-test-1.id'
 MOCK_ACTION_EXECUTION.name = 'actionexec-test-1.name'
 MOCK_ACTION_EXECUTION.status = 'scheduled'
 
-MOCK_RULE_1 = RuleDB()
-MOCK_RULE_1.id = 'rule-test-1'
-MOCK_RULE_1.trigger = reference.get_str_resource_ref_from_model(MOCK_TRIGGER)
-MOCK_RULE_1.criteria = {}
-MOCK_RULE_1.action = ActionExecutionSpecDB()
-MOCK_RULE_1.action.ref = reference.get_ref_from_model(MOCK_ACTION)
-MOCK_RULE_1.enabled = True
 
-MOCK_RULE_2 = RuleDB()
-MOCK_RULE_2.id = 'rule-test-2'
-MOCK_RULE_2.trigger = reference.get_str_resource_ref_from_model(MOCK_TRIGGER)
-MOCK_RULE_2.criteria = {}
-MOCK_RULE_2.action = ActionExecutionSpecDB()
-MOCK_RULE_2.action.ref = reference.get_ref_from_model(MOCK_ACTION)
-MOCK_RULE_2.enabled = True
+class EnforceTest(DbTestCase):
 
-
-class EnforceTest(unittest2.TestCase):
+    models = None
 
     @classmethod
     def setUpClass(cls):
-        tests_config.parse_args()
+        super(EnforceTest, cls).setUpClass()
+        # Create TriggerTypes before creation of Rule to avoid failure. Rule requires the
+        # Trigger and therefore TriggerType to be created prior to rule creation.
+        cls.models = FixturesLoader().save_fixtures_to_db(
+            fixtures_pack=PACK, fixtures_dict=FIXTURES_1)
+        cls.models.update(FixturesLoader().save_fixtures_to_db(
+            fixtures_pack=PACK, fixtures_dict=FIXTURES_2))
+        MOCK_TRIGGER_INSTANCE.trigger = reference.get_ref_from_model(
+            cls.models['triggers']['trigger1.json'])
 
     @mock.patch.object(action_service, 'schedule', mock.MagicMock(
         return_value=MOCK_ACTION_EXECUTION))
     def test_ruleenforcement_occurs(self):
-        enforcer = RuleEnforcer(MOCK_TRIGGER_INSTANCE, MOCK_RULE_1)
+        enforcer = RuleEnforcer(MOCK_TRIGGER_INSTANCE, self.models['rules']['rule1.json'])
         execution_id = enforcer.enforce()
         self.assertTrue(execution_id is not None)

--- a/st2reactor/tests/unit/test_enforce.py
+++ b/st2reactor/tests/unit/test_enforce.py
@@ -14,22 +14,15 @@
 # limitations under the License.
 
 import datetime
-
 import mock
 
-import st2tests.config
-st2tests.config.parse_args()
-
-from st2common.models.db.reactor import TriggerInstanceDB, \
-    RuleDB, ActionExecutionSpecDB
+from st2common.models.db.reactor import TriggerInstanceDB
 from st2common.models.db.action import ActionExecutionDB
-import st2common.services.action as action_service
+from st2common.services import action as action_service
 from st2common.util import reference
 from st2reactor.rules.enforcer import RuleEnforcer
-
 from st2tests import DbTestCase
 from st2tests.fixturesloader import FixturesLoader
-
 
 PACK = 'generic'
 FIXTURES_1 = {

--- a/st2reactor/tests/unit/test_enforce.py
+++ b/st2reactor/tests/unit/test_enforce.py
@@ -33,13 +33,13 @@ from st2tests.fixturesloader import FixturesLoader
 
 PACK = 'generic'
 FIXTURES_1 = {
-    'runners': ['testrunner1.json'],
-    'actions': ['action1.json'],
+    'runners': ['testrunner1.json', 'testrunner2.json'],
+    'actions': ['action1.json', 'a2.json'],
     'triggertypes': ['triggertype1.json'],
     'triggers': ['trigger1.json']
 }
 FIXTURES_2 = {
-    'rules': ['rule1.json']
+    'rules': ['rule1.json', 'rule2.json']
 }
 
 MOCK_TRIGGER_INSTANCE = TriggerInstanceDB()
@@ -75,3 +75,13 @@ class EnforceTest(DbTestCase):
         enforcer = RuleEnforcer(MOCK_TRIGGER_INSTANCE, self.models['rules']['rule1.json'])
         execution_id = enforcer.enforce()
         self.assertTrue(execution_id is not None)
+
+    @mock.patch.object(action_service, 'schedule', mock.MagicMock(
+        return_value=MOCK_ACTION_EXECUTION))
+    def test_ruleenforcement_casts(self):
+        enforcer = RuleEnforcer(MOCK_TRIGGER_INSTANCE, self.models['rules']['rule2.json'])
+        execution_id = enforcer.enforce()
+        self.assertTrue(execution_id is not None)
+        self.assertTrue(action_service.schedule.called)
+        self.assertTrue(isinstance(action_service.schedule.call_args[0][0].parameters['objtype'],
+                                   dict))

--- a/st2tests/st2tests/fixtures/generic/rules/rule1.json
+++ b/st2tests/st2tests/fixtures/generic/rules/rule1.json
@@ -14,7 +14,7 @@
     "action": {
         "ref": "wolfpack.action-1",
         "parameters": {
-            "ip2": "{{rule.k1}}",
+            "ip2": "{{trigger}}",
             "ip1": "{{trigger.t1_p}}"
         }
     },

--- a/st2tests/st2tests/fixtures/generic/rules/rule2.json
+++ b/st2tests/st2tests/fixtures/generic/rules/rule2.json
@@ -1,0 +1,25 @@
+{
+    "name": "rule2",
+    "description": "",
+    "enabled": true,
+    "trigger": {
+        "type": "wolfpack.triggertype-1"
+    },
+    "criteria": {
+        "t1_p": {
+            "pattern": "t1_p_v",
+            "type": "equals"
+        }
+    },
+    "action": {
+        "ref": "wolfpack.a2",
+        "parameters": {
+            "objtype": "{{trigger}}",
+            "strtype": "{{trigger.t1_p}}"
+        }
+    },
+    "tags": [
+        {"name": "tag1", "value": "dont-care"},
+        {"name": "tag2", "value": "dont-care"}
+    ]
+}

--- a/st2tests/st2tests/fixturesloader.py
+++ b/st2tests/st2tests/fixturesloader.py
@@ -88,7 +88,7 @@ class FixturesLoader(object):
     def __init__(self):
         self.meta_loader = MetaLoader()
 
-    def save_fixtures_to_db(self, fixtures_pack=None, fixtures_dict={}):
+    def save_fixtures_to_db(self, fixtures_pack=None, fixtures_dict=None):
         """
         Loads fixtures specified in fixtures_dict into the database
         and returns DB models for the fixtures.
@@ -108,6 +108,8 @@ class FixturesLoader(object):
 
         :rtype: ``dict``
         """
+        if fixtures_dict is None:
+            fixtures_dict = {}
         fixtures_pack_path = self._validate_fixtures_pack(fixtures_pack)
         self._validate_fixture_dict(fixtures_dict, allowed=ALLOWED_DB_FIXTURES)
 


### PR DESCRIPTION
- Action params should be cast to their proper types as described in the metadata prior to scheduling an action.
- This way actions executed from rules can be of various types.