### PR TITLE
Validate parameters for system triggers during rule creation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,11 @@ in development
 * CLI now has ``get`` and ``list`` commands for triggerinstance. (new-feature)
 * Validate parameters during rule creation for system triggers. (improvement)
 
+v0.9.2 - May 26, 2015
+---------------------
+
+* Fix broken ``packs.download`` action. (bug-fix)
+
 v0.9.1 - May 12, 2015
 ---------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,9 +20,10 @@ in development
   (new-feature)
 * Rules should be part of a pack. (improvement)
 * Update Windows runner code so it also works with a newer versions of winexe (> 1.0).
-  (improvements)
+  (improvement)
   [James Sigurðarson]
 * CLI now has ``get`` and ``list`` commands for triggerinstance. (new-feature)
+* Validate parameters during rule creation for system triggers. (improvement)
 
 v0.9.1 - May 12, 2015
 ---------------------

--- a/st2api/st2api/controllers/v1/rules.py
+++ b/st2api/st2api/controllers/v1/rules.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import six
+import jsonschema
 from pecan import abort
 from mongoengine import ValidationError
 
@@ -69,7 +70,7 @@ class RuleController(resource.ContentPackResourceController):
             LOG.exception('Validation failed for rule data=%s.', rule)
             abort(http_client.BAD_REQUEST, str(e))
             return
-        except ValueValidationException as e:
+        except (ValueValidationException, jsonschema.ValidationError) as e:
             LOG.exception('Validation failed for rule data=%s.', rule)
             abort(http_client.BAD_REQUEST, str(e))
             return
@@ -109,7 +110,7 @@ class RuleController(resource.ContentPackResourceController):
             rule_db = RuleAPI.to_model(rule)
             rule_db.id = rule_ref_or_id
             rule_db = Rule.add_or_update(rule_db)
-        except (ValidationError, ValueError) as e:
+        except (ValueValidationException, jsonschema.ValidationError, ValueError) as e:
             LOG.exception('Validation failed for rule data=%s', rule)
             abort(http_client.BAD_REQUEST, str(e))
             return

--- a/st2api/tests/unit/controllers/v1/test_rules.py
+++ b/st2api/tests/unit/controllers/v1/test_rules.py
@@ -51,6 +51,9 @@ class TestRuleController(FunctionalTest):
         TestRuleController.RULE_1 = TestRuleController.fixtures_loader.load_fixtures(
             fixtures_pack=FIXTURES_PACK,
             fixtures_dict={'rules': ['rule1.yaml']})['rules']['rule1.yaml']
+        TestRuleController.RULE_2 = TestRuleController.fixtures_loader.load_fixtures(
+            fixtures_pack=FIXTURES_PACK,
+            fixtures_dict={'rules': ['cron_timer_rule_invalid_parameters.yaml']})['rules']['cron_timer_rule_invalid_parameters.yaml']
 
     @classmethod
     def tearDownClass(cls):
@@ -98,6 +101,13 @@ class TestRuleController(FunctionalTest):
         self.assertEqual(post_resp_2.status_int, http_client.CONFLICT)
         self.assertEqual(post_resp_2.json['conflict-id'], org_id)
         self.__do_delete(org_id)
+
+    def test_post_trigger_parameter_schema_validation_fails(self):
+        post_resp = self.__do_post(TestRuleController.RULE_2)
+        self.assertEqual(post_resp.status_int, http_client.BAD_REQUEST)
+
+        expected_msg = 'Additional properties are not allowed (u\'minutex\' was unexpected)'
+        self.assertTrue(expected_msg in post_resp.body)
 
     def test_put(self):
         post_resp = self.__do_post(TestRuleController.RULE_1)

--- a/st2api/tests/unit/controllers/v1/test_rules.py
+++ b/st2api/tests/unit/controllers/v1/test_rules.py
@@ -48,12 +48,15 @@ class TestRuleController(FunctionalTest):
         TestRuleController.TRIGGER = models['triggers']['trigger1.yaml']
 
         # Don't load rule into DB as that is what is being tested.
