### PR TITLE
Allow user to exclude result from /actionexecutions, new endpoints for retrieving execution result, stdout and stderr

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 v0.9dev - Under development
 ---------------------------
 
+* Allow user to exclude particular attributes from a response by passing
+  ``?exclude_attributes=result,trigger_instance`` query parameter to the ``/actionexecutions/``
+  and ``/actionexecutions/<execution id>/`` endpoint (new-feature)
+* Add new ``/actionexecutions/<id>/attribute/<attribute name>`` endpoint which allows user to
+  retrieve a value of a particular action execution attribute. (new-feature)
+
 v0.8 - March 2, 2015
 -----------------------
 

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -65,11 +65,13 @@ class ResourceController(rest.RestController):
     def get_one(self, id):
         return self._get_one(id)
 
-    def _get_all(self, exclude_fields, **kwargs):
+    def _get_all(self, exclude_fields=None, **kwargs):
         """
         :param exclude_fields: A list of object fields to exclude.
         :type exclude_fields: ``list``
         """
+        exclude_fields = exclude_fields or []
+
         # TODO: Why do we use comma delimited string, user can just specify
         # multiple values using ?sort=foo&sort=bar and we get a list back
         sort = kwargs.get('sort').split(',') if kwargs.get('sort') else []

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -65,7 +65,11 @@ class ResourceController(rest.RestController):
     def get_one(self, id):
         return self._get_one(id)
 
-    def _get_all(self, **kwargs):
+    def _get_all(self, exclude_fields, **kwargs):
+        """
+        :param exclude_fields: A list of object fields to exclude.
+        :type exclude_fields: ``list``
+        """
         # TODO: Why do we use comma delimited string, user can just specify
         # multiple values using ?sort=foo&sort=bar and we get a list back
         sort = kwargs.get('sort').split(',') if kwargs.get('sort') else []
@@ -94,6 +98,7 @@ class ResourceController(rest.RestController):
         # TODO: To protect us from DoS, we need to make max_limit mandatory
         offset = int(kwargs.pop('offset', 0))
         limit = kwargs.pop('limit', None)
+
         if limit and int(limit) > self.max_limit:
             limit = self.max_limit
         eop = offset + int(limit) if limit else None
@@ -114,7 +119,7 @@ class ResourceController(rest.RestController):
 
         LOG.info('GET all %s with filters=%s', pecan.request.path, filters)
 
-        instances = self.access.query(**filters)
+        instances = self.access.query(exclude_fields=exclude_fields, **filters)
 
         if limit:
             pecan.response.headers['X-Limit'] = str(limit)

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -129,12 +129,18 @@ class ResourceController(rest.RestController):
 
         return [self.model.from_model(instance) for instance in instances[offset:eop]]
 
-    def _get_one(self, id):
+    def _get_one(self, id, exclude_fields=None):
+        """
+        :param exclude_fields: A list of object fields to exclude.
+        :type exclude_fields: ``list``
+        """
+
         LOG.info('GET %s with id=%s', pecan.request.path, id)
 
         instance = None
+
         try:
