### PR TITLE
Adds proper Debian test in st2_deploy.sh

### DIFF
--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -115,7 +115,7 @@ else
     MISTRAL_STABLE_BRANCH="st2-0.5.1"
 fi
 
-if [[ "$DEBTEST" == "Ubuntu" ]]; then
+if [[ -n "$DEBTEST" ]]; then
   TYPE="debs"
   PYTHONPACK="/usr/lib/python2.7/dist-packages"
   echo "###########################################################################################"


### PR DESCRIPTION
This commit adds a test that matches the test in `st2_bootstrap.sh`, allowing the installer to run on Debian systems.