### PR TITLE
Add another example of mistral workflow

### DIFF
--- a/contrib/examples/actions/mistral-workbook-multiple-subflows.json
+++ b/contrib/examples/actions/mistral-workbook-multiple-subflows.json
@@ -1,0 +1,15 @@
+{
+    "name": "mistral-workbook-multiple-subflows",
+    "pack": "examples",
+    "runner_type": "mistral-v2",
+    "description": "Run a series of subflows to illustrate some uncommon cases.",
+    "enabled": true,
+    "entry_point":"mistral-workbook-multiple-subflows.yaml",
+    "parameters": {
+        "workflow": {
+            "type": "string",
+            "default": "examples.mistral-workbook-multiple-subflows.main",
+            "immutable": true
+        }
+    }
+}

--- a/contrib/examples/actions/mistral-workbook-multiple-subflows.yaml
+++ b/contrib/examples/actions/mistral-workbook-multiple-subflows.yaml
@@ -1,0 +1,76 @@
+version: "2.0"
+name: "examples.mistral-workbook-multiple-subflows"
+
+workflows:
+
+    main:
+        type: direct
+        output:
+            report: $.report
+            state: $.state 
+        task-defaults:
+          on-error:
+            - fail
+        tasks:
+            call_internal_workflow:
+                workflow: internal_workflow
+                input:
+                    name: $.vm_name
+                publish:
+                    report: $.call_internal_workflow.report
+                on-success:
+                    - call_internal_workflow_multiple_tasks
+            call_internal_workflow_multiple_tasks:
+                workflow: internal_workflow_multiple_tasks
+                input:
+                    vm_id: $.vm_id
+                    cpu_cores: $.cpu_cores
+                    memory_mb: $.memory_mb
+                on-success:
+                    - call_external_workflow
+            call_external_workflow:
+                action: examples.mistral-basic
+                input:
+                    cmd: "sleep 2; echo external workflow ok"
+                publish:
+                    state: $.call_external_workflow.stdout
+                on-success:
+                    - call_action_chain
+            call_action_chain:
+                action: examples.echochain
+
+    internal_workflow:
+        type: direct
+        input:
+            - name
+        output:
+            report: $.report
+        task-defaults:
+          on-error:
+            - fail
+        tasks:
+            task1:
+                action: core.local
+                input:
+                    cmd: "sleep 3; echo task1 ok"
+                publish:
+                    report: $.task1.stdout
+
+    internal_workflow_multiple_tasks:
+        type: direct
+        input:
+            - vm_id
+            - cpu_cores
+            - memory_mb
+        task-defaults:
+          on-error:
+            - fail
+        tasks:
+            task1:
+                action: core.local
+                input:
+                    cmd: "sleep 2; echo task1 ok"
+            task2:
+                action: core.local
+                input:
+                    cmd: "sleep 4; echo task2 ok"


### PR DESCRIPTION
The workflow exposes several flaws in mistral integration:
 - internal workflow call doesn't create another execution. First `task1` should be a child of `call_internal_workflow` and the second `task1` and `task2` should be childs of `call_internal_workflow_multiple_tasks`.
 - mistral workflow called from another mistral workflow (`call_external_workflow`) doesn't have task name in its context. For comparison, `call_action_chain` execution has it.
![screen shot 2015-02-13 at 12 03 49](https://cloud.githubusercontent.com/assets/1357357/6182960/1019e690-b370-11e4-9e7f-196af063850d.png)

