### PR TITLE
Modifying artifact directory to mount only packs

### DIFF
--- a/instructables/chatops.md
+++ b/instructables/chatops.md
@@ -51,10 +51,10 @@ st2express:
     facts:
       role: st2express
   mounts:
-    - "/opt/stackstorm:artifacts/stackstorm"
+    - "/opt/stackstorm/packs:artifacts/packs"
 ```
 
-This will setup StackStorm to store all pack files and chatops aliases in the `artifacts/stackstorm` directory at the root of the workroom. This will allow you to edit files using your favorite editor on your computer.
+This will setup StackStorm to store all pack files and chatops aliases in the `artifacts/packs` directory at the root of the workroom. This will allow you to edit files using your favorite editor on your computer.
 
 Now, let's setup the contents of the workroom. Create the workroom config file by starting with the example template.
 
@@ -157,10 +157,10 @@ If successful, proceed to the section [Configure Stackstorm](#configuring-stacks
 
 At this point, it is necessary to introduce a few new terms as it relates to how ChatOps messages are processed internally. First, you will need to create a _notification_ rule. This will leverage the new notifications system, and allow us to send messages back to Hubot. Then, you will configure _aliases_ which map commands from Hubot to actions in StackStorm. Finally, you'll configure actions to use the _notifications_, thus completing the entire chain of events. Let's get started.
 
-First, let's configure our global notification rule. To do this, let's create a new pack in StackStorm called `chatops`. Navigate to the `artifacts/stackstorm` directory, and create a new pack directory.
+First, let's configure our global notification rule. To do this, let's create a new pack in StackStorm called `chatops`. Navigate to the `artifacts/packs` directory, and create a new pack directory.
 
 ```
-$ cd ~/stackstorm/st2workroom/artifacts/stackstorm/packs
+$ cd ~/stackstorm/st2workroom/artifacts/packs
 $ mkdir -p chatops/{actions,rules,sensors,aliases}
 ```
 
@@ -172,11 +172,11 @@ $ vagrant ssh
 $ st2 run packs.install packs=google
 ```
 
-Now, let's setup an alias. For purpose of this setup aliases are stored in the directory `/opt/stackstorm/packs/chatops/aliases` on the filesystem. From your host filesystem, you can access them from `~/stackstorm/st2workroom/artifacts/stackstorm/packs/chatops/aliases`. We have already created this directory in a previous step.
+Now, let's setup an alias. For purpose of this setup aliases are stored in the directory `/opt/stackstorm/packs/chatops/aliases` on the filesystem. From your host filesystem, you can access them from `~/stackstorm/st2workroom/artifacts/packs/chatops/aliases`. We have already created this directory in a previous step.
 
 ```
 $ cd ~/stackstorm/st2workroom
-$ cd artifacts/stackstorm/packs/chatops/aliases
+$ cd artifacts/packs/chatops/aliases
 ```
 
 Create a new file called `google.yaml`, and add the following contents.
@@ -193,7 +193,7 @@ formats:
 Now, navigate to the hubot pack `rules` directory, and view the notify_hubot rule. This is a notification rule that sets up a notification channel.
 
 ```
-$ cd ~/stackstorm/st2workroom/artifacts/stackstorm/packs/hubot/rules
+$ cd ~/stackstorm/st2workroom/artifacts/packs/hubot/rules
 $ vi notify_hubot.yaml
 ```
 


### PR DESCRIPTION
This change follws the change made in https://github.com/StackStorm/st2workroom/commit/ce4e9446230debdb15aa388c37dcdcd8e9d659a9,
which only mounts the needed directory for pack development
on a local machine. This omits the directories `vcs`, `static`,
and `virtualenvs` from being mounted on the local machine.

Fixes errors observed by @dzimine during bootstrap testing
of the https://github.com/StackStorm/st2workroom project.