### PR TITLE
RFR: s/notification_channel/notification_route leftovers

### DIFF
--- a/st2api/tests/unit/controllers/v1/test_alias_execution.py
+++ b/st2api/tests/unit/controllers/v1/test_alias_execution.py
@@ -87,6 +87,6 @@ class TestAliasExecution(FunctionalTest):
                      'command': command,
                      'user': 'stanley',
                      'source_channel': 'test',
-                     'notification_channel': 'test'}
+                     'notification_route': 'test'}
         return self.app.post_json('/v1/aliasexecution', execution,
                                   expect_errors=expect_errors)

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -547,7 +547,12 @@ class AliasExecutionAPI(BaseAPI):
             "notification_channel": {
                 "type": "string",
                 "description": "StackStorm notification channel to use to respond.",
-                "required": True
+                "required": False
+            },
+            "notification_route": {
+                "type": "string",
+                "description": "StackStorm notification route to use to respond.",
+                "required": False
             }
         },
         "additionalProperties": False


### PR DESCRIPTION
```
(virtualenv)/m/s/s/st2 git:notification_channel_leftovers ❯❯❯ ag -C 5 "notification_channel"                             ✭ ◼
st2api/st2api/controllers/v1/aliasexecution.py
100-        return parser.get_extracted_param_value()
101-
102-    def _get_notify_field(self, payload):
103-        on_complete = NotificationSubSchema()
104-        route = (getattr(payload, 'notification_route', None) or
105:                 getattr(payload, 'notification_channel', None))
106-        on_complete.routes = [route]
107-        on_complete.data = {
108-            'user': payload.user,
109-            'source_channel': payload.source_channel
110-        }

st2common/st2common/models/api/action.py
542-            "source_channel": {
543-                "type": "string",
544-                "description": "Channel from which the execution was requested. This is not the \
545-                                channel as defined by the notification system."
546-            },
547:            "notification_channel": {
548-                "type": "string",
549-                "description": "StackStorm notification channel to use to respond.",
550-                "required": False
551-            },
552-            "notification_route": {
(virtualenv)/m/s/s/st2 git:notification_channel_leftovers ❯❯❯
```