### PR TITLE
WIP: Refactor executions exporter to own file

### DIFF
--- a/st2exporter/st2exporter/consumers/base.py
+++ b/st2exporter/st2exporter/consumers/base.py
@@ -1,0 +1,122 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import Queue
+
+import abc
+import eventlet
+from oslo_config import cfg
+import six
+
+from st2common import log as logging
+from st2exporter.exporter.dumper import Dumper
+from st2common.persistence.marker import DumperMarker
+from st2common.transport import consumers
+from st2common.util import isotime
+
+__all__ = [
+    'ModelExporter'
+]
+
+LOG = logging.getLogger(__name__)
+
+
+@six.add_metaclass(abc.ABCMeta)
+class ModelExporter(consumers.MessageHandler):
+    api_model = None
+    persistence_model = None
+
+    def __init__(self, model_type, connection, queues):
+        super(ModelExporter, self).__init__(connection, queues)
+        self.pending_models = Queue.Queue()
+        self._dumper = Dumper(queue=self.pending_models,
+                              export_dir=cfg.CONF.exporter.dump_dir)
+        self._consumer_thread = None
+        self._model_type = model_type
+        if not self.api_model or not self.persistence_model:
+            raise Exception('No API or persistence model defined for exporter.')
+
+    def start(self, wait=False):
+        LOG.info('Starting model exporter -- %s.', self._model_type)
+        try:
+            self.bootstrap()
+        except:
+            LOG.info('Failed bootstrap for model -- %s', self._model_type)
+            raise
+        self._consumer_thread = eventlet.spawn(super(ModelExporter, self).start, wait=True)
+        self._dumper.start()
+        if wait:
+            self.wait()
+
+    def wait(self):
+        self._consumer_thread.wait()
+        self._dumper.wait()
+
+    def shutdown(self):
+        self._dumper.stop()
+        super(ModelExporter, self).shutdown()
+
+    def process(self, db_model):
+        LOG.debug('Got model from queue: %s', db_model)
+        if self.should_export(db_model):
+            model_api = self.api_model.from_model(db_model, mask_secrets=True)
+            self.pending_models.put_nowait(model_api)
+            LOG.debug("Added execution to queue.")
+
+    def bootstrap(self):
+        marker = self._get_export_marker_from_db()
+        LOG.info('Using marker %s...' % marker)
+        missed_models = self.get_missed_models_from_db(export_marker=marker)
+        LOG.info('Found %d models not exported yet...', len(missed_models))
+
+        for missed_model in missed_models:
+            if not self.should_export(missed_model):
+                continue
+            model_api = self.api_model.from_model(missed_model, mask_secrets=True)
+            try:
+                LOG.debug('Missed execution %s', model_api)
+                self.pending_models.put_nowait(model_api)
+            except:
+                LOG.exception('Failed adding execution to in-memory queue.')
+                continue
+        LOG.info('Bootstrapped models...')
+
+    def should_export(self, db_model):
+        return True
+
+    def get_missed_models_from_db(self, export_marker=None):
+        if not export_marker:
+            return self._get_all_models_from_db()
+
+        # XXX: Should adapt this query to get only executions with status
+        # in COMPLETION_STATUSES.
+        filters = {'end_timestamp__gt': export_marker}
+        LOG.info('Querying for executions with filters: %s', filters)
+        return ModelExporter.persistence_model.query(**filters)
+
+    def _get_export_marker_from_db(self):
+        try:
+            markers = DumperMarker.get_all()
+        except:
+            return None
+        else:
+            if len(markers) >= 1:
+                marker = markers[0]
+                return isotime.parse(marker.marker)
+            else:
+                return None
+
+    def _get_all_models_from_db(self):
+        return self.persistence_model.get_all()

