### PR TITLE
Freeze tooz version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pyyaml
 requests
 setuptools==11.1
 six==1.9.0
-tooz
+tooz==1.20.0
 git+https://github.com/StackStorm/python-mistralclient.git@st2-0.9.0
 git+https://github.com/StackStorm/fabric.git@stanley-patched
 passlib>=1.6.2,<1.7


### PR DESCRIPTION
* tooz 1.21.0 breaks test and unleashes monsters from the pits of hell. So until
  the gods have mercy on us and fix the break freeze to last known version.
* Test test_over_threshold (tests.unit.policies.test_concurrency.ConcurrencyPolicyTest)
  woudl simply block.