### PR TITLE
Examples installer & self-check v1

### DIFF
--- a/tools/self-check
+++ b/tools/self-check
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+## Script to install samples, tests, and run all workflows in tests pack.
+
 USER='testu'
 PASS='testp'
 

--- a/tools/self-check
+++ b/tools/self-check
@@ -2,9 +2,9 @@
 
 ## Script to install samples, tests, and run all workflows in tests pack.
 
-USER='testu'
-PASS='testp'
+PACKS="tests examples"
 
+#Determine Distro
 DEBTEST=`lsb_release -a 2> /dev/null | grep Distributor | awk '{print $3}'`
 
 if [[ "$DEBTEST" == "Ubuntu" ]]; then
@@ -18,28 +18,30 @@ else
   exit 2
 fi
 
-INSTALL=`${PYTHONPACK}/st2common/bin/st2-setup-tests`
+# Install required packs if necessary
+for PACK in $PACKS; do
+  CHECK=`st2 action list --pack=${PACK} | grep ${PACK}`
+  if [ $? -ne 0 ]; then
+    INSTALL=`${PYTHONPACK}/st2common/bin/st2-setup-${PACK}`
 
-EXITCODE=$?
-echo $INSTALL
+    EXITCODE=$?
+    echo $INSTALL
+  fi
+done
 
-INSTALL=`${PYTHONPACK}/st2common/bin/st2-setup-examples`
-
-EXITCODE=$?
-echo $INSTALL
-
-ST2_AUTH_TOKEN=`st2 auth ${USER} -p ${PASS} | grep token | awk '{ print $4 }'`
-export ST2_AUTH_TOKEN=${ST2_AUTH_TOKEN}
-
+# Retrieve test action list
 TEST_ACTION_LIST=`st2 action list --pack=tests | awk '{ print $2 }' | grep -v "|" | grep -v "ref"`
 
+# Run all the tests
 for TEST in $TEST_ACTION_LIST
     do
-        TEST_OUTPUT=`st2 run ${TEST}`
+        echo -n "Attempting to run ${TEST}..."
+        TEST_OUTPUT=`st2 run ${TEST} token=${ST2_AUTH_TOKEN}`
         if [ $? -ne 0 ]; then
-            echo "FAILED: ${TEST} failed! OUTPUT: ${TEST_OUTPUT}"
+            echo "FAILED!\n${TEST} failed! OUTPUT: ${TEST_OUTPUT}"
             exit 2
         fi
+        echo "OK!"
     done
 
 echo "SUCCESS: All tests passed!"

--- a/tools/self-check
+++ b/tools/self-check
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+USER='testu'
+PASS='testp'
+
+DEBTEST=`lsb_release -a 2> /dev/null | grep Distributor | awk '{print $3}'`
+
+if [[ "$DEBTEST" == "Ubuntu" ]]; then
+  TYPE="debs"
+  PYTHONPACK="/usr/lib/python2.7/dist-packages"
+elif [[ -f "/etc/redhat-release" ]]; then
+  TYPE="rpms"
+  PYTHONPACK="/usr/lib/python2.7/site-packages"
+else
+  echo "Unknown Operating System"
+  exit 2
+fi
+
+INSTALL=`${PYTHONPACK}/st2common/bin/st2-setup-tests`
+
+EXITCODE=$?
+echo $INSTALL
+
+INSTALL=`${PYTHONPACK}/st2common/bin/st2-setup-examples`
+
+EXITCODE=$?
+echo $INSTALL
+
+ST2_AUTH_TOKEN=`st2 auth ${USER} -p ${PASS} | grep token | awk '{ print $4 }'`
+export ST2_AUTH_TOKEN=${ST2_AUTH_TOKEN}
+
+TEST_ACTION_LIST=`st2 action list --pack=tests | awk '{ print $2 }' | grep -v "|" | grep -v "ref"`
+
+for TEST in $TEST_ACTION_LIST
+    do
+        TEST_OUTPUT=`st2 run ${TEST}`
+        if [ $? -ne 0 ]; then
+            echo "FAILED: ${TEST} failed! OUTPUT: ${TEST_OUTPUT}"
+            exit 2
+        fi
+    done
+
+echo "SUCCESS: All tests passed!"

