### PR TITLE
Rule criteria lookup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ git+https://github.com/StackStorm/python-mistralclient.git@st2-0.5.1
 git+https://github.com/StackStorm/fabric.git@stanley-patched
 passlib>=1.6.2,<1.7
 lockfile>=0.10.2,<0.11
+jsonpath-rw>=1.3.0

--- a/st2common/st2common/constants/rules.py
+++ b/st2common/st2common/constants/rules.py
@@ -1,0 +1,16 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TRIGGER_PAYLOAD_PREFIX = 'trigger'

--- a/st2reactor/st2reactor/rules/datatransform.py
+++ b/st2reactor/st2reactor/rules/datatransform.py
@@ -17,19 +17,16 @@ import json
 import copy
 import jinja2
 
+from st2common.constants.rules import TRIGGER_PAYLOAD_PREFIX
 from st2common.constants.system import SYSTEM_KV_PREFIX
 from st2common.services.keyvalues import KeyValueLookup
 import six
 
 
-PAYLOAD_PREFIX = 'trigger'
-RULE_DATA_PREFIX = 'rule'
-
-
 class Jinja2BasedTransformer(object):
     def __init__(self, payload):
         self._payload_context = Jinja2BasedTransformer.\
-            _construct_context(PAYLOAD_PREFIX, payload, {})
+            _construct_context(TRIGGER_PAYLOAD_PREFIX, payload, {})
 
     def __call__(self, mapping):
         context = copy.copy(self._payload_context)

--- a/st2reactor/st2reactor/rules/filter.py
+++ b/st2reactor/st2reactor/rules/filter.py
@@ -20,7 +20,6 @@ from st2common import log as logging
 from st2common.constants.rules import TRIGGER_PAYLOAD_PREFIX
 from st2common.constants.system import SYSTEM_KV_PREFIX
 from st2common.services.keyvalues import KeyValueLookup
-from st2reactor.rules.datatransform import get_transformer
 
 
 LOG = logging.getLogger('st2reactor.ruleenforcement.filter')

--- a/st2reactor/tests/unit/test_filter.py
+++ b/st2reactor/tests/unit/test_filter.py
@@ -34,7 +34,7 @@ MOCK_TRIGGER.type = 'system.test'
 MOCK_TRIGGER_INSTANCE = TriggerInstanceDB()
 MOCK_TRIGGER_INSTANCE.id = bson.ObjectId()
 MOCK_TRIGGER_INSTANCE.trigger = MOCK_TRIGGER.get_reference().ref
-MOCK_TRIGGER_INSTANCE.payload = {'p1': 'v1'}
+MOCK_TRIGGER_INSTANCE.payload = {'p1': 'v1', 'bool': True, 'int': 1, 'float': 0.8}
 MOCK_TRIGGER_INSTANCE.occurrence_time = datetime.datetime.utcnow()
 
 MOCK_ACTION = ActionDB()
@@ -104,3 +104,21 @@ class FilterTest(DbTestCase):
         rule.criteria = {'trigger.p1': {'type': 'equals', 'pattern': 'v'}}
         f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
         self.assertFalse(f.filter(), 'equals check should have failed.')
+
+    def test_equals_bool_value(self):
+        rule = MOCK_RULE_1
+        rule.criteria = {'trigger.bool': {'type': 'equals', 'pattern': True}}
+        f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
+        self.assertTrue(f.filter(), 'equals check should have passed.')
+
+    def test_equals_int_value(self):
+        rule = MOCK_RULE_1
+        rule.criteria = {'trigger.int': {'type': 'equals', 'pattern': 1}}
+        f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
+        self.assertTrue(f.filter(), 'equals check should have passed.')
+
+    def test_equals_float_value(self):
+        rule = MOCK_RULE_1
+        rule.criteria = {'trigger.float': {'type': 'equals', 'pattern': 0.8}}
+        f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
+        self.assertTrue(f.filter(), 'equals check should have passed.')


### PR DESCRIPTION
- Use jsonpath to lookup payload instead of jinja2
- validate support for bool, int and float in criteria 