### PR TITLE
RFR: kvp argument in keystore PUT controller is set to object

### DIFF
--- a/st2api/st2api/controllers/v1/datastore.py
+++ b/st2api/st2api/controllers/v1/datastore.py
@@ -78,7 +78,7 @@ class KeyValuePairController(RestController):
 
         return kvps
 
-    @jsexpose(arg_types=[str], body_cls=KeyValuePairAPI)
+    @jsexpose(arg_types=[str, object], body_cls=KeyValuePairAPI)
     def put(self, name, kvp):
         """
         Create a new entry or update an existing one.

--- a/st2api/tests/unit/controllers/v1/test_kvps.py
+++ b/st2api/tests/unit/controllers/v1/test_kvps.py
@@ -20,6 +20,26 @@ KVP = {
     'value': 'http://localhost:5000/v3'
 }
 
+KVP_INT = {
+    'name': 'foo',
+    'value': 666
+}
+
+KVP_BOOL = {
+    'name': 'foo',
+    'value': True
+}
+
+KVP_LIST = {
+    'name': 'foo',
+    'value': [1, 2, 3]
+}
+
+KVP_DICT = {
+    'name': 'foo',
+    'value': {'foo': 'bar', 'int': 1, 'bool': True}
+}
+
 KVP_2 = {
     'name': 'keystone_version',
     'value': 'v3'
@@ -77,6 +97,17 @@ class TestKeyValuePairController(FunctionalTest):
         update_input['value'] = 'http://localhost:35357/v3'
         put_resp = self.__do_put(self.__get_kvp_id(put_resp), update_input)
         self.assertEqual(put_resp.status_int, 200)
+        self.__do_delete(self.__get_kvp_id(put_resp))
+
+    def test_put_types(self):
+        put_resp = self.__do_put('key1', KVP_INT)
+        self.assertEqual(KVP_INT['value'], put_resp.json['value'])
+        put_resp = self.__do_put('key1', KVP_BOOL)
+        self.assertEqual(KVP_BOOL['value'], put_resp.json['value'])
+        put_resp = self.__do_put('key1', KVP_LIST)
+        self.assertEqual(KVP_LIST['value'], put_resp.json['value'])
+        put_resp = self.__do_put('key1', KVP_DICT)
+        self.assertEqual(KVP_DICT['value'], put_resp.json['value'])
         self.__do_delete(self.__get_kvp_id(put_resp))
 
     def test_put_with_ttl(self):

--- a/st2common/st2common/models/api/datastore.py
+++ b/st2common/st2common/models/api/datastore.py
@@ -37,7 +37,6 @@ class KeyValuePairAPI(BaseAPI):
                 'type': 'string'
             },
             'value': {
-                'type': 'string',
                 'required': True
             },
             'expire_timestamp': {

--- a/st2common/st2common/models/db/datastore.py
+++ b/st2common/st2common/models/db/datastore.py
@@ -29,7 +29,7 @@ class KeyValuePairDB(stormbase.StormBaseDB):
         value: Arbitrary value to be stored.
     """
     name = me.StringField(required=True, unique=True)
-    value = me.StringField()
+    value = me.DynamicField()
     expire_timestamp = me.DateTimeField()
 
     meta = {


### PR DESCRIPTION
Before:

```
WARNING log [-] Type definition for 'kvp' argument of 'put' is missing.
```

After:

```
2015-04-21 18:56:29,100 139840334395344 DEBUG log [-] Database lookup for name="foo1" resulted in exception : Unable to find the KeyValuePairDB instance. {'name': 'foo1'}.
2015-04-21 18:56:29,101 139840334395344 AUDIT log [-] KeyValuePair updated. KeyValuePair.id=55369d5d6d0aff104375c39e (kvp_db={'expire_timestamp': None, 'value': u'bar1', 'description': None, 'name': 'foo1', 'id': '55369d5d6d0aff104375c39e'})
2015-04-21 18:56:29,102 139840334395344 INFO log [-] PUT /v1/keys/foo1 result={"name": "foo1", "value": "bar1"} (remote_addr='127.0.0.1',method='PUT',result='{"name": "foo1", "value": "bar1"}',status_code='200 OK',path='/v1/keys/foo1')
2015-04-21 18:56:33,866 139840334395344 INFO log [-] PUT /v1/keys/foo1 with filters={} (remote_addr='127.0.0.1',method='PUT',filters={},path='/v1/keys/foo1')
2015-04-21 18:56:33,870 139840334395344 AUDIT log [-] KeyValuePair updated. KeyValuePair.id=55369d5d6d0aff104375c39e (kvp_db={'expire_timestamp': None, 'value': u'True', 'description': None, 'name': 'foo1', 'id': '55369d5d6d0aff104375c39e'})
2015-04-21 18:56:33,870 139840334395344 INFO log [-] PUT /v1/keys/foo1 result={"name": "foo1", "value": "True"} (remote_addr='127.0.0.1',method='PUT',result='{"name": "foo1", "value": "True"}',status_code='200 OK',path='/v1/keys/foo1')
```

```
~/st2 git:STORM-1233/fix_kvp_controller ❯❯❯ st2 key list                                                                                                                                                      ✭ ◼
+------------------------------------------+------------+------------------+
| name                                     | value      | expire_timestamp |
+------------------------------------------+------------+------------------+
| foo1                                     | True       |                  |
| foo                                      | 1          |                  |
| slack.SlackSensor:last_message_timestamp | 1429642520 |                  |
+------------------------------------------+------------+------------------+
~/st2 git:STORM-1233/fix_kvp_controller ❯❯❯
```