### PR TITLE
Fail on missing pack

### DIFF
--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -209,6 +209,7 @@ class DownloadGitRepoAction(Action):
 
         repo = Repo(pack_root)
         payload = {
+            "repo_url": repo.remotes[0].url,
             "branch": repo.active_branch.name,
             "ref": repo.head.commit.hexsha
         }

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -36,6 +36,20 @@ STACKSTORM_CONTRIB_REPOS = [
     'st2incubator'
 ]
 
+#####
+# This NEEDS a rewrite. Too many features and far too many assumption
+# to keep this impl straight any longer. If you only want to read code do
+# so at your own peril.
+#
+# If you are here to fix a bug or add a feature answer these questions -
+# 1. Am I fixing a broken feature?
+# 2. Is this the only module in which to fix the bug?
+# 3. Am I sure this is a bug fix and not a feature?
+#
+# Only if you can emphatically answer 'YES' to allow about questions you should
+# touch this file. Else, be warned you might loose a part of you soul or sanity.
+#####
+
 
 class DownloadGitRepoAction(Action):
     def __init__(self, config=None):
@@ -194,6 +208,8 @@ class DownloadGitRepoAction(Action):
     @staticmethod
     def _eval_repo_url(repo_url):
         """Allow passing short GitHub style URLs"""
+        if not repo_url:
+            raise Exception('No valid reo_url provided or could be inferred.')
         has_git_extension = repo_url.endswith('.git')
         if len(repo_url.split('/')) == 2 and "git@" not in repo_url:
             url = "https://github.com/{}".format(repo_url)
@@ -217,16 +233,12 @@ class DownloadGitRepoAction(Action):
             raise Exception('No packs specified.')
         gitinfo_location = os.path.join(abs_repo_base, packs[0], GITINFO_FILE)
         if not os.path.exists(gitinfo_location):
-            raise Exception('No .gitinfo found at "%s". repo_url should be specified.' %
-                            gitinfo_location)
+            return repo_url, branch, subtree
         with open(gitinfo_location, 'r') as gitinfo_fp:
             gitinfo = json.load(gitinfo_fp)
             repo_url = gitinfo.get('repo_url', None)
             branch = gitinfo.get('branch', None)
             subtree = gitinfo.get('subtree', False)
-
-        if not repo_url:
-            raise Exception('No repo_url found in gitinfo "%s".' % gitinfo_location)
         return repo_url, branch, subtree
 
     @staticmethod

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -37,6 +37,10 @@ STACKSTORM_CONTRIB_REPOS = [
 ]
 
 #####
+# !!!!!!!!!!!!!!
+# !!! README !!!
+# !!!!!!!!!!!!!!
+#
 # This NEEDS a rewrite. Too many features and far too many assumption
 # to keep this impl straight any longer. If you only want to read code do
 # so at your own peril.

--- a/st2common/tests/unit/test_pack_management.py
+++ b/st2common/tests/unit/test_pack_management.py
@@ -61,3 +61,24 @@ class InstallPackTestCase(unittest2.TestCase):
         repo_url = 'https://git-wip-us.apache.org/repos/asf/libcloud.git'
         result = DownloadGitRepoAction._eval_repo_url(repo_url)
         self.assertEqual(result, repo_url)
+
+    def test_eval_repo_name(self):
+        result = DownloadGitRepoAction._eval_repo_name(
+            'https://github.com/StackStorm/st2contrib.git')
+        self.assertEqual(result, 'st2contrib')
+
+        result = DownloadGitRepoAction._eval_repo_name(
+            'https://github.com/StackStorm/st2contrib')
+        self.assertEqual(result, 'st2contrib')
+
+        result = DownloadGitRepoAction._eval_repo_name(
+            'git@github.com:StackStorm/st2contrib.git')
+        self.assertEqual(result, 'st2contrib')
+
+        result = DownloadGitRepoAction._eval_repo_name(
+            'git@github.com:StackStorm/st2contrib')
+        self.assertEqual(result, 'st2contrib')
+
+        result = DownloadGitRepoAction._eval_repo_name(
+            'https://git-wip-us.apache.org/repos/asf/libcloud.git')
+        self.assertEqual(result, 'libcloud')


### PR DESCRIPTION
* If a pack is missing then fail the install
* Some refactors in code to fix latent issues

