### PR TITLE
st2 key create user stanley -> st2 key set user stanley

### DIFF
--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -141,7 +141,7 @@ as ``{{system.my_parameter}}``. This creates ``user=stanley`` key-value pair:
 
 .. code-block:: bash
 
-    st2 key create user stanley
+    st2 key set user stanley
     st2 key list
 
 What are the triggers availabe to use in rules? Just like with actions,


### PR DESCRIPTION
The command:
st2 key create user stanley
does not work; the command
st2 key set user stanley
does what the description describes (creates ``user=stanley`` key-value pair)