### PR TITLE
RFR: Cleanup registration logs for actions and rules

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ in development
 * Sensor container now can dynamically load/reload/unload sensors on data model changes.
   (new-feature)
 * Fix a bug in datastore operations exposed in st2client. (bug-fix)
+* Catch exception if rule operator functions throw excepton and ignore the rule. (bug-fix)
+* Remove expected "runnertype not found" error logs on action registration
+  in clean db. (improvement)
+* Clean up rule registrar logging. (improvement)
 
 v0.8.3 - TBD
 ------------

--- a/st2common/st2common/util/action_db.py
+++ b/st2common/st2common/util/action_db.py
@@ -57,8 +57,6 @@ def get_runnertype_by_name(runnertype_name):
                                               % runnertype_name)
 
     if not runnertypes:
-        LOG.error('Database lookup for RunnerType with name="%s" produced no results',
-                  runnertype_name)
         raise StackStormDBObjectNotFoundError('Unable to find RunnerType with name="%s"'
                                               % runnertype_name)
 

--- a/st2reactor/st2reactor/bootstrap/rulesregistrar.py
+++ b/st2reactor/st2reactor/bootstrap/rulesregistrar.py
@@ -97,7 +97,7 @@ class RulesRegistrar(ResourceRegistrar):
                 try:
                     rule_db.id = Rule.get_by_name(rule_api.name).id
                 except ValueError:
-                    LOG.info('Rule %s not found. Creating new one.', rule)
+                    LOG.debug('Rule %s not found. Creating new one.', rule)
 
                 try:
                     rule_db = Rule.add_or_update(rule_db)


### PR DESCRIPTION
```
(virtualenv)~/st2 git:remove_obnoxious_error_log_runner_not_found ❯❯❯ ST2_CONF=~/st2.dev.conf tools/launchdev.sh startclean                                                                                                        ✭ ◼
MongoDB shell version: 2.6.3
connecting to: st2
[object Object]
Starting all st2 servers...
Changing working directory to /home/lakshmi/st2/tools/.....
Using st2 config file: /home/lakshmi/st2.dev.conf
Using content packs base dir: /opt/stackstorm/packs
There are screens on:
	30711.st2-sensorcontainer	(03/26/2015 11:13:18 PM)	(Detached)
	30705.st2-actionrunner	(03/26/2015 11:13:18 PM)	(Detached)
2 Sockets in /var/run/screen/S-lakshmi.

Killing existing st2 screen sessions...
Starting screen session st2-api...
Starting screen session st2-actionrunner...
    starting runner  1 ...
Starting screen session st2-sensorcontainer
Starting screen session st2-rulesengine...
Starting screen session st2-resultstracker...

Registering sensors, actions and rules...
2015-03-26 23:18:37,396 INFO [-] Connecting to database "st2" @ "0.0.0.0:27017" as user "None".
2015-03-26 23:18:37,515 INFO [-] =========================================================
2015-03-26 23:18:37,519 INFO [-] ############## Registering sensors ######################
2015-03-26 23:18:37,519 INFO [-] =========================================================
2015-03-26 23:18:38,762 INFO [-] Registered 5 sensors.
2015-03-26 23:18:38,763 INFO [-] =========================================================
2015-03-26 23:18:38,763 INFO [-] ############## Registering actions ######################
2015-03-26 23:18:38,763 INFO [-] =========================================================
2015-03-26 23:18:40,496 INFO [-] Registered 57 actions.
2015-03-26 23:18:40,497 INFO [-] =========================================================
2015-03-26 23:18:40,497 INFO [-] ############## Registering rules ########################
2015-03-26 23:18:40,498 INFO [-] =========================================================
2015-03-26 23:18:40,537 INFO [-] Registered 3 rules.
There are screens on:
	310.st2-resultstracker	(03/26/2015 11:18:36 PM)	(Detached)
	307.st2-rulesengine	(03/26/2015 11:18:36 PM)	(Detached)
	303.st2-sensorcontainer	(03/26/2015 11:18:36 PM)	(Detached)
	32765.st2-actionrunner	(03/26/2015 11:18:36 PM)	(Detached)
	32762.st2-api	(03/26/2015 11:18:36 PM)	(Detached)
5 Sockets in /var/run/screen/S-lakshmi.

(virtualenv)~/st2 git:remove_obnoxious_error_log_runner_not_found ❯❯❯                                                                                                                                                            ⏎ ✭ ◼

```