### PR TITLE
Display friendly message for error in action parameters validation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,7 @@ in development
 * Fix a bug in action container where rendering params was done twice. (bug-fix)
 * Move /exp/actionalias/ and /exp/aliasexecution to /v1/actionalias/ and /v1/aliasexecution/
   respectively. (upgrade)
+* Display friendly message for error in parameters validation on action execution. (improvement)
 
 0.11.4 - June 30, 2015
 ----------------------

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import copy
+import re
 
 import jsonschema
 from oslo_config import cfg
@@ -100,7 +101,7 @@ class ActionExecutionsControllerMixin(BaseRestControllerMixin):
             abort(http_client.BAD_REQUEST, str(e))
         except jsonschema.ValidationError as e:
             LOG.exception('Unable to execute action. Parameter validation failed.')
-            abort(http_client.BAD_REQUEST, str(e))
+            abort(http_client.BAD_REQUEST, re.sub("u'([^']*)'", r"'\1'", e.message))
         except Exception as e:
             LOG.exception('Unable to execute action. Unexpected error encountered.')
             abort(http_client.INTERNAL_SERVER_ERROR, str(e))

--- a/st2api/tests/unit/controllers/v1/test_executions_simple.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_simple.py
@@ -240,16 +240,20 @@ class TestActionExecutionController(FunctionalTest):
         execution['parameters']['foo'] = 'bar'
         post_resp = self._do_post(execution, expect_errors=True)
         self.assertEqual(post_resp.status_int, 400)
+        self.assertEqual(post_resp.json['faultstring'],
+                         "Additional properties are not allowed ('foo' was unexpected)")
 
         # Runner type expects parameter "hosts".
         execution['parameters'] = {}
         post_resp = self._do_post(execution, expect_errors=True)
         self.assertEqual(post_resp.status_int, 400)
+        self.assertEqual(post_resp.json['faultstring'], "'hosts' is a required property")
 
         # Runner type expects parameters "cmd" to be str.
         execution['parameters'] = {"hosts": "localhost", "cmd": 1000}
         post_resp = self._do_post(execution, expect_errors=True)
         self.assertEqual(post_resp.status_int, 400)
+        self.assertEqual(post_resp.json['faultstring'], "1000 is not of type 'string'")
 
         # Runner type expects parameters "cmd" to be str.
         execution['parameters'] = {"hosts": "localhost", "cmd": "1000", "c": 1}
@@ -321,7 +325,7 @@ class TestActionExecutionController(FunctionalTest):
         re_run_resp = self.app.post_json('/v1/executions/%s/re_run' % (execution_id),
                                          data, expect_errors=True)
         self.assertEqual(re_run_resp.status_int, 400)
-        self.assertIn('1000 is not of type u\'string\'', re_run_resp.json['faultstring'])
+        self.assertIn('1000 is not of type \'string\'', re_run_resp.json['faultstring'])
 
     @staticmethod
     def _get_actionexecution_id(resp):


### PR DESCRIPTION
Display only the human friendly message from the jsonschema validation error. Remove the unicode prefix in the string.

```
~/st2$ st2 run core.local
ERROR: 400 Client Error: Bad Request
MESSAGE: 'cmd' is a required property

~/st2$ st2 run default.ping count=x
ERROR: 400 Client Error: Bad Request
MESSAGE: Additional properties are not allowed ('count' was unexpected)
```