### PR TITLE
RFR - Fix exit_codes returned by SensorContainer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ in development
   rules_engine is now st2rulesengine, actionrunner is now st2actionrunner) (improvement)
 * Return a user friendly error on no sensors found or typo in sensor class name in single
   sensor mode. (improvement)
+* Sensor container now returns non-zero exit codes for errors. (bug-fix)
 
 v0.8.3 - TBD
 ------------

--- a/st2common/st2common/exceptions/sensors.py
+++ b/st2common/st2common/exceptions/sensors.py
@@ -27,3 +27,7 @@ class TriggerTypeRegistrationException(SensorPluginException):
 
 class NoSensorsFoundException(StackStormBaseException):
     pass
+
+
+class SensorNotFoundException(StackStormBaseException):
+    pass

--- a/st2reactor/bin/st2sensorcontainer
+++ b/st2reactor/bin/st2sensorcontainer
@@ -18,4 +18,4 @@ if DEVEL:
     sys.path.append(python_lib_dir)
 
 if __name__ == '__main__':
-    sensormanager.main()
+    sys.exit(sensormanager.main())

--- a/st2reactor/st2reactor/cmd/sensormanager.py
+++ b/st2reactor/st2reactor/cmd/sensormanager.py
@@ -6,6 +6,7 @@ from oslo.config import cfg
 
 from st2common import log as logging
 from st2common.exceptions.sensors import NoSensorsFoundException
+from st2common.exceptions.sensors import SensorNotFoundException
 from st2common.models.db import db_setup
 from st2common.models.db import db_teardown
 from st2common.constants.logging import DEFAULT_LOGGING_CONF_PATH
@@ -72,7 +73,7 @@ def main():
             sensors = [sensor for sensor in sensors if
                        sensor.name == cfg.CONF.sensor_name]
             if not sensors:
-                raise NoSensorsFoundException('Sensor %s not found in db.' % cfg.CONF.sensor_name)
+                raise SensorNotFoundException('Sensor %s not found in db.' % cfg.CONF.sensor_name)
 
         if not sensors:
             msg = 'No sensors configured to run. See http://docs.stackstorm.com/sensors.html.'
@@ -80,9 +81,15 @@ def main():
 
         return container_manager.run_sensors(sensors=sensors)
     except SystemExit as exit_code:
-        sys.exit(exit_code)
+        return exit_code
+    except NoSensorsFoundException as e:
+        LOG.exception(e)
+        return 0
+    except SensorNotFoundException as e:
+        LOG.exception(e)
+        return 1
     except:
         LOG.exception('(PID:%s) SensorContainer quit due to exception.', os.getpid())
-        return 1
+        return 2
     finally:
         _teardown()

