### PR TITLE
RFR: Support for st2 triggerinstance (get | list)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ in development
 * Add new API endpoint for re-running an execution (``POST /executions/<id>/re_run/``).
   (new-feature)
 * Rules should be part of a pack. (improvement)
+* CLI now has ``get`` and ``list`` commands for triggerinstance. (new-feature)
 
 v0.9.1 - May 12, 2015
 ---------------------

--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -372,6 +372,35 @@ Output:
     === RULE DOES NOT MATCH ===
     1
 
+If you are debugging and would like to see the list of trigger instances sent to |st2|,
+you can use the CLI to do so.
+
+..  code-block:: bash
+
+  st2 triggerinstance list
+
+You can also filter trigger instances by trigger.
+
+.. code-block:: bash
+
+  st2 triggerinstance list --trigger=core.f9e09284-b2b1-4127-aedd-dcde7a752819
+
+
+Also, you can get trigger instances within a time range by using ``timestamp_gt`` and ``timestamp_lt`` filter
+options.
+
+.. code-block:: bash
+
+  st2 triggerinstance list --trigger="core.f9e09284-b2b1-4127-aedd-dcde7a752819" -timestamp_gt=2015-06-01T12:00:00Z -timestamp_lt=2015-06-02T12:00:00Z
+
+Note that you can also specify one of ``timestamp_lt`` or ``timestamp_gt`` too. You can
+get details about a trigger instance by using ``get``.
+
+.. code-block:: bash
+
+  st2 triggerinstance get 556e135232ed35569ff23238
+
+
 Timers
 ------
 

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -18,16 +18,17 @@ from pecan import abort
 from pecan.rest import RestController
 import six
 
+from st2api.controllers import resource
 from st2common import log as logging
 from st2common.models.api.trigger import TriggerTypeAPI, TriggerAPI, TriggerInstanceAPI
 from st2common.models.api.base import jsexpose
 from st2common.models.system.common import ResourceReference
 from st2common.persistence.trigger import TriggerType, Trigger, TriggerInstance
 from st2common.services import triggers as TriggerService
-from st2api.controllers import resource
 from st2common.exceptions.apivalidation import ValueValidationException
 from st2common.exceptions.db import StackStormDBObjectConflictError
 from st2common.validators.api.misc import validate_not_part_of_system_pack
+from st2common.util import isotime
 
 http_client = six.moves.http_client
 
@@ -324,10 +325,17 @@ class TriggerInstanceController(resource.ResourceController):
 
     supported_filters = {
         'trigger': 'trigger',
+        'timestamp_gt': 'occurrence_time.gt',
+        'timestamp_lt': 'occurrence_time.lt'
+    }
+
+    filter_transform_functions = {
+        'timestamp_gt': lambda value: isotime.parse(value=value),
+        'timestamp_lt': lambda value: isotime.parse(value=value)
     }
 
     query_options = {
-        'sort': ['-occurence_time', 'trigger']
+        'sort': ['-occurrence_time', 'trigger']
     }
 
     def __init__(self):

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -314,11 +314,19 @@ class TriggerController(RestController):
             return []
 
 
-class TriggerInstanceController(RestController):
+class TriggerInstanceController(resource.ResourceController):
     """
         Implements the RESTful web endpoint that handles
         the lifecycle of TriggerInstances in the system.
     """
+    model = TriggerInstanceAPI
+    access = TriggerInstance
+
+    supported_filters = {
+    }
+
+    def __init__(self):
+        super(TriggerInstanceController, self).__init__()
 
     @jsexpose(arg_types=[str])
     def get_one(self, id):
