### PR TITLE
RFR: Add support for exists and nexists operators

### DIFF
--- a/st2common/st2common/operators.py
+++ b/st2common/st2common/operators.py
@@ -38,7 +38,7 @@ def get_operator(op):
 
 
 def equals(value, criteria_pattern):
-    if not criteria_pattern:
+    if criteria_pattern is None:
         return False
     return value == criteria_pattern
 
@@ -48,73 +48,73 @@ def nequals(value, criteria_pattern):
 
 
 def iequals(value, criteria_pattern):
-    if not criteria_pattern:
+    if criteria_pattern is None:
         return False
     return value.lower() == criteria_pattern.lower()
 
 
 def contains(value, criteria_pattern):
-    if not criteria_pattern:
+    if criteria_pattern is None:
         return False
     return criteria_pattern in value
 
 
 def icontains(value, criteria_pattern):
-    if not criteria_pattern:
+    if criteria_pattern is None:
         return False
     return criteria_pattern.lower() in value.lower()
 
 
 def ncontains(value, criteria_pattern):
-    if not criteria_pattern:
+    if criteria_pattern is None:
         return False
     return criteria_pattern not in value
 
 
 def incontains(value, criteria_pattern):
-    if not criteria_pattern:
+    if criteria_pattern is None:
         return False
     return criteria_pattern.lower() not in value.lower()
 
 
 def startswith(value, criteria_pattern):
-    if not criteria_pattern:
+    if criteria_pattern is None:
         return False
     return value.startswith(criteria_pattern)
 
 
 def istartswith(value, criteria_pattern):
-    if not criteria_pattern:
+    if criteria_pattern is None:
         return False
     return value.lower().startswith(criteria_pattern.lower())
 
 
 def endswith(value, criteria_pattern):
-    if not criteria_pattern:
+    if criteria_pattern is None:
         return False
     return value.endswith(criteria_pattern)
 
 
 def iendswith(value, criteria_pattern):
-    if not criteria_pattern:
+    if criteria_pattern is None:
         return False
     return value.lower().endswith(criteria_pattern.lower())
 
 
 def less_than(value, criteria_pattern):
-    if not criteria_pattern:
+    if criteria_pattern is None:
         return False
     return value < criteria_pattern
 
 
 def greater_than(value, criteria_pattern):
-    if not criteria_pattern:
+    if criteria_pattern is None:
         return False
     return value > criteria_pattern
 
 
 def match_regex(value, criteria_pattern):
-    if not criteria_pattern:
+    if criteria_pattern is None:
         return False
     regex = re.compile(criteria_pattern)
     # check for a match and not for details of the match.
@@ -131,13 +131,13 @@ def _timediff(diff_target, period_seconds, operator):
 
 
 def timediff_lt(value, criteria_pattern):
-    if not criteria_pattern:
+    if criteria_pattern is None:
         return False
     return _timediff(diff_target=value, period_seconds=criteria_pattern, operator=less_than)
 
 
 def timediff_gt(value, criteria_pattern):
-    if not criteria_pattern:
+    if criteria_pattern is None:
         return False
     return _timediff(diff_target=value, period_seconds=criteria_pattern, operator=greater_than)
 

--- a/st2common/st2common/operators.py
+++ b/st2common/st2common/operators.py
@@ -22,60 +22,6 @@ __all__ = [
     'get_allowed_operators'
 ]
 
