### PR TITLE
Pass many 'register' components for 'packs.install', 'packs.load', 'st2ctl reload' #1619

### DIFF
--- a/contrib/packs/actions/install.meta.yaml
+++ b/contrib/packs/actions/install.meta.yaml
@@ -21,5 +21,5 @@
       default: "master"
     register:
       type: "string"
-      default: "actions"
+      default: "actions,aliases,sensors"
       description: "Possible options are all, sensors, actions, rules, aliases."

--- a/contrib/packs/actions/load.yaml
+++ b/contrib/packs/actions/load.yaml
@@ -9,7 +9,7 @@
       immutable: true
     cmd:
       immutable: true
-      default: "st2ctl reload{% for item in register.split(',') %} --register-{{item}}{% endfor %}"
+      default: "st2ctl reload{% for item in register.split(',') %} --register-{{ item|trim }}{% endfor %}"
     register:
       type: "string"
       default: "actions,aliases,sensors"

--- a/contrib/packs/actions/load.yaml
+++ b/contrib/packs/actions/load.yaml
@@ -9,10 +9,10 @@
       immutable: true
     cmd:
       immutable: true
-      default: "st2ctl reload --register-{{register}}"
+      default: "st2ctl reload{% for item in register.split(',') %} --register-{{item}}{% endfor %}"
     register:
       type: "string"
-      default: "actions"
+      default: "actions,aliases,sensors"
       description: "Possible options are all, sensors, actions, rules, aliases."
     kwarg_op:
       immutable: true

--- a/tools/st2ctl
+++ b/tools/st2ctl
@@ -47,12 +47,12 @@ function print_usage() {
     echo
     echo "usage: st2ctl {reload, clean}"
     echo "optional arguments:"
-    echo "  --register-all      Register all sensors, rules, and actions."
-    echo "  --register-sensors  Register all sensors only."
-    echo "  --register-rules    Register all rules only."
-    echo "  --register-actions  Register all actions only."
-    echo "  --register-aliases  Register all aliases only."
-    echo "  --register-policies Register all policies only."
+    echo "  --register-all      Register all."
+    echo "  --register-sensors  Register all sensors."
+    echo "  --register-rules    Register all rules."
+    echo "  --register-actions  Register all actions."
+    echo "  --register-aliases  Register all aliases."
+    echo "  --register-policies Register all policies."
     echo "  --verbose           Output additional debug and informational messages."
 }
 
@@ -93,19 +93,26 @@ then
 fi
 
 # Note: Scripts already call reload with "--register-<content>"
-# TODO: Update packs. actions to only pass in a resource name excluding # --register prefix
 if [ ${1} == "reload" -o ${1} == "clean" ]; then
+    ALLOWED_REGISTER_FLAGS=(--register-all --register-actions --register-aliases --register-policies --register-rules --register-sensors --verbose)
+    DEFAULT_REGISTER_FLAGS='--register-actions --register-aliases --register-sensors'
+
+    if [ ! -z ${2} ]; then
+        for arg in ${@:2}; do
+            if [[ " ${ALLOWED_REGISTER_FLAGS[*]} " != *" $arg "* ]]; then # argument not allowed
+                echo -e "\e[31mError: Invalid argument provided: ${arg} \e[0m\n"
+                print_usage
+                exit 1
+            fi
+        done
+    fi
+
     if [ -z ${2} ]; then
-        REGISTER_FLAGS="--register-sensors --register-actions --register-aliases"
-    elif [ ! -z ${2} ] && [ ${2} == "--register-all" -o ${2} == "--register-sensors"  -o ${2} == "--register-rules" -o ${2} == "--register-actions" -o ${2} == "--register-aliases" -o ${2} == "--register-policies" ]; then
-        REGISTER_FLAGS=${2}
-        if [ ! -z ${3} ] && [ ${3} == "--verbose" ]; then
-            REGISTER_FLAGS="${REGISTER_FLAGS} ${3}"
-        fi
-    elif [ ${2} == "--verbose" ] && [ -z ${3} ]; then
-        REGISTER_FLAGS="--register-sensors --register-actions --register-aliases ${2}"
-    elif [ ${2} == "--verbose" ] && [ ${3} == "--register-all" -o ${3} == "--register-sensors"  -o ${3} == "--register-rules" -o ${3} == "--register-actions" -o ${3} == "--register-aliases" -o ${3} == "--register-policies" ]; then
-        REGISTER_FLAGS="${3} ${2}"
+        REGISTER_FLAGS=${DEFAULT_REGISTER_FLAGS}
+    elif [ ${2} == '--verbose' ] && [ -z ${3} ]; then
+        REGISTER_FLAGS="$DEFAULT_REGISTER_FLAGS ${2}"
+    elif [ ! -z ${2} ]; then
+        REGISTER_FLAGS=${@:2}
     else
         print_usage
         exit 1


### PR DESCRIPTION
#### Problem

One of the problems described in #1619 is that `packs.install` reloads only `actions` by default, bringing problems (especially in ChatOps) when installed pack contains aliases or sensors:
```
st2 run packs.install packs=st2-google repo_url=jfryman/st2-google
```

#### Solution
This PR brings possibility to pass several `register` components.
If not provided `register=actions,aliases,sensors` is default value.

```sh
# before (1 component only):
st2 run packs.load register=actions

# now:
st2 run packs.install packs=hubot register=aliases,rules
st2 run packs.load register=rules,sensors
```
which would trigger reload with many arguments (only 1 was accepted before):
```sh
st2ctl reload --register-aliases --register-rules
```