### PR TITLE
[RFR] Bootstrap rabbit

### DIFF
--- a/st2actions/st2actions/cmd/actionrunner.py
+++ b/st2actions/st2actions/cmd/actionrunner.py
@@ -8,6 +8,7 @@ from st2common import log as logging
 from st2common.models.db import db_setup
 from st2common.models.db import db_teardown
 from st2common.constants.logging import DEFAULT_LOGGING_CONF_PATH
+from st2common.transport.utils import register_exchanges
 from st2actions import config
 from st2actions import worker
 
@@ -40,7 +41,7 @@ def _setup():
     password = cfg.CONF.database.password if hasattr(cfg.CONF.database, 'password') else None
     db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
              username=username, password=password)
-
+    register_exchanges()
     # 4. Register internal triggers
     # Note: We need to do import here because of a messed up configuration
     # situation (this module depends on configuration being parsed)

--- a/st2actions/st2actions/cmd/st2resultstracker.py
+++ b/st2actions/st2actions/cmd/st2resultstracker.py
@@ -8,6 +8,7 @@ from st2common import log as logging
 from st2common.models.db import db_setup
 from st2common.models.db import db_teardown
 from st2common.constants.logging import DEFAULT_LOGGING_CONF_PATH
+from st2common.transport.utils import register_exchanges
 from st2actions import config
 from st2actions import resultstracker
 
@@ -38,7 +39,7 @@ def _setup():
     password = cfg.CONF.database.password if hasattr(cfg.CONF.database, 'password') else None
     db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
              username=username, password=password)
-
+    register_exchanges()
 
 def _run_worker():
     LOG.info('(PID=%s) Results tracker started.', os.getpid())

--- a/st2actions/st2actions/cmd/st2resultstracker.py
+++ b/st2actions/st2actions/cmd/st2resultstracker.py
@@ -41,6 +41,7 @@ def _setup():
              username=username, password=password)
     register_exchanges()
 
+
 def _run_worker():
     LOG.info('(PID=%s) Results tracker started.', os.getpid())
     tracker = resultstracker.get_tracker()

--- a/st2api/st2api/cmd/api.py
+++ b/st2api/st2api/cmd/api.py
@@ -24,6 +24,7 @@ from st2common import log as logging
 from st2common.models.db import db_setup
 from st2common.models.db import db_teardown
 from st2common.constants.logging import DEFAULT_LOGGING_CONF_PATH
+from st2common.transport.utils import register_exchanges
 from st2api.listener import get_listener_if_set
 from st2api import config
 from st2api import app
@@ -56,6 +57,7 @@ def _setup():
     password = cfg.CONF.database.password if hasattr(cfg.CONF.database, 'password') else None
     db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
              username=username, password=password)
+    register_exchanges()
 
 
 def _run_server():

--- a/st2common/bin/bootstraprmq.py
+++ b/st2common/bin/bootstraprmq.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python2.7
+
+import sys
+import st2common.transport.bootstrap as transport_bootstrap
+
+if __name__ == '__main__':
+    sys.exit(transport_bootstrap.main())

--- a/st2common/st2common/transport/bootstrap.py
+++ b/st2common/st2common/transport/bootstrap.py
@@ -16,15 +16,7 @@
 import logging
 import st2common.config as config
 
-from kombu import Connection
-from oslo.config import cfg
-from st2common.transport.execution import EXECUTION_XCHG
-from st2common.transport.liveaction import LIVEACTION_XCHG
-from st2common.transport.reactor import TRIGGER_CUD_XCHG, TRIGGER_INSTANCES_XCHG
-
-LOG = logging.getLogger('st2common.transport.bootstrap')
-
-EXCHANGES = [EXECUTION_XCHG, LIVEACTION_XCHG, TRIGGER_CUD_XCHG, TRIGGER_INSTANCES_XCHG]
+from st2common.transport.utils import register_exchanges
 
 
 def _setup():
@@ -35,28 +27,10 @@ def _setup():
                         level=logging.DEBUG)
 
 
