### PR TITLE
Fixes for ActionChain docs and examples

### DIFF
--- a/contrib/examples/actions/chains/publish_data.yaml
+++ b/contrib/examples/actions/chains/publish_data.yaml
@@ -1,0 +1,45 @@
+---
+vars:
+    domain: "{{ system.domain }}" # `system` references DataStore key-values. Null if not set.
+    port: 9101
+chain:
+    -
+        name: "get_host"
+        ref: "core.local"
+        params:
+            cmd: hostname | tr -d ' \n'
+        publish:
+            # Publish a variable to shortcut a long expression
+            url: "http://{{ get_host.stdout }}:{{ port }}"
+            host: "{{ get_host.stdout }}"
+            # Jinja woodoo used for basic logic
+            fqdn: "{{ get_host.stdout }}{% if domain %}.{{ domain }}{% endif %}"
+            # A complex object can be published
+            paths:
+                api: [ "v1/actions", "v1/triggers"]
+                webui: "webui/"
+                auth_port: "{{ port + 1 }}"
+        on-success: say_the_names
+    -
+        name: say_the_names
+        description: Print out all the interesting stuff. In real life we post to chatops.
+        ref: "core.local"
+        params:
+            cmd: "echo host={{host}}, domain={{domain}}, fqdn={{fqdn}}, url={{url}}"
+        on-success: call_api
+    -
+        name: call_api
+        description: Check the API endpoint
+        ref: "core.http"
+        params:
+            method: GET
+            url: "{{ url }}/{{paths.api[0]}}"
+        on-success: call_webui
+    -
+        name: call_webui
+        description: Check that WebUI is serving
+        ref: "core.http"
+        params:
+            method: GET
+            url: "{{ url }}/{{paths.webui}}"
+            allow_redirects: True

--- a/contrib/examples/actions/chains/test_quickstart.yaml
+++ b/contrib/examples/actions/chains/test_quickstart.yaml
@@ -1,0 +1,73 @@
+---
+chain:
+    -
+        name: "test_basics"
+        ref: "core.local"
+        params:
+            cmd: "st2 --version; st2 -h"
+        on-success: test_action_list
+        on-failure: "error_handler"
+    -
+        name: test_action_list
+        ref: "core.local"
+        params:
+            cmd: "st2 action list -j --pack=core | egrep -w 'core.local|core.remote'"
+        on-success: test_action_get
+        on-failure: error_handler
+    -
+        name: test_action_get
+        ref: "core.local"
+        params:
+            cmd: "st2 action get -j core.http"
+        on-success: test_run_action
+        on-failure: error_handler
+    -
+        name: test_run_action
+        ref: core.local
+        params:
+            # Funny inception - core.local calls core.local :)
+            cmd: st2 run core.local -- date -R
+        on-success: test_execution_list
+        on-failure: "error_handler"
+    -
+        name: test_execution_list
+        ref: core.local
+        params:
+            cmd: st2 execution list -n 1
+        on-success: test_sensor_list
+        on-failure: "error_handler"
+    -
+        name: test_sensor_list
+        ref: core.local
+        params:
+            cmd: st2 sensor list -j
+        on-success: test_trigger_list
+        on-failure: "error_handler"
+    -
+        name: test_trigger_list
+        ref: core.local
+        params:
+            # get the trigger list as JSON with all attributes
+            cmd: st2 trigger list -j -a=all
+        on-success: test_trigger_get
+        on-failure: "error_handler"
+    -
+        name: test_trigger_get
+        ref: core.local
+        params:
+            cmd: "st2 trigger get -j {{test_trigger_list.stdout[0].id}}"
+        on-success: test_run_remote
+        on-failure: "error_handler"
+    -
+        name: test_run_remote
+        ref: core.local
+        params:
+            cmd: st2 run core.remote hosts='localhost' -- uname -a
+        on-failure: "error_handler"
+    -
+        name: error_handler
+        description: Error handler
+        ref: "core.local"
+        params:
+            cmd: "echo fail c4"
+

