### PR TITLE
Fix st2ctl restart-component action for st2notifier service

### DIFF
--- a/tools/st2ctl
+++ b/tools/st2ctl
@@ -85,7 +85,7 @@ fi
 
 if [ ${1} == "restart-component" ]
 then
-    if  [ -z ${2} ] || [ ${2} != "st2actionrunner" -a ${2} != "st2api" -a ${2} != "st2sensorcontainer" -a ${2} != "st2rulesengine" -a ${2} != "mistral" -a ${2} != "st2resultstracker" -a ${2} != "st2web" ]
+    if  [ -z ${2} ] || [ ${2} != "st2actionrunner" -a ${2} != "st2api" -a ${2} != "st2sensorcontainer" -a ${2} != "st2rulesengine" -a ${2} != "mistral" -a ${2} != "st2resultstracker" -a ${2} != "st2notifier" -a ${2} != "st2web" ]
     then
         print_usage
         exit 1


### PR DESCRIPTION
st2ctl was missing an if clause which means `restart-component` action didn't work / wasn't available for `st2notifier` service.