### PR TITLE
Update oslo config imports (drop namespace prefix)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,8 @@ in development
 * Support for masking secret parameters in the API responses. Secret parameters can only be viewed
   through the API by admin users. (new-feature)
 * Single sensor mode of Sensor Container uses ``--sensor-ref`` instead of ``--sensor-name``.
+* ``six`` library is now available by default in the Python sandbox to all the newly installed
+  packs. (improvement)
 
 0.11.3 - June 16, 2015
 ----------------------

--- a/contrib/packs/actions/pack_mgmt/delete.py
+++ b/contrib/packs/actions/pack_mgmt/delete.py
@@ -16,7 +16,7 @@
 import os
 import shutil
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2actions.runners.pythonrunner import Action
 from st2common.constants.pack import SYSTEM_PACK_NAMES

--- a/contrib/packs/actions/pack_mgmt/setup_virtualenv.py
+++ b/contrib/packs/actions/pack_mgmt/setup_virtualenv.py
@@ -16,7 +16,7 @@
 import os
 import re
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common.util.shell import run_command
 from st2actions.runners.pythonrunner import Action

--- a/contrib/packs/actions/pack_mgmt/unload.py
+++ b/contrib/packs/actions/pack_mgmt/unload.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common.models.db import db_setup
 from st2actions.runners.pythonrunner import Action

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ jinja2
 jsonschema>=2.3.0
 kombu
 mongoengine>=0.8.7,<0.9
-oslo.config
+oslo.config>=1.12.1,<1.13
 paramiko
 pecan==0.7.0
 pymongo<3.0

--- a/st2actions/st2actions/config.py
+++ b/st2actions/st2actions/config.py
@@ -19,7 +19,7 @@ Configuration options registration and useful routines.
 
 import sys
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 import st2common.config as common_config
 from st2common.constants.system import VERSION_STRING

--- a/st2actions/st2actions/handlers/mistral.py
+++ b/st2actions/st2actions/handlers/mistral.py
@@ -18,7 +18,7 @@ import eventlet
 import json
 import requests
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common.constants import action as action_constants
 from st2common import log as logging

--- a/st2actions/st2actions/notifier/config.py
+++ b/st2actions/st2actions/notifier/config.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 import st2common.config as common_config
 from st2common.constants.system import VERSION_STRING

--- a/st2actions/st2actions/notifier/notifier.py
+++ b/st2actions/st2actions/notifier/notifier.py
@@ -16,7 +16,7 @@
 import json
 
 from kombu import Connection
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import log as logging
 from st2common.constants.action import LIVEACTION_STATUS_SUCCEEDED, LIVEACTION_STATUS_FAILED

--- a/st2actions/st2actions/notifier/scheduler.py
+++ b/st2actions/st2actions/notifier/scheduler.py
@@ -15,7 +15,7 @@
 
 import datetime
 
-from oslo.config import cfg
+from oslo_config import cfg
 from apscheduler.schedulers.background import BlockingScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 import apscheduler.util as aps_utils

--- a/st2actions/st2actions/query/mistral/v2.py
+++ b/st2actions/st2actions/query/mistral/v2.py
@@ -1,7 +1,7 @@
 import traceback
 import uuid
 
-from oslo.config import cfg
+from oslo_config import cfg
 import requests
 
 from st2actions.query.base import Querier

--- a/st2actions/st2actions/resultstracker/config.py
+++ b/st2actions/st2actions/resultstracker/config.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import config as common_config
 from st2common.constants.system import VERSION_STRING

--- a/st2actions/st2actions/resultstracker/resultstracker.py
+++ b/st2actions/st2actions/resultstracker/resultstracker.py
@@ -19,7 +19,7 @@ import six
 
 from collections import defaultdict
 from kombu import Connection
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2actions.query.base import QueryContext
 from st2common import log as logging

--- a/st2actions/st2actions/runners/cloudslang/cloudslang_runner.py
+++ b/st2actions/st2actions/runners/cloudslang/cloudslang_runner.py
@@ -18,7 +18,7 @@ import os
 import tempfile
 import yaml
 
-from oslo.config import cfg
+from oslo_config import cfg
 from eventlet.green import subprocess
 
 from st2common.util.green.shell import run_command

--- a/st2actions/st2actions/runners/fabric_runner.py
+++ b/st2actions/st2actions/runners/fabric_runner.py
@@ -17,7 +17,7 @@ import os
 import abc
 
 from fabric.api import (env, execute)
