### PR TITLE
Mistral itests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,11 @@ python:
 env:
   - TASK=unit
   - TASK=integration
+  - TASK=mistral
 
 services:
   - mongodb
+  - postgresql
   - rabbitmq
 
 cache:
@@ -20,7 +22,8 @@ cache:
 install:
   - pip install python-coveralls
   - make requirements
-  - if [ ${TASK} = 'integration' ]; then sudo ./scripts/travis/prepare-integration.sh; fi
+  - if [ ${TASK} = 'integration' ] || [ ${TASK} = 'mistral' ]; then sudo ./scripts/travis/prepare-integration.sh; fi
+  - if [ ${TASK} = 'mistral' ]; then sudo ./scripts/travis/setup-mistral.sh; fi
 
 script:
   - ./scripts/travis/build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ env:
   - TASK=integration
   - TASK=mistral
 
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: TASK=mistral
+
 services:
   - mongodb
   - postgresql

--- a/Makefile
+++ b/Makefile
@@ -304,6 +304,15 @@ mistral-itests: requirements .mistral-itests
 	@echo
 	. $(VIRTUALENV_DIR)/bin/activate; nosetests -s -v st2tests/integration || exit 1;
 
+.PHONY: .mistral-itests-coverage-html
+.mistral-itests-coverage-html:
+	@echo
+	@echo "==================== MISTRAL integration tests with coverage (HTML reports) ===================="
+	@echo "The tests assume both st2 and mistral are running on localhost."
+	@echo
+	. $(VIRTUALENV_DIR)/bin/activate; nosetests -s -v --with-coverage \
+		--cover-inclusive --cover-html st2tests/integration || exit 1;
+
 .PHONY: rpms
 rpms:
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,7 @@ mistral-itests: requirements .mistral-itests
 	@echo "==================== MISTRAL integration tests ===================="
 	@echo "The tests assume both st2 and mistral are running on localhost."
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate; nosetests -s -v st2tests/integration || exit 1;
+	. $(VIRTUALENV_DIR)/bin/activate; nosetests -s -v st2tests/integration/mistral || exit 1;
 
 .PHONY: .mistral-itests-coverage-html
 .mistral-itests-coverage-html:
@@ -311,7 +311,7 @@ mistral-itests: requirements .mistral-itests
 	@echo "The tests assume both st2 and mistral are running on localhost."
 	@echo
 	. $(VIRTUALENV_DIR)/bin/activate; nosetests -s -v --with-coverage \
-		--cover-inclusive --cover-html st2tests/integration || exit 1;
+		--cover-inclusive --cover-html st2tests/integration/mistral || exit 1;
 
 .PHONY: rpms
 rpms:

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -12,6 +12,8 @@ if [ ${TASK} == 'unit' ]; then
   make .unit-tests-coverage-html
 elif [ ${TASK} == 'integration' ]; then
   make .itests-coverage-html
+elif [ ${TASK} == 'mistral' ]; then
+  make .mistral-itests-coverage-html
 else
   echo "Invalid task: ${TASK}"
   exit 2

--- a/scripts/travis/prepare-integration.sh
+++ b/scripts/travis/prepare-integration.sh
@@ -12,7 +12,6 @@ TYPE='debs'
 SYSTEMUSER='stanley'
 STAN="/home/${SYSTEMUSER}/${TYPE}"
 mkdir -p ${STAN}
