### PR TITLE
Action alias requires a description

### DIFF
--- a/instructables/chatops.md
+++ b/instructables/chatops.md
@@ -194,6 +194,7 @@ Create a new file called `google.yaml`, and add the following contents.
 # packs/chatops/aliases/google.yaml
 ---
 name: "google_query"
+description: "Perform a google search"
 action_ref: "google.get_search_results"
 formats:
   - "google {{query}}"


### PR DESCRIPTION
Prior to 0.12 it seems like a description was not required, but it is now.