-def _do_register_exchange(exchange, channel):
-    try:
-        channel.exchange_declare(exchange=exchange.name, type=exchange.type,
-                                 durable=exchange.durable, auto_delete=exchange.auto_delete,
-                                 arguments=exchange.arguments, nowait=False, passive=None)
-        LOG.info('registered exchange %s.', exchange.name)
-    except Exception:
-        LOG.exception('Failed to register exchange : %s.', exchange.name)
-
-
-def _resgister_exchanges():
-    LOG.info('=========================================================')
-    LOG.info('############## Registering exchanges ####################')
-    LOG.info('=========================================================')
-    with Connection(cfg.CONF.messaging.url) as conn:
-        channel = conn.default_channel
-        for exchange in EXCHANGES:
-            _do_register_exchange(exchange, channel)
-
 def main():
     _setup()
-    _resgister_exchanges()
+    register_exchanges()
+
 
 # The scripts sets up Exchanges in RabbitMQ.
 if __name__ == '__main__':

--- a/st2common/st2common/transport/bootstrap.py
+++ b/st2common/st2common/transport/bootstrap.py
@@ -1,0 +1,63 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import st2common.config as config
+
+from kombu import Connection
+from oslo.config import cfg
+from st2common.transport.execution import EXECUTION_XCHG
+from st2common.transport.liveaction import LIVEACTION_XCHG
+from st2common.transport.reactor import TRIGGER_CUD_XCHG, TRIGGER_INSTANCES_XCHG
+
+LOG = logging.getLogger('st2common.transport.bootstrap')
+
+EXCHANGES = [EXECUTION_XCHG, LIVEACTION_XCHG, TRIGGER_CUD_XCHG, TRIGGER_INSTANCES_XCHG]
+
+
+def _setup():
+    config.parse_args()
+
+    # 2. setup logging.
+    logging.basicConfig(format='%(asctime)s %(levelname)s [-] %(message)s',
+                        level=logging.DEBUG)
+
+
+def _do_register_exchange(exchange, channel):
+    try:
+        channel.exchange_declare(exchange=exchange.name, type=exchange.type,
+                                 durable=exchange.durable, auto_delete=exchange.auto_delete,
+                                 arguments=exchange.arguments, nowait=False, passive=None)
+        LOG.info('registered exchange %s.', exchange.name)
+    except Exception:
+        LOG.exception('Failed to register exchange : %s.', exchange.name)
+
+
+def _resgister_exchanges():
+    LOG.info('=========================================================')
+    LOG.info('############## Registering exchanges ####################')
+    LOG.info('=========================================================')
+    with Connection(cfg.CONF.messaging.url) as conn:
+        channel = conn.default_channel
+        for exchange in EXCHANGES:
+            _do_register_exchange(exchange, channel)
+
+def main():
+    _setup()
+    _resgister_exchanges()
+
+# The scripts sets up Exchanges in RabbitMQ.
+if __name__ == '__main__':
+    main()

--- a/st2common/st2common/transport/execution.py
+++ b/st2common/st2common/transport/execution.py
@@ -18,14 +18,14 @@
 from kombu import Exchange, Queue
 from st2common.transport import publishers
 
-HISTORY_XCHG = Exchange('st2.execution', type='topic')
+EXECUTION_XCHG = Exchange('st2.execution', type='topic')
 
 
 class ActionExecutionPublisher(publishers.CUDPublisher):
 
     def __init__(self, url):
-        super(ActionExecutionPublisher, self).__init__(url, HISTORY_XCHG)
+        super(ActionExecutionPublisher, self).__init__(url, EXECUTION_XCHG)
 
 
 def get_queue(name=None, routing_key=None, exclusive=False):
-    return Queue(name, HISTORY_XCHG, routing_key=routing_key, exclusive=exclusive)
+    return Queue(name, EXECUTION_XCHG, routing_key=routing_key, exclusive=exclusive)

