### PR TITLE
Add verbose flag to register content in st2ctl

### DIFF
--- a/st2common/bin/registercontent.py
+++ b/st2common/bin/registercontent.py
@@ -4,4 +4,4 @@ import sys
 import st2common.content.bootstrap as content_loader
 
 if __name__ == '__main__':
-    sys.exit(content_loader.main())
+    sys.exit(content_loader.main(sys.argv[1:]))

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -24,6 +24,7 @@ from st2common.models.db import db_teardown
 
 
 LOG = logging.getLogger('st2common.content.bootstrap')
+cfg.CONF.register_cli_opt(cfg.BoolOpt('verbose', short='v', default=False))
 
 
 def register_opts():
@@ -109,12 +110,12 @@ def register_content():
         register_rules()
 
 
-def _setup():
+def _setup(argv):
     config.parse_args()
 
     # 2. setup logging.
-    logging.basicConfig(format='%(asctime)s %(levelname)s [-] %(message)s',
-                        level=logging.DEBUG)
+    log_level = logging.DEBUG if cfg.CONF.verbose else logging.ERROR
+    logging.basicConfig(format='%(asctime)s %(levelname)s [-] %(message)s', level=log_level)
 
     # 3. all other setup which requires config to be parsed and logging to
     # be correctly setup.
@@ -128,12 +129,12 @@ def _teardown():
     db_teardown()
 
 
-def main():
-    _setup()
+def main(argv):
+    _setup(argv)
     register_content()
     _teardown()
 
 
 # This script registers actions and rules from content-packs.
 if __name__ == '__main__':
-    main()
+    main(sys.argv[1:])

--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+echo $AR
+exit 1
+
 runner_count=1
 if [ "$#" -gt 1 ]; then
     runner_count=${2}
@@ -80,7 +83,7 @@ function st2start(){
     echo 'Registering sensors, actions and rules...'
     ./virtualenv/bin/python \
         ./st2common/bin/registercontent.py \
-        --config-file $ST2_CONF --register-all
+        --config-file $ST2_CONF --register-all --verbose
 
     # Run the action runner server
     echo 'Starting screen session st2-actionrunner...'

--- a/tools/st2ctl
+++ b/tools/st2ctl
@@ -122,12 +122,18 @@ function register_content() {
   echo "Registering content..."
 
   if [ ! ${1} ]; then
-      REGISTER_FLAGS="--register-sensors --register-actions"
+    REGISTER_FLAGS="--register-sensors --register-actions"
+  elif [ ${1} == "-v" -o ${1} == "--verbose" ]; then
+    if [ ! ${2} ]; then
+      REGISTER_FLAGS="--register-sensors --register-actions --verbose"
+    else
+      REGISTER_FLAGS="${2} --verbose"
+    fi
   else
-      # Note: Scripts already call reload with "--register-<content>"
-      # TODO: Update packs. actions to only pass in a resource name excluding
-      # --register prefix
-      REGISTER_FLAGS="${1}"
+    # Note: Scripts already call reload with "--register-<content>"
+    # TODO: Update packs. actions to only pass in a resource name excluding
+    # --register prefix
+    REGISTER_FLAGS="${1} ${2}"
   fi
 
   $PYTHON ${PYTHONPACK}/st2common/bin/registercontent.py --config-file ${STANCONF} ${REGISTER_FLAGS}


### PR DESCRIPTION
By default, register content will only output logs that has level ERROR or above. If "-v" or "--verbose" is included, the log level will change to DEBUG.

```
Examples:
st2ctl reload -v
st2ctl reload --verbose
st2ctl clean -v
st2ctl clean --verbose
```