### PR TITLE
Update database connection settings for mistral

### DIFF
--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -191,9 +191,7 @@ touch $config
 cat <<mistral_config >$config
 [database]
 connection=mysql://mistral:StackStorm@localhost/mistral
-max_pool_size=100
-max_overflow=400
-pool_recycle=3600
+max_pool_size=50
 
 [pecan]
 auth_enable=false


### PR DESCRIPTION
Only max_pool_size is required. Not to be confused with MySQL's max connection, this setting limits each mistral process to 50 client connections.