### PR TITLE
RFR -  Rename notify channels to routes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ in development
 * Fix key name for error message in liveaction result. (bug-fix)
 * Fix 500 API response when rule with no pack info is supplied. (bug-fix)
 * Fix bug in trigger-instance re-emit (extra kwargs passed to manager is now handled). (bug-fix)
+* Rename notfication "channels" to "routes". (improvement)
 
 0.12.1 - July 31, 2015
 ----------------------

--- a/contrib/examples/actions/echochain.meta.yaml
+++ b/contrib/examples/actions/echochain.meta.yaml
@@ -17,5 +17,5 @@ parameters:
 notify:
   on-complete:
     message: "\"@channel: Action succeeded.\""
-    channels:
+    routes:
       - "slack"

--- a/contrib/examples/actions/local.yaml
+++ b/contrib/examples/actions/local.yaml
@@ -5,7 +5,7 @@ entry_point: ''
 name: local-notify
 notify:
   on-complete:
-    channels:
+    routes:
     - slack
     message: '"@channel: Action succeeded."'
 parameters:

--- a/contrib/examples/actions/mistral-basic-two-tasks-with-notifications.yaml
+++ b/contrib/examples/actions/mistral-basic-two-tasks-with-notifications.yaml
@@ -24,5 +24,5 @@ parameters:
 notify:
   on-complete:
     message: "\"@channel: Action succeeded.\""
-    channels:
+    routes:
       - "slack"

--- a/instructables/chatops.md
+++ b/instructables/chatops.md
@@ -87,7 +87,7 @@ hubot::env_export:
  HUBOT_LOG_LEVEL: "debug"
  HUBOT_SLACK_TOKEN: "xoxb-XXXX"
  EXPRESS_PORT: 8081
- ST2_CHANNEL: "hubot"
+ ST2_ROUTE: "hubot"
 hubot::external_scripts:
   - "hubot-stackstorm"
 hubot::dependencies:
@@ -96,6 +96,8 @@ hubot::dependencies:
   "hubot-slack": ">=3.3.0 < 4.0.0"
   "hubot-stackstorm": ">= 0.1.0 < 0.2.0"
 ```
+
+Note: ST2_ROUTE used to be ST2_CHANNEL but to avoid confusions with chat client channels, we renamed it.
 
 Take note of the `EXPRESS_PORT` environment variable. Hubot's HTTP port in `st2workroom` needs to be moved to `TCP 8081` to avoid port conflict with `st2web`, which serves on `TCP 8080`. If you are not running your bot on the same machine where StackStorm is running, you can omit this variable. Pay attention to this information, however, as it is needed in order to configure a callback from StackStorm.
 
@@ -200,7 +202,7 @@ formats:
   - "google {{query}}"
 ```
 
-Now, navigate to the hubot pack `rules` directory, and view the notify_hubot rule. This is a notification rule that sets up a notification channel.
+Now, navigate to the hubot pack `rules` directory, and view the notify_hubot rule. This is a notification rule that sets up a notification route.
 
 ```
 $ cd ~/stackstorm/st2workroom/artifacts/packs/hubot/rules
@@ -219,7 +221,7 @@ trigger:
   pack: "chatops"
   type: "core.st2.generic.notifytrigger"
 criteria:
-  trigger.channel:
+  trigger.route:
     pattern: "hubot"
     type: "equals"
 action:
@@ -229,6 +231,10 @@ action:
     user: "{{trigger.data.user}}"
     result: "{{trigger}}"
 ```
+
+Note: trigger.route used to be trigger.channel but to avoid confusions, we renamed it. trigger
+.channel would still work but please use trigger.route everywhere. trigger.channel would be
+deprecated soon.
 
 This file is also here to serve as an example on how to setup other notification triggers.
 