--- a/contrib/examples/actions/echochain.meta.yaml
+++ b/contrib/examples/actions/echochain.meta.yaml
@@ -1,8 +1,13 @@
 ---
 # Action definition metadata
-    name: "echochain"
-    runner_type: "action-chain"
-    description: "Simple Action Chain workflow"
-    enabled: true
-    entry_point: "chains/echochain.yaml"
-    parameters: {}
+name: "echochain"
+description: "Simple Action Chain workflow"
+
+# `runner_type` has value `action-chain` to identify that action is an ActionChain.
+runner_type: "action-chain"
+
+# `entry_point` path to the ActionChain definition file, relative to the pack's action directory.
+entry_point: "chains/echochain.yaml"
+
+enabled: true
+parameters: {}

--- a/contrib/examples/actions/echochain_param.meta.yaml
+++ b/contrib/examples/actions/echochain_param.meta.yaml
@@ -1,11 +1,14 @@
 ---
 # Action definition metadata
-    name: "echochain-param"
-    runner_type: "action-chain"
-    description: "Action Chain workflow passing variables"
-    enabled: true
-    entry_point: "chains/echochain_param.yaml"
-    parameters: 
-      input1: 
+name: "echochain-param"
+description: "Action Chain workflow passing variables"
+# `runner_type` identifies the runner
+runner_type: "action-chain"
+# `entry_point` path to the ActionChain definition file, relative to the pack's action directory.
+entry_point: "chains/echochain_param.yaml"
+enabled: true
+parameters:
+    input1:
         type: "string"
         required: true
+        description: "Any string to pass down"

--- a/contrib/examples/actions/publish_data.meta.yaml
+++ b/contrib/examples/actions/publish_data.meta.yaml
@@ -1,0 +1,7 @@
+---
+# Action definition metadata
+name: "publish_data"
+description: "Example showing use of variables and data publishing in ActinoChain"
+runner_type: "action-chain"
+enabled: true
+entry_point: "chains/publish_data.yaml"

--- a/contrib/examples/actions/test_quickstart.meta.yaml
+++ b/contrib/examples/actions/test_quickstart.meta.yaml
@@ -1,0 +1,8 @@
+---
+# Action definition metadata
+name: "test_quickstart"
+description: "Simple Action Chain workflow"
+runner_type: "action-chain"
+enabled: true
+entry_point: "chains/test_quickstart.yaml"
+parameters: {}

--- a/docs/source/actionchain.rst
+++ b/docs/source/actionchain.rst
@@ -12,8 +12,7 @@ ActionChain's are described in YAML (JSON supported for backward compatibiltiy) 
 ActionChain definition
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Following is sample ActionChain workflow definition named :github_st2:`echochain.yaml
-<contrib/examples/actions/chains/echochain.yaml>`:
+Following is sample ActionChain workflow definition named :github_st2:`echochain.yaml <contrib/examples/actions/chains/echochain.yaml>`:
 
 .. literalinclude:: /../../contrib/examples/actions/chains/echochain.yaml
    :language: yaml

--- a/docs/source/actionchain.rst
+++ b/docs/source/actionchain.rst
@@ -9,8 +9,8 @@ Authoring an ActionChain
 ActionChain's are described in YAML (JSON supported for backward compatibiltiy) and placed inside a pack similar to other script or python actions. An ActionChain must also be associated with a metadata file that allows it to be registered as an Action by |st2|. This metadata contains name and parameter description of an action.
 
 
-ActionChain script
-~~~~~~~~~~~~~~~~~~
+ActionChain definition
+~~~~~~~~~~~~~~~~~~~~~~
 
 Following is sample ActionChain workflow definition named :github_st2:`echochain.yaml
 <contrib/examples/actions/chains/echochain.yaml>`:
