### PR TITLE
[STORM-1339] Alias docs

### DIFF
--- a/contrib/packs/actions/install.meta.yaml
+++ b/contrib/packs/actions/install.meta.yaml
@@ -22,4 +22,4 @@
     register:
       type: "string"
       default: "actions"
-      description: "Possible options are all, sensors, actions, rules."
+      description: "Possible options are all, sensors, actions, rules, aliases."

--- a/contrib/packs/actions/load.yaml
+++ b/contrib/packs/actions/load.yaml
@@ -13,6 +13,6 @@
     register:
       type: "string"
       default: "actions"
-      description: "Possible options are all, sensors, actions, rules."
+      description: "Possible options are all, sensors, actions, rules, aliases."
     kwarg_op:
       immutable: true

--- a/docs/source/alias.rst
+++ b/docs/source/alias.rst
@@ -1,0 +1,132 @@
+Action Alias
+============
+
+Alias for an action in StackStorm. A simplified and more human readable representation
+of actions in StackStorm which are useful in text based interfaces like ChatOps.
+
+For now ActionAlias is only leveraged via ChatOps clients.
+
+Action Alias Structure
+^^^^^^^^^^^^^^^^^^^^^^
+
+Action aliases are content like actions, rules and sensors. They are also defined in yaml
+files and deployed via packs.
+
+e.g.
+
+.. code-block:: yaml
+    ---
+    name: "google_query"
+    action_ref: "google.get_search_results"
+    formats:
+      - "google {{query}}"
+
+
+In the above example ``google_query`` is an alias for ``google.get_search_results`` action. The
+supported format for the alias is specified in the ``formats`` field. A single alias can support
+multiple formats for the same action.
+
+Property description
+~~~~~~~~~~~~~~~~~~~~
+
+1. name : unique name of the alias.
+2. action_ref : reference to the action that is being aliased.
+3. formats : possible options for user to invoke action. Typically specified by the user in a textual
+             interface as supported by ChatOps.
+
+Location
+~~~~~~~~
+
+Action Aliases are supplied in packs as yaml files.
+
+.. code-block:: bash
+    packs/my_pack$ ls
+    actions  aliases  rules  sensors
+
+Each alias is a single yaml file with the alias and supporting multiple formats.
+
+Loading
+~~~~~~~
+
+When a pack is registered the aliases are not automatically loaded. To load all aliases use -
+
+.. code-block:: bash
+   st2ctl reload --register-aliases
+
+
+Supported formats
+^^^^^^^^^^^^^^^^^
+
+Aliases support following format structures.
+
+Basic
+~~~~~
+
+.. code:: yaml
+    formats:
+      - "google {{query}}"
+
+
+In this case if user were to provide ``google StackStorm``, via a ChatOps interface, the aliasing mechanism
+would interpret ``query = StackStorm``. The action google.get_search_results would be called with the
+parameters -
+
+.. code:: yaml
+   parameters:
+       query: StackStorm
+
+With default
+~~~~~~~~~~~~
+
+Using example -
+
+.. code:: yaml
+    formats:
+      - "google {{query=StackStorm}}"
+
+In this case the query has a default value assigned which will be used if not value is provided by user.
+Therefore,  simple ``google`` instead of ``google StackStorm`` would still result in assumption of the
+default value much like how an Action default parameter values are interpretted.
+
+
+Key-Value parameters
+~~~~~~~~~~~~~~~~~~~~
+
+Using example -
+
+.. code:: yaml
+    formats:
+      - "google {{query}}"
+
+It is possible to supply extra key value parameters like ``google StackStorm limit=10``. In this case even
+though ``limit`` does not appear in any alias format it will still be extracted and supplied for execution.
+In this the action google.get_search_results would be called with the parameters -
+
+.. code:: yaml
+   parameters:
+       query: StackStorm
+       limit: 10
+
+Multiple formats in single alias
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A single alias file allow multiple formats to be specified for a single alias e.g.
+
+.. code:: yaml
+    ---
+    name: "st2_sensors_list"
+    action_ref: "st2.sensors.list"
+    description: "List available StackStorm sensors."
+    formats:
+        - "list sensors"
+        - "list sensors from {{ pack }}"
+        - "sensors list"
+
+The above alias supports the following commands -
+
+.. code:: bash
+    !sensors list
+    !list sensors
+    !sensors list pack=examples
+    !list sensors from examples
+    !list sensors from examples limit=2

