### PR TITLE
RFR: Create subfolders based on date in exports dir.

### DIFF
--- a/st2exporter/tests/unit/test_dumper.py
+++ b/st2exporter/tests/unit/test_dumper.py
@@ -26,6 +26,7 @@ from st2exporter.exporter.dumper import Dumper
 from st2exporter.exporter.file_writer import TextFileWriter
 from st2tests.base import EventletTestCase
 from st2tests.fixturesloader import FixturesLoader
+from st2common.util import date as date_utils
 
 DESCENDANTS_PACK = 'descendants'
 
@@ -81,7 +82,8 @@ class TestDumper(EventletTestCase):
                         export_dir='/tmp',
                         file_prefix='st2-stuff-', file_format='json')
         file_name = dumper._get_file_name()
-        self.assertTrue(file_name.startswith('/tmp/st2-stuff-'))
+        export_date = date_utils.get_datetime_utc_now().strftime('%Y-%m-%d')
+        self.assertTrue(file_name.startswith('/tmp/' + export_date + '/st2-stuff-'))
         self.assertTrue(file_name.endswith('json'))
 
     @mock.patch.object(os.path, 'exists', mock.MagicMock(return_value=True))

--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -133,6 +133,7 @@ function st2start(){
     if [ -n "$ST2_EXPORTER" ]; then
         EXPORTS_DIR=$(exportsdir)
         sudo mkdir -p $EXPORTS_DIR
+        sudo chown -R ${CURRENT_USER}:${CURRENT_USER_GROUP} $EXPORTS_DIR
         echo 'Starting screen session st2-exporter...'
         screen -d -m -S st2-exporter ./virtualenv/bin/python \
             ./st2exporter/bin/st2exporter \


### PR DESCRIPTION
## Example
```
(virtualenv)/m/s/s/st2 git:STORM-1445/export_by_date ❯❯❯ ls /opt/stackstorm/exports                                                                                                                                                                  ⏎ ✭ ✱ ◼
2015-06-15
(virtualenv)/m/s/s/st2 git:STORM-1445/export_by_date ❯❯❯ ls /opt/stackstorm/exports/2015-06-15/st2-executions-2015-06-15T21:58:50.375516Z.json                                                                                                         ✭ ✱ ◼
/opt/stackstorm/exports/2015-06-15/st2-executions-2015-06-15T21:58:50.375516Z.json
(virtualenv)/m/s/s/st2 git:STORM-1445/export_by_date ❯❯❯ cat /opt/stackstorm/exports/2015-06-15/st2-executions-2015-06-15T21:58:50.375516Z.json                                                                                                        ✭ ✱ ◼
[
    {
        "status": "succeeded",
        "start_timestamp": "2015-06-15T21:58:23.181210Z",
        "parameters": {
            "cmd": "date"
        },
```