### PR TITLE
Fix a bug in ComplexDateTimeField

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ in development
   local, remote and python runner: ``ST2_ACTION_API_URL``, ``ST2_ACTION_AUTH_TOKEN``. (new-feature)
 * Jinja filter to make working with regex and semver possible in any place that
   support jinja (improvement)
+* Fix a bug with ``start_timestamp`` and ``end_timestamp`` sometimes returning an invalid value in
+  a local instead of UTC timezone. (bug-fix)
 
 0.11 - June 5, 2015
 -------------------

--- a/st2common/st2common/fields.py
+++ b/st2common/st2common/fields.py
@@ -74,10 +74,11 @@ class ComplexDateTimeField(LongField):
         :rtype: ``int``
         """
         # Verify that the value which is passed in contains UTC timezone
-        # information or no TZ info (datetime.datetime.utc now includes no
-        # tzinfo by default).
-        if value.tzinfo and (value.tzinfo.utcoffset(value) != datetime.timedelta(0)):
-            raise ValueError('Value passed to this function needs to be in UTC timezone')
+        # information.
+        # TODO: Re-enable the check once we update all the code to use time-zone
+        # (UTC) aware datetime objects
+        #  if not value.tzinfo or (value.tzinfo.utcoffset(value) != datetime.timedelta(0)):
+        #    raise ValueError('Value passed to this function needs to be in UTC timezone')
 
         seconds = calendar.timegm(value.timetuple())
         microseconds_reminder = value.time().microsecond

--- a/st2common/st2common/fields.py
+++ b/st2common/st2common/fields.py
@@ -17,6 +17,7 @@ import time
 import datetime
 import calendar
 
+import dateutil.tz
 from mongoengine import LongField
 
 from st2common.util import isotime
@@ -74,6 +75,12 @@ class ComplexDateTimeField(LongField):
 
         :rtype: ``int``
         """
+        # Verify that the value which is passed in contains UTC timezone
+        # information or no TZ info (datetime.datetime.utc now includes no
+        # tzinfo by default)
+        if value.tzinfo not in [None, dateutil.tz.tzutc()]:
+            raise ValueError('value passed to this function needs to be in UTC timezone')
+
         seconds = calendar.timegm(value.timetuple())
         microseconds_reminder = value.time().microsecond
         result = (int(seconds * SECOND_TO_MICROSECONDS) + microseconds_reminder)

--- a/st2common/st2common/fields.py
+++ b/st2common/st2common/fields.py
@@ -76,9 +76,9 @@ class ComplexDateTimeField(LongField):
         """
         # Verify that the value which is passed in contains UTC timezone
         # information or no TZ info (datetime.datetime.utc now includes no
-        # tzinfo by default)
+        # tzinfo by default).
         if value.tzinfo not in [None, dateutil.tz.tzutc()]:
-            raise ValueError('value passed to this function needs to be in UTC timezone')
+            raise ValueError('Value passed to this function needs to be in UTC timezone')
 
         seconds = calendar.timegm(value.timetuple())
         microseconds_reminder = value.time().microsecond

--- a/st2common/st2common/fields.py
+++ b/st2common/st2common/fields.py
@@ -19,6 +19,8 @@ import calendar
 
 from mongoengine import LongField
 
+from st2common.util import isotime
+
 __all__ = [
     'ComplexDateTimeField'
 ]
@@ -60,9 +62,18 @@ class ComplexDateTimeField(LongField):
         result = datetime.datetime.utcfromtimestamp(data // SECOND_TO_MICROSECONDS)
         microseconds_reminder = (data % SECOND_TO_MICROSECONDS)
         result = result.replace(microsecond=microseconds_reminder)
+        result = isotime.add_utc_tz(result)
         return result
 
     def _datetime_to_microseconds_since_epoch(self, value):
+        """
+        Convert datetime in UTC to number of microseconds from epoch.
+
+        Note: datetime which is passed to the function needs to be in UTC timezone (e.g. as returned
+        by ``datetime.datetime.utcnow``).
+
+        :rtype: ``int``
+        """
         seconds = calendar.timegm(value.timetuple())
         microseconds_reminder = value.time().microsecond
         result = (int(seconds * SECOND_TO_MICROSECONDS) + microseconds_reminder)

--- a/st2common/st2common/fields.py
+++ b/st2common/st2common/fields.py
@@ -16,7 +16,6 @@
 import datetime
 import calendar
 
-import dateutil.tz
 from mongoengine import LongField
 
 from st2common.util import isotime
@@ -77,7 +76,7 @@ class ComplexDateTimeField(LongField):
         # Verify that the value which is passed in contains UTC timezone
         # information or no TZ info (datetime.datetime.utc now includes no
         # tzinfo by default).
-        if value.tzinfo not in [None, dateutil.tz.tzutc()]:
+        if value.tzinfo and (value.tzinfo.utcoffset(value) != datetime.timedelta(0)):
             raise ValueError('Value passed to this function needs to be in UTC timezone')
 
         seconds = calendar.timegm(value.timetuple())

--- a/st2common/st2common/fields.py
+++ b/st2common/st2common/fields.py
@@ -15,6 +15,7 @@
 
 import time
 import datetime
+import calendar
 
 from mongoengine import LongField
 
@@ -56,13 +57,13 @@ class ComplexDateTimeField(LongField):
         :param data: Number of microseconds since the epoch.
         :type data: ``int``
         """