--- a/docs/source/aliases.rst
+++ b/docs/source/aliases.rst
@@ -15,6 +15,7 @@ files and deployed via packs.
 e.g.
 
 .. code-block:: yaml
+
     ---
     name: "google_query"
     action_ref: "google.get_search_results"
@@ -40,6 +41,7 @@ Location
 Action Aliases are supplied in packs as yaml files.
 
 .. code-block:: bash
+
     packs/my_pack$ ls
     actions  aliases  rules  sensors
 
@@ -51,6 +53,7 @@ Loading
 When a pack is registered the aliases are not automatically loaded. To load all aliases use -
 
 .. code-block:: bash
+
    st2ctl reload --register-aliases
 
 
@@ -62,16 +65,18 @@ Aliases support following format structures.
 Basic
 ~~~~~
 
-.. code:: yaml
+.. code-block:: yaml
+
     formats:
       - "google {{query}}"
 
 
 In this case if user were to provide ``google StackStorm``, via a ChatOps interface, the aliasing mechanism
-would interpret ``query = StackStorm``. The action google.get_search_results would be called with the
+would interpret ``query = StackStorm``. The action ``google.get_search_results`` would be called with the
 parameters -
 
-.. code:: yaml
+.. code-block:: yaml
+
    parameters:
        query: StackStorm
 
@@ -80,7 +85,8 @@ With default
 
 Using example -
 
-.. code:: yaml
+.. code-block:: yaml
+
     formats:
       - "google {{query=StackStorm}}"
 
@@ -94,7 +100,8 @@ Key-Value parameters
 
 Using example -
 
-.. code:: yaml
+.. code-block:: yaml
+
     formats:
       - "google {{query}}"
 
@@ -102,7 +109,8 @@ It is possible to supply extra key value parameters like ``google StackStorm lim
 though ``limit`` does not appear in any alias format it will still be extracted and supplied for execution.
 In this the action google.get_search_results would be called with the parameters -
 
-.. code:: yaml
+.. code-block:: yaml
+
    parameters:
        query: StackStorm
        limit: 10
@@ -112,7 +120,8 @@ Multiple formats in single alias
 
 A single alias file allow multiple formats to be specified for a single alias e.g.
 
-.. code:: yaml
+.. code-block:: yaml
+
     ---
     name: "st2_sensors_list"
     action_ref: "st2.sensors.list"
@@ -124,7 +133,8 @@ A single alias file allow multiple formats to be specified for a single alias e.
 
 The above alias supports the following commands -
 
-.. code:: bash
+.. code-block:: bash
+
     !sensors list
     !list sensors
     !sensors list pack=examples

--- a/docs/source/aliases.rst
+++ b/docs/source/aliases.rst
@@ -140,3 +140,10 @@ The above alias supports the following commands -
     !sensors list pack=examples
     !list sensors from examples
     !list sensors from examples limit=2
+
+ChatOps
+^^^^^^^
+
+To see how to use aliases with your favorite Chat client and implement ChatOps in your infrastructure
+go `here <https://github.com/StackStorm/st2/blob/master/instructables/chatops.md>_`.
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,6 +15,7 @@ Contents:
     runners
     rules
     sensors
+    aliases
     webhooks
     datastore
     workflows


### PR DESCRIPTION
Doc for aliases. This PR is general and not ChatOps specific but does liberally callout to ChatOps for example purposes.

This PR starts us off with having some docs for Action Alias. As we notice more behaviors and details or answer user question will add more content to the docs.