### PR TITLE
Use full absolute path to the share directory in the Windows script runner

### DIFF
--- a/st2actions/st2actions/runners/windows_script_runner.py
+++ b/st2actions/st2actions/runners/windows_script_runner.py
@@ -248,13 +248,18 @@ class WindowsScriptRunner(BaseWindowsRunner):
             line = line.strip()
             split = re.split('\s{3,}', line)
 
-            if len(split) != 2:
+            if len(split) not in [1, 2]:
                 # Invalid line, skip it
                 continue
 
             key = split[0]
-            key = key.lower().replace(' ', '')
-            value = split[1].strip()
+            key = key.lower().replace(' ', '_')
+
+            if len(split) == 2:
+                value = split[1].strip()
+            else:
+                value = None
+
             result[key] = value
 
         return result

--- a/st2actions/st2actions/runners/windows_script_runner.py
+++ b/st2actions/st2actions/runners/windows_script_runner.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import os
+import re
 import uuid
 
 from eventlet.green import subprocess
@@ -85,14 +86,19 @@ class WindowsScriptRunner(BaseWindowsRunner):
         self._verify_winexe_exists()
         self._verify_smbclient_exists()
 
-        # 1. Upload script file to a temporary location
-        local_path = self.entry_point
-        script_path, temporary_directory_path = self._upload_file(local_path=local_path)
+        # 1. Retrieve full absolute path for the share name
+        # TODO: Cache resolved paths
+        base_path = self._get_share_absolute_path(share=self._share)
 
-        # 2. Execute the script
+        # 2. Upload script file to a temporary location
+        local_path = self.entry_point
+        script_path, temporary_directory_path = self._upload_file(local_path=local_path,
+                                                                  base_path=base_path)
+
+        # 3. Execute the script
         exit_code, stdout, stderr, timed_out = self._run_script(script_path=script_path)
 
-        # 3. Delete temporary directory
+        # 4. Delete temporary directory
         self._delete_directory(directory_path=temporary_directory_path)
 
         if timed_out:
@@ -140,12 +146,15 @@ class WindowsScriptRunner(BaseWindowsRunner):
 
         return exit_code, stdout, stderr, timed_out
 
-    def _upload_file(self, local_path):
+    def _upload_file(self, local_path, base_path):
         """
         Upload provided file to the remote server in a temporary directory.
 
         :param local_path: Local path to the file to upload.
         :type local_path: ``str``
+
+        :param base_path: Absolute base path for the share.
+        :type base_path: ``str``
         """
         file_name = os.path.basename(local_path)
 
@@ -190,11 +199,65 @@ class WindowsScriptRunner(BaseWindowsRunner):
         extra = {'exit_code': exit_code, 'stdout': stdout, 'stderr': stderr}
         LOG.debug('File uploaded to "%s"' % (remote_path), extra=extra)
 
-        # TODO: Get full path, use share name, etc.
-        full_remote_file_path = 'C:\\\\' + remote_path
-        full_temporary_directory_path = 'C:\\\\' + temporary_directory_name
+        full_remote_file_path = base_path + '\\' + remote_path
+        full_temporary_directory_path = base_path + '\\' + temporary_directory_name
 
         return full_remote_file_path, full_temporary_directory_path
+
+    def _get_share_absolute_path(self, share):
+        """
+        Retrieve full absolute path for a share with the provided name.
+
+        :param share: Share name.
+        :type share: ``str``
+        """
+        command = 'net share %s' % (quote_windows(share))
+        args = self._get_winexe_command_args(host=self._host, username=self._username,
+                                             password=self._password,
+                                             command=command)
+
+        LOG.debug('Retrieving full absolute path for share "%s"' % (share))
+        exit_code, stdout, stderr, timed_out = run_command(cmd=args, stdout=subprocess.PIPE,
+                                                           stderr=subprocess.PIPE, shell=False,
+                                                           timeout=self._timeout)
+
+        if exit_code != 0:
+            msg = 'Failed to retrieve absolute path for share "%s"' % (share)
+            raise Exception(msg)
+
+        share_info = self._parse_share_information(stdout=stdout)
+        share_path = share_info.get('path', None)
+
+        if not share_path:
+            msg = 'Failed to retrieve absolute path for share "%s"' % (share)
+            raise Exception(msg)
+
+        return share_path
+
+    def _parse_share_information(self, stdout):
+        """
+        Parse share information retrieved using "net share <share name>".
+
+        :rtype: ``dict``
+        """
+        lines = stdout.split('\n')
+
+        result = {}
+
+        for line in lines:
+            line = line.strip()
+            split = re.split('\s{3,}', line)
+
+            if len(split) != 2:
+                # Invalid line, skip it
+                continue
+
+            key = split[0]
+            key = key.lower().replace(' ', '')
+            value = split[1].strip()
+            result[key] = value
+
+        return result
 
     def _delete_file(self, file_path):
         command = 'rm %(file_path)s' % {'file_path': quote_windows(file_path)}

