### PR TITLE
Fix dependency conflicts

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 coverage
 pep8>=1.6.0,<1.7
-flake8
+flake8>=2.3.0,<2.4
 ipython
 mock>=1.0
 nose


### PR DESCRIPTION
We want to use flake8 < 2.4 since newer version of flake8 pips pep8 (finally!) to a different / incompatible version we do.

This fixes build failures.