### PR TITLE
Rebase mistral DSL transformers, tests, and examples

### DIFF
--- a/contrib/examples/actions/workflows/mistral-basic.yaml
+++ b/contrib/examples/actions/workflows/mistral-basic.yaml
@@ -5,10 +5,10 @@ examples.mistral-basic:
     input:
         - cmd
     output:
-        stdout: $.stdout
+        stdout: <% $.stdout %>
     tasks:
         task1:
-            action: core.local cmd={$.cmd}
+            action: core.local cmd=<% $.cmd %>
             publish:
-                stdout: $.task1.stdout
-                stderr: $.task1.stderr
+                stdout: <% $.task1.stdout %>
+                stderr: <% $.task1.stderr %>

--- a/contrib/examples/actions/workflows/mistral-handle-error.yaml
+++ b/contrib/examples/actions/workflows/mistral-handle-error.yaml
@@ -5,18 +5,18 @@ examples.mistral-handle-error:
     input:
         - cmd
     output:
-        stdout: $.stdout
+        stdout: <% $.stdout %>
     task-defaults:
         on-error:
             - notify_on_error
             - fail
     tasks:
         task1:
-            action: core.local cmd={$.cmd}
+            action: core.local cmd=<% $.cmd %>
             publish:
-                stdout: $.task1.stdout
-                stderr: $.task1.stderr
+                stdout: <% $.task1.stdout %>
+                stderr: <% $.task1.stderr %>
         notify_on_error:
             action: core.local
             input:
-                cmd: "printf '{$.error}'"
+                cmd: "printf '<% $.error %>'"

--- a/contrib/examples/actions/workflows/mistral-repeat-with-items.yaml
+++ b/contrib/examples/actions/workflows/mistral-repeat-with-items.yaml
@@ -9,7 +9,7 @@ examples.mistral-repeat-with-items:
         - cmds
     tasks:
         repeat:
-            with-items: cmd in $.cmds
-            action: core.local cmd={$.cmd}
+            with-items: cmd in <% $.cmds %>
+            action: core.local cmd=<% $.cmd %>
             publish:
-                resut: $.repeat.stdout
+                resut: <% $.repeat.stdout %>

--- a/contrib/examples/actions/workflows/mistral-repeat.yaml
+++ b/contrib/examples/actions/workflows/mistral-repeat.yaml
@@ -11,11 +11,11 @@ examples.mistral-repeat:
     tasks:
         setup:
             publish:
-                times_to_repeat: range(0, $.count).list() 
+                times_to_repeat: <% range(0, $.count).list() %> 
             on-success:
                 - repeat
         repeat:
-            with-items: i in $.times_to_repeat
-            action: core.local cmd={$.cmd}
+            with-items: i in <% $.times_to_repeat %>
+            action: core.local cmd=<% $.cmd %>
             publish:
-                result: $.repeat.stdout
+                result: <% $.repeat.stdout %>

--- a/contrib/examples/actions/workflows/mistral-workbook-basic.yaml
+++ b/contrib/examples/actions/workflows/mistral-workbook-basic.yaml
@@ -7,12 +7,12 @@ workflows:
         input:
             - cmd
         output:
-            stdout: $.stdout
+            stdout: <% $.stdout %>
         tasks:
             task1:
                 action: core.local
                 input:
-                    cmd: $.cmd
+                    cmd: <% $.cmd %>
                 publish:
-                    stdout: $.task1.stdout
-                    stderr: $.task1.stderr
+                    stdout: <% $.task1.stdout %>
+                    stderr: <% $.task1.stderr %>

--- a/contrib/examples/actions/workflows/mistral-workbook-complex.yaml
+++ b/contrib/examples/actions/workflows/mistral-workbook-complex.yaml
@@ -10,8 +10,8 @@ workflows:
             - cpu_cores
             - memory_mb
         output:
-            vm_id: $.vm_id
-            vm_state: $.vm_state 
+            vm_id: <% $.vm_id %>
+            vm_state: <% $.vm_state %>
         task-defaults:
           on-error:
             - fail
