### PR TITLE
Fix a bug with actions update API endpoint throwing on missing "enabled" attribute

### DIFF
--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -77,13 +77,6 @@ class ActionsController(resource.ContentPackResourceController):
             Handles requests:
                 POST /actions/
         """
-        if not hasattr(action, 'enabled'):
-            LOG.debug('POST /actions/ incoming action data has enabled field unset. '
-                      'Defaulting enabled to True.')
-            setattr(action, 'enabled', True)
-        else:
-            action.enabled = bool(action.enabled)
-
         if not hasattr(action, 'pack'):
             setattr(action, 'pack', DEFAULT_PACK_NAME)
 

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -208,7 +208,7 @@ class ActionAPI(BaseAPI):
     @classmethod
     def to_model(cls, action):
         model = super(cls, cls).to_model(action)
-        model.enabled = bool(action.enabled)
+        model.enabled = bool(getattr(action, 'enabled', True))
         model.entry_point = str(action.entry_point)
         model.pack = str(action.pack)
         model.runner_type = {'name': str(action.runner_type)}


### PR DESCRIPTION
If a user didn't specify a value for `enabled` attribute when updating an action, an exception would be throw and 500 internal server error returned to the user.

This pull request fixes that by specifying a default value inside the API model and not inside the controller (previously, the controller would only set it on create, but not on update).