### PR TITLE
Temporarily silencing rule create and get tasks

### DIFF
--- a/contrib/tests/actions/chains/test_quickstart_rules.yaml
+++ b/contrib/tests/actions/chains/test_quickstart_rules.yaml
@@ -28,7 +28,7 @@ chain:
         params:
             env:
               ST2_AUTH_TOKEN: "{{token}}"
-            cmd: "st2 rule create /usr/share/doc/st2/examples/rules/sample_rule_with_webhook.yaml"
+            cmd: "st2 rule create /usr/share/doc/st2/examples/rules/sample_rule_with_webhook.yaml &> /dev/null"
         on-success: test_rule_list
     -
         name: test_rule_list
@@ -44,7 +44,7 @@ chain:
         params:
             env:
               ST2_AUTH_TOKEN: "{{token}}"
-            cmd: "st2 rule get {{ tested_rule }}"
+            cmd: "st2 rule get {{ tested_rule }} &> /dev/null"
         on-success: setup_post_to_web_hook_via_curl
     -
         name: setup_post_to_web_hook_via_curl


### PR DESCRIPTION
There is a bug with actiontrigger parsing when the nested object has Jinja templating.  This PR redirects output to /dev/null for the two tasks that have output that would trigger this bug.  This is a work-around until the platform bug is fixed.