@@ -18,29 +18,46 @@ Following is sample ActionChain workflow definition named :github_st2:`echochain
 .. literalinclude:: /../../contrib/examples/actions/chains/echochain.yaml
    :language: yaml
 
-Note:
+Details:
 
 * `chain` is the array property that contains action elements.
 * Action elements are named action execution specifications. The name is scoped to an ActionChain and is used as a reference to an action element.
 * `ref` property of an action element points to an Action registered in |st2|.
 * `on-success` is the link to action element to invoke next on a successful execution. If not provided the ActionChain will terminate with status set to success.
 * `on-failure` is the link to action element to invoke next on a failed execution. If not provided the ActionChain will terminate with the status set to error.
-* `default` is the top level property that specifies start of an ActionChain.
+* `default` is an optional top level property that specifies the start of an ActionChain.
 
 ActionChain metadata
 ~~~~~~~~~~~~~~~~~~~~
 
-The :github_st2:`metadata
-<contrib/examples/actions/echochain.meta.yaml>` for the ActionChain above looks like this:
+ActionChain action defined and operated like :doc:`any other action <actions>`.
+The action medatata schema
+is the same for any action in the system: specify ``action-chain`` as a runner,
+and point to the workflow definition file
+in the ``entry_point``. The action definition metadata :github_st2:`echochain.meta.yaml
+<contrib/examples/actions/echochain.meta.yaml>` for an ActionChain :github_st2:`echochain.yaml
+<contrib/examples/actions/chains/echochain.yaml>` looks like this:
 
 .. literalinclude:: /../../contrib/examples/actions/echochain.meta.yaml
    :language: yaml
 
-Note:
 
-* `runner_type` has value `action-chain` to identify that action is an `action-chain`.
-* `entry_point` links to the actual chain file relative to the location of the meta file.
-* Schema followed is identical to any other action i.e. echochain is now an action in the system.
+Once action definition and metadata files are created, load the action:
+
+.. code-block:: bash
+
+    # Register the action
+    st2 action create /opt/stackstorm/packs/default/actions/echochain.meta.yaml
+    # Check it is available
+    st2 action list --pack=default
+    # Run it
+    st2 run default.echochain
+
+Any changes in ActionChain workflow definition are picked up automatically.
+However if you change action metadata (e.g. rename or move , add parameters) - you will have to
+update the action with ``st2 action update <action.ref> <action.metadata.file>```.
+Alternatively, full context reload with ``st2clt reload`` will pick up all the changes.
+
 
 Providing input
 ~~~~~~~~~~~~~~~
@@ -71,18 +88,19 @@ The input parameter `input1` can now be referenced in the parameters field of an
                action1_input: "{{input1}}"
       # ...
 
-`action1_input` has value `{{input1}}`. This syntax is variable referencing as supported by Jinja2 templating. Similar constructs are also used in :doc:`Rule </rules>` criteria and action fields.
+`action1_input` has value `{{input1}}`. This syntax is variable referencing as supported
+by `Jinja templating <http://jinja.pocoo.org/docs/dev/templates/>`__.
+Similar constructs are also used in :doc:`Rule </rules>` criteria and action fields.
 
 Data passing
 ~~~~~~~~~~~~
 
-Similar to how input to an ActionChain can be referenced in an action elements; the output of previous action elements can also be referenced. Below is a version of the previously seen `echochain`, :github_st2:`echochain_param.yaml
-<contrib/examples/actions/chains/echochain_param.yaml>` with input and data passing down the flow:
+Similar to how input to an ActionChain can be referenced in an action elements; the output of previous action elements can also be referenced. Below is a version of the previously seen `echochain`, :github_st2:`echochain_param.yaml <contrib/examples/actions/chains/echochain_param.yaml>` with input and data passing down the flow:
 
 .. literalinclude:: /../../contrib/examples/actions/chains/echochain_param.yaml
    :language: yaml
 
-Note:
+Details:
 
 * Output of an action elements is always prefixed by element name. e.g. In ``{"cmd":"echo c2 {{c1.stdout}}"}`` `c1.stdout` refers to the output of 'c1' and further drills down into properties of the output.
 * A special ``__results`` key provides access to the entire result upto that point of execution.

--- a/docs/source/actionchain.rst
+++ b/docs/source/actionchain.rst
@@ -1,10 +1,11 @@
 ActionChain
 ============
 
