### PR TITLE
Use python2.7 explicitly

### DIFF
--- a/tools/st2ctl
+++ b/tools/st2ctl
@@ -6,7 +6,7 @@ LOGFILE="/tmp/st2_startup.log"
 WEBUI_LOG_FILE="/var/log/st2/st2web.log"
 COMPONENTS="st2actionrunner st2api st2auth st2sensorcontainer st2rulesengine mistral st2web st2resultstracker st2notifier"
 STANCONF="/etc/st2/st2.conf"
-PYTHON="which python2.7"
+PYTHON=`which python2.7`
 
 # AR is assumed to be an environment variable.
 if [ -z "$AR" ];

--- a/tools/st2ctl
+++ b/tools/st2ctl
@@ -6,7 +6,8 @@ LOGFILE="/tmp/st2_startup.log"
 WEBUI_LOG_FILE="/var/log/st2/st2web.log"
 COMPONENTS="st2actionrunner st2api st2auth st2sensorcontainer st2rulesengine mistral st2web st2resultstracker st2notifier"
 STANCONF="/etc/st2/st2.conf"
-PYTHON=`which python2.7`
+PYTHONVER="python2.7"
+PYTHON="/usr/bin/env ${PYTHONVER}"
 
 # AR is assumed to be an environment variable.
 if [ -z "$AR" ];

--- a/tools/st2ctl
+++ b/tools/st2ctl
@@ -6,7 +6,7 @@ LOGFILE="/tmp/st2_startup.log"
 WEBUI_LOG_FILE="/var/log/st2/st2web.log"
 COMPONENTS="st2actionrunner st2api st2auth st2sensorcontainer st2rulesengine mistral st2web st2resultstracker st2notifier"
 STANCONF="/etc/st2/st2.conf"
-PYTHON=`which python`
+PYTHON=`which python2.7`
 
 # AR is assumed to be an environment variable.
 if [ -z "$AR" ];

--- a/tools/st2ctl
+++ b/tools/st2ctl
@@ -6,8 +6,7 @@ LOGFILE="/tmp/st2_startup.log"
 WEBUI_LOG_FILE="/var/log/st2/st2web.log"
 COMPONENTS="st2actionrunner st2api st2auth st2sensorcontainer st2rulesengine mistral st2web st2resultstracker st2notifier"
 STANCONF="/etc/st2/st2.conf"
-PYTHONVER="python2.7"
-PYTHON="/usr/bin/env ${PYTHONVER}"
+PYTHON="which python2.7"
 
 # AR is assumed to be an environment variable.
 if [ -z "$AR" ];


### PR DESCRIPTION
RHEL/CentOS6 uses Python 2.6 as the system Python. We need to explicitly point to the python2.7 binary in order for this to work out of the box on those hosts.