### PR TITLE
Some pretty cli for trace

### DIFF
--- a/st2client/st2client/commands/trace.py
+++ b/st2client/st2client/commands/trace.py
@@ -58,17 +58,17 @@ class SingleTraceDisplayMixin(object):
 
         if any(attr in args.attr for attr in ['all', 'trigger_instances']):
             components.extend([Resource(**{'id': trigger_instance['object_id'],
-                                           'type': TriggerInstance.get_alias().lower(),
+                                           'type': TriggerInstance._alias.lower(),
                                            'updated_at': trigger_instance['updated_at']})
                                for trigger_instance in trace.trigger_instances])
         if any(attr in args.attr for attr in ['all', 'rules']):
             components.extend([Resource(**{'id': rule['object_id'],
-                                           'type': Rule.get_alias().lower(),
+                                           'type': Rule._alias.lower(),
                                            'updated_at': rule['updated_at']})
                                for rule in trace.rules])
         if any(attr in args.attr for attr in ['all', 'action_executions', 'executions']):
             components.extend([Resource(**{'id': execution['object_id'],
-                                           'type': LiveAction.get_alias().lower(),
+                                           'type': LiveAction._alias.lower(),
                                            'updated_at': execution['updated_at']})
                                for execution in trace.action_executions])
         if components:

--- a/st2client/st2client/commands/trace.py
+++ b/st2client/st2client/commands/trace.py
@@ -13,14 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from st2client.models import Resource
 from st2client.models import Trace
+from st2client.exceptions.operations import OperationFailureException
 from st2client.formatters import table
+from st2client.formatters import execution as execution_formatter
 from st2client.commands import resource
 from st2client.utils.date import format_isodate
 
 
 TRACE_ATTRIBUTE_DISPLAY_ORDER = ['id', 'trace_tag', 'action_executions', 'rules',
                                  'triggerinstances', 'start_timestamp']
+
+TRACE_HEADER_DISPLAY_ORDER = ['id', 'trace_tag', 'start_timestamp']
+
+TRACE_COMPONENT_DISPLAY_LABELS = ['id', 'type', 'updated_at']
 
 TRACE_DISPLAY_ATTRIBUTES = ['all']
 
@@ -37,7 +44,37 @@ class TraceBranch(resource.ResourceBranch):
             })
 
 
