### PR TITLE
Fix late-assignment of the variables on the model instances

### DIFF
--- a/st2actions/tests/unit/test_actions_registrar.py
+++ b/st2actions/tests/unit/test_actions_registrar.py
@@ -24,9 +24,7 @@ from st2common.models.db.runner import RunnerTypeDB
 import st2tests.base as tests_base
 import st2tests.fixturesloader as fixtures_loader
 
-MOCK_RUNNER_TYPE_DB = RunnerTypeDB()
-MOCK_RUNNER_TYPE_DB.name = 'run-local'
-MOCK_RUNNER_TYPE_DB.runner_module = 'st2.runners.local'
+MOCK_RUNNER_TYPE_DB = RunnerTypeDB(name='run-local', runner_module='st2.runners.local')
 
 
 class ActionsRegistrarTest(tests_base.DbTestCase):

--- a/st2actions/tests/unit/test_param_utils.py
+++ b/st2actions/tests/unit/test_param_utils.py
@@ -301,11 +301,11 @@ class ParamsUtilsTest(DbTestCase):
                                 action_parameter_info={})
 
     def _get_action_exec_db_model(self, params):
-        liveaction_db = LiveActionDB()
-        liveaction_db.status = 'initializing'
-        liveaction_db.start_timestamp = date_utils.get_datetime_utc_now()
-        liveaction_db.action = ResourceReference(name=ParamsUtilsTest.action_db.name,
-                                                 pack=ParamsUtilsTest.action_db.pack).ref
-        liveaction_db.parameters = params
+        status = 'initializing'
+        start_timestamp = date_utils.get_datetime_utc_now()
+        action_ref = ResourceReference(name=ParamsUtilsTest.action_db.name,
+                                      pack=ParamsUtilsTest.action_db.pack).ref
+        liveaction_db = LiveActionDB(status=status, start_timestamp=start_timestamp,
+                                     action=action_ref, parameters=params)
 
         return liveaction_db

--- a/st2actions/tests/unit/test_queue_consumers.py
+++ b/st2actions/tests/unit/test_queue_consumers.py
@@ -44,13 +44,11 @@ class QueueConsumerTest(DbTestCase):
         self.dispatcher = worker.get_worker()
 
     def _get_execution_db_model(self, status=action_constants.LIVEACTION_STATUS_REQUESTED):
-        live_action_db = LiveActionDB()
-        live_action_db.status = status
-        live_action_db.start_timestamp = date_utils.get_datetime_utc_now()
-        live_action_db.action = ResourceReference(
-            name='test_action',
-            pack='test_pack').ref
-        live_action_db.parameters = None
+        start_timestamp = date_utils.get_datetime_utc_now()
+        action_ref = ResourceReference(name='test_action', pack='test_pack').ref
+        parameters = None
+        live_action_db = LiveActionDB(status=status, start_timestamp=start_timestamp,
+                                      action=action_ref, parameters=parameters)
         return action.LiveAction.add_or_update(live_action_db, publish=False)
 
     @mock.patch.object(RunnerContainer, 'dispatch', mock.MagicMock(return_value={'key': 'value'}))

--- a/st2actions/tests/unit/test_runner_container.py
+++ b/st2actions/tests/unit/test_runner_container.py
@@ -70,8 +70,7 @@ class RunnerContainerTest(DbTestCase):
         self.assertTrue(runner is not None, 'TestRunner must be valid.')
 
     def test_get_runner_module_fail(self):
-        runnertype_db = RunnerTypeDB()
-        runnertype_db.runner_module = 'absent.module'
+        runnertype_db = RunnerTypeDB(runner_module='absent.module')
         runner = None
         try:
             runner = get_runner(runnertype_db.runner_module)
@@ -157,25 +156,27 @@ class RunnerContainerTest(DbTestCase):
         self.assertTrue(found.query_module is not None)
 
     def _get_action_exec_db_model(self, action_db, params):
