### PR TITLE
Removing suppression of white space

### DIFF
--- a/contrib/linux/actions/cp.yaml
+++ b/contrib/linux/actions/cp.yaml
@@ -27,4 +27,4 @@
             position: 0
         args:
             description: 'Command line arguments passed to cp'
-            default: '-v{% if recursive == true -%} -r{% endif -%}{% if force == true -%} -f{% endif -%}'
+            default: '-v{% if recursive == true %} -r{% endif %}{% if force == true %} -f{% endif %}'

--- a/contrib/linux/actions/mv.yaml
+++ b/contrib/linux/actions/mv.yaml
@@ -22,4 +22,4 @@
             default: 'mv {{args}} {{source}} {{destination}}'
         args:
             description: 'Command line arguments passed to mv'
-            default: '-v{% if force == true -%} -f{% endif -%}'
+            default: '-v{% if force == true %} -f{% endif %}'

--- a/contrib/linux/actions/rm.yaml
+++ b/contrib/linux/actions/rm.yaml
@@ -22,4 +22,4 @@
             default: 'rm {{args}} {{target}}'
         args:
             description: 'Command line arguments passed to rm'
-            default: '-v{% if recursive == true -%} -r{% endif -%}{% if force == true -%} -f{% endif -%}'
+            default: '-v{% if recursive == true %} -r{% endif %}{% if force == true %} -f{% endif %}'

--- a/contrib/linux/actions/scp.yaml
+++ b/contrib/linux/actions/scp.yaml
@@ -39,4 +39,4 @@
             position: 0
         args:
             description: 'Command line arguments passed to cp'
-            default: '-o stricthostkeychecking=no -v{% if recursive == true -%} -r{% endif -%}{% if force == true -%} -f{% endif -%}'
+            default: '-o stricthostkeychecking=no -v{% if recursive == true %} -r{% endif %}{% if force == true %} -f{% endif %}'


### PR DESCRIPTION
The trailing '-' was squashing the white space between the arguments.