-        result = datetime.datetime.fromtimestamp(data // SECOND_TO_MICROSECONDS)
+        result = datetime.datetime.utcfromtimestamp(data // SECOND_TO_MICROSECONDS)
         microseconds_reminder = (data % SECOND_TO_MICROSECONDS)
         result = result.replace(microsecond=microseconds_reminder)
         return result
 
     def _datetime_to_microseconds_since_epoch(self, value):
-        seconds = time.mktime(value.timetuple())
+        seconds = calendar.timegm(value.timetuple())
         microseconds_reminder = value.time().microsecond
         result = (int(seconds * SECOND_TO_MICROSECONDS) + microseconds_reminder)
         return result

--- a/st2common/st2common/fields.py
+++ b/st2common/st2common/fields.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
 import datetime
 import calendar
 

--- a/st2common/st2common/util/isotime.py
+++ b/st2common/st2common/util/isotime.py
@@ -19,11 +19,30 @@ import datetime
 import dateutil.tz
 import dateutil.parser
 
+__all__ = [
+    'get_datetime_utc_now',
+    'add_utc_tz',
+    'format',
+    'validate',
+    'parse'
+]
+
 
 ISO8601_FORMAT = '%Y-%m-%dT%H:%M:%S'
 ISO8601_FORMAT_MICROSECOND = '%Y-%m-%dT%H:%M:%S.%f'
 ISO8601_UTC_REGEX = \
     '^\d{4}\-\d{2}\-\d{2}(\s|T)\d{2}:\d{2}:\d{2}(\.\d{3,6})?(Z|\+00|\+0000|\+00:00)$'
+
+
+def get_datetime_utc_now():
+    """
+    Retrieve datetime object for current time with included UTC timezone info.
+
+    :rtype: ``datetime.datetime``
+    """
+    dt = datetime.datetime.utcnow()
+    dt = add_utc_tz(dt)
+    return dt
 
 
 def add_utc_tz(dt):

--- a/st2common/tests/unit/test_action_db_utils.py
+++ b/st2common/tests/unit/test_action_db_utils.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import copy
-import datetime
 import uuid
 
 import mock
@@ -29,6 +28,7 @@ from st2common.persistence.action import Action
 from st2common.persistence.liveaction import LiveAction
 from st2common.persistence.runner import RunnerType
 from st2common.transport.liveaction import LiveActionPublisher
+from st2common.util.isotime import get_datetime_utc_now
 import st2common.util.action_db as action_db_utils
 from st2tests.base import DbTestCase
 
@@ -92,7 +92,7 @@ class ActionDBUtilsTestCase(DbTestCase):
     def test_update_liveaction_status(self):
         liveaction_db = LiveActionDB()
         liveaction_db.status = 'initializing'
-        liveaction_db.start_timestamp = datetime.datetime.utcnow()
+        liveaction_db.start_timestamp = get_datetime_utc_now()
         liveaction_db.action = ResourceReference(
             name=ActionDBUtilsTestCase.action_db.name,
             pack=ActionDBUtilsTestCase.action_db.pack).ref
@@ -118,7 +118,7 @@ class ActionDBUtilsTestCase(DbTestCase):
         LiveActionPublisher.publish_state.assert_called_once_with(newliveaction_db, 'running')
 
         # Update status, result, context, and end timestamp.
-        now = datetime.datetime.utcnow()
+        now = get_datetime_utc_now()
         status = 'succeeded'
         result = 'Work is done.'
         context = {'third_party_id': uuid.uuid4().hex}
@@ -136,7 +136,7 @@ class ActionDBUtilsTestCase(DbTestCase):
     def test_update_LiveAction_status_invalid(self):
         liveaction_db = LiveActionDB()
         liveaction_db.status = 'initializing'
-        liveaction_db.start_timestamp = datetime.datetime.utcnow()
+        liveaction_db.start_timestamp = get_datetime_utc_now()
         liveaction_db.action = ResourceReference(
             name=ActionDBUtilsTestCase.action_db.name,
             pack=ActionDBUtilsTestCase.action_db.pack).ref
@@ -159,7 +159,7 @@ class ActionDBUtilsTestCase(DbTestCase):
     def test_update_same_liveaction_status(self):
         liveaction_db = LiveActionDB()
         liveaction_db.status = 'requested'
-        liveaction_db.start_timestamp = datetime.datetime.utcnow()
+        liveaction_db.start_timestamp = get_datetime_utc_now()
         liveaction_db.action = ResourceReference(
             name=ActionDBUtilsTestCase.action_db.name,
             pack=ActionDBUtilsTestCase.action_db.pack).ref
@@ -248,7 +248,7 @@ class ActionDBUtilsTestCase(DbTestCase):
 
         liveaction_db = LiveActionDB()
         liveaction_db.status = 'initializing'
-        liveaction_db.start_timestamp = datetime.datetime.utcnow()
+        liveaction_db.start_timestamp = get_datetime_utc_now()
         liveaction_db.action = ActionDBUtilsTestCase.action_db.ref
         params = {
             'actionstr': 'foo',

--- a/st2common/tests/unit/test_db_fields.py
+++ b/st2common/tests/unit/test_db_fields.py
@@ -21,6 +21,7 @@ import mock
 import unittest2
 
 from st2common.fields import ComplexDateTimeField
+from st2common.util import isotime
 
 
 class ComplexDateTimeFieldTestCase(unittest2.TestCase):
@@ -28,6 +29,8 @@ class ComplexDateTimeFieldTestCase(unittest2.TestCase):
         field = ComplexDateTimeField()
 
         date = datetime.datetime.utcnow()
+        date = isotime.add_utc_tz(date)
+
         us = field._datetime_to_microseconds_since_epoch(date)
         result = field._microseconds_since_epoch_to_datetime(us)
         self.assertEqual(date, result)
@@ -37,6 +40,11 @@ class ComplexDateTimeFieldTestCase(unittest2.TestCase):
             datetime.datetime(2015, 1, 1, 15, 0, 0).replace(microsecond=500),
             datetime.datetime(2015, 1, 1, 15, 0, 0).replace(microsecond=0),
             datetime.datetime(2015, 1, 1, 15, 0, 0).replace(microsecond=999999)
+        ]
+        datetime_values = [
+            isotime.add_utc_tz(datetime_values[0]),
+            isotime.add_utc_tz(datetime_values[1]),
+            isotime.add_utc_tz(datetime_values[2])
         ]
         microsecond_values = []
 
@@ -77,6 +85,7 @@ class ComplexDateTimeFieldTestCase(unittest2.TestCase):
 
         # Microseconds
         dt = datetime.datetime(2015, 1, 1, 15, 0, 0).replace(microsecond=500)
+        dt = isotime.add_utc_tz(dt)
         us = field._datetime_to_microseconds_since_epoch(value=dt)
         mock_get.return_value = us
         self.assertEqual(field.__get__(instance=None, owner=None), dt)

--- a/st2common/tests/unit/test_db_fields.py
+++ b/st2common/tests/unit/test_db_fields.py
@@ -15,6 +15,7 @@
 
 import time
 import datetime
+import calendar
 
 import mock
 import unittest2
@@ -23,6 +24,14 @@ from st2common.fields import ComplexDateTimeField
 
 
 class ComplexDateTimeFieldTestCase(unittest2.TestCase):
+    def test_what_comes_in_goes_out(self):
+        field = ComplexDateTimeField()
+
+        date = datetime.datetime.utcnow()
+        us = field._datetime_to_microseconds_since_epoch(date)
+        result = field._microseconds_since_epoch_to_datetime(us)
+        self.assertEqual(date, result)
+
     def test_round_trip_conversion(self):
         datetime_values = [
             datetime.datetime(2015, 1, 1, 15, 0, 0).replace(microsecond=500),
@@ -33,7 +42,7 @@ class ComplexDateTimeFieldTestCase(unittest2.TestCase):
 
         # Calculate microsecond values
         for value in datetime_values:
-            seconds = time.mktime(value.timetuple())
+            seconds = calendar.timegm(value.timetuple())
             microseconds_reminder = value.time().microsecond
             result = int(seconds * 1000000) + microseconds_reminder
             microsecond_values.append(result)

--- a/st2common/tests/unit/test_db_fields.py
+++ b/st2common/tests/unit/test_db_fields.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
 import datetime
 import calendar
 


### PR DESCRIPTION
We were not handling the values correctly (sometimes we used local instead of UTC time) which means that sometimes the result would be a datetime object in a local instead of a UTC timezone.