### PR TITLE
send_empty_body parameter in sendmail action

### DIFF
--- a/contrib/core/actions/send_mail/send_mail
+++ b/contrib/core/actions/send_mail/send_mail
@@ -8,9 +8,12 @@ TO=$1
 shift
 SUBJECT=$1
 shift
+SEND_EMPTY_BODY=$1
+shift
 BODY="$@"
 
-${MAIL} <<EOF
+if [[ -z "${BODY// }" && $SEND_EMPTY_BODY == 'True' ]] || [[ -n $BODY ]]; then
+  ${MAIL} <<EOF
 TO: ${TO}
 FROM: ${FROM}
 SUBJECT: ${SUBJECT}
@@ -21,6 +24,8 @@ ${BODY}
 ${FOOTER}
 
 EOF
+
+fi
 
 if [ $? -ne 0 ]; then
   echo "Failed to send mail to ${TO}"

--- a/contrib/core/actions/sendmail.yaml
+++ b/contrib/core/actions/sendmail.yaml
@@ -6,7 +6,7 @@ name: sendmail
 parameters:
   body:
     description: Body of the email.
-    position: 2
+    position: 3
     required: true
     type: string
   subject:
@@ -21,4 +21,10 @@ parameters:
     position: 0
     required: true
     type: string
+  send_empty_body:
+    description: Send a message even if the body is empty.
+    position: 2
+    required: false
+    type: boolean
+    default: True
 runner_type: "local-shell-script"


### PR DESCRIPTION
Although "body" is a required parameter, results of actions can be empty
or contain all whitespace characters. Sometimes it's only desireable to
receive an email if the action actually had output (similar to cron) and
this can now be done by setting this parameter to False.