### PR TITLE
Fix escaped liveaction result

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 * Un-registering a pack also removes ``rules`` and ``action aliases`` from the pack. (bug-fix)
 * Disable parallel SSH in fabric runner which causes issues with eventlets. (bug-fix)
 * Fix executions stuck in ``running`` state if runner container throws exception. (bug-fix)
+* Fix cases where liveaction result in dict are escaped and passed to Mistral. (bug-fix)
 
 0.12.0 - July 20, 2015
 ----------------------

--- a/st2common/st2common/models/db/stormbase.py
+++ b/st2common/st2common/models/db/stormbase.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import datetime
 
 import bson
@@ -111,11 +110,11 @@ class StormBaseDB(StormFoundationDB):
 class EscapedDictField(me.DictField):
 
     def to_mongo(self, value):
-        value = mongoescape.escape_chars(copy.deepcopy(value))
+        value = mongoescape.escape_chars(value)
         return super(EscapedDictField, self).to_mongo(value)
 
     def to_python(self, value):
-        value = super(EscapedDictField, self).to_python(copy.deepcopy(value))
+        value = super(EscapedDictField, self).to_python(value)
         return mongoescape.unescape_chars(value)
 
     def validate(self, value):
@@ -129,11 +128,11 @@ class EscapedDictField(me.DictField):
 class EscapedDynamicField(me.DynamicField):
 
     def to_mongo(self, value):
-        value = mongoescape.escape_chars(copy.deepcopy(value))
+        value = mongoescape.escape_chars(value)
         return super(EscapedDynamicField, self).to_mongo(value)
 
     def to_python(self, value):
-        value = super(EscapedDynamicField, self).to_python(copy.deepcopy(value))
+        value = super(EscapedDynamicField, self).to_python(value)
         return mongoescape.unescape_chars(value)
 
 

--- a/st2common/st2common/models/db/stormbase.py
+++ b/st2common/st2common/models/db/stormbase.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import datetime
 
 import bson
@@ -110,11 +111,11 @@ class StormBaseDB(StormFoundationDB):
 class EscapedDictField(me.DictField):
 
     def to_mongo(self, value):
-        value = mongoescape.escape_chars(value)
+        value = mongoescape.escape_chars(copy.deepcopy(value))
         return super(EscapedDictField, self).to_mongo(value)
 
     def to_python(self, value):
-        value = super(EscapedDictField, self).to_python(value)
+        value = super(EscapedDictField, self).to_python(copy.deepcopy(value))
         return mongoescape.unescape_chars(value)
 
     def validate(self, value):
@@ -128,11 +129,11 @@ class EscapedDictField(me.DictField):
 class EscapedDynamicField(me.DynamicField):
 
     def to_mongo(self, value):
-        value = mongoescape.escape_chars(value)
+        value = mongoescape.escape_chars(copy.deepcopy(value))
         return super(EscapedDynamicField, self).to_mongo(value)
 
     def to_python(self, value):
-        value = super(EscapedDynamicField, self).to_python(value)
+        value = super(EscapedDynamicField, self).to_python(copy.deepcopy(value))
         return mongoescape.unescape_chars(value)
 
 

--- a/st2common/st2common/util/mongoescape.py
+++ b/st2common/st2common/util/mongoescape.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import six
 
 # http://docs.mongodb.org/manual/faq/developers/#faq-dollar-sign-escaping
@@ -53,10 +54,12 @@ def _translate_chars(field, translation):
 
 
 def escape_chars(field):
-    return _translate_chars(field, ESCAPE_TRANSLATION)
+    value = copy.deepcopy(field)
+    return _translate_chars(value, ESCAPE_TRANSLATION)
 
 
 def unescape_chars(field):
-    translated = _translate_chars(field, UNESCAPE_TRANSLATION)
-    translated = _translate_chars(field, RULE_CRITERIA_UNESCAPE_TRANSLATION)
+    value = copy.deepcopy(field)
+    translated = _translate_chars(value, UNESCAPE_TRANSLATION)
+    translated = _translate_chars(value, RULE_CRITERIA_UNESCAPE_TRANSLATION)
     return translated

