### PR TITLE
RFR: Hack to get task name for mistral nested workflows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,7 @@ Docs: http://docks.stackstorm.com/latest
 * API url change /v1/history/execution/views/filters?execution to /v1/history/liveactions/views/filters?liveaction (refactor)
 * Add new ``nequals`` (``neq``) rule criteria operator. This criteria operator
   performs not equals check on values of an arbitrary type. (new-feature)
+* Mistral subworkflows kicked off in st2 should include task name. (bug-fix)
 
 v0.7 - January 16, 2015
 -----------------------

--- a/st2actions/st2actions/runners/mistral/v2.py
+++ b/st2actions/st2actions/runners/mistral/v2.py
@@ -190,7 +190,7 @@ class MistralRunner(AsyncActionRunner):
             'workflow_name': execution.workflow_name
         }
 
-        exec_context = copy.deepcopy(self.context)
+        exec_context = self.context
         exec_context = self._build_mistral_context(exec_context, current_context)
         LOG.info('Mistral query context is %s' % exec_context)
 
@@ -198,6 +198,13 @@ class MistralRunner(AsyncActionRunner):
 
     @staticmethod
     def _build_mistral_context(parent, current):
+        """
+        Mistral workflow might be kicked off in st2 by a parent Mistral
+        workflow. In that case, we need to make sure that the existing
+        mistral 'context' is moved as 'parent' and the child workflow
+        'context' is added.
+        """
+        parent = copy.deepcopy(parent)
         context = dict()
 
         if not parent:

--- a/st2actions/st2actions/runners/mistral/v2.py
+++ b/st2actions/st2actions/runners/mistral/v2.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import uuid
 
 import six
@@ -189,7 +190,7 @@ class MistralRunner(AsyncActionRunner):
             'workflow_name': execution.workflow_name
         }
 
-        exec_context = self.context
+        exec_context = copy.deepcopy(self.context)
         exec_context = self._build_mistral_context(exec_context, current_context)
         LOG.info('Mistral query context is %s' % exec_context)
 

--- a/st2actions/tests/unit/test_mistral_v2.py
+++ b/st2actions/tests/unit/test_mistral_v2.py
@@ -465,10 +465,11 @@ class TestMistralRunner(DbTestCase):
         context = MistralRunner._build_mistral_context(parent, current)
         self.assertTrue(context is not None)
         self.assertTrue('parent' in context['mistral'].keys())
-        self.assertDictEqual(context['mistral']['parent'], {
+        parent_dict = {
             'workflow_name': parent['mistral']['workflow_name'],
             'execution_id': parent['mistral']['execution_id']
-            })
+        }
+        self.assertDictEqual(context['mistral']['parent'], parent_dict)
         self.assertEqual(context['mistral']['execution_id'], current['execution_id'])
 
         parent = None

--- a/st2actions/tests/unit/test_mistral_v2.py
+++ b/st2actions/tests/unit/test_mistral_v2.py
@@ -455,3 +455,22 @@ class TestMistralRunner(DbTestCase):
                                             data=json.dumps({'state': 'SUCCESS',
                                                              'result': NON_EMPTY_RESULT}),
                                             headers={'content-type': 'application/json'})
+
+    def test_build_context(self):
+        parent = {'mistral': {
+                  'workflow_name': 'foo', 'execution_id': 'zbbjb-r87t84-bbjd',
+                  'task_tags': None, 'task_name': 'some_fancy_wf_task',
+                  'task_id': '6c7d4334-3e7d-49c6-918d-698e846affaf'}}
+        current = {'workflow_name': 'foo.subwf', 'execution_id': 'cbjhv-csvhjvsh-vvshvc'}
+        context = MistralRunner._build_mistral_context(parent, current)
+        self.assertTrue(context is not None)
+        self.assertTrue('parent' in context['mistral'].keys())
+        self.assertDictEqual(context['mistral']['parent'], {
+            'workflow_name': parent['mistral']['workflow_name'],
+            'execution_id': parent['mistral']['execution_id']
+            })
+        self.assertEqual(context['mistral']['execution_id'], current['execution_id'])
+
+        parent = None
+        context = MistralRunner._build_mistral_context(parent, current)
+        self.assertDictEqual(context['mistral'], current)


### PR DESCRIPTION
Before this PR, nested mistral workflows kicked off via st2 (we call it external workflows) had a problem with task name. 

Example workflow:
https://gist.github.com/lakshmi-kannan/492ca36919de99e6e1bf

LiveAction DB objects: (Pay attention to the 'context' fields)
https://gist.github.com/lakshmi-kannan/d65b09700d26d74f71dd

LiveActionDB objects after fix:
https://gist.github.com/lakshmi-kannan/3d5d859e1cacc7670788