-            instance = self.access.get(id=id)
+            instance = self.access.get(id=id, exclude_fields=exclude_fields)
         except ValidationError:
             instance = None  # Someone supplied a mongo non-comformant id.
 

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -165,14 +165,13 @@ class ActionExecutionsController(ActionExecutionsControllerMixin, ResourceContro
         return self._get_one(id=id)
 
     @jsexpose()
-    def get_all(self, **kw):
+    def get_all(self, exclude_result='0', **kw):
         """
             List all actionexecutions.
 
             Handles requests:
                 GET /actionexecutions/
         """
-        exclude_result = kw.get('exclude_result', '0')
         exclude_result = exclude_result == '1'
 
         if exclude_result:

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -75,7 +75,6 @@ class ActionExecutionsControllerMixin(RestController):
         return [self.model.from_model(descendant) for descendant in descendants]
 
 
-
 class ActionExecutionChildrenController(ActionExecutionsControllerMixin):
     @jsexpose(str)
     def get(self, id, **kwargs):

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -172,8 +172,16 @@ class ActionExecutionsController(ActionExecutionsControllerMixin, ResourceContro
             Handles requests:
                 GET /actionexecutions/
         """
+        exclude_result = kw.get('exclude_result', '0')
+        exclude_result = exclude_result == '1'
+
+        if exclude_result:
+            exclude_fields = ['result']
+        else:
+            exclude_fields = None
+
         LOG.info('GET all /actionexecutions/ with filters=%s', kw)
-        return self._get_action_executions(**kw)
+        return self._get_action_executions(exclude_fields=exclude_fields, **kw)
 
     @jsexpose(body=LiveActionAPI, status_code=http_client.CREATED)
     def post(self, execution):
@@ -218,8 +226,13 @@ class ActionExecutionsController(ActionExecutionsControllerMixin, ResourceContro
     def options(self, *args, **kw):
         return
 
-    def _get_action_executions(self, **kw):
+    def _get_action_executions(self, exclude_fields=None, **kw):
+        """
+        :param exclude_fields: A list of object fields to exclude.
+        :type exclude_fields: ``list``
+        """
         kw['limit'] = int(kw.get('limit', 100))
 
         LOG.debug('Retrieving all action liveactions with filters=%s', kw)
-        return super(ActionExecutionsController, self)._get_all(**kw)
+        return super(ActionExecutionsController, self)._get_all(exclude_fields=exclude_fields,
+                                                                **kw)

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -142,7 +142,6 @@ class MongoDBAccess(object):
             dt1 = isotime.parse(values[0])
             dt2 = isotime.parse(values[1])
 
-
             k__gte = '%s__gte' % k
             k__lte = '%s__lte' % k
             if dt1 < dt2:

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -126,11 +126,22 @@ class MongoDBAccess(object):
     @process_null_filter
     @process_datetime_ranges
     def query(self, *args, **kwargs):
+        # TODO: Fix kwargs abuse
         offset = int(kwargs.pop('offset', 0))
         limit = kwargs.pop('limit', None)
-        eop = offset + int(limit) if limit else None
         order_by = kwargs.pop('order_by', [])
-        return self.model.objects(**kwargs).order_by(*order_by)[offset:eop]
+        exclude_fields = kwargs.pop('exclude_fields', [])
+        eop = offset + int(limit) if limit else None
+
+        result = self.model.objects(**kwargs)
+
+        if exclude_fields:
+            result = result.exclude(*exclude_fields)
+
+        result = result.order_by(*order_by)
+        result = result[offset:eop]
+
+        return result
 
     def distinct(self, *args, **kwargs):
         field = kwargs.pop('field')

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -71,10 +71,16 @@ class MongoDBAccess(object):
     def get_by_id(self, value):
         return self.get(id=value, raise_exception=True)
 
-    def get(self, *args, **kwargs):
+    def get(self, exclude_fields=None, *args, **kwargs):
         raise_exception = kwargs.pop('raise_exception', False)
+
         instances = self.model.objects(**kwargs)
+
+        if exclude_fields:
+            instances = instances.exclude(*exclude_fields)
+
         instance = instances[0] if instances else None
+
         if not instance and raise_exception:
             raise ValueError('Unable to find the %s instance. %s' % (self.model.__name__, kwargs))
         return instance


### PR DESCRIPTION
## Changes

This pull request includes the following changes.

* Allow user to retrieve executions without the `result` attribute by passing `?exclude_result=1` query parameter to the `/actionexecutions/` endpoint.
* New endpoints:
  * `GET /actionexecutions/<id>/result` - retrieve execution result object
  * `GET /actionexecutions/<id>/stdout` - retrieve raw value of the execution result `stdout` attribute
  * `GET /actionexecutions/<id>/stderr` - retrieve raw value of the execution result `stderr` attribute

Other changes:

* Technical debt cleanup 
  * Removed awful pecan controller hackery and replaced it with nested controllers.
  * Tried to remove as much as the kwargs abuse and magical code as I could.

## Example responses

TBW

## Reasoning / Context

Currently, if an action generates a lot of output (`stdout`, `stderr`), retrieving all the actions executions will be very expensive. On top of that, JSON parsing of the response might fail due to the memory exhaustion if the object is too big (this happened in the ui when running in the browser).

This pull request solves this problem by allowing user to only retrieve action executions without the `result` attribute. In addition to that, it adds new endpoints for retrieving result, stdout and stderr attributes. This way, we can, for example inside the UI load the actions executions first and only request stdout and stderr when user hovers / clicks on the action execution (we can also pre-fetch some of that, etc., but that's a ui performance optimization).

This also goes along well with "result attribute needs to contain a result in a structured format" and the value of "stdout" and "stderr" is just an opaque (binary) data to us. I know this is currently not 100% true, but imo, we need to change and fix this in the near future (see https://github.com/StackStorm/st2/pull/1019#issuecomment-71622276).

This implementation is also very similar to the one I proposed for streaming (https://github.com/StackStorm/discussions/issues/27) and in the future, we can build streaming on top of those new endpoints.

Another thing related to the "stdout" and "stderr" being just an opaque binary data to us - currently we more or less use MongoDB for storing different meta data in it. This means storing potentially large "binary" / log structured data in it, in addition to the existing metadata is not the best fit (different access patterns, we don't need to query based on the value of this binary data, etc.)

In the future, we should (and probably will need to because of the performance reasons) look into storing this "binary" / log structured data in a different way / data store (e.g. even storing it in flat files might be better in some cases, but something like Cassandra is of course better than that).