### PR TITLE
Important Doc Fixes

### DIFF
--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -19,11 +19,10 @@ APT
 Pip
 '''
 
-The easiest way to install these is to use the requirements.txt file from the |st2| downloads server.  This is kept up to date for the version specified in the path.
+The easiest way to install these is to use the requirements.txt file from the |st2| repository.  This is kept up to date for the version specified in the path.
 
 ::
-
-    curl -q -k -O https://ops.stackstorm.net/releases/st2/0.9dev/requirements.txt
+    curl -q -k -O https://raw.githubusercontent.com/StackStorm/st2/master/requirements.txt
     pip install -r requirements.txt
 
 RabbitMQ
@@ -33,7 +32,7 @@ In order to get the latest version of RabbitMQ, you will want to follow the dire
 
 ::
 
-    http://www.rabbitmq.com/install-rpm.html
+    http://www.rabbitmq.com/install-debian.html
 
 Once you have RabbitMQ installed, you will need to run the following commands to enable certain plugins.
 


### PR DESCRIPTION
This is a bit of cleanup from a review @kirilstrax did for us. I'd like to be able to use something like `|version|` to dynamically populate areas like this in code, and will look at this shortly. In the meantime, this fixes documentation to be functional for debian.

:cherries:-picked a similar fix at https://github.com/StackStorm/st2/commit/545b34fb40068a70a070fab8ed42abd44993c3ed