-from oslo.config import cfg
+from oslo_config import cfg
 import six
 
 from st2actions.runners import ActionRunner

--- a/st2actions/st2actions/runners/httprunner.py
+++ b/st2actions/st2actions/runners/httprunner.py
@@ -19,7 +19,7 @@ import json
 import uuid
 
 import requests
-from oslo.config import cfg
+from oslo_config import cfg
 from six.moves.urllib import parse as urlparse
 
 from st2actions.runners import ActionRunner

--- a/st2actions/st2actions/runners/localrunner.py
+++ b/st2actions/st2actions/runners/localrunner.py
@@ -17,7 +17,7 @@ import os
 import pwd
 import uuid
 
-from oslo.config import cfg
+from oslo_config import cfg
 from eventlet.green import subprocess
 
 from st2common import log as logging

--- a/st2actions/st2actions/runners/mistral/v2.py
+++ b/st2actions/st2actions/runners/mistral/v2.py
@@ -22,7 +22,7 @@ import six
 import yaml
 from mistralclient.api import client as mistral
 from mistralclient.api.base import APIException
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common.constants.action import LIVEACTION_STATUS_RUNNING
 from st2actions.runners import AsyncActionRunner

--- a/st2actions/st2actions/runners/remote_command_runner.py
+++ b/st2actions/st2actions/runners/remote_command_runner.py
@@ -15,7 +15,7 @@
 
 import uuid
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import log as logging
 from st2actions.runners.fabric_runner import BaseFabricRunner

--- a/st2actions/st2actions/runners/remote_script_runner.py
+++ b/st2actions/st2actions/runners/remote_script_runner.py
@@ -16,7 +16,7 @@
 import os
 import uuid
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import log as logging
 from st2actions.runners.fabric_runner import BaseFabricRunner

--- a/st2actions/st2actions/scheduler.py
+++ b/st2actions/st2actions/scheduler.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from kombu import Connection
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import log as logging
 from st2common.constants import action as action_constants

--- a/st2actions/st2actions/worker.py
+++ b/st2actions/st2actions/worker.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from kombu import Connection
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2actions.container.base import RunnerContainer
 from st2common import log as logging

--- a/st2actions/tests/integration/test_action_state_consumer.py
+++ b/st2actions/tests/integration/test_action_state_consumer.py
@@ -16,7 +16,7 @@
 import mock
 
 from kombu import Connection
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2actions.resultstracker.resultstracker import ACTIONSTATE_WORK_Q, ResultsTracker
 from st2common.models.db.executionstate import ActionExecutionStateDB

--- a/st2actions/tests/unit/test_rescheduler.py
+++ b/st2actions/tests/unit/test_rescheduler.py
@@ -20,7 +20,7 @@ import six
 from st2tests import config as test_config
 test_config.parse_args()
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2actions.notifier import scheduler
 from st2common.constants import action as action_constants

--- a/st2actions/tests/unit/test_runner_container.py
+++ b/st2actions/tests/unit/test_runner_container.py
@@ -15,7 +15,7 @@
 
 import mock
 
-from oslo.config import cfg
+from oslo_config import cfg
 from st2common.constants import action as action_constants
 from st2actions.runners import get_runner
 from st2common.exceptions.actionrunner import ActionRunnerCreateError

--- a/st2actions/tests/unit/test_runner_container_service.py
+++ b/st2actions/tests/unit/test_runner_container_service.py
@@ -15,7 +15,7 @@
 
 import os
 
-from oslo.config import cfg
+from oslo_config import cfg
 import unittest2
 
 from st2common.constants.action import LIBS_DIR as ACTION_LIBS_DIR

--- a/st2api/st2api/app.py
+++ b/st2api/st2api/app.py
@@ -16,7 +16,7 @@
 import os
 
 import pecan
-from oslo.config import cfg
+from oslo_config import cfg
 from pecan.middleware.static import StaticFileMiddleware
 
 from st2common import hooks

--- a/st2api/st2api/cmd/api.py
+++ b/st2api/st2api/cmd/api.py
@@ -17,7 +17,7 @@ import os
 import sys
 
 import eventlet
-from oslo.config import cfg
+from oslo_config import cfg
 from eventlet import wsgi
 
 from st2common import log as logging

--- a/st2api/st2api/config.py
+++ b/st2api/st2api/config.py
@@ -19,7 +19,7 @@ Configuration options registration and useful routines.
 
 import os
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 import st2common.config as common_config
 from st2common.constants.system import VERSION_STRING

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -16,7 +16,7 @@
 import copy
 
 import jsonschema
