### PR TITLE
Notify & action triggers should contain Execution id as opposed to LiveAction id.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ in development
   (bug-fix)
 * Throw a HTTP BAD REQUEST when TTL requested for a token is larger than max configured in st2
   system. (improvement)
+* Action trigger now contains execution id as opposed to liveaction id. (bug-fix)
 
 v0.9.0 - April 29, 2015
 -----------------------

--- a/st2actions/st2actions/notifier.py
+++ b/st2actions/st2actions/notifier.py
@@ -59,9 +59,9 @@ class Notifier(consumers.MessageHandler):
         execution_id = self._get_execution_id(liveaction)
 
         if liveaction.notify is not None:
-            self._post_notify_triggers(liveaction, execution_id)
+            self._post_notify_triggers(liveaction=liveaction, execution_id=execution_id)
 
-        self._post_generic_trigger(liveaction, execution_id)
+        self._post_generic_trigger(liveaction=liveaction, execution_id=execution_id)
 
     def _get_execution_id(self, liveaction):
         try:
@@ -72,7 +72,7 @@ class Notifier(consumers.MessageHandler):
                           str(liveaction.id))
             return None
 
-    def _post_notify_triggers(self, liveaction, execution_id):
+    def _post_notify_triggers(self, liveaction=None, execution_id=None):
         notify = getattr(liveaction, 'notify', None)
 
         if not notify:
@@ -80,16 +80,23 @@ class Notifier(consumers.MessageHandler):
 
         if notify.on_complete:
             self._post_notify_subsection_triggers(
-                liveaction, execution_id, notify.on_complete, default_message_suffix='completed.')
+                liveaction=liveaction, execution_id=execution_id,
+                notify_subsection=notify.on_complete,
+                default_message_suffix='completed.')
         if liveaction.status == LIVEACTION_STATUS_SUCCEEDED and notify.on_success:
             self._post_notify_subsection_triggers(
-                liveaction, execution_id, notify.on_success, default_message_suffix='succeeded.')
+                liveaction=liveaction, execution_id=execution_id,
+                notify_subsection=notify.on_success,
+                default_message_suffix='succeeded.')
         if liveaction.status == LIVEACTION_STATUS_FAILED and notify.on_failure:
             self._post_notify_subsection_triggers(
-                liveaction, execution_id, notify.on_failure, default_message_suffix='failed.')
+                liveaction=liveaction, execution_id=execution_id,
+                notify_subsection=notify.on_failure,
+                default_message_suffix='failed.')
 
-    def _post_notify_subsection_triggers(self, liveaction, execution_id, notify_subsection,
-                                         default_message_suffix):
+    def _post_notify_subsection_triggers(self, liveaction=None, execution_id=None,
+                                         notify_subsection=None,
+                                         default_message_suffix=None):
         if notify_subsection.channels and len(notify_subsection.channels) >= 1:
             payload = {}
             message = notify_subsection.message or (
@@ -123,7 +130,7 @@ class Notifier(consumers.MessageHandler):
             if len(failed_channels) > 0:
                 raise Exception('Failed notifications to channels: %s' % ', '.join(failed_channels))
 
-    def _post_generic_trigger(self, liveaction, execution_id):
+    def _post_generic_trigger(self, liveaction=None, execution_id=None):
         if not ACTION_SENSOR_ENABLED:
             return
 

--- a/st2actions/tests/unit/test_notifier.py
+++ b/st2actions/tests/unit/test_notifier.py
@@ -15,6 +15,7 @@
 
 import datetime
 
+import mock
 import unittest2
 
 import st2tests.config as tests_config
@@ -28,6 +29,7 @@ from st2common.models.system.common import ResourceReference
 
 ACTION_TRIGGER_TYPE = INTERNAL_TRIGGER_TYPES['action'][0]
 NOTIFY_TRIGGER_TYPE = INTERNAL_TRIGGER_TYPES['action'][1]
+MOCK_EXECUTION_ID = '287r8383t5BDSVBNVDNBVD'
 
 
 class NotifierTestCase(unittest2.TestCase):
@@ -51,6 +53,7 @@ class NotifierTestCase(unittest2.TestCase):
                 if args[0] == self.notify_trigger:
                     self.tester.assertEqual(payload['status'], 'succeeded')
                     self.tester.assertTrue('execution_id' in payload)
+                    self.tester.assertEqual(payload['execution_id'], MOCK_EXECUTION_ID)
                     self.tester.assertTrue('start_timestamp' in payload)
                     self.tester.assertTrue('end_timestamp' in payload)
                     self.tester.assertEqual('core.local', payload['action_ref'])
@@ -60,6 +63,7 @@ class NotifierTestCase(unittest2.TestCase):
                 if args[0] == self.action_trigger:
                     self.tester.assertEqual(payload['status'], 'succeeded')
                     self.tester.assertTrue('execution_id' in payload)
+                    self.tester.assertEqual(payload['execution_id'], MOCK_EXECUTION_ID)
                     self.tester.assertTrue('start_timestamp' in payload)
                     self.tester.assertEqual('core.local', payload['action_name'])
                     self.tester.assertTrue('result' in payload)
@@ -67,6 +71,8 @@ class NotifierTestCase(unittest2.TestCase):
             except Exception:
                 self.tester.fail('Test failed')
 
+    @mock.patch.object(Notifier, '_get_execution_id', mock.MagicMock(
+        return_value=MOCK_EXECUTION_ID))
     def test_notify_triggers(self):
         liveaction = LiveActionDB(action='core.local')
         liveaction.description = ''


### PR DESCRIPTION
We don't want to expose LiveAction id to users. LiveAction is an internal data model. This PR fixes that. 

I went with the approach to consume Execution updates from queue but decided against it because we want the system to deal with LiveAction objects which are there for this purpose. This minimizes the chance of us messing up the execution object. 

We can port this to 0.9.1.