### PR TITLE
Execution tracking

### DIFF
--- a/st2actions/st2actions/worker.py
+++ b/st2actions/st2actions/worker.py
@@ -99,13 +99,14 @@ class Worker(ConsumerMixin):
         try:
             result = self.container.dispatch(liveaction_db)
             LOG.debug('Runner dispatch produced result: %s', result)
+            if not result:
+                raise ActionRunnerException('Failed to execute action.')
         except Exception:
             liveaction_db = update_liveaction_status(status=LIVEACTION_STATUS_FAILED,
                                                      liveaction_id=liveaction_db.id)
             raise
 
-        if not result:
-            raise ActionRunnerException('Failed to execute action.')
+
 
         return result
 

--- a/st2actions/st2actions/worker.py
+++ b/st2actions/st2actions/worker.py
@@ -91,11 +91,15 @@ class Worker(ConsumerMixin):
         liveaction_db = update_liveaction_status(status=LIVEACTION_STATUS_RUNNING,
                                                  runner_info=runner_info,
                                                  liveaction_id=liveaction_db.id)
-        executions.update_execution(liveaction_db)
+        action_execution_db = executions.update_execution(liveaction_db)
+
         # Launch action
         LOG.audit('Launching action execution.',
-                  extra={'liveaction': liveaction_db.to_serializable_dict()})
-
+                  extra={'action_execution_id': str(action_execution_db.id),
+                         'liveaction': liveaction_db.to_serializable_dict()})
+        # the extra field will not be shown in non-audit logs so temporarily log at info.
+        LOG.info('{~}action_execution: %s / {~}live_action: %s',
+                 action_execution_db.id, liveaction_db.id)
         try:
             result = self.container.dispatch(liveaction_db)
             LOG.debug('Runner dispatch produced result: %s', result)

--- a/st2actions/st2actions/worker.py
+++ b/st2actions/st2actions/worker.py
@@ -26,6 +26,7 @@ from st2common.constants.action import LIVEACTION_STATUS_FAILED
 from st2common.exceptions.actionrunner import ActionRunnerException
 from st2common.services import executions
 from st2common.transport import liveaction, publishers
+from st2common.util import system_info
 from st2common.util.action_db import (get_liveaction_by_id, update_liveaction_status)
 from st2common.util.greenpooldispatch import BufferedDispatcher
 
@@ -83,9 +84,12 @@ class Worker(ConsumerMixin):
             LOG.exception('Failed to find liveaction %s in the database.',
                           liveaction.id)
             raise
+        # stamp liveaction with process_info
+        runner_info = system_info.get_process_info()
 
         # Update liveaction status to "running"
         liveaction_db = update_liveaction_status(status=LIVEACTION_STATUS_RUNNING,
+                                                 runner_info=runner_info,
                                                  liveaction_id=liveaction_db.id)
         executions.update_execution(liveaction_db)
         # Launch action

--- a/st2actions/st2actions/worker.py
+++ b/st2actions/st2actions/worker.py
@@ -106,8 +106,6 @@ class Worker(ConsumerMixin):
                                                      liveaction_id=liveaction_db.id)
             raise
 
-
-
         return result
 
 

--- a/st2actions/tests/unit/test_worker.py
+++ b/st2actions/tests/unit/test_worker.py
@@ -28,7 +28,7 @@ from st2common.models.system.common import ResourceReference
 from st2common.persistence import action
 from st2common.services import executions
 from st2common.transport.publishers import PoolPublisher
-from st2common.util.action_db import (get_liveaction_by_id, update_liveaction_status)
+from st2common.util.action_db import get_liveaction_by_id
 from st2tests.base import DbTestCase
 
 

