### PR TITLE
Fix and expand isotime regex

### DIFF
--- a/st2common/st2common/util/isotime.py
+++ b/st2common/st2common/util/isotime.py
@@ -22,7 +22,7 @@ import dateutil.parser
 
 ISO8601_FORMAT = '%Y-%m-%dT%H:%M:%S'
 ISO8601_FORMAT_MICROSECOND = '%Y-%m-%dT%H:%M:%S.%f'
-ISO8601_UTC_REGEX = '^\d{4}\-\d{2}\-\d{2}(\s|T)\d{2}:\d{2}:\d{2}(\.\d{6})?(Z|\+00|\+0000|\+00:00)$'
+ISO8601_UTC_REGEX = '^\d{4}\-\d{2}\-\d{2}(\s|T)\d{2}:\d{2}:\d{2}(\.\d{3,6})?(Z|\+00|\+0000|\+00:00)$'
 
 
 def add_utc_tz(dt):

--- a/st2common/st2common/util/isotime.py
+++ b/st2common/st2common/util/isotime.py
@@ -22,7 +22,8 @@ import dateutil.parser
 
 ISO8601_FORMAT = '%Y-%m-%dT%H:%M:%S'
 ISO8601_FORMAT_MICROSECOND = '%Y-%m-%dT%H:%M:%S.%f'
-ISO8601_UTC_REGEX = '^\d{4}\-\d{2}\-\d{2}(\s|T)\d{2}:\d{2}:\d{2}(\.\d{3,6})?(Z|\+00|\+0000|\+00:00)$'
+ISO8601_UTC_REGEX = \
+    '^\d{4}\-\d{2}\-\d{2}(\s|T)\d{2}:\d{2}:\d{2}(\.\d{3,6})?(Z|\+00|\+0000|\+00:00)$'
 
 
 def add_utc_tz(dt):

--- a/st2common/st2common/util/isotime.py
+++ b/st2common/st2common/util/isotime.py
@@ -22,7 +22,7 @@ import dateutil.parser
 
 ISO8601_FORMAT = '%Y-%m-%dT%H:%M:%S'
 ISO8601_FORMAT_MICROSECOND = '%Y-%m-%dT%H:%M:%S.%f'
-ISO8601_UTC_REGEX = '^\d{4}-\d{2}-\d{2}(\s|T)\d{2}:\d{2}:\d{2}(.\d{6})?(Z|\+00|\+0000|\+00:00)$'
+ISO8601_UTC_REGEX = '^\d{4}\-\d{2}\-\d{2}(\s|T)\d{2}:\d{2}:\d{2}(\.\d{6})?(Z|\+00|\+0000|\+00:00)$'
 
 
 def add_utc_tz(dt):

--- a/st2common/tests/unit/test_isotime.py
+++ b/st2common/tests/unit/test_isotime.py
@@ -42,6 +42,7 @@ class TestTimeUtil(unittest.TestCase):
         self.assertTrue(isotime.validate('2000-01-01T12:00:00.000000Z'))
         self.assertTrue(isotime.validate('2000-01-01T12:00:00+00:00'))
         self.assertTrue(isotime.validate('2000-01-01T12:00:00.000000+00:00'))
+        self.assertTrue(isotime.validate('2015-02-10T21:21:53.399Z'))
         self.assertFalse(isotime.validate('2000-01-01', raise_exception=False))
         self.assertFalse(isotime.validate('2000-01-01T12:00:00', raise_exception=False))
         self.assertFalse(isotime.validate('2000-01-01T12:00:00+00:00Z', raise_exception=False))
@@ -64,6 +65,7 @@ class TestTimeUtil(unittest.TestCase):
         self.assertEqual(isotime.parse('2000-01-01T12:00:00+00:00'), dt)
         self.assertEqual(isotime.parse('2000-01-01T12:00:00.000000Z'), dt)
         self.assertEqual(isotime.parse('2000-01-01T12:00:00.000000+00:00'), dt)
+        self.assertEqual(isotime.parse('2000-01-01T12:00:00.000Z'), dt)
 
     def test_format(self):
         dt = isotime.add_utc_tz(datetime.datetime(2000, 1, 1, 12))


### PR DESCRIPTION
Noticed it while working on / testing new aws notifications sensor.