### PR TITLE
RFR: Disable parallel execution of SSH actions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 0.12.1 - Inprogress
 -------------------
 * Un-registering a pack also removes ``rules`` and ``action aliases`` from the pack. (bug-fix)
+* Disable parallel SSH in fabric runner which causes issues with eventlets. (bug-fix)
 
 0.12.0 - July 20, 2015
 ----------------------

--- a/st2actions/st2actions/bootstrap/runnersregistrar.py
+++ b/st2actions/st2actions/bootstrap/runnersregistrar.py
@@ -156,7 +156,7 @@ RUNNER_TYPES = [
             'parallel': {
                 'description': 'Default to parallel execution.',
                 'type': 'boolean',
-                'default': True,
+                'default': False,
                 'immutable': True
             },
             'sudo': {
@@ -220,7 +220,7 @@ RUNNER_TYPES = [
             'parallel': {
                 'description': 'Default to parallel execution.',
                 'type': 'boolean',
-                'default': True,
+                'default': False,
                 'immutable': True
             },
             'cwd': {


### PR DESCRIPTION
* Fabric doesn't behave well with eventlets especially when parallel is
set to True. Parallel basically executes a command on a bunch of hosts.
Parallel uses multiprocessing and calls fork(). We don't understand the
root cause yet. Fabric has other issues as well. So until we use
Paramiko straight and replace our SSH runner, let's disable parallel
SSH execution.