### PR TITLE
Add a script for visualizing action chain workflows

### DIFF
--- a/tools/visualize_action_chain.py
+++ b/tools/visualize_action_chain.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Script which creates graphviz visualization of an action-chain workflow.
+"""
+
+import os
+import argparse
+
+try:
+    from graphviz import Digraph
+except ImportError:
+    msg = ('Missing "graphviz" dependency. You can install it using pip: \n'
+           'pip install graphviz')
+    raise ImportError(msg)
+
+from st2common.content.loader import MetaLoader
+from st2actions.runners.actionchainrunner import ChainHolder
+
+
+def main(metadata_path, print_source=False):
+    metadata_path = os.path.abspath(metadata_path)
+    metadata_dir = os.path.dirname(metadata_path)
+
+    meta_loader = MetaLoader()
+    data = meta_loader.load(metadata_path)
+
+    action_name = data['name']
+    entry_point = data['entry_point']
+
+    workflow_metadata_path = os.path.join(metadata_dir, entry_point)
+    chainspec = meta_loader.load(workflow_metadata_path)
+
+    chain_holder = ChainHolder(chainspec, 'workflow')
+
+    graph_label = '%s action-chain workflow visualization' % (action_name)
+
+    graph_attr = {
+        'rankdir': 'TD',
+        'labelloc': 't',
+        'fontsize': '15',
+        'label': graph_label
+    }
+    node_attr = {}
+    dot = Digraph(comment='Action chain work-flow visualization',
+                  node_attr=node_attr, graph_attr=graph_attr)
+    #  dot.body.extend(['rankdir=TD', 'size="10,5"'])
+
+    # Add all nodes
+    node = chain_holder.get_next_node()
+    while node:
+        dot.node(node.name, node.name)
+        node = chain_holder.get_next_node(curr_node_name=node.name)
+
+    # Add connections
+    node = chain_holder.get_next_node()
+    while node:
+        previous_node = node
+        success_node = chain_holder.get_next_node(curr_node_name=node.name,
+                                                  condition='on-success')
+        failure_node = chain_holder.get_next_node(curr_node_name=node.name,
+                                                  condition='on-failure')
+
+        if not success_node:
+            # We are done
+            break
+
+        # Add success node
+        dot.edge(previous_node.name, success_node.name, constraint='true',
+                 color='green', label='on success')
+
+        # Add failure node (if any)
+        if failure_node:
+            dot.edge(previous_node.name, failure_node.name, constraint='true',
+                     color='red', label='on failure')
+
+        node = success_node
+        if not node:
+            break
+
+    if print_source:
+        print(dot.source)
+
+    dot.format = 'png'
+    dot.render(action_name)
+
+    graph_path = os.path.join(os.getcwd(), '%s.png' % (action_name))
+    print('Graph saved at %s' % (graph_path))
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Action chain visualization')
+    parser.add_argument('--metadata-path', action='store', required=True,
+                        help='Path to the workflow action metadata file')
+    parser.add_argument('--print-source', action='store_true', default=False,
+                        help='Print graphviz source code to the stdout')
+    args = parser.parse_args()
+
+    main(metadata_path=args.metadata_path, print_source=args.print_source)


### PR DESCRIPTION
I had this script laying around locally for a while now. I decided to clean it up a bit and add it to the repo.

I believe james created a similar thing so it might make sense to combine those scripts together.

Generated visualization file looks like this ([here](https://github.com/Kami/stackstorm-bsides-demo/blob/master/packs/bsides/actions/workflows/information_collection.yaml) is a work-flow used as an input):

![information_collection](https://cloud.githubusercontent.com/assets/125088/6547711/7d889082-c5e0-11e4-8188-a2eeffa1fde1.png)
