### PR TITLE
Fix reinstallation of a pack with no config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ in development
 * Allow user to specify new ``secret`` attribute (boolean) for each action parameters. Values of
   parameters which have this attribute set to true will be masked in the log files. (new-feature)
 * API server now gracefully shuts down on SIGINT (CTRL-C). (improvement)
+* Fix a bug with with reinstalling a pack with no existing config - only try to move the config
+  file over if it exists. (bug fix)
 
 0.11.3 - June 16, 2015
 ----------------------

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -96,11 +96,16 @@ class DownloadGitRepoAction(Action):
                 if os.path.exists(dest_pack_path):
                     self.logger.debug('Removing existing pack %s in %s to replace.', pack,
                                       dest_pack_path)
+
                     # Ensure to preserve any existing configuration
                     old_config_file = os.path.join(dest_pack_path, CONFIG_FILE)
                     new_config_file = os.path.join(abs_pack_temp_location, CONFIG_FILE)
-                    shutil.move(old_config_file, new_config_file)
+
+                    if os.path.isfile(old_config_file):
+                        shutil.move(old_config_file, new_config_file)
+
                     shutil.rmtree(dest_pack_path)
+
                 self.logger.debug('Moving pack from %s to %s.', abs_pack_temp_location, to)
                 shutil.move(abs_pack_temp_location, to)
                 message = 'Success.'


### PR DESCRIPTION
Previously, if an existing pack which was installed had no config file we would still to try to move it over to new location which would cause installation (download action) to fail.

Resolves #1653.