### PR TITLE
Support for improved ChatOps command format notation

### DIFF
--- a/st2api/st2api/controllers/exp/aliasexecution.py
+++ b/st2api/st2api/controllers/exp/aliasexecution.py
@@ -17,7 +17,6 @@ import jsonschema
 import pecan
 import six
 
-from mongoengine import ValidationError
 from pecan import rest
 from st2common import log as logging
 from st2common.models.api.base import jsexpose
@@ -26,7 +25,6 @@ from st2common.models.db.action import LiveActionDB, NotificationSchema, Notific
 from st2common.models.utils import action_alias_utils, action_param_utils
 from st2common.persistence.action import ActionAlias
 from st2common.services import action as action_service
-from st2common.exceptions.db import StackStormDBObjectNotFoundError
 
 
 http_client = six.moves.http_client

--- a/st2api/st2api/controllers/exp/aliasexecution.py
+++ b/st2api/st2api/controllers/exp/aliasexecution.py
@@ -37,10 +37,10 @@ class ActionAliasExecutionController(rest.RestController):
 
     @jsexpose(body_cls=AliasExecutionAPI, status_code=http_client.OK)
     def post(self, payload):
-        action_alias_name = payload.command if payload else None
+        action_alias_name = payload.name if payload else None
 
         if not action_alias_name:
-            pecan.abort(http_client.BAD_REQUEST, 'Alias execution command should no non-empty.')
+            pecan.abort(http_client.BAD_REQUEST, 'Alias execution "name" is required')
 
         arguments = payload.arguments or ''
 

--- a/st2api/st2api/controllers/exp/aliasexecution.py
+++ b/st2api/st2api/controllers/exp/aliasexecution.py
@@ -42,6 +42,7 @@ class ActionAliasExecutionController(rest.RestController):
         if not action_alias_name:
             pecan.abort(http_client.BAD_REQUEST, 'Alias execution "name" is required')
 
+        format = payload.format or ''
         command = payload.command or ''
 
         try:
@@ -54,6 +55,7 @@ class ActionAliasExecutionController(rest.RestController):
             pecan.abort(http_client.NOT_FOUND, msg)
 
         execution_parameters = self._extract_parameters(action_alias_db=action_alias_db,
+                                                        format=format,
                                                         param_stream=command)
         notify = self._get_notify_field(payload)
         execution = self._schedule_execution(action_alias_db=action_alias_db,
@@ -66,11 +68,12 @@ class ActionAliasExecutionController(rest.RestController):
         tokens = alias_execution.strip().split(' ', 1)
         return (tokens[0], tokens[1] if len(tokens) > 1 else None)
 
-    def _extract_parameters(self, action_alias_db, param_stream):
-        if action_alias_db.formats:
-            alias_format = action_alias_db.formats[0]
+    def _extract_parameters(self, action_alias_db, format, param_stream):
+        if action_alias_db.formats and format in action_alias_db.formats:
+            alias_format = format
         else:
             alias_format = None
+
         parser = action_alias_utils.ActionAliasFormatParser(alias_format=alias_format,
                                                             param_stream=param_stream)
         return parser.get_extracted_param_value()

--- a/st2api/st2api/controllers/exp/aliasexecution.py
+++ b/st2api/st2api/controllers/exp/aliasexecution.py
@@ -26,6 +26,7 @@ from st2common.models.db.action import LiveActionDB, NotificationSchema, Notific
 from st2common.models.utils import action_alias_utils, action_param_utils
 from st2common.persistence.action import ActionAlias
 from st2common.services import action as action_service
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
 
 
 http_client = six.moves.http_client
@@ -47,7 +48,7 @@ class ActionAliasExecutionController(rest.RestController):
 
         try:
             action_alias_db = ActionAlias.get_by_name(action_alias_name)
-        except ValidationError:
+        except ValueError:
             action_alias_db = None
 
         if not action_alias_db:

--- a/st2api/st2api/controllers/exp/aliasexecution.py
+++ b/st2api/st2api/controllers/exp/aliasexecution.py
@@ -42,7 +42,7 @@ class ActionAliasExecutionController(rest.RestController):
         if not action_alias_name:
             pecan.abort(http_client.BAD_REQUEST, 'Alias execution "name" is required')
 
-        arguments = payload.arguments or ''
+        command = payload.command or ''
 
         try:
             action_alias_db = ActionAlias.get_by_name(action_alias_name)
@@ -54,7 +54,7 @@ class ActionAliasExecutionController(rest.RestController):
             pecan.abort(http_client.NOT_FOUND, msg)
 
         execution_parameters = self._extract_parameters(action_alias_db=action_alias_db,
-                                                        param_stream=arguments)
+                                                        param_stream=command)
         notify = self._get_notify_field(payload)
         execution = self._schedule_execution(action_alias_db=action_alias_db,
                                              params=execution_parameters,

--- a/st2api/st2api/controllers/exp/aliasexecution.py
+++ b/st2api/st2api/controllers/exp/aliasexecution.py
@@ -37,11 +37,12 @@ class ActionAliasExecutionController(rest.RestController):
 
     @jsexpose(body_cls=AliasExecutionAPI, status_code=http_client.OK)
     def post(self, payload):
-        alias_execution = payload.command if payload else None
-        if not alias_execution:
+        action_alias_name = payload.command if payload else None
+
+        if not action_alias_name:
             pecan.abort(http_client.BAD_REQUEST, 'Alias execution command should no non-empty.')
 
-        action_alias_name, leftover = self._tokenize_alias_execution(alias_execution)
+        arguments = payload.arguments or ''
 
         try:
             action_alias_db = ActionAlias.get_by_name(action_alias_name)
@@ -53,7 +54,7 @@ class ActionAliasExecutionController(rest.RestController):
             pecan.abort(http_client.NOT_FOUND, msg)
 
         execution_parameters = self._extract_parameters(action_alias_db=action_alias_db,
-                                                        param_stream=leftover)
+                                                        param_stream=arguments)
         notify = self._get_notify_field(payload)
         execution = self._schedule_execution(action_alias_db=action_alias_db,
                                              params=execution_parameters,

--- a/st2api/tests/unit/controllers/exp/test_alias_execution.py
+++ b/st2api/tests/unit/controllers/exp/test_alias_execution.py
@@ -57,14 +57,17 @@ class TestAliasExecution(FunctionalTest):
     @mock.patch.object(action_service, 'request',
                        return_value=(None, DummyActionExecution(id_=1)))
     def testBasicExecution(self, request):
-        alias_execution = 'alias1 Lorem ipsum value1 dolor sit "value2 value3" amet.'
-        post_resp = self._do_post(alias_execution)
+        command = 'Lorem ipsum value1 dolor sit "value2 value3" amet.'
+        post_resp = self._do_post(alias_execution=self.alias1, command=command)
         self.assertEqual(post_resp.status_int, 200)
         expected_parameters = {'param1': 'value1', 'param2': 'value2 value3'}
         self.assertEquals(request.call_args[0][0].parameters, expected_parameters)
 
-    def _do_post(self, execution, expect_errors=False):
-        execution = {'command': execution,
+    def _do_post(self, alias_execution, command, expect_errors=False):
+        print alias_execution
+        execution = {'name': alias_execution.name,
+                     'format': alias_execution.formats[0],
+                     'command': command,
                      'user': 'stanley',
                      'source_channel': 'test',
                      'notification_channel': 'test'}

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -455,12 +455,12 @@ class AliasExecutionAPI(BaseAPI):
             "format": {
                 "type": "string",
                 "description": "Format string which matched.",
-                "required": False
+                "required": True
             },
             "command": {
                 "type": "string",
                 "description": "Command used in chat.",
-                "required": False
+                "required": True
             },
             "user": {
                 "type": "string",

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -449,10 +449,15 @@ class AliasExecutionAPI(BaseAPI):
         "properties": {
             "name": {
                 "type": "string",
-                "description": "Name of the action alias.",
+                "description": "Name of the action alias which matched.",
                 "required": True
             },
-            "command":{
+            "format": {
+                "type": "string",
+                "description": "Format string which matched.",
+                "required": False
+            },
+            "command": {
                 "type": "string",
                 "description": "Command used in chat.",
                 "required": False

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -452,6 +452,11 @@ class AliasExecutionAPI(BaseAPI):
                 "description": "Name of the action alias.",
                 "required": True
             },
+            "arguments":{
+                "type": "string",
+                "description": "Command (action alias) arguments",
+                "required": False
+            },
             "user": {
                 "type": "string",
                 "description": "User that requested the execution.",

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -433,7 +433,7 @@ class ActionAliasAPI(BaseAPI):
         model.pack = alias.pack
         model.ref = ResourceReference.to_string_reference(pack=model.pack, name=model.name)
         model.action_ref = alias.action_ref
-        model.formats = getattr(alias, 'formats', [])
+        model.formats = alias.formats
         return model
 
 
@@ -447,7 +447,7 @@ class AliasExecutionAPI(BaseAPI):
         "description": "Execution of an ActionAlias.",
         "type": "object",
         "properties": {
-            "command": {
+            "name": {
                 "type": "string",
                 "description": "Name of the action alias.",
                 "required": True

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -452,9 +452,9 @@ class AliasExecutionAPI(BaseAPI):
                 "description": "Name of the action alias.",
                 "required": True
             },
-            "arguments":{
+            "command":{
                 "type": "string",
-                "description": "Command (action alias) arguments",
+                "description": "Command used in chat.",
                 "required": False
             },
             "user": {


### PR DESCRIPTION
This pull request adds support for a more flexible and future-proof format for specifying ChatOps command.

`name` attribute is now only used as a primary key for a particular alias and the command format is specified using `formats` attribute.

This notation is more flexible and allows users to group related formats together in a single metadata file. Previously, if a user wanted to use formats which are specified bellow, they would need to create multiple alias metadata files.

Note: Getting this to work required moving more logic into the client which resulted in more coupling between the client and the server. Sadly there is no way around it if we want to support this notation with the current hubot approach.

Lets say we have the following alias definition:

```yaml
---
name: "st2_sensors_list"
action_ref: "st2.sensors.list"
description: "List available StackStorm sensors."
formats:
    - "list sensors"
    - "list sensors from {{ pack }}"
    - "sensors list"
```

With the definition above, the following commands now work:

```
!sensors list
!list sensors
!sensors list pack=examples
!list sensors from examples
!list sensors from examples limit=2
...
```

Related PRs:

* https://github.com/StackStorm/hubot-stanley/pull/14
* https://github.com/StackStorm/st2contrib/pull/212