### PR TITLE
Add mistral reference to context on action execution

### DIFF
--- a/st2actions/st2actions/query/mistral/v2.py
+++ b/st2actions/st2actions/query/mistral/v2.py
@@ -36,7 +36,7 @@ class MistralResultsQuerier(Querier):
 
         :rtype: (``str``, ``object``)
         """
-        exec_id = query_context.get('mistral_execution_id', None)
+        exec_id = query_context.get('mistral', {}).get('execution_id', None)
         if not exec_id:
             raise Exception('Mistral execution id invalid in query_context %s.' %
                             str(query_context))

--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -203,7 +203,7 @@ class ActionChainRunner(ActionRunner):
         else:
             status = ACTIONEXEC_STATUS_SUCCEEDED
 
-        return (status, result)
+        return (status, result, None)
 
     @staticmethod
     def _render_publish_vars(action_node, execution_result, previous_execution_results,

--- a/st2actions/st2actions/runners/fabricrunner.py
+++ b/st2actions/st2actions/runners/fabricrunner.py
@@ -121,7 +121,7 @@ class FabricRunner(ActionRunner, ShellRunnerMixin):
             result, cfg.CONF.ssh_runner.allow_partial_failure)
 
         # TODO (manas) : figure out the right boolean representation.
-        return (status, result)
+        return (status, result, None)
 
     def _run(self, remote_action):
         LOG.info('Executing action via FabricRunner :%s for user: %s.',

--- a/st2actions/st2actions/runners/httprunner.py
+++ b/st2actions/st2actions/runners/httprunner.py
@@ -80,7 +80,7 @@ class HttpRunner(ActionRunner):
         LOG.debug('action_parameters = %s', action_parameters)
         output = client.run()
         status = HttpRunner._get_result_status(output.get('status_code', None))
-        return (status, output)
+        return (status, output, None)
 
     def _get_http_client(self, action_parameters):
         body = action_parameters.get(ACTION_BODY, None)

--- a/st2actions/st2actions/runners/localrunner.py
+++ b/st2actions/st2actions/runners/localrunner.py
@@ -169,4 +169,4 @@ class LocalShellRunner(ActionRunner, ShellRunnerMixin):
             result['error'] = error
 
         status = ACTIONEXEC_STATUS_SUCCEEDED if exit_code == 0 else ACTIONEXEC_STATUS_FAILED
-        return (status, jsonify.json_loads(result, LocalShellRunner.KEYS_TO_TRANSFORM))
+        return (status, jsonify.json_loads(result, LocalShellRunner.KEYS_TO_TRANSFORM), None)

--- a/st2actions/st2actions/runners/mistral/v2.py
+++ b/st2actions/st2actions/runners/mistral/v2.py
@@ -170,8 +170,15 @@ class MistralRunner(AsyncActionRunner):
                                                        **options)
 
         status = ACTIONEXEC_STATUS_RUNNING
-        query_context = {'mistral_execution_id': str(execution.id)}
-        LOG.info('Mistral query_context is %s' % query_context)
         partial_results = {'tasks': []}
 
-        return (status, partial_results, query_context)
+        context = {
+            'mistral': {
+                'execution_id': str(execution.id),
+                'workflow_name': execution.workflow_name
+            }
+        }
+
+        LOG.info('Mistral query context is %s' % context)
+
+        return (status, partial_results, context)

--- a/st2actions/st2actions/runners/pythonrunner.py
+++ b/st2actions/st2actions/runners/pythonrunner.py
@@ -182,7 +182,7 @@ class PythonRunner(ActionRunner):
 
         status = ACTIONEXEC_STATUS_SUCCEEDED if exit_code == 0 else ACTIONEXEC_STATUS_FAILED
         LOG.debug('Action output : %s. exit_code : %s. status : %s', str(output), exit_code, status)
-        return (status, output)
+        return (status, output, None)
 
     def _get_env_vars(self):
         """

--- a/st2actions/tests/unit/test_actionchain.py
+++ b/st2actions/tests/unit/test_actionchain.py
@@ -155,7 +155,7 @@ class TestActionChainRunner(DbTestCase):
         chain_runner.action = ACTION_1
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
-        status, _ = chain_runner.run({})
+        status, _, _ = chain_runner.run({})
         self.assertEqual(status, ACTIONEXEC_STATUS_FAILED)
         self.assertNotEqual(chain_runner.chain_holder.actionchain, None)
         # based on the chain the callcount is known to be 2. Not great but works.
