### PR TITLE
Update st2api server to also server webui static files

### DIFF
--- a/conf/st2.conf
+++ b/conf/st2.conf
@@ -5,6 +5,7 @@
 host = 0.0.0.0
 port = 9101
 logging = st2api/conf/logging.conf
+serve_webui_files = True
 # allow_origin is required for handling CORS in st2 web UI.
 # allow_origin = http://myhost1.example.com:3000,http://myhost2.example.com:3000
 

--- a/docs/source/install/config.rst
+++ b/docs/source/install/config.rst
@@ -1,11 +1,12 @@
 Configuration
 ==============
+
 .. note:: If you are using the "all in one" :doc:`/install/index`, all configurations are already setup.
 
 |st2| configuration file is at :github_st2:`/etc/st2/st2.conf </conf/st2.conf>`
 
 SUDO Access
--------------------------
+-----------
 
 All actions run by |st2| are performed by a single user. Typically, this user is named ``stanley`` and that is configurable via :github_st2:`st2.conf </conf/st2.conf>`.
 
@@ -23,7 +24,7 @@ One option of setting up passwordless sudo is perform the below operation on eac
 .. _config-configure-ssh:
 
 Configure SSH
-----------------
+-------------
 
 To run actions on remote hosts, |st2| uses `Fabric <http://www.fabfile.org/>`_. It is required to configure identity file based SSH access on all remote hosts.
 
@@ -55,9 +56,8 @@ To verify do the following from the |st2| box
     # make sure that no password is prompted.
     sudo su
 
-
 SSH Troubleshooting
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 * Validate that passwordless SSH configuration works fine for the destination. Assuming default user `stanley`:
 
@@ -65,9 +65,9 @@ SSH Troubleshooting
 
         sudo ssh -i /home/stanley/.ssh/stanley_rsa -t stanley@host.example.com uname -a
 
-
 Configure Logging
--------------------
+-----------------
+
 By default, the logs can be found in ``/var/log/st2``.
 
 * With the standard logging setup you will notice files like ``st2*.log`` and ``st2*.audit.log`` in the log folder.
@@ -78,5 +78,14 @@ By default, the logs can be found in ``/var/log/st2``.
 
 * Check out LogStash configuration and Kibana dashboard for pretty logging and audit at :github_contrib:`st2contrib/extra/logstash </extra/logstash>`
 
+Serve WebUI files from the API server
+-------------------------------------
+
+By default, static WebUI files are served on the API server. This means you can
+access the web interface by going to ``http://<api host>:<api port>/webui``.
+
+For production deployments, we encourage you to disable this option by settings
+``api.serve_webui_files`` option to ``False`` and use nginx, Apache or a similar
+dedicated web server to serve those static files.
 
 .. include:: /engage.rst

--- a/st2api/st2api/app.py
+++ b/st2api/st2api/app.py
@@ -58,6 +58,8 @@ def setup_app(config=None):
     if cfg.CONF.auth.enable:
         active_hooks.append(hooks.AuthHook())
 
+    active_hooks.append(hooks.JSONErrorResponseHook())
+
     app = pecan.make_app(app_conf.pop('root'),
                          logging=getattr(config, 'logging', {}),
                          hooks=active_hooks,

--- a/st2api/st2api/app.py
+++ b/st2api/st2api/app.py
@@ -32,7 +32,7 @@ def __get_pecan_config():
             'root': opts.root,
             'template_path': opts.template_path,
             'modules': opts.modules,
-            'debug': False,
+            'debug': opts.debug,
             'auth_enable': opts.auth_enable,
             'errors': opts.errors
         }

--- a/st2api/st2api/app.py
+++ b/st2api/st2api/app.py
@@ -13,8 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from oslo.config import cfg
 import pecan
+from oslo.config import cfg
+from pecan.middleware.static import StaticFileMiddleware
 
 from st2common import hooks
 from st2common import log as logging
@@ -42,9 +43,11 @@ def __get_pecan_config():
 
 
 def setup_app(config=None):
