### PR TITLE
[WIP] Time based action execution filterting

### DIFF
--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -139,8 +139,9 @@ class ActionChainRunner(ActionRunner):
             chainspec = self._meta_loader.load(chainspec_file)
             self.chain_holder = ChainHolder(chainspec, self.action_name)
         except Exception as e:
+            message = e.message or str(e)
             LOG.exception('Failed to instantiate ActionChain.')
-            raise runnerexceptions.ActionRunnerPreRunError(e.message)
+            raise runnerexceptions.ActionRunnerPreRunError(message)
 
     def run(self, action_parameters):
         action_node = self.chain_holder.get_next_node()

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -43,10 +43,12 @@ class ResourceController(rest.RestController):
     access = abc.abstractproperty
     supported_filters = abc.abstractproperty
 
+    max_limit = 100
+
     query_options = {   # Do not use options.
         'sort': []
     }
-    max_limit = 100
+    filter_transform_functions = {}
 
     def __init__(self):
         self.supported_filters = copy.deepcopy(self.__class__.supported_filters)
@@ -111,8 +113,16 @@ class ResourceController(rest.RestController):
         filters = {}
 
         for k, v in six.iteritems(self.supported_filters):
-            if kwargs.get(k):
-                filters['__'.join(v.split('.'))] = kwargs[k]
+            filter_value = kwargs.get(k, None)
+
+            if not filter_value:
+                continue
+
+            value_transform_function = self.filter_transform_functions.get(k, None)
+            value_transform_function = value_transform_function or (lambda value: value)
+            filter_value = value_transform_function(value=filter_value)
+
+            filters['__'.join(v.split('.'))] = filter_value
 
         LOG.info('GET all %s with filters=%s', pecan.request.path, filters)
 

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -43,11 +43,14 @@ class ResourceController(rest.RestController):
     access = abc.abstractproperty
     supported_filters = abc.abstractproperty
 
+    # Maximum value of limit which can be specified by user
     max_limit = 100
 
-    query_options = {   # Do not use options.
+    query_options = {
         'sort': []
     }
+
+    # A list of optional transformation functions for user provided filter values
     filter_transform_functions = {}
 
     def __init__(self):

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -49,8 +49,6 @@ class ActionExecutionsController(ResourceController):
     access = ActionExecution
     views = ExecutionViewsController()
 
-    supported_filters = SUPPORTED_FILTERS
-
     query_options = {
         'sort': ['-start_timestamp', 'action']
     }
@@ -62,6 +60,11 @@ class ActionExecutionsController(ResourceController):
         'start_timestamp_gt': lambda value: isotime.parse(value=value),
         'start_timestamp_lt': lambda value: isotime.parse(value=value)
     }
+
+    def __init__(self):
+        super(ActionExecutionsController, self).__init__()
+        # Add common execution view supported filters
+        self.supported_filters.update(SUPPORTED_FILTERS)
 
     @jsexpose()
     def get_all(self, **kw):

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -53,12 +53,12 @@ class ActionExecutionsController(ResourceController):
         'sort': ['-start_timestamp', 'action']
     }
     supported_filters = {
-        'start_timestamp_gt': 'start_timestamp.gt',
-        'start_timestamp_lt': 'start_timestamp.lt'
+        'timestamp_gt': 'start_timestamp.gt',
+        'timestamp_lt': 'start_timestamp.lt'
     }
     filter_transform_functions = {
-        'start_timestamp_gt': lambda value: isotime.parse(value=value),
-        'start_timestamp_lt': lambda value: isotime.parse(value=value)
+        'timestamp_gt': lambda value: isotime.parse(value=value),
+        'timestamp_lt': lambda value: isotime.parse(value=value)
     }
 
     def __init__(self):

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -58,6 +58,10 @@ class ActionExecutionsController(ResourceController):
         'start_timestamp_gt': 'start_timestamp.gt',
         'start_timestamp_lt': 'start_timestamp.lt'
     }
+    filter_transform_functions = {
+        'start_timestamp_gt': lambda value: isotime.parse(value=value),
+        'start_timestamp_lt': lambda value: isotime.parse(value=value)
+    }
 
     @jsexpose()
     def get_all(self, **kw):
@@ -118,12 +122,6 @@ class ActionExecutionsController(ResourceController):
             del kw['action']
             kw['action.name'] = action_name
             kw['action.pack'] = action_pack
