### PR TITLE
Rmq cluster support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ in development
 * Add new OpenStack Keystone authentication backend.
   [Itxaka Serrano]
 * Information about parent workflow is now a dict in child's context field. (improvement)
+* Support for RabbitMQ cluster. StackStorm works with a RabbitMQ cluster and switches
+  nodes on failover. (feature)
 
 0.12.0 - July 20, 2015
 ----------------------

--- a/docs/source/install/config.rst
+++ b/docs/source/install/config.rst
@@ -38,6 +38,21 @@ In :github_st2:`/etc/st2/st2.conf <conf/st2.prod.conf>` include the following se
 
 .. note:: The #RMQ_VHOST property is optional and can be left blank.
 
+StackStorm also supports RabbitMQ cluster.
+
+In :github_st2:`/etc/st2/st2.conf <conf/st2.prod.conf>` include the following section :
+
+.. code-block:: bash
+
+    [messaging]
+    cluster_urls = <amqp://#RMQ_USER:#RMQ_PASSWD@#RMQ_NODE_1:#RMQ_PORT/#RMQ_VHOST>,
+                   <amqp://#RMQ_USER:#RMQ_PASSWD@#RMQ_NODE_2:#RMQ_PORT/#RMQ_VHOST>,
+                   <amqp://#RMQ_USER:#RMQ_PASSWD@#RMQ_NODE_3:#RMQ_PORT/#RMQ_VHOST>
+
+
+* To understand more about setting up a RabbitMQ cluster - https://www.rabbitmq.com/clustering.html
+* RabbitMQ HA guide - https://www.rabbitmq.com/ha.html
+
 SUDO Access
 -----------
 

--- a/st2actions/st2actions/notifier/notifier.py
+++ b/st2actions/st2actions/notifier/notifier.py
@@ -28,6 +28,7 @@ from st2common import policies
 from st2common.models.system.common import ResourceReference
 from st2common.persistence.execution import ActionExecution
 from st2common.transport import consumers, liveaction, publishers
