### PR TITLE
More specific grep to avoid uninstalling non StackStorm packages

### DIFF
--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -337,7 +337,7 @@ download_pkgs() {
 deploy_rpm() {
   echo "###########################################################################################"
   echo "# Removing any current st2 components"
-  for i in `rpm -qa | grep st2 | grep -v common`; do rpm -e $i; done
+  for i in `rpm -qa | grep -e "^st2" | grep -v common`; do rpm -e $i; done
   for i in `rpm -qa | grep st2common `; do rpm -e $i; done
 
   echo "###########################################################################################"


### PR DESCRIPTION
Fedora 21 installation was failing on the uninstall step for the packages.  This makes the grep more specific to help avoid this situation.