### PR TITLE
RFR: Allow rendering of non-string parameters in rule

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -63,6 +63,7 @@ Docs: http://docks.stackstorm.com/latest
 * Allow sensors to list datastore items using ``list_values`` sensor_service method. (new-feature)
 * Allow users to filter datastore items by name prefix by passing ``?prefix=<value>`` query
   parameter to the /keys endpoint. (new-feature)
+* Fix non-string types to be rendered correctly in action parameters when used in rule. (bug-fix)
 
 v0.7 - January 16, 2015
 -----------------------

--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -14,9 +14,6 @@
 # limitations under the License.
 
 import eventlet
-import jinja2
-import json
-import six
 import traceback
 import uuid
 import datetime
@@ -35,33 +32,11 @@ from st2common.services import action as action_service
 from st2common.services.keyvalues import KeyValueLookup
 from st2common.util import action_db as action_db_util
 from st2common.util import isotime
+from st2common.util import jinja as jinja_utils
 
 
 LOG = logging.getLogger(__name__)
 RESULTS_KEY = '__results'
-
-
-def render_values(values, context):
-    env = jinja2.Environment(undefined=jinja2.StrictUndefined)
-    rendered_values = {}
-    for k, v in six.iteritems(values):
-        # jinja2 works with string so transform list and dict to strings.
-        reverse_json_dumps = False
-        if isinstance(v, dict) or isinstance(v, list):
-            v = json.dumps(v)
-            reverse_json_dumps = True
-        else:
-            v = str(v)
-        rendered_v = env.from_string(v).render(context)
-        # no change therefore no templatization so pick params from original to retain
-        # original type
-        if rendered_v == v:
-            rendered_values[k] = values[k]
-            continue
-        if reverse_json_dumps:
-            rendered_v = json.loads(rendered_v)
-        rendered_values[k] = rendered_v
-    return rendered_values
 
 
 class ChainHolder(object):
@@ -106,7 +81,7 @@ class ChainHolder(object):
         if not vars:
             return {}
         context = {SYSTEM_KV_PREFIX: KeyValueLookup()}
-        return render_values(vars, context)
+        return jinja_utils.render_values(mapping=vars, context=context)
 
     def get_node(self, node_name=None):
         for node in self.actionchain.chain:
@@ -224,7 +199,7 @@ class ActionChainRunner(ActionRunner):
         context.update(chain_vars)
         context.update({RESULTS_KEY: previous_execution_results})
         context.update({SYSTEM_KV_PREFIX: KeyValueLookup()})
-        rendered_result = render_values(action_node.publish, context)
+        rendered_result = jinja_utils.render_values(mapping=action_node.publish, context=context)
         return rendered_result
 
     @staticmethod
@@ -236,7 +211,7 @@ class ActionChainRunner(ActionRunner):
         context.update(chain_vars)
         context.update({RESULTS_KEY: results})
         context.update({SYSTEM_KV_PREFIX: KeyValueLookup()})
-        rendered_params = render_values(action_node.params, context)
+        rendered_params = jinja_utils.render_values(mapping=action_node.params, context=context)
         LOG.debug('Rendered params: %s: Type: %s', rendered_params, type(rendered_params))
         return rendered_params
 

--- a/st2common/st2common/util/jinja.py
+++ b/st2common/st2common/util/jinja.py
@@ -1,3 +1,18 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import json
 
 import jinja2

--- a/st2common/st2common/util/jinja.py
+++ b/st2common/st2common/util/jinja.py
@@ -1,0 +1,43 @@
+import json
+
+import jinja2
+import six
+
+
+def render_values(mapping=None, context=None):
+    """
+    Render an incoming mapping using context provided in context using Jinja2. Returns a dict
+    containing rendered mapping.
+
+    :param mapping: Input as a dictionary of key value pairs.
+    :type mapping: ``dict``
+
+    :param context: Context to be used for dictionary.
+    :type context: ``dict``
+
+    :rtype: ``dict``
+    """
+
+    if not context or not mapping:
+        return mapping
+
+    env = jinja2.Environment(undefined=jinja2.StrictUndefined)
+    rendered_mapping = {}
+    for k, v in six.iteritems(mapping):
+        # jinja2 works with string so transform list and dict to strings.
+        reverse_json_dumps = False
+        if isinstance(v, dict) or isinstance(v, list):
+            v = json.dumps(v)
+            reverse_json_dumps = True
+        else:
+            v = str(v)
+        rendered_v = env.from_string(v).render(context)
+        # no change therefore no templatization so pick params from original to retain
+        # original type
+        if rendered_v == v:
+            rendered_mapping[k] = mapping[k]
+            continue
+        if reverse_json_dumps:
+            rendered_v = json.loads(rendered_v)
+        rendered_mapping[k] = rendered_v
+    return rendered_mapping

