### PR TITLE
Implicit "key=value" command format support for action aliases

### DIFF
--- a/st2api/st2api/controllers/exp/aliasexecution.py
+++ b/st2api/st2api/controllers/exp/aliasexecution.py
@@ -66,7 +66,10 @@ class ActionAliasExecutionController(rest.RestController):
         return (tokens[0], tokens[1] if len(tokens) > 1 else None)
 
     def _extract_parameters(self, action_alias_db, param_stream):
-        alias_format = action_alias_db.formats[0]
+        if action_alias_db.formats:
+            alias_format = action_alias_db.formats[0]
+        else:
+            alias_format = None
         parser = action_alias_utils.ActionAliasFormatParser(alias_format=alias_format,
                                                             param_stream=param_stream)
         return parser.get_extracted_param_value()

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -433,7 +433,7 @@ class ActionAliasAPI(BaseAPI):
         model.pack = alias.pack
         model.ref = ResourceReference.to_string_reference(pack=model.pack, name=model.name)
         model.action_ref = alias.action_ref
-        model.formats = alias.formats
+        model.formats = getattr(alias, 'formats', [])
         return model
 
 

--- a/st2common/st2common/models/utils/action_alias_utils.py
+++ b/st2common/st2common/models/utils/action_alias_utils.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import re
+import shlex
 
 from st2common.exceptions import content
 
@@ -122,7 +122,22 @@ class KeyValueActionAliasFormatParser(object):
         self._param_stream = param_stream or ''
 
     def parse(self):
-        result = dict(re.findall(r'([^=\s,]+)=([^=\s,]+)', self._param_stream))
+        result = {}
+
+        try:
+            tokens = shlex.split(self._param_stream)
+        except ValueError:
+            return result
+
+        for token in tokens:
+            split = token.split('=', 1)
+
+            if len(split) != 2:
+                continue
+
+            key, value = split
+
+            result[key] = value
         return result
 
 

--- a/st2common/st2common/models/utils/action_alias_utils.py
+++ b/st2common/st2common/models/utils/action_alias_utils.py
@@ -13,7 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 from st2common.exceptions import content
+
+__all__ = [
+    'JsonValueParser',
+    'StringValueParser',
+    'DefaultParser',
+
+    'KeyValueActionAliasFormatParser',
+    'ActionAliasFormatParser'
+]
 
 
 class JsonValueParser(object):
@@ -98,14 +109,31 @@ class DefaultParser(object):
 PARSERS = [JsonValueParser, StringValueParser, DefaultParser]
 
 
+class KeyValueActionAliasFormatParser(object):
+    """
+    Parser which parses action parameters in the format of "key=value" from the provided param
+    string.
+    """
+
+    delimiter = '='
+
+    def __init__(self, alias_format, param_stream=None):
+        self._format_stream = alias_format
+        self._param_stream = param_stream or ''
+
+    def parse(self):
+        result = dict(re.findall(r'([^=\s,]+)=([^=\s,]+)', self._param_stream))
+        return result
+
+
 class ActionAliasFormatParser(object):
 
     FORMAT_MARKER_START = '{{'
     FORMAT_MARKER_END = '}}'
     PARAM_DEFAULT_VALUE_SEPARATOR = '='
 
-    def __init__(self, alias_format, param_stream):
-        self._format = alias_format
+    def __init__(self, alias_format=None, param_stream=None):
+        self._format = alias_format or ''
         self._param_stream = param_stream or ''
         self._alias_fmt_ptr = 0
         self._param_strm_ptr = 0
@@ -145,7 +173,19 @@ class ActionAliasFormatParser(object):
         return param_name, value if value else default_value
 
     def get_extracted_param_value(self):
