### PR TITLE
[COMMENT] Logrotate Rules

### DIFF
--- a/conf/logrotate.conf
+++ b/conf/logrotate.conf
@@ -1,0 +1,65 @@
+## Global
+compress
+copytruncate
+notifyempty
+
+## Rules engine
+/var/log/st2/st2rulesengine.audit.log {
+  rotate 5
+  size 10M
+  postrotate
+    st2ctl restart-component rules_engine
+  endscript
+}
+
+/var/log/st2/st2rulesengine.log {
+  size 100M
+  rotate 5
+  postrotate
+    st2ctl restart-component rules_engine
+  endscript
+}
+
+## API
+/var/log/st2/st2api.log {
+  daily
+  rotate 5
+  postrotate
+    st2ctl restart-component st2api
+  endscript
+}
+
+/var/log/st2/st2api.audit.log {
+  daily
+  rotate 5
+  postrotate
+    st2ctl restart-component st2api
+  endscript
+}
+
+## Results Tracker
+/var/log/st2/st2resultstracker*.log {
+  daily
+  rotate 5
+  postrotate
+    st2ctl restart-component st2resultstracker
+  endscript
+}
+
+## Sensor Containers
+/var/log/st2/st2sensorcontainer*.log {
+  daily
+  rotate 5
+  postrotate
+    st2ctl restart-component sensor_container
+  endscript
+}
+
+## Action Runners
+/var/log/st2/st2actionrunner*.log {
+  daily
+  rotate 5
+  postrotate
+    st2ctl restart-component actionrunner
+  endscript
+}

--- a/conf/logrotate.conf
+++ b/conf/logrotate.conf
@@ -60,6 +60,9 @@ notifyempty
   daily
   rotate 5
   postrotate
+    # Delete all files that haven't been modified in over 30 days
+    # Clean up stale PID logs
+    find . -type f -name "st2actionrunner*" -mtime +30 -exec rm -f {} \;
     st2ctl restart-component actionrunner
   endscript
 }


### PR DESCRIPTION
This PR introduces a logrotate file that will eventually be placed on systems to encourage good health and hygiene of logs on a system.

Things I don't love:
* Restarting components: Can't `HUP` currently and let go of file descriptors for old log files. As such, a component restart is in order. But, I don't necessarily want to restart the entire component just to release a log file.
* ActionRunner PID files: This is interesting... old log files from runners will just collect here because two new log files are created for each runner. I'm doing some ops trickery there to cleanup old files, but also ugly.