@@ -27,11 +27,11 @@ workflows:
             create_vm:
                 workflow: create_vm
                 input:
-                    name: $.vm_name
-                    ip: $.ip
+                    name: <% $.vm_name %>
+                    ip: <% $.ip %>
                 publish:
-                    vm_id: $.create_vm.vm_id
-                    message: "VM {$.vm_name} is created."
+                    vm_id: <% $.create_vm.vm_id %>
+                    message: "VM <% $.vm_name %> is created."
                 on-success:
                     - power_off_vm
                     - notify
@@ -40,19 +40,19 @@ workflows:
                 input:
                     cmd: "sleep 2; printf 'stopped'"
                 publish:
-                    vm_state: $.power_off_vm.stdout
-                    message: "VM {$.vm_name} is powered off."
+                    vm_state: <% $.power_off_vm.stdout %>
+                    message: "VM <% $.vm_name %> is powered off."
                 on-success:
                     - reconfig_vm
                     - notify
             reconfig_vm:
                 workflow: reconfig_vm
                 input:
-                    vm_id: $.vm_id
-                    cpu_cores: $.cpu_cores
-                    memory_mb: $.memory_mb
+                    vm_id: <% $.vm_id %>
+                    cpu_cores: <% $.cpu_cores %>
+                    memory_mb: <% $.memory_mb %>
                 publish:
-                    message: "VM {$.vm_name} is reconfigured."
+                    message: "VM <% $.vm_name %> is reconfigured."
                 on-success:
                     - power_on_vm
                     - notify
@@ -61,8 +61,8 @@ workflows:
                 input:
                     cmd: "sleep 2; printf 'running'"
                 publish:
-                    vm_state: $.power_on_vm.stdout
-                    message: "VM {$.vm_name} is powered on."
+                    vm_state: <% $.power_on_vm.stdout %>
+                    message: "VM <% $.vm_name %> is powered on."
                 on-success:
                     - notify_request_fulfilled
                     - notify
@@ -74,7 +74,7 @@ workflows:
             notify:
                 action: core.local
                 input:
-                    cmd: "printf '{$.message}'"
+                    cmd: "printf '<% $.message %>'"
 
     create_vm:
         type: direct
@@ -82,7 +82,7 @@ workflows:
             - name
             - ip
         output:
-            vm_id: $.vm_id
+            vm_id: <% $.vm_id %>
         task-defaults:
           on-error:
             - fail
@@ -92,7 +92,7 @@ workflows:
                 input:
                     cmd: "sleep 5; printf 'vm1234'"
                 publish:
-                    vm_id: $.create.stdout
+                    vm_id: <% $.create.stdout %>
 
     reconfig_vm:
         type: direct

--- a/contrib/examples/actions/workflows/mistral-workbook-multiple-subflows.yaml
+++ b/contrib/examples/actions/workflows/mistral-workbook-multiple-subflows.yaml
@@ -6,8 +6,8 @@ workflows:
     main:
         type: direct
         output:
-            report: $.report
-            state: $.state 
+            report: <% $.report %>
+            state: <% $.state %>
         task-defaults:
           on-error:
             - fail
@@ -15,17 +15,17 @@ workflows:
             call_internal_workflow:
                 workflow: internal_workflow
                 input:
-                    name: $.vm_name
+                    name: <% $.vm_name %>
                 publish:
-                    report: $.call_internal_workflow.report
+                    report: <% $.call_internal_workflow.report %>
                 on-success:
                     - call_internal_workflow_multiple_tasks
             call_internal_workflow_multiple_tasks:
                 workflow: internal_workflow_multiple_tasks
                 input:
-                    vm_id: $.vm_id
-                    cpu_cores: $.cpu_cores
-                    memory_mb: $.memory_mb
+                    vm_id: <% $.vm_id %>
+                    cpu_cores: <% $.cpu_cores %>
+                    memory_mb: <% $.memory_mb %>
                 on-success:
                     - call_external_workflow
             call_external_workflow:
