### PR TITLE
linux.wait_for_ssh should throw on timeout

### DIFF
--- a/contrib/linux/actions/wait_for_ssh.py
+++ b/contrib/linux/actions/wait_for_ssh.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 
+import time
+
 import paramiko
-import argparse
+
 from st2actions.runners.pythonrunner import Action
-import os, yaml, json, time
+
 
 class BaseAction(Action):
     def run(self, keyfile, username, hostname, ssh_timeout, retries):
@@ -15,7 +17,7 @@ class BaseAction(Action):
             try:
                 client.connect(hostname=hostname, username=username, pkey=key)
                 return True
-            except Exception, e: 
+            except Exception, e:
                 self.logger.info(e)
                 time.sleep(ssh_timeout)
             time.sleep(20)

--- a/contrib/linux/actions/wait_for_ssh.py
+++ b/contrib/linux/actions/wait_for_ssh.py
@@ -6,9 +6,7 @@ from st2actions.runners.pythonrunner import Action
 import os, yaml, json, time
 
 class BaseAction(Action):
-
     def run(self, keyfile, username, hostname, ssh_timeout, retries):
- 
         key = paramiko.RSAKey.from_private_key_file(keyfile)
         client = paramiko.SSHClient()
         client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -21,5 +19,5 @@ class BaseAction(Action):
                 self.logger.info(e)
                 time.sleep(ssh_timeout)
             time.sleep(20)
-        self.logger.info("Exceeded max retries")
-        return False
+
+        raise Exception("Exceeded max retries")

--- a/contrib/linux/actions/wait_for_ssh.py
+++ b/contrib/linux/actions/wait_for_ssh.py
@@ -13,13 +13,15 @@ class BaseAction(Action):
         client = paramiko.SSHClient()
         client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
-        for x in range(retries):
+        for index in range(retries):
+            attempt = index + 1
+
             try:
+                self.logger.debug('SSH connection attempt: %s' % (attempt))
                 client.connect(hostname=hostname, username=username, pkey=key)
                 return True
-            except Exception, e:
-                self.logger.info(e)
+            except Exception as e:
+                self.logger.info('Attempt %s failed (%s), sleeping...' % (attempt, str(e)))
                 time.sleep(ssh_timeout)
-            time.sleep(20)
 
-        raise Exception("Exceeded max retries")
+        raise Exception('Exceeded max retries (%s)' % (retries))


### PR DESCRIPTION
Previously, we returned `False` if a timeout was reached which means the action would exit with a zero status code instead of non-zero.

This means that if the action was used inside a workflow, `on-success` would be called instead of `on-failure`.

Inside one of out workflows we were lucky, because "retries * sleep delay" was >= default runner action timeout (600 seconds) so the exception was still thrown, but in this case it was because of the runner action timeout.