### PR TITLE
[st2ctl] Start st2web before Mistral

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,6 +39,8 @@ in development
   To switch to fabric runner, set ``use_paramiko_ssh_runner`` to false in st2.conf. (improvement)
 * Add OpenStack Keystone authentication configuration for Mistral. (improvement)
 * Add ability to add trace tag to ``st2 run`` CLI command. (feature)
+* Update ``st2ctl`` to correctly start ``st2web`` even if even if Mistral is no installed.
+  (bug-fix, improvement)
 
 0.12.2 - August 11, 2015.
 -------------------------

--- a/tools/st2ctl
+++ b/tools/st2ctl
@@ -4,7 +4,7 @@ set -e
 
 LOGFILE="/tmp/st2_startup.log"
 WEBUI_LOG_FILE="/var/log/st2/st2web.log"
-COMPONENTS="st2actionrunner st2api st2auth st2sensorcontainer st2rulesengine mistral st2web st2resultstracker st2notifier"
+COMPONENTS="st2actionrunner st2api st2auth st2sensorcontainer st2rulesengine st2web mistral st2resultstracker st2notifier"
 STANCONF="/etc/st2/st2.conf"
 PYTHON=`which python2.7`
 
@@ -177,16 +177,17 @@ function st2start_classic(){
   nohup st2resultstracker --config-file ${STANCONF} &>> ${LOGFILE} &
   nohup st2notifier --config-file ${STANCONF} &>> ${LOGFILE} &
   nohup st2rulesengine --config-file ${STANCONF} &>> ${LOGFILE} &
+
+  # Only run WebUI HTTP Server if flag is not set
+  if [ -z "${ST2_DISABLE_HTTPSERVER}" ]; then
+    (cd /opt/stackstorm/static/webui && nohup python -m SimpleHTTPServer $WEBUI_PORT) &>> ${WEBUI_LOG_FILE} &
+  fi
+
   if [[ "${CONTAINER}" == "DOCKER" ]]
   then
     /opt/openstack/mistral/.venv/bin/python /opt/openstack/mistral/mistral/cmd/launch.py --config-file /etc/mistral/mistral.conf --log-file /var/log/mistral.log &> /dev/null &
   else
     service mistral start
-  fi
-
-  # Only run WebUI HTTP Server if flag is not set
-  if [ -z "${ST2_DISABLE_HTTPSERVER}" ]; then
-    (cd /opt/stackstorm/static/webui && nohup python -m SimpleHTTPServer $WEBUI_PORT) &>> ${WEBUI_LOG_FILE} &
   fi
 }
 


### PR DESCRIPTION
This is a simple workaround for a problem described here - https://github.com/StackStorm/st2/issues/1841#issuecomment-132733152

> I am not planning to use mistral and by default, mistral is not installed. But, st2ctl script doesn't start st2web service unless mistral is installed. https://github.com/StackStorm/st2/blob/master/tools/st2ctl#L184 . It fails when mistral service is tried to start and it exits before starting st2web.

The solution is not ideal since "st2ctl start" will still exit with non-zero if Mistral is not installed, but at least st2web will still be started.

Ideal / proper solution would be to detect if Mistral is installed / available and only start it if it is. That solution requires a lot more work though, especially if we want to do it the right way.