### PR TITLE
Fixes missing Erlang dependency for RHEL7/CentOS7 installation

### DIFF
--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -216,9 +216,13 @@ install_apt() {
 install_yum() {
   echo "###########################################################################################"
   echo "# Installing packages via yum"
+  if cat /etc/redhat-release | grep -q ' 7\.[0-9]'
+  then
+    yum install -y epel-release
+  fi
   yum update -y
-  rpm --import http://www.rabbitmq.com/rabbitmq-signing-key-public.asc
-  curl -sS -k -o /tmp/rabbitmq-server.rpm http://www.rabbitmq.com/releases/rabbitmq-server/v3.3.5/rabbitmq-server-3.3.5-1.noarch.rpm
+  rpm --import https://www.rabbitmq.com/rabbitmq-signing-key-public.asc
+  curl -sS -k -o /tmp/rabbitmq-server.rpm https://www.rabbitmq.com/releases/rabbitmq-server/v3.3.5/rabbitmq-server-3.3.5-1.noarch.rpm
   yum localinstall -y /tmp/rabbitmq-server.rpm
 
   # Add StackStorm YUM repo


### PR DESCRIPTION
Fixes #1696, adds EPEL repo for RHEL7/CentOS7 installations via `st2_deploy.sh`

Tried different ways, like [install erlang rpm only](https://www.rabbitmq.com/install-rpm.html), but adding EPEL is the best way.
