### PR TITLE
Repair packs download

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 in development
 --------------
 
+
+0.11 - June 5, 2015
+-------------------
+
 * Allow user to configure the CLI using an ini style config file located at ``~/.st2rc``.
   (new-feature)
 * Add support for caching of the retrieved auth tokens to the CLI. (new-feature)

--- a/contrib/packs/actions/download.yaml
+++ b/contrib/packs/actions/download.yaml
@@ -11,7 +11,7 @@
         type: "string"
     repo_url:
       type: "string"
-      default: "https://github.com/StackStorm/st2contrib.git"
+      default: "StackStorm/st2contrib"
     branch:
       type: "string"
       default: "master"
@@ -19,6 +19,9 @@
       type: "string"
       default: "/opt/stackstorm/packs/"
       immutable: true
+    subtree:
+      type: "boolean"
+      default: false
     verifyssl:
       type: "boolean"
       default: true

--- a/contrib/packs/actions/info.yaml
+++ b/contrib/packs/actions/info.yaml
@@ -1,0 +1,12 @@
+---
+name: "info"
+runner_type: "python-script"
+description: "Get currently deployed pack information"
+enabled: true
+entry_point: "pack_mgmt/info.py"
+parameters:
+  pack:
+    type: "string"
+    description: "Name of pack to introspect"
+    required: true
+

--- a/contrib/packs/actions/install.meta.yaml
+++ b/contrib/packs/actions/install.meta.yaml
@@ -15,7 +15,7 @@
         - "*"
     repo_url:
       type: "string"
-      default: "https://github.com/StackStorm/st2contrib.git"
+      default: "StackStorm/st2contrib"
     branch:
       type: "string"
       default: "master"

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -144,7 +144,7 @@ class InstallGitRepoAction(Action):
         """Allow passing short GitHub style URLs"""
         has_git_extension = repo_url.endswith('.git')
         if len(repo_url.split('/')) == 2 and not "git@" in repo_url:
-            url = "git@github.com:{}".format(repo_url)
+            url = "https://github.com/{}".format(repo_url)
         else:
             url = repo_url
         return url if has_git_extension.search(url) else "{}.git".format(url)

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -142,7 +142,7 @@ class InstallGitRepoAction(Action):
     @staticmethod
     def _eval_repo_url(repo_url):
         """Allow passing short GitHub style URLs"""
-        has_git_extension = re.compile('.git$')
+        has_git_extension = repo_url.endswith('.git')
         if len(repo_url.split('/')) == 2 and not "git@" in repo_url:
             url = "git@github.com:{}".format(repo_url)
         else:

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -37,7 +37,7 @@ class InstallGitRepoAction(Action):
                     pack_abs_local_path = abs_local_path
 
                 self._tag_pack(pack_abs_local_path, packs, self._subtree)
-                result = self._move_packs(abs_repo_base, packs, pack_abs_local_path)
+                result = self._move_packs(abs_repo_base, packs, pack_abs_local_path, self._subtree)
             finally:
                 self._cleanup_repo(abs_local_path)
         return self._validate_result(result=result, packs=packs, repo_url=repo_url)
@@ -56,13 +56,13 @@ class InstallGitRepoAction(Action):
         Repo.clone_from(repo_url, abs_local_path, branch=branch)
         return abs_local_path
 
-    def _move_packs(self, abs_repo_base, packs, abs_local_path):
+    def _move_packs(self, abs_repo_base, packs, abs_local_path, subtree):
         result = {}
         # all_packs should be removed as a pack with that name is not expected to be found.
         if ALL_PACKS in packs:
             packs = os.listdir(abs_local_path)
         for pack in packs:
-            abs_pack_temp_location = os.path.join(abs_local_path, pack)
+            abs_pack_temp_location = os.path.join(abs_local_path, pack) if subtree else abs_local_path
             desired, message = InstallGitRepoAction._is_desired_pack(abs_pack_temp_location, pack)
             if desired:
                 to = abs_repo_base
@@ -104,7 +104,8 @@ class InstallGitRepoAction(Action):
     @staticmethod
     def _cleanup_repo(abs_local_path):
         # basic lock checking etc?
-        shutil.rmtree(abs_local_path)
+        if os.path.isdir(abs_local_path):
+            shutil.rmtree(abs_local_path)
 
     @staticmethod
     def _validate_result(result, packs, repo_url):

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -141,10 +141,12 @@ class InstallGitRepoAction(Action):
     @staticmethod
     def _eval_repo_url(repo_url):
         """Allow passing short GitHub style URLs"""
+        has_git_extension = re.compile('.git$')
         if len(repo_url.split('/')) == 2 and not "git@" in repo_url:
-            return "https://github.com/{}.git".format(repo_url)
+            url = "git@github.com:{}".format(repo_url)
         else:
-            return "{}.git".format(repo_url)
+            url = repo_url
+        return url if has_git_extension.search(url) else "{}.git".format(url)
 
     @staticmethod
     def _tag_pack(pack_dir, packs, subtree):

