### PR TITLE
Workaround for stdin bug in Windows runners

### DIFF
--- a/st2actions/st2actions/runners/windows_command_runner.py
+++ b/st2actions/st2actions/runners/windows_command_runner.py
@@ -68,8 +68,13 @@ class WindowsCommandRunner(BaseWindowsRunner):
                                              password=self._password,
                                              command=self._command)
 
-        exit_code, stdout, stderr, timed_out = run_command(cmd=args, stdout=subprocess.PIPE,
-                                                           stderr=subprocess.PIPE, shell=False,
+        # Note: We don't send anything over stdin, we just create an unused pipe
+        # to avoid some obscure failures
+        exit_code, stdout, stderr, timed_out = run_command(cmd=args,
+                                                           stdin=subprocess.PIPE,
+                                                           stdout=subprocess.PIPE,
+                                                           stderr=subprocess.PIPE,
+                                                           shell=False,
                                                            timeout=self._timeout)
 
         if timed_out:

--- a/st2actions/st2actions/runners/windows_script_runner.py
+++ b/st2actions/st2actions/runners/windows_script_runner.py
@@ -137,8 +137,13 @@ class WindowsScriptRunner(BaseWindowsRunner):
 
         LOG.debug('Running script "%s"' % (script_path))
 
-        exit_code, stdout, stderr, timed_out = run_command(cmd=args, stdout=subprocess.PIPE,
-                                                           stderr=subprocess.PIPE, shell=False,
+        # Note: We don't send anything over stdin, we just create an unused pipe
+        # to avoid some obscure failures
+        exit_code, stdout, stderr, timed_out = run_command(cmd=args,
+                                                           stdin=subprocess.PIPE,
+                                                           stdout=subprocess.PIPE,
+                                                           stderr=subprocess.PIPE,
+                                                           shell=False,
                                                            timeout=self._timeout)
 
         extra = {'exit_code': exit_code, 'stdout': stdout, 'stderr': stderr}


### PR DESCRIPTION
Create a new PIPE for stdin in the Windows runners.

Note: We don't actually send anything over this PIPE, this is just a work-around for an obscure failure.
