### PR TITLE
Report a more user-friendly error if action-chain task references an invalid action ; report a top level error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+in development
+--------------
+
+* Report a more user-friendly error if an action-chain task references an invalid or inexistent
+  action. (improvement)
+
 v0.8.2 - March 10, 2015
 -----------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ in development
 --------------
 
 * Report a more user-friendly error if an action-chain task references an invalid or inexistent
-  action. (improvement)
+  action. Also treat invalid / inexistent action as a top-level action-chain error. (improvement)
 
 v0.8.2 - March 10, 2015
 -----------------------

--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -190,7 +190,7 @@ class ActionChainRunner(ActionRunner):
             action_db = action_db_util.get_action_by_ref(ref=action_ref)
 
             if not action_db:
-                error = ('Failed to run task "%s". Action with ref "%s" doesn\'t exist.' %
+                error = ('Failed to run task "%s". Action with reference "%s" doesn\'t exist.' %
                          (action_node.name, action_ref))
                 LOG.exception(error)
 

--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -184,6 +184,23 @@ class ActionChainRunner(ActionRunner):
                 }
                 break
 
+            # Verify that the referenced task exists - note we do another lookup in cast_params -
+            # refactor and improve that
+            action_ref = action_node.ref
+            action_db = action_db_util.get_action_by_ref(ref=action_ref)
+
+            if not action_db:
+                error = ('Failed to run action "%s". Action with ref "%s" doesn\'t exist.' %
+                         (action_node.name, action_ref))
+                LOG.exception(error)
+
+                fail = True
+                top_level_error = {
+                    'error': error,
+                    'traceback': error
+                }
+                break
+
             try:
                 liveaction = ActionChainRunner._run_action(
                     action_node=action_node, parent_execution_id=self.liveaction_id,

--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -190,7 +190,7 @@ class ActionChainRunner(ActionRunner):
             action_db = action_db_util.get_action_by_ref(ref=action_ref)
 
             if not action_db:
-                error = ('Failed to run action "%s". Action with ref "%s" doesn\'t exist.' %
+                error = ('Failed to run task "%s". Action with ref "%s" doesn\'t exist.' %
                          (action_node.name, action_ref))
                 LOG.exception(error)
 

--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -184,8 +184,8 @@ class ActionChainRunner(ActionRunner):
                 }
                 break
 
-            # Verify that the referenced task exists - note we do another lookup in cast_params -
-            # refactor and improve that
+            # Verify that the referenced action exists
+            # TODO: We do another lookup in cast_param, refactor to reduce number of lookups
             action_ref = action_node.ref
             action_db = action_db_util.get_action_by_ref(ref=action_ref)
 

--- a/st2actions/tests/unit/test_actionchain.py
+++ b/st2actions/tests/unit/test_actionchain.py
@@ -507,7 +507,8 @@ class TestActionChainRunner(DbTestCase):
         action_parameters = {}
         status, output, _ = chain_runner.run(action_parameters=action_parameters)
 
-        expected_error = 'Failed to run action "c1". Action with ref "wolfpack.a2" doesn\'t exist.'
+        expected_error = ('Failed to run task "c1". Action with reference "wolfpack.a2" '
+                          'doesn\'t exist.')
         self.assertEqual(status, LIVEACTION_STATUS_FAILED)
         self.assertTrue(expected_error in output['error'])
         self.assertTrue(expected_error in output['traceback'])

--- a/st2tests/st2tests/fixtures/generic/actionchains/chain_with_invalid_action.json
+++ b/st2tests/st2tests/fixtures/generic/actionchains/chain_with_invalid_action.json
@@ -1,0 +1,30 @@
+{
+    "vars": {
+        "strtype": "{{system.a}}",
+        "inttype": 1
+    },
+    "chain": [
+        {
+            "name": "c1",
+            "ref": "wolfpack.a2",
+            "params":
+            {
+                "inttype": "{{inttype}}",
+                "strtype": "{{strtype}}",
+                "booltype": true
+            },
+            "on-success": "c2"
+        },
+        {
+            "name": "c2",
+            "ref": "wolfpack.doesntexist",
+            "params":
+            {
+                "inttype": "{{inttype}}",
+                "strtype": "{{o1}}",
+                "booltype": true
+            }
+        }
+    ],
+    "default": "c1"
+}


### PR DESCRIPTION
Previously this was also considered as a task error, but now it bubbles up as a top-level action-chain error. This way it's consistent with the way we handle other action-chain errors (/cc @manasdk).

Before:

```bash
id: 550068e70640fd6ed48e7513
action.ref: bsides.notify_administrators
status: failed
start_timestamp: 2015-03-11T16:10:15.662128Z
end_timestamp: 2015-03-11T16:10:15.836978Z
result: 
{
    "tasks": [
        {
            "name": "retrieve_archive_cdn_url_from_datastore", 
            "workflow": null, 
            "created_at": "2015-03-11T16:10:15.826694+00:00", 
            "updated_at": "2015-03-11T16:10:15.835345+00:00", 
            "state": "failed", 
            "result": {
                "traceback": "Traceback (most recent call last):
  File "/data/stanley/st2actions/st2actions/runners/actionchainrunner.py", line 190, in run
    params=resolved_params)
  File "/data/stanley/st2actions/st2actions/runners/actionchainrunner.py", line 299, in _run_action
    params=params)
  File "/data/stanley/st2common/st2common/models/utils/action_param_utils.py", line 86, in cast_params
    action_parameters_schema = action_db.parameters
AttributeError: 'NoneType' object has no attribute 'parameters'
", 
                "error": "Task "retrieve_archive_cdn_url_from_datastore" failed: 'NoneType' object has no attribute 'parameters'"
            }, 
            "id": "retrieve_archive_cdn_url_from_datastore", 
            "execution_id": null
        }
    ]
}```


After:


```bash
id: 55006f930640fd6ed48e7523
action.ref: bsides.notify_administrators
status: failed
start_timestamp: 2015-03-11T16:38:43.853572Z
end_timestamp: 2015-03-11T16:38:45.051046Z
result: 
{
    "tasks": [], 
    "traceback": null, 
    "error": "Failed to run task "retrieve_archive_cdn_url_from_datastore". Action with reference "st2.kv.getxx" doesn't exist."
}
```