### PR TITLE
RFR: Add linux pack requirements to st2 requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,9 @@ passlib>=1.6.2,<1.7
 lockfile>=0.10.2,<0.11
 python-gnupg>=0.3.7,<0.4
 jsonpath-rw>=1.3.0
+# Requirements for linux pack
+# used by file watcher sensor
+pyinotify>=0.9.5,<=0.10
+-e git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper
+# used by nmap actions
+python-nmap>=0.3.4,<0.4


### PR DESCRIPTION
Since `linux` is now a system pack, we need it's requirements to be part of system requirements. This is definitely a work around for now. We need to come up with a better way to ship packs with st2. 