### PR TITLE
Fix an infinite loop bug inside template rendering

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,7 @@ Docs: http://docks.stackstorm.com/latest
 * Use QuerySet.count() instead of len(QuerySet) to avoid the caching of the entire result which
   improve running time of API request. (bug-fix)
 * CLI commands to return non-zero exit codes for failed operations (new-feature)
+* Fix a bug with template rendering, under some conditions, ending in an infinite loop. (bug-fix)
 
 v0.7 - January 16, 2015
 -----------------------

--- a/st2actions/st2actions/utils/param_utils.py
+++ b/st2actions/st2actions/utils/param_utils.py
@@ -216,7 +216,6 @@ def _do_render_params(renderable_params, context):
     rendered_params = {}
     rendered_params.update(context)
 
-    keys_to_delete = []
     while len(renderable_params) != 0:
         for k, v in six.iteritems(renderable_params):
             template = env.from_string(v)
@@ -224,16 +223,12 @@ def _do_render_params(renderable_params, context):
             try:
                 rendered = template.render(rendered_params)
                 rendered_params[k] = rendered
-                keys_to_delete.append(k)
-            except Exception:
-                # TODO: Maybe we should throw here and abort action execution?
+            except Exception as e:
                 LOG.debug('Failed to render %s: %s', k, v, exc_info=True)
+                msg = 'Failed to render parameter "%s": %s' % (k, str(e))
+                raise actionrunner.ActionRunnerException(msg)
 
-                # Delete key from renderable_params to prevent infinite loop on
-                # exception
-                keys_to_delete.append(k)
-
-        for k in keys_to_delete:
+        for k in rendered_params:
             if k in renderable_params:
                 del renderable_params[k]
     return rendered_params

--- a/st2actions/st2actions/utils/param_utils.py
+++ b/st2actions/st2actions/utils/param_utils.py
@@ -215,15 +215,25 @@ def _do_render_params(renderable_params, context):
     env = Environment(undefined=StrictUndefined)
     rendered_params = {}
     rendered_params.update(context)
+
+    keys_to_delete = []
     while len(renderable_params) != 0:
         for k, v in six.iteritems(renderable_params):
             template = env.from_string(v)
+
             try:
                 rendered = template.render(rendered_params)
                 rendered_params[k] = rendered
-            except:
+                keys_to_delete.append(k)
+            except Exception:
+                # TODO: Maybe we should throw here and abort action execution?
                 LOG.debug('Failed to render %s: %s', k, v, exc_info=True)
-        for k in rendered_params:
+
+                # Delete key from renderable_params to prevent infinite loop on
+                # exception
+                keys_to_delete.append(k)
+
+        for k in keys_to_delete:
             if k in renderable_params:
                 del renderable_params[k]
     return rendered_params

--- a/st2actions/st2actions/utils/param_utils.py
+++ b/st2actions/st2actions/utils/param_utils.py
@@ -15,6 +15,7 @@
 
 import copy
 import json
+
 import six
 
 from jinja2 import Template, Environment, StrictUndefined, meta, exceptions
@@ -216,21 +217,50 @@ def _do_render_params(renderable_params, context):
     rendered_params = {}
     rendered_params.update(context)
 
+    # Maps parameter key to render exception
+    # We save the exception so we can throw a more meaningful exception at the end if rendering of
+    # some parameter fails
+    parameter_render_exceptions = {}
+
+    num_parameters = len(renderable_params) + len(context)
+    # After how many attempts at failing to render parameter we should bail out
+    max_rendered_parameters_unchanged_count = num_parameters
+    rendered_params_unchanged_count = 0
+
     while len(renderable_params) != 0:
+        renderable_params_pre_loop = renderable_params.copy()
         for k, v in six.iteritems(renderable_params):
             template = env.from_string(v)
 
             try:
                 rendered = template.render(rendered_params)
                 rendered_params[k] = rendered
+
+                if k in parameter_render_exceptions:
+                    del parameter_render_exceptions[k]
             except Exception as e:
+                # Note: This sucks, but because we support multi level and out of order
+                # rendering, we can't throw an exception here yet since the parameter could get
+                # rendered in future iteration
                 LOG.debug('Failed to render %s: %s', k, v, exc_info=True)
-                msg = 'Failed to render parameter "%s": %s' % (k, str(e))
-                raise actionrunner.ActionRunnerException(msg)
+                parameter_render_exceptions[k] = e
 
         for k in rendered_params:
             if k in renderable_params:
                 del renderable_params[k]
+
+        if renderable_params_pre_loop == renderable_params:
+            rendered_params_unchanged_count += 1
+
+        # Make sure we terminate and don't end up in an infinite loop if we
+        # tried to render all the parameters but rendering of some parameters
+        # still fails
+        if rendered_params_unchanged_count >= max_rendered_parameters_unchanged_count:
+            k = parameter_render_exceptions.keys()[0]
+            e = parameter_render_exceptions[k]
+            msg = 'Failed to render parameter "%s": %s' % (k, str(e))
+            raise actionrunner.ActionRunnerException(msg)
+
     return rendered_params
 
 

--- a/st2actions/tests/unit/test_param_utils.py
+++ b/st2actions/tests/unit/test_param_utils.py
@@ -287,6 +287,19 @@ class ParamsUtilsTest(DbTestCase):
             test_pass = e.message.find('Dependecy') == 0
         self.assertTrue(test_pass)
 
+    def test_get_rendered_params_param_rendering_failure(self):
+        runner_params = {}
+        action_params = {'cmd': '{{a2.foo}}', 'a2': 'test'}
+
+        expected_msg = 'Failed to render parameter "cmd": .*'
+        self.assertRaisesRegexp(actionrunner.ActionRunnerException,
+                                expected_msg,
+                                param_utils.get_rendered_params,
+                                runner_parameters=runner_params,
+                                action_parameters=action_params,
+                                runnertype_parameter_info={},
+                                action_parameter_info={})
+
     def _get_action_exec_db_model(self, params):
         actionexec_db = ActionExecutionDB()
         actionexec_db.status = 'initializing'


### PR DESCRIPTION
Previously we ended up in an infinite loop if rendering a param failed.