### PR TITLE
Correctly set "PATH" environment variable for the sandboxed Python runner process

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,8 @@ in development
 * Add X-Request-ID header to all API calls for easier debugging. (improvement)
 * Add new CLI commands for disabling and enabling content pack resources
   (``{sensor,action,rule} {enable, disable} <ref or id>``) (feature)
+* Make sure that the ``$PATH`` environment variable which is set for the sandboxed Python
+  process contains "<virtualenv path>/bin" directory as the first entry. (bug fix)
 
 0.12.2 - August 11, 2015.
 -------------------------

--- a/st2actions/st2actions/runners/pythonrunner.py
+++ b/st2actions/st2actions/runners/pythonrunner.py
@@ -29,6 +29,7 @@ from st2common import log as logging
 from st2common.constants.action import ACTION_OUTPUT_RESULT_DELIMITER
 from st2common.constants.action import LIVEACTION_STATUS_SUCCEEDED, LIVEACTION_STATUS_FAILED
 from st2common.constants.error_messages import PACK_VIRTUALENV_DOESNT_EXIST
+from st2common.util.sandboxing import get_sandbox_path
 from st2common.util.sandboxing import get_sandbox_python_path
 from st2common.util.sandboxing import get_sandbox_python_binary_path
 from st2common.util.sandboxing import get_sandbox_virtualenv_path
@@ -130,6 +131,7 @@ class PythonRunner(ActionRunner):
         # We need to ensure all the st2 dependencies are also available to the
         # subprocess
         env = os.environ.copy()
+        env['PATH'] = get_sandbox_path(virtualenv_path=virtualenv_path)
         env['PYTHONPATH'] = get_sandbox_python_path(inherit_from_parent=True,
                                                     inherit_parent_virtualenv=True)
 

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -66,6 +66,9 @@ def get_sandbox_path(virtualenv_path):
     sandbox_path = []
 
     parent_path = os.environ.get('PATH', '')
+    if not virtualenv_path:
+        return parent_path
+
     parent_path = parent_path.split(':')
     parent_path = [path for path in parent_path if path]
 

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -29,6 +29,7 @@ from st2common.constants.pack import SYSTEM_PACK_NAMES
 __all__ = [
     'get_sandbox_python_binary_path',
     'get_sandbox_python_path',
+    'get_sandbox_path',
     'get_sandbox_virtualenv_path'
 ]
 
@@ -52,9 +53,34 @@ def get_sandbox_python_binary_path(pack=None):
     return python_path
 
 
+def get_sandbox_path(virtualenv_path):
+    """
+    Return PATH environment variable value for the sandboxed environment.
+
+    This function makes sure that virtualenv/bin directory is in the path and has precedence over
+    the global PATH values.
+
+    Note: This function needs to be called from the parent process (one which is spawning a
+    sandboxed process).
+    """
+    sandbox_path = []
+
+    parent_path = os.environ.get('PATH', '')
+    parent_path = parent_path.split(':')
+    parent_path = [path for path in parent_path if path]
+
+    # Add virtualenv bin directory
+    virtualenv_bin_path = os.path.join(virtualenv_path, 'bin/')
+    sandbox_path.append(virtualenv_bin_path)
+    sandbox_path.extend(parent_path)
+
+    sandbox_path = ':'.join(sandbox_path)
+    return sandbox_path
+
+
 def get_sandbox_python_path(inherit_from_parent=True, inherit_parent_virtualenv=True):
     """
-    Return PYTHONPATH for the new sandboxed environment.
+    Return PYTHONPATH environment variable value for the new sandboxed environment.
 
     This function takes into account if the current (parent) process is running under virtualenv
     and other things like that.

--- a/st2common/tests/unit/test_util_sandboxing.py
+++ b/st2common/tests/unit/test_util_sandboxing.py
@@ -5,6 +5,7 @@ import unittest
 import mock
 
 from st2common.constants.pack import SYSTEM_PACK_NAMES
+from st2common.util.sandboxing import get_sandbox_path
 from st2common.util.sandboxing import get_sandbox_python_path
 from st2common.util.sandboxing import get_sandbox_python_binary_path
 import st2tests.config as tests_config
@@ -23,6 +24,17 @@ class SandboxingUtilsTestCase(unittest.TestCase):
         # System content pack, should use current process (system) python binary
         result = get_sandbox_python_binary_path(pack=SYSTEM_PACK_NAMES[0])
         self.assertEqual(result, sys.executable)
+
+    def test_get_sandbox_path(self):
+        # Mock the current PATH value
+        old_path = os.environ.get('PATH', '')
+        os.environ['PATH'] = '/home/path1:/home/path2:/home/path3:'
+
+        virtualenv_path = '/home/venv/test'
+        result = get_sandbox_path(virtualenv_path=virtualenv_path)
+        self.assertEqual(result, '/home/venv/test/bin/:/home/path1:/home/path2:/home/path3')
+
+        os.environ['PATH'] = old_path
 
     @mock.patch('st2common.util.sandboxing.get_python_lib')
     def test_get_sandbox_python_path(self, mock_get_python_lib):


### PR DESCRIPTION
Previously, we didn't add `<path to virtualenv>/bin` directory to the "$PATH" environment variable which is set for the sandboxed Python runner process (good catch @manasdk!).

This means that if the Python action tried to access a binary / script which was installed inside a virtual environment bin directory (e.g. ansible Python package installs ansible binary, etc.) or if they wanted to spawn a new python process, a default system version would be used instead of the one which is specific to the virtual environment.

Once this issue is resolved, workaround described at https://github.com/StackStorm/st2contrib/issues/273 won't be needed anymore.

@manasdk and I discussed this change and decided to skip inclusion in v0.13.0. This change needs a bit more testing so we can be sure it doesn't introduce some unexpected regression.