### PR TITLE
Update st2_deploy to configure authentication service with test credentials

### DIFF
--- a/conf/st2.dev.conf
+++ b/conf/st2.dev.conf
@@ -45,7 +45,7 @@ redirect_stderr = False
 
 [system_user]
 user = stanley
-ssh_key_file = /vagrant/.ssh/stanley_rsa
+ssh_key_file = /home/vagrant/.ssh/stanley_rsa
 
 [messaging]
 url = amqp://guest:guest@localhost:5672/

--- a/conf/st2.dev.conf
+++ b/conf/st2.dev.conf
@@ -24,8 +24,10 @@ port = 9100
 use_ssl = False
 debug = False
 enable = False
-mode = proxy
 logging = st2auth/conf/logging.conf
+
+mode = proxy
+backend_kwargs =
 
 # Base URL to the API endpoint excluding the version (e.g. http://myhost.net:9101/)
 api_url = http://127.0.0.1:9101/

--- a/conf/st2.prod.conf
+++ b/conf/st2.prod.conf
@@ -24,8 +24,10 @@ port = 9100
 use_ssl = False
 debug = False
 enable = True
-mode = proxy
 logging = /etc/st2auth/logging.conf
+
+mode = proxy
+backend_kwargs =
 
 # Base URL to the API endpoint excluding the version (e.g. http://myhost.net:9101/)
 api_url =

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -103,4 +103,32 @@ Example usage
     st2auth --config-file /etc/stanley/st2.conf --auth-use_ssl --auth-mode=standalone \
         --auth-backend=flat_file --auth-backend_kwargs='{"file_path": "/etc/private/htpaswd"}'
 
+MongoDB backend
+~~~~~~~~~~~~~~~
+
+MongoDB backend supports reading credentials from a MongoDB collection called
+``users``.
+
+Entries in this collection need to have the following attributes:
+
+* ``username`` - Username
+* ``salt`` - Password salt
+* ``password`` - SHA256 hash for the salt+password - SHA256(<salt><password>)
+
+Configuration options
+^^^^^^^^^^^^^^^^^^^^^
+
+* ``db_host`` - MongoDB server host.
+* ``db_port`` - MongoDB server port.
+* ``db_name`` - Name of the database to use.
+
+Example usage
+^^^^^^^^^^^^^^
+
+.. sourcecode:: bash
+
+    st2auth --config-file /etc/stanley/st2.conf --auth-use_ssl--auth-mode=standalone \
+        --auth-backend=mongodb \
+        --auth-backend_kwargs='{"db_host": "196.168.100.10", "db_port": 27017, "db_name": "st2auth"}'
+
 .. _htpasswd: https://httpd.apache.org/docs/2.2/programs/htpasswd.html

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -119,7 +119,6 @@ exclude_patterns = [
     'engage.rst',  # included file
     'install/on_complete.rst',  # included file
     'todo.rst',  # included file
-    'authentication.rst'  # not included right now
 ]
 
 # The reST default role (used for this markup: `text`) to use for all

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,6 +23,7 @@ Contents:
     troubleshooting
     resources/index
     reference/index
+    authentication
     changelog
     upgrade_notes
     development/index

--- a/docs/source/install/deploy.rst
+++ b/docs/source/install/deploy.rst
@@ -30,6 +30,10 @@ The available options are described below:
 * ``backend_kwargs`` - JSON serialized keyword arguments which are passed to
   the authentication backend.
 
+For more information about authentication service and different authentication
+backends available in the standalone mode, see
+:doc:`Authentication Service </authentication>` page.
+
 Setup the service using proxy mode
 ----------------------------------
 

--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -1,6 +1,17 @@
 Installation
 ============
 
+.. note::
+
+    st2_deploy.sh script allows you to easily install and run |st2| with all the
+    dependencies on a single server. It's only intented to be used for testing,
+    evaluation and demonstration purposes (it doesn't use HTTPS, it uses flat file
+    htpasswd based authentication, etc.) - you should **not** use it for production
+    deployments.
+
+    For production deployments you follow deb / rpm installation methods linked
+    at the bottom of the page or use our puppet module.
+
 To install and run |st2| on Ubuntu/Debian or RedHat/Fedora with all dependencies,
 download and run the deployment script.
 
@@ -11,7 +22,7 @@ download and run the deployment script.
     sudo ./st2_deploy.sh
 
 This will download and install the stable release of |st2| (currently |release|).
