### PR TITLE
Make model validation optional

### DIFF
--- a/st2actions/st2actions/bootstrap/actionsregistrar.py
+++ b/st2actions/st2actions/bootstrap/actionsregistrar.py
@@ -111,6 +111,7 @@ class ActionsRegistrar(ResourceRegistrar):
                             (pack, pack_field))
 
         action_api = ActionAPI(**content)
+        action_api.validate()
         action_validator.validate_action(action_api)
         model = ActionAPI.to_model(action_api)
 

--- a/st2actions/st2actions/bootstrap/runnersregistrar.py
+++ b/st2actions/st2actions/bootstrap/runnersregistrar.py
@@ -375,6 +375,7 @@ def register_runner_types():
             update = False
 
         runnertype_api = RunnerTypeAPI(**runnertype)
+        runnertype_api.validate()
         runner_type_model = RunnerTypeAPI.to_model(runnertype_api)
 
         if runnertype_db:

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import jsonschema
-
 from st2common.util import isotime
 from st2common.util import schema as util_schema
 from st2common import log as logging
@@ -95,7 +93,6 @@ class RunnerTypeAPI(BaseAPI):
         # default values from draft schema, but, either because of a bug or some weird intention, it
         # has continued to resolve $ref'erenced properties against the initial draft schema, not the
         # modified one
-        jsonschema.validate(kw, self.schema, util_schema.get_validator())
         for key, value in kw.items():
             setattr(self, key, value)
         if not hasattr(self, 'runner_parameters'):
@@ -176,7 +173,6 @@ class ActionAPI(BaseAPI):
     }
 
     def __init__(self, **kw):
-        jsonschema.validate(kw, self.schema, util_schema.get_validator())
         for key, value in kw.items():
             setattr(self, key, value)
         if not hasattr(self, 'parameters'):

--- a/st2common/st2common/services/triggers.py
+++ b/st2common/st2common/services/triggers.py
@@ -142,6 +142,7 @@ def create_or_update_trigger_db(trigger):
         is_update = False
 
     trigger_api = TriggerAPI(**trigger)
+    trigger_api.validate()
     trigger_db = TriggerAPI.to_model(trigger_api)
 
     if is_update:
@@ -186,6 +187,7 @@ def create_trigger_type_db(trigger_type):
     :rtype: ``object``
     """
     trigger_type_api = TriggerTypeAPI(**trigger_type)
+    trigger_type_api.validate()
     ref = ResourceReference.to_string_reference(name=trigger_type_api.name,
                                                 pack=trigger_type_api.pack)
     trigger_type_db = get_trigger_type_db(ref)
@@ -209,6 +211,7 @@ def create_or_update_trigger_type_db(trigger_type):
     assert isinstance(trigger_type, dict)
 
     trigger_type_api = TriggerTypeAPI(**trigger_type)
+    trigger_type_api.validate()
     trigger_type_api = TriggerTypeAPI.to_model(trigger_type_api)
 
     ref = ResourceReference.to_string_reference(name=trigger_type_api.name,

--- a/st2reactor/st2reactor/bootstrap/rulesregistrar.py
+++ b/st2reactor/st2reactor/bootstrap/rulesregistrar.py
@@ -92,6 +92,7 @@ class RulesRegistrar(ResourceRegistrar):
             try:
                 content = self._meta_loader.load(rule)
                 rule_api = RuleAPI(**content)
+                rule_api.validate()
                 rule_db = RuleAPI.to_model(rule_api)
 
                 try:

--- a/st2reactor/tests/fixtures/packs/pack_with_rules/rules/rule_with_the_same_timer.yaml
+++ b/st2reactor/tests/fixtures/packs/pack_with_rules/rules/rule_with_the_same_timer.yaml
@@ -1,0 +1,15 @@
+
+---
+  name: "sample.with_the_same_timer"
+  description: "Sample rule using an Interval Timer."
+  trigger:
+    type: "core.st2.IntervalTimer"
+    parameters:
+      delta: 5
+      unit: "seconds"
+  criteria: {}
+  action:
+    ref: "core.local"
+    parameters:
+      cmd: "echo \"{{trigger.executed_at}}\""
+  enabled: true

--- a/st2reactor/tests/fixtures/packs/pack_with_rules/rules/rule_without_action.yaml
+++ b/st2reactor/tests/fixtures/packs/pack_with_rules/rules/rule_without_action.yaml
@@ -1,0 +1,11 @@
+
+---
+  name: "sample.without_action"
+  description: "Sample rule using an Interval Timer."
+  trigger:
+    type: "core.st2.IntervalTimer"
+    parameters:
+      delta: 5
+      unit: "seconds"
+  criteria: {}
+  enabled: true

--- a/st2reactor/tests/unit/test_sensor_and_rule_registration.py
+++ b/st2reactor/tests/unit/test_sensor_and_rule_registration.py
@@ -126,10 +126,11 @@ class RuleRegistrationTestCase(DbTestCase):
         # Verify modeles are created
         rule_dbs = Rule.get_all()
         trigger_dbs = Trigger.get_all()
-        self.assertEqual(len(rule_dbs), 1)
+        self.assertEqual(len(rule_dbs), 2)
         self.assertEqual(len(trigger_dbs), 1)
 
-        self.assertEqual(rule_dbs[0].name, 'sample.with_timer')
+        self.assertEqual(rule_dbs[0].name, 'sample.with_the_same_timer')
+        self.assertEqual(rule_dbs[1].name, 'sample.with_timer')
         self.assertTrue(trigger_dbs[0].name is not None)
 
         # Verify second register call updates existing models
@@ -137,5 +138,5 @@ class RuleRegistrationTestCase(DbTestCase):
 
         rule_dbs = Rule.get_all()
         trigger_dbs = Trigger.get_all()
-        self.assertEqual(len(rule_dbs), 1)
+        self.assertEqual(len(rule_dbs), 2)
         self.assertEqual(len(trigger_dbs), 1)


### PR DESCRIPTION
Model validation is rather expensive operation that is only needed in a limited number of cases (usually, when we add new documents to the system).

Right now, we are revalidating all the actions and executions we return during GET requests. This drastically affects response time (up to several seconds of TTFB) harming usability in a major way.

This patch would require us to explicitly validate every model manually the moment it is created.

The patch resulting in 2x reduction of response time for `limit=50` over the collection of 1214 action execution records and 10x reduction for the whole collection of 363 actions.