### PR TITLE
Fix docs version selector.

### DIFF
--- a/conf/st2.dev.conf
+++ b/conf/st2.dev.conf
@@ -46,7 +46,7 @@ excludes = requests,paramiko
 redirect_stderr = False
 
 [system_user]
-user = stanley
+user = vagrant
 ssh_key_file = /home/vagrant/.ssh/stanley_rsa
 
 [messaging]

--- a/conf/st2.dev.conf
+++ b/conf/st2.dev.conf
@@ -46,7 +46,7 @@ excludes = requests,paramiko
 redirect_stderr = False
 
 [system_user]
-user = vagrant
+user = stanley
 ssh_key_file = /home/vagrant/.ssh/stanley_rsa
 
 [messaging]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -72,7 +72,11 @@ def previous_version(ver):
     # XXX: on incrementing major version, minor version counter is lost!
     major, minor = ver.split('.')
     minor = int("".join(itertools.takewhile(str.isdigit, minor)))
-    return ".".join([major, str(minor - 1)])
+    prev = minor - 1
+    # XXX(dzimine): work around CI/CD bug: version can't end with 0
+    if not prev % 10:
+        prev = prev - 1
+    return ".".join([major, str(prev)])
 
 # The short versions of two previous releases, e.g. 0.8 and 0.7
 version_minus_1 = previous_version(version)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,9 +73,8 @@ def previous_version(ver):
     major, minor = ver.split('.')
     minor = int("".join(itertools.takewhile(str.isdigit, minor)))
     prev = minor - 1
-    # XXX(dzimine): work around CI/CD bug: version can't end with 0
-    if not prev % 10:
-        prev = prev - 1
+    # Note(dzimine): work around CI/CD bug on v 0.10
+    prev = 9 if prev == 10 else prev
     return ".".join([major, str(prev)])
 
 # The short versions of two previous releases, e.g. 0.8 and 0.7

--- a/docs/source/install/config.rst
+++ b/docs/source/install/config.rst
@@ -71,8 +71,8 @@ Follow these steps on a remote box to setup `stanley` user on remote boxes.
     mkdir -p /home/stanley/.ssh
     chmod 0700 /home/stanley/.ssh
 
-    # generate ssh keys on |st2| box and copy over public key into remote box.
-    # ssh-keygen -f /home/stanley/.ssh/stanley_rsa -P ""
+    # generate ssh keys on StackStorm box and copy over public key into remote box.
+    ssh-keygen -f /home/stanley/.ssh/stanley_rsa -P ""
     cp ${KEY_LOCATION}/stanley_rsa.pub /home/stanley/.ssh/stanley_rsa.pub
 
     # authorize key-base acces.


### PR DESCRIPTION
* skip versions ending with 0 as our CI/CD don't grok them yet.

This is a hack but does the trick. I can have bug to remind us to remove it once CI/CD fixed.