### PR TITLE
uwsgi support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ passlib>=1.6.2,<1.7
 lockfile>=0.10.2,<0.11
 python-gnupg>=0.3.7,<0.4
 jsonpath-rw>=1.3.0
+uwsgi>=2.0

--- a/st2api/st2api/wsgi.py
+++ b/st2api/st2api/wsgi.py
@@ -1,0 +1,34 @@
+from oslo.config import cfg
+
+from st2common.constants.logging import DEFAULT_LOGGING_CONF_PATH
+from st2common import log as logging
+from st2common.models.db import db_setup
+from st2common.transport.utils import register_exchanges
+from st2api import app
+from st2api import config
+
+
+LOG = logging.getLogger(__name__)
+
+
+def setup():
+    # Set up logger which logs everything which happens during and before config
+    # parsing to sys.stdout
+    logging.setup(DEFAULT_LOGGING_CONF_PATH)
+
+    # 1. parse args to setup config.
+    config.parse_args()
+
+    # 2. setup logging.
+    logging.setup(cfg.CONF.api.logging)
+
+    # 3. all other setup which requires config to be parsed and logging to
+    # be correctly setup.
+    username = cfg.CONF.database.username if hasattr(cfg.CONF.database, 'username') else None
+    password = cfg.CONF.database.password if hasattr(cfg.CONF.database, 'password') else None
+    db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
+             username=username, password=password)
+    register_exchanges()
+
+    # 4. setup an application.
+    return app.setup_app()


### PR DESCRIPTION
You can still run it as before by using cmd.py or you can serve it using uWSGI:
```
uwsgi --http :9101 --module 'st2api.wsgi:setup()' --pyargv '--config-file conf/st2.dev.conf'
```

In case of uWSGI, stream won't work due to:
a) uWSGI doesn't support eventlet, only gevent
b) uWSGI expects `application(environ, start_response)` to be a generator itself rather than return generator as Pecan does it. I've spent the whole day digging though Pecan code to figure out how to change it behavior accordingly and wasn't able to find another way except for making stream a middleware (which I also haven't tested yet).
c) every doc in uwsgi at least slightly related to streaming or sse insist on using uWSGI off-loading to avoid resources (processes and threads) being fully consumed by long-living sse connections. Common sense agrees, I think we need to remove streams from API and make them a separate service. Whether we're going to off-load connections to it or make it a separate eventlet\gevent app on its own port, we'll see, but it is clear now that streams have very different performance requirements and mixing short-living API calls and long-living Stream connections is not we want to do.