### PR TITLE
Fix unit tests for the concurrency policies

### DIFF
--- a/st2actions/tests/unit/policies/test_concurrency.py
+++ b/st2actions/tests/unit/policies/test_concurrency.py
@@ -13,10 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import eventlet
 import mock
 import six
-import unittest2
 
 from st2common.constants import action as action_constants
 from st2common.models.api.action import ActionAPI, RunnerTypeAPI
@@ -60,17 +58,11 @@ SCHEDULED_STATES = [
     action_constants.LIVEACTION_STATUS_SUCCEEDED
 ]
 
-RUN_DELAY = 2
-
-
-def mock_run(action_parameters):
-    eventlet.sleep(RUN_DELAY)
-    return (action_constants.LIVEACTION_STATUS_SUCCEEDED, NON_EMPTY_RESULT, None)
-
 
 @mock.patch.object(
     TestRunner, 'run',
-    mock.MagicMock(side_effect=mock_run))
+    mock.MagicMock(
+        return_value=(action_constants.LIVEACTION_STATUS_RUNNING, NON_EMPTY_RESULT, None)))
 @mock.patch.object(
     CUDPublisher, 'publish_update',
     mock.MagicMock(side_effect=MockLiveActionPublisher.publish_update))
@@ -103,17 +95,13 @@ class ConcurrencyPolicyTest(EventletTestCase, DbTestCase):
             instance = PolicyAPI(**fixture)
             Policy.add_or_update(PolicyAPI.to_model(instance))
 
-    @unittest2.skip('Failing test, race?')
     def test_over_threshold(self):
         policy_db = Policy.get_by_ref('wolfpack.action-1.concurrency')
         self.assertGreater(policy_db.parameters['threshold'], 0)
 
         for i in range(0, policy_db.parameters['threshold']):
             liveaction = LiveActionDB(action='wolfpack.action-1', parameters={'actionstr': 'foo'})
-            eventlet.spawn(action_service.request, liveaction)
-
-        # Sleep here to let the threads above schedule the action execution.
-        eventlet.sleep(1)
+            action_service.request(liveaction)
 
         scheduled = LiveAction.get_all()
         self.assertEqual(len(scheduled), policy_db.parameters['threshold'])
@@ -126,8 +114,9 @@ class ConcurrencyPolicyTest(EventletTestCase, DbTestCase):
         liveaction = LiveAction.get_by_id(str(liveaction.id))
         self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_DELAYED)
 
-        # Sleep here to let the threads above complete the action execution.
-        eventlet.sleep(RUN_DELAY + 1)
+        # Mark one of the execution as completed.
+        action_service.update_status(
+            scheduled[0], action_constants.LIVEACTION_STATUS_SUCCEEDED, publish=True)
 
         # Execution is expected to be rescheduled.
         liveaction = LiveAction.get_by_id(str(liveaction.id))

--- a/st2actions/tests/unit/policies/test_concurrency_by_attr.py
+++ b/st2actions/tests/unit/policies/test_concurrency_by_attr.py
@@ -13,10 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import eventlet
 import mock
 import six
-import unittest2
 
 from st2common.constants import action as action_constants
 from st2common.models.api.action import ActionAPI, RunnerTypeAPI
@@ -60,17 +58,11 @@ SCHEDULED_STATES = [
     action_constants.LIVEACTION_STATUS_SUCCEEDED
 ]
 
-RUN_DELAY = 2
-
-
-def mock_run(action_parameters):
-    eventlet.sleep(RUN_DELAY)
-    return (action_constants.LIVEACTION_STATUS_SUCCEEDED, NON_EMPTY_RESULT, None)
-
 
 @mock.patch.object(
     TestRunner, 'run',
-    mock.MagicMock(side_effect=mock_run))
+    mock.MagicMock(
+        return_value=(action_constants.LIVEACTION_STATUS_RUNNING, NON_EMPTY_RESULT, None)))
 @mock.patch.object(
     CUDPublisher, 'publish_update',
     mock.MagicMock(side_effect=MockLiveActionPublisher.publish_update))
@@ -101,7 +93,6 @@ class ConcurrencyByAttributePolicyTest(EventletTestCase, DbTestCase):
             instance = PolicyAPI(**fixture)
             Policy.add_or_update(PolicyAPI.to_model(instance))
 
-    @unittest2.skip('Failing test, race?')
     def test_over_threshold(self):
         policy_db = Policy.get_by_ref('wolfpack.action-1.concurrency.attr')
         self.assertGreater(policy_db.parameters['threshold'], 0)
@@ -109,10 +100,7 @@ class ConcurrencyByAttributePolicyTest(EventletTestCase, DbTestCase):
 
         for i in range(0, policy_db.parameters['threshold']):
             liveaction = LiveActionDB(action='wolfpack.action-1', parameters={'actionstr': 'fu'})
-            eventlet.spawn(action_service.request, liveaction)
-
-        # Sleep here to let the threads above schedule the action execution.
-        eventlet.sleep(2)
+            action_service.request(liveaction)
 
         scheduled = LiveAction.get_all()
         self.assertEqual(len(scheduled), policy_db.parameters['threshold'])
@@ -132,8 +120,9 @@ class ConcurrencyByAttributePolicyTest(EventletTestCase, DbTestCase):
         liveaction = LiveAction.get_by_id(str(liveaction.id))
         self.assertIn(liveaction.status, SCHEDULED_STATES)
 
-        # Sleep here to let the threads above complete the action execution.
-        eventlet.sleep(RUN_DELAY + 1)
+        # Mark one of the execution as completed.
+        action_service.update_status(
+            scheduled[0], action_constants.LIVEACTION_STATUS_SUCCEEDED, publish=True)
 
         # Execution is expected to be rescheduled.
         liveaction = LiveAction.get_by_id(str(delayed.id))


### PR DESCRIPTION
Manually step thru the process to avoid time outs.