-        return {name: value for name, value in self}
+        result = {}
+
+        # First extract key=value params provided in the param string
+        kv_parser = KeyValueActionAliasFormatParser(alias_format=self._format,
+                                                    param_stream=self._param_stream)
+        kv_params = kv_parser.parse()
+        result.update(kv_params)
+
+        # Second extract params using the defined param formats
+        other_params = {name: value for name, value in self}
+        result.update(other_params)
+
+        return result
 
     def _get_next_param_format(self):
         mrkr_strt_ps = self._format.index(self.FORMAT_MARKER_START, self._alias_fmt_ptr)

--- a/st2common/tests/unit/test_action_alias_utils.py
+++ b/st2common/tests/unit/test_action_alias_utils.py
@@ -147,6 +147,47 @@ class TestJsonValueParser(TestCase):
 
 
 class TestActionAliasParser(TestCase):
+    def test_default_key_value_param_parsing(self):
+        # Empty string
+        alias_format = ''
+        param_stream = ''
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {})
+
+        # 1 key value pair provided in the param stream
+        alias_format = ''
+        param_stream = 'a=foobar1'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'a': 'foobar1'})
+
+        alias_format = ''
+        param_stream = 'foo a=foobar2 poonies bar'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'a': 'foobar2'})
+
+        # Multiple params provided
+        alias_format = ''
+        param_stream = 'a=foobar1 b=boobar2 c=coobar3'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'a': 'foobar1', 'b': 'boobar2', 'c': 'coobar3'})
+
+        # Multiple params provided
+        alias_format = ''
+        param_stream = 'a=foobar4 b=boobar5 c=coobar6'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'a': 'foobar4', 'b': 'boobar5', 'c': 'coobar6'})
+
+        # Multiple params provided
+        alias_format = ''
+        param_stream = 'mixed a=foobar1 some more b=boobar2 text c=coobar3 yeah'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'a': 'foobar1', 'b': 'boobar2', 'c': 'coobar3'})
 
     def testSimpleParsing(self):
         alias_format = 'skip {{a}} more skip {{b}} and skip more.'
@@ -182,35 +223,6 @@ class TestActionAliasParser(TestCase):
         parser = ActionAliasFormatParser(alias_format, param_stream)
         extracted_values = parser.get_extracted_param_value()
         self.assertEqual(extracted_values, {'a': '{"a": "b", "c": "d"}', 'b': 'x'})
-
-    def test_mixed_parsing_with_default_values(self):
-        # All default values
-        alias_format = '!foo a={{ a=None }} b={{ b=10 }} c={{ c=foo }}'
-        param_stream = '!foo'
-        parser = ActionAliasFormatParser(alias_format, param_stream)
-        extracted_values = parser.get_extracted_param_value()
-        self.assertEqual(extracted_values, {'a': None, 'b': '10', 'c': 'foo'})
-
-        # a provided
-        alias_format = '!foo a={{ a=None }} b={{ b=10 }} c={{ c=foo }}'
-        param_stream = '!foo a=ponies'
-        parser = ActionAliasFormatParser(alias_format, param_stream)
-        extracted_values = parser.get_extracted_param_value()
-        self.assertEqual(extracted_values, {'a': 'ponies', 'b': '10', 'c': 'foo'})
-
-        # b provided
-        alias_format = '!foo a={{ a=None }} b={{ b=10 }} c={{ c=foo }}'
-        param_stream = '!foo b=20'
-        parser = ActionAliasFormatParser(alias_format, param_stream)
-        extracted_values = parser.get_extracted_param_value()
-        self.assertEqual(extracted_values, {'a': None, 'b': '20', 'c': 'foo'})
-
-        # All values provided
-        alias_format = '!foo a={{ a=None }} b={{ b=10 }} c={{ c=foo }}'
-        param_stream = '!foo a=ponies b=5 c=bar'
-        parser = ActionAliasFormatParser(alias_format, param_stream)
-        extracted_values = parser.get_extracted_param_value()
-        self.assertEqual(extracted_values, {'a': 'ponies', 'b': '5', 'c': 'bar'})
 
     def test_stream_is_none_with_all_default_values(self):
         alias_format = 'skip {{d=test}} more skip {{e=test}}.'

