### PR TITLE
Create shadow tigger on internal trigger registration

### DIFF
--- a/st2common/st2common/services/triggers.py
+++ b/st2common/st2common/services/triggers.py
@@ -202,6 +202,24 @@ def create_trigger_type_db(trigger_type):
     return trigger_type_db
 
 
+def create_shadow_trigger(trigger_type_db):
+    """
+    Create a shadow trigger for TriggerType with no parameters.
+    """
+    trigger_type_ref = trigger_type_db.get_reference().ref
+
+    if trigger_type_db.parameters_schema:
+        LOG.debug('Skip shadow trigger for TriggerType with parameters %s.', trigger_type_ref)
+        return None
+
+    trigger = {'name': trigger_type_db.name,
+               'pack': trigger_type_db.pack,
+               'type': trigger_type_ref,
+               'parameters': {}}
+
+    return create_or_update_trigger_db(trigger)
+
+
 def create_or_update_trigger_type_db(trigger_type):
     """
     Create or update a trigger type db object in the db given trigger_type definition as dict.

--- a/st2common/tests/unit/test_register_internal_trigger.py
+++ b/st2common/tests/unit/test_register_internal_trigger.py
@@ -1,0 +1,33 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the 'License'); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from st2common.persistence.trigger import Trigger
+from st2common.triggers import register_internal_trigger_types
+from st2tests.base import DbTestCase
+
+
+class TestRegisterInternalTriggers(DbTestCase):
+
+    def test_register_internal_trigger_types(self):
+        registered_trigger_types_db = register_internal_trigger_types()
+        for trigger_type_db in registered_trigger_types_db:
+            self._validate_shadow_trigger(trigger_type_db)
+
+    def _validate_shadow_trigger(self, trigger_type_db):
+        if trigger_type_db.parameters_schema:
+            return
+        trigger_type_ref = trigger_type_db.get_reference().ref
+        triggers = Trigger.query(type=trigger_type_ref)
+        self.assertTrue(len(triggers) > 0, 'Shadow trigger not created for %s.' % trigger_type_ref)


### PR DESCRIPTION
* Previously internal trigger registration was via the API which automatically
  handled shadow trigger registration. Since that was skipped to registering
  in st2api the shadow trigger registration was also dropped leading to regressions.
* Added registration back in and also some basic test to validate shadow trigger
  creation.

Testing -

Validated that creation of `notify_hubot` from the hubot pack works.

```
$ st2 rule create notify_hubot.yaml
+-------------+--------------------------------------------------------+
| Property    | Value                                                  |
+-------------+--------------------------------------------------------+
| id          | 5592174132ed355332f81a8e                               |
| name        | chatops.notify_hubot                                   |
| pack        | default                                                |
| description | Notification rule to send messages to Hubot            |
| action      | {                                                      |
|             |     "ref": "hubot.post_result",                        |
|             |     "parameters": {                                    |
|             |         "user": "{{trigger.data.user}}",               |
|             |         "channel": "{{trigger.data.source_channel}}",  |
|             |         "result": "{{trigger}}"                        |
|             |     }                                                  |
|             | }                                                      |
| criteria    | {                                                      |
|             |     "trigger.channel": {                               |
|             |         "pattern": "hubot",                            |
|             |         "type": "equals"                               |
|             |     }                                                  |
|             | }                                                      |
| enabled     | True                                                   |
| ref         | default.chatops.notify_hubot                           |
| tags        |                                                        |
| trigger     | {                                                      |
|             |     "type": "core.st2.generic.notifytrigger",          |
|             |     "parameters": {},                                  |
|             |     "pack": "core"                                     |
|             | }                                                      |
+-------------+--------------------------------------------------------+
```