-from oslo.config import cfg
+from oslo_config import cfg
 import pecan
 from pecan import abort
 from six.moves import http_client

--- a/st2api/st2api/listener.py
+++ b/st2api/st2api/listener.py
@@ -32,7 +32,7 @@ import eventlet
 
 from kombu import Connection, Queue
 from kombu.mixins import ConsumerMixin
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common.models.api.action import LiveActionAPI
 from st2common.models.api.execution import ActionExecutionAPI

--- a/st2api/tests/base.py
+++ b/st2api/tests/base.py
@@ -15,7 +15,7 @@
 
 from pecan import load_app
 from pecan.testing import load_test_app
-from oslo.config import cfg
+from oslo_config import cfg
 from webtest import TestApp
 
 

--- a/st2api/tests/unit/controllers/v1/test_base.py
+++ b/st2api/tests/unit/controllers/v1/test_base.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from oslo.config import cfg
+from oslo_config import cfg
 from tests import FunctionalTest
 
 

--- a/st2auth/st2auth/app.py
+++ b/st2auth/st2auth/app.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import pecan
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import hooks
 from st2common import log as logging

--- a/st2auth/st2auth/backends/__init__.py
+++ b/st2auth/st2auth/backends/__init__.py
@@ -16,7 +16,7 @@
 import json
 import importlib
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common.util.loader import _get_classes_in_module
 

--- a/st2auth/st2auth/backends/mongodb.py
+++ b/st2auth/st2auth/backends/mongodb.py
@@ -17,7 +17,7 @@ import hashlib
 
 import pymongo
 from pymongo import MongoClient
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import log as logging
 from st2auth.backends.base import BaseAuthenticationBackend

--- a/st2auth/st2auth/cmd/api.py
+++ b/st2auth/st2auth/cmd/api.py
@@ -17,7 +17,7 @@ import eventlet
 import os
 import sys
 
-from oslo.config import cfg
+from oslo_config import cfg
 from eventlet import wsgi
 
 from st2common import log as logging

--- a/st2auth/st2auth/config.py
+++ b/st2auth/st2auth/config.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import config as st2cfg
 from st2common.constants.system import VERSION_STRING

--- a/st2auth/st2auth/controllers/auth.py
+++ b/st2auth/st2auth/controllers/auth.py
@@ -18,7 +18,7 @@ import base64
 import pecan
 from pecan import rest
 from six.moves import http_client
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common.exceptions.auth import TTLTooLargeException
 from st2common.models.api.base import jsexpose

--- a/st2auth/st2auth/wsgi.py
+++ b/st2auth/st2auth/wsgi.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from pecan import load_app
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2auth import config  # noqa
 from st2common import log as logging

--- a/st2auth/tests/unit/test_token.py
+++ b/st2auth/tests/unit/test_token.py
@@ -20,7 +20,7 @@ import string
 
 import mock
 import pecan
-from oslo.config import cfg
+from oslo_config import cfg
 
 from tests.base import FunctionalTest
 from st2common.util import isotime

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -15,7 +15,7 @@
 
 import os
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common.constants.system import VERSION_STRING
 

