### PR TITLE
Fix default parameter parsing in the aliases parser

### DIFF
--- a/st2common/st2common/models/utils/action_alias_utils.py
+++ b/st2common/st2common/models/utils/action_alias_utils.py
@@ -106,7 +106,7 @@ class ActionAliasFormatParser(object):
 
     def __init__(self, alias_format, param_stream):
         self._format = alias_format
-        self._param_stream = param_stream
+        self._param_stream = param_stream or ''
         self._alias_fmt_ptr = 0
         self._param_strm_ptr = 0
 
@@ -132,6 +132,12 @@ class ActionAliasFormatParser(object):
             # move the alias_fmt_ptr to one beyond the end of each
             self._alias_fmt_ptr = p_end
             self._param_strm_ptr = v_end
+        elif v_start < len(self._format):
+            # Advance in the format string
+            # Note: We still want to advance in the format string even though
+            # there is nothing left in the param stream since we support default
+            # values and param_stream can be empty
+            self._alias_fmt_ptr = p_end
 
         if not value and not default_value:
             raise content.ParseException('No value supplied and no default value found.')


### PR DESCRIPTION
This pull request fixes alias parser so it correctly parses the default values and works if param stream is empty.

Previously alias_stream was depended on the alias_stream, which means that if param_stream was empty, we would end up in an infinite loop and never parse the alias_stream. That's not the desired behavior, since we want to parse and use the default param values even if the param_stream is empty.