@@ -33,7 +33,7 @@ workflows:
                 input:
                     cmd: "sleep 2; echo external workflow ok"
                 publish:
-                    state: $.call_external_workflow.stdout
+                    state: <% $.call_external_workflow.stdout %>
                 on-success:
                     - call_action_chain
             call_action_chain:
@@ -44,7 +44,7 @@ workflows:
         input:
             - name
         output:
-            report: $.report
+            report: <% $.report %>
         task-defaults:
           on-error:
             - fail
@@ -54,7 +54,7 @@ workflows:
                 input:
                     cmd: "sleep 3; echo task1 ok"
                 publish:
-                    report: $.task1.stdout
+                    report: <% $.task1.stdout %>
 
     internal_workflow_multiple_tasks:
         type: direct

--- a/contrib/examples/actions/workflows/mistral-workbook-subflows.yaml
+++ b/contrib/examples/actions/workflows/mistral-workbook-subflows.yaml
@@ -9,7 +9,7 @@ workflows:
             - subject
             - adjective
         output:
-            tagline: "{$.printed_subject} is {$.printed_adjective}!"
+            tagline: "<% $.printed_subject %> is <% $.printed_adjective %>!"
         task-defaults:
           on-error:
             - fail
@@ -17,14 +17,14 @@ workflows:
             print_subject:
                 action: examples.mistral-basic
                 input:
-                    cmd: "printf '{$.subject}'"
+                    cmd: "printf '<% $.subject %>'"
                 publish:
-                    printed_subject: $.print_subject.stdout
+                    printed_subject: <% $.print_subject.stdout %>
                 on-success:
                     - print_adjective
             print_adjective:
                 action: examples.mistral-basic
                 input:
-                    cmd: "printf '{$.adjective}'"
+                    cmd: "printf '<% $.adjective %>'"
                 publish:
-                    printed_adjective: $.print_adjective.stdout
+                    printed_adjective: <% $.print_adjective.stdout %>

--- a/docs/source/mistral.rst
+++ b/docs/source/mistral.rst
@@ -6,7 +6,7 @@ Basic Workflow
 ++++++++++++++
 Let's start with a very basic workflow that calls a |st2| action and notifies |st2| when the workflow is done. The files used in this example is also located under /usr/share/doc/st2/examples if |st2| is already installed. The first task is named **run-cmd** that executes a shell command on the local server where st2 is installed. The run-cmd task is calling **core.local** and passing the cmd as input. **core.local** is an action that comes installed with |st2|. In the workflow, we can reference |st2| action directly. When the workflow is invoked, |st2| will translate the workflow definition appropriately before sending it to Mistral. Let's save this as mistral-workbook-basic.yaml at /opt/stackstorm/packs/examples/actions/ where |st2| is installed.
 
-.. literalinclude:: /../../contrib/examples/actions/mistral-workbook-basic.yaml
+.. literalinclude:: /../../contrib/examples/actions/workflows/mistral-workbook-basic.yaml
 
 The following is the corresponding |st2| action metadata for example above. The |st2| pack for this workflow action is named "examples". Please note that the workbook is named fully qualified as "<pack>.<action>" in the workbook definition above. The |st2| action runner is "mistral-v2". The entry point for the |st2| action refers to the YAML file of the workbook definition. Under the parameters section, we added an immutable parameter that specifies which workflow in the workbook to execute and a second parameter that takes the command to execute. Let's save this metadata as mistral-workbook-basic.json at /opt/stackstorm/packs/examples/actions/.
 

--- a/st2actions/st2actions/query/mistral/v2.py
+++ b/st2actions/st2actions/query/mistral/v2.py
@@ -135,10 +135,9 @@ class MistralResultsQuerier(Querier):
         result['updated_at'] = task.get('updated_at', None)
         result['state'] = task.get('state', None)
         result['input'] = task.get('input', None)
