### PR TITLE
Fix bug in triggers emitted on key value pair changes and sensor spawn/exit.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ in development
 * Fix key name for error message in liveaction result. (bug-fix)
 * Fix 500 API response when rule with no pack info is supplied. (bug-fix)
 * Fix bug in trigger-instance re-emit (extra kwargs passed to manager is now handled). (bug-fix)
+* Fix bug in triggers emitted on key value pair changes and sensor spawn/exit. (bug-fix)
 
 0.12.1 - July 31, 2015
 ----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,8 @@ in development
 * Fix key name for error message in liveaction result. (bug-fix)
 * Fix 500 API response when rule with no pack info is supplied. (bug-fix)
 * Fix bug in trigger-instance re-emit (extra kwargs passed to manager is now handled). (bug-fix)
-* Fix bug in triggers emitted on key value pair changes and sensor spawn/exit. (bug-fix)
+* Fix bug in triggers emitted on key value pair changes and sensor spawn/exit. When
+  dispatching   those triggers, the reference used didn't contain the pack names which meant it was invalid and lookups in the rules engine would fail. (bug-fix)
 
 0.12.1 - July 31, 2015
 ----------------------

--- a/st2common/st2common/constants/triggers.py
+++ b/st2common/st2common/constants/triggers.py
@@ -69,6 +69,31 @@ NOTIFY_TRIGGER = {
     }
 }
 
