### PR TITLE
Display error message when running an execution when a workflow action fails

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,8 @@ in development
   (bug-fix)
 * Throw a HTTP BAD REQUEST when TTL requested for a token is larger than max configured in st2
   system. (improvement)
+* Update CLI so it displays the error at the top level when using ``run``, ``execution run`` or
+  ``execution get`` when executed workflow fails. (improvement)
 
 v0.9.0 - April 29, 2015
 -----------------------

--- a/contrib/examples/actions/chains/echochain_task_failure.yaml
+++ b/contrib/examples/actions/chains/echochain_task_failure.yaml
@@ -1,0 +1,22 @@
+---
+    chain:
+        -
+            name: "c1"
+            ref: "core.local"
+            params:
+                cmd: "echo c1"
+            on-success: "c2"
+            on-failure: "c4"
+        -
+            name: "c2"
+            ref: "core.local"
+            params:
+                cmd: "echo 'all aboard the fail boat' >&2; exit 1"
+            on-success: "c3"
+        -
+            name: "c3"
+            ref: "core.local"
+            params:
+                cmd: "echo c3"
+
+    default: "c1"

--- a/contrib/examples/actions/chains/echochain_top_level_failure.yaml
+++ b/contrib/examples/actions/chains/echochain_top_level_failure.yaml
@@ -1,0 +1,20 @@
+---
+    chain:
+        -
+            name: "c1"
+            ref: "core.local"
+            params:
+                cmd: "echo c1"
+            on-success: "c2"
+            on-failure: "c4"
+        -
+            name: "c2"
+            ref: "core.invalid-action"
+            on-success: "c3"
+        -
+            name: "c3"
+            ref: "core.local"
+            params:
+                cmd: "echo c3"
+
+    default: "c1"

--- a/contrib/examples/actions/echochain_task_failure.meta.yaml
+++ b/contrib/examples/actions/echochain_task_failure.meta.yaml
@@ -1,0 +1,6 @@
+---
+name: "echochain_task_failure"
+description: "Simple Action Chain workflow with task failure"
+runner_type: "action-chain"
+entry_point: "chains/echochain_task_failure.yaml"
+enabled: true

--- a/contrib/examples/actions/echochain_top_level_failure.meta.yaml
+++ b/contrib/examples/actions/echochain_top_level_failure.meta.yaml
@@ -1,0 +1,6 @@
+---
+name: "echochain_top_level_failure"
+description: "Simple Action Chain workflow with a top level (chain) failure"
+runner_type: "action-chain"
+entry_point: "chains/echochain_top_level_failure.yaml"
+enabled: true

--- a/st2actions/st2actions/worker.py
+++ b/st2actions/st2actions/worker.py
@@ -99,7 +99,10 @@ class ActionExecutionDispatcher(consumers.MessageHandler):
             LOG.debug('Runner dispatch produced result: %s', result)
             if not result:
                 raise ActionRunnerException('Failed to execute action.')
-        except Exception:
+        except Exception as e:
+            extra['error'] = str(e)
+            LOG.info('Action "%s" failed: %s' % (liveaction_db.action, str(e)), extra=extra)
+
             liveaction_db = action_utils.update_liveaction_status(
                 status=action_constants.LIVEACTION_STATUS_FAILED,
                 liveaction_id=liveaction_db.id)

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -281,6 +281,13 @@ class ActionRunCommandMixin(object):
             # No child error, there might be a global error, include result in the output
             options['attributes'].append('result')
 
+        # On failure we also want to include error message and traceback at the top level view
+        if instance.status == 'failed':
+            # TODO: If there is no top level error, retrieve error from the last task
+            status_index = options['attributes'].index('status')
+            options['attributes'].insert(status_index + 1, 'result.error')
+            options['attributes'].insert(status_index + 2, 'result.traceback')
+
         # print root task
         self.print_output(instance, formatter, **options)
 

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -281,12 +281,28 @@ class ActionRunCommandMixin(object):
             # No child error, there might be a global error, include result in the output
             options['attributes'].append('result')
 
-        # On failure we also want to include error message and traceback at the top level view
+        # On failure we also want to include error message and traceback at the top level
         if instance.status == 'failed':
