### PR TITLE
Disable content-type guessing from URL path in pecan app

### DIFF
--- a/st2api/st2api/app.py
+++ b/st2api/st2api/app.py
@@ -38,7 +38,8 @@ def __get_pecan_config():
             'modules': opts.modules,
             'debug': opts.debug,
             'auth_enable': opts.auth_enable,
-            'errors': opts.errors
+            'errors': opts.errors,
+            'guess_content_type_from_ext': False
         }
     }
 


### PR DESCRIPTION
```
resp = requests.get('http://localhost:9101/v1/actions/linux%2Erm')
>>> resp = requests.get('http://localhost:9101/v1/actions/linux.mp3')
>>> print(resp.json())
{u'faultstring': u'The resource could not be found.'}
>>>
|             |         "type": "boolean",

lakshmi [17:48]
Feb 28 01:39:32 localhost st2api[17184]: ERROR 140049251479056 [-] Controller 'get_one' defined does not support content_type 'audio/x-pn-realaudio'. Supported type(s): ['application/json']
Feb 28 01:39:59 localhost st2api[17184]: ERROR 140049251479056 [-] Controller 'get_one' defined does not support content_type 'audio/mpeg'. Supported type(s): ['application/json']
```