### PR TITLE
Re-open log files on SIGUSR1 signal

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ in development
 * ``register`` param in packs.install should be passed to packs.load. (bug-fix)
 * Fix validation code to validate value types correctly. (bug-fix)
 * Add ability to best-effort cancel actions and actionchain via API. (new-feature)
+* Update all the Python services to re-open log files on the ``SIGUSR`` signal. (new-feature)
 
 v0.8.3 - March 23, 2015
 -----------------------

--- a/conf/logrotate.conf
+++ b/conf/logrotate.conf
@@ -8,7 +8,7 @@ notifyempty
   rotate 5
   size 10M
   postrotate
-    st2ctl restart-component rules_engine
+    st2ctl reopen-log-files st2rulesengine
   endscript
 }
 
@@ -16,7 +16,7 @@ notifyempty
   size 100M
   rotate 5
   postrotate
-    st2ctl restart-component rules_engine
+    st2ctl reopen-log-files st2rulesengine
   endscript
 }
 
@@ -25,7 +25,7 @@ notifyempty
   daily
   rotate 5
   postrotate
-    st2ctl restart-component st2api
+    st2ctl reopen-log-files st2api
   endscript
 }
 
@@ -33,7 +33,7 @@ notifyempty
   daily
   rotate 5
   postrotate
-    st2ctl restart-component st2api
+    st2ctl reopen-log-files st2api
   endscript
 }
 
@@ -42,7 +42,7 @@ notifyempty
   daily
   rotate 5
   postrotate
-    st2ctl restart-component st2resultstracker
+    st2ctl reopen-log-files st2resultstracker
   endscript
 }
 
@@ -51,7 +51,7 @@ notifyempty
   daily
   rotate 5
   postrotate
-    st2ctl restart-component sensor_container
+    st2ctl reopen-log-files st2sensorcontainer
   endscript
 }
 
@@ -63,6 +63,6 @@ notifyempty
     # Delete all files that haven't been modified in over 30 days
     # Clean up stale PID logs
     find . -type f -name "st2actionrunner*" -mtime +30 -exec rm -f {} \;
-    st2ctl restart-component actionrunner
+    st2ctl reopen-log-files st2actionrunner
   endscript
 }

--- a/docs/source/install/config.rst
+++ b/docs/source/install/config.rst
@@ -7,6 +7,7 @@ Configuration
 
 Configure MongoDB
 -----------------
+
 StackStorm requires a connection to MongoDB to operate.
 
 
@@ -25,6 +26,7 @@ In :github_st2:`/etc/st2/st2.conf <conf/st2.prod.conf>` include the following se
 
 Configure RabbitMQ
 ------------------
+
 StackStorm uses RabbitMQ for messaging between its services.
 
 In :github_st2:`/etc/st2/st2.conf <conf/st2.prod.conf>` include the following section :
@@ -101,15 +103,40 @@ Configure Logging
 
 By default, the logs can be found in ``/var/log/st2``.
 
-* With the standard logging setup you will notice files like ``st2*.log`` and ``st2*.audit.log`` in the log folder.
+* With the standard logging setup you will notice files like ``st2*.log`` and
+  ``st2*.audit.log`` in the log folder.
 
-* Per component logging configuration can be found in ``/etc/st2*/logging.conf``. Those files use `Python logging configuration format
-  <https://docs.python.org/2/library/logging.config.html#configuration-file-format>`_. If you desire to change location of the log files,
-  the paths and other settings can be modified in these files.
+* Per component logging configuration can be found in ``/etc/st2*/logging.conf``.
+  Those files use `Python logging configuration format <https://docs.python.org/2/library/logging.config.html#configuration-file-format>`_.
+  If you desire to change location of the log files, the paths and other
+  settings can be modified in these files.
 
-* To configure logging with syslog, grab the configuration and follow instructions at :github_contrib:`st2contrib/extra/syslog <extra/syslog>`
+* By default, log rotation is handled via logrotate. Default log rotation config
+  (:github_st2:`logrotate.conf <conf/logrotate.conf>`) is included with all the
+  package based installations. If you want Python services instead of logrotate
+  to handle the log rotation for you, you can update the logging configs as
+  shown below:
 