--- a/contrib/packs/actions/pack_mgmt/info.py
+++ b/contrib/packs/actions/pack_mgmt/info.py
@@ -1,0 +1,16 @@
+from st2actions.runners.pythonrunner import Action
+import json
+import os
+
+GITINFO_FILE = '.gitinfo'
+
+
+class PackInfo(Action):
+    def run(self, pack, pack_dir="/opt/stackstorm/packs"):
+        gitinfo = os.path.join(pack_dir, pack, GITINFO_FILE)
+        try:
+            with open(gitinfo) as data_file:
+                details = json.load(data_file)
+                return details
+        except:
+            print "Unable to load git info for {}".format(pack)

--- a/contrib/packs/actions/workflows/install.yaml
+++ b/contrib/packs/actions/workflows/install.yaml
@@ -25,6 +25,12 @@
       ref: "packs.load"
       params:
         register: "{{register}}"
+      on-success: "reload-aliases"
+    -
+      name: "reload-aliases"
+      ref: "packs.load"
+      params:
+        register: "aliases"
       on-success: "restart-sensor-container"
     -
       name: "restart-sensor-container"

--- a/contrib/packs/aliases/pack_deploy.yaml
+++ b/contrib/packs/aliases/pack_deploy.yaml
@@ -1,0 +1,7 @@
+---
+name: "deploy_pack"
+action_ref: "packs.install"
+description: "Download StackStorm packs via ChatOps"
+formats:
+  - "pack deploy {{packs}}"
+  - "pack deploy {{packs}} from {{repo_url}}"

--- a/contrib/packs/aliases/pack_info.yaml
+++ b/contrib/packs/aliases/pack_info.yaml
@@ -1,0 +1,6 @@
+---
+name: "pack_info"
+action_ref: "packs.info"
+description: "Get StackStorm pack information via ChatOps"
+formats:
+  - "pack info {{pack}}"

--- a/instructables/chatops.md
+++ b/instructables/chatops.md
@@ -164,7 +164,7 @@ And should get something like this back:
 Now, install the `hubot` pack into your StackStorm installation.
 
 ```
-  $ st2 packs.install packs=hubot
+  $ st2 run packs.install packs=hubot
 ```
 
 If successful, proceed to the section [Configure Stackstorm](#configuring-stackstorm) to continue.

--- a/st2api/st2api/controllers/exp/aliasexecution.py
+++ b/st2api/st2api/controllers/exp/aliasexecution.py
@@ -32,6 +32,10 @@ http_client = six.moves.http_client
 
 LOG = logging.getLogger(__name__)
 
+CAST_OVERRIDES = {
+    'array': (lambda cs_x: [v.strip() for v in cs_x.split(',')])
+}
+
 
 class ActionAliasExecutionController(rest.RestController):
 
@@ -99,7 +103,8 @@ class ActionAliasExecutionController(rest.RestController):
         try:
             # prior to shipping off the params cast them to the right type.
             params = action_param_utils.cast_params(action_ref=action_alias_db.action_ref,
-                                                    params=params)
+                                                    params=params,
+                                                    cast_overrides=CAST_OVERRIDES)
             liveaction = LiveActionDB(action=action_alias_db.action_ref, context={},
                                       parameters=params, notify=notify)
             _, action_execution_db = action_service.request(liveaction)

--- a/st2api/tests/unit/controllers/exp/test_alias_execution.py
+++ b/st2api/tests/unit/controllers/exp/test_alias_execution.py
@@ -63,8 +63,25 @@ class TestAliasExecution(FunctionalTest):
         expected_parameters = {'param1': 'value1', 'param2': 'value2 value3'}
         self.assertEquals(request.call_args[0][0].parameters, expected_parameters)
 
+    @mock.patch.object(action_service, 'request',
+                       return_value=(None, DummyActionExecution(id_=1)))
+    def testExecutionWithArrayTypeSingleValue(self, request):
+        command = 'Lorem ipsum value1 dolor sit value2 amet.'
+        post_resp = self._do_post(alias_execution=self.alias2, command=command)
+        self.assertEqual(post_resp.status_int, 200)
+        expected_parameters = {'param1': 'value1', 'param3': ['value2']}
+        self.assertEquals(request.call_args[0][0].parameters, expected_parameters)
+
+    @mock.patch.object(action_service, 'request',
+                       return_value=(None, DummyActionExecution(id_=1)))
+    def testExecutionWithArrayTypeMultiValue(self, request):
+        command = 'Lorem ipsum value1 dolor sit "value2, value3" amet.'
+        post_resp = self._do_post(alias_execution=self.alias2, command=command)
+        self.assertEqual(post_resp.status_int, 200)
+        expected_parameters = {'param1': 'value1', 'param3': ['value2', 'value3']}
+        self.assertEquals(request.call_args[0][0].parameters, expected_parameters)
+
     def _do_post(self, alias_execution, command, expect_errors=False):
