### PR TITLE
[DONT MERGE] Fix st2_deploy.sh script for Debian based systems

### DIFF
--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -24,7 +24,7 @@ INSTALL_WINDOWS_RUNNER_DEPENDENCIES=${INSTALL_WINDOWS_RUNNER_DEPENDENCIES:-1}
 DOWNLOAD_SERVER="https://downloads.stackstorm.net"
 RABBIT_PUBLIC_KEY="rabbitmq-signing-key-public.asc"
 PACKAGES="st2common st2reactor st2actions st2api st2auth st2debug"
-CLI_PACKAGE="st2client"
+CLI_PACKAGE="st2client"  # TODO: Use same package name on Debian and RHEL based systems
 PYTHON=`which python`
 BUILD="current"
 DEBTEST=`lsb_release -a 2> /dev/null | grep Distributor | awk '{print $3}'`
@@ -96,11 +96,13 @@ fi
 
 if [[ "$DEBTEST" == "Ubuntu" ]]; then
   TYPE="debs"
+  CLI_PACKAGE="python-st2client"
   PYTHONPACK="/usr/lib/python2.7/dist-packages"
   echo "###########################################################################################"
   echo "# Detected Distro is ${DEBTEST}"
 elif [[ -f "/etc/redhat-release" ]]; then
   TYPE="rpms"
+  CLI_PACKAGE="st2client"
   PYTHONPACK="/usr/lib/python2.7/site-packages"
   echo "###########################################################################################"
   echo "# Detected linux distribution is RedHat compatible"
@@ -494,7 +496,7 @@ install_st2client() {
     fi
     echo "########## Installing st2client ${VER} ##########"
     apt-get -y install gdebi-core
-    gdebi --n st2client*
+    gdebi --n ${CLI_PACKAGE}*
   elif [[ "$TYPE" == "rpms" ]]; then
     yum localinstall -y st2client-${VER}-${RELEASE}.noarch.rpm
   fi


### PR DESCRIPTION
This pull request fixes st2_deploy issue spotted by a person on the IRC.

In v0.9.2, the deploy script is broken for Debian based systems since downloads server contains package named `python-st2client...deb`, but the script expects package to just be called `st2client...deb`.

See:

* http://downloads.stackstorm.net/releases/st2/0.9.2/debs/current/
* http://downloads.stackstorm.net/releases/st2/0.9.1/debs/current/
* http://downloads.stackstorm.net/releases/st2/0.9.2/rpms/current/
* http://downloads.stackstorm.net/releases/st2/0.9.1/rpms/current/

(rpm package doesn't have `python-` prefix)

I believe this issue is related to our new apt repository since the package name in the apt repository also contains `python-` prefix.

This is a temporary fix for now to get v0.9.2 working. As far as long term solution and approach goes, I will wait for @DoriftoShoes input (we should also try to figure this out asap and get a final "solution" into v0.9.3).