@@ -170,7 +170,7 @@ class TestActionChainRunner(DbTestCase):
         chain_runner.action = ACTION_1
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
-        status, results = chain_runner.run({})
+        status, results, context = chain_runner.run({})
         self.assertEqual(status, ACTIONEXEC_STATUS_FAILED)
         self.assertNotEqual(chain_runner.chain_holder.actionchain, None)
 

--- a/st2actions/tests/unit/test_mistral_v2.py
+++ b/st2actions/tests/unit/test_mistral_v2.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import json
 import uuid
 
@@ -71,6 +72,8 @@ PACK = 'generic'
 LOADER = FixturesLoader()
 FIXTURES = LOADER.load_fixtures(fixtures_pack=PACK, fixtures_dict=TEST_FIXTURES)
 
+MISTRAL_EXECUTION = {'id': str(uuid.uuid4()), 'state': 'RUNNING', 'workflow_name': None}
+
 # Workbook with a single workflow
 WB1_YAML_FILE_NAME = TEST_FIXTURES['workflows'][0]
 WB1_YAML_FILE_PATH = LOADER.get_fixture_file_path_abs(PACK, 'workflows', WB1_YAML_FILE_NAME)
@@ -79,6 +82,8 @@ WB1_YAML = yaml.safe_dump(WB1_SPEC, default_flow_style=False)
 WB1_NAME = '%s.%s' % (PACK, WB1_YAML_FILE_NAME.replace('.yaml', ''))
 WB1 = workbooks.Workbook(None, {'name': WB1_NAME, 'definition': WB1_YAML})
 WB1_OLD = workbooks.Workbook(None, {'name': WB1_NAME, 'definition': ''})
+WB1_EXEC = copy.deepcopy(MISTRAL_EXECUTION)
+WB1_EXEC['workflow_name'] = WB1_NAME
 
 # Workbook with many workflows
 WB2_YAML_FILE_NAME = TEST_FIXTURES['workflows'][1]
@@ -87,6 +92,8 @@ WB2_SPEC = FIXTURES['workflows'][WB2_YAML_FILE_NAME]
 WB2_YAML = yaml.safe_dump(WB2_SPEC, default_flow_style=False)
 WB2_NAME = '%s.%s' % (PACK, WB2_YAML_FILE_NAME.replace('.yaml', ''))
 WB2 = workbooks.Workbook(None, {'name': WB2_NAME, 'definition': WB2_YAML})
+WB2_EXEC = copy.deepcopy(MISTRAL_EXECUTION)
+WB2_EXEC['workflow_name'] = WB2_NAME
 
 # Workbook with many workflows but no default workflow is defined
 WB3_YAML_FILE_NAME = TEST_FIXTURES['workflows'][2]
@@ -95,6 +102,8 @@ WB3_SPEC = FIXTURES['workflows'][WB3_YAML_FILE_NAME]
 WB3_YAML = yaml.safe_dump(WB3_SPEC, default_flow_style=False)
 WB3_NAME = '%s.%s' % (PACK, WB3_YAML_FILE_NAME.replace('.yaml', ''))
 WB3 = workbooks.Workbook(None, {'name': WB3_NAME, 'definition': WB3_YAML})
+WB3_EXEC = copy.deepcopy(MISTRAL_EXECUTION)
+WB3_EXEC['workflow_name'] = WB3_NAME
 
 # Non-workbook with a single workflow
 WF1_YAML_FILE_NAME = TEST_FIXTURES['workflows'][3]
@@ -104,6 +113,8 @@ WF1_YAML = yaml.safe_dump(WF1_SPEC, default_flow_style=False)
 WF1_NAME = '%s.%s' % (PACK, WF1_YAML_FILE_NAME.replace('.yaml', ''))
 WF1 = workflows.Workflow(None, {'name': WF1_NAME, 'definition': WF1_YAML})
 WF1_OLD = workflows.Workflow(None, {'name': WF1_NAME, 'definition': ''})
+WF1_EXEC = copy.deepcopy(MISTRAL_EXECUTION)
+WF1_EXEC['workflow_name'] = WF1_NAME
 
 # Non-workbook with a many workflows
 WF2_YAML_FILE_NAME = TEST_FIXTURES['workflows'][4]
