### PR TITLE
Chatops alias updates

### DIFF
--- a/conf/st2.conf.sample
+++ b/conf/st2.conf.sample
@@ -59,8 +59,6 @@ port = 9100
 backend = flat_file
 
 [content]
-# Paths which will be searched for aliases.
-aliases_base_paths = /opt/stackstorm/aliases
 # Path to the directory which contains system packs.
 system_packs_base_path = /opt/stackstorm/packs
 # Paths which will be searched for integration packs.
@@ -90,7 +88,7 @@ port = 6001
 # Controls if stderr should be redirected to the logs.
 redirect_stderr = False
 # Exclusion list of loggers to omit.
-excludes = 
+excludes =
 
 [messaging]
 # URL of the messaging server.

--- a/st2api/st2api/controllers/exp/aliasexecution.py
+++ b/st2api/st2api/controllers/exp/aliasexecution.py
@@ -76,7 +76,7 @@ class ActionAliasExecutionController(rest.RestController):
         on_complete.channels = [payload.notification_channel]
         on_complete.data = {
             'user': payload.user,
-            'room': payload.source_channel
+            'source_channel': payload.source_channel
         }
         notify = NotificationSchema()
         notify.on_complete = on_complete

--- a/st2api/st2api/controllers/exp/aliasexecution.py
+++ b/st2api/st2api/controllers/exp/aliasexecution.py
@@ -73,8 +73,8 @@ class ActionAliasExecutionController(rest.RestController):
 
     def _get_notify_field(self, payload):
         on_complete = NotificationSubSchema()
-        on_complete.message = "@%s action complete." % payload.user
         on_complete.channels = [payload.channel]
+        on_complete.data = {'user': payload.user}
         notify = NotificationSchema()
         notify.on_complete = on_complete
         return notify

--- a/st2api/st2api/controllers/exp/aliasexecution.py
+++ b/st2api/st2api/controllers/exp/aliasexecution.py
@@ -73,8 +73,11 @@ class ActionAliasExecutionController(rest.RestController):
 
     def _get_notify_field(self, payload):
         on_complete = NotificationSubSchema()
-        on_complete.channels = [payload.channel]
-        on_complete.data = {'user': payload.user}
+        on_complete.channels = [payload.notification_channel]
+        on_complete.data = {
+            'user': payload.user,
+            'room': payload.source_channel
+        }
         notify = NotificationSchema()
         notify.on_complete = on_complete
         return notify

--- a/st2api/tests/unit/controllers/exp/test_action_alias.py
+++ b/st2api/tests/unit/controllers/exp/test_action_alias.py
@@ -21,11 +21,11 @@ from tests import FunctionalTest
 FIXTURES_PACK = 'aliases'
 
 TEST_MODELS = {
-    'actionaliases': ['alias1.yaml', 'alias2.yaml']
+    'aliases': ['alias1.yaml', 'alias2.yaml']
 }
 
 TEST_LOAD_MODELS = {
-    'actionaliases': ['alias3.yaml']
+    'aliases': ['alias3.yaml']
 }
 
 
@@ -41,12 +41,12 @@ class TestActionAlias(FunctionalTest):
         super(TestActionAlias, cls).setUpClass()
         cls.models = FixturesLoader().save_fixtures_to_db(fixtures_pack=FIXTURES_PACK,
                                                           fixtures_dict=TEST_MODELS)
-        cls.alias1 = cls.models['actionaliases']['alias1.yaml']
-        cls.alias2 = cls.models['actionaliases']['alias2.yaml']
+        cls.alias1 = cls.models['aliases']['alias1.yaml']
+        cls.alias2 = cls.models['aliases']['alias2.yaml']
 
         loaded_models = FixturesLoader().load_models(fixtures_pack=FIXTURES_PACK,
                                                      fixtures_dict=TEST_LOAD_MODELS)
-        cls.alias3 = loaded_models['actionaliases']['alias3.yaml']
+        cls.alias3 = loaded_models['aliases']['alias3.yaml']
 
     def test_get_all(self):
         resp = self.app.get('/exp/actionalias')

