### PR TITLE
[RFR] Avoid unnecessary timestamp

### DIFF
--- a/st2common/st2common/fields.py
+++ b/st2common/st2common/fields.py
@@ -70,7 +70,7 @@ class ComplexDateTimeField(LongField):
     def __get__(self, instance, owner):
         data = super(ComplexDateTimeField, self).__get__(instance, owner)
         if data is None:
-            return datetime.datetime.now()
+            return None
         if isinstance(data, datetime.datetime):
             return data
         return self._convert_from_db(data)

--- a/st2common/tests/unit/test_db_fields.py
+++ b/st2common/tests/unit/test_db_fields.py
@@ -16,6 +16,7 @@
 import time
 import datetime
 
+import mock
 import unittest2
 
 from st2common.fields import ComplexDateTimeField
@@ -52,3 +53,21 @@ class ComplexDateTimeFieldTestCase(unittest2.TestCase):
             actual_value = field._microseconds_since_epoch_to_datetime(data=value)
             expected_value = datetime_values[index]
             self.assertEqual(actual_value, expected_value)
+
+    @mock.patch('st2common.fields.LongField.__get__')
+    def test_get_(self, mock_get):
+        field = ComplexDateTimeField()
+
+        # No value set
+        mock_get.return_value = None
+        self.assertEqual(field.__get__(instance=None, owner=None), None)
+
+        # Already a datetime
+        mock_get.return_value = datetime.datetime.now()
+        self.assertEqual(field.__get__(instance=None, owner=None), mock_get.return_value)
+
+        # Microseconds
+        dt = datetime.datetime(2015, 1, 1, 15, 0, 0).replace(microsecond=500)
+        us = field._datetime_to_microseconds_since_epoch(value=dt)
+        mock_get.return_value = us
+        self.assertEqual(field.__get__(instance=None, owner=None), dt)


### PR DESCRIPTION
* By assigning datetime.now in case of None we end up assigning a value to end_timestamp