### PR TITLE
Fix broken packs.download action

### DIFF
--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -20,7 +20,8 @@ class InstallGitRepoAction(Action):
         lock_name = hashlib.md5(repo_name).hexdigest() + '.lock'
 
         with LockFile('/tmp/%s' % (lock_name)):
-            abs_local_path = self._clone_repo(repo_url, branch=branch)
+            abs_local_path = self._clone_repo(repo_url=repo_url, verifyssl=verifyssl,
+                                              branch=branch)
             try:
                 # st2-contrib repo has a top-level packs folder that actually contains the
                 pack_abs_local_path = os.path.join(abs_local_path, PACK_REPO_ROOT)
@@ -30,7 +31,7 @@ class InstallGitRepoAction(Action):
         return self._validate_result(result=result, packs=packs, repo_url=repo_url)
 
     @staticmethod
-    def _clone_repo(repo_url, branch='master'):
+    def _clone_repo(repo_url, verifyssl=True, branch='master'):
         user_home = os.path.expanduser('~')
         # Assuming git url is of form git@github.com:user/git-repo.git
         repo_name = repo_url[repo_url.rfind('/') + 1: repo_url.rfind('.')]


### PR DESCRIPTION
We didn't propagate `verifyssl` argument to the _clone_repo method.