### PR TITLE
Store value of ComplexDateTimeField as number of microseconds since the epoch in the db

### DIFF
--- a/st2common/st2common/fields.py
+++ b/st2common/st2common/fields.py
@@ -56,7 +56,7 @@ class ComplexDateTimeField(LongField):
         :param data: Number of microseconds since the epoch.
         :type data: ``int``
         """
-        result = datetime.datetime.fromtimestamp(data//SECOND_TO_MICROSECONDS)
+        result = datetime.datetime.fromtimestamp(data // SECOND_TO_MICROSECONDS)
         microseconds_reminder = (data % SECOND_TO_MICROSECONDS)
         result.replace(microsecond=microseconds_reminder)
         return result

--- a/st2common/st2common/fields.py
+++ b/st2common/st2common/fields.py
@@ -1,0 +1,100 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import datetime
+
+from mongoengine import LongField
+
+__all__ = [
+    'ComplexDateTimeField'
+]
+
+SECOND_TO_MICROSECONDS = 1000000
+
+
+class ComplexDateTimeField(LongField):
+    """
+    Date time field which handles microseconds exactly and internally stores
+    the timestamp as number of microseconds since the unix epoch.
+
+    Note: We need to do that because mongoengine serializes this field as comma
+    delimited string which breaks sorting.
+    """
+
+    def _convert_from_datetime(self, val):
+        """
+        Convert a `datetime` object to number of microseconds since epoch representation
+        (which will be stored in MongoDB). This is the reverse function of
+        `_convert_from_db`.
+        """
+        result = self._datetime_to_microseconds_since_epoch(value=val)
+        return result
+
+    def _convert_from_db(self, value):
+        result = self._microseconds_since_epoch_to_datetime(data=value)
+        return result
+
+    def _microseconds_since_epoch_to_datetime(self, data):
+        """
+        Convert a number representation to a `datetime` object (the object you
+        will manipulate). This is the reverse function of
+        `_convert_from_datetime`.
+
+        :param data: Number of microseconds since the epoch.
+        :type data: ``int``
+        """
+        result = datetime.datetime.fromtimestamp(data//SECOND_TO_MICROSECONDS)
+        microseconds_reminder = (data % SECOND_TO_MICROSECONDS)
+        result.replace(microsecond=microseconds_reminder)
+        return result
+
+    def _datetime_to_microseconds_since_epoch(self, value):
+        seconds = time.mktime(value.timetuple())
+        microseconds_reminder = value.time().microsecond
+        result = (int(seconds * SECOND_TO_MICROSECONDS) + microseconds_reminder)
+        return result
+
+    def __get__(self, instance, owner):
+        data = super(ComplexDateTimeField, self).__get__(instance, owner)
+        if data is None:
+            return datetime.datetime.now()
+        if isinstance(data, datetime.datetime):
+            return data
+        return self._convert_from_db(data)
+
+    def __set__(self, instance, value):
+        value = self._convert_from_datetime(value) if value else value
+        return super(ComplexDateTimeField, self).__set__(instance, value)
+
+    def validate(self, value):
+        value = self.to_python(value)
+        if not isinstance(value, datetime.datetime):
+            self.error('Only datetime objects may used in a '
+                       'ComplexDateTimeField')
+
+    def to_python(self, value):
+        original_value = value
+        try:
+            return self._convert_from_db(value)
+        except:
+            return original_value
+
+    def to_mongo(self, value):
+        value = self.to_python(value)
+        return self._convert_from_datetime(value)
+
+    def prepare_query_value(self, op, value):
+        return self._convert_from_datetime(value)

--- a/st2common/st2common/fields.py
+++ b/st2common/st2common/fields.py
@@ -58,7 +58,7 @@ class ComplexDateTimeField(LongField):
         """
         result = datetime.datetime.fromtimestamp(data // SECOND_TO_MICROSECONDS)
         microseconds_reminder = (data % SECOND_TO_MICROSECONDS)
-        result.replace(microsecond=microseconds_reminder)
+        result = result.replace(microsecond=microseconds_reminder)
         return result
 
     def _datetime_to_microseconds_since_epoch(self, value):

--- a/st2common/st2common/models/db/action.py
+++ b/st2common/st2common/models/db/action.py
@@ -19,6 +19,7 @@ import mongoengine as me
 from st2common import log as logging
 from st2common.models.db import MongoDBAccess
 from st2common.models.db import stormbase
+from st2common.fields import ComplexDateTimeField
 
 __all__ = [
     'RunnerTypeDB',
@@ -109,10 +110,10 @@ class LiveActionDB(stormbase.StormFoundationDB):
     status = me.StringField(
         required=True,
         help_text='The current status of the liveaction.')
-    start_timestamp = me.ComplexDateTimeField(
+    start_timestamp = ComplexDateTimeField(
         default=datetime.datetime.utcnow,
         help_text='The timestamp when the liveaction was created.')
-    end_timestamp = me.ComplexDateTimeField(
+    end_timestamp = ComplexDateTimeField(
         help_text='The timestamp when the liveaction has finished.')
     action = me.StringField(
         required=True,

--- a/st2common/tests/unit/test_db_fields.py
+++ b/st2common/tests/unit/test_db_fields.py
@@ -1,0 +1,54 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import datetime
+
+import unittest2
+
+from st2common.fields import ComplexDateTimeField
+
+
+class ComplexDateTimeFieldTestCase(unittest2.TestCase):
+    def test_round_trip_conversion(self):
+        datetime_values = [
+            datetime.datetime(2015, 1, 1, 15, 0, 0).replace(microsecond=500),
+            datetime.datetime(2015, 1, 1, 15, 0, 0).replace(microsecond=0),
+            datetime.datetime(2015, 1, 1, 15, 0, 0).replace(microsecond=999999)
+        ]
+        microsecond_values = []
+
+        # Calculate microsecond values
+        for value in datetime_values:
+            seconds = time.mktime(value.timetuple())
+            microseconds_reminder = value.time().microsecond
+            result = int(seconds * 1000000) + microseconds_reminder
+            microsecond_values.append(result)
+
+        field = ComplexDateTimeField()
+        # datetime to us
+        for index, value in enumerate(datetime_values):
+            actual_value = field._datetime_to_microseconds_since_epoch(value=value)
+            expected_value = microsecond_values[index]
+            expected_microseconds = value.time().microsecond
+
+            self.assertEqual(actual_value, expected_value)
+            self.assertTrue(str(actual_value).endswith(str(expected_microseconds)))
+
+        # us to datetime
+        for index, value in enumerate(microsecond_values):
+            actual_value = field._microseconds_since_epoch_to_datetime(data=value)
+            expected_value = datetime_values[index]
+            self.assertEqual(actual_value, expected_value)


### PR DESCRIPTION
With this change we now store values of ``ComplexDateTimeField`` fields as number of microseconds since the epoch internally in MongoDB.

MongoEngine's version of ``ComplexDateTimeField`` stores it as a comma delimited string (e.g. ``2011,06,08,20,26,24,192284``) which results in a wrong sort order when lleading zeros are present.

This should fix an issue with action execution tests intermediate failures.

Storing is as a number should also be more efficient in terms of storage space and retrieval / querying speed.

This should fix the bug with action execution tests failing.

TODO:

- [x] Tests