### PR TITLE
Fixing STORM-1193 - part 2

### DIFF
--- a/contrib/examples/sensors/sample_sensor.py
+++ b/contrib/examples/sensors/sample_sensor.py
@@ -31,3 +31,15 @@ class SimpleSensor(Sensor):
         # This is called when the st2 system goes down. You can perform cleanup operations like
         # closing the connections to external system here.
         pass
+
+    def add_trigger(self, trigger):
+        # This method is called when trigger is created
+        pass
+
+    def update_trigger(self, trigger):
+        # This method is called when trigger is updated
+        pass
+
+    def remove_trigger(self, trigger):
+        # This method is called when trigger is deleted
+        pass


### PR DESCRIPTION
Resolves "Class "SimpleSensor" doesn't implement required "update_trigger" method from the base class" error when running sensor using "st2sensorcontainer --config-file=/etc/st2/st2.conf --sensor-name=SimpleSensor"