### PR TITLE
Update HTTP runner to parse JSON response body if Content-Type is application/json

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,8 @@ Docs: http://docks.stackstorm.com/latest
 * Dispatch an internal trigger when a sensor process is spawned / started
   (``st2.sensor.process_spawn``) and when a process exits / is stopped
   (``st2.sensor.process_exit``).
+* Update HTTP runner to automatically parse JSON response body if Content-Type is
+  ``application/json`` (new-feature)
 
 v0.7 - January 16, 2015
 -----------------------

--- a/docs/source/actions.rst
+++ b/docs/source/actions.rst
@@ -31,7 +31,7 @@ allow the Action author to concentrate only on the implementation of the
 action itself rather than setting up the environment.
 
 Available runners
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 The environment in which the action runs is specified by the runner.
 Currently the system provides the following runners:
@@ -44,10 +44,12 @@ Currently the system provides the following runners:
 3. ``run-python`` - This is a Python runner. Actions are implemented as Python
    classes with a ``run`` method. They run locally on the same machine where
    |st2| components are running.
-4. ``action-chain`` - This runner supports executing simple linear work-flows.
+4. ``http-runner`` - HTTP client which performs HTTP requests for running HTTP
+   actions.
+5. ``action-chain`` - This runner supports executing simple linear work-flows.
    For more information, please refer to the :doc:`Workflows </workflows>`
    and :doc:`ActionChain </actionchain>` section of documentation.
-5. ``mistral-v1``, ``mistral-v2`` - Those runners are built on top of the
+6. ``mistral-v1``, ``mistral-v2`` - Those runners are built on top of the
    Mistral OpenStack project and support executing complex work-flows. For more
    information, please refer to the :doc:`Workflows </workflows>` and
    :doc:`Mistral </mistral>` section of documentation.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,7 @@ Contents:
     start
     packs
     actions
+    runners
     rules
     sensors
     webhooks

