### PR TITLE
[RFC] [WIP] Structured logging with contexual information

### DIFF
--- a/docs/source/install/config.rst
+++ b/docs/source/install/config.rst
@@ -72,7 +72,9 @@ By default, the logs can be found in ``/var/log/st2``.
 
 * With the standard logging setup you will notice files like ``st2*.log`` and ``st2*.audit.log`` in the log folder.
 
-* Per component logging configuration can be found in ``/etc/st2*/logging.conf``. If you desire to change location of the log files the paths can be modified in these files.
+* Per component logging configuration can be found in ``/etc/st2*/logging.conf``. Those files use `Python logging configuration format
+  <https://docs.python.org/2/library/logging.config.html#configuration-file-format>`_. If you desire to change location of the log files,
+  the paths and other settings can be modified in these files.
 
 * To configure logging with syslog, grab the configuration and follow instructions at :github_contrib:`st2contrib/extra/syslog </extra/syslog>`
 

--- a/st2actions/conf/logging.conf
+++ b/st2actions/conf/logging.conf
@@ -5,7 +5,7 @@ keys=root
 keys=consoleHandler, fileHandler, auditHandler
 
 [formatters]
-keys=verboseFormatter, simpleFormatter, jsonFormatter
+keys=simpleConsoleFormatter, verboseConsoleFormatter, gelfFormatter, jsonFormatter
 
 [logger_root]
 level=INFO
@@ -14,13 +14,13 @@ handlers=consoleHandler, fileHandler, auditHandler
 [handler_consoleHandler]
 class=StreamHandler
 level=INFO
-formatter=simpleFormatter
+formatter=simpleConsoleFormatter
 args=(sys.stdout,)
 
 [handler_fileHandler]
 class=st2common.log.FormatNamedFileHandler
 level=INFO
-formatter=verboseFormatter
+formatter=verboseConsoleFormatter
 args=('logs/st2actionrunner.{pid}.log',)
 
 [handler_auditHandler]
@@ -29,14 +29,20 @@ level=AUDIT
 formatter=jsonFormatter
 args=('logs/st2actionrunner.{pid}.audit.log',)
 
-[formatter_verboseFormatter]
+[formatter_simpleConsoleFormatter]
+class=st2common.logging.formatters.ConsoleLogFormatter
+format=%(asctime)s %(levelname)s [-] %(message)s
+datefmt=
+
+[formatter_verboseConsoleFormatter]
+class=st2common.logging.formatters.ConsoleLogFormatter
 format=%(asctime)s %(thread)s %(levelname)s %(module)s [-] %(message)s
 datefmt=
+
+[formatter_gelfFormatter]
+class=st2common.logging.formatters.GelfLogFormatter
+format=%(message)s
 
 [formatter_jsonFormatter]
 class=pythonjsonlogger.jsonlogger.JsonFormatter
 format=%(asctime) %(thread) %(levelname) %(module) %(message)
-
-[formatter_simpleFormatter]
-format=%(asctime)s %(levelname)s [-] %(message)s
-datefmt=

--- a/st2actions/conf/logging.resultstracker.conf
+++ b/st2actions/conf/logging.resultstracker.conf
@@ -5,7 +5,7 @@ keys=root
 keys=consoleHandler, fileHandler, auditHandler
 
 [formatters]
-keys=verboseFormatter, simpleFormatter
+keys=simpleConsoleFormatter, verboseConsoleFormatter, gelfFormatter
 
 [logger_root]
 level=DEBUG
@@ -14,25 +14,31 @@ handlers=consoleHandler, fileHandler, auditHandler
 [handler_consoleHandler]
 class=StreamHandler
 level=INFO
-formatter=simpleFormatter
+formatter=simpleConsoleFormatter
 args=(sys.stdout,)
 
 [handler_fileHandler]
 class=st2common.log.FormatNamedFileHandler
 level=DEBUG
-formatter=verboseFormatter
+formatter=verboseConsoleFormatter
 args=('logs/st2resultstracker.log',)
 
 [handler_auditHandler]
 class=st2common.log.FormatNamedFileHandler
 level=AUDIT
-formatter=verboseFormatter
+formatter=gelfFormatter
 args=('logs/st2resultstracker.audit.log',)
 
-[formatter_verboseFormatter]
+[formatter_simpleConsoleFormatter]
+class=st2common.logging.formatters.ConsoleLogFormatter
+format=%(asctime)s %(levelname)s [-] %(message)s
+datefmt=
+
+[formatter_verboseConsoleFormatter]
+class=st2common.logging.formatters.ConsoleLogFormatter
 format=%(asctime)s %(thread)s %(levelname)s %(module)s [-] %(message)s
 datefmt=
 
-[formatter_simpleFormatter]
-format=%(asctime)s %(levelname)s [-] %(message)s
-datefmt=
+[formatter_gelfFormatter]
+class=st2common.logging.formatters.GelfLogFormatter
+format=%(message)s

--- a/st2api/conf/logging.conf
+++ b/st2api/conf/logging.conf
@@ -5,7 +5,7 @@ keys=root
 keys=consoleHandler, fileHandler, auditHandler
 
 [formatters]
-keys=verboseFormatter, simpleFormatter
+keys=simpleConsoleFormatter, verboseConsoleFormatter, gelfFormatter
 
 [logger_root]
 level=DEBUG
@@ -14,25 +14,31 @@ handlers=consoleHandler, fileHandler, auditHandler
 [handler_consoleHandler]
 class=StreamHandler
 level=DEBUG
-formatter=simpleFormatter
+formatter=simpleConsoleFormatter
 args=(sys.stdout,)
 
 [handler_fileHandler]
 class=FileHandler
 level=DEBUG
-formatter=verboseFormatter
+formatter=verboseConsoleFormatter
 args=("logs/st2api.log",)
 
 [handler_auditHandler]
 class=FileHandler
 level=AUDIT
-formatter=verboseFormatter
+formatter=gelfFormatter
 args=("logs/st2api.audit.log",)
 
-[formatter_verboseFormatter]
+[formatter_simpleConsoleFormatter]
+class=st2common.logging.formatters.ConsoleLogFormatter
+format=%(asctime)s %(levelname)s [-] %(message)s
+datefmt=
+
+[formatter_verboseConsoleFormatter]
+class=st2common.logging.formatters.ConsoleLogFormatter
 format=%(asctime)s %(thread)s %(levelname)s %(module)s [-] %(message)s
 datefmt=
 
-[formatter_simpleFormatter]
-format=%(asctime)s %(levelname)s [-] %(message)s
-datefmt=
+[formatter_gelfFormatter]
+class=st2common.logging.formatters.GelfLogFormatter
+format=%(message)s

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -61,7 +61,7 @@ class ResourceController(rest.RestController):
     def get_all(self, **kwargs):
         return self._get_all(**kwargs)
 
-    @jsexpose(str)
+    @jsexpose(arg_types=[str])
     def get_one(self, id):
         return self._get_one(id)
 
@@ -189,7 +189,7 @@ class ResourceController(rest.RestController):
 class ContentPackResourceControler(ResourceController):
     include_reference = False
 