-* Check out LogStash configuration and Kibana dashboard for pretty logging and audit at :github_contrib:`st2contrib/extra/logstash <extra/logstash>`
+  .. code-block:: ini
+
+      [handler_fileHandler]
+      class=handlers.RotatingFileHandler
+      level=DEBUG
+      formatter=verboseConsoleFormatter
+      args=("logs/st2api.log", , "a", 100000000, 5)
+
+  In this case the log file will be rotated when it reaches 100000000 bytes (100
+  MB) and a maximum of 5 old log files will be kept. For more information, see
+  `RotatingFileHandler <https://docs.python.org/2/library/logging.handlers.html#rotatingfilehandler>`_
+  docs.
+
+* To configure logging with syslog, grab the configuration and follow
+  instructions at :github_contrib:`st2contrib/extra/syslog <extra/syslog>`
+
+* Check out LogStash configuration and Kibana dashboard for pretty logging and
+  audit at :github_contrib:`st2contrib/extra/logstash <extra/logstash>`
+
+  logrotate log rotation
 
 Sample configuration file
 -------------------------

--- a/st2actions/conf/logging.conf
+++ b/st2actions/conf/logging.conf
@@ -21,13 +21,13 @@ args=(sys.stdout,)
 class=st2common.log.FormatNamedFileHandler
 level=INFO
 formatter=verboseConsoleFormatter
-args=('logs/st2actionrunner.{pid}.log', 'a', 100000000, 5,)
+args=('logs/st2actionrunner.{pid}.log',)
 
 [handler_auditHandler]
 class=st2common.log.FormatNamedFileHandler
 level=AUDIT
 formatter=jsonFormatter
-args=('logs/st2actionrunner.{pid}.audit.log', 'a', 100000000, 5,)
+args=('logs/st2actionrunner.{pid}.audit.log',)
 
 [formatter_simpleConsoleFormatter]
 class=st2common.logging.formatters.ConsoleLogFormatter

--- a/st2actions/conf/logging.notifier.conf
+++ b/st2actions/conf/logging.notifier.conf
@@ -21,13 +21,13 @@ args=(sys.stdout,)
 class=st2common.log.FormatNamedFileHandler
 level=DEBUG
 formatter=verboseConsoleFormatter
-args=('logs/st2notifier.log', 'a', 100000000, 5,)
+args=('logs/st2notifier.log',)
 
 [handler_auditHandler]
 class=st2common.log.FormatNamedFileHandler
 level=AUDIT
 formatter=gelfFormatter
-args=('logs/st2notifier.audit.log', 'a', 100000000, 5,)
+args=('logs/st2notifier.audit.log',)
 
 [formatter_simpleConsoleFormatter]
 class=st2common.logging.formatters.ConsoleLogFormatter

--- a/st2actions/conf/logging.resultstracker.conf
+++ b/st2actions/conf/logging.resultstracker.conf
@@ -21,13 +21,13 @@ args=(sys.stdout,)
 class=st2common.log.FormatNamedFileHandler
 level=DEBUG
 formatter=verboseConsoleFormatter
-args=('logs/st2resultstracker.log', 'a', 100000000, 5,)
+args=('logs/st2resultstracker.log',)
 
 [handler_auditHandler]
 class=st2common.log.FormatNamedFileHandler
 level=AUDIT
 formatter=gelfFormatter
-args=('logs/st2resultstracker.audit.log', 'a', 100000000, 5,)
+args=('logs/st2resultstracker.audit.log',)
 
 [formatter_simpleConsoleFormatter]
 class=st2common.logging.formatters.ConsoleLogFormatter

--- a/st2actions/st2actions/cmd/actionrunner.py
+++ b/st2actions/st2actions/cmd/actionrunner.py
@@ -9,6 +9,7 @@ from st2common.models.db import db_setup
 from st2common.models.db import db_teardown
 from st2common.constants.logging import DEFAULT_LOGGING_CONF_PATH
 from st2common.transport.utils import register_exchanges
+from st2common.signal_handlers import register_common_signal_handlers
 from st2actions import config
 from st2actions import worker
 
@@ -42,6 +43,8 @@ def _setup():
     db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
              username=username, password=password)
     register_exchanges()
+    register_common_signal_handlers()
+
     # 4. Register internal triggers
     # Note: We need to do import here because of a messed up configuration
     # situation (this module depends on configuration being parsed)

