### PR TITLE
Allow user to include additional context when submitting debug info

### DIFF
--- a/st2debug/st2debug/cmd/submit_debug_info.py
+++ b/st2debug/st2debug/cmd/submit_debug_info.py
@@ -312,6 +312,9 @@ def create_archive(include_logs, include_configs, include_content, include_syste
             file_path = os.path.normpath(file_path)
             source_dir = file_path
 
+            if not os.path.exists(source_dir):
+                continue
+
             if '.' in file_path:
                 arcname = os.path.basename(file_path)
             else:

--- a/st2debug/st2debug/cmd/submit_debug_info.py
+++ b/st2debug/st2debug/cmd/submit_debug_info.py
@@ -213,7 +213,7 @@ def get_system_information():
 
 
 def create_archive(include_logs, include_configs, include_content, include_system_info,
-                   debug=False):
+                   user_info=None, debug=False):
     """
     Create an archive with debugging information.
 
@@ -234,7 +234,8 @@ def create_archive(include_logs, include_configs, include_content, include_syste
         'logs': os.path.join(temp_dir_path, 'logs/'),
         'configs': os.path.join(temp_dir_path, 'configs/'),
         'content': os.path.join(temp_dir_path, 'content/'),
-        'system_info': os.path.join(temp_dir_path, 'system_info.yaml')
+        'system_info': os.path.join(temp_dir_path, 'system_info.yaml'),
+        'user_info': os.path.join(temp_dir_path, 'user_info.yaml')
     }
 
     for directory_name in DIRECTORY_STRUCTURE:
@@ -279,6 +280,13 @@ def create_archive(include_logs, include_configs, include_content, include_syste
 
         with open(output_paths['system_info'], 'w') as fp:
             fp.write(system_information)
+
+    if user_info:
+        LOG.debug('Including user info')
+        user_info = yaml.dump(user_info, default_flow_style=False)
+
+        with open(output_paths['user_info'], 'w') as fp:
+            fp.write(user_info)
 
     # Configs
     st2_config_path = os.path.join(output_paths['configs'], ST2_CONFIG_FILE_NAME)
@@ -358,12 +366,14 @@ def upload_archive(archive_file_path):
 
 
 def create_and_review_archive(include_logs, include_configs, include_content, include_system_info,
-                              debug=False):
+                              user_info=None, debug=False):
     try:
         plain_text_output_path = create_archive(include_logs=include_logs,
                                                 include_configs=include_configs,
                                                 include_content=include_content,
-                                                include_system_info=include_system_info)
+                                                include_system_info=include_system_info,
+                                                user_info=user_info,
+                                                debug=debug)
     except Exception:
         LOG.exception('Failed to generate tarball', exc_info=True)
     else:
@@ -372,12 +382,14 @@ def create_and_review_archive(include_logs, include_configs, include_content, in
 
 
 def create_and_upload_archive(include_logs, include_configs, include_content, include_system_info,
-                              debug=False):
+                              user_info=None, debug=False):
     try:
         plain_text_output_path = create_archive(include_logs=include_logs,
                                                 include_configs=include_configs,
                                                 include_content=include_content,
-                                                include_system_info=include_system_info)
+                                                include_system_info=include_system_info,
+                                                user_info=user_info,
+                                                debug=debug)
         encrypted_output_path = encrypt_archive(archive_file_path=plain_text_output_path)
         upload_archive(archive_file_path=encrypted_output_path)
     except Exception:
@@ -389,6 +401,7 @@ def create_and_upload_archive(include_logs, include_configs, include_content, in
         LOG.info('Debug tarball successfully uploaded to StackStorm (name=%s)' % (tarball_name))
         LOG.info('When communicating with support, please let them know the tarball name - %s' %
                  (tarball_name))
+
     finally:
         # Remove tarballs
         if plain_text_output_path:
@@ -447,6 +460,19 @@ def main():
             print('Aborting')
             sys.exit(1)
 
+    # Prompt user for optional additional context info
+    user_info = {}
+
+    print('If you want us to get back to you via email, you can provide additional context '
+          'such as your name, email and an optional comment')
+    value = six.moves.input('Would you like to provide additional context? [y/n] ')
+    if value.strip().lower() in ['y', 'yes']:
+        user_info['name'] = six.moves.input('Name: ')
+        user_info['email'] = six.moves.input('Email: ')
+        user_info['comment'] = six.moves.input('Comment: ')
+    else:
+        user_info = {}
+
     setup_logging()
 
     if args.review:
@@ -454,10 +480,12 @@ def main():
                                   include_configs=not args.exclude_configs,
                                   include_content=not args.exclude_content,
                                   include_system_info=not args.exclude_system_info,
+                                  user_info=user_info,
                                   debug=args.debug)
     else:
         create_and_upload_archive(include_logs=not args.exclude_logs,
                                   include_configs=not args.exclude_configs,
                                   include_content=not args.exclude_content,
                                   include_system_info=not args.exclude_system_info,
+                                  user_info=user_info,
                                   debug=args.debug)


### PR DESCRIPTION
This change allows user to include additional context (name, email and optional email) when submitting debug info.

Keep in mind that this is opt-in and user is not required to provide this info.