### PR TITLE
added mkdir for logrotate.d

### DIFF
--- a/st2common/packaging/rpm/st2common.spec
+++ b/st2common/packaging/rpm/st2common.spec
@@ -29,6 +29,7 @@ mkdir -p %{buildroot}/usr/bin
 mkdir -p %{buildroot}%{python2_sitelib}
 mkdir -p %{buildroot}/var/log/st2
 mkdir -p %{buildroot}/etc/st2
+mkdir -p %{buildroot}/etc/logrotate.d
 mkdir -p %{buildroot}/opt/stackstorm/packs
 mkdir -p %{buildroot}/opt/stackstorm/packs/default
 mkdir -p %{buildroot}/opt/stackstorm/packs/default/actions


### PR DESCRIPTION
We need to create /etc/logrotate.d in the buildroot.