-
-        # Correctly format started_timestamp filters
-        if 'start_timestamp_gt' in kw:
-            kw['start_timestamp_gt'] = isotime.parse(kw['start_timestamp_gt'])
-        if 'start_timestamp_lt' in kw:
-            kw['start_timestamp_lt'] = isotime.parse(kw['start_timestamp_lt'])
 
         LOG.debug('Retrieving all action liveactions with filters=%s', kw)
         return super(ActionExecutionsController, self)._get_all(**kw)

--- a/st2api/tests/unit/controllers/v1/test_executions_filters.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_filters.py
@@ -133,7 +133,8 @@ class TestActionExecutionFilters(FunctionalTest):
         self.assertListEqual(sorted(ids), sorted(refs))
 
     def test_filters(self):
-        excludes = ['parent', 'timestamp', 'action', 'liveaction']
+        excludes = ['parent', 'timestamp', 'action', 'liveaction', 'start_timestamp_gt',
+                    'start_timestamp_lt']
         for param, field in six.iteritems(ActionExecutionsController.supported_filters):
             if param in excludes:
                 continue

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -529,7 +529,7 @@ class ActionExecutionBranch(resource.ResourceBranch):
 
 class ActionExecutionListCommand(resource.ResourceCommand):
 
-    display_attributes = ['id', 'action', 'context.user', 'status', 'start_timestamp',
+    display_attributes = ['id', 'action.ref', 'context.user', 'status', 'start_timestamp',
                           'end_timestamp']
     attribute_transform_functions = {
         'start_timestamp': format_isodate,

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -122,8 +122,10 @@ class ActionRunCommandMixin(object):
     """
     Mixin class which contains utility functions related to action execution.
     """
+    display_attributes = ['id', 'ref', 'context', 'parameters', 'status',
+                          'start_timestamp', 'end_timestamp', 'result']
     attribute_display_order = ['id', 'ref', 'context', 'parameters', 'status',
-                               'start_timestamp', 'result']
+                               'start_timestamp', 'end_timestamp', 'result']
     attribute_transform_functions = {
         'start_timestamp': format_isodate,
         'end_timestamp': format_isodate,
@@ -139,7 +141,7 @@ class ActionRunCommandMixin(object):
 
         execution = self.run(args, **kwargs)
         self.print_output(execution, table.PropertyValueTable,
-                          attributes=['all'], json=args.json,
+                          attributes=self.display_attributes, json=args.json,
                           attribute_display_order=self.attribute_display_order,
                           attribute_transform_functions=self.attribute_transform_functions)
 

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -528,7 +528,6 @@ class ActionExecutionBranch(resource.ResourceBranch):
 
 
 class ActionExecutionListCommand(resource.ResourceCommand):
-
     display_attributes = ['id', 'action.ref', 'context.user', 'status', 'start_timestamp',
                           'end_timestamp']
     attribute_transform_functions = {
@@ -574,8 +573,8 @@ class ActionExecutionListCommand(resource.ResourceCommand):
 
 
 class ActionExecutionGetCommand(resource.ResourceCommand):
-
-    display_attributes = ['all']
+    display_attributes = ['id', 'action.ref', 'parameters', 'status', 'start_timestamp',
+                          'end_timestamp', 'context']
     attribute_transform_functions = {
         'start_timestamp': format_isodate,
         'end_timestamp': format_isodate,

--- a/st2client/st2client/commands/resource.py
+++ b/st2client/st2client/commands/resource.py
@@ -323,8 +323,9 @@ class ResourceCreateCommand(ResourceCommand):
             self.print_output(instance, table.PropertyValueTable,
                               attributes=['all'], json=args.json)
         except Exception as e:
-            print('ERROR: %s' % e.message)
-            raise OperationFailureException(e.message)
+            message = e.message or str(e)
+            print('ERROR: %s' % (message))
+            raise OperationFailureException(message)
 
 
 class ResourceUpdateCommand(ResourceCommand):


### PR DESCRIPTION
Allows user to filter action executions based on the value of `start_timestamp` attribute.

Use can either use "greater than" or "lower than" filter.

TODO:

* [ ] Use `action.ref` in the CLI once the action execution POST response is updated to include action.ref attribute
* [ ] Add filters to the CLI command