### PR TITLE
Minor ContentPackResourceController refactoring and improvements

### DIFF
--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -271,6 +271,9 @@ class ContentPackResourceController(ResourceController):
     def _get_by_ref_or_id(self, ref_or_id):
         """
         Retrieve resource object by an id of a reference.
+
+        Note: This method throws StackStormDBObjectNotFoundError exception if the object is not
+        found in the database.
         """
 
         if ResourceReference.is_resource_reference(ref_or_id):

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -28,7 +28,7 @@ from st2common.models.api.base import jsexpose
 from st2common import log as logging
 from st2common.models.system.common import InvalidResourceReferenceError
 from st2common.models.system.common import ResourceReference
-
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
 
 LOG = logging.getLogger(__name__)
 
@@ -286,7 +286,7 @@ class ContentPackResourceController(ResourceController):
 
         if not resource_db:
             msg = 'Resource with a reference or id "%s" not found' % (ref_or_id)
-            raise Exception(msg)
+            raise StackStormDBObjectNotFoundError(msg)
 
         return resource_db
 

--- a/st2api/st2api/controllers/v1/actionalias.py
+++ b/st2api/st2api/controllers/v1/actionalias.py
@@ -20,7 +20,6 @@ from mongoengine import ValidationError
 from st2api.controllers import resource
 from st2common import log as logging
 from st2common.exceptions.apivalidation import ValueValidationException
-from st2common.exceptions.db import StackStormDBObjectConflictError
 from st2common.models.api.action import ActionAliasAPI
 from st2common.persistence.actionalias import ActionAlias
 from st2common.models.api.base import jsexpose
@@ -61,11 +60,6 @@ class ActionAliasController(resource.ContentPackResourceController):
         except (ValidationError, ValueError, ValueValidationException) as e:
             LOG.exception('Validation failed for action alias data=%s.', action_alias)
             pecan.abort(http_client.BAD_REQUEST, str(e))
-            return
-        except StackStormDBObjectConflictError as e:
-            LOG.warn('ActionAlias creation of %s failed with uniqueness conflict.', action_alias,
-                     exc_info=True)
-            pecan.abort(http_client.CONFLICT, str(e), body={'conflict-id': e.conflict_id})
             return
 
         extra = {'action_alias_db': action_alias_db}

--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -114,13 +114,7 @@ class ActionsController(resource.ContentPackResourceController):
 
     @jsexpose(arg_types=[str], body_cls=ActionAPI)
     def put(self, action_ref_or_id, action):
-        try:
-            action_db = self._get_by_ref_or_id(ref_or_id=action_ref_or_id)
-        except Exception as e:
-            LOG.exception(e.message)
-            abort(http_client.NOT_FOUND, e.message)
-            return
-
+        action_db = self._get_by_ref_or_id(ref_or_id=action_ref_or_id)
         action_id = action_db.id
 
         try:
@@ -161,13 +155,7 @@ class ActionsController(resource.ContentPackResourceController):
                 DELETE /actions/1
                 DELETE /actions/mypack.myaction
         """
-        try:
-            action_db = self._get_by_ref_or_id(ref_or_id=action_ref_or_id)
-        except Exception as e:
-            LOG.exception(e.message)
-            abort(http_client.NOT_FOUND, e.message)
-            return
-
+        action_db = self._get_by_ref_or_id(ref_or_id=action_ref_or_id)
         action_id = action_db.id
 
         try:

--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -89,14 +89,7 @@ class ActionsController(resource.ContentPackResourceController):
         action_model = ActionAPI.to_model(action)
 
         LOG.debug('/actions/ POST verified ActionAPI object=%s', action)
-        try:
-            action_db = Action.add_or_update(action_model)
-        except Exception as e:
-            LOG.exception('/actions/ POST unable to save ActionDB object "%s". %s',
-                          action_model, e)
-            abort(http_client.INTERNAL_SERVER_ERROR, str(e))
-            return
-
+        action_db = Action.add_or_update(action_model)
         LOG.debug('/actions/ POST saved ActionDB object=%s', action_db)
 
         extra = {'action_db': action_db}

--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -27,7 +27,6 @@ from st2api.controllers.v1.actionviews import ActionViewsController
 from st2common import log as logging
 from st2common.constants.pack import DEFAULT_PACK_NAME
 from st2common.exceptions.apivalidation import ValueValidationException
-from st2common.exceptions.db import StackStormDBObjectConflictError
 from st2common.models.api.base import jsexpose
 from st2common.persistence.action import Action
 from st2common.models.api.action import ActionAPI
@@ -92,12 +91,6 @@ class ActionsController(resource.ContentPackResourceController):
         LOG.debug('/actions/ POST verified ActionAPI object=%s', action)
         try:
             action_db = Action.add_or_update(action_model)
-        except StackStormDBObjectConflictError as e:
-            # If an existing DB object conflicts with new object then raise error.
-            LOG.warn('/actions/ POST unable to save ActionDB object "%s" due to uniqueness '
-                     'conflict. %s', action_model, str(e))
-            abort(http_client.CONFLICT, str(e), body={'conflict-id': e.conflict_id})
-            return
         except Exception as e:
             LOG.exception('/actions/ POST unable to save ActionDB object "%s". %s',
                           action_model, e)

--- a/st2api/st2api/controllers/v1/policies.py
+++ b/st2api/st2api/controllers/v1/policies.py
@@ -156,12 +156,7 @@ class PolicyController(resource.ContentPackResourceController):
         db_model = self.model.to_model(instance)
         LOG.debug('%s verified object: %s', op, db_model)
 
-        try:
-            db_model = self.access.add_or_update(db_model)
-        except Exception as e:
-            LOG.exception('%s unable to create object: %s', op, db_model)
-            abort(http_client.INTERNAL_SERVER_ERROR, str(e))
-            return
+        db_model = self.access.add_or_update(db_model)
 
         LOG.debug('%s created object: %s', op, db_model)
         LOG.audit('Policy created. Policy.id=%s' % (db_model.id), extra={'policy_db': db_model})

--- a/st2api/st2api/controllers/v1/policies.py
+++ b/st2api/st2api/controllers/v1/policies.py
@@ -23,7 +23,6 @@ from six.moves import http_client
 from st2api.controllers import resource
 from st2common import log as logging
 from st2common.exceptions.apivalidation import ValueValidationException
-from st2common.exceptions.db import StackStormDBObjectConflictError
 from st2common.models.api.base import jsexpose
 from st2common.models.api.policy import PolicyTypeAPI, PolicyAPI
 from st2common.models.db.policy import PolicyTypeReference
@@ -159,12 +158,6 @@ class PolicyController(resource.ContentPackResourceController):
 
         try:
             db_model = self.access.add_or_update(db_model)
-        except StackStormDBObjectConflictError as e:
-            # If an existing DB object conflicts with new object then raise error.
-            LOG.exception('%s unable to create object due to uniqueness '
-                          'conflict: %s', op, db_model)
-            abort(http_client.CONFLICT, str(e), body={'conflict-id': e.conflict_id})
-            return
         except Exception as e:
             LOG.exception('%s unable to create object: %s', op, db_model)
             abort(http_client.INTERNAL_SERVER_ERROR, str(e))

--- a/st2api/st2api/controllers/v1/rules.py
+++ b/st2api/st2api/controllers/v1/rules.py
@@ -93,13 +93,7 @@ class RuleController(resource.ContentPackResourceController):
 
     @jsexpose(arg_types=[str], body_cls=RuleAPI)
     def put(self, rule_ref_or_id, rule):
-        try:
-            rule_db = self._get_by_ref_or_id(rule_ref_or_id)
-        except Exception as e:
-            LOG.exception(e.message)
-            abort(http_client.NOT_FOUND, e.message)
-            return
-
+        rule_db = self._get_by_ref_or_id(rule_ref_or_id)
         LOG.debug('PUT /rules/ lookup with id=%s found object: %s', rule_ref_or_id, rule_db)
 
         try:

--- a/st2api/st2api/controllers/v1/rules.py
+++ b/st2api/st2api/controllers/v1/rules.py
@@ -21,7 +21,6 @@ from mongoengine import ValidationError
 from st2common import log as logging
 from st2common.constants.pack import DEFAULT_PACK_NAME
 from st2common.exceptions.apivalidation import ValueValidationException
-from st2common.exceptions.db import StackStormDBObjectConflictError
 from st2common.exceptions.triggers import TriggerDoesNotExistException
 from st2api.controllers import resource
 from st2common.models.api.rule import RuleAPI
@@ -78,11 +77,6 @@ class RuleController(resource.ContentPackResourceController):
             msg = 'Trigger %s in rule does not exist in system' % rule.trigger['type']
             LOG.exception(msg)
             abort(http_client.BAD_REQUEST, msg)
-            return
-        except StackStormDBObjectConflictError as e:
-            LOG.warn('Rule creation of %s failed with uniqueness conflict. Exception %s',
-                     rule, str(e))
-            abort(http_client.CONFLICT, str(e), body={'conflict-id': e.conflict_id})
             return
 
         extra = {'rule_db': rule_db}

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -89,13 +89,7 @@ class TriggerTypeController(resource.ContentPackResourceController):
 
     @jsexpose(arg_types=[str], body_cls=TriggerTypeAPI)
     def put(self, triggertype_ref_or_id, triggertype):
-        try:
-            triggertype_db = self._get_by_ref_or_id(ref_or_id=triggertype_ref_or_id)
-        except Exception as e:
-            LOG.exception(e.message)
-            abort(http_client.NOT_FOUND, e.message)
-            return
-
+        triggertype_db = self._get_by_ref_or_id(ref_or_id=triggertype_ref_or_id)
         triggertype_id = triggertype_db.id
 
         try:
@@ -135,13 +129,7 @@ class TriggerTypeController(resource.ContentPackResourceController):
         LOG.info('DELETE /triggertypes/ with ref_or_id=%s',
                  triggertype_ref_or_id)
 
-        try:
-            triggertype_db = self._get_by_ref_or_id(ref_or_id=triggertype_ref_or_id)
-        except Exception as e:
-            LOG.exception(e.message)
-            abort(http_client.NOT_FOUND, e.message)
-            return
-
+        triggertype_db = self._get_by_ref_or_id(ref_or_id=triggertype_ref_or_id)
         triggertype_id = triggertype_db.id
 
         try:

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -72,11 +72,6 @@ class TriggerTypeController(resource.ContentPackResourceController):
             LOG.exception('Validation failed for triggertype data=%s.', triggertype)
             abort(http_client.BAD_REQUEST, str(e))
             return
-        except StackStormDBObjectConflictError as e:
-            LOG.warn('TriggerType creation of %s failed with uniqueness conflict. Exception : %s',
-                     triggertype, str(e))
-            abort(http_client.CONFLICT, str(e), body={'conflict-id': e.conflict_id})
-            return
         else:
             extra = {'triggertype_db': triggertype_db}
             LOG.audit('TriggerType created. TriggerType.id=%s' % (triggertype_db.id), extra=extra)
@@ -234,11 +229,6 @@ class TriggerController(RestController):
         except (ValidationError, ValueError) as e:
             LOG.exception('Validation failed for trigger data=%s.', trigger)
             abort(http_client.BAD_REQUEST, str(e))
-            return
-        except StackStormDBObjectConflictError as e:
-            LOG.warn('Trigger creation of %s failed with uniqueness conflict. Exception %s',
-                     trigger, str(e))
-            abort(http_client.CONFLICT, str(e), body={'conflict-id': e.conflict_id})
             return
 
         extra = {'trigger': trigger_db}

--- a/st2common/st2common/exceptions/db.py
+++ b/st2common/st2common/exceptions/db.py
@@ -28,6 +28,7 @@ class StackStormDBObjectConflictError(StackStormBaseException):
     """
     Exception that captures a DB object conflict error.
     """
-    def __init__(self, message, conflict_id):
+    def __init__(self, message, conflict_id, model_object):
         super(StackStormDBObjectConflictError, self).__init__(message)
         self.conflict_id = conflict_id
+        self.model_object = model_object

--- a/st2common/st2common/hooks.py
+++ b/st2common/st2common/hooks.py
@@ -25,6 +25,7 @@ from webob import exc
 from st2common import log as logging
 from st2common.persistence.auth import User
 from st2common.exceptions import auth as exceptions
+from st2common.exceptions import db as db_exceptions
 from st2common.util.jsonify import json_encode
 from st2common.util.auth import validate_token
 from st2common.constants.auth import HEADER_ATTRIBUTE_NAME
@@ -176,6 +177,9 @@ class JSONErrorResponseHook(PecanHook):
 
         if isinstance(e, exc.HTTPException):
             status_code = state.response.status
+            message = str(e)
+        elif isinstance(e, db_exceptions.StackStormDBObjectNotFoundError):
+            status_code = httplib.NOT_FOUND
             message = str(e)
         elif isinstance(e, ValueError):
             status_code = httplib.BAD_REQUEST

--- a/st2common/st2common/hooks.py
+++ b/st2common/st2common/hooks.py
@@ -169,7 +169,8 @@ class JSONErrorResponseHook(PecanHook):
         error_msg = getattr(e, 'comment', str(e))
         extra = {
             'exception_class': e.__class__.__name__,
-            'exception_message': str(e)
+            'exception_message': str(e),
+            'exception_data': e.__dict__
         }
 
         LOG.debug('API call failed: %s', error_msg, extra=extra)

--- a/st2common/st2common/hooks.py
+++ b/st2common/st2common/hooks.py
@@ -174,7 +174,9 @@ class JSONErrorResponseHook(PecanHook):
         }
 
         LOG.debug('API call failed: %s', error_msg, extra=extra)
-        LOG.debug(traceback.format_exc())
+
+        if cfg.CONF.debug:
+            LOG.debug(traceback.format_exc())
 
         if hasattr(e, 'body') and isinstance(e.body, dict):
             body = e.body

--- a/st2common/st2common/hooks.py
+++ b/st2common/st2common/hooks.py
@@ -181,6 +181,10 @@ class JSONErrorResponseHook(PecanHook):
         elif isinstance(e, db_exceptions.StackStormDBObjectNotFoundError):
             status_code = httplib.NOT_FOUND
             message = str(e)
+        elif isinstance(e, db_exceptions.StackStormDBObjectConflictError):
+            status_code = httplib.CONFLICT
+            message = str(e)
+            body['conflict-id'] = e.conflict_id
         elif isinstance(e, ValueError):
             status_code = httplib.BAD_REQUEST
             message = getattr(e, 'message', str(e))

--- a/st2common/st2common/hooks.py
+++ b/st2common/st2common/hooks.py
@@ -167,7 +167,12 @@ class JSONErrorResponseHook(PecanHook):
 
     def on_error(self, state, e):
         error_msg = getattr(e, 'comment', str(e))
-        LOG.debug('API call failed: %s', error_msg)
+        extra = {
+            'exception_class': e.__class__.__name__,
+            'exception_message': str(e)
+        }
+
+        LOG.debug('API call failed: %s', error_msg, extra=extra)
         LOG.debug(traceback.format_exc())
 
         if hasattr(e, 'body') and isinstance(e.body, dict):

--- a/st2common/st2common/persistence/base.py
+++ b/st2common/st2common/persistence/base.py
@@ -122,7 +122,9 @@ class Access(object):
             # the raised exception.
             conflict_object = cls._get_by_object(model_object)
             conflict_id = str(conflict_object.id) if conflict_object else None
-            raise StackStormDBObjectConflictError(str(e), conflict_id)
+            message = str(e)
+            raise StackStormDBObjectConflictError(message=message, conflict_id=conflict_id,
+                                                  model_object=model_object)
 
         is_update = str(pre_persist_id) == str(model_object.id)
 


### PR DESCRIPTION
This pull request refactors `ContentPackResourceController._get_by_ref_or_id` method to throw a correct `StackStormDBObjectNotFoundError` exception.

This way we can get rid of now unnecessary try / except blocks when calling `_get_by_ref_or_id` and we can simply translate this exception into 404 inside the JSON error response hooks.

@enykeev made the JSONErrorResponseHook refactor ago. This hook is now the place where all the exceptions should be translated to a correct status code and error message. This is good since we previously didn't have a centralized way to translate and handle API exceptions and means we can get rid of a lot of duplicated code.

In the future, when working on new controllers we should make sure we throw correct exceptions there and translate it into an error inside the hook. If you see yourself calling `abort()` function inside the controller this means you are probably doing something wrong and should throw an exception instead.

This is more refactoring to be done with regards to translating the errors inside the hook, but I only need this change right now for the RBAC stuff.