-            # TODO: If there is no top level error, retrieve error from the last task
             status_index = options['attributes'].index('status')
-            options['attributes'].insert(status_index + 1, 'result.error')
-            options['attributes'].insert(status_index + 2, 'result.traceback')
+            tasks = instance.result.get('tasks', [])
+
+            top_level_error, top_level_traceback = self._get_top_level_error(live_action=instance)
+            task_error, task_traceback = self._get_task_error(task=tasks[-1])
+
+            if top_level_error:
+                # Top-level error
+                instance.error = top_level_error
+                instance.traceback = top_level_traceback
+                options['attributes'].insert(status_index + 1, 'error')
+                options['attributes'].insert(status_index + 2, 'traceback')
+            elif task_error:
+                # Task error
+                instance.error = task_error
+                instance.traceback = task_traceback
+                instance.failed_on = tasks[-1].get('name', 'unknown')
+                options['attributes'].insert(status_index + 1, 'error')
+                options['attributes'].insert(status_index + 2, 'traceback')
+                options['attributes'].insert(status_index + 3, 'failed_on')
 
         # print root task
         self.print_output(instance, formatter, **options)
@@ -322,6 +338,34 @@ class ActionRunCommandMixin(object):
                 execution.result = self._format_error_result(execution.result)
 
         return execution
+
+    def _get_top_level_error(self, live_action):
+        """
+        Retrieve a top level workflow error.
+
+        :return: (error, traceback)
+        """
+        error = live_action.result.get('error', None)
+        traceback = live_action.result.get('traceback', None)
+
+        return error, traceback
+
+    def _get_task_error(self, task):
+        """
+        Retrieve error message from the provided task.
+
+        :return: (error, traceback)
+        """
+        if not task:
+            return None, None
+
+        result = task['result']
+        stderr = result.get('stderr', None)
+        error = result.get('error', None)
+        traceback = result.get('traceback', None)
+        error = error if error else stderr
+
+        return error, traceback
 
     def _is_error_result(self, result):
         if not isinstance(result, dict):

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -71,8 +71,8 @@ class Resource(object):
         exclude_attributes = exclude_attributes or []
 
         attributes = self.__dict__.keys()
-        attributes = [attr for attr in attributes if not attr.startswith('__')
-                      and attr not in exclude_attributes]
+        attributes = [attr for attr in attributes if not attr.startswith('__') and
+                      attr not in exclude_attributes]
 
         result = {}
         for attribute in attributes:

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -59,14 +59,20 @@ class Resource(object):
         for k, v in six.iteritems(kwargs):
             setattr(self, k, v)
 
-    def to_dict(self):
+    def to_dict(self, exclude_attributes=None):
         """
         Return a dictionary representation of this object.
 
+        :param exclude_attributes: Optional list of attributes to exclude.
+        :type exclude_attributes: ``list``
+
         :rtype: ``dict``
         """
+        exclude_attributes = exclude_attributes or []
+
         attributes = self.__dict__.keys()
-        attributes = [attr for attr in attributes if not attr.startswith('__')]
+        attributes = [attr for attr in attributes if not attr.startswith('__')
+                      and attr not in exclude_attributes]
 
         result = {}
         for attribute in attributes:


### PR DESCRIPTION
The title says it all.

In short this saves everyone an additional command (previously you needed to run `execution get` to retrieve the error message and the error and traceback attributes were also "hidden" among other data).

Before:

![screenshot from 2015-05-12 17 00 25](https://cloud.githubusercontent.com/assets/125088/7590775/6ee0df04-f8ca-11e4-9d16-220c1ce07e14.png)

After (top level workflow failure):

![top_level_failure](https://cloud.githubusercontent.com/assets/125088/7611218/4ebda4c8-f983-11e4-9f05-8daabf1c23e1.png)

After (task level workflow failure):

![task_level_failure](https://cloud.githubusercontent.com/assets/125088/7611224/55b20eea-f983-11e4-83af-0b89fda7d37d.png)

This partly solves #1315, but not fully. We still need to account for a case when there is no top level error but a task fails. I will make that change shortly.