### PR TITLE
RFR: Print exit_code when operations fail on CLI commands

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,7 @@ Docs: http://docks.stackstorm.com/latest
   parameters in an action. (new-feature)
 * Use QuerySet.count() instead of len(QuerySet) to avoid the caching of the entire result which
   improve running time of API request. (bug-fix)
+* CLI commands to return non-zero exit codes for failed operations (new-feature)
 
 v0.7 - January 16, 2015
 -----------------------

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -73,6 +73,47 @@ Example output (error):
         return func(*args, **kwargs)
         ...
 
+Using CLI inside scripts
+------------------------
+
+CLI returns a non-zero return code for any erroneous operation. You can capture the return code of CLI commands to check whether the command succeeded. For example:
+
+.. sourcecode:: bash
+
+    st2 action get twilio.send_sms
+
+    +-------------+--------------------------------------------------------------+
+    | Property    | Value                                                        |
+    +-------------+--------------------------------------------------------------+
+    | id          | 54bfff490640fd2f6224ac1a                                     |
+    | ref         | twilio.send_sms                                              |
+    | pack        | twilio                                                       |
+    | name        | send_sms
+
+Now, let's get the exit code of the previous command.
+
+.. sourcecode:: bash
+
+    echo $?
+
+    0
+
+Now, let's run a command that we know will fail.
+
+.. sourcecode:: bash
+
+    st2 action get twilio.make_call
+
+    Action "twilio.make_call" is not found.
+
+Let's check the exit code of the last command.
+
+.. sourcecode:: bash
+
+    echo $?
+
+    2
+
 Changing the CLI output format
 ------------------------------
 

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -28,6 +28,7 @@ from os.path import join as pjoin
 from st2client import models
 from st2client.commands import resource
 from st2client.commands.resource import add_auth_token_to_kwargs_from_cli
+from st2client.exceptions.operations import OperationFailureException
 from st2client.formatters import table, execution
 from st2client.utils.date import format_isodate
 
@@ -579,3 +580,4 @@ class ActionExecutionGetCommand(resource.ResourceCommand):
             self.print_output(instance, formatter, **options)
         except resource.ResourceNotFoundError:
             self.print_not_found(args.id)
+            raise OperationFailureException('Execution %s not found.' % args.id)

--- a/st2client/st2client/commands/resource.py
+++ b/st2client/st2client/commands/resource.py
@@ -22,6 +22,7 @@ import logging
 import yaml
 
 from st2client import commands
+from st2client.exceptions.operations import OperationFailureException
 from st2client.formatters import table
 
 ALLOWED_EXTS = ['.json', '.yaml', '.yml']
@@ -278,6 +279,7 @@ class ResourceGetCommand(ResourceCommand):
         except ResourceNotFoundError:
             resource_id = getattr(args, self.pk_argument_name, None)
             self.print_not_found(resource_id)
+            raise OperationFailureException('Resource %s not found.' % resource_id)
 
 
 class ContentPackResourceGetCommand(ResourceGetCommand):
@@ -314,9 +316,15 @@ class ResourceCreateCommand(ResourceCommand):
         return self.manager.create(instance, **kwargs)
 
     def run_and_print(self, args, **kwargs):
-        instance = self.run(args, **kwargs)
-        self.print_output(instance, table.PropertyValueTable,
-                          attributes=['all'], json=args.json)
+        try:
+            instance = self.run(args, **kwargs)
+            if not instance:
+                raise Exception('Server did not create instance.')
+            self.print_output(instance, table.PropertyValueTable,
+                              attributes=['all'], json=args.json)
+        except Exception as e:
+            print('ERROR: %s' % e.message)
+            raise OperationFailureException('Create failed.')
 
 
 class ResourceUpdateCommand(ResourceCommand):
@@ -358,8 +366,12 @@ class ResourceUpdateCommand(ResourceCommand):
 
     def run_and_print(self, args, **kwargs):
         instance = self.run(args, **kwargs)
-        self.print_output(instance, table.PropertyValueTable,
-                          attributes=['all'], json=args.json)
+        try:
+            self.print_output(instance, table.PropertyValueTable,
+                              attributes=['all'], json=args.json)
+        except Exception as e:
+            print('ERROR: %s' % e.message)
+            raise OperationFailureException('Update failed.')
 
 
 class ContentPackResourceUpdateCommand(ResourceUpdateCommand):
@@ -395,6 +407,7 @@ class ResourceDeleteCommand(ResourceCommand):
         except ResourceNotFoundError:
             resource_id = getattr(args, self.pk_argument_name, None)
             self.print_not_found(resource_id)
+            raise OperationFailureException('Resource %s not found.' % resource_id)
 
 
 class ContentPackResourceDeleteCommand(ResourceDeleteCommand):

--- a/st2client/st2client/commands/resource.py
+++ b/st2client/st2client/commands/resource.py
@@ -324,7 +324,7 @@ class ResourceCreateCommand(ResourceCommand):
                               attributes=['all'], json=args.json)
         except Exception as e:
             print('ERROR: %s' % e.message)
-            raise OperationFailureException('Create failed.')
+            raise OperationFailureException(e.message)
 
 
 class ResourceUpdateCommand(ResourceCommand):
@@ -371,7 +371,7 @@ class ResourceUpdateCommand(ResourceCommand):
                               attributes=['all'], json=args.json)
         except Exception as e:
             print('ERROR: %s' % e.message)
-            raise OperationFailureException('Update failed.')
+            raise OperationFailureException(e.message)
 
 
 class ContentPackResourceUpdateCommand(ResourceUpdateCommand):

--- a/st2client/st2client/exceptions/base.py
+++ b/st2client/st2client/exceptions/base.py
@@ -1,0 +1,22 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class StackStormCLIBaseException(Exception):
+    """
+        The root of the exception class hierarchy for all
+        StackStorm CLI exceptions.
+    """
+    pass

--- a/st2client/st2client/exceptions/operations.py
+++ b/st2client/st2client/exceptions/operations.py
@@ -1,0 +1,20 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from st2client.exceptions.base import StackStormCLIBaseException
+
+
+class OperationFailureException(StackStormCLIBaseException):
+    pass


### PR DESCRIPTION
```
(virtualenv)~/stanley git:STORM-960/exit_code_when_fail ❯❯❯ st2 rule create -j bad_rule.json                 ✭ ✱ ◼
ERROR: Expecting property name: line 2 column 3 (char 4)
(virtualenv)~/stanley git:STORM-960/exit_code_when_fail ❯❯❯ echo $?                                        ⏎ ✭ ✱ ◼
2
(virtualenv)~/stanley git:STORM-960/exit_code_when_fail ❯❯❯ st2 action get twilio.get_sms                    ✭ ✱ ◼
Action "twilio.get_sms" is not found.

(virtualenv)~/stanley git:STORM-960/exit_code_when_fail ❯❯❯ echo $?                                        ⏎ ✭ ✱ ◼
2
(virtualenv)~/stanley git:STORM-960/exit_code_when_fail ❯❯❯

```