### PR TITLE
Fix mongoescape util to handle complex dict

### DIFF
--- a/st2common/st2common/util/mongoescape.py
+++ b/st2common/st2common/util/mongoescape.py
@@ -31,25 +31,38 @@ RULE_CRITERIA_UNESCAPE_TRANSLATION = dict(zip(RULE_CRITERIA_ESCAPED,
                                               RULE_CRITERIA_UNESCAPED))
 
 
+def _prep_work_items(d):
+    return [(k, v, d) for k, v in six.iteritems(d)]
+
+
 def _translate_chars(field, translation):
     # Only translate the fields of a dict
     if not isinstance(field, dict):
         return field
-    work_items = [(k, v, field) for k, v in six.iteritems(field)]
+
+    work_items = _prep_work_items(field)
+
     while len(work_items) > 0:
         work_item = work_items.pop(0)
         oldkey = work_item[0]
         value = work_item[1]
         work_field = work_item[2]
         newkey = oldkey
+
         for t_k, t_v in six.iteritems(translation):
             newkey = newkey.replace(t_k, t_v)
+
         if newkey != oldkey:
             work_field[newkey] = value
             del work_field[oldkey]
+
         if isinstance(value, dict):
-            nested_work_items = [(k, v, value) for k, v in six.iteritems(value)]
-            work_items.extend(nested_work_items)
+            work_items.extend(_prep_work_items(value))
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, dict):
+                    work_items.extend(_prep_work_items(item))
+
     return field
 
 

--- a/st2common/tests/unit/test_mongoescape.py
+++ b/st2common/tests/unit/test_mongoescape.py
@@ -68,3 +68,24 @@ class TestMongoEscape(unittest.TestCase):
         unescaped = mongoescape.unescape_chars(escaped)
         self.assertIn('k1.k2.k3', unescaped.keys())
         self.assertIn(u'k1\uff0ek2\uff0ek3', escaped.keys())
+
+    def test_complex(self):
+        field = {
+            'k1.k2': [{'l1.l2': '123'}, {'l3.l4': '456'}],
+            'k3': [{'l5.l6': '789'}],
+            'k4.k5': [1, 2, 3],
+            'k6': ['a', 'b']
+        }
+
+        expected = {
+            u'k1\uff0ek2': [{u'l1\uff0el2': '123'}, {u'l3\uff0el4': '456'}],
+            'k3': [{u'l5\uff0el6': '789'}],
+            u'k4\uff0ek5': [1, 2, 3],
+            'k6': ['a', 'b']
+        }
+
+        escaped = mongoescape.escape_chars(field)
+        self.assertDictEqual(expected, escaped)
+
+        unescaped = mongoescape.unescape_chars(escaped)
+        self.assertDictEqual(field, unescaped)


### PR DESCRIPTION
Fix mongoescape util to handle escaped chars in nested list of dicts.