### PR TITLE
WIP: token_perm_fix

### DIFF
--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -575,6 +575,7 @@ echo "# Starting St2 Services"
 st2ctl restart
 sleep 20
 ##This is a hack around a weird issue with actions getting stuck in scheduled state
+su stanley
 TOKEN=`st2 auth ${TEST_ACCOUNT_USERNAME} -p ${TEST_ACCOUNT_PASSWORD} | grep token | awk '{print $4}'`
 ST2_AUTH_TOKEN=${TOKEN} st2 run core.local date &> /dev/null
 ACTIONEXIT=$?
@@ -613,4 +614,5 @@ echo ""
 echo "st2 auth ${TEST_ACCOUNT_USERNAME} -p ${TEST_ACCOUNT_PASSWORD}"
 echo ""
 echo "For more information see http://docs.stackstorm.com/install/deploy.html#usage"
+exit 0
 exit 0


### PR DESCRIPTION
The test action run at the end of st2_deploy is causing permissions issues on the token file for the Stanley user.  It needs to be run as stanley, not root.