### PR TITLE
Throw a better error when enforcing a rule if referenced action doesn't exist

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 in development
 --------------
 
+* Throw a more-user friendly exception when enforcing a rule if an action referenced inside
+  the rule definition doesn't exist. (improvement)
+
 v0.9.0 - April 29, 2015
 -----------------------
 


### PR DESCRIPTION
Before this change:

```bash
015-05-07 16:56:17,262 140034745491280 ERROR engine [-] Exception enforcing rule RuleDB(action=ActionExecutionSpecDB@140034739839824(ref="sdlcm", parameters="{u'change': u'{trigger.body.change}'}"), criteria={u'trigger.body.change': {u'pattern': u'', u'type': u'exists'}}, description="firing the CR submit case from /v1/webhooks/Sdlcm/sdlcm", enabled=True, id=554a7b0b0ba1603bd4571511, name="wh_sdlcm", tags=[], trigger="core.7bfd8485-8c52-4778-ab9e-ae247c1217dd"): 'NoneType' object has no attribute 'parameters'
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/st2reactor/rules/engine.py", line 59, in enforce_rules
    enforcer.enforce()  # Should this happen in an eventlet pool?
  File "/usr/lib/python2.7/dist-packages/st2reactor/rules/enforcer.py", line 48, in enforce
    liveaction = RuleEnforcer._invoke_action(self.rule.action, data, context)
  File "/usr/lib/python2.7/dist-packages/st2reactor/rules/enforcer.py", line 65, in _invoke_action
    params = action_param_utils.cast_params(action_ref, params)
  File "/usr/lib/python2.7/dist-packages/st2common/models/utils/action_param_utils.py", line 86, in cast_params
    action_parameters_schema = action_db.parameters
AttributeError: 'NoneType' object has no attribute 'parameters'
```

After this change:

```bash
2015-05-07 19:32:40,388 ERROR [-] Exception enforcing rule RuleDB(action=ActionExecutionSpecDB@140211180910928(ref="core.localaaa", parameters="{u'cmd': u'echo "{{trigger.executed_at}}"'}"), criteria={}, description="Sample rule using an Interval Timer.", enabled=True, id=554bb2400640fd04aae15ec0, name="sample.with_timer", tags=[], trigger="core.f62572f1-b04e-4583-8495-c562e09d6dd3"): Action "core.localaaa" doesn't exist
Traceback (most recent call last):
  File "/data/stanley/st2reactor/st2reactor/rules/engine.py", line 59, in enforce_rules
    enforcer.enforce()  # Should this happen in an eventlet pool?
  File "/data/stanley/st2reactor/st2reactor/rules/enforcer.py", line 44, in enforce
    raise ValueError('Action "%s" doesn\'t exist' % (action_ref))
ValueError: Action "core.localaaa" doesn't exist
```

Spotted by @luisgtz on IRC.