### PR TITLE
Fixes #1654, adds no timeout for action runners

### DIFF
--- a/docs/source/_includes/runner_parameters/cloudslang.rst
+++ b/docs/source/_includes/runner_parameters/cloudslang.rst
@@ -1,4 +1,4 @@
 .. NOTE: This file has been generated automatically, don't manually edit it
 
 * ``inputs`` (object) - Inputs which will be available to CLoudSlang flow execution(e.g. input1=val1,input2=val2)
-* ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds.
+* ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds. 0 means no timeout.

--- a/docs/source/_includes/runner_parameters/local_shell_cmd.rst
+++ b/docs/source/_includes/runner_parameters/local_shell_cmd.rst
@@ -4,5 +4,5 @@
 * ``env`` (object) - Environment variables which will be available to the command(e.g. key1=val1,key2=val2)
 * ``cmd`` (string) - Arbitrary Linux command to be executed on the host.
 * ``kwarg_op`` (string) - Operator to use in front of keyword args i.e. "--" or "-".
-* ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds.
+* ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds. 0 means no timeout.
 * ``cwd`` (string) - Working directory where the command will be executed in

--- a/docs/source/_includes/runner_parameters/local_shell_script.rst
+++ b/docs/source/_includes/runner_parameters/local_shell_script.rst
@@ -1,7 +1,7 @@
 .. NOTE: This file has been generated automatically, don't manually edit it
 
 * ``kwarg_op`` (string) - Operator to use in front of keyword args i.e. "--" or "-".
-* ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds.
+* ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds. 0 means no timeout.
 * ``sudo`` (boolean) - The command will be executed with sudo.
 * ``cwd`` (string) - Working directory where the script will be executed in
 * ``env`` (object) - Environment variables which will be available to the script(e.g. key1=val1,key2=val2)

--- a/docs/source/_includes/runner_parameters/python_script.rst
+++ b/docs/source/_includes/runner_parameters/python_script.rst
@@ -1,4 +1,4 @@
 .. NOTE: This file has been generated automatically, don't manually edit it
 
-* ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds.
+* ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds. 0 means no timeout.
 * ``env`` (object) - Environment variables which will be available to the script(e.g. key1=val1,key2=val2)

--- a/st2actions/st2actions/bootstrap/runnersregistrar.py
+++ b/st2actions/st2actions/bootstrap/runnersregistrar.py
@@ -66,7 +66,7 @@ RUNNER_TYPES = [
             },
             'timeout': {
                 'description': ('Action timeout in seconds. Action will get killed if it '
-                                'doesn\'t finish in timeout seconds.'),
+                                'doesn\'t finish in timeout seconds. 0 means no timeout.'),
                 'type': 'integer',
                 'default': LOCAL_RUNNER_DEFAULT_ACTION_TIMEOUT
             }
@@ -100,7 +100,7 @@ RUNNER_TYPES = [
             },
             'timeout': {
                 'description': ('Action timeout in seconds. Action will get killed if it '
-                                'doesn\'t finish in timeout seconds.'),
+                                'doesn\'t finish in timeout seconds. 0 means no timeout.'),
                 'type': 'integer',
                 'default': LOCAL_RUNNER_DEFAULT_ACTION_TIMEOUT
             }
@@ -353,7 +353,7 @@ RUNNER_TYPES = [
             },
             'timeout': {
                 'description': ('Action timeout in seconds. Action will get killed if it '
-                                'doesn\'t finish in timeout seconds.'),
+                                'doesn\'t finish in timeout seconds. 0 means no timeout.'),
                 'type': 'integer',
                 'default': PYTHON_RUNNER_DEFAULT_ACTION_TIMEOUT
             }
@@ -455,7 +455,7 @@ RUNNER_TYPES = [
             },
             'timeout': {
                 'description': ('Action timeout in seconds. Action will get killed if it '
-                                'doesn\'t finish in timeout seconds.'),
+                                'doesn\'t finish in timeout seconds. 0 means no timeout.'),
                 'type': 'integer',
                 'default': LOCAL_RUNNER_DEFAULT_ACTION_TIMEOUT
             }

