### PR TITLE
Add NG_INIT flag for migration to init scripts

### DIFF
--- a/tools/st2ctl
+++ b/tools/st2ctl
@@ -7,8 +7,6 @@ WEBUI_LOG_FILE="/var/log/st2/st2web.log"
 COMPONENTS="st2actionrunner st2api st2auth st2sensorcontainer st2rulesengine mistral st2web st2resultstracker st2notifier"
 STANCONF="/etc/st2/st2.conf"
 PYTHON=`which python`
-NG_INIT=false
-
 
 # AR is assumed to be an environment variable.
 if [ -z "$AR" ];

--- a/tools/st2ctl
+++ b/tools/st2ctl
@@ -183,7 +183,11 @@ function st2start_classic(){
   else
     service mistral start
   fi
-  (cd /opt/stackstorm/static/webui && nohup python -m SimpleHTTPServer $WEBUI_PORT) &>> ${WEBUI_LOG_FILE} &
+
+  # Only run WebUI HTTP Server if flag is not set
+  if [ -z "${ST2_DISABLE_HTTPSERVER}" ]; then
+    (cd /opt/stackstorm/static/webui && nohup python -m SimpleHTTPServer $WEBUI_PORT) &>> ${WEBUI_LOG_FILE} &
+  fi
 }
 
 function st2stop_classic(){
@@ -209,16 +213,20 @@ function st2stop_classic(){
       fi
     elif [[ "${COM}" == "st2web" ]]
     then
-      PID=`ps ax | grep -v grep | egrep "SimpleHTTPServer $WEBUI_PORT\$" | awk '{print $1}'`
-      if [[ ! -z $PID ]]
-      then
-        for p in $PID
-        do
-           echo "Killing ${COM} PID: ${p}"
-           kill $p
-        done
+      if [ -z "${ST2_DISABLE_HTTPSERVER}" ]; then
+        PID=`ps ax | grep -v grep | egrep "SimpleHTTPServer $WEBUI_PORT\$" | awk '{print $1}'`
+        if [[ ! -z $PID ]]
+        then
+          for p in $PID
+          do
+             echo "Killing ${COM} PID: ${p}"
+             kill $p
+          done
+        else
+          echo "${COM} is not running"
+        fi
       else
-        echo "${COM} is not running"
+        echo "*Built-in WebUI HTTP Server has been disabled*"
       fi
     else
       ALT_COM=`service_map $COM`
@@ -265,17 +273,21 @@ function restart_component_classic() {
       fi
     elif [[ "${COM}" == "st2web" ]]
     then
-      PID=`ps ax | grep -v grep | egrep "SimpleHTTPServer $WEBUI_PORT\$" | awk '{print $1}'`
-      if [[ ! -z $PID ]]
-      then
-        for p in $PID
-        do
-           kill $p
-           sleep 1
-           (cd /opt/stackstorm/static/webui && nohup python -m SimpleHTTPServer $WEBUI_PORT) &>> ${WEBUI_LOG_FILE} &
-        done
+      if [ -z "${ST2_DISABLE_HTTPSERVER}" ]; then
+        PID=`ps ax | grep -v grep | egrep "SimpleHTTPServer $WEBUI_PORT\$" | awk '{print $1}'`
+        if [[ ! -z $PID ]]
+        then
+          for p in $PID
+          do
+             kill $p
+             sleep 1
+             (cd /opt/stackstorm/static/webui && nohup python -m SimpleHTTPServer $WEBUI_PORT) &>> ${WEBUI_LOG_FILE} &
+          done
+        else
+          echo "${COM} is not running"
+        fi
       else
-        echo "${COM} is not running"
+        echo "*Built-in WebUI HTTP Server has been disabled*"
       fi
     else
       PID=`ps ax | grep -v grep | grep -v st2ctl | egrep "${COM}|${ALT_COM}" | awk '{print $1}'`
@@ -350,7 +362,7 @@ function getpids(){
 
   for COM in $COMPONENTS
   do
-    if [[ "${COM}" == "st2web" ]]
+    if [[ "${COM}" == "st2web" && -z "${ST2_DISABLE_HTTPSERVER}" ]]
     then
       PID=`ps ax | grep -v grep | egrep "SimpleHTTPServer $WEBUI_PORT\$" | awk '{print $1}'`
     else

--- a/tools/st2ctl
+++ b/tools/st2ctl
@@ -7,6 +7,8 @@ WEBUI_LOG_FILE="/var/log/st2/st2web.log"
 COMPONENTS="st2actionrunner st2api st2auth st2sensorcontainer st2rulesengine mistral st2web st2resultstracker st2notifier"
 STANCONF="/etc/st2/st2.conf"
 PYTHON=`which python`
+NG_INIT=false
+
 
 # AR is assumed to be an environment variable.
 if [ -z "$AR" ];
@@ -119,7 +121,53 @@ if [ ${1} == "reload" -o ${1} == "clean" ]; then
     fi
 fi
 
-function st2start(){
+# Adapter to start services for transition to init scripts
+function st2start() {
+  if [ "${NG_INIT}" = true ]; then
+    st2start_ng
+  else
+    st2start_classic
+  fi
+}
+
+# Adapter to start services for transition to init scripts
+function st2stop() {
+  if [ "${NG_INIT}" = true ]; then
+    st2stop_ng
+  else
+    st2stop_classic
+  fi
+}
+
+# Adapter to restart_compontent for transition to init scripts
+function restart_component() {
+  if [ "${NG_INIT}" = true ]; then
+    restart_component_ng $1
+  else
+    restart_component_classic $1
+  fi
+}
+
+function st2start_ng() {
+  for COM in $COMPONENTS
+  do
+    service $COM start
+  done
+}
+
+function st2stop_ng() {
+  for COM in $COMPONENTS
+  do
+    service $COM stop
+  done
+}
+
+function restart_component_ng() {
+  COM=${1}
+  service $COM restart
+}
+
+function st2start_classic(){
   for i in `seq 1 ${AR}`
   do
     nohup st2actionrunner --config-file ${STANCONF} &>> ${LOGFILE} &
@@ -140,7 +188,7 @@ function st2start(){
   (cd /opt/stackstorm/static/webui && nohup python -m SimpleHTTPServer $WEBUI_PORT) &>> ${WEBUI_LOG_FILE} &
 }
 
-function st2stop(){
+function st2stop_classic(){
   for COM in $COMPONENTS
   do
     if [[ "${COM}" == "mistral" ]]
@@ -194,7 +242,7 @@ function st2stop(){
   done
 }
 
-function restart_component() {
+function restart_component_classic() {
   COM=${1}
   ALT_COM=`service_map $COM`
 


### PR DESCRIPTION
This PR adds a new flag to our old trusty `st2ctl` command, which is bound to be with us for some time longer.

In lieu of this, we're about to add real, honest to goodness init scripts for all of our services to the native packages. However, it's going to take a bit of :frog: jumping around to get to the final state.

This first commit adds an internal-only flag to the init script. giA bit ugly, but it's a way to allow testing to happen in parallel while not breaking existing behavior. 