-ActionChain is a no-frills linear workflow. On completion of a constituent action the choice between on-success and on-failure is evaluated to pick the next action. This implementation allows for passing of data between actions and finally publishes the result of each of the constituent action elements. From perspective of |st2| an ActionChain is itself an action therefore all the features of an action like execution from cli, usage in Rules etc. are automatically supported.
+ActionChain is a no-frills linear workflow, a simple chain of action invocations. On completion of a constituent action the choice between on-success and on-failure is evaluated to pick the next action. This implementation allows for passing of data between actions and finally publishes the result of each of the constituent actions. From perspective of |st2| an ActionChain is itself an action, therefore all the operations and features of an action like definition, registration, execution from cli, usage in Rules etc. are the same.
 
 Authoring an ActionChain
 ------------------------
+
 
 ActionChain's are described in YAML (JSON supported for backward compatibiltiy) and placed inside a pack similar to other script or python actions. An ActionChain must also be associated with a metadata file that allows it to be registered as an Action by |st2|. This metadata contains name and parameter description of an action.
 
@@ -19,12 +20,12 @@ Following is sample ActionChain workflow definition named :github_st2:`echochain
 
 Details:
 
-* `chain` is the array property that contains action elements.
-* Action elements are named action execution specifications. The name is scoped to an ActionChain and is used as a reference to an action element.
-* `ref` property of an action element points to an Action registered in |st2|.
-* `on-success` is the link to action element to invoke next on a successful execution. If not provided the ActionChain will terminate with status set to success.
-* `on-failure` is the link to action element to invoke next on a failed execution. If not provided the ActionChain will terminate with the status set to error.
-* `default` is an optional top level property that specifies the start of an ActionChain.
+* ``chain`` is the array property that contains tasks, which incapsulate action invocation.
+* Tasks are named action execution specifications. The name is scoped to an ActionChain and is used as a reference to a task.
+* ``ref`` property of an task points to an Action registered in |st2|.
+* ``on-success`` is the link to a task to invoke next on a successful action execution. If not provided, the ActionChain will terminate with status set to `success`.
+* ``on-failure`` is an optional link to a task to invoke next on a failed action execution. If not provided, the ActionChain will terminate with the status set to `error`.
+* ``default`` is an optional top level property that specifies the start of an ActionChain. If ``default`` not explicitly specified, the ActionChanin starts from the first action.
 
 ActionChain metadata
 ~~~~~~~~~~~~~~~~~~~~
@@ -73,7 +74,7 @@ For a user to provide input to an ActionChain the input parameters must be defin
             required: true
       # ...
 
-The input parameter `input1` can now be referenced in the parameters field of an action element.
+The input parameter ``input1`` can now be referenced in the parameters field of a task.
 
 ::
 
@@ -87,22 +88,61 @@ The input parameter `input1` can now be referenced in the parameters field of an
                action1_input: "{{input1}}"
       # ...
 
-`action1_input` has value `{{input1}}`. This syntax is variable referencing as supported
+``action1_input`` has value ``{{input1}}``. This syntax is variable referencing as supported
 by `Jinja templating <http://jinja.pocoo.org/docs/dev/templates/>`__.
 Similar constructs are also used in :doc:`Rule </rules>` criteria and action fields.
 
 Data passing
 ~~~~~~~~~~~~
 
-Similar to how input to an ActionChain can be referenced in an action elements; the output of previous action elements can also be referenced. Below is a version of the previously seen `echochain`, :github_st2:`echochain_param.yaml <contrib/examples/actions/chains/echochain_param.yaml>` with input and data passing down the flow:
+Similar to how input to an ActionChain can be referenced in a task; the output of previous tasks can also be referenced. Below is a version of the previously seen `echochain`, :github_st2:`echochain_param.yaml <contrib/examples/actions/chains/echochain_param.yaml>` with input and data passing down the flow:
 
 .. literalinclude:: /../../contrib/examples/actions/chains/echochain_param.yaml
    :language: yaml
 
 Details:
 
