### PR TITLE
Add path to Python binary to be added to spec file

### DIFF
--- a/st2client/Makefile
+++ b/st2client/Makefile
@@ -9,7 +9,7 @@ COMPONENTS := st2client
 
 .PHONY: rpm
 rpm: 
-	$(PY27) setup.py bdist_rpm
+	$(PY27) setup.py bdist_rpm --python=$(PY27)
 	mkdir -p $(RPM_ROOT)/RPMS/noarch
 	cp dist/$(COMPONENTS)*noarch.rpm $(RPM_ROOT)/RPMS/noarch/$(COMPONENTS)-$(VER)-$(RELEASE).noarch.rpm
 	mkdir -p $(RPM_ROOT)/SRPMS


### PR DESCRIPTION
Yet another fix for EL6.