### PR TITLE
Fix mistral callback handler

### DIFF
--- a/contrib/examples/actions/workflows/mistral-workbook-complex.yaml
+++ b/contrib/examples/actions/workflows/mistral-workbook-complex.yaml
@@ -12,7 +12,6 @@ workflows:
             - memory_mb
         output:
             vm_id: <% $.vm_id %>
-            vm_state: <% $.vm_state %>
             ip: <% $.ip %>
         tasks:
             register_dns:

--- a/st2actions/st2actions/handlers/mistral.py
+++ b/st2actions/st2actions/handlers/mistral.py
@@ -61,10 +61,7 @@ class MistralCallbackHandler(handlers.ActionExecutionCallbackHandler):
                 result.pop('tasks', None)
 
             output = json.dumps(result) if type(result) in [dict, list] else str(result)
-
-            v1 = 'v1' in url
-            output_key = 'output' if v1 else 'result'
-            data = {'state': STATUS_MAP[status], output_key: output}
+            data = {'state': STATUS_MAP[status], 'output': output}
 
             for i in range(cfg.CONF.mistral.max_attempts):
                 try:

--- a/st2actions/st2actions/runners/mistral/v2.py
+++ b/st2actions/st2actions/runners/mistral/v2.py
@@ -233,9 +233,10 @@ class MistralRunner(AsyncActionRunner):
                 if 'workflow_name' in orig_parent_context.keys():
                     actual_parent['workflow_name'] = orig_parent_context['workflow_name']
                     del orig_parent_context['workflow_name']
-                if 'execution_id' in orig_parent_context.keys():
-                    actual_parent['execution_id'] = orig_parent_context['execution_id']
-                    del orig_parent_context['execution_id']
+                if 'workflow_execution_id' in orig_parent_context.keys():
+                    actual_parent['workflow_execution_id'] = \
+                        orig_parent_context['workflow_execution_id']
+                    del orig_parent_context['workflow_execution_id']
                 context['mistral'] = orig_parent_context
                 context['mistral'].update(current)
                 context['mistral']['parent'] = actual_parent

--- a/st2tests/integration/mistral/test_wiring.py
+++ b/st2tests/integration/mistral/test_wiring.py
@@ -15,7 +15,6 @@
 
 import eventlet
 import unittest2
-import multiprocessing
 
 from st2client import client as st2
 from st2client import models
@@ -27,11 +26,6 @@ class TestWorkflowExecution(unittest2.TestCase):
     def setUpClass(cls):
         cls.st2client = st2.Client(base_url='http://localhost')
 
-    @unittest2.skip('multiprocessing.cpu_count isn\'t reliable')
-    def test_cpu_count(self):
-        # Ensure tests are run on multi-processor system to catch race conditions
-        self.assertGreaterEqual(multiprocessing.cpu_count(), 2)
-
     def _execute_workflow(self, action, parameters):
         execution = models.LiveAction(action=action, parameters=parameters)
         execution = self.st2client.liveactions.create(execution)
@@ -42,7 +36,7 @@ class TestWorkflowExecution(unittest2.TestCase):
 
     def _wait_for_completion(self, execution, wait=300):
         for i in range(wait):
-            eventlet.sleep(1)
+            eventlet.sleep(3)
             execution = self.st2client.liveactions.get_by_id(execution.id)
             if execution.status in ['succeeded', 'failed']:
                 break
@@ -80,7 +74,6 @@ class TestWorkflowExecution(unittest2.TestCase):
         execution = self._wait_for_completion(execution)
         self._assert_success(execution)
         self.assertIn('vm_id', execution.result)
-        self.assertIn('vm_state', execution.result)
 
     def test_complex_workbook_subflow_actions(self):
         execution = self._execute_workflow(
@@ -100,15 +93,18 @@ class TestWorkflowExecution(unittest2.TestCase):
     def test_concurrent_load(self):
         wf_name = 'examples.mistral-workbook-complex'
         wf_params = {'vm_name': 'demo1'}
-        executions = [self._execute_workflow(wf_name, wf_params) for i in range(20)]
+        executions = [self._execute_workflow(wf_name, wf_params) for i in range(10)]
 
-        eventlet.sleep(10)
-
-        for execution in executions:
+        def assert_successful_completion(execution):
+            eventlet.sleep(30)
             execution = self._wait_for_completion(execution)
             self._assert_success(execution)
             self.assertIn('vm_id', execution.result)
-            self.assertIn('vm_state', execution.result)
+
+        threads = [eventlet.spawn(assert_successful_completion, execution)
+                   for execution in executions]
+
+        [thread.wait() for thread in threads]
 
     def test_execution_failure(self):
         execution = self._execute_workflow('examples.mistral-basic', {'cmd': 'foo'})


### PR DESCRIPTION
Mistral added an action execution endpoint. Action result should be posted as output to the action execution endpoint instead of the task endpoint.