### PR TITLE
Pack deployment chatops

### DIFF
--- a/contrib/packs/actions/download.yaml
+++ b/contrib/packs/actions/download.yaml
@@ -11,7 +11,7 @@
         type: "string"
     repo_url:
       type: "string"
-      default: "https://github.com/StackStorm/st2contrib.git"
+      default: "StackStorm/st2contrib"
     branch:
       type: "string"
       default: "master"
@@ -19,6 +19,9 @@
       type: "string"
       default: "/opt/stackstorm/packs/"
       immutable: true
+    subtree:
+      type: "boolean"
+      default: false
     verifyssl:
       type: "boolean"
       default: true

--- a/contrib/packs/actions/info.yaml
+++ b/contrib/packs/actions/info.yaml
@@ -1,0 +1,12 @@
+---
+name: "info"
+runner_type: "python-script"
+description: "Get currently deployed pack information"
+enabled: true
+entry_point: "pack_mgmt/info.py"
+parameters:
+  pack:
+    type: "string"
+    description: "Name of pack to introspect"
+    required: true
+

--- a/contrib/packs/actions/pack_mgmt/info.py
+++ b/contrib/packs/actions/pack_mgmt/info.py
@@ -1,0 +1,16 @@
+from st2actions.runners.pythonrunner import Action
+import json
+import os
+
+GITINFO_FILE = '.gitinfo'
+
+
+class PackInfo(Action):
+    def run(self, pack, pack_dir="/opt/stackstorm/packs"):
+        gitinfo = os.path.join(pack_dir, pack, GITINFO_FILE)
+        try:
+            with open(gitinfo) as data_file:
+                details = json.load(data_file)
+                return details
+        except:
+            print "Unable to load git info for {}".format(pack)

--- a/contrib/packs/aliases/pack_deploy.yaml
+++ b/contrib/packs/aliases/pack_deploy.yaml
@@ -1,6 +1,6 @@
 ---
 name: "deploy_pack"
-action_ref: "packs.download"
+action_ref: "packs.install"
 description: "Download StackStorm packs via ChatOps"
 formats:
   - "pack deploy {{packs}}"

--- a/contrib/packs/aliases/pack_deploy.yaml
+++ b/contrib/packs/aliases/pack_deploy.yaml
@@ -1,0 +1,7 @@
+---
+name: "deploy_pack"
+action_ref: "packs.download"
+description: "Download StackStorm packs via ChatOps"
+formats:
+  - "pack download {{packs}}"
+  - "pack download {{packs}} from {{repo_url}}"

--- a/contrib/packs/aliases/pack_deploy.yaml
+++ b/contrib/packs/aliases/pack_deploy.yaml
@@ -3,5 +3,5 @@ name: "deploy_pack"
 action_ref: "packs.download"
 description: "Download StackStorm packs via ChatOps"
 formats:
-  - "pack download {{packs}}"
-  - "pack download {{packs}} from {{repo_url}}"
+  - "pack deploy {{packs}}"
+  - "pack deploy {{packs}} from {{repo_url}}"

--- a/contrib/packs/aliases/pack_info.yaml
+++ b/contrib/packs/aliases/pack_info.yaml
@@ -1,0 +1,6 @@
+---
+name: "pack_info"
+action_ref: "packs.info"
+description: "Get StackStorm pack information via ChatOps"
+formats:
+  - "pack info {{packs}}"

--- a/contrib/packs/aliases/pack_info.yaml
+++ b/contrib/packs/aliases/pack_info.yaml
@@ -3,4 +3,4 @@ name: "pack_info"
 action_ref: "packs.info"
 description: "Get StackStorm pack information via ChatOps"
 formats:
-  - "pack info {{packs}}"
+  - "pack info {{pack}}"

--- a/st2api/st2api/controllers/exp/aliasexecution.py
+++ b/st2api/st2api/controllers/exp/aliasexecution.py
@@ -32,6 +32,10 @@ http_client = six.moves.http_client
 
 LOG = logging.getLogger(__name__)
 
+CAST_OVERRIDES = {
+    'array': (lambda cs_x: [v.strip() for v in cs_x.split(',')])
+}
+
 
 class ActionAliasExecutionController(rest.RestController):
 