-If you want to install the latest bits, run ``sudo ./st2_deploy.sh latest``.
+If you want to install the latest development version, run ``sudo ./st2_deploy.sh latest``.
 Installation should take about 5 min. Grab a coffee and watch :doc:`/video` while it is being installed.
 
 .. include:: on_complete.rst

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -2,8 +2,15 @@ Upgrade Notes
 =============
 
 |st2| 0.9dev
-~~~~~~~~~~~~
+------------
 
-* Process names for all |st2| services now start with "st2". sensor_container now runs as st2sensorcontainer, rules_engine runs as st2rulesengine, actionrunner now runs as st2actionrunner. st2ctl has been updated to handle the name change seamlessly. If you have tools that rely on the old process names, upgrade them to use new names.
+* Process names for all |st2| services now start with "st2". sensor_container now runs as
+  st2sensorcontainer, rules_engine runs as st2rulesengine, actionrunner now runs as
+  st2actionrunner. st2ctl has been updated to handle the name change seamlessly. If you have tools
+  that rely on the old process names, upgrade them to use new names.
 
-* All |st2| tools now use "st2" prefix as well. rule_tester is now st2-rule-tester, registercontent is now st2-register-content.
+* All |st2| tools now use "st2" prefix as well. rule_tester is now st2-rule-tester, registercontent
+  is now st2-register-content.
+
+* Authentication is now enabled by default for production (package based) deployments. For
+  information on how to configure auth, see http://docs.stackstorm.com/install/deploy.html.

--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -12,6 +12,8 @@ is not intended to be used for production deployments.
 For more information, see http://docs.stackstorm.com/install/index.html
 EOM
 
+WARNING_SLEEP_DELAY=5
+
 # Common variables
 RABBIT_PUBLIC_KEY="rabbitmq-signing-key-public.asc"
 PACKAGES="st2common st2reactor st2actions st2api st2auth st2debug"
@@ -40,7 +42,9 @@ function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" 
 # Actual code starts here
 
 echo "${WARNING_MSG}"
-sleep 2
+echo ""
+echo "To abort press CTRL-C otherwise installation will continue in ${WARNING_SLEEP_DELAY} seconds"
+sleep ${WARNING_SLEEP_DELAY}
 
 if [ -z $1 ]
 then

--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# Constants
 read -r -d '' WARNING_MSG << EOM
 ######################################################################
 ######                       WARNING                           #######
@@ -8,13 +9,38 @@ read -r -d '' WARNING_MSG << EOM
 This scripts allows you to evaluate StackStorm on a single server and
 is not intended to be used for production deployments.
 
-For more information, see http://docs.stackstorm.com/TODO
+For more information, see http://docs.stackstorm.com/install/index.html
 EOM
+
+# Common variables
+RABBIT_PUBLIC_KEY="rabbitmq-signing-key-public.asc"
+PACKAGES="st2common st2reactor st2actions st2api st2auth st2debug"
+CLI_PACKAGE="st2client"
+PYTHON=`which python`
+BUILD="current"
+DEBTEST=`lsb_release -a 2> /dev/null | grep Distributor | awk '{print $3}'`
+SYSTEMUSER='stanley'
+STANCONF="/etc/st2/st2.conf"
+
+# Information about a test account which used by st2_deploy
+TEST_ACCOUNT_USERNAME="testu"
+TEST_ACCOUNT_PASSWORD="testp"
+
+# Content for the test htpasswd file used by auth
+AUTH_FILE_PATH="/etc/st2/htpasswd"
+HTPASSWD_FILE_CONTENT="testu:{SHA}V1t6eZLxnehb7CTBuj61Nq3lIh4="
+
+# WebUI
+WEBUI_CONFIG_PATH="/opt/stackstorm/static/webui/config.js"
+
+# Common utility functions
+
+function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" == "$1"; }
+
+# Actual code starts here
 
 echo "${WARNING_MSG}"
 sleep 2
-
-function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" == "$1"; }
 
 if [ -z $1 ]
 then
@@ -38,15 +64,6 @@ elif version_ge $VER "0.8"; then
 else
     MISTRAL_STABLE_BRANCH="st2-0.5.1"
 fi
-
-RABBIT_PUBLIC_KEY="rabbitmq-signing-key-public.asc"
-PACKAGES="st2common st2reactor st2actions st2api st2auth st2debug"
-CLI_PACKAGE="st2client"
-PYTHON=`which python`
-BUILD="current"
-DEBTEST=`lsb_release -a 2> /dev/null | grep Distributor | awk '{print $3}'`
-SYSTEMUSER='stanley'
-STANCONF="/etc/st2/st2.conf"
 
 if [[ "$DEBTEST" == "Ubuntu" ]]; then
   TYPE="debs"
