### PR TITLE
RFR: Raise ResourceNotFound execption if action not found

### DIFF
--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -463,6 +463,8 @@ class ActionRunCommandMixin(object):
             if action_ref_or_id:
                 try:
                     action = action_mgr.get_by_ref_or_id(args.ref_or_id, **kwargs)
+                    if not action:
+                        raise resource.ResourceNotFoundError('Action %s not found', args.ref_or_id)
                     runner_mgr = self.app.client.managers['RunnerType']
                     runner = runner_mgr.get_by_name(action.runner_type, **kwargs)
                     parameters, required, optional, _ = self._get_params_types(runner,
@@ -485,7 +487,8 @@ class ActionRunCommandMixin(object):
                         [self._print_param(name, parameters.get(name))
                             for name in optional]
                 except resource.ResourceNotFoundError:
-                    print('Action "%s" is not found.' % args.ref_or_id)
+                    print(('Action "%s" is not found. ' % args.ref_or_id) +
+                          'Do "st2 action list" to see list of available actions.')
                 except Exception as e:
                     print('ERROR: Unable to print help for action "%s". %s' %
                           (args.ref_or_id, e))


### PR DESCRIPTION
Before

```
root@vm-st2-03:/home/stackstorm/repo/maestro/packs/citeis-test/actions# st2 run cities-test.run_load_modified -h
ERROR: Unable to print help for action "cities-test.run_load_modified". 'NoneType' object has no attribute 'runner_type'
root@vm-st2-03:/home/stackstorm/repo/maestro/packs/citeis-test/actions#
```
After

```
(virtualenv)~/st2 git:STORM-1174/fix_bug_in_cli_run_help ❯❯❯ st2 run core.locale -h
Action "core.locale" is not found. Do "st2 action list" to see list of available actions.
(virtualenv)~/st2 git:STORM-1174/fix_bug_in_cli_run_help ❯❯❯
```