### PR TITLE
Fix result for ActionChain actions in Mistral

### DIFF
--- a/st2actions/st2actions/handlers/mistral.py
+++ b/st2actions/st2actions/handlers/mistral.py
@@ -57,11 +57,6 @@ class MistralCallbackHandler(handlers.ActionExecutionCallbackHandler):
                 if type(value) in [dict, list]:
                     result = value
 
-            if isinstance(result, dict):
-                # Remove the list of tasks created by the results
-                # tracker before sending the output.
-                result.pop('tasks', None)
-
             output = json.dumps(result) if type(result) in [dict, list] else str(result)
             data = {'state': STATUS_MAP[status], 'output': output}
 


### PR DESCRIPTION
Mistral callback handler removed tasks from the result therefore the WF is unable to access output for the ActionChain actions.