### PR TITLE
Document SETENV sudo requirement for system (stanley) user

### DIFF
--- a/docs/source/install/config.rst
+++ b/docs/source/install/config.rst
@@ -41,18 +41,22 @@ In :github_st2:`/etc/st2/st2.conf <conf/st2.prod.conf>` include the following se
 SUDO Access
 -----------
 
-All actions run by |st2| are performed by a single user. Typically, this user is named ``stanley`` and that is configurable via :github_st2:`st2.conf <conf/st2.prod.conf>`.
+By default, all actions run by |st2| are performed by a single user. Typically, this user is named
+``stanley`` and that is configurable via :github_st2:`st2.conf <conf/st2.prod.conf>`.
 
 .. note:: `stanley` user requires the following access -
 
     * Sudo access to all boxes on which action will run.
+    * SETENV option needs to be set for all the commands. This way environment variables which are
+      available to the local runner actions will also be available when user executes local runner
+      action under a different user or with root privileges.
     * As some actions require sudo privileges password-less sudo access to all boxes.
 
 One option of setting up passwordless sudo is perform the below operation on each remote box.
 
 .. code-block:: bash
 
-    echo "stanley    ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/st2
+    echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2
 
 .. _config-configure-ssh:
 
@@ -79,7 +83,7 @@ Follow these steps on a remote box to setup `stanley` user on remote boxes.
     cat /home/stanley/.ssh/stanley_rsa.pub >> /home/stanley/.ssh/authorized_keys
     chmod 0600 /home/stanley/.ssh/authorized_keys
     chown -R stanley:stanley /home/stanley
-    echo "stanley    ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/st2
+    echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2
 
     # ensure requiretty is not set to default in the /etc/sudoers file.
 

--- a/st2reactor/st2reactor/container/process_container.py
+++ b/st2reactor/st2reactor/container/process_container.py
@@ -160,7 +160,7 @@ class ProcessSensorContainer(object):
             return False
 
         self._stop_sensor_process(sensor_id=sensor_id)
-        LOG.debug('Sesnor %s stopped.', sensor_id)
+        LOG.debug('Sensor %s stopped.', sensor_id)
         return True
 
     def _run_all_sensors(self):
@@ -254,7 +254,7 @@ class ProcessSensorContainer(object):
 
         :param exit_timeout: How long to wait for process to exit after
                              sending SIGTERM signal. If the process doesn't
-                             exit in this amount of seconds, SIGTERM signal
+                             exit in this amount of seconds, SIGKILL signal
                              will be sent to the process.
         :type exit__timeout: ``int``
         """

--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -166,7 +166,7 @@ create_user() {
     chown -R ${SYSTEMUSER}:${SYSTEMUSER} /home/${SYSTEMUSER}
     if [ $(grep 'stanley' /etc/sudoers.d/* &> /dev/null; echo $?) != 0 ]
     then
-      echo "${SYSTEMUSER}    ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/st2
+      echo "${SYSTEMUSER}    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2
       chmod 0440 /etc/sudoers.d/st2
     fi
 


### PR DESCRIPTION
If `SETENV` option is not set and user runs local runner action under a different user, environment variables which are specified as parameter or available to the system user won't be available to the action since sudo will clean the environment variables.

This pull request "fixes" that by documenting that `SETENV` sudoers option needs to be set system user.

Related to #1646