### PR TITLE
Log traceback on API error

### DIFF
--- a/st2common/st2common/hooks.py
+++ b/st2common/st2common/hooks.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import httplib
+import traceback
 
 import webob
 from oslo.config import cfg
@@ -148,9 +149,9 @@ class JSONErrorResponseHook(PecanHook):
     """
 
     def on_error(self, state, e):
-
         error_msg = getattr(e, 'comment', str(e))
         LOG.debug('API call failed: %s', error_msg)
+        LOG.debug(traceback.format_exc())
 
         if hasattr(e, 'body') and isinstance(e.body, dict):
             body = e.body


### PR DESCRIPTION
Recent API refactoring probably accidentally removed (or didn't add back) this part.

Without a traceback, most of the errors are pretty much useless.

Before:

```bash
015-05-11 18:20:03,463 DEBUG [-] API call failed: object of type 'NoneType' has no len()
2015-05-11 18:20:03,463 INFO [-] POST /exp/aliasexecution result={
    "faultstring": "Internal Server Error"
} (remote_addr='127.0.0.1',method='POST',result='{\n    "faultstring": "Internal Server Error"\n}',status_code='500 Internal Server Error',path='/exp/aliasexecution')
```

After:

```bash
2015-05-11 18:26:19,155 DEBUG [-] Traceback (most recent call last):
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/pecan/core.py", line 625, in __call__
    self.invoke_controller(controller, args, kwargs, state)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/pecan/core.py", line 531, in invoke_controller
    result = controller(*args, **kwargs)
  File "/data/stanley/st2common/st2common/models/api/base.py", line 160, in callfunction
    result = f(*args, **kwargs)
  File "/data/stanley/st2api/st2api/controllers/exp/aliasexecution.py", line 56, in post
    param_stream=leftover)
  File "/data/stanley/st2api/st2api/controllers/exp/aliasexecution.py", line 73, in _extract_parameters
    return parser.get_extracted_param_value()
  File "/data/stanley/st2common/st2common/models/utils/action_alias_utils.py", line 142, in get_extracted_param_value
    return {name: value for name, value in self}
  File "/data/stanley/st2common/st2common/models/utils/action_alias_utils.py", line 142, in <dictcomp>
    return {name: value for name, value in self}
  File "/data/stanley/st2common/st2common/models/utils/action_alias_utils.py", line 129, in next
    if v_start < len(self._param_stream):
TypeError: object of type 'NoneType' has no len()

2015-05-11 18:26:19,165 INFO [-] POST /exp/aliasexecution result={
    "faultstring": "Internal Server Error"
} (remote_addr='127.0.0.1',method='POST',result='{\n    "faultstring": "Internal Server Error"\n}',status_code='500 Internal Server Error',path='/exp/aliasexecution')

```