### PR TITLE
Notification consistency

### DIFF
--- a/contrib/examples/actions/echochain.meta.yaml
+++ b/contrib/examples/actions/echochain.meta.yaml
@@ -15,7 +15,7 @@ parameters:
     default:
       - c2
 notify:
-  on_complete:
+  on-complete:
     message: "\"@channel: Action succeeded.\""
     channels:
       - "slack"

--- a/contrib/examples/actions/local.yaml
+++ b/contrib/examples/actions/local.yaml
@@ -4,7 +4,7 @@ enabled: true
 entry_point: ''
 name: local-notify
 notify:
-  on_complete:
+  on-complete:
     channels:
     - slack
     message: '"@channel: Action succeeded."'

--- a/contrib/examples/actions/mistral-basic-two-tasks-with-notifications.yaml
+++ b/contrib/examples/actions/mistral-basic-two-tasks-with-notifications.yaml
@@ -22,7 +22,7 @@ parameters:
     immutable: true
     type: string
 notify:
-  on_complete:
+  on-complete:
     message: "\"@channel: Action succeeded.\""
     channels:
       - "slack"

--- a/st2actions/tests/unit/test_mistral_v2.py
+++ b/st2actions/tests/unit/test_mistral_v2.py
@@ -39,6 +39,7 @@ from st2actions.runners.mistral.v2 import MistralRunner
 from st2common.constants import action as action_constants
 from st2common.models.api.auth import TokenAPI
 from st2common.models.api.action import ActionAPI
+from st2common.models.api.notification import NotificationsHelper
 from st2common.models.db.liveaction import LiveActionDB
 from st2common.persistence.action import Action
 from st2common.persistence.liveaction import LiveAction
@@ -289,7 +290,7 @@ class TestMistralRunner(DbTestCase):
                     'st2_context': {
                         'endpoint': 'http://0.0.0.0:9101/v1/actionexecutions',
                         'parent': str(liveaction.id),
-                        'notify': notify_data,
+                        'notify': NotificationsHelper.from_model(liveaction.notify),
                         'skip_notify_tasks': []
                     }
                 }

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -176,9 +176,9 @@ class ActionAPI(BaseAPI):
                 "description": "Notification settings for action.",
                 "type": "object",
                 "properties": {
-                    "on_complete": NotificationSubSchemaAPI,
-                    "on_failure": NotificationSubSchemaAPI,
-                    "on_success": NotificationSubSchemaAPI
+                    "on-complete": NotificationSubSchemaAPI,
+                    "on-failure": NotificationSubSchemaAPI,
+                    "on-success": NotificationSubSchemaAPI
                 },
                 "additionalProperties": False
             }
@@ -292,9 +292,9 @@ class LiveActionAPI(BaseAPI):
                 "description": "Notification settings for liveaction.",
                 "type": "object",
                 "properties": {
-                    "on_complete": NotificationSubSchemaAPI,
-                    "on_failure": NotificationSubSchemaAPI,
-                    "on_success": NotificationSubSchemaAPI
+                    "on-complete": NotificationSubSchemaAPI,
+                    "on-failure": NotificationSubSchemaAPI,
+                    "on-success": NotificationSubSchemaAPI
                 },
                 "additionalProperties": False
             }

--- a/st2common/st2common/models/api/notification.py
+++ b/st2common/st2common/models/api/notification.py
@@ -40,15 +40,15 @@ class NotificationsHelper(object):
     @staticmethod
     def to_model(notify_api_object):
         model = NotificationSchema()
-        if notify_api_object.get('on_complete', None):
+        if notify_api_object.get('on-complete', None):
             model.on_complete = NotificationsHelper._to_model_sub_schema(
-                notify_api_object['on_complete'])
-        if notify_api_object.get('on_success', None):
+                notify_api_object['on-complete'])
+        if notify_api_object.get('on-success', None):
             model.on_success = NotificationsHelper._to_model_sub_schema(
-                notify_api_object['on_success'])
-        if notify_api_object.get('on_failure', None):
+                notify_api_object['on-success'])
+        if notify_api_object.get('on-failure', None):
             model.on_failure = NotificationsHelper._to_model_sub_schema(
-                notify_api_object['on_failure'])
+                notify_api_object['on-failure'])
         return model
 
     @staticmethod
@@ -63,13 +63,13 @@ class NotificationsHelper(object):
     def from_model(notify_model):
         notify = {}
         if getattr(notify_model, 'on_complete', None):
