### PR TITLE
Support to allow ssh_config for fabric based runners.

### DIFF
--- a/docs/source/install/config.rst
+++ b/docs/source/install/config.rst
@@ -106,6 +106,19 @@ SSH Troubleshooting
 
         sudo ssh -i /home/stanley/.ssh/stanley_rsa -t stanley@host.example.com uname -a
 
+Using SSH config
+~~~~~~~~~~~~~~~~
+
+StackStorm allows loading of the SSH config file local to the system user. This is a configurable option and to
+enable add following to ``/etc/st2/st2.conf``
+
+.. code-block:: bash
+
+    [ssh_runner]
+    use_ssh_config = True
+    ...
+
+
 Configure Logging
 -----------------
 

--- a/st2actions/st2actions/config.py
+++ b/st2actions/st2actions/config.py
@@ -62,7 +62,10 @@ def _register_action_runner_opts():
                    help='Location of the script on the remote filesystem.'),
         cfg.BoolOpt('allow_partial_failure',
                     default=False,
-                    help='How partial success of actions run on multiple nodes should be treated.')
+                    help='How partial success of actions run on multiple nodes should be treated.'),
+        cfg.BoolOpt('use_ssh_config',
+                    default=False,
+                    help='Use the .ssh/config file. Useful to override ports etc.')
     ]
     CONF.register_opts(ssh_runner_opts, group='ssh_runner')
 

--- a/st2actions/st2actions/runners/fabric_runner.py
+++ b/st2actions/st2actions/runners/fabric_runner.py
@@ -35,6 +35,7 @@ LOG = logging.getLogger(__name__)
 # Fabric environment level settings.
 # XXX: Note fabric env is a global singleton.
 env.parallel = True  # By default, execute things in parallel. Uses multiprocessing under the hood.
+env.use_ssh_config = cfg.CONF.ssh_runner.use_ssh_config
 env.user = cfg.CONF.system_user.user
 ssh_key_file = cfg.CONF.system_user.ssh_key_file
 

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -118,7 +118,10 @@ def _register_api_opts():
                    help='Location of the script on the remote filesystem.'),
         cfg.BoolOpt('allow_partial_failure',
                     default=False,
-                    help='How partial success of actions run on multiple nodes should be treated.')
+                    help='How partial success of actions run on multiple nodes should be treated.'),
+        cfg.BoolOpt('use_ssh_config',
+                    default=False,
+                    help='Use the .ssh/config file. Useful to override ports etc.')
     ]
     _register_opts(ssh_runner_opts, group='ssh_runner')
 


### PR DESCRIPTION
* Setting is not enabled by default but exposed as configuration to avoid
  any odd behavior - Since it is fabric afterall.
* Fabric support for ssh_config is limited and should only really be used
  for simple things like ports (http://docs.fabfile.org/en/1.4.0/usage/execution.html#leveraging-native-ssh-config-files)