### PR TITLE
Action alias CLI commands and minor consistency changes

### DIFF
--- a/st2api/st2api/controllers/exp/actionalias.py
+++ b/st2api/st2api/controllers/exp/actionalias.py
@@ -30,7 +30,7 @@ http_client = six.moves.http_client
 LOG = logging.getLogger(__name__)
 
 
-class ActionAliasController(resource.ResourceController):
+class ActionAliasController(resource.ContentPackResourceController):
     """
         Implements the RESTful interface for ActionAliases.
     """
@@ -43,16 +43,6 @@ class ActionAliasController(resource.ResourceController):
     query_options = {
         'sort': ['name']
     }
-
-    @jsexpose(arg_types=[str])
-    def get_one(self, name_or_id):
-        try:
-            action_alias_db = self._get_by_name_or_id(name_or_id=name_or_id)
-        except Exception as e:
-            LOG.exception('Unable to find requested object.')
-            pecan.abort(http_client.NOT_FOUND, e.message)
-            return
-        return self.model.from_model(action_alias_db)
 
     @jsexpose(body_cls=ActionAliasAPI, status_code=http_client.CREATED)
     def post(self, action_alias):

--- a/st2api/st2api/controllers/exp/actionalias.py
+++ b/st2api/st2api/controllers/exp/actionalias.py
@@ -37,11 +37,12 @@ class ActionAliasController(resource.ContentPackResourceController):
     model = ActionAliasAPI
     access = ActionAlias
     supported_filters = {
-        'name': 'name'
+        'name': 'name',
+        'pack': 'pack'
     }
 
     query_options = {
-        'sort': ['name']
+        'sort': ['pack', 'name']
     }
 
     @jsexpose(body_cls=ActionAliasAPI, status_code=http_client.CREATED)
@@ -74,19 +75,19 @@ class ActionAliasController(resource.ContentPackResourceController):
         return action_alias_api
 
     @jsexpose(arg_types=[str], body_cls=ActionAliasAPI)
-    def put(self, action_alias_id, action_alias):
-        action_alias_db = self._get_one(ref_or_id=action_alias_id)
-        LOG.debug('PUT /actionalias/ lookup with id=%s found object: %s', action_alias_id,
+    def put(self, action_alias_ref_or_id, action_alias):
+        action_alias_db = self._get_by_ref_or_id(ref_or_id=action_alias_ref_or_id)
+        LOG.debug('PUT /actionalias/ lookup with id=%s found object: %s', action_alias_ref_or_id,
                   action_alias_db)
 
         try:
             if action_alias.id is not None and action_alias.id is not '' and \
-               action_alias.id != action_alias_id:
+               action_alias.id != action_alias_ref_or_id:
                 LOG.warning('Discarding mismatched id=%s found in payload and using uri_id=%s.',
-                            action_alias.id, action_alias_id)
+                            action_alias.id, action_alias_ref_or_id)
             old_action_alias_db = action_alias_db
             action_alias_db = ActionAliasAPI.to_model(action_alias)
-            action_alias_db.id = action_alias_id
+            action_alias_db.id = action_alias_ref_or_id
             action_alias_db = ActionAlias.add_or_update(action_alias_db)
         except (ValidationError, ValueError) as e:
             LOG.exception('Validation failed for action alias data=%s', action_alias)
@@ -100,21 +101,21 @@ class ActionAliasController(resource.ContentPackResourceController):
         return action_alias_api
 
     @jsexpose(arg_types=[str], status_code=http_client.NO_CONTENT)
-    def delete(self, action_alias_id):
+    def delete(self, action_alias_ref_or_id):
         """
             Delete an action alias.
 
             Handles requests:
                 DELETE /actionalias/1
         """
-        action_alias_db = self._get_one(ref_or_id=action_alias_id)
-        LOG.debug('DELETE /actionalias/ lookup with id=%s found object: %s', action_alias_id,
+        action_alias_db = self._get_by_ref_or_id(ref_or_id=action_alias_ref_or_id)
+        LOG.debug('DELETE /actionalias/ lookup with id=%s found object: %s', action_alias_ref_or_id,
                   action_alias_db)
         try:
             ActionAlias.delete(action_alias_db)
         except Exception as e:
             LOG.exception('Database delete encountered exception during delete of id="%s".',
-                          action_alias_id)
+                          action_alias_ref_or_id)
             pecan.abort(http_client.INTERNAL_SERVER_ERROR, str(e))
             return
 