-# Operation implementations
-
-
-def equals(value, criteria_pattern):
-    return value == criteria_pattern
-
-
-def nequals(value, criteria_pattern):
-    return value != criteria_pattern
-
-
-def iequals(value, criteria_pattern):
-    return value.lower() == criteria_pattern.lower()
-
-
-def contains(value, criteria_pattern):
-    return criteria_pattern in value
-
-
-def icontains(value, criteria_pattern):
-    return criteria_pattern.lower() in value.lower()
-
-
-def ncontains(value, criteria_pattern):
-    return criteria_pattern not in value
-
-
-def incontains(value, criteria_pattern):
-    return criteria_pattern.lower() not in value.lower()
-
-
-def startswith(value, criteria_pattern):
-    return value.startswith(criteria_pattern)
-
-
-def istartswith(value, criteria_pattern):
-    return value.lower().startswith(criteria_pattern.lower())
-
-
-def endswith(value, criteria_pattern):
-    return value.endswith(criteria_pattern)
-
-
-def iendswith(value, criteria_pattern):
-    return value.lower().endswith(criteria_pattern.lower())
-
-
-def less_than(value, criteria_pattern):
-    return value < criteria_pattern
-
-
-def greater_than(value, criteria_pattern):
-    return value > criteria_pattern
-
 
 def get_allowed_operators():
     return operators
@@ -88,8 +34,88 @@ def get_operator(op):
     else:
         raise Exception('Invalid operator: ' + op)
 
+# Operation implementations
+
+
+def equals(value, criteria_pattern):
+    if not criteria_pattern:
+        return False
+    return value == criteria_pattern
+
+
+def nequals(value, criteria_pattern):
+    return value != criteria_pattern
+
+
+def iequals(value, criteria_pattern):
+    if not criteria_pattern:
+        return False
+    return value.lower() == criteria_pattern.lower()
+
+
+def contains(value, criteria_pattern):
+    if not criteria_pattern:
+        return False
+    return criteria_pattern in value
+
+
+def icontains(value, criteria_pattern):
+    if not criteria_pattern:
+        return False
+    return criteria_pattern.lower() in value.lower()
+
+
+def ncontains(value, criteria_pattern):
+    if not criteria_pattern:
+        return False
+    return criteria_pattern not in value
+
+
+def incontains(value, criteria_pattern):
+    if not criteria_pattern:
+        return False
+    return criteria_pattern.lower() not in value.lower()
+
+
+def startswith(value, criteria_pattern):
+    if not criteria_pattern:
+        return False
+    return value.startswith(criteria_pattern)
+
+
+def istartswith(value, criteria_pattern):
+    if not criteria_pattern:
+        return False
+    return value.lower().startswith(criteria_pattern.lower())
+
+
+def endswith(value, criteria_pattern):
+    if not criteria_pattern:
+        return False
+    return value.endswith(criteria_pattern)
+
+
+def iendswith(value, criteria_pattern):
+    if not criteria_pattern:
+        return False
+    return value.lower().endswith(criteria_pattern.lower())
+
+
+def less_than(value, criteria_pattern):
+    if not criteria_pattern:
+        return False
+    return value < criteria_pattern
+
+
+def greater_than(value, criteria_pattern):
+    if not criteria_pattern:
+        return False
+    return value > criteria_pattern
+
 
 def match_regex(value, criteria_pattern):
+    if not criteria_pattern:
+        return False
     regex = re.compile(criteria_pattern)
     # check for a match and not for details of the match.
     return regex.match(value) is not None
@@ -105,11 +131,23 @@ def _timediff(diff_target, period_seconds, operator):
 
 
 def timediff_lt(value, criteria_pattern):
+    if not criteria_pattern:
+        return False
     return _timediff(diff_target=value, period_seconds=criteria_pattern, operator=less_than)
 
 
 def timediff_gt(value, criteria_pattern):
+    if not criteria_pattern:
+        return False
     return _timediff(diff_target=value, period_seconds=criteria_pattern, operator=greater_than)
+
+
+def exists(value, criteria_pattern):
+    return value is not None
+
+
+def nexists(value, criteria_pattern):
+    return value is None
 
 # operator match strings
 MATCH_REGEX = 'matchregex'
@@ -135,6 +173,8 @@ TIMEDIFF_LT_SHORT = 'td_lt'
 TIMEDIFF_LT_LONG = 'timediff_lt'
 TIMEDIFF_GT_SHORT = 'td_gt'
 TIMEDIFF_GT_LONG = 'timediff_gt'
