### PR TITLE
[0.8.3] Fix api url used by sensors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,9 @@ v0.8.3 - TBD
   exception when running an action. (improvement)
 * Fix ``packs.setup_virtualenv`` command so it works correctly if user specified multiple packs
   search paths. (bug-fix)
+* Update sensor container to use ``auth.api_url`` setting when talking to the API (e.g. when
+  accessing a datastore, etc.). This way it also works correctly if sensor container is running
+  on a different host than the API. (bug-fix)
 
 v0.8.2 - March 10, 2015
 -----------------------

--- a/conf/st2.conf
+++ b/conf/st2.conf
@@ -10,7 +10,6 @@ serve_webui_files = True
 # allow_origin = http://myhost1.example.com:3000,http://myhost2.example.com:3000
 
 [sensorcontainer]
-actionexecution_base_url = http://0.0.0.0:9101/actionexecutions
 logging = st2reactor/conf/logging.sensorcontainer.conf
 
 [rulesengine]

--- a/st2common/st2common/util/api.py
+++ b/st2common/st2common/util/api.py
@@ -16,17 +16,36 @@
 from oslo.config import cfg
 
 from st2common.constants.api import DEFAULT_API_VERSION
+from st2common.util.url import get_url_without_trailing_slash
 
 __all__ = [
-    'get_full_api_url'
+    'get_base_public_api_url',
+    'get_full_public_api_url'
 ]
 
 
-def get_full_api_url(api_version=DEFAULT_API_VERSION):
+def get_base_public_api_url():
     """
-    Return full URL to the API endpoint.
+    Return full public URL to the API endpoint (excluding the API version).
 
     :rtype: ``str``
     """
-    api_url = 'http://%s:%s/%s' % (cfg.CONF.api.host, cfg.CONF.api.port, api_version)
+    # Note: This is here for backward compatibility reasons - if api_url is not set we fall back
+    # to the old approach (using api listen host and port)
+    if cfg.CONF.auth.api_url:
+        api_url = get_url_without_trailing_slash(cfg.CONF.auth.api_url)
+    else:
+        api_url = 'http://%s:%s' % (cfg.CONF.api.host, cfg.CONF.api.port)
+
+    return api_url
+
+
+def get_full_public_api_url(api_version=DEFAULT_API_VERSION):
+    """
+    Return full public URL to the API endpoint (including the API version).
+
+    :rtype: ``str``
+    """
+    api_url = get_base_public_api_url()
+    api_url = '%s/%s' % (api_url, api_version)
     return api_url

--- a/st2common/tests/unit/test_util_api.py
+++ b/st2common/tests/unit/test_util_api.py
@@ -1,0 +1,68 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest2
+
+from oslo.config import cfg
+
+from st2common.constants.api import DEFAULT_API_VERSION
+from st2common.util.api import get_base_public_api_url
+from st2common.util.api import get_full_public_api_url
+from st2tests.config import parse_args
+parse_args()
+
+
+class APIUtilsTestCase(unittest2.TestCase):
+    def test_get_base_public_api_url(self):
+        values = [
+            'http://foo.bar.com',
+            'http://foo.bar.com/',
+            'http://foo.bar.com:8080',
+            'http://foo.bar.com:8080/',
+            'http://localhost:8080/',
+        ]
+        expected = [
+            'http://foo.bar.com',
+            'http://foo.bar.com',
+            'http://foo.bar.com:8080',
+            'http://foo.bar.com:8080',
+            'http://localhost:8080',
+        ]
+
+        for mock_value, expected_result in zip(values, expected):
+            cfg.CONF.auth.api_url = mock_value
+            actual = get_base_public_api_url()
+            self.assertEqual(actual, expected_result)
+
+    def test_get_full_public_api_url(self):
+        values = [
+            'http://foo.bar.com',
+            'http://foo.bar.com/',
+            'http://foo.bar.com:8080',
+            'http://foo.bar.com:8080/',
+            'http://localhost:8080/',
+        ]
+        expected = [
+            'http://foo.bar.com/' + DEFAULT_API_VERSION,
+            'http://foo.bar.com/' + DEFAULT_API_VERSION,
+            'http://foo.bar.com:8080/' + DEFAULT_API_VERSION,
+            'http://foo.bar.com:8080/' + DEFAULT_API_VERSION,
+            'http://localhost:8080/' + DEFAULT_API_VERSION,
+        ]
+
+        for mock_value, expected_result in zip(values, expected):
+            cfg.CONF.auth.api_url = mock_value
+            actual = get_full_public_api_url()
+            self.assertEqual(actual, expected_result)

--- a/st2debug/tests/integration/fixtures/configs/st2.conf
+++ b/st2debug/tests/integration/fixtures/configs/st2.conf
@@ -17,7 +17,6 @@ password = ponies
 url = ponies
 
 [sensorcontainer]
-actionexecution_base_url = http://0.0.0.0:9101/actionexecutions
 logging = st2reactor/conf/logging.sensorcontainer.conf
 
 [rulesengine]

--- a/st2reactor/st2reactor/container/process_container.py
+++ b/st2reactor/st2reactor/container/process_container.py
@@ -25,7 +25,7 @@ from st2common.constants.system import API_URL_ENV_VARIABLE_NAME
 from st2common.constants.system import AUTH_TOKEN_ENV_VARIABLE_NAME
 from st2common.constants.error_messages import PACK_VIRTUALENV_DOESNT_EXIST
 from st2common.services.access import create_token
-from st2common.util.api import get_full_api_url
+from st2common.util.api import get_full_public_api_url
 from st2common.util.sandboxing import get_sandbox_python_path
 from st2common.util.sandboxing import get_sandbox_python_binary_path
 from st2common.util.sandboxing import get_sandbox_virtualenv_path
@@ -200,7 +200,7 @@ class ProcessSensorContainer(object):
         ttl = (24 * 60 * 60)
         temporary_token = create_token(username='sensors_container', ttl=ttl)
 
-        env[API_URL_ENV_VARIABLE_NAME] = get_full_api_url()
+        env[API_URL_ENV_VARIABLE_NAME] = get_full_public_api_url()
         env[AUTH_TOKEN_ENV_VARIABLE_NAME] = temporary_token.token
 
         # TODO 1: Purge temporary token when service stops or sensor process dies

--- a/st2tests/conf/st2.conf
+++ b/st2tests/conf/st2.conf
@@ -9,7 +9,6 @@ logging = st2api/conf/logging.conf
 # allow_origin = http://myhost1.example.com:3000,http://myhost2.example.com:3000
 
 [sensorcontainer]
-actionexecution_base_url = http://0.0.0.0:9101/actionexecutions
 logging = st2reactor/conf/logging.sensorcontainer.conf
 
 [rulesengine]


### PR DESCRIPTION
Previously, sensors used api listen host and port setting to obtain a public URL to the API.

Obviously this wasn't a good idea and it wouldn't work if sensor container ran on a different host or similar (well, you could get it to work, but you would need to use different values for `api.host` setting on different servers which is nasty). This pull request fixes that and makes it use `auth.api_url` setting.

This way it's also consistent with other code and we only have one placed where a public URL to the API is configured.

Installation documentation already mentions that this setting needs to be configured correctly because it's also used in other places so no changes are needed there.