### PR TITLE
Update st2tests fixtures

### DIFF
--- a/st2actions/tests/unit/test_executions.py
+++ b/st2actions/tests/unit/test_executions.py
@@ -72,7 +72,7 @@ class TestActionExecutionHistoryWorker(DbTestCase):
         super(TestActionExecutionHistoryWorker, self).tearDown()
 
     def test_basic_execution(self):
-        liveaction = LiveActionDB(action='core.local', parameters={'cmd': 'uname -a'})
+        liveaction = LiveActionDB(action='executions.local', parameters={'cmd': 'uname -a'})
         liveaction, _ = action_service.request(liveaction)
         liveaction = LiveAction.get_by_id(str(liveaction.id))
         self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_FAILED)
@@ -82,7 +82,7 @@ class TestActionExecutionHistoryWorker(DbTestCase):
         self.assertDictEqual(execution.trigger_type, {})
         self.assertDictEqual(execution.trigger_instance, {})
         self.assertDictEqual(execution.rule, {})
-        action = action_utils.get_action_by_ref('core.local')
+        action = action_utils.get_action_by_ref('executions.local')
         self.assertDictEqual(execution.action, vars(ActionAPI.from_model(action)))
         runner = RunnerType.get_by_name(action.runner_type['name'])
         self.assertDictEqual(execution.runner, vars(RunnerTypeAPI.from_model(runner)))
@@ -100,13 +100,13 @@ class TestActionExecutionHistoryWorker(DbTestCase):
         self.test_basic_execution()
 
     def test_chained_executions(self):
-        liveaction = LiveActionDB(action='core.chain')
+        liveaction = LiveActionDB(action='executions.chain')
         liveaction, _ = action_service.request(liveaction)
         liveaction = LiveAction.get_by_id(str(liveaction.id))
         self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_FAILED)
         execution = self._get_action_execution(liveaction__id=str(liveaction.id),
                                                raise_exception=True)
-        action = action_utils.get_action_by_ref('core.chain')
+        action = action_utils.get_action_by_ref('executions.chain')
         self.assertDictEqual(execution.action, vars(ActionAPI.from_model(action)))
         runner = RunnerType.get_by_name(action.runner_type['name'])
         self.assertDictEqual(execution.runner, vars(RunnerTypeAPI.from_model(runner)))

