### PR TITLE
Update ChatOps docs with updated Hubot pack

### DIFF
--- a/instructables/chatops.md
+++ b/instructables/chatops.md
@@ -148,7 +148,7 @@ And should get something like this back:
 Now, install the `hubot` pack into your StackStorm installation.
 
 ```
-  $ st2 packs.install packs=hubot http://github.com/StackStorm/st2incubator.git
+  $ st2 packs.install packs=hubot
 ```
 
 If successful, proceed to the section [Configure Stackstorm](#configuring-stackstorm) to continue.


### PR DESCRIPTION
This PR updates ChatOps instructables to download the Hubot pack from the `st2contrib` repository as opposed to the `st2incubator` repository.