### PR TITLE
Adjust column width

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,8 @@ Docs: http://docs.stackstorm.com/0.8/
   user-friendly output by default. (improvement)
 * Update ``run``, ``action execute``, ``execution get`` and ``execution re-run`` CLI commands to
   take the same options and return output in the same consistent format.
+* Indent workflow children properly in CLI (bug fix)
+* Make sure that wait indicator is visible in CLI on some systems where stdout is buffered.
 
 v0.8.0 - March 2, 2015
 ----------------------

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -289,6 +289,7 @@ class ActionRunCommandMixin(object):
                 time.sleep(self.poll_interval)
                 if not args.json:
                     sys.stdout.write('.')
+                    sys.stdout.flush()
                 execution = action_exec_mgr.get_by_id(execution.id, **kwargs)
 
             sys.stdout.write('\n')

--- a/st2client/st2client/formatters/table.py
+++ b/st2client/st2client/formatters/table.py
@@ -47,10 +47,13 @@ class MultiColumnTable(formatters.Formatter):
             lines, cols = get_terminal_size()
 
             if attributes[0] == 'id':
+                # consume iterator and save as entries so collection is accessible later.
+                entries = [e for e in entries]
                 # first column contains id, make sure it's not broken up
-                cols = (cols - MIN_ID_COL_WIDTH)
+                first_col_width = cls._get_required_column_width(values=[e.id for e in entries],
+                                                                 minimum_width=MIN_ID_COL_WIDTH)
+                cols = (cols - first_col_width)
                 col_width = int(math.floor((cols / len(attributes))))
-                first_col_width = MIN_ID_COL_WIDTH
             else:
                 col_width = int(math.floor((cols / len(attributes))))
                 first_col_width = col_width
@@ -141,6 +144,12 @@ class MultiColumnTable(formatters.Formatter):
 
         friendly_name = name.replace('_', ' ').replace('.', ' ').capitalize()
         return friendly_name
+
+    @staticmethod
+    def _get_required_column_width(values, minimum_width=0):
+        width = minimum_width
+        max_width = len(max(values, key=len))
+        return max_width if max_width > width else width
 
 
 class PropertyValueTable(formatters.Formatter):


### PR DESCRIPTION
With fix
```
$ st2 execution get 54f8d0010640fd2d7cd58ad7
id: 54f8d0010640fd2d7cd58ad7
action.ref: default.nested_wf
status: succeeded
start_timestamp: 2015-03-05T21:52:01.798774Z
end_timestamp: 2015-03-05T21:52:12.077042Z
+-----------------------------+-----------+------+-------------------+-------------------------------+
| id                          | status    | task | action            | start_timestamp               |
+-----------------------------+-----------+------+-------------------+-------------------------------+
| + 54f8d0010640fd2d918c93f5  | succeeded | 1    | default.simple_wf | Thu, 05 Mar 2015 21:52:01 UTC |
|    54f8d0020640fd2d918c93f8 | succeeded | 1    | core.local        | Thu, 05 Mar 2015 21:52:01 UTC |
|    54f8d0030640fd2d918c93fb | succeeded | 2    | core.local        | Thu, 05 Mar 2015 21:52:03 UTC |
|    54f8d0040640fd2d918c93fe | succeeded | 3    | core.local        | Thu, 05 Mar 2015 21:52:04 UTC |
|    54f8d0050640fd2d918c9401 | succeeded | 4    | core.local        | Thu, 05 Mar 2015 21:52:05 UTC |
| + 54f8d0070640fd2d918c9404  | succeeded | 2    | default.simple_wf | Thu, 05 Mar 2015 21:52:06 UTC |
|    54f8d0070640fd2d918c9407 | succeeded | 1    | core.local        | Thu, 05 Mar 2015 21:52:07 UTC |
|    54f8d0080640fd2d918c940a | succeeded | 2    | core.local        | Thu, 05 Mar 2015 21:52:08 UTC |
|    54f8d0090640fd2d918c940d | succeeded | 3    | core.local        | Thu, 05 Mar 2015 21:52:09 UTC |
|    54f8d00a0640fd2d918c9410 | succeeded | 4    | core.local        | Thu, 05 Mar 2015 21:52:10 UTC |
+-----------------------------+-----------+------+-------------------+-------------------------------+
```

without fix
```
$ st2 execution get 54f8d0010640fd2d7cd58ad7
id: 54f8d0010640fd2d7cd58ad7
action.ref: default.nested_wf
status: succeeded
start_timestamp: 2015-03-05T21:52:01.798774Z
end_timestamp: 2015-03-05T21:52:12.077042Z
+----------------------------+-----------+------+-------------------+-------------------------------+
| id                         | status    | task | action            | start_timestamp               |
+----------------------------+-----------+------+-------------------+-------------------------------+
| + 54f8d0010640fd2d918c93f5 | succeeded | 1    | default.simple_wf | Thu, 05 Mar 2015 21:52:01 UTC |
| 54f8d0020640fd2d918c93f8   | succeeded | 1    | core.local        | Thu, 05 Mar 2015 21:52:01 UTC |
| 54f8d0030640fd2d918c93fb   | succeeded | 2    | core.local        | Thu, 05 Mar 2015 21:52:03 UTC |
| 54f8d0040640fd2d918c93fe   | succeeded | 3    | core.local        | Thu, 05 Mar 2015 21:52:04 UTC |
| 54f8d0050640fd2d918c9401   | succeeded | 4    | core.local        | Thu, 05 Mar 2015 21:52:05 UTC |
| + 54f8d0070640fd2d918c9404 | succeeded | 2    | default.simple_wf | Thu, 05 Mar 2015 21:52:06 UTC |
| 54f8d0070640fd2d918c9407   | succeeded | 1    | core.local        | Thu, 05 Mar 2015 21:52:07 UTC |
| 54f8d0080640fd2d918c940a   | succeeded | 2    | core.local        | Thu, 05 Mar 2015 21:52:08 UTC |
| 54f8d0090640fd2d918c940d   | succeeded | 3    | core.local        | Thu, 05 Mar 2015 21:52:09 UTC |
| 54f8d00a0640fd2d918c9410   | succeeded | 4    | core.local        | Thu, 05 Mar 2015 21:52:10 UTC |
+----------------------------+-----------+------+-------------------+-------------------------------+
```

Since the column width was fixed to a static value originally shifting the table seemed to trim whitspace to try to fit within that space. Making it dynamic allows the indents to be shown correct.