### PR TITLE
Reduce duplicated code and refactor local runner to use run_command function

### DIFF
--- a/st2common/st2common/util/shell.py
+++ b/st2common/st2common/util/shell.py
@@ -14,17 +14,23 @@
 # limitations under the License.
 
 import os
+import shlex
 import subprocess
 from subprocess import list2cmdline
 
 import six
 
+from st2common import log as logging
+
 __all__ = [
     'run_command',
+    'kill_process',
 
     'quote_unix',
     'quote_windows'
 ]
+
+LOG = logging.getLogger(__name__)
 
 
 # pylint: disable=too-many-function-args
@@ -68,6 +74,26 @@ def run_command(cmd, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
     exit_code = process.returncode
 
     return (exit_code, stdout, stderr)
+
+
+def kill_process(process):
+    """
+    Kill the provided process by sending it TERM signal using "pkill" shell
+    command.
+
+    Note: This function only works on Linux / Unix based systems.
+
+    :param process: Process object as returned by subprocess.Popen.
+    :type process: ``object``
+    """
+    kill_command = shlex.split('sudo pkill -TERM -s %s' % (process.pid))
+
+    try:
+        status = subprocess.call(kill_command)
+    except Exception:
+        LOG.exception('Unable to pkill process.')
+
+    return status
 
 
 def quote_unix(value):


### PR DESCRIPTION
This pull request refactors local runner to use `st2common.util.green.shell.run_command` function and as such, reduces code duplication.

This will also help by substantially reducing code duplication in #1491 branch.