### PR TITLE
Fixed path /usr/share/stackstorm in file list

### DIFF
--- a/st2common/packaging/rpm/st2common-rhel6.spec
+++ b/st2common/packaging/rpm/st2common-rhel6.spec
@@ -49,7 +49,7 @@ install -m755 tools/st2ctl %{buildroot}/usr/bin/st2ctl
 %files
 /usr/local/lib/python2.7/site-packages/st2common*
 /usr/share/doc/st2/*
-/usr/share/doc/stackstorm/*
+/usr/share/stackstorm/*
 /etc/st2/*
 /opt/stackstorm/*
 /var/log/st2

--- a/st2common/packaging/rpm/st2common.spec
+++ b/st2common/packaging/rpm/st2common.spec
@@ -51,7 +51,7 @@ install -m755 tools/st2ctl %{buildroot}/usr/bin/st2ctl
 %files
 %{python2_sitelib}/st2common*
 /usr/share/doc/st2/*
-/usr/share/doc/stackstorm/*
+/usr/share/stackstorm/*
 /etc/st2/*
 /opt/stackstorm/*
 /var/log/st2


### PR DESCRIPTION
This PR fixes a typo in the file list for the st2common RPM spec files.