### PR TITLE
RFR: Return HTTP BAD REQUEST when TTL requested for token > Max configured TTL

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ in development
   the rule definition doesn't exist. (improvement)
 * Fix a bug with the rule evaluation failing if the trigger payload contained a key with a
   dot in the name. (bug-fix)
+* Throw a HTTP BAD REQUEST when TTL requested for a token is larger than max configured in st2
+  system. (improvement)
 
 v0.9.0 - April 29, 2015
 -----------------------

--- a/docs/source/auth_usage.rst
+++ b/docs/source/auth_usage.rst
@@ -29,7 +29,9 @@ for 10 minutes, use the following:
 ::
 
     # with TTL and password
-    st2 auth yourusername -p yourpassword -t 600
+    st2 auth yourusername -p yourpassword -l 600
+
+Note that if the TTL requested is greater than maximum allowed TTL in st2 configuration, you'd get an error.
 
 If you don't want to retrieve a new token and configure the environment variable
 every time you start a new shell session, you can put your StackStorm

--- a/st2auth/tests/unit/test_token.py
+++ b/st2auth/tests/unit/test_token.py
@@ -121,15 +121,12 @@ class TestTokenController(FunctionalTest):
         mock.MagicMock(return_value=UserDB(name=USERNAME)))
     def test_token_post_set_ttl_over_policy(self):
         ttl = cfg.CONF.auth.token_ttl
-        timestamp = isotime.add_utc_tz(datetime.datetime.utcnow())
-        response = self.app.post_json('/tokens', {'ttl': ttl + 60}, expect_errors=False)
-        expected_expiry = datetime.datetime.utcnow() + datetime.timedelta(seconds=ttl)
-        expected_expiry = isotime.add_utc_tz(expected_expiry)
-        self.assertLess(expected_expiry, timestamp + datetime.timedelta(seconds=ttl + 60))
-        self.assertEqual(response.status_int, 201)
-        actual_expiry = isotime.parse(response.json['expiry'])
-        self.assertLess(timestamp, actual_expiry)
-        self.assertLess(actual_expiry, expected_expiry)
+        response = self.app.post_json('/tokens', {'ttl': ttl + 60}, expect_errors=True)
+        self.assertEqual(response.status_int, 400)
+        message = 'TTL specified %s is greater than max allowed %s.' % (
+                  ttl + 60, ttl
+        )
+        self.assertEqual(response.json['faultstring'], message)
 
     @mock.patch.object(
         User, 'get_by_name',

--- a/st2common/st2common/exceptions/access.py
+++ b/st2common/st2common/exceptions/access.py
@@ -27,3 +27,7 @@ class TokenNotFoundError(StackStormDBObjectNotFoundError):
 
 class TokenExpiredError(StackStormBaseException):
     pass
+
+
+class TTLTooLargeException(StackStormBaseException):
+    pass

--- a/st2common/st2common/services/access.py
+++ b/st2common/st2common/services/access.py
@@ -20,6 +20,7 @@ from oslo.config import cfg
 
 from st2common.util import isotime
 from st2common.exceptions.access import TokenNotFoundError
+from st2common.exceptions.access import TTLTooLargeException
 from st2common.models.db.access import TokenDB, UserDB
 from st2common.persistence.access import Token, User
 from st2common import log as logging
@@ -44,7 +45,14 @@ def create_token(username, ttl=None, metadata=None):
     :param metadata: Optional metadata to associate with the token.
     :type metadata: ``dict``
     """
-    if not ttl or ttl > cfg.CONF.auth.token_ttl:
+
+    if ttl:
+        if ttl > cfg.CONF.auth.token_ttl:
+            msg = 'TTL specified %s is greater than max allowed %s.' % (
+                ttl, cfg.CONF.auth.token_ttl
+            )
+            raise TTLTooLargeException(msg)
+    else:
         ttl = cfg.CONF.auth.token_ttl
 
     if username:


### PR DESCRIPTION
Fixes: https://github.com/StackStorm/st2/issues/1467

```
(virtualenv)~/st2 git:ttl_greater_than_max ❯❯❯ st2 auth -p <hidden> testu -l 5000000                                       ✭ ✱ ◼
ERROR: 400 Client Error: Bad Request
MESSAGE: TTL specified 5000000 is greater than max allowed 86400.

(virtualenv)~/st2 git:ttl_greater_than_max ❯❯❯
```

```
(virtualenv)~/st2 git:ttl_greater_than_max ❯❯❯ st2 auth -p <hidden> testu -l 10                                            ✭ ✱ ◼
+----------+----------------------------------+
| Property | Value                            |
+----------+----------------------------------+
| user     | testu                            |
| token    | 0cc9261fc08c419294576f22cf15e0ca |
| expiry   | 2015-05-12T17:17:52.196630Z      |
+----------+----------------------------------+
(virtualenv)~/st2 git:ttl_greater_than_max ❯❯
```