-        result['output'] = task.get('output', None)
         result['result'] = task.get('result', None)
 
-        for attr in ['result', 'input', 'output']:
+        for attr in ['result', 'input']:
             result[attr] = jsonify.try_loads(task.get(attr, None))
 
         return result

--- a/st2actions/st2actions/runners/mistral/utils.py
+++ b/st2actions/st2actions/runners/mistral/utils.py
@@ -27,30 +27,45 @@ from st2common.persistence.action import Action
 
 LOG = logging.getLogger(__name__)
 
-REGEX_ACTION = re.compile("^[\w\.]+[^=\s\"]*")
-REGEX_ACTION_PARAMS = re.compile("([\w]+)=(\"[^\"]*\"\s*|'[^']*'\s*|"
-                                 "\{[^}]*\}\s*|\[.*\]\s*|[\.,:\w\d\.]+)")
+
+CMD_PTRN = re.compile("^[\w\.]+[^=\s\"]*")
+
+INLINE_YAQL = '<%.*?%>'
+_ALL_IN_BRACKETS = "\[.*\]\s*"
+_ALL_IN_QUOTES = "\"[^\"]*\"\s*"
+_ALL_IN_APOSTROPHES = "'[^']*'\s*"
+_DIGITS = "\d+"
+_TRUE = "true"
+_FALSE = "false"
+_NULL = "null"
+
+ALL = (
+    _ALL_IN_QUOTES, _ALL_IN_APOSTROPHES, INLINE_YAQL,
+    _ALL_IN_BRACKETS, _TRUE, _FALSE, _NULL, _DIGITS
+)
+
+PARAMS_PTRN = re.compile("([\w]+)=(%s)" % "|".join(ALL))
 
 
 def _parse_cmd_and_input(cmd_str):
-    cmd_matcher = REGEX_ACTION.search(cmd_str)
+    cmd_matcher = CMD_PTRN.search(cmd_str)
 
     if not cmd_matcher:
-        raise ValueError('Invalid action/workflow task property: %s' % cmd_str)
+        raise ValueError("Invalid action/workflow task property: %s" % cmd_str)
 
     cmd = cmd_matcher.group()
 
     params = {}
-    for k, v in re.findall(REGEX_ACTION_PARAMS, cmd_str):
+    for k, v in re.findall(PARAMS_PTRN, cmd_str):
+        # Remove embracing quotes.
         v = v.strip()
-
-        try:
-            v = json.loads(v)
-        except Exception:
-            pass
-
-        if isinstance(v, basestring) and (v[:1], v[-1:]) == ('{', '}'):
-            v = v.strip('{}')
+        if v[0] == '"' or v[0] == "'":
+            v = v[1:-1]
+        else:
+            try:
+                v = json.loads(v)
+            except Exception:
+                pass
 
         params[k] = v
 
@@ -99,8 +114,8 @@ def _transform_action(spec, action_key, input_key):
     #
     # action: some_action
     # input:
-    #   var1: $.value1
-    #   var2: $.value2
+    #   var1: <% $.value1 %>
+    #   var2: <% $.value2 %>
     #
     # This step to separate the action name and the input parameters is required
     # to wrap them with the st2.action proxy.
@@ -109,8 +124,8 @@ def _transform_action(spec, action_key, input_key):
     # input:
     #   ref: some_action
     #   parameters:
-    #     var1: $.value1
-    #     var2: $.value2
+    #     var1: <% $.value1 %>
+    #     var2: <% $.value2 %>
     _eval_inline_params(spec, action_key, input_key)
 
     action_ref = spec.get(action_key)

--- a/st2tests/st2tests/fixtures/generic/workflows/wb_post_xform.yaml
+++ b/st2tests/st2tests/fixtures/generic/workflows/wb_post_xform.yaml
@@ -16,17 +16,17 @@ workflows:
             create_vm:
                 workflow: create_vm
                 input:
