### PR TITLE
More friendly error message on action API validation fails

### DIFF
--- a/st2common/st2common/validators/api/action.py
+++ b/st2common/st2common/validators/api/action.py
@@ -19,6 +19,7 @@ from st2common.exceptions.apivalidation import ValueValidationException
 from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2common import log as logging
 from st2common.util.action_db import get_runnertype_by_name
+from st2common.content.utils import get_packs_base_paths()
 from st2common.content.utils import check_pack_content_directory_exists
 
 
@@ -30,8 +31,11 @@ def validate_action(action_api):
 
     # Check if pack is valid.
     if not _is_valid_pack(action_api.pack):
-        msg = ('Content pack "%s" is not found or doesn\'t contain actions directory' %
-               (action_api.pack))
+        packs_base_paths = get_packs_base_paths()
+        packs_base_paths = ','.join(packs_base_paths)
+        msg = ('Content pack "%s" is not found or doesn\'t contain actions directory. '
+               'Searched in: %s' %
+               (action_api.pack, packs_base_paths))
         raise ValueValidationException(msg)
 
     # Check if parameters defined are valid.

--- a/st2common/st2common/validators/api/action.py
+++ b/st2common/st2common/validators/api/action.py
@@ -19,7 +19,7 @@ from st2common.exceptions.apivalidation import ValueValidationException
 from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2common import log as logging
 from st2common.util.action_db import get_runnertype_by_name
-from st2common.content.utils import get_packs_base_paths()
+from st2common.content.utils import get_packs_base_paths
 from st2common.content.utils import check_pack_content_directory_exists
 
 

--- a/st2common/st2common/validators/api/action.py
+++ b/st2common/st2common/validators/api/action.py
@@ -30,7 +30,8 @@ def validate_action(action_api):
 
     # Check if pack is valid.
     if not _is_valid_pack(action_api.pack):
-        msg = 'Content pack "%s" doesn\'t exist in any of the packs paths' % (action_api.pack)
+        msg = ('Content pack "%s" is not found or doesn\'t contain actions directory' %
+               (action_api.pack))
         raise ValueValidationException(msg)
 
     # Check if parameters defined are valid.


### PR DESCRIPTION
`_is_valid_pack` also returns `False` if a pack directory exists, but it doesn't contain `actions/` directory so we should also make that clear in the error message.