-* Output of an action elements is always prefixed by element name. e.g. In ``{"cmd":"echo c2 {{c1.stdout}}"}`` `c1.stdout` refers to the output of 'c1' and further drills down into properties of the output.
-* A special ``__results`` key provides access to the entire result upto that point of execution.
+* Output of a task is always prefixed by task name. e.g. In ``{"cmd":"echo c2 {{c1.stdout}}"}`` ``c1.stdout`` refers to the output of 'c1' and further drills down into properties of the output. The reference point is the ``result`` field of ``action execution`` object.
+* A special ``__results`` key provides access to the entire result of the whole chain upto that point of execution.
+
+
+Variables
+~~~~~~~~~~~~~~~
+ActionChain offers the convinience of named variables. Global vars are set at the top of the definition with the ``var`` keyword.
+Tasks publish new varialbes with the ``publish`` keyword. Variables handy when you need to mash up
+a reusable value from the input, globals, DataStore values, and results of multiple actions executions.
+All variables are referred with Jinja syntax.
+
+.. code-block:: yaml
+
+    ---
+    vars:
+        domain: {{ system.domain }} #
+        port: 9101
+
+    chain:
+        -
+            name: get_service_data
+            ref:  my_pack.get_services
+            publish:
+                url_1: http://"{{ get_service_data.result[0].host.name }}.{{ domain }}:{{ port }}"
+
+
+The :github_st2:`publish_data.yaml <contrib/examples/actions/chains/publish_data.yaml>` from `examples` shows a complete working examples of using ``vars`` and ``publish``.
+
+.. literalinclude:: /../../contrib/examples/actions/chains/publish_data.yaml
+   :language: yaml
+   :lines: 1-29
+
+
+Gotchas
+~~~~~~~~~~~~~~~
+Using YAML and Jinja implied some constraints on how to name and reference variables:
+
+* Variable names can use letters, underscores, and numbers. No dashes! This applies to all variables: global vars, input parameters, :ref:`DataStore keys <datastore>`, and published variables.
+* Same naming rules apply to task names: ``this-is-wrong-task-name``! Use ``task_names_with_underscores``.
+* Always quote variable reference "{{ my_variable.or.expression }}" (remember that ``{ }`` is a YAML dictionary). The types are respected inside the Jinja template but converted to strings outside: "{{ 1 + 2 }} + 3" resolves to "3 + 3".
+
 
 Error Reporting
 ~~~~~~~~~~~~~~~

--- a/docs/source/actions.rst
+++ b/docs/source/actions.rst
@@ -17,8 +17,9 @@ implemented as actions:
 * snapshot a VM
 * run nagios check
 
-Action is executed when a rule with a matching criteria is found. For more
-information about the rules, please see the :doc:`rules </rules>` section.
+Actions can be executed when a :doc:`Rule </rules>` with a matching criteria is triggered.
+Multiple Actions can be stringed together into a :doc:`Workflow </workflows>`. And each action can
+be executed directly from the clients via CLI, API, or UI.
 
 Action runner
 ^^^^^^^^^^^^^
@@ -114,12 +115,26 @@ the Twilio web service.
                 description: "Body of the message."
                 required: true
                 position: 2
+                default: "Hello {% if system.user %} {{ system.user }} {% else %} dude {% endif %}!"
 
 
 This action is using a Python runner (``run-python``), the class which
 implements a ``run`` method is contained in a file called ``send_sms.py`` which
 is located in the same directory as the metadata file and the action takes three
 parameters (from_number, to_number, body).
+
+
+Action Registration
+~~~~~~~~~~~~~~~~~~~~
+Once action is created 1) place it into the content location, and 2) tell the system
+that the action is avalable. The actions are grouped in :doc:`packs </packs>` and located
+at ``/opt/stackstorm/pacsk`` (default, configured, multiple locations supported).
+For hacking one-off actions, the convention is to use `default` pack - just create your action in
+``/opt/stackstorm/pack/default/actions``.
+
+Register individual action by calling `st2 action create my_action_metadata.yaml`.
+To reload all the action, use ``st2ctl reload --register-actions``
+
 
 .. _ref-actions-converting-scripts:
 

