### PR TITLE
New CLI command for re-running an action

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,6 +46,8 @@ Docs: http://docks.stackstorm.com/latest
 * Add new ``nequals`` (``neq``) rule criteria operator. This criteria operator
   performs not equals check on values of an arbitrary type. (new-feature)
 * Mistral subworkflows kicked off in st2 should include task name. (bug-fix)
+* Add new ``execution re-run <execution id>`` CLI command for re-running an
+  existing action. (new-feature)
 
 v0.7 - January 16, 2015
 -----------------------

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -267,6 +267,80 @@ Example:
 
     st2 run core.remote hosts=<host> username=<username> @private_key=/home/myuser/.ssh/id_rsa cmd=<cmd>
 
+Re-running an action
+--------------------
+
+To re-run a particular action, you can use the ``execution re-run <existing
+execution id>`` command.
+This command re-runs an action with the same set of the input parameters which
+were used for the original action.
+
+For example:
+
+.. sourcecode:: bash
+
+    st2 run core.local env=VAR=hello cmd='echo $VAR; date'
+    .
+    +-----------------+--------------------------------+
+    | Property        | Value                          |
+    +-----------------+--------------------------------+
+    | id              | 54e37a3c0640fd0bd07b1930       |
+    | context         | {                              |
+    |                 |     "user": "stanley"          |
+    |                 | }                              |
+    | parameters      | {                              |
+    |                 |     "cmd": "echo $VAR; date",  |
+    |                 |     "env": {                   |
+    |                 |         "VAR": "hello"         |
+    |                 |     }                          |
+    |                 | }                              |
+    | status          | succeeded                      |
+    | start_timestamp | Tue, 17 Feb 2015 17:28:28 UTC  |
+    | result          | {                              |
+    |                 |     "failed": false,           |
+    |                 |     "stderr": "",              |
+    |                 |     "return_code": 0,          |
+    |                 |     "succeeded": true,         |
+    |                 |     "stdout": "hello           |
+    |                 | Tue Feb 17 17:28:28 UTC 2015   |
+    |                 | "                              |
+    |                 | }                              |
+    | action          | core.local                     |
+    | callback        |                                |
+    | end_timestamp   | Tue, 17 Feb 2015 17:28:28 UTC  |
+    +-----------------+--------------------------------+
+
+    st2 run re-run 54e37a3c0640fd0bd07b1930
+    .
+    +-----------------+--------------------------------+
+    | Property        | Value                          |
+    +-----------------+--------------------------------+
+    | id              | 54e37a630640fd0bd07b1932       |
+    | context         | {                              |
+    |                 |     "user": "stanley"          |
+    |                 | }                              |
+    | parameters      | {                              |
+    |                 |     "cmd": "echo $VAR; date",  |
+    |                 |     "env": {                   |
+    |                 |         "VAR": "hello"         |
+    |                 |     }                          |
+    |                 | }                              |
+    | status          | succeeded                      |
+    | start_timestamp | Tue, 17 Feb 2015 17:29:07 UTC  |
+    | result          | {                              |
+    |                 |     "failed": false,           |
+    |                 |     "stderr": "",              |
+    |                 |     "return_code": 0,          |
+    |                 |     "succeeded": true,         |
+    |                 |     "stdout": "hello           |
+    |                 | Tue Feb 17 17:29:07 UTC 2015   |
+    |                 | "                              |
+    |                 | }                              |
+    | action          | core.local                     |
+    | callback        |                                |
+    | end_timestamp   | Tue, 17 Feb 2015 17:29:07 UTC  |
+    +-----------------+--------------------------------+
+
 Inheriting all the environment variables which are accessible to the CLI and passing them to runner as env parameter
 --------------------------------------------------------------------------------------------------------------------
 

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -272,14 +272,20 @@ Re-running an action
 
 To re-run a particular action, you can use the ``execution re-run <existing
 execution id>`` command.
