### PR TITLE
Parameterize Content-Type for SMTP action

### DIFF
--- a/contrib/core/actions/send_mail/send_mail
+++ b/contrib/core/actions/send_mail/send_mail
@@ -3,6 +3,7 @@
 HOSTNAME=$(hostname -f)
 FROM="stanley@${HOSTNAME}"
 SENDMAIL=`which sendmail`
+EOM=""
 
 if [ $? -ne 0 ]; then
     echo "Unable to find sendmail binary in PATH" >&2
@@ -21,6 +22,12 @@ CONTENT_TYPE=$1
 shift
 BODY="$@"
 
+if [[ "${CONTENT_TYPE}" = "text/html" ]]; then
+  LINE_BREAK="<br><br>"
+else
+  LINE_BREAK="\n\n"
+fi
+
 if [[ -z "${BODY// }" && $SEND_EMPTY_BODY == 'True' ]] || [[ -n $BODY ]]; then
   ${MAIL} <<EOF
 TO: ${TO}
@@ -29,7 +36,7 @@ SUBJECT: ${SUBJECT}
 Content-Type: ${CONTENT_TYPE}
 
 ${BODY}
-<br><br>
+${BREAK}
 ${FOOTER}
 
 EOF

--- a/contrib/core/actions/send_mail/send_mail
+++ b/contrib/core/actions/send_mail/send_mail
@@ -3,7 +3,7 @@
 HOSTNAME=$(hostname -f)
 FROM="stanley@${HOSTNAME}"
 SENDMAIL=`which sendmail`
-EOM=""
+LINE_BREAK=""
 
 if [ $? -ne 0 ]; then
     echo "Unable to find sendmail binary in PATH" >&2
@@ -36,7 +36,7 @@ SUBJECT: ${SUBJECT}
 Content-Type: ${CONTENT_TYPE}
 
 ${BODY}
-${BREAK}
+${LINE_BREAK}
 ${FOOTER}
 
 EOF

--- a/contrib/core/actions/send_mail/send_mail
+++ b/contrib/core/actions/send_mail/send_mail
@@ -17,6 +17,8 @@ SUBJECT=$1
 shift
 SEND_EMPTY_BODY=$1
 shift
+CONTENT_TYPE=$1
+shift
 BODY="$@"
 
 if [[ -z "${BODY// }" && $SEND_EMPTY_BODY == 'True' ]] || [[ -n $BODY ]]; then
@@ -24,7 +26,7 @@ if [[ -z "${BODY// }" && $SEND_EMPTY_BODY == 'True' ]] || [[ -n $BODY ]]; then
 TO: ${TO}
 FROM: ${FROM}
 SUBJECT: ${SUBJECT}
-Content-Type: text/html
+Content-Type: ${CONTENT_TYPE}
 
 ${BODY}
 <br><br>

--- a/contrib/core/actions/sendmail.yaml
+++ b/contrib/core/actions/sendmail.yaml
@@ -21,6 +21,14 @@ parameters:
     position: 0
     required: true
     type: string
+  content_type:
+    type: string
+    description: Content type of message to be sent
+    enum:
+      - "text/plain"
+      - "text/html"
+    default: "text/plain"
+    position: 4
   send_empty_body:
     description: Send a message even if the body is empty.
     position: 2

--- a/contrib/core/actions/sendmail.yaml
+++ b/contrib/core/actions/sendmail.yaml
@@ -27,7 +27,7 @@ parameters:
     enum:
       - "text/plain"
       - "text/html"
-    default: "text/plain"
+    default: "text/html"
     position: 4
   send_empty_body:
     description: Send a message even if the body is empty.


### PR DESCRIPTION
This PR updates the core.smtp action to take Content-Type parameters of both text/html and text/plain. This repairs issues when attempting to send plain text, and having linefeeds not being respected.

Reported from IRC via hikertechy

Analog of https://github.com/StackStorm/st2/pull/1663 for master branch. 