### PR TITLE
Fix packs.setup_virtualenv so it works correctly if user specified multiple packs search paths

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ v0.8.3 - TBD
 
 * Don't allow ``run-remote-script`` actions without an ``entry_point`` attribute - throw an
   exception when running an action. (improvement)
+* Fix ``packs.setup_virtualenv`` command so it works correctly if user specified multiple packs
+  search paths. (bug-fix)
 
 v0.8.2 - March 10, 2015
 -----------------------

--- a/contrib/packs/actions/pack_mgmt/delete.py
+++ b/contrib/packs/actions/pack_mgmt/delete.py
@@ -4,7 +4,6 @@ import shutil
 
 from oslo.config import cfg
 
-import st2common.config as config
 from st2actions.runners.pythonrunner import Action
 from st2common.constants.pack import SYSTEM_PACK_NAMES
 
@@ -14,16 +13,8 @@ BLOCKED_PACKS = frozenset(SYSTEM_PACK_NAMES)
 class UninstallPackAction(Action):
     def __init__(self, config=None):
         super(UninstallPackAction, self).__init__(config=config)
-        self.initialize()
-
         self._base_virtualenvs_path = os.path.join(cfg.CONF.system.base_path,
                                                    'virtualenvs/')
-
-    def initialize(self):
-        try:
-            config.parse_args()
-        except:
-            pass
 
     def run(self, packs, abs_repo_base):
         intersection = BLOCKED_PACKS & frozenset(packs)

--- a/contrib/packs/actions/pack_mgmt/setup_virtualenv.py
+++ b/contrib/packs/actions/pack_mgmt/setup_virtualenv.py
@@ -4,7 +4,6 @@ import pipes
 
 from oslo.config import cfg
 
-import st2common.config as config
 from st2common.util.shell import run_command
 from st2actions.runners.pythonrunner import Action
 from st2common.constants.pack import PACK_NAME_WHITELIST
@@ -26,16 +25,8 @@ class SetupVirtualEnvironmentAction(Action):
 
     def __init__(self, config=None):
         super(SetupVirtualEnvironmentAction, self).__init__(config=config)
-        self.initialize()
-
         self._base_virtualenvs_path = os.path.join(cfg.CONF.system.base_path,
                                                    'virtualenvs/')
-
-    def initialize(self):
-        try:
-            config.parse_args()
-        except:
-            pass
 
     def run(self, packs):
         """

--- a/contrib/packs/actions/pack_mgmt/unload.py
+++ b/contrib/packs/actions/pack_mgmt/unload.py
@@ -1,6 +1,5 @@
 from oslo.config import cfg
 
-import st2common.config as config
 from st2common.models.db import db_setup
 from st2actions.runners.pythonrunner import Action
 from st2common.persistence import reactor
@@ -16,13 +15,7 @@ class UnregisterPackAction(Action):
         self.initialize()
 
     def initialize(self):
-        # 1. Parse config
-        try:
-            config.parse_args()
-        except:
-            pass
-
-        # 2. Setup db connection
+        # 1. Setup db connection
         username = cfg.CONF.database.username if hasattr(cfg.CONF.database, 'username') else None
         password = cfg.CONF.database.password if hasattr(cfg.CONF.database, 'password') else None
         db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,

--- a/st2actions/st2actions/runners/python_action_wrapper.py
+++ b/st2actions/st2actions/runners/python_action_wrapper.py
@@ -32,7 +32,7 @@ LOG = logging.getLogger(__name__)
 
 
 class PythonActionWrapper(object):
-    def __init__(self, pack, file_path, parameters=None):
+    def __init__(self, pack, file_path, parameters=None, parent_args=None):
         """
         :param pack: Name of the pack this action belongs to.
         :type pack: ``str``
@@ -42,13 +42,17 @@ class PythonActionWrapper(object):
 
         :param parameters: action parameters.
         :type parameters: ``dict`` or ``None``