--- a/st2api/st2api/controllers/exp/actionalias.py
+++ b/st2api/st2api/controllers/exp/actionalias.py
@@ -75,7 +75,7 @@ class ActionAliasController(resource.ContentPackResourceController):
 
     @jsexpose(arg_types=[str], body_cls=ActionAliasAPI)
     def put(self, action_alias_id, action_alias):
-        action_alias_db = self._get_one(action_alias_id)
+        action_alias_db = self._get_one(ref_or_id=action_alias_id)
         LOG.debug('PUT /actionalias/ lookup with id=%s found object: %s', action_alias_id,
                   action_alias_db)
 
@@ -107,7 +107,7 @@ class ActionAliasController(resource.ContentPackResourceController):
             Handles requests:
                 DELETE /actionalias/1
         """
-        action_alias_db = self._get_by_id(action_alias_id)
+        action_alias_db = self._get_one(ref_or_id=action_alias_id)
         LOG.debug('DELETE /actionalias/ lookup with id=%s found object: %s', action_alias_id,
                   action_alias_db)
         try:

--- a/st2api/st2api/controllers/exp/aliasexecution.py
+++ b/st2api/st2api/controllers/exp/aliasexecution.py
@@ -51,8 +51,14 @@ class ActionAliasExecutionController(rest.RestController):
             action_alias_db = None
 
         if not action_alias_db:
-            msg = 'Unable to identify action alias with name "%s".' % action_alias_name
+            msg = 'Unable to identify action alias with name "%s".' % (action_alias_name)
             pecan.abort(http_client.NOT_FOUND, msg)
+            return
+
+        if not action_alias_db.enabled:
+            msg = 'Action alias with name "%s" is disabled.' % (action_alias_name)
+            pecan.abort(http_client.BAD_REQUEST, msg)
+            return
 
         execution_parameters = self._extract_parameters(action_alias_db=action_alias_db,
                                                         format=format,

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -166,7 +166,7 @@ class ResourceController(rest.RestController):
             resource_db = self._get_by_name(resource_name=name_or_id)
 
         if not resource_db:
-            msg = 'Resource with a name of id "%s" not found' % (name_or_id)
+            msg = 'Resource with a name or id "%s" not found' % (name_or_id)
             raise Exception(msg)
 
         return resource_db
@@ -248,7 +248,7 @@ class ContentPackResourceController(ResourceController):
             resource_db = self._get_by_id(resource_id=ref_or_id)
 
         if not resource_db:
-            msg = 'Resource with a reference of id "%s" not found' % (ref_or_id)
+            msg = 'Resource with a reference or id "%s" not found' % (ref_or_id)
             raise Exception(msg)
 
         return resource_db

--- a/st2api/tests/unit/controllers/exp/test_action_alias.py
+++ b/st2api/tests/unit/controllers/exp/test_action_alias.py
@@ -59,7 +59,7 @@ class TestActionAlias(FunctionalTest):
                          'Incorrect aliases retrieved.')
 
     def test_get_one(self):
-        resp = self.app.get('/exp/actionalias/%s' % self.alias1.name)
+        resp = self.app.get('/exp/actionalias/%s' % self.alias1.id)
         self.assertEqual(resp.status_int, 200)
         self.assertEqual(resp.json['name'], self.alias1.name,
                          'Incorrect aliases retrieved.')
@@ -68,7 +68,7 @@ class TestActionAlias(FunctionalTest):
         post_resp = self._do_post(vars(ActionAliasAPI.from_model(self.alias3)))
         self.assertEqual(post_resp.status_int, 201)
 
-        get_resp = self.app.get('/exp/actionalias/%s' % post_resp.json['name'])
+        get_resp = self.app.get('/exp/actionalias/%s' % post_resp.json['id'])
         self.assertEqual(get_resp.status_int, 200)
         self.assertEqual(get_resp.json['name'], self.alias3.name,
                          'Incorrect aliases retrieved.')
@@ -76,7 +76,7 @@ class TestActionAlias(FunctionalTest):
         del_resp = self.__do_delete(post_resp.json['id'])
         self.assertEqual(del_resp.status_int, 204)
 
-        get_resp = self.app.get('/exp/actionalias/%s' % post_resp.json['name'], expect_errors=True)
+        get_resp = self.app.get('/exp/actionalias/%s' % post_resp.json['id'], expect_errors=True)
         self.assertEqual(get_resp.status_int, 404)
 
     def _do_post(self, actionalias, expect_errors=False):

--- a/st2client/st2client/client.py
+++ b/st2client/st2client/client.py
@@ -18,6 +18,7 @@ import logging
 
 from st2client import models
 from st2client.models.core import ResourceManager
+from st2client.models.core import ActionAliasResourceManager
 from st2client.models.core import LiveActionResourceManager
 
 
@@ -81,6 +82,8 @@ class Client(object):
             models.RunnerType, self.endpoints['api'], cacert=self.cacert, debug=self.debug)
         self.managers['Action'] = ResourceManager(
             models.Action, self.endpoints['api'], cacert=self.cacert, debug=self.debug)
+        self.managers['ActionAlias'] = ActionAliasResourceManager(
+            models.ActionAlias, self.endpoints['api'], cacert=self.cacert, debug=self.debug)
         self.managers['LiveAction'] = LiveActionResourceManager(
             models.LiveAction, self.endpoints['api'], cacert=self.cacert, debug=self.debug)
         self.managers['Policy'] = ResourceManager(

--- a/st2client/st2client/commands/action_alias.py
+++ b/st2client/st2client/commands/action_alias.py
@@ -1,0 +1,65 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from st2client.models.action_alias import ActionAlias
+from st2client.commands import resource
+from st2client.commands.resource import add_auth_token_to_kwargs_from_cli
+from st2client.formatters import table
+
+__all__ = [
+    'ActionAliasBranch'
+]
+
+
+class ActionAliasBranch(resource.ResourceBranch):
+    def __init__(self, description, app, subparsers, parent_parser=None):
+        super(ActionAliasBranch, self).__init__(
+            ActionAlias, description, app, subparsers,
+            parent_parser=parent_parser, read_only=True,
+            commands={
+                'list': ActionAliasListCommand,
+            })
+
+
+class ActionAliasListCommand(resource.ResourceCommand):
+    display_attributes = ['ref', 'pack', 'name', 'description', 'enabled', 'formats']
+    attribute_transform_functions = {}
+
+    def __init__(self, resource, *args, **kwargs):
+        super(ActionAliasListCommand, self).__init__(
+            resource, 'list', 'Get the list of the %s' %
+            (resource.get_plural_display_name().lower()),
+            *args, **kwargs)
+
+        # Display options
+        self.parser.add_argument('-a', '--attr', nargs='+',
+                                 default=self.display_attributes,
+                                 help=('List of attributes to include in the '
+                                       'output. "all" will return all '
+                                       'attributes.'))
+        self.parser.add_argument('-w', '--width', nargs='+', type=int,
+                                 default=None,
+                                 help=('Set the width of columns in output.'))
+
+    @add_auth_token_to_kwargs_from_cli
+    def run(self, args, **kwargs):
+        return self.manager.query(**kwargs)
+
+    def run_and_print(self, args, **kwargs):
+        result = self.run(args, **kwargs)
+        self.print_output(result, table.MultiColumnTable,
+                          attributes=args.attr, widths=args.width,
+                          json=args.json,
+                          attribute_transform_functions=self.attribute_transform_functions)

--- a/st2client/st2client/commands/action_alias.py
+++ b/st2client/st2client/commands/action_alias.py
@@ -29,12 +29,12 @@ class ActionAliasBranch(resource.ResourceBranch):
             ActionAlias, description, app, subparsers,
             parent_parser=parent_parser, read_only=True,
             commands={
-                'list': ActionAliasListCommand,
+                'list': ActionAliasListCommand
             })
 
 
 class ActionAliasListCommand(resource.ResourceCommand):
-    display_attributes = ['ref', 'pack', 'name', 'description', 'enabled', 'formats']
+    display_attributes = ['ref', 'pack', 'name', 'description', 'enabled']
     attribute_transform_functions = {}
 
     def __init__(self, resource, *args, **kwargs):

--- a/st2client/st2client/models/action_alias.py
+++ b/st2client/st2client/models/action_alias.py
@@ -21,7 +21,7 @@ __all__ = [
 
 
 class ActionAlias(core.Resource):
-    _alias = 'ActionAlias'
+    _alias = 'Action-Alias'
     _display_name = 'Action Alias'
     _plural = 'ActionAliases'
     _plural_display_name = 'Runners'

--- a/st2client/st2client/models/action_alias.py
+++ b/st2client/st2client/models/action_alias.py
@@ -13,11 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from st2client.models.core import *         # noqa
-from st2client.models.auth import *       # noqa
-from st2client.models.action import *       # noqa
-from st2client.models.action_alias import *  # noqa
-from st2client.models.keyvalue import *    # noqa
-from st2client.models.policy import *       # noqa
-from st2client.models.reactor import *      # noqa
-from st2client.models.webhook import *      # noqa
+from st2client.models import core
+
+__all__ = [
+    'ActionAlias'
+]
+
+
+class ActionAlias(core.Resource):
+    _alias = 'ActionAlias'
+    _display_name = 'Action Alias'
+    _plural = 'ActionAliases'
+    _plural_display_name = 'Runners'
+    _url_path = 'actionalias'
+    _repr_attributes = ['name', 'pack', 'action_ref']

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -307,6 +307,14 @@ class ResourceManager(object):
         return True
 
 
+class ActionAliasResourceManager(ResourceManager):
+    def __init__(self, resource, endpoint, cacert=None, debug=False):
+        endpoint = endpoint.replace('v1', 'exp')
+        self.resource = resource
+        self.debug = debug
+        self.client = httpclient.HTTPClient(root=endpoint, cacert=cacert, debug=debug)
+
+
 class LiveActionResourceManager(ResourceManager):
     @add_auth_token_to_kwargs_from_env
     def re_run(self, execution_id, parameters=None, **kwargs):

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -36,6 +36,7 @@ from st2client import models
 from st2client.client import Client
 from st2client.commands import auth
 from st2client.commands import action
+from st2client.commands import action_alias
 from st2client.commands import keyvalue
 from st2client.commands import policy
 from st2client.commands import resource
@@ -175,6 +176,10 @@ class Shell(object):
 
         self.commands['action'] = action.ActionBranch(
             'An activity that happens as a response to the external event.',
+            self, self.subparsers)
+
+        self.commands['action-alias'] = action_alias.ActionAliasBranch(
+            'Action aliases.',
             self, self.subparsers)
 
         self.commands['auth'] = auth.TokenCreateCommand(

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -47,6 +47,7 @@ register_opts()
 
 
 def register_sensors():
+    registered_count = 0
     try:
         LOG.info('=========================================================')
         LOG.info('############## Registering sensors ######################')
@@ -64,6 +65,8 @@ def register_sensors():
 def register_actions():
     # Register runnertypes and actions. The order is important because actions require action
     # types to be present in the system.
+    registered_count = 0
+
     try:
         LOG.info('=========================================================')
         LOG.info('############## Registering actions ######################')
@@ -73,7 +76,6 @@ def register_actions():
         import st2actions.bootstrap.runnersregistrar as runners_registrar
         runners_registrar.register_runner_types(experimental=cfg.CONF.experimental)
     except Exception as e:
-        registered_count = 0
         LOG.warning('Failed to register runner types: %s', e, exc_info=True)
         LOG.warning('Not registering stock runners .')
     else:
@@ -90,6 +92,8 @@ def register_actions():
 
 def register_rules():
     # Register rules.
+    registered_count = 0
+
     try:
         LOG.info('=========================================================')
         LOG.info('############## Registering rules ########################')
@@ -106,6 +110,7 @@ def register_rules():
 
 def register_aliases():
     # Register rules.
+    registered_count = 0
     try:
         LOG.info('=========================================================')
         LOG.info('############## Registering aliases ######################')

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -414,6 +414,11 @@ class ActionAliasAPI(BaseAPI):
                 "type": "string",
                 "description": "Description of the action alias."
             },
+            "enabled": {
+                "description": "Flag indicating of action alias is enabled.",
+                "type": "boolean",
+                "default": True
+            },
             "action_ref": {
                 "type": "string",
                 "description": "Reference to the aliased action.",
@@ -433,6 +438,7 @@ class ActionAliasAPI(BaseAPI):
         model = super(cls, cls).to_model(alias)
         model.name = alias.name
         model.pack = alias.pack
+        model.enabled = getattr(alias, 'enabled', True)
         model.ref = ResourceReference.to_string_reference(pack=model.pack, name=model.name)
         model.action_ref = alias.action_ref
         model.formats = alias.formats

--- a/st2common/st2common/models/db/actionalias.py
+++ b/st2common/st2common/models/db/actionalias.py
@@ -37,6 +37,9 @@ class ActionAliasDB(stormbase.StormBaseDB):
     pack = me.StringField(
         required=True,
         help_text='Name of the content pack.')
+    enabled = me.BooleanField(
+        required=True, default=True,
+        help_text='A flag indicating whether the action alias is enabled.')
     action_ref = me.StringField(
         required=True,
         help_text='Reference of the Action map this alias.')


### PR DESCRIPTION
This pull request adds CLI comments for viewing action aliases (list, get).

In addition to that, I made some other changes so it's consistent with other content pack resources (actions, rules, etc.):

* Also allow user to retrieve action alias by ref
* Update supported query param filters
* Add `enabled` attribute to the ActionAlias model