### PR TITLE
Add verification before deleting LOGDIR contents

### DIFF
--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -183,7 +183,9 @@ function st2clean(){
     mongo st2 --eval "db.dropDatabase();"
     # start with clean logs
     LOGDIR=$(dirname $0)/../logs
-    rm ${LOGDIR}/*
+    if [ "$(ls -A ${LOGDIR} | wc -l)" != "0" ]; then
+        rm ${LOGDIR}/*
+    fi
     if [ -n "$ST2_EXPORTER" ]; then
         EXPORTS_DIR=$(exportsdir)
         echo "Removing $EXPORTS_DIR..."


### PR DESCRIPTION
I had no files in the ${LOGDIR}, which caused rm ${LOGDIR}/* to fail
Added a verification: only attempt deletion, if there are files in the folder