--- a/st2common/st2common/constants/pack.py
+++ b/st2common/st2common/constants/pack.py
@@ -54,4 +54,5 @@ USER_PACK_NAME_BLACKLIST = [
 # Python requirements which are common to all the packs and are installed into the Python pack
 # sandbox (virtualenv)
 BASE_PACK_REQUIREMENTS = [
+    'six>=1.9.0,<2.0'
 ]

--- a/st2common/st2common/constants/pack.py
+++ b/st2common/st2common/constants/pack.py
@@ -51,9 +51,7 @@ USER_PACK_NAME_BLACKLIST = [
     PACKS_PACK_NAME
 ]
 
-# Requirements which are common to all the packs
+# Python requirements which are common to all the packs and are installed into the Python pack
+# sandbox (virtualenv)
 BASE_PACK_REQUIREMENTS = [
-    # Note: We don't currently handle .pth files corectly so los.config
-    # needs to be installed inside virtualenv
-    'oslo.config'
 ]

--- a/st2common/st2common/constants/runners.py
+++ b/st2common/st2common/constants/runners.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 __all__ = [
     'LOCAL_RUNNER_DEFAULT_ACTION_TIMEOUT',

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -16,7 +16,7 @@
 import logging
 import sys
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import config
 from st2common.service_setup import db_setup

--- a/st2common/st2common/content/utils.py
+++ b/st2common/st2common/content/utils.py
@@ -15,7 +15,7 @@
 
 import os
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common.constants.action import LIBS_DIR as ACTION_LIBS_DIR
 from st2common.util.types import OrderedSet

--- a/st2common/st2common/hooks.py
+++ b/st2common/st2common/hooks.py
@@ -17,7 +17,7 @@ import httplib
 import traceback
 
 import webob
-from oslo.config import cfg
+from oslo_config import cfg
 from pecan.hooks import PecanHook
 from six.moves.urllib import parse as urlparse
 from webob import exc

--- a/st2common/st2common/log.py
+++ b/st2common/st2common/log.py
@@ -23,7 +23,7 @@ import traceback
 from functools import wraps
 
 import six
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common.logging.filters import ExclusionFilter
 

--- a/st2common/st2common/logging/formatters.py
+++ b/st2common/st2common/logging/formatters.py
@@ -23,7 +23,7 @@ import copy
 import traceback
 
 import six
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common.constants.secrets import MASKED_ATTRIBUTES_BLACKLIST
 from st2common.constants.secrets import MASKED_ATTRIBUTE_VALUE

--- a/st2common/st2common/logging/handlers.py
+++ b/st2common/st2common/logging/handlers.py
@@ -17,7 +17,7 @@ import os
 import socket
 import logging
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common.util import date as date_utils
 

--- a/st2common/st2common/models/api/auth.py
+++ b/st2common/st2common/models/api/auth.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from oslo.config import cfg
+from oslo_config import cfg
 from st2common.util import isotime
 from st2common.models.api.base import BaseAPI
 from st2common.models.db.auth import UserDB, TokenDB

--- a/st2common/st2common/models/api/base.py
+++ b/st2common/st2common/models/api/base.py
@@ -25,7 +25,7 @@ from webob import exc
 import pecan
 import pecan.jsonify
 import traceback
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common.util import mongoescape as util_mongodb
 from st2common.util import schema as util_schema

--- a/st2common/st2common/models/db/stormbase.py
+++ b/st2common/st2common/models/db/stormbase.py
@@ -18,7 +18,7 @@ import datetime
 import bson
 import six
 import mongoengine as me
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common.util import mongoescape
 from st2common.models.base import DictSerializableClassMixin

--- a/st2common/st2common/models/system/action.py
+++ b/st2common/st2common/models/system/action.py
@@ -25,7 +25,7 @@ from fabric.api import (put, run, sudo)
 from fabric.context_managers import shell_env
 from fabric.context_managers import settings
 from fabric.tasks import WrappedCallableTask
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import log as logging
 from st2common.models.base import DictSerializableClassMixin

--- a/st2common/st2common/persistence/execution.py
+++ b/st2common/st2common/persistence/execution.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import transport
 from st2common.models.db import MongoDBAccess

--- a/st2common/st2common/persistence/executionstate.py
+++ b/st2common/st2common/persistence/executionstate.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import transport
 from st2common.models.db.executionstate import actionexecstate_access

--- a/st2common/st2common/persistence/liveaction.py
+++ b/st2common/st2common/persistence/liveaction.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import transport
 from st2common.models.db.liveaction import liveaction_access

--- a/st2common/st2common/persistence/sensor.py
+++ b/st2common/st2common/persistence/sensor.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import transport
 from st2common.models.db.sensor import sensor_type_access

--- a/st2common/st2common/persistence/trigger.py
+++ b/st2common/st2common/persistence/trigger.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import transport
 from st2common.models.db.trigger import triggertype_access, trigger_access, triggerinstance_access

--- a/st2common/st2common/rbac/utils.py
+++ b/st2common/st2common/rbac/utils.py
@@ -17,7 +17,7 @@
 RBAC related utility functions.
 """
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common.constants.rbac import SystemRole
 

--- a/st2common/st2common/service_setup.py
+++ b/st2common/st2common/service_setup.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 import os
 import logging as stdlib_logging
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import log as logging
 from st2common.models import db

--- a/st2common/st2common/services/access.py
+++ b/st2common/st2common/services/access.py
@@ -16,7 +16,7 @@
 import uuid
 import datetime
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common.util import isotime
 from st2common.util import date as date_utils

--- a/st2common/st2common/services/coordination.py
+++ b/st2common/st2common/services/coordination.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from oslo.config import cfg
+from oslo_config import cfg
 from tooz import coordination as tooz_coord
 
 from st2common import log as logging

--- a/st2common/st2common/services/sensor_watcher.py
+++ b/st2common/st2common/services/sensor_watcher.py
@@ -20,7 +20,7 @@ import eventlet
 import uuid
 from kombu.mixins import ConsumerMixin
 from kombu import Connection
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import log as logging
 from st2common.transport import reactor, publishers

--- a/st2common/st2common/services/triggerwatcher.py
+++ b/st2common/st2common/services/triggerwatcher.py
@@ -17,7 +17,7 @@ import eventlet
 import uuid
 from kombu.mixins import ConsumerMixin
 from kombu import Connection
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import log as logging
 from st2common.persistence.trigger import Trigger

--- a/st2common/st2common/transport/reactor.py
+++ b/st2common/st2common/transport/reactor.py
@@ -15,7 +15,7 @@
 
 from kombu import Exchange, Queue
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import log as logging
 from st2common.transport import publishers

--- a/st2common/st2common/transport/utils.py
+++ b/st2common/st2common/transport/utils.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from kombu import Connection
-from oslo.config import cfg
+from oslo_config import cfg
 from st2common import log as logging
 from st2common.transport.execution import EXECUTION_XCHG
 from st2common.transport.liveaction import LIVEACTION_XCHG

--- a/st2common/st2common/triggers.py
+++ b/st2common/st2common/triggers.py
@@ -19,7 +19,7 @@ import eventlet
 import json
 import requests
 import requests.exceptions
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import log as logging
 from st2common.constants.triggers import (INTERNAL_TRIGGER_TYPES, ACTION_SENSOR_TRIGGER)

--- a/st2common/st2common/util/api.py
+++ b/st2common/st2common/util/api.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common.constants.api import DEFAULT_API_VERSION
 from st2common.util.url import get_url_without_trailing_slash

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -22,7 +22,7 @@ import os
 import sys
 from distutils.sysconfig import get_python_lib
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common.constants.pack import SYSTEM_PACK_NAMES
 

--- a/st2common/tests/unit/services/test_access.py
+++ b/st2common/tests/unit/services/test_access.py
@@ -16,7 +16,7 @@
 import datetime
 import uuid
 
-from oslo.config import cfg
+from oslo_config import cfg
 from st2tests.base import DbTestCase
 from st2common.util import isotime
 from st2common.util import date as date_utils

--- a/st2common/tests/unit/services/test_synchronization.py
+++ b/st2common/tests/unit/services/test_synchronization.py
@@ -16,7 +16,7 @@
 import unittest2
 import uuid
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common.services import coordination
 import st2tests.config as tests_config

--- a/st2common/tests/unit/test_content_utils.py
+++ b/st2common/tests/unit/test_content_utils.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import unittest2
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common.content.utils import get_packs_base_paths, get_aliases_base_paths
 from st2tests import config as tests_config

--- a/st2common/tests/unit/test_db.py
+++ b/st2common/tests/unit/test_db.py
@@ -16,7 +16,7 @@
 import jsonschema
 import mock
 import mongoengine.connection
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common.models.system.common import ResourceReference
 from st2common.transport.publishers import PoolPublisher

--- a/st2common/tests/unit/test_queue_consumer.py
+++ b/st2common/tests/unit/test_queue_consumer.py
@@ -15,7 +15,7 @@
 
 import mock
 from kombu import Connection, Exchange, Queue
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common.transport import consumers
 from st2tests.base import DbTestCase

--- a/st2common/tests/unit/test_rbac_utils.py
+++ b/st2common/tests/unit/test_rbac_utils.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import mock
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2tests.base import DbTestCase
 from st2tests.config import parse_args

--- a/st2common/tests/unit/test_state_publisher.py
+++ b/st2common/tests/unit/test_state_publisher.py
@@ -16,7 +16,7 @@
 import kombu
 import mock
 import mongoengine as me
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common.models import db
 from st2common.models.db import stormbase

--- a/st2common/tests/unit/test_util_api.py
+++ b/st2common/tests/unit/test_util_api.py
@@ -15,7 +15,7 @@
 
 import unittest2
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common.constants.api import DEFAULT_API_VERSION
 from st2common.util.api import get_base_public_api_url

--- a/st2exporter/st2exporter/config.py
+++ b/st2exporter/st2exporter/config.py
@@ -17,7 +17,7 @@
 Configuration options registration and useful routines.
 """
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 import st2common.config as common_config
 from st2common.constants.system import VERSION_STRING

--- a/st2exporter/st2exporter/worker.py
+++ b/st2exporter/st2exporter/worker.py
@@ -17,7 +17,7 @@ import Queue
 
 import eventlet
 from kombu import Connection
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import log as logging
 from st2common.constants.action import (LIVEACTION_STATUS_SUCCEEDED, LIVEACTION_STATUS_FAILED,

--- a/st2reactor/st2reactor/cmd/rulesengine.py
+++ b/st2reactor/st2reactor/cmd/rulesengine.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 import eventlet
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import log as logging
 from st2common.service_setup import setup as common_setup

--- a/st2reactor/st2reactor/cmd/sensormanager.py
+++ b/st2reactor/st2reactor/cmd/sensormanager.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 import eventlet
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import log as logging
 from st2common.service_setup import setup as common_setup

--- a/st2reactor/st2reactor/cmd/trigger_re_fire.py
+++ b/st2reactor/st2reactor/cmd/trigger_re_fire.py
@@ -17,7 +17,7 @@ import sys
 import logging as std_logging
 import pprint
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import config as st2cfg
 from st2common import log as logging

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -20,7 +20,7 @@ import atexit
 import argparse
 
 import eventlet
-from oslo.config import cfg
+from oslo_config import cfg
 from st2client.client import Client
 
 from st2common import log as logging

--- a/st2reactor/st2reactor/rules/config.py
+++ b/st2reactor/st2reactor/rules/config.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 import st2common.config as common_config
 from st2common.constants.system import VERSION_STRING

--- a/st2reactor/st2reactor/rules/worker.py
+++ b/st2reactor/st2reactor/rules/worker.py
@@ -1,5 +1,5 @@
 from kombu import Connection
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import log as logging
 from st2common.util import date as date_utils

--- a/st2reactor/st2reactor/sensor/config.py
+++ b/st2reactor/st2reactor/sensor/config.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import config as st2cfg
 from st2common.constants.system import VERSION_STRING

--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -23,7 +23,7 @@ import sys
 import shutil
 
 import eventlet
-from oslo.config import cfg
+from oslo_config import cfg
 import six
 from unittest2 import TestCase
 

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import log as logging
 import st2common.config as common_config

--- a/tools/config_gen.py
+++ b/tools/config_gen.py
@@ -20,7 +20,7 @@ import six
 import sys
 import traceback
 
-from oslo.config import cfg
+from oslo_config import cfg
 
 
 CONFIGS = ['st2common.config',

--- a/tools/diff-db-disk.py
+++ b/tools/diff-db-disk.py
@@ -29,7 +29,7 @@ import os
 import sys
 
 import eventlet
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import config
 from st2common.constants.pack import DEFAULT_PACK_NAME

--- a/tools/migrate_rules_to_include_pack.py
+++ b/tools/migrate_rules_to_include_pack.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import mongoengine as me
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import config
 from st2common.constants.pack import DEFAULT_PACK_NAME

--- a/tools/purge_executions.py
+++ b/tools/purge_executions.py
@@ -26,7 +26,7 @@ from datetime import datetime, timedelta
 import sys
 
 import eventlet
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import config
 from st2common.models.db import db_setup

--- a/tools/queue_consumer.py
+++ b/tools/queue_consumer.py
@@ -24,7 +24,7 @@ from pprint import pprint
 
 from kombu.mixins import ConsumerMixin
 from kombu import Connection, Exchange, Queue
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import config
 

--- a/tools/queue_producer.py
+++ b/tools/queue_producer.py
@@ -21,7 +21,7 @@ A utility script which sends test messages to a queue.
 import argparse
 
 from kombu import Connection, Exchange
-from oslo.config import cfg
+from oslo_config import cfg
 
 from st2common import config
 

--- a/tools/st2-inject-trigger-instances.py
+++ b/tools/st2-inject-trigger-instances.py
@@ -32,7 +32,7 @@ import random
 import sys
 
 import eventlet
-from oslo.config import cfg
+from oslo_config import cfg
 import yaml
 
 from st2common import config


### PR DESCRIPTION
This pull request drops "oslo." namespace prefix from the oslo imports.

In addition to that, I also removed "oslo.config" from the base pack requirements (we don't need this anymore now) and I added `six` library to the base pack requirements.

Note: Since we don't pin oslo.config to a specific version, this would break when a new oslo.config package which drops support for "oslo." namespace is published.

Resolves #1658