-    LOG.info(VERSION_STRING)
+    opts = cfg.CONF.api_pecan
 
+    LOG.info(VERSION_STRING)
     LOG.info('Creating %s as Pecan app.' % __name__)
+
     if not config:
         config = __get_pecan_config()
 
@@ -60,6 +63,7 @@ def setup_app(config=None):
                          hooks=active_hooks,
                          **app_conf
                          )
+    app = StaticFileMiddleware(app=app, directory=opts.static_root)
 
     LOG.info('%s app created.' % __name__)
 

--- a/st2api/st2api/app.py
+++ b/st2api/st2api/app.py
@@ -63,7 +63,10 @@ def setup_app(config=None):
                          hooks=active_hooks,
                          **app_conf
                          )
-    app = StaticFileMiddleware(app=app, directory=opts.static_root)
+
+    if cfg.CONF.api.serve_webui_files:
+        LOG.info('Serving WebUi at /webui/index.html')
+        app = StaticFileMiddleware(app=app, directory=opts.static_root)
 
     LOG.info('%s app created.' % __name__)
 

--- a/st2api/st2api/app.py
+++ b/st2api/st2api/app.py
@@ -30,7 +30,6 @@ def __get_pecan_config():
     cfg_dict = {
         'app': {
             'root': opts.root,
-            'static_root': opts.static_root,
             'template_path': opts.template_path,
             'modules': opts.modules,
             'debug': False,

--- a/st2api/st2api/config.py
+++ b/st2api/st2api/config.py
@@ -17,6 +17,8 @@
 Configuration options registration and useful routines.
 """
 
+import os
+
 from oslo.config import cfg
 
 import st2common.config as common_config
@@ -42,11 +44,12 @@ def _register_app_opts():
     ]
     CONF.register_opts(api_opts, group='api')
 
+    static_root = os.path.join(cfg.CONF.system.base_path, 'static')
     pecan_opts = [
         cfg.StrOpt('root',
                    default='st2api.controllers.root.RootController',
                    help='Action root controller'),
-        cfg.StrOpt('static_root', default='/opt/stackstorm/static'),
+        cfg.StrOpt('static_root', default=static_root),
         cfg.StrOpt('template_path',
                    default='%(confdir)s/st2api/st2api/templates'),
         cfg.ListOpt('modules', default=['st2api']),

--- a/st2api/st2api/config.py
+++ b/st2api/st2api/config.py
@@ -46,7 +46,7 @@ def _register_app_opts():
         cfg.StrOpt('root',
                    default='st2api.controllers.root.RootController',
                    help='Action root controller'),
-        cfg.StrOpt('static_root', default='/opt/stackstorm'),
+        cfg.StrOpt('static_root', default='/opt/stackstorm/static'),
         cfg.StrOpt('template_path',
                    default='%(confdir)s/st2api/st2api/templates'),
         cfg.ListOpt('modules', default=['st2api']),

--- a/st2api/st2api/config.py
+++ b/st2api/st2api/config.py
@@ -35,6 +35,8 @@ def _register_app_opts():
     api_opts = [
         cfg.ListOpt('allow_origin', default=['http://localhost:3000'],
                     help='List of origins allowed'),
+        cfg.BoolOpt('serve_webui_files', default=True,
+                    help='Enable to serve static WebUI files using the API service'),
         cfg.IntOpt('heartbeat', default=25,
                    help='Send empty message every N seconds to keep connection open')
     ]

--- a/st2api/st2api/config.py
+++ b/st2api/st2api/config.py
@@ -44,11 +44,11 @@ def _register_app_opts():
         cfg.StrOpt('root',
                    default='st2api.controllers.root.RootController',
                    help='Action root controller'),
-        cfg.StrOpt('static_root', default='%(confdir)s/public'),
+        cfg.StrOpt('static_root', default='/opt/stackstorm'),
         cfg.StrOpt('template_path',
                    default='%(confdir)s/st2api/st2api/templates'),
         cfg.ListOpt('modules', default=['st2api']),
-        cfg.BoolOpt('debug', default=True),
+        cfg.BoolOpt('debug', default=False),
         cfg.BoolOpt('auth_enable', default=True),
         cfg.DictOpt('errors', default={'__force_dict__': True})
     ]

--- a/st2api/st2api/controllers/root.py
+++ b/st2api/st2api/controllers/root.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from pecan import expose
+from pecan.core import redirect
 
 from st2common import __version__
 from st2common import log as logging
@@ -22,12 +23,22 @@ import st2api.controllers.v1.root as v1_root
 LOG = logging.getLogger(__name__)
 
 
+class WebUIRootController(object):
+    @expose(generic=True)
+    def index(self):
+        return redirect(location='/webui/index.html')
+
+
 class RootController(object):
 
     def __init__(self):
-        v1 = v1_root.RootController()
-        self.controllers = {'v1': v1}
-        self.default_controller = v1
+        v1_controller = v1_root.RootController()
+        webui_controller = WebUIRootController()
+        self.controllers = {
+            'v1': v1_controller,
+            'webui': webui_controller
+        }
+        self.default_controller = v1_controller
 
     @expose(generic=True, template='index.html')
     def index(self):
@@ -47,6 +58,10 @@ class RootController(object):
         version = ''
         if len(remainder) > 0:
             version = remainder[0]
+            if version == 'webui':
+                # Special case for handling webui requests
+                return self.controllers['webui'], remainder[1:]
+
             if remainder[len(remainder) - 1] == '':
                 # If the url has a trailing '/' remainder will contain an empty string.
                 # In order for further pecan routing to work this method needs to remove

--- a/st2api/st2api/controllers/root.py
+++ b/st2api/st2api/controllers/root.py
@@ -21,6 +21,11 @@ from st2common import __version__
 from st2common import log as logging
 import st2api.controllers.v1.root as v1_root
 
+__all__ = [
+    'WebUIRootController',
+    'RootController'
+]
+
 LOG = logging.getLogger(__name__)
 
 
@@ -63,7 +68,7 @@ class RootController(object):
         version = ''
         if len(remainder) > 0:
             version = remainder[0]
-            if version == 'webui':
+            if cfg.CONF.api.serve_webui_files and version == 'webui':
                 # Special case for handling webui requests
                 return self.controllers['webui'], remainder[1:]
 

--- a/st2api/st2api/controllers/root.py
+++ b/st2api/st2api/controllers/root.py
@@ -15,6 +15,7 @@
 
 from pecan import expose
 from pecan.core import redirect
+from oslo.config import cfg
 
 from st2common import __version__
 from st2common import log as logging
@@ -33,11 +34,14 @@ class RootController(object):
 
     def __init__(self):
         v1_controller = v1_root.RootController()
-        webui_controller = WebUIRootController()
         self.controllers = {
-            'v1': v1_controller,
-            'webui': webui_controller
+            'v1': v1_controller
         }
+
+        if cfg.CONF.api.serve_webui_files:
+            webui_controller = WebUIRootController()
+            self.controllers['webui'] = webui_controller
+
         self.default_controller = v1_controller
 
     @expose(generic=True, template='index.html')
@@ -51,6 +55,7 @@ class RootController(object):
 
         data['version'] = __version__
         data['docs_url'] = docs_url
+        data['webui_enabled'] = cfg.CONF.api.serve_webui_files
         return data
 
     @expose()

--- a/st2api/st2api/controllers/v1/root.py
+++ b/st2api/st2api/controllers/v1/root.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pecan import expose
-
 from st2api.controllers.v1.actions import ActionsController
 from st2api.controllers.v1.actionexecutions import ActionExecutionsController
 from st2api.controllers.v1.datastore import KeyValuePairController

--- a/st2api/st2api/controllers/v1/root.py
+++ b/st2api/st2api/controllers/v1/root.py
@@ -40,7 +40,3 @@ class RootController(object):
     keys = KeyValuePairController()
     webhooks = WebhooksController()
     stream = StreamController()
-
-    @expose(generic=True, template='index.html')
-    def index(self):
-        return dict()

--- a/st2api/st2api/templates/index.html
+++ b/st2api/st2api/templates/index.html
@@ -1,2 +1,3 @@
 <h1>Welcome to StackStorm v${version}</h1>
 <p>Documentation: <a href="${docs_url}">${docs_url}</a></p>
+<p>WebUI: <a href="/webui">click</a></p>

--- a/st2api/st2api/templates/index.html
+++ b/st2api/st2api/templates/index.html
@@ -1,3 +1,6 @@
 <h1>Welcome to StackStorm v${version}</h1>
 <p>Documentation: <a href="${docs_url}">${docs_url}</a></p>
-<p>WebUI: <a href="/webui">click</a></p>
+
+% if webui_enabled:
+  <p>WebUI: <a href="/webui">click</a></p>
+% endif

--- a/st2auth/st2auth/app.py
+++ b/st2auth/st2auth/app.py
@@ -47,6 +47,6 @@ def setup_app(config=None):
     return pecan.make_app(
         app_conf.pop('root'),
         logging=getattr(config, 'logging', {}),
-        hooks=[hooks.CorsHook()],
+        hooks=[hooks.CorsHook(), hooks.JSONErrorResponseHook()],
         **app_conf
     )

--- a/st2auth/st2auth/config.py
+++ b/st2auth/st2auth/config.py
@@ -51,9 +51,7 @@ def _register_app_opts():
                    (','.join(VALID_BACKEND_NAMES))),
         cfg.StrOpt('backend_kwargs', default=None,
                    help='JSON serialized arguments which are passed to the authentication backend'
-                        ' in a standalone mode.'),
-        cfg.StrOpt('api_url', default=None,
-                   help='Base URL to the API endpoint excluding the version')
+                        ' in a standalone mode.')
 
     ]
     cfg.CONF.register_cli_opts(auth_opts, group='auth')

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -321,7 +321,7 @@ class ActionRunCommandMixin(object):
                 action_exec = action_exec_mgr.get_by_id(action_exec_id, **kwargs)
                 args.ref_or_id = action_exec.action
 
-            if args.ref_or_id:
+            if action_ref_or_id:
                 try:
                     action = action_mgr.get_by_ref_or_id(args.ref_or_id, **kwargs)
                     runner_mgr = self.app.client.managers['RunnerType']

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -117,6 +117,13 @@ def register_opts(ignore_errors=False):
     ]
     do_register_opts(api_opts, 'api', ignore_errors)
 
+    # Common auth options
+    auth_opts = [
+        cfg.StrOpt('api_url', default=None,
+                   help='Base URL to the API endpoint excluding the version')
+    ]
+    do_register_opts(auth_opts, 'auth', ignore_errors)
+
     # Common options (used by action runner and sensor container)
     action_sensor_opts = [
         cfg.BoolOpt('enable', default=True,

--- a/st2common/st2common/hooks.py
+++ b/st2common/st2common/hooks.py
@@ -23,7 +23,6 @@ from st2common import log as logging
 from st2common.exceptions import access as exceptions
 from st2common.util.jsonify import json_encode
 from st2common.util.auth import validate_token
-from st2common.util.api import get_full_api_url
 from st2common.constants.auth import HEADER_ATTRIBUTE_NAME
 from st2common.constants.auth import QUERY_PARAM_ATTRIBUTE_NAME
 
@@ -38,6 +37,7 @@ class CorsHook(PecanHook):
 
         origin = state.request.headers.get('Origin')
         origins = cfg.CONF.api.allow_origin
+        serve_webui_files = cfg.CONF.api.serve_webui_files
 
         # Build a list of the default allowed origins
         api_port = cfg.CONF.api.port
@@ -47,11 +47,12 @@ class CorsHook(PecanHook):
         # Default WebUI URL
         default_allowed_origins.append('http://localhost:3000')
 
-        # Local API URL
-        default_allowed_origins.append('http://localhost:%s' % (api_port))
-        default_allowed_origins.append('http://127.0.0.1:%s' % (api_port))
+        if serve_webui_files:
+            # Local API URL
+            default_allowed_origins.append('http://localhost:%s' % (api_port))
+            default_allowed_origins.append('http://127.0.0.1:%s' % (api_port))
 
-        if public_api_url:
+        if serve_webui_files and public_api_url:
             # Public API URL
             default_allowed_origins.append(public_api_url)
 
@@ -60,7 +61,7 @@ class CorsHook(PecanHook):
                 origin_allowed = '*'
             else:
                 # See http://www.w3.org/TR/cors/#access-control-allow-origin-response-header
-                if origin in default_allowed_origins:
+                if serve_webui_files and origin in default_allowed_origins:
                     # Allow requests originating from the API server
                     origin_allowed = origin
                 else:

--- a/st2common/st2common/hooks.py
+++ b/st2common/st2common/hooks.py
@@ -23,6 +23,7 @@ from st2common import log as logging
 from st2common.exceptions import access as exceptions
 from st2common.util.jsonify import json_encode
 from st2common.util.auth import validate_token
+from st2common.util.api import get_full_api_url
 from st2common.constants.auth import HEADER_ATTRIBUTE_NAME
 from st2common.constants.auth import QUERY_PARAM_ATTRIBUTE_NAME
 
@@ -37,14 +38,36 @@ class CorsHook(PecanHook):
 
         origin = state.request.headers.get('Origin')
         origins = cfg.CONF.api.allow_origin
+
+        # Build a list of the default allowed origins
+        api_port = cfg.CONF.api.port
+        public_api_url = cfg.CONF.auth.api_url
+        default_allowed_origins = []
+
+        # Default WebUI URL
+        default_allowed_origins.append('http://localhost:3000')
+
+        # Local API URL
+        default_allowed_origins.append('http://localhost:%s' % (api_port))
+        default_allowed_origins.append('http://127.0.0.1:%s' % (api_port))
+
+        if public_api_url:
+            # Public API URL
+            default_allowed_origins.append(public_api_url)
+
         if origin:
             if '*' in origins:
                 origin_allowed = '*'
             else:
                 # See http://www.w3.org/TR/cors/#access-control-allow-origin-response-header
-                origin_allowed = origin if origin in origins else 'null'
+                if origin in default_allowed_origins:
+                    # Allow requests originating from the API server
+                    origin_allowed = origin
+                else:
+                    origin_allowed = origin if origin in origins else 'null'
         else:
-            origin_allowed = origins[0] if len(origins) > 0 else 'http://localhost:3000'
+            default_allowed_origins = ','.join(default_allowed_origins)
+            origin_allowed = origins[0] if len(origins) > 0 else default_allowed_origins
 
         methods_allowed = ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS']
         request_headers_allowed = ['Content-Type', 'Authorization', 'X-Auth-Token']

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -61,6 +61,7 @@ def _override_db_opts():
 def _override_common_opts():
     packs_base_path = get_fixtures_base_path()
     CONF.set_override(name='system_packs_base_path', override=packs_base_path, group='content')
+    CONF.set_override(name='api_url', override='http://localhost', group='auth')
 
 
 def _register_common_opts():
@@ -74,6 +75,7 @@ def _register_api_opts():
     api_opts = [
         cfg.ListOpt('allow_origin', default=['http://localhost:3000', 'http://dev'],
                     help='List of origins allowed'),
+        cfg.BoolOpt('serve_webui_files', default=False),
         cfg.IntOpt('heartbeat', default=25,
                    help='Send empty message every N seconds to keep connection open')
     ]

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -33,7 +33,8 @@ def _setup_config_opts():
 
     try:
         _register_config_opts()
-    except Exception:
+    except Exception as e:
+        print(e)
         # Some scripts register the options themselves which means registering them again will
         # cause a non-fatal exception
         return
@@ -118,7 +119,6 @@ def _register_auth_opts():
         cfg.StrOpt('mode', default='proxy'),
         cfg.StrOpt('logging', default='conf/logging.conf'),
         cfg.IntOpt('token_ttl', default=86400, help='Access token ttl in seconds.'),
-        cfg.StrOpt('api_url', default='http://localhost:9101/'),
         cfg.BoolOpt('debug', default=True)
     ]
     _register_opts(auth_opts, group='auth')

--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -362,6 +362,9 @@ install_webui() {
   # Copy the files over to the webui static root
   mkdir -p /opt/stackstorm/static/webui
   cp -R ${temp_dir}/* /opt/stackstorm/static/webui
+
+  rm -r ${temp_dir}
+  rm -f /tmp/webui.tar.gz
 }
 
 install_st2client

--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" == "$1"; }
 
 if [ -z $1 ]
@@ -7,6 +8,9 @@ then
 else
   VER=$1
 fi
+
+INSTALL_ST2CLIENT=${INSTALL_ST2CLIENT:-1}
+INSTALL_WEBUI=${INSTALL_WEBUI:-1}
 
 # Determine which mistral version to use
 if version_ge $VER "0.8"; then
@@ -374,8 +378,14 @@ install_webui() {
   rm -f /tmp/webui.tar.gz
 }
 
-install_st2client
-install_webui
+if [ ${INSTALL_ST2CLIENT} == "1" ]; then
+    install_st2client
+fi
+
+if [ ${INSTALL_WEBUI} == "1" ]; then
+    install_webui
+fi
+
 register_content
 echo "########## Starting St2 Services ##########"
 st2ctl restart

--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -360,8 +360,8 @@ install_webui() {
   tar -xzvf /tmp/webui.tar.gz -C ${temp_dir} --strip-components=1
 
   # Copy the files over to the webui static root
-  mkdir -p /opt/stackstorm/webui
-  cp -R ${temp_dir}/* /opt/stackstorm/webui
+  mkdir -p /opt/stackstorm/static/webui
+  cp -R ${temp_dir}/* /opt/stackstorm/static/webui
 }
 
 install_st2client

--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -351,6 +351,19 @@ install_st2client() {
   popd
 }
 
+install_webui() {
+  # Download artifact
+  curl -sS -k -o /tmp/webui.tar.gz "https://ops.stackstorm.net/releases/st2/${VER}/webui/webui-${VER}-${RELEASE}.tar.gz"
+
+  # Unpack it into a temporary directory
+  temp_dir=$(mktemp -d)
+  tar -xzvf /tmp/webui.tar.gz -C ${temp_dir} --strip-components=1
+
+  # Copy the files over to the webui static root
+  mkdir -p /opt/stackstorm/webui
+  cp -R ${temp_dir}/* /opt/stackstorm/webui
+}
+
 install_st2client
 register_content
 echo "########## Starting St2 Services ##########"

--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -1,6 +1,4 @@
-#!/bin/bash
-set -e
-
+#!/usr/bin/env bash
 function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" == "$1"; }
 
 if [ -z $1 ]
@@ -42,7 +40,16 @@ else
   exit 2
 fi
 
-RELEASE=`curl -sS -k https://ops.stackstorm.net/releases/st2/${VER}/${TYPE}/current/VERSION.txt`
+RELEASE=$(curl -sS -k -f "https://ops.stackstorm.net/releases/st2/${VER}/${TYPE}/current/VERSION.txt")
+EXIT_CODE=$?
+
+if [ ${EXIT_CODE} -ne 0 ]; then
+    echo "Invalid or unsupported version: ${VER}"
+    exit 1
+fi
+
+# From here on, fail on errors
+set -e
 
 STAN="/home/${SYSTEMUSER}/${TYPE}"
 mkdir -p ${STAN}

--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -365,6 +365,7 @@ install_webui() {
 }
 
 install_st2client
+install_webui
 register_content
 echo "########## Starting St2 Services ##########"
 st2ctl restart


### PR DESCRIPTION
WebUi files are only served if `serve_webui` option is enabled. In documentation we will encourage users to disable this option in production and use something like nginx or Apache to serve static webui files there.

TODO:

* [x] Docs

Blocked by:

* https://github.com/StackStorm/st2incubator/pull/65