-                    name: $.vm_name
+                    name: <% $.vm_name %>
                 publish:
-                    vm_id: $.vm_id
+                    vm_id: <% $.vm_id %>
                 on-success:
                     - reconfig_vm
             reconfig_vm:
                 workflow: reconfig_vm
                 input:
-                    vm_id: $.vm_id
-                    cpu_cores: $.cpu_cores
-                    memory_mb: $.memory_mb
+                    vm_id: <% $.vm_id %>
+                    cpu_cores: <% $.cpu_cores %>
+                    memory_mb: <% $.memory_mb %>
                 on-success:
                     - power_on_vm
             power_on_vm:
@@ -36,14 +36,14 @@ workflows:
                     parameters:
                         cmd: "sleep 2; printf 'running'"
                 publish:
-                    vm_state: $.stdout
+                    vm_state: <% $.power_on_vm.stdout %>
 
     create_vm:
         type: direct
         input:
             - name
         output:
-            vm_id: $.vm_id
+            vm_id: <% $.vm_id %>
         task-defaults:
           on-error:
             - fail
@@ -55,7 +55,7 @@ workflows:
                     parameters:
                         cmd: "sleep 3; printf 'vm1234'"
                 publish:
-                    vm_id: $.stdout
+                    vm_id: <% $.create.stdout %>
 
     reconfig_vm:
         type: direct
@@ -72,10 +72,10 @@ workflows:
                 input:
                     ref: core.local
                     parameters:
-                        cmd: "sleep 1; printf '{$.vm_id}'"
+                        cmd: "sleep 1; printf '<% $.vm_id %>'"
             edit_cpu_mem:
                 action: st2.action
                 input:
                     ref: core.local
                     parameters:
-                        cmd: "sleep 1; printf '{\"vm_id\": \"{$.vm_id}\", \"cpu\": {$.cpu_cores}, \"memory\": {$.memory_mb}}'"
+                        cmd: "sleep 1; printf '{\"vm_id\": \"<% $.vm_id %>\", \"cpu\": <% $.cpu_cores %>, \"memory\": <% $.memory_mb %>}'"

--- a/st2tests/st2tests/fixtures/generic/workflows/wb_pre_xform.yaml
+++ b/st2tests/st2tests/fixtures/generic/workflows/wb_pre_xform.yaml
@@ -16,17 +16,17 @@ workflows:
             create_vm:
                 workflow: create_vm
                 input:
-                    name: $.vm_name
+                    name: <% $.vm_name %>
                 publish:
-                    vm_id: $.vm_id
+                    vm_id: <% $.vm_id %>
                 on-success:
                     - reconfig_vm
             reconfig_vm:
                 workflow: reconfig_vm
                 input:
-                    vm_id: $.vm_id
-                    cpu_cores: $.cpu_cores
-                    memory_mb: $.memory_mb
+                    vm_id: <% $.vm_id %>
+                    cpu_cores: <% $.cpu_cores %>
+                    memory_mb: <% $.memory_mb %>
                 on-success:
                     - power_on_vm
             power_on_vm:
@@ -34,14 +34,14 @@ workflows:
                 input:
                     cmd: "sleep 2; printf 'running'"
                 publish:
-                    vm_state: $.stdout
+                    vm_state: <% $.power_on_vm.stdout %>
 
     create_vm:
         type: direct
         input:
             - name
         output:
-            vm_id: $.vm_id
+            vm_id: <% $.vm_id %>
         task-defaults:
           on-error:
             - fail
@@ -51,7 +51,7 @@ workflows:
                 input:
                     cmd: "sleep 3; printf 'vm1234'"
                 publish:
-                    vm_id: $.stdout
+                    vm_id: <% $.create.stdout %>
 
     reconfig_vm:
         type: direct
@@ -66,8 +66,8 @@ workflows:
             add_disk:
                 action: core.local
                 input:
-                    cmd: "sleep 1; printf '{$.vm_id}'"
+                    cmd: "sleep 1; printf '<% $.vm_id %>'"
             edit_cpu_mem:
                 action: core.local
                 input:
