### PR TITLE
Fix Travis build script

### DIFF
--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 if [ -z ${TASK} ]; then
   echo "No task provided"
@@ -17,5 +18,3 @@ else
   echo "Invalid task: ${TASK}"
   exit 2
 fi
-
-exit $?


### PR DESCRIPTION
Exit immediately if any command in `scripts/travis.sh` exits with a non-zero status.

My fail with recent changes, see: 
https://travis-ci.org/StackStorm/st2/jobs/71310549#L156
