### PR TITLE
Update mistral version to st2-0.8.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pyyaml
 requests
 setuptools==11.1
 six==1.9.0
-git+https://github.com/StackStorm/python-mistralclient.git@st2-0.8.0
+git+https://github.com/StackStorm/python-mistralclient.git@st2-0.8.1
 git+https://github.com/StackStorm/fabric.git@stanley-patched
 passlib>=1.6.2,<1.7
 lockfile>=0.10.2,<0.11

--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -17,7 +17,9 @@ INSTALL_ST2CLIENT=${INSTALL_ST2CLIENT:-1}
 INSTALL_WEBUI=${INSTALL_WEBUI:-1}
 
 # Determine which mistral version to use
-if version_ge $VER "0.8"; then
+if version_ge $VER "0.8.1"; then
+    MISTRAL_STABLE_BRANCH="st2-0.8.1"
+elif version_ge $VER "0.8"; then
     MISTRAL_STABLE_BRANCH="st2-0.8.0"
 else
     MISTRAL_STABLE_BRANCH="st2-0.5.1"


### PR DESCRIPTION
Update requirements.txt and st2_deploy.sh to use the st2-0.8.1 branch for mistral.