### PR TITLE
Cache pip packages in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,16 @@ python:
   - "2.6"
   - "2.7"
 env:
-  - "TASK=flake8"
-  - "TASK=pylint"
-  - "TASK=docs"
-  - "TASK=tests"
+  global:
+    - "PIP_DOWNLOAD_CACHE=$HOME/.pip-cache"
+  matrix:
+    - "TASK=flake8"
+    - "TASK=pylint"
+    - "TASK=docs"
+    - "TASK=tests"
+cache:
+  directories:
+    - $HOME/.pip-cache/
 script:
   - ./scripts/travis.sh
 services:

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,9 +1,18 @@
 #!/usr/bin/env bash
 
+function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" == "$1"; }
+
 if [ -z ${TASK} ]; then
   echo "No task provided"
   exit 2
   fi
+
+# Note: We only want to run tests under multiple Python versions
+
+if version_ge ${TRAVIS_PYTHON_VERSION} "2.7" && [ ${TASK} != "tests" ]; then
+    echo "Skipping task ${TASK} on ${TRAVIS_PYTHON_VERSION}"
+    exit 0
+fi
 
 if [ ${TASK} == "flake8" ]; then
   make flake8


### PR DESCRIPTION
Builds should now complete even faster.

If there is ever an issue with cache some how getting corrupted, pip should automatically take care of it, but if it doesn't, you can manually nuke it on this page  - https://travis-ci.org/StackStorm/st2 (Settings -> Cache).