### PR TITLE
Update pip and rehash

### DIFF
--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -50,8 +50,8 @@ function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" 
 function join { local IFS="$1"; shift; echo "$*"; }
 
 # Distribution specific variables
-APT_PACKAGE_LIST=("rabbitmq-server" "make" "python-virtualenv" "python-dev" "realpath" "mongodb" "mongodb-server" "gcc" "git")
-YUM_PACKAGE_LIST=("python-virtualenv" "python-devel" "gcc-c++" "git-all" "mongodb" "mongodb-server" "mailcap")
+APT_PACKAGE_LIST=("python-pip" "rabbitmq-server" "make" "python-virtualenv" "python-dev" "realpath" "mongodb" "mongodb-server" "gcc" "git")
+YUM_PACKAGE_LIST=("python-pip" "python-virtualenv" "python-devel" "gcc-c++" "git-all" "mongodb" "mongodb-server" "mailcap")
 
 # Add windows runner dependencies
 # Note: winexe is provided by Stackstorm repos
@@ -160,7 +160,8 @@ create_user() {
 install_pip() {
   echo "###########################################################################################"
   echo "# Installing packages via pip"
-  easy_install pip
+  pip install -U pip
+  hash -d pip
   curl -sS -k -o /tmp/requirements.txt https://raw.githubusercontent.com/StackStorm/st2/master/requirements.txt
   pip install -U -r /tmp/requirements.txt
 }


### PR DESCRIPTION
This is a fix for a missing dependency problem on the jsonschema pip package.  Previously, functools32 was not getting installed.