### PR TITLE
RFR - Tasks in action chain inherit notify from chain

### DIFF
--- a/contrib/examples/actions/echochain.meta.yaml
+++ b/contrib/examples/actions/echochain.meta.yaml
@@ -16,4 +16,5 @@ parameters:
 notify:
   on_complete:
     message: "\"@channel: Action succeeded.\""
-    channels: ["slack"]
+    channels:
+      - "slack"

--- a/contrib/examples/actions/echochain.meta.yaml
+++ b/contrib/examples/actions/echochain.meta.yaml
@@ -10,4 +10,10 @@ runner_type: "action-chain"
 entry_point: "chains/echochain.yaml"
 
 enabled: true
-parameters: {}
+parameters:
+  skip_notify:
+    default: c2
+notify:
+  on_complete:
+    message: "\"@channel: Action succeeded.\""
+    channels: ["slack"]

--- a/contrib/examples/actions/echochain.meta.yaml
+++ b/contrib/examples/actions/echochain.meta.yaml
@@ -12,7 +12,8 @@ entry_point: "chains/echochain.yaml"
 enabled: true
 parameters:
   skip_notify:
-    default: c2
+    default:
+      - c2
 notify:
   on_complete:
     message: "\"@channel: Action succeeded.\""

--- a/st2actions/st2actions/bootstrap/runnersregistrar.py
+++ b/st2actions/st2actions/bootstrap/runnersregistrar.py
@@ -348,7 +348,13 @@ RUNNER_TYPES = [
         'aliases': [],
         'description': 'A runner for launching linear action chains.',
         'enabled': True,
-        'runner_parameters': {},
+        'runner_parameters': {
+            'skip_notify': {
+                'description': 'Comma separated list of tasks to skip notifications for.',
+                'type': 'string',
+                'default': ''
+            }
+        },
         'runner_module': 'st2actions.runners.actionchainrunner'
     },
     {

--- a/st2actions/st2actions/bootstrap/runnersregistrar.py
+++ b/st2actions/st2actions/bootstrap/runnersregistrar.py
@@ -351,8 +351,8 @@ RUNNER_TYPES = [
         'runner_parameters': {
             'skip_notify': {
                 'description': 'Comma separated list of tasks to skip notifications for.',
-                'type': 'string',
-                'default': ''
+                'type': 'array',
+                'default': []
             }
         },
         'runner_module': 'st2actions.runners.actionchainrunner'

--- a/st2actions/st2actions/container/base.py
+++ b/st2actions/st2actions/container/base.py
@@ -77,6 +77,7 @@ class RunnerContainer(object):
         runner.container_service = RunnerContainerService()
         runner.action = action_db
         runner.action_name = action_db.name
+        runner.liveaction = liveaction_db
         runner.liveaction_id = str(liveaction_db.id)
         runner.entry_point = resolved_entry_point
         runner.runner_parameters = runner_params

--- a/st2actions/st2actions/runners/__init__.py
+++ b/st2actions/st2actions/runners/__init__.py
@@ -72,6 +72,7 @@ class ActionRunner(object):
         self.runner_parameters = None
         self.action = None
         self.action_name = None
+        self.liveaction = None
         self.liveaction_id = None
         self.entry_point = None
         self.libs_dir_path = None

--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -360,10 +360,6 @@ class ActionChainRunner(ActionRunner):
 
         return liveaction
 
-    def _get_notify(self, chain_notify, task_notify):
-        # XXX: Implement notify merge
-        pass
-
     def _format_action_exec_result(self, action_node, liveaction_db, created_at, updated_at,
                                    error=None):
         """

--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -322,11 +322,17 @@ class ActionChainRunner(ActionRunner):
         return rendered_params
 
     def _run_action(self, action_node, parent_execution_id, params, wait_for_completion=True):
+        parent_notify = None
+        if getattr(self, 'liveaction', None):
+            parent_notify = getattr(self.liveaction, 'notify', None)
         liveaction = LiveActionDB(action=action_node.ref)
         liveaction.parameters = action_param_utils.cast_params(action_ref=action_node.ref,
                                                                params=params)
         if action_node.notify:
             liveaction.notify = NotificationsHelper.to_model(action_node.notify)
+        elif parent_notify:
+            print('Parent_notify = %s', parent_notify)
+            liveaction.notify = parent_notify
 
         liveaction.context = {
             'parent': str(parent_execution_id),

--- a/st2actions/tests/unit/test_actionchain.py
+++ b/st2actions/tests/unit/test_actionchain.py
@@ -21,7 +21,10 @@ from st2common.exceptions import actionrunner as runnerexceptions
 from st2common.constants.action import LIVEACTION_STATUS_RUNNING
 from st2common.constants.action import LIVEACTION_STATUS_SUCCEEDED
 from st2common.constants.action import LIVEACTION_STATUS_FAILED
+from st2common.models.api.notification import NotificationsHelper
+from st2common.models.db.action import LiveActionDB
 from st2common.models.db.datastore import KeyValuePairDB
+from st2common.models.system.common import ResourceReference
 from st2common.persistence.datastore import KeyValuePair
 from st2common.persistence.action import RunnerType
 from st2common.services import action as action_service
@@ -83,6 +86,9 @@ CHAIN_WITH_PUBLISH = FixturesLoader().get_fixture_file_path_abs(
 CHAIN_WITH_INVALID_ACTION = FixturesLoader().get_fixture_file_path_abs(
     FIXTURES_PACK, 'actionchains', 'chain_with_invalid_action.yaml')
 
+CHAIN_NOTIFY_API = {'notify': {'on-complete': {'message': 'foo happened.'}}}
+CHAIN_NOTIFY_DB = NotificationsHelper.to_model(CHAIN_NOTIFY_API)
+
 
 @mock.patch.object(action_db_util, 'get_runnertype_by_name',
                    mock.MagicMock(return_value=RUNNER))
@@ -111,6 +117,10 @@ class TestActionChainRunner(DbTestCase):
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_1_PATH
         chain_runner.action = ACTION_1
+        action_ref = ResourceReference.to_string_reference(name=ACTION_1.name,
+                                                           pack=ACTION_1.pack)
+        chain_runner.liveaction = LiveActionDB(action=action_ref)
+        chain_runner.liveaction.notify = CHAIN_NOTIFY_DB
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
         chain_runner.run({})


### PR DESCRIPTION
Without skip_notify:

```
~/st2 git:chain_inherit_notifications ❯❯❯ st2 run examples.echochain                                                  ⏎ ✭ ✱ ◼
..
id: 555223ff6d0aff6d610ca22f
action.ref: examples.echochain
status: succeeded
start_timestamp: 2015-05-12T16:02:07.610206Z
end_timestamp: 2015-05-12T16:02:10.853135Z
+--------------------------+-----------+------+------------+----------------------+
| id                       | status    | task | action     | start_timestamp      |
+--------------------------+-----------+------+------------+----------------------+
| 555223ff6d0aff6d6779609b | succeeded | c1   | core.local | Tue, 12 May 2015     |
|                          |           |      |            | 16:02:07 UTC         |
| 555224006d0aff6d6779609f | succeeded | c2   | core.local | Tue, 12 May 2015     |
|                          |           |      |            | 16:02:08 UTC         |
| 555224016d0aff6d677960a3 | succeeded | c3   | core.local | Tue, 12 May 2015     |
|                          |           |      |            | 16:02:09 UTC         |
+--------------------------+-----------+------+------------+----------------------+
~/st2 git:chain_inherit_notifications ❯❯❯ st2 execution list                                                            ✭ ✱ ◼
+----------------------------+------------------+--------------+-----------+------------------+------------------+
| id                         | action.ref       | context.user | status    | start_timestamp  | end_timestamp    |
+----------------------------+------------------+--------------+-----------+------------------+------------------+
| + 555223ff6d0aff6d610ca22f | examples.echocha | stanley      | succeeded | Tue, 12 May 2015 | Tue, 12 May 2015 |
|                            | in               |              |           | 16:02:07 UTC     | 16:02:10 UTC     |
|   555223ff6d0aff6d6d708577 | slack.post_messa | stanley      | succeeded | Tue, 12 May 2015 | Tue, 12 May 2015 |
|                            | ge               |              |           | 16:02:07 UTC     | 16:02:13 UTC     |
|   555224006d0aff6d6d70857b | slack.post_messa | stanley      | succeeded | Tue, 12 May 2015 | Tue, 12 May 2015 |
|                            | ge               |              |           | 16:02:08 UTC     | 16:02:14 UTC     |
|   555224016d0aff6d6d70857f | slack.post_messa | stanley      | succeeded | Tue, 12 May 2015 | Tue, 12 May 2015 |
|                            | ge               |              |           | 16:02:09 UTC     | 16:02:15 UTC     |
|   555224026d0aff6d6d708583 | slack.post_messa | stanley      | running   | Tue, 12 May 2015 |                  |
|                            | ge               |              |           | 16:02:10 UTC     |                  |
+----------------------------+------------------+--------------+-----------+------------------+------------------+
~/st2 git:chain_inherit_notifications ❯❯❯ st2 execution list                                                            ✭ ✱ ◼
+----------------------------+------------------+--------------+-----------+------------------+------------------+
| id                         | action.ref       | context.user | status    | start_timestamp  | end_timestamp    |
+----------------------------+------------------+--------------+-----------+------------------+------------------+
| + 555223ff6d0aff6d610ca22f | examples.echocha | stanley      | succeeded | Tue, 12 May 2015 | Tue, 12 May 2015 |
|                            | in               |              |           | 16:02:07 UTC     | 16:02:10 UTC     |
|   555223ff6d0aff6d6d708577 | slack.post_messa | stanley      | succeeded | Tue, 12 May 2015 | Tue, 12 May 2015 |
|                            | ge               |              |           | 16:02:07 UTC     | 16:02:13 UTC     |
|   555224006d0aff6d6d70857b | slack.post_messa | stanley      | succeeded | Tue, 12 May 2015 | Tue, 12 May 2015 |
|                            | ge               |              |           | 16:02:08 UTC     | 16:02:14 UTC     |
|   555224016d0aff6d6d70857f | slack.post_messa | stanley      | succeeded | Tue, 12 May 2015 | Tue, 12 May 2015 |
|                            | ge               |              |           | 16:02:09 UTC     | 16:02:15 UTC     |
|   555224026d0aff6d6d708583 | slack.post_messa | stanley      | succeeded | Tue, 12 May 2015 | Tue, 12 May 2015 |
|                            | ge               |              |           | 16:02:10 UTC     | 16:02:16 UTC     |
+----------------------------+------------------+--------------+-----------+------------------+------------------+
~/st2 git:chain_inherit_notifications ❯❯❯
```

With skip_notify:

```
~/st2 git:chain_inherit_notifications ❯❯❯ ST2_CONF=~/st2.dev.conf tools/launchdev.sh stop                               ✭ ✱ ◼
Killing existing st2 screen sessions...
~/st2 git:chain_inherit_notifications ❯❯❯ ST2_CONF=~/st2.dev.conf tools/launchdev.sh startclean                         ✭ ✱ ◼
MongoDB shell version: 2.6.3
connecting to: st2
[object Object]
Starting all st2 servers...
Changing working directory to /home/lakshmi/st2/tools/.....
Using st2 config file: /home/lakshmi/st2.dev.conf
Using content packs base dir: /opt/stackstorm/packs
There is a screen on:
	28002.st2-actionrunner	(05/12/2015 04:01:55 PM)	(Detached)
1 Socket in /var/run/screen/S-lakshmi.

Killing existing st2 screen sessions...
Starting screen session st2-api...
Starting screen session st2-actionrunner...
    starting runner  1 ...
Starting screen session st2-sensorcontainer
Starting screen session st2-rulesengine...
Starting screen session st2-resultstracker...
Starting screen session st2-notifier...

Registering sensors, actions, rules and aliases...
2015-05-12 16:03:17,643 INFO [-] Connecting to database "st2" @ "0.0.0.0:27017" as user "None".
2015-05-12 16:03:17,914 INFO [-] =========================================================
2015-05-12 16:03:17,919 INFO [-] ############## Registering sensors ######################
2015-05-12 16:03:17,919 INFO [-] =========================================================
2015-05-12 16:03:18,408 INFO [-] Registered 4 sensors.
2015-05-12 16:03:18,408 INFO [-] =========================================================
2015-05-12 16:03:18,408 INFO [-] ############## Registering actions ######################
2015-05-12 16:03:18,408 INFO [-] =========================================================
2015-05-12 16:03:19,112 INFO [-] Registered 55 actions.
2015-05-12 16:03:19,112 INFO [-] =========================================================
2015-05-12 16:03:19,112 INFO [-] ############## Registering rules ########################
2015-05-12 16:03:19,112 INFO [-] =========================================================
2015-05-12 16:03:19,166 INFO [-] Registered 4 rules.
2015-05-12 16:03:19,166 INFO [-] =========================================================
2015-05-12 16:03:19,166 INFO [-] ############## Registering aliases ######################
2015-05-12 16:03:19,167 INFO [-] =========================================================
2015-05-12 16:03:19,171 INFO [-] ActionAlias /opt/stackstorm/packs/deploy/aliases/pack_delete.yaml not found. Creating new one.
2015-05-12 16:03:19,179 INFO [-] ActionAlias /opt/stackstorm/packs/deploy/aliases/pack_deploy.yaml not found. Creating new one.
2015-05-12 16:03:19,188 INFO [-] ActionAlias /opt/stackstorm/packs/deploy/aliases/pack_info.yaml not found. Creating new one.
2015-05-12 16:03:19,189 INFO [-] Registered 3 aliases.
There are screens on:
	28624.st2-resultstracker	(05/12/2015 04:03:17 PM)	(Detached)
	28626.st2-notifier	(05/12/2015 04:03:17 PM)	(Detached)
	28620.st2-rulesengine	(05/12/2015 04:03:17 PM)	(Detached)
	28617.st2-sensorcontainer	(05/12/2015 04:03:17 PM)	(Detached)
	28611.st2-actionrunner	(05/12/2015 04:03:17 PM)	(Detached)
	28608.st2-api	(05/12/2015 04:03:17 PM)	(Detached)
6 Sockets in /var/run/screen/S-lakshmi.

~/st2 git:chain_inherit_notifications ❯❯❯ st2 run examples.echochain                                                  ⏎ ✭ ✱ ◼
..
id: 5552244a6d0aff6fc280197b
action.ref: examples.echochain
status: succeeded
start_timestamp: 2015-05-12T16:03:22.145231Z
end_timestamp: 2015-05-12T16:03:25.378969Z
+--------------------------+-----------+------+------------+----------------------+
| id                       | status    | task | action     | start_timestamp      |
+--------------------------+-----------+------+------------+----------------------+
| 5552244a6d0aff6fc7c9e9a5 | succeeded | c1   | core.local | Tue, 12 May 2015     |
|                          |           |      |            | 16:03:22 UTC         |
| 5552244b6d0aff6fc7c9e9a9 | succeeded | c2   | core.local | Tue, 12 May 2015     |
|                          |           |      |            | 16:03:23 UTC         |
| 5552244c6d0aff6fc7c9e9ac | succeeded | c3   | core.local | Tue, 12 May 2015     |
|                          |           |      |            | 16:03:24 UTC         |
+--------------------------+-----------+------+------------+----------------------+
~/st2 git:chain_inherit_notifications ❯❯❯ st2 execution list                                                            ✭ ✱ ◼
+----------------------------+------------------+--------------+-----------+------------------+------------------+
| id                         | action.ref       | context.user | status    | start_timestamp  | end_timestamp    |
+----------------------------+------------------+--------------+-----------+------------------+------------------+
| + 5552244a6d0aff6fc280197b | examples.echocha | stanley      | succeeded | Tue, 12 May 2015 | Tue, 12 May 2015 |
|                            | in               |              |           | 16:03:22 UTC     | 16:03:25 UTC     |
|   5552244a6d0aff6fce293025 | slack.post_messa | stanley      | succeeded | Tue, 12 May 2015 | Tue, 12 May 2015 |
|                            | ge               |              |           | 16:03:22 UTC     | 16:03:28 UTC     |
|   5552244c6d0aff6fce29302a | slack.post_messa | stanley      | running   | Tue, 12 May 2015 |                  |
|                            | ge               |              |           | 16:03:24 UTC     |                  |
|   5552244d6d0aff6fce29302e | slack.post_messa | stanley      | running   | Tue, 12 May 2015 |                  |
|                            | ge               |              |           | 16:03:25 UTC     |                  |
+----------------------------+------------------+--------------+-----------+------------------+------------------+
~/st2 git:chain_inherit_notifications ❯❯❯ st2 execution list                                                            ✭ ✱ ◼
+----------------------------+------------------+--------------+-----------+------------------+------------------+
| id                         | action.ref       | context.user | status    | start_timestamp  | end_timestamp    |
+----------------------------+------------------+--------------+-----------+------------------+------------------+
| + 5552244a6d0aff6fc280197b | examples.echocha | stanley      | succeeded | Tue, 12 May 2015 | Tue, 12 May 2015 |
|                            | in               |              |           | 16:03:22 UTC     | 16:03:25 UTC     |
|   5552244a6d0aff6fce293025 | slack.post_messa | stanley      | succeeded | Tue, 12 May 2015 | Tue, 12 May 2015 |
|                            | ge               |              |           | 16:03:22 UTC     | 16:03:28 UTC     |
|   5552244c6d0aff6fce29302a | slack.post_messa | stanley      | succeeded | Tue, 12 May 2015 | Tue, 12 May 2015 |
|                            | ge               |              |           | 16:03:24 UTC     | 16:03:29 UTC     |
|   5552244d6d0aff6fce29302e | slack.post_messa | stanley      | succeeded | Tue, 12 May 2015 | Tue, 12 May 2015 |
|                            | ge               |              |           | 16:03:25 UTC     | 16:03:31 UTC     |
+----------------------------+------------------+--------------+-----------+------------------+------------------+
~/st2 git:chain_inherit_notifications ❯❯❯
```