### PR TITLE
Allow users to correctly mix and match "format string" and "key=value" action alias parameters

### DIFF
--- a/st2common/st2common/models/utils/action_alias_utils.py
+++ b/st2common/st2common/models/utils/action_alias_utils.py
@@ -190,15 +190,15 @@ class ActionAliasFormatParser(object):
     def get_extracted_param_value(self):
         result = {}
 
-        # First extract key=value params provided in the param string
+        # First extract format params provided in the string (if any)
+        format_params = {name: value for name, value in self}
+        result.update(format_params)
+
+        # Second extract key=value params provided in the param string
         kv_parser = KeyValueActionAliasFormatParser(alias_format=self._format,
                                                     param_stream=self._param_stream)
         kv_params = kv_parser.parse()
         result.update(kv_params)
-
-        # Second extract params using the defined param formats
-        other_params = {name: value for name, value in self}
-        result.update(other_params)
 
         return result
 

--- a/st2common/tests/unit/test_action_alias_utils.py
+++ b/st2common/tests/unit/test_action_alias_utils.py
@@ -217,6 +217,25 @@ class TestActionAliasParser(TestCase):
         extracted_values = parser.get_extracted_param_value()
         self.assertEqual(extracted_values, {'a': 'foobar1'})
 
+        # Mixed format and kv params
+        alias_format = 'somestuff {{a}} more stuff {{b}}'
+        param_stream = 'somestuff a=foobar more stuff coobar'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'a': 'foobar', 'b': 'coobar'})
+
+        alias_format = 'somestuff {{a}} more stuff {{b}}'
+        param_stream = 'somestuff ponies more stuff coobar'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'a': 'ponies', 'b': 'coobar'})
+
+        alias_format = 'somestuff {{a}} more stuff {{b}}'
+        param_stream = 'somestuff ponies more stuff coobar b=foo'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'a': 'ponies', 'b': 'foo'})
+
     def testSimpleParsing(self):
         alias_format = 'skip {{a}} more skip {{b}} and skip more.'
         param_stream = 'skip a1 more skip b1 and skip more.'


### PR DESCRIPTION
Addresses the issue mentioned in this comment - https://github.com/StackStorm/st2/pull/1496#issuecomment-103560158