### PR TITLE
Update st2client so it doesn't explode if the user doesn't have read / write permissions to ~/.st2/token file

### DIFF
--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -369,6 +369,10 @@ class Shell(object):
         if not os.path.isfile(CACHED_TOKEN_PATH):
             return None
 
+        if not os.access(CACHED_TOKEN_PATH, os.R_OK):
+            # We don't have read access to the file with a cached token
+            return None
+
         with open(CACHED_TOKEN_PATH) as fp:
             data = fp.read()
 
@@ -397,6 +401,10 @@ class Shell(object):
         """
         if not os.path.isdir(ST2_CONFIG_DIRECTORY):
             os.makedirs(ST2_CONFIG_DIRECTORY)
+
+        if not os.access(CACHED_TOKEN_PATH, os.W_OK):
+            # We don't have write access to the file with a cached token
+            return None
 
         token = token_obj.token
         expire_timestamp = parse_isotime(token_obj.expiry)

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -476,7 +476,19 @@ class Shell(object):
         return result
 
 
+def setup_logging():
+    root = LOG
+    root.setLevel(logging.WARNING)
+
+    ch = logging.StreamHandler(sys.stderr)
+    ch.setLevel(logging.WARNING)
+    formatter = logging.Formatter('%(asctime)s  %(levelname)s - %(message)s')
+    ch.setFormatter(formatter)
+    root.addHandler(ch)
+
+
 def main(argv=sys.argv[1:]):
+    setup_logging()
     return Shell().run(argv)
 
 

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -371,6 +371,8 @@ class Shell(object):
 
         if not os.access(CACHED_TOKEN_PATH, os.R_OK):
             # We don't have read access to the file with a cached token
+            LOG.warn('User "%s" doesn\'t have read access to file "%s"' % (os.getlogin(),
+                                                                           CACHED_TOKEN_PATH))
             return None
 
         with open(CACHED_TOKEN_PATH) as fp:
@@ -404,6 +406,8 @@ class Shell(object):
 
         if not os.access(CACHED_TOKEN_PATH, os.W_OK):
             # We don't have write access to the file with a cached token
+            LOG.warn('User "%s" doesn\'t have write access to file "%s"' % (os.getlogin(),
+                                                                            CACHED_TOKEN_PATH))
             return None
 
         token = token_obj.token


### PR DESCRIPTION
If user doesn't have read and write permissions, we will now simply always authenticate and retrieve a new auth token on every CLI invocation instead of caching the retrieved token and re-using it on subsequent requests.