### PR TITLE
Fix mistral DSL transformer on inline parameters

### DIFF
--- a/st2actions/st2actions/runners/mistral/utils.py
+++ b/st2actions/st2actions/runners/mistral/utils.py
@@ -49,6 +49,9 @@ def _parse_cmd_and_input(cmd_str):
         except Exception:
             pass
 
+        if isinstance(v, basestring) and (v[:1], v[-1:]) == ('{', '}'):
+            v = v.strip('{}')
+
         params[k] = v
 
     return cmd, params

--- a/st2actions/tests/unit/test_mistral_dsl_transform.py
+++ b/st2actions/tests/unit/test_mistral_dsl_transform.py
@@ -63,8 +63,16 @@ class DSLTransformTestCase(DbTestCase):
     def setUpClass(cls):
         super(DSLTransformTestCase, cls).setUpClass()
         runners_registrar.register_runner_types()
+
         action_local = ActionAPI(**copy.deepcopy(FIXTURES['actions']['local.json']))
         Action.add_or_update(ActionAPI.to_model(action_local))
+
+        for action_name in ['action1', 'action2', 'action3']:
+            metadata = copy.deepcopy(FIXTURES['actions']['local.json'])
+            metadata['name'] = action_name
+            metadata['pack'] = 'demo'
+            action = ActionAPI(**metadata)
+            Action.add_or_update(ActionAPI.to_model(action))
 
     @staticmethod
     def _read_file_content(path):

--- a/st2tests/st2tests/fixtures/generic/workflows/wf_post_xform.yaml
+++ b/st2tests/st2tests/fixtures/generic/workflows/wf_post_xform.yaml
@@ -3,18 +3,28 @@ version: '2.0'
 demo:
     type: direct
     input:
-        - cmd
+        - var1
+        - var2
     tasks:
-        task_with_input:
+        task_with_inputs:
             action: st2.action
             input:
-                ref: core.local
+                ref: demo.action1
                 parameters:
-                    cmd: $.cmd
+                    var1: $.var1
+                    var2: $.var2
             publish:
-                stdout: $.stdout
-                stderr: $.stderr
+                var3: $.var3
+                var4: $.var4
+        task_with_inline_inputs:
+            action: st2.action
+            input:
+                ref: demo.action2
+                parameters:
+                    var1: $.var1
+                    var2: some string
+                    var3: some {$.var2} string
         task_with_no_input:
             action: st2.action
             input:
-                ref: core.local
+                ref: demo.action3

--- a/st2tests/st2tests/fixtures/generic/workflows/wf_pre_xform.yaml
+++ b/st2tests/st2tests/fixtures/generic/workflows/wf_pre_xform.yaml
@@ -3,14 +3,18 @@ version: '2.0'
 demo:
     type: direct
     input:
-        - cmd
+        - var1
+        - var2
     tasks:
-        task_with_input:
-            action: core.local
+        task_with_inputs:
+            action: demo.action1
             input:
-                cmd: $.cmd
+                var1: $.var1
+                var2: $.var2
             publish:
-                stdout: $.stdout
-                stderr: $.stderr
+                var3: $.var3
+                var4: $.var4
+        task_with_inline_inputs:
+            action: demo.action2 var1={$.var1} var2="some string" var3="some {$.var2} string"
         task_with_no_input:
-            action: core.local
+            action: demo.action3


### PR DESCRIPTION
Modify mistral DSL transformer to strip curly braces from strings for
inline parameters of actions. This only applies to inline parameters
that are YAQL expressions only.