### PR TITLE
Repair failing pack installation

### DIFF
--- a/contrib/packs/actions/install.meta.yaml
+++ b/contrib/packs/actions/install.meta.yaml
@@ -15,7 +15,7 @@
         - "*"
     repo_url:
       type: "string"
-      default: "https://github.com/StackStorm/st2contrib.git"
+      default: "StackStorm/st2contrib"
     branch:
       type: "string"
       default: "master"

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -144,7 +144,7 @@ class InstallGitRepoAction(Action):
         """Allow passing short GitHub style URLs"""
         has_git_extension = repo_url.endswith('.git')
         if len(repo_url.split('/')) == 2 and not "git@" in repo_url:
-            url = "git@github.com:{}".format(repo_url)
+            url = "https://github.com/{}".format(repo_url)
         else:
             url = repo_url
         return url if has_git_extension.search(url) else "{}.git".format(url)

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -142,7 +142,7 @@ class InstallGitRepoAction(Action):
     @staticmethod
     def _eval_repo_url(repo_url):
         """Allow passing short GitHub style URLs"""
-        has_git_extension = re.compile('.git$')
+        has_git_extension = repo_url.endswith('.git')
         if len(repo_url.split('/')) == 2 and not "git@" in repo_url:
             url = "git@github.com:{}".format(repo_url)
         else:

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -37,7 +37,7 @@ class InstallGitRepoAction(Action):
                     pack_abs_local_path = abs_local_path
 
                 self._tag_pack(pack_abs_local_path, packs, self._subtree)
-                result = self._move_packs(abs_repo_base, packs, pack_abs_local_path)
+                result = self._move_packs(abs_repo_base, packs, pack_abs_local_path, self._subtree)
             finally:
                 self._cleanup_repo(abs_local_path)
         return self._validate_result(result=result, packs=packs, repo_url=repo_url)
@@ -56,13 +56,13 @@ class InstallGitRepoAction(Action):
         Repo.clone_from(repo_url, abs_local_path, branch=branch)
         return abs_local_path
 
-    def _move_packs(self, abs_repo_base, packs, abs_local_path):
+    def _move_packs(self, abs_repo_base, packs, abs_local_path, subtree):
         result = {}
         # all_packs should be removed as a pack with that name is not expected to be found.
         if ALL_PACKS in packs:
             packs = os.listdir(abs_local_path)
         for pack in packs:
-            abs_pack_temp_location = os.path.join(abs_local_path, pack)
+            abs_pack_temp_location = os.path.join(abs_local_path, pack) if subtree else abs_local_path
             desired, message = InstallGitRepoAction._is_desired_pack(abs_pack_temp_location, pack)
             if desired:
                 to = abs_repo_base
@@ -104,7 +104,8 @@ class InstallGitRepoAction(Action):
     @staticmethod
     def _cleanup_repo(abs_local_path):
         # basic lock checking etc?
-        shutil.rmtree(abs_local_path)
+        if os.path.isdir(abs_local_path):
+            shutil.rmtree(abs_local_path)
 
     @staticmethod
     def _validate_result(result, packs, repo_url):

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -141,10 +141,12 @@ class InstallGitRepoAction(Action):
     @staticmethod
     def _eval_repo_url(repo_url):
         """Allow passing short GitHub style URLs"""
+        has_git_extension = re.compile('.git$')
         if len(repo_url.split('/')) == 2 and not "git@" in repo_url:
-            return "https://github.com/{}.git".format(repo_url)
+            url = "git@github.com:{}".format(repo_url)
         else:
-            return "{}.git".format(repo_url)
+            url = repo_url
+        return url if has_git_extension.search(url) else "{}.git".format(url)
 
     @staticmethod
     def _tag_pack(pack_dir, packs, subtree):

--- a/contrib/packs/actions/workflows/install.yaml
+++ b/contrib/packs/actions/workflows/install.yaml
@@ -25,6 +25,12 @@
       ref: "packs.load"
       params:
         register: "{{register}}"
+      on-success: "reload-aliases"
+    -
+      name: "reload-aliases"
+      ref: "packs.load"
+      params:
+        register: "aliases"
       on-success: "restart-sensor-container"
     -
       name: "restart-sensor-container"


### PR DESCRIPTION
This PR fixes two bugs introduced in #1570 / #1571

* Double `.git` extension
* SSH protocol downloads via Git

In certain circumstances, the `repo_url` passed into the `packs.download`
action is returns a double `.git.git` extension. Contains fix to only
append `.git` suffix if doesn't already exist.

In #1570, the protocol for Git was changed from SSH -> HTTPS. In cases
where a git-helper is not installed (ref: st2workroom), the protocol
needs to be reverted to avoid credential prompts.