-This command re-runs an action with the same set of the input parameters which
-were used for the original action.
+
+By default, this command re-runs an action with the same set of input parameters
+which were used with the original action.
+
+The command takes the same arguments as the ``run`` / ``action execute``
+command. This means you can pass additional runner or action specific parameters
+to the command. Those parameters are then merged with the parameters from the
+original action and used to run a new action.
 
 For example:
 
 .. sourcecode:: bash
 
-    st2 run core.local env=VAR=hello cmd='echo $VAR; date'
+    st2 run core.local env="VAR=hello" cmd='echo $VAR; date'
     .
     +-----------------+--------------------------------+
     | Property        | Value                          |
@@ -339,6 +345,37 @@ For example:
     | action          | core.local                     |
     | callback        |                                |
     | end_timestamp   | Tue, 17 Feb 2015 17:29:07 UTC  |
+    +-----------------+--------------------------------+
+
+    st2 run re-run 7a3c0640fd0bd07b1930 env="VAR=world"
+    .
+    +-----------------+--------------------------------+
+    | Property        | Value                          |
+    +-----------------+--------------------------------+
+    | id              | 54e3a8f50640fd140ae20af7       |
+    | context         | {                              |
+    |                 |     "user": "stanley"          |
+    |                 | }                              |
+    | parameters      | {                              |
+    |                 |     "cmd": "echo $VAR; date",  |
+    |                 |     "env": {                   |
+    |                 |         "VAR": "world"         |
+    |                 |     }                          |
+    |                 | }                              |
+    | status          | succeeded                      |
+    | start_timestamp | Tue, 17 Feb 2015 20:47:49 UTC  |
+    | result          | {                              |
+    |                 |     "failed": false,           |
+    |                 |     "stderr": "",              |
+    |                 |     "return_code": 0,          |
+    |                 |     "succeeded": true,         |
+    |                 |     "stdout": "world           |
+    |                 | Tue Feb 17 20:47:49 UTC 2015   |
+    |                 | "                              |
+    |                 | }                              |
+    | action          | core.local                     |
+    | callback        |                                |
+    | end_timestamp   | Tue, 17 Feb 2015 20:47:49 UTC  |
     +-----------------+--------------------------------+
 
 Inheriting all the environment variables which are accessible to the CLI and passing them to runner as env parameter

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -130,6 +130,9 @@ class ActionRunCommandMixin(object):
         'parameters': format_parameters
     }
 
+    def get_resource(self, ref_or_id, **kwargs):
+        return self.get_resource_by_ref_or_id(ref_or_id=ref_or_id, **kwargs)
+
     def run_and_print(self, args, **kwargs):
         if self._print_help(args, **kwargs):
             return
@@ -179,96 +182,17 @@ class ActionRunCommandMixin(object):
                 result['traceback'])
         return result
 
