### PR TITLE
[RFR] Try literal_eval if json.loads fails.

### DIFF
--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -194,7 +194,11 @@ class ActionRunCommand(resource.ResourceCommand):
             # Also support simple key1=val1,key2=val2 syntax
             if value.startswith('{'):
                 # Assume it's JSON
-                result = value = json.loads(value)
+                result = None
+                try:
+                    result = value = json.loads(value)
+                except:
+                    result = value = ast.literal_eval(value)
             else:
                 pairs = value.split(',')
 


### PR DESCRIPTION
* Often a user friendly json string may not be somthing json.loads like because it isn't properly escaped etc. For those cases ast.literal_eval can work.