### PR TITLE
Pass runner generated auth token to Mistral

### DIFF
--- a/st2actions/st2actions/runners/mistral/v2.py
+++ b/st2actions/st2actions/runners/mistral/v2.py
@@ -139,6 +139,9 @@ class MistralRunner(AsyncActionRunner):
             'parent': self.liveaction_id
         }
 
+        if self.auth_token:
+            st2_execution_context['auth_token'] = self.auth_token.token
+
         options = {
             'env': {
                 '__actions': {


### PR DESCRIPTION
When auth is turned on, in order for Mistral to be able to launch st2 actions, the API calls to st2 from Mistral requires a token. The runner container generates a temporary token for authenticated calls. This auth token is passed to Mistral under st2_context in the environment on workbook and workflow execution.