--- a/st2actions/st2actions/cmd/st2notifier.py
+++ b/st2actions/st2actions/cmd/st2notifier.py
@@ -9,6 +9,7 @@ from st2common.models.db import db_setup
 from st2common.models.db import db_teardown
 from st2common.constants.logging import DEFAULT_LOGGING_CONF_PATH
 from st2common.transport.utils import register_exchanges
+from st2common.signal_handlers import register_common_signal_handlers
 from st2actions import config
 from st2actions import notifier
 
@@ -40,6 +41,7 @@ def _setup():
     db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
              username=username, password=password)
     register_exchanges()
+    register_common_signal_handlers()
 
 
 def _run_worker():

--- a/st2actions/st2actions/cmd/st2resultstracker.py
+++ b/st2actions/st2actions/cmd/st2resultstracker.py
@@ -9,6 +9,7 @@ from st2common.models.db import db_setup
 from st2common.models.db import db_teardown
 from st2common.constants.logging import DEFAULT_LOGGING_CONF_PATH
 from st2common.transport.utils import register_exchanges
+from st2common.signal_handlers import register_common_signal_handlers
 from st2actions import config
 from st2actions import resultstracker
 
@@ -40,6 +41,7 @@ def _setup():
     db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
              username=username, password=password)
     register_exchanges()
+    register_common_signal_handlers()
 
 
 def _run_worker():

--- a/st2api/conf/logging.conf
+++ b/st2api/conf/logging.conf
@@ -21,13 +21,13 @@ args=(sys.stdout,)
 class=handlers.RotatingFileHandler
 level=DEBUG
 formatter=verboseConsoleFormatter
-args=("logs/st2api.log", 'a', 100000000, 5,)
+args=("logs/st2api.log",)
 
 [handler_auditHandler]
 class=handlers.RotatingFileHandler
 level=AUDIT
 formatter=gelfFormatter
-args=("logs/st2api.audit.log", 'a', 100000000, 5,)
+args=("logs/st2api.audit.log")
 
 [formatter_simpleConsoleFormatter]
 class=st2common.logging.formatters.ConsoleLogFormatter

--- a/st2api/st2api/cmd/api.py
+++ b/st2api/st2api/cmd/api.py
@@ -15,6 +15,7 @@
 
 import os
 import sys
+import logging as stdlib_logging
 
 import eventlet
 from oslo.config import cfg
@@ -25,6 +26,7 @@ from st2common.models.db import db_setup
 from st2common.models.db import db_teardown
 from st2common.constants.logging import DEFAULT_LOGGING_CONF_PATH
 from st2common.transport.utils import register_exchanges
+from st2common.signal_handlers import register_common_signal_handlers
 from st2api.listener import get_listener_if_set
 from st2api import config
 from st2api import app
@@ -58,6 +60,7 @@ def _setup():
     db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
              username=username, password=password)
     register_exchanges()
+    register_common_signal_handlers()
 
 
 def _run_server():

--- a/st2api/st2api/cmd/api.py
+++ b/st2api/st2api/cmd/api.py
@@ -15,7 +15,6 @@
 
 import os
 import sys
-import logging as stdlib_logging
 
 import eventlet
 from oslo.config import cfg

--- a/st2auth/conf/logging.conf
+++ b/st2auth/conf/logging.conf
@@ -21,13 +21,13 @@ args=(sys.stdout,)
 class=handlers.RotatingFileHandler
 level=DEBUG
 formatter=verboseConsoleFormatter
-args=("logs/st2auth.log", 'a', 100000000, 5,)
+args=("logs/st2auth.log",)
 
 [handler_auditHandler]
 class=handlers.RotatingFileHandler
 level=AUDIT
 formatter=gelfFormatter
-args=("logs/st2auth.audit.log", 'a', 100000000, 5,)
+args=("logs/st2auth.audit.log",)
 
 [formatter_simpleConsoleFormatter]
 class=st2common.logging.formatters.ConsoleLogFormatter

