### PR TITLE
Fix mistral examples

### DIFF
--- a/contrib/examples/actions/mistral-basic.json
+++ b/contrib/examples/actions/mistral-basic.json
@@ -16,6 +16,11 @@
             "default": null,
             "immutable": true
         },
+        "context": {
+            "type": "object",
+            "default": {},
+            "immutable": true
+        },
         "cmd": {
             "type": "string",
             "required": true

--- a/contrib/examples/actions/mistral-basic.json
+++ b/contrib/examples/actions/mistral-basic.json
@@ -6,6 +6,16 @@
     "enabled": true,
     "entry_point":"workflows/mistral-basic.yaml",
     "parameters": {
+        "workflow": {
+            "type": "string",
+            "default": null,
+            "immutable": true
+        },
+        "task": {
+            "type": "string",
+            "default": null,
+            "immutable": true
+        },
         "cmd": {
             "type": "string",
             "required": true

--- a/contrib/examples/actions/mistral-handle-error.json
+++ b/contrib/examples/actions/mistral-handle-error.json
@@ -6,6 +6,16 @@
     "enabled": true,
     "entry_point":"workflows/mistral-handle-error.yaml",
     "parameters": {
+        "workflow": {
+            "type": "string",
+            "default": null,
+            "immutable": true
+        },
+        "task": {
+            "type": "string",
+            "default": null,
+            "immutable": true
+        },
         "cmd": {
             "type": "string",
             "default": "foobar",

--- a/contrib/examples/actions/mistral-handle-error.json
+++ b/contrib/examples/actions/mistral-handle-error.json
@@ -16,6 +16,11 @@
             "default": null,
             "immutable": true
         },
+        "context": {
+            "type": "object",
+            "default": {},
+            "immutable": true
+        },
         "cmd": {
             "type": "string",
             "default": "foobar",

--- a/contrib/examples/actions/mistral-handle-retry.json
+++ b/contrib/examples/actions/mistral-handle-retry.json
@@ -15,6 +15,11 @@
             "type": "string",
             "default": null,
             "immutable": true
+        },
+        "context": {
+            "type": "object",
+            "default": {},
+            "immutable": true
         }
     }
 }

--- a/contrib/examples/actions/mistral-handle-retry.json
+++ b/contrib/examples/actions/mistral-handle-retry.json
@@ -10,6 +10,11 @@
             "type": "string",
             "default": "examples.mistral-handle-retry.main",
             "immutable": true
+        },
+        "task": {
+            "type": "string",
+            "default": null,
+            "immutable": true
         }
     }
 }

--- a/contrib/examples/actions/mistral-repeat-with-items.json
+++ b/contrib/examples/actions/mistral-repeat-with-items.json
@@ -16,6 +16,11 @@
             "default": null,
             "immutable": true
         },