+
+        :param parent_args: Command line arguments passed to the parent process.
+        :type parse_args: ``list``
         """
         self._pack = pack
         self._file_path = file_path
         self._parameters = parameters or {}
+        self._parent_args = parent_args or []
 
         try:
-            config.parse_args(args=[])
+            config.parse_args(args=self._parent_args)
         except Exception:
             pass
 
@@ -95,12 +99,18 @@ if __name__ == '__main__':
                         help='Path to the action module')
     parser.add_argument('--parameters', required=False,
                         help='Serialized action parameters')
+    parser.add_argument('--parent-args', required=False,
+                        help='Command line arguments passed to the parent process')
     args = parser.parse_args()
 
     parameters = args.parameters
     parameters = json.loads(parameters) if parameters else {}
+    parent_args = json.loads(args.parent_args) if args.parent_args else []
+    assert isinstance(parent_args, list)
 
     obj = PythonActionWrapper(pack=args.pack,
                               file_path=args.file_path,
-                              parameters=parameters)
+                              parameters=parameters,
+                              parent_args=parent_args)
+
     obj.run()

--- a/st2actions/st2actions/runners/pythonrunner.py
+++ b/st2actions/st2actions/runners/pythonrunner.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import os
+import sys
 import abc
 import json
 import uuid
@@ -122,7 +123,8 @@ class PythonRunner(ActionRunner):
             WRAPPER_SCRIPT_PATH,
             '--pack=%s' % (pack),
             '--file-path=%s' % (self.entry_point),
-            '--parameters=%s' % (serialized_parameters)
+            '--parameters=%s' % (serialized_parameters),
+            '--parent-args=%s' % (json.dumps(sys.argv[1:]))
         ]
 
         # We need to ensure all the st2 dependencies are also available to the

--- a/st2actions/tests/unit/test_pythonrunner.py
+++ b/st2actions/tests/unit/test_pythonrunner.py
@@ -30,7 +30,13 @@ import st2tests.config as tests_config
 PACAL_ROW_ACTION_PATH = os.path.join(tests_base.get_resources_path(), 'packs',
                                      'pythonactions/actions/pascal_row.py')
 
+# Note: runner inherits parent args which doesn't work with tests since test pass additional
+# unrecognized args
+mock_sys = mock.Mock()
+mock_sys.argv = []
 
+
+@mock.patch('st2actions.runners.pythonrunner.sys', mock_sys)
 class PythonRunnerTestCase(TestCase):
 
     @classmethod

--- a/st2common/st2common/content/utils.py
+++ b/st2common/st2common/content/utils.py
@@ -25,6 +25,7 @@ __all__ = [
     'get_system_packs_base_path',
     'get_packs_base_paths',
     'get_pack_base_path',
+    'get_pack_directory',
     'check_pack_directory_exists',
     'check_pack_content_directory_exists'
 ]
@@ -136,6 +137,32 @@ def get_pack_base_path(pack_name):
     pack_base_path = os.path.join(packs_base_paths[0], pipes.quote(pack_name))
     pack_base_path = os.path.abspath(pack_base_path)
     return pack_base_path
+
+
+def get_pack_directory(pack_name):
+    """
+    Retrieve a directory for the provided pack.
+
+    If a directory for the provided pack doesn't exist in any of the search paths, None
+    is returned instead.
+
+    Note: If same pack exists in multiple search path, path to the first one is returned.
+
+    :param pack_name: Pack name.
+    :type pack_name: ``str``
+
+    :return: Pack to the pack directory.
+    :rtype: ``str`` or ``None``
+    """
+    packs_base_paths = get_packs_base_paths()
+    for packs_base_path in packs_base_paths:
+        pack_base_path = os.path.join(packs_base_path, pipes.quote(pack_name))
+        pack_base_path = os.path.abspath(pack_base_path)
+
+        if os.path.isdir(pack_base_path):
+            return pack_base_path
+
+    return None
 
 
 def get_entry_point_abs_path(pack=None, entry_point=None):


### PR DESCRIPTION
Previously packs.setup_virtualenv command didn't work correctly if user used multiple packs search paths (`content.packs_base_paths` setting).