Failure to install missing pack -
```
$ st2 run packs.install packs=bitcon
........
id: 5594731032ed3558b5db84ec
action.ref: packs.install
status: failed
error: st2.actions.python.DownloadGitRepoAction: WARNING  bitcon is missing. Expected location "/home/manas/st2contrib/packs/bitcon".
Traceback (most recent call last):
  File "/mnt/st2repos/st2/st2actions/st2actions/runners/python_action_wrapper.py", line 116, in <module>
    obj.run()
  File "/mnt/st2repos/st2/st2actions/st2actions/runners/python_action_wrapper.py", line 61, in run
    output = action.run(**self._parameters)
  File "/opt/stackstorm/packs/packs/actions/pack_mgmt/download.py", line 70, in run
    return self._validate_result(result=result, packs=packs, repo_url=repo_url)
  File "/opt/stackstorm/packs/packs/actions/pack_mgmt/download.py", line 167, in _validate_result
    raise Exception(message)
Exception: No packs were downloaded from repository "StackStorm/st2contrib".

Errors:
 - bitcon: Failure : Pack "bitcon" not found or it's missing a "pack.yaml" file.

traceback: None
failed_on: download
start_timestamp: 2015-07-01T23:09:04.980215Z
end_timestamp: 2015-07-01T23:09:20.177253Z
+--------------------------+--------+----------+----------------+-----------------------+
| id                       | status | task     | action         | start_timestamp       |
+--------------------------+--------+----------+----------------+-----------------------+
| 5594731132ed3558ba9aaeac | failed | download | packs.download | Wed, 01 Jul 2015      |
|                          |        |          |                | 23:09:05 UTC          |
+--------------------------+--------+----------+----------------+-----------------------+
```

1 sucess 1 failure
```
$ st2 run packs.install packs=bitcon,slack
.................
id: 5594736532ed3558b5db84ee
action.ref: packs.install
status: failed
error: bash: st2ctl: command not found

traceback: None
failed_on: reload
start_timestamp: 2015-07-01T23:10:29.283940Z
end_timestamp: 2015-07-01T23:11:01.592532Z
+--------------------------+-----------+-------------------+-----------------------+-----------------------+
| id                       | status    | task              | action                | start_timestamp       |
+--------------------------+-----------+-------------------+-----------------------+-----------------------+
| 5594736532ed3558ba9aaeb0 | succeeded | download          | packs.download        | Wed, 01 Jul 2015      |
|                          |           |                   |                       | 23:10:29 UTC          |
| 5594737532ed3558ba9aaeb3 | succeeded | virtualenv_prerun | packs.virtualenv_prer | Wed, 01 Jul 2015      |
|                          |           |                   | un                    | 23:10:45 UTC          |
| 5594737632ed3558ba9aaeb6 | succeeded | setup_virtualenv  | packs.setup_virtualen | Wed, 01 Jul 2015      |
|                          |           |                   | v                     | 23:10:46 UTC          |
| 5594738432ed3558ba9aaeb9 | failed    | reload            | packs.load            | Wed, 01 Jul 2015      |
|                          |           |                   |                       | 23:11:00 UTC          |
+--------------------------+-----------+-------------------+-----------------------+-----------------------+
(virtualenv)manas@st2dev:~/st2$ st2 execution get 5594736532ed3558ba9aaeb0
id: 5594736532ed3558ba9aaeb0
status: succeeded
result:
{
    "result": {
        "bitcon": "Failure : Pack "bitcon" not found or it's missing a "pack.yaml" file.",
        "slack": "Success."
    },
    "exit_code": 0,
    "stderr": "st2.actions.python.DownloadGitRepoAction: WARNING  bitcon is missing. Expected location "/home/manas/st2contrib/packs/bitcon".
st2.actions.python.DownloadGitRepoAction: DEBUG    Moving pack from /home/manas/st2contrib/packs/slack to /opt/stackstorm/packs/.
",
    "stdout": ""
}
```

### With a91949a44062773d744cb333c437adf06506ae75 the download action tries to guess the repo_url the best it can.

* If pack not previously installed
```
$ st2 run packs.download repo_url='' packs=st2-slack branch=master
.
id: 5594d54232ed35710e93e423
status: failed
result:
{
    "result": null,
    "exit_code": 1,
    "stderr": "Traceback (most recent call last):
  File "/mnt/st2repos/st2/st2actions/st2actions/runners/python_action_wrapper.py", line 116, in <module>
    obj.run()
  File "/mnt/st2repos/st2/st2actions/st2actions/runners/python_action_wrapper.py", line 61, in run
    output = action.run(**self._parameters)
  File "/opt/stackstorm/packs/packs/actions/pack_mgmt/download.py", line 48, in run
    repo_url = self._lookup_repo_url(abs_repo_base, packs)
  File "/opt/stackstorm/packs/packs/actions/pack_mgmt/download.py", line 209, in _lookup_repo_url
    gitinfo_location)
Exception: No .gitinfo found at "/opt/stackstorm/packs/st2-slack/.gitinfo". repo_url should be specified.
",
    "stdout": ""
}
```

* If pack previously installed
```
$ st2 run packs.download repo_url='' packs=st2-slack branch=master
.......
id: 5594d4f132ed35710e93e421
status: succeeded
result:
{
    "result": {
        "st2-slack": "Success."
    },
    "exit_code": 0,
    "stderr": "st2.actions.python.DownloadGitRepoAction: DEBUG    Removing existing pack st2-slack in /opt/stackstorm/packs/st2-slack to replace.
st2.actions.python.DownloadGitRepoAction: DEBUG    Moving pack from /home/manas/st2-slack to /opt/stackstorm/packs/.
",
    "stdout": ""
}
```