### PR TITLE
CLI, Mistral "end_timestamp" bug fix

### DIFF
--- a/docs/source/roadmap.rst
+++ b/docs/source/roadmap.rst
@@ -3,7 +3,6 @@ Roadmap
 
 StackStorm is new and under active development. We are opening it early to engage community, get  feedback, and refine directions, and welcome contributions. Below are key next items we see as top priorities.
 
-
 * **RBAC:** Role based access control for actions, triggers, rules, and datastore keys.
 * **Web UI advanced functionality:** visual workflow design representation, drag&drop workflow designer.
 * **Scale improvements:** refactoring and fixes to scale out better to manage large volumes of events and actions.
@@ -37,13 +36,10 @@ See :doc:`/changelog` for details on what is done.
 * **Operational supportability:** Better output formats, better visibility to ongoing actions, better logs, better debugging tools.
 * **Scale and reliability improvements:** deployed and run at scale, shown some good numbers, and more work identified.
 
-
 .. rubric:: Done in v0.6.0
 
 * **YAML:** complete moving to YAML for defining rules, action and trigger metadata, configurations, etc.
 * **Plugin isolation and management:** Improved managements of sensors, action runners and provide isolated environments.
 * **Reliability:** improvements on sensor and action isolation and reliability
-
-
 
 .. include:: engage.rst

--- a/st2actions/st2actions/query/base.py
+++ b/st2actions/st2actions/query/base.py
@@ -28,6 +28,7 @@ from st2common.persistence.executionstate import ActionExecutionState
 from st2common.persistence.liveaction import LiveAction
 from st2common.services import executions
 from st2common.util.action_db import (get_action_by_ref, get_runnertype_by_name)
+from st2common.util import date as date_utils
 
 LOG = logging.getLogger(__name__)
 DONE_STATES = [LIVEACTION_STATUS_FAILED, LIVEACTION_STATUS_SUCCEEDED]
@@ -119,8 +120,14 @@ class Querier(object):
         liveaction_db = LiveAction.get_by_id(execution_id)
         if not liveaction_db:
             raise Exception('No DB model for liveaction_id: %s' % execution_id)
+
         liveaction_db.result = results
         liveaction_db.status = status
+
+        done = status in DONE_STATES
+        if done and not liveaction_db.end_timestamp:
+            liveaction_db.end_timestamp = date_utils.get_datetime_utc_now()
+
         # update liveaction, update actionexecution and then publish update.
         updated_liveaction = LiveAction.add_or_update(liveaction_db, publish=False)
         executions.update_execution(updated_liveaction)

--- a/st2actions/st2actions/query/base.py
+++ b/st2actions/st2actions/query/base.py
@@ -126,12 +126,14 @@ class Querier(object):
 
         done = status in DONE_STATES
         if done and not liveaction_db.end_timestamp:
+            # Action has completed, record end_timestamp
             liveaction_db.end_timestamp = date_utils.get_datetime_utc_now()
 
         # update liveaction, update actionexecution and then publish update.
         updated_liveaction = LiveAction.add_or_update(liveaction_db, publish=False)
         executions.update_execution(updated_liveaction)
         LiveAction.publish_update(updated_liveaction)
+
         return updated_liveaction
 
     def _invoke_post_run(self, actionexec_db, action_db):

--- a/st2actions/st2actions/query/base.py
+++ b/st2actions/st2actions/query/base.py
@@ -33,6 +33,11 @@ from st2common.util import date as date_utils
 LOG = logging.getLogger(__name__)
 DONE_STATES = [LIVEACTION_STATUS_FAILED, LIVEACTION_STATUS_SUCCEEDED]
 
+__all__ = [
+    'Querier',
+    'QueryContext'
+]
+
 
 @six.add_metaclass(abc.ABCMeta)
 class Querier(object):

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -370,10 +370,16 @@ class ActionRunCommandMixin(object):
             return None, None
 
         result = task['result']
-        stderr = result.get('stderr', None)
-        error = result.get('error', None)
-        traceback = result.get('traceback', None)
-        error = error if error else stderr
+
+        if isinstance(result, dict):
+            stderr = result.get('stderr', None)
+            error = result.get('error', None)
+            traceback = result.get('traceback', None)
+            error = error if error else stderr
+        else:
+            stderr = None
+            error = None
+            traceback = None
 
         return error, traceback
 


### PR DESCRIPTION
This pull request fixes two bugs:

1. CLI throwing an exception when displaying a result for a failed Mistral workflow run.
2. CLI not displaying `end_timestamp` attribute for Mistral workflows. In this case the problem lied in the querier module - we never set `end_timestamp` attribute for a LiveActionDB object which has completed.