@@ -112,10 +123,11 @@ WF2_SPEC = FIXTURES['workflows'][WF2_YAML_FILE_NAME]
 WF2_YAML = yaml.safe_dump(WF2_SPEC, default_flow_style=False)
 WF2_NAME = '%s.%s' % (PACK, WF2_YAML_FILE_NAME.replace('.yaml', ''))
 WF2 = workflows.Workflow(None, {'name': WF2_NAME, 'definition': WF2_YAML})
+WF2_EXEC = copy.deepcopy(MISTRAL_EXECUTION)
+WF2_EXEC['workflow_name'] = WF2_NAME
 
 # Action executions' requirements
 ACTION_PARAMS = {'friend': 'Rocky'}
-EXECUTION = executions.Execution(None, {'id': str(uuid.uuid4()), 'state': 'RUNNING'})
 CHAMPION = worker.Worker(None)
 
 
@@ -125,7 +137,7 @@ def process_create(payload):
 
 
 @mock.patch.object(LocalShellRunner, 'run', mock.
-                   MagicMock(return_value=(ACTIONEXEC_STATUS_SUCCEEDED, {})))
+                   MagicMock(return_value=(ACTIONEXEC_STATUS_SUCCEEDED, {}, None)))
 @mock.patch.object(CUDPublisher, 'publish_create', mock.MagicMock(side_effect=process_create))
 @mock.patch.object(CUDPublisher, 'publish_update', mock.MagicMock(return_value=None))
 class TestMistralRunner(DbTestCase):
@@ -150,13 +162,18 @@ class TestMistralRunner(DbTestCase):
         mock.MagicMock(return_value=[WF1]))
     @mock.patch.object(
         executions.ExecutionManager, 'create',
-        mock.MagicMock(return_value=EXECUTION))
+        mock.MagicMock(return_value=executions.Execution(None, WF1_EXEC)))
     def test_launch_workflow(self):
         MistralRunner.entry_point = mock.PropertyMock(return_value=WF1_YAML_FILE_PATH)
         execution = ActionExecutionDB(action=WF1_NAME, parameters=ACTION_PARAMS)
         execution = action_service.schedule(execution)
         execution = ActionExecution.get_by_id(str(execution.id))
         self.assertEqual(execution.status, ACTIONEXEC_STATUS_RUNNING)
+
+        mistral_context = execution.context.get('mistral', None)
+        self.assertIsNotNone(mistral_context)
+        self.assertEqual(mistral_context['execution_id'], WF1_EXEC.get('id'))
+        self.assertEqual(mistral_context['workflow_name'], WF1_EXEC.get('workflow_name'))
 
     @mock.patch.object(
         workflows.WorkflowManager, 'list',
@@ -172,13 +189,18 @@ class TestMistralRunner(DbTestCase):
         mock.MagicMock(return_value=[WF1]))
     @mock.patch.object(
         executions.ExecutionManager, 'create',
-        mock.MagicMock(return_value=EXECUTION))
+        mock.MagicMock(return_value=executions.Execution(None, WF1_EXEC)))
     def test_launch_when_workflow_definition_changed(self):
         MistralRunner.entry_point = mock.PropertyMock(return_value=WF1_YAML_FILE_PATH)
         execution = ActionExecutionDB(action=WF1_NAME, parameters=ACTION_PARAMS)
         execution = action_service.schedule(execution)
         execution = ActionExecution.get_by_id(str(execution.id))
         self.assertEqual(execution.status, ACTIONEXEC_STATUS_RUNNING)
+
+        mistral_context = execution.context.get('mistral', None)
+        self.assertIsNotNone(mistral_context)
+        self.assertEqual(mistral_context['execution_id'], WF1_EXEC.get('id'))
+        self.assertEqual(mistral_context['workflow_name'], WF1_EXEC.get('workflow_name'))
 
     @mock.patch.object(
         workflows.WorkflowManager, 'list',
@@ -194,12 +216,17 @@ class TestMistralRunner(DbTestCase):
         mock.MagicMock(return_value=[WF1]))
     @mock.patch.object(
         executions.ExecutionManager, 'create',
-        mock.MagicMock(return_value=EXECUTION))
+        mock.MagicMock(return_value=executions.Execution(None, WF1_EXEC)))
     def test_launch_when_workflow_not_exists(self):
         execution = ActionExecutionDB(action=WF1_NAME, parameters=ACTION_PARAMS)
         execution = action_service.schedule(execution)
         execution = ActionExecution.get_by_id(str(execution.id))
         self.assertEqual(execution.status, ACTIONEXEC_STATUS_RUNNING)
