### PR TITLE
Make action parameters schema not fail validation if required attribute specifies a default value and no value is provided

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -64,6 +64,8 @@ Docs: http://docks.stackstorm.com/latest
 * Allow users to filter datastore items by name prefix by passing ``?prefix=<value>`` query
   parameter to the /keys endpoint. (new-feature)
 * Fix non-string types to be rendered correctly in action parameters when used in rule. (bug-fix)
+* Allow user to specify default value for required attributes in the definition of action
+  parameters. (bug-fix)
 
 v0.7 - January 16, 2015
 -----------------------

--- a/st2common/st2common/services/action.py
+++ b/st2common/st2common/services/action.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import datetime
-import jsonschema
 import six
 
 from st2common import log as logging
@@ -64,7 +63,7 @@ def schedule(liveaction):
     # Validate action parameters.
     schema = util_schema.get_parameter_schema(action_db)
     validator = util_schema.get_validator()
-    jsonschema.validate(liveaction.parameters, schema, validator)
+    util_schema.validate(liveaction.parameters, schema, validator, use_default=True)
 
     # validate that no immutable params are being overriden. Although possible to
     # ignore the override it is safer to inform the user to avoid surprises.

--- a/st2common/tests/unit/test_json_schema.py
+++ b/st2common/tests/unit/test_json_schema.py
@@ -1,0 +1,77 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest2 import TestCase
+from jsonschema.exceptions import ValidationError
+
+from st2common.util import schema as util_schema
+
+TEST_SCHEMA_1 = {
+    'additionalProperties': False,
+    'title': 'foo',
+    'description': 'Foo.',
+    'type': 'object',
+    'properties': {
+        'cmd_no_default': {
+            'description': 'Foo',
+            'required': True,
+            'type': 'string'
+        }
+    }
+}
+
+TEST_SCHEMA_2 = {
+    'additionalProperties': False,
+    'title': 'foo',
+    'description': 'Foo.',
+    'type': 'object',
+    'properties': {
+        'cmd_default': {
+            'default': 'date',
+            'description': 'Foo',
+            'required': True,
+            'type': 'string'
+        }
+    }
+}
+
+
+class JSONSchemaTestCase(TestCase):
+    def test_use_default_value(self):
+        # No default, no value provided, should fail
+        instance = {}
+        validator = util_schema.get_validator()
+
+        expected_msg = '\'cmd_no_default\' is a required property'
+        self.assertRaisesRegexp(ValidationError, expected_msg, util_schema.validate,
+                                instance=instance, schema=TEST_SCHEMA_1, cls=validator,
+                                use_default=True)
+
+        # No default, value provided
+        instance = {'cmd_no_default': 'foo'}
+        util_schema.validate(instance=instance, schema=TEST_SCHEMA_1, cls=validator,
+                             use_default=True)
+
+        # default value provided, no value, should pass
+        instance = {}
+        validator = util_schema.get_validator()
+        util_schema.validate(instance=instance, schema=TEST_SCHEMA_2, cls=validator,
+                             use_default=True)
+
+        # default value provided, value provided, should pass
+        instance = {'cmd_default': 'foo'}
+        validator = util_schema.get_validator()
+        util_schema.validate(instance=instance, schema=TEST_SCHEMA_2, cls=validator,
+                             use_default=True)


### PR DESCRIPTION
JSON schema doesn't support default values, so previously, is a parameter specified `required: True` and `default: "some value"`, schema validator would still fail if user didn't provide a value for this parameter.

This pull request fixes that and makes schema validator not fail in that case.