--- a/tools/st2-setup-examples
+++ b/tools/st2-setup-examples
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+PACK="examples"
+USRPATH="/usr/share/doc/st2"
+PACKSPATH="/opt/stackstorm/packs"
+
+if [ -d ${USRPATH}/${PACK} ]; then
+    mkdir -p ${TESTSPATH}
+    cp -Rf ${USRPATH}/${PACK} ${TESTSPATH}
+else
+    echo "${PACK} does not exist in ${USRPATH}"
+    exit 2
+fi
+
+echo -e "Restarting St2 for new path to take affect..."
+st2ctl restart
+echo -e "Reloading St2 content..."
+st2ctl reload
+
+if [ -f ${PACKSPATH}/${PACK}/requirements.txt ]; then
+    echo "Creating virtualenv for ${PACK}..."
+    mkdir -p /opt/stackstorm/virtualenvs
+    virtualenv --system-site-packages /opt/stackstorm/virtualenvs/${PACK}
+    echo "Installing requirements.txt for ${PACK}..."
+    pip install -r ${TESTSPATH}/${PACK}/requirements.txt -E /opt/stackstorm/virtualenvs/${PACK}
+fi

--- a/tools/st2-setup-examples
+++ b/tools/st2-setup-examples
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+## Installer for the examples pack
+
 PACK="examples"
 USRPATH="/usr/share/doc/st2"
 PACKSPATH="/opt/stackstorm/packs"

--- a/tools/st2-setup-tests
+++ b/tools/st2-setup-tests
@@ -25,10 +25,10 @@ else
     st2ctl reload
 fi
 
-if [ -f ${TESTSPATH}/${PACK}requirements.txt ]; then
+if [ -f ${TESTSPATH}/${PACK}/requirements.txt ]; then
     echo "Creating virtualenv for ${PACK}..."
     mkdir -p /opt/stackstorm/virtualenvs
     virtualenv --system-site-packages /opt/stackstorm/virtualenvs/${PACK}
     echo "Installing requirements.txt for ${PACK}..."
-    pip install -r ${TESTSPATH}/${PACK}requirements.txt -E /opt/stackstorm/virtualenvs/${PACK}
+    pip install -r ${TESTSPATH}/${PACK}/requirements.txt -E /opt/stackstorm/virtualenvs/${PACK}
 fi

--- a/tools/st2-setup-tests
+++ b/tools/st2-setup-tests
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+## Installer for tests pack
+
 PACK="tests"
 USRPATH="/usr/share/stackstorm"
 TESTSPATH="/opt/stackstorm/tests/packs"

--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -51,7 +51,7 @@ YUM_PACKAGE_LIST=("python-pip" "python-virtualenv" "python-devel" "gcc-c++" "git
 
 if [ ${INSTALL_MISTRAL} == "1" ]; then
     APT_PACKAGE_LIST+=("mysql-server")
-    YUM_PACKAGE_LIST+=("mysql-server")
+    YUM_PACKAGE_LIST+=("mariadb" "mariadb-libs" "mariadb-devel" "mariadb-server")
 fi
 
 APT_PACKAGE_LIST=$(join " " ${APT_PACKAGE_LIST[@]})

--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -194,7 +194,7 @@ setup_rabbitmq() {
 
   # Enable rabbit to start on boot
   if [[ "$TYPE" == "rpms" ]]; then
-    systemctl enable rabbitmq-server
+    chkconfig rabbitmq-server on
   fi
 
   # Restart rabbitmq

--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -204,7 +204,7 @@ setup_rabbitmq() {
   rabbitmqctl status
 
   # rabbitmaadmin is useful to inspect exchanges, queues etc.
-  curl -sS -o /usr/bin/rabbitmqadmin http://localhost:15672/cli/rabbitmqadmin
+  curl -sS -o /usr/bin/rabbitmqadmin http://127.0.0.1:15672/cli/rabbitmqadmin
   chmod 755 /usr/bin/rabbitmqadmin
 }
 


### PR DESCRIPTION
This adds an installs script for the examples pack and fixes a path issue on the tests install script.  A self-check script was also added.  The self-check script runs all of the tests in the tests pack.

Sample output of self-check:

```
root@st2stage201:/home/phool# ./self-check 
Attempting Test tests.test_packs_pack...OK!
Attempting Test tests.test_quickstart...OK!
Attempting Test tests.test_quickstart_key...OK!
Attempting Test tests.test_quickstart_rules...OK!
SUCCESS: All tests passed!
```