### PR TITLE
Separated more visibly a Datastore section of quick start

### DIFF
--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -166,6 +166,7 @@ as ``{{system.my_parameter}}``. This creates ``user=stanley`` key-value pair:
     st2 key set user stanley
     st2 key list
 
+For more information on datastore, check :doc:`datastore`
 
 Deploy a Rule
 -------------------------

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -137,16 +137,6 @@ Trigger payload is referred with ``{{trigger}}``. If trigger payload is valid JS
 it is parsed and can be accessed like ``{{trigger.path.to.parameter}}`` (it's
 `Jinja template syntax <http://jinja.pocoo.org/docs/dev/templates/>`__).
 
-While the most data are retrieved as needed by |st2|, you may need to
-store and share some common variables. Use |st2| datastore service to store
-the values and reference them in rules and workflows
-as ``{{system.my_parameter}}``. This creates ``user=stanley`` key-value pair:
-
-.. code-block:: bash
-
-    st2 key set user stanley
-    st2 key list
-
 What are the triggers availabe to use in rules? Just like with actions,
 use the CLI to browse triggers, learn what the trigger does,
 how to configure it, and what is it’s payload structure:
@@ -161,6 +151,20 @@ how to configure it, and what is it’s payload structure:
 
     # Check details on the Webhook trigger
     st2 trigger get core.st2.webhook
+
+
+Datastore
+-------------------------
+
+While the most data are retrieved as needed by |st2|, you may need to
+store and share some common variables. Use |st2| datastore service to store
+the values and reference them in rules and workflows
+as ``{{system.my_parameter}}``. This creates ``user=stanley`` key-value pair:
+
+.. code-block:: bash
+
+    st2 key set user stanley
+    st2 key list
 
 
 Deploy a Rule


### PR DESCRIPTION
Datastore was embedded in the Define a rule section, although it seems quite independent. Instead, I separated it to be a separate subsection (also referencing it in the https://github.com/StackStorm/st2/blob/master/contrib/tests/README.md)