+from st2common.transport import utils as transport_utils
 from st2common.transport.reactor import TriggerDispatcher
 
 __all__ = [
@@ -189,5 +190,5 @@ class Notifier(consumers.MessageHandler):
 
 
 def get_notifier():
-    with Connection(cfg.CONF.messaging.url) as conn:
+    with Connection(transport_utils.get_messaging_urls()) as conn:
         return Notifier(conn, [ACTIONUPDATE_WORK_Q], trigger_dispatcher=TriggerDispatcher(LOG))

--- a/st2actions/st2actions/resultstracker/resultstracker.py
+++ b/st2actions/st2actions/resultstracker/resultstracker.py
@@ -19,13 +19,13 @@ import six
 
 from collections import defaultdict
 from kombu import Connection
-from oslo_config import cfg
 
 from st2actions.query.base import QueryContext
 from st2common import log as logging
 from st2common.models.db.executionstate import ActionExecutionStateDB
 from st2common.persistence.executionstate import ActionExecutionState
 from st2common.transport import actionexecutionstate, consumers, publishers
+from st2common.transport import utils as transport_utils
 
 
 LOG = logging.getLogger(__name__)
@@ -58,7 +58,7 @@ class ResultsTracker(consumers.MessageHandler):
         self._print_stats()
 
     def _print_stats(self):
-        for name, querier in six.iteritems(self._queriers):
+        for _, querier in six.iteritems(self._queriers):
             if querier:
                 querier.print_stats()
 
@@ -110,5 +110,5 @@ class ResultsTracker(consumers.MessageHandler):
 
 
 def get_tracker():
-    with Connection(cfg.CONF.messaging.url) as conn:
+    with Connection(transport_utils.get_messaging_urls()) as conn:
         return ResultsTracker(conn, [ACTIONSTATE_WORK_Q])

--- a/st2actions/st2actions/scheduler.py
+++ b/st2actions/st2actions/scheduler.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 from kombu import Connection
-from oslo_config import cfg
 
 from st2common import log as logging
 from st2common.constants import action as action_constants
@@ -25,6 +24,7 @@ from st2common.persistence.liveaction import LiveAction
 from st2common.persistence.policy import Policy
 from st2common import policies
 from st2common.transport import consumers, liveaction
+from st2common.transport import utils as transport_utils
 from st2common.util import action_db as action_utils
 
 __all__ = [
@@ -96,5 +96,5 @@ class ActionExecutionScheduler(consumers.MessageHandler):
 
 
 def get_scheduler():
-    with Connection(cfg.CONF.messaging.url) as conn:
+    with Connection(transport_utils.get_messaging_urls()) as conn:
         return ActionExecutionScheduler(conn, [ACTIONRUNNER_REQUEST_Q])

--- a/st2actions/st2actions/worker.py
+++ b/st2actions/st2actions/worker.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 from kombu import Connection
-from oslo_config import cfg
 
 from st2actions.container.base import RunnerContainer
 from st2common import log as logging
@@ -24,6 +23,7 @@ from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2common.models.db.liveaction import LiveActionDB
 from st2common.services import executions
 from st2common.transport import consumers, liveaction
+from st2common.transport import utils as transport_utils
 from st2common.util import action_db as action_utils
 from st2common.util import system_info
 
@@ -113,5 +113,5 @@ class ActionExecutionDispatcher(consumers.MessageHandler):
 
 
 def get_worker():
-    with Connection(cfg.CONF.messaging.url) as conn:
+    with Connection(transport_utils.get_messaging_urls()) as conn:
         return ActionExecutionDispatcher(conn, [ACTIONRUNNER_WORK_Q])

--- a/st2actions/tests/integration/test_action_state_consumer.py
+++ b/st2actions/tests/integration/test_action_state_consumer.py
@@ -16,11 +16,11 @@
 import mock
 
 from kombu import Connection
-from oslo_config import cfg
 
 from st2actions.resultstracker.resultstracker import ACTIONSTATE_WORK_Q, ResultsTracker
 from st2common.models.db.executionstate import ActionExecutionStateDB
 from st2common.persistence.executionstate import ActionExecutionState
+from st2common.transport import utils as transport_utils
 from st2tests.base import DbTestCase, EventletTestCase
 from st2tests.fixturesloader import FixturesLoader
 from tests.resources.test_querymodule import TestQuerier
@@ -44,7 +44,7 @@ class ActionStateConsumerTests(EventletTestCase, DbTestCase):
 
     @mock.patch.object(TestQuerier, 'query', mock.MagicMock(return_value=(False, {})))
     def test_process_message(self):
-        with Connection(cfg.CONF.messaging.url) as conn:
+        with Connection(transport_utils.get_messaging_urls()) as conn:
             tracker = ResultsTracker(conn, [ACTIONSTATE_WORK_Q])
             tracker._bootstrap()
             state = ActionStateConsumerTests.get_state(

--- a/st2api/st2api/listener.py
+++ b/st2api/st2api/listener.py
@@ -37,6 +37,7 @@ from oslo_config import cfg
 from st2common.models.api.action import LiveActionAPI
 from st2common.models.api.execution import ActionExecutionAPI
 from st2common.transport import liveaction, execution, publishers
+from st2common.transport import utils as transport_utils
 from st2common import log as logging
 
 __all__ = [
@@ -120,7 +121,7 @@ def listen(listener):
 def get_listener():
     global _listener
     if not _listener:
-        with Connection(cfg.CONF.messaging.url) as conn:
+        with Connection(transport_utils.get_messaging_urls()) as conn:
             _listener = Listener(conn)
             eventlet.spawn_n(listen, _listener)
     return _listener

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -93,8 +93,12 @@ def register_opts(ignore_errors=False):
     do_register_opts(db_opts, 'database', ignore_errors)
 
     messaging_opts = [
+        # It would be nice to be able to deprecate url and completely switch to using
+        # url. However, this will be a breaking change and will have impact so allowing both.
         cfg.StrOpt('url', default='amqp://guest:guest@localhost:5672//',
-                   help='URL of the messaging server.')
+                   help='URL of the messaging server.'),
+        cfg.ListOpt('cluster_urls', default=[],
+                    help='URL of all the nodes in a messaging service cluster.')
     ]
     do_register_opts(messaging_opts, 'messaging', ignore_errors)
 

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -22,7 +22,7 @@ from st2common import config
 from st2common.service_setup import db_setup
 from st2common.service_setup import db_teardown
 from st2common.logging.filters import LogLevelFilter
-from st2common.transport.utils import register_exchanges
+from st2common.transport.bootstrap_utils import register_exchanges
 
 
 LOG = logging.getLogger('st2common.content.bootstrap')

--- a/st2common/st2common/persistence/execution.py
+++ b/st2common/st2common/persistence/execution.py
@@ -13,12 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from oslo_config import cfg
-
 from st2common import transport
 from st2common.models.db import MongoDBAccess
 from st2common.models.db.execution import ActionExecutionDB
 from st2common.persistence.base import Access
+from st2common.transport import utils as transport_utils
 
 
 class ActionExecution(Access):
@@ -33,5 +32,5 @@ class ActionExecution(Access):
     def _get_publisher(cls):
         if not cls.publisher:
             cls.publisher = transport.execution.ActionExecutionPublisher(
-                cfg.CONF.messaging.url)
+                urls=transport_utils.get_messaging_urls())
         return cls.publisher

--- a/st2common/st2common/persistence/executionstate.py
+++ b/st2common/st2common/persistence/executionstate.py
@@ -13,11 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from oslo_config import cfg
-
 from st2common import transport
 from st2common.models.db.executionstate import actionexecstate_access
 from st2common.persistence import base as persistence
+from st2common.transport import utils as transport_utils
 
 
 class ActionExecutionState(persistence.Access):
@@ -32,5 +31,5 @@ class ActionExecutionState(persistence.Access):
     def _get_publisher(cls):
         if not cls.publisher:
             cls.publisher = transport.actionexecutionstate.ActionExecutionStatePublisher(
-                cfg.CONF.messaging.url)
+                urls=transport_utils.get_messaging_urls())
         return cls.publisher

--- a/st2common/st2common/persistence/liveaction.py
+++ b/st2common/st2common/persistence/liveaction.py
@@ -13,11 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from oslo_config import cfg
-
 from st2common import transport
 from st2common.models.db.liveaction import liveaction_access
 from st2common.persistence import base as persistence
+from st2common.transport import utils as transport_utils
 
 
 class LiveAction(persistence.StatusBasedResource):
@@ -32,5 +31,5 @@ class LiveAction(persistence.StatusBasedResource):
     def _get_publisher(cls):
         if not cls.publisher:
             cls.publisher = transport.liveaction.LiveActionPublisher(
-                cfg.CONF.messaging.url)
+                urls=transport_utils.get_messaging_urls())
         return cls.publisher

