### PR TITLE
Include runner_ref in the notification trigger payload.

### DIFF
--- a/st2actions/st2actions/notifier.py
+++ b/st2actions/st2actions/notifier.py
@@ -121,7 +121,9 @@ class Notifier(consumers.MessageHandler):
         payload = {'execution_id': str(liveaction.id),
                    'status': liveaction.status,
                    'start_timestamp': str(liveaction.start_timestamp),
+                   # deprecate 'action_name' at some point and switch to 'action_ref'
                    'action_name': liveaction.action,
+                   'action_ref': liveaction.action,
                    'runner_ref': self._get_runner(liveaction.action),
                    'parameters': liveaction.parameters,
                    'result': liveaction.result}

--- a/st2actions/tests/unit/test_notifier.py
+++ b/st2actions/tests/unit/test_notifier.py
@@ -64,6 +64,7 @@ class NotifierTestCase(unittest2.TestCase):
                     self.tester.assertTrue('execution_id' in payload)
                     self.tester.assertTrue('start_timestamp' in payload)
                     self.tester.assertEqual('core.local', payload['action_name'])
+                    self.tester.assertEqual('core.local', payload['action_ref'])
                     self.tester.assertTrue('result' in payload)
                     self.tester.assertTrue('parameters' in payload)
                     self.tester.assertTrue('run-local-cmd', payload['runner_ref'])

--- a/st2actions/tests/unit/test_notifier.py
+++ b/st2actions/tests/unit/test_notifier.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import datetime
-
+import mock
 import unittest2
 
 import st2tests.config as tests_config
@@ -24,6 +24,7 @@ from st2actions.notifier import Notifier
 from st2common.constants.triggers import INTERNAL_TRIGGER_TYPES
 from st2common.models.db.action import LiveActionDB, NotificationSchema
 from st2common.models.db.action import NotificationSubSchema
+from st2common.persistence.action import Action
 from st2common.models.system.common import ResourceReference
 
 ACTION_TRIGGER_TYPE = INTERNAL_TRIGGER_TYPES['action'][0]
@@ -56,6 +57,7 @@ class NotifierTestCase(unittest2.TestCase):
                     self.tester.assertEqual('core.local', payload['action_ref'])
                     self.tester.assertEqual('Action succeeded.', payload['message'])
                     self.tester.assertTrue('data' in payload)
+                    self.tester.assertTrue('run-local-cmd', payload['runner_ref'])
 
                 if args[0] == self.action_trigger:
                     self.tester.assertEqual(payload['status'], 'succeeded')
@@ -64,9 +66,13 @@ class NotifierTestCase(unittest2.TestCase):
                     self.tester.assertEqual('core.local', payload['action_name'])
                     self.tester.assertTrue('result' in payload)
                     self.tester.assertTrue('parameters' in payload)
+                    self.tester.assertTrue('run-local-cmd', payload['runner_ref'])
+
             except Exception:
                 self.tester.fail('Test failed')
 
+    @mock.patch.object(Action, 'get_by_ref',
+                       mock.MagicMock(return_value={'runner_type': {'name': 'run-local-cmd'}}))
     def test_notify_triggers(self):
         liveaction = LiveActionDB(action='core.local')
         liveaction.description = ''


### PR DESCRIPTION
* Including the payload means client can use this info to better understand
  the results.