### PR TITLE
Small docs updates

### DIFF
--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -10,7 +10,9 @@ download and run the deployment script.
     chmod +x st2_deploy.sh
     sudo ./st2_deploy.sh
 
-This will download and install the latest release of |st2| (currently |release|). Installation should take about 5 min. Grab a coffee and watch :doc:`/video` while it is being installed.
+This will download and install the stable release of |st2| (currently |release|).
+If you want to install the latest bits, run ``sudo ./st2_deploy.sh latest``.
+Installation should take about 5 min. Grab a coffee and watch :doc:`/video` while it is being installed.
 
 .. include:: on_complete.rst
 

--- a/docs/source/packs.rst
+++ b/docs/source/packs.rst
@@ -76,7 +76,9 @@ Let's install the Docker pack:
     # Check out README.md and if necessary, adjust configuration for your environment
     less /opt/stackstorm/packs/docker/README.md
 
-    # Reload all the content
+    # Load ALL the content: actions, sensors, rules
+    # If you don't want to load sample rules by default, do
+    # st2 run packs.load register=sensors & st2 run packs.load register=actions
     st2 run packs.load register=all
 
     # To pick up sensors, need to bounce the sensor_container.
@@ -90,7 +92,7 @@ Let's install the Docker pack:
 
 The docker pack is now installed and ready to use.
 
-Packs may contain automations - rules and workflows. Rules are not loaded by default - you may want to review and adjust them before loading. Pass ``register=rules`` option to ``packs.install`` and ``packs.load`` actions to get the rules loaded.
+Packs may contain automations - rules and workflows. Rules are not loaded by default - you may want to review and adjust them before loading. Pass ``register=all`` option to ``packs.install`` and ``packs.load`` actions to get the rules loaded. Use `st2clt reload` for fine control - packs.load is an st2 action wrapper around it.
 
 .. note:: Pack management is implemented as a pack of st2 actions. Check out :github_st2:`/opt/stackstorm/packs </contrib/packs>` for examples of defining actions and workflows.
 

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -196,16 +196,18 @@ Congratulations, your first |st2| rule is up and running!
 
 Examples of rules, custom sensors, actions, and workflows are installed with |st2| and located
 at :github_st2:`/usr/share/doc/st2/examples <contrib/examples/>`. To get them deployed, copy them
-to /opt/stackstorm/packs/ and reload the content:
+to /opt/stackstorm/packs/, setup, and reload the content:
 
 .. code-block:: bash
 
     # Copy examples to st2 content directory
     sudo cp -r /usr/share/doc/st2/examples/ /opt/stackstorm/packs/
 
+    # Run setup
+    st2 run packs.setup_virtualenv packs=examples
+
     # Reload stackstorm context
     st2ctl reload --register-all
-
 
 For more content, checkout `st2contrib`_ community repo on GitHub.
 
@@ -215,8 +217,8 @@ Troubleshooting
 If something goes wrong:
 
 * Check recent executions: ``st2 execution list``
-* Inspect the logs at ``/var/log/st2.``
 * Use service control ``st2ctl`` to check service status, restart services, reload packs, or clean the db.
+* Inspect the logs at ``/var/log/st2/``
 * Follow :doc:`/troubleshooting` guide
 * Engage with developers at `#stackstorm on irc.freenode.org <http://webchat.freenode.net/?channels=stackstorm>`__
 


### PR DESCRIPTION
* Installer - mention 'latest'.
* Packs - more details on `pacsk.load register`
* Quick Start - mention to setup virtual env when deploying examples,
or else they won't work.