--- a/st2common/st2common/persistence/sensor.py
+++ b/st2common/st2common/persistence/sensor.py
@@ -13,11 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from oslo_config import cfg
-
 from st2common import transport
 from st2common.models.db.sensor import sensor_type_access
 from st2common.persistence.base import ContentPackResource
+from st2common.transport import utils as transport_utils
 
 
 class SensorType(ContentPackResource):
@@ -31,5 +30,6 @@ class SensorType(ContentPackResource):
     @classmethod
     def _get_publisher(cls):
         if not cls.publisher:
-            cls.publisher = transport.reactor.SensorCUDPublisher(cfg.CONF.messaging.url)
+            cls.publisher = transport.reactor.SensorCUDPublisher(
+                urls=transport_utils.get_messaging_urls())
         return cls.publisher

--- a/st2common/st2common/persistence/trigger.py
+++ b/st2common/st2common/persistence/trigger.py
@@ -13,11 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from oslo_config import cfg
-
 from st2common import transport
 from st2common.models.db.trigger import triggertype_access, trigger_access, triggerinstance_access
 from st2common.persistence.base import (Access, ContentPackResource)
+from st2common.transport import utils as transport_utils
 
 
 class TriggerType(ContentPackResource):
@@ -39,7 +38,8 @@ class Trigger(ContentPackResource):
     @classmethod
     def _get_publisher(cls):
         if not cls.publisher:
-            cls.publisher = transport.reactor.TriggerCUDPublisher(cfg.CONF.messaging.url)
+            cls.publisher = transport.reactor.TriggerCUDPublisher(
+                urls=transport_utils.get_messaging_urls())
         return cls.publisher
 
 

--- a/st2common/st2common/service_setup.py
+++ b/st2common/st2common/service_setup.py
@@ -28,7 +28,7 @@ from st2common import log as logging
 from st2common.models import db
 from st2common.constants.logging import DEFAULT_LOGGING_CONF_PATH
 from st2common.logging.misc import set_log_level_for_all_loggers
-from st2common.transport.utils import register_exchanges
+from st2common.transport.bootstrap_utils import register_exchanges
 from st2common.signal_handlers import register_common_signal_handlers
 
 __all__ = [

--- a/st2common/st2common/services/sensor_watcher.py
+++ b/st2common/st2common/services/sensor_watcher.py
@@ -24,6 +24,7 @@ from oslo_config import cfg
 
 from st2common import log as logging
 from st2common.transport import reactor, publishers
+from st2common.transport import utils as transport_utils
 
 LOG = logging.getLogger(__name__)
 
@@ -87,7 +88,7 @@ class SensorWatcher(ConsumerMixin):
 
     def start(self):
         try:
-            self.connection = Connection(cfg.CONF.messaging.url)
+            self.connection = Connection(transport_utils.get_messaging_urls())
             self._updates_thread = eventlet.spawn(self.run)
         except:
             LOG.exception('Failed to start sensor_watcher.')

--- a/st2common/st2common/services/sensor_watcher.py
+++ b/st2common/st2common/services/sensor_watcher.py
@@ -20,7 +20,6 @@ import eventlet
 import uuid
 from kombu.mixins import ConsumerMixin
 from kombu import Connection
-from oslo_config import cfg
 
 from st2common import log as logging
 from st2common.transport import reactor, publishers

--- a/st2common/st2common/services/triggerwatcher.py
+++ b/st2common/st2common/services/triggerwatcher.py
@@ -22,6 +22,7 @@ from oslo_config import cfg
 from st2common import log as logging
 from st2common.persistence.trigger import Trigger
 from st2common.transport import reactor, publishers
+from st2common.transport import utils as transport_utils
 
 LOG = logging.getLogger(__name__)
 
@@ -101,7 +102,7 @@ class TriggerWatcher(ConsumerMixin):
 
     def start(self):
         try:
-            self.connection = Connection(cfg.CONF.messaging.url)
+            self.connection = Connection(transport_utils.get_messaging_urls())
             self._updates_thread = eventlet.spawn(self.run)
             self._load_thread = eventlet.spawn(self._load_triggers_from_db)
         except:

--- a/st2common/st2common/services/triggerwatcher.py
+++ b/st2common/st2common/services/triggerwatcher.py
@@ -17,7 +17,6 @@ import eventlet
 import uuid
 from kombu.mixins import ConsumerMixin
 from kombu import Connection
-from oslo_config import cfg
 
 from st2common import log as logging
 from st2common.persistence.trigger import Trigger

--- a/st2common/st2common/transport/__init__.py
+++ b/st2common/st2common/transport/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from st2common.transport import liveaction, actionexecutionstate, execution, publishers, reactor
-from st2common.transport import bootstrap_utils, utils
+from st2common.transport import bootstrap_utils, utils, connection_retry_wrapper
 
 # TODO(manas) : Exchanges, Queues and RoutingKey design discussion pending.
 
@@ -25,5 +25,6 @@ __all__ = [
     'publishers',
     'reactor',
     'bootstrap_utils',
-    'utils'
+    'utils',
+    'connection_retry_wrapper'
 ]

--- a/st2common/st2common/transport/__init__.py
+++ b/st2common/st2common/transport/__init__.py
@@ -14,7 +14,16 @@
 # limitations under the License.
 
 from st2common.transport import liveaction, actionexecutionstate, execution, publishers, reactor
+from st2common.transport import bootstrap_utils, utils
 
 # TODO(manas) : Exchanges, Queues and RoutingKey design discussion pending.
 
-__all__ = ['liveaction', 'actionexecutionstate', 'execution', 'publishers', 'reactor']
+__all__ = [
+    'liveaction',
+    'actionexecutionstate',
+    'execution',
+    'publishers',
+    'reactor',
+    'bootstrap_utils',
+    'utils'
+]

--- a/st2common/st2common/transport/actionexecutionstate.py
+++ b/st2common/st2common/transport/actionexecutionstate.py
@@ -24,8 +24,8 @@ ACTIONEXECUTIONSTATE_XCHG = Exchange('st2.actionexecutionstate',
 
 class ActionExecutionStatePublisher(publishers.CUDPublisher):
 
-    def __init__(self, url):
-        super(ActionExecutionStatePublisher, self).__init__(url, ACTIONEXECUTIONSTATE_XCHG)
+    def __init__(self, urls):
+        super(ActionExecutionStatePublisher, self).__init__(urls, ACTIONEXECUTIONSTATE_XCHG)
 
 
 def get_queue(name, routing_key):

--- a/st2common/st2common/transport/bootstrap.py
+++ b/st2common/st2common/transport/bootstrap.py
@@ -16,7 +16,7 @@
 import logging
 import st2common.config as config
 
-from st2common.transport.utils import register_exchanges
+from st2common.transport.bootstrap_utils import register_exchanges
 
 
 def _setup():

--- a/st2common/st2common/transport/bootstrap_utils.py
+++ b/st2common/st2common/transport/bootstrap_utils.py
@@ -1,0 +1,49 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kombu import Connection
+from st2common import log as logging
+from st2common.transport import utils as transport_utils
+from st2common.transport.execution import EXECUTION_XCHG
+from st2common.transport.liveaction import LIVEACTION_XCHG
+from st2common.transport.reactor import TRIGGER_CUD_XCHG, TRIGGER_INSTANCE_XCHG
+from st2common.transport.reactor import SENSOR_CUD_XCHG
+
+LOG = logging.getLogger('st2common.transport.bootstrap')
+
+__all__ = [
+    'register_exchanges'
+]
+
+EXCHANGES = [EXECUTION_XCHG, LIVEACTION_XCHG, TRIGGER_CUD_XCHG, TRIGGER_INSTANCE_XCHG,
+             SENSOR_CUD_XCHG]
+
+
+def _do_register_exchange(exchange, channel):
+    try:
+        channel.exchange_declare(exchange=exchange.name, type=exchange.type,
+                                 durable=exchange.durable, auto_delete=exchange.auto_delete,
+                                 arguments=exchange.arguments, nowait=False, passive=None)
+        LOG.debug('registered exchange %s.', exchange.name)
+    except Exception:
+        LOG.exception('Failed to register exchange : %s.', exchange.name)
+
+
+def register_exchanges():
+    LOG.debug('Registering exchanges...')
+    with Connection(transport_utils.get_messaging_urls()) as conn:
+        channel = conn.default_channel
+        for exchange in EXCHANGES:
+            _do_register_exchange(exchange, channel)

--- a/st2common/st2common/transport/connection_retry_wrapper.py
+++ b/st2common/st2common/transport/connection_retry_wrapper.py
@@ -15,7 +15,7 @@
 
 import eventlet
 
-__all__ = ['ConnectionRetryWrapper']
+__all__ = ['ConnectionRetryWrapper', 'ClusterRetryContext']
 
 
 class ClusterRetryContext(object):

--- a/st2common/st2common/transport/connection_retry_wrapper.py
+++ b/st2common/st2common/transport/connection_retry_wrapper.py
@@ -1,0 +1,100 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+__all__ = ['ConnectionRetryWrapper']
+
+
+class ClusterRetryContext(object):
+    """
+    Stores retry context for cluster retries. It makes certain assumptions
+    on how cluster_size and retry should be determined.
+    """
+    def __init__(self, cluster_size):
+        # No of nodes in a cluster
+        self.cluster_size = cluster_size
+        # No of times to retry in a cluster
+        self.cluster_retry = 2
+        # time to wait between retry in a cluster
+        self.wait_between_cluster = 10
+
+        # No of nodes attempted. Starts at 1 since the
+        self._nodes_attempted = 1
+
+    def test_should_stop(self):
+        should_stop = True
+        if self._nodes_attempted > self.cluster_size * self.cluster_retry:
+            return should_stop, -1
+        wait = 0
+        should_stop = False
+        if self._nodes_attempted % self.cluster_size == 0:
+            wait = self.wait_between_cluster
+        self._nodes_attempted += 1
+        return should_stop, wait
+
+
+class ConnectionRetryWrapper(object):
+
+    def __init__(self, cluster_size, logger):
+        self._retry_context = ClusterRetryContext(cluster_size=cluster_size)
+        self._logger = logger
+
+    def errback(self, exc, interval):
+        self._logger.error('Rabbitmq connection error: %s', exc.message)
+
+    def run(self, connection, wrapped_callback):
+        should_stop = False
+        channel = None
+        while not should_stop:
+            try:
+                channel = connection.channel()
+                wrapped_callback(connection=connection, channel=channel)
+                should_stop = True
+            except connection.connection_errors + connection.channel_errors as e:
+                self._logger.error('Connection or channel error identified.')
+                should_stop, wait = self._retry_context.test_should_stop()
+                # reset channel to None to avoid any channel closing errors. At this point
+                # in case of an exception there should be no channel but that is better to
+                # guarantee.
+                channel = None
+                # All attempts to re-establish connections have failed. This error needs to
+                # be notified so raise.
+                if should_stop:
+                    raise
+                # -1, 0 and 1+ are handled properly by eventlet.sleep
+                eventlet.sleep(wait)
+
+                connection.close()
+                # ensure_connection will automatically switch to an alternate. Other connections
+                # in the pool will be fixed independently. It would be nice to cut-over the
+                # entire ConnectionPool simultaneously but that would require writing our own
+                # ConnectionPool. If a server recovers it could happen that the same process
+                # ends up talking to separate nodes in a cluster.
+                connection.ensure_connection()
+
+            except Exception as e:
+                self._logger.error('Connections to rabbitmq cannot be re-established: %s', e.message)
+                # Not being able to publish a message could be a significant issue for an app.
+                raise
+            finally:
+                if should_stop and channel:
+                    try:
+                        channel.close()
+                    except Exception:
+                        self._logger.warning('Error closing channel.', exc_info=True)
+
+    def ensured(self, connection, obj, to_ensure_func, **kwargs):
+        ensuring_func = connection.ensure(obj, to_ensure_func, errback=self.errback, max_retries=3)
+        ensuring_func(**kwargs)

--- a/st2common/st2common/transport/connection_retry_wrapper.py
+++ b/st2common/st2common/transport/connection_retry_wrapper.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import eventlet
 
 __all__ = ['ConnectionRetryWrapper']
 
@@ -85,7 +86,8 @@ class ConnectionRetryWrapper(object):
                 connection.ensure_connection()
 
             except Exception as e:
-                self._logger.error('Connections to rabbitmq cannot be re-established: %s', e.message)
+                self._logger.error('Connections to rabbitmq cannot be re-established: %s',
+                                   e.message)
                 # Not being able to publish a message could be a significant issue for an app.
                 raise
             finally:

--- a/st2common/st2common/transport/execution.py
+++ b/st2common/st2common/transport/execution.py
@@ -23,8 +23,8 @@ EXECUTION_XCHG = Exchange('st2.execution', type='topic')
 
 class ActionExecutionPublisher(publishers.CUDPublisher):
 
-    def __init__(self, url):
-        super(ActionExecutionPublisher, self).__init__(url, EXECUTION_XCHG)
+    def __init__(self, urls):
+        super(ActionExecutionPublisher, self).__init__(urls, EXECUTION_XCHG)
 
 
 def get_queue(name=None, routing_key=None, exclusive=False):

--- a/st2common/st2common/transport/liveaction.py
+++ b/st2common/st2common/transport/liveaction.py
@@ -25,9 +25,9 @@ LIVEACTION_STATUS_MGMT_XCHG = Exchange('st2.liveaction.status', type='topic')
 
 class LiveActionPublisher(publishers.CUDPublisher, publishers.StatePublisherMixin):
 
-    def __init__(self, url):
-        publishers.CUDPublisher.__init__(self, url, LIVEACTION_XCHG)
-        publishers.StatePublisherMixin.__init__(self, url, LIVEACTION_STATUS_MGMT_XCHG)
+    def __init__(self, urls):
+        publishers.CUDPublisher.__init__(self, urls, LIVEACTION_XCHG)
+        publishers.StatePublisherMixin.__init__(self, urls, LIVEACTION_STATUS_MGMT_XCHG)
 
 
 def get_queue(name, routing_key):

--- a/st2common/st2common/transport/publishers.py
+++ b/st2common/st2common/transport/publishers.py
@@ -27,8 +27,8 @@ LOG = logging.getLogger(__name__)
 
 
 class PoolPublisher(object):
-    def __init__(self, url):
-        self.pool = Connection(url).Pool(limit=10)
+    def __init__(self, urls):
+        self.pool = Connection(urls).Pool(limit=10)
 
     def errback(self, exc, interval):
         LOG.error('Rabbitmq connection error: %s', exc.message, exc_info=False)
@@ -59,8 +59,8 @@ class PoolPublisher(object):
 
 
 class CUDPublisher(object):
-    def __init__(self, url, exchange):
-        self._publisher = PoolPublisher(url)
+    def __init__(self, urls, exchange):
+        self._publisher = PoolPublisher(urls=urls)
         self._exchange = exchange
 
     def publish_create(self, payload):
@@ -74,8 +74,8 @@ class CUDPublisher(object):
 
 
 class StatePublisherMixin(object):
-    def __init__(self, url, exchange):
-        self._state_publisher = PoolPublisher(url)
+    def __init__(self, urls, exchange):
+        self._state_publisher = PoolPublisher(urls=urls)
         self._state_exchange = exchange
 
     def publish_state(self, payload, state):

--- a/st2common/st2common/transport/publishers.py
+++ b/st2common/st2common/transport/publishers.py
@@ -50,6 +50,7 @@ class ClusterRetryContext(object):
         if self._nodes_attempted > self.cluster_size * self.cluster_retry:
             return should_stop, -1
         wait = 0
+        should_stop = False
         if self._nodes_attempted % self.cluster_size == 0:
             wait = self.wait_between_cluster
         self._nodes_attempted += 1

--- a/st2common/st2common/transport/publishers.py
+++ b/st2common/st2common/transport/publishers.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import copy
-import eventlet
 
 from kombu import Connection
 from kombu.messaging import Producer

--- a/st2common/st2common/transport/publishers.py
+++ b/st2common/st2common/transport/publishers.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import eventlet
 
 from kombu import Connection
@@ -127,6 +128,7 @@ class SharedPoolPublishers(object):
         # The publisher_key format here only works because we are aware that urls will be a
         # list of strings. Sorting to end up with the same PoolPublisher regardless of
         # ordering in supplied list.
+        urls = copy.copy(urls)
         urls.sort()
         publisher_key = ''.join(urls)
         publisher = self.shared_publishers.get(publisher_key, None)

--- a/st2common/st2common/transport/reactor.py
+++ b/st2common/st2common/transport/reactor.py
@@ -15,10 +15,9 @@
 
 from kombu import Exchange, Queue
 
-from oslo_config import cfg
-
 from st2common import log as logging
 from st2common.transport import publishers
+from st2common.transport import utils as transport_utils
 
 __all__ = [
     'TriggerCUDPublisher',
@@ -48,8 +47,8 @@ class SensorCUDPublisher(publishers.CUDPublisher):
     Publisher responsible for publishing Trigger model CUD events.
     """
 
-    def __init__(self, url):
-        super(SensorCUDPublisher, self).__init__(url, SENSOR_CUD_XCHG)
+    def __init__(self, urls):
+        super(SensorCUDPublisher, self).__init__(urls, SENSOR_CUD_XCHG)
 
 
 class TriggerCUDPublisher(publishers.CUDPublisher):
@@ -57,13 +56,13 @@ class TriggerCUDPublisher(publishers.CUDPublisher):
     Publisher responsible for publishing Trigger model CUD events.
     """
 
-    def __init__(self, url):
-        super(TriggerCUDPublisher, self).__init__(url, TRIGGER_CUD_XCHG)
+    def __init__(self, urls):
+        super(TriggerCUDPublisher, self).__init__(urls, TRIGGER_CUD_XCHG)
 
 
 class TriggerInstancePublisher(object):
-    def __init__(self, url):
-        self._publisher = publishers.PoolPublisher(url=url)
+    def __init__(self, urls):
+        self._publisher = publishers.PoolPublisher(urls=urls)
 
     def publish_trigger(self, payload=None, routing_key=None):
         # TODO: We should use trigger reference as a routing key
@@ -76,7 +75,7 @@ class TriggerDispatcher(object):
     """
 
     def __init__(self, logger=LOG):
-        self._publisher = TriggerInstancePublisher(url=cfg.CONF.messaging.url)
+        self._publisher = TriggerInstancePublisher(urls=transport_utils.get_messaging_urls())
         self._logger = logger
 
     def dispatch(self, trigger, payload=None):

--- a/st2common/st2common/transport/utils.py
+++ b/st2common/st2common/transport/utils.py
@@ -19,6 +19,8 @@ __all__ = [
     'get_messaging_urls'
 ]
 
+CONF = cfg.CONF
+
 
 def get_messaging_urls():
     '''
@@ -27,6 +29,6 @@ def get_messaging_urls():
 
     :rtype: ``list``
     '''
-    if cfg.messaging.cluster_urls:
-        return cfg.messaging.cluster_urls
-    return [cfg.messaging.url]
+    if CONF.messaging.cluster_urls:
+        return CONF.messaging.cluster_urls
+    return [CONF.messaging.url]

--- a/st2common/st2common/transport/utils.py
+++ b/st2common/st2common/transport/utils.py
@@ -13,33 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from kombu import Connection
 from oslo_config import cfg
-from st2common import log as logging
-from st2common.transport.execution import EXECUTION_XCHG
-from st2common.transport.liveaction import LIVEACTION_XCHG
-from st2common.transport.reactor import TRIGGER_CUD_XCHG, TRIGGER_INSTANCE_XCHG
-from st2common.transport.reactor import SENSOR_CUD_XCHG
-
-LOG = logging.getLogger('st2common.transport.bootstrap')
 
 __all__ = [
-    'get_messaging_urls',
-    'register_exchanges'
+    'get_messaging_urls'
 ]
-
-EXCHANGES = [EXECUTION_XCHG, LIVEACTION_XCHG, TRIGGER_CUD_XCHG, TRIGGER_INSTANCE_XCHG,
-             SENSOR_CUD_XCHG]
-
-
-def _do_register_exchange(exchange, channel):
-    try:
-        channel.exchange_declare(exchange=exchange.name, type=exchange.type,
-                                 durable=exchange.durable, auto_delete=exchange.auto_delete,
-                                 arguments=exchange.arguments, nowait=False, passive=None)
-        LOG.debug('registered exchange %s.', exchange.name)
-    except Exception:
-        LOG.exception('Failed to register exchange : %s.', exchange.name)
 
 
 def get_messaging_urls():
@@ -52,11 +30,3 @@ def get_messaging_urls():
     if cfg.messaging.cluster_urls:
         return cfg.messaging.cluster_urls
     return [cfg.messaging.url]
-
-
-def register_exchanges():
-    LOG.debug('Registering exchanges...')
-    with Connection(get_messaging_urls()) as conn:
-        channel = conn.default_channel
-        for exchange in EXCHANGES:
-            _do_register_exchange(exchange, channel)

--- a/st2common/st2common/transport/utils.py
+++ b/st2common/st2common/transport/utils.py
@@ -23,6 +23,11 @@ from st2common.transport.reactor import SENSOR_CUD_XCHG
 
 LOG = logging.getLogger('st2common.transport.bootstrap')
 
+__all__ = [
+    'get_messaging_urls',
+    'register_exchanges'
+]
+
 EXCHANGES = [EXECUTION_XCHG, LIVEACTION_XCHG, TRIGGER_CUD_XCHG, TRIGGER_INSTANCE_XCHG,
              SENSOR_CUD_XCHG]
 
@@ -37,9 +42,21 @@ def _do_register_exchange(exchange, channel):
         LOG.exception('Failed to register exchange : %s.', exchange.name)
 
 
+def get_messaging_urls():
+    '''
+    Determines the right messaging urls to supply. In case the `cluster_urls` config is
+    specified then that is used. Else the single `url` property is used.
+
+    :rtype: ``list``
+    '''
+    if cfg.messaging.cluster_urls:
+        return cfg.messaging.cluster_urls
+    return [cfg.messaging.url]
+
+
 def register_exchanges():
     LOG.debug('Registering exchanges...')
-    with Connection(cfg.CONF.messaging.url) as conn:
+    with Connection(get_messaging_urls()) as conn:
         channel = conn.default_channel
         for exchange in EXCHANGES:
             _do_register_exchange(exchange, channel)

--- a/st2common/tests/unit/test_connection_retry_wrapper.py
+++ b/st2common/tests/unit/test_connection_retry_wrapper.py
@@ -49,7 +49,7 @@ class TestClusterRetryContext(unittest.TestCase):
                 self.assertFalse(should_stop, 'Not done trying.')
                 # on cluster boundaries the wait is longer. Short wait when switching
                 # to a different server within a cluster.
-                if (i +1) % cluster_size == 0:
+                if (i + 1) % cluster_size == 0:
                     self.assertEqual(wait, 10)
                 else:
                     self.assertEqual(wait, 0)

--- a/st2common/tests/unit/test_connection_retry_wrapper.py
+++ b/st2common/tests/unit/test_connection_retry_wrapper.py
@@ -1,0 +1,61 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from st2common.transport.connection_retry_wrapper import ClusterRetryContext
+
+
+class TestClusterRetryContext(unittest.TestCase):
+
+    def test_single_node_cluster_retry(self):
+        retry_context = ClusterRetryContext(cluster_size=1)
+        should_stop, wait = retry_context.test_should_stop()
+        self.assertFalse(should_stop, 'Not done trying.')
+        self.assertEqual(wait, 10)
+
+        should_stop, wait = retry_context.test_should_stop()
+        self.assertFalse(should_stop, 'Not done trying.')
+        self.assertEqual(wait, 10)
+
+        should_stop, wait = retry_context.test_should_stop()
+        self.assertTrue(should_stop, 'Done trying.')
+        self.assertEqual(wait, -1)
+
+    def test_multiple_node_cluster_retry(self):
+        cluster_size = 3
+        last_index = cluster_size * 2
+
+        retry_context = ClusterRetryContext(cluster_size=cluster_size)
+
+        for i in range(last_index + 1):
+            should_stop, wait = retry_context.test_should_stop()
+            if i == last_index:
+                self.assertTrue(should_stop, 'Done trying.')
+                self.assertEqual(wait, -1)
+            else:
+                self.assertFalse(should_stop, 'Not done trying.')
+                # on cluster boundaries the wait is longer. Short wait when switching
+                # to a different server within a cluster.
+                if (i +1) % cluster_size == 0:
+                    self.assertEqual(wait, 10)
+                else:
+                    self.assertEqual(wait, 0)
+
+    def test_zero_node_cluster_retry(self):
+        retry_context = ClusterRetryContext(cluster_size=0)
+        should_stop, wait = retry_context.test_should_stop()
+        self.assertTrue(should_stop, 'Done trying.')
+        self.assertEqual(wait, -1)

--- a/st2common/tests/unit/test_queue_consumer.py
+++ b/st2common/tests/unit/test_queue_consumer.py
@@ -15,9 +15,9 @@
 
 import mock
 from kombu import Connection, Exchange, Queue
-from oslo_config import cfg
 
 from st2common.transport import consumers
+from st2common.transport import utils as transport_utils
 from st2tests.base import DbTestCase
 from tests.unit.base import FakeModelDB
 
@@ -34,7 +34,7 @@ class FakeMessageHandler(consumers.MessageHandler):
 
 
 def get_handler():
-    with Connection(cfg.CONF.messaging.url) as conn:
+    with Connection(transport_utils.get_messaging_urls()) as conn:
         return FakeMessageHandler(conn, [FAKE_WORK_Q])
 
 

--- a/st2common/tests/unit/test_state_publisher.py
+++ b/st2common/tests/unit/test_state_publisher.py
@@ -16,12 +16,12 @@
 import kombu
 import mock
 import mongoengine as me
-from oslo_config import cfg
 
 from st2common.models import db
 from st2common.models.db import stormbase
 from st2common.persistence import base as persistence
 from st2common.transport import publishers
+from st2common.transport import utils as transport_utils
 from st2tests import DbTestCase
 
 
@@ -48,7 +48,7 @@ class FakeModel(persistence.Access):
     @classmethod
     def _get_publisher(cls):
         if not cls.publisher:
-            cls.publisher = FakeModelPublisher(cfg.CONF.messaging.url)
+            cls.publisher = FakeModelPublisher(transport_utils.get_messaging_urls())
         return cls.publisher
 
     @classmethod

--- a/st2exporter/st2exporter/worker.py
+++ b/st2exporter/st2exporter/worker.py
@@ -27,6 +27,7 @@ from st2common.models.db.execution import ActionExecutionDB
 from st2common.persistence.execution import ActionExecution
 from st2common.persistence.marker import DumperMarker
 from st2common.transport import consumers, execution, publishers
+from st2common.transport import utils as transport_utils
 from st2common.util import isotime
 from st2exporter.exporter.dumper import Dumper
 
@@ -125,5 +126,5 @@ class ExecutionsExporter(consumers.MessageHandler):
 
 
 def get_worker():
-    with Connection(cfg.CONF.messaging.url) as conn:
+    with Connection(transport_utils.get_messaging_urls()) as conn:
         return ExecutionsExporter(conn, [EXPORTER_WORK_Q])

--- a/st2reactor/st2reactor/rules/worker.py
+++ b/st2reactor/st2reactor/rules/worker.py
@@ -1,9 +1,24 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from kombu import Connection
-from oslo_config import cfg
 
 from st2common import log as logging
 from st2common.util import date as date_utils
 from st2common.transport import consumers, reactor
+from st2common.transport import utils as transport_utils
 import st2reactor.container.utils as container_utils
 from st2reactor.rules.engine import RulesEngine
 
@@ -42,5 +57,5 @@ class TriggerInstanceDispatcher(consumers.MessageHandler):
 
 
 def get_worker():
-    with Connection(cfg.CONF.messaging.url) as conn:
+    with Connection(transport_utils.get_messaging_urls()) as conn:
         return TriggerInstanceDispatcher(conn, [RULESENGINE_WORK_Q])

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -108,7 +108,9 @@ def _register_api_opts():
 
     messaging_opts = [
         cfg.StrOpt('url', default='amqp://guest:guest@localhost:5672//',
-                   help='URL of the messaging server.')
+                   help='URL of the messaging server.'),
+        cfg.ListOpt('cluster_urls', default=[],
+                    help='URL of all the nodes in a messaging service cluster.')
     ]
     _register_opts(messaging_opts, group='messaging')
 

--- a/tools/queue_consumer.py
+++ b/tools/queue_consumer.py
@@ -24,9 +24,9 @@ from pprint import pprint
 
 from kombu.mixins import ConsumerMixin
 from kombu import Connection, Exchange, Queue
-from oslo_config import cfg
 
 from st2common import config
+from st2common.transport import utils as transport_utils
 
 
 class QueueConsumer(ConsumerMixin):
@@ -58,7 +58,7 @@ def main(queue, exchange, routing_key='#'):
     queue = Queue(name=queue, exchange=exchange, routing_key=routing_key,
                   auto_delete=True)
 
-    with Connection(cfg.CONF.messaging.url) as connection:
+    with Connection(transport_utils.get_messaging_urls()) as connection:
         watcher = QueueConsumer(connection=connection, queue=queue)
         watcher.run()
 

--- a/tools/queue_producer.py
+++ b/tools/queue_producer.py
@@ -20,21 +20,18 @@ A utility script which sends test messages to a queue.
 
 import argparse
 
-from kombu import Connection, Exchange
-from oslo_config import cfg
+from kombu import Exchange
 
 from st2common import config
 
+from st2common.transport import utils as transport_utils
 from st2common.transport.publishers import PoolPublisher
 
 
 def main(exchange, routing_key, payload):
     exchange = Exchange(exchange, type='topic')
-    publisher = PoolPublisher(cfg.CONF.messaging.url)
-
-    with Connection(cfg.CONF.messaging.url):
-        publisher.publish(payload=payload, exchange=exchange,
-                          routing_key=routing_key)
+    publisher = PoolPublisher(urls=transport_utils.get_messaging_urls())
+    publisher.publish(payload=payload, exchange=exchange, routing_key=routing_key)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Config varible messaging.cluster_urls can be used to specify a list of host
  for rabbitmq cluster configuration.
* messaging.urls is effectively deprecated but presevered to support existing
  configuration.
* utility added to hide away precendence order of cluster_urls and urls.

Testing
* Non clustered RMQ
   - [X] With `messaging.url` 
   - [X] With `messaging.cluster_urls`
* clustered RMQ
   - [X] With `messaging.url` pointing to a single node in the cluster
   - [x] With `messaging.cluster_urls` pointing to a single node in the cluster
   - [x] With `messaging.cluster_urls` pointing to all nodes in the cluster
* Failover
   - [x] pull the plug on connected node which stackstorm is running
   - [x] first in the list of nodes is offline i.e. starts by trying to connect to offline node