--- a/st2common/tests/unit/test_action_db_utils.py
+++ b/st2common/tests/unit/test_action_db_utils.py
@@ -132,7 +132,35 @@ class ActionDBUtilsTestCase(DbTestCase):
         self.assertDictEqual(newliveaction_db.context, context)
         self.assertEqual(newliveaction_db.end_timestamp, now)
 
-        # Update result in dict.
+    @mock.patch.object(LiveActionPublisher, 'publish_state', mock.MagicMock())
+    def test_update_liveaction_result_with_dotted_key(self):
+        liveaction_db = LiveActionDB()
+        liveaction_db.status = 'initializing'
+        liveaction_db.start_timestamp = get_datetime_utc_now()
+        liveaction_db.action = ResourceReference(
+            name=ActionDBUtilsTestCase.action_db.name,
+            pack=ActionDBUtilsTestCase.action_db.pack).ref
+        params = {
+            'actionstr': 'foo',
+            'some_key_that_aint_exist_in_action_or_runner': 'bar',
+            'runnerint': 555
+        }
+        liveaction_db.parameters = params
+        liveaction_db = LiveAction.add_or_update(liveaction_db)
+        origliveaction_db = copy.copy(liveaction_db)
+
+        # Update by id.
+        newliveaction_db = action_db_utils.update_liveaction_status(
+            status='running', liveaction_id=liveaction_db.id)
+
+        # Verify id didn't change.
+        self.assertEqual(origliveaction_db.id, newliveaction_db.id)
+        self.assertEqual(newliveaction_db.status, 'running')
+
+        # Verify that state is published.
+        self.assertTrue(LiveActionPublisher.publish_state.called)
+        LiveActionPublisher.publish_state.assert_called_once_with(newliveaction_db, 'running')
+
         now = get_datetime_utc_now()
         status = 'succeeded'
         result = {'a': 1, 'b': True, 'a.b.c': 'abc'}

--- a/st2common/tests/unit/test_action_db_utils.py
+++ b/st2common/tests/unit/test_action_db_utils.py
@@ -132,6 +132,22 @@ class ActionDBUtilsTestCase(DbTestCase):
         self.assertDictEqual(newliveaction_db.context, context)
         self.assertEqual(newliveaction_db.end_timestamp, now)
 
+        # Update result in dict.
+        now = get_datetime_utc_now()
+        status = 'succeeded'
+        result = {'a': 1, 'b': True, 'a.b.c': 'abc'}
+        context = {'third_party_id': uuid.uuid4().hex}
+        newliveaction_db = action_db_utils.update_liveaction_status(
+            status=status, result=result, context=context, end_timestamp=now,
+            liveaction_id=liveaction_db.id)
+
+        self.assertEqual(origliveaction_db.id, newliveaction_db.id)
+        self.assertEqual(newliveaction_db.status, status)
+        self.assertIn('a.b.c', result.keys())
+        self.assertDictEqual(newliveaction_db.result, result)
+        self.assertDictEqual(newliveaction_db.context, context)
+        self.assertEqual(newliveaction_db.end_timestamp, now)
+
     @mock.patch.object(LiveActionPublisher, 'publish_state', mock.MagicMock())
     def test_update_LiveAction_status_invalid(self):
         liveaction_db = LiveActionDB()

--- a/st2common/tests/unit/test_mongoescape.py
+++ b/st2common/tests/unit/test_mongoescape.py
@@ -57,3 +57,14 @@ class TestMongoEscape(unittest.TestCase):
 
         result = mongoescape.unescape_chars(escaped)
         self.assertEqual(result, unescaped)
+
+    def test_original_value(self):
+        field = {'k1.k2.k3': 'v1'}
+
+        escaped = mongoescape.escape_chars(field)
+        self.assertIn('k1.k2.k3', field.keys())
+        self.assertIn(u'k1\uff0ek2\uff0ek3', escaped.keys())
+
+        unescaped = mongoescape.unescape_chars(escaped)
+        self.assertIn('k1.k2.k3', unescaped.keys())
+        self.assertIn(u'k1\uff0ek2\uff0ek3', escaped.keys())


### PR DESCRIPTION
The DB model permanently changed the dict result when escaping the characters for persistence and then cascade the changes to other components. The fix makes a copy of the dict before escaping.