### PR TITLE
Correctly preserve the username of the user who has triggered the action execution

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -66,6 +66,8 @@ Docs: http://docks.stackstorm.com/latest
 * Fix non-string types to be rendered correctly in action parameters when used in rule. (bug-fix)
 * Allow user to specify default value for required attributes in the definition of action
   parameters. (bug-fix)
+* When running with auth enabled, correctly preserve the username of the authenticated user who
+  has triggered the action execution. (bug-fix)
 
 v0.7 - January 16, 2015
 -----------------------

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -95,10 +95,15 @@ class ActionExecutionsController(ResourceController):
             if not hasattr(execution, 'context'):
                 execution.context = dict()
 
-            # Retrieve user context from the request header.
-            user = pecan.request.headers.get('X-User-Name')
-            if not user:
+            # Retrieve username of the authed user (note - if auth is disabled, user will not be
+            # set so we fall back to the system user name)
+            request_token = pecan.request.context.get('token', None)
+
+            if request_token:
+                user = request_token.user
+            else:
                 user = cfg.CONF.system_user.user
+
             execution.context['user'] = user
 
             # Retrieve other st2 context from request header.

--- a/st2api/tests/unit/controllers/v1/test_executions_simple.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_simple.py
@@ -292,7 +292,7 @@ class TestActionExecutionController(FunctionalTest):
 NOW = isotime.add_utc_tz(datetime.datetime.utcnow())
 EXPIRY = NOW + datetime.timedelta(seconds=300)
 SYS_TOKEN = TokenDB(id=bson.ObjectId(), user='system', token=uuid.uuid4().hex, expiry=EXPIRY)
-USR_TOKEN = TokenDB(id=bson.ObjectId(), user='stanley', token=uuid.uuid4().hex, expiry=EXPIRY)
+USR_TOKEN = TokenDB(id=bson.ObjectId(), user='tokenuser', token=uuid.uuid4().hex, expiry=EXPIRY)
 
 
 def mock_get_token(*args, **kwargs):
@@ -336,14 +336,14 @@ class TestActionExecutionControllerAuthEnabled(AuthMiddlewareTest):
         headers = {'content-type': 'application/json', 'X-Auth-Token': str(USR_TOKEN.token)}
         resp = self._do_post(copy.deepcopy(LIVE_ACTION_1), headers=headers)
         self.assertEqual(resp.status_int, 201)
-        self.assertEqual(resp.json['context']['user'], 'stanley')
+        self.assertEqual(resp.json['context']['user'], 'tokenuser')
         context = {'parent': str(resp.json['liveaction']['id'])}
         headers = {'content-type': 'application/json',
                    'X-Auth-Token': str(SYS_TOKEN.token),
                    'st2-context': json.dumps(context)}
         resp = self._do_post(copy.deepcopy(LIVE_ACTION_1), headers=headers)
         self.assertEqual(resp.status_int, 201)
-        self.assertEqual(resp.json['context']['user'], 'stanley')
+        self.assertEqual(resp.json['context']['user'], 'tokenuser')
         self.assertEqual(resp.json['context']['parent'], context['parent'])
 
 


### PR DESCRIPTION
When running st2api with auth enabled, we didn't correctly preserve the username of the authenticated user who has triggered the action execution (we always just used a default value of ``stanley``).

@enykeev said he has updated a ticket with this issue, but I couldn't find the ticket.