--- a/tools/st2ctl
+++ b/tools/st2ctl
@@ -233,10 +233,19 @@ function getpids(){
       echo "${COM} is not running"
       if [ "$COM" == "st2sensorcontainer" ] || [ "$COM" == "sensor_container" ]
       then
-        echo "Sensor container did not detect valid sensors to run."
-        echo "Please install sensors or check sensors configuration for existing ones."
-        echo "See http://docs.stackstorm.com/sensors.html."
-        echo "Use 'st2ctl restart-component st2sensorcontainer' to restart after you fix the problems."
+        msg="
+  Sensor container service was unable to load any sensors to load in
+  the 'base_pack' directory (or whatever path this needs to be). This may
+  be caused due to not having any sensors installed, or the sensors that
+  are installed are misconfigured.
+
+  Take a moment and review http://docs.stackstorm.com/sensors.html
+  for more information.
+
+  Once resolved, you can simply restart the service with the
+  'st2ctl restart-component st2sensorcontainer' command."
+        echo "$msg" | fmt -w 72
+        echo
       fi
     fi
   done

--- a/tools/st2ctl
+++ b/tools/st2ctl
@@ -234,10 +234,9 @@ function getpids(){
       if [ "$COM" == "st2sensorcontainer" ] || [ "$COM" == "sensor_container" ]
       then
         msg="
-  Sensor container service was unable to load any sensors to load in
-  the 'base_pack' directory (or whatever path this needs to be). This may
-  be caused due to not having any sensors installed, or the sensors that
-  are installed are misconfigured.
+  Sensor container service was unable to load any sensors from packs in
+  the 'base_pack' (See st2 config file) directory. This may be caused due to not having any
+  sensors installed, or the sensors that are installed are misconfigured.
 
   Take a moment and review http://docs.stackstorm.com/sensors.html
   for more information.


### PR DESCRIPTION
```
(virtualenv)~/st2 git:STORM-1153/sensor_container_messages ❯❯❯ virtualenv/bin/python ./st2reactor/bin/st2sensorcontainer --config-file conf/st2.conf --sensor-name=GitCommitSensor
2015-03-19 20:19:25,836 INFO [-] Connecting to database "st2" @ "0.0.0.0:27017" as user "None".
2015-03-19 20:19:26,052 INFO [-] Registering exchanges...
2015-03-19 20:19:26,227 INFO [-] registered exchange st2.execution.
2015-03-19 20:19:26,293 INFO [-] registered exchange st2.liveaction.
2015-03-19 20:19:26,325 INFO [-] registered exchange st2.trigger.
2015-03-19 20:19:26,339 INFO [-] registered exchange st2.trigger_instances_dispatch.
2015-03-19 20:19:26,483 INFO [-] Found 0 sensors.
2015-03-19 20:19:26,484 ERROR [-] Sensor GitCommitSensor not found in db.
Traceback (most recent call last):
  File "/home/lakshmi/st2/st2reactor/st2reactor/cmd/sensormanager.py", line 76, in main
    raise SensorNotFoundException('Sensor %s not found in db.' % cfg.CONF.sensor_name)
SensorNotFoundException: Sensor GitCommitSensor not found in db.
(virtualenv)~/st2 git:STORM-1153/sensor_container_messages ❯❯❯ echo $?                                                ⏎ ✭ ✱ ◼
1
(virtualenv)~/st2 git:STORM-1153/sensor_container_messages ❯❯❯ virtualenv/bin/python ./st2reactor/bin/st2sensorcontainer --config-file conf/st2.conf
2015-03-19 20:30:28,826 INFO [-] Connecting to database "st2" @ "0.0.0.0:27017" as user "None".
2015-03-19 20:30:28,871 INFO [-] Registering exchanges...
2015-03-19 20:30:28,897 INFO [-] registered exchange st2.execution.
2015-03-19 20:30:28,903 INFO [-] registered exchange st2.liveaction.
2015-03-19 20:30:28,906 INFO [-] registered exchange st2.trigger.
2015-03-19 20:30:28,907 INFO [-] registered exchange st2.trigger_instances_dispatch.
2015-03-19 20:30:28,961 INFO [-] Found 0 sensors.
2015-03-19 20:30:28,962 ERROR [-] No sensors configured to run. See http://docs.stackstorm.com/sensors.html.
Traceback (most recent call last):
  File "/home/lakshmi/st2/st2reactor/st2reactor/cmd/sensormanager.py", line 80, in main
    raise NoSensorsFoundException(msg)
NoSensorsFoundException: No sensors configured to run. See http://docs.stackstorm.com/sensors.html.
(virtualenv)~/st2 git:STORM-1153/sensor_container_messages ❯❯❯ echo $?                                                  ✭ ✱ ◼
0
(virtualenv)~/st2 git:STORM-1153/sensor_container_messages ❯❯❯

(virtualenv)~/st2 git:STORM-1153/sensor_container_messages ❯❯❯ virtualenv/bin/python ./st2reactor/bin/st2sensorcontainer --config-file conf/st2.conf
2015-03-19 20:55:52,016 INFO [-] Connecting to database "st2" @ "0.0.0.0:27017" as user "None".
2015-03-19 20:55:52,183 INFO [-] Registering exchanges...
2015-03-19 20:55:52,241 INFO [-] registered exchange st2.execution.
2015-03-19 20:55:52,243 INFO [-] registered exchange st2.liveaction.
2015-03-19 20:55:52,249 INFO [-] registered exchange st2.trigger.
2015-03-19 20:55:52,250 INFO [-] registered exchange st2.trigger_instances_dispatch.
2015-03-19 20:55:52,446 INFO [-] Found 1 sensors.
2015-03-19 20:55:52,447 INFO [-] Setting up container to run 1 sensors.
2015-03-19 20:55:52,448 INFO [-] (PID:23042) SensorContainer started.
2015-03-19 20:55:52,452 INFO [-] Running sensor IRCSensor
2015-03-19 20:55:52,515 AUDIT [-] Access granted to "sensors_container" with the token set to expire at "2015-03-20T20:55:52.463860Z". (username='sensors_container',token_expiration='2015-03-20T20:55:52.463860Z')
2015-03-19 20:55:52,636 INFO [-] Sensor IRCSensor started
2015-03-19 20:55:54,417 INFO [-] Using config "/opt/stackstorm/packs/irc/config.yaml" for sensor "IRCSensor"
2015-03-19 20:55:54,418 INFO [-] Watcher started
2015-03-19 20:55:54,418 INFO [-] Running sensor initialization code
2015-03-19 20:55:54,418 INFO [-] Running sensor in passive mode
2015-03-19 20:55:54,620 INFO [-] Connected to amqp://guest:**@127.0.0.1:5672//
^C2015-03-19 20:56:00,491 INFO [-] Container shutting down. Invoking cleanup on sensors.
2015-03-19 20:56:01,493 INFO [-] All sensors are shut down.
2015-03-19 20:56:01,493 INFO [-] (PID:23042) SensorContainer stopped. Reason - KeyboardInterrupt
(virtualenv)~/st2 git:STORM-1153/sensor_container_messages ❯❯❯ echo $?                                                  ✭ ✱ ◼
0
(virtualenv)~/st2 git:STORM-1153/sensor_container_messages ❯❯❯

(virtualenv)~/st2 git:STORM-1153/sensor_container_messages ❯❯❯ virtualenv/bin/python ./st2reactor/bin/st2sensorcontainer --config-file conf/st2.conf
2015-03-19 20:57:01,259 INFO [-] Connecting to database "st2" @ "0.0.0.0:27017" as user "None".
2015-03-19 20:57:01,310 INFO [-] Registering exchanges...
2015-03-19 20:57:01,401 INFO [-] registered exchange st2.execution.
2015-03-19 20:57:01,412 INFO [-] registered exchange st2.liveaction.
2015-03-19 20:57:01,420 INFO [-] registered exchange st2.trigger.
2015-03-19 20:57:01,421 INFO [-] registered exchange st2.trigger_instances_dispatch.
2015-03-19 20:57:01,541 INFO [-] Found 1 sensors.
2015-03-19 20:57:01,541 INFO [-] Setting up container to run 1 sensors.
2015-03-19 20:57:01,542 ERROR [-] (PID:23178) SensorContainer quit due to exception.
Traceback (most recent call last):
  File "/home/lakshmi/st2/st2reactor/st2reactor/cmd/sensormanager.py", line 82, in main
    return container_manager.run_sensors(sensors=sensors)
  File "/home/lakshmi/st2/st2reactor/st2reactor/container/manager.py", line 37, in run_sensors
    raise Exception("mocking an exception")
Exception: mocking an exception
(virtualenv)~/st2 git:STORM-1153/sensor_container_messages ❯❯❯ echo $?                                                ⏎ ✭ ✱ ◼
2
(virtualenv)~/st2 git:STORM-1153/sensor_container_messages ❯❯❯
```

## st2ctl message

```
(virtualenv)~/st2 git:STORM-1153/sensor_container_messages ❯❯❯ tools/st2ctl status                                        ✭ ◼
##### st2 components status #####
st2actionrunner is not running
st2api is not running
st2sensorcontainer is not running

  Sensor container service was unable to load any sensors from packs
  in the 'base_pack' (See st2 config file) directory. This may be
  caused due to not having any sensors installed, or the sensors that
  are installed are misconfigured.

  Take a moment and review http://docs.stackstorm.com/sensors.html
  for more information.

  Once resolved, you can simply restart the service with the 'st2ctl
  restart-component st2sensorcontainer' command.

st2rulesengine is not running
mistral PID: 1235
st2resultstracker is not running
(virtualenv)~/st2 git:STORM-1153/sensor_container_messages ❯❯❯
```