@@ -99,7 +103,8 @@ class ActionAliasExecutionController(rest.RestController):
         try:
             # prior to shipping off the params cast them to the right type.
             params = action_param_utils.cast_params(action_ref=action_alias_db.action_ref,
-                                                    params=params)
+                                                    params=params,
+                                                    cast_overrides=CAST_OVERRIDES)
             liveaction = LiveActionDB(action=action_alias_db.action_ref, context={},
                                       parameters=params, notify=notify)
             _, action_execution_db = action_service.request(liveaction)

--- a/st2api/tests/unit/controllers/exp/test_alias_execution.py
+++ b/st2api/tests/unit/controllers/exp/test_alias_execution.py
@@ -63,8 +63,25 @@ class TestAliasExecution(FunctionalTest):
         expected_parameters = {'param1': 'value1', 'param2': 'value2 value3'}
         self.assertEquals(request.call_args[0][0].parameters, expected_parameters)
 
+    @mock.patch.object(action_service, 'request',
+                       return_value=(None, DummyActionExecution(id_=1)))
+    def testExecutionWithArrayTypeSingleValue(self, request):
+        command = 'Lorem ipsum value1 dolor sit value2 amet.'
+        post_resp = self._do_post(alias_execution=self.alias2, command=command)
+        self.assertEqual(post_resp.status_int, 200)
+        expected_parameters = {'param1': 'value1', 'param3': ['value2']}
+        self.assertEquals(request.call_args[0][0].parameters, expected_parameters)
+
+    @mock.patch.object(action_service, 'request',
+                       return_value=(None, DummyActionExecution(id_=1)))
+    def testExecutionWithArrayTypeMultiValue(self, request):
+        command = 'Lorem ipsum value1 dolor sit "value2, value3" amet.'
+        post_resp = self._do_post(alias_execution=self.alias2, command=command)
+        self.assertEqual(post_resp.status_int, 200)
+        expected_parameters = {'param1': 'value1', 'param3': ['value2', 'value3']}
+        self.assertEquals(request.call_args[0][0].parameters, expected_parameters)
+
     def _do_post(self, alias_execution, command, expect_errors=False):
-        print alias_execution
         execution = {'name': alias_execution.name,
                      'format': alias_execution.formats[0],
                      'command': command,

--- a/st2common/st2common/models/utils/action_param_utils.py
+++ b/st2common/st2common/models/utils/action_param_utils.py
@@ -79,7 +79,7 @@ def get_params_view(action_db=None, runner_db=None, merged_only=False):
     return (required_params, optional_params, immutable_params)
 
 
-def cast_params(action_ref, params):
+def cast_params(action_ref, params, cast_overrides=None):
     """
     """
     action_db = action_db_util.get_action_by_ref(action_ref)
@@ -102,7 +102,10 @@ def cast_params(action_ref, params):
         if not parameter_type:
             LOG.debug('Will skip cast of param[name: %s, value: %s]. No type.', k, v)
             continue
-        cast = get_cast(cast_type=parameter_type)
+        # Pick up cast from teh override and then from the system suppied ones.
+        cast = cast_overrides.get(parameter_type, None) if cast_overrides else None
+        if not cast:
+            cast = get_cast(cast_type=parameter_type)
         if not cast:
             LOG.debug('Will skip cast of param[name: %s, value: %s]. No cast for %s.', k, v,
                       parameter_type)

--- a/st2tests/st2tests/fixtures/aliases/actions/action1.yaml
+++ b/st2tests/st2tests/fixtures/aliases/actions/action1.yaml
@@ -10,3 +10,5 @@
             type: "string"
         param2:
             type: "string"
+        param3:
+            type: "array"

--- a/st2tests/st2tests/fixtures/aliases/aliases/alias2.yaml
+++ b/st2tests/st2tests/fixtures/aliases/aliases/alias2.yaml
@@ -4,4 +4,4 @@
     description: "DON'T CARE"
     action_ref: "wolfpack.action1"
     formats:
-        - "Lorem ipsum {{param1}} dolor sit {{param2}} amet."
+        - "Lorem ipsum {{param1}} dolor sit {{param3}} amet."


### PR DESCRIPTION
This commit introduces several new fixes for the existing Pack deployment
actions. Namely:

* Do not overwrite config.txt on existing pack installations
* Allow short repo_url for GitHub shortcuts (repo_url=StackStorm/st2contrib)
* Deploy from monorepo repositories and single-pack repositories
  - Introduces subtree flag, for used when packs are nested within top-level packs directory
* Tag each download with Git information
  - Used to introspect versions of deployed packs