### PR TITLE
Updating Pack Deploy Strategy

### DIFF
--- a/contrib/packs/actions/download.yaml
+++ b/contrib/packs/actions/download.yaml
@@ -11,7 +11,7 @@
         type: "string"
     repo_url:
       type: "string"
-      default: "https://github.com/StackStorm/st2contrib.git"
+      default: "StackStorm/st2contrib"
     branch:
       type: "string"
       default: "master"
@@ -19,6 +19,9 @@
       type: "string"
       default: "/opt/stackstorm/packs/"
       immutable: true
+    subtree:
+      type: "boolean"
+      default: false
     verifyssl:
       type: "boolean"
       default: true

--- a/contrib/packs/actions/info.yaml
+++ b/contrib/packs/actions/info.yaml
@@ -1,0 +1,12 @@
+---
+name: "info"
+runner_type: "python-script"
+description: "Get currently deployed pack information"
+enabled: true
+entry_point: "pack_mgmt/info.py"
+parameters:
+  pack:
+    type: "string"
+    description: "Name of pack to introspect"
+    required: true
+

--- a/contrib/packs/actions/pack_mgmt/info.py
+++ b/contrib/packs/actions/pack_mgmt/info.py
@@ -1,0 +1,16 @@
+from st2actions.runners.pythonrunner import Action
+import json
+import os
+
+GITINFO_FILE = '.gitinfo'
+
+
+class PackInfo(Action):
+    def run(self, pack, pack_dir="/opt/stackstorm/packs"):
+        gitinfo = os.path.join(pack_dir, pack, GITINFO_FILE)
+        try:
+            with open(gitinfo) as data_file:
+                details = json.load(data_file)
+                return details
+        except:
+            print "Unable to load git info for {}".format(pack)

--- a/contrib/packs/aliases/pack_deploy.yaml
+++ b/contrib/packs/aliases/pack_deploy.yaml
@@ -1,0 +1,7 @@
+---
+name: "deploy_pack"
+action_ref: "packs.download"
+description: "Download StackStorm packs via ChatOps"
+formats:
+  - "pack download {{packs}}"
+  - "pack download {{packs}} from {{repo_url}}"

--- a/contrib/packs/aliases/pack_deploy.yaml
+++ b/contrib/packs/aliases/pack_deploy.yaml
@@ -3,5 +3,5 @@ name: "deploy_pack"
 action_ref: "packs.download"
 description: "Download StackStorm packs via ChatOps"
 formats:
-  - "pack download {{packs}}"
-  - "pack download {{packs}} from {{repo_url}}"
+  - "pack deploy {{packs}}"
+  - "pack deploy {{packs}} from {{repo_url}}"

--- a/contrib/packs/aliases/pack_info.yaml
+++ b/contrib/packs/aliases/pack_info.yaml
@@ -1,0 +1,6 @@
+---
+name: "pack_info"
+action_ref: "packs.info"
+description: "Get StackStorm pack information via ChatOps"
+formats:
+  - "pack info {{packs}}"

--- a/contrib/packs/aliases/pack_info.yaml
+++ b/contrib/packs/aliases/pack_info.yaml
@@ -3,4 +3,4 @@ name: "pack_info"
 action_ref: "packs.info"
 description: "Get StackStorm pack information via ChatOps"
 formats:
-  - "pack info {{packs}}"
+  - "pack info {{pack}}"


### PR DESCRIPTION
This commit introduces several new fixes for the existing Pack deployment
actions. Namely:

* Do not overwrite `config.txt` on existing pack installations
* Allow short `repo_url` for GitHub shortcuts (repo_url=StackStorm/st2contrib)
* Deploy from monorepo repositories and single-pack repositories
  - Introduces `subtree` flag, for used when packs are nested within top-level `packs` directory
* Tag each download with Git information
  - Used to introspect versions of deployed packs