+        file_name = 'rule1.yaml'
         TestRuleController.RULE_1 = TestRuleController.fixtures_loader.load_fixtures(
             fixtures_pack=FIXTURES_PACK,
-            fixtures_dict={'rules': ['rule1.yaml']})['rules']['rule1.yaml']
+            fixtures_dict={'rules': [file_name]})['rules'][file_name]
+
+        file_name = 'cron_timer_rule_invalid_parameters.yaml'
         TestRuleController.RULE_2 = TestRuleController.fixtures_loader.load_fixtures(
             fixtures_pack=FIXTURES_PACK,
-            fixtures_dict={'rules': ['cron_timer_rule_invalid_parameters.yaml']})['rules']['cron_timer_rule_invalid_parameters.yaml']
+            fixtures_dict={'rules': [file_name]})['rules'][file_name]
 
     @classmethod
     def tearDownClass(cls):

--- a/st2common/st2common/models/api/rule.py
+++ b/st2common/st2common/models/api/rule.py
@@ -164,7 +164,7 @@ class RuleAPI(BaseAPI):
         # Validate criteria
         validator.validate_criteria(model.criteria)
 
-        # Validate triggerd
+        # Validate trigger parameters
         validator.validate_trigger_parameters(trigger_db=trigger_db)
 
         model.action = ActionExecutionSpecDB()

--- a/st2common/st2common/models/api/rule.py
+++ b/st2common/st2common/models/api/rule.py
@@ -160,7 +160,13 @@ class RuleAPI(BaseAPI):
         model.criteria = dict(getattr(rule, 'criteria', {}))
         model.pack = str(rule.pack)
         model.ref = ResourceReference.to_string_reference(pack=model.pack, name=model.name)
+
+        # Validate criteria
         validator.validate_criteria(model.criteria)
+
+        # Validate triggerd
+        validator.validate_trigger_parameters(trigger_db=trigger_db)
+
         model.action = ActionExecutionSpecDB()
         model.action.ref = rule.action['ref']
         model.action.parameters = rule.action['parameters']

--- a/st2common/st2common/validators/api/reactor.py
+++ b/st2common/st2common/validators/api/reactor.py
@@ -16,7 +16,7 @@
 import six
 
 from st2common.exceptions.apivalidation import ValueValidationException
-from st2common.constants.triggers import TIMER_TRIGGER_TYPES
+from st2common.constants.triggers import SYSTEM_TRIGGER_TYPES
 from st2common.util import schema as util_schema
 import st2common.operators as criteria_operators
 
@@ -63,12 +63,11 @@ def validate_trigger_parameters(trigger_db):
     trigger_type_ref = trigger_db.type
     parameters = trigger_db.parameters
 
-    # TODO: ALso validate it for other system triggers (webhook, etc.)
-    if trigger_type_ref not in TIMER_TRIGGER_TYPES:
+    if trigger_type_ref not in SYSTEM_TRIGGER_TYPES:
         # Not a system trigger, skip validation for now
         return None
 
-    parameters_schema = TIMER_TRIGGER_TYPES[trigger_type_ref]['parameters_schema']
+    parameters_schema = SYSTEM_TRIGGER_TYPES[trigger_type_ref]['parameters_schema']
     VALIDATOR(parameters_schema).validate(parameters)
 
     return True

--- a/st2common/st2common/validators/api/reactor.py
+++ b/st2common/st2common/validators/api/reactor.py
@@ -13,10 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from st2common.exceptions.apivalidation import ValueValidationException
-import st2common.operators as criteria_operators
 import six
 
+from st2common.exceptions.apivalidation import ValueValidationException
+from st2common.constants.triggers import TIMER_TRIGGER_TYPES
+from st2common.util import schema as util_schema
+import st2common.operators as criteria_operators
+
+__all__ = [
+    'validate_criteria',
+    'validate_trigger_parameters'
+]
+
+VALIDATOR = util_schema.get_validator(assign_property_default=False)
 allowed_operators = criteria_operators.get_allowed_operators()
 
 
@@ -36,3 +45,30 @@ def validate_criteria(criteria):
         if pattern is None:
             raise ValueValidationException('For field: ' + key + ', no pattern specified ' +
                                            'for operator ' + operator)
