### PR TITLE
RFR: Update execution object when liveaction is updated

### DIFF
--- a/st2actions/st2actions/container/base.py
+++ b/st2actions/st2actions/container/base.py
@@ -129,10 +129,17 @@ class RunnerContainer(object):
             LOG.debug('Action "%s" completed.' % (action_db.name), extra=extra)
 
             # Always clean-up the auth_token
-            updated_liveaction_db = self._update_live_action_db(liveaction_db.id, status,
-                                                                result, context)
-            executions.update_execution(updated_liveaction_db)
+            try:
+                LOG.debug('Setting status: %s for liveaction: %s', status, liveaction_db.id)
+                updated_liveaction_db = self._update_live_action_db(liveaction_db.id, status,
+                                                                    result, context)
+            except:
+                error = 'Cannot update LiveAction object for id: %s, status: %s, result: %s.' % (
+                    liveaction_db.id, status, result)
+                LOG.exception(error)
+                raise
 
+            executions.update_execution(updated_liveaction_db)
             extra = {'liveaction_db': updated_liveaction_db}
             LOG.debug('Updated liveaction after run', extra=extra)
 

--- a/st2actions/st2actions/worker.py
+++ b/st2actions/st2actions/worker.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+import traceback
+
 from kombu import Connection
 from oslo_config import cfg
 
@@ -58,10 +61,11 @@ class ActionExecutionDispatcher(consumers.MessageHandler):
             LOG.info('%s is not executing %s (id=%s) with "%s" status.',
                      self.__class__.__name__, type(liveaction), liveaction.id, liveaction.status)
             if not liveaction.result:
-                action_utils.update_liveaction_status(
+                updated_liveaction = action_utils.update_liveaction_status(
                     status=liveaction.status,
                     result={'message': 'Action execution canceled by user.'},
                     liveaction_id=liveaction.id)
+                executions.update_execution(updated_liveaction)
             return
 
         if liveaction.status != action_constants.LIVEACTION_STATUS_SCHEDULED:
@@ -99,14 +103,16 @@ class ActionExecutionDispatcher(consumers.MessageHandler):
             LOG.debug('Runner dispatch produced result: %s', result)
             if not result:
                 raise ActionRunnerException('Failed to execute action.')
-        except Exception as e:
-            extra['error'] = str(e)
-            LOG.info('Action "%s" failed: %s' % (liveaction_db.action, str(e)), extra=extra)
+        except:
+            _, ex, tb = sys.exc_info()
+            extra['error'] = str(ex)
+            LOG.info('Action "%s" failed: %s' % (liveaction_db.action, str(ex)), extra=extra)
 
             liveaction_db = action_utils.update_liveaction_status(
                 status=action_constants.LIVEACTION_STATUS_FAILED,
-                liveaction_id=liveaction_db.id)
-
+                liveaction_id=liveaction_db.id,
+                result={'error': str(ex), 'traceback': ''.join(traceback.format_tb(tb, 20))})
+            executions.update_execution(liveaction_db)
             raise
 
         return result

--- a/st2actions/st2actions/worker.py
+++ b/st2actions/st2actions/worker.py
@@ -98,6 +98,10 @@ class ActionExecutionDispatcher(consumers.MessageHandler):
         LOG.info('Dispatched {~}action_execution: %s / {~}live_action: %s with "%s" status.',
                  action_execution_db.id, liveaction_db.id, liveaction.status)
 
+        return self._run_action(liveaction_db)
+
+    def _run_action(self, liveaction_db):
+        extra = {'liveaction_db': liveaction_db}
         try:
             result = self.container.dispatch(liveaction_db)
             LOG.debug('Runner dispatch produced result: %s', result)

--- a/st2actions/tests/unit/test_runner_container.py
+++ b/st2actions/tests/unit/test_runner_container.py
@@ -15,6 +15,7 @@
 
 import mock
 
+from bson.errors import InvalidStringData
 from oslo_config import cfg
 from st2common.constants import action as action_constants
 from st2actions.runners import get_runner
@@ -39,8 +40,9 @@ from st2tests.fixturesloader import FixturesLoader
 from st2actions.container.base import get_runner_container
 
 TEST_FIXTURES = {
-    'runners': ['testrunner1.yaml', 'testfailingrunner1.yaml', 'testasyncrunner1.yaml'],
-    'actions': ['action1.yaml', 'async_action1.yaml', 'action-invalid-runner.yaml']
+    'runners': ['run-local.yaml', 'testrunner1.yaml', 'testfailingrunner1.yaml',
+                'testasyncrunner1.yaml'],
+    'actions': ['local.yaml', 'action1.yaml', 'async_action1.yaml', 'action-invalid-runner.yaml']
 }
 
 FIXTURES_PACK = 'generic'
@@ -61,6 +63,7 @@ class RunnerContainerTest(DbTestCase):
             fixtures_pack=FIXTURES_PACK, fixtures_dict=TEST_FIXTURES)
         RunnerContainerTest.runnertype_db = models['runners']['testrunner1.yaml']
         RunnerContainerTest.action_db = models['actions']['action1.yaml']