--- a/st2common/st2common/logging/misc.py
+++ b/st2common/st2common/logging/misc.py
@@ -1,0 +1,44 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import logging
+
+LOG = logging.getLogger(__name__)
+
+
+def reopen_log_files(handlers):
+    """
+    This method iterates through all of the providers handlers looking for the FileHandler types.
+
+    A lock is acquired, the underlying stream closed, reopened, then the lock is released.
+
+
+    This method should be called when logs are to be rotated by an external process. The simplest
+    way to do this is via a signal handler.
+    """
+    for handler in handlers:
+        if not isinstance(handler, logging.FileHandler):
+            continue
+
+        LOG.info('Re-opening log file "%s" with mode "%s"\n' %
+                 (handler.baseFilename, handler.mode))
+        try:
+            handler.acquire()
+            handler.stream.close()
+            handler.stream = open(handler.baseFilename, handler.mode)
+        finally:
+            handler.release()

--- a/st2common/st2common/signal_handlers.py
+++ b/st2common/st2common/signal_handlers.py
@@ -1,0 +1,39 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module contains handler methods for different signals which are handled in the same way across
+the whole code base.
+"""
+
+from __future__ import absolute_import
+
+import signal
+import logging
+
+from st2common.logging.misc import reopen_log_files
+
+__all__ = [
+    'register_common_signal_handlers',
+]
+
+
+def register_common_signal_handlers():
+    signal.signal(signal.SIGUSR1, handle_sigusr1)
+
+
+def handle_sigusr1(signal, stack):
+    handlers = logging.getLoggerClass().manager.root.handlers
+    reopen_log_files(handlers=handlers)

--- a/st2reactor/conf/logging.rulesengine.conf
+++ b/st2reactor/conf/logging.rulesengine.conf
@@ -21,13 +21,13 @@ args=(sys.stdout,)
 class=handlers.RotatingFileHandler
 level=INFO
 formatter=verboseConsoleFormatter
-args=("logs/st2rulesengine.log", 'a', 100000000, 5,)
+args=("logs/st2rulesengine.log",)
 
 [handler_auditHandler]
 class=handlers.RotatingFileHandler
 level=AUDIT
 formatter=gelfFormatter
-args=("logs/st2rulesengine.audit.log", 'a', 100000000, 5,)
+args=("logs/st2rulesengine.audit.log",)
 
 [formatter_simpleConsoleFormatter]
 class=st2common.logging.formatters.ConsoleLogFormatter

--- a/st2reactor/conf/logging.sensorcontainer.conf
+++ b/st2reactor/conf/logging.sensorcontainer.conf
@@ -21,13 +21,13 @@ args=(sys.stdout,)
 class=handlers.RotatingFileHandler
 level=INFO
 formatter=verboseConsoleFormatter
-args=("logs/st2sensorcontainer.log", 'a', 100000000, 5,)
+args=("logs/st2sensorcontainer.log",)
 
 [handler_auditHandler]
 class=handlers.RotatingFileHandler
 level=AUDIT
 formatter=gelfFormatter
-args=("logs/st2sensorcontainer.audit.log", 'a', 100000000, 5,)
+args=("logs/st2sensorcontainer.audit.log",)
 
 [formatter_simpleConsoleFormatter]
 class=st2common.logging.formatters.ConsoleLogFormatter

--- a/st2reactor/st2reactor/cmd/rulesengine.py
+++ b/st2reactor/st2reactor/cmd/rulesengine.py
@@ -9,6 +9,7 @@ from st2common.models.db import db_setup
 from st2common.models.db import db_teardown
 from st2common.constants.logging import DEFAULT_LOGGING_CONF_PATH
 from st2common.transport.utils import register_exchanges
+from st2common.signal_handlers import register_common_signal_handlers
 from st2reactor.rules import config
 from st2reactor.rules import worker
 from st2reactor.timer.base import St2Timer
@@ -41,6 +42,7 @@ def _setup():
     db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
              username=username, password=password)
     register_exchanges()
+    register_common_signal_handlers()
 
 
 def _teardown():

--- a/st2reactor/st2reactor/cmd/sensormanager.py
+++ b/st2reactor/st2reactor/cmd/sensormanager.py
@@ -10,6 +10,7 @@ from st2common.models.db import db_setup
 from st2common.models.db import db_teardown
 from st2common.constants.logging import DEFAULT_LOGGING_CONF_PATH
 from st2common.transport.utils import register_exchanges
+from st2common.signal_handlers import register_common_signal_handlers
 from st2reactor.sensor import config
 from st2common.persistence.reactor import SensorType
 from st2reactor.container.manager import SensorContainerManager
@@ -43,6 +44,7 @@ def _setup():
     db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
              username=username, password=password)
     register_exchanges()
+    register_common_signal_handlers()
 
     # 4. Register internal triggers
     # Note: We need to do import here because of a messed up configuration

--- a/tools/st2ctl
+++ b/tools/st2ctl
@@ -34,6 +34,11 @@ function print_usage() {
     echo "  component           Name of the st2 service to restart."
     echo "                      ${COMPONENTS}"
     echo
+    echo "usage: st2ctl {reopen-log-files}"
+    echo "positional arguments:"
+    echo "  component           Name of the st2 service to reopen the log files for."
+    echo "                      ${COMPONENTS}"
+    echo
     echo "usage: st2ctl {reload, clean}"
     echo "optional arguments:"
     echo "  --register-all      Register all sensors, rules, and actions."
@@ -64,7 +69,7 @@ function service_map() {
 }
 
 
-if [ -z ${1} ] || [ ${1} != "start" -a ${1} != "stop" -a ${1} != "restart" -a ${1} != "status" -a ${1} != "restart-component" -a ${1} != "reload" -a ${1} != "clean" ]
+if [ -z ${1} ] || [ ${1} != "start" -a ${1} != "stop" -a ${1} != "restart" -a ${1} != "status" -a ${1} != "restart-component" -a ${1} != "reopen-log-files" -a ${1} != "-component" -a ${1} != "reload" -a ${1} != "clean" ]
 then
     print_usage
     exit 1
@@ -204,6 +209,37 @@ function restart_component() {
   fi
 }
 
+function reopen_component_log_files() {
+  COM=${1}
+  ALT_COM=`service_map $COM`
+
+  if [[ ! -z $COM ]]
+  then
+    if [[ "${COM}" == "st2actionrunner" ]]
+    then
+      PROC_COUNT=${AR}
+    else
+      PROC_COUNT=1
+    fi
+
+    echo "Sending SIGUSR1 to service ${COM}|${ALT_COM} with ${PROC_COUNT} process(es)."
+
+    PID=`ps ax | grep -v grep | grep -v st2ctl | egrep "${COM}|${ALT_COM}" | awk '{print $1}'`
+    if [[ ! -z $PID ]]
+    then
+      for p in $PID
+      do
+        echo "Sending SIGUSR1 to ${COM} PID: ${p}"
+        kill -USR1 $p
+      done
+    else
+      echo "${COM} is not running"
+    fi
+  else
+    echo "No component specified to reopen the log files for."
+  fi
+}
+
 function register_content() {
   echo "Registering content...[flags = ${REGISTER_FLAGS}]"
   $PYTHON ${PYTHONPACK}/st2common/bin/st2-register-content --config-file ${STANCONF} ${REGISTER_FLAGS}
@@ -256,6 +292,11 @@ case ${1} in
     sleep 1
     getpids
     ;;
+  reopen-log-files)
+    reopen_component_log_files ${2}
+    sleep 1
+    getpids
+    ;;
   reload)
     register_content
     getpids
@@ -278,6 +319,6 @@ case ${1} in
     getpids
     ;;
   *)
-    echo "Valid actions: start|stop|restart|restart-component|reload|clean|status"
+    echo "Valid actions: start|stop|restart|restart-component|reopen-log-files|reload|clean|status"
     ;;
 esac


### PR DESCRIPTION
With this pull request all the Python service processes now re-open log files when receiving `SIGUSR1` signal.

To test it start the st2api service and run the commands listed bellow.

Screen 1:

```bash
tail -F logs/st2api.log
```

Screen 2:

```bash
python ./st2client/st2client/shell.py runner list - you should see new messages in the log file
rm logs/st2api.log
python ./st2client/st2client/shell.py runner list - you should see no new messages in the log file since the process is still referencing the old file handle
kill -USR1 <st2api pid>
python ./st2client/st2client/shell.py runner list - you should see new messages in the log file because SIGUSR1 causes process to reopen the log files
```

TODO:

- [x] Do the same for all the Python services
- [x] Update log rotate configs
- [x] Remove rotating file handler code