### PR TITLE
Add "-t" / "--only-token" option to the st2 auth command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ in development
 * Remove expected "runnertype not found" error logs on action registration
   in clean db. (improvement)
 * Clean up rule registrar logging. (improvement)
+* Add ``-t`` / ``--only-token`` flag to the ``st2 auth`` command. (new-feature)
 
 v0.8.3 - March 23, 2015
 -----------------------

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -117,6 +117,35 @@ Let's check the exit code of the last command.
 
     2
 
+Obtaining authentication token inside scripts
+---------------------------------------------
+
+If you want to authenticate and obtain an authentication token inside your
+(shell) scripts, you can use `st2 auth` CLI command in combination with ``-t``
+flag to do that.
+
+This flag will cause the command to only print the token to the stdout on
+successful authentication - this means you don't need to deal with parsing
+JSON or CLI output format.
+
+Example command usage:
+
+.. sourcecode:: bash
+
+    st2 auth test1 -p testpassword -t
+
+    0280826688c74bb9bd541c26631df298
+
+Example usage inside a bash script:
+
+.. sourcecode:: bash
+
+    TOKEN=$(st2 auth test1 -p testpassword -t)
+
+    # Now you can use the token (e.g. pass it to other commands, set an
+    # environment variable, etc.)
+    echo ${TOKEN}
+
 Changing the CLI output format
 ------------------------------
 

--- a/st2client/st2client/commands/access.py
+++ b/st2client/st2client/commands/access.py
@@ -45,6 +45,10 @@ class TokenCreateCommand(resource.ResourceCommand):
         self.parser.add_argument('-l', '--ttl', type=int, dest='ttl', default=None,
                                  help='The life span of the token in seconds. '
                                       'Max TTL configured by the admin supersedes this.')
+        self.parser.add_argument('-t', '--only-token', action='store_true', dest='only_token',
+                                 default=False,
+                                 help='Only print token to the console on successful '
+                                      'authentication.')
 
     def run(self, args, **kwargs):
         if not args.password:
@@ -54,5 +58,9 @@ class TokenCreateCommand(resource.ResourceCommand):
 
     def run_and_print(self, args, **kwargs):
         instance = self.run(args, **kwargs)
-        self.print_output(instance, table.PropertyValueTable,
-                          attributes=self.display_attributes, json=args.json)
+
+        if args.only_token:
+            print(instance.token)
+        else:
+            self.print_output(instance, table.PropertyValueTable,
+                              attributes=self.display_attributes, json=args.json)


### PR DESCRIPTION
This way we can simply use this option when retrieving a token inside different scripts (it's more robust and less fragile than awk foo :))

Note: Sadly we will only be able to switch to using this flag once 0.9 is out.

```bash
st2 auth test1 -p testpassword
+----------+----------------------------------+
| Property | Value                            |
+----------+----------------------------------+
| user     | test1                            |
| token    | a9dae5a11b0542f7a9110da2176d26e7 |
| expiry   | 2015-03-28T17:31:06.274051Z      |
+----------+----------------------------------+

st2 auth test1 -p testpassword -t
0280826688c74bb9bd541c26631df298
```