### PR TITLE
RFR: GET /triggertypes before POST /triggertypes for internal ones

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ in development
 * Return a user friendly error on no sensors found or typo in sensor class name in single
   sensor mode. (improvement)
 * Sensor container now returns non-zero exit codes for errors. (bug-fix)
+* Check if internal trigger types are already registered before registering
+  them again. (improvement)
 
 v0.8.3 - TBD
 ------------

--- a/conf/st2.dev.conf
+++ b/conf/st2.dev.conf
@@ -64,7 +64,7 @@ port = 6001
 url = /webhooks/generic/
 
 [action_sensor]
-triggers_base_url = http://localhost:9101/triggertypes/
+triggers_base_url = http://localhost:9101/v1/triggertypes/
 
 [resultstracker]
 logging = st2actions/conf/logging.resultstracker.conf

--- a/conf/st2.prod.conf
+++ b/conf/st2.prod.conf
@@ -64,7 +64,7 @@ port = 6001
 url = /webhooks/generic/
 
 [action_sensor]
-triggers_base_url = http://localhost:9101/triggertypes/
+triggers_base_url = http://localhost:9101/v1/triggertypes/
 
 [resultstracker]
 logging = /etc/st2actions/conf/logging.resultstracker.conf

--- a/st2common/st2common/triggers.py
+++ b/st2common/st2common/triggers.py
@@ -24,6 +24,7 @@ from oslo.config import cfg
 from st2common import log as logging
 from st2common.constants.triggers import INTERNAL_TRIGGER_TYPES
 from st2common.models.system.common import ResourceReference
+from st2common.util.url import get_url_without_trailing_slash
 
 __all__ = [
     'register_internal_trigger_types'
@@ -40,10 +41,8 @@ MAX_ATTEMPTS = cfg.CONF.action_sensor.max_attempts
 
 
 def _get_trigger_type_url(triggertype_ref):
-    if TRIGGER_TYPE_ENDPOINT.endswith('/'):
-        return TRIGGER_TYPE_ENDPOINT + triggertype_ref
-    else:
-        return '%s/%s' % (TRIGGER_TYPE_ENDPOINT, triggertype_ref)
+    base_url = get_url_without_trailing_slash(TRIGGER_TYPE_ENDPOINT)
+    return '%s/%s' % (base_url, triggertype_ref)
 
 
 def _do_register_internal_trigger_types():


### PR DESCRIPTION
This PR suppresses logs such as 
```
2015-03-18 12:05:19,221 140286007899952 WARNING triggers [-] TriggerType creation of TriggerTypeAPI[payload_schema={u'type': u'object', u'properties': {u'status': {}, u'start_timestamp': {}, u'parameters': {}, u'action_name': {}, u'result': {}, u'execution_id': {}}}, pack=u'core', description=u'Trigger encapsulating the completion of an action execution.', name=u'st2.generic.actiontrigger'] failed with uniqueness conflict. Exception : Tried to save duplicate unique keys (E11000 duplicate key error index: st2.trigger_type_d_b.$pack_1_name_1  dup key: { : "core", : "st2.generic.actiontrigger" })
2015-03-18 12:05:19,222 140286007899952 ERROR base [-] API call failed.
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/st2common/models/api/base.py", line 163, in callfunction
    result = f(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/st2api/controllers/v1/triggers.py", line 74, in post
    abort(http_client.CONFLICT, str(e), body={'conflict-id': e.conflict_id})
  File "/usr/local/lib/python2.7/site-packages/pecan/core.py", line 119, in abort
    **kw
HTTPConflict: Tried to save duplicate unique keys (E11000 duplicate key error index: st2.trigger_type_d_b.$pack_1_name_1  dup key: { : "core", : "st2.generic.actiontrigger" })
```
in API.

This will still show the first time someone installs st2 and sets it up. After that restarts won't have these logs. 