--- a/docs/source/runners.rst
+++ b/docs/source/runners.rst
@@ -1,0 +1,146 @@
+Action Runners
+==============
+
+An action runner is the execution environment for user-implemented
+actions. For now |st2| comes with pre-canned action runners like a
+remote runner and shell runner which provide for user-implemented
+actions to be run remotely (via SSH) and locally. The objective is to
+allow the Action author to concentrate only on the implementation of the
+action itself rather than setting up the environment.
+
+Local command runner (run-local)
+--------------------------------
+
+This is the local runner. This runner executes a Linux command on the same host
+where |st2| components are running.
+
+Runner parameters
+~~~~~~~~~~~~~~~~~
+
+* ``sudo`` (boolean) - The command will be executed with sudo.
+* ``env`` (object) - Environment variables which will be available to the command(e.g. key1=val1,key2=val2)
+* ``cmd`` (string) - Arbitrary Linux command to be executed on the host.
+* ``kwarg_op`` (string) - Operator to use in front of keyword args i.e. "--" or "-".
+* ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds.
+* ``cwd`` (string) - Working directory where the command will be executed in
+
+Local script runner (run-local-script)
+--------------------------------------
+
+This is the local runner. Actions are implemented as scripts. They are executed
+on the same hosts where |st2| components are running.
+
+Runner parameters
+~~~~~~~~~~~~~~~~~
+
+* ``kwarg_op`` (string) - Operator to use in front of keyword args i.e. "--" or "-".
+* ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds.
+* ``sudo`` (boolean) - The command will be executed with sudo.
+* ``cwd`` (string) - Working directory where the script will be executed in
+* ``env`` (object) - Environment variables which will be available to the script(e.g. key1=val1,key2=val2)
+
+Remote command runner (run-remote)
+----------------------------------
+
+This is a remote runner. This runner executes a Linux command on one or more
+remote hosts provided by the user.
+
+Runner parameters
+~~~~~~~~~~~~~~~~~
+
+* ``username`` (string) - Username used to log-in. If not provided, default username from config is used.
+* ``private_key`` (string) - Private key used to log in. If not provided, private key from the config file is used.
+* ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds.
+* ``sudo`` (boolean) - The remote command will be executed with sudo.
+* ``kwarg_op`` (string) - Operator to use in front of keyword args i.e. "--" or "-".
+* ``password`` (string) - Password used to log in. If not provided, private key from the config file is used.
+* ``parallel`` (boolean) - Default to parallel execution.
+* ``cmd`` (string) - Arbitrary Linux command to be executed on the remote host(s).
+* ``hosts`` (string) - A comma delimited string of a list of hosts where the remote command will be executed.
+* ``env`` (object) - Environment variables which will be available to the command(e.g. key1=val1,key2=val2)
+* ``cwd`` (string) - Working directory where the script will be executed in
+* ``dir`` (string) - The working directory where the script will be copied to on the remote host.
+
+Remote script runner (run-remote-script)
+----------------------------------------
+
+This is a remote runner. Actions are implemented as scripts. They run on one or
+more remote hosts provided by the user.
+
+Runner parameters
+~~~~~~~~~~~~~~~~~
+
+* ``username`` (string) - Username used to log-in. If not provided, default username from config is used.
+* ``private_key`` (string) - Private key used to log in. If not provided, private key from the config file is used.
+* ``env`` (object) - Environment variables which will be available to the script(e.g. key1=val1,key2=val2)
+* ``sudo`` (boolean) - The remote command will be executed with sudo.
+* ``kwarg_op`` (string) - Operator to use in front of keyword args i.e. "--" or "-".
+* ``password`` (string) - Password used to log in. If not provided, private key from the config file is used.
+* ``parallel`` (boolean) - Default to parallel execution.
+* ``hosts`` (string) - A comma delimited string of a list of hosts where the remote command will be executed.
+* ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds.
+* ``cwd`` (string) - Working directory where the script will be executed in.
+* ``dir`` (string) - The working directory where the script will be copied to on the remote host.
+
+Runner parameters
+~~~~~~~~~~~~~~~~~
+
+* ``kwarg_op`` (string) - Operator to use in front of keyword args i.e. "--" or "-".
+* ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds.
+* ``sudo`` (boolean) - The command will be executed with sudo.
+* ``cwd`` (string) - Working directory where the script will be executed in
+* ``env`` (object) - Environment variables which will be available to the script(e.g. key1=val1,key2=val2)
+
+HTTP runner (http-runner)
+-------------------------
+
+HTTP runner works by performing HTTP request to the provided URL.
+
+Runner parameters
+~~~~~~~~~~~~~~~~~
+
+* ``cookies`` (object) - Optional cookies to send with the request.
+* ``https_proxy`` (string) - A URL of a HTTPs proxy to use (e.g. http://10.10.1.10:3128).
+* ``url`` (string) - URL to the HTTP endpoint.
+* ``http_proxy`` (string) - A URL of a HTTP proxy to use (e.g. http://10.10.1.10:3128).
+* ``headers`` (string) - HTTP headers for the request.
+* ``allow_redirects`` (boolean) - Set to True if POST/PUT/DELETE redirect following is allowed.
+
+Runner result
+~~~~~~~~~~~~~
+
+Result object from this runner contains the following keys:
+
+* ``status_code`` (integer) - Response status code (e.g. 200, 404, etc.)
+* ``body`` (string / object) - Response body. If the response body contains JSON
+  and the response Content-Type header is ``application/json``, the body will be
+  automatically parsed as JSON.
+* ``parsed`` (boolean) - Flag which indicates if the response body has been parsed.
+* ``headers`` - Response headers.
+
+Python runner (run-python)
+--------------------------
+
+This is a Python runner. Actions are implemented as Python classes with a
+``run`` method. They run locally on the same machine where |st2| components are
+running.
+
+Runner parameters
+~~~~~~~~~~~~~~~~~
+
+* ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds.
+* ``env`` (object) - Environment variables which will be available to the script(e.g. key1=val1,key2=val2)
+
+Mistral runners (mistral-v1, mistral-v2)
+----------------------------------------
+
+Those runners are built on top of the Mistral OpenStack project and support
+executing complex work-flows. For more information, please refer to the
+:doc:`Workflows </workflows>` and :doc:`Mistral </mistral>` section of documentation.
+
+Runner parameters
+~~~~~~~~~~~~~~~~~
+
+* ``task`` (string) - The name of the task to run for reverse workflow.
+* ``context`` (object) - Additional workflow inputs.
+* ``workflow`` (string) - The name of the workflow to run if the entry_point is a workbook of many workflows. The name should be in the format "<pack_name>.<action_name>.<workflow_name>". If entry point is a workflow or a workbook with a single workflow, the runner will identify the workflow automatically.

--- a/scripts/generate-runner-parameters-documentation.py
+++ b/scripts/generate-runner-parameters-documentation.py
@@ -1,0 +1,50 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Script which generates documentation section which contains information about
+available runner parameters.
+"""
+
+import argparse
+
+from st2actions.bootstrap.runnersregistrar import RUNNER_TYPES
+
+
+def main(name):
+    result = []
+
+    runner = [runner for runner in RUNNER_TYPES if runner['name'] == name][0]
+
+    result.append('Runner parameters')
+    result.append('~~~~~~~~~~~~~~~~~')
+    result.append('')
+
+    for name, values in runner['runner_parameters'].items():
+        format_values = {'name': name}
+        format_values.update(values)
+        line = '* ``%(name)s`` (%(type)s) - %(description)s' % format_values
+        result.append(line)
+
+    result = '\n'.join(result)
+    print(result)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Runner parameter documentation generation')
+    parser.add_argument('--name', required=True,
+                        help='Name of the runner to generate the documentation for')
+    args = parser.parse_args()
+
+    main(name=args.name)

--- a/st2actions/st2actions/bootstrap/runnersregistrar.py
+++ b/st2actions/st2actions/bootstrap/runnersregistrar.py
@@ -20,354 +20,352 @@ from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2common.models.api.action import RunnerTypeAPI
 from st2common.persistence.action import RunnerType
 from st2common.util.action_db import get_runnertype_by_name
-from st2actions.runners import pythonrunner
+from st2common.constants.runners import LOCAL_RUNNER_DEFAULT_ACTION_TIMEOUT
+from st2common.constants.runners import FABRIC_RUNNER_DEFAULT_ACTION_TIMEOUT
+from st2common.constants.runners import FABRIC_RUNNER_DEFAULT_REMOTE_DIR
+from st2common.constants.runners import PYTHON_RUNNER_DEFAULT_ACTION_TIMEOUT
+
+__all__ = [
+    'register_runner_types',
+    'RUNNER_TYPES'
+]
 
 
 LOG = logging.getLogger(__name__)
 
+RUNNER_TYPES = [
+    {
+        'name': 'run-local',
+        'description': 'A runner to execute local actions as a fixed user.',
+        'enabled': True,
+        'runner_parameters': {
+            'cmd': {
+                'description': 'Arbitrary Linux command to be executed on the '
+                               'host.',
+                'type': 'string'
+            },
+            'cwd': {
+                'description': 'Working directory where the command will be executed in',
+                'type': 'string'
+            },
+            'env': {
+                'description': ('Environment variables which will be available to the command'
+                                '(e.g. key1=val1,key2=val2)'),
+                'type': 'object'
+            },
+            'sudo': {
+                'description': 'The command will be executed with sudo.',
+                'type': 'boolean',
+                'default': False
+            },
+            'kwarg_op': {
+                'description': 'Operator to use in front of keyword args i.e. "--" or "-".',
+                'type': 'string',
+                'default': '--'
+            },
+            'timeout': {
+                'description': ('Action timeout in seconds. Action will get killed if it '
+                                'doesn\'t finish in timeout seconds.'),
+                'type': 'integer',
+                'default': LOCAL_RUNNER_DEFAULT_ACTION_TIMEOUT
+            }
+        },
+        'runner_module': 'st2actions.runners.localrunner'
+    },
+    {
+        'name': 'run-local-script',
+        'description': 'A runner to execute local actions as a fixed user.',
+        'enabled': True,
+        'runner_parameters': {
+            'cwd': {
+                'description': 'Working directory where the script will be executed in',
+                'type': 'string'
+            },
+            'env': {
+                'description': ('Environment variables which will be available to the script'
+                                '(e.g. key1=val1,key2=val2)'),
+                'type': 'object'
+            },
+            'sudo': {
+                'description': 'The command will be executed with sudo.',
+                'type': 'boolean',
+                'default': False
+            },
+            'kwarg_op': {
+                'description': 'Operator to use in front of keyword args i.e. "--" or "-".',
+                'type': 'string',
+                'default': '--'
+            },
+            'timeout': {
+                'description': ('Action timeout in seconds. Action will get killed if it '
+                                'doesn\'t finish in timeout seconds.'),
+                'type': 'integer',
+                'default': LOCAL_RUNNER_DEFAULT_ACTION_TIMEOUT
+            }
+        },
+        'runner_module': 'st2actions.runners.localrunner'
+    },
+    {
+        'name': 'run-remote',
+        'description': 'A remote execution runner that executes actions '
+                       'as a fixed system user.',
+        'enabled': True,
+        'runner_parameters': {
+            'hosts': {
+                'description': 'A comma delimited string of a list of hosts '
+                               'where the remote command will be executed.',
+                'type': 'string',
+                'required': True
+            },
+            'username': {
+                'description': ('Username used to log-in. If not provided, '
+                                'default username from config is used.'),
+                'type': 'string',
+                'required': False
+            },
+            'password': {
+                'description': ('Password used to log in. If not provided, '
+                                'private key from the config file is used.'),
+                'type': 'string',
+                'required': False
+            },
+            'private_key': {
+                'description': ('Private key used to log in. If not provided, '
+                                'private key from the config file is used.'),
+                'type': 'string',
+                'required': False
+            },
+            'cmd': {
+                'description': 'Arbitrary Linux command to be executed on the '
+                               'remote host(s).',
+                'type': 'string'
+            },
+            'cwd': {
+                'description': 'Working directory where the script will be executed in',
+                'type': 'string'
+            },
+            'env': {
+                'description': ('Environment variables which will be available to the command'
+                                '(e.g. key1=val1,key2=val2)'),
+                'type': 'object'
+            },
+            'parallel': {
+                'description': 'Default to parallel execution.',
+                'type': 'boolean',
+                'default': True,
+                'immutable': True
+            },
+            'sudo': {
+                'description': 'The remote command will be executed with sudo.',
+                'type': 'boolean',
+                'default': False
+            },
+            'dir': {
+                'description': 'The working directory where the script will be copied to ' +
+                               'on the remote host.',
+                'type': 'string',
+                'default': FABRIC_RUNNER_DEFAULT_REMOTE_DIR,
+                'immutable': True
+            },
+            'kwarg_op': {
+                'description': 'Operator to use in front of keyword args i.e. "--" or "-".',
+                'type': 'string',
+                'default': '--'
+            },
+            'timeout': {
+                'description': ('Action timeout in seconds. Action will get killed if it '
+                                'doesn\'t finish in timeout seconds.'),
+                'type': 'integer',
+                'default': FABRIC_RUNNER_DEFAULT_ACTION_TIMEOUT
+            }
+        },
+        'runner_module': 'st2actions.runners.fabricrunner'
+    },
+    {
+        'name': 'run-remote-script',
+        'description': 'A remote execution runner that executes actions '
+                       'as a fixed system user.',
+        'enabled': True,
+        'runner_parameters': {
+            'hosts': {
+                'description': 'A comma delimited string of a list of hosts '
+                               'where the remote command will be executed.',
+                'type': 'string',
+                'required': True
+            },
+            'username': {
+                'description': ('Username used to log-in. If not provided, '
+                                'default username from config is used.'),
+                'type': 'string',
+                'required': False
+            },
+            'password': {
+                'description': ('Password used to log in. If not provided, '
+                                'private key from the config file is used.'),
+                'type': 'string',
+                'required': False
+            },
+            'private_key': {
+                'description': ('Private key used to log in. If not provided, '
+                                'private key from the config file is used.'),
+                'type': 'string',
+                'required': False
+            },
+            'parallel': {
+                'description': 'Default to parallel execution.',
+                'type': 'boolean',
+                'default': True,
+                'immutable': True
+            },
+            'cwd': {
+                'description': 'Working directory where the script will be executed in.',
+                'type': 'string',
+                'default': FABRIC_RUNNER_DEFAULT_REMOTE_DIR
+            },
+            'env': {
+                'description': ('Environment variables which will be available to the script'
+                                '(e.g. key1=val1,key2=val2)'),
+                'type': 'object'
+            },
+            'sudo': {
+                'description': 'The remote command will be executed with sudo.',
+                'type': 'boolean',
+                'default': False
+            },
+            'dir': {
+                'description': 'The working directory where the script will be copied to ' +
+                               'on the remote host.',
+                'type': 'string',
+                'default': FABRIC_RUNNER_DEFAULT_REMOTE_DIR
+            },
+            'kwarg_op': {
+                'description': 'Operator to use in front of keyword args i.e. "--" or "-".',
+                'type': 'string',
+                'default': '--'
+            },
+            'timeout': {
+                'description': ('Action timeout in seconds. Action will get killed if it '
+                                'doesn\'t finish in timeout seconds.'),
+                'type': 'integer',
+                'default': FABRIC_RUNNER_DEFAULT_ACTION_TIMEOUT
+            }
+        },
+        'runner_module': 'st2actions.runners.fabricrunner'
+    },
+    {
+        'name': 'http-runner',
+        'description': 'A HTTP client for running HTTP actions.',
+        'enabled': True,
+        'runner_parameters': {
+            'url': {
+                'description': 'URL to the HTTP endpoint.',
+                'type': 'string',
+                'required': True
+            },
+            'headers': {
+                'description': 'HTTP headers for the request.',
+                'type': 'string'
+            },
+            'cookies': {
+                'description': 'Optional cookies to send with the request.',
+                'type': 'object'
+            },
+            'http_proxy': {
+                'description': 'A URL of a HTTP proxy to use (e.g. http://10.10.1.10:3128).',
+                'type': 'string'
+            },
+            'https_proxy': {
+                'description': 'A URL of a HTTPs proxy to use (e.g. http://10.10.1.10:3128).',
+                'type': 'string'
+            },
+            'allow_redirects': {
+                'description': 'Set to True if POST/PUT/DELETE redirect following is allowed.',
+                'type': 'boolean',
+                'default': False
+            },
+        },
+        'runner_module': 'st2actions.runners.httprunner'
+    },
+    {
+        'name': 'mistral-v1',
+        'description': 'A runner for executing mistral v1 workflow.',
+        'enabled': True,
+        'runner_parameters': {
+            'workbook': {
+                'description': 'The name of the workbook.',
+                'type': 'string',
+                'required': True
+            },
+            'task': {
+                'description': 'The startup task in the workbook to execute.',
+                'type': 'string',
+                'required': True
+            },
+            'context': {
+                'description': 'Context for the startup task.',
+                'type': 'object',
+                'default': {}
+            }
+        },
+        'runner_module': 'st2actions.runners.mistral.v1'
+    },
+    {
+        'name': 'mistral-v2',
+        'description': 'A runner for executing mistral v2 workflow.',
+        'enabled': True,
+        'runner_parameters': {
+            'workflow': {
+                'description': ('The name of the workflow to run if the entry_point is a '
+                                'workbook of many workflows. The name should be in the '
+                                'format "<pack_name>.<action_name>.<workflow_name>". '
+                                'If entry point is a workflow or a workbook with a single '
+                                'workflow, the runner will identify the workflow '
+                                'automatically.'),
+                'type': 'string'
+            },
+            'task': {
+                'description': 'The name of the task to run for reverse workflow.',
+                'type': 'string'
+            },
+            'context': {
+                'description': 'Additional workflow inputs.',
+                'type': 'object',
+                'default': {}
+            }
+        },
+        'runner_module': 'st2actions.runners.mistral.v2',
+        'query_module': 'st2actions.query.mistral.v2'
+    },
+    {
+        'name': 'action-chain',
+        'description': 'A runner for launching linear action chains.',
+        'enabled': True,
+        'runner_parameters': {},
+        'runner_module': 'st2actions.runners.actionchainrunner'
+    },
+    {
+        'name': 'run-python',
+        'description': 'A runner for launching python actions.',
+        'enabled': True,
+        'runner_parameters': {
+            'env': {
+                'description': ('Environment variables which will be available to the script'
+                                '(e.g. key1=val1,key2=val2)'),
+                'type': 'object'
+            },
+            'timeout': {
+                'description': ('Action timeout in seconds. Action will get killed if it '
+                                'doesn\'t finish in timeout seconds.'),
+                'type': 'integer',
+                'default': PYTHON_RUNNER_DEFAULT_ACTION_TIMEOUT
+            }
+        },
+        'runner_module': 'st2actions.runners.pythonrunner'
+    }
+]
+
 
 def register_runner_types():
-    # Note: We need to do import here because config needs to be parsed for this
-    # import to work
-    from st2actions.runners import fabricrunner
-    from st2actions.runners import localrunner
-
-    try:
-        default_remote_dir = cfg.CONF.ssh_runner.remote_dir
-    except:
-        default_remote_dir = '/tmp'
-
-    RUNNER_TYPES = [
-        {
-            'name': 'run-local',
-            'description': 'A runner to execute local actions as a fixed user.',
-            'enabled': True,
-            'runner_parameters': {
-                'cmd': {
-                    'description': 'Arbitrary Linux command to be executed on the '
-                                   'host.',
-                    'type': 'string'
-                },
-                'cwd': {
-                    'description': 'Working directory where the command will be executed in',
-                    'type': 'string'
-                },
-                'env': {
-                    'description': ('Environment variables which will be available to the command'
-                                    '(e.g. key1=val1,key2=val2)'),
-                    'type': 'object'
-                },
-                'sudo': {
-                    'description': 'The command will be executed with sudo.',
-                    'type': 'boolean',
-                    'default': False
-                },
-                'kwarg_op': {
-                    'description': 'Operator to use in front of keyword args i.e. "--" or "-".',
-                    'type': 'string',
-                    'default': '--'
-                },
-                'timeout': {
-                    'description': ('Action timeout in seconds. Action will get killed if it '
-                                    'doesn\'t finish in timeout seconds.'),
-                    'type': 'integer',
-                    'default': localrunner.DEFAULT_ACTION_TIMEOUT
-                }
-            },
-            'runner_module': 'st2actions.runners.localrunner'
-        },
-        {
-            'name': 'run-local-script',
-            'description': 'A runner to execute local actions as a fixed user.',
-            'enabled': True,
-            'runner_parameters': {
-                'cwd': {
-                    'description': 'Working directory where the script will be executed in',
-                    'type': 'string'
-                },
-                'env': {
-                    'description': ('Environment variables which will be available to the script'
-                                    '(e.g. key1=val1,key2=val2)'),
-                    'type': 'object'
-                },
-                'sudo': {
-                    'description': 'The command will be executed with sudo.',
-                    'type': 'boolean',
-                    'default': False
-                },
-                'kwarg_op': {
-                    'description': 'Operator to use in front of keyword args i.e. "--" or "-".',
-                    'type': 'string',
-                    'default': '--'
-                },
-                'timeout': {
-                    'description': ('Action timeout in seconds. Action will get killed if it '
-                                    'doesn\'t finish in timeout seconds.'),
-                    'type': 'integer',
-                    'default': fabricrunner.DEFAULT_ACTION_TIMEOUT
-                }
-            },
-            'runner_module': 'st2actions.runners.localrunner'
-        },
-        {
-            'name': 'run-remote',
-            'description': 'A remote execution runner that executes actions '
-                           'as a fixed system user.',
-            'enabled': True,
-            'runner_parameters': {
-                'hosts': {
-                    'description': 'A comma delimited string of a list of hosts '
-                                   'where the remote command will be executed.',
-                    'type': 'string',
-                    'required': True
-                },
-                'username': {
-                    'description': ('Username used to log-in. If not provided, '
-                                    'default username from config is used.'),
-                    'type': 'string',
-                    'required': False
-                },
-                'password': {
-                    'description': ('Password used to log in. If not provided, '
-                                    'private key from the config file is used.'),
-                    'type': 'string',
-                    'required': False
-                },
-                'private_key': {
-                    'description': ('Private key used to log in. If not provided, '
-                                    'private key from the config file is used.'),
-                    'type': 'string',
-                    'required': False
-                },
-                'cmd': {
-                    'description': 'Arbitrary Linux command to be executed on the '
-                                   'remote host(s).',
-                    'type': 'string'
-                },
-                'cwd': {
-                    'description': 'Working directory where the script will be executed in',
-                    'type': 'string'
-                },
-                'env': {
-                    'description': ('Environment variables which will be available to the command'
-                                    '(e.g. key1=val1,key2=val2)'),
-                    'type': 'object'
-                },
-                'parallel': {
-                    'description': 'Default to parallel execution.',
-                    'type': 'boolean',
-                    'default': True,
-                    'immutable': True
-                },
-                'sudo': {
-                    'description': 'The remote command will be executed with sudo.',
-                    'type': 'boolean',
-                    'default': False
-                },
-                'dir': {
-                    'description': 'The working directory where the script will be copied to ' +
-                                   'on the remote host.',
-                    'type': 'string',
-                    'default': default_remote_dir,
-                    'immutable': True
-                },
-                'kwarg_op': {
-                    'description': 'Operator to use in front of keyword args i.e. "--" or "-".',
-                    'type': 'string',
-                    'default': '--'
-                },
-                'timeout': {
-                    'description': ('Action timeout in seconds. Action will get killed if it '
-                                    'doesn\'t finish in timeout seconds.'),
-                    'type': 'integer',
-                    'default': fabricrunner.DEFAULT_ACTION_TIMEOUT
-                }
-            },
-            'runner_module': 'st2actions.runners.fabricrunner'
-        },
-        {
-            'name': 'run-remote-script',
-            'description': 'A remote execution runner that executes actions '
-                           'as a fixed system user.',
-            'enabled': True,
-            'runner_parameters': {
-                'hosts': {
-                    'description': 'A comma delimited string of a list of hosts '
-                                   'where the remote command will be executed.',
-                    'type': 'string',
-                    'required': True
-                },
-                'username': {
-                    'description': ('Username used to log-in. If not provided, '
-                                    'default username from config is used.'),
-                    'type': 'string',
-                    'required': False
-                },
-                'password': {
-                    'description': ('Password used to log in. If not provided, '
-                                    'private key from the config file is used.'),
-                    'type': 'string',
-                    'required': False
-                },
-                'private_key': {
-                    'description': ('Private key used to log in. If not provided, '
-                                    'private key from the config file is used.'),
-                    'type': 'string',
-                    'required': False
-                },
-                'parallel': {
-                    'description': 'Default to parallel execution.',
-                    'type': 'boolean',
-                    'default': True,
-                    'immutable': True
-                },
-                'cwd': {
-                    'description': 'Working directory where the script will be executed in.',
-                    'type': 'string',
-                    'default': default_remote_dir
-                },
-                'env': {
-                    'description': ('Environment variables which will be available to the script'
-                                    '(e.g. key1=val1,key2=val2)'),
-                    'type': 'object'
-                },
-                'sudo': {
-                    'description': 'The remote command will be executed with sudo.',
-                    'type': 'boolean',
-                    'default': False
-                },
-                'dir': {
-                    'description': 'The working directory where the script will be copied to ' +
-                                   'on the remote host.',
-                    'type': 'string',
-                    'default': default_remote_dir
-                },
-                'kwarg_op': {
-                    'description': 'Operator to use in front of keyword args i.e. "--" or "-".',
-                    'type': 'string',
-                    'default': '--'
-                },
-                'timeout': {
-                    'description': ('Action timeout in seconds. Action will get killed if it '
-                                    'doesn\'t finish in timeout seconds.'),
-                    'type': 'integer',
-                    'default': fabricrunner.DEFAULT_ACTION_TIMEOUT
-                }
-            },
-            'runner_module': 'st2actions.runners.fabricrunner'
-        },
-        {
-            'name': 'http-runner',
-            'description': 'A HTTP client for running HTTP actions.',
-            'enabled': True,
-            'runner_parameters': {
-                'url': {
-                    'description': 'URL to the HTTP endpoint.',
-                    'type': 'string',
-                    'required': True
-                },
-                'headers': {
-                    'description': 'HTTP headers for the request.',
-                    'type': 'string'
-                },
-                'cookies': {
-                    'description': 'Optional cookies to send with the request.',
-                    'type': 'object'
-                },
-                'http_proxy': {
-                    'description': 'A URL of a HTTP proxy to use (e.g. http://10.10.1.10:3128).',
-                    'type': 'string'
-                },
-                'https_proxy': {
-                    'description': 'A URL of a HTTPs proxy to use (e.g. http://10.10.1.10:3128).',
-                    'type': 'string'
-                },
-                'allow_redirects': {
-                    'description': 'Set to True if POST/PUT/DELETE redirect following is allowed.',
-                    'type': 'boolean',
-                    'default': False
-                },
-            },
-            'runner_module': 'st2actions.runners.httprunner'
-        },
-        {
-            'name': 'mistral-v1',
-            'description': 'A runner for executing mistral v1 workflow.',
-            'enabled': True,
-            'runner_parameters': {
-                'workbook': {
-                    'description': 'The name of the workbook.',
-                    'type': 'string',
-                    'required': True
-                },
-                'task': {
-                    'description': 'The startup task in the workbook to execute.',
-                    'type': 'string',
-                    'required': True
-                },
-                'context': {
-                    'description': 'Context for the startup task.',
-                    'type': 'object',
-                    'default': {}
-                }
-            },
-            'runner_module': 'st2actions.runners.mistral.v1'
-        },
-        {
-            'name': 'mistral-v2',
-            'description': 'A runner for executing mistral v2 workflow.',
-            'enabled': True,
-            'runner_parameters': {
-                'workflow': {
-                    'description': ('The name of the workflow to run if the entry_point is a '
-                                    'workbook of many workflows. The name should be in the '
-                                    'format "<pack_name>.<action_name>.<workflow_name>". '
-                                    'If entry point is a workflow or a workbook with a single '
-                                    'workflow, the runner will identify the workflow '
-                                    'automatically.'),
-                    'type': 'string'
-                },
-                'task': {
-                    'description': 'The name of the task to run for reverse workflow.',
-                    'type': 'string'
-                },
-                'context': {
-                    'description': 'Additional workflow inputs.',
-                    'type': 'object',
-                    'default': {}
-                }
-            },
-            'runner_module': 'st2actions.runners.mistral.v2',
-            'query_module': 'st2actions.query.mistral.v2'
-        },
-        {
-            'name': 'action-chain',
-            'description': 'A runner for launching linear action chains.',
-            'enabled': True,
-            'runner_parameters': {},
-            'runner_module': 'st2actions.runners.actionchainrunner'
-        },
-        {
-            'name': 'run-python',
-            'description': 'A runner for launching python actions.',
-            'enabled': True,
-            'runner_parameters': {
-                'env': {
-                    'description': ('Environment variables which will be available to the script'
-                                    '(e.g. key1=val1,key2=val2)'),
-                    'type': 'object'
-                },
-                'timeout': {
-                    'description': ('Action timeout in seconds. Action will get killed if it '
-                                    'doesn\'t finish in timeout seconds.'),
-                    'type': 'integer',
-                    'default': pythonrunner.DEFAULT_ACTION_TIMEOUT
-                }
-            },
-            'runner_module': 'st2actions.runners.pythonrunner'
-        }
-    ]
-
     LOG.info('Start : register default RunnerTypes.')
 
     for runnertype in RUNNER_TYPES:

--- a/st2actions/st2actions/bootstrap/runnersregistrar.py
+++ b/st2actions/st2actions/bootstrap/runnersregistrar.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from oslo.config import cfg
-
 from st2common import log as logging
 from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2common.models.api.action import RunnerTypeAPI

--- a/st2actions/st2actions/runners/fabricrunner.py
+++ b/st2actions/st2actions/runners/fabricrunner.py
@@ -26,12 +26,11 @@ from st2common import log as logging
 from st2common.exceptions.actionrunner import ActionRunnerPreRunError
 from st2common.exceptions.fabricrunner import FabricExecutionFailureException
 from st2common.constants.action import LIVEACTION_STATUS_SUCCEEDED, LIVEACTION_STATUS_FAILED
+from st2common.constants.runners import FABRIC_RUNNER_DEFAULT_ACTION_TIMEOUT
 from st2common.models.system.action import (FabricRemoteAction, FabricRemoteScriptAction)
 
 # Replace with container call to get logger.
 LOG = logging.getLogger(__name__)
-
-DEFAULT_ACTION_TIMEOUT = 60
 
 
 # Fabric environment level settings.
@@ -47,7 +46,7 @@ if ssh_key_file and os.path.exists(ssh_key_file):
     env.key_filename = ssh_key_file
 
 env.timeout = 10  # Timeout for connections (in seconds)
-env.command_timeout = DEFAULT_ACTION_TIMEOUT  # timeout for commands (in seconds)
+env.command_timeout = FABRIC_RUNNER_DEFAULT_ACTION_TIMEOUT  # timeout for commands (in seconds)
 env.combine_stderr = False
 env.group = 'staff'
 env.abort_exception = FabricExecutionFailureException
@@ -107,7 +106,8 @@ class FabricRunner(ActionRunner, ShellRunnerMixin):
         self._cwd = self.runner_parameters.get(RUNNER_CWD, None)
         self._env = self.runner_parameters.get(RUNNER_ENV, {})
         self._kwarg_op = self.runner_parameters.get(RUNNER_KWARG_OP, '--')
-        self._timeout = self.runner_parameters.get(RUNNER_TIMEOUT, DEFAULT_ACTION_TIMEOUT)
+        self._timeout = self.runner_parameters.get(RUNNER_TIMEOUT,
+                                                   FABRIC_RUNNER_DEFAULT_ACTION_TIMEOUT)
 
         LOG.info('[FabricRunner="%s", liveaction_id="%s"] Finished pre_run.',
                  self.runner_id, self.liveaction_id)

--- a/st2actions/st2actions/runners/localrunner.py
+++ b/st2actions/st2actions/runners/localrunner.py
@@ -29,6 +29,7 @@ from st2common.models.system.action import ShellCommandAction
 from st2common.models.system.action import ShellScriptAction
 from st2common.constants.action import LIVEACTION_STATUS_SUCCEEDED
 from st2common.constants.action import LIVEACTION_STATUS_FAILED
+from st2common.constants.runners import LOCAL_RUNNER_DEFAULT_ACTION_TIMEOUT
 import st2common.util.jsonify as jsonify
 
 __all__ = [
@@ -37,7 +38,6 @@ __all__ = [
 
 LOG = logging.getLogger(__name__)
 
-DEFAULT_ACTION_TIMEOUT = 60
 DEFAULT_KWARG_OP = '--'
 LOGGED_USER_USERNAME = pwd.getpwuid(os.getuid())[0]
 
@@ -76,7 +76,8 @@ class LocalShellRunner(ActionRunner, ShellRunnerMixin):
         self._env = self.runner_parameters.get(RUNNER_ENV, {})
         self._env = self._env or {}
         self._kwarg_op = self.runner_parameters.get(RUNNER_KWARG_OP, DEFAULT_KWARG_OP)
-        self._timeout = self.runner_parameters.get(RUNNER_TIMEOUT, DEFAULT_ACTION_TIMEOUT)
+        self._timeout = self.runner_parameters.get(RUNNER_TIMEOUT,
+                                                   LOCAL_RUNNER_DEFAULT_ACTION_TIMEOUT)
 
     def run(self, action_parameters):
         LOG.debug('    action_parameters = %s', action_parameters)

--- a/st2actions/st2actions/runners/pythonrunner.py
+++ b/st2actions/st2actions/runners/pythonrunner.py
@@ -31,12 +31,9 @@ from st2common.constants.error_messages import PACK_VIRTUALENV_DOESNT_EXIST
 from st2common.util.sandboxing import get_sandbox_python_path
 from st2common.util.sandboxing import get_sandbox_python_binary_path
 from st2common.util.sandboxing import get_sandbox_virtualenv_path
-
+from st2common.constants.runners import PYTHON_RUNNER_DEFAULT_ACTION_TIMEOUT
 
 LOG = logging.getLogger(__name__)
-
-# Default timeout (in seconds) for actions executed by Python runner
-DEFAULT_ACTION_TIMEOUT = 10 * 60
 
 # constants to lookup in runner_parameters.
 RUNNER_ENV = 'env'
@@ -92,7 +89,7 @@ class Action(object):
 
 class PythonRunner(ActionRunner):
 
-    def __init__(self, runner_id, timeout=DEFAULT_ACTION_TIMEOUT):
+    def __init__(self, runner_id, timeout=PYTHON_RUNNER_DEFAULT_ACTION_TIMEOUT):
         """
         :param timeout: Action execution timeout in seconds.
         :type timeout: ``int``

--- a/st2actions/tests/integration/test_localrunner.py
+++ b/st2actions/tests/integration/test_localrunner.py
@@ -24,6 +24,7 @@ from st2actions.container.service import RunnerContainerService
 from st2actions.runners import localrunner
 from st2common.constants import action as action_constants
 from st2tests.fixturesloader import FixturesLoader
+from st2common.constants.runners import LOCAL_RUNNER_DEFAULT_ACTION_TIMEOUT
 
 
 class TestLocalShellRunner(TestCase):
@@ -87,7 +88,7 @@ class TestLocalShellRunner(TestCase):
                     on_behalf_user=None,
                     user=None,
                     kwarg_op=localrunner.DEFAULT_KWARG_OP,
-                    timeout=localrunner.DEFAULT_ACTION_TIMEOUT,
+                    timeout=LOCAL_RUNNER_DEFAULT_ACTION_TIMEOUT,
                     sudo=False):
         runner = localrunner.LocalShellRunner(uuid.uuid4().hex)
         runner.container_service = RunnerContainerService()

--- a/st2actions/tests/unit/test_http_runner.py
+++ b/st2actions/tests/unit/test_http_runner.py
@@ -1,0 +1,77 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import mock
+import unittest2
+
+from st2actions.runners.httprunner import HTTPClient
+import st2tests.config as tests_config
+
+
+class MockResult(object):
+    close = mock.Mock()
+
+
+class HTTPRunnerTestCase(unittest2.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        tests_config.parse_args()
+
+    @mock.patch('st2actions.runners.httprunner.requests')
+    def test_parse_response_body(self, mock_requests):
+        client = HTTPClient(url='http://localhost')
+        mock_result = MockResult()
+
+        # Unknown content type, body should be returned raw
+        mock_result.text = 'foo bar ponies'
+        mock_result.headers = {'Content-Type': 'text/html'}
+        mock_result.status_code = 200
+
+        mock_requests.request.return_value = mock_result
+        result = client.run()
+
+        self.assertEqual(result['body'], mock_result.text)
+        self.assertEqual(result['status_code'], mock_result.status_code)
+        self.assertEqual(result['headers'], mock_result.headers)
+
+        # Unknown content type, JSON body
+        mock_result.text = '{"test1": "val1"}'
+        mock_result.headers = {'Content-Type': 'text/html'}
+
+        mock_requests.request.return_value = mock_result
+        result = client.run()
+
+        self.assertEqual(result['body'], mock_result.text)
+
+        # JSON content-type and JSON body
+        mock_result.text = '{"test1": "val1"}'
+        mock_result.headers = {'Content-Type': 'application/json'}
+
+        mock_requests.request.return_value = mock_result
+        result = client.run()
+
+        self.assertTrue(isinstance(result['body'], dict))
+        self.assertEqual(result['body'], {'test1': 'val1'})
+
+        # JSON content-type and invalid json body
+        mock_result.text = 'not json'
+        mock_result.headers = {'Content-Type': 'application/json'}
+
+        mock_requests.request.return_value = mock_result
+        result = client.run()
+
+        self.assertFalse(isinstance(result['body'], dict))
+        self.assertEqual(result['body'], mock_result.text)

--- a/st2common/st2common/constants/runners.py
+++ b/st2common/st2common/constants/runners.py
@@ -1,0 +1,38 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = [
+    'LOCAL_RUNNER_DEFAULT_ACTION_TIMEOUT',
+
+    'FABRIC_RUNNER_DEFAULT_ACTION_TIMEOUT',
+    'FABRIC_RUNNER_DEFAULT_REMOTE_DIR'
+
+    'PYTHON_RUNNER_DEFAULT_ACTION_TIMEOUT'
+]
+
+# Local runner
+LOCAL_RUNNER_DEFAULT_ACTION_TIMEOUT = 60
+
+# Remote (fabric runner)
+FABRIC_RUNNER_DEFAULT_ACTION_TIMEOUT = 60
+
+try:
+    FABRIC_RUNNER_DEFAULT_REMOTE_DIR = cfg.CONF.ssh_runner.remote_dir
+except:
+    FABRIC_RUNNER_DEFAULT_REMOTE_DIR = '/tmp'
+
+# Python runner
+# Default timeout (in seconds) for actions executed by Python runner
+PYTHON_RUNNER_DEFAULT_ACTION_TIMEOUT = 10 * 60

--- a/st2common/st2common/constants/runners.py
+++ b/st2common/st2common/constants/runners.py
@@ -13,11 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from oslo.config import cfg
+
 __all__ = [
     'LOCAL_RUNNER_DEFAULT_ACTION_TIMEOUT',
 
     'FABRIC_RUNNER_DEFAULT_ACTION_TIMEOUT',
-    'FABRIC_RUNNER_DEFAULT_REMOTE_DIR'
+    'FABRIC_RUNNER_DEFAULT_REMOTE_DIR',
 
     'PYTHON_RUNNER_DEFAULT_ACTION_TIMEOUT'
 ]


### PR DESCRIPTION
With this change HTTP runner now parses a body if a response contains a known Content-Type.

For now, we only parse JSON responses with Content-Type of `application/json`.

To make it easier for the user, I've also added `parsed` flag to the result. This flag indicates if the response body has been parsed or not.

In the future, we can also add support for parsing other content-types, e.g. XML and HTML (e.g. with xmltodict and beautifulsoup library).

XML and HTML don't really directly map to a dictionary, so this feature would probably be an opt-in via a runner parameter.

On a semi related note - unless I've failed at grepping, we don't have any tests for the HTTP runner.