-        print alias_execution
         execution = {'name': alias_execution.name,
                      'format': alias_execution.formats[0],
                      'command': command,

--- a/st2common/st2common/__init__.py
+++ b/st2common/st2common/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.10dev'
+__version__ = '0.12dev'

--- a/st2common/st2common/models/utils/action_param_utils.py
+++ b/st2common/st2common/models/utils/action_param_utils.py
@@ -79,7 +79,7 @@ def get_params_view(action_db=None, runner_db=None, merged_only=False):
     return (required_params, optional_params, immutable_params)
 
 
-def cast_params(action_ref, params):
+def cast_params(action_ref, params, cast_overrides=None):
     """
     """
     action_db = action_db_util.get_action_by_ref(action_ref)
@@ -102,7 +102,10 @@ def cast_params(action_ref, params):
         if not parameter_type:
             LOG.debug('Will skip cast of param[name: %s, value: %s]. No type.', k, v)
             continue
-        cast = get_cast(cast_type=parameter_type)
+        # Pick up cast from teh override and then from the system suppied ones.
+        cast = cast_overrides.get(parameter_type, None) if cast_overrides else None
+        if not cast:
+            cast = get_cast(cast_type=parameter_type)
         if not cast:
             LOG.debug('Will skip cast of param[name: %s, value: %s]. No cast for %s.', k, v,
                       parameter_type)

--- a/st2tests/st2tests/fixtures/aliases/actions/action1.yaml
+++ b/st2tests/st2tests/fixtures/aliases/actions/action1.yaml
@@ -10,3 +10,5 @@
             type: "string"
         param2:
             type: "string"
+        param3:
+            type: "array"

--- a/st2tests/st2tests/fixtures/aliases/aliases/alias2.yaml
+++ b/st2tests/st2tests/fixtures/aliases/aliases/alias2.yaml
@@ -4,4 +4,4 @@
     description: "DON'T CARE"
     action_ref: "wolfpack.action1"
     formats:
-        - "Lorem ipsum {{param1}} dolor sit {{param2}} amet."
+        - "Lorem ipsum {{param1}} dolor sit {{param3}} amet."

--- a/tools/st2_bootstrap.sh
+++ b/tools/st2_bootstrap.sh
@@ -7,7 +7,7 @@ STABLE=`curl -Ss -q https://downloads.stackstorm.net/deb/pool/trusty_stable/main
 LATEST=`curl -Ss -q https://downloads.stackstorm.net/deb/pool/trusty_unstable/main/s/st2api/ | grep 'amd64.deb' | sed -e "s~.*>st2api_\(.*\)-.*<.*~\1~g" | sort --version-sort -r | uniq | head -n 1`
 
 if [ -z $1 ]; then
-    ST2VER=0.9.0
+    ST2VER=0.11.0
 else
     if [[ "$1" == "stable" ]]; then
         ST2VER=${STABLE}
@@ -16,7 +16,7 @@ else
     else
         ST2VER=$1
     fi
-    
+
 fi
 
 DEBTEST=`lsb_release -a 2> /dev/null | grep Distributor | awk '{print $3}'`

--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -346,6 +346,7 @@ setup_mistral() {
   if [ -d "/opt/openstack/mistral" ]; then
     rm -r /opt/openstack/mistral
   fi
+  echo "Cloning Mistral branch: ${MISTRAL_STABLE_BRANCH}..."
   git clone -b ${MISTRAL_STABLE_BRANCH} https://github.com/StackStorm/mistral.git
 
   # Setup virtualenv for running mistral.
@@ -361,6 +362,7 @@ setup_mistral() {
   if [ -d "/etc/mistral/actions/st2mistral" ]; then
     rm -r /etc/mistral/actions/st2mistral
   fi
+  echo "Cloning St2mistral branch: ${MISTRAL_STABLE_BRANCH}..."
   cd /etc/mistral/actions
   git clone -b ${MISTRAL_STABLE_BRANCH} https://github.com/StackStorm/st2mistral.git
   cd /etc/mistral/actions/st2mistral

--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -77,9 +77,9 @@ sleep ${WARNING_SLEEP_DELAY}
 
 if [ -z $1 ]
 then
-  VER='0.9.1'
+  VER='0.11.0'
 elif [[ "$1" == "latest" ]]; then
-   VER='0.10dev'
+   VER='0.12dev'
 else
   VER=$1
 fi


### PR DESCRIPTION
This PR fixes two bugs introduced in #1570 / #1571

Double .git extension
SSH protocol downloads via Git
In certain circumstances, the repo_url passed into the packs.download
action is returns a double .git.git extension. Contains fix to only
append .git suffix if doesn't already exist.

In #1570, the protocol for Git was changed from SSH -> HTTPS. In cases
where a git-helper is not installed (ref: st2workroom), the protocol
needs to be reverted to avoid credential prompts.

Recreating https://github.com/StackStorm/st2/pull/1576