-    @jsexpose(str)
+    @jsexpose(arg_types=[str])
     def get_one(self, ref_or_id):
         return self._get_one(ref_or_id)
 

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -172,7 +172,6 @@ class ActionExecutionsController(ActionExecutionsControllerMixin, ResourceContro
 
         exclude_fields = self._validate_exclude_fields(exclude_fields=exclude_fields)
 
-        LOG.info('GET all /actionexecutions/ with filters=%s', kw)
         return self._get_action_executions(exclude_fields=exclude_fields, **kw)
 
     @jsexpose(str)

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -114,7 +114,7 @@ class ActionExecutionAttributeController(ActionExecutionsControllerMixin):
 
         Handles requests:
 
-            GET /actionexecutions/<id>/attribute/<value>
+            GET /actionexecutions/<id>/<attribute>/<value>
 
         :rtype: ``dict``
         """

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -96,7 +96,7 @@ class ActionExecutionsControllerMixin(RestController):
 
 
 class ActionExecutionChildrenController(ActionExecutionsControllerMixin):
-    @jsexpose(str)
+    @jsexpose(arg_types=[str])
     def get(self, id, **kwargs):
         """
         Retrieve children for the provided action execution.
@@ -174,7 +174,7 @@ class ActionExecutionsController(ActionExecutionsControllerMixin, ResourceContro
 
         return self._get_action_executions(exclude_fields=exclude_fields, **kw)
 
-    @jsexpose(str)
+    @jsexpose(arg_types=[str])
     def get_one(self, id, exclude_attributes=None, **kwargs):
         """
         Retrieve a single execution.
@@ -194,7 +194,7 @@ class ActionExecutionsController(ActionExecutionsControllerMixin, ResourceContro
 
         return self._get_one(id=id, exclude_fields=exclude_fields)
 
-    @jsexpose(body=LiveActionAPI, status_code=http_client.CREATED)
+    @jsexpose(body_cls=LiveActionAPI, status_code=http_client.CREATED)
     def post(self, execution):
         try:
             # Initialize execution context if it does not exist.

--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -77,9 +77,6 @@ class ActionsController(resource.ContentPackResourceControler):
             Handles requests:
                 POST /actions/
         """
-
-        LOG.info('POST /actions/ with action data=%s', action)
-
         if not hasattr(action, 'enabled'):
             LOG.debug('POST /actions/ incoming action data has enabled field unset. '
                       'Defaulting enabled to True.')
@@ -119,7 +116,6 @@ class ActionsController(resource.ContentPackResourceControler):
         LOG.audit('Action created. Action=%s', action_db)
         action_api = ActionAPI.from_model(action_db)
 
-        LOG.debug('POST /actions/ client_result=%s', action_api)
         return action_api
 
     @jsexpose(str, body=ActionAPI)
@@ -171,9 +167,6 @@ class ActionsController(resource.ContentPackResourceControler):
                 DELETE /actions/1
                 DELETE /actions/mypack.myaction
         """
-
-        LOG.info('DELETE /actions/ with ref_or_id="%s"', action_ref_or_id)
-
         try:
             action_db = self._get_by_ref_or_id(ref_or_id=action_ref_or_id)
         except Exception as e:
@@ -200,6 +193,4 @@ class ActionsController(resource.ContentPackResourceControler):
             return
 
         LOG.audit('Action deleted. Action=%s', action_db)
-        LOG.info('DELETE /actions/ with ref_or_id="%s" completed',
-                 action_ref_or_id)
         return None

--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -69,7 +69,7 @@ class ActionsController(resource.ContentPackResourceControler):
             LOG.error(msg)
             abort(http_client.CONFLICT, msg)
 
-    @jsexpose(body=ActionAPI, status_code=http_client.CREATED)
+    @jsexpose(body_cls=ActionAPI, status_code=http_client.CREATED)
     def post(self, action):
         """
             Create a new action.
@@ -118,7 +118,7 @@ class ActionsController(resource.ContentPackResourceControler):
 
         return action_api
 
-    @jsexpose(str, body=ActionAPI)
+    @jsexpose(arg_types=[str], body_cls=ActionAPI)
     def put(self, action_ref_or_id, action):
         try:
             action_db = self._get_by_ref_or_id(ref_or_id=action_ref_or_id)
@@ -157,7 +157,7 @@ class ActionsController(resource.ContentPackResourceControler):
 
         return action_api
 
-    @jsexpose(str, status_code=http_client.NO_CONTENT)
+    @jsexpose(arg_types=[str], status_code=http_client.NO_CONTENT)
     def delete(self, action_ref_or_id):
         """
             Delete an action.

--- a/st2api/st2api/controllers/v1/actionviews.py
+++ b/st2api/st2api/controllers/v1/actionviews.py
@@ -64,7 +64,7 @@ class LookupUtils(object):
 
 class ParametersViewController(RestController):
 
-    @jsexpose(str, status_code=http_client.OK)
+    @jsexpose(arg_types=[str], status_code=http_client.OK)
     def get_one(self, action_id):
         return self._get_one(action_id)
 
@@ -97,7 +97,7 @@ class OverviewController(resource.ContentPackResourceControler):
 
     include_reference = True
 
-    @jsexpose(str)
+    @jsexpose(arg_types=[str])
     def get_one(self, ref_or_id):
         """
             List action by id.
@@ -108,7 +108,7 @@ class OverviewController(resource.ContentPackResourceControler):
         action_api = super(OverviewController, self)._get_one(ref_or_id)
         return self._transform_action_api(action_api)
 
-    @jsexpose(str)
+    @jsexpose(arg_types=[str])
     def get_all(self, **kwargs):
         """
             List all actions.
@@ -136,7 +136,7 @@ class EntryPointController(resource.ContentPackResourceControler):
     def get_all(self, **kwargs):
         return abort(404)
 
-    @jsexpose(str, content_type='text/plain', status_code=http_client.OK)
+    @jsexpose(arg_types=[str], content_type='text/plain', status_code=http_client.OK)
     def get_one(self, ref_or_id):
         """
             Outputs the file associated with action entry_point

--- a/st2api/st2api/controllers/v1/datastore.py
+++ b/st2api/st2api/controllers/v1/datastore.py
@@ -35,7 +35,7 @@ class KeyValuePairController(RestController):
 
     # TODO: Port to use ResourceController
 
-    @jsexpose(str)
+    @jsexpose(arg_types=[str])
     def get_one(self, name):
         """
             List key by name.
@@ -58,7 +58,7 @@ class KeyValuePairController(RestController):
 
         return kvp_api
 
-    @jsexpose(str)
+    @jsexpose(arg_types=[str])
     def get_all(self, **kw):
         """
             List all keys.
@@ -78,7 +78,7 @@ class KeyValuePairController(RestController):
 
         return kvps
 
-    @jsexpose(str, body=KeyValuePairAPI)
+    @jsexpose(arg_types=[str], body_cls=KeyValuePairAPI)
     def put(self, name, kvp):
         """
         Create a new entry or update an existing one.
@@ -106,7 +106,7 @@ class KeyValuePairController(RestController):
 
         return kvp_api
 
-    @jsexpose(str, status_code=http_client.NO_CONTENT)
+    @jsexpose(arg_types=[str], status_code=http_client.NO_CONTENT)
     def delete(self, name):
         """
             Delete the key value pair.

--- a/st2api/st2api/controllers/v1/datastore.py
+++ b/st2api/st2api/controllers/v1/datastore.py
@@ -43,13 +43,10 @@ class KeyValuePairController(RestController):
             Handle:
                 GET /keys/key1
         """
-        LOG.info('GET /keys/ with name=%s', name)
-
         kvp_db = self.__get_by_name(name=name)
 
         if not kvp_db:
-            LOG.exception('Database lookup for name="%s" '
-                          'resulted in exception.', name)
+            LOG.exception('Database lookup for name="%s" resulted in exception.', name)
             abort(http_client.NOT_FOUND)
             return
 
@@ -59,7 +56,6 @@ class KeyValuePairController(RestController):
             abort(http_client.INTERNAL_SERVER_ERROR, str(e))
             return
 
-        LOG.debug('GET /keys/ with name=%s, client_result=%s', name, kvp_api)
         return kvp_api
 
     @jsexpose(str)
@@ -70,8 +66,6 @@ class KeyValuePairController(RestController):
             Handles requests:
                 GET /keys/
         """
-        LOG.info('GET all /keys/ with filters=%s', kw)
-
         # Prefix filtering
         prefix_filter = kw.get('prefix', None)
 
@@ -81,7 +75,6 @@ class KeyValuePairController(RestController):
 
         kvp_dbs = KeyValuePair.get_all(**kw)
         kvps = [KeyValuePairAPI.from_model(kvp_db) for kvp_db in kvp_dbs]
-        LOG.debug('GET all /keys/ client_result=%s', kvps)
 
         return kvps
 
@@ -90,8 +83,6 @@ class KeyValuePairController(RestController):
         """
         Create a new entry or update an existing one.
         """
-        LOG.info('PUT /keys/ with key name=%s and data=%s', name, kvp)
-
         # TODO: There is a race, add custom add_or_update which updates by non
         # id field
         existing_kvp = self.__get_by_name(name=name)
@@ -112,7 +103,6 @@ class KeyValuePairController(RestController):
 
         LOG.audit('KeyValuePair updated. KeyValuePair=%s', kvp_db)
         kvp_api = KeyValuePairAPI.from_model(kvp_db)
-        LOG.debug('PUT /keys/ client_result=%s', kvp_api)
 
         return kvp_api
 
@@ -124,17 +114,14 @@ class KeyValuePairController(RestController):
             Handles requests:
                 DELETE /keys/1
         """
-        LOG.info('DELETE /keys/ with id=%s', id)
         kvp_db = self.__get_by_name(name=name)
 
         if not kvp_db:
-            LOG.exception('Database lookup for name="%s" '
-                          'resulted in exception.', name)
             abort(http_client.NOT_FOUND)
             return
 
-        LOG.debug('DELETE /keys/ lookup with name=%s found '
-                  'object: %s', name, kvp_db)
+        LOG.debug('DELETE /keys/ lookup with name=%s found object: %s', name, kvp_db)
+
         try:
             KeyValuePair.delete(kvp_db)
         except Exception as e:
@@ -150,6 +137,5 @@ class KeyValuePairController(RestController):
         try:
             return KeyValuePair.get_by_name(name)
         except ValueError as e:
-            LOG.debug('Database lookup for name="%s" '
-                      'resulted in exception : %s.', name, e)
+            LOG.debug('Database lookup for name="%s" resulted in exception : %s.', name, e)
             return None

--- a/st2api/st2api/controllers/v1/executionviews.py
+++ b/st2api/st2api/controllers/v1/executionviews.py
@@ -50,8 +50,6 @@ class FiltersController(RestController):
             Handles requests:
                 GET /executions/views/filters
         """
-        LOG.info('GET all /executions/views/filters')
-
         filters = {}
 
         for name, field in six.iteritems(SUPPORTED_FILTERS):

--- a/st2api/st2api/controllers/v1/rules.py
+++ b/st2api/st2api/controllers/v1/rules.py
@@ -48,7 +48,7 @@ class RuleController(resource.ResourceController):
         'sort': ['name']
     }
 
-    @jsexpose(str)
+    @jsexpose(arg_types=[str])
     def get_one(self, name_or_id):
         try:
             rule_db = self._get_by_name_or_id(name_or_id=name_or_id)
@@ -60,7 +60,7 @@ class RuleController(resource.ResourceController):
         result = self.model.from_model(rule_db)
         return result
 
-    @jsexpose(body=RuleAPI, status_code=http_client.CREATED)
+    @jsexpose(body_cls=RuleAPI, status_code=http_client.CREATED)
     def post(self, rule):
         """
             Create a new rule.
@@ -96,7 +96,7 @@ class RuleController(resource.ResourceController):
 
         return rule_api
 
-    @jsexpose(str, body=RuleAPI)
+    @jsexpose(arg_types=[str], body_cls=RuleAPI)
     def put(self, rule_id, rule):
         rule_db = RuleController.__get_by_id(rule_id)
         LOG.debug('PUT /rules/ lookup with id=%s found object: %s', rule_id, rule_db)
@@ -118,7 +118,7 @@ class RuleController(resource.ResourceController):
 
         return rule_api
 
-    @jsexpose(str, status_code=http_client.NO_CONTENT)
+    @jsexpose(arg_types=[str], status_code=http_client.NO_CONTENT)
     def delete(self, rule_id):
         """
             Delete a rule.

--- a/st2api/st2api/controllers/v1/rules.py
+++ b/st2api/st2api/controllers/v1/rules.py
@@ -68,8 +68,6 @@ class RuleController(resource.ResourceController):
             Handles requests:
                 POST /rules/
         """
-        LOG.info('POST /rules/ with rule data=%s', rule)
-
         try:
             rule_db = RuleAPI.to_model(rule)
             LOG.debug('/rules/ POST verified RuleAPI and formulated RuleDB=%s', rule_db)
@@ -95,13 +93,11 @@ class RuleController(resource.ResourceController):
 
         LOG.audit('Rule created. Rule=%s', rule_db)
         rule_api = RuleAPI.from_model(rule_db)
-        LOG.debug('POST /rules/ client_result=%s', rule_api)
 
         return rule_api
 
     @jsexpose(str, body=RuleAPI)
     def put(self, rule_id, rule):
-        LOG.info('PUT /rules/ with rule id=%s and data=%s', rule_id, rule)
         rule_db = RuleController.__get_by_id(rule_id)
         LOG.debug('PUT /rules/ lookup with id=%s found object: %s', rule_id, rule_db)
 
@@ -119,7 +115,6 @@ class RuleController(resource.ResourceController):
             return
         LOG.audit('Rule updated. Rule=%s and original Rule=%s.', rule_db, old_rule_db)
         rule_api = RuleAPI.from_model(rule_db)
-        LOG.debug('PUT /rules/ client_result=%s', rule_api)
 
         return rule_api
 
@@ -131,7 +126,6 @@ class RuleController(resource.ResourceController):
             Handles requests:
                 DELETE /rules/1
         """
-        LOG.info('DELETE /rules/ with id=%s', rule_id)
         rule_db = RuleController.__get_by_id(rule_id)
         LOG.debug('DELETE /rules/ lookup with id=%s found object: %s', rule_id, rule_db)
         try:

--- a/st2api/st2api/controllers/v1/runnertypes.py
+++ b/st2api/st2api/controllers/v1/runnertypes.py
@@ -59,10 +59,8 @@ class RunnerTypesController(RestController):
             Handle:
                 GET /runnertypes/1
         """
-        LOG.info('GET /runnertypes/ with id=%s', id)
         runnertype_db = RunnerTypesController.__get_by_id(id)
         runnertype_api = RunnerTypeAPI.from_model(runnertype_db)
-        LOG.debug('GET /runnertypes/ with id=%s, client_result=%s', id, runnertype_api)
         return runnertype_api
 
     @jsexpose(str)
@@ -73,9 +71,7 @@ class RunnerTypesController(RestController):
             Handles requests:
                 GET /runnertypes/
         """
-        LOG.info('GET all /runnertypes/ with filters=%s', kw)
         runnertype_dbs = RunnerType.get_all(**kw)
         runnertype_apis = [RunnerTypeAPI.from_model(runnertype_db)
                            for runnertype_db in runnertype_dbs]
-        LOG.debug('GET all /runnertypes/ client_result=%s', runnertype_apis)
         return runnertype_apis

--- a/st2api/st2api/controllers/v1/runnertypes.py
+++ b/st2api/st2api/controllers/v1/runnertypes.py
@@ -51,7 +51,7 @@ class RunnerTypesController(RestController):
             LOG.debug('Database lookup for name="%s" resulted in exception : %s.', name, e)
             return []
 
-    @jsexpose(str)
+    @jsexpose(arg_types=[str])
     def get_one(self, id):
         """
             List RunnerType objects by id.
@@ -63,7 +63,7 @@ class RunnerTypesController(RestController):
         runnertype_api = RunnerTypeAPI.from_model(runnertype_db)
         return runnertype_api
 
-    @jsexpose(str)
+    @jsexpose(arg_types=[str])
     def get_all(self, **kw):
         """
             List all RunnerType objects.

--- a/st2api/st2api/controllers/v1/stream.py
+++ b/st2api/st2api/controllers/v1/stream.py
@@ -43,8 +43,6 @@ def format(gen):
 class StreamController(RestController):
     @jsexpose(content_type='text/event-stream')
     def get_all(self):
-        LOG.info('GET /stream/')
-
         def make_response():
             res = Response(content_type='text/event-stream',
                            app_iter=format(get_listener().generator()))

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -60,7 +60,7 @@ class TriggerTypeController(resource.ContentPackResourceControler):
             Handles requests:
                 POST /triggertypes/
         """
-        LOG.info('POST /triggertypes/ with triggertype data=%s', triggertype)
+
         try:
             triggertype_db = TriggerTypeAPI.to_model(triggertype)
             triggertype_db = TriggerType.add_or_update(triggertype_db)
@@ -79,15 +79,11 @@ class TriggerTypeController(resource.ContentPackResourceControler):
                 TriggerTypeController._create_shadow_trigger(triggertype_db)
 
         triggertype_api = TriggerTypeAPI.from_model(triggertype_db)
-        LOG.debug('POST /triggertypes/ client_result=%s', triggertype_api)
 
         return triggertype_api
 
     @jsexpose(str, body=TriggerTypeAPI)
     def put(self, triggertype_ref_or_id, triggertype):
-        LOG.info('PUT /triggertypes/ with triggertype ref_or_id=%s and data=%s',
-                 triggertype_ref_or_id, triggertype)
-
         try:
             triggertype_db = self._get_by_ref_or_id(ref_or_id=triggertype_ref_or_id)
         except Exception as e:
@@ -119,8 +115,6 @@ class TriggerTypeController(resource.ContentPackResourceControler):
         LOG.audit('TriggerType updated. TriggerType=%s and original TriggerType=%s',
                   triggertype_db, old_triggertype_db)
         triggertype_api = TriggerTypeAPI.from_model(triggertype_db)
-        LOG.debug('PUT /triggertypes/ client_result=%s', triggertype_api)
-
         return triggertype_api
 
     @jsexpose(str, status_code=http_client.NO_CONTENT)
@@ -212,10 +206,8 @@ class TriggerController(RestController):
             Handle:
                 GET /triggers/1
         """
-        LOG.info('GET /triggers/ with id=%s', id)
         trigger_db = TriggerController.__get_by_id(trigger_id)
         trigger_api = TriggerAPI.from_model(trigger_db)
-        LOG.debug('GET /triggers/ with id=%s, client_result=%s', id, trigger_api)
         return trigger_api
 
     @jsexpose(str)
@@ -226,7 +218,6 @@ class TriggerController(RestController):
             Handles requests:
                 GET /triggers/
         """
-        LOG.info('GET all /triggers/ with filters=%s', kw)
         trigger_dbs = Trigger.get_all(**kw)
         trigger_apis = [TriggerAPI.from_model(trigger_db) for trigger_db in trigger_dbs]
         return trigger_apis
@@ -239,8 +230,6 @@ class TriggerController(RestController):
             Handles requests:
                 POST /triggers/
         """
-        LOG.info('POST /triggers/ with trigger data=%s', trigger)
-
         try:
             trigger_db = TriggerService.create_trigger_db(trigger)
         except (ValidationError, ValueError) as e:
@@ -255,13 +244,11 @@ class TriggerController(RestController):
 
         LOG.audit('Trigger created. Trigger=%s', trigger_db)
         trigger_api = TriggerAPI.from_model(trigger_db)
-        LOG.debug('POST /triggers/ client_result=%s', trigger_api)
 
         return trigger_api
 
     @jsexpose(str, body=TriggerAPI)
     def put(self, trigger_id, trigger):
-        LOG.info('PUT /triggers/ with trigger id=%s and data=%s', trigger_id, trigger)
         trigger_db = TriggerController.__get_by_id(trigger_id)
         try:
             if trigger.id is not None and trigger.id is not '' and trigger.id != trigger_id:
@@ -277,7 +264,6 @@ class TriggerController(RestController):
 
         LOG.audit('Trigger updated. Trigger=%s and original Trigger=%s.', trigger, trigger_db)
         trigger_api = TriggerAPI.from_model(trigger_db)
-        LOG.debug('PUT /triggers/ client_result=%s', trigger_api)
 
         return trigger_api
 
@@ -332,8 +318,6 @@ class TriggerInstanceController(RestController):
             Handle:
                 GET /triggerinstances/1
         """
-        LOG.info('GET /triggerinstances/ with id=%s', id)
-
         try:
             trigger_instance_db = TriggerInstance.get_by_id(id)
         except (ValueError, ValidationError):
@@ -342,8 +326,6 @@ class TriggerInstanceController(RestController):
             return
 
         trigger_instance_api = TriggerInstanceAPI.from_model(trigger_instance_db)
-        LOG.debug('GET /triggerinstances/ with id=%s, client_result=%s', id, trigger_instance_api)
-
         return trigger_instance_api
 
     @jsexpose()
@@ -354,7 +336,6 @@ class TriggerInstanceController(RestController):
             Handles requests:
                 GET /triggerinstances/
         """
-        LOG.info('GET all /triggerinstances/')
         trigger_instance_apis = [TriggerInstanceAPI.from_model(trigger_instance_db)
                                  for trigger_instance_db in TriggerInstance.get_all(**kw)]
         return trigger_instance_apis

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -52,7 +52,7 @@ class TriggerTypeController(resource.ContentPackResourceControler):
 
     include_reference = True
 
-    @jsexpose(body=TriggerTypeAPI, status_code=http_client.CREATED)
+    @jsexpose(body_cls=TriggerTypeAPI, status_code=http_client.CREATED)
     def post(self, triggertype):
         """
             Create a new triggertype.
@@ -82,7 +82,7 @@ class TriggerTypeController(resource.ContentPackResourceControler):
 
         return triggertype_api
 
-    @jsexpose(str, body=TriggerTypeAPI)
+    @jsexpose(arg_types=[str], body_cls=TriggerTypeAPI)
     def put(self, triggertype_ref_or_id, triggertype):
         try:
             triggertype_db = self._get_by_ref_or_id(ref_or_id=triggertype_ref_or_id)
@@ -117,7 +117,7 @@ class TriggerTypeController(resource.ContentPackResourceControler):
         triggertype_api = TriggerTypeAPI.from_model(triggertype_db)
         return triggertype_api
 
-    @jsexpose(str, status_code=http_client.NO_CONTENT)
+    @jsexpose(arg_types=[str], status_code=http_client.NO_CONTENT)
     def delete(self, triggertype_ref_or_id):
         """
             Delete a triggertype.
@@ -197,7 +197,7 @@ class TriggerController(RestController):
         Implements the RESTful web endpoint that handles
         the lifecycle of Triggers in the system.
     """
-    @jsexpose(str)
+    @jsexpose(arg_types=[str])
     def get_one(self, trigger_id):
 
         """
@@ -210,7 +210,7 @@ class TriggerController(RestController):
         trigger_api = TriggerAPI.from_model(trigger_db)
         return trigger_api
 
-    @jsexpose(str)
+    @jsexpose(arg_types=[str])
     def get_all(self, **kw):
         """
             List all triggers.
@@ -222,7 +222,7 @@ class TriggerController(RestController):
         trigger_apis = [TriggerAPI.from_model(trigger_db) for trigger_db in trigger_dbs]
         return trigger_apis
 
-    @jsexpose(body=TriggerAPI, status_code=http_client.CREATED)
+    @jsexpose(body_cls=TriggerAPI, status_code=http_client.CREATED)
     def post(self, trigger):
         """
             Create a new trigger.
@@ -247,7 +247,7 @@ class TriggerController(RestController):
 
         return trigger_api
 
-    @jsexpose(str, body=TriggerAPI)
+    @jsexpose(arg_types=[str], body_cls=TriggerAPI)
     def put(self, trigger_id, trigger):
         trigger_db = TriggerController.__get_by_id(trigger_id)
         try:
@@ -267,7 +267,7 @@ class TriggerController(RestController):
 
         return trigger_api
 
-    @jsexpose(str, status_code=http_client.NO_CONTENT)
+    @jsexpose(arg_types=[str], status_code=http_client.NO_CONTENT)
     def delete(self, trigger_id):
         """
             Delete a trigger.
@@ -310,7 +310,7 @@ class TriggerInstanceController(RestController):
         the lifecycle of TriggerInstances in the system.
     """
 
-    @jsexpose(str)
+    @jsexpose(arg_types=[str])
     def get_one(self, id):
         """
             List triggerinstance by id.

--- a/st2api/st2api/controllers/v1/webhooks.py
+++ b/st2api/st2api/controllers/v1/webhooks.py
@@ -67,7 +67,7 @@ class WebhooksController(RestController):
 
         return hook
 
-    @jsexpose(str, status_code=http_client.ACCEPTED)
+    @jsexpose(arg_types=[str], status_code=http_client.ACCEPTED)
     def post(self, *args, **kwargs):
         hook = '/'.join(args)  # TODO: There must be a better way to do this.
         body = pecan.request.body

--- a/st2api/st2api/controllers/v1/webhooks.py
+++ b/st2api/st2api/controllers/v1/webhooks.py
@@ -70,7 +70,6 @@ class WebhooksController(RestController):
     @jsexpose(str, status_code=http_client.ACCEPTED)
     def post(self, *args, **kwargs):
         hook = '/'.join(args)  # TODO: There must be a better way to do this.
-        LOG.info('POST /webhooks/ with hook=%s', hook)
         body = pecan.request.body
         try:
             body = json.loads(body)

--- a/st2api/tests/unit/controllers/v1/test_stream.py
+++ b/st2api/tests/unit/controllers/v1/test_stream.py
@@ -22,6 +22,7 @@ from tests import FunctionalTest
 
 
 @mock.patch.object(pecan, 'request', type('request', (object,), {'environ': {}}))
+@mock.patch.object(pecan, 'response', mock.MagicMock())
 class TestStreamController(FunctionalTest):
 
     @mock.patch.object(stream, 'format', mock.Mock())

--- a/st2auth/conf/logging.conf
+++ b/st2auth/conf/logging.conf
@@ -5,7 +5,7 @@ keys=root
 keys=consoleHandler, fileHandler, auditHandler
 
 [formatters]
-keys=verboseFormatter, simpleFormatter
+keys=simpleConsoleFormatter, verboseConsoleFormatter, gelfFormatter
 
 [logger_root]
 level=DEBUG
@@ -14,25 +14,31 @@ handlers=consoleHandler, fileHandler, auditHandler
 [handler_consoleHandler]
 class=StreamHandler
 level=DEBUG
-formatter=simpleFormatter
+formatter=simpleConsoleFormatter
 args=(sys.stdout,)
 
 [handler_fileHandler]
 class=FileHandler
 level=DEBUG
-formatter=verboseFormatter
+formatter=verboseConsoleFormatter
 args=("logs/st2auth.log",)
 
 [handler_auditHandler]
 class=FileHandler
 level=AUDIT
-formatter=verboseFormatter
+formatter=gelfFormatter
 args=("logs/st2auth.audit.log",)
 
-[formatter_verboseFormatter]
+[formatter_simpleConsoleFormatter]
+class=st2common.logging.formatters.ConsoleLogFormatter
+format=%(asctime)s %(levelname)s [-] %(message)s
+datefmt=
+
+[formatter_verboseConsoleFormatter]
+class=st2common.logging.formatters.ConsoleLogFormatter
 format=%(asctime)s %(thread)s %(levelname)s %(module)s [-] %(message)s
 datefmt=
 
-[formatter_simpleFormatter]
-format=%(asctime)s %(levelname)s [-] %(message)s
-datefmt=
+[formatter_gelfFormatter]
+class=st2common.logging.formatters.GelfLogFormatter
+format=%(message)s

--- a/st2auth/st2auth/controllers/access.py
+++ b/st2auth/st2auth/controllers/access.py
@@ -39,7 +39,7 @@ class TokenController(rest.RestController):
         else:
             self._auth_backend = None
 
-    @jsexpose(body=TokenAPI, status_code=http_client.CREATED)
+    @jsexpose(body_cls=TokenAPI, status_code=http_client.CREATED)
     def post(self, request, **kwargs):
         if cfg.CONF.auth.mode == 'proxy':
             return self._handle_proxy_auth(request=request, **kwargs)

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -88,7 +88,7 @@ def register_rules():
     # Register rules.
     try:
         LOG.info('=========================================================')
-        LOG.info('############## Registering rules ######################')
+        LOG.info('############## Registering rules ########################')
         LOG.info('=========================================================')
         # Importing here to reduce scope of dependency. This way even if st2reactor
         # is not installed bootstrap continues.

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -19,7 +19,7 @@ import sys
 import st2common.config as config
 
 from oslo.config import cfg
-from st2common.log import LogLevelFilter
+from st2common.logging.filters import LogLevelFilter
 from st2common.models.db import db_setup
 from st2common.models.db import db_teardown
 

--- a/st2common/st2common/log.py
+++ b/st2common/st2common/log.py
@@ -52,6 +52,7 @@ LOGGER_KEYS = [
     'error',
     'critical',
     'exception',
+    'log'
 ]
 
 

--- a/st2common/st2common/log.py
+++ b/st2common/st2common/log.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+
 import socket
 import datetime
 import logging

--- a/st2common/st2common/log.py
+++ b/st2common/st2common/log.py
@@ -30,7 +30,7 @@ from st2common.logging.filters import ExclusionFilter
 # Those are here for backward compatibility reasons
 from st2common.logging.handlers import FormatNamedFileHandler
 from st2common.logging.handlers import ConfigurableSyslogHandler
-from st2common.util.misc import prefix_with_underscore
+from st2common.util.misc import prefix_dict_keys
 
 __all__ = [
     'getLogger',
@@ -60,7 +60,7 @@ def decorate_log_method(func):
     def func_wrapper(*args, **kwargs):
         # Prefix extra keys with underscore
         if 'extra' in kwargs:
-            kwargs['extra'] = prefix_with_underscore(kwargs['extra'])
+            kwargs['extra'] = prefix_dict_keys(dictionary=kwargs['extra'], prefix='_')
         return func(*args, **kwargs)
     return func_wrapper
 

--- a/st2common/st2common/logging/filters.py
+++ b/st2common/st2common/logging/filters.py
@@ -1,0 +1,50 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+__all__ = [
+    'ExclusionFilter',
+    'LogLevelFilter',
+]
+
+
+class ExclusionFilter(object):
+
+    def __init__(self, exclusions):
+        self._exclusions = set(exclusions)
+
+    def filter(self, record):
+        if len(self._exclusions) < 1:
+            return True
+        module_decomposition = record.name.split('.')
+        exclude = len(module_decomposition) > 0 and module_decomposition[0] in self._exclusions
+        return not exclude
+
+
+class LogLevelFilter(logging.Filter):
+    """
+    Filter which excludes log messages which match the provided log levels.
+    """
+
+    def __init__(self, log_levels):
+        self._log_levels = log_levels
+
+    def filter(self, record):
+        level = record.levelno
+        if level in self._log_levels:
+            return False
+
+        return True

--- a/st2common/st2common/logging/formatters.py
+++ b/st2common/st2common/logging/formatters.py
@@ -31,11 +31,11 @@ __all__ = [
 HOSTNAME = socket.gethostname()
 COMMON_ATTRIBUTE_NAMES = [
     'process',
+    'processName',
     'module',
     'filename',
     'funcName',
     'lineno'
-    'processName',
 ]
 
 
@@ -149,7 +149,7 @@ class GelfLogFormatter(BaseExtraLogFormatter):
             data['_exception'] = str(exc_value)
             data['_traceback'] = tb_str
 
-        # Include common Python process attributes
+        # Include common Python log record attributes
         data['_python'] = common_attributes
 
         # Include user extra attributes

--- a/st2common/st2common/logging/formatters.py
+++ b/st2common/st2common/logging/formatters.py
@@ -114,7 +114,10 @@ class ConsoleLogFormatter(BaseExtraLogFormatter):
         # Call the parent format method so the final message is formed based on the "format"
         # attribute in the config
         msg = super(ConsoleLogFormatter, self).format(record)
-        msg = '%s (%s)' % (msg, attributes)
+
+        if attributes:
+            msg = '%s (%s)' % (msg, attributes)
+
         return msg
 
     def _dict_to_str(self, attributes):

--- a/st2common/st2common/logging/formatters.py
+++ b/st2common/st2common/logging/formatters.py
@@ -109,6 +109,18 @@ class GelfLogFormatter(BaseExtraLogFormatter):
     """
     Formatter which formats messages as GELF 2 - https://www.graylog.org/resources/gelf-2/
     """
+
+    # Maps python log level to syslog / gelf log level
+    PYTHON_TO_GELF_LEVEL_MAP = {
+        50: 2,  # critical -> critical
+        40: 3,  # error -> error
+        30: 4,  # warning -> warning
+        20: 6,  # info -> informational
+        10: 7,  # debug -> debug
+        0: 6,  # notset -> information
+    }
+    DEFAULT_LOG_LEVEL = 6  # info
+
     def format(self, record):
         attributes = self._get_extra_attributes(record=record)
         attributes = self._format_extra_attributes(attributes=attributes)
@@ -116,6 +128,7 @@ class GelfLogFormatter(BaseExtraLogFormatter):
         msg = record.msg
         exc_info = record.exc_info
         now = int(time.time())
+        level = self.PYTHON_TO_GELF_LEVEL_MAP.get(record.levelno, self.DEFAULT_LOG_LEVEL)
 
         common_attributes = self._get_common_extra_attributes(record=record)
         full_msg = super(GelfLogFormatter, self).format(record)
@@ -126,7 +139,7 @@ class GelfLogFormatter(BaseExtraLogFormatter):
             'short_message': msg,
             'full_message': full_msg,
             'timestamp': now,
-            'level': record.levelno
+            'level': level
         }
 
         if exc_info:

--- a/st2common/st2common/logging/formatters.py
+++ b/st2common/st2common/logging/formatters.py
@@ -1,0 +1,132 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import logging
+import socket
+import time
+import json
+
+import six
+
+__all__ = [
+    'ConsoleLogFormatter',
+    'GelfLogFormatter'
+]
+
+HOSTNAME = socket.gethostname()
+COMMON_ATTRIBUTE_NAMES = [
+    'process',
+    'module',
+    'filename',
+    'funcName',
+    'lineno'
+    'processName',
+]
+
+
+class BaseExtraLogFormatter(logging.Formatter):
+    def _get_extra_attributes(self, record):
+        attributes = dict([(k, v) for k, v in six.iteritems(record.__dict__)
+                           if k.startswith('_')])
+        return attributes
+
+    def _get_common_extra_attributes(self, record):
+        result = {}
+
+        for name in COMMON_ATTRIBUTE_NAMES:
+            value = getattr(record, name, None)
+
+            if not value:
+                continue
+
+            result[name] = value
+
+        return result
+
+    def _format_extra_attributes(self, attributes):
+        simple_types = (list, dict, int, float) + six.string_types
+
+        result = {}
+        for key, value in six.iteritems(attributes):
+            if isinstance(value, simple_types):
+                # Leave simple types as is
+                value = value
+            elif isinstance(value, object):
+                if getattr(value, 'to_dict', None):
+                    # Check for a custom serialization method
+                    value = value.to_dict()
+                else:
+                    value = repr(value)
+
+            result[key] = value
+
+        return result
+
+
+class ConsoleLogFormatter(BaseExtraLogFormatter):
+    """
+    Custom log formatter which attaches all the attributes from the "extra"
+    dictionary which start with an underscore to the end of the log message.
+    For example:
+    extra={'_id': 'user-1', '_path': '/foo/bar'}
+    """
+
+    def format(self, record):
+        attributes = self._get_extra_attributes(record=record)
+        attributes = self._format_extra_attributes(attributes=attributes)
+        attributes = self._dict_to_str(attributes=attributes)
+
+        msg = super(ConsoleLogFormatter, self).format(record)
+        msg = '%s (%s)' % (msg, attributes)
+        return msg
+
+    def _dict_to_str(self, attributes):
+        result = []
+        for key, value in six.iteritems(attributes):
+            item = '%s=%s' % (key[1:], repr(value))
+            result.append(item)
+
+        result = ','.join(result)
+        return result
+
+
+class GelfLogFormatter(BaseExtraLogFormatter):
+    """
+    Formatter which formats messages as GELF 2 - https://www.graylog.org/resources/gelf-2/
+    """
+    def format(self, record):
+        attributes = self._get_extra_attributes(record=record)
+        attributes = self._format_extra_attributes(attributes=attributes)
+
+        msg = record.msg
+        now = int(time.time())
+
+        common_attributes = self._get_common_extra_attributes(record=record)
+
+        data = {
+            'version': '1.1',
+            'host': HOSTNAME,
+            'short_message': msg,
+            'full_message': msg,
+            'timestamp': now,
+            'level': record.levelno
+        }
+        data['_python'] = common_attributes
+        data.update(attributes)
+
+        msg = json.dumps(data)
+        return msg

--- a/st2common/st2common/logging/formatters.py
+++ b/st2common/st2common/logging/formatters.py
@@ -29,6 +29,8 @@ __all__ = [
 ]
 
 HOSTNAME = socket.gethostname()
+GELF_SPEC_VERSION = '1.1'
+
 COMMON_ATTRIBUTE_NAMES = [
     'process',
     'processName',
@@ -184,7 +186,7 @@ class GelfLogFormatter(BaseExtraLogFormatter):
         full_msg = super(GelfLogFormatter, self).format(record)
 
         data = {
-            'version': '1.1',
+            'version': GELF_SPEC_VERSION,
             'host': HOSTNAME,
             'short_message': msg,
             'full_message': full_msg,

--- a/st2common/st2common/logging/handlers.py
+++ b/st2common/st2common/logging/handlers.py
@@ -1,0 +1,56 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import socket
+import logging
+import datetime
+
+from oslo.config import cfg
+
+__all__ = [
+    'FormatNamedFileHandler',
+    'ConfigurableSyslogHandler',
+]
+
+
+class FormatNamedFileHandler(logging.FileHandler):
+    def __init__(self, filename, mode='a', encoding=None, delay=False):
+        # Include timestamp in the name.
+        filename = filename.format(ts=str(datetime.datetime.utcnow()).replace(' ', '_'),
+                                   pid=os.getpid())
+        super(FormatNamedFileHandler, self).__init__(filename, mode, encoding, delay)
+
+
+class ConfigurableSyslogHandler(logging.handlers.SysLogHandler):
+    def __init__(self, address=None, facility=None, socktype=None):
+        if not address:
+            address = (cfg.CONF.syslog.host, cfg.CONF.syslog.port)
+        if not facility:
+            facility = cfg.CONF.syslog.facility
+        if not socktype:
+            protocol = cfg.CONF.syslog.protocol.lower()
+
+            if protocol == 'udp':
+                socktype = socket.SOCK_DGRAM
+            elif protocol == 'tcp':
+                socktype = socket.SOCK_STREAM
+            else:
+                raise ValueError('Unsupported protocol: %s' % (protocol))
+
+        if socktype:
+            super(ConfigurableSyslogHandler, self).__init__(address, facility, socktype)
+        else:
+            super(ConfigurableSyslogHandler, self).__init__(address, facility)

--- a/st2common/st2common/models/api/base.py
+++ b/st2common/st2common/models/api/base.py
@@ -199,7 +199,7 @@ def jsexpose(*argtypes, **opts):
                                          e.headers)
 
             except Exception as e:
-                LOG.exception('API call failed.')
+                LOG.exception('API call failed: %s' % (str(e)))
                 return _handle_error(e, http_client.INTERNAL_SERVER_ERROR)
 
         pecan_json_decorate(callfunction)

--- a/st2common/st2common/models/api/base.py
+++ b/st2common/st2common/models/api/base.py
@@ -28,7 +28,6 @@ import pecan.jsonify
 from st2common.util import mongoescape as util_mongodb
 from st2common.util import schema as util_schema
 from st2common.util.jsonify import json_encode
-from st2common.util.misc import prefix_with_underscore
 from st2common import log as logging
 from st2common.constants.auth import QUERY_PARAM_ATTRIBUTE_NAME
 
@@ -147,8 +146,7 @@ def jsexpose(arg_types=None, body_cls=None, status_code=None, content_type='appl
             # Log the incoming request
             values = copy.copy(request_info)
             values['filters'] = kwargs
-            extra = prefix_with_underscore(values)
-            LOG.info('%(method)s %(path)s with filters=%(filters)s' % values, extra=extra)
+            LOG.info('%(method)s %(path)s with filters=%(filters)s' % values, extra=values)
 
             if QUERY_PARAM_ATTRIBUTE_NAME in params and QUERY_PARAM_ATTRIBUTE_NAME in kwargs:
                 # Remove auth token if one is provided via query params
@@ -219,8 +217,7 @@ def jsexpose(arg_types=None, body_cls=None, status_code=None, content_type='appl
                         # methods which have a large result
                         log_msg = '%(method)s %(path)s' % values
 
-                    extra = prefix_with_underscore(values)
-                    LOG.info(log_msg, extra=extra)
+                    LOG.info(log_msg, extra=values)
 
                     if status_code:
                         pecan.response.status = status_code

--- a/st2common/st2common/models/api/base.py
+++ b/st2common/st2common/models/api/base.py
@@ -111,9 +111,21 @@ def _handle_error(e, status_code, body=None, headers=None):
     return json_encode(error_body)
 
 
-def jsexpose(*argtypes, **opts):
-    content_type = opts.get('content_type', 'application/json')
+def jsexpose(arg_types=None, body_cls=None, status_code=None, content_type='application/json'):
+    """
+    :param arg_types: A list of types for the function arguments.
+    :type arg_types: ``list``
 
+    :param body_cls: Request body class. If provided, this class will be used to create an instance
+                     out of the request body.
+    :type body_cls: :class:`object`
+
+    :param status_code: Response status code.
+    :type status_code: ``int``
+
+    :param content_type: Response content type.
+    :type content_type: ``str``
+    """
     pecan_json_decorate = pecan.expose(
         content_type=content_type,
         generic=False)
@@ -144,10 +156,10 @@ def jsexpose(*argtypes, **opts):
 
             try:
                 args = list(args)
-                types = list(argtypes)
+                types = copy.copy(arg_types)
                 more = [args.pop(0)]
 
-                if len(types):
+                if types:
                     argspec = inspect.getargspec(f)
                     names = argspec.args[1:]
 
@@ -164,7 +176,6 @@ def jsexpose(*argtypes, **opts):
                             except KeyError:
                                 pass
 
-                body_cls = opts.get('body')
                 if body_cls:
                     if pecan.request.body:
                         data = pecan.request.json
@@ -177,8 +188,6 @@ def jsexpose(*argtypes, **opts):
                     more.append(obj)
 
                 args = tuple(more) + tuple(args)
-
-                status_code = opts.get('status_code')
 
                 noop_codes = [http_client.NOT_IMPLEMENTED,
                               http_client.METHOD_NOT_ALLOWED,

--- a/st2common/st2common/models/api/base.py
+++ b/st2common/st2common/models/api/base.py
@@ -109,11 +109,14 @@ def jsexpose(*argtypes, **opts):
     def decorate(f):
         @functools.wraps(f)
         def callfunction(*args, **kwargs):
+            # Note: We use getattr since in some places (tests) request is mocked
             params = getattr(pecan.request, 'params', {})
+            method = getattr(pecan.request, 'method', None)
+            path = getattr(pecan.request, 'path', None)
+            remote_addr = getattr(pecan.request, 'remote_addr', None)
 
             # Common request information included in the log context
-            request_info = {'method': pecan.request.method, 'path': pecan.request.path,
-                            'remote_addr': pecan.request.remote_addr}
+            request_info = {'method': method, 'path': path, 'remote_addr': remote_addr}
 
             # Log the incoming request
             values = copy.copy(request_info)

--- a/st2common/st2common/models/api/base.py
+++ b/st2common/st2common/models/api/base.py
@@ -177,9 +177,16 @@ def jsexpose(*argtypes, **opts):
                     # Log the outgoing response
                     values = copy.copy(request_info)
                     values['status_code'] = status_code or pecan.response.status
-                    values['result'] = result
+
+                    if f.__name__ not in ['get_all']:
+                        # Note: We don't want to include a result for get_all since it could be huge
+                        values['result'] = result
+                        log_msg = '%(method)s %(path)s result=%(result)s' % values
+                    else:
+                        log_msg = '%(method)s %(path)s' % values
+
                     extra = prefix_with_underscore(values)
-                    LOG.info('%(method)s %(path)s result=%(result)s' % values, extra=extra)
+                    LOG.info(log_msg, extra=extra)
 
                     if status_code:
                         pecan.response.status = status_code

--- a/st2common/st2common/util/misc.py
+++ b/st2common/st2common/util/misc.py
@@ -1,0 +1,34 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import six
+
+__all__ = [
+    'prefix_with_underscore'
+]
+
+
+def prefix_with_underscore(dictionary):
+    """
+    Prefix dictionary keys with an underscore.
+
+    :rtype: ``dict``:
+    """
+    result = {}
+
+    for key, value in six.iteritems(dictionary):
+        result['_%s' % (key)] = value
+
+    return result

--- a/st2common/st2common/util/misc.py
+++ b/st2common/st2common/util/misc.py
@@ -16,19 +16,25 @@
 import six
 
 __all__ = [
-    'prefix_with_underscore'
+    'prefix_dict_keys'
 ]
 
 
-def prefix_with_underscore(dictionary):
+def prefix_dict_keys(dictionary, prefix='_'):
     """
-    Prefix dictionary keys with an underscore.
+    Prefix dictionary keys with a provided prefix.
+
+    :param dictionary: Dictionary whose keys to prefix.
+    :type dictionary: ``dict``
+
+    :param prefix: Key prefix.
+    :type prefix: ``str``
 
     :rtype: ``dict``:
     """
     result = {}
 
     for key, value in six.iteritems(dictionary):
-        result['_%s' % (key)] = value
+        result['%s%s' % (prefix, key)] = value
 
     return result

--- a/st2common/tests/unit/test_logger.py
+++ b/st2common/tests/unit/test_logger.py
@@ -20,7 +20,7 @@ import tempfile
 import logging as logbase
 
 from st2common import log as logging
-
+import st2tests.config as tests_config
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 RESOURCES_DIR = os.path.abspath(os.path.join(CURRENT_DIR, '../resources'))
@@ -28,6 +28,9 @@ CONFIG_FILE_PATH = os.path.join(RESOURCES_DIR, 'logging.conf')
 
 
 class TestLogger(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        tests_config.parse_args()
 
     def setUp(self):
         super(TestLogger, self).setUp()

--- a/st2common/tests/unit/test_logger.py
+++ b/st2common/tests/unit/test_logger.py
@@ -15,6 +15,7 @@
 
 import unittest
 import os
+import sys
 import json
 import uuid
 import tempfile
@@ -200,3 +201,30 @@ class GelfLogFormatterTestCase(unittest.TestCase):
         self.assertEqual(parsed['_user_id'], 1)
         self.assertEqual(parsed['_value'], 'bar')
         self.assertTrue('ignored' not in parsed)
+
+        # Record with an exception
+        mock_exception = Exception('mock exception bar')
+
+        try:
+            raise mock_exception
+        except Exception:
+            mock_exc_info = sys.exc_info()
+
+        # Some extra attributes
+        mock_message = 'test message 3'
+
+        record = MockRecord()
+        record.msg = mock_message
+        record.exc_info = mock_exc_info
+
+        message = formatter.format(record=record)
+        parsed = json.loads(message)
+
+        for key in expected_keys:
+            self.assertTrue(key in parsed)
+
+        self.assertEqual(parsed['short_message'], mock_message)
+        self.assertTrue(mock_message in parsed['full_message'])
+        self.assertTrue('Traceback' in parsed['full_message'])
+        self.assertTrue('_exception' in parsed)
+        self.assertTrue('_traceback' in parsed)

--- a/st2common/tests/unit/test_model_base.py
+++ b/st2common/tests/unit/test_model_base.py
@@ -70,7 +70,7 @@ class TestModelBase(unittest.TestCase):
         self.f.assert_called_once_with(self, ('11',), {})
 
     def test_expose_argument_type_casting(self):
-        @base.jsexpose(int)
+        @base.jsexpose(arg_types=[int])
         def f(self, id, *args, **kwargs):
             self.f(self, id, args, kwargs)
 
@@ -79,7 +79,7 @@ class TestModelBase(unittest.TestCase):
         self.f.assert_called_once_with(self, 11, (), {})
 
     def test_expose_argument_with_default(self):
-        @base.jsexpose(int)
+        @base.jsexpose(arg_types=[int])
         def f(self, id, some=None, *args, **kwargs):
             self.f(self, id, some, args, kwargs)
 
@@ -88,7 +88,7 @@ class TestModelBase(unittest.TestCase):
         self.f.assert_called_once_with(self, 11, None, (), {})
 
     def test_expose_kv_unused(self):
-        @base.jsexpose(int, int, str)
+        @base.jsexpose([int, int, str])
         def f(self, id, *args, **kwargs):
             self.f(self, id, args, kwargs)
 
@@ -97,7 +97,7 @@ class TestModelBase(unittest.TestCase):
         self.f.assert_called_once_with(self, 11, (), {'number': '7', 'name': 'fox'})
 
     def test_expose_kv_type_casting(self):
-        @base.jsexpose(int, int, str)
+        @base.jsexpose([int, int, str])
         def f(self, id, number, name, *args, **kwargs):
             self.f(self, id, number, name, args, kwargs)
 
@@ -108,7 +108,7 @@ class TestModelBase(unittest.TestCase):
     def test_expose_body_unused(self):
         APIModelMock = mock.MagicMock()
 
-        @base.jsexpose(body=APIModelMock)
+        @base.jsexpose(body_cls=APIModelMock)
         def f(self, *args, **kwargs):
             self.f(self, args, kwargs)
 
@@ -120,7 +120,7 @@ class TestModelBase(unittest.TestCase):
     def test_expose_body(self):
         APIModelMock = mock.MagicMock()
 
-        @base.jsexpose(body=APIModelMock)
+        @base.jsexpose(body_cls=APIModelMock)
         def f(self, body, *args, **kwargs):
             self.f(self, body, args, kwargs)
 
@@ -132,7 +132,7 @@ class TestModelBase(unittest.TestCase):
     def test_expose_body_and_arguments_unused(self):
         APIModelMock = mock.MagicMock()
 
-        @base.jsexpose(body=APIModelMock)
+        @base.jsexpose(body_cls=APIModelMock)
         def f(self, body, *args, **kwargs):
             self.f(self, body, args, kwargs)
 
@@ -144,7 +144,7 @@ class TestModelBase(unittest.TestCase):
     def test_expose_body_and_arguments_type_casting(self):
         APIModelMock = mock.MagicMock()
 
-        @base.jsexpose(int, body=APIModelMock)
+        @base.jsexpose(arg_types=[int], body_cls=APIModelMock)
         def f(self, id, body, *args, **kwargs):
             self.f(self, id, body, args, kwargs)
 
@@ -157,7 +157,7 @@ class TestModelBase(unittest.TestCase):
     def test_expose_body_and_typed_arguments_unused(self):
         APIModelMock = mock.MagicMock()
 
-        @base.jsexpose(int, body=APIModelMock)
+        @base.jsexpose(arg_types=[int], body_cls=APIModelMock)
         def f(self, id, body, *args, **kwargs):
             self.f(self, id, body, args, kwargs)
 
@@ -170,7 +170,7 @@ class TestModelBase(unittest.TestCase):
     def test_expose_body_and_typed_kw_unused(self):
         APIModelMock = mock.MagicMock()
 
-        @base.jsexpose(int, body=APIModelMock)
+        @base.jsexpose(arg_types=[int], body_cls=APIModelMock)
         def f(self, body, id, *args, **kwargs):
             self.f(self, body, id, args, kwargs)
 
@@ -182,7 +182,7 @@ class TestModelBase(unittest.TestCase):
     @mock.patch.object(pecan, 'response', mock.MagicMock(status=200))
     def test_expose_schema_validation_failed(self):
 
-        @base.jsexpose(body=FakeModel)
+        @base.jsexpose(body_cls=FakeModel)
         def f(self, body, *args, **kwargs):
             self.f(self, body, *args, **kwargs)
 

--- a/st2common/tests/unit/test_model_base.py
+++ b/st2common/tests/unit/test_model_base.py
@@ -35,6 +35,7 @@ class FakeModel(base.BaseAPI):
 
 
 @mock.patch.object(pecan, 'request', mock.MagicMock(json={'a': 'b'}))
+@mock.patch.object(pecan, 'response', mock.MagicMock())
 class TestModelBase(unittest.TestCase):
 
     def setUp(self):

--- a/st2reactor/conf/logging.rulesengine.conf
+++ b/st2reactor/conf/logging.rulesengine.conf
@@ -5,7 +5,7 @@ keys=root
 keys=consoleHandler, fileHandler, auditHandler
 
 [formatters]
-keys=verboseFormatter, simpleFormatter
+keys=simpleConsoleFormatter, verboseConsoleFormatter, gelfFormatter
 
 [logger_root]
 level=DEBUG
@@ -14,25 +14,31 @@ handlers=consoleHandler, fileHandler, auditHandler
 [handler_consoleHandler]
 class=StreamHandler
 level=INFO
-formatter=simpleFormatter
+formatter=simpleConsoleFormatter
 args=(sys.stdout,)
 
 [handler_fileHandler]
 class=FileHandler
 level=INFO
-formatter=verboseFormatter
+formatter=verboseConsoleFormatter
 args=("logs/st2rulesengine.log",)
 
 [handler_auditHandler]
 class=FileHandler
 level=AUDIT
-formatter=verboseFormatter
+formatter=gelfFormatter
 args=("logs/st2rulesengine.audit.log",)
 
-[formatter_verboseFormatter]
+[formatter_simpleConsoleFormatter]
+class=st2common.logging.formatters.ConsoleLogFormatter
+format=%(asctime)s %(levelname)s [-] %(message)s
+datefmt=
+
+[formatter_verboseConsoleFormatter]
+class=st2common.logging.formatters.ConsoleLogFormatter
 format=%(asctime)s %(thread)s %(levelname)s %(module)s [-] %(message)s
 datefmt=
 
-[formatter_simpleFormatter]
-format=%(asctime)s %(levelname)s [-] %(message)s
-datefmt=
+[formatter_gelfFormatter]
+class=st2common.logging.formatters.GelfLogFormatter
+format=%(message)s

--- a/st2reactor/conf/logging.sensorcontainer.conf
+++ b/st2reactor/conf/logging.sensorcontainer.conf
@@ -5,7 +5,7 @@ keys=root
 keys=consoleHandler, fileHandler, auditHandler
 
 [formatters]
-keys=verboseFormatter, simpleFormatter
+keys=simpleConsoleFormatter, verboseConsoleFormatter, gelfFormatter
 
 [logger_root]
 level=DEBUG
@@ -14,25 +14,31 @@ handlers=consoleHandler, fileHandler, auditHandler
 [handler_consoleHandler]
 class=StreamHandler
 level=INFO
-formatter=simpleFormatter
+formatter=simpleConsoleFormatter
 args=(sys.stdout,)
 
 [handler_fileHandler]
 class=FileHandler
 level=INFO
-formatter=verboseFormatter
+formatter=verboseConsoleFormatter
 args=("logs/st2sensorcontainer.log",)
 
 [handler_auditHandler]
 class=FileHandler
 level=AUDIT
-formatter=verboseFormatter
+formatter=gelfFormatter
 args=("logs/st2sensorcontainer.audit.log",)
 
-[formatter_verboseFormatter]
+[formatter_simpleConsoleFormatter]
+class=st2common.logging.formatters.ConsoleLogFormatter
+format=%(asctime)s %(levelname)s [-] %(message)s
+datefmt=
+
+[formatter_verboseConsoleFormatter]
+class=st2common.logging.formatters.ConsoleLogFormatter
 format=%(asctime)s %(thread)s %(levelname)s %(module)s [-] %(message)s
 datefmt=
 
-[formatter_simpleFormatter]
-format=%(asctime)s %(levelname)s [-] %(message)s
-datefmt=
+[formatter_gelfFormatter]
+class=st2common.logging.formatters.GelfLogFormatter
+format=%(message)s

--- a/st2reactor/st2reactor/bootstrap/rulesregistrar.py
+++ b/st2reactor/st2reactor/bootstrap/rulesregistrar.py
@@ -46,7 +46,7 @@ class RulesRegistrar(ResourceRegistrar):
                                                 content_type='rules')
         for pack, rules_dir in six.iteritems(content):
             try:
-                LOG.info('Registering rules from pack: %s', pack)
+                LOG.debug('Registering rules from pack: %s', pack)
                 rules = self._get_rules_from_pack(rules_dir)
                 count = self._register_rules_from_pack(pack, rules)
                 registered_count += count


### PR DESCRIPTION
This pull request introduces support for structured log messages with additional context information.

Structured logs by itself are really not all that useful if you just wrap `message` attribute in a JSON object. They become more useful when you include additional contextual information (you can then query, filter, etc. based on the presence and value of those additional attributes / contextual information).

I've considered using `structlog` and discussed it with @lakshmi-kannan, but I believe the custom formatters + extra attribute approach I went with is better in this case. We already use logging module from Python stdlib and this approach just builds on top of that.

All of the existing logging code and infrastructure (filters, formatters, handlers, etc.) will still work. If we want to use new structured format, we simply need to configure formatter in the logging configs as shown bellow.

And this approach also allows us to incrementaly build the context - same as structlog.

## Configuration

```ini
...
[formatter_consoleFormatter]
class=st2common.logging.formatters.ConsoleLogFormatter
format=%(asctime)s %(levelname)s [-] %(message)s

[formatter_gelfFormatter]
class=st2common.logging.formatters.GelfLogFormatter
format=%(message)s
...
```

## Example log message

```python
extra = {'_host': db_host, '_port': db_port, '_username': username, '_foo': [1,2,3], '_aa': {'abc': "d"}}
LOG.info('Connecting to database "%s" @ "%s:%s" as user "%s".' % (db_name, db_host, db_port, str(username)), extra=extra)
```

`extra` argument is a dictionary which includes additional context information which is added to the log message. All the items are prefixed with an underscore to avoid clashes with standard log record attributes (https://docs.python.org/2/library/logging.html#logrecord-attributes).

If user includes a model or some other class instance in `extra`, we call `to_dict()` method if one exists, otherwise we fall back to `repr()`. This allows us to eventually implement custom logging representation for model, api and other objects.

### ConsoleLogFormatter

This is a default "user-friendly" console log formatter we should use when logging to console and files.

```
2015-03-16 15:27:12,186 INFO [-] Connecting to database "st2" @ "0.0.0.0:27017" as user "None". (host='0.0.0.0',foo=[1, 2, 3],username='None',aa={'abc': 'd'},port=27017)
```

This formatter includes extra attributes at the end of the message as key=value pairs. This is nice because it allows users to grep for stuff (e.g. `grep id=foo`).

We should update all of our services to use this format by default when logging to console and file.

### GELFLogFormatter

This formatter formats messages as GELF-2 (https://www.graylog.org/resources/gelf-2/). Gelf format is basically structured JSON with some common attributes.

```json
{"_username": "None", "version": "1.1", "level": 20, "timestamp": 1426519705, "_python": {"process": 4880, "funcName": "db_setup", "module": "__init__", "filename": "__init__.py"}, "_port": 27017, "_foo": [1, 2, 3], "host": "vagrant-ubuntu-trusty-64", "full_message": "Connecting to database \"st2\" @ \"0.0.0.0:27017\" as user \"None\".", "_aa": {"abc": "d"}, "_host": "0.0.0.0", "short_message": "Connecting to database \"st2\" @ \"0.0.0.0:27017\" as user \"None\"."}
```

This formatter can be used when user wants structured log messages (e.g. when shipping logs to Graylog / loggly / splunk / logstash / etc.).

## TODO

In short, the goal is to get the foundation and basic changes in first. After those changes have been merged, we can start populating `extra` and adding contextual information to log lines.

- [x] Update affected code in st2api/
- [x] Update affected code in st2auth/
- [ ] Update affected code in st2common/
- [ ] Update affected code in st2debug/
- [ ] Update affected code in st2actions/
- [ ] Update affected code in st2reactor/
- [ ] Update default logging configs
- [x] Documentation section on logging