-    @add_auth_token_to_kwargs_from_cli
-    def _print_help(self, args, **kwargs):
-        # Print appropriate help message if the help option is given.
-        if getattr(args, 'help', False):
-            if args.ref_or_id:
-                try:
-                    action = self.get_resource(args.ref_or_id, **kwargs)
-                    runner_mgr = self.app.client.managers['RunnerType']
-                    runner = runner_mgr.get_by_name(action.runner_type, **kwargs)
-                    parameters, required, optional, _ = self._get_params_types(runner,
-                                                                               action)
-                    print('')
-                    print(textwrap.fill(action.description))
-                    print('')
-                    if required:
-                        required = self._sort_parameters(parameters=parameters,
-                                                         names=required)
+    def _get_action_parameters_from_args(self, action, runner, args):
+        """
+        Build a dictionary with parameters which will be passed to the action by
+        parsing parameters passed to the CLI.
 
-                        print('Required Parameters:')
-                        [self.print_param(name, parameters.get(name))
-                            for name in required]
-                    if optional:
-                        optional = self._sort_parameters(parameters=parameters,
-                                                         names=optional)
+        :param args: CLI argument.
+        :type args: ``object``
 
-                        print('Optional Parameters:')
-                        [self.print_param(name, parameters.get(name))
-                            for name in optional]
-                except resource.ResourceNotFoundError:
-                    print('Action "%s" is not found.' % args.ref_or_id)
-                except Exception as e:
-                    print('ERROR: Unable to print help for action "%s". %s' %
-                          (args.ref_or_id, e))
-            else:
-                self.parser.print_help()
-            return True
-        return False
-
-
-class ActionRunCommand(ActionRunCommandMixin, resource.ResourceCommand):
-    def __init__(self, resource, *args, **kwargs):
-
-        super(ActionRunCommand, self).__init__(
-            resource, kwargs.pop('name', 'execute'),
-            'A command to invoke an action manually.',
-            *args, **kwargs)
-
-        self.parser.add_argument('ref_or_id', nargs='?',
-                                 metavar='ref-or-id',
-                                 help='Fully qualified name (pack.action_name) ' +
-                                 'or ID of the action.')
-        self.parser.add_argument('parameters', nargs='*',
-                                 help='List of keyword args, positional args, '
-                                      'and optional args for the action.')
-
-        self.parser.add_argument('-h', '--help',
-                                 action='store_true', dest='help',
-                                 help='Print usage for the given action.')
-
-        if self.name == 'run':
-            self.parser.add_argument('-a', '--async',
-                                     action='store_true', dest='async',
-                                     help='Do not wait for action to finish.')
-            self.parser.add_argument('-e', '--inherit-env',
-                                     action='store_true', dest='inherit_env',
-                                     help='Pass all the environment variables '
-                                          'which are accessible to the CLI as "env" '
-                                          'parameter to the action. Note: Only works '
-                                          'with python, local and remote runners.')
-        else:
-            self.parser.set_defaults(async=True)
-
-    def get_resource(self, ref_or_id, **kwargs):
-        return self.get_resource_by_ref_or_id(ref_or_id=ref_or_id, **kwargs)
-
-    @add_auth_token_to_kwargs_from_cli
-    def run(self, args, **kwargs):
-        if not args.ref_or_id:
-            self.parser.error('too few arguments')
-
-        action = self.get_resource(args.ref_or_id, **kwargs)
-        if not action:
-            raise resource.ResourceNotFoundError('Action "%s" cannot be found.'
-                                                 % args.ref_or_id)
-
-        runner_mgr = self.app.client.managers['RunnerType']
-        runner = runner_mgr.get_by_name(action.runner_type, **kwargs)
-        if not runner:
-            raise resource.ResourceNotFoundError('Runner type "%s" for action "%s" cannot be found.'
-                                                 % (action.runner_type, action.name))
+        :rtype: ``dict``
+        """
+        action_ref_or_id = action.ref
 
         def read_file(file_path):
             if not os.path.exists(file_path):
@@ -322,13 +246,7 @@ class ActionRunCommand(ActionRunCommandMixin, resource.ResourceCommand):
                     return transformer[param['type']](value)
             return value
 
-        action_ref = '.'.join([action.pack, action.name])
-        execution = models.LiveAction()
-        execution.action = action_ref
-        execution.parameters = dict()
-
-        action_ref_or_id = args.ref_or_id
-
+        result = {}
         for idx in range(len(args.parameters)):
             arg = args.parameters[idx]
             if '=' in arg:
@@ -351,12 +269,12 @@ class ActionRunCommand(ActionRunCommandMixin, resource.ResourceCommand):
 
                         if action_ref_or_id == 'core.http':
                             # Special case for http runner
-                            execution.parameters['_file_name'] = file_name
-                            execution.parameters['file_content'] = content
+                            result['_file_name'] = file_name
+                            result['file_content'] = content
                         else:
-                            execution.parameters[k] = content
+                            result[k] = content
                     else:
