### PR TITLE
Fix doc version on master.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,6 +14,7 @@
 
 import sys
 import os
+import itertools
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -219,6 +220,16 @@ html_static_path = ['_static']
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'StackStormDoc'
 
+
+def previous_version(ver):
+    # XXX: on incrementing major version, minor version counter is lost!
+    major, minor = ver.split('.')
+    minor = int("".join(itertools.takewhile(str.isdigit, minor)))
+    return ".".join([major, str(minor - 1)])
+
+version_minus_1 = previous_version(version)
+version_minus_2 = previous_version(version_minus_1)
+
 # Variables to be used by templates
 html_context = {
     'github_repo': 'StackStorm/st2',
@@ -229,10 +240,8 @@ html_context = {
     'versions': [
         ('latest', 'http://docs.stackstorm.com/latest'),
         (version, 'http://docs.stackstorm.com/latest'),
-        # TODO(dzimine): get "prev stable version" from somewhere (?)
-        ('0.8', 'http://docs.stackstorm.com/'),
-        ('0.7', 'http://docs.stackstorm.com/0.7'),
-        ('0.6', 'http://docs.stackstorm.com/0.6.0')
+        (version_minus_1, 'http://docs.stackstorm.com/%s' % version_minus_1),
+        (version_minus_2, 'http://docs.stackstorm.com/%s' % version_minus_2),
     ],
     'current_version': version
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -61,10 +61,22 @@ copyright = u'2014, StackStorm Inc'
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-# The short X.Y version.
+# the __version__ is 0.8.0 or 0.9dev
+# the version is short 0.8 version, to refer docs.
 version = '.'.join(__version__.split('.')[:2])
 # The full version, including alpha/beta/rc tags.
 release = __version__
+
+
+def previous_version(ver):
+    # XXX: on incrementing major version, minor version counter is lost!
+    major, minor = ver.split('.')
+    minor = int("".join(itertools.takewhile(str.isdigit, minor)))
+    return ".".join([major, str(minor - 1)])
+
+# The short versions of two previous releases, e.g. 0.8 and 0.7
+version_minus_1 = previous_version(version)
+version_minus_2 = previous_version(version_minus_1)
 
 # extlink configurator sphinx.ext.extlinks
 extlinks = {
@@ -219,16 +231,6 @@ html_static_path = ['_static']
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'StackStormDoc'
-
-
-def previous_version(ver):
-    # XXX: on incrementing major version, minor version counter is lost!
-    major, minor = ver.split('.')
-    minor = int("".join(itertools.takewhile(str.isdigit, minor)))
-    return ".".join([major, str(minor - 1)])
-
-version_minus_1 = previous_version(version)
-version_minus_2 = previous_version(version_minus_1)
 
 # Variables to be used by templates
 html_context = {


### PR DESCRIPTION
Let's cross the t's on how we deploy and reference docs. 

## What we need:
* one docs/source/conf.py [1]
* Two build jobs.

## How it looks:
Picture worth 1000 words. 
![image](https://cloud.githubusercontent.com/assets/1294734/6461609/5aed017c-c156-11e4-8499-ec48c072122c.png)

## On Release:
* <stable_version> branch cut, __versioin__ updated to new <stable_version>, e.g. from 0.9dev to 0.9.
* On master, __version__ incremented to next dev version, e.g. from 0.9dev to 0.10dev.
* Create a new s3./<stable_version> bucket and 's3/<next_version>.dev buckets
* Cut a new <stable_version> branch, switch stable build to it.
* "Build Stable" keeps building s3/root and s3/<stable_version>. s3/root now contains new stable version.
* Increment version on master to <next_version>.dev, switch master build to it. 
* "Build Master" keeps building s3/latest and s3/<next_version>.dev s3/latest now contains new latest version.
* All previous docs are intact, and referencing each other properly. User can navigate to anything follow 'latest' and than down the version number. 

[1] The docs/source/conf.py will need to be manually updated on major version increment as there's no way to guess a minor number at the time.