### PR TITLE
Trigger instance typo and command name consistency fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,7 +28,7 @@ in development
   [James Sigurðarson]
 * CLI now has ``get`` and ``list`` commands for triggerinstance. (new-feature)
 * Validate parameters during rule creation for system triggers. (improvement)
-* CLI now has ``re_emit`` command for triggerinstance. (new-feature)
+* CLI now has ``re-emit`` command for triggerinstance. (new-feature)
 
 v0.9.2 - May 26, 2015
 ---------------------

--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -401,11 +401,11 @@ get details about a trigger instance by using ``get``.
   st2 triggerinstance get 556e135232ed35569ff23238
 
 Something that might be useful in debugging a rule is to re-send a trigger instance into |st2|. You
-can use the ``re_emit`` command for that.
+can use the ``re-emit`` command for that.
 
 .. code-block:: bash
 
-  st2 triggerinstance re_emit 556e135232ed35569ff23238
+  st2 triggerinstance re-emit 556e135232ed35569ff23238
 
 
 Timers

--- a/st2actions/tests/unit/policies/test_concurrency_by_attr.py
+++ b/st2actions/tests/unit/policies/test_concurrency_by_attr.py
@@ -80,9 +80,7 @@ def mock_run(action_parameters):
     LiveActionPublisher, 'publish_state',
     mock.MagicMock(side_effect=MockLiveActionPublisher.publish_state))
 class ConcurrencyByAttributePolicyTest(EventletTestCase, DbTestCase):
-
-    @classmethod
-    def setUpClass(cls):
+    def setUp(self):
         EventletTestCase.setUpClass()
         DbTestCase.setUpClass()
 
@@ -112,7 +110,7 @@ class ConcurrencyByAttributePolicyTest(EventletTestCase, DbTestCase):
             eventlet.spawn(action_service.request, liveaction)
 
         # Sleep here to let the threads above schedule the action execution.
-        eventlet.sleep(1)
+        eventlet.sleep(2)
 
         scheduled = LiveAction.get_all()
         self.assertEqual(len(scheduled), policy_db.parameters['threshold'])

--- a/st2client/st2client/models/reactor.py
+++ b/st2client/st2client/models/reactor.py
@@ -35,7 +35,7 @@ class TriggerType(core.Resource):
 
 
 class TriggerInstance(core.Resource):
-    _alias = 'TriggerInstance'
+    _alias = 'Trigger-Instance'
     _display_name = 'TriggerInstance'
     _plural = 'Triggerinstances'
     _plural_display_name = 'TriggerInstances'

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -225,7 +225,7 @@ class Shell(object):
             'st2 invocation point.',
             self, self.subparsers)
 
-        self.commands['triggerinstances'] = triggerinstance.TriggerInstanceBranch(
+        self.commands['trigger-instance'] = triggerinstance.TriggerInstanceBranch(
             'Actual instances of triggers received by st2.',
             self, self.subparsers)
 


### PR DESCRIPTION
See:

* https://github.com/StackStorm/st2/pull/1554#discussion_r31784141
* https://github.com/StackStorm/st2/pull/1554#discussion_r31784041