### PR TITLE
Correct propagate "unauthorized exceptions" in the CLI "get" commands

### DIFF
--- a/st2client/st2client/commands/resource.py
+++ b/st2client/st2client/commands/resource.py
@@ -18,6 +18,7 @@ import abc
 import six
 import json
 import logging
+import httplib
 
 import yaml
 
@@ -137,7 +138,13 @@ class ResourceCommand(commands.Command):
         """
         try:
             instance = self.manager.get_by_id(pk, **kwargs)
-        except Exception:
+        except Exception as e:
+            # Hack for "Unauthorized" exceptions, we do want to propagate those
+            response = getattr(e, 'response', None)
+            status_code = getattr(response, 'status_code', None)
+            if status_code and status_code == httplib.UNAUTHORIZED:
+                raise e
+
             instance = None
 
         return instance

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -183,10 +183,14 @@ class Shell(object):
                 self._print_debug_info()
             return 2
         except Exception as e:
+            # We allow exception to define custom exit codes
+            exit_code = getattr(e, 'exit_code', 1)
+
             print('ERROR: %s\n' % e)
             if debug:
                 self._print_debug_info()
-            return 1
+
+            return exit_code
 
     def _print_debug_info(self):
         # Print client settings


### PR DESCRIPTION
Previously (with auth enabled):

```bash
(virtualenv)vagrant@vagrant-ubuntu-trusty-64:/data/stanley$ python ./st2client/st2client/shell.py execution get 1
Action Execution "1" is not found.
```

Now:

```bash
(virtualenv)vagrant@vagrant-ubuntu-trusty-64:/data/stanley$ python ./st2client/st2client/shell.py execution get 1
ERROR: 401 Client Error: Unauthorized
MESSAGE: Unauthorized
```
