### PR TITLE
Fix Coveralls & Optimize Travis builds

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+; http://nedbatchelder.com/code/coverage/config.html
+
+[run]
+omit = *tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,26 @@
 language: python
 sudo: false
 python:
-  - "2.6"
-  - "2.7"
-install:
-  - pip install python-coveralls
+  - 2.7
+
 env:
-  global:
-    - "PIP_DOWNLOAD_CACHE=$HOME/.pip-cache"
-  matrix:
-    - "TASK=flake8"
-    - "TASK=pylint"
-    - "TASK=docs"
-    - "TASK=tests"
-cache:
-  directories:
-    - $HOME/.pip-cache/
-script:
-  - ./scripts/travis.sh
+  - TASK=checks
+  - TASK=unit
+
 services:
   - mongodb
   - rabbitmq
-after_success: coveralls
+
+cache:
+  directories:
+    - $HOME/.cache/pip/
+
+install:
+ - if [[ ${TASK} == 'unit' ]]; then pip install python-coveralls; fi
+ - make requirements
+
+script:
+  - ./scripts/travis.sh
+
+after_success:
+  - if [[ ${TASK} == 'unit' ]]; then coveralls; fi

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,12 @@ lint: requirements .lint
 .PHONY: clean
 clean: .cleanpycs .cleandocs
 
+.PHONY: compile
+compile:
+	@echo "======================= compile ========================"
+	@echo "------- Compile all .py files (syntax check test) ------"
+	@if python -c 'import compileall,re; compileall.compile_dir(".", rx=re.compile(r"/virtualenv"), quiet=True)' | grep .; then exit 1; else exit 0; fi
+
 .PHONY: .cleanpycs
 .cleanpycs:
 	@echo "Removing all .pyc files"
@@ -218,10 +224,10 @@ tests: pytests
 tests-travis: requirements unit-tests-coverage-xml
 
 .PHONY: pytests
-pytests: requirements .flake8 .pylint .pytests-coverage
+pytests: compile requirements .flake8 .pylint .pytests-coverage
 
 .PHONY: .pytests
-.pytests: unit-tests itests clean
+.pytests: compile unit-tests itests clean
 
 .PHONY: .pytests-coverage
 .pytests-coverage: unit-tests-coverage-html itests clean

--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ unit-tests-coverage-xml:
 		echo "Running tests in" $$component; \
 		echo "==========================================================="; \
 		. $(VIRTUALENV_DIR)/bin/activate; nosetests -sv --with-coverage \
-			--cover-inclusive --cover-erase --cover-xml \
+			--cover-inclusive --cover-xml \
 			--cover-package=$$component $$component/tests/unit &&  \
 			mv coverage.xml coverage-$$component.xml || exit 1; \
 	done

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **StackStorm** is a platform for integration and automation across services and tools, taking actions in response to events. Learn more at [www.stackstorm.com](http://www.stackstorm.com/product).
 
-[![Build Status](https://api.travis-ci.org/StackStorm/st2.svg?branch=master)](https://travis-ci.org/StackStorm/st2) [![IRC](https://img.shields.io/irc/%23stackstorm.png)](http://webchat.freenode.net/?channels=stackstorm) [![Coverage Status](https://coveralls.io/repos/StackStorm/st2/badge.svg?branch=master&service=github)](https://coveralls.io/github/StackStorm/st2?branch=master)
+[![Build Status](https://api.travis-ci.org/StackStorm/st2.svg?branch=master)](https://travis-ci.org/StackStorm/st2) [![Coverage Status](https://coveralls.io/repos/StackStorm/st2/badge.svg?branch=master&service=github)](https://coveralls.io/github/StackStorm/st2?branch=master) ![Python 2.7](https://img.shields.io/badge/python-2.7-blue.svg) [![IRC](https://img.shields.io/irc/%23stackstorm.png)](http://webchat.freenode.net/?channels=stackstorm)
 
 ## StackStorm Overview
 

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,27 +1,18 @@
 #!/usr/bin/env bash
 
-function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" == "$1"; }
-
 if [ -z ${TASK} ]; then
   echo "No task provided"
   exit 2
-  fi
-
-# Note: We only want to run tests under multiple Python versions
-
-if version_ge ${TRAVIS_PYTHON_VERSION} "2.7" && [ ${TASK} != "tests" ]; then
-    echo "Skipping task ${TASK} on ${TRAVIS_PYTHON_VERSION}"
-    exit 0
 fi
 
-if [ ${TASK} == "flake8" ]; then
-  make flake8
-elif [ ${TASK} == "pylint" ]; then
-  make pylint
-elif [ ${TASK} == "docs" ]; then
-  make docs
-elif [ ${TASK} == "tests" ]; then
-  make tests-travis
+if [ ${TASK} == 'checks' ]; then
+  make .flake8
+  make .pylint
+  make .docs
+elif [ ${TASK} == 'unit' ]; then
+  # compile .py files, useful as compatibility syntax check
+  make compile
+  make unit-tests-coverage-xml
 else
   echo "Invalid task: ${TASK}"
   exit 2


### PR DESCRIPTION
I started to dig into Coveralls.io problem we recently discussed before with @lakshmi-kannan, when only files from one st2package were included in coverage report, but had more fun and curiosity and optimized travis builds also.
Surprising that some bits of code were incompatible with Python2.6, despite 2.6 is included in Travis build matrix.

- [x] [Fix Coveralls coverage, all files are included now](https://coveralls.io/builds/3034692) [![Coverage Status](https://coveralls.io/repos/armab/st2/badge.svg?branch=coveralls&service=github)](https://coveralls.io/github/armab/st2?branch=coveralls)
- [x] Add compile .py files task, useful as syntax check
- [x] Optimize Travis build matrix, use exclude
- [x] Merge `flake8`, `pylint`, `docs` tasks into single build (`make requirements` is expensive)


##### Travis builds before:
![travis](http://i.imgur.com/D1T946P.png)


##### Travis builds after:
![travis](http://i.imgur.com/jbSzZHY.png)