### PR TITLE
Allow option to bypass SSL Certificate Check

### DIFF
--- a/contrib/packs/actions/download.yaml
+++ b/contrib/packs/actions/download.yaml
@@ -19,3 +19,6 @@
       type: "string"
       default: "/opt/stackstorm/packs/"
       immutable: true
+    verifyssl:
+      type: "boolean"
+      default: true

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -15,7 +15,7 @@ PACK_RESERVE_CHARACTER = '.'
 
 
 class InstallGitRepoAction(Action):
-    def run(self, packs, repo_url, abs_repo_base, branch='master'):
+    def run(self, packs, repo_url, abs_repo_base, verifyssl=True, branch='master'):
         repo_name = repo_url[repo_url.rfind('/') + 1: repo_url.rfind('.')]
         lock_name = hashlib.md5(repo_name).hexdigest() + '.lock'
 
@@ -35,6 +35,11 @@ class InstallGitRepoAction(Action):
         # Assuming git url is of form git@github.com:user/git-repo.git
         repo_name = repo_url[repo_url.rfind('/') + 1: repo_url.rfind('.')]
         abs_local_path = os.path.join(user_home, repo_name)
+
+        # Disable SSL cert checking if explictly asked
+        if not verifyssl:
+            os.environ['GIT_SSL_NO_VERIFY'] = 'true'
+
         Repo.clone_from(repo_url, abs_local_path, branch=branch)
         return abs_local_path
 


### PR DESCRIPTION
The recommended behavior is to have all certificates checked for
validity before performing a clone. However, there are times when
this is outright not possible (development with a self-signed cert,
for example).

This commit updates the `packs.download` command, introducing a new
attribute `verifyssl`. By default, the behavior is to continue checking
SSL certificate validity, but now it is possible to clone with an
invalid certificate and proceed along without a care in the world.

Be careful using this... especially in the context of Infra as Code.