-                        execution.parameters[k] = normalize(k, v)
+                        result[k] = normalize(k, v)
                 except Exception as e:
                     # TODO: Move transformers in a separate module and handle
                     # exceptions there
@@ -367,33 +285,76 @@ class ActionRunCommand(ActionRunCommandMixin, resource.ResourceCommand):
                     else:
                         raise e
             else:
-                execution.parameters['cmd'] = ' '.join(args.parameters[idx:])
+                result['cmd'] = ' '.join(args.parameters[idx:])
                 break
 
-        if 'file_content' in execution.parameters:
-            if 'method' not in execution.parameters:
+        # Special case for http runner
+        if 'file_content' in result:
+            if 'method' not in result:
                 # Default to POST if a method is not provided
-                execution.parameters['method'] = 'POST'
+                result['method'] = 'POST'
 
-            if 'file_name' not in execution.parameters:
+            if 'file_name' not in result:
                 # File name not provided, use default file name
-                execution.parameters['file_name'] = execution.parameters['_file_name']
+                result['file_name'] = result['_file_name']
 
-            del execution.parameters['_file_name']
+            del result['_file_name']
 
         if args.inherit_env:
-            execution.parameters['env'] = self._get_inherited_env_vars()
+            result['env'] = self._get_inherited_env_vars()
 
+        return result
+
+    @add_auth_token_to_kwargs_from_cli
+    def _print_help(self, args, **kwargs):
+        # Print appropriate help message if the help option is given.
+        action_mgr = self.app.client.managers['Action']
         action_exec_mgr = self.app.client.managers['LiveAction']
 
-        execution = action_exec_mgr.create(execution, **kwargs)
-        execution = self._get_execution_result(execution=execution,
-                                               action_exec_mgr=action_exec_mgr,
-                                               args=args, **kwargs)
-        return execution
+        if args.help:
+            action_ref_or_id = getattr(args, 'ref_or_id', None)
+            action_exec_id = getattr(args, 'id', None)
+
+            if action_exec_id and not action_ref_or_id:
+                action_exec = action_exec_mgr.get_by_id(action_exec_id, **kwargs)
+                args.ref_or_id = action_exec.action
+
+            if args.ref_or_id:
+                try:
+                    action = action_mgr.get_by_ref_or_id(args.ref_or_id, **kwargs)
+                    runner_mgr = self.app.client.managers['RunnerType']
+                    runner = runner_mgr.get_by_name(action.runner_type, **kwargs)
+                    parameters, required, optional, _ = self._get_params_types(runner,
+                                                                               action)
+                    print('')
+                    print(textwrap.fill(action.description))
+                    print('')
+                    if required:
+                        required = self._sort_parameters(parameters=parameters,
+                                                         names=required)
+
+                        print('Required Parameters:')
+                        [self._print_param(name, parameters.get(name))
+                            for name in required]
+                    if optional:
+                        optional = self._sort_parameters(parameters=parameters,
+                                                         names=optional)
+
+                        print('Optional Parameters:')
+                        [self._print_param(name, parameters.get(name))
+                            for name in optional]
+                except resource.ResourceNotFoundError:
+                    print('Action "%s" is not found.' % args.ref_or_id)
+                except Exception as e:
+                    print('ERROR: Unable to print help for action "%s". %s' %
+                          (args.ref_or_id, e))
+            else:
+                self.parser.print_help()
+            return True
+        return False
 
     @staticmethod
-    def print_param(name, schema):
+    def _print_param(name, schema):
         if not schema:
             raise ValueError('Missing schema for parameter "%s"' % (name))
 
@@ -481,6 +442,75 @@ class ActionRunCommand(ActionRunCommandMixin, resource.ResourceCommand):
         return env_vars
 
 
