### PR TITLE
Fix mistral test case where task status is not updated yet

### DIFF
--- a/st2tests/integration/mistral/base.py
+++ b/st2tests/integration/mistral/base.py
@@ -42,8 +42,12 @@ class TestWorkflowExecution(unittest2.TestCase):
         for i in range(wait):
             eventlet.sleep(3)
             execution = self.st2client.liveactions.get_by_id(execution.id)
+
             if execution.status in ['succeeded', 'failed']:
-                break
+                if hasattr(execution, 'result') and 'tasks' in execution.result:
+                    if ([task for task in execution.result['tasks']
+                         if task['state'] in ['SUCCESS', 'ERROR']]):
+                        break
 
         return execution
 


### PR DESCRIPTION
If multiple tasks are specified for on-error task defaults and fail is in the list, the WF will fail immediately without waiting for the other tasks to finish.