### PR TITLE
Fix doc link in st2api

### DIFF
--- a/st2api/st2api/controllers/root.py
+++ b/st2api/st2api/controllers/root.py
@@ -46,7 +46,8 @@ class RootController(object):
         if 'dev' in __version__:
             docs_url = 'http://docs.stackstorm.com/latest'
         else:
-            docs_url = 'http://docs.stackstorm.com/%s' % (__version__)
+            docs_version = '.'.join(__version__.split('.')[:2])
+            docs_url = 'http://docs.stackstorm.com/%s' % docs_version
 
         data['version'] = __version__
         data['docs_url'] = docs_url


### PR DESCRIPTION
Setting up my st2workroom. Wile with this, fixing broken link in api root.
Doc version is two-digit (0.9).

IMAO, the root should not return html, but a proper json with the links to the next level resources. `GET https://api.github.com/` to see what I mean. 
