### PR TITLE
Throw if a run-remote-script action is missing an entry_point parameter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ in development
   action. Also treat invalid / inexistent action as a top-level action-chain error. (improvement)
 * Report a more user-friendly error if an action-chain definition contains an invalid type.
   (improvements)
+* Don't allow ``run-remote-script`` actions without an ``entry_point`` attribute - throw an
+  exception when running an action. (improvement)
 
 v0.8.2 - March 10, 2015
 -----------------------

--- a/st2actions/st2actions/runners/fabricrunner.py
+++ b/st2actions/st2actions/runners/fabricrunner.py
@@ -114,9 +114,16 @@ class FabricRunner(ActionRunner, ShellRunnerMixin):
 
     def run(self, action_parameters):
         LOG.debug('    action_parameters = %s', action_parameters)
-        remote_action = self._get_fabric_remote_action(action_parameters) \
-            if self.entry_point is None or len(self.entry_point) < 1 \
-            else self._get_fabric_remote_script_action(action_parameters)
+
+        runner_type = self.action.runner_type['name']
+
+        if runner_type == 'run-remote-script':
+            remote_action = self._get_fabric_remote_script_action(action_parameters)
+        elif runner_type == 'run-remote':
+            remote_action = self._get_fabric_remote_action(action_parameters)
+        else:
+            raise Exception('Invalid runner: %s' % (runner_type))
+
         LOG.debug('Will execute remote_action : %s.', str(remote_action))
         result = self._run(remote_action)
         LOG.debug('Executed remote_action : %s. Result is : %s.', remote_action, result)

--- a/st2actions/st2actions/runners/fabricrunner.py
+++ b/st2actions/st2actions/runners/fabricrunner.py
@@ -162,6 +162,13 @@ class FabricRunner(ActionRunner, ShellRunnerMixin):
                                   cwd=self._cwd)
 
     def _get_fabric_remote_script_action(self, action_parameters):
+        # remote script actions without entry_point don't make sense, user probably wanted to use
+        # "run-remote" action
+        if not self.entry_point:
+            msg = ('Action "%s" is missing entry_point attribute. Perhaps wanted to use '
+                   '"run-remote" runner?')
+            raise Exception(msg % (self.action_name))
+
         script_local_path_abs = self.entry_point
         pos_args, named_args = self._get_script_args(action_parameters)
         named_args = self._transform_named_args(named_args)


### PR DESCRIPTION
run-remote-script actions without entry_point don't make sense.

This would save @jfryman and I at least 30 minutes :P

Before:

```bash
id: 5500c10d0640fd0d53077989
status: failed
result: 
{
    "xxx": {
        "failed": true, 
        "traceback": "  File "/data/stanley/st2common/st2common/models/system/action.py", line 395, in _sudo
    'return_code': output.return_code,
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/fabric/network.py", line 639, in host_prompting_wrapper
    return func(*args, **kwargs)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/fabric/operations.py", line 1095, in sudo
    stderr=stderr, timeout=timeout, shell_escape=shell_escape,
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/fabric/operations.py", line 895, in _run_command
    _prefix_commands(_prefix_env_vars(command), 'remote'),
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/fabric/operations.py", line 704, in _prefix_env_vars
    return shell_env_str + command
", 
        "succeeded": false, 
        "error": "coercing to Unicode: need string or buffer, NoneType found"
    }
}
```

After:

```bash
id: 5500c48a0640fd0d530779b6
status: failed
result: Message: Action "apt_get_update" is missing entry_point attribute. Perhaps wanted to use "run-remote" runner?
Traceback:   File "/data/stanley/st2actions/st2actions/container/base.py", line 103, in _do_run
    (status, result, context) = runner.run(action_params)
  File "/data/stanley/st2actions/st2actions/runners/fabricrunner.py", line 121, in run
    remote_action = self._get_fabric_remote_script_action(action_parameters)
  File "/data/stanley/st2actions/st2actions/runners/fabricrunner.py", line 170, in _get_fabric_remote_script_action
    raise Exception(msg % (self.action_name))
```