--- a/st2api/tests/unit/controllers/v1/test_action_views.py
+++ b/st2api/tests/unit/controllers/v1/test_action_views.py
@@ -25,7 +25,7 @@ ACTION_1 = {
     'description': 'test description',
     'enabled': True,
     'pack': 'wolfpack',
-    'entry_point': '/tmp/test/action1.sh',
+    'entry_point': 'test/action1.sh',
     'runner_type': 'local-shell-script',
     'parameters': {
         'a': {'type': 'string', 'default': 'A1'},
@@ -39,7 +39,7 @@ ACTION_2 = {
     'description': 'test description',
     'enabled': True,
     'pack': 'wolfpack',
-    'entry_point': '/tmp/test/action2.py',
+    'entry_point': 'test/action2.py',
     'runner_type': 'local-shell-script',
     'parameters': {
         'c': {'type': 'string', 'default': 'C1', 'position': 0},

--- a/st2api/tests/unit/controllers/v1/test_executions_filters.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_filters.py
@@ -99,13 +99,13 @@ class TestActionExecutionFilters(FunctionalTest):
 
     def test_get_all_exclude_attributes(self):
         # No attributes excluded
-        response = self.app.get('/v1/executions?action=core.local&limit=1')
+        response = self.app.get('/v1/executions?action=executions.local&limit=1')
 
         self.assertEqual(response.status_int, 200)
         self.assertTrue('result' in response.json[0])
 
         # Exclude "result" attribute
-        path = '/v1/executions?action=core.local&limit=1&exclude_attributes=result'
+        path = '/v1/executions?action=executions.local&limit=1&exclude_attributes=result'
         response = self.app.get(path)
 
         self.assertEqual(response.status_int, 200)
@@ -131,7 +131,7 @@ class TestActionExecutionFilters(FunctionalTest):
     def test_limit(self):
         limit = 10
         refs = [k for k, v in six.iteritems(self.refs) if v.action['name'] == 'chain']
-        response = self.app.get('/v1/executions?action=core.chain&limit=%s' %
+        response = self.app.get('/v1/executions?action=executions.chain&limit=%s' %
                                 limit)
         self.assertEqual(response.status_int, 200)
         self.assertIsInstance(response.json, list)
@@ -143,7 +143,7 @@ class TestActionExecutionFilters(FunctionalTest):
 
     def test_query(self):
         refs = [k for k, v in six.iteritems(self.refs) if v.action['name'] == 'chain']
-        response = self.app.get('/v1/executions?action=core.chain')
+        response = self.app.get('/v1/executions?action=executions.chain')
         self.assertEqual(response.status_int, 200)
         self.assertIsInstance(response.json, list)
         self.assertEqual(len(response.json), len(refs))

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -66,6 +66,7 @@ def _override_db_opts():
 def _override_common_opts():
     packs_base_path = get_fixtures_base_path()
     CONF.set_override(name='system_packs_base_path', override=packs_base_path, group='content')
+    CONF.set_override(name='packs_base_paths', override=packs_base_path, group='content')
     CONF.set_override(name='api_url', override='http://localhost', group='auth')
     CONF.set_override(name='admin_users', override=['admin_user'], group='system')
     CONF.set_override(name='mask_secrets', override=True, group='log')

--- a/st2tests/st2tests/fixtures/dummy_pack_1/pack.yaml
+++ b/st2tests/st2tests/fixtures/dummy_pack_1/pack.yaml
@@ -1,0 +1,6 @@
+---
+name : dummy_pack_1
+description : dummy pack
+version : 0.1
+author : st2-dev
+email : info@stackstorm.com

--- a/st2tests/st2tests/fixtures/dummy_pack_2/pack.yaml
+++ b/st2tests/st2tests/fixtures/dummy_pack_2/pack.yaml
@@ -1,0 +1,6 @@
+---
+name : dummy_pack_1
+description : dummy pack
+version : 0.1
+author : st2-dev
+email : info@stackstorm.com

--- a/st2tests/st2tests/fixtures/dummy_pack_3/pack.yaml
+++ b/st2tests/st2tests/fixtures/dummy_pack_3/pack.yaml
@@ -1,0 +1,6 @@
+---
+name : dummy_pack_1
+description : dummy pack
+version : 0.1
+author : st2-dev
+email : info@stackstorm.com

--- a/st2tests/st2tests/fixtures/executions/actions.yaml
+++ b/st2tests/st2tests/fixtures/executions/actions.yaml
@@ -2,48 +2,48 @@
 action-immutable-param-no-default:
   enabled: true
   name: action-immutable-param-no-default
-  pack: core
+  pack: executions
   parameters:
     foo:
       immutable: true
-  ref: core.action-immutable-param-no-default
+  ref: executions.action-immutable-param-no-default
   runner_type: run-local
 action-immutable-runner-param-no-default:
   enabled: true
   name: action-immutable-param-no-default
-  pack: core
+  pack: executions
   parameters:
     sudo:
       immutable: true
-  ref: core.action-immutable-param-no-default
+  ref: executions.action-immutable-param-no-default
   runner_type: run-local
 action-with-invalid-runner:
   enabled: true
   name: action-with-invalid-runner
-  pack: core
+  pack: executions
   parameters:
     hosts:
       immutable: false
-  ref: core.action-with-invalid-runner
+  ref: executions.action-with-invalid-runner
   runner_type: invalid-runner
 chain:
   enabled: true
   name: chain
-  pack: core
-  ref: core.chain
+  pack: executions
+  ref: executions.chain
   runner_type: action-chain
 local:
   enabled: true
   name: local
-  pack: core
-  ref: core.local
+  pack: executions
+  ref: executions.local
   runner_type: run-local
 local-override-runner-immutable:
   enabled: true
   name: local-override-runner-immutable
-  pack: core
+  pack: executions
   parameters:
     hosts:
       immutable: false
-  ref: core.local-override-runner-immutable
+  ref: executions.local-override-runner-immutable
   runner_type: run-local

--- a/st2tests/st2tests/fixtures/executions/chain.yaml
+++ b/st2tests/st2tests/fixtures/executions/chain.yaml
@@ -4,9 +4,9 @@ chain:
   on-success: a2
   params:
     cmd: uname -a
-  ref: core.local
+  ref: executions.local
 - name: a2
   params:
     cmd: pwd
-  ref: core.local
+  ref: executions.local
 default: a1

--- a/st2tests/st2tests/fixtures/executions/liveactions.yaml
+++ b/st2tests/st2tests/fixtures/executions/liveactions.yaml
@@ -1,6 +1,6 @@
 ---
 task1:
-  action: core.local
+  action: executions.local
   callback: {}
   context:
     user: system
@@ -20,7 +20,7 @@ task1:
   start_timestamp: '2014-09-01T00:00:02.000000Z'
   status: succeeded
 task2:
-  action: core.local
+  action: executions.local
   callback: {}
   context:
     user: system
@@ -40,7 +40,7 @@ task2:
   start_timestamp: '2014-09-01T00:00:03.000000Z'
   status: succeeded
 workflow:
-  action: core.chain
+  action: executions.chain
   callback: {}
   context:
     user: system

--- a/st2tests/st2tests/fixtures/executions/rule.yaml
+++ b/st2tests/st2tests/fixtures/executions/rule.yaml
@@ -2,7 +2,7 @@
 action:
   parameters:
     cmd: echo "{{trigger}}" >> /tmp/st2.persons.out
-  ref: core.local
+  ref: executions.local
 criteria:
   trigger.name:
     pattern: Joe

--- a/st2tests/st2tests/fixtures/history_views/filters.yaml
+++ b/st2tests/st2tests/fixtures/history_views/filters.yaml
@@ -1,7 +1,7 @@
 ---
 action:
-- core.local
-- core.chain
+- executions.local
+- executions.chain
 rule:
 - st2.person.joe
 runner:


### PR DESCRIPTION
This pull request updates `packs_base_path` in the tests config to point to the `st2tests/fixtures/` directory.

This way we can test resource loading and a lot of other things without needing to mock a bunch of stuff.

In addition to that, #1785 adds constraint that the entry point files needs to be located inside the pack. Before this change, a lot of tests violated this constraint causing failures and a lot of pain.

Note 1: This changes are cherry-pick from #1785 since I also need them in the RBAC branch.

Note 2: Eventually, I will move packs to `st2tests/fixtures/packs/` directory, but now it's not that time :P