### PR TITLE
Common CLI script setup and teardown code

### DIFF
--- a/st2actions/bin/st2actionrunner
+++ b/st2actions/bin/st2actionrunner
@@ -1,4 +1,18 @@
 #!/usr/bin/env python2.7
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import sys
 from st2actions.cmd import actionrunner

--- a/st2actions/bin/st2notifier
+++ b/st2actions/bin/st2notifier
@@ -1,4 +1,18 @@
 #!/usr/bin/env python2.7
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import sys
 from st2actions.cmd import st2notifier

--- a/st2actions/bin/st2resultstracker
+++ b/st2actions/bin/st2resultstracker
@@ -1,4 +1,18 @@
 #!/usr/bin/env python2.7
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import sys
 from st2actions.cmd import st2resultstracker

--- a/st2common/bin/paramiko_ssh_evenlets_tester.py
+++ b/st2common/bin/paramiko_ssh_evenlets_tester.py
@@ -1,4 +1,19 @@
 #!/usr/bin/env python2.7
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 import argparse
 import os

--- a/st2common/bin/st2-bootstrap-rmq
+++ b/st2common/bin/st2-bootstrap-rmq
@@ -1,4 +1,19 @@
 #!/usr/bin/env python2.7
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 import sys
 import st2common.transport.bootstrap as transport_bootstrap

--- a/st2common/bin/st2-register-content
+++ b/st2common/bin/st2-register-content
@@ -1,4 +1,19 @@
 #!/usr/bin/env python2.7
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 import sys
 import st2common.content.bootstrap as content_loader

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -19,14 +19,15 @@ import sys
 from oslo_config import cfg
 
 from st2common import config
-from st2common.service_setup import db_setup
-from st2common.service_setup import db_teardown
-from st2common.logging.filters import LogLevelFilter
-from st2common.transport.bootstrap_utils import register_exchanges
+from st2common.script_setup import setup as common_setup
+from st2common.script_setup import teardown as common_teardown
 
+__all__ = [
+    'main'
+]
 
 LOG = logging.getLogger('st2common.content.bootstrap')
-cfg.CONF.register_cli_opt(cfg.BoolOpt('verbose', short='v', default=False))
+
 cfg.CONF.register_cli_opt(cfg.BoolOpt('experimental', default=False))
 
 
@@ -177,32 +178,18 @@ def register_content():
         register_policies()
 
 
-def _setup(argv):
-    config.parse_args()
-
-    log_level = logging.DEBUG
-    logging.basicConfig(format='%(asctime)s %(levelname)s [-] %(message)s', level=log_level)
-
-    if not cfg.CONF.verbose:
-        # Note: We still want to print things at the following log levels: INFO, ERROR, CRITICAL
-        exclude_log_levels = [logging.AUDIT, logging.DEBUG]
-        handlers = logging.getLoggerClass().manager.root.handlers
-
-        for handler in handlers:
-            handler.addFilter(LogLevelFilter(log_levels=exclude_log_levels))
-
-    db_setup()
-    register_exchanges()
+def setup(argv):
+    common_setup(config=config, setup_db=True, register_mq_exchanges=True)
 
 
-def _teardown():
-    db_teardown()
+def teardown():
+    common_teardown()
 
 
 def main(argv):
-    _setup(argv)
+    setup(argv)
     register_content()
-    _teardown()
+    teardown()
 
 
 # This script registers actions and rules from content-packs.

--- a/st2common/st2common/script_setup.py
+++ b/st2common/st2common/script_setup.py
@@ -1,0 +1,96 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module contains common script setup and teardown code.
+
+Note: In this context script is every module which is not long running and can be executed from the
+command line (e.g. st2-submit-debug-info, st2-register-content, etc.).
+"""
+
+from __future__ import absolute_import
+
+import logging as stdlib_logging
+
+from oslo_config import cfg
+
+from st2common import log as logging
+from st2common.service_setup import db_setup
+from st2common.service_setup import db_teardown
+from st2common.logging.filters import LogLevelFilter
+from st2common.transport.bootstrap_utils import register_exchanges
+
+__all__ = [
+    'setup',
+    'teardown',
+
+    'db_setup',
+    'db_teardown'
+]
+
+LOG = logging.getLogger(__name__)
+
+
+def register_common_cli_options():
+    """
+    Register common CLI options.
+    """
+    cfg.CONF.register_cli_opt(cfg.BoolOpt('verbose', short='v', default=False))
+
+
+def setup(config, setup_db=True, register_mq_exchanges=True):
+    """
+    Common setup function.
+
+    Currently it performs the following operations:
+
+    1. Parses config and CLI arguments
+    2. Establishes DB connection
+    3. Suppress DEBUG log level if --verbose flag is not used
+    4. Registers RabbitMQ exchanges
+
+    :param config: Config object to use to parse args.
+    """
+    # Register common CLI options
+    register_common_cli_options()
+
+    # Parse args to setup config
+    config.parse_args()
+
+    # Set up logging
+    log_level = stdlib_logging.DEBUG
+    stdlib_logging.basicConfig(format='%(asctime)s %(levelname)s [-] %(message)s', level=log_level)
+
+    if not cfg.CONF.verbose:
+        # Note: We still want to print things at the following log levels: INFO, ERROR, CRITICAL
+        exclude_log_levels = [stdlib_logging.AUDIT, stdlib_logging.DEBUG]
+        handlers = stdlib_logging.getLoggerClass().manager.root.handlers
+
+        for handler in handlers:
+            handler.addFilter(LogLevelFilter(log_levels=exclude_log_levels))
+
+    # All other setup code which requires config to be parsed and logging to be correctly setup
+    if setup_db:
+        db_setup()
+
+    if register_mq_exchanges:
+        register_exchanges()
+
+
+def teardown():
+    """
+    Common teardown function.
+    """
+    db_teardown()

--- a/st2common/st2common/service_setup.py
+++ b/st2common/st2common/service_setup.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 """
-This module contains common service setup code.
+This module contains common service setup and teardown code.
 """
 
 from __future__ import absolute_import

--- a/st2reactor/bin/st2-rule-tester
+++ b/st2reactor/bin/st2-rule-tester
@@ -1,4 +1,19 @@
 #!/usr/bin/env python2.7
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 from st2reactor.cmd import rule_tester
 

--- a/st2reactor/bin/st2-trigger-refire
+++ b/st2reactor/bin/st2-trigger-refire
@@ -1,4 +1,18 @@
 #!/usr/bin/env python2.7
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from st2reactor.cmd import trigger_re_fire
 

--- a/st2reactor/bin/st2rulesengine
+++ b/st2reactor/bin/st2rulesengine
@@ -1,4 +1,18 @@
 #!/usr/bin/env python2.7
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 #
 #   st2 rules_engine

--- a/st2reactor/bin/st2sensorcontainer
+++ b/st2reactor/bin/st2sensorcontainer
@@ -1,8 +1,23 @@
 #!/usr/bin/env python2.7
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 #
 #   st2 sensor_container
 #
+
 import os
 import sys
 from st2reactor.cmd import sensormanager


### PR DESCRIPTION
This pull request adds common CLI script setup code which can be used by all the CLI scripts.

I needed a similar functionality in the `st2-apply-rbac-definitions` script and instead of increasing the technical debt and just copy and pasting some code over I did a minor refactor :P