+        RunnerContainerTest.local_action_db = models['actions']['local.yaml']
         RunnerContainerTest.async_action_db = models['actions']['async_action1.yaml']
         RunnerContainerTest.failingaction_db = models['actions']['action-invalid-runner.yaml']
 
@@ -83,7 +86,7 @@ class RunnerContainerTest(DbTestCase):
         params = {
             'actionstr': 'bar'
         }
-        liveaction_db = self._get_action_exec_db_model(RunnerContainerTest.action_db, params)
+        liveaction_db = self._get_liveaction_model(RunnerContainerTest.action_db, params)
         liveaction_db = LiveAction.add_or_update(liveaction_db)
         executions.create_execution_object(liveaction_db)
         # Assert that execution ran successfully.
@@ -102,6 +105,24 @@ class RunnerContainerTest(DbTestCase):
         }
 
         self.assertDictEqual(liveaction_db.context, context)
+
+    def test_dispatch_non_utf8_result(self):
+        runner_container = get_runner_container()
+        params = {
+            'cmd': 'python -c \'print \"\\x82\"\''
+        }
+        liveaction_db = self._get_liveaction_model(RunnerContainerTest.local_action_db, params)
+        liveaction_db = LiveAction.add_or_update(liveaction_db)
+        executions.create_execution_object(liveaction_db)
+        print(liveaction_db)
+
+        try:
+            runner_container.dispatch(liveaction_db)
+            self.fail('Mongo won\'t handle non UTF-8 strings. Should have failed.')
+        except InvalidStringData:
+            liveaction_db = LiveAction.get_by_id(liveaction_db.id)
+            result = liveaction_db.result
+            print(result)
 
     def test_dispatch_runner_failure(self):
         runner_container = get_runner_container()
@@ -123,7 +144,7 @@ class RunnerContainerTest(DbTestCase):
             'actionstr': 'foo',
             'actionint': 20
         }
-        liveaction_db = self._get_action_exec_db_model(RunnerContainerTest.action_db, params)
+        liveaction_db = self._get_liveaction_model(RunnerContainerTest.action_db, params)
         liveaction_db = LiveAction.add_or_update(liveaction_db)
         executions.create_execution_object(liveaction_db)
         # Assert that execution ran successfully.
@@ -140,7 +161,7 @@ class RunnerContainerTest(DbTestCase):
             'actionint': 20,
             'async_test': True
         }
-        liveaction_db = self._get_action_exec_db_model(RunnerContainerTest.async_action_db, params)
+        liveaction_db = self._get_liveaction_model(RunnerContainerTest.async_action_db, params)
         liveaction_db = LiveAction.add_or_update(liveaction_db)
         executions.create_execution_object(liveaction_db)
         # Assert that execution ran without exceptions.
@@ -155,7 +176,7 @@ class RunnerContainerTest(DbTestCase):
         self.assertTrue(found.query_context is not None)
         self.assertTrue(found.query_module is not None)
 
-    def _get_action_exec_db_model(self, action_db, params):
+    def _get_liveaction_model(self, action_db, params):
         status = action_constants.LIVEACTION_STATUS_REQUESTED
         start_timestamp = date_utils.get_datetime_utc_now()
         action_ref = ResourceReference(name=action_db.name, pack=action_db.pack).ref

--- a/st2actions/tests/unit/test_worker.py
+++ b/st2actions/tests/unit/test_worker.py
@@ -1,0 +1,89 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from bson.errors import InvalidStringData
+import mock
+from oslo_config import cfg
+
+from st2actions.runners.localrunner import LocalShellRunner
+import st2actions.worker as actions_worker
+from st2common.constants import action as action_constants
+from st2common.models.db.liveaction import LiveActionDB
+from st2common.models.system.common import ResourceReference
+from st2common.persistence.execution import ActionExecution
+from st2common.persistence.liveaction import LiveAction
+from st2common.services import executions
+from st2common.util import date as date_utils
+
+
+from st2tests.base import DbTestCase
+from st2tests.fixturesloader import FixturesLoader
+import st2tests.config as tests_config
+tests_config.parse_args()
+
+TEST_FIXTURES = {
+    'runners': ['run-local.yaml'],
+    'actions': ['local.yaml']
+}
+
+FIXTURES_PACK = 'generic'
+
+NON_UTF8_RESULT = {'stderr': '', 'stdout': '\x82\n', 'succeeded': True, 'failed': False,
+                   'return_code': 0}
+
+
+class WorkerTestCase(DbTestCase):
+    fixtures_loader = FixturesLoader()
+
+    @classmethod
+    def setUpClass(cls):
+        super(WorkerTestCase, cls).setUpClass()
+        models = WorkerTestCase.fixtures_loader.save_fixtures_to_db(
+            fixtures_pack=FIXTURES_PACK, fixtures_dict=TEST_FIXTURES)
+        WorkerTestCase.local_runnertype_db = models['runners']['run-local.yaml']
+        WorkerTestCase.local_action_db = models['actions']['local.yaml']
+
+    @mock.patch.object(LocalShellRunner, 'run', mock.MagicMock(
+        return_value=(action_constants.LIVEACTION_STATUS_SUCCEEDED, NON_UTF8_RESULT, None)))
+    def test_non_utf8_action_result_string(self):
+        action_worker = actions_worker.get_worker()
+        params = {
+            'cmd': "python -c 'print \"\\x82\"'"
+        }
+        liveaction_db = self._get_liveaction_model(WorkerTestCase.local_action_db, params)
+        liveaction_db = LiveAction.add_or_update(liveaction_db)
+        execution_db = executions.create_execution_object(liveaction_db)
+
+        try:
+            action_worker._run_action(liveaction_db)
+        except InvalidStringData:
+            liveaction_db = LiveAction.get_by_id(liveaction_db.id)
+            self.assertEqual(liveaction_db.status, "failed")
+            self.assertTrue('error' in liveaction_db.result)
+            self.assertTrue('traceback' in liveaction_db.result)
+            execution_db = ActionExecution.get_by_id(execution_db.id)
+            self.assertEqual(liveaction_db.status, "failed")
+
+    def _get_liveaction_model(self, action_db, params):
+        status = action_constants.LIVEACTION_STATUS_REQUESTED
+        start_timestamp = date_utils.get_datetime_utc_now()
+        action_ref = ResourceReference(name=action_db.name, pack=action_db.pack).ref
+        parameters = params
+        context = {'user': cfg.CONF.system_user.user}
+        liveaction_db = LiveActionDB(status=status, start_timestamp=start_timestamp,
+                                     action=action_ref, parameters=parameters,
+                                     context=context)
+        return liveaction_db
+

--- a/st2actions/tests/unit/test_worker.py
+++ b/st2actions/tests/unit/test_worker.py
@@ -86,4 +86,3 @@ class WorkerTestCase(DbTestCase):
                                      action=action_ref, parameters=parameters,
                                      context=context)
         return liveaction_db
-


### PR DESCRIPTION
Fixes: https://github.com/StackStorm/st2/issues/1717

Several things were uncovered with this bug report.

1) A non UTF-8 string '\x82' in stdout causes mongo to throw an
exception when updating the results. We don't have a check
for validating if string is UTF-8 in document schema.
So this must be some mongo internal validation. We should
figure out if we can turn it off.

2) An exception thrown is caught by worker and liveaction
object is updated but the execution object is not. This
results in execution state shown as `running` even though
liveaction status is `failed`.

3) While fixing this, I also noticed that when an action is
canceled, we don't execute the execution object status to
`canceled` which also is consistent with the bug report.

## TODO: 

* [X] - Tests
* [ ] - CHANGELOG

## Example:

```
(virtualenv)/m/s/s/st2 git:master ❯❯❯ st2 run core.local cmd="python -c 'print \"\x82\"'" -a                 ✭ ✱
To get the results, execute:
 st2 execution get 55b948ca32ed3506d57fabff
(virtualenv)/m/s/s/st2 git:master ❯❯❯ st2 execution get 55b948ca32ed3506d57fabff                             ✭ ✱
id: 55b948ca32ed3506d57fabff
status: failed
result:
{
    "traceback": "  File "/mnt/src/storm/st2/st2actions/st2actions/worker.py", line 102, in process
    result = self.container.dispatch(liveaction_db)
  File "/mnt/src/storm/st2/st2actions/st2actions/container/base.py", line 59, in dispatch
    liveaction_db = self._do_run(runner, runnertype_db, action_db, liveaction_db)
  File "/mnt/src/storm/st2/st2actions/st2actions/container/base.py", line 135, in _do_run
    result, context)
  File "/mnt/src/storm/st2/st2actions/st2actions/container/base.py", line 179, in _update_live_action_db
    liveaction_db=liveaction_db)
  File "/mnt/src/storm/st2/st2common/st2common/util/action_db.py", line 195, in update_liveaction_status
    liveaction_db = LiveAction.add_or_update(liveaction_db)
  File "/mnt/src/storm/st2/st2common/st2common/persistence/base.py", line 118, in add_or_update
    model_object = cls._get_impl().add_or_update(model_object)
  File "/mnt/src/storm/st2/st2common/st2common/models/db/__init__.py", line 134, in add_or_update
    instance.save()
  File "/mnt/src/storm/st2/virtualenv/local/lib/python2.7/site-packages/mongoengine/document.py", line 267, in save
    upsert=True, **write_concern)
  File "/mnt/src/storm/st2/virtualenv/local/lib/python2.7/site-packages/pymongo/collection.py", line 572, in update
    check_keys, self.uuid_subtype), safe)
",
    "error": "strings in documents must be valid UTF-8: '\x82\n'"
}
(virtualenv)/m/s/s/st2 git:master ❯❯❯
```