### PR TITLE
Pass st2 context via env kwargs in mistral on start_workflow

### DIFF
--- a/st2actions/st2actions/runners/mistral/v2.py
+++ b/st2actions/st2actions/runners/mistral/v2.py
@@ -132,10 +132,22 @@ class MistralRunner(AsyncActionRunner):
         # Setup inputs for the workflow execution.
         inputs = self.runner_parameters.get('context', dict())
         inputs.update(action_parameters)
+
         endpoint = 'http://%s:%s/v1/actionexecutions' % (cfg.CONF.api.host, cfg.CONF.api.port)
+
+        st2_execution_context = {
+            'endpoint': endpoint,
+            'parent': self.action_execution_id
+        }
+
         options = {
-            'st2_api_url': endpoint,
-            'st2_parent': self.action_execution_id
+            'env': {
+                '__actions': {
+                    'st2.action': {
+                        'st2_context': st2_execution_context
+                    }
+                }
+            }
         }
 
         # Get workbook/workflow definition from file.


### PR DESCRIPTION
Pass the st2 context (i.e. original action execution, API endpoint, auth
token, etc.) to mistral using the env kwargs in start_workflow.
Previously, the st2 context is passed as start params and the custom
action in mistral has to get the st2 context directly from the database.