@@ -82,7 +99,6 @@ mkdir -p ${STAN}
 mkdir -p /var/log/st2
 
 create_user() {
-
   if [ $(id -u ${SYSTEMUSER} &> /devnull; echo $?) != 0 ]
   then
     echo "###########################################################################################"
@@ -112,7 +128,7 @@ install_pip() {
   pip install -U -q -r /tmp/requirements.txt
 }
 
-install_apt(){
+install_apt() {
   echo "###########################################################################################"
   echo "# Installing packages via apt-get"
 
@@ -324,6 +340,24 @@ setup_mistral() {
   pip install -q -U git+https://github.com/StackStorm/python-mistralclient.git@${MISTRAL_STABLE_BRANCH}
 }
 
+function setup_auth() {
+    echo "###########################################################################################"
+    echo "# Setting up authentication service"
+
+    # Install test htpasswd file
+    if [[ ! -f ${AUTH_FILE_PATH} ]]; then
+        # File doesn't exist yet
+        echo "${HTPASSWD_FILE_CONTENT}" >> ${AUTH_FILE_PATH}
+    elif [ -f ${AUTH_FILE_PATH} ] && [ ! `grep -Fxq "${HTPASSWD_FILE_CONTENT}" ${AUTH_FILE_PATH}` ]; then
+        # File exists, but the line is not present yet
+        echo "${HTPASSWD_FILE_CONTENT}" >> ${AUTH_FILE_PATH}
+    fi
+
+    # Configure st2auth to run in standalone mode with the created htpasswd file
+    sed -i "s#^mode = proxy\$#mode = standalone#g" ${STANCONF}
+    sed -i "s#^backend_kwargs =\$#backend_kwargs = {\"file_path\": \"${AUTH_FILE_PATH}\"}#g" ${STANCONF}
+}
+
 download_pkgs() {
   echo "###########################################################################################"
   echo "# Downloading ${TYPE} packages"
@@ -433,13 +467,17 @@ install_webui() {
     .constant('st2Config', {
     hosts: [{
       name: 'StackStorm',
-      url: ''
+      url: '',  # use current url from the address bar
+      auth: true  # use current url from the address bar, replace the port with default st2auth port
     }]
-  });" > /opt/stackstorm/static/webui/config.js
+  });" > ${WEBUI_CONFIG_PATH}
 
+  # Cleanup
   rm -r ${temp_dir}
   rm -f /tmp/webui.tar.gz
 }
+
+setup_auth
 
 if [ ${INSTALL_ST2CLIENT} == "1" ]; then
     install_st2client
@@ -456,8 +494,6 @@ st2ctl restart
 sleep 20
 ##This is a hack around a weird issue with actions getting stuck in scheduled state
 st2 run core.local date &> /dev/null
-ACTIONEXIT=$?
-
 ACTIONEXIT=$?
 
 echo "=========================================="
@@ -478,7 +514,21 @@ else
   echo ""
   echo "  st2 is installed and ready to use."
 fi
+
 if [ ${INSTALL_WEBUI} == "1" ]; then
   echo "  WebUI at http://`hostname`:9101/webui/"
 fi
+echo "=========================================="
+echo ""
 
+echo "Test StackStorm user account details"
+echo ""
+echo "Username: ${TEST_ACCOUNT_USERNAME}"
+echo "Password: ${TEST_ACCOUNT_PASSWORD}"
+echo ""
+echo "To login and obtain an authentication token, run the following command:"
+echo ""
+echo "st2 auth ${TEST_ACCOUNT_USERNAME} -p ${TEST_ACCOUNT_PASSWORD}"
+echo ""
+echo "For more information see http://docs.stackstorm.com/install/deploy.html#usage"
+exit 0

--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+read -r -d '' WARNING_MSG << EOM
+######################################################################
+######                       WARNING                           #######
+######################################################################
+
+This scripts allows you to evaluate StackStorm on a single server and
+is not intended to be used for production deployments.
+
+For more information, see http://docs.stackstorm.com/TODO
+EOM
+
+echo "${WARNING_MSG}"
+sleep 2
+
 function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" == "$1"; }
 
 if [ -z $1 ]


### PR DESCRIPTION
TODO:

- [x] Add back auth backend specific docs.
- [x] This depends on the st2client.js change - client needs to be updated to inherit the protocol and not default to https for auth (@enykeev is on it)