### PR TITLE
[RFR] Update action chain runner - allow users to access action parameters inside "publish" scope

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ Docs: http://docs.stackstorm.com/0.8/
 * Make sure that wait indicator is visible in CLI on some systems where stdout is buffered. (bug-fix)
 * Fix a bug with ``end_timestamp`` attribute on the ``LiveAction`` and ``ActionExecution`` model
   containing an invalid value if the action hasn't finished yet. (bug-fix)
+* Fix a bug in the action chain runner and make sure action parameters are also available for
+  substitution in the ``publish`` scope. (bug-fix)
 
 v0.8.0 - March 2, 2015
 ----------------------

--- a/contrib/examples/actions/chains/publish_data.yaml
+++ b/contrib/examples/actions/chains/publish_data.yaml
@@ -19,6 +19,9 @@ chain:
                 api: [ "v1/actions", "v1/triggers"]
                 webui: "webui/"
                 auth_port: "{{ port + 1 }}"
+                # This variable references "system_info_path" variable which is an action parameter
+                system_info: "{{ system_info_path }}"
+
         on-success: say_the_names
     -
         name: say_the_names

--- a/contrib/examples/actions/publish_data.meta.yaml
+++ b/contrib/examples/actions/publish_data.meta.yaml
@@ -5,3 +5,9 @@ description: "Example showing use of variables and data publishing in ActinoChai
 runner_type: "action-chain"
 enabled: true
 entry_point: "chains/publish_data.yaml"
+parameters:
+  system_info_path:
+      type: "string"
+      description: "Path where system info is available"
+      required: true
+      default: "/system-info"

--- a/docs/source/actionchain.rst
+++ b/docs/source/actionchain.rst
@@ -109,7 +109,7 @@ Details:
 Variables
 ~~~~~~~~~~~~~~~
 ActionChain offers the convinience of named variables. Global vars are set at the top of the definition with the ``var`` keyword.
-Tasks publish new varialbes with the ``publish`` keyword. Variables handy when you need to mash up
+Tasks publish new variables with the ``publish`` keyword. Variables handy when you need to mash up
 a reusable value from the input, globals, DataStore values, and results of multiple actions executions.
 All variables are referred with Jinja syntax.
 

--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -130,12 +130,15 @@ class ActionChainRunner(ActionRunner):
             raise runnerexceptions.ActionRunnerPreRunError(message)
 
     def run(self, action_parameters):
-
         result = {'tasks': []}  # holds final result we store
         context_result = {}  # holds result which is used for the template context purposes
         top_level_error = None  # stores a reference to a top level error
         fail = True
         action_node = None
+
+        # Add action parameters to the context result so they can be accessed
+        # inside "publish"
+        context_result['parameters'] = action_parameters
 
         try:
             action_node = self.chain_holder.get_next_node()

--- a/st2actions/tests/unit/test_actionchain.py
+++ b/st2actions/tests/unit/test_actionchain.py
@@ -476,11 +476,17 @@ class TestActionChainRunner(DbTestCase):
         chain_runner.action = ACTION_2
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
-        chain_runner.run({})
+
+        action_parameters = {'action_param_1': 'test value 1'}
+        chain_runner.run(action_parameters=action_parameters)
+
+        # We also assert that the action parameters are available in the
+        # "publish" scope
         self.assertNotEqual(chain_runner.chain_holder.actionchain, None)
         expected_value = {'inttype': 1,
                           'strtype': 'published',
-                          'booltype': True}
+                          'booltype': True,
+                          'published_action_param': action_parameters['action_param_1']}
         mock_args, _ = schedule.call_args
         self.assertEqual(mock_args[0].parameters, expected_value)
 

--- a/st2tests/st2tests/fixtures/generic/actionchains/chain_with_publish.json
+++ b/st2tests/st2tests/fixtures/generic/actionchains/chain_with_publish.json
@@ -15,7 +15,8 @@
             },
             "publish":
             {
-                "o1": "{{c1.raw_out}}"
+                "o1": "{{c1.raw_out}}",
+                "published_action_param": "{{ action_param_1 }}"
             },
             "on-success": "c2"
         },
@@ -26,7 +27,8 @@
             {
                 "inttype": "{{inttype}}",
                 "strtype": "{{o1}}",
-                "booltype": true
+                "booltype": true,
+                "published_action_param": "{{ published_action_param }}"
             }
         }
     ],

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 coverage
 pep8>=1.6.0,<1.7
-flake8
+flake8>=2.3.0,<2.4
 ipython
 mock>=1.0
 nose


### PR DESCRIPTION
Previously, user was unable to access action parameters inside the "publish" scope. This limitation made any things harder.

Here is an example of a work-flow where I use this functionality:

Metadata:

```yaml
 ...
  parameters:
    ip_address:
      type: "string"
      description: "IP address of a remote server to collect the informatiom from"
      required: true
```

Workflow:

```yaml
---
  chain:
    -
      name: "create_temporary_directory"
      ref: "core.remote_sudo"
      params:
        hosts: "{{ ip_address }}"
        cmd: "mktemp -d"
      publish:
        temp_dir: "{{ create_temporary_directory[parameters.ip_address].stdout }}"
      on-success: "retrieve_logged_users"

...
```

TODO:

- [x] Tests
- [x] Update changelog
- [x] Update docs