### PR TITLE
Fix stdout reporting and interception for python runner actions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,13 @@
 Changelog
 =========
 
-v0.8.1 - March 6, 2015
+In development
+---------------
+
+* Fix a bug with python-runner actions sometimes not correctly reporting the action's ``stdout``.
+  (bug-fix)
+
+v0.8.1 - March 10, 2015
 -----------------------
 
 Docs: http://docs.stackstorm.com/0.8/

--- a/st2actions/st2actions/runners/pythonrunner.py
+++ b/st2actions/st2actions/runners/pythonrunner.py
@@ -158,7 +158,7 @@ class PythonRunner(ActionRunner):
             split = stdout.split(ACTION_OUTPUT_RESULT_DELIMITER)
             assert len(split) == 3
             result = split[1].strip()
-            stdout = split[0] = split[2]
+            stdout = split[0] + split[2]
         else:
             result = None
 

--- a/st2actions/tests/unit/test_pythonrunner.py
+++ b/st2actions/tests/unit/test_pythonrunner.py
@@ -20,6 +20,7 @@ import mock
 
 from st2actions.runners import pythonrunner
 from st2actions.container import service
+from st2common.constants.action import ACTION_OUTPUT_RESULT_DELIMITER
 from st2common.constants.action import LIVEACTION_STATUS_SUCCEEDED, LIVEACTION_STATUS_FAILED
 from st2common.constants.pack import SYSTEM_PACK_NAME
 import st2tests.base as tests_base
@@ -110,6 +111,52 @@ class PythonRunnerTestCase(TestCase):
                 self.assertTrue(actual_env[key] != value)
             else:
                 self.assertEqual(actual_env[key], value)
+
+    @mock.patch('st2actions.runners.pythonrunner.subprocess.Popen')
+    def test_stdout_interception_and_parsing(self, mock_popen):
+        values = {'delimiter': ACTION_OUTPUT_RESULT_DELIMITER}
+
+        # No output to stdout and no result (implicit None)
+        mock_stdout = '%(delimiter)sNone%(delimiter)s' % values
+        mock_stderr = 'foo stderr'
+        mock_process = mock.Mock()
+        mock_process.communicate.return_value = (mock_stdout, mock_stderr)
+        mock_process.returncode = 0
+        mock_popen.return_value = mock_process
+
+        runner = pythonrunner.get_runner()
+        runner.action = self._get_mock_action_obj()
+        runner.runner_parameters = {}
+        runner.entry_point = PACAL_ROW_ACTION_PATH
+        runner.container_service = service.RunnerContainerService()
+        runner.pre_run()
+        (_, output, _) = runner.run({'row_index': 4})
+
+        self.assertEqual(output['stdout'], '')
+        self.assertEqual(output['stderr'], mock_stderr)
+        self.assertEqual(output['result'], 'None')
+        self.assertEqual(output['exit_code'], 0)
+
+        # Output to stdout and no result (implicit None)
+        mock_stdout = 'pre result%(delimiter)sNone%(delimiter)spost result' % values
+        mock_stderr = 'foo stderr'
+        mock_process = mock.Mock()
+        mock_process.communicate.return_value = (mock_stdout, mock_stderr)
+        mock_process.returncode = 0
+        mock_popen.return_value = mock_process
+
+        runner = pythonrunner.get_runner()
+        runner.action = self._get_mock_action_obj()
+        runner.runner_parameters = {}
+        runner.entry_point = PACAL_ROW_ACTION_PATH
+        runner.container_service = service.RunnerContainerService()
+        runner.pre_run()
+        (_, output, _) = runner.run({'row_index': 4})
+
+        self.assertEqual(output['stdout'], 'pre resultpost result')
+        self.assertEqual(output['stderr'], mock_stderr)
+        self.assertEqual(output['result'], 'None')
+        self.assertEqual(output['exit_code'], 0)
 
     def _get_mock_action_obj(self):
         """


### PR DESCRIPTION
Note: If we plan to get 0.8.2 out today, we should also include this bug fix.