--- a/st2actions/tests/unit/test_mistral_v2.py
+++ b/st2actions/tests/unit/test_mistral_v2.py
@@ -276,7 +276,7 @@ class TestMistralRunner(DbTestCase):
         executions.ExecutionManager, 'create',
         mock.MagicMock(return_value=executions.Execution(None, WF1_EXEC)))
     def test_launch_workflow_with_notifications(self):
-        notify_data = {'on_complete': {'channels': ['slack'],
+        notify_data = {'on_complete': {'routes': ['slack'],
                        'message': '"@channel: Action succeeded."', 'data': {}}}
 
         MistralRunner.entry_point = mock.PropertyMock(return_value=WF1_YAML_FILE_PATH)

--- a/st2api/st2api/controllers/v1/aliasexecution.py
+++ b/st2api/st2api/controllers/v1/aliasexecution.py
@@ -101,7 +101,7 @@ class ActionAliasExecutionController(rest.RestController):
 
     def _get_notify_field(self, payload):
         on_complete = NotificationSubSchema()
-        on_complete.channels = [payload.notification_channel]
+        on_complete.routes = [payload.notification_channel]
         on_complete.data = {
             'user': payload.user,
             'source_channel': payload.source_channel

--- a/st2api/st2api/controllers/v1/aliasexecution.py
+++ b/st2api/st2api/controllers/v1/aliasexecution.py
@@ -101,7 +101,7 @@ class ActionAliasExecutionController(rest.RestController):
 
     def _get_notify_field(self, payload):
         on_complete = NotificationSubSchema()
-        route = (getattr(payload, 'notification_route') or
+        route = (getattr(payload, 'notification_route', None) or
                  getattr(payload, 'notification_channel', None))
         on_complete.routes = [route]
         on_complete.data = {

--- a/st2api/st2api/controllers/v1/aliasexecution.py
+++ b/st2api/st2api/controllers/v1/aliasexecution.py
@@ -101,7 +101,9 @@ class ActionAliasExecutionController(rest.RestController):
 
     def _get_notify_field(self, payload):
         on_complete = NotificationSubSchema()
-        on_complete.routes = [payload.notification_channel]
+        route = (getattr(payload, 'notification_route') or
+                 getattr(payload, 'notification_channel', None))
+        on_complete.routes = [route]
         on_complete.data = {
             'user': payload.user,
             'source_channel': payload.source_channel

--- a/st2common/st2common/models/api/notification.py
+++ b/st2common/st2common/models/api/notification.py
@@ -26,7 +26,11 @@ NotificationSubSchemaAPI = {
             "type": "object",
             "description": "Data to be sent as part of notification"
         },
-        "channels": {
+        "routes": {
+            "type": "array",
+            "description": "Channels to post notifications to."
+        },
+        "channels": {  # Deprecated. Only here for backward compatibility.
             "type": "array",
             "description": "Channels to post notifications to."
         },
@@ -63,9 +67,10 @@ class NotificationsHelper(object):
     def _to_model_sub_schema(notification_settings_json):
         message = notification_settings_json.get('message' or None)
         data = notification_settings_json.get('data' or {})
-        channels = notification_settings_json.get('channels' or [])
+        routes = (notification_settings_json.get('routes') or
+                  notification_settings_json.get('channels', []))
 
-        model = NotificationSubSchema(message=message, data=data, channels=channels)
+        model = NotificationSubSchema(message=message, data=data, routes=routes)
         return model
 
     @staticmethod
@@ -90,7 +95,9 @@ class NotificationsHelper(object):
             notify_sub_schema['message'] = notify_sub_schema_model.message
         if getattr(notify_sub_schema_model, 'message', None):
             notify_sub_schema['data'] = notify_sub_schema_model.data
-        if getattr(notify_sub_schema_model, 'channels', None):
-            notify_sub_schema['channels'] = notify_sub_schema_model.channels
+        routes = (getattr(notify_sub_schema_model, 'routes') or
+                  getattr(notify_sub_schema_model, 'channels'))
+        if routes:
+            notify_sub_schema['routes'] = routes
 
         return notify_sub_schema

--- a/st2common/st2common/models/db/notification.py
+++ b/st2common/st2common/models/db/notification.py
@@ -26,9 +26,12 @@ class NotificationSubSchema(me.EmbeddedDocument):
     data = stormbase.EscapedDynamicField(
         default={},
         help_text='Payload to be sent as part of notification.')
-    channels = me.ListField(
+    routes = me.ListField(
         default=['notify.default'],
-        help_text='Channels to post notifications to.')
+        help_text='Routes to post notifications to.')
+    channels = me.ListField(  # Deprecated. Only here for backward compatibility reasons.
+        default=['notify.default'],
+        help_text='Routes to post notifications to.')
 
     def __str__(self):
         result = []
@@ -36,7 +39,8 @@ class NotificationSubSchema(me.EmbeddedDocument):
         result.append(str(id(self)))
         result.append('(message="%s", ' % str(self.message))
         result.append('data="%s", ' % str(self.data))
-        result.append('channels="%s")' % str(self.channels))
+        result.append('routes="%s")' % str(self.channels))
+        result.append('(**deprecated**) channels="%s")' % str(self.channels))
         return ''.join(result)
 
 

--- a/st2common/tests/unit/services/test_action.py
+++ b/st2common/tests/unit/services/test_action.py
@@ -57,7 +57,7 @@ ACTION = {
     'notify': {
         'on-complete': {
             'message': 'My awesome action is complete. Party time!!!',
-            'channels': ['notify.slack']
+            'routes': ['notify.slack']
         }
     }
 }

--- a/st2common/tests/unit/test_db_liveaction.py
+++ b/st2common/tests/unit/test_db_liveaction.py
@@ -77,7 +77,7 @@ class LiveActionModelTest(DbTestCase):
         # Assert notify settings saved are right.
         self.assertEqual(notify_sub_schema.message, retrieved.notify.on_complete.message)
         self.assertDictEqual(notify_sub_schema.data, retrieved.notify.on_complete.data)
-        self.assertListEqual(notify_sub_schema.channels, retrieved.notify.on_complete.channels)
+        self.assertListEqual(notify_sub_schema.routes, retrieved.notify.on_complete.routes)
         self.assertEqual(retrieved.notify.on_success, None)
         self.assertEqual(retrieved.notify.on_failure, None)
 
@@ -106,7 +106,7 @@ class LiveActionModelTest(DbTestCase):
         self.assertEqual(notify_sub_schema.message,
                          retrieved.notify.on_success.message)
         self.assertDictEqual(notify_sub_schema.data, retrieved.notify.on_success.data)
-        self.assertListEqual(notify_sub_schema.channels, retrieved.notify.on_success.channels)
+        self.assertListEqual(notify_sub_schema.routes, retrieved.notify.on_success.routes)
         self.assertEqual(retrieved.notify.on_failure, None)
         self.assertEqual(retrieved.notify.on_complete, None)
 

--- a/st2tests/st2tests/fixtures/generic/actionchains/chain_with_notifications.yaml
+++ b/st2tests/st2tests/fixtures/generic/actionchains/chain_with_notifications.yaml
@@ -11,17 +11,17 @@
                 on-complete:
                     message: "on complete"
                     data: {}
-                    channels:
+                    routes:
                         - "channel1"
                 on-failure:
                     message: "on failure"
                     data: {}
-                    channels:
+                    routes:
                         - "channel1"
                 on-success:
                     message: "on success"
                     data: {}
-                    channels:
+                    routes:
                         - "channel1"
         -
             name: "c2"


### PR DESCRIPTION
I think I got all the changes done. Preliminary backward compatiblity testing seems to pass but I am not confident yet. Will run more tests tomorrow. 

Related:

* - [X] hubot-stackstorm - https://github.com/StackStorm/hubot-stackstorm/pull/34/files
* - [X] chatops instructables - https://github.com/StackStorm/st2/commit/7b82e811f738e2611f405814baa8eb98e58c752b