### PR TITLE
RFR - Fix sudo in Paramiko remote script runner

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,7 @@ in development
   (new feature)
 * Allow user to retrieve content of a file inside a pack by using the new
   ``/packs/views/files/`` API endpoint. (new feature)
+* Handle sudo in paramiko remote script runner. (bug-fix)
 
 0.12.2 - August 11, 2015.
 -------------------------

--- a/st2actions/st2actions/runners/remote_script_runner.py
+++ b/st2actions/st2actions/runners/remote_script_runner.py
@@ -24,7 +24,8 @@ from st2common import log as logging
 from st2actions.runners.ssh.fabric_runner import BaseFabricRunner
 from st2actions.runners.ssh.fabric_runner import RUNNER_REMOTE_DIR
 from st2actions.runners.ssh.paramiko_ssh_runner import BaseParallelSSHRunner
-from st2common.models.system.action import (FabricRemoteScriptAction, RemoteScriptAction)
+from st2common.models.system.action import FabricRemoteScriptAction
+from st2common.models.system.paramiko_script_action import ParamikoRemoteScriptAction
 
 __all__ = [
     'get_runner',
@@ -177,23 +178,23 @@ class ParamikoRemoteScriptRunner(BaseParallelSSHRunner):
         remote_dir = self.runner_parameters.get(RUNNER_REMOTE_DIR,
                                                 cfg.CONF.ssh_runner.remote_dir)
         remote_dir = os.path.join(remote_dir, self.liveaction_id)
-        return RemoteScriptAction(self.action_name,
-                                  str(self.liveaction_id),
-                                  script_local_path_abs,
-                                  self.libs_dir_path,
-                                  named_args=named_args,
-                                  positional_args=pos_args,
-                                  env_vars=env_vars,
-                                  on_behalf_user=self._on_behalf_user,
-                                  user=self._username,
-                                  password=self._password,
-                                  private_key=self._private_key,
-                                  remote_dir=remote_dir,
-                                  hosts=self._hosts,
-                                  parallel=self._parallel,
-                                  sudo=self._sudo,
-                                  timeout=self._timeout,
-                                  cwd=self._cwd)
+        return ParamikoRemoteScriptAction(self.action_name,
+                                          str(self.liveaction_id),
+                                          script_local_path_abs,
+                                          self.libs_dir_path,
+                                          named_args=named_args,
+                                          positional_args=pos_args,
+                                          env_vars=env_vars,
+                                          on_behalf_user=self._on_behalf_user,
+                                          user=self._username,
+                                          password=self._password,
+                                          private_key=self._private_key,
+                                          remote_dir=remote_dir,
+                                          hosts=self._hosts,
+                                          parallel=self._parallel,
+                                          sudo=self._sudo,
+                                          timeout=self._timeout,
+                                          cwd=self._cwd)
 
     @staticmethod
     def _generate_error_results(error, tb):

--- a/st2common/st2common/models/system/action.py
+++ b/st2common/st2common/models/system/action.py
@@ -41,7 +41,6 @@ __all__ = [
     'ShellScriptAction',
     'RemoteAction',
     'RemoteScriptAction',
-    'ParamikoSSHCommandAction',
     'FabricRemoteAction',
     'FabricRemoteScriptAction',
     'ResolvedActionParameters'
@@ -356,10 +355,6 @@ class RemoteScriptAction(ShellScriptAction):
         str_rep.append('hosts: %s)' % self.hosts)
 
         return ', '.join(str_rep)
-
-
-class ParamikoSSHCommandAction(SSHCommandAction):
-    pass
 
 
 class FabricRemoteAction(RemoteAction):

--- a/st2common/st2common/models/system/paramiko_script_action.py
+++ b/st2common/st2common/models/system/paramiko_script_action.py
@@ -30,18 +30,19 @@ class ParamikoRemoteScriptAction(RemoteScriptAction):
         script_arguments = self._get_script_arguments(named_args=self.named_args,
                                                       positional_args=self.positional_args)
 
-        command = self._get_quoted_command_string(self.remote_script, script_arguments)
-
         if self.sudo:
-            command = 'sudo -E -- bash -c %s' % command
+            if script_arguments:
+                command = quote_unix('%s %s' % (self.remote_script, script_arguments))
+            else:
+                command = quote_unix(self.remote_script)
 
-        return command
-
-    @staticmethod
-    def _get_quoted_command_string(remote_script_path, script_arguments):
-        if script_arguments:
-            command = quote_unix('%s %s' % (remote_script_path, script_arguments))
+            command = 'sudo -E -- bash -c %s' % (command)
         else:
-            command = quote_unix(remote_script_path)
+            script_path = quote_unix(self.remote_script)
+
+            if script_arguments:
+                command = '%s %s' % (script_path, script_arguments)
+            else:
+                command = script_path
 
         return command

--- a/st2common/st2common/models/system/paramiko_script_action.py
+++ b/st2common/st2common/models/system/paramiko_script_action.py
@@ -1,0 +1,47 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from st2common import log as logging
+from st2common.models.system.action import RemoteScriptAction
+from st2common.util.shell import quote_unix
+
+__all__ = [
+    'ParamikoRemoteScriptAction',
+]
+
+
+LOG = logging.getLogger(__name__)
+
+
+class ParamikoRemoteScriptAction(RemoteScriptAction):
+    def _format_command(self):
+        script_arguments = self._get_script_arguments(named_args=self.named_args,
+                                                      positional_args=self.positional_args)
+
+        command = self._get_quoted_command_string(self.remote_script, script_arguments)
+
+        if self.sudo:
+            command = 'sudo -E -- bash -c %s' % command
+
+        return command
+
+    @staticmethod
+    def _get_quoted_command_string(remote_script_path, script_arguments):
+        if script_arguments:
+            command = quote_unix('%s %s' % (remote_script_path, script_arguments))
+        else:
+            command = quote_unix(remote_script_path)
+
+        return command

--- a/st2common/tests/unit/test_paramiko_script_action_model.py
+++ b/st2common/tests/unit/test_paramiko_script_action_model.py
@@ -1,0 +1,46 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest2
+
+from st2common.models.system.paramiko_script_action import ParamikoRemoteScriptAction
+
+
+class ParamikoRemoteScriptActionTests(unittest2.TestCase):
+
+    def test_get_command_string(self):
+        local_script_path = '/opt/stackstorm/packs/fixtures/actions/remote_script.sh'
+        script_action = ParamikoRemoteScriptAction('fixtures.remote_script',
+                                                   '55ce39d532ed3543aecbe71d',
+                                                   local_script_path,
+                                                   '/opt/stackstorm/packs/fixtures/actions/lib/',
+                                                   named_args={'stream': 'stdout'},
+                                                   positional_args=[],
+                                                   env_vars={},
+                                                   on_behalf_user='stanley',
+                                                   user='vagrant',
+                                                   private_key='/home/vagrant/.ssh/stanley_rsa',
+                                                   remote_dir='/tmp',
+                                                   hosts=['localhost'],
+                                                   parallel=True,
+                                                   sudo=False,
+                                                   timeout=60)
+        expected_command = '/tmp/remote_script.sh stream=stdout'
+        self.assertEqual(script_action.get_full_command_string(), expected_command)
+
+        # Test with sudo
+        script_action.sudo = True
+        expected_command = 'sudo -E -- bash -c \'/tmp/remote_script.sh stream=stdout\''
+        self.assertEqual(script_action.get_full_command_string(), expected_command)

--- a/st2common/tests/unit/test_paramiko_script_action_model.py
+++ b/st2common/tests/unit/test_paramiko_script_action_model.py
@@ -26,8 +26,8 @@ class ParamikoRemoteScriptActionTests(unittest2.TestCase):
                                                    '55ce39d532ed3543aecbe71d',
                                                    local_script_path,
                                                    '/opt/stackstorm/packs/fixtures/actions/lib/',
-                                                   named_args={'stream': 'stdout'},
-                                                   positional_args=[],
+                                                   named_args={'song': 'b s'},
+                                                   positional_args='"taylor swift"',
                                                    env_vars={},
                                                    on_behalf_user='stanley',
                                                    user='vagrant',
@@ -37,10 +37,10 @@ class ParamikoRemoteScriptActionTests(unittest2.TestCase):
                                                    parallel=True,
                                                    sudo=False,
                                                    timeout=60)
-        expected_command = '/tmp/remote_script.sh stream=stdout'
-        self.assertEqual(script_action.get_full_command_string(), expected_command)
+        expected = '/tmp/remote_script.sh song=\'b s\' "taylor swift"'
+        self.assertEqual(script_action.get_full_command_string(), expected)
 
         # Test with sudo
         script_action.sudo = True
-        expected_command = 'sudo -E -- bash -c \'/tmp/remote_script.sh stream=stdout\''
-        self.assertEqual(script_action.get_full_command_string(), expected_command)
+        ex = 'sudo -E -- bash -c \'/tmp/remote_script.sh song=\'"\'"\'b s\'"\'"\' "taylor swift"\''
+        self.assertEqual(script_action.get_full_command_string(), ex)


### PR DESCRIPTION
Tried a bunch of approaches and settled on this approach. (See PR https://github.com/StackStorm/st2/pull/1824)

```
(virtualenv)/m/s/s/st2 git:paramiko_remote_script_sudo ❯❯❯ st2 run fixtures.streamwriter-script-remote hosts=localhost stream=stdout sudo=false
.
id: 55ce3efe32ed354d080341a1
status: succeeded
result:
{
    "localhost": {
        "succeeded": true,
        "failed": false,
        "return_code": 0,
        "stderr": "",
        "stdout": "STREAM IS STDOUT."
    }
}
(virtualenv)/m/s/s/st2 git:paramiko_remote_script_sudo ❯❯❯ st2 run fixtures.streamwriter-script-remote hosts=localhost stream=stdout sudo=true
.
id: 55ce3f0532ed354d080341a3
status: succeeded
result:
{
    "localhost": {
        "succeeded": true,
        "failed": false,
        "return_code": 0,
        "stderr": "",
        "stdout": "STREAM IS STDOUT."
    }
}
(virtualenv)/m/s/s/st2 git:paramiko_remote_script_sudo ❯❯❯
```