### PR TITLE
Content registration message filtering improvements

### DIFF
--- a/st2actions/st2actions/bootstrap/actionsregistrar.py
+++ b/st2actions/st2actions/bootstrap/actionsregistrar.py
@@ -42,7 +42,12 @@ class ActionsRegistrar(ResourceRegistrar):
         """
         Discover all the packs in the provided directory and register actions from all of the
         discovered packs.
+
+        :return: Number of actions registered.
+        :rtype: ``int``
         """
+        registered_count = 0
+
         content = self._pack_loader.get_content(base_dirs=base_dirs,
                                                 content_type='actions')
 
@@ -50,29 +55,39 @@ class ActionsRegistrar(ResourceRegistrar):
             try:
                 LOG.debug('Registering actions from pack %s:, dir: %s', pack, actions_dir)
                 actions = self._get_actions_from_pack(actions_dir)
-                self._register_actions_from_pack(pack=pack, actions=actions)
+                count = self._register_actions_from_pack(pack=pack, actions=actions)
+                registered_count += count
             except:
                 LOG.exception('Failed registering all actions from pack: %s', actions_dir)
+
+        return registered_count
 
     def register_actions_from_pack(self, pack_dir):
         """
         Register all the actions from the provided pack.
+
+        :return: Number of actions registered.
+        :rtype: ``int``
         """
         pack_dir = pack_dir[:-1] if pack_dir.endswith('/') else pack_dir
         _, pack = os.path.split(pack_dir)
         actions_dir = self._pack_loader.get_content_from_pack(pack_dir=pack_dir,
                                                               content_type='actions')
 
+        registered_count = 0
+
         if not actions_dir:
-            return None
+            return registered_count
 
         LOG.debug('Registering actions from pack %s:, dir: %s', pack, actions_dir)
 
         try:
             actions = self._get_actions_from_pack(actions_dir=actions_dir)
-            self._register_actions_from_pack(pack=pack, actions=actions)
+            registered_count = self._register_actions_from_pack(pack=pack, actions=actions)
         except:
             LOG.exception('Failed registering all actions from pack: %s', actions_dir)
+
+        return registered_count
 
     def _get_actions_from_pack(self, actions_dir):
         actions = self._get_resources_from_pack(resources_dir=actions_dir)
@@ -116,6 +131,8 @@ class ActionsRegistrar(ResourceRegistrar):
             raise
 
     def _register_actions_from_pack(self, pack, actions):
+        registered_count = 0
+
         for action in actions:
             try:
                 LOG.debug('Loading action from %s.', action)
@@ -123,6 +140,10 @@ class ActionsRegistrar(ResourceRegistrar):
             except Exception:
                 LOG.exception('Unable to register action: %s', action)
                 continue
+            else:
+                registered_count += 1
+
+        return registered_count
 
 
 def register_actions(packs_base_paths=None, pack_dir=None):

--- a/st2actions/st2actions/bootstrap/actionsregistrar.py
+++ b/st2actions/st2actions/bootstrap/actionsregistrar.py
@@ -102,10 +102,10 @@ class ActionsRegistrar(ResourceRegistrar):
         action_ref = ResourceReference.to_string_reference(pack=pack, name=str(content['name']))
         existing = action_utils.get_action_by_ref(action_ref)
         if not existing:
-            LOG.info('Action %s not found. Creating new one with: %s', action_ref, content)
+            LOG.debug('Action %s not found. Creating new one with: %s', action_ref, content)
         else:
-            LOG.info('Action %s found. Will be updated from: %s to: %s',
-                     action_ref, existing, model)
+            LOG.debug('Action %s found. Will be updated from: %s to: %s',
+                      action_ref, existing, model)
             model.id = existing.id
 
         try:

--- a/st2actions/st2actions/bootstrap/runnersregistrar.py
+++ b/st2actions/st2actions/bootstrap/runnersregistrar.py
@@ -364,7 +364,7 @@ RUNNER_TYPES = [
 
 
 def register_runner_types():
-    LOG.info('Start : register default RunnerTypes.')
+    LOG.debug('Start : register default RunnerTypes.')
 
     for runnertype in RUNNER_TYPES:
         try:
@@ -390,4 +390,4 @@ def register_runner_types():
         except Exception:
             LOG.exception('Unable to register runner type %s.', runnertype['name'])
 
-    LOG.info('End : register default RunnerTypes.')
+    LOG.debug('End : register default RunnerTypes.')

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -51,11 +51,11 @@ def register_sensors():
         # Importing here to reduce scope of dependency. This way even if st2reactor
         # is not installed bootstrap continues.
         import st2reactor.bootstrap.sensorsregistrar as sensors_registrar
-        sensors_registrar.register_sensors(pack_dir=cfg.CONF.register.pack)
+        registered_count = sensors_registrar.register_sensors(pack_dir=cfg.CONF.register.pack)
     except Exception as e:
         LOG.warning('Failed to register sensors: %s', e, exc_info=True)
-    else:
-        LOG.info('Sensors registered.')
+
+    LOG.info('Registered %s sensors.' % (registered_count))
 
 
 def register_actions():
@@ -70,17 +70,18 @@ def register_actions():
         import st2actions.bootstrap.runnersregistrar as runners_registrar
         runners_registrar.register_runner_types()
     except Exception as e:
-        LOG.warning('Failed to register action types: %s', e, exc_info=True)
-        LOG.warning('Not registering stock actions.')
+        LOG.warning('Failed to register runner types: %s', e, exc_info=True)
+        LOG.warning('Not registering stock runners .')
     else:
         try:
             # Importing here to reduce scope of dependency. This way even if st2action
             # is not installed bootstrap continues.
             import st2actions.bootstrap.actionsregistrar as actions_registrar
-            actions_registrar.register_actions(pack_dir=cfg.CONF.register.pack)
+            registered_count = actions_registrar.register_actions(pack_dir=cfg.CONF.register.pack)
         except Exception as e:
             LOG.warning('Failed to register actions: %s', e, exc_info=True)
-    LOG.info('Actions registered.')
+
+    LOG.info('Registered %s actions.' % (registered_count))
 
 
 def register_rules():
@@ -92,10 +93,11 @@ def register_rules():
         # Importing here to reduce scope of dependency. This way even if st2reactor
         # is not installed bootstrap continues.
         import st2reactor.bootstrap.rulesregistrar as rules_registrar
-        rules_registrar.register_rules(pack_dir=cfg.CONF.register.pack)
+        registered_count = rules_registrar.register_rules(pack_dir=cfg.CONF.register.pack)
     except Exception as e:
         LOG.warning('Failed to register rules: %s', e, exc_info=True)
-    LOG.info('Rules registered.')
+
+    LOG.info('Registered %s rules.' % (registered_count))
 
 
 def register_content():

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -54,6 +54,8 @@ def register_sensors():
         sensors_registrar.register_sensors(pack_dir=cfg.CONF.register.pack)
     except Exception as e:
         LOG.warning('Failed to register sensors: %s', e, exc_info=True)
+    else:
+        LOG.info('Sensors registered.')
 
 
 def register_actions():
@@ -78,6 +80,7 @@ def register_actions():
             actions_registrar.register_actions(pack_dir=cfg.CONF.register.pack)
         except Exception as e:
             LOG.warning('Failed to register actions: %s', e, exc_info=True)
+    LOG.info('Actions registered.')
 
 
 def register_rules():
@@ -92,6 +95,7 @@ def register_rules():
         rules_registrar.register_rules(pack_dir=cfg.CONF.register.pack)
     except Exception as e:
         LOG.warning('Failed to register rules: %s', e, exc_info=True)
+    LOG.info('Rules registered.')
 
 
 def register_content():
@@ -115,14 +119,16 @@ def _setup(argv):
     config.parse_args()
 
     # 2. setup logging
-    log_level = logging.DEBUG if cfg.CONF.verbose else logging.ERROR
+    log_level = logging.DEBUG
     logging.basicConfig(format='%(asctime)s %(levelname)s [-] %(message)s', level=log_level)
 
     if not cfg.CONF.verbose:
+        # Note: We still want to print things at the following log levels: INFO, ERROR, CRITICAL
+        exclude_log_levels = [logging.AUDIT, logging.DEBUG]
         handlers = logging.getLoggerClass().manager.root.handlers
 
         for handler in handlers:
-            handler.addFilter(LogLevelFilter(log_levels=[logging.AUDIT]))
+            handler.addFilter(LogLevelFilter(log_levels=exclude_log_levels))
 
     # 3. all other setup which requires config to be parsed and logging to
     # be correctly setup.

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -19,6 +19,7 @@ import sys
 import st2common.config as config
 
 from oslo.config import cfg
+from st2common.log import LogLevelFilter
 from st2common.models.db import db_setup
 from st2common.models.db import db_teardown
 
@@ -113,9 +114,15 @@ def register_content():
 def _setup(argv):
     config.parse_args()
 
-    # 2. setup logging.
+    # 2. setup logging
     log_level = logging.DEBUG if cfg.CONF.verbose else logging.ERROR
     logging.basicConfig(format='%(asctime)s %(levelname)s [-] %(message)s', level=log_level)
+
+    if not cfg.CONF.verbose:
+        handlers = logging.getLoggerClass().manager.root.handlers
+
+        for handler in handlers:
+            handler.addFilter(LogLevelFilter(log_levels=[logging.AUDIT]))
 
     # 3. all other setup which requires config to be parsed and logging to
     # be correctly setup.

--- a/st2common/st2common/log.py
+++ b/st2common/st2common/log.py
@@ -25,6 +25,19 @@ import traceback
 
 from oslo.config import cfg
 
+__all__ = [
+    'getLogger',
+    'setup',
+
+    'FormatNamedFileHandler',
+    'ConfigurableSyslogHandler',
+
+    'ExclusionFilter',
+    'LogLevelFilter',
+
+    'LoggingStream'
+]
+
 logging.AUDIT = logging.CRITICAL + 10
 logging.addLevelName(logging.AUDIT, 'AUDIT')
 
@@ -77,6 +90,22 @@ class ExclusionFilter(object):
         return not exclude
 
 
+class LogLevelFilter(logging.Filter):
+    """
+    Filter which excludes log messages which match the provided log levels.
+    """
+
+    def __init__(self, log_levels):
+        self._log_levels = log_levels
+
+    def filter(self, record):
+        level = record.levelno
+        if level in self._log_levels:
+            return False
+
+        return True
+
+
 class LoggingStream(object):
 
     def __init__(self, name, level=logging.ERROR):
@@ -106,7 +135,8 @@ def _redirect_stderr():
 
 
 def setup(config_file, disable_existing_loggers=False):
-    """Configure logging from file.
+    """
+    Configure logging from file.
     """
     try:
         logging.config.fileConfig(config_file,


### PR DESCRIPTION
Pull request #1173 added "log level higher than" based filtering, but this didn't really help much since most of the "offending" messages contain log level `AUDIT` and `AUDIT` level > `ERROR` level which means those messages were still logged (and there were hundreds of them).

With this pull request, we now exclude messages with level `AUDIT` and `DEBUG` when not running in `verbose` mode.

In addition to that, we now print out everything under level INFO - we still want user to know that something is indeed happening.

Imo, the default output now looks a lot more sensible:

```
(virtualenv)vagrant@vagrant-ubuntu-trusty-64:/data/stanley$ ./st2common/bin/registercontent.py --config-file conf/st2.conf --register-all
2015-03-02 23:08:23,078 INFO [-] Connecting to database "st2" @ "0.0.0.0:27017" as user "None".
2015-03-02 23:08:23,131 INFO [-] =========================================================
2015-03-02 23:08:23,132 INFO [-] ############## Registering sensors ######################
2015-03-02 23:08:23,132 INFO [-] =========================================================
2015-03-02 23:08:29,067 INFO [-] Sensors registered.
2015-03-02 23:08:29,067 INFO [-] =========================================================
2015-03-02 23:08:29,068 INFO [-] ############## Registering actions ######################
2015-03-02 23:08:29,068 INFO [-] =========================================================
2015-03-02 23:08:35,282 INFO [-] Actions registered.
2015-03-02 23:08:35,283 INFO [-] =========================================================
2015-03-02 23:08:35,284 INFO [-] ############## Registering rules ######################
2015-03-02 23:08:35,284 INFO [-] =========================================================
2015-03-02 23:08:35,312 INFO [-] Registering rules from pack: default
2015-03-02 23:08:35,313 INFO [-] Registering rules from pack: twitter
2015-03-02 23:08:35,324 INFO [-] Registering rules from pack: examples
2015-03-02 23:08:35,355 ERROR [-] Failed registering rule from /opt/stackstorm/packs/examples/rules/sensu_action_runners_rule.json.
Traceback (most recent call last):
  File "/data/stanley/st2reactor/st2reactor/bootstrap/rulesregistrar.py", line 78, in _register_rules_from_pack
    rule_db = RuleAPI.to_model(rule_api)
  File "/data/stanley/st2common/st2common/models/api/rule.py", line 149, in to_model
    trigger_db = TriggerService.create_trigger_db_from_rule(rule)
  File "/data/stanley/st2common/st2common/services/triggers.py", line 169, in create_trigger_db_from_rule
    'triggertype. Cannot create trigger: %s.' % (trigger_dict))
TriggerDoesNotExistException: A simple trigger should have been created when registering triggertype. Cannot create trigger: {'type': u'sensu.event_handler', 'parameters': {}, 'pack': u'sensu'}.
2015-03-02 23:08:35,361 INFO [-] Rules registered.
```