### PR TITLE
Adding required description to ActionAlias example

### DIFF
--- a/docs/source/aliases.rst
+++ b/docs/source/aliases.rst
@@ -18,6 +18,7 @@ e.g.
 
     ---
     name: "google_query"
+    description: "Perform a Google Query"
     action_ref: "google.get_search_results"
     formats:
       - "google {{query}}"


### PR DESCRIPTION
Found while working today at a client site. Copy-paste of this block fails, because `description` is a required field. 