### PR TITLE
Fix a bug in the run-remote-script runner

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+In development
+--------------
+
+* Fix a bug in the ``run-remote-script`` runner - the runner ignored environment variables and
+  authentication settings which were supplied to the action as parameters. (bug-fix)
+
 v0.8.1 - March 6, 2015
 -----------------------
 

--- a/st2common/st2common/models/system/action.py
+++ b/st2common/st2common/models/system/action.py
@@ -499,7 +499,7 @@ class FabricRemoteScriptAction(RemoteScriptAction, FabricRemoteAction):
             output_put = self._put(self.script_local_path_abs,
                                    mirror_local_mode=False, mode=0744)
             if output_put.get('failed'):
-                return output_putric_settings
+                return output_put
 
             # Copy libs.
             if self.script_local_libs_path_abs and os.path.exists(self.script_local_libs_path_abs):

--- a/st2common/tests/unit/test_action_system_models.py
+++ b/st2common/tests/unit/test_action_system_models.py
@@ -92,7 +92,7 @@ class FabricRemoteActionTestCase(unittest2.TestCase):
         self.assertEqual(remote_action.get_on_behalf_user(), 'stan')
         fabric_task = remote_action.get_fabric_task()
         self.assertTrue(fabric_task is not None)
-        self.assertTrue(fabric_task.wrapped == remote_action._run_script)
+        self.assertTrue(fabric_task.wrapped == remote_action._run_script_with_settings)
 
     def test_remote_dir_script_action_method_default(self):
         remote_action = FabricRemoteScriptAction('foo', 'foo-id', '/tmp/st2.py',


### PR DESCRIPTION
The runner ignored environment variables and authentication settings supplied as parameters (it always just used default global authentication settings).

We should also get this into the 0.8.2 release.