### PR TITLE
Fix http runner json body parsing bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,8 @@ Docs: http://docs.stackstorm.com/0.8/
   user-friendly output by default. (improvement)
 * Update ``run``, ``action execute``, ``execution get`` and ``execution re-run`` CLI commands to
   take the same options and return output in the same consistent format.
+* Fix a bug with http runner not parsing JSON HTTP response body if the content-type header also
+  contained a charset. (bug-fix)
 
 v0.8.0 - March 2, 2015
 ----------------------

--- a/st2actions/st2actions/runners/httprunner.py
+++ b/st2actions/st2actions/runners/httprunner.py
@@ -237,6 +237,8 @@ class HTTPClient(object):
         if not content_type:
             return (body, parsed)
 
+        # The header can also contain charset which we simply discard
+        content_type = content_type.split(';')[0]
         parse_func = RESPONSE_BODY_PARSE_FUNCTIONS.get(content_type, None)
 
         if not parse_func:

--- a/st2actions/tests/unit/test_http_runner.py
+++ b/st2actions/tests/unit/test_http_runner.py
@@ -66,6 +66,16 @@ class HTTPRunnerTestCase(unittest2.TestCase):
         self.assertTrue(isinstance(result['body'], dict))
         self.assertEqual(result['body'], {'test1': 'val1'})
 
+        # JSON content-type with charset and JSON body
+        mock_result.text = '{"test1": "val1"}'
+        mock_result.headers = {'Content-Type': 'application/json; charset=UTF-8'}
+
+        mock_requests.request.return_value = mock_result
+        result = client.run()
+
+        self.assertTrue(isinstance(result['body'], dict))
+        self.assertEqual(result['body'], {'test1': 'val1'})
+
         # JSON content-type and invalid json body
         mock_result.text = 'not json'
         mock_result.headers = {'Content-Type': 'application/json'}


### PR DESCRIPTION
We didn't parse the body if the JSON content-type header also contained a charset.