+
+        mistral_context = execution.context.get('mistral', None)
+        self.assertIsNotNone(mistral_context)
+        self.assertEqual(mistral_context['execution_id'], WF1_EXEC.get('id'))
+        self.assertEqual(mistral_context['workflow_name'], WF1_EXEC.get('workflow_name'))
 
     @mock.patch.object(
         workflows.WorkflowManager, 'list',
@@ -244,7 +271,7 @@ class TestMistralRunner(DbTestCase):
         mock.MagicMock(return_value=WB1))
     @mock.patch.object(
         executions.ExecutionManager, 'create',
-        mock.MagicMock(return_value=EXECUTION))
+        mock.MagicMock(return_value=executions.Execution(None, WB1_EXEC)))
     def test_launch_workbook(self):
         MistralRunner.entry_point = mock.PropertyMock(return_value=WB1_YAML_FILE_PATH)
         execution = ActionExecutionDB(action=WB1_NAME, parameters=ACTION_PARAMS)
@@ -252,6 +279,11 @@ class TestMistralRunner(DbTestCase):
         execution = ActionExecution.get_by_id(str(execution.id))
         self.assertEqual(execution.status, ACTIONEXEC_STATUS_RUNNING)
 
+        mistral_context = execution.context.get('mistral', None)
+        self.assertIsNotNone(mistral_context)
+        self.assertEqual(mistral_context['execution_id'], WB1_EXEC.get('id'))
+        self.assertEqual(mistral_context['workflow_name'], WB1_EXEC.get('workflow_name'))
+
     @mock.patch.object(
         workflows.WorkflowManager, 'list',
         mock.MagicMock(return_value=[]))
@@ -266,13 +298,18 @@ class TestMistralRunner(DbTestCase):
         mock.MagicMock(return_value=WB2))
     @mock.patch.object(
         executions.ExecutionManager, 'create',
-        mock.MagicMock(return_value=EXECUTION))
+        mock.MagicMock(return_value=executions.Execution(None, WB2_EXEC)))
     def test_launch_workbook_with_many_workflows(self):
         MistralRunner.entry_point = mock.PropertyMock(return_value=WB2_YAML_FILE_PATH)
         execution = ActionExecutionDB(action=WB2_NAME, parameters=ACTION_PARAMS)
         execution = action_service.schedule(execution)
         execution = ActionExecution.get_by_id(str(execution.id))
         self.assertEqual(execution.status, ACTIONEXEC_STATUS_RUNNING)
+
+        mistral_context = execution.context.get('mistral', None)
+        self.assertIsNotNone(mistral_context)
+        self.assertEqual(mistral_context['execution_id'], WB2_EXEC.get('id'))
+        self.assertEqual(mistral_context['workflow_name'], WB2_EXEC.get('workflow_name'))
 
     @mock.patch.object(
         workflows.WorkflowManager, 'list',
@@ -288,7 +325,7 @@ class TestMistralRunner(DbTestCase):
         mock.MagicMock(return_value=WB3))
     @mock.patch.object(
         executions.ExecutionManager, 'create',
-        mock.MagicMock(return_value=EXECUTION))
+        mock.MagicMock(return_value=executions.Execution(None, WB3_EXEC)))
     def test_launch_workbook_with_many_workflows_no_default(self):
         MistralRunner.entry_point = mock.PropertyMock(return_value=WB3_YAML_FILE_PATH)
         execution = ActionExecutionDB(action=WB3_NAME, parameters=ACTION_PARAMS)
@@ -311,13 +348,18 @@ class TestMistralRunner(DbTestCase):
         mock.MagicMock(return_value=WB1))
     @mock.patch.object(
         executions.ExecutionManager, 'create',
-        mock.MagicMock(return_value=EXECUTION))
+        mock.MagicMock(return_value=executions.Execution(None, WB1_EXEC)))
     def test_launch_when_workbook_definition_changed(self):
         MistralRunner.entry_point = mock.PropertyMock(return_value=WB1_YAML_FILE_PATH)
         execution = ActionExecutionDB(action=WB1_NAME, parameters=ACTION_PARAMS)
         execution = action_service.schedule(execution)
         execution = ActionExecution.get_by_id(str(execution.id))
         self.assertEqual(execution.status, ACTIONEXEC_STATUS_RUNNING)
