### PR TITLE
Graceful API WSGI server shutdown

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ in development
   date formats - previously it only worked with ISO8601 date strings. (improvement)
 * Allow user to specify new ``secret`` attribute (boolean) for each action parameters. Values of
   parameters which have this attribute set to true will be masked in the log files. (new-feature)
+* API server now gracefully shuts down on SIGINT (CTRL-C). (improvement)
 
 0.11.3 - June 16, 2015
 ----------------------

--- a/st2api/st2api/signal_handlers.py
+++ b/st2api/st2api/signal_handlers.py
@@ -13,32 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-This module contains handler methods for different signals which are handled in the same way across
-the whole code base.
-"""
-
-from __future__ import absolute_import
-
 import signal
-import logging
-
-from st2common.logging.misc import reopen_log_files
 
 __all__ = [
-    'register_common_signal_handlers',
+    'register_api_signal_handlers'
 ]
 
 
-def register_common_signal_handlers():
-    signal.signal(signal.SIGUSR1, handle_sigusr1)
-
-
-def handle_sigusr1(signal_number, stack_frame):
-    """
-    Global SIGUSR1 signal handler which causes all the loggers to re-open log file handles.
-
-    Note: This function is used with log rotation utilities such as logrotate.
-    """
-    handlers = logging.getLoggerClass().manager.root.handlers
-    reopen_log_files(handlers=handlers)
+def register_api_signal_handlers(handler_func):
+    signal.signal(signal.SIGINT, handler_func)

--- a/st2common/st2common/util/wsgi.py
+++ b/st2common/st2common/util/wsgi.py
@@ -1,0 +1,58 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Eventlet WSGI server related utility functions.
+"""
+
+import eventlet
+
+from st2common import log as logging
+
+LOG = logging.getLogger(__name__)
+
+__all__ = [
+    'shutdown_server_kill_pending_requests'
+]
+
+
+def shutdown_server_kill_pending_requests(sock, worker_pool, wait_time=2):
+    """
+    Custom WSGI server shutdown function which gives outgoing requests some time to finish
+    before killing them.
+
+    Without that, long running requests such as stream block and prevent server from shutting down.
+
+    :param sock: WSGI server socket.
+    :param worker_pool: WSGI server worker pool.
+    :param wait_time: How long to give to the active requests to finish processing before
+                      forcefully killing them.
+    :type wait_time: ``int``
+    """
+    worker_pool.resize(0)
+    sock.close()
+
+    LOG.info('Shutting down. Requests left: %s', worker_pool.running())
+
+    # Give running requests some time to finish
+    eventlet.sleep(wait_time)
+
+    # Kill requests which still didn't finish
+    running_corutines = worker_pool.coroutines_running.copy()
+    for coro in running_corutines:
+        eventlet.greenthread.kill(coro)
+
+    LOG.info('Exiting...')
+    raise SystemExit()


### PR DESCRIPTION
This pull request implements graceful API WSGI server shutdown. On shutdown (or CTRL-C / SIGINT signal), we stop receiving new requests and give existing active requests some time to shut down (2 seconds by default) before we kill requests which still didn't finish.

This is needed since we support long-running requests (stream endpoint). Previously, if there was an active long-running request, it would block API server from gracefully shutting down and we would need to send `SIGTERM` to the server to kill it.

This is also important and will be utilized when we support requests draining and zero-impact and zero-downtime (rolling) upgrades / restarts.

Note: This is something @enykeev were passively trying to figure out in the past.