-                    cmd: "sleep 1; printf '{\"vm_id\": \"{$.vm_id}\", \"cpu\": {$.cpu_cores}, \"memory\": {$.memory_mb}}'"
+                    cmd: "sleep 1; printf '{\"vm_id\": \"<% $.vm_id %>\", \"cpu\": <% $.cpu_cores %>, \"memory\": <% $.memory_mb %>}'"

--- a/st2tests/st2tests/fixtures/generic/workflows/wf_post_xform.yaml
+++ b/st2tests/st2tests/fixtures/generic/workflows/wf_post_xform.yaml
@@ -11,19 +11,19 @@ demo:
             input:
                 ref: demo.action1
                 parameters:
-                    var1: $.var1
-                    var2: $.var2
+                    var1: <% $.var1 %>
+                    var2: <% $.var2 %>
             publish:
-                var3: $.var3
-                var4: $.var4
+                var3: <% $.var3 %>
+                var4: <% $.var4 %>
         task_with_inline_inputs:
             action: st2.action
             input:
                 ref: demo.action2
                 parameters:
-                    var1: $.var1
+                    var1: <% $.var1 %>
                     var2: some string
-                    var3: some {$.var2} string
+                    var3: some <% $.var2 %> string
         task_with_no_input:
             action: st2.action
             input:

--- a/st2tests/st2tests/fixtures/generic/workflows/wf_pre_xform.yaml
+++ b/st2tests/st2tests/fixtures/generic/workflows/wf_pre_xform.yaml
@@ -9,12 +9,12 @@ demo:
         task_with_inputs:
             action: demo.action1
             input:
-                var1: $.var1
-                var2: $.var2
+                var1: <% $.var1 %>
+                var2: <% $.var2 %>
             publish:
-                var3: $.var3
-                var4: $.var4
+                var3: <% $.var3 %>
+                var4: <% $.var4 %>
         task_with_inline_inputs:
-            action: demo.action2 var1={$.var1} var2="some string" var3="some {$.var2} string"
+            action: demo.action2 var1=<% $.var1 %> var2="some string" var3="some <% $.var2 %> string"
         task_with_no_input:
             action: demo.action3

--- a/st2tests/st2tests/fixtures/generic/workflows/workbook_v2.yaml
+++ b/st2tests/st2tests/fixtures/generic/workflows/workbook_v2.yaml
@@ -12,14 +12,14 @@ workflows:
       say-greeting:
         action: core.hey
         input:
-          cmd: $.count
+          cmd: <% $.count %>
         publish:
-          greet: $.stdout
+          greet: <% $.say-greeting.stdout %>
         on-success:
           - say-friend
       say-friend:
         action: core.friend
         input:
-          cmd: $.friend
+          cmd: <% $.friend %>
         publish:
-          towhom: $.stdout
+          towhom: <% $.say-friend.stdout %>

--- a/st2tests/st2tests/fixtures/generic/workflows/workbook_v2_many_workflows.yaml
+++ b/st2tests/st2tests/fixtures/generic/workflows/workbook_v2_many_workflows.yaml
@@ -10,9 +10,9 @@ workflows:
       - friend
     tasks:
       greet:
-        workflow: subflow1 count={$.count} friend={$.friend} 
+        workflow: subflow1 count=<% $.count %> friend=<% $.friend %>
         publish:
-          towhom: $.towhom
+          towhom: <% $.greet.towhom %>
 
   subflow1:
     type: direct
@@ -20,19 +20,19 @@ workflows:
       - count
       - friend
     output:
-      towhom: $.towhom
+      towhom: <% $.towhom %>
     tasks:
       say-greeting:
         action: core.hey
         input:
-          cmd: $.count
+          cmd: <% $.count %>
         publish:
-          greet: $.stdout
+          greet: <% $.say-greeting.stdout %>
         on-success:
           - say-friend
       say-friend:
         action: core.friend
         input:
