### PR TITLE
Unify options and output for the following CLI commands: run, action execute, execution get, execution re-run

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ v0.8.1 - in development
   retrieve a value of a particular action execution attribute. (new-feature)
 * Update ``execution get`` CLI command so it automatically detects workflows and returns more
   user-friendly output by default. (improvement)
+* Update ``run``, ``action execute``, ``execution get`` and ``execution re-run`` CLI commands to
+  take the same options and return output in the same consistent format.
 
 v0.8.0 - March 2, 2015
 ----------------------

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -289,6 +289,7 @@ class ActionRunCommandMixin(object):
                 time.sleep(self.poll_interval)
                 if not args.json:
                     sys.stdout.write('.')
+                    sys.stdout.flush()
                 execution = action_exec_mgr.get_by_id(execution.id, **kwargs)
 
             sys.stdout.write('\n')

--- a/st2client/tests/fixtures/execution_get_default.txt
+++ b/st2client/tests/fixtures/execution_get_default.txt
@@ -1,3 +1,4 @@
+id: 547e19561e2e2417d3dde398
 status: succeeded
 result: 
 {

--- a/st2client/tests/unit/test_formatters.py
+++ b/st2client/tests/unit/test_formatters.py
@@ -96,7 +96,7 @@ class TestExecutionResultFormatter(unittest2.TestCase):
         self.assertEqual(content, FIXTURES['results']['execution_get_default.txt'])
 
     def test_execution_get_attributes(self):
-        argv = ['execution', 'get', EXECUTION['id'], '-a', 'status', 'end_timestamp']
+        argv = ['execution', 'get', EXECUTION['id'], '--attr', 'status', 'end_timestamp']
         content = self._get_execution(argv)
         self.assertEqual(content, FIXTURES['results']['execution_get_attributes.txt'])
 
@@ -104,7 +104,7 @@ class TestExecutionResultFormatter(unittest2.TestCase):
         argv = ['execution', 'get', EXECUTION['id'], '-j']
         content = self._get_execution(argv)
         self.assertEqual(json.loads(content),
-                         jsutil.get_kvps(EXECUTION, ['status', 'result']))
+                         jsutil.get_kvps(EXECUTION, ['id', 'status', 'result']))
 
     def test_execution_get_detail(self):
         argv = ['execution', 'get', EXECUTION['id'], '-d']


### PR DESCRIPTION
This pull request unifies options and output for ``run``, ``action execute``, ``execution get`` and ``execution re-run`` CLI commands (something we should have really done from the beginning - remember, consistency!)

CLI output means more than thousand of words so without further ado, see - https://gist.github.com/Kami/cf260d474efd3bb0069a

Note 1: We don't really have automated tests for the CLI so everyone should participate in testing those commands manually for now. We should of course also work on automated tests asap.

Note 2: I advise against merging this into 0.8.1 until everyone spent some time testing it, otherwise there is a pretty high chance of a regression.