### PR TITLE
Fix a bug with secrets masking

### DIFF
--- a/st2common/st2common/logging/formatters.py
+++ b/st2common/st2common/logging/formatters.py
@@ -19,6 +19,7 @@ import logging
 import socket
 import time
 import json
+import copy
 import traceback
 
 import six
@@ -88,6 +89,9 @@ def process_attribute_value(key, value):
         if key in MASKED_ATTRIBUTES:
             value = MASKED_ATTRIBUTE_VALUE
     elif isinstance(value, dict):
+        # Note: We don't want to modify the original value`
+        value = copy.deepcopy(value)
+
         for dict_key, dict_value in six.iteritems(value):
             value[dict_key] = process_attribute_value(key=dict_key, value=dict_value)
 

--- a/st2common/tests/unit/test_logger.py
+++ b/st2common/tests/unit/test_logger.py
@@ -311,3 +311,8 @@ class GelfLogFormatterTestCase(unittest.TestCase):
         self.assertEqual(parsed['_blacklisted_3']['blacklisted_1'], MASKED_ATTRIBUTE_VALUE)
         self.assertEqual(parsed['_blacklisted_3']['key3'], 'val3')
         self.assertEqual(parsed['_foo1'], 'bar')
+
+        # Assert that the original dict is left unmodified
+        self.assertEqual(record._blacklisted_3['key1'], 'val1')
+        self.assertEqual(record._blacklisted_3['blacklisted_1'], 'val2')
+        self.assertEqual(record._blacklisted_3['key3'], 'val3')

--- a/st2common/tests/unit/test_logger.py
+++ b/st2common/tests/unit/test_logger.py
@@ -313,6 +313,8 @@ class GelfLogFormatterTestCase(unittest.TestCase):
         self.assertEqual(parsed['_foo1'], 'bar')
 
         # Assert that the original dict is left unmodified
+        self.assertEqual(record._blacklisted_1, 'test value 1')
+        self.assertEqual(record._blacklisted_2, 'test value 2')
         self.assertEqual(record._blacklisted_3['key1'], 'val1')
         self.assertEqual(record._blacklisted_3['blacklisted_1'], 'val2')
         self.assertEqual(record._blacklisted_3['key3'], 'val3')


### PR DESCRIPTION
This pull request fixes a bug which would cause the masking could to modify the original dictionary in place instead of modifying a copy of it and using a copy to interpolate the log message.