+# Sensor spawn/exit triggers.
+SENSOR_SPAWN_TRIGGER = {
+    'name': 'st2.sensor.process_spawn',
+    'pack': SYSTEM_PACK_NAME,
+    'description': 'Trigger indicating sensor process is started up.',
+    'payload_schema': {
+        'type': 'object',
+        'properties': {
+            'object': {}
+        }
+    }
+}
+
+SENSOR_EXIT_TRIGGER = {
+    'name': 'st2.sensor.process_exit',
+    'pack': SYSTEM_PACK_NAME,
+    'description': 'Trigger indicating sensor process is stopped.',
+    'payload_schema': {
+        'type': 'object',
+        'properties': {
+            'object': {}
+        }
+    }
+}
+
 # KeyValuePair resource triggers
 KEY_VALUE_PAIR_CREATE_TRIGGER = {
     'name': 'st2.key_value_pair.create',
@@ -126,33 +151,8 @@ INTERNAL_TRIGGER_TYPES = {
         NOTIFY_TRIGGER
     ],
     'sensor': [
-        {
-            'name': 'st2.sensor.process_spawn',
-            'pack': SYSTEM_PACK_NAME,
-            'description': 'Trigger encapsulating spawning of a sensor process.',
-            'payload_schema': {
-                'type': 'object',
-                'properties': {
-                    'id': {},
-                    'timestamp': {},
-                    'pid': {},
-                    'cmd': {}
-                }
-            }
-        },
-        {
-            'name': 'st2.sensor.process_exit',
-            'pack': SYSTEM_PACK_NAME,
-            'description': 'Trigger encapsulating exit of a sensor process.',
-            'payload_schema': {
-                'type': 'object',
-                'properties': {
-                    'id': {},
-                    'timestamp': {},
-                    'exit_code': {}
-                }
-            }
-        }
+        SENSOR_SPAWN_TRIGGER,
+        SENSOR_EXIT_TRIGGER
     ],
     'key_value_pair': [
         KEY_VALUE_PAIR_CREATE_TRIGGER,

--- a/st2common/st2common/persistence/keyvalue.py
+++ b/st2common/st2common/persistence/keyvalue.py
@@ -16,6 +16,7 @@
 from st2common.persistence.base import Access
 from st2common.models.db import keyvalue
 from st2common.models.api.keyvalue import KeyValuePairAPI
+from st2common.models.system.common import ResourceReference
 from st2common.constants.triggers import KEY_VALUE_PAIR_CREATE_TRIGGER
 from st2common.constants.triggers import KEY_VALUE_PAIR_UPDATE_TRIGGER
 from st2common.constants.triggers import KEY_VALUE_PAIR_VALUE_CHANGE_TRIGGER
@@ -29,10 +30,18 @@ class KeyValuePair(Access):
     api_model_cls = KeyValuePairAPI
     dispatch_trigger_for_operations = ['create', 'update', 'value_change', 'delete']
     operation_to_trigger_ref_map = {
-        'create': KEY_VALUE_PAIR_CREATE_TRIGGER['name'],
-        'update': KEY_VALUE_PAIR_UPDATE_TRIGGER['name'],
-        'value_change': KEY_VALUE_PAIR_VALUE_CHANGE_TRIGGER['name'],
-        'delete': KEY_VALUE_PAIR_DELETE_TRIGGER['name'],
+        'create': ResourceReference.to_string_reference(
+            name=KEY_VALUE_PAIR_CREATE_TRIGGER['name'],
+            pack=KEY_VALUE_PAIR_CREATE_TRIGGER['pack']),
+        'update': ResourceReference.to_string_reference(
+            name=KEY_VALUE_PAIR_UPDATE_TRIGGER['name'],
+            pack=KEY_VALUE_PAIR_UPDATE_TRIGGER['pack']),
+        'value_change': ResourceReference.to_string_reference(
+            name=KEY_VALUE_PAIR_VALUE_CHANGE_TRIGGER['name'],
+            pack=KEY_VALUE_PAIR_VALUE_CHANGE_TRIGGER['pack']),
+        'delete': ResourceReference.to_string_reference(
+            name=KEY_VALUE_PAIR_DELETE_TRIGGER['name'],
+            pack=KEY_VALUE_PAIR_DELETE_TRIGGER['pack']),
     }
 
     @classmethod

--- a/st2reactor/st2reactor/container/utils.py
+++ b/st2reactor/st2reactor/container/utils.py
@@ -16,8 +16,9 @@
 import six
 
 from st2common import log as logging
-from st2common.persistence.trigger import TriggerInstance
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2common.models.db.trigger import TriggerInstanceDB
+from st2common.persistence.trigger import TriggerInstance
 from st2common.services import triggers as TriggerService
 
 LOG = logging.getLogger('st2reactor.sensor.container_utils')
@@ -47,7 +48,7 @@ def create_trigger_instance(trigger, payload, occurrence_time, raise_on_no_trigg
     if trigger_db is None:
         LOG.debug('No trigger in db for %s', trigger)
         if raise_on_no_trigger:
-            raise ValueError('Trigger not found for %s', trigger)
+            raise StackStormDBObjectNotFoundError('Trigger not found for %s', trigger)
         return None
 
     trigger_ref = trigger_db.get_reference().ref

--- a/st2reactor/st2reactor/container/utils.py
+++ b/st2reactor/st2reactor/container/utils.py
@@ -23,7 +23,7 @@ from st2common.services import triggers as TriggerService
 LOG = logging.getLogger('st2reactor.sensor.container_utils')
 
 
-def create_trigger_instance(trigger, payload, occurrence_time):
+def create_trigger_instance(trigger, payload, occurrence_time, raise_on_no_trigger=False):
     """
     This creates a trigger instance object given trigger and payload.
     Trigger can be just a string reference (pack.name) or a ``dict``
@@ -46,6 +46,8 @@ def create_trigger_instance(trigger, payload, occurrence_time):
 
     if trigger_db is None:
         LOG.debug('No trigger in db for %s', trigger)
+        if raise_on_no_trigger:
+            raise ValueError('Trigger not found for %s', trigger)
         return None
 
     trigger_ref = trigger_db.get_reference().ref

--- a/st2reactor/st2reactor/rules/worker.py
+++ b/st2reactor/st2reactor/rules/worker.py
@@ -48,6 +48,8 @@ class TriggerInstanceDispatcher(consumers.MessageHandler):
 
             if trigger_instance:
                 self.rules_engine.handle_trigger_instance(trigger_instance)
+            else:
+                LOG.info('No trigger found in db for instance. %s', instance)
         except:
             # This could be a large message but at least in case of an exception
             # we get to see more context.

--- a/st2reactor/st2reactor/rules/worker.py
+++ b/st2reactor/st2reactor/rules/worker.py
@@ -40,22 +40,29 @@ class TriggerInstanceDispatcher(consumers.MessageHandler):
         trigger = instance['trigger']
         payload = instance['payload']
 
+        trigger_instance = None
         try:
             trigger_instance = container_utils.create_trigger_instance(
                 trigger,
                 payload or {},
-                date_utils.get_datetime_utc_now())
-
-            if trigger_instance:
-                self.rules_engine.handle_trigger_instance(trigger_instance)
-            else:
-                LOG.info('No trigger found in db for instance. %s', instance)
+                date_utils.get_datetime_utc_now(),
+                raise_on_no_trigger=True)
         except:
-            # This could be a large message but at least in case of an exception
-            # we get to see more context.
-            # Beyond this point code cannot really handle the exception anyway so
-            # eating up the exception.
-            LOG.exception('Failed to handle trigger_instance %s.', instance)
+            # We got a trigger ref but we were unable to create a trigger instance.
+            # This could be because a trigger object wasn't found in db for the ref.
+            LOG.exception('Failed to create trigger_instance %s.', instance)
+            return
+
+        if trigger_instance:
+            try:
+                self.rules_engine.handle_trigger_instance(trigger_instance)
+            except:
+                # This could be a large message but at least in case of an exception
+                # we get to see more context.
+                # Beyond this point code cannot really handle the exception anyway so
+                # eating up the exception.
+                LOG.exception('Failed to handle trigger_instance %s.', instance)
+                return
 
 
 def get_worker():


### PR DESCRIPTION
We were publishing the triggers with just name before. This failed lookup when creating trigger instances. So basically this feature never worked before. 

I added tests for sensor spawn and exit but for KVP, the code has multiple levels of abstraction. 