-class TraceListCommand(resource.ResourceCommand):
+class SingleTraceDisplayMixin(object):
+
+    def print_trace_details(self, trace, args, **kwargs):
+        options = {'attributes': TRACE_HEADER_DISPLAY_ORDER}
+        options['json'] = args.json
+        options['attribute_transform_functions'] = self.attribute_transform_functions
+
+        formatter = execution_formatter.ExecutionResult
+
+        self.print_output(trace, formatter, **options)
+
+        components = [Resource(**{'id': trigger_instance['object_id'],
+                                  'type': 'triggerinstance',
+                                  'updated_at': trigger_instance['updated_at']})
+                      for trigger_instance in trace.trigger_instances]
+        components.extend([Resource(**{'id': rule['object_id'],
+                                       'type': 'rule',
+                                       'updated_at': rule['updated_at']})
+                           for rule in trace.rules])
+        components.extend([Resource(**{'id': execution['object_id'],
+                                       'type': 'execution',
+                                       'updated_at': execution['updated_at']})
+                           for execution in trace.action_executions])
+        if components:
+            components.sort(key=lambda resource: resource.updated_at)
+            self.print_output(components, table.MultiColumnTable,
+                              attributes=TRACE_COMPONENT_DISPLAY_LABELS,
+                              json=args.json)
+
+
+class TraceListCommand(resource.ResourceCommand, SingleTraceDisplayMixin):
     display_attributes = ['id', 'trace_tag', 'start_timestamp']
 
     attribute_transform_functions = {
@@ -92,14 +129,7 @@ class TraceListCommand(resource.ResourceCommand):
     def run_and_print(self, args, **kwargs):
         instances = self.run(args, **kwargs)
         if instances and len(instances) == 1:
-            # If there is an attribute override from the CLI use that value else
-            # use TRACE_DISPLAY_ATTRIBUTES as those are preferred for a single trace.
-            attributes = args.attr
-            if args.attr == self.display_attributes:
-                attributes = TRACE_DISPLAY_ATTRIBUTES
-            self.print_output(instances[0], table.PropertyValueTable,
-                              attributes=attributes, json=args.json,
-                              attribute_display_order=self.attribute_display_order)
+            self.print_trace_details(trace=instances[0], args=args)
         else:
             self.print_output(reversed(instances), table.MultiColumnTable,
                               attributes=args.attr, widths=args.width,
@@ -107,7 +137,7 @@ class TraceListCommand(resource.ResourceCommand):
                               attribute_transform_functions=self.attribute_transform_functions)
 
 
-class TraceGetCommand(resource.ResourceGetCommand):
+class TraceGetCommand(resource.ResourceGetCommand, SingleTraceDisplayMixin):
     display_attributes = ['all']
     attribute_display_order = TRACE_ATTRIBUTE_DISPLAY_ORDER
     attribute_transform_functions = {
@@ -120,3 +150,13 @@ class TraceGetCommand(resource.ResourceGetCommand):
     def run(self, args, **kwargs):
         resource_id = getattr(args, self.pk_argument_name, None)
         return self.get_resource_by_id(resource_id, **kwargs)
+
+    @resource.add_auth_token_to_kwargs_from_cli
+    def run_and_print(self, args, **kwargs):
+        trace = None
+        try:
+            trace = self.run(args, **kwargs)
+        except resource.ResourceNotFoundError:
+            self.print_not_found(args.id)
+            raise OperationFailureException('Trace %s not found.' % (args.id))
+        return self.print_trace_details(trace=trace, args=args)

--- a/st2client/st2client/models/reactor.py
+++ b/st2client/st2client/models/reactor.py
@@ -51,5 +51,6 @@ class Trigger(core.Resource):
 
 
 class Rule(core.Resource):
+    _alias = 'Rule'
     _plural = 'Rules'
     _repr_attributes = ['name', 'pack', 'trigger', 'criteria', 'enabled']


### PR DESCRIPTION
See the output to see what the client does.

```
$ st2 trace list
+--------------------------+----------------------------------------------------+-------------------------------+
| id                       | trace_tag                                          | start_timestamp               |
+--------------------------+----------------------------------------------------+-------------------------------+
| 55d3c9b132ed35435dd6a68f | trigger_instance-55d3c9b132ed35435dd6a68e          | Wed, 19 Aug 2015 00:11:29 UTC |
| 55d3c9ac32ed35435dd6a68d | trigger_instance-55d3c9ac32ed35435dd6a68c          | Wed, 19 Aug 2015 00:11:24 UTC |
| 55d3c9a732ed35435dd6a68b | trigger_instance-55d3c9a732ed35435dd6a68a          | Wed, 19 Aug 2015 00:11:19 UTC |
| 55d3c9a532ed35435dd6a689 | trigger_instance-55d3c9a532ed35435dd6a688          | Wed, 19 Aug 2015 00:11:17 UTC |
| 55d3c9a232ed35435dd6a687 | trigger_instance-55d3c9a232ed35435dd6a686          | Wed, 19 Aug 2015 00:11:14 UTC |
| 55d3c99f32ed35435dd6a685 | trigger_instance-55d3c99f32ed35435dd6a684          | Wed, 19 Aug 2015 00:11:11 UTC |
| 55d3c99f32ed35435dd6a683 | trigger_instance-55d3c99f32ed35435dd6a682          | Wed, 19 Aug 2015 00:11:11 UTC |
| 55d3d29732ed35435dd6a691 | TestPassiveSensor-ec4cf37b7bc94b4aab66cc033f1fbefa | Wed, 19 Aug 2015 00:49:27 UTC |
+--------------------------+----------------------------------------------------+-------------------------------+
```


```
$ st2 trace get 55d3d29732ed35435dd6a691
id: 55d3d29732ed35435dd6a691
trace_tag: TestPassiveSensor-ec4cf37b7bc94b4aab66cc033f1fbefa
start_timestamp: 2015-08-19T00:49:27.034587Z
+--------------------------+-----------------+-----------------------------+
| id                       | type            | updated_at                  |
+--------------------------+-----------------+-----------------------------+
| 55d3d29732ed35435dd6a690 | triggerinstance | 2015-08-19T00:49:27.034665Z |
| 55d3c99e32ed354372c0f7fe | rule            | 2015-08-19T00:49:27.057020Z |
| 55d3d29732ed35435dd6a693 | execution       | 2015-08-19T00:49:27.102228Z |
| 55d3d29732ed35435dd6a694 | triggerinstance | 2015-08-19T00:49:27.285334Z |
+--------------------------+-----------------+-----------------------------+
```

```
$ st2 trace list -c TestPassiveSensor-ec4cf37b7bc94b4aab66cc033f1fbefa
id: 55d3d29732ed35435dd6a691
trace_tag: TestPassiveSensor-ec4cf37b7bc94b4aab66cc033f1fbefa
start_timestamp: 2015-08-19T00:49:27.034587Z
+--------------------------+-----------------+-----------------------------+
| id                       | type            | updated_at                  |
+--------------------------+-----------------+-----------------------------+
| 55d3d29732ed35435dd6a690 | triggerinstance | 2015-08-19T00:49:27.034665Z |
| 55d3c99e32ed354372c0f7fe | rule            | 2015-08-19T00:49:27.057020Z |
| 55d3d29732ed35435dd6a693 | execution       | 2015-08-19T00:49:27.102228Z |
| 55d3d29732ed35435dd6a694 | triggerinstance | 2015-08-19T00:49:27.285334Z |
+--------------------------+-----------------+-----------------------------+
```