### PR TITLE
Provide sensor_ref instead of sensor_name to run a single sensor

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ in development
 * API server now gracefully shuts down on SIGINT (CTRL-C). (improvement)
 * Fix a bug with with reinstalling a pack with no existing config - only try to move the config
   file over if it exists. (bug fix)
+* Single sensor mode of Sensor Container uses ``--sensor-ref`` instead of ``--sensor-name``.
 
 0.11.3 - June 16, 2015
 ----------------------

--- a/docs/source/sensors.rst
+++ b/docs/source/sensors.rst
@@ -214,13 +214,13 @@ use the st2sensorcontainer to run just that single sensor.
 
 ::
 
-    st2sensorcontainer --config-file=/etc/st2/st2.conf --sensor-name=SensorClassName
+    st2sensorcontainer --config-file=/etc/st2/st2.conf --sensor-ref=pack.SensorClassName
 
 For example:
 
 ::
 
-    st2sensorcontainer --config-file=/etc/st2/st2.conf --sensor-name=GitCommitSensor
+    st2sensorcontainer --config-file=/etc/st2/st2.conf --sensor-ref=git.GitCommitSensor
 
 Examples
 --------

--- a/st2reactor/st2reactor/cmd/sensormanager.py
+++ b/st2reactor/st2reactor/cmd/sensormanager.py
@@ -45,14 +45,14 @@ def main():
     try:
         _setup()
         container_manager = SensorContainerManager()
-        sensors = _get_all_sensors()
+        sensors = None
 
-        if cfg.CONF.sensor_name:
-            # Only run a single sensor
-            sensors = [sensor for sensor in sensors if
-                       sensor.name == cfg.CONF.sensor_name]
+        if cfg.CONF.sensor_ref:
+            sensors = [SensorType.get_by_ref(cfg.CONF.sensor_ref)]
             if not sensors:
-                raise SensorNotFoundException('Sensor %s not found in db.' % cfg.CONF.sensor_name)
+                raise SensorNotFoundException('Sensor %s not found in db.' % cfg.CONF.sensor_ref)
+        else:
+            sensors = _get_all_sensors()
 
         if not sensors:
             msg = 'No sensors configured to run. See http://docs.stackstorm.com/sensors.html. ' + \

--- a/st2reactor/st2reactor/cmd/sensormanager.py
+++ b/st2reactor/st2reactor/cmd/sensormanager.py
@@ -48,9 +48,10 @@ def main():
         sensors = None
 
         if cfg.CONF.sensor_ref:
-            sensors = [SensorType.get_by_ref(cfg.CONF.sensor_ref)]
-            if not sensors:
+            sensor = SensorType.get_by_ref(cfg.CONF.sensor_ref)
+            if not sensor:
                 raise SensorNotFoundException('Sensor %s not found in db.' % cfg.CONF.sensor_ref)
+            sensors = [sensor]
         else:
             sensors = _get_all_sensors()
 

--- a/st2reactor/st2reactor/sensor/config.py
+++ b/st2reactor/st2reactor/sensor/config.py
@@ -45,7 +45,8 @@ def _register_sensor_container_opts(ignore_errors=False):
     ]
     st2cfg.do_register_opts(logging_opts, group='sensorcontainer', ignore_errors=ignore_errors)
 
-    sensor_test_opt = cfg.StrOpt('sensor-name', help='Only run sensor with the provided name.')
+    sensor_test_opt = cfg.StrOpt('sensor-ref', help='Only run sensor with the provided reference. \
+        Value is of the form pack.sensor-name.')
     st2cfg.do_register_cli_opts(sensor_test_opt, ignore_errors=ignore_errors)
 
     st2_webhook_opts = [


### PR DESCRIPTION
* We only guarantee uniqueness of ref and not of name therefore to
      target a single sensor it is better to use sensor_ref.