### PR TITLE
`local-shell-cmd` documentation fix

### DIFF
--- a/docs/source/actions.rst
+++ b/docs/source/actions.rst
@@ -84,17 +84,19 @@ Currently the system provides the following runners:
 2. ``local-shell-script`` - This is the local runner. Actions are implemented as
    scripts. They are executed on the same hosts where |st2| components are
    running.
-3. ``remote-script`` - This is a remote runner. Actions are implemented as scripts.
+3. ``remote-shell-cmd`` - This is a remote runner. This runner executes
+   a Linux command on one or more remote hosts provided by the user.
+4. ``remote-shell-script`` - This is a remote runner. Actions are implemented as scripts.
    They run on one or more remote hosts provided by the user.
-4. ``python-script`` - This is a Python runner. Actions are implemented as Python
+5. ``python-script`` - This is a Python runner. Actions are implemented as Python
    classes with a ``run`` method. They run locally on the same machine where
    |st2| components are running.
-5. ``http-request`` - HTTP client which performs HTTP requests for running HTTP
+6. ``http-request`` - HTTP client which performs HTTP requests for running HTTP
    actions.
-6. ``action-chain`` - This runner supports executing simple linear work-flows.
+7. ``action-chain`` - This runner supports executing simple linear work-flows.
    For more information, please refer to the :doc:`Workflows </workflows>`
    and :doc:`ActionChain </actionchain>` section of documentation.
-7. ``mistral-v1``, ``mistral-v2`` - Those runners are built on top of the
+8. ``mistral-v1``, ``mistral-v2`` - Those runners are built on top of the
    Mistral OpenStack project and support executing complex work-flows. For more
    information, please refer to the :doc:`Workflows </workflows>` and
    :doc:`Mistral </mistral>` section of documentation.

--- a/docs/source/actions.rst
+++ b/docs/source/actions.rst
@@ -79,20 +79,22 @@ Available runners
 The environment in which the action runs is specified by the runner.
 Currently the system provides the following runners:
 
-1. ``local-script`` - This is the local runner. Actions are implemented as
+1. ``local-shell-cmd`` - This is the local runner. This runner executes
+   a Linux command on the same host where |st2| components are running.
+2. ``local-shell-script`` - This is the local runner. Actions are implemented as
    scripts. They are executed on the same hosts where |st2| components are
    running.
-2. ``remote-script`` - This is a remote runner. Actions are implemented as scripts.
+3. ``remote-script`` - This is a remote runner. Actions are implemented as scripts.
    They run on one or more remote hosts provided by the user.
-3. ``python-script`` - This is a Python runner. Actions are implemented as Python
+4. ``python-script`` - This is a Python runner. Actions are implemented as Python
    classes with a ``run`` method. They run locally on the same machine where
    |st2| components are running.
-4. ``http-request`` - HTTP client which performs HTTP requests for running HTTP
+5. ``http-request`` - HTTP client which performs HTTP requests for running HTTP
    actions.
-5. ``action-chain`` - This runner supports executing simple linear work-flows.
+6. ``action-chain`` - This runner supports executing simple linear work-flows.
    For more information, please refer to the :doc:`Workflows </workflows>`
    and :doc:`ActionChain </actionchain>` section of documentation.
-6. ``mistral-v1``, ``mistral-v2`` - Those runners are built on top of the
+7. ``mistral-v1``, ``mistral-v2`` - Those runners are built on top of the
    Mistral OpenStack project and support executing complex work-flows. For more
    information, please refer to the :doc:`Workflows </workflows>` and
    :doc:`Mistral </mistral>` section of documentation.

--- a/docs/source/runners.rst
+++ b/docs/source/runners.rst
@@ -8,7 +8,7 @@ actions to be run remotely (via SSH) and locally. The objective is to
 allow the Action author to concentrate only on the implementation of the
 action itself rather than setting up the environment.
 
-Local command runner (local-script-cmd)
+Local command runner (local-shell-cmd)
 ---------------------------------------
 
 This is the local runner. This runner executes a Linux command on the same host


### PR DESCRIPTION
According to [RUNNER_TYPES](https://github.com/StackStorm/st2/blob/master/st2actions/st2actions/bootstrap/runnersregistrar.py#L62) there are no such Action Runners like [`local-script-cmd`](https://github.com/StackStorm/st2/blob/master/docs/source/runners.rst#local-command-runner-local-script-cmd)
and [`local-script`](https://github.com/StackStorm/st2/blob/master/docs/source/actions.rst#available-runners)

Seems documentation typo.