--- a/st2actions/st2actions/utils/param_utils.py
+++ b/st2actions/st2actions/utils/param_utils.py
@@ -64,7 +64,7 @@ def _get_resolved_runner_params(runner_parameters, action_parameters,
         # pickup the override.
         if param_name in action_parameters:
             action_param = action_parameters[param_name]
-            if action_param.get('default', False):
+            if 'default' in action_param:
                 resolved_params[param_name] = action_param['default']
 
             # No further override (from liveaction) if param is immutable

--- a/st2actions/tests/unit/test_param_utils.py
+++ b/st2actions/tests/unit/test_param_utils.py
@@ -51,7 +51,8 @@ class ParamsUtilsTest(DbTestCase):
             'some_key_that_aint_exist_in_action_or_runner': 'bar',
             'runnerint': 555,
             'runnerimmutable': 'failed_override',
-            'actionimmutable': 'failed_override'
+            'actionimmutable': 'failed_override',
+            'defaults_ovverriden_by_execution': 0,
         }
         liveaction_db = self._get_action_exec_db_model(params)
 
@@ -65,11 +66,16 @@ class ParamsUtilsTest(DbTestCase):
         self.assertEqual(runner_params.get('runnerstr'), 'defaultfoo')
         # Assert that a runner param from action exec is picked up.
         self.assertEqual(runner_params.get('runnerint'), 555)
-        # Assert that a runner param can be overriden by action param default.
+        # Assert that a runner param can be overridden by action param default.
         self.assertEqual(runner_params.get('runnerdummy'), 'actiondummy')
-        # Asser that runner param made immutable in action can use default value in runner.
+        # Assert that a runner param default can be overridden by 'falsey' action param default,
+        # (timeout: 0 case).
+        self.assertEqual(runner_params.get('runnerdefaultint'), 0)
+        # Assert that execution param overrides both runner and action params defaults.
+        self.assertEqual(runner_params.get('defaults_ovverriden_by_execution'), 0)
+        # Assert that runner param made immutable in action can use default value in runner.
         self.assertEqual(runner_params.get('runnerfoo'), 'FOO')
-        # Assert that an immutable param cannot be overriden by action param or execution param.
+        # Assert that an immutable param cannot be overridden by action param or execution param.
         self.assertEqual(runner_params.get('runnerimmutable'), 'runnerimmutable')
 
         # Asserts for action params.
@@ -77,7 +83,7 @@ class ParamsUtilsTest(DbTestCase):
         # Assert that a param that is provided in action exec that isn't in action or runner params
         # isn't in resolved params.
         self.assertEqual(action_params.get('some_key_that_aint_exist_in_action_or_runner'), None)
-        # Assert that an immutable param cannot be overriden by execution param.
+        # Assert that an immutable param cannot be overridden by execution param.
         self.assertEqual(action_params.get('actionimmutable'), 'actionimmutable')
         # Assert that none of runner params are present in action_params.
         for k in action_params:
@@ -103,9 +109,9 @@ class ParamsUtilsTest(DbTestCase):
         self.assertEqual(runner_params.get('runnerstr'), 'defaultfoo')
         # Assert that a runner param from action exec is picked up.
         self.assertEqual(runner_params.get('runnerint'), 555)
-        # Assert that a runner param can be overriden by action param default.
+        # Assert that a runner param can be overridden by action param default.
         self.assertEqual(runner_params.get('runnerdummy'), 'actiondummy')
-        # Assert that an immutable param cannot be overriden by action param or execution param.
+        # Assert that an immutable param cannot be overridden by action param or execution param.
         self.assertEqual(runner_params.get('runnerimmutable'), 'runnerimmutable')
 
         # Asserts for action params.
@@ -113,7 +119,7 @@ class ParamsUtilsTest(DbTestCase):
         # Assert that a param that is provided in action exec that isn't in action or runner params
         # isn't in resolved params.
         self.assertEqual(action_params.get('some_key_that_aint_exist_in_action_or_runner'), None)
-        # Assert that an immutable param cannot be overriden by execution param.
+        # Assert that an immutable param cannot be overridden by execution param.
         self.assertEqual(action_params.get('actionimmutable'), 'actionimmutable')
         # Assert that none of runner params are present in action_params.
         for k in action_params:
@@ -137,7 +143,7 @@ class ParamsUtilsTest(DbTestCase):
         self.assertEqual(runner_params.get('runnerstr'), 'defaultfoo')
         # Assert that a runner param from action exec is picked up.
         self.assertEqual(runner_params.get('runnerint'), 555)
-        # Assert that an immutable param cannot be overriden by action param or execution param.
+        # Assert that an immutable param cannot be overridden by action param or execution param.
         self.assertEqual(runner_params.get('runnerimmutable'), 'runnerimmutable')
 
         # Asserts for action params.
@@ -163,7 +169,7 @@ class ParamsUtilsTest(DbTestCase):
         self.assertEqual(runner_params.get('runnerstr'), 'defaultfoo')
         # Assert that a runner param from action exec is picked up.
         self.assertEqual(runner_params.get('runnerint'), 555)
