### PR TITLE
Adding console based logger configs

### DIFF
--- a/st2actions/conf/console.conf
+++ b/st2actions/conf/console.conf
@@ -1,0 +1,23 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=consoleHandler
+
+[formatters]
+keys=simpleConsoleFormatter
+
+[logger_root]
+level=INFO
+handlers=consoleHandler
+
+[handler_consoleHandler]
+class=StreamHandler
+level=DEBUG
+formatter=simpleConsoleFormatter
+args=(sys.stdout,)
+
+[formatter_simpleConsoleFormatter]
+class=st2common.logging.formatters.ConsoleLogFormatter
+format=%(asctime)s %(levelname)s [-] %(message)s
+datefmt=

--- a/st2api/conf/console.conf
+++ b/st2api/conf/console.conf
@@ -1,0 +1,23 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=consoleHandler
+
+[formatters]
+keys=simpleConsoleFormatter
+
+[logger_root]
+level=INFO
+handlers=consoleHandler
+
+[handler_consoleHandler]
+class=StreamHandler
+level=DEBUG
+formatter=simpleConsoleFormatter
+args=(sys.stdout,)
+
+[formatter_simpleConsoleFormatter]
+class=st2common.logging.formatters.ConsoleLogFormatter
+format=%(asctime)s %(levelname)s [-] %(message)s
+datefmt=

--- a/st2auth/conf/console.conf
+++ b/st2auth/conf/console.conf
@@ -1,0 +1,23 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=consoleHandler
+
+[formatters]
+keys=simpleConsoleFormatter
+
+[logger_root]
+level=INFO
+handlers=consoleHandler
+
+[handler_consoleHandler]
+class=StreamHandler
+level=DEBUG
+formatter=simpleConsoleFormatter
+args=(sys.stdout,)
+
+[formatter_simpleConsoleFormatter]
+class=st2common.logging.formatters.ConsoleLogFormatter
+format=%(asctime)s %(levelname)s [-] %(message)s
+datefmt=

--- a/st2reactor/conf/console.conf
+++ b/st2reactor/conf/console.conf
@@ -1,0 +1,23 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=consoleHandler
+
+[formatters]
+keys=simpleConsoleFormatter
+
+[logger_root]
+level=INFO
+handlers=consoleHandler
+
+[handler_consoleHandler]
+class=StreamHandler
+level=DEBUG
+formatter=simpleConsoleFormatter
+args=(sys.stdout,)
+
+[formatter_simpleConsoleFormatter]
+class=st2common.logging.formatters.ConsoleLogFormatter
+format=%(asctime)s %(levelname)s [-] %(message)s
+datefmt=


### PR DESCRIPTION
This commit adds console logger configs to each of the components
within this project. These configs are meant to be used with
containerized configurations, where log messages are piped only
to STDOUT as general practice. (See http://12factor.net/logs)