### PR TITLE
Distinguish between invalid auth info and missing passwordless sudo remote runner error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Docs: http://docs.stackstorm.com/0.8/
 * Make sure that wait indicator is visible in CLI on some systems where stdout is buffered. (bug-fix)
 * Fix a bug with ``end_timestamp`` attribute on the ``LiveAction`` and ``ActionExecution`` model
   containing an invalid value if the action hasn't finished yet. (bug-fix)
+* Correctly report an invalid authentication information error in the remote runner. (bug-fix)
 
 v0.8.0 - March 2, 2015
 ----------------------

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 coverage
 pep8>=1.6.0,<1.7
-flake8
+flake8>=2.3.0,<2.4
 ipython
 mock>=1.0
 nose


### PR DESCRIPTION
As noted in https://github.com/StackStorm/st2/pull/1149#issuecomment-77754610 we return the same error message if we can't execute a command on the remote server either if we can't connect to the remote server due to an authentication issue (invalid username / password / key) or if a remote user can't execute sudo (e.g. sudo not available for that user or it requires a password)

This is of course wrong and confusing. This pull request fixes that.

As you can see, the way we check for that is really awful, but because of the way fabric works, there is no nicer way to do that. Only way to distinguish between those two errors is based on the traceback value.

See bellow for an example.

Invalid authentication information:

```
{
    "xxx": {
        "failed": true, 
        "traceback": "  File \"/data/stanley/st2common/st2common/models/system/action.py\", line 382, in _sudo\n    output = sudo(self.command, combine_stderr=False, pty=True, quiet=True)\n  File \"/data/stanley/virtualenv/local/lib/python2.7/site-packages/fabric/network.py\", line 639, in host_prompting_wrapper\n    return func(*args, **kwargs)\n  File \"/data/stanley/virtualenv/local/lib/python2.7/site-packages/fabric/operations.py\", line 1095, in sudo\n    stderr=stderr, timeout=timeout, shell_escape=shell_escape,\n  File \"/data/stanley/virtualenv/local/lib/python2.7/site-packages/fabric/operations.py\", line 911, in _run_command\n    stderr=stderr, timeout=timeout)\n  File \"/data/stanley/virtualenv/local/lib/python2.7/site-packages/fabric/operations.py\", line 795, in _execute\n    worker.raise_if_needed()\n  File \"/data/stanley/virtualenv/local/lib/python2.7/site-packages/fabric/thread_handling.py\", line 12, in wrapper\n    callable(*args, **kwargs)\n  File \"/data/stanley/virtualenv/local/lib/python2.7/site-packages/fabric/io.py\", line 35, in output_loop\n    OutputLooper(*args, **kwargs).loop()\n  File \"/data/stanley/virtualenv/local/lib/python2.7/site-packages/fabric/io.py\", line 168, in loop\n    self.prompt()\n  File \"/data/stanley/virtualenv/local/lib/python2.7/site-packages/fabric/io.py\", line 201, in prompt\n    prompt=\" \", no_colon=True, stream=self.stream\n  File \"/data/stanley/virtualenv/local/lib/python2.7/site-packages/fabric/network.py\", line 596, in prompt_for_password\n    handle_prompt_abort(\"a connection or sudo password\")\n  File \"/data/stanley/virtualenv/local/lib/python2.7/site-packages/fabric/utils.py\", line 154, in handle_prompt_abort\n    abort(reason % \"input would be ambiguous in parallel mode\")\n  File \"/data/stanley/virtualenv/local/lib/python2.7/site-packages/fabric/utils.py\", line 32, in abort\n    raise env.abort_exception(msg)\n", 
        "succeeded": false, 
        "error": "Passwordless sudo needs to be setup for user: stanley"
    }
```

Passwordless sudo not set up:

```
{
    "xxx": {
        "failed": true, 
        "traceback": "  File \"/data/stanley/st2common/st2common/models/system/action.py\", line 382, in _sudo\n    output = sudo(self.command, combine_stderr=False, pty=True, quiet=True)\n  File \"/data/stanley/virtualenv/local/lib/python2.7/site-packages/fabric/network.py\", line 639, in host_prompting_wrapper\n    return func(*args, **kwargs)\n  File \"/data/stanley/virtualenv/local/lib/python2.7/site-packages/fabric/operations.py\", line 1095, in sudo\n    stderr=stderr, timeout=timeout, shell_escape=shell_escape,\n  File \"/data/stanley/virtualenv/local/lib/python2.7/site-packages/fabric/operations.py\", line 909, in _run_command\n    channel=default_channel(), command=wrapped_command, pty=pty,\n  File \"/data/stanley/virtualenv/local/lib/python2.7/site-packages/fabric/state.py\", line 390, in default_channel\n    chan = _open_session()\n  File \"/data/stanley/virtualenv/local/lib/python2.7/site-packages/fabric/state.py\", line 382, in _open_session\n    return connections[env.host_string].get_transport().open_session()\n  File \"/data/stanley/virtualenv/local/lib/python2.7/site-packages/fabric/network.py\", line 151, in __getitem__\n    self.connect(key)\n  File \"/data/stanley/virtualenv/local/lib/python2.7/site-packages/fabric/network.py\", line 143, in connect\n    self[key] = connect(user, host, port, cache=self)\n  File \"/data/stanley/virtualenv/local/lib/python2.7/site-packages/fabric/network.py\", line 523, in connect\n    password = prompt_for_password(text)\n  File \"/data/stanley/virtualenv/local/lib/python2.7/site-packages/fabric/network.py\", line 596, in prompt_for_password\n    handle_prompt_abort(\"a connection or sudo password\")\n  File \"/data/stanley/virtualenv/local/lib/python2.7/site-packages/fabric/utils.py\", line 154, in handle_prompt_abort\n    abort(reason % \"input would be ambiguous in parallel mode\")\n  File \"/data/stanley/virtualenv/local/lib/python2.7/site-packages/fabric/utils.py\", line 32, in abort\n    raise env.abort_exception(msg)\n", 
        "succeeded": false, 
        "error": "Passwordless sudo needs to be setup for user: stanley"
    }
}
```

Note: This needs to be merged in 0.8.1 and master.