+
+
+def validate_trigger_parameters(trigger_db):
+    """
+    This function validates parameters for system triggers (e.g. timers).
+
+    Note: Eventually we should also validate parameters for user defined triggers which correctly
+    specify JSON schema for the parameters.
+
+    :param trigger_db: Trigger DB object.
+    :type trigger_db: :class:`TriggerDB`
+    """
+    if not trigger_db:
+        return None
+
+    trigger_type_ref = trigger_db.type
+    parameters = trigger_db.parameters
+
+    # TODO: ALso validate it for other system triggers (webhook, etc.)
+    if trigger_type_ref not in TIMER_TRIGGER_TYPES:
+        # Not a system trigger, skip validation for now
+        return None
+
+    parameters_schema = TIMER_TRIGGER_TYPES[trigger_type_ref]['parameters_schema']
+    VALIDATOR(parameters_schema).validate(parameters)
+
+    return True

--- a/st2tests/st2tests/fixtures/generic/rules/cron_timer_rule_1.yaml
+++ b/st2tests/st2tests/fixtures/generic/rules/cron_timer_rule_1.yaml
@@ -21,4 +21,4 @@ trigger:
   parameters:
     minute: 0
     second: 0
-  type: core.CronTimer
+  type: core.st2.CronTimer

--- a/st2tests/st2tests/fixtures/generic/rules/cron_timer_rule_2.yaml
+++ b/st2tests/st2tests/fixtures/generic/rules/cron_timer_rule_2.yaml
@@ -21,4 +21,4 @@ trigger:
   parameters:
     minute: 0
     second: 0
-  type: core.CronTimer
+  type: core.st2.CronTimer

--- a/st2tests/st2tests/fixtures/generic/rules/cron_timer_rule_3.yaml
+++ b/st2tests/st2tests/fixtures/generic/rules/cron_timer_rule_3.yaml
@@ -21,4 +21,4 @@ trigger:
   parameters:
     minute: 0
     second: 1
-  type: core.CronTimer
+  type: core.st2.CronTimer

--- a/st2tests/st2tests/fixtures/generic/rules/cron_timer_rule_invalid_parameters.yaml
+++ b/st2tests/st2tests/fixtures/generic/rules/cron_timer_rule_invalid_parameters.yaml
@@ -1,0 +1,24 @@
+---
+action:
+  parameters:
+    ip1: '{{trigger.t1_p}}'
+    ip2: '{{rule.k1}}'
+  ref: wolfpack.action-1
+criteria:
+  t1_p:
+    pattern: t1_p_v
+    type: equals
+description: ''
+enabled: true
+name: cron_timer_rule_1
+pack: timer_rules
+tags:
+- name: tag1
+  value: dont-care
+- name: tag2
+  value: dont-care
+trigger:
+  parameters:
+    minutex: 0
+    second: 0
+  type: core.st2.CronTimer


### PR DESCRIPTION
This pull request adds support for validating parameters for system triggers (webhook, timers) during rule creation.

Previously, rule creation would proceed normally even if user didn't provide all or provided invalid parameters for a system trigger.

For example:

```bash
(virtualenv)vagrant@vagrant-ubuntu-trusty-64:/data/stanley$ python st2client/st2client/shell.py rule create rule.yaml 
ERROR: 400 Client Error: Bad Request
MESSAGE: Additional properties are not allowed (u'until' was unexpected)

Failed validating 'additionalProperties' in schema:
    {'additionalProperties': False,
     'properties': {'delta': {'type': 'integer'},
                    'timezone': {'type': 'string'},
                    'unit': {'enum': ['weeks',
                                      'days',
                                      'hours',
                                      'minutes',
                                      'seconds']}},
     'required': ['unit', 'delta'],
     'type': 'object'}

On instance:
    {u'delta': 4, u'until': u'hours'}
```

In the future, we could and should also turn this on for user created triggers (trigger types) which specify parameters schema in the metadata file. Currently, most of the triggers in st2contrib/ already specify it, but a lot of it is out of date or using wrong syntax since we don't actually really validate or use it.