--- a/st2exporter/st2exporter/consumers/execution.py
+++ b/st2exporter/st2exporter/consumers/execution.py
@@ -1,0 +1,123 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import Queue
+
+import eventlet
+
+
+from oslo_config import cfg
+
+from st2common import log as logging
+from st2common.constants.action import (LIVEACTION_STATUS_SUCCEEDED, LIVEACTION_STATUS_FAILED,
+                                        LIVEACTION_STATUS_CANCELED)
+from st2common.models.api.execution import ActionExecutionAPI
+from st2common.models.db.execution import ActionExecutionDB
+from st2common.persistence.execution import ActionExecution
+from st2common.persistence.marker import DumperMarker
+from st2common.transport import consumers
+from st2common.util import isotime
+from st2exporter.exporter.dumper import Dumper
+
+__all__ = [
+    'ExecutionsExporter'
+]
+
+COMPLETION_STATUSES = [LIVEACTION_STATUS_SUCCEEDED, LIVEACTION_STATUS_FAILED,
+                       LIVEACTION_STATUS_CANCELED]
+LOG = logging.getLogger(__name__)
+
+
+class ExecutionsExporter(consumers.MessageHandler):
+    message_type = ActionExecutionDB
+
+    def __init__(self, connection, queues):
+        super(ExecutionsExporter, self).__init__(connection, queues)
+        self.pending_executions = Queue.Queue()
+        self._dumper = Dumper(queue=self.pending_executions,
+                              export_dir=cfg.CONF.exporter.dump_dir)
+        self._consumer_thread = None
+
+    def start(self, wait=False):
+        LOG.info('Starting executions exporter.')
+        LOG.info('Bootstrapping executions from db...')
+        try:
+            self._bootstrap()
+        except:
+            LOG.exception('Unable to bootstrap executions from db. Aborting.')
+            raise
+        self._consumer_thread = eventlet.spawn(super(ExecutionsExporter, self).start, wait=True)
+        self._dumper.start()
+        if wait:
+            self.wait()
+
+    def wait(self):
+        self._consumer_thread.wait()
+        self._dumper.wait()
+
+    def shutdown(self):
+        self._dumper.stop()
+        super(ExecutionsExporter, self).shutdown()
+
+    def process(self, execution):
+        LOG.debug('Got execution from queue: %s', execution)
+        if execution.status not in COMPLETION_STATUSES:
+            return
+        execution_api = ActionExecutionAPI.from_model(execution, mask_secrets=True)
+        self.pending_executions.put_nowait(execution_api)
+        LOG.debug("Added execution to queue.")
+
+    def _bootstrap(self):
+        marker = self._get_export_marker_from_db()
+        LOG.info('Using marker %s...' % marker)
+        missed_executions = self._get_missed_executions_from_db(export_marker=marker)
+        LOG.info('Found %d executions not exported yet...', len(missed_executions))
+
+        for missed_execution in missed_executions:
+            if missed_execution.status not in COMPLETION_STATUSES:
+                continue
+            execution_api = ActionExecutionAPI.from_model(missed_execution, mask_secrets=True)
+            try:
+                LOG.debug('Missed execution %s', execution_api)
+                self.pending_executions.put_nowait(execution_api)
+            except:
+                LOG.exception('Failed adding execution to in-memory queue.')
+                continue
+        LOG.info('Bootstrapped executions...')
+
+    def _get_export_marker_from_db(self):
+        try:
+            markers = DumperMarker.get_all()
+        except:
+            return None
+        else:
+            if len(markers) >= 1:
+                marker = markers[0]
+                return isotime.parse(marker.marker)
+            else:
+                return None
+
+    def _get_missed_executions_from_db(self, export_marker=None):
+        if not export_marker:
+            return self._get_all_executions_from_db()
+
+        # XXX: Should adapt this query to get only executions with status
+        # in COMPLETION_STATUSES.
+        filters = {'end_timestamp__gt': export_marker}
+        LOG.info('Querying for executions with filters: %s', filters)
+        return ActionExecution.query(**filters)
+
+    def _get_all_executions_from_db(self):
+        return ActionExecution.get_all()  # XXX: Paginated call.

--- a/st2exporter/st2exporter/worker.py
+++ b/st2exporter/st2exporter/worker.py
@@ -13,118 +13,65 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import Queue
-
 import eventlet
+
 from kombu import Connection
-from oslo_config import cfg
 
 from st2common import log as logging
-from st2common.constants.action import (LIVEACTION_STATUS_SUCCEEDED, LIVEACTION_STATUS_FAILED,
-                                        LIVEACTION_STATUS_CANCELED)
-from st2common.models.api.execution import ActionExecutionAPI
-from st2common.models.db.execution import ActionExecutionDB
-from st2common.persistence.execution import ActionExecution
-from st2common.persistence.marker import DumperMarker
-from st2common.transport import consumers, execution, publishers
+from st2common.transport import execution, publishers
 from st2common.transport import utils as transport_utils
-from st2common.util import isotime
-from st2exporter.exporter.dumper import Dumper
+from st2exporter.consumers.execution import ExecutionsExporter
 
-__all__ = [
-    'ExecutionsExporter'
-]
-
-COMPLETION_STATUSES = [LIVEACTION_STATUS_SUCCEEDED, LIVEACTION_STATUS_FAILED,
-                       LIVEACTION_STATUS_CANCELED]
-LOG = logging.getLogger(__name__)
 
 EXPORTER_WORK_Q = execution.get_queue(
     'st2.exporter.work', routing_key=publishers.UPDATE_RK)
+LOG = logging.getLogger(__name__)
 
 
-class ExecutionsExporter(consumers.MessageHandler):
-    message_type = ActionExecutionDB
+class Exporter(object):
+    def __init__(self):
+        self._model_exporters = []
 