+
+        mistral_context = execution.context.get('mistral', None)
+        self.assertIsNotNone(mistral_context)
+        self.assertEqual(mistral_context['execution_id'], WB1_EXEC.get('id'))
+        self.assertEqual(mistral_context['workflow_name'], WB1_EXEC.get('workflow_name'))
 
     @mock.patch.object(
         workflows.WorkflowManager, 'list',
@@ -333,12 +375,17 @@ class TestMistralRunner(DbTestCase):
         mock.MagicMock(return_value=WB1))
     @mock.patch.object(
         executions.ExecutionManager, 'create',
-        mock.MagicMock(return_value=EXECUTION))
+        mock.MagicMock(return_value=executions.Execution(None, WB1_EXEC)))
     def test_launch_when_workbook_not_exists(self):
         execution = ActionExecutionDB(action=WB1_NAME, parameters=ACTION_PARAMS)
         execution = action_service.schedule(execution)
         execution = ActionExecution.get_by_id(str(execution.id))
         self.assertEqual(execution.status, ACTIONEXEC_STATUS_RUNNING)
+
+        mistral_context = execution.context.get('mistral', None)
+        self.assertIsNotNone(mistral_context)
+        self.assertEqual(mistral_context['execution_id'], WB1_EXEC.get('id'))
+        self.assertEqual(mistral_context['workflow_name'], WB1_EXEC.get('workflow_name'))
 
     @mock.patch.object(
         workflows.WorkflowManager, 'list',

--- a/st2actions/tests/unit/test_pythonrunner.py
+++ b/st2actions/tests/unit/test_pythonrunner.py
@@ -48,7 +48,7 @@ class PythonRunnerTestCase(TestCase):
         runner.entry_point = PACAL_ROW_ACTION_PATH
         runner.container_service = service.RunnerContainerService()
         runner.pre_run()
-        (status, result) = runner.run({'row_index': 4})
+        (status, result, context) = runner.run({'row_index': 4})
         self.assertEqual(status, ACTIONEXEC_STATUS_SUCCEEDED)
         self.assertTrue(result is not None)
         self.assertEqual(result['result'], [1, 4, 6, 4, 1])
@@ -60,7 +60,7 @@ class PythonRunnerTestCase(TestCase):
         runner.entry_point = PACAL_ROW_ACTION_PATH
         runner.container_service = service.RunnerContainerService()
         runner.pre_run()
-        (status, result) = runner.run({'row_index': '4'})
+        (status, result, context) = runner.run({'row_index': '4'})
         self.assertTrue(result is not None)
         self.assertEqual(status, ACTIONEXEC_STATUS_FAILED)
 
@@ -71,7 +71,7 @@ class PythonRunnerTestCase(TestCase):
         runner.entry_point = 'foo.py'
         runner.container_service = service.RunnerContainerService()
         runner.pre_run()
-        (status, result) = runner.run({})
+        (status, result, context) = runner.run({})
         self.assertTrue(result is not None)
         self.assertEqual(status, ACTIONEXEC_STATUS_FAILED)
 
@@ -99,7 +99,7 @@ class PythonRunnerTestCase(TestCase):
         runner.entry_point = PACAL_ROW_ACTION_PATH
         runner.container_service = service.RunnerContainerService()
         runner.pre_run()
-        (status, result) = runner.run({'row_index': 4})
+        (status, result, context) = runner.run({'row_index': 4})
 
         call_args, call_kwargs = mock_popen.call_args
         actual_env = call_kwargs['env']

--- a/st2actions/tests/unit/test_runner.py
+++ b/st2actions/tests/unit/test_runner.py
@@ -49,7 +49,13 @@ class TestRunner(ActionRunner):
                 'action_params': action_params
             }
 
-        return (ACTIONEXEC_STATUS_SUCCEEDED, json.dumps(result))
+        context = {
+            'third_party_system': {
+                'ref_id': '1234'
+            }
+        }
+
+        return (ACTIONEXEC_STATUS_SUCCEEDED, json.dumps(result), context)
 
     def post_run(self, status, result):
         self.post_run_called = True

