### PR TITLE
Skip payload render

### DIFF
--- a/st2reactor/st2reactor/rules/datatransform.py
+++ b/st2reactor/st2reactor/rules/datatransform.py
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import copy
-import jinja2
 
 from st2common.constants.rules import TRIGGER_PAYLOAD_PREFIX
 from st2common.constants.system import SYSTEM_KV_PREFIX
@@ -37,15 +35,14 @@ class Jinja2BasedTransformer(object):
     def _construct_context(prefix, data, context):
         if data is None:
             return context
-        # setup initial context as system context to help resolve the original context
-        # which may itself contain references to system variables.
         context = {SYSTEM_KV_PREFIX: KeyValueLookup()}
-        template = jinja2.Template(json.dumps(data))
-        resolved_data = json.loads(template.render(context))
-        if resolved_data:
-            if prefix not in context:
-                context[prefix] = {}
-            context[prefix].update(resolved_data)
+        # add in the data in the context without any processing. Payload may
+        # contain renderable keys however those are often due to nature of the
+        # events being posted e.g. ActionTrigger with template variables. Rendering
+        # these values would lead to bugs in the data so best to avoid.
+        if prefix not in context:
+            context[prefix] = {}
+        context[prefix].update(data)
         return context
 
 

--- a/st2reactor/st2reactor/rules/enforcer.py
+++ b/st2reactor/st2reactor/rules/enforcer.py
@@ -37,7 +37,7 @@ class RuleEnforcer(object):
         try:
             self.data_transformer = get_transformer(trigger_instance.payload)
         except Exception as e:
-            message = ('Failed to template-ize trigger payload: %s. If the payload contains'
+            message = ('Failed to template-ize trigger payload: %s. If the payload contains '
                        'special characters such as "{{" which dont\'t reference value in '
                        'a datastore, those characters need to be escaped' % (str(e)))
             raise ValueError(message)

--- a/st2reactor/tests/unit/test_data_transform.py
+++ b/st2reactor/tests/unit/test_data_transform.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
-
 from st2tests import DbTestCase
 from st2common.models.db.keyvalue import KeyValuePairDB
 from st2common.persistence.keyvalue import KeyValuePair
@@ -22,9 +20,6 @@ from st2reactor.rules import datatransform
 
 
 PAYLOAD = {'k1': 'v1', 'k2': 'v2', 'k3': 3, 'k4': True, 'k5': {'foo': 'bar'}, 'k6': [1, 3]}
-
-PAYLOAD_WITH_KVP = copy.copy(PAYLOAD)
-PAYLOAD_WITH_KVP.update({'k5': '{{system.k5}}'})
 
 
 class DataTransformTest(DbTestCase):
@@ -71,12 +66,12 @@ class DataTransformTest(DbTestCase):
         k6 = KeyValuePair.add_or_update(KeyValuePairDB(name='k6', value='v6'))
         k7 = KeyValuePair.add_or_update(KeyValuePairDB(name='k7', value='v7'))
         try:
-            transformer = datatransform.get_transformer(PAYLOAD_WITH_KVP)
-            mapping = {'ip5': '{{trigger.k5}}-static',
+            transformer = datatransform.get_transformer(PAYLOAD)
+            mapping = {'ip5': '{{trigger.k2}}-static',
                        'ip6': '{{system.k6}}-static',
                        'ip7': '{{system.k7}}-static'}
             result = transformer(mapping)
-            expected = {'ip5': 'v5-static',
+            expected = {'ip5': 'v2-static',
                         'ip6': 'v6-static',
                         'ip7': 'v7-static'}
             self.assertEqual(result, expected)


### PR DESCRIPTION
Payload render in cases where the payload itself contains tokens from a rule etc is incorrect and also causes failure.

Apart from that there is no real reason to render these token. If a value is to be rendered eventually that will be handled at actionexecution time anyway.