-    def __init__(self, connection, queues):
-        super(ExecutionsExporter, self).__init__(connection, queues)
-        self.pending_executions = Queue.Queue()
-        self._dumper = Dumper(queue=self.pending_executions,
-                              export_dir=cfg.CONF.exporter.dump_dir)
-        self._consumer_thread = None
+        self._executions_exporter = None
+        with Connection(transport_utils.get_messaging_urls()) as conn:
+            self._executions_exporter = ExecutionsExporter(conn, [EXPORTER_WORK_Q])
+
+        self._model_exporters.append(self._executions_exporter)
+        LOG.info('Available model exporters %s.', self._model_exporters)
+        self._model_exporters_pool = eventlet.GreenPool(len(self._model_exporters))
+        self._stopped = False
 
     def start(self, wait=False):
-        LOG.info('Bootstrapping executions from db...')
-        try:
-            self._bootstrap()
-        except:
-            LOG.exception('Unable to bootstrap executions from db. Aborting.')
-            raise
-        self._consumer_thread = eventlet.spawn(super(ExecutionsExporter, self).start, wait=True)
-        self._dumper.start()
+        LOG.info('Starting model exporters...')
+        for model_exporter in self._model_exporters:
+            while self._model_exporters_pool.free() <= 0 and not self._stopped:
+                eventlet.sleep(0.1)
+            if not self._stopped:
+                try:
+                    self._model_exporters_pool.spawn(model_exporter.start, wait=False)
+                except:
+                    LOG.exception('Failed to start model exporter %s.', model_exporter)
+        self._model_exporters_pool.waitall()
+
         if wait:
             self.wait()
 
-    def wait(self):
-        self._consumer_thread.wait()
-        self._dumper.wait()
-
     def shutdown(self):
-        self._dumper.stop()
-        super(ExecutionsExporter, self).shutdown()
-
-    def process(self, execution):
-        LOG.debug('Got execution from queue: %s', execution)
-        if execution.status not in COMPLETION_STATUSES:
-            return
-        execution_api = ActionExecutionAPI.from_model(execution, mask_secrets=True)
-        self.pending_executions.put_nowait(execution_api)
-        LOG.debug("Added execution to queue.")
-
-    def _bootstrap(self):
-        marker = self._get_export_marker_from_db()
-        LOG.info('Using marker %s...' % marker)
-        missed_executions = self._get_missed_executions_from_db(export_marker=marker)
-        LOG.info('Found %d executions not exported yet...', len(missed_executions))
-
-        for missed_execution in missed_executions:
-            if missed_execution.status not in COMPLETION_STATUSES:
-                continue
-            execution_api = ActionExecutionAPI.from_model(missed_execution, mask_secrets=True)
+        for model_exporter in self._model_exporters:
+            while not self._model_exporters_pool.free():
+                eventlet.sleep(0.1)
             try:
-                LOG.debug('Missed execution %s', execution_api)
-                self.pending_executions.put_nowait(execution_api)
+                self._model_exporters_pool.spawn(model_exporter.shutdown)
             except:
-                LOG.exception('Failed adding execution to in-memory queue.')
-                continue
-        LOG.info('Bootstrapped executions...')
+                LOG.exception('Failed shutting down model exporter %s.', model_exporter)
+        self._stopped = True
 
-    def _get_export_marker_from_db(self):
-        try:
-            markers = DumperMarker.get_all()
-        except:
-            return None
-        else:
-            if len(markers) >= 1:
-                marker = markers[0]
-                return isotime.parse(marker.marker)
-            else:
-                return None
-
-    def _get_missed_executions_from_db(self, export_marker=None):
-        if not export_marker:
-            return self._get_all_executions_from_db()
-
-        # XXX: Should adapt this query to get only executions with status
-        # in COMPLETION_STATUSES.
-        filters = {'end_timestamp__gt': export_marker}
-        LOG.info('Querying for executions with filters: %s', filters)
-        return ActionExecution.query(**filters)
-
-    def _get_all_executions_from_db(self):
-        return ActionExecution.get_all()  # XXX: Paginated call.
+    def wait(self):
+        for model_exporter in self._model_exporters:
+            model_exporter.wait()
+            LOG.info('Model exporter %s quit.', model_exporter)
+            # XXX: We should probably raising an exception at this point.
 
 
 def get_worker():
-    with Connection(transport_utils.get_messaging_urls()) as conn:
-        return ExecutionsExporter(conn, [EXPORTER_WORK_Q])
+    return Exporter()


### PR DESCRIPTION
I am moving executions exporter to own file. This is needed for introducing exporters for other models. All model exporters will have a base class. This will probably be next PR. 