--- a/st2api/tests/unit/controllers/exp/test_alias_execution.py
+++ b/st2api/tests/unit/controllers/exp/test_alias_execution.py
@@ -64,6 +64,9 @@ class TestAliasExecution(FunctionalTest):
         self.assertEquals(schedule.call_args[0][0].parameters, expected_parameters)
 
     def _do_post(self, execution, expect_errors=False):
-        execution = {'command': execution}
+        execution = {'command': execution,
+                     'user': 'stanley',
+                     'source_channel': 'test',
+                     'notification_channel': 'test'}
         return self.app.post_json('/exp/aliasexecution', execution,
                                   expect_errors=expect_errors)

--- a/st2api/tests/unit/controllers/exp/test_alias_execution.py
+++ b/st2api/tests/unit/controllers/exp/test_alias_execution.py
@@ -23,13 +23,13 @@ from tests import FunctionalTest
 FIXTURES_PACK = 'aliases'
 
 TEST_MODELS = {
-    'actionaliases': ['alias1.yaml', 'alias2.yaml'],
+    'aliases': ['alias1.yaml', 'alias2.yaml'],
     'actions': ['action1.yaml'],
     'runners': ['runner1.yaml']
 }
 
 TEST_LOAD_MODELS = {
-    'actionaliases': ['alias3.yaml']
+    'aliases': ['alias3.yaml']
 }
 
 
@@ -51,8 +51,8 @@ class TestAliasExecution(FunctionalTest):
         super(TestAliasExecution, cls).setUpClass()
         cls.models = FixturesLoader().save_fixtures_to_db(fixtures_pack=FIXTURES_PACK,
                                                           fixtures_dict=TEST_MODELS)
-        cls.alias1 = cls.models['actionaliases']['alias1.yaml']
-        cls.alias2 = cls.models['actionaliases']['alias2.yaml']
+        cls.alias1 = cls.models['aliases']['alias1.yaml']
+        cls.alias2 = cls.models['aliases']['alias2.yaml']
 
     @mock.patch.object(action_service, 'schedule',
                        return_value=(None, DummyActionExecution(id_=1)))

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -67,14 +67,11 @@ def register_opts(ignore_errors=False):
     do_register_opts(system_opts, 'system', ignore_errors)
 
     system_packs_base_path = os.path.join(cfg.CONF.system.base_path, 'packs')
-    default_aliases_path = os.path.join(cfg.CONF.system.base_path, 'aliases')
     content_opts = [
         cfg.StrOpt('system_packs_base_path', default=system_packs_base_path,
                    help='Path to the directory which contains system packs.'),
         cfg.StrOpt('packs_base_paths', default=None,
-                   help='Paths which will be searched for integration packs.'),
-        cfg.StrOpt('aliases_base_paths', default=default_aliases_path,
-                   help='Paths which will be searched for aliases.')
+                   help='Paths which will be searched for integration packs.')
     ]
     do_register_opts(content_opts, 'content', ignore_errors)
 

--- a/st2common/st2common/content/aliasesregistrar.py
+++ b/st2common/st2common/content/aliasesregistrar.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import six
+
 import st2common.content.utils as content_utils
 
 from st2common import log as logging
@@ -32,62 +35,116 @@ LOG = logging.getLogger(__name__)
 class AliasesRegistrar(ResourceRegistrar):
     ALLOWED_EXTENSIONS = ALLOWED_EXTS
 