+        "context": {
+            "type": "object",
+            "default": {},
+            "immutable": true
+        },
         "cmds": {
             "type": "array",
             "items": {

--- a/contrib/examples/actions/mistral-repeat-with-items.json
+++ b/contrib/examples/actions/mistral-repeat-with-items.json
@@ -6,6 +6,16 @@
     "enabled": true,
     "entry_point":"workflows/mistral-repeat-with-items.yaml",
     "parameters": {
+        "workflow": {
+            "type": "string",
+            "default": null,
+            "immutable": true
+        },
+        "task": {
+            "type": "string",
+            "default": null,
+            "immutable": true
+        },
         "cmds": {
             "type": "array",
             "items": {

--- a/contrib/examples/actions/mistral-repeat.json
+++ b/contrib/examples/actions/mistral-repeat.json
@@ -6,6 +6,16 @@
     "enabled": true,
     "entry_point":"workflows/mistral-repeat.yaml",
     "parameters": {
+        "workflow": {
+            "type": "string",
+            "default": null,
+            "immutable": true
+        },
+        "task": {
+            "type": "string",
+            "default": null,
+            "immutable": true
+        },
         "count": {
             "type": "integer",
             "default": 3

--- a/contrib/examples/actions/mistral-repeat.json
+++ b/contrib/examples/actions/mistral-repeat.json
@@ -16,6 +16,11 @@
             "default": null,
             "immutable": true
         },
+        "context": {
+            "type": "object",
+            "default": {},
+            "immutable": true
+        },
         "count": {
             "type": "integer",
             "default": 3

--- a/contrib/examples/actions/mistral-workbook-basic.json
+++ b/contrib/examples/actions/mistral-workbook-basic.json
@@ -6,6 +6,16 @@
     "enabled": true,
     "entry_point":"workflows/mistral-workbook-basic.yaml",
     "parameters": {
+        "workflow": {
+            "type": "string",
+            "default": null,
+            "immutable": true
+        },
+        "task": {
+            "type": "string",
+            "default": null,
+            "immutable": true
+        },
         "cmd": {
             "type": "string",
             "required": true

--- a/contrib/examples/actions/mistral-workbook-basic.json
+++ b/contrib/examples/actions/mistral-workbook-basic.json
@@ -16,6 +16,11 @@
             "default": null,
             "immutable": true
         },
+        "context": {
+            "type": "object",
+            "default": {},
+            "immutable": true
+        },
         "cmd": {
             "type": "string",
             "required": true

--- a/contrib/examples/actions/mistral-workbook-complex.json
+++ b/contrib/examples/actions/mistral-workbook-complex.json
@@ -16,6 +16,11 @@
             "default": null,
             "immutable": true
         },
+        "context": {
+            "type": "object",
+            "default": {},
+            "immutable": true
+        },
         "vm_name": {
             "type": "string",
             "required": true

--- a/contrib/examples/actions/mistral-workbook-complex.json
+++ b/contrib/examples/actions/mistral-workbook-complex.json
@@ -11,6 +11,11 @@
             "default": "examples.mistral-workbook-complex.main",
             "immutable": true
         },
+        "task": {
+            "type": "string",
+            "default": null,
+            "immutable": true
+        },
         "vm_name": {
             "type": "string",
             "required": true

--- a/contrib/examples/actions/mistral-workbook-multiple-subflows.json
+++ b/contrib/examples/actions/mistral-workbook-multiple-subflows.json
@@ -15,6 +15,11 @@
             "type": "string",
             "default": null,
             "immutable": true
+        },
+        "context": {
+            "type": "object",
+            "default": {},
+            "immutable": true
         }
     }
 }

--- a/contrib/examples/actions/mistral-workbook-multiple-subflows.json
+++ b/contrib/examples/actions/mistral-workbook-multiple-subflows.json
@@ -10,6 +10,11 @@
             "type": "string",
             "default": "examples.mistral-workbook-multiple-subflows.main",
             "immutable": true
+        },
+        "task": {
+            "type": "string",
+            "default": null,
+            "immutable": true
         }
     }
 }

--- a/contrib/examples/actions/mistral-workbook-subflows.json
+++ b/contrib/examples/actions/mistral-workbook-subflows.json
@@ -16,6 +16,11 @@
             "default": null,
             "immutable": true
         },
+        "context": {
+            "type": "object",
+            "default": {},
+            "immutable": true
+        },
         "subject": {
             "type": "string",
             "default": "StackStorm"

--- a/contrib/examples/actions/mistral-workbook-subflows.json
+++ b/contrib/examples/actions/mistral-workbook-subflows.json
@@ -6,6 +6,16 @@
     "enabled": true,
     "entry_point":"workflows/mistral-workbook-subflows.yaml",
     "parameters": {
+        "workflow": {
+            "type": "string",
+            "default": null,
+            "immutable": true
+        },
+        "task": {
+            "type": "string",
+            "default": null,
+            "immutable": true
+        },
         "subject": {
             "type": "string",
             "default": "StackStorm"

--- a/contrib/examples/actions/workflows/mistral-handle-retry.yaml
+++ b/contrib/examples/actions/workflows/mistral-handle-retry.yaml
@@ -17,7 +17,7 @@ workflows:
                     retry:
                         count: 10
                         delay: 2
-                on-complete:
+                on-success:
                     - delete-file
             create-file:
                 action: core.local
@@ -25,10 +25,7 @@ workflows:
                     cmd: "touch /tmp/done"
                 policies:
                     wait-before: 10
-                on-complete:
-                    - delete-file
             delete-file:
-                join: all
                 action: core.local
                 input:
                     cmd: "rm -f /tmp/done"


### PR DESCRIPTION
Make the workflow and task parameters immutable so they are not displayed in CLI/UI.  Fix the retry example to run the delete-file task after the retry task.