--- a/st2common/tests/unit/test_action_alias_utils.py
+++ b/st2common/tests/unit/test_action_alias_utils.py
@@ -183,6 +183,35 @@ class TestActionAliasParser(TestCase):
         extracted_values = parser.get_extracted_param_value()
         self.assertEqual(extracted_values, {'a': '{"a": "b", "c": "d"}', 'b': 'x'})
 
+    def test_mixed_parsing_with_default_values(self):
+        # All default values
+        alias_format = '!foo a={{ a=None }} b={{ b=10 }} c={{ c=foo }}'
+        param_stream = '!foo'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'a': None, 'b': '10', 'c': 'foo'})
+
+        # a provided
+        alias_format = '!foo a={{ a=None }} b={{ b=10 }} c={{ c=foo }}'
+        param_stream = '!foo a=ponies'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'a': 'ponies', 'b': '10', 'c': 'foo'})
+
+        # b provided
+        alias_format = '!foo a={{ a=None }} b={{ b=10 }} c={{ c=foo }}'
+        param_stream = '!foo b=20'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'a': None, 'b': '20', 'c': 'foo'})
+
+        # All values provided
+        alias_format = '!foo a={{ a=None }} b={{ b=10 }} c={{ c=foo }}'
+        param_stream = '!foo a=ponies b=5 c=bar'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'a': 'ponies', 'b': '5', 'c': 'bar'})
+
     def test_stream_is_none_with_all_default_values(self):
         alias_format = 'skip {{d=test}} more skip {{e=test}}.'
         param_stream = None

--- a/st2common/tests/unit/test_action_alias_utils.py
+++ b/st2common/tests/unit/test_action_alias_utils.py
@@ -189,6 +189,34 @@ class TestActionAliasParser(TestCase):
         extracted_values = parser.get_extracted_param_value()
         self.assertEqual(extracted_values, {'a': 'foobar1', 'b': 'boobar2', 'c': 'coobar3'})
 
+        # Param with quotes, make sure they are stripped
+        alias_format = ''
+        param_stream = 'mixed a="foobar1"'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'a': 'foobar1'})
+
+        # Param with quotes, make sure they are stripped
+        alias_format = ''
+        param_stream = 'mixed a="foobar test" ponies a'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'a': 'foobar test'})
+
+        # Param with quotes, make sure they are stripped
+        alias_format = ''
+        param_stream = "mixed a='foobar1 ponies' test"
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'a': 'foobar1 ponies'})
+
+        # Param with quotes, make sure they are stripped
+        alias_format = ''
+        param_stream = 'mixed a="foobar1"'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'a': 'foobar1'})
+
     def testSimpleParsing(self):
         alias_format = 'skip {{a}} more skip {{b}} and skip more.'
         param_stream = 'skip a1 more skip b1 and skip more.'


### PR DESCRIPTION
This pull request adds support for implicit "key=value" command format for action aliases.

This means that by default, if you want to make action available via ChatOps, you just need to create an alias file and you don't need to define any format strings since the "key=value" format is available by default.

For example (alias definition):

```yaml
---
name: "st2-sensors-list"
action_ref: "st2.sensors.list"
description: "List available StackStorm sensors."
```

And lets say this action takes "pack" and "limit" parameter. With this change, the following command now works out of the box:

`!st2-sensors-list pack=examples limit=2`

They way it's implemented, we merge "key=value" parameters with parameters parsed from a custom format. 

This allows users to mix and match parameters and use commands like this:

Format:

```yaml
formats:
  - "actions from {{pack}}"
```

Command:

`list actions from examples limit=2`

I also plan to open a workroom pull request which documents this default format. Eventually we should also move some of those docs into this repo.

Related PRs:

* https://github.com/StackStorm/hubot-stanley/pull/10

![screenshot from 2015-05-18 21 17 50](https://cloud.githubusercontent.com/assets/125088/7688244/7222abec-fda3-11e4-8a4e-217f6d2f12bf.png)