-        # Assert that a runner param can be overriden by action param default.
+        # Assert that a runner param can be overridden by action param default.
         self.assertEqual(runner_params.get('runnerdummy'), 'actiondummy')
 
         # Asserts for action params.

--- a/st2common/st2common/util/green/shell.py
+++ b/st2common/st2common/util/green/shell.py
@@ -57,7 +57,7 @@ def run_command(cmd, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                 environment from the current process is inherited.
     :type env: ``dict``
 
-    :param timeout: How long to wait before timing out.
+    :param timeout: How long to wait before timing out. 0 means no timeout.
     :type timeout: ``float``
 
     :param preexec_func: Optional pre-exec function.
@@ -80,29 +80,30 @@ def run_command(cmd, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
     process = subprocess.Popen(args=cmd, stdin=stdin, stdout=stdout, stderr=stderr,
                                env=env, cwd=cwd, shell=shell, preexec_fn=preexec_func)
 
-    def on_timeout_expired(timeout):
-        global timed_out
-
-        try:
-            process.wait(timeout=timeout)
-        except subprocess.TimeoutExpired:
-            # Command has timed out, kill the process and propagate the error.
-            # Note: We explicitly set the returncode to indicate the timeout.
-            process.returncode = TIMEOUT_EXIT_CODE
-
-            if kill_func:
-                kill_func(process=process)
-            else:
-                process.kill()
-
-    timeout_thread = eventlet.spawn(on_timeout_expired, timeout)
-    stdout, stderr = process.communicate()
-    timeout_thread.cancel()
-    exit_code = process.returncode
-
-    if exit_code == TIMEOUT_EXIT_CODE:
-        timed_out = True
+    if not timeout:
+        stdout, stderr = process.communicate()
     else:
-        timed_out = False
+        def on_timeout_expired(timeout):
+            """
+            Thread to control subprocess timeout. Kills the process if timeout reached.
 
-    return (exit_code, stdout, stderr, timed_out)
+            :param timeout: How long to wait before timing out.
+            :type: timeout: ``float``
+            :return:
+            """
+            try:
+                process.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                # Command has timed out, kill the process and propagate the error.
+                # Note: We explicitly set the returncode to indicate the timeout.
+                process.returncode = TIMEOUT_EXIT_CODE
+
+                if kill_func:
+                    kill_func(process=process)
+                else:
+                    process.kill()
+        timeout_thread = eventlet.spawn(on_timeout_expired, timeout)
+        stdout, stderr = process.communicate()
+        timeout_thread.cancel()
+
+    return (process.returncode, stdout, stderr, process.returncode == TIMEOUT_EXIT_CODE)

--- a/st2tests/st2tests/fixtures/generic/actions/action1.yaml
+++ b/st2tests/st2tests/fixtures/generic/actions/action1.yaml
@@ -26,6 +26,14 @@ parameters:
     default: FOO
     immutable: true
     type: string
+  runnerdefaultint:
+    default: 0
+    description: Falsey integer param, overrides runner default. Covers timeout 0 issue.
+    type: integer
+  defaults_ovverriden_by_execution:
+    default: 1
+    description: Overrides runner default. Will be overriden by live action.
+    type: integer
   runnerimmutable:
     default: failed_override
     type: string

--- a/st2tests/st2tests/fixtures/generic/runners/testrunner1.yaml
+++ b/st2tests/st2tests/fixtures/generic/runners/testrunner1.yaml
@@ -19,6 +19,14 @@ runner_parameters:
   runnerint:
     description: Foo int param.
     type: number
+  runnerdefaultint:
+    default: 60
+    description: Default integer param.
+    type: integer
+  defaults_ovverriden_by_execution:
+    default: 90
+    description: Will be overridden by action and then by live execution.
+    type: integer
   runnerstr:
     default: defaultfoo
     description: Foo str param.


### PR DESCRIPTION
Adds an option to run actions with no timeout.

Also fixes an issue #1654 , when runner parameters were not overridden with "falsey" action parameters (0, False, etc), so this meta was buggy:
```yaml
---
  name: "test"
  runner_type: "local-shell-cmd"
  description: "Action that tests timeout."
  enabled: true
  entry_point: ""
  parameters:
    timeout:
      # this worked as default 60 seconds
      #default: 0

      # this worked as 0 seconds
      # default: "0"

      # now 0 means no timeout
      default: 0
    cmd:
      default: "echo 'TIMEOUT: {{timeout}}'"
```

