### PR TITLE
Add support for whitespaces in the action alias command names

### DIFF
--- a/st2api/st2api/controllers/exp/aliasexecution.py
+++ b/st2api/st2api/controllers/exp/aliasexecution.py
@@ -37,11 +37,12 @@ class ActionAliasExecutionController(rest.RestController):
 
     @jsexpose(body_cls=AliasExecutionAPI, status_code=http_client.OK)
     def post(self, payload):
-        alias_execution = payload.command if payload else None
-        if not alias_execution:
+        action_alias_name = payload.command if payload else None
+
+        if not action_alias_name:
             pecan.abort(http_client.BAD_REQUEST, 'Alias execution command should no non-empty.')
 
-        action_alias_name, leftover = self._tokenize_alias_execution(alias_execution)
+        arguments = payload.arguments or ''
 
         try:
             action_alias_db = ActionAlias.get_by_name(action_alias_name)
@@ -53,7 +54,7 @@ class ActionAliasExecutionController(rest.RestController):
             pecan.abort(http_client.NOT_FOUND, msg)
 
         execution_parameters = self._extract_parameters(action_alias_db=action_alias_db,
-                                                        param_stream=leftover)
+                                                        param_stream=arguments)
         notify = self._get_notify_field(payload)
         execution = self._schedule_execution(action_alias_db=action_alias_db,
                                              params=execution_parameters,

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -452,6 +452,11 @@ class AliasExecutionAPI(BaseAPI):
                 "description": "Name of the action alias.",
                 "required": True
             },
+            "arguments":{
+                "type": "string",
+                "description": "Command (action alias) arguments",
+                "required": False
+            },
             "user": {
                 "type": "string",
                 "description": "User that requested the execution.",


### PR DESCRIPTION
The title says it all.

In addition to that, tokenzation (splitting command string into command name and arguments) now also happens on the client and this data gets sent to the API endpoint.

See related PR for more information.

Related PRs:

* https://github.com/StackStorm/hubot-stanley/pull/11