### PR TITLE
Add "to_dict" method to the Resource class

### DIFF
--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -57,6 +57,22 @@ class Resource(object):
         for k, v in six.iteritems(kwargs):
             setattr(self, k, v)
 
+    def to_dict(self):
+        """
+        Return a dictionary representation of this object.
+
+        :rtype: ``dict``
+        """
+        attributes = self.__dict__.keys()
+        attributes = [attr for attr in attributes if not attr.startswith('__')]
+
+        result = {}
+        for attribute in attributes:
+            value = getattr(self, attribute, None)
+            result[attribute] = value
+
+        return result
+
     @classmethod
     def get_alias(cls):
         return cls._alias if cls._alias else cls.__name__


### PR DESCRIPTION
I plan to use this functionality inside actions inside the ``st2`` pack. Returning actual Python objects from the ``st2`` actions makes little sense since common currency in StackStorm (workflows, etc). are simple types + dict and you can't do anything with those custom objects before converting them to a dictionary.

If you think this should really only leave in st2 pack, I can also move it there.