### PR TITLE
Throw a more user-friendly error is action chain runner fails to parse definition file, report top-level errors in the CLI better

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ Docs: http://docs.stackstorm.com/0.8/
 * Make sure that wait indicator is visible in CLI on some systems where stdout is buffered. (bug-fix)
 * Fix a bug with ``end_timestamp`` attribute on the ``LiveAction`` and ``ActionExecution`` model
   containing an invalid value if the action hasn't finished yet. (bug-fix)
+* Throw a more friendly error in the action chain runner if it fails to parse the action chain
+  definition file. (improvement)
 
 v0.8.0 - March 2, 2015
 ----------------------

--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -121,8 +121,16 @@ class ActionChainRunner(ActionRunner):
         chainspec_file = self.entry_point
         LOG.debug('Reading action chain from %s for action %s.', chainspec_file,
                   self.action)
+
         try:
             chainspec = self._meta_loader.load(chainspec_file)
+        except Exception as e:
+            message = ('Failed to parse action chain definition from "%s": %s' %
+                       (chainspec_file, str(e)))
+            LOG.exception('Failed to load action chain definition.')
+            raise runnerexceptions.ActionRunnerPreRunError(message)
+
+        try:
             self.chain_holder = ChainHolder(chainspec, self.action_name)
         except Exception as e:
             message = e.message or str(e)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 coverage
 pep8>=1.6.0,<1.7
-flake8
+flake8>=2.3.0,<2.4
 ipython
 mock>=1.0
 nose


### PR DESCRIPTION
This pull request includes two fixes.

1. Throw a more user-friendly error if action chain runner fails to parse definition file

Before:

```bash
+-----------------+--------------------------------------------------------------+
| Property        | Value                                                        |
+-----------------+--------------------------------------------------------------+
| id              | 54fc88440640fd0b9e5de1ed                                     |
| action.ref      | bsides.information_collection                                |
| context.user    | stanley                                                      |
| parameters      |                                                              |
| status          | failed                                                       |
| start_timestamp | Sun, 08 Mar 2015 17:35:00 UTC                                |
| end_timestamp   | Sun, 08 Mar 2015 17:35:00 UTC                                |
| result          | Message: while parsing a block mapping                       |
|                 |   in "/opt/stackstorm/packs/bsides/actions/workflows/informa |
|                 | tion_collection.yaml", line 65, column 6                     |
|                 | expected <block end>, but found '<block mapping start>'      |
|                 |   in "/opt/stackstorm/packs/bsides/actions/workflows/informa |
|                 | tion_collection.yaml", line 66, column 7                     |
|                 | Traceback:   File                                            |
|                 | "/data/stanley/st2actions/st2actions/container/base.py",     |
|                 | line 100, in _do_run                                         |
|                 |     runner.pre_run()                                         |
|                 |   File "/data/stanley/st2actions/st2actions/runners/actionch |
|                 | ainrunner.py", line 130, in pre_run                          |
|                 |     raise runnerexceptions.ActionRunnerPreRunError(message)  |
|                 |                                                              |
+-----------------+--------------------------------------------------------------+
```

After

```bash
+-----------------+--------------------------------------------------------------+
| Property        | Value                                                        |
+-----------------+--------------------------------------------------------------+
| id              | 54fc8fce0640fd0b9e5de207                                     |
| action.ref      | bsides.information_collection                                |
| context.user    | stanley                                                      |
| parameters      |                                                              |
| status          | failed                                                       |
| start_timestamp | Sun, 08 Mar 2015 18:07:10 UTC                                |
| end_timestamp   | Sun, 08 Mar 2015 18:07:10 UTC                                |
| result          | Message: Failed to parse action chain definition from "/opt/ |
|                 | stackstorm/packs/bsides/actions/workflows/information_collec |
|                 | tion.yaml": while parsing a block mapping                    |
|                 |   in "/opt/stackstorm/packs/bsides/actions/workflows/informa |
|                 | tion_collection.yaml", line 71, column 6                     |
|                 | expected <block end>, but found '<block mapping start>'      |
|                 |   in "/opt/stackstorm/packs/bsides/actions/workflows/informa |
|                 | tion_collection.yaml", line 72, column 7                     |
|                 | Traceback:   File                                            |
|                 | "/data/stanley/st2actions/st2actions/container/base.py",     |
|                 | line 100, in _do_run                                         |
|                 |     runner.pre_run()                                         |
|                 |   File "/data/stanley/st2actions/st2actions/runners/actionch |
|                 | ainrunner.py", line 131, in pre_run                          |
|                 |     raise runnerexceptions.ActionRunnerPreRunError(message)  |
|                 |                                                              |
+-----------------+--------------------------------------------------------------+
```

2. Include `result` attribute printing an output for a workflow action in the CLI which contains no sub-tasks (e.g. action chain failed with a global error)

Before:

```bash
(virtualenv)vagrant@vagrant-ubuntu-trusty-64:/data/stanley$ python ./st2client/st2client/shell.py run bsides.information_collection
id: 54fc9e930640fd0b9e5de20d
action.ref: bsides.information_collection
status: failed
start_timestamp: 2015-03-08T19:10:11.901052Z
end_timestamp: 2015-03-08T19:10:12.024862Z
No matching items found
```

After:

```bash
(virtualenv)vagrant@vagrant-ubuntu-trusty-64:/data/stanley$ python ./st2client/st2client/shell.py run bsides.information_collection
id: 54fc9fbc0640fd0b9e5de215
action.ref: bsides.information_collection
status: failed
start_timestamp: 2015-03-08T19:15:08.742826Z
end_timestamp: 2015-03-08T19:15:08.878913Z
result: Message: Failed to parse action chain definition from "/opt/stackstorm/packs/bsides/actions/workflows/information_collection.yaml": while parsing a block mapping
  in "/opt/stackstorm/packs/bsides/actions/workflows/information_collection.yaml", line 71, column 6
expected <block end>, but found '<block mapping start>'
  in "/opt/stackstorm/packs/bsides/actions/workflows/information_collection.yaml", line 72, column 7
Traceback:   File "/data/stanley/st2actions/st2actions/container/base.py", line 100, in _do_run
    runner.pre_run()
  File "/data/stanley/st2actions/st2actions/runners/actionchainrunner.py", line 131, in pre_run
    raise runnerexceptions.ActionRunnerPreRunError(message)
```