### PR TITLE
RFR: Add X-Request-ID API headers so we can trace request in logs easily.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,7 @@ in development
 * Add OpenStack Keystone authentication configuration for Mistral. (improvement)
 * Add ability to add trace tag in ``st2 run`` CLI command. (feature)
 * Add ability to specify trace id in ``st2 run`` CLI command. (feature)
+* Add X-Request-ID header to all API calls for easier debugging. (improvement)
 
 0.12.2 - August 11, 2015.
 -------------------------

--- a/st2api/st2api/app.py
+++ b/st2api/st2api/app.py
@@ -55,7 +55,7 @@ def setup_app(config=None):
 
     app_conf = dict(config.app)
 
-    active_hooks = [hooks.JSONErrorResponseHook(), hooks.LoggingHook()]
+    active_hooks = [hooks.RequestIDHook(), hooks.JSONErrorResponseHook(), hooks.LoggingHook()]
 
     if cfg.CONF.auth.enable:
         active_hooks.append(hooks.AuthHook())

--- a/st2api/tests/unit/controllers/v1/test_base.py
+++ b/st2api/tests/unit/controllers/v1/test_base.py
@@ -26,9 +26,9 @@ class TestBase(FunctionalTest):
         self.assertEqual(response.headers['Access-Control-Allow-Methods'],
                          'GET,POST,PUT,DELETE,OPTIONS')
         self.assertEqual(response.headers['Access-Control-Allow-Headers'],
-                         'Content-Type,Authorization,X-Auth-Token')
+                         'Content-Type,Authorization,X-Auth-Token,X-Request-ID')
         self.assertEqual(response.headers['Access-Control-Expose-Headers'],
-                         'Content-Type,X-Limit,X-Total-Count')
+                         'Content-Type,X-Limit,X-Total-Count,X-Request-ID')
 
     def test_origin(self):
         response = self.app.get('/', headers={

--- a/st2common/st2common/constants/api.py
+++ b/st2common/st2common/constants/api.py
@@ -19,3 +19,5 @@ __all__ = [
 
 
 DEFAULT_API_VERSION = 'v1'
+
+REQUEST_ID_HEADER = 'X-Request-ID'

--- a/st2common/st2common/hooks.py
+++ b/st2common/st2common/hooks.py
@@ -258,10 +258,12 @@ class LoggingHook(PecanHook):
         method = getattr(state.request, 'method', None)
         path = getattr(state.request, 'path', None)
         remote_addr = getattr(state.request, 'remote_addr', None)
+        request_id = state.request.headers.get(REQUEST_ID_HEADER, None)
 
         # Log the outgoing response
         values = {'method': method, 'path': path, 'remote_addr': remote_addr}
         values['status_code'] = state.response.status
+        values['request_id'] = request_id
 
         if hasattr(state.controller, 'im_self'):
             function_name = state.controller.im_func.__name__
@@ -275,11 +277,11 @@ class LoggingHook(PecanHook):
 
         if log_result:
             values['result'] = state.response.body
-            log_msg = '%(method)s %(path)s result=%(result)s' % values
+            log_msg = '%(request_id)s - %(method)s %(path)s result=%(result)s' % values
         else:
             # Note: We don't want to include a result for some
             # methods which have a large result
-            log_msg = '%(method)s %(path)s' % values
+            log_msg = '%(request_id)s - %(method)s %(path)s' % values
 
         LOG.info(log_msg, extra=values)
 


### PR DESCRIPTION
Example:

```
(virtualenv)/m/s/s/st2 git:support_trace_id_in_cli_run ❯❯❯ grep "a64fd291-f9cf-4797-89e8-b4a58c8f12db" logs/st2api.log
2015-08-19 16:42:38,875 140597257636112 INFO log [-] a64fd291-f9cf-4797-89e8-b4a58c8f12db -  GET /v1/rules with filters={} (remote_addr='127.0.0.1',method='GET',filters={},request_id='a64fd291-f9cf-4797-89e8-b4a58c8f12db',path='/v1/rules')
(virtualenv)/m/s/s/st2 git:support_trace_id_in_cli_run ❯❯❯
```

```
(virtualenv)/m/s/s/st2 git:support_trace_id_in_cli_run ❯❯❯ http http://localhost:9101/v1/rules             ✭ ✱ ◼
HTTP/1.1 200 OK
Access-Control-Allow-Headers: Content-Type,Authorization,X-Auth-Token,X-Request-ID
Access-Control-Allow-Methods: GET,POST,PUT,DELETE,OPTIONS
Access-Control-Allow-Origin: http://127.0.0.1:9101/
Access-Control-Expose-Headers: Content-Type,X-Limit,X-Total-Count,X-Request-ID
Connection: keep-alive
Content-Length: 30806
Content-Type: application/json; charset=UTF-8
Date: Wed, 19 Aug 2015 23:42:38 GMT
X-Request-Id: a64fd291-f9cf-4797-89e8-b4a58c8f12db
X-Total-Count: 38
```

```
(virtualenv)/m/s/s/st2 git:support_trace_id_in_cli_run ❯❯❯ http http://localhost:9101/v1/rules                         ✭ ✱ ◼
HTTP/1.1 500 Internal Server Error
Access-Control-Allow-Headers: Content-Type,Authorization,X-Auth-Token,X-Request-ID
Access-Control-Allow-Methods: GET,POST,PUT,DELETE,OPTIONS
Access-Control-Allow-Origin: http://127.0.0.1:9101/
Access-Control-Expose-Headers: Content-Type,X-Limit,X-Total-Count,X-Request-ID
Connection: keep-alive
Content-Length: 36
Content-Type: application/json
Date: Wed, 19 Aug 2015 23:50:24 GMT
X-Request-Id: 15612f18-21b7-47b9-82fb-34657b7be2d5

{
    "faultstring": "500 testing"
}

(virtualenv)/m/s/s/st2 git:support_trace_id_in_cli_run ❯❯❯

(virtualenv)/m/s/s/st2 git:support_trace_id_in_cli_run ❯❯❯ grep "15612f18-21b7-47b9-82fb-34657b7be2d5" logs/st2api.log
2015-08-19 16:50:24,186 140260114315536 INFO log [-] 15612f18-21b7-47b9-82fb-34657b7be2d5 -  GET /v1/rules with filters={} (remote_addr='127.0.0.1',method='GET',filters={},request_id='15612f18-21b7-47b9-82fb-34657b7be2d5',path='/v1/rules')
(virtualenv)/m/s/s/st2 git:support_trace_id_in_cli_run ❯❯❯
```