--- a/st2actions/tests/unit/test_worker.py
+++ b/st2actions/tests/unit/test_worker.py
@@ -1,0 +1,112 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import st2tests.config as tests_config
+tests_config.parse_args()
+
+import datetime
+import mock
+
+from st2actions import worker
+from st2actions.container.base import RunnerContainer
+from st2common.constants import action as action_constants
+from st2common.exceptions.actionrunner import ActionRunnerException
+from st2common.models.db.action import LiveActionDB
+from st2common.models.system.common import ResourceReference
+from st2common.persistence import action
+from st2common.services import executions
+from st2common.transport.publishers import PoolPublisher
+from st2common.util.action_db import (get_liveaction_by_id, update_liveaction_status)
+from st2tests.base import DbTestCase
+
+
+@mock.patch.object(PoolPublisher, 'publish', mock.MagicMock())
+@mock.patch.object(executions, 'update_execution', mock.MagicMock())
+class TestWorker(DbTestCase):
+
+    @mock.patch.object(RunnerContainer, 'dispatch', mock.MagicMock())
+    def test_basic_execution_success(self):
+        testworker = worker.Worker(None)
+        live_action_db = self._get_execution_db_model(
+            status=action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        testworker.execute_action(live_action_db)
+        updated_live_action_db = get_liveaction_by_id(live_action_db.id)
+        self.assertEqual(updated_live_action_db.status,
+                         action_constants.LIVEACTION_STATUS_SUCCEEDED)
+
+    @mock.patch.object(RunnerContainer, 'dispatch', mock.MagicMock())
+    def test_basic_execution_fail(self):
+        testworker = worker.Worker(None)
+        live_action_db = self._get_execution_db_model(
+            status=action_constants.LIVEACTION_STATUS_FAILED)
+        testworker.execute_action(live_action_db)
+        updated_live_action_db = get_liveaction_by_id(live_action_db.id)
+        self.assertEqual(updated_live_action_db.status,
+                         action_constants.LIVEACTION_STATUS_FAILED)
+
+    @mock.patch.object(RunnerContainer, 'dispatch', mock.MagicMock(return_value=None))
+    def test_basic_execution_no_result(self):
+        testworker = worker.Worker(None)
+        live_action_db = self._get_execution_db_model()
+        try:
+            testworker.execute_action(live_action_db)
+            self.assertTrue(False, 'Exception expected.')
+        except ActionRunnerException:
+            self.assertTrue(True)
+        updated_live_action_db = get_liveaction_by_id(live_action_db.id)
+        self.assertEqual(updated_live_action_db.status,
+                         action_constants.LIVEACTION_STATUS_FAILED)
+
+    @mock.patch.object(RunnerContainer, 'dispatch', mock.MagicMock(side_effect=Exception('Boom!')))
+    def test_failed_execution_handling(self):
+        testworker = worker.Worker(None)
+        live_action_db = self._get_execution_db_model()
+        try:
+            testworker.execute_action(live_action_db)
+            self.assertTrue(False, 'Exception expected.')
+        except Exception:
+            self.assertTrue(True)
+        updated_live_action_db = get_liveaction_by_id(live_action_db.id)
+        self.assertEqual(updated_live_action_db.status,
+                         action_constants.LIVEACTION_STATUS_FAILED)
+
+    @mock.patch.object(RunnerContainer, 'dispatch', mock.MagicMock(return_value='dont_care'))
+    def test_succeeded_execution_handling(self):
+        testworker = worker.Worker(None)
+        live_action_db = self._get_execution_db_model()
+        testworker.execute_action(live_action_db)
+        updated_live_action_db = get_liveaction_by_id(live_action_db.id)
+        self.assertEqual(updated_live_action_db.status,
+                         action_constants.LIVEACTION_STATUS_RUNNING)
+
+    @mock.patch.object(RunnerContainer, 'dispatch', mock.MagicMock(return_value='dont_care'))
+    def test_runner_info(self):
+        testworker = worker.Worker(None)
+        live_action_db = self._get_execution_db_model()
+        testworker.execute_action(live_action_db)
+        updated_live_action_db = get_liveaction_by_id(live_action_db.id)
+        self.assertEqual(updated_live_action_db.status,
+                         action_constants.LIVEACTION_STATUS_RUNNING)
+        self.assertTrue(updated_live_action_db.runner_info, 'runner_info should have value.')
+
+    def _get_execution_db_model(self, status=action_constants.LIVEACTION_STATUS_SCHEDULED):
+        live_action_db = LiveActionDB()
+        live_action_db.status = status
+        live_action_db.start_timestamp = datetime.datetime.utcnow()
+        live_action_db.action = ResourceReference(
+            name='test_action',
+            pack='test_pack').ref
+        live_action_db.parameters = None
+        return action.LiveAction.add_or_update(live_action_db, publish=False)

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -267,6 +267,9 @@ class LiveActionAPI(BaseAPI):
             },
             "callback": {
                 "type": "object"
+            },
+            "runner_info": {
+                "type": "object"
             }
         },
         "additionalProperties": False