+class ActionRunCommand(ActionRunCommandMixin, resource.ResourceCommand):
+    def __init__(self, resource, *args, **kwargs):
+
+        super(ActionRunCommand, self).__init__(
+            resource, kwargs.pop('name', 'execute'),
+            'A command to invoke an action manually.',
+            *args, **kwargs)
+
+        self.parser.add_argument('ref_or_id', nargs='?',
+                                 metavar='ref-or-id',
+                                 help='Fully qualified name (pack.action_name) ' +
+                                 'or ID of the action.')
+        self.parser.add_argument('parameters', nargs='*',
+                                 help='List of keyword args, positional args, '
+                                      'and optional args for the action.')
+
+        self.parser.add_argument('-h', '--help',
+                                 action='store_true', dest='help',
+                                 help='Print usage for the given action.')
+
+        if self.name in ['run', 'execute']:
+            self.parser.add_argument('-a', '--async',
+                                     action='store_true', dest='async',
+                                     help='Do not wait for action to finish.')
+            self.parser.add_argument('-e', '--inherit-env',
+                                     action='store_true', dest='inherit_env',
+                                     help='Pass all the environment variables '
+                                          'which are accessible to the CLI as "env" '
+                                          'parameter to the action. Note: Only works '
+                                          'with python, local and remote runners.')
+
+        if self.name == 'run':
+            self.parser.set_defaults(async=False)
+        else:
+            self.parser.set_defaults(async=True)
+
+    @add_auth_token_to_kwargs_from_cli
+    def run(self, args, **kwargs):
+        if not args.ref_or_id:
+            self.parser.error('too few arguments')
+
+        action = self.get_resource(args.ref_or_id, **kwargs)
+        if not action:
+            raise resource.ResourceNotFoundError('Action "%s" cannot be found.'
+                                                 % args.ref_or_id)
+
+        runner_mgr = self.app.client.managers['RunnerType']
+        runner = runner_mgr.get_by_name(action.runner_type, **kwargs)
+        if not runner:
+            raise resource.ResourceNotFoundError('Runner type "%s" for action "%s" cannot be found.'
+                                                 % (action.runner_type, action.name))
+
+        action_ref = '.'.join([action.pack, action.name])
+        action_parameters = self._get_action_parameters_from_args(action=action, runner=runner,
+                                                                  args=args)
+
+        execution = models.LiveAction()
+        execution.action = action_ref
+        execution.parameters = action_parameters
+
+        action_exec_mgr = self.app.client.managers['LiveAction']
+
+        execution = action_exec_mgr.create(execution, **kwargs)
+        execution = self._get_execution_result(execution=execution,
+                                               action_exec_mgr=action_exec_mgr,
+                                               args=args, **kwargs)
+        return execution
+
+
 class ActionExecutionBranch(resource.ResourceBranch):
 
     def __init__(self, description, app, subparsers, parent_parser=None):
@@ -492,7 +522,7 @@ class ActionExecutionBranch(resource.ResourceBranch):
 
         # Register extended commands
         self.commands['re-run'] = ActionExecutionReRunCommand(self.resource, self.app,
-                                                              self.subparsers)
+                                                              self.subparsers, add_help=False)
 
 
 class ActionExecutionListCommand(resource.ResourceCommand):
