### PR TITLE
Update apache config sample

### DIFF
--- a/st2auth/conf/apache.sample.conf
+++ b/st2auth/conf/apache.sample.conf
@@ -3,7 +3,7 @@
     ServerName myhost.example.com:9100
 
     WSGIScriptAlias / /path/to/st2auth/wsgi.py
-    WSGIDaemonProcess st2auth user=stanley group=stanley processes=2 threads=25 python-path=/path/to/st2auth:/path/to/st2common:/path/to/virtualenv/local/lib/python2.7/site-packages
+    WSGIDaemonProcess st2auth user=stanley group=stanley processes=2 threads=25
     WSGIProcessGroup st2auth
 
     SSLEngine on
@@ -26,7 +26,10 @@
         AuthName "Restricted"
         AuthBasicProvider external
         AuthExternal pwauth
-        require unix-group st2ops
+        Require unix-group st2ops
+        <LimitExcept OPTIONS>
+            Satisfy Any
+        </LimitExcept>
     </Directory>
 
 </VirtualHost>


### PR DESCRIPTION
Based on IRC report from @chrisssss.

In previous version, st2common.logging and st2auth.cmd had more priority than python's own cmd.py and logging.py which resulted in problems with Pecan.core and PDB modules.

Also, to avoid authentication being applied to preflight requests, we need to make an exception for OPTIONS requests.

Other common problems include an absence of `stanley` group and lack of privileges to write into log folder, though it seems they should be addressed on a case-by-case basis.