### PR TITLE
Adding ability in API and CLI to filter executions based on the trigger instance id

### DIFF
--- a/st2api/st2api/controllers/v1/executionviews.py
+++ b/st2api/st2api/controllers/v1/executionviews.py
@@ -33,6 +33,7 @@ SUPPORTED_FILTERS = {
     'timestamp': 'start_timestamp',
     'trigger': 'trigger.name',
     'trigger_type': 'trigger_type.name',
+    'trigger_instance': 'trigger_instance.id',
     'user': 'liveaction.context.user'
 }
 

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -830,7 +830,8 @@ class ActionExecutionListCommand(resource.ResourceCommand):
                                                   ' Possible values are \'%s\', \'%s\', \'%s\','
                                                   '\'%s\' or \'%s\''
                                                   '.' % POSSIBLE_ACTION_STATUS_VALUES))
-        self.group.add_argument('--trigger_instance', help='Trigger instance id to filter the list.')
+        self.group.add_argument('--trigger_instance',
+                                help='Trigger instance id to filter the list.')
         self.parser.add_argument('-tg', '--timestamp-gt', type=str, dest='timestamp_gt',
                                  default=None,
                                  help=('Only return executions with timestamp '

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -830,6 +830,7 @@ class ActionExecutionListCommand(resource.ResourceCommand):
                                                   ' Possible values are \'%s\', \'%s\', \'%s\','
                                                   '\'%s\' or \'%s\''
                                                   '.' % POSSIBLE_ACTION_STATUS_VALUES))
+        self.group.add_argument('--trigger_instance', help='Trigger instance id to filter the list.')
         self.parser.add_argument('-tg', '--timestamp-gt', type=str, dest='timestamp_gt',
                                  default=None,
                                  help=('Only return executions with timestamp '
@@ -860,6 +861,8 @@ class ActionExecutionListCommand(resource.ResourceCommand):
             kwargs['action'] = args.action
         if args.status:
             kwargs['status'] = args.status
+        if args.trigger_instance:
+            kwargs['trigger_instance'] = args.trigger_instance
         if not args.showall:
             # null is the magic string that translates to does not exist.
             kwargs['parent'] = 'null'

--- a/st2tests/st2tests/fixtures/executions/trigger_instance.yaml
+++ b/st2tests/st2tests/fixtures/executions/trigger_instance.yaml
@@ -1,4 +1,5 @@
 ---
+id: 556cd0a0b353414b9708a51a
 occurrence_time: '2014-09-01T00:00:01.000000Z'
 payload:
   foo: bar


### PR DESCRIPTION
This will let users track the sequence of what happened after a particular trigger was dispatched.