### PR TITLE
St2client py27

### DIFF
--- a/st2client/Makefile
+++ b/st2client/Makefile
@@ -9,7 +9,7 @@ COMPONENTS := st2client
 
 .PHONY: rpm
 rpm: 
-	${PY27} setup.py bdist_rpm
+	$(PY27) setup.py bdist_rpm
 	mkdir -p $(RPM_ROOT)/RPMS/noarch
 	cp dist/$(COMPONENTS)*noarch.rpm $(RPM_ROOT)/RPMS/noarch/$(COMPONENTS)-$(VER)-$(RELEASE).noarch.rpm
 	mkdir -p $(RPM_ROOT)/SRPMS
@@ -18,7 +18,7 @@ rpm:
 
 .PHONY: rhel-rpm
 rhel-rpm:
-	${PY27} setup.py bdist_rpm --python=$(PY27)
+	$(PY27) setup.py bdist_rpm --python=$(PY27)
 	mkdir -p $(RPM_ROOT)/RPMS/noarch
 	cp dist/$(COMPONENTS)*noarch.rpm $(RPM_ROOT)/RPMS/noarch/$(COMPONENTS)-$(VER)-$(RELEASE).noarch.rpm
 	mkdir -p $(RPM_ROOT)/SRPMS

--- a/st2client/Makefile
+++ b/st2client/Makefile
@@ -9,7 +9,7 @@ COMPONENTS := st2client
 
 .PHONY: rpm
 rpm: 
-	python2.7 setup.py bdist_rpm
+	${PY27} setup.py bdist_rpm
 	mkdir -p $(RPM_ROOT)/RPMS/noarch
 	cp dist/$(COMPONENTS)*noarch.rpm $(RPM_ROOT)/RPMS/noarch/$(COMPONENTS)-$(VER)-$(RELEASE).noarch.rpm
 	mkdir -p $(RPM_ROOT)/SRPMS

--- a/st2client/Makefile
+++ b/st2client/Makefile
@@ -27,7 +27,7 @@ rhel-rpm:
 
 .PHONY: deb
 deb:
-	python setup.py --command-packages=stdeb.command bdist_deb
+	$(PY27) setup.py --command-packages=stdeb.command bdist_deb
 	mkdir -p ~/debbuild
 	cp deb_dist/python-$(COMPONENTS)*-1_all.deb ~/debbuild/$(COMPONENTS)_$(VER)-$(RELEASE)_amd64.deb
 	rm -Rf dist deb_dist $(COMPONENTS)-$(VER).tar.gz $(COMPONENTS).egg-info ChangeLog AUTHORS build

--- a/st2client/Makefile
+++ b/st2client/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-PY27 := /usr/local/bin/python2.7
+PY27 := /usr/bin/python2.7
 RPM_ROOT=~/rpmbuild
 RPM_SOURCES_DIR := $(RPM_ROOT)/SOURCES/
 RPM_SPECS_DIR := $(RPM_ROOT)/SPECS/
@@ -9,7 +9,7 @@ COMPONENTS := st2client
 
 .PHONY: rpm
 rpm: 
-	python setup.py bdist_rpm
+	python2.7 setup.py bdist_rpm
 	mkdir -p $(RPM_ROOT)/RPMS/noarch
 	cp dist/$(COMPONENTS)*noarch.rpm $(RPM_ROOT)/RPMS/noarch/$(COMPONENTS)-$(VER)-$(RELEASE).noarch.rpm
 	mkdir -p $(RPM_ROOT)/SRPMS
@@ -18,7 +18,7 @@ rpm:
 
 .PHONY: rhel-rpm
 rhel-rpm:
-	$(PY27) setup.py bdist_rpm --python=$(PY27)
+	${PY27} setup.py bdist_rpm --python=$(PY27)
 	mkdir -p $(RPM_ROOT)/RPMS/noarch
 	cp dist/$(COMPONENTS)*noarch.rpm $(RPM_ROOT)/RPMS/noarch/$(COMPONENTS)-$(VER)-$(RELEASE).noarch.rpm
 	mkdir -p $(RPM_ROOT)/SRPMS


### PR DESCRIPTION
This fixes the shebang on the st2 CLI for systems that use something other than Python 2.7 as the system Python version.