### PR TITLE
Fix `packs/views/file` endpoint throwing error on binary data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ kombu
 mongoengine>=0.8.7,<0.9
 oslo.config>=1.12.1,<1.13
 paramiko
-pecan==0.7.0
+-e git+https://github.com/StackStorm/pecan.git@st2-patched#egg=pecan
 pymongo<3.0
 python-dateutil
 python-json-logger


### PR DESCRIPTION
Had to fork pecan and manually cherry pick the change from later version.