### PR TITLE
RFR - TriggerInstance API controller to support re_emit

### DIFF
--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -318,12 +318,12 @@ class TriggerController(RestController):
             return []
 
 
-class TriggerInstanceMixin(RestController):
+class TriggerInstanceControllerMixin(RestController):
     model = TriggerInstanceAPI
     access = TriggerInstance
 
 
-class TriggerInstanceResendController(TriggerInstanceMixin, resource.ResourceController):
+class TriggerInstanceResendController(TriggerInstanceControllerMixin, resource.ResourceController):
     supported_filters = {}
 
     def __init__(self, *args, **kwargs):
@@ -369,12 +369,11 @@ class TriggerInstanceResendController(TriggerInstanceMixin, resource.ResourceCon
             abort(http_client.INTERNAL_SERVER_ERROR, str(e))
 
 
-class TriggerInstanceController(TriggerInstanceMixin, resource.ResourceController):
+class TriggerInstanceController(TriggerInstanceControllerMixin, resource.ResourceController):
     """
         Implements the RESTful web endpoint that handles
         the lifecycle of TriggerInstances in the system.
     """
-    re_send = TriggerInstanceResendController()
     re_emit = TriggerInstanceResendController()
 
     supported_filters = {

--- a/st2api/tests/unit/controllers/v1/test_triggerinstances.py
+++ b/st2api/tests/unit/controllers/v1/test_triggerinstances.py
@@ -64,6 +64,18 @@ class TestTriggerController(FunctionalTest):
         resp = self.app.get('/v1/triggerinstances?timestamp_lt=%s' % timestamp_middle)
         self.assertEqual(len(resp.json), 1)
 
+    def test_reemit_trigger_instance(self):
+        resp = self.app.get('/v1/triggerinstances')
+        self.assertEqual(resp.status_int, http_client.OK)
+        instance_id = resp.json[0]['id']
+        resp = self.app.post('/v1/triggerinstances/%s/re_emit' % instance_id)
+        self.assertEqual(resp.status_int, http_client.OK)
+        resent_message = resp.json['message']
+        resent_payload = resp.json['payload']
+        self.assertTrue(instance_id in resent_message)
+        self.assertTrue('__context' in resent_payload)
+        self.assertEqual(resent_payload['__context']['original_id'], instance_id)
+
     def test_get_one(self):
         triggerinstance_id = str(self.triggerinstance_1.id)
         resp = self._do_get_one(triggerinstance_id)

--- a/st2client/st2client/client.py
+++ b/st2client/st2client/client.py
@@ -20,6 +20,7 @@ from st2client import models
 from st2client.models.core import ResourceManager
 from st2client.models.core import ActionAliasResourceManager
 from st2client.models.core import LiveActionResourceManager
+from st2client.models.core import TriggerInstanceResourceManager
 
 
 LOG = logging.getLogger(__name__)
@@ -98,7 +99,7 @@ class Client(object):
             models.TriggerType, self.endpoints['api'], cacert=self.cacert, debug=self.debug)
         self.managers['Trigger'] = ResourceManager(
             models.Trigger, self.endpoints['api'], cacert=self.cacert, debug=self.debug)
-        self.managers['TriggerInstance'] = ResourceManager(
+        self.managers['TriggerInstance'] = TriggerInstanceResourceManager(
             models.TriggerInstance, self.endpoints['api'], cacert=self.cacert, debug=self.debug)
         self.managers['KeyValuePair'] = ResourceManager(
             models.KeyValuePair, self.endpoints['api'], cacert=self.cacert, debug=self.debug)

--- a/st2client/st2client/commands/triggerinstance.py
+++ b/st2client/st2client/commands/triggerinstance.py
@@ -19,6 +19,32 @@ from st2client.models import TriggerInstance
 from st2client.utils.date import format_isodate
 
 
+class TriggerInstanceResendCommand(resource.ResourceCommand):
+    def __init__(self, resource, *args, **kwargs):
+
+        super(TriggerInstanceResendCommand, self).__init__(
+            resource, kwargs.pop('name', 're-emit'),
+            'A command to re-emit a particular trigger instance.',
+            *args, **kwargs)
+
+        self.parser.add_argument('id', nargs='?',
+                                 metavar='id',
+                                 help='ID of trigger instance to re-emit.')
+        self.parser.add_argument(
+            '-h', '--help',
+            action='store_true', dest='help',
+            help='Print usage for the given command.')
+
+    def run(self, args, **kwargs):
+        return self.manager.re_emit(args.id)
+
+    @resource.add_auth_token_to_kwargs_from_cli
+    def run_and_print(self, args, **kwargs):
+        ret = self.run(args, **kwargs)
+        if 'message' in ret:
+            print(ret['message'])
+
+
 class TriggerInstanceBranch(resource.ResourceBranch):
     def __init__(self, description, app, subparsers, parent_parser=None):
         super(TriggerInstanceBranch, self).__init__(
@@ -28,6 +54,9 @@ class TriggerInstanceBranch(resource.ResourceBranch):
                 'list': TriggerInstanceListCommand,
                 'get': TriggerInstanceGetCommand
             })
+
+        self.commands['re-emit'] = TriggerInstanceResendCommand(self.resource, self.app,
+                                                                self.subparsers, add_help=False)
 
 
 class TriggerInstanceListCommand(resource.ResourceCommand):

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -330,3 +330,13 @@ class LiveActionResourceManager(ResourceManager):
 
         instance = self.resource.deserialize(response.json())
         return instance
+
+
+class TriggerInstanceResourceManager(ResourceManager):
+    @add_auth_token_to_kwargs_from_env
+    def re_emit(self, trigger_instance_id):
+        url = '/%s/%s/re_emit' % (self.resource.get_url_path_name(), trigger_instance_id)
+        response = self.client.post(url, None)
+        if response.status_code != 200:
+            self.handle_error(response)
+        return response.json()


### PR DESCRIPTION
## TODO

[X]  - CLI change

## API

```
(virtualenv)/m/s/s/st2 git:STORM-1367/reemit_trigger_instances ❯❯❯ http POST http://localhost:9101/v1/triggerinstances/556f9d4632ed352054607408/re_emit                                                                                                  ✭ ✱ ◼
HTTP/1.1 200 OK
Access-Control-Allow-Headers: Content-Type,Authorization,X-Auth-Token
Access-Control-Allow-Methods: GET,POST,PUT,DELETE,OPTIONS
Access-Control-Allow-Origin: http://127.0.0.1:9101/
Access-Control-Expose-Headers: Content-Type,X-Limit,X-Total-Count
Connection: keep-alive
Content-Length: 239
Content-Type: application/json; charset=UTF-8
Date: Thu, 04 Jun 2015 00:35:39 GMT

{
    "message": "Trigger instance 556f9d4632ed352054607408 succesfully re-sent.",
    "payload": {
        "__context": {
            "original_id": "556f9d4632ed352054607408"
        },
        "boo": true,
        "int": 1,
        "lst": [
            1,
            5,
            7
        ],
        "obj": {
            "baz": 1,
            "foo": "bar"
        },
        "str": "String"
    }
}
```

## Example test

```
(virtualenv)/m/s/s/st2 git:STORM-1367/reemit_trigger_instances ❯❯❯ st2 triggerinstance list                                                                                                                                                              ✭ ✱ ◼
+--------------------------+-----------------------------+-------------------------------+-----------------------------------------------------------+
| id                       | trigger                     | occurrence_time               | payload                                                   |
+--------------------------+-----------------------------+-------------------------------+-----------------------------------------------------------+
| 556f9d3932ed352054607405 | fixtures.test_trigger.dummy | Thu, 04 Jun 2015 00:35:05 UTC | {u'int': 1, u'lst': [1, 5, 7], u'obj': {u'foo': u'bar',   |
|                          |                             |                               | u'baz': 1}, u'str': u'String', u'boo': True}              |
| 556f9d3e32ed352054607406 | fixtures.test_trigger.dummy | Thu, 04 Jun 2015 00:35:10 UTC | {u'int': 1, u'lst': [1, 5, 7], u'obj': {u'foo': u'bar',   |
|                          |                             |                               | u'baz': 1}, u'str': u'String', u'boo': True}              |
+--------------------------+-----------------------------+-------------------------------+-----------------------------------------------------------+
(virtualenv)/m/s/s/st2 git:STORM-1367/reemit_trigger_instances ❯❯❯ http POST http://127.0.0.1:8888/webhooks/passivesensor/test                                                                                                                           ✭ ✱ ◼
HTTP/1.0 200 OK
Content-Length: 91
Content-Type: text/html; charset=utf-8
Date: Thu, 04 Jun 2015 00:35:18 GMT
Server: Werkzeug/0.10.4 Python/2.7.6

{"int": 1, "lst": [1, 5, 7], "obj": {"foo": "bar", "baz": 1}, "str": "String", "boo": true}

(virtualenv)/m/s/s/st2 git:STORM-1367/reemit_trigger_instances ❯❯❯ st2 triggerinstance list                                                                                                                                                              ✭ ✱ ◼
+--------------------------+-------------------------------------+-------------------------------+-----------------------------------------------------------+
| id                       | trigger                             | occurrence_time               | payload                                                   |
+--------------------------+-------------------------------------+-------------------------------+-----------------------------------------------------------+
| 556f9d3932ed352054607405 | fixtures.test_trigger.dummy         | Thu, 04 Jun 2015 00:35:05 UTC | {u'int': 1, u'lst': [1, 5, 7], u'obj': {u'foo': u'bar',   |
|                          |                                     |                               | u'baz': 1}, u'str': u'String', u'boo': True}              |
| 556f9d3e32ed352054607406 | fixtures.test_trigger.dummy         | Thu, 04 Jun 2015 00:35:10 UTC | {u'int': 1, u'lst': [1, 5, 7], u'obj': {u'foo': u'bar',   |
|                          |                                     |                               | u'baz': 1}, u'str': u'String', u'boo': True}              |
| 556f9d4332ed352054607407 | fixtures.test_trigger.dummy         | Thu, 04 Jun 2015 00:35:15 UTC | {u'int': 1, u'lst': [1, 5, 7], u'obj': {u'foo': u'bar',   |
|                          |                                     |                               | u'baz': 1}, u'str': u'String', u'boo': True}              |
| 556f9d4632ed352054607408 | fixtures.test_passive_trigger.dummy | Thu, 04 Jun 2015 00:35:18 UTC | {u'int': 1, u'lst': [1, 5, 7], u'obj': {u'foo': u'bar',   |
|                          |                                     |                               | u'baz': 1}, u'str': u'String', u'boo': True}              |
| 556f9d4832ed352054607409 | fixtures.test_trigger.dummy         | Thu, 04 Jun 2015 00:35:20 UTC | {u'int': 1, u'lst': [1, 5, 7], u'obj': {u'foo': u'bar',   |
|                          |                                     |                               | u'baz': 1}, u'str': u'String', u'boo': True}              |
+--------------------------+-------------------------------------+-------------------------------+-----------------------------------------------------------+
(virtualenv)/m/s/s/st2 git:STORM-1367/reemit_trigger_instances ❯❯❯ http POST http://localhost:9101/v1/triggerinstances/556f9d4632ed352054607408/re_emit                                                                                                  ✭ ✱ ◼
HTTP/1.1 200 OK
Access-Control-Allow-Headers: Content-Type,Authorization,X-Auth-Token
Access-Control-Allow-Methods: GET,POST,PUT,DELETE,OPTIONS
Access-Control-Allow-Origin: http://127.0.0.1:9101/
Access-Control-Expose-Headers: Content-Type,X-Limit,X-Total-Count
Connection: keep-alive
Content-Length: 239
Content-Type: application/json; charset=UTF-8
Date: Thu, 04 Jun 2015 00:35:39 GMT

{
    "message": "Trigger instance 556f9d4632ed352054607408 succesfully re-sent.",
    "payload": {
        "__context": {
            "original_id": "556f9d4632ed352054607408"
        },
        "boo": true,
        "int": 1,
        "lst": [
            1,
            5,
            7
        ],
        "obj": {
            "baz": 1,
            "foo": "bar"
        },
        "str": "String"
    }
}

(virtualenv)/m/s/s/st2 git:STORM-1367/reemit_trigger_instances ❯❯❯ st2 triggerinstance list --trigger=fixtures.test_passive_trigger.dummy  -n=3                                                                                                          ✭ ✚ ◼
+--------------------------+-------------------------------------+-------------------------------+-----------------------------------------------------------+
| id                       | trigger                             | occurrence_time               | payload                                                   |
+--------------------------+-------------------------------------+-------------------------------+-----------------------------------------------------------+
| 556f9d4632ed352054607408 | fixtures.test_passive_trigger.dummy | Thu, 04 Jun 2015 00:35:18 UTC | {u'int': 1, u'lst': [1, 5, 7], u'obj': {u'foo': u'bar',   |
|                          |                                     |                               | u'baz': 1}, u'str': u'String', u'boo': True}              |
| 556f9d5b32ed35205460740d | fixtures.test_passive_trigger.dummy | Thu, 04 Jun 2015 00:35:39 UTC | {u'obj': {u'foo': u'bar', u'baz': 1}, u'int': 1, u'lst':  |
|                          |                                     |                               | [1, 5, 7], u'__context': {u'original_id':                 |
|                          |                                     |                               | u'556f9d4632ed352054607408'}, u'str': u'String', u'boo':  |
|                          |                                     |                               | True}                                                     |
+--------------------------+-------------------------------------+-------------------------------+-----------------------------------------------------------+
(virtualenv)/m/s/s/st2 git:STORM-1367/reemit_trigger_instances ❯❯❯
```

## CLI re_emit

```
virtualenv)/m/s/s/s/st2client git:STORM-1367/reemit_trigger_instances ❯❯❯ st2 triggerinstance re-emit 556fe6f132ed35205460847c
Trigger instance 556fe6f132ed35205460847c succesfully re-sent.
(virtualenv)/m/s/s/s/st2client git:STORM-1367/reemit_trigger_instances ❯❯❯ st2 triggerinstance re-emit 556fe6f132ed35205460847
ERROR: 404 Client Error: Not Found
MESSAGE: Unable to identify resource with id "556fe6f132ed35205460847".

(virtualenv)/m/s/s/s/st2client git:STORM-1367/reemit_trigger_instances ❯❯❯ st2 triggerinstance -h                      ⏎ ✭ ✱ ◼
usage: st2 triggerinstance [-h] {list,get,re-emit} ...

Actual instances of triggers received by st2.

positional arguments:
  {list,get,re-emit}  List of commands for managing triggerinstances.
    list              Get the list of the 50 most recent triggerinstances.
    get               Get individual triggerinstance.
    re-emit           A command to re-emit a particular trigger instance.

optional arguments:
  -h, --help          show this help message and exit
(virtualenv)/m/s/s/s/st2client git:STORM-1367/reemit_trigger_instances ❯❯
```