-            notify['on_complete'] = NotificationsHelper._from_model_sub_schema(
+            notify['on-complete'] = NotificationsHelper._from_model_sub_schema(
                 notify_model.on_complete)
         if getattr(notify_model, 'on_success', None):
-            notify['on_success'] = NotificationsHelper._from_model_sub_schema(
+            notify['on-success'] = NotificationsHelper._from_model_sub_schema(
                 notify_model.on_success)
         if getattr(notify_model, 'on_failure', None):
-            notify['on_failure'] = NotificationsHelper._from_model_sub_schema(
+            notify['on-failure'] = NotificationsHelper._from_model_sub_schema(
                 notify_model.on_failure)
         return notify
 

--- a/st2common/st2common/models/system/actionchain.py
+++ b/st2common/st2common/models/system/actionchain.py
@@ -70,9 +70,9 @@ class Node(object):
                 "description": "Notification settings for action.",
                 "type": "object",
                 "properties": {
-                    "on_complete": NotificationSubSchemaAPI,
-                    "on_failure": NotificationSubSchemaAPI,
-                    "on_success": NotificationSubSchemaAPI
+                    "on-complete": NotificationSubSchemaAPI,
+                    "on-failure": NotificationSubSchemaAPI,
+                    "on-success": NotificationSubSchemaAPI
                 },
                 "additionalProperties": False
             }

--- a/st2common/tests/unit/services/test_action.py
+++ b/st2common/tests/unit/services/test_action.py
@@ -55,7 +55,7 @@ ACTION = {
         }
     },
     'notify': {
-        'on_complete': {
+        'on-complete': {
             'message': 'My awesome action is complete. Party time!!!',
             'channels': ['notify.slack']
         }

--- a/st2common/tests/unit/test_notification_helper.py
+++ b/st2common/tests/unit/test_notification_helper.py
@@ -22,7 +22,7 @@ class NotificationsHelperTestCase(unittest2.TestCase):
 
     def test_model_transformations(self):
         notify = {}
-        notify['on_complete'] = {
+        notify['on-complete'] = {
             'message': 'Action completed.',
             'data': {
                 'foo': '{{foo}}',
@@ -30,7 +30,7 @@ class NotificationsHelperTestCase(unittest2.TestCase):
                 'baz': [1, 2, 3]
             }
         }
-        notify['on_success'] = {
+        notify['on-success'] = {
             'message': 'Action succeeded.',
             'data': {
                 'foo': '{{foo}}',
@@ -38,13 +38,13 @@ class NotificationsHelperTestCase(unittest2.TestCase):
             }
         }
         notify_model = NotificationsHelper.to_model(notify)
-        self.assertEqual(notify['on_complete']['message'], notify_model.on_complete.message)
-        self.assertDictEqual(notify['on_complete']['data'], notify_model.on_complete.data)
-        self.assertEqual(notify['on_success']['message'], notify_model.on_success.message)
-        self.assertDictEqual(notify['on_success']['data'], notify_model.on_success.data)
+        self.assertEqual(notify['on-complete']['message'], notify_model.on_complete.message)
+        self.assertDictEqual(notify['on-complete']['data'], notify_model.on_complete.data)
+        self.assertEqual(notify['on-success']['message'], notify_model.on_success.message)
+        self.assertDictEqual(notify['on-success']['data'], notify_model.on_success.data)
 
         notify_api = NotificationsHelper.from_model(notify_model)
-        self.assertEqual(notify['on_complete']['message'], notify_api['on_complete']['message'])
-        self.assertDictEqual(notify['on_complete']['data'], notify_api['on_complete']['data'])
-        self.assertEqual(notify['on_success']['message'], notify_api['on_success']['message'])
-        self.assertDictEqual(notify['on_success']['data'], notify_api['on_success']['data'])
+        self.assertEqual(notify['on-complete']['message'], notify_api['on-complete']['message'])
+        self.assertDictEqual(notify['on-complete']['data'], notify_api['on-complete']['data'])
+        self.assertEqual(notify['on-success']['message'], notify_api['on-success']['message'])
+        self.assertDictEqual(notify['on-success']['data'], notify_api['on-success']['data'])

--- a/st2tests/st2tests/fixtures/generic/actionchains/chain_with_notifications.yaml
+++ b/st2tests/st2tests/fixtures/generic/actionchains/chain_with_notifications.yaml
@@ -8,17 +8,17 @@
             on-success: "c2"
             on-failure: "c4"
             notify:
-                on_complete:
+                on-complete:
                     message: "on_complete"
                     data: {}
                     channels:
                         - "channel1"
-                on_failure:
+                on-failure:
                     message: "on_failure"
                     data: {}
                     channels:
                         - "channel1"
-                on_success:
+                on-success:
                     message: "on_success"
                     data: {}
                     channels:

--- a/st2tests/st2tests/fixtures/generic/actionchains/chain_with_notifications.yaml
+++ b/st2tests/st2tests/fixtures/generic/actionchains/chain_with_notifications.yaml
@@ -9,17 +9,17 @@
             on-failure: "c4"
             notify:
                 on-complete:
-                    message: "on_complete"
+                    message: "on complete"
                     data: {}
                     channels:
                         - "channel1"
                 on-failure:
-                    message: "on_failure"
+                    message: "on failure"
                     data: {}
                     channels:
                         - "channel1"
                 on-success:
-                    message: "on_success"
+                    message: "on success"
                     data: {}
                     channels:
                         - "channel1"


### PR DESCRIPTION
* actionchain already uses 'on-success' and similar therefore making
  sure that notification which can also exist in an actionchain task use
  'on-success'. All instances like Action & LiveAction can contain
  notfication schema have been updated for sake of consistency.
* The preferred value is 'on_success' however mistral DSL has already
  taken the approach to use '-' and not '_'. To avoid confusion and
  inconsistency to user better to stick with '-'.
* All the internal proeprties though use '_' since '-' being the 'minus'
  operator should not be used in a property name.