-          cmd: $.friend
+          cmd: <% $.friend %>
         publish:
-          towhom: $.stdout
+          towhom: <% $.say-friend.stdout %>

--- a/st2tests/st2tests/fixtures/generic/workflows/workbook_v2_many_workflows_no_default.yaml
+++ b/st2tests/st2tests/fixtures/generic/workflows/workbook_v2_many_workflows_no_default.yaml
@@ -10,9 +10,9 @@ workflows:
       - friend
     tasks:
       greet:
-        workflow: subflow1 count={$.count} friend={$.friend} 
+        workflow: subflow1 count=<% $.count %> friend=<% $.friend %> 
         publish:
-          towhom: $.towhom
+          towhom: <% $.greet.towhom %>
 
   main2:
     type: direct
@@ -21,9 +21,9 @@ workflows:
       - friend
     tasks:
       greet:
-        workflow: subflow1 count={$.count} friend={$.friend}
+        workflow: subflow1 count=<% $.count %> friend=<% $.friend %>
         publish:
-          towhom: $.towhom
+          towhom: <% $.greet.towhom %>
 
   subflow1:
     type: direct
@@ -31,19 +31,19 @@ workflows:
       - count
       - friend
     output:
-      towhom: $.towhom
+      towhom: <% $.towhom %>
     tasks:
       say-greeting:
         action: core.hey
         input:
-          cmd: $.count
+          cmd: <% $.count %>
         publish:
-          greet: $.stdout
+          greet: <% $.say-greeting.stdout %>
         on-success:
           - say-friend
       say-friend:
         action: core.friend
         input:
-          cmd: $.friend
+          cmd: <% $.friend %>
         publish:
-          towhom: $.stdout
+          towhom: <% $.say-friend.stdout %>

--- a/st2tests/st2tests/fixtures/generic/workflows/workflow_v2.yaml
+++ b/st2tests/st2tests/fixtures/generic/workflows/workflow_v2.yaml
@@ -9,14 +9,14 @@ generic.workflow_v2:
     say-greeting:
       action: core.hey
       input:
-        cmd: $.count
+        cmd: <% $.count %>
       publish:
-        greet: $.stdout
+        greet: <% $.say-greeting.stdout %>
       on-success:
         - say-friend
     say-friend:
       action: core.friend
       input:
-        cmd: $.friend
+        cmd: <% $.friend %>
       publish:
-        towhom: $.stdout
+        towhom: <% $.say-friend.stdout %>

--- a/st2tests/st2tests/fixtures/generic/workflows/workflow_v2_many_workflows.yaml
+++ b/st2tests/st2tests/fixtures/generic/workflows/workflow_v2_many_workflows.yaml
@@ -9,17 +9,17 @@ generic.workflow_v2.main1:
     say-greeting:
       action: core.hey
       input:
-        cmd: $.count
+        cmd: <% $.count %>
       publish:
-        greet: $.stdout
+        greet: <% $.say-greeting.stdout %>
       on-success:
         - say-friend
     say-friend:
       action: core.friend
       input:
-        cmd: $.friend
+        cmd: <% $.friend %>
       publish:
-        towhom: $.stdout
+        towhom: <% $.say-friend.stdout %>
 
 generic.workflow_v2.main2:
   type: direct
@@ -30,14 +30,14 @@ generic.workflow_v2.main2:
     say-greeting:
       action: core.hey
       input:
-        cmd: $.count
+        cmd: <% $.count %>
       publish:
-        greet: $.stdout
+        greet: <% $.say-greeting.stdout %>
       on-success:
         - say-friend
     say-friend:
       action: core.friend
       input:
-        cmd: $.friend
+        cmd: <% $.friend %>
       publish:
-        towhom: $.stdout
+        towhom: <% $.say-friend.stdout %>


### PR DESCRIPTION
Mistral changed YAQL delimiter from {} to <% %>.  Refactor the DSL transformer, tests, and examples accordingly.