--- a/st2actions/tests/fixtures/windows/net_share_C_stdout.txt
+++ b/st2actions/tests/fixtures/windows/net_share_C_stdout.txt
@@ -1,0 +1,10 @@
+Share name        C$
+Path              C:\
+Remark            Default share
+Maximum users     No limit
+Users             
+Caching           Manual caching of documents
+Permission        Everyone, FULL
+
+The command completed successfully.
+

--- a/st2actions/tests/unit/test_windows_runners.py
+++ b/st2actions/tests/unit/test_windows_runners.py
@@ -13,9 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 from unittest2 import TestCase
 
 from st2actions.runners.windows_runner import BaseWindowsRunner
+from st2actions.runners.windows_script_runner import WindowsScriptRunner
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+FIXTURES_DIR = os.path.abspath(os.path.join(BASE_DIR, '../fixtures/windows'))
 
 
 class WindowsRunnerTestCase(TestCase):
@@ -123,6 +129,24 @@ class WindowsRunnerTestCase(TestCase):
         for arguments, expected_value in zip(arguments, expected_values):
             actual_value = runner._get_smbclient_command_args(**arguments)
             self.assertEqual(actual_value, expected_value)
+
+    def test_parse_share_information(self):
+        runner = WindowsScriptRunner('id')
+
+        fixture_path = os.path.join(FIXTURES_DIR, 'net_share_C_stdout.txt')
+        with open(fixture_path, 'r') as fp:
+            stdout = fp.read()
+
+        result = runner._parse_share_information(stdout=stdout)
+
+        expected_keys = ['share_name', 'path', 'remark', 'maximum_users', 'users', 'caching',
+                         'permission']
+        for key in expected_keys:
+            self.assertTrue(key in result)
+
+        self.assertEqual(result['share_name'], 'C$')
+        self.assertEqual(result['path'], 'C:\\')
+        self.assertEqual(result['users'], None)
 
     def test_shell_command_parameter_escaping(self):
         pass

--- a/st2actions/tests/unit/test_windows_runners.py
+++ b/st2actions/tests/unit/test_windows_runners.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 
 import os
-
 from unittest2 import TestCase
+
+import mock
 
 from st2actions.runners.windows_runner import BaseWindowsRunner
 from st2actions.runners.windows_script_runner import WindowsScriptRunner
@@ -131,7 +132,7 @@ class WindowsRunnerTestCase(TestCase):
             self.assertEqual(actual_value, expected_value)
 
     def test_parse_share_information(self):
-        runner = WindowsScriptRunner('id')
+        runner = self._get_script_runner()
 
         fixture_path = os.path.join(FIXTURES_DIR, 'net_share_C_stdout.txt')
         with open(fixture_path, 'r') as fp:
@@ -148,6 +149,27 @@ class WindowsRunnerTestCase(TestCase):
         self.assertEqual(result['path'], 'C:\\')
         self.assertEqual(result['users'], None)
 
+    @mock.patch('st2actions.runners.windows_script_runner.run_command')
+    def test_get_share_absolute_path(self, mock_run_command):
+        runner = self._get_script_runner()
+
+        fixture_path = os.path.join(FIXTURES_DIR, 'net_share_C_stdout.txt')
+        with open(fixture_path, 'r') as fp:
+            stdout = fp.read()
+
+        # Failure, non-zero status code
+        mock_run_command.return_value = (2, '', '', False)
+        self.assertRaises(Exception, runner._get_share_absolute_path, share='C$')
+
+        # Failure, missing / corrupted data
+        mock_run_command.return_value = (0, '', '', False)
+        self.assertRaises(Exception, runner._get_share_absolute_path, share='C$')
+
+        # Success, everything OK
+        mock_run_command.return_value = (0, stdout, '', False)
+        share_path = runner._get_share_absolute_path(share='C$')
+        self.assertEqual(share_path, 'C:\\')
+
     def test_shell_command_parameter_escaping(self):
         pass
 
@@ -160,4 +182,13 @@ class WindowsRunnerTestCase(TestCase):
                 pass
 
         runner = Runner('id')
+        return runner
+
+    def _get_script_runner(self):
+        runner = WindowsScriptRunner('id')
+        runner._host = None
+        runner._username = None
+        runner._password = None
+        runner._timeout = None
+
         return runner


### PR DESCRIPTION
Previously, the path was hard-coded to "C:\\" so it would only work with shares which shared the whole C drive.

This pull request fixes that and it now works with an arbitrary directory or drive share.