--- a/st2actions/tests/unit/test_runner_container.py
+++ b/st2actions/tests/unit/test_runner_container.py
@@ -89,6 +89,16 @@ class RunnerContainerTest(DbTestCase):
         self.assertTrue(result.get('action_params').get('actionint') == 10)
         self.assertTrue(result.get('action_params').get('actionstr') == 'bar')
 
+        # Assert that context is written correctly.
+        context = {
+            'user': 'stanley',
+            'third_party_system': {
+                'ref_id': '1234'
+            }
+        }
+
+        self.assertDictEqual(actionexec_db.context, context)
+
     def test_dispatch_runner_failure(self):
         runner_container = get_runner_container()
         params = {

--- a/st2common/st2common/util/action_db.py
+++ b/st2common/st2common/util/action_db.py
@@ -124,7 +124,8 @@ def get_actionexec_by_id(actionexec_id):
     return actionexec
 
 
-def update_actionexecution_status(status=None, result=None, end_timestamp=None, actionexec_id=None,
+def update_actionexecution_status(status=None, result=None, context=None,
+                                  end_timestamp=None, actionexec_id=None,
                                   actionexec_db=None):
     """
         Update the status of the specified ActionExecution to the value provided in
@@ -148,15 +149,21 @@ def update_actionexecution_status(status=None, result=None, end_timestamp=None, 
 
     LOG.debug('Updating ActionExection: "%s" with status="%s"',
               actionexec_db, status)
+
     actionexec_db.status = status
+
     if result:
         actionexec_db.result = result
+
+    if context:
+        actionexec_db.context.update(context)
 
     if end_timestamp:
         actionexec_db.end_timestamp = end_timestamp
 
     actionexec_db = ActionExecution.add_or_update(actionexec_db)
     LOG.debug('Updated status for ActionExecution object: %s', actionexec_db)
+
     return actionexec_db
 
 

--- a/st2common/tests/unit/test_action_db_utils.py
+++ b/st2common/tests/unit/test_action_db_utils.py
@@ -15,6 +15,7 @@
 
 import copy
 import datetime
+import uuid
 
 import mock
 
@@ -102,29 +103,24 @@ class ActionDBUtilsTestCase(DbTestCase):
         # Update by id.
         newactionexec_db = action_db_utils.update_actionexecution_status(
             status='running', actionexec_id=actionexec_db.id)
+
         # Verify id didn't change.
         self.assertEqual(origactionexec_db.id, newactionexec_db.id)
         self.assertEqual(newactionexec_db.status, 'running')
 
-    def test_update_actionexecution_status_and_end_timestamp(self):
-        actionexec_db = ActionExecutionDB()
-        actionexec_db.status = 'initializing'
-        actionexec_db.start_timestamp = datetime.datetime.utcnow()
-        actionexec_db.action = ResourceReference(
-            name=ActionDBUtilsTestCase.action_db.name,
-            pack=ActionDBUtilsTestCase.action_db.pack).ref
-        actionexec_db.parameters = {}
-        actionexec_db = ActionExecution.add_or_update(actionexec_db)
-        origactionexec_db = copy.copy(actionexec_db)
-
-        # Update by id
-        now = datetime.datetime.now()
+        # Update status, result, context, and end timestamp.
+        now = datetime.datetime.utcnow()
+        status = 'succeeded'
+        result = 'Work is done.'
+        context = {'third_party_id': uuid.uuid4().hex}
         newactionexec_db = action_db_utils.update_actionexecution_status(
-            status='running', end_timestamp=now, actionexec_id=actionexec_db.id)
+            status=status, result=result, context=context, end_timestamp=now,
+            actionexec_id=actionexec_db.id)
 
-        # Verify id didn't change and end_timestamp has been set
         self.assertEqual(origactionexec_db.id, newactionexec_db.id)
-        self.assertEqual(newactionexec_db.status, 'running')
+        self.assertEqual(newactionexec_db.status, status)
+        self.assertEqual(newactionexec_db.result, result)
+        self.assertDictEqual(newactionexec_db.context, context)
         self.assertEqual(newactionexec_db.end_timestamp, now)
 
     def test_update_actionexecution_status_invalid(self):


### PR DESCRIPTION
Add mistral execution ID and workflow name to the context on action
execution of the main workflow. Refactor all runners to include context
in the output of the run method. Refactor the asyn worker to use the
same context to build the query context.