### PR TITLE
More explicit error when sudo requires password for actions

### DIFF
--- a/st2common/st2common/models/system/action.py
+++ b/st2common/st2common/models/system/action.py
@@ -102,6 +102,9 @@ class ShellCommandAction(object):
         result = {}
         result['failed'] = True
         result['succeeded'] = False
+        exc_value = str(exc_value)
+        if 'sudo password' in exc_value:
+            exc_value = 'Passwordless sudo needs to be setup for user: %s' % self.user
         result['error'] = str(exc_value)
         result['traceback'] = ''.join(traceback.format_tb(exc_traceback))
         return result

--- a/st2common/st2common/models/system/action.py
+++ b/st2common/st2common/models/system/action.py
@@ -26,8 +26,9 @@ from fabric.context_managers import shell_env
 from fabric.context_managers import settings
 from fabric.tasks import WrappedCallableTask
 
-from st2common.constants.action import LIBS_DIR as ACTION_LIBS_DIR
 from st2common import log as logging
+from st2common.constants.action import LIBS_DIR as ACTION_LIBS_DIR
+from st2common.exceptions.fabricrunner import FabricExecutionFailureException
 import st2common.util.jsonify as jsonify
 
 __all__ = [
@@ -102,8 +103,9 @@ class ShellCommandAction(object):
         result = {}
         result['failed'] = True
         result['succeeded'] = False
+        is_fabric_failure = isinstance(exc_value, FabricExecutionFailureException)
         exc_value = str(exc_value)
-        if 'sudo password' in exc_value:
+        if is_fabric_failure and 'sudo password' in exc_value:
             exc_value = 'Passwordless sudo needs to be setup for user: %s' % self.user
         result['error'] = str(exc_value)
         result['traceback'] = ''.join(traceback.format_tb(exc_traceback))


### PR DESCRIPTION
```
(virtualenv)~/stanley git:linux_pack_improvements ❯❯❯ st2 run linux.lsof_pids hosts=localhost pids=20430 username=stanley                                                                                                       ✭ ✱ ◼
.
+-----------------+--------------------------------------------------------------+
| Property        | Value                                                        |
+-----------------+--------------------------------------------------------------+
| id              | 54f0fcd10640fd02810515cc                                     |
| action.ref      | linux.lsof_pids                                              |
| context.user    | lakshmi                                                      |
| parameters      | {                                                            |
|                 |     "username": "stanley",                                   |
|                 |     "pids": "20430",                                         |
|                 |     "hosts": "localhost"                                     |
|                 | }                                                            |
| status          | failed                                                       |
| start_timestamp | Fri, 27 Feb 2015 23:25:05 UTC                                |
| end_timestamp   | Fri, 27 Feb 2015 23:25:06 UTC                                |
| result          | {                                                            |
|                 |     "localhost": {                                           |
|                 |         "failed": true,                                      |
|                 |         "traceback": "  File "/home/lakshmi/stanley/st2commo |
|                 | n/st2common/models/system/action.py", line 376, in _sudo     |
|                 |     output = sudo(self.command, combine_stderr=False,        |
|                 | pty=True, quiet=True)                                        |
|                 |   File "/home/lakshmi/stanley/virtualenv/local/lib/python2.7 |
|                 | /site-packages/fabric/network.py", line 639, in              |
|                 | host_prompting_wrapper                                       |
|                 |     return func(*args, **kwargs)                             |
|                 |   File "/home/lakshmi/stanley/virtualenv/local/lib/python2.7 |
|                 | /site-packages/fabric/operations.py", line 1095, in sudo     |
|                 |     stderr=stderr, timeout=timeout,                          |
|                 | shell_escape=shell_escape,                                   |
|                 |   File "/home/lakshmi/stanley/virtualenv/local/lib/python2.7 |
|                 | /site-packages/fabric/operations.py", line 909, in           |
|                 | _run_command                                                 |
|                 |     channel=default_channel(), command=wrapped_command,      |
|                 | pty=pty,                                                     |
|                 |   File "/home/lakshmi/stanley/virtualenv/local/lib/python2.7 |
|                 | /site-packages/fabric/state.py", line 390, in                |
|                 | default_channel                                              |
|                 |     chan = _open_session()                                   |
|                 |   File "/home/lakshmi/stanley/virtualenv/local/lib/python2.7 |
|                 | /site-packages/fabric/state.py", line 382, in _open_session  |
|                 |     return                                                   |
|                 | connections[env.host_string].get_transport().open_session()  |
|                 |   File "/home/lakshmi/stanley/virtualenv/local/lib/python2.7 |
|                 | /site-packages/fabric/network.py", line 151, in __getitem__  |
|                 |     self.connect(key)                                        |
|                 |   File "/home/lakshmi/stanley/virtualenv/local/lib/python2.7 |
|                 | /site-packages/fabric/network.py", line 143, in connect      |
|                 |     self[key] = connect(user, host, port, cache=self)        |
|                 |   File "/home/lakshmi/stanley/virtualenv/local/lib/python2.7 |
|                 | /site-packages/fabric/network.py", line 523, in connect      |
|                 |     password = prompt_for_password(text)                     |
|                 |   File "/home/lakshmi/stanley/virtualenv/local/lib/python2.7 |
|                 | /site-packages/fabric/network.py", line 596, in              |
|                 | prompt_for_password                                          |
|                 |     handle_prompt_abort("a connection or sudo password")     |
|                 |   File "/home/lakshmi/stanley/virtualenv/local/lib/python2.7 |
|                 | /site-packages/fabric/utils.py", line 154, in                |
|                 | handle_prompt_abort                                          |
|                 |     abort(reason % "input would be ambiguous in parallel     |
|                 | mode")                                                       |
|                 |   File "/home/lakshmi/stanley/virtualenv/local/lib/python2.7 |
|                 | /site-packages/fabric/utils.py", line 32, in abort           |
|                 |     raise env.abort_exception(msg)                           |
|                 | ",                                                           |
|                 |         "succeeded": false,                                  |
|                 |         "error": "Passwordless sudo needs to be setup for    |
|                 | user: stanley"                                               |
|                 |     }                                                        |
|                 | }                                                            |
+-----------------+--------------------------------------------------------------+
(virtualenv)~/stanley git:linux_pack_improvements ❯❯❯
```