### PR TITLE
Pin pep8 to a specific version, clean up violations reported by new version

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 100
-ignore = E128
+ignore = E128,E402
 exclude=*.egg/*

--- a/st2actions/st2actions/utils/param_utils.py
+++ b/st2actions/st2actions/utils/param_utils.py
@@ -30,8 +30,10 @@ LOG = logging.getLogger(__name__)
 
 
 def _split_params(runner_parameters, action_parameters, mixed_params):
-    pf = lambda params, skips: {k: v for k, v in six.iteritems(mixed_params)
-                                if k in params and k not in skips}
+    def pf(params, skips):
+        result = {k: v for k, v in six.iteritems(mixed_params)
+                  if k in params and k not in skips}
+        return result
     return (pf(runner_parameters, {}), pf(action_parameters, runner_parameters))
 
 

--- a/st2actions/tests/integration/test_localrunner.py
+++ b/st2actions/tests/integration/test_localrunner.py
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import uuid
+
 import st2tests.config as tests_config
 tests_config.parse_args()
-
-import uuid
 
 from unittest2 import TestCase
 from st2actions.container.service import RunnerContainerService

--- a/st2common/st2common/operators.py
+++ b/st2common/st2common/operators.py
@@ -22,30 +22,55 @@ __all__ = [
     'get_allowed_operators'
 ]
 
-# operator impls
-equals = lambda value, criteria_pattern: value == criteria_pattern
+# Operation implementations
 
-iequals = lambda value, criteria_pattern: value.lower() == criteria_pattern.lower()
 
-contains = lambda value, criteria_pattern: criteria_pattern in value
+def equals(value, criteria_pattern):
+    return value == criteria_pattern
 
-icontains = lambda value, criteria_pattern: criteria_pattern.lower() in value.lower()
 
-ncontains = lambda value, criteria_pattern: criteria_pattern not in value
+def iequals(value, criteria_pattern):
+    return value.lower() == criteria_pattern.lower()
 
-incontains = lambda value, criteria_pattern: criteria_pattern.lower() not in value.lower()
 
-startswith = lambda value, criteria_pattern: value.startswith(criteria_pattern)
+def contains(value, criteria_pattern):
+    return criteria_pattern in value
 
-istartswith = lambda value, criteria_pattern: value.lower().startswith(criteria_pattern.lower())
 
-endswith = lambda value, criteria_pattern: value.endswith(criteria_pattern)
+def icontains(value, criteria_pattern):
+    return criteria_pattern.lower() in value.lower()
 
-iendswith = lambda value, criteria_pattern: value.lower().endswith(criteria_pattern.lower())
 
-less_than = lambda value, criteria_pattern: value < criteria_pattern
+def ncontains(value, criteria_pattern):
+    return criteria_pattern not in value
 
-greater_than = lambda value, criteria_pattern: value > criteria_pattern
+
+def incontains(value, criteria_pattern):
+    return criteria_pattern.lower() not in value.lower()
+
+
+def startswith(value, criteria_pattern):
+    return value.startswith(criteria_pattern)
+
+
+def istartswith(value, criteria_pattern):
+    return value.lower().startswith(criteria_pattern.lower())
+
+
+def endswith(value, criteria_pattern):
+    return value.endswith(criteria_pattern)
+
+
+def iendswith(value, criteria_pattern):
+    return value.lower().endswith(criteria_pattern.lower())
+
+
+def less_than(value, criteria_pattern):
+    return value < criteria_pattern
+
+
+def greater_than(value, criteria_pattern):
+    return value > criteria_pattern
 
 
 def get_allowed_operators():

--- a/st2common/st2common/util/schema/__init__.py
+++ b/st2common/st2common/util/schema/__init__.py
@@ -103,10 +103,13 @@ def get_validator(version='custom', assign_property_default=False):
 
 def get_parameter_schema(model):
     # Dynamically construct JSON schema from the parameters metadata.
+    def normalize(x):
+        return {k: v if v else SCHEMA_ANY_TYPE for k, v in six.iteritems(x)}
+
     schema = {}
     from st2common.util.action_db import get_runnertype_by_name
     runner_type = get_runnertype_by_name(model.runner_type['name'])
-    normalize = lambda x: {k: v if v else SCHEMA_ANY_TYPE for k, v in six.iteritems(x)}
+
     properties = normalize(runner_type.runner_parameters)
     properties.update(normalize(model.parameters))
     if properties:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 coverage
+pep8>=1.6.0,<1.7
 flake8
 ipython
 mock>=1.0


### PR DESCRIPTION
We didn't pin pep8 to a specific version so when a new version of pep8 which reports new violations was released, tests started to fail.