### PR TITLE
Fix handling of arrays which are passed as string inside the action-chain workflows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ in development
   the rule definition doesn't exist. (improvement)
 * Fix a bug with the rule evaluation failing if the trigger payload contained a key with a
   dot in the name. (bug-fix)
+* Fix a bug with publishing array (list) values as strings inside the action chain workflows.
+  (bug-fix)
 
 v0.9.0 - April 29, 2015
 -----------------------

--- a/st2common/st2common/util/casts.py
+++ b/st2common/st2common/util/casts.py
@@ -17,10 +17,17 @@
 import ast
 import json
 
+import six
+
 from st2common.util.compat import to_unicode
 
 
 def _cast_object(x):
+    """
+    Method for casting string to an object (dict) or array.
+
+    Note: String can be either serialized as JSON or a raw Python output.
+    """
     if isinstance(x, str) or isinstance(x, unicode):
         try:
             return json.loads(x)
@@ -30,12 +37,17 @@ def _cast_object(x):
         return x
 
 
+def _cast_boolean(x):
+    if isinstance(x, six.string_types):
+        return ast.literal_eval(x.capitalize())
+
+    return x
+
+
 # These types as they appear in json schema.
 CASTS = {
-    'array': (lambda x: ast.literal_eval(x) if isinstance(x, str) or isinstance(x, unicode)
-              else x),
-    'boolean': (lambda x: ast.literal_eval(x.capitalize())
-                if isinstance(x, str) or isinstance(x, unicode) else x),
+    'array': _cast_object,
+    'boolean': _cast_boolean,
     'integer': int,
     'number': float,
     'object': _cast_object,

--- a/st2common/st2common/util/casts.py
+++ b/st2common/st2common/util/casts.py
@@ -28,7 +28,7 @@ def _cast_object(x):
 
     Note: String can be either serialized as JSON or a raw Python output.
     """
-    if isinstance(x, str) or isinstance(x, unicode):
+    if isinstance(x, six.string_types):
         try:
             return json.loads(x)
         except:

--- a/st2common/tests/unit/test_casts.py
+++ b/st2common/tests/unit/test_casts.py
@@ -1,0 +1,39 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import unittest2
+
+from st2common.util.casts import get_cast
+
+
+class CastsTestCase(unittest2.TestCase):
+    def test_cast_array(self):
+        cast_func = get_cast('array')
+
+        # Python literal
+        value = str([1, 2, 3])
+        result = cast_func(value)
+        self.assertEqual(result, [1, 2, 3])
+
+        # JSON serialized
+        value = json.dumps([4, 5, 6])
+        result = cast_func(value)
+        self.assertEqual(result, [4, 5, 6])
+
+        # Can't cast, should throw
+        value = "\\invalid"
+        self.assertRaises(SyntaxError, cast_func, value)


### PR DESCRIPTION
We serialize arrays to strings using two different approaches - either as JSON or raw Python string, same as we do with dicts.

The problem with that is, that we didn't take JSON serialization into account when casting a parameter for an action which means things would blow up and not work if you passed in array serialized as JSON.

TODO:

- [x] Tests