### PR TITLE
Optimize and speed up Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,13 @@ sudo: false
 python:
   - "2.6"
   - "2.7"
-script: make tests-travis
+env:
+  - "TASK=flake8"
+  - "TASK=pylint"
+  - "TASK=docs"
+  - "TASK=tests"
+script:
+  - ./scripts/travis.sh
 services:
   - mongodb
   - rabbitmq

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ tests: pytests
 # Travis cannot run itests since those require users to be configured etc.
 # Creating special travis target. (Yuck!)
 .PHONY: tests-travis
-tests-travis: requirements .flake8 .pylint unit-tests-coverage
+tests-travis: requirements unit-tests-coverage
 
 .PHONY: pytests
 pytests: requirements .flake8 .pylint .pytests-coverage

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+if [ -z ${TASK} ]; then
+  echo "No task provided"
+  exit 2
+  fi
+
+if [ ${TASK} == "flake8" ]; then
+  make flake8
+elif [ ${TASK} == "pylint" ]; then
+  make pylint
+elif [ ${TASK} == "docs" ]; then
+  make docs
+elif [ ${TASK} == "tests" ]; then
+  make tests-travis
+else
+  echo "Invalid task: ${TASK}"
+  exit 2
+fi
+
+exit $?


### PR DESCRIPTION
With this pull request we now also build documentation on Travis. In addition to that, I split things out so we now run 4 builds in parallel (flake8, pylint, docs, tests) instead of running everything sequentially in a single build.

Well, in reality we now actually run 8 builds because we run every task under Python 2.6 and 2.7 (2 x 4), but I will optimize this once we switch to tox (the way Travis works it's not possible to do that without something like tox).

This means the builds should now complete faster (fingers crossed).