### PR TITLE
adds st2auth to the list of components that can be restarted

### DIFF
--- a/tools/st2ctl
+++ b/tools/st2ctl
@@ -85,7 +85,7 @@ fi
 
 if [ ${1} == "restart-component" ]
 then
-    if  [ -z ${2} ] || [ ${2} != "st2actionrunner" -a ${2} != "st2api" -a ${2} != "st2sensorcontainer" -a ${2} != "st2rulesengine" -a ${2} != "mistral" -a ${2} != "st2resultstracker" -a ${2} != "st2notifier" -a ${2} != "st2web" ]
+    if  [ -z ${2} ] || [ ${2} != "st2actionrunner" -a ${2} != "st2api" -a ${2} != "st2sensorcontainer" -a ${2} != "st2rulesengine" -a ${2} != "mistral" -a ${2} != "st2resultstracker" -a ${2} != "st2notifier" -a ${2} != "st2web" -a ${2} != "st2auth" ]
     then
         print_usage
         exit 1


### PR DESCRIPTION
Looks like st2auth is missing from the restart-component checks, so you are unable to restart only that component.

@Kami ?