### PR TITLE
Make sure that the "default" pack which we create during installation has a pack.yaml file

### DIFF
--- a/contrib/default/actions/README.md
+++ b/contrib/default/actions/README.md
@@ -1,0 +1,5 @@
+# actions
+
+The actions folder contains action scripts and metadata files. See [Actions](http://docs.stackstorm.com/actions.html)
+and [Workflows](http://docs.stackstorm.com/workflows.html) for specifics on writing actions. Note that the lib sub-folder
+is always available for access for an action script.

--- a/contrib/default/pack.yaml
+++ b/contrib/default/pack.yaml
@@ -1,0 +1,6 @@
+---
+name: default
+description: Pack where all the resources which are created using the API and don't have a pack specified get saved.
+version: 0.1.0
+author : st2-dev
+email : info@stackstorm.com

--- a/contrib/default/rules/README.md
+++ b/contrib/default/rules/README.md
@@ -1,0 +1,3 @@
+# rules
+
+The rules folder contains rules. See [Rules](http://docs.stackstorm.com/rules.html) for specifics on writing rules.

--- a/contrib/default/sensors/README.md
+++ b/contrib/default/sensors/README.md
@@ -1,0 +1,4 @@
+# sensors
+
+The sensors folder contains sensoros. See [Sensors](http://docs.stackstorm.com/sensors.html) for specifics on writing
+sensors and registering TriggerTypes.

--- a/st2common/packaging/debian/install
+++ b/st2common/packaging/debian/install
@@ -1,3 +1,4 @@
+contrib/default opt/stackstorm/packs/
 contrib/core opt/stackstorm/packs/
 contrib/packs opt/stackstorm/packs/
 contrib/linux opt/stackstorm/packs/

--- a/st2common/packaging/debian/preinst
+++ b/st2common/packaging/debian/preinst
@@ -3,7 +3,4 @@
 set -e
 mkdir -p /var/log/st2
 mkdir -p /etc/st2
-mkdir -p /opt/stackstorm/packs/default
-mkdir -p /opt/stackstorm/packs/default/actions
-mkdir -p /opt/stackstorm/packs/default/sensors
-mkdir -p /opt/stackstorm/packs/default/rules
+mkdir -p /opt/stackstorm/packs

--- a/st2common/packaging/rpm/st2common-rhel6.spec
+++ b/st2common/packaging/rpm/st2common-rhel6.spec
@@ -31,11 +31,8 @@ mkdir -p %{buildroot}/var/log/st2
 mkdir -p %{buildroot}/etc/st2
 mkdir -p %{buildroot}/etc/logrotate.d
 mkdir -p %{buildroot}/opt/stackstorm/packs
-mkdir -p %{buildroot}/opt/stackstorm/packs/default
-mkdir -p %{buildroot}/opt/stackstorm/packs/default/actions
-mkdir -p %{buildroot}/opt/stackstorm/packs/default/sensors
-mkdir -p %{buildroot}/opt/stackstorm/packs/default/rules
 mkdir -p %{buildroot}/usr/share/doc/st2
+cp -R contrib/default %{buildroot}/opt/stackstorm/packs/
 cp -R contrib/core %{buildroot}/opt/stackstorm/packs/
 cp -R contrib/packs %{buildroot}/opt/stackstorm/packs/
 cp -R contrib/linux %{buildroot}/opt/stackstorm/packs/

--- a/st2common/packaging/rpm/st2common.spec
+++ b/st2common/packaging/rpm/st2common.spec
@@ -31,12 +31,9 @@ mkdir -p %{buildroot}/var/log/st2
 mkdir -p %{buildroot}/etc/st2
 mkdir -p %{buildroot}/etc/logrotate.d
 mkdir -p %{buildroot}/opt/stackstorm/packs
-mkdir -p %{buildroot}/opt/stackstorm/packs/default
-mkdir -p %{buildroot}/opt/stackstorm/packs/default/actions
-mkdir -p %{buildroot}/opt/stackstorm/packs/default/sensors
-mkdir -p %{buildroot}/opt/stackstorm/packs/default/rules
 mkdir -p %{buildroot}/usr/share/doc/st2
 mkdir -p %{buildroot}/usr/share/stackstorm
+cp -R contrib/default %{buildroot}/opt/stackstorm/packs/
 cp -R contrib/core %{buildroot}/opt/stackstorm/packs/
 cp -R contrib/packs %{buildroot}/opt/stackstorm/packs/
 cp -R contrib/linux %{buildroot}/opt/stackstorm/packs/


### PR DESCRIPTION
This pull request makes sure that the directory for the "default" pack which we create during the installation has a "pack.yaml" file.

If a pack directory doesn't contain pack.yaml file, that directory is not treated as a pack (rightly so since pack.yaml makes a pack). This breaks many things. Among others, it means that the content from this pack won't be loaded when register-content is used.

This issue was originally discovered by @enykeev while trying to use the new "data_files" functionality - he was not able to create new files in the "default" pack because we could not find a corresponding `PackDB` model in the database (as noted above, the directory didn't contain "pack.yaml" which means PackDB model wasn't not created when the register content script was ran).

P.S. Yes you read it correctly - it breaks some things, but not all. The problem is that we are not 100% consistent across the code base and we use slightly different logic in different places. If we were consistent and used the same strict and correct logic everywhere, things would explode and be noticed earlier (which is the right behavior). In any case, baby steps and we are getting better with that :)