@@ -610,9 +640,21 @@ class ActionExecutionReRunCommand(ActionRunCommandMixin, resource.ResourceComman
         self.parser.add_argument('id', nargs='?',
                                  metavar='id',
                                  help='ID of action execution to re-run ')
+        self.parser.add_argument('parameters', nargs='*',
+                                 help='List of keyword args, positional args, '
+                                      'and optional args for the action.')
         self.parser.add_argument('-a', '--async',
                                  action='store_true', dest='async',
                                  help='Do not wait for action to finish.')
+        self.parser.add_argument('-e', '--inherit-env',
+                                 action='store_true', dest='inherit_env',
+                                 help='Pass all the environment variables '
+                                      'which are accessible to the CLI as "env" '
+                                      'parameter to the action. Note: Only works '
+                                      'with python, local and remote runners.')
+        self.parser.add_argument('-h', '--help',
+                                 action='store_true', dest='help',
+                                 help='Print usage for the given action.')
 
     @add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
@@ -622,7 +664,20 @@ class ActionExecutionReRunCommand(ActionRunCommandMixin, resource.ResourceComman
             raise resource.ResourceNotFoundError('Action execution with id "%s" cannot be found.' %
                                                  (args.id))
 
+        action_mgr = self.app.client.managers['Action']
+        runner_mgr = self.app.client.managers['RunnerType']
         action_exec_mgr = self.app.client.managers['LiveAction']
+
+        action = action_mgr.get_by_ref_or_id(existing_execution.action)
+        runner = runner_mgr.get_by_name(action.runner_type)
+
+        action_parameters = self._get_action_parameters_from_args(action=action, runner=runner,
+                                                                  args=args)
+
+        # If user provides parameters merge and override with the ones from the
+        # existing execution
+        existing_execution.parameters.update(action_parameters)
+
         execution = action_exec_mgr.create(existing_execution, **kwargs)
         execution = self._get_execution_result(execution=execution,
                                                action_exec_mgr=action_exec_mgr,

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -118,7 +118,10 @@ class ActionDeleteCommand(resource.ContentPackResourceDeleteCommand):
     pass
 
 
-class ActionRunCommand(resource.ResourceCommand):
+class ActionRunCommandMixin(object):
+    """
+    Mixin class which contains utility functions related to action execution.
+    """
     attribute_display_order = ['id', 'ref', 'context', 'parameters', 'status',
                                'start_timestamp', 'result']
     attribute_transform_functions = {
@@ -127,6 +130,95 @@ class ActionRunCommand(resource.ResourceCommand):
         'parameters': format_parameters
     }
 
+    def run_and_print(self, args, **kwargs):
+        if self._print_help(args, **kwargs):
+            return
+
+        execution = self.run(args, **kwargs)
+        self.print_output(execution, table.PropertyValueTable,
+                          attributes=['all'], json=args.json,
+                          attribute_display_order=self.attribute_display_order,
+                          attribute_transform_functions=self.attribute_transform_functions)
+
+        if args.async:
+            self.print_output('To get the results, execute: \n'
+                              '    $ st2 execution get %s' % execution.id,
+                              six.text_type)
+
+    def _get_execution_result(self, execution, action_exec_mgr, args, **kwargs):
+        pending_statuses = [LIVEACTION_STATUS_SCHEDULED, LIVEACTION_STATUS_RUNNING]
+
+        if not args.async:
+            while execution.status in pending_statuses:
+                time.sleep(1)
+                if not args.json:
+                    sys.stdout.write('.')
+                execution = action_exec_mgr.get_by_id(execution.id, **kwargs)
+
+            sys.stdout.write('\n')
+
+            if self._is_error_result(result=execution.result):
+                execution.result = self._format_error_result(execution.result)
+
+        return execution
+
+    def _is_error_result(self, result):
+        if not isinstance(result, dict):
+            return False
+
+        if 'message' not in result:
+            return False
+
+        if 'traceback' not in result:
+            return False
+
+        return True
+
+    def _format_error_result(self, result):
+        result = 'Message: %s\nTraceback: %s' % (result['message'],
+                result['traceback'])
+        return result
+
+    @add_auth_token_to_kwargs_from_cli
+    def _print_help(self, args, **kwargs):
+        # Print appropriate help message if the help option is given.
+        if getattr(args, 'help', False):
+            if args.ref_or_id:
+                try:
+                    action = self.get_resource(args.ref_or_id, **kwargs)
+                    runner_mgr = self.app.client.managers['RunnerType']
+                    runner = runner_mgr.get_by_name(action.runner_type, **kwargs)
+                    parameters, required, optional, _ = self._get_params_types(runner,
+                                                                               action)
+                    print('')
+                    print(textwrap.fill(action.description))
+                    print('')
+                    if required:
+                        required = self._sort_parameters(parameters=parameters,
+                                                         names=required)
+
+                        print('Required Parameters:')
+                        [self.print_param(name, parameters.get(name))
+                            for name in required]
+                    if optional:
+                        optional = self._sort_parameters(parameters=parameters,
+                                                         names=optional)
+
+                        print('Optional Parameters:')
+                        [self.print_param(name, parameters.get(name))
+                            for name in optional]
+                except resource.ResourceNotFoundError:
+                    print('Action "%s" is not found.' % args.ref_or_id)
+                except Exception as e:
+                    print('ERROR: Unable to print help for action "%s". %s' %
+                          (args.ref_or_id, e))
+            else:
+                self.parser.print_help()
+            return True
+        return False
+
+
+class ActionRunCommand(ActionRunCommandMixin, resource.ResourceCommand):
     def __init__(self, resource, *args, **kwargs):
 
         super(ActionRunCommand, self).__init__(
@@ -295,20 +387,9 @@ class ActionRunCommand(resource.ResourceCommand):
         action_exec_mgr = self.app.client.managers['LiveAction']
 
         execution = action_exec_mgr.create(execution, **kwargs)
-
-        if not args.async:
-            while execution.status == LIVEACTION_STATUS_SCHEDULED \
-                    or execution.status == LIVEACTION_STATUS_RUNNING:
-                time.sleep(1)
-                if not args.json:
-                    sys.stdout.write('.')
-                execution = action_exec_mgr.get_by_id(execution.id, **kwargs)
-
-            sys.stdout.write('\n')
-
-            if self._is_error_result(result=execution.result):
-                execution.result = self._format_error_result(execution.result)
-
+        execution = self._get_execution_result(execution=execution,
+                                               action_exec_mgr=action_exec_mgr,
+                                               args=args, **kwargs)
         return execution
 
     @staticmethod
@@ -358,59 +439,6 @@ class ActionRunCommand(resource.ResourceCommand):
 
         return parameters, required, optional, immutable
 
-    @add_auth_token_to_kwargs_from_cli
-    def print_help(self, args, **kwargs):
-        # Print appropriate help message if the help option is given.
-        if args.help:
-            if args.ref_or_id:
-                try:
-                    action = self.get_resource(args.ref_or_id, **kwargs)
-                    runner_mgr = self.app.client.managers['RunnerType']
-                    runner = runner_mgr.get_by_name(action.runner_type, **kwargs)
-                    parameters, required, optional, _ = self._get_params_types(runner,
-                                                                               action)
-                    print('')
-                    print(textwrap.fill(action.description))
-                    print('')
-                    if required:
-                        required = self._sort_parameters(parameters=parameters,
-                                                         names=required)
-
-                        print('Required Parameters:')
-                        [self.print_param(name, parameters.get(name))
-                            for name in required]
-                    if optional:
-                        optional = self._sort_parameters(parameters=parameters,
-                                                         names=optional)
-
-                        print('Optional Parameters:')
-                        [self.print_param(name, parameters.get(name))
-                            for name in optional]
-                except resource.ResourceNotFoundError:
-                    print('Action "%s" is not found.' % args.ref_or_id)
-                except Exception as e:
-                    print('ERROR: Unable to print help for action "%s". %s' %
-                          (args.ref_or_id, e))
-            else:
-                self.parser.print_help()
-            return True
-        return False
-
-    def run_and_print(self, args, **kwargs):
-        if self.print_help(args, **kwargs):
-            return
-
-        # Execute the action.
-        instance = self.run(args, **kwargs)
-        self.print_output(instance, table.PropertyValueTable,
-                          attributes=['all'], json=args.json,
-                          attribute_display_order=self.attribute_display_order,
-                          attribute_transform_functions=self.attribute_transform_functions)
-        if args.async:
-            self.print_output('To get the results, execute: \n'
-                              '    $ st2 execution get %s' % instance.id,
-                              six.text_type)
-
     def _sort_parameters(self, parameters, names):
         """
         Sort a provided list of action parameters.
@@ -441,23 +469,6 @@ class ActionRunCommand(resource.ResourceCommand):
         sort_value = parameter.get('position', name)
         return sort_value
 
-    def _is_error_result(self, result):
-        if not isinstance(result, dict):
-            return False
-
-        if 'message' not in result:
-            return False
-
-        if 'traceback' not in result:
-            return False
-
-        return True
-
-    def _format_error_result(self, result):
-        result = 'Message: %s\nTraceback: %s' % (result['message'],
-                result['traceback'])
-        return result
-
     def _get_inherited_env_vars(self):
         env_vars = os.environ.copy()
 
@@ -478,6 +489,10 @@ class ActionExecutionBranch(resource.ResourceBranch):
             parent_parser=parent_parser, read_only=True,
             commands={'list': ActionExecutionListCommand,
                       'get': ActionExecutionGetCommand})
+
+        # Register extended commands
+        self.commands['re-run'] = ActionExecutionReRunCommand(self.resource, self.app,
+                                                              self.subparsers)
 
 
 class ActionExecutionListCommand(resource.ResourceCommand):
@@ -582,3 +597,34 @@ class ActionExecutionGetCommand(resource.ResourceCommand):
         except resource.ResourceNotFoundError:
             self.print_not_found(args.id)
             raise OperationFailureException('Execution %s not found.' % args.id)
+
+
+class ActionExecutionReRunCommand(ActionRunCommandMixin, resource.ResourceCommand):
+    def __init__(self, resource, *args, **kwargs):
+
+        super(ActionExecutionReRunCommand, self).__init__(
+            resource, kwargs.pop('name', 're-run'),
+            'A command to re-run a particular action.',
+            *args, **kwargs)
+
+        self.parser.add_argument('id', nargs='?',
+                                 metavar='id',
+                                 help='ID of action execution to re-run ')
+        self.parser.add_argument('-a', '--async',
+                                 action='store_true', dest='async',
+                                 help='Do not wait for action to finish.')
+
+    @add_auth_token_to_kwargs_from_cli
+    def run(self, args, **kwargs):
+        existing_execution = self.manager.get_by_id(args.id, **kwargs)
+
+        if not existing_execution:
+            raise resource.ResourceNotFoundError('Action execution with id "%s" cannot be found.' %
+                                                 (args.id))
+
+        action_exec_mgr = self.app.client.managers['LiveAction']
+        execution = action_exec_mgr.create(existing_execution, **kwargs)
+        execution = self._get_execution_result(execution=execution,
+                                               action_exec_mgr=action_exec_mgr,
+                                               args=args, **kwargs)
+        return execution

--- a/st2client/tests/unit/test_action.py
+++ b/st2client/tests/unit/test_action.py
@@ -39,6 +39,7 @@ RUNNER1 = {
 }
 
 ACTION1 = {
+    "ref": "mockety.mock1",
     "runner_type": "mock-runner1",
     "name": "mock1",
     "parameters": {},
@@ -54,6 +55,7 @@ RUNNER2 = {
 }
 
 ACTION2 = {
+    "ref": "mockety.mock2",
     "runner_type": "mock-runner2",
     "name": "mock2",
     "parameters": {


### PR DESCRIPTION
This pull request adds a new CLI command for re-running an existing action (new action is ran with the same set of the input parameters as the existing one).

As discussed in the first iteration it's implemented fully as a client side feature. If more people think it's a good idea to also have this functionality in the UI, we can change it and implement it on the server side.

Implementing it as a new endpoint on the server is fully backward compatible. CLI syntax will stay the same, only thing which will change is the internal implementation of the command.