@@ -346,6 +354,11 @@ class TriggerInstanceController(RestController):
             Handles requests:
                 GET /triggerinstances/
         """
-        trigger_instance_apis = [TriggerInstanceAPI.from_model(trigger_instance_db)
-                                 for trigger_instance_db in TriggerInstance.get_all(**kw)]
-        return trigger_instance_apis
+        trigger_instances = self._get_trigger_instances(**kw)
+        return trigger_instances
+
+    def _get_trigger_instances(self, **kw):
+        kw['limit'] = int(kw.get('limit', 100))
+
+        LOG.debug('Retrieving all trigger instances with filters=%s', kw)
+        return super(TriggerInstanceController, self)._get_all(**kw)

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -323,6 +323,11 @@ class TriggerInstanceController(resource.ResourceController):
     access = TriggerInstance
 
     supported_filters = {
+        'trigger': 'trigger',
+    }
+
+    query_options = {
+        'sort': ['-occurence_time', 'trigger']
     }
 
     def __init__(self):

--- a/st2api/tests/unit/controllers/v1/test_triggerinstances.py
+++ b/st2api/tests/unit/controllers/v1/test_triggerinstances.py
@@ -46,6 +46,12 @@ class TestTriggerController(FunctionalTest):
         self.assertEqual(resp.status_int, http_client.OK)
         self.assertEqual(len(resp.json), limit, 'Get all failure. Length doesn\'t match limit.')
 
+    def test_get_all_filter_by_trigger(self):
+        trigger = 'dummy_pack_1.st2.test.trigger0'
+        resp = self.app.get('/v1/triggerinstances?trigger=%s' % trigger)
+        self.assertEqual(resp.status_int, http_client.OK)
+        self.assertEqual(len(resp.json), 1, 'Get all failure. Must get only one such instance.')
+
     def test_get_one(self):
         triggerinstance_id = str(self.triggerinstance_1.id)
         resp = self._do_get_one(triggerinstance_id)

--- a/st2api/tests/unit/controllers/v1/test_triggerinstances.py
+++ b/st2api/tests/unit/controllers/v1/test_triggerinstances.py
@@ -52,6 +52,18 @@ class TestTriggerController(FunctionalTest):
         self.assertEqual(resp.status_int, http_client.OK)
         self.assertEqual(len(resp.json), 1, 'Get all failure. Must get only one such instance.')
 
+    def test_get_all_filter_by_timestamp(self):
+        resp = self.app.get('/v1/triggerinstances')
+        self.assertEqual(resp.status_int, http_client.OK)
+        timestamp_largest = resp.json[0]['occurrence_time']
+        timestamp_middle = resp.json[1]['occurrence_time']
+        resp = self.app.get('/v1/triggerinstances?timestamp_gt=%s' % timestamp_largest)
+        # Since we sort trigger instances by time (latest first), the previous
+        # get should return no trigger instances.
+        self.assertEqual(len(resp.json), 0)
+        resp = self.app.get('/v1/triggerinstances?timestamp_lt=%s' % timestamp_middle)
+        self.assertEqual(len(resp.json), 1)
+
     def test_get_one(self):
         triggerinstance_id = str(self.triggerinstance_1.id)
         resp = self._do_get_one(triggerinstance_id)

--- a/st2api/tests/unit/controllers/v1/test_triggerinstances.py
+++ b/st2api/tests/unit/controllers/v1/test_triggerinstances.py
@@ -40,6 +40,12 @@ class TestTriggerController(FunctionalTest):
         self.assertEqual(resp.status_int, http_client.OK)
         self.assertEqual(len(resp.json), self.triggerinstance_count, 'Get all failure.')
 
+    def test_get_all_limit(self):
+        limit = 1
+        resp = self.app.get('/v1/triggerinstances?limit=%d' % limit)
+        self.assertEqual(resp.status_int, http_client.OK)
+        self.assertEqual(len(resp.json), limit, 'Get all failure. Length doesn\'t match limit.')
+
     def test_get_one(self):
         triggerinstance_id = str(self.triggerinstance_1.id)
         resp = self._do_get_one(triggerinstance_id)

--- a/st2client/st2client/client.py
+++ b/st2client/st2client/client.py
@@ -95,6 +95,8 @@ class Client(object):
             models.TriggerType, self.endpoints['api'], cacert=self.cacert, debug=self.debug)
         self.managers['Trigger'] = ResourceManager(
             models.Trigger, self.endpoints['api'], cacert=self.cacert, debug=self.debug)
+        self.managers['TriggerInstance'] = ResourceManager(
+            models.TriggerInstance, self.endpoints['api'], cacert=self.cacert, debug=self.debug)
         self.managers['KeyValuePair'] = ResourceManager(
             models.KeyValuePair, self.endpoints['api'], cacert=self.cacert, debug=self.debug)
         self.managers['Webhook'] = ResourceManager(
@@ -139,3 +141,7 @@ class Client(object):
     @property
     def triggertypes(self):
         return self.managers['TriggerType']
+
+    @property
+    def triggerinstances(self):
+        return self.managers['TriggerInstance']

--- a/st2client/st2client/commands/keyvalue.py
+++ b/st2client/st2client/commands/keyvalue.py
@@ -19,19 +19,13 @@ import logging
 from os.path import join as pjoin
 
 from st2client.commands import resource
+from st2client.commands.noop import NoopCommand
 from st2client.commands.resource import add_auth_token_to_kwargs_from_cli
 from st2client.formatters import table
 from st2client.models.keyvalue import KeyValuePair
 from st2client.utils.date import format_isodate
 
 LOG = logging.getLogger(__name__)
-
-
-class NoopCommand(object):
-    # Hack until we fix ResourceBranch API
-    # TODO: Refactor ResourceBranch and make it nicer
-    def __init__(self, *args, **kwargs):
-        pass
 
 
 class KeyValuePairBranch(resource.ResourceBranch):

--- a/st2client/st2client/commands/noop.py
+++ b/st2client/st2client/commands/noop.py
@@ -1,0 +1,21 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class NoopCommand(object):
+    # Hack until we fix ResourceBranch API
+    # TODO: Refactor ResourceBranch and make it nicer
+    def __init__(self, *args, **kwargs):
+        pass

--- a/st2client/st2client/commands/triggerinstance.py
+++ b/st2client/st2client/commands/triggerinstance.py
@@ -15,7 +15,9 @@
 
 from st2client.commands import resource
 from st2client.commands.noop import NoopCommand
+from st2client.formatters import table
 from st2client.models import TriggerInstance
+from st2client.utils.date import format_isodate
 
 
 class TriggerInstanceBranch(resource.ResourceBranch):
@@ -32,8 +34,67 @@ class TriggerInstanceBranch(resource.ResourceBranch):
             })
 
 
-class TriggerInstanceListCommand(resource.ResourceListCommand):
+class TriggerInstanceListCommand(resource.ResourceCommand):
     display_attributes = ['id', 'trigger', 'occurrence_time', 'payload']
+
+    attribute_transform_functions = {
+        'occurrence_time': format_isodate
+    }
+
+    def __init__(self, resource, *args, **kwargs):
+        super(TriggerInstanceListCommand, self).__init__(
+            resource, 'list', 'Get the list of the 50 most recent %s.' %
+            resource.get_plural_display_name().lower(),
+            *args, **kwargs)
+
+        self.group = self.parser.add_argument_group()
+        self.parser.add_argument('-n', '--last', type=int, dest='last',
+                                 default=50,
+                                 help=('List N most recent %s; '
+                                       'list all if 0.' %
+                                       resource.get_plural_display_name().lower()))
+
+        # Filter options
+        self.group.add_argument('--trigger', help='Trigger reference to filter the list.')
+
+        self.parser.add_argument('-tg', '--timestamp-gt', type=str, dest='timestamp_gt',
+                                 default=None,
+                                 help=('Only return trigger instances with occurrence_time '
+                                       'greater than the one provided. '
+                                       'Use time in the format 2000-01-01T12:00:00.000Z'))
+        self.parser.add_argument('-tl', '--timestamp-lt', type=str, dest='timestamp_lt',
+                                 default=None,
+                                 help=('Only return trigger instances with timestamp '
+                                       'lower than the one provided. '
+                                       'Use time in the format 2000-01-01T12:00:00.000Z'))
+        # Display options
+        self.parser.add_argument('-a', '--attr', nargs='+',
+                                 default=self.display_attributes,
+                                 help=('List of attributes to include in the '
+                                       'output. "all" will return all '
+                                       'attributes.'))
+        self.parser.add_argument('-w', '--width', nargs='+', type=int,
+                                 default=None,
+                                 help=('Set the width of columns in output.'))
+
+    @resource.add_auth_token_to_kwargs_from_cli
+    def run(self, args, **kwargs):
+        # Filtering options
+        if args.trigger:
+            kwargs['trigger'] = args.trigger
+        if args.timestamp_gt:
+            kwargs['timestamp_gt'] = args.timestamp_gt
+        if args.timestamp_lt:
+            kwargs['timestamp_lt'] = args.timestamp_lt
+
+        return self.manager.query(limit=args.last, **kwargs)
+
+    def run_and_print(self, args, **kwargs):
+        instances = self.run(args, **kwargs)
+        self.print_output(reversed(instances), table.MultiColumnTable,
+                          attributes=args.attr, widths=args.width,
+                          json=args.json,
+                          attribute_transform_functions=self.attribute_transform_functions)
 
 
 class TriggerInstanceGetCommand(resource.ResourceGetCommand):

--- a/st2client/st2client/commands/triggerinstance.py
+++ b/st2client/st2client/commands/triggerinstance.py
@@ -1,0 +1,48 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from st2client.commands import resource
+from st2client.commands.noop import NoopCommand
+from st2client.models import TriggerInstance
+
+
+class TriggerInstanceBranch(resource.ResourceBranch):
+    def __init__(self, description, app, subparsers, parent_parser=None):
+        super(TriggerInstanceBranch, self).__init__(
+            TriggerInstance, description, app, subparsers,
+            parent_parser=parent_parser,
+            commands={
+                'list': TriggerInstanceListCommand,
+                'get': TriggerInstanceGetCommand,
+                'delete': NoopCommand,
+                'create': NoopCommand,
+                'update': NoopCommand
+            })
+
+
+class TriggerInstanceListCommand(resource.ResourceListCommand):
+    display_attributes = ['id', 'trigger', 'occurrence_time', 'payload']
+
+
+class TriggerInstanceGetCommand(resource.ResourceGetCommand):
+    display_attributes = ['all']
+    attribute_display_order = ['id', 'trigger', 'occurrence_time', 'payload']
+
+    pk_argument_name = 'id'
+
+    @resource.add_auth_token_to_kwargs_from_cli
+    def run(self, args, **kwargs):
+        resource_id = getattr(args, self.pk_argument_name, None)
+        return self.get_resource_by_id(resource_id, **kwargs)

--- a/st2client/st2client/commands/triggerinstance.py
+++ b/st2client/st2client/commands/triggerinstance.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 from st2client.commands import resource
-from st2client.commands.noop import NoopCommand
 from st2client.formatters import table
 from st2client.models import TriggerInstance
 from st2client.utils.date import format_isodate
@@ -24,13 +23,10 @@ class TriggerInstanceBranch(resource.ResourceBranch):
     def __init__(self, description, app, subparsers, parent_parser=None):
         super(TriggerInstanceBranch, self).__init__(
             TriggerInstance, description, app, subparsers,
-            parent_parser=parent_parser,
+            parent_parser=parent_parser, read_only=True,
             commands={
                 'list': TriggerInstanceListCommand,
-                'get': TriggerInstanceGetCommand,
-                'delete': NoopCommand,
-                'create': NoopCommand,
-                'update': NoopCommand
+                'get': TriggerInstanceGetCommand
             })
 
 

--- a/st2client/st2client/models/reactor.py
+++ b/st2client/st2client/models/reactor.py
@@ -34,6 +34,14 @@ class TriggerType(core.Resource):
     _repr_attributes = ['name', 'pack']
 
 
+class TriggerInstance(core.Resource):
+    _alias = 'TriggerInstance'
+    _display_name = 'TriggerInstance'
+    _plural = 'Triggerinstances'
+    _plural_display_name = 'TriggerInstances'
+    _repr_attributes = ['id', 'trigger', 'occurrence_time', 'payload']
+
+
 class Trigger(core.Resource):
     _alias = 'TriggerSpecification'
     _display_name = 'Trigger Specification'

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -41,6 +41,7 @@ from st2client.commands import policy
 from st2client.commands import resource
 from st2client.commands import sensor
 from st2client.commands import trigger
+from st2client.commands import triggerinstance
 from st2client.commands import webhook
 from st2client.commands import rule
 from st2client.config_parser import CLIConfigParser
@@ -217,6 +218,10 @@ class Shell(object):
         self.commands['trigger'] = trigger.TriggerTypeBranch(
             'An external event that is mapped to a st2 input. It is the '
             'st2 invocation point.',
+            self, self.subparsers)
+
+        self.commands['triggerinstances'] = triggerinstance.TriggerInstanceBranch(
+            'Actual instances of triggers received by st2.',
             self, self.subparsers)
 
         self.commands['webhook'] = webhook.WebhookBranch(


### PR DESCRIPTION
## TODO:

* - [X]  Tests for timestamp filter in API
* - [X] Docs

## API Examples:

```
(virtualenv)/m/s/s/st2 git:STORM-1385/trigger_instances_list ❯❯❯ http localhost:9101/v1/triggerinstances                                                                                                                                             ⏎ ✭ ✱ ◼
HTTP/1.1 200 OK
Access-Control-Allow-Headers: Content-Type,Authorization,X-Auth-Token
Access-Control-Allow-Methods: GET,POST,PUT,DELETE,OPTIONS
Access-Control-Allow-Origin: http://127.0.0.1:9101/
Access-Control-Expose-Headers: Content-Type,X-Limit,X-Total-Count
Connection: keep-alive
Content-Length: 872
Content-Type: application/json; charset=UTF-8
Date: Mon, 01 Jun 2015 23:20:17 GMT
X-Limit: 100
X-Total-Count: 4

[
    {
        "id": "556ce89f32ed35231a8b5400",
        "occurrence_time": "2015-06-01T23:19:59.711000Z",
        "payload": {
            "executed_at": "2015-06-01 23:19:59.698431",
            "schedule": null
        },
        "trigger": "core.e09d7174-f91c-45b0-92f7-0dcfeb0e311a"
    },
    {
        "id": "556ce8a432ed35231a8b5401",
        "occurrence_time": "2015-06-01T23:20:04.736000Z",
        "payload": {
            "executed_at": "2015-06-01 23:20:04.712198",
            "schedule": null
        },
        "trigger": "core.e09d7174-f91c-45b0-92f7-0dcfeb0e311a"
    },
    {
        "id": "556ce8a932ed35231a8b5402",
        "occurrence_time": "2015-06-01T23:20:09.726000Z",
        "payload": {
            "executed_at": "2015-06-01 23:20:09.723382",
            "schedule": null
        },
        "trigger": "core.e09d7174-f91c-45b0-92f7-0dcfeb0e311a"
    },
    {
        "id": "556ce8ae32ed35231a8b5403",
        "occurrence_time": "2015-06-01T23:20:14.706000Z",
        "payload": {
            "executed_at": "2015-06-01 23:20:14.702854",
            "schedule": null
        },
        "trigger": "core.e09d7174-f91c-45b0-92f7-0dcfeb0e311a"
    }
]

(virtualenv)/m/s/s/st2 git:STORM-1385/trigger_instances_list ❯❯❯ http "localhost:9101/v1/triggerinstances?limit=1"                                                                                                                                     ✭ ✱ ◼
HTTP/1.1 200 OK
Access-Control-Allow-Headers: Content-Type,Authorization,X-Auth-Token
Access-Control-Allow-Methods: GET,POST,PUT,DELETE,OPTIONS
Access-Control-Allow-Origin: http://127.0.0.1:9101/
Access-Control-Expose-Headers: Content-Type,X-Limit,X-Total-Count
Connection: keep-alive
Content-Length: 218
Content-Type: application/json; charset=UTF-8
Date: Mon, 01 Jun 2015 23:20:26 GMT
X-Limit: 1
X-Total-Count: 6

[
    {
        "id": "556ce89f32ed35231a8b5400",
        "occurrence_time": "2015-06-01T23:19:59.711000Z",
        "payload": {
            "executed_at": "2015-06-01 23:19:59.698431",
            "schedule": null
        },
        "trigger": "core.e09d7174-f91c-45b0-92f7-0dcfeb0e311a"
    }
]

(virtualenv)/m/s/s/st2 git:STORM-1385/trigger_instances_list ❯❯❯ http "localhost:9101/v1/triggerinstances?limit=1&trigger=core.e09d7174-f91c-45b0-92f7-0dcfeb0e311a"                                                                                   ✭ ✱ ◼
HTTP/1.1 200 OK
Access-Control-Allow-Headers: Content-Type,Authorization,X-Auth-Token
Access-Control-Allow-Methods: GET,POST,PUT,DELETE,OPTIONS
Access-Control-Allow-Origin: http://127.0.0.1:9101/
Access-Control-Expose-Headers: Content-Type,X-Limit,X-Total-Count
Connection: keep-alive
Content-Length: 218
Content-Type: application/json; charset=UTF-8
Date: Mon, 01 Jun 2015 23:20:49 GMT
X-Limit: 1
X-Total-Count: 11

[
    {
        "id": "556ce89f32ed35231a8b5400",
        "occurrence_time": "2015-06-01T23:19:59.711000Z",
        "payload": {
            "executed_at": "2015-06-01 23:19:59.698431",
            "schedule": null
        },
        "trigger": "core.e09d7174-f91c-45b0-92f7-0dcfeb0e311a"
    }
]

(virtualenv)/m/s/s/st2 git:STORM-1385/trigger_instances_list ❯❯❯
```

## CLI Examples:

```
(virtualenv)/m/s/s/st2 git:STORM-1385/trigger_instances_list ❯❯❯ st2 triggerinstance list -tg 2015-06-02T00:55:05Z                                                                                                                                       ✭ ◼
+--------------------------+-------------------------------------------+-------------------------------+----------------------------------------------------------+
| id                       | trigger                                   | occurrence_time               | payload                                                  |
+--------------------------+-------------------------------------------+-------------------------------+----------------------------------------------------------+
| 556cfeea32ed35569ff2233c | core.f9e09284-b2b1-4127-aedd-dcde7a752819 | Tue, 02 Jun 2015 00:55:06 UTC | {u'executed_at': u'2015-06-02 00:55:06.462994',          |
|                          |                                           |                               | u'schedule': None}                                       |
| 556cfeef32ed35569ff2233d | core.f9e09284-b2b1-4127-aedd-dcde7a752819 | Tue, 02 Jun 2015 00:55:11 UTC | {u'executed_at': u'2015-06-02 00:55:11.463324',          |
|                          |                                           |                               | u'schedule': None}                                       |
| 556cfef432ed35569ff2233e | core.f9e09284-b2b1-4127-aedd-dcde7a752819 | Tue, 02 Jun 2015 00:55:16 UTC | {u'executed_at': u'2015-06-02 00:55:16.463044',          |
|                          |                                           |                               | u'schedule': None}                                       |
+--------------------------+-------------------------------------------+-------------------------------+----------------------------------------------------------+
(virtualenv)/m/s/s/st2 git:STORM-1385/trigger_instances_list ❯❯❯ st2 triggerinstance list -tg 2015-06-02T00:55:05Z -n=1                                                                                                                                  ✭ ◼
+--------------------------+-------------------------------------------+-------------------------------+----------------------------------------------------------+
| id                       | trigger                                   | occurrence_time               | payload                                                  |
+--------------------------+-------------------------------------------+-------------------------------+----------------------------------------------------------+
| 556cfef932ed35569ff2233f | core.f9e09284-b2b1-4127-aedd-dcde7a752819 | Tue, 02 Jun 2015 00:55:21 UTC | {u'executed_at': u'2015-06-02 00:55:21.464630',          |
|                          |                                           |                               | u'schedule': None}                                       |
+--------------------------+-------------------------------------------+-------------------------------+----------------------------------------------------------+
(virtualenv)/m/s/s/st2 git:STORM-1385/trigger_instances_list ❯❯❯ st2 triggerinstance get 556cfef932ed35569ff2233f                                                                                                                                        ✭ ◼
+-----------------+---------------------------------------------------+
| Property        | Value                                             |
+-----------------+---------------------------------------------------+
| id              | 556cfef932ed35569ff2233f                          |
| trigger         | core.f9e09284-b2b1-4127-aedd-dcde7a752819         |
| occurrence_time | 2015-06-02T00:55:21.470000Z                       |
| payload         | {                                                 |
|                 |     "executed_at": "2015-06-02 00:55:21.464630",  |
|                 |     "schedule": null                              |
|                 | }                                                 |
+-----------------+---------------------------------------------------+
(virtualenv)/m/s/s/st2 git:STORM-1385/trigger_instances_list ❯❯❯ st2 triggerinstance get -h                                                                                                                                                              ✭ ◼
usage: st2 triggerinstance get [-h] [-t TOKEN] [-j] [-a ATTR [ATTR ...]] id

Get individual triggerinstance.

positional arguments:
  id                    Id of the triggerinstance.

optional arguments:
  -h, --help            show this help message and exit
  -t TOKEN, --token TOKEN
                        Access token for user authentication. Get
                        ST2_AUTH_TOKEN from the environment variables by
                        default.
  -j, --json            Prints output in JSON format.
  -a ATTR [ATTR ...], --attr ATTR [ATTR ...]
                        List of attributes to include in the output. "all" or
                        unspecified will return all attributes.
(virtualenv)/m/s/s/st2 git:STORM-1385/trigger_instances_list ❯❯❯ st2 triggerinstance list -h                                                                                                                                                             ✭ ◼
usage: st2 triggerinstance list [-h] [-t TOKEN] [-j] [-n LAST]
                                [--trigger TRIGGER] [-tg TIMESTAMP_GT]
                                [-tl TIMESTAMP_LT] [-a ATTR [ATTR ...]]
                                [-w WIDTH [WIDTH ...]]

Get the list of the 50 most recent triggerinstances.

optional arguments:
  -h, --help            show this help message and exit
  -t TOKEN, --token TOKEN
                        Access token for user authentication. Get
                        ST2_AUTH_TOKEN from the environment variables by
                        default.
  -j, --json            Prints output in JSON format.
  -n LAST, --last LAST  List N most recent triggerinstances; list all if 0.
  -tg TIMESTAMP_GT, --timestamp-gt TIMESTAMP_GT
                        Only return trigger instances with occurrence_time
                        greater than the one provided. Use time in the format
                        2000-01-01T12:00:00.000Z
  -tl TIMESTAMP_LT, --timestamp-lt TIMESTAMP_LT
                        Only return trigger instances with timestamp lower
                        than the one provided. Use time in the format
                        2000-01-01T12:00:00.000Z
  -a ATTR [ATTR ...], --attr ATTR [ATTR ...]
                        List of attributes to include in the output. "all"
                        will return all attributes.
  -w WIDTH [WIDTH ...], --width WIDTH [WIDTH ...]
                        Set the width of columns in output.

  --trigger TRIGGER     Trigger reference to filter the list.
(virtualenv)/m/s/s/st2 git:STORM-1385/trigger_instances_list ❯❯❯
```