### PR TITLE
Throw a more user-friendly error if action chain definition contains invalid type

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+in development
+--------------
+
+* Report a more user-friendly error if an action-chain definition contains an invalid type.
+  (improvements)
+
 v0.8.2 - March 10, 2015
 -----------------------
 

--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -123,7 +123,8 @@ class ActionChainRunner(ActionRunner):
                   self.action)
 
         try:
-            chainspec = self._meta_loader.load(chainspec_file)
+            chainspec = self._meta_loader.load(file_path=chainspec_file,
+                                               expected_type=dict)
         except Exception as e:
             message = ('Failed to parse action chain definition from "%s": %s' %
                        (chainspec_file, str(e)))

--- a/st2common/st2common/content/loader.py
+++ b/st2common/st2common/content/loader.py
@@ -142,7 +142,7 @@ class ContentPackLoader(object):
 
 
 class MetaLoader(object):
-    def load(self, file_path):
+    def load(self, file_path, expected_type=None):
         """
         Loads content from file_path if file_path's extension
         is one of allowed ones (See ALLOWED_EXTS).
@@ -153,6 +153,9 @@ class MetaLoader(object):
         :param file_path: Absolute path to the file to load content from.
         :type file_path: ``str``
 
+        :param expected_type: Expected type for the loaded and parsed content (optional).
+        :type expected_type: ``object``
+
         :rtype: ``dict``
         """
         file_name, file_ext = os.path.splitext(file_path)
@@ -161,7 +164,14 @@ class MetaLoader(object):
             raise Exception('Unsupported meta type %s, file %s. Allowed: %s' %
                             (file_ext, file_path, ALLOWED_EXTS))
 
-        return self._load(PARSER_FUNCS[file_ext], file_path)
+        result = self._load(PARSER_FUNCS[file_ext], file_path)
+
+        if expected_type and not isinstance(result, expected_type):
+            actual_type = type(result).__name__
+            error = 'Expected "%s", got "%s"' % (expected_type.__name__, actual_type)
+            raise ValueError(error)
+
+        return result
 
     def _load(self, parser_func, file_path):
         with open(file_path, 'r') as fd:


### PR DESCRIPTION
Previously you got a really confusing error if workflow definition contained an invalid type.

We have similar problem in other places and that's a stop gap solution for now. Ideally, we would also leverage json / yaml schema for that.

Before:

```bash
id: 5500776b0640fd6ed48e7529
action.ref: bsides.notify_administrators
status: failed
start_timestamp: 2015-03-11T17:12:11.202264Z
end_timestamp: 2015-03-11T17:12:11.821527Z
result: Message: type object argument after ** must be a mapping, not list
Traceback:   File "/data/stanley/st2actions/st2actions/container/base.py", line 100, in _do_run
    runner.pre_run()
  File "/data/stanley/st2actions/st2actions/runners/actionchainrunner.py", line 138, in pre_run
    raise runnerexceptions.ActionRunnerPreRunError(message)

(virtualenv)vagrant@vagrant-ubuntu-trusty-64:/data/stanley$ python ./st2client/st2client/shell.py run bsides.notify_administrators
```

After:

```bash
id: 550079880640fd7427fb607d
action.ref: bsides.notify_administrators
status: failed
start_timestamp: 2015-03-11T17:21:12.310825Z
end_timestamp: 2015-03-11T17:21:12.636661Z
result: Message: Failed to parse action chain definition from "/opt/stackstorm/packs/bsides/actions/workflows/notify_administrators.yaml": Expected "dict", got "list"
Traceback:   File "/data/stanley/st2actions/st2actions/container/base.py", line 100, in _do_run
    runner.pre_run()
  File "/data/stanley/st2actions/st2actions/runners/actionchainrunner.py", line 132, in pre_run
    raise runnerexceptions.ActionRunnerPreRunError(message)
```
