### PR TITLE
Try to delete the virtualenv before creating it. fixes #1757

### DIFF
--- a/contrib/packs/actions/pack_mgmt/setup_virtualenv.py
+++ b/contrib/packs/actions/pack_mgmt/setup_virtualenv.py
@@ -139,7 +139,8 @@ class SetupVirtualEnvironmentAction(Action):
         try:
             shutil.rmtree(virtualenv_path)
         except Exception as error:
-            self.logger.error('Error while removing virtualenv at "%s": "%s"' % (virtualenv_path, error))
+            self.logger.error('Error while removing virtualenv at "%s": "%s"' %
+                              (virtualenv_path, error))
             raise
         return True
 

--- a/contrib/packs/actions/pack_mgmt/setup_virtualenv.py
+++ b/contrib/packs/actions/pack_mgmt/setup_virtualenv.py
@@ -15,6 +15,7 @@
 
 import os
 import re
+import shutil
 
 from oslo_config import cfg
 
@@ -83,6 +84,9 @@ class SetupVirtualEnvironmentAction(Action):
         if not os.path.exists(self._base_virtualenvs_path):
             os.makedirs(self._base_virtualenvs_path)
 
+        # 0. Delete virtual environment if it exists
+        self._remove_virtualenv(virtualenv_path=virtualenv_path)
+
         # 1. Create virtual environment
         self.logger.debug('Creating virtualenv for pack "%s" in "%s"' %
                           (pack_name, virtualenv_path))
@@ -124,6 +128,19 @@ class SetupVirtualEnvironmentAction(Action):
             raise Exception('Failed to create virtualenv in "%s": %s' %
                             (virtualenv_path, stderr))
 
+        return True
+
+    def _remove_virtualenv(self, virtualenv_path):
+        if not os.path.exists(virtualenv_path):
+            self.logger.info('Virtualenv path "%s" doesn\'t exist' % virtualenv_path)
+            return True
+
+        self.logger.debug('Removing virtualenv in "%s"' % virtualenv_path)
+        try:
+            shutil.rmtree(virtualenv_path)
+        except Exception as error:
+            self.logger.error('Error while removing virtualenv at "%s": "%s"' % (virtualenv_path, error))
+            raise
         return True
 
     def _install_requirements(self, virtualenv_path, requirements_file_path):


### PR DESCRIPTION
Kind of a workaround as it would be better to stop the sensor, delete the venv, create it and register the sensor again so it cleaner.

On sensor registration, sensorcontainer kills the old one and launches the new one so there seems to be no side effects for this.

```
2015-07-29 21:43:35,644 140695903024464 INFO log [-] Container shutting down. Invoking cleanup on sensors.
2015-07-29 21:43:35,932 139779226957136 INFO log [-] Connecting to database "st2" @ "0.0.0.0:27017" as user "None".
2015-07-29 21:43:35,972 139779226957136 INFO log [-] Using partitioner default with sensornode sensornode1.
2015-07-29 21:43:35,973 139779226957136 INFO log [-] Found 2 registered sensors in db scan.
2015-07-29 21:43:35,973 139779226957136 INFO log [-] Setting up container to run 2 sensors.
2015-07-29 21:43:35,973 139779226957136 INFO log [-] 	Sensors list - [u'linux.FileWatchSensor', u'mmonit.MmonitEventsSensor'].
2015-07-29 21:43:35,974 139779226957136 INFO log [-] (PID:22506) SensorContainer started.
2015-07-29 21:43:35,974 57355632 INFO log [-] Running sensor linux.FileWatchSensor
2015-07-29 21:43:35,982 57355472 INFO mixins [-] Connected to amqp://guest:**@127.0.0.1:5672//
2015-07-29 21:43:35,985 57355632 AUDIT log [-] Access granted to "sensors_container" with the token set to expire at "2015-07-30T21:43:35.984435Z". (username='sensors_container',token_expiration='2015-07-30T21:43:35.984435Z')
2015-07-29 21:43:36,007 57355632 INFO log [-] Sensor linux.FileWatchSensor started
2015-07-29 21:43:36,007 57355632 INFO log [-] Running sensor mmonit.MmonitEventsSensor
2015-07-29 21:43:36,012 57355632 AUDIT log [-] Access granted to "sensors_container" with the token set to expire at "2015-07-30T21:43:36.011274Z". (username='sensors_container',token_expiration='2015-07-30T21:43:36.011274Z')
2015-07-29 21:43:36,028 57355632 INFO log [-] Sensor mmonit.MmonitEventsSensor started
2015-07-29 21:43:36,267 38551376 INFO log [-] Using config "/opt/stackstorm/packs/linux/config.yaml" for sensor "FileWatchSensor"
2015-07-29 21:43:36,304 22353552 INFO log [-] Using config "/opt/stackstorm/packs/mmonit/config.yaml" for sensor "MmonitEventsSensor"
2015-07-29 21:43:36,304 22353552 INFO log [-] Watcher started
2015-07-29 21:43:36,304 22353552 INFO log [-] Running sensor initialization code
2015-07-29 21:43:36,327 38299440 INFO mixins [-] Connected to amqp://guest:**@127.0.0.1:5672//
2015-07-29 21:43:36,362 22353552 INFO log [-] Running sensor in active mode (poll interval=10s)

```