### PR TITLE
Action: fix default parameters override

### DIFF
--- a/st2actions/st2actions/utils/param_utils.py
+++ b/st2actions/st2actions/utils/param_utils.py
@@ -65,7 +65,7 @@ def _get_resolved_runner_params(runner_parameters, action_parameters,
         # pickup the override.
         if param_name in action_parameters:
             action_param = action_parameters[param_name]
-            if action_param.get('default', False):
+            if 'default' in action_param:
                 resolved_params[param_name] = action_param['default']
 
             # No further override (from liveaction) if param is immutable

--- a/st2actions/tests/unit/test_param_utils.py
+++ b/st2actions/tests/unit/test_param_utils.py
@@ -51,7 +51,8 @@ class ParamsUtilsTest(DbTestCase):
             'some_key_that_aint_exist_in_action_or_runner': 'bar',
             'runnerint': 555,
             'runnerimmutable': 'failed_override',
-            'actionimmutable': 'failed_override'
+            'actionimmutable': 'failed_override',
+            'defaults_ovverriden_by_execution': 0,
         }
         liveaction_db = self._get_liveaction_model(params)
 
@@ -65,11 +66,16 @@ class ParamsUtilsTest(DbTestCase):
         self.assertEqual(runner_params.get('runnerstr'), 'defaultfoo')
         # Assert that a runner param from action exec is picked up.
         self.assertEqual(runner_params.get('runnerint'), 555)
-        # Assert that a runner param can be overriden by action param default.
+        # Assert that a runner param can be overridden by action param default.
         self.assertEqual(runner_params.get('runnerdummy'), 'actiondummy')
-        # Asser that runner param made immutable in action can use default value in runner.
+        # Assert that a runner param default can be overridden by 'falsey' action param default,
+        # (timeout: 0 case).
+        self.assertEqual(runner_params.get('runnerdefaultint'), 0)
+        # Assert that execution param overrides both runner and action params defaults.
+        self.assertEqual(runner_params.get('defaults_ovverriden_by_execution'), 0)
+        # Assert that runner param made immutable in action can use default value in runner.
         self.assertEqual(runner_params.get('runnerfoo'), 'FOO')
-        # Assert that an immutable param cannot be overriden by action param or execution param.
+        # Assert that an immutable param cannot be overridden by action param or execution param.
         self.assertEqual(runner_params.get('runnerimmutable'), 'runnerimmutable')
 
         # Asserts for action params.
@@ -77,7 +83,7 @@ class ParamsUtilsTest(DbTestCase):
         # Assert that a param that is provided in action exec that isn't in action or runner params
         # isn't in resolved params.
         self.assertEqual(action_params.get('some_key_that_aint_exist_in_action_or_runner'), None)
-        # Assert that an immutable param cannot be overriden by execution param.
+        # Assert that an immutable param cannot be overridden by execution param.
         self.assertEqual(action_params.get('actionimmutable'), 'actionimmutable')
         # Assert that none of runner params are present in action_params.
         for k in action_params:
@@ -104,9 +110,9 @@ class ParamsUtilsTest(DbTestCase):
         self.assertEqual(runner_params.get('runnerstr'), 'defaultfoo')
         # Assert that a runner param from action exec is picked up.
         self.assertEqual(runner_params.get('runnerint'), 555)
-        # Assert that a runner param can be overriden by action param default.
+        # Assert that a runner param can be overridden by action param default.
         self.assertEqual(runner_params.get('runnerdummy'), 'actiondummy')
-        # Assert that an immutable param cannot be overriden by action param or execution param.
+        # Assert that an immutable param cannot be overridden by action param or execution param.
         self.assertEqual(runner_params.get('runnerimmutable'), 'runnerimmutable')
 
         # Asserts for action params.
@@ -114,7 +120,7 @@ class ParamsUtilsTest(DbTestCase):
         # Assert that a param that is provided in action exec that isn't in action or runner params
         # isn't in resolved params.
         self.assertEqual(action_params.get('some_key_that_aint_exist_in_action_or_runner'), None)
-        # Assert that an immutable param cannot be overriden by execution param.
+        # Assert that an immutable param cannot be overridden by execution param.
         self.assertEqual(action_params.get('actionimmutable'), 'actionimmutable')
         # Assert that an action context param is set correctly.
         self.assertEqual(action_params.get('action_api_user'), 'noob')
@@ -141,7 +147,7 @@ class ParamsUtilsTest(DbTestCase):
         self.assertEqual(runner_params.get('runnerstr'), 'defaultfoo')
         # Assert that a runner param from action exec is picked up.
         self.assertEqual(runner_params.get('runnerint'), 555)
-        # Assert that an immutable param cannot be overriden by action param or execution param.
+        # Assert that an immutable param cannot be overridden by action param or execution param.
         self.assertEqual(runner_params.get('runnerimmutable'), 'runnerimmutable')
 
         # Asserts for action params.
@@ -167,7 +173,7 @@ class ParamsUtilsTest(DbTestCase):
         self.assertEqual(runner_params.get('runnerstr'), 'defaultfoo')
         # Assert that a runner param from action exec is picked up.
         self.assertEqual(runner_params.get('runnerint'), 555)
-        # Assert that a runner param can be overriden by action param default.
+        # Assert that a runner param can be overridden by action param default.
         self.assertEqual(runner_params.get('runnerdummy'), 'actiondummy')
 
         # Asserts for action params.

--- a/st2tests/st2tests/fixtures/generic/actions/action_4_action_context_param.yaml
+++ b/st2tests/st2tests/fixtures/generic/actions/action_4_action_context_param.yaml
@@ -31,4 +31,12 @@ parameters:
   runnerimmutable:
     default: failed_override
     type: string
+  runnerdefaultint:
+    default: 0
+    description: Falsey integer param, overrides runner default. Covers timeout 0 issue
+    type: integer
+  defaults_ovverriden_by_execution:
+    default: 1
+    description: Overrides runner default. Will be overriden by live action
+    type: integer
 runner_type: test-runner-1

--- a/st2tests/st2tests/fixtures/generic/runners/testrunner1.yaml
+++ b/st2tests/st2tests/fixtures/generic/runners/testrunner1.yaml
@@ -19,6 +19,14 @@ runner_parameters:
   runnerint:
     description: Foo int param.
     type: number
+  runnerdefaultint:
+    default: 60
+    description: Default integer param.
+    type: integer
+  defaults_ovverriden_by_execution:
+    default: 90
+    description: Will be overridden by action and then by live execution.
+    type: integer
   runnerstr:
     default: defaultfoo
     description: Foo str param.


### PR DESCRIPTION
Fixes #1654 , when runner parameters were not overridden with "falsey" action parameters (0, False, etc), so this meta was buggy:

```yaml
---
  name: "test"
  runner_type: "local-shell-cmd"
  description: "Action that tests timeout."
  enabled: true
  entry_point: ""
  parameters:
    timeout:
      # this worked as default 60 seconds
      # default: 0

      # however this worked as 0 seconds
      # default: "0"
    cmd:
      default: "echo 'TIMEOUT: {{timeout}}'"
```

(extracted from #1712 )