-    def register_aliases_from_dirs(self, aliases_dirs=None):
-        if not aliases_dirs:
-            return 0
-        result = 0
-        for aliases_dir in aliases_dirs:
-            result += self.register_aliases_from_dir(aliases_dir=aliases_dir)
-        return result
+    def register_aliases_from_packs(self, base_dirs):
+        """
+        Discover all the packs in the provided directory and register aliases from all of the
+        discovered packs.
 
-    def register_aliases_from_dir(self, aliases_dir=None):
+        :return: Number of aliases registered.
+        :rtype: ``int``
+        """
+        registered_count = 0
+
+        content = self._pack_loader.get_content(base_dirs=base_dirs,
+                                                content_type='aliases')
+
+        for pack, aliases_dir in six.iteritems(content):
+            try:
+                LOG.debug('Registering aliases from pack %s:, dir: %s', pack, aliases_dir)
+                aliases = self._get_aliases_from_pack(aliases_dir)
+                count = self._register_aliases_from_pack(pack=pack, aliases=aliases)
+                registered_count += count
+            except:
+                LOG.exception('Failed registering all aliases from pack: %s', aliases_dir)
+
+        return registered_count
+
+    def register_aliases_from_pack(self, pack_dir):
+        """
+        Register all the aliases from the provided pack.
+
+        :return: Number of aliases registered.
+        :rtype: ``int``
+        """
+        pack_dir = pack_dir[:-1] if pack_dir.endswith('/') else pack_dir
+        _, pack = os.path.split(pack_dir)
+        aliases_dir = self._pack_loader.get_content_from_pack(pack_dir=pack_dir,
+                                                              content_type='aliases')
+
+        registered_count = 0
+
         if not aliases_dir:
-            return 0
-        resources = self._get_resources_from_pack(resources_dir=aliases_dir)
-        return self._register_aliases(aliases=resources)
+            return registered_count
 
-    def _register_aliases(self, aliases=None):
+        LOG.debug('Registering aliases from pack %s:, dir: %s', pack, aliases_dir)
+
+        try:
+            aliases = self._get_aliases_from_pack(aliases_dir=aliases_dir)
+            registered_count = self._register_aliases_from_pack(pack=pack, aliases=aliases)
+        except:
+            LOG.exception('Failed registering all aliases from pack: %s', aliases_dir)
+
+        return registered_count
+
+    def _get_aliases_from_pack(self, aliases_dir):
+        return self._get_resources_from_pack(resources_dir=aliases_dir)
+
+    def _register_action_alias(self, pack, action_alias):
+        content = self._meta_loader.load(action_alias)
+        pack_field = content.get('pack', None)
+        if not pack_field:
+            content['pack'] = pack
+            pack_field = pack
+        if pack_field != pack:
+            raise Exception('Model is in pack "%s" but field "pack" is different: %s' %
+                            (pack, pack_field))
+
+        action_alias_api = ActionAliasAPI(**content)
+        action_alias_api.validate()
+        action_alias_db = ActionAliasAPI.to_model(action_alias_api)
+
+        try:
+            action_alias_db.id = ActionAlias.get_by_name(action_alias_api.name).id
+        except ValueError:
+            LOG.info('ActionAlias %s not found. Creating new one.', action_alias)
+
+        try:
+            action_alias_db = ActionAlias.add_or_update(action_alias_db)
+            extra = {'action_alias_db': action_alias_db}
+            LOG.audit('Action alias updated. Action alias %s from %s.', action_alias_db,
+                      action_alias, extra=extra)
+        except Exception:
+            LOG.exception('Failed to create action alias %s.', action_alias_api.name)
+            raise
+
+    def _register_aliases_from_pack(self, pack, aliases):
         registered_count = 0
 
         for alias in aliases:
-            LOG.debug('Loading alias from %s.', alias)
             try:
-                content = self._meta_loader.load(alias)
-                action_alias_api = ActionAliasAPI(**content)
-                action_alias_db = ActionAliasAPI.to_model(action_alias_api)
-
-                try:
-                    action_alias_db.id = ActionAlias.get_by_name(action_alias_api.name).id
-                except ValueError:
-                    LOG.info('ActionAlias %s not found. Creating new one.', alias)
-
-                try:
-                    action_alias_db = ActionAlias.add_or_update(action_alias_db)
-                    extra = {'action_alias_db': action_alias_db}
-                    LOG.audit('Action alias updated. Action alias %s from %s.', action_alias_db,
-                              alias, extra=extra)
-                except Exception:
-                    LOG.exception('Failed to create action alias %s.', action_alias_api.name)
-
+                LOG.debug('Loading alias from %s.', alias)
+                self._register_action_alias(pack, alias)
             except Exception:
-                LOG.exception('Failed registering alias from %s.', alias)
+                LOG.exception('Unable to register alias: %s', alias)
+                continue
             else:
                 registered_count += 1
 
         return registered_count
 
 
-def register_aliases(aliases_base_paths=None, aliases_dir=None):
-    if aliases_base_paths:
-        assert(isinstance(aliases_base_paths, list))
+def register_aliases(packs_base_paths=None, pack_dir=None):
+    if packs_base_paths:
+        assert(isinstance(packs_base_paths, list))
+
+    if not packs_base_paths:
+        packs_base_paths = content_utils.get_packs_base_paths()
 
     registrar = AliasesRegistrar()
 
-    if aliases_dir:
-        result = registrar.register_aliases_from_dir(aliases_dir=aliases_dir)
+    if pack_dir:
+        result = registrar.register_aliases_from_pack(pack_dir=pack_dir)
     else:
-        if not aliases_base_paths:
-            aliases_base_paths = content_utils.get_aliases_base_paths()
-        result = registrar.register_aliases_from_dirs(aliases_dirs=aliases_base_paths)
+        result = registrar.register_aliases_from_packs(base_dirs=packs_base_paths)
 
     return result

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -110,7 +110,7 @@ def register_aliases():
         import st2common.content.aliasesregistrar as aliases_registrar
         # This count is broken. If register_aliases throws an exception it has
         # no assigned value. (FIX ME!)
-        registered_count = aliases_registrar.register_aliases()
+        registered_count = aliases_registrar.register_aliases(pack_dir=cfg.CONF.register.pack)
     except Exception:
         LOG.warning('Failed to register aliases.', exc_info=True)
 

--- a/st2common/st2common/content/loader.py
+++ b/st2common/st2common/content/loader.py
@@ -30,7 +30,7 @@ LOG = logging.getLogger(__name__)
 
 
 class ContentPackLoader(object):