--- a/st2common/st2common/models/db/action.py
+++ b/st2common/st2common/models/db/action.py
@@ -131,6 +131,9 @@ class LiveActionDB(stormbase.StormFoundationDB):
     callback = me.DictField(
         default={},
         help_text='Callback information for the on completion of action execution.')
+    runner_info = me.DictField(
+        default={},
+        help_text='Reference to the runner that executed this liveaction.')
 
     meta = {
         'indexes': ['-start_timestamp', 'action']

--- a/st2common/st2common/services/executions.py
+++ b/st2common/st2common/services/executions.py
@@ -44,7 +44,7 @@ from st2common import log as logging
 
 LOG = logging.getLogger(__name__)
 
-SKIPPED = ['id', 'callback', 'action']
+SKIPPED = ['id', 'callback', 'action', 'runner_info']
 
 
 def _decompose_liveaction(liveaction_db):

--- a/st2common/st2common/util/action_db.py
+++ b/st2common/st2common/util/action_db.py
@@ -125,7 +125,7 @@ def get_liveaction_by_id(liveaction_id):
 
 
 def update_liveaction_status(status=None, result=None, context=None, end_timestamp=None,
-                             liveaction_id=None, liveaction_db=None):
+                             liveaction_id=None, runner_info=None, liveaction_db=None):
     """
         Update the status of the specified LiveAction to the value provided in
         new_status.
@@ -157,6 +157,9 @@ def update_liveaction_status(status=None, result=None, context=None, end_timesta
 
     if end_timestamp:
         liveaction_db.end_timestamp = end_timestamp
+
+    if runner_info:
+        liveaction_db.runner_info = runner_info
 
     liveaction_db = LiveAction.add_or_update(liveaction_db)
 

--- a/st2common/st2common/util/system_info.py
+++ b/st2common/st2common/util/system_info.py
@@ -1,0 +1,25 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import socket
+
+
+def get_process_info():
+    runner_info = {
+        'hostname': socket.gethostname(),
+        'pid': os.getpid()
+    }
+    return runner_info

--- a/st2common/tests/unit/test_system_info.py
+++ b/st2common/tests/unit/test_system_info.py
@@ -1,0 +1,29 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+import socket
+import unittest
+
+from st2common.util import system_info
+
+
+class TestLogger(unittest.TestCase):
+
+    def test_process_info(self):
+        process_info = system_info.get_process_info()
+        self.assertEqual(process_info['hostname'], socket.gethostname())
+        self.assertEqual(process_info['pid'], os.getpid())


### PR DESCRIPTION
* runner_info is now included in the execution result. This helps track the runner an action executed on.

```
 st2 execution get 54ff64460640fd0be8d21030 -dj
{
    "action": {
        "ref": "core.local"
    },
    "context": {
        "user": "stanley"
    },
    "end_timestamp": "2015-03-10T21:38:14.788372Z",
    "id": "54ff64460640fd0be8d21030",
    "liveaction": {
        "action": "core.local",
        "callback": {},
        "id": "54ff64460640fd0be8d2102f",
        "runner_info": {
            "hostname": "vagrant-ubuntu-trusty-64",
            "pid": 3071
        }
    },
    "parameters": {
        "cmd": "date"
    },
    "result": {
        "failed": false,
        "return_code": 0,
        "stderr": "",
        "stdout": "Tue Mar 10 21:38:14 UTC 2015\n",
        "succeeded": true
    },
    "start_timestamp": "2015-03-10T21:38:14.411289Z",
    "status": "succeeded"
}
```

* Add some logs to help track start of an ActionExecution.
* Added some more tests.