+KEY_EXISTS = 'exists'
+KEY_NOT_EXISTS = 'nexists'
 
 # operator lookups
 operators = {
@@ -160,5 +200,7 @@ operators = {
     TIMEDIFF_LT_SHORT: timediff_lt,
     TIMEDIFF_LT_LONG: timediff_lt,
     TIMEDIFF_GT_SHORT: timediff_gt,
-    TIMEDIFF_GT_LONG: timediff_gt
+    TIMEDIFF_GT_LONG: timediff_gt,
+    KEY_EXISTS: exists,
+    KEY_NOT_EXISTS: nexists
 }

--- a/st2common/tests/unit/test_operators.py
+++ b/st2common/tests/unit/test_operators.py
@@ -42,6 +42,7 @@ class OperatorTest(unittest2.TestCase):
     def test_equals_string(self):
         op = operators.get_operator('equals')
         self.assertTrue(op('1', '1'), 'Failed equals.')
+        self.assertTrue(op('', ''), 'Failed equals.')
 
     def test_equals_fail(self):
         op = operators.get_operator('equals')

--- a/st2common/tests/unit/test_operators.py
+++ b/st2common/tests/unit/test_operators.py
@@ -196,7 +196,7 @@ class OperatorTest(unittest2.TestCase):
     def test_timediff_lt_fail(self):
         op = operators.get_operator('timediff_lt')
         self.assertFalse(op('2014-07-01T00:01:01.000000', 10),
-                        'Passed test_timediff_lt.')
+                         'Passed test_timediff_lt.')
 
     def test_timediff_gt(self):
         op = operators.get_operator('timediff_gt')
@@ -207,3 +207,17 @@ class OperatorTest(unittest2.TestCase):
         op = operators.get_operator('timediff_gt')
         self.assertFalse(op(datetime.datetime.utcnow().isoformat(), 10),
                          'Passed test_timediff_gt.')
+
+    def test_exists(self):
+        op = operators.get_operator('exists')
+        self.assertTrue(op(False, None), 'Should return True')
+        self.assertTrue(op(1, None), 'Should return True')
+        self.assertTrue(op('foo', None), 'Should return True')
+        self.assertFalse(op(None, None), 'Should return False')
+
+    def test_nexists(self):
+        op = operators.get_operator('nexists')
+        self.assertFalse(op(False, None), 'Should return False')
+        self.assertFalse(op(1, None), 'Should return False')
+        self.assertFalse(op('foo', None), 'Should return False')
+        self.assertTrue(op(None, None), 'Should return True')

--- a/st2reactor/tests/unit/test_filter.py
+++ b/st2reactor/tests/unit/test_filter.py
@@ -122,3 +122,21 @@ class FilterTest(DbTestCase):
         rule.criteria = {'trigger.float': {'type': 'equals', 'pattern': 0.8}}
         f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
         self.assertTrue(f.filter(), 'equals check should have passed.')
+
+    def test_exists(self):
+        rule = MOCK_RULE_1
+        rule.criteria = {'trigger.float': {'type': 'exists'}}
+        f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
+        self.assertTrue(f.filter(), '"float" key exists in trigger. Should return true.')
+        rule.criteria = {'trigger.floattt': {'type': 'exists'}}
+        f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
+        self.assertFalse(f.filter(), '"floattt" key ain\'t exist in trigger. Should return false.')
+
+    def test_nexists(self):
+        rule = MOCK_RULE_1
+        rule.criteria = {'trigger.float': {'type': 'nexists'}}
+        f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
+        self.assertFalse(f.filter(), '"float" key exists in trigger. Should return false.')
+        rule.criteria = {'trigger.floattt': {'type': 'nexists'}}
+        f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
+        self.assertTrue(f.filter(), '"floattt" key ain\'t exist in trigger. Should return true.')


### PR DESCRIPTION
Not too happy with the changes. Things work but the op_func always assume there is a value and there is criteria_pattern. exists and nexists don't fit into this category. We'll need a better interface. I am still thinking about this. 