### PR TITLE
RFR - Use Authed APIs for internal trigger registration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ in development
   compatibility reasons, runners can still be referenced using their old names.
   (improvement)
 * Update all the Python services to re-open log files on the ``SIGUSR1`` signal. (new-feature)
+* Internal trigger types registered using APIs should use auth token. (bug-fix)
 
 v0.8.3 - March 23, 2015
 -----------------------

--- a/st2actions/st2actions/cmd/actionrunner.py
+++ b/st2actions/st2actions/cmd/actionrunner.py
@@ -4,15 +4,15 @@ import sys
 
 from oslo.config import cfg
 
-from st2common import log as logging
-from st2common.models.db import db_setup
-from st2common.models.db import db_teardown
-from st2common.constants.logging import DEFAULT_LOGGING_CONF_PATH
-from st2common.transport.utils import register_exchanges
-from st2common.signal_handlers import register_common_signal_handlers
 from st2actions import config
 from st2actions import worker
-
+from st2common import log as logging
+from st2common.constants.logging import DEFAULT_LOGGING_CONF_PATH
+from st2common.models.db import db_setup
+from st2common.models.db import db_teardown
+from st2common.signal_handlers import register_common_signal_handlers
+from st2common.transport.utils import register_exchanges
+from st2common.triggers import register_internal_trigger_types
 
 LOG = logging.getLogger(__name__)
 
@@ -46,9 +46,6 @@ def _setup():
     register_common_signal_handlers()
 
     # 4. Register internal triggers
-    # Note: We need to do import here because of a messed up configuration
-    # situation (this module depends on configuration being parsed)
-    from st2common.triggers import register_internal_trigger_types
     register_internal_trigger_types()
 
 

--- a/st2common/st2common/constants/triggers.py
+++ b/st2common/st2common/constants/triggers.py
@@ -24,48 +24,55 @@ __all__ = [
     'CRON_PARAMETERS_SCHEMA',
     'TIMER_PAYLOAD_SCHEMA',
 
+    'ACTION_SENSOR_TRIGGER',
+    'NOTIFY_TRIGGER',
+
     'TIMER_TRIGGER_TYPES',
     'INTERNAL_TRIGGER_TYPES',
     'SYSTEM_TRIGGER_TYPES'
 ]
 