-        liveaction_db = LiveActionDB()
-        liveaction_db.status = action_constants.LIVEACTION_STATUS_REQUESTED
-        liveaction_db.start_timestamp = date_utils.get_datetime_utc_now()
-        liveaction_db.action = ResourceReference(
-            name=action_db.name,
-            pack=action_db.pack).ref
-        liveaction_db.parameters = params
-        liveaction_db.context = {'user': cfg.CONF.system_user.user}
+        status = action_constants.LIVEACTION_STATUS_REQUESTED
+        start_timestamp = date_utils.get_datetime_utc_now()
+        action_ref = ResourceReference(name=action_db.name, pack=action_db.pack).ref
+        parameters = params
+        context = {'user': cfg.CONF.system_user.user}
+        liveaction_db = LiveActionDB(status=status, start_timestamp=start_timestamp,
+                                     action=action_ref, parameters=parameters,
+                                     context=context)
         return liveaction_db
 
     def _get_failingaction_exec_db_model(self, params):
-        liveaction_db = LiveActionDB()
-        liveaction_db.status = action_constants.LIVEACTION_STATUS_REQUESTED
-        liveaction_db.start_timestamp = date_utils.get_datetime_utc_now()
-        liveaction_db.action = ResourceReference(
+        status = action_constants.LIVEACTION_STATUS_REQUESTED
+        start_timestamp = date_utils.get_datetime_utc_now()
+        action_ref = ResourceReference(
             name=RunnerContainerTest.failingaction_db.name,
             pack=RunnerContainerTest.failingaction_db.pack).ref
-        liveaction_db.parameters = params
-        liveaction_db.context = {'user': cfg.CONF.system_user.user}
+        parameters = params
+        context = {'user': cfg.CONF.system_user.user}
+        liveaction_db = LiveActionDB(status=status, start_timestamp=start_timestamp,
+                                     action=action_ref, parameters=parameters,
+                                     context=context)
         return liveaction_db
 
     @classmethod

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -242,7 +242,7 @@ class ActionExecutionReRunController(ActionExecutionsControllerMixin, ResourceCo
 
         # Create object for the new execution
         action_ref = existing_execution.action['ref']
-        new_execution = LiveActionDB(action=action_ref, parameters=parameters)
+        new_execution = LiveActionDB(action=action_ref, parameters=new_parameters)
 
         result = self._handle_schedule_execution(execution=new_execution)
         return result

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -242,10 +242,7 @@ class ActionExecutionReRunController(ActionExecutionsControllerMixin, ResourceCo
 
         # Create object for the new execution
         action_ref = existing_execution.action['ref']
-
-        new_execution = LiveActionDB()
-        new_execution.action = action_ref
-        new_execution.parameters = new_parameters
+        new_execution = LiveActionDB(action=action_ref, parameters=parameters)
 
         result = self._handle_schedule_execution(execution=new_execution)
         return result

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -103,13 +103,18 @@ class RunnerTypeAPI(BaseAPI):
             setattr(self, 'runner_parameters', dict())
 
     @classmethod
-    def to_model(cls, runnertype):
-        model = super(cls, cls).to_model(runnertype)
-        model.enabled = bool(runnertype.enabled)
-        model.runner_module = str(runnertype.runner_module)
-        if getattr(runnertype, 'query_module', None):
-            model.query_module = str(runnertype.query_module)
-        model.runner_parameters = getattr(runnertype, 'runner_parameters', dict())
+    def to_model(cls, runner_type):
+        name = runner_type.name
+        description = runner_type.description
+        enabled = bool(runner_type.enabled)
+        runner_module = str(runner_type.runner_module)
+        runner_parameters = getattr(runner_type, 'runner_parameters', dict())
+        query_module = getattr(runner_type, 'query_module', None)
+
+        model = cls.model(name=name, description=description, enabled=enabled,
+                          runner_module=runner_module, runner_parameters=runner_parameters,
+                          query_module=query_module)
+
         return model
 
 
@@ -207,16 +212,25 @@ class ActionAPI(BaseAPI):
 
     @classmethod
     def to_model(cls, action):
-        model = super(cls, cls).to_model(action)
-        model.enabled = bool(getattr(action, 'enabled', True))
-        model.entry_point = str(action.entry_point)
-        model.pack = str(action.pack)
-        model.runner_type = {'name': str(action.runner_type)}
-        model.parameters = getattr(action, 'parameters', dict())
-        model.tags = TagsHelper.to_model(getattr(action, 'tags', []))
-        model.ref = ResourceReference.to_string_reference(pack=model.pack, name=model.name)
+        name = getattr(action, 'name', None)
+        description = getattr(action, 'description', None)
+        enabled = bool(getattr(action, 'enabled', True))
+        entry_point = str(action.entry_point)
+        pack = str(action.pack)
+        runner_type = {'name': str(action.runner_type)}
+        parameters = getattr(action, 'parameters', dict())
+        tags = TagsHelper.to_model(getattr(action, 'tags', []))
+        ref = ResourceReference.to_string_reference(pack=pack, name=name)
+
         if getattr(action, 'notify', None):
-            model.notify = NotificationsHelper.to_model(action.notify)
+            notify = NotificationsHelper.to_model(action.notify)
+        else:
+            notify = None
+
+        model = cls.model(name=name, description=description, enable=enabled, enabled=enabled,
+                          entry_point=entry_point, pack=pack, runner_type=runner_type,
+                          tags=tags, parameters=parameters, notify=notify,
+                          ref=ref)
 
         return model
 
@@ -316,24 +330,36 @@ class LiveActionAPI(BaseAPI):
         return cls(**doc)
 
     @classmethod
-    def to_model(cls, liveaction):
-        model = super(cls, cls).to_model(liveaction)
-        model.action = liveaction.action
+    def to_model(cls, live_action):
+        name = getattr(live_action, 'name', None)
+        description = getattr(live_action, 'description', None)
+        action = live_action.action
 
-        if getattr(liveaction, 'start_timestamp', None):
-            model.start_timestamp = isotime.parse(liveaction.start_timestamp)
+        if getattr(live_action, 'start_timestamp', None):
+            start_timestamp = isotime.parse(live_action.start_timestamp)
+        else:
+            start_timestamp = None
 
-        if getattr(liveaction, 'end_timestamp', None):
-            model.end_timestamp = isotime.parse(liveaction.end_timestamp)
+        if getattr(live_action, 'end_timestamp', None):
+            end_timestamp = isotime.parse(live_action.end_timestamp)
+        else:
+            end_timestamp = None
 
-        model.status = getattr(liveaction, 'status', None)
-        model.parameters = getattr(liveaction, 'parameters', dict())
-        model.context = getattr(liveaction, 'context', dict())
-        model.callback = getattr(liveaction, 'callback', dict())
-        model.result = getattr(liveaction, 'result', None)
+        status = getattr(live_action, 'status', None)
+        parameters = getattr(live_action, 'parameters', dict())
+        context = getattr(live_action, 'context', dict())
+        callback = getattr(live_action, 'callback', dict())
+        result = getattr(live_action, 'result', None)
 
-        if getattr(liveaction, 'notify', None):
-            model.notify = NotificationsHelper.to_model(liveaction.notify)
+        if getattr(live_action, 'notify', None):
+            notify = NotificationsHelper.to_model(live_action.notify)
+        else:
+            notify = None
+
+        model = cls.model(name=name, description=description, action=action,
+                          start_timestamp=start_timestamp, end_timestamp=end_timestamp,
+                          status=status, parameters=parameters, context=context,
+                          callback=callback, result=result, notify=notify)
 
         return model
 
@@ -374,10 +400,12 @@ class ActionExecutionStateAPI(BaseAPI):
 
     @classmethod
     def to_model(cls, state):
-        model = super(cls, cls).to_model(state)
-        model.query_module = state.query_module
-        model.execution_id = state.execution_id
-        model.query_context = state.query_context
+        execution_id = state.execution_id
+        query_module = state.query_module
+        query_context = state.query_context
+
+        model = cls(execution_id=execution_id, query_module=query_module,
+                    query_context=query_context)
         return model
 
 
@@ -435,13 +463,16 @@ class ActionAliasAPI(BaseAPI):
 
     @classmethod
     def to_model(cls, alias):
-        model = super(cls, cls).to_model(alias)
-        model.name = alias.name
-        model.pack = alias.pack
-        model.enabled = getattr(alias, 'enabled', True)
-        model.ref = ResourceReference.to_string_reference(pack=model.pack, name=model.name)
-        model.action_ref = alias.action_ref
-        model.formats = alias.formats
+        name = alias.name
+        description = alias.description
+        pack = alias.pack
+        ref = ResourceReference.to_string_reference(pack=pack, name=name)
+        enabled = getattr(alias, 'enabled', True)
+        action_ref = alias.action_ref
+        formats = alias.formats
+
+        model = cls.model(name=name, description=description, pack=pack, ref=ref, enabled=enabled,
+                          action_ref=action_ref, formats=formats)
         return model
 
 

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -404,8 +404,8 @@ class ActionExecutionStateAPI(BaseAPI):
         query_module = state.query_module
         query_context = state.query_context
 
-        model = cls(execution_id=execution_id, query_module=query_module,
-                    query_context=query_context)
+        model = cls.model(execution_id=execution_id, query_module=query_module,
+                          query_context=query_context)
         return model
 
 

--- a/st2common/st2common/models/api/auth.py
+++ b/st2common/st2common/models/api/auth.py
@@ -41,6 +41,12 @@ class UserAPI(BaseAPI):
         "additionalProperties": False
     }
 
+    @classmethod
+    def to_model(cls, user):
+        name = user.name
+        model = cls.model(name=name)
+        return model
+
 
 class TokenAPI(BaseAPI):
     model = TokenDB
@@ -79,10 +85,10 @@ class TokenAPI(BaseAPI):
         return cls(**doc)
 
     @classmethod
-    def to_model(cls, token):
-        model = super(cls, cls).to_model(token)
-        model.user = str(token.user) if token.user else None
-        model.token = str(token.token) if token.token else None
-        model.ttl = getattr(token, 'ttl', None)
-        model.expiry = isotime.parse(token.expiry) if token.expiry else None
+    def to_model(cls, instance):
+        user = str(instance.user) if instance.user else None
+        token = str(instance.token) if instance.token else None
+        expiry = isotime.parse(instance.expiry) if instance.expiry else None
+
+        model = cls.model(user=user, token=token, expiry=expiry)
         return model

--- a/st2common/st2common/models/api/base.py
+++ b/st2common/st2common/models/api/base.py
@@ -98,13 +98,7 @@ class BaseAPI(object):
 
         :param doc: MongoDB document.
         """
-        # pylint: disable=no-member
-        # TODO: Add plugin which lets pylint know each MongoEngine document has model
-        # method
-        model = cls.model()
-        setattr(model, 'name', getattr(doc, 'name', None))
-        setattr(model, 'description', getattr(doc, 'description', None))
-        return model
+        raise NotImplementedError()
 
 
 def jsexpose(arg_types=None, body_cls=None, status_code=None, content_type='application/json'):

--- a/st2common/st2common/models/api/execution.py
+++ b/st2common/st2common/models/api/execution.py
@@ -125,7 +125,7 @@ class ActionExecutionAPI(BaseAPI):
 
     @classmethod
     def to_model(cls, instance):
-        model = cls.model()
+        values = {}
         for attr, meta in six.iteritems(cls.schema.get('properties', dict())):
             default = copy.deepcopy(meta.get('default', None))
             value = getattr(instance, attr, default)
@@ -136,7 +136,10 @@ class ActionExecutionAPI(BaseAPI):
             if not value and not cls.model._fields[attr].required:
                 continue
             if attr not in ActionExecutionAPI.SKIP:
-                setattr(model, attr, value)
-        model.start_timestamp = isotime.parse(instance.start_timestamp)
-        model.end_timestamp = isotime.parse(instance.end_timestamp)
+                values[attr] = value
+
+        values['start_timestamp'] = isotime.parse(instance.start_timestamp)
+        values['end_timestamp'] = isotime.parse(instance.end_timestamp)
+
+        model = cls.model(**values)
         return model

--- a/st2common/st2common/models/api/keyvalue.py
+++ b/st2common/st2common/models/api/keyvalue.py
@@ -69,12 +69,17 @@ class KeyValuePairAPI(BaseAPI):
 
     @classmethod
     def to_model(cls, kvp):
-        model = super(cls, cls).to_model(kvp)
-        model.value = kvp.value
+        name = getattr(kvp, 'name', None)
+        description = getattr(kvp, 'description', None)
+        value = kvp.value
 
         if getattr(kvp, 'ttl', None):
             expire_timestamp = (date_utils.get_datetime_utc_now() +
                                 datetime.timedelta(seconds=kvp.ttl))
-            model.expire_timestamp = expire_timestamp
+        else:
+            expire_timestamp = None
+
+        model = cls.model(name=name, description=description, value=value,
+                          expire_timestamp=expire_timestamp)
 
         return model

--- a/st2common/st2common/models/api/notification.py
+++ b/st2common/st2common/models/api/notification.py
@@ -39,25 +39,34 @@ class NotificationsHelper(object):
 
     @staticmethod
     def to_model(notify_api_object):
-        model = NotificationSchema()
-        if notify_api_object.get('on-complete', None):
-            model.on_complete = NotificationsHelper._to_model_sub_schema(
-                notify_api_object['on-complete'])
         if notify_api_object.get('on-success', None):
-            model.on_success = NotificationsHelper._to_model_sub_schema(
-                notify_api_object['on-success'])
+            on_success = NotificationsHelper._to_model_sub_schema(notify_api_object['on-success'])
+        else:
+            on_success = None
+
+        if notify_api_object.get('on-complete', None):
+            on_complete = NotificationsHelper._to_model_sub_schema(
+                notify_api_object['on-complete'])
+        else:
+            on_complete = None
+
         if notify_api_object.get('on-failure', None):
-            model.on_failure = NotificationsHelper._to_model_sub_schema(
-                notify_api_object['on-failure'])
+            on_failure = NotificationsHelper._to_model_sub_schema(notify_api_object['on-failure'])
+        else:
+            on_failure = None
+
+        model = NotificationSchema(on_success=on_success, on_failure=on_failure,
+                                   on_complete=on_complete)
         return model
 
     @staticmethod
     def _to_model_sub_schema(notification_settings_json):
-        notify_sub_schema = NotificationSubSchema()
-        notify_sub_schema.message = notification_settings_json.get('message' or None)
-        notify_sub_schema.data = notification_settings_json.get('data' or {})
-        notify_sub_schema.channels = notification_settings_json.get('channels' or [])
-        return notify_sub_schema
+        message = notification_settings_json.get('message' or None)
+        data = notification_settings_json.get('data' or {})
+        channels = notification_settings_json.get('channels' or [])
+
+        model = NotificationSubSchema(message=message, data=data, channels=channels)
+        return model
 
     @staticmethod
     def from_model(notify_model):

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -61,11 +61,15 @@ class PackAPI(BaseAPI):
 
     @classmethod
     def to_model(cls, pack):
-        model = super(cls, cls).to_model(pack)
-        model.ref = pack.ref
-        model.keywords = getattr(pack, 'keywords', [])
-        model.version = str(pack.version)
-        model.author = pack.author
-        model.email = pack.email
+        name = pack.name
+        description = pack.description
+        ref = pack.ref
+        keywords = getattr(pack, 'keywords', [])
+        version = str(pack.version)
+        author = pack.author
+        email = pack.email
+
+        model = cls.model(name=name, description=description, ref=ref, keywords=keywords,
+                          version=version, author=author, email=email)
 
         return model

--- a/st2common/st2common/models/api/tag.py
+++ b/st2common/st2common/models/api/tag.py
@@ -15,6 +15,10 @@
 
 from st2common.models.db.stormbase import TagField
 
+__all__ = [
+    'TagsHelper'
+]
+
 
 class TagsHelper(object):
 

--- a/st2common/st2common/models/api/trigger.py
+++ b/st2common/st2common/models/api/trigger.py
@@ -61,12 +61,17 @@ class TriggerTypeAPI(BaseAPI):
     }
 
     @classmethod
-    def to_model(cls, triggertype):
-        model = super(cls, cls).to_model(triggertype)
-        model.pack = getattr(triggertype, 'pack', None)
-        model.payload_schema = getattr(triggertype, 'payload_schema', {})
-        model.parameters_schema = getattr(triggertype, 'parameters_schema', {})
-        model.tags = TagsHelper.to_model(getattr(triggertype, 'tags', []))
+    def to_model(cls, trigger_type):
+        name = getattr(trigger_type, 'name', None)
+        description = getattr(trigger_type, 'description', None)
+        pack = getattr(trigger_type, 'pack', None)
+        payload_schema = getattr(trigger_type, 'payload_schema', {})
+        parameters_schema = getattr(trigger_type, 'parameters_schema', {})
+        tags = TagsHelper.to_model(getattr(trigger_type, 'tags', []))
+
+        model = cls.model(name=name, description=description, pack=pack,
+                          payload_schema=payload_schema, parameters_schema=parameters_schema,
+                          tags=tags)
         return model
 
     @classmethod
@@ -112,20 +117,24 @@ class TriggerAPI(BaseAPI):
 
     @classmethod
     def to_model(cls, trigger):
-        model = super(cls, cls).to_model(trigger)
-        model.pack = getattr(trigger, 'pack', None)
-        model.type = getattr(trigger, 'type', None)
-        model.parameters = getattr(trigger, 'parameters', {})
+        name = getattr(trigger, 'name', None)
+        description = getattr(trigger, 'description', None)
+        pack = getattr(trigger, 'pack', None)
+        _type = getattr(trigger, 'type', None)
+        parameters = getattr(trigger, 'parameters', {})
 
-        if model.type and not model.parameters:
-            triggertype_ref = ResourceReference.from_string_reference(model.type)
-            model.name = triggertype_ref.name
+        if _type and not parameters:
+            trigger_type_ref = ResourceReference.from_string_reference(_type)
+            name = trigger_type_ref.name
 
         if hasattr(trigger, 'name') and trigger.name:
-            model.name = trigger.name
+            name = trigger.name
         else:
             # assign a name if none is provided.
-            model.name = str(uuid.uuid4())
+            name = str(uuid.uuid4())
+
+        model = cls.model(name=name, description=description, pack=pack, type=_type,
+                          parameters=parameters)
         return model
 
 
@@ -161,8 +170,9 @@ class TriggerInstanceAPI(BaseAPI):
 
     @classmethod
     def to_model(cls, instance):
-        model = super(cls, cls).to_model(instance)
-        model.trigger = instance.trigger
-        model.payload = instance.payload
-        model.occurrence_time = isotime.parse(instance.occurrence_time)
+        trigger = instance.trigger
+        payload = instance.payload
+        occurrence_time = isotime.parse(instance.occurrence_time)
+
+        model = cls.model(trigger=trigger, payload=payload, occurrence_time=occurrence_time)
         return model

--- a/st2common/st2common/models/utils/sensor_type_utils.py
+++ b/st2common/st2common/models/utils/sensor_type_utils.py
@@ -84,16 +84,10 @@ def _create_trigger_types(trigger_types):
 def _create_sensor_type(pack=None, name=None, description=None, artifact_uri=None,
                         entry_point=None, trigger_types=None, poll_interval=10, enabled=True):
 
-    sensor_type = SensorTypeDB()
-    sensor_type.pack = pack
-    sensor_type.name = name
-    sensor_type.description = description
-    sensor_type.artifact_uri = artifact_uri
-    sensor_type.entry_point = entry_point
-    sensor_type.trigger_types = trigger_types
-    sensor_type.poll_interval = poll_interval
-    sensor_type.enabled = enabled
-
+    sensor_type = SensorTypeDB(pack=pack, name=name, description=description,
+                               artifact_uri=artifact_uri, entry_point=entry_point,
+                               poll_interval=poll_interval, enabled=enabled,
+                               trigger_types=trigger_types)
     return sensor_type
 
 

--- a/st2common/tests/unit/test_db.py
+++ b/st2common/tests/unit/test_db.py
@@ -206,9 +206,10 @@ class ReactorModelTest(DbTestCase):
 
     @staticmethod
     def _create_save_rule(trigger, action=None, enabled=True):
-        created = RuleDB(name='rule-1', pack='default',
-                         ref=ResourceReference.to_string_reference(name=created.name,
-                                                                   pack=created.pack))
+        name = 'rule-1'
+        pack = 'default'
+        ref = ResourceReference.to_string_reference(name=name, pack=pack)
+        created = RuleDB(name=name, pack=pack, ref=ref)
         created.description = ''
         created.enabled = enabled
         created.trigger = reference.get_str_resource_ref_from_model(trigger)
@@ -368,9 +369,12 @@ class ActionModelTest(DbTestCase):
 
     @staticmethod
     def _create_save_action(runnertype, metadata=False):
-        created = ActionDB(name='action-1', description='awesomeness', enabled=True,
-                           entry_point='/tmp/action.py', pack='wolfpack',
-                           ref=ResourceReference(pack=created.pack, name=created.name).ref,
+        name = 'action-1'
+        pack = 'wolfpack'
+        ref = ResourceReference(pack=pack, name=name).ref
+        created = ActionDB(name=name, description='awesomeness', enabled=True,
+                           entry_point='/tmp/action.py', pack=pack,
+                           ref=ref,
                            runner_type={'name': runnertype.name})
 
         if not metadata:

--- a/st2common/tests/unit/test_db.py
+++ b/st2common/tests/unit/test_db.py
@@ -206,11 +206,9 @@ class ReactorModelTest(DbTestCase):
 
     @staticmethod
     def _create_save_rule(trigger, action=None, enabled=True):
-        created = RuleDB()
-        created.name = 'rule-1'
-        created.pack = 'default'
-        created.ref = ResourceReference.to_string_reference(name=created.name,
-                                                            pack=created.pack)
+        created = RuleDB(name='rule-1', pack='default',
+                         ref=ResourceReference.to_string_reference(name=created.name,
+                                                                   pack=created.pack))
         created.description = ''
         created.enabled = enabled
         created.trigger = reference.get_str_resource_ref_from_model(trigger)
@@ -370,14 +368,11 @@ class ActionModelTest(DbTestCase):
 
     @staticmethod
     def _create_save_action(runnertype, metadata=False):
-        created = ActionDB()
-        created.name = 'action-1'
-        created.description = 'awesomeness'
-        created.enabled = True
-        created.entry_point = '/tmp/action.py'
-        created.pack = 'wolfpack'
-        created.ref = ResourceReference(pack=created.pack, name=created.name).ref
-        created.runner_type = {'name': runnertype.name}
+        created = ActionDB(name='action-1', description='awesomeness', enabled=True,
+                           entry_point='/tmp/action.py', pack='wolfpack',
+                           ref=ResourceReference(pack=created.pack, name=created.name).ref,
+                           runner_type={'name': runnertype.name})
+
         if not metadata:
             created.parameters = {'p1': None, 'p2': None, 'p3': None}
         else:

--- a/st2exporter/st2exporter/exporter/dumper.py
+++ b/st2exporter/st2exporter/exporter/dumper.py
@@ -186,5 +186,5 @@ class Dumper(object):
         else:
             marker_id = None
 
-        marker_db = DumperMarkerDB(marker_id=marker_id, marker=marker, updated_at=updated_at)
+        marker_db = DumperMarkerDB(id=marker_id, marker=marker, updated_at=updated_at)
         return DumperMarker.add_or_update(marker_db)

--- a/st2exporter/st2exporter/exporter/dumper.py
+++ b/st2exporter/st2exporter/exporter/dumper.py
@@ -173,18 +173,18 @@ class Dumper(object):
 
     def _write_marker_to_db(self, new_marker):
         LOG.info('Updating marker in db to: %s', new_marker)
-        marker = DumperMarker.get_all()
+        markers = DumperMarker.get_all()
 
-        if len(marker) > 1:
+        if len(markers) > 1:
             LOG.exception('More than one dumper marker found. Using first found one.')
 
-        marker_db = None
-        if marker:
-            marker = marker[0]
-            marker_db = DumperMarkerDB(id=marker['id'])
-        else:
-            marker_db = DumperMarkerDB()
+        marker = isotime.format(new_marker, offset=False)
+        updated_at = date_utils.get_datetime_utc_now()
 
-        marker_db.marker = isotime.format(new_marker, offset=False)
-        marker_db.updated_at = date_utils.get_datetime_utc_now()
+        if markers:
+            marker_id = markers[0]['id']
+        else:
+            marker_id = None
+
+        marker_db = DumperMarkerDB(marker_id=marker_id, marker=marker, updated_at=updated_at)
         return DumperMarker.add_or_update(marker_db)

--- a/st2reactor/st2reactor/rules/tester.py
+++ b/st2reactor/st2reactor/rules/tester.py
@@ -51,10 +51,7 @@ class RuleTester(object):
 
         trigger_ref = ResourceReference.from_string_reference(trigger_instance_db['trigger'])
 
-        trigger_db = TriggerDB()
-        trigger_db.pack = trigger_ref.pack
-        trigger_db.name = trigger_ref.name
-        trigger_db.type = trigger_ref.ref
+        trigger_db = TriggerDB(pack=trigger_ref.pack, name=trigger_ref.name, type=trigger_ref.ref)
 
         matcher = RulesMatcher(trigger_instance=trigger_instance_db, trigger=trigger_db,
                                rules=[rule_db])
@@ -63,11 +60,10 @@ class RuleTester(object):
 
     def _get_rule_db_from_file(self, file_path):
         data = self._meta_loader.load(file_path=file_path)
-        rule_db = RuleDB()
-        rule_db.trigger = data['trigger']['type']
-        rule_db.criteria = data.get('criteria', None)
-        rule_db.action = {}
-        rule_db.enabled = True
+        trigger = data['trigger']['type']
+        criteria = data.get('criteria', None)
+
+        rule_db = RuleDB(trigger=trigger, criteria=criteria, action={}, enabled=True)
         return rule_db
 
     def _get_trigger_instance_db_from_file(self, file_path):

--- a/st2reactor/tests/unit/test_filter.py
+++ b/st2reactor/tests/unit/test_filter.py
@@ -44,23 +44,15 @@ MOCK_TRIGGER_INSTANCE.payload = {
 }
 MOCK_TRIGGER_INSTANCE.occurrence_time = date_utils.get_datetime_utc_now()
 
-MOCK_ACTION = ActionDB()
-MOCK_ACTION.id = bson.ObjectId()
-MOCK_ACTION.name = 'action-test-1.name'
+MOCK_ACTION = ActionDB(id=bson.ObjectId(), name='action-test-1.name')
 
-MOCK_RULE_1 = RuleDB()
-MOCK_RULE_1.id = bson.ObjectId()
-MOCK_RULE_1.name = "some1"
-MOCK_RULE_1.trigger = reference.get_str_resource_ref_from_model(MOCK_TRIGGER)
-MOCK_RULE_1.criteria = {}
-MOCK_RULE_1.action = ActionExecutionSpecDB(ref="somepack.someaction")
+MOCK_RULE_1 = RuleDB(id=bson.ObjectId(), name='some1',
+                     trigger=reference.get_str_resource_ref_from_model(MOCK_TRIGGER),
+                     criteria={}, action=ActionExecutionSpecDB(ref="somepack.someaction"))
 
-MOCK_RULE_2 = RuleDB()
-MOCK_RULE_2.id = bson.ObjectId()
-MOCK_RULE_1.name = "some2"
-MOCK_RULE_2.trigger = reference.get_str_resource_ref_from_model(MOCK_TRIGGER)
-MOCK_RULE_2.criteria = {}
-MOCK_RULE_2.action = ActionExecutionSpecDB(ref="somepack.someaction")
+MOCK_RULE_2 = RuleDB(id=bson.ObjectId(), name='some2',
+                     trigger=reference.get_str_resource_ref_from_model(MOCK_TRIGGER),
+                     criteria={}, action=ActionExecutionSpecDB(ref="somepack.someaction"))
 
 
 @mock.patch.object(reference, 'get_model_by_resource_ref',

--- a/st2reactor/tests/unit/test_rule_matcher.py
+++ b/st2reactor/tests/unit/test_rule_matcher.py
@@ -58,20 +58,12 @@ class RuleMatcherTest(DbTestCase):
         self.assertEqual(len(matching_rules), 1)
 
     def _setup_sample_trigger(self, name):
-        trigtype = TriggerTypeDB()
-        trigtype.name = name
-        trigtype.pack = 'dummy_pack_1'
-        trigtype.description = ''
-        trigtype.payload_schema = {}
-        trigtype.parameters_schema = {}
+        trigtype = TriggerTypeDB(name=name, pack='dummy_pack_1', payload_schema={},
+                                 parameters_schema={})
         TriggerType.add_or_update(trigtype)
 
-        created = TriggerDB()
-        created.name = name
-        created.pack = 'dummy_pack_1'
-        created.description = ''
-        created.type = trigtype.get_reference().ref
-        created.parameters = {}
+        created = TriggerDB(name=name, pack='dummy_pack_1', type=trigtype.get_reference().ref,
+                            parameters={})
         Trigger.add_or_update(created)
 
     def _get_sample_rules(self):


### PR DESCRIPTION
This branch updates all the `to_model` methods on the API models and other related code to pass all the model arguments to the constructor instead of performing a late variable assignment on the model instance.

Late variable assignment shouldn't be used unless there is a good and valid use case for it (same as with the decorators) since it breaks many assumptions and "static" analysis. We don't know if and when variable will be set which makes constructors useless.

For example, if I want to create a new attribute based on the value of other attributes and assign it inside the constructor, I can't do that when using late variable assignment approach. Only way to get this to kinda consistently work with a late variable assignment is to instead implement `__getattribute__`, but that's a hack on top of another hack.

P.S. 1: I noticed @m4dcoder encounter a similar issue when working Policy models. He assigns `ref` attribute inside the constructor and to get this to work, he couldn't do late variable assignment - https://github.com/StackStorm/st2/blob/master/st2common/st2common/models/api/policy.py#L135

P.S. 2: We have a similar issue with the runners, but we can fix that later. I couldn't wait with fixing this though since I have some related changes in the RBAC branch which wouldn't be possible without this change (well, I could write a hack on top of a hack, but that's awful and we already have enough debt in other places).