### PR TITLE
Improve history call

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,8 @@ Docs: http://docks.stackstorm.com/latest
   being executed. (new-feature)
 * Cast params of an execution before scheduling in the RulesEngine. This allows non-string
   parameters in an action. (new-feature)
+* Use QuerySet.count() instead of len(QuerySet) to avoid the caching of the entire result which
+  improve running time of API request. (bug-fix)
 
 v0.7 - January 16, 2015
 -----------------------

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -120,7 +120,7 @@ class ResourceController(rest.RestController):
 
         if limit:
             pecan.response.headers['X-Limit'] = str(limit)
-        pecan.response.headers['X-Total-Count'] = str(len(instances))
+        pecan.response.headers['X-Total-Count'] = str(instances.count())
 
         return [self.model.from_model(instance) for instance in instances[offset:eop]]
 


### PR DESCRIPTION
* Use count() method on queryset which has a better runtime. 

https://github.com/MongoEngine/mongoengine/blob/master/mongoengine/queryset/queryset.py#L47 <- caches result.

https://github.com/MongoEngine/mongoengine/blob/master/mongoengine/queryset/queryset.py#L97 <- no caching of result.