--- a/docs/source/roadmap.rst
+++ b/docs/source/roadmap.rst
@@ -4,20 +4,29 @@ Roadmap
 StackStorm is new and under active development. We are opening it early to engage community, get  feedback, and refine directions, and welcome contributions. Below are key next items we see as top priorities.
 
 
-* **Web UI:** refactor history view, create and edit rules and workflows, add graphical representations for workflow definitions and executions.
-* **Improving** `Mistal <https://wiki.openstack.org/wiki/Mistral>`_  **integration:** focus on simplifying Mistral DSL for |st2| actions, visibility of workflow executions, and reliability of |st2|-Mistral communication.
-* **Operational supportability:** Better output formats, better visibility to ongoing actions, better logs, better debugging tools.
+* **ChatOps:** two-way chat integration beyond imagination.
+* **Web UI complete basics:** rule create/edit/delete in UI.
 * **Pack management:** Improve support for pack creation lifecycle. REST API to manage and configure packs installed in the system. Smoother integration with community content.
 * **Scale improvements:** refactoring and fixes to scale out better to manage large volumes of events and actions.
 * **Reliability:** Focus on availability of services and improve system reliability.
 * **Tags:** tag any resources, to handle actions, triggers and rules as their number grows to hundreds.
 * **RBAC:** Role based access control for actions, triggers, rules, and datastore keys.
+* **Web UI advanced functionality:** visual workflow design representation, drag&drop workflow designer.
 * **Database:** move away from Mongo to Postgres and/or MySQL.
 * **Pluggable runners:** We have heard that a Ruby runner would be great.
+* **Windows support:** via pluggable runners.
 * **Datastore:**  Hierarchical, pluggable and secure datastore to bring together all the gnarly config and key spread in operations environments.
 * **Bugs and smaller improvements**
 * **Documentation:** generate REST API docs.
 * **More integration packs:** push more content to the community to help work with most common and widely used tool. Tell us if there is tool you love and think we should integrate with or better yet write a pack yourself.
+
+.. rubric:: Done in v0.8
+
+* **Web UI:** refactor history view, create and edit rules and workflows, add graphical representations for workflow definitions and executions.
+* **Improving** `Mistal <https://wiki.openstack.org/wiki/Mistral>`_  **integration:** simplified Mistral DSL for |st2| actions, visibility of workflow executions, and reliabile of |st2|-Mistral communication. Includes Mistral improvements, features, and fixes.
+* **Operational supportability:** Better output formats, better visibility to ongoing actions, better logs, better debugging tools.
+* **Scale and reliability improvements:** deployed and run at scale, shown some good numbers, and more work identified.
+
 
 .. rubric:: Done in v0.6.0
 

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -194,8 +194,10 @@ the file and see that it appends the payload if the name=Joe.
 
 Congratulations, your first |st2| rule is up and running!
 
+Deploy Examples
+-------------------------
 Examples of rules, custom sensors, actions, and workflows are installed with |st2| and located
-at :github_st2:`/usr/share/doc/st2/examples <contrib/examples/>`. To get them deployed, copy them
+at :github_st2:`/usr/share/doc/st2/examples <contrib/examples/>`. To deployed, copy them
 to /opt/stackstorm/packs/, setup, and reload the content:
 
 .. code-block:: bash
@@ -209,7 +211,7 @@ to /opt/stackstorm/packs/, setup, and reload the content:
     # Reload stackstorm context
     st2ctl reload --register-all
 
-For more content, checkout `st2contrib`_ community repo on GitHub.
+For more content - actions, sensors, rules - checkout `st2contrib`_ community repo on GitHub.
 
 
 Troubleshooting


### PR DESCRIPTION
- [x] Fix broken examples, update docs, add "action registration" instructions.
- [x] Move workflows under `actions/workflows` 
- [ ] Describe and add example for `vars` and `publish`.