+ACTION_SENSOR_TRIGGER = {
+    'name': 'st2.generic.actiontrigger',
+    'pack': SYSTEM_PACK_NAME,
+    'description': 'Trigger encapsulating the completion of an action execution.',
+    'payload_schema': {
+        'type': 'object',
+        'properties': {
+            'execution_id': {},
+            'status': {},
+            'start_timestamp': {},
+            'action_name': {},
+            'parameters': {},
+            'result': {}
+        }
+    }
+}
+
+NOTIFY_TRIGGER = {
+    'name': 'st2.generic.notifytrigger',
+    'pack': SYSTEM_PACK_NAME,
+    'description': 'Notification trigger.',
+    'payload_schema': {
+        'type': 'object',
+        'properties': {
+            'execution_id': {},
+            'status': {},
+            'start_timestamp': {},
+            'end_timestamp': {},
+            'action_ref': {},
+            'channel': {},
+            'message': {},
+            'data': {}
+        }
+    }
+}
+
 # Internal system triggers which are available for each resource
 INTERNAL_TRIGGER_TYPES = {
     'action': [
-        {
-            'name': 'st2.generic.actiontrigger',
-            'pack': SYSTEM_PACK_NAME,
-            'description': 'Trigger encapsulating the completion of an action execution.',
-            'payload_schema': {
-                'type': 'object',
-                'properties': {
-                    'execution_id': {},
-                    'status': {},
-                    'start_timestamp': {},
-                    'action_name': {},
-                    'parameters': {},
-                    'result': {}
-                }
-            }
-        },
-        {
-            'name': 'st2.generic.notifytrigger',
-            'pack': SYSTEM_PACK_NAME,
-            'description': 'Notification trigger.',
-            'payload_schema': {
-                'type': 'object',
-                'properties': {
-                    'execution_id': {},
-                    'status': {},
-                    'start_timestamp': {},
-                    'end_timestamp': {},
-                    'action_ref': {},
-                    'channel': {},
-                    'message': {},
-                    'data': {}
-                }
-            }
-        }
+        ACTION_SENSOR_TRIGGER,
+        NOTIFY_TRIGGER
     ],
     'sensor': [
         {

--- a/st2common/st2common/triggers.py
+++ b/st2common/st2common/triggers.py
@@ -22,8 +22,9 @@ import requests.exceptions
 from oslo.config import cfg
 
 from st2common import log as logging
-from st2common.constants.triggers import INTERNAL_TRIGGER_TYPES
+from st2common.constants.triggers import (INTERNAL_TRIGGER_TYPES, ACTION_SENSOR_TRIGGER)
 from st2common.models.system.common import ResourceReference
+from st2common.services.access import (create_token, delete_token)
 from st2common.util.url import get_url_without_trailing_slash
 
 __all__ = [
@@ -32,75 +33,83 @@ __all__ = [
 
 LOG = logging.getLogger(__name__)
 
-ACTION_SENSOR_ENABLED = cfg.CONF.action_sensor.enable
-TRIGGER_TYPE_ENDPOINT = cfg.CONF.action_sensor.triggers_base_url
-HTTP_POST_HEADER = {'content-type': 'application/json'}
-RETRY_WAIT = cfg.CONF.action_sensor.retry_wait
-TIMEOUT = cfg.CONF.action_sensor.request_timeout
-MAX_ATTEMPTS = cfg.CONF.action_sensor.max_attempts
 
+class InternalTriggerTypesRegistrar(object):
 
-def _get_trigger_type_url(triggertype_ref):
-    base_url = get_url_without_trailing_slash(TRIGGER_TYPE_ENDPOINT)
-    return '%s/%s' % (base_url, triggertype_ref)
+    def __init__(self):
+        self._action_sensor_enabled = cfg.CONF.action_sensor.enable
+        self._trigger_type_endpoint = cfg.CONF.action_sensor.triggers_base_url
+        self._retry_wait = cfg.CONF.action_sensor.retry_wait
+        self._timeout = cfg.CONF.action_sensor.request_timeout
+        self._max_attempts = cfg.CONF.action_sensor.max_attempts
+        self._temporary_token = create_token('system.internal_trigger_registrar',
+                                             ttl=(24 * 60 * 60)).token
+        self._http_post_headers = {'content-type': 'application/json',
+                                   'X-Auth-Token': self._temporary_token}
+        self._get_headers = {'X-Auth-Token': self._temporary_token}
 
+    def register_internal_trigger_types(self):
+        LOG.debug('Registering internal trigger types...')
 
-def _do_register_internal_trigger_types():
-    LOG.debug('Registering internal trigger types...')
+        for resource_name, trigger_definitions in INTERNAL_TRIGGER_TYPES.items():
+            for trigger_definition in trigger_definitions:
+                LOG.debug('Registering internal trigger: %s', trigger_definition['name'])
+                if (trigger_definition['name'] == ACTION_SENSOR_TRIGGER['name'] and
+                        not self._action_sensor_enabled):
+                    continue
+                self._register_trigger_type(trigger_definition=trigger_definition, attempt_no=0)
 
-    for resource_name, trigger_definitions in INTERNAL_TRIGGER_TYPES.items():
-        for trigger_definition in trigger_definitions:
-            LOG.debug('Registering internal trigger: %s', trigger_definition['name'])
-            register_trigger_type(trigger_definition=trigger_definition, attempt_no=0)
+        delete_token(self._temporary_token)
 
+    def _register_trigger_type(self, trigger_definition, attempt_no=0):
+        LOG.debug('Attempt no %s to register trigger %s.', attempt_no, trigger_definition['name'])
 
-def _is_triggertype_exists(ref):
-    try:
-        r = requests.get(url=_get_trigger_type_url(ref))
-        if r.status_code == httplib.OK:
-            return True
-    except:
-        return False
+        ref = ResourceReference.to_string_reference(pack=trigger_definition['pack'],
+                                                    name=trigger_definition['name'])
+        if self._is_triggertype_exists(ref):
+            return
 
+        payload = json.dumps(trigger_definition)
 
-def register_trigger_type(trigger_definition, attempt_no=0):
-    LOG.debug('Attempt no %s to register trigger %s.', attempt_no, trigger_definition['name'])
+        try:
+            r = requests.post(url=self._trigger_type_endpoint, data=payload,
+                              headers=self._http_post_headers, timeout=self._timeout)
+            if r.status_code == httplib.CREATED:
+                LOG.info('Registered trigger %s.', trigger_definition['name'])
+            elif r.status_code == httplib.CONFLICT:
+                LOG.info('Trigger %s is already registered.', trigger_definition['name'])
+            else:
+                LOG.error('Seeing status code %s on an attempt to register trigger %s.',
+                          r.status_code, trigger_definition['name'])
+        except requests.exceptions.ConnectionError:
+            if attempt_no < self._max_attempts:
+                self._retry_wait = self._retry_wait * (attempt_no + 1)
+                LOG.debug('    ConnectionError. Will retry in %ss.', self._retry_wait)
+                eventlet.spawn_after(self._retry_wait, self._register_trigger_type,
+                                     trigger_definition=trigger_definition,
+                                     attempt_no=(attempt_no + 1))
+            else:
+                LOG.warn('Failed to register trigger %s. ' % trigger_definition['name'] +
+                         ' Exceeded max attempts to register trigger.')
+        except:
+            LOG.exception('Failed to register trigger %s.', trigger_definition['name'])
 
-    ref = ResourceReference.to_string_reference(pack=trigger_definition['pack'],
-                                                name=trigger_definition['name'])
-    if _is_triggertype_exists(ref):
-        return
+    def _get_trigger_type_url(self, triggertype_ref):
+        base_url = get_url_without_trailing_slash(self._trigger_type_endpoint)
+        return '%s/%s' % (base_url, triggertype_ref)
 
-    payload = json.dumps(trigger_definition)
-
-    try:
-        r = requests.post(url=TRIGGER_TYPE_ENDPOINT, data=payload,
-                          headers=HTTP_POST_HEADER, timeout=TIMEOUT)
-        if r.status_code == httplib.CREATED:
-            LOG.info('Registered trigger %s.', trigger_definition['name'])
-        elif r.status_code == httplib.CONFLICT:
-            LOG.info('Trigger %s is already registered.', trigger_definition['name'])
-        else:
-            LOG.error('Seeing status code %s on an attempt to register trigger %s.',
-                      r.status_code, trigger_definition['name'])
-    except requests.exceptions.ConnectionError:
-        if attempt_no < MAX_ATTEMPTS:
-            retry_wait = RETRY_WAIT * (attempt_no + 1)
-            LOG.debug('    ConnectionError. Will retry in %ss.', retry_wait)
-            eventlet.spawn_after(retry_wait, register_trigger_type,
-                                 trigger_definition=trigger_definition,
-                                 attempt_no=(attempt_no + 1))
-        else:
-            LOG.warn('Failed to register trigger %s. Exceeded max attempts to register trigger.',
-                     trigger_definition['name'])
-    except:
-        LOG.exception('Failed to register trigger %s.', trigger_definition['name'])
+    def _is_triggertype_exists(self, ref):
+        try:
+            r = requests.get(url=self._get_trigger_type_url(ref),
+                             headers=self._get_headers)
+            if r.status_code == httplib.OK:
+                return True
+        except:
+            return False
 
 
 def register_internal_trigger_types():
-    if not ACTION_SENSOR_ENABLED:
-        return
-
+    trigger_types_registrar = InternalTriggerTypesRegistrar()
     # spawn a thread to process this in order to unblock the main thread which at this point could
     # be in the middle of bootstraping the process.
-    eventlet.greenthread.spawn(_do_register_internal_trigger_types)
+    eventlet.greenthread.spawn(trigger_types_registrar.register_internal_trigger_types)

--- a/st2common/st2common/triggers.py
+++ b/st2common/st2common/triggers.py
@@ -42,11 +42,11 @@ class InternalTriggerTypesRegistrar(object):
         self._retry_wait = cfg.CONF.action_sensor.retry_wait
         self._timeout = cfg.CONF.action_sensor.request_timeout
         self._max_attempts = cfg.CONF.action_sensor.max_attempts
-        self._temporary_token = create_token('system.internal_trigger_registrar',
-                                             ttl=(24 * 60 * 60)).token
+        self._auth_creds = create_token('system.internal_trigger_registrar',
+                                        ttl=(1 * 60 * 60))
         self._http_post_headers = {'content-type': 'application/json',
-                                   'X-Auth-Token': self._temporary_token}
-        self._get_headers = {'X-Auth-Token': self._temporary_token}
+                                   'X-Auth-Token': self._auth_creds.token}
+        self._get_headers = {'X-Auth-Token': self._auth_creds.token}
 
     def register_internal_trigger_types(self):
         LOG.debug('Registering internal trigger types...')
@@ -59,7 +59,7 @@ class InternalTriggerTypesRegistrar(object):
                     continue
                 self._register_trigger_type(trigger_definition=trigger_definition, attempt_no=0)
 
-        delete_token(self._temporary_token)
+        delete_token(self._auth_creds.token)
 
     def _register_trigger_type(self, trigger_definition, attempt_no=0):
         LOG.debug('Attempt no %s to register trigger %s.', attempt_no, trigger_definition['name'])
@@ -106,6 +106,8 @@ class InternalTriggerTypesRegistrar(object):
                 return True
         except:
             return False
+
+        return False
 
 
 def register_internal_trigger_types():

--- a/st2common/st2common/triggers.py
+++ b/st2common/st2common/triggers.py
@@ -46,7 +46,7 @@ class InternalTriggerTypesRegistrar(object):
                                         ttl=(1 * 60 * 60))
         self._http_post_headers = {'content-type': 'application/json',
                                    'X-Auth-Token': self._auth_creds.token}
-        self._get_headers = {'X-Auth-Token': self._auth_creds.token}
+        self._http_get_headers = {'X-Auth-Token': self._auth_creds.token}
 
     def register_internal_trigger_types(self):
         LOG.debug('Registering internal trigger types...')
@@ -101,7 +101,7 @@ class InternalTriggerTypesRegistrar(object):
     def _is_triggertype_exists(self, ref):
         try:
             r = requests.get(url=self._get_trigger_type_url(ref),
-                             headers=self._get_headers)
+                             headers=self._http_get_headers)
             if r.status_code == httplib.OK:
                 return True
         except:

--- a/st2common/tests/unit/test_internal_trigger_types_registrar.py
+++ b/st2common/tests/unit/test_internal_trigger_types_registrar.py
@@ -1,0 +1,74 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the 'License'); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+try:
+    import simplejson as json
+except ImportError:
+    import json
+
+import mock
+import requests
+
+from st2common.services.access import delete_token
+from st2common.triggers import InternalTriggerTypesRegistrar
+from st2common.util import isotime
+
+from st2tests.base import (DbTestCase, FakeResponse)
+
+from st2tests import config as tests_config
+tests_config.parse_args()
+
+FAKE_TRIGGER = {
+    'name': 'foo',
+    'pack': 'bar',
+    'parameters': {}
+}
+
+
+class InternalTriggerTypesTests(DbTestCase):
+
+    def test_token_successfully_obtained(self):
+        time_now = isotime.add_utc_tz(datetime.datetime.now())
+        registrar = InternalTriggerTypesRegistrar()
+        self.assertTrue(registrar._auth_creds is not None)
+        # TTL is at least 10 mins
+        self.assertTrue((registrar._auth_creds.expiry - time_now).seconds > 10 * 60)
+        delete_token(registrar._auth_creds.token)
+
+    def test_get_trigger_type_url(self):
+        registrar = InternalTriggerTypesRegistrar()
+        url = registrar._get_trigger_type_url('foo.bar')
+        self.assertEqual(url, 'http://localhost:9101/v1/triggertypes/foo.bar')
+        delete_token(registrar._auth_creds.token)
+
+    @mock.patch.object(
+        requests, 'get',
+        mock.MagicMock(return_value=FakeResponse(json.dumps(FAKE_TRIGGER), 200, 'OK')))
+    def test_is_triger_type_exists_happy_case(self):
+        registrar = InternalTriggerTypesRegistrar()
+        is_exists = registrar._is_triggertype_exists('bar.foo')
+        self.assertEqual(is_exists, True)
+        delete_token(registrar._auth_creds.token)
+
+    @mock.patch.object(
+        requests, 'get',
+        mock.MagicMock(return_value=FakeResponse(json.dumps('trigger not found'), 404,
+                                                 'NOT FOUND')))
+    def test_is_triger_type_exists_sad_case(self):
+        registrar = InternalTriggerTypesRegistrar()
+        is_exists = registrar._is_triggertype_exists('bar.foo')
+        self.assertEqual(is_exists, False)
+        delete_token(registrar._auth_creds.token)

--- a/st2reactor/st2reactor/cmd/sensormanager.py
+++ b/st2reactor/st2reactor/cmd/sensormanager.py
@@ -5,14 +5,15 @@ import eventlet
 from oslo.config import cfg
 
 from st2common import log as logging
+from st2common.constants.logging import DEFAULT_LOGGING_CONF_PATH
 from st2common.exceptions.sensors import SensorNotFoundException
 from st2common.models.db import db_setup
 from st2common.models.db import db_teardown
-from st2common.constants.logging import DEFAULT_LOGGING_CONF_PATH
-from st2common.transport.utils import register_exchanges
+from st2common.persistence.reactor import SensorType
 from st2common.signal_handlers import register_common_signal_handlers
 from st2reactor.sensor import config
-from st2common.persistence.reactor import SensorType
+from st2common.transport.utils import register_exchanges
+from st2common.triggers import register_internal_trigger_types
 from st2reactor.container.manager import SensorContainerManager
 
 eventlet.monkey_patch(
@@ -47,9 +48,6 @@ def _setup():
     register_common_signal_handlers()
 
     # 4. Register internal triggers
-    # Note: We need to do import here because of a messed up configuration
-    # situation (this module depends on configuration being parsed)
-    from st2common.triggers import register_internal_trigger_types
     register_internal_trigger_types()
 
 

--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+try:
+    import simplejson as json
+except ImportError:
+    import json
 import os
 import sys
 import shutil
@@ -174,6 +178,20 @@ class CleanFilesTestCase(TestCase):
                 shutil.rmtree(file_path)
             except Exception:
                 pass
+
+
+class FakeResponse(object):
+
+    def __init__(self, text, status_code, reason):
+        self.text = text
+        self.status_code = status_code
+        self.reason = reason
+
+    def json(self):
+        return json.loads(self.text)
+
+    def raise_for_status(self):
+        raise Exception(self.reason)
 
 
 def get_fixtures_path():


### PR DESCRIPTION
With this, also refactored code into a class. Config is not read during import time. This should save us from import dependencies. 

Seems to work in dev env. I am going to see if I can add some tests for the class. 

```
~/st2 git:master ❯❯❯ mongo                                                                                             ✭ ✱ ◼
MongoDB shell version: 2.6.3
connecting to: test
> use st2
switched to db st2
> show db.trigger_d_b.find()
2015-04-28T05:39:10.278+0000 don't know how to show [db.trigger_d_b.find()] at src/mongo/shell/utils.js:729
> show db.trigger_d_b.find()
2015-04-28T05:39:13.094+0000 don't know how to show [db.trigger_d_b.find()] at src/mongo/shell/utils.js:729
> db.trigger_d_b.find()
{ "_id" : ObjectId("553f1cd56d0aff6cae840d2b"), "name" : "polling_event", "pack" : "examples", "type" : "examples.polling_event", "parameters" : {  } }
{ "_id" : ObjectId("553f1cd56d0aff6cae840d2e"), "name" : "event", "pack" : "examples", "type" : "examples.event", "parameters" : {  } }
{ "_id" : ObjectId("553f1cd66d0aff6c889ff253"), "name" : "st2.generic.actiontrigger", "pack" : "core", "type" : "core.st2.generic.actiontrigger", "parameters" : {  } }
{ "_id" : ObjectId("553f1cd66d0aff6c889ff255"), "name" : "st2.generic.notifytrigger", "pack" : "core", "type" : "core.st2.generic.notifytrigger", "parameters" : {  } }
{ "_id" : ObjectId("553f1cd66d0aff6c889ff254"), "name" : "st2.sensor.process_spawn", "pack" : "core", "type" : "core.st2.sensor.process_spawn", "parameters" : {  } }
{ "_id" : ObjectId("553f1cd66d0aff6c889ff256"), "name" : "st2.sensor.process_exit", "pack" : "core", "type" : "core.st2.sensor.process_exit", "parameters" : {  } }
{ "_id" : ObjectId("553f1cd66d0aff6cae840d6c"), "name" : "dff2ae4c-3f8b-44ad-9b65-8c8afe541637", "pack" : "core", "type" : "core.st2.IntervalTimer", "parameters" : { "unit" : "seconds", "delta" : 5 } }
{ "_id" : ObjectId("553f1cd66d0aff6cae840d6e"), "name" : "1cdc5709-281c-44a2-b582-44586744dc1a", "pack" : "core", "type" : "core.st2.webhook", "parameters" : { "url" : "sample" } }
>
```