### PR TITLE
Make url in st2client trailing slash agnostic

### DIFF
--- a/st2client/st2client/utils/httpclient.py
+++ b/st2client/st2client/utils/httpclient.py
@@ -55,7 +55,7 @@ def add_json_content_type_to_headers(func):
 class HTTPClient(object):
 
     def __init__(self, root, cacert=None, debug=False):
-        self.root = root
+        self.root = self._get_url_without_trailing_slash(root)
         self.cacert = cacert
         self.debug = debug
 
@@ -133,3 +133,15 @@ class HTTPClient(object):
 
         curl_line = ' '.join(parts)
         return curl_line
+
+    def _get_url_without_trailing_slash(self, value):
+        """
+        Function which strips a trailing slash from the provided url if one is present.
+
+        :param value: URL to format.
+        :type value: ``str``
+
+        :rtype: ``str``
+        """
+        result = value[:-1] if value.endswith('/') else value
+        return result


### PR DESCRIPTION
* Specifying ST2_AUTH_URL and ST2_API_URL with or without trailing slash has no impact
  on the behavior. Previously Specifying a trailing slash would cause st2client to
  fail.