### PR TITLE
Execution get improvements - automatically infer action type from the execution and format user-friendly output accordingly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ v0.8.1 - in development
   and ``/actionexecutions/<execution id>/`` endpoint (new-feature)
 * Add new ``/actionexecutions/<id>/attribute/<attribute name>`` endpoint which allows user to
   retrieve a value of a particular action execution attribute. (new-feature)
+* Update ``execution get`` CLI command so it automatically detects workflows and returns more
+  user-friendly output by default. (improvement)
 
 v0.8.0 - March 2, 2015
 ----------------------

--- a/st2client/st2client/commands/resource.py
+++ b/st2client/st2client/commands/resource.py
@@ -142,6 +142,14 @@ class ResourceCommand(commands.Command):
 
         return instance
 
+    def get_resource_by_id(self, id, **kwargs):
+        instance = self.get_resource_by_pk(pk=id, **kwargs)
+
+        if not instance:
+            message = ('Resource with id "%s" doesn\'t exist.' % (id))
+            raise ResourceNotFoundError(message)
+        return instance
+
     def get_resource_by_name(self, name, **kwargs):
         """
         Retrieve resource by name.


### PR DESCRIPTION
## Changes

1. We now automatically infer action type (workflow / non-workflow) when using `execution get` command. If execution refers to a workflow, `--tasks` option is implied and the output formatted accordingly. If user wants a raw (non formatted output), they can use the existing `-d` flag or a new `--raw` flag. For backward compatibility reasons, `--tasks` option wasn't removed and is still there.

2. Print an error if user uses `--tasks` option with a non-workflow action (tasks doesn't make sense there).

Example outputs - https://gist.github.com/Kami/6702083a1a05e0b47f19