### PR TITLE
RFR: Fix trigger-instance manager to handle kwargs passed down

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ in development
 * Add action parameters validation to Mistral workflow on invocation. (improvement)
 * Fix key name for error message in liveaction result. (bug-fix)
 * Fix 500 API response when rule with no pack info is supplied. (bug-fix)
+* Fix bug in trigger-instance re-emit (extra kwargs passed to manager is now handled). (bug-fix)
 
 0.12.1 - July 31, 2015
 ----------------------

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -333,7 +333,7 @@ class LiveActionResourceManager(ResourceManager):
 
 class TriggerInstanceResourceManager(ResourceManager):
     @add_auth_token_to_kwargs_from_env
-    def re_emit(self, trigger_instance_id):
+    def re_emit(self, trigger_instance_id, **kwargs):
         url = '/%s/%s/re_emit' % (self.resource.get_url_path_name(), trigger_instance_id)
         response = self.client.post(url, None)
         if response.status_code != 200:


### PR DESCRIPTION
An extra keyword token is now passed to the managers which is causing trigger_instance re_emit to break. Gosh, abusing kwargs. 