-mkdir -p /var/log/st2
 
 create_user() {
   if [ $(id -u ${SYSTEMUSER} &> /devnull; echo $?) != 0 ]

--- a/scripts/travis/prepare-integration.sh
+++ b/scripts/travis/prepare-integration.sh
@@ -10,25 +10,38 @@ fi
 # proudly stolen from `./tools/st2_deploy.sh`
 TYPE='debs'
 SYSTEMUSER='stanley'
+STAN="/home/${SYSTEMUSER}/${TYPE}"
+mkdir -p ${STAN}
+mkdir -p /var/log/st2
 
-echo "###########################################################################################"
-echo "# Creating system user: ${SYSTEMUSER}"
-useradd ${SYSTEMUSER}
-mkdir -p /home/${SYSTEMUSER}/.ssh
-chmod 0700 /home/${SYSTEMUSER}/.ssh
-mkdir -p /home/${SYSTEMUSER}/${TYPE}
-echo "###########################################################################################"
-echo "# Generating system user ssh keys"
-ssh-keygen -f /home/${SYSTEMUSER}/.ssh/stanley_rsa -P ""
-cat /home/${SYSTEMUSER}/.ssh/stanley_rsa.pub >> /home/${SYSTEMUSER}/.ssh/authorized_keys
-chmod 0600 /home/${SYSTEMUSER}/.ssh/authorized_keys
-chown -R ${SYSTEMUSER}:${SYSTEMUSER} /home/${SYSTEMUSER}
-if [ $(grep 'stanley' /etc/sudoers.d/* &> /dev/null; echo $?) != 0 ]; then
-    echo "${SYSTEMUSER}    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2
-    chmod 0440 /etc/sudoers.d/st2
-fi
-# make sure requiretty is disabled.
-sed -i "s/^Defaults\s\+requiretty/# Defaults requiretty/g" /etc/sudoers
+create_user() {
+  if [ $(id -u ${SYSTEMUSER} &> /devnull; echo $?) != 0 ]
+  then
+    echo "###########################################################################################"
+    echo "# Creating system user: ${SYSTEMUSER}"
+    useradd ${SYSTEMUSER}
+    mkdir -p /home/${SYSTEMUSER}/.ssh
+    rm -Rf ${STAN}/*
+    chmod 0700 /home/${SYSTEMUSER}/.ssh
+    mkdir -p /home/${SYSTEMUSER}/${TYPE}
+    echo "###########################################################################################"
+    echo "# Generating system user ssh keys"
+    ssh-keygen -f /home/${SYSTEMUSER}/.ssh/stanley_rsa -P ""
+    cat /home/${SYSTEMUSER}/.ssh/stanley_rsa.pub >> /home/${SYSTEMUSER}/.ssh/authorized_keys
+    chmod 0600 /home/${SYSTEMUSER}/.ssh/authorized_keys
+    chown -R ${SYSTEMUSER}:${SYSTEMUSER} /home/${SYSTEMUSER}
+    if [ $(grep 'stanley' /etc/sudoers.d/* &> /dev/null; echo $?) != 0 ]
+    then
+      echo "${SYSTEMUSER}    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2
+      chmod 0440 /etc/sudoers.d/st2
+    fi
+
+    # make sure requiretty is disabled.
+    sed -i "s/^Defaults\s\+requiretty/# Defaults requiretty/g" /etc/sudoers
+  fi
+}
+
+create_user
 
 # install st2 client
 python ./st2client/setup.py develop

--- a/scripts/travis/setup-mistral.sh
+++ b/scripts/travis/setup-mistral.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -e
+
+if [ "$(whoami)" != 'root' ]; then
+    echo 'Please run with sudo'
+    exit 2
+fi
+
+MISTRAL_STABLE_BRANCH="st2-0.9.0"
+STANCONF="${PWD}/conf/st2.dev.conf"
+
+setup_mistral_st2_config()
+{
+  echo "" >> ${STANCONF}
+  echo "[mistral]" >> ${STANCONF}
+  echo "v2_base_url = http://127.0.0.1:8989/v2" >> ${STANCONF}
+}
+
+setup_mistral_config()
+{
+config=/etc/mistral/mistral.conf
+echo "Writing Mistral configuration file to $config..."
+if [ -e "$config" ]; then
+  rm $config
+fi
+touch $config
+cat <<mistral_config >$config
+[database]
+connection=postgresql://mistral:StackStorm@localhost/mistral
+max_pool_size=50
+
+[pecan]
+auth_enable=false
+mistral_config
+}
+
+setup_mistral_log_config()
+{
+log_config=/etc/mistral/wf_trace_logging.conf
+echo "Writing Mistral log configuration file to $log_config..."
+if [ -e "$log_config" ]; then
+    rm $log_config
+fi
+cp /opt/openstack/mistral/etc/wf_trace_logging.conf.sample $log_config
+sed -i "s~tmp~var/log~g" $log_config
+}
+
+setup_mistral_db()
+{
+  echo "Setting up Mistral DB in PostgreSQL..."
+  sudo -u postgres psql -c "DROP DATABASE IF EXISTS mistral;"
+  sudo -u postgres psql -c "DROP USER IF EXISTS mistral;"
+  sudo -u postgres psql -c "CREATE USER mistral WITH ENCRYPTED PASSWORD 'StackStorm';"
+  sudo -u postgres psql -c "CREATE DATABASE mistral OWNER mistral;"
+
+  echo "Creating and populating DB tables for Mistral..."
+  config=/etc/mistral/mistral.conf
+  cd /opt/openstack/mistral
+  /opt/openstack/mistral/.venv/bin/python ./tools/sync_db.py --config-file ${config}
+}
+
+setup_mistral_upstart()
+{
+echo "Setting up upstart for Mistral..."
+upstart=/etc/init/mistral.conf
+if [ -e "$upstart" ]; then
+    rm $upstart
+fi
+touch $upstart
+cat <<mistral_upstart >$upstart
+description "Mistral Workflow Service"
+
+start on runlevel [2345]
+stop on runlevel [016]
+respawn
+
+exec /opt/openstack/mistral/.venv/bin/python /opt/openstack/mistral/mistral/cmd/launch.py --config-file /etc/mistral/mistral.conf --log-config-append /etc/mistral/wf_trace_logging.conf
+mistral_upstart
+}
+
+setup_mistral() {
+  echo "###########################################################################################"
+  echo "# Setting up Mistral"
+
+  # Clone mistral from github.
+  mkdir -p /opt/openstack
+  cd /opt/openstack
+  if [ -d "/opt/openstack/mistral" ]; then
+    rm -r /opt/openstack/mistral
+  fi
+  echo "Cloning Mistral branch: ${MISTRAL_STABLE_BRANCH}..."
+  git clone -b ${MISTRAL_STABLE_BRANCH} https://github.com/StackStorm/mistral.git
+
+  # Setup virtualenv for running mistral.
+  cd /opt/openstack/mistral
+  virtualenv --no-site-packages .venv
+  . /opt/openstack/mistral/.venv/bin/activate
+  pip install -q -r requirements.txt
+  pip install -q psycopg2
+  python setup.py develop
+
+  # Setup plugins for actions.
+  mkdir -p /etc/mistral/actions
+  if [ -d "/etc/mistral/actions/st2mistral" ]; then
+    rm -r /etc/mistral/actions/st2mistral
+  fi
+  echo "Cloning St2mistral branch: ${MISTRAL_STABLE_BRANCH}..."
+  cd /etc/mistral/actions
+  git clone -b ${MISTRAL_STABLE_BRANCH} https://github.com/StackStorm/st2mistral.git
+  cd /etc/mistral/actions/st2mistral
+  python setup.py develop
+
+  # Create configuration files.
+  mkdir -p /etc/mistral
+  setup_mistral_config
+  setup_mistral_log_config
+  setup_mistral_st2_config
+
+  # Setup database.
+  setup_mistral_db
+
+  # Setup service.
+  setup_mistral_upstart
+
+  # Deactivate venv.
+  deactivate
+
+  # Setup mistral client.
+  pip install -q -U git+https://github.com/StackStorm/python-mistralclient.git@${MISTRAL_STABLE_BRANCH}
+}
+
+setup_mistral
+
+start mistral
+
+echo 'Done!'


### PR DESCRIPTION
Adds existing mistral tests to Travis.

As I remember there were some mistral installation problems before (dependencies). This addition might be useful to identify and react on mistral-related issues faster and it's just cool to have more tests in Travis.

---

[`scripts/travis/setup-mistral.sh`](https://github.com/armab/st2/blob/c2a8b002b92f554d7bd967f9ab5de665bf9d1064/scripts/travis/setup-mistral.sh) uses code from [`st2_deploy.sh`](https://github.com/StackStorm/st2/blob/master/tools/st2_deploy.sh)

The thing I'm afraid of is synchronization with original `st2_deploy.sh`. I couldn't find an easy way to reuse bash functions from that script.
Not sure if it worth to rewrite a bit `st2_deploy.sh` and use Pythonish way `if __name__ == '__main__':` (you got the idea) to allow reusing functions from that file.