-    ALLOWED_CONTENT_TYPES = ['sensors', 'actions', 'rules']
+    ALLOWED_CONTENT_TYPES = ['sensors', 'actions', 'rules', 'aliases']
 
     def get_content(self, base_dirs, content_type):
         """
@@ -118,6 +118,8 @@ class ContentPackLoader(object):
             get_func = self._get_actions
         elif content_type == 'rules':
             get_func = self._get_rules
+        elif content_type == 'aliases':
+            get_func = self._get_aliases
 
         if not os.path.isdir(pack_dir):
             raise ValueError('Directory "%s" doesn\'t exist' % (pack_dir))
@@ -126,19 +128,22 @@ class ContentPackLoader(object):
         return pack_content
 
     def _get_sensors(self, pack_dir):
-        if 'sensors' not in os.listdir(pack_dir):
-            raise ValueError('No sensors found in "%s".' % (pack_dir))
-        return os.path.join(pack_dir, 'sensors')
+        return self._get_folder(pack_dir=pack_dir, content_type='sensors')
 
     def _get_actions(self, pack_dir):
-        if 'actions' not in os.listdir(pack_dir):
-            raise ValueError('No actions found in "%s".' % (pack_dir))
-        return os.path.join(pack_dir, 'actions')
+        return self._get_folder(pack_dir=pack_dir, content_type='actions')
 
     def _get_rules(self, pack_dir):
-        if 'rules' not in os.listdir(pack_dir):
-            raise ValueError('No rules found in "%s".' % (pack_dir))
-        return os.path.join(pack_dir, 'rules')
+        return self._get_folder(pack_dir=pack_dir, content_type='rules')
+
+    def _get_aliases(self, pack_dir):
+        return self._get_folder(pack_dir=pack_dir, content_type='aliases')
+
+    def _get_folder(self, pack_dir, content_type):
+        path = os.path.join(pack_dir, content_type)
+        if not os.path.isdir(path):
+            raise ValueError('No %s found in "%s".' % (content_type, pack_dir))
+        return path
 
 
 class MetaLoader(object):

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -393,10 +393,19 @@ class ActionAliasAPI(BaseAPI):
                 "description": "The unique identifier for the action alias.",
                 "type": "string"
             },
+            "ref": {
+                "description": "System computed user friendly reference for the alias. \
+                                Provided value will be overridden by computed value.",
+                "type": "string"
+            },
             "name": {
                 "type": "string",
                 "description": "Name of the action alias.",
                 "required": True
+            },
+            "pack": {
+                "description": "The content pack this actionalias belongs to.",
+                "type": "string"
             },
             "description": {
                 "type": "string",
@@ -420,6 +429,8 @@ class ActionAliasAPI(BaseAPI):
     def to_model(cls, alias):
         model = super(cls, cls).to_model(alias)
         model.name = alias.name
+        model.pack = alias.pack
+        model.ref = ResourceReference.to_string_reference(pack=model.pack, name=model.name)
         model.action_ref = alias.action_ref
         model.formats = alias.formats
         return model

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -445,10 +445,14 @@ class AliasExecutionAPI(BaseAPI):
                 "description": "User that requested the execution.",
                 "default": "channel"
             },
-            "channel": {
+            "source_channel": {
                 "type": "string",
                 "description": "Channel from which the execution was requested. This is not the channel \
-                                as defined by the notification system.",
+                                as defined by the notification system."
+            },
+            "notification_channel": {
+                "type": "string",
+                "description": "StackStorm notification channel to use to respond.",
                 "required": True
             }
         },

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -405,7 +405,8 @@ class ActionAliasAPI(BaseAPI):
             },
             "pack": {
                 "description": "The content pack this actionalias belongs to.",
-                "type": "string"
+                "type": "string",
+                "required": True
             },
             "description": {
                 "type": "string",

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -439,6 +439,17 @@ class AliasExecutionAPI(BaseAPI):
                 "type": "string",
                 "description": "Name of the action alias.",
                 "required": True
+            },
+            "user": {
+                "type": "string",
+                "description": "User that requested the execution.",
+                "default": "channel"
+            },
+            "channel": {
+                "type": "string",
+                "description": "Channel from which the execution was requested. This is not the channel \
+                                as defined by the notification system.",
+                "required": True
             }
         },
         "additionalProperties": False

--- a/st2common/st2common/models/db/action.py
+++ b/st2common/st2common/models/db/action.py
@@ -188,7 +188,6 @@ class ActionExecutionStateDB(stormbase.StormFoundationDB):
     """
         Database entity that represents the state of Action execution.
     """
-
     execution_id = me.ObjectIdField(
         required=True,
         unique=True,
@@ -209,6 +208,10 @@ class ActionAliasDB(stormbase.StormBaseDB):
     """
         Database entity that represent an Alias for an action.
     """
+    ref = me.StringField(required=True)
+    pack = me.StringField(
+        required=True,
+        help_text='Name of the content pack.')
     action_ref = me.StringField(
         required=True,
         help_text='Reference of the Action map this alias.')

--- a/st2common/tests/unit/test_aliasesregistrar.py
+++ b/st2common/tests/unit/test_aliasesregistrar.py
@@ -19,12 +19,13 @@ from st2common.content import aliasesregistrar
 from st2tests import DbTestCase, fixturesloader
 
 
-ALIASES_FIXTURE_PATH = os.path.join(fixturesloader.get_fixtures_base_path(), 'alias_registrar')
+ALIASES_FIXTURE_PACK_PATH = os.path.join(fixturesloader.get_fixtures_base_path(), 'dummy_pack_1')
+ALIASES_FIXTURE_PATH = os.path.join(ALIASES_FIXTURE_PACK_PATH, 'aliases')
 
 
 class TestAliasRegistrar(DbTestCase):
 
     def test_alias_registration(self):
-        count = aliasesregistrar.register_aliases(aliases_dir=ALIASES_FIXTURE_PATH)
+        count = aliasesregistrar.register_aliases(pack_dir=ALIASES_FIXTURE_PACK_PATH)
         # expect all files to contain be aliases
         self.assertEqual(count, len(os.listdir(ALIASES_FIXTURE_PATH)))

--- a/st2tests/st2tests/fixtures/aliases/aliases/alias1.yaml
+++ b/st2tests/st2tests/fixtures/aliases/aliases/alias1.yaml
@@ -1,5 +1,6 @@
 ---
     name: "alias1"
+    pack: "aliases"
     description: "DON'T CARE"
     action_ref: "wolfpack.action1"
     formats:

--- a/st2tests/st2tests/fixtures/aliases/aliases/alias2.yaml
+++ b/st2tests/st2tests/fixtures/aliases/aliases/alias2.yaml
@@ -1,5 +1,6 @@
 ---
     name: "alias2"
+    pack: "aliases"
     description: "DON'T CARE"
     action_ref: "wolfpack.action1"
     formats:

--- a/st2tests/st2tests/fixtures/aliases/aliases/alias3.yaml
+++ b/st2tests/st2tests/fixtures/aliases/aliases/alias3.yaml
@@ -1,5 +1,6 @@
 ---
     name: "alias3"
+    pack: "aliases"
     description: "DON'T CARE"
     action_ref: "core.remote"
     formats:

--- a/st2tests/st2tests/fixtures/dummy_pack_1/aliases/alias1.yaml
+++ b/st2tests/st2tests/fixtures/dummy_pack_1/aliases/alias1.yaml
@@ -1,5 +1,6 @@
 ---
     name: "alias1"
+    pack: "dummy_pack_1"
     description: "DON'T CARE"
     action_ref: "core.local"
     formats:

--- a/st2tests/st2tests/fixtures/dummy_pack_1/aliases/alias2.yaml
+++ b/st2tests/st2tests/fixtures/dummy_pack_1/aliases/alias2.yaml
@@ -1,5 +1,6 @@
 ---
     name: "alias2"
+    pack: "dummy_pack_1"
     description: "DON'T CARE"
     action_ref: "core.local"
     formats:

--- a/st2tests/st2tests/fixturesloader.py
+++ b/st2tests/st2tests/fixturesloader.py
@@ -37,13 +37,13 @@ from st2common.persistence.execution import (ActionExecution)
 from st2common.persistence.reactor import (Rule, Trigger, TriggerType, TriggerInstance)
 
 ALLOWED_DB_FIXTURES = ['actions', 'actionstates', 'executions', 'liveactions', 'rules', 'runners',
-                       'triggertypes', 'triggers', 'triggerinstances', 'actionaliases']
+                       'triggertypes', 'triggers', 'triggerinstances', 'aliases']
 ALLOWED_FIXTURES = copy.copy(ALLOWED_DB_FIXTURES)
 ALLOWED_FIXTURES.extend(['actionchains', 'workflows'])
 
 FIXTURE_DB_MODEL = {
     'actions': ActionDB,
-    'actionaliases': ActionAliasDB,
+    'aliases': ActionAliasDB,
     'actionstates': ActionExecutionStateDB,
     'executions': ActionExecutionDB,
     'liveactions': LiveActionDB,
@@ -56,7 +56,7 @@ FIXTURE_DB_MODEL = {
 
 FIXTURE_API_MODEL = {
     'actions': ActionAPI,
-    'actionaliases': ActionAliasAPI,
+    'aliases': ActionAliasAPI,
     'actionstates': ActionExecutionStateAPI,
     'executions': ActionExecutionAPI,
     'liveactions': LiveActionAPI,
@@ -70,7 +70,7 @@ FIXTURE_API_MODEL = {
 
 FIXTURE_PERSISTENCE_MODEL = {
     'actions': Action,
-    'actionaliases': ActionAlias,
+    'aliases': ActionAlias,
     'actionstates': ActionExecutionState,
     'executions': ActionExecution,
     'liveactions': LiveAction,


### PR DESCRIPTION
- No need to change the Action metadata to inclued channel and message.
- User is also pass through the notifications system.

- [x] pass user and channel from bot to notification
- [x] fix alias location to be inside a pack
- [x] fix tests
- [x] update rules in st2incubator/hubot [https://github.com/StackStorm/st2incubator/pull/190]
- [x] update chatops.md/some other instructions [https://github.com/StackStorm/blogs/pull/4]