--- a/st2common/st2common/transport/utils.py
+++ b/st2common/st2common/transport/utils.py
@@ -1,0 +1,45 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kombu import Connection
+from oslo.config import cfg
+from st2common import log as logging
+from st2common.transport.execution import EXECUTION_XCHG
+from st2common.transport.liveaction import LIVEACTION_XCHG
+from st2common.transport.reactor import TRIGGER_CUD_XCHG, TRIGGER_INSTANCES_XCHG
+
+LOG = logging.getLogger('st2common.transport.bootstrap')
+
+EXCHANGES = [EXECUTION_XCHG, LIVEACTION_XCHG, TRIGGER_CUD_XCHG, TRIGGER_INSTANCES_XCHG]
+
+
+def _do_register_exchange(exchange, channel):
+    try:
+        channel.exchange_declare(exchange=exchange.name, type=exchange.type,
+                                 durable=exchange.durable, auto_delete=exchange.auto_delete,
+                                 arguments=exchange.arguments, nowait=False, passive=None)
+        LOG.info('registered exchange %s.', exchange.name)
+    except Exception:
+        LOG.exception('Failed to register exchange : %s.', exchange.name)
+
+
+def register_exchanges():
+    LOG.info('=========================================================')
+    LOG.info('############## Registering exchanges ####################')
+    LOG.info('=========================================================')
+    with Connection(cfg.CONF.messaging.url) as conn:
+        channel = conn.default_channel
+        for exchange in EXCHANGES:
+            _do_register_exchange(exchange, channel)

--- a/st2common/st2common/transport/utils.py
+++ b/st2common/st2common/transport/utils.py
@@ -36,9 +36,7 @@ def _do_register_exchange(exchange, channel):
 
 
 def register_exchanges():
-    LOG.info('=========================================================')
-    LOG.info('############## Registering exchanges ####################')
-    LOG.info('=========================================================')
+    LOG.info('Registering exchanges...')
     with Connection(cfg.CONF.messaging.url) as conn:
         channel = conn.default_channel
         for exchange in EXCHANGES:

--- a/st2reactor/st2reactor/cmd/rulesengine.py
+++ b/st2reactor/st2reactor/cmd/rulesengine.py
@@ -8,6 +8,7 @@ from st2common import log as logging
 from st2common.models.db import db_setup
 from st2common.models.db import db_teardown
 from st2common.constants.logging import DEFAULT_LOGGING_CONF_PATH
+from st2common.transport.utils import register_exchanges
 from st2reactor.rules import config
 from st2reactor.rules import worker
 from st2reactor.timer.base import St2Timer
@@ -39,6 +40,7 @@ def _setup():
     password = cfg.CONF.database.password if hasattr(cfg.CONF.database, 'password') else None
     db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
              username=username, password=password)
+    register_exchanges()
 
 
 def _teardown():

--- a/st2reactor/st2reactor/cmd/sensormanager.py
+++ b/st2reactor/st2reactor/cmd/sensormanager.py
@@ -8,6 +8,7 @@ from st2common import log as logging
 from st2common.models.db import db_setup
 from st2common.models.db import db_teardown
 from st2common.constants.logging import DEFAULT_LOGGING_CONF_PATH
+from st2common.transport.utils import register_exchanges
 from st2reactor.sensor import config
 from st2common.persistence.reactor import SensorType
 from st2reactor.container.manager import SensorContainerManager
@@ -40,6 +41,7 @@ def _setup():
     password = cfg.CONF.database.password if hasattr(cfg.CONF.database, 'password') else None
     db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
              username=username, password=password)
+    register_exchanges()
 
     # 4. Register internal triggers
     # Note: We need to do import here because of a messed up configuration


### PR DESCRIPTION
* Command to bootstrap rabbitmq. For now only exchanges are created.
* Command is called from all start/launch scripts.

Note : Since it is a bootstrap step decided to keep it outside. Similar to the registercontent step just that it is configuring an external component.

Fixes : https://stackstorm.atlassian.net/browse/STORM-1020