--- a/st2reactor/st2reactor/rules/datatransform.py
+++ b/st2reactor/st2reactor/rules/datatransform.py
@@ -20,7 +20,7 @@ import jinja2
 from st2common.constants.rules import TRIGGER_PAYLOAD_PREFIX
 from st2common.constants.system import SYSTEM_KV_PREFIX
 from st2common.services.keyvalues import KeyValueLookup
-import six
+from st2common.util import jinja as jinja_utils
 
 
 class Jinja2BasedTransformer(object):
@@ -31,11 +31,7 @@ class Jinja2BasedTransformer(object):
     def __call__(self, mapping):
         context = copy.copy(self._payload_context)
         context[SYSTEM_KV_PREFIX] = KeyValueLookup()
-        resolved_mapping = {}
-        for mapping_k, mapping_v in six.iteritems(mapping):
-            template = jinja2.Template(mapping_v)
-            resolved_mapping[mapping_k] = template.render(context)
-        return resolved_mapping
+        return jinja_utils.render_values(mapping=mapping, context=context)
 
     @staticmethod
     def _construct_context(prefix, data, context):

--- a/st2reactor/tests/unit/test_data_transform.py
+++ b/st2reactor/tests/unit/test_data_transform.py
@@ -21,7 +21,7 @@ from st2common.persistence.datastore import KeyValuePair
 from st2reactor.rules import datatransform
 
 
-PAYLOAD = {'k1': 'v1', 'k2': 'v2'}
+PAYLOAD = {'k1': 'v1', 'k2': 'v2', 'k3': 3, 'k4': True, 'k5': {'foo': 'bar'}, 'k6': [1, 3]}
 
 PAYLOAD_WITH_KVP = copy.copy(PAYLOAD)
 PAYLOAD_WITH_KVP.update({'k5': '{{system.k5}}'})
@@ -35,6 +35,28 @@ class DataTransformTest(DbTestCase):
                    'ip2': '{{trigger.k2}} static'}
         result = transformer(mapping)
         self.assertEqual(result, {'ip1': 'v1-static', 'ip2': 'v2 static'})
+
+    def test_payload_transofrm_int_type(self):
+        transformer = datatransform.get_transformer(PAYLOAD)
+        mapping = {'int': 666}
+        result = transformer(mapping)
+        self.assertEqual(result, {'int': 666})
+
+    def test_payload_transform_bool_type(self):
+        transformer = datatransform.get_transformer(PAYLOAD)
+        mapping = {'bool': True}
+        result = transformer(mapping)
+        self.assertEqual(result, {'bool': True})
+
+    def test_payload_transform_complex_type(self):
+        transformer = datatransform.get_transformer(PAYLOAD)
+        mapping = {'complex_dict': {'bool': True, 'int': 666, 'str': '{{trigger.k1}}-string'}}
+        result = transformer(mapping)
+        expected = {'complex_dict': {'bool': True, 'int': 666, 'str': 'v1-string'}}
+        self.assertEqual(result, expected)
+        mapping = {'simple_list': [1, 2, 3]}
+        result = transformer(mapping)
+        self.assertEqual(result, mapping)
 
     def test_hypenated_payload_transform(self):
         payload = {'headers': {'hypenated-header': 'dont-care'}, 'k2': 'v2'}


### PR DESCRIPTION
Refactored render_values used in action_chain to st2common to avoid code dupes. Improved tests. 