### PR TITLE
Allow dots in trigger instance payload (bug fix)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ in development
 * Add support for caching of the retrieved auth tokens to the CLI. (new-feature)
 * Throw a more-user friendly exception when enforcing a rule if an action referenced inside
   the rule definition doesn't exist. (improvement)
+* Fix a bug with the rule evaluation failing if the trigger payload contained a key with a
+  dot in the name. (bug-fix)
 
 v0.9.0 - April 29, 2015
 -----------------------

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ pylint: requirements .pylint
 		echo "==========================================================="; \
 		echo "Running pylint on" $$component; \
 		echo "==========================================================="; \
-		. $(VIRTUALENV_DIR)/bin/activate; pylint -E --rcfile=./.pylintrc --load-plugins=pylint_plugins.api_models $$component/$$component; \
+		. $(VIRTUALENV_DIR)/bin/activate; pylint -E --rcfile=./.pylintrc --load-plugins=pylint_plugins.api_models $$component/$$component || exit 1; \
 	done
 
 .PHONY: flake8

--- a/st2actions/st2actions/resultstracker.py
+++ b/st2actions/st2actions/resultstracker.py
@@ -49,7 +49,7 @@ class ResultsTracker(consumers.MessageHandler):
 
     def wait(self):
         super(ResultsTracker, self).wait()
-        for thread in self._query_threads():
+        for thread in self._query_threads:
             thread.wait()
 
     def shutdown(self):

--- a/st2common/st2common/models/db/reactor.py
+++ b/st2common/st2common/models/db/reactor.py
@@ -91,7 +91,7 @@ class TriggerInstanceDB(stormbase.StormFoundationDB):
         occurrence_time (datetime): time of occurrence of the trigger.
     """
     trigger = me.StringField()
-    payload = me.DictField()
+    payload = stormbase.EscapedDictField()
     occurrence_time = me.DateTimeField()
 
 

--- a/st2reactor/tests/unit/test_rule_matcher.py
+++ b/st2reactor/tests/unit/test_rule_matcher.py
@@ -42,11 +42,12 @@ class RuleMatcherTest(DbTestCase):
         self.assertEqual(len(matching_rules), 1)
 
     def test_trigger_instance_payload_with_special_values(self):
-        # Test a rule where TriggerInstance payload contains a dot (".")
+        # Test a rule where TriggerInstance payload contains a dot (".") and $
         self._setup_sample_trigger('st2.test.trigger2')
         trigger_instance = container_utils.create_trigger_instance(
             'dummy_pack_1.st2.test.trigger2',
-            {'k1': 't1_p_v', 'k2.k2': 'v2', 'k3.more.nested.deep': 'some.value'},
+            {'k1': 't1_p_v', 'k2.k2': 'v2', 'k3.more.nested.deep': 'some.value',
+             'k4.even.more.nested$': 'foo', 'yep$aaa': 'b'},
             datetime.datetime.utcnow()
         )
         trigger = get_trigger_db_by_ref(trigger_instance.trigger)


### PR DESCRIPTION
Previously, rules engine would explode if a TriggerInstance dictionated payload contained a dot or $ in the key name.

```bash
640fd7215ce2f1a', u'end_timestamp': u'2015-05-11T21:33:10.971247Z'}}, 'execution_id': '555124210640fd7d31ab0409'}}
Traceback (most recent call last):
  File "/data/stanley/st2common/st2common/transport/consumers.py", line 59, in _process_message
    self._handler.process(body)
  File "/data/stanley/st2reactor/st2reactor/rules/worker.py", line 32, in process
    datetime.datetime.utcnow())
  File "/data/stanley/st2reactor/st2reactor/container/utils.py", line 62, in create_trigger_instance
    return TriggerInstance.add_or_update(trigger_instance)
  File "/data/stanley/st2common/st2common/persistence/base.py", line 83, in add_or_update
    model_object = cls._get_impl().add_or_update(model_object)
  File "/data/stanley/st2common/st2common/models/db/__init__.py", line 125, in add_or_update
    instance.save()
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/mongoengine/document.py", line 224, in save
    self.validate(clean=clean)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/mongoengine/base/document.py", line 323, in validate
    raise ValidationError(message, errors=errors)
ValidationError: ValidationError (TriggerInstanceDB:None) (Invalid dictionary key name - keys may not contain "." or "$" characters: ['payload'])
```

This also resolves #1368