### PR TITLE
Added test_packs_pack

### DIFF
--- a/contrib/tests/actions/chains/test_packs_pack.yaml
+++ b/contrib/tests/actions/chains/test_packs_pack.yaml
@@ -1,0 +1,110 @@
+---
+vars:
+        base_repo_url: "https://github.com/StackStorm"
+        pack_to_install_1: "docker"
+        pack_to_install_2: "sensu"
+        install_from_repo: "st2contrib.git"
+
+chain:
+    -
+        name: setup_check_pack_to_install_1_installed
+        ref: core.local
+        params:
+            cmd: "st2 action list --pack {{ pack_to_install_1 }} | grep 'No matching items found'"
+        on-success: setup_check_pack_to_install_2_installed
+        on-failure: setup_uninstall_pack_to_install_1
+    -
+        name: setup_uninstall_pack_to_install_1
+        ref: core.local
+        params:
+            cmd: "st2 run packs.uninstall packs={{ pack_to_install_1 }}"
+        on-success: setup_check_pack_to_install_2_installed
+        on-failure: error_handler
+    -
+        name: setup_check_pack_to_install_2_installed
+        ref: core.local
+        params:
+            cmd: "st2 action list --pack {{ pack_to_install_2 }} | grep 'No matching items found'"
+        on-success: test_packs_install_multiple_packs_from_repo
+        on-failure: setup_uninstall_pack_to_install_2
+    -
+        name: setup_uninstall_pack_to_install_2
+        ref: core.local
+        params:
+            cmd: "st2 run packs.uninstall packs={{ pack_to_install_2 }}"
+        on-success: test_packs_install_multiple_packs_from_repo
+        on-failure: error_handler
+    -
+        name: test_packs_install_multiple_packs_from_repo
+        ref: core.local
+        params:
+            cmd: "st2 run packs.install packs={{ pack_to_install_1 }},{{ pack_to_install_2 }} repo_url={{ base_repo_url }}/{{ install_from_repo }}"
+        on-success: test_check_pack_to_install_1_installed
+        on-failure: error_handler
+    -
+        name: test_check_pack_to_install_1_installed
+        ref: core.local
+        params:
+            cmd: "st2 action list --pack {{ pack_to_install_1 }} | grep '{{ pack_to_install_1 }}'"
+        on-success: test_check_pack_to_install_2_installed
+        on-failure: error_handler
+    -
+        name: test_check_pack_to_install_2_installed
+        ref: core.local
+        params:
+            cmd: "st2 action list --pack {{ pack_to_install_2 }} | grep '{{ pack_to_install_2 }}'"
+        on-success: test_packs_uninstall_multiple_packs
+        on-failure: error_handler
+    -
+        name: test_packs_uninstall_multiple_packs
+        ref: core.local
+        params:
+            cmd: "st2 run packs.uninstall packs={{ pack_to_install_1 }},{{ pack_to_install_2 }}"
+        on-success: test_check_pack_to_install_1_uninstalled
+        on-failure: error_handler
+    -
+        name: test_check_pack_to_install_1_uninstalled
+        ref: core.local
+        params:
+            cmd: "st2 action list --pack {{ pack_to_install_1 }} | grep 'No matching items found'"
+        on-success: test_check_pack_to_install_2_uninstalled
+        on-failure: error_handler
+    -
+        name: test_check_pack_to_install_2_uninstalled
+        ref: core.local
+        params:
+            cmd: "st2 action list --pack {{ pack_to_install_2 }} | grep 'No matching items found'"
+        on-success: test_packs_download
+        on-failure: error_handler
+    -
+        name: test_packs_download
+        ref: core.local
+        params:
+            cmd: "st2 run packs.download packs={{ pack_to_install_1 }}"
+        on-success: test_packs_setup_virtualenv
+        on-failure: error_handler
+    -
+        name: test_packs_setup_virtualenv
+        ref: core.local
+        params:
+            cmd: "st2 run packs.setup_virtualenv packs={{ pack_to_install_1 }} | grep 'successfully created'"
+        on-success: test_packs_load_register_all
+        on-failure: error_handler
+    -
+        name: test_packs_load_register_all
+        ref: core.local
+        params:
+            cmd: "st2 run packs.load register=all | grep -c 'Registered' | grep 3"
+        on-success: success_handler
+        on-failure: error_handler
+    -
+        name: success_handler
+        ref: core.local
+        params:
+            cmd: "echo packs pack test succeed; exit 0"
+    -
+        name: error_handler
+        description: Error handler
+        ref: "core.local"
+        params:
+           cmd: "echo packs pack test failed; exit 1"

--- a/contrib/tests/actions/test_packs_pack.meta.yaml
+++ b/contrib/tests/actions/test_packs_pack.meta.yaml
@@ -1,0 +1,8 @@
+---
+# Action definition metadata
+name: "test_packs_pack"
+description: "Workflow tests functionality provided by Packs pack"
+runner_type: "action-chain"
+enabled: true
+entry_point: "chains/test_packs_pack.yaml"
+parameters: {}


### PR DESCRIPTION
Tests almost all actions on packs page, except for:
- st2 run packs.install register=all repo_url=https://github.com/StackStorm/st2incubator.git - installing all packs as part of sanity seems too much
- st2 run packs.restart_component servicename=st2sensorcontainer - I didn't find the way to reliably test that this action does something
- st2 action list --pack=docker, st2 sensor list --pack=docker, st2 trigger list --pack=docker - since they are not parts of packs pack