### PR TITLE
Throw a better exception if we fail to templatize trigger payload in the rule enforcer

### DIFF
--- a/st2reactor/st2reactor/rules/enforcer.py
+++ b/st2reactor/st2reactor/rules/enforcer.py
@@ -33,7 +33,14 @@ class RuleEnforcer(object):
     def __init__(self, trigger_instance, rule):
         self.trigger_instance = trigger_instance
         self.rule = rule
-        self.data_transformer = get_transformer(trigger_instance.payload)
+
+        try:
+            self.data_transformer = get_transformer(trigger_instance.payload)
+        except Exception as e:
+            message = ('Failed to template-ize trigger payload: %s. If the payload contains'
+                       'special characters such as "{{" which dont\'t reference value in '
+                       'a datastore, those characters need to be escaped' % (str(e)))
+            raise ValueError(message)
 
     def enforce(self):
         # TODO: Refactor this to avoid additiona lookup in cast_params


### PR DESCRIPTION
Currently, a known limitation is that trigger payload which is matched against in the rules engine can't contain special Jinja2 characters such as "{{", unless you are referencing variable in a datastore inside the payload.

For example, the following would fail:

```bash
curl -X POST http://127.0.0.1:9101/v1/webhooks/sample -H "Content-Type: application/json" -d '{"a": "{{ foo.bar }}"}'
```

(we try to reference attribute "bar" of variable "foo" which is not defined / available inside the template context)

If the payload contains those special characters, they need to be explicitly escaped inside the payload before sending trigger into the system.

Before this change, a really cryptic exception was thrown which made it hard to figure out the root cause. This pull request doesn't solve the root cause (we need to decide how to handle that), but it at least saves user some time debugging what went wrong.

Explicit escaping is obviously not ideal (especially since in a lot of cases, users just want to directly pipe data from 3rd party systems into StackStorm and they don't want to add another step which processes / sanitizes this data), but as long as we support key-value looks in the trigger payload, I can't think of any good solution for that.

Suggestions welcome.