### PR TITLE
Add a mandatory ST2_AUTH_TOKEN param

### DIFF
--- a/tools/st2-self-check
+++ b/tools/st2-self-check
@@ -4,6 +4,11 @@
 ERRORS=0
 PACKS="tests examples"
 
+if [ -z $ST2_AUTH_TOKEN ]; then
+  echo "Please set ST2_AUTH_TOKEN and re-run"
+  exit 1
+fi
+
 #Determine Distro
 DEBTEST=`lsb_release -a 2> /dev/null | grep Distributor | awk '{print $3}'`
 


### PR DESCRIPTION
This PR adds a mandatory ST2_AUTH_TOKEN attribute to the `self-check` to ensure tests run correctly.