### PR TITLE
st2-self-check error handling

### DIFF
--- a/tools/st2-self-check
+++ b/tools/st2-self-check
@@ -63,7 +63,7 @@ echo -n "Attempting Example examples.mistral_examples..."
 MISTRAL_EXAMPLES=`st2 run examples.mistral_examples -j`
 CHECK_STATUS=`echo ${MISTRAL_EXAMPLES} | grep '"status": "succeeded"'`
 if [ $? -ne 0 ]; then
-    ERRORS=$(($ERRORS + $?))
+    ERRORS=((ERRORS++))
 fi
 
 if [ $ERRORS -ne 0 ]; then

--- a/tools/st2-self-check
+++ b/tools/st2-self-check
@@ -57,7 +57,6 @@ for TEST in $TEST_ACTION_LIST
         else
             echo "OK!"
         fi
-        echo "total errors: ${ERRORS}"
     done
 
 echo -n "Attempting Example examples.mistral_examples..."
@@ -67,7 +66,6 @@ if [ $? -ne 0 ]; then
     ERRORS=$(($ERRORS + $?))
 fi
 
-echo "total errors: ${ERRORS}"
 if [ $ERRORS -ne 0 ]; then
     echo "ERROR!"
     echo "st2-self-check failed.  See above.  Also check the execution list for details."

--- a/tools/st2-self-check
+++ b/tools/st2-self-check
@@ -35,6 +35,10 @@ for PACK in $PACKS; do
 
     EXITCODE=$?
     echo $INSTALL
+    if [ ${EXITCODE} -ne 0 ]; then
+      echo "st2-self-check failed.  See above."
+      exit 2
+    fi
   fi
 done
 
@@ -49,20 +53,24 @@ for TEST in $TEST_ACTION_LIST
         CHECK_STATUS=`echo ${TEST_OUTPUT} | grep '"status": "succeeded"'`
         if [ $? -ne 0 ]; then
             echo -e "ERROR!"
-            #echo -e "FAILED!\nOUTPUT: ${TEST_OUTPUT}"
-            #exit 2
+            ((ERRORS++))
         else
             echo "OK!"
         fi
-        ERRORS=$(($ERRORS + $?))
+        echo "total errors: ${ERRORS}"
     done
 
 echo -n "Attempting Example examples.mistral_examples..."
 MISTRAL_EXAMPLES=`st2 run examples.mistral_examples -j`
 CHECK_STATUS=`echo ${MISTRAL_EXAMPLES} | grep '"status": "succeeded"'`
+if [ $? -ne 0 ]; then
+    ERRORS=$(($ERRORS + $?))
+fi
+
+echo "total errors: ${ERRORS}"
 if [ $ERRORS -ne 0 ]; then
     echo "ERROR!"
-    echo "Tests failed.  See above.  Also check the execution list for details."
+    echo "st2-self-check failed.  See above.  Also check the execution list for details."
     echo "st2 execution list"
 else
     echo -e "OK!"

--- a/tools/st2-self-check
+++ b/tools/st2-self-check
@@ -63,7 +63,7 @@ echo -n "Attempting Example examples.mistral_examples..."
 MISTRAL_EXAMPLES=`st2 run examples.mistral_examples -j`
 CHECK_STATUS=`echo ${MISTRAL_EXAMPLES} | grep '"status": "succeeded"'`
 if [ $? -ne 0 ]; then
-    ERRORS=((ERRORS++))
+    ((ERRORS++))
 fi
 
 if [ $ERRORS -ne 0 ]; then


### PR DESCRIPTION
Resolves Issue #1740

The st2-self-check script needed better error handling.

Failure:

```
ttempting Test tests.test_packs_pack...ERROR!
Attempting Test tests.test_quickstart...OK!
Attempting Test tests.test_quickstart_key...OK!
Attempting Test tests.test_quickstart_local_script_actions...OK!
Attempting Test tests.test_quickstart_passive_sensor...OK!
Attempting Test tests.test_quickstart_polling_sensor...OK!
Attempting Test tests.test_quickstart_python_actions...OK!
Attempting Test tests.test_quickstart_remote_script_actions...OK!
Attempting Test tests.test_quickstart_rules...ERROR!
Attempting Test tests.test_timer_rule...ERROR!
Attempting Test tests.test_windows_runners...ERROR!
Attempting Example examples.mistral_examples...ERROR!
st2-self-check failed.  See above.  Also check the execution list for details.
st2 execution list
```