### PR TITLE
Additional detail on configuring trusted SSL CA

### DIFF
--- a/docs/source/install/docker.rst
+++ b/docs/source/install/docker.rst
@@ -54,6 +54,9 @@ variables for each container instance:
     - /home/stanley/.ssh/st2_stanley_key - SSH private key to access remote systems
 
     ## Environment Variables
+    ### SSL
+    REQUESTS_CA_BUNDLE - path to trusted root CA bundles. Default: OS default
+
     ### StackStorm Variables
     * ST2_API_URL - URL and port to the StackStorm API Endpoint. Default: http://localhost:9101
 


### PR DESCRIPTION
As reported in https://github.com/StackStorm/st2contrib/issues/240,
not all environments are treated equally. Many environment fall into a
scenario where a custom CA must be trusted by the OS and Applications,
or else validation will fail and connections will be rejected. To that
end, this commit adds detail on how to configure the underlying Python
`requests` library to load a custom SSL CA bundle into the OpenSSL trust
chain.

h/t @amaline :tophat: