### PR TITLE
Fix links in docs

### DIFF
--- a/docs/source/config/authentication.rst
+++ b/docs/source/config/authentication.rst
@@ -100,7 +100,7 @@ Install Apache and other dependencies. ::
 
 Follow the example below and create /etc/apache2/sites-available/st2-auth.conf. The following configures st2auth to authenticate users who belong to the st2ops group, with PAM via apache.
 
-.. literalinclude:: ../../st2auth/conf/apache.sample.conf
+.. literalinclude:: ../../../st2auth/conf/apache.sample.conf
 
 The path to the st2auth module is different depending on how |st2| is installed.
 
@@ -245,6 +245,6 @@ Usage
 Once st2auth is setup, API calls require token to be passed via the headers and the CLI calls
 require the token to be included as a CLI argument or be provided as an environment variable.
 
-.. include:: auth_usage.rst
+.. include:: ../auth_usage.rst
 
 .. _htpasswd: https://httpd.apache.org/docs/2.2/programs/htpasswd.html

--- a/docs/source/config/webui.rst
+++ b/docs/source/config/webui.rst
@@ -73,6 +73,6 @@ Also, please note that although this is not recommended and will undermine your 
 Authentication
 --------------
 
-To configure st2web to support authentication, edit ``config.js`` and add ``auth:true`` to every server that supports authentication. To enable authentication on a server side, please refer to :doc:`/authentication`.
+To configure st2web to support authentication, edit ``config.js`` and add ``auth:true`` to every server that supports authentication. To enable authentication on a server side, please refer to :doc:`authentication`.
 
 

--- a/docs/source/config/windows_runners.rst
+++ b/docs/source/config/windows_runners.rst
@@ -24,9 +24,6 @@ Samba client is available in standard APT and Yum repositories and winexe is
 available in our repositories. Both of those dependencies are installed by
 default when using ``st2_deploy.sh`` script or a pupped based installation.
 
-For information on configuring and enabling StackStorm repository, see
-:ref:`stackstorm-repos`.
-
 Installing on Ubuntu
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/install/deb.rst
+++ b/docs/source/install/deb.rst
@@ -75,5 +75,5 @@ Complete instructions coming soon, along with updated packages. Meantime, read a
 Configuration
 ^^^^^^^^^^^^^
 
-See  :doc:`/install/config` for more information on setting up SSH access for a user.
+See  :doc:`/config/config` for more information on setting up SSH access for a user.
 

--- a/docs/source/install/on_complete.rst
+++ b/docs/source/install/on_complete.rst
@@ -20,7 +20,7 @@ Use the supervisor script to manage |st2| services: ::
 .. rubric:: What's Next?
 
 * Get going with :doc:`/start`.
-* How to configure and use :doc:`authentication </authentication>`.
+* How to configure and use :doc:`authentication <../config/authentication>`.
 * Check out `tutorials on stackstorm.com <http://stackstorm.com/category/tutorials/>`__ - a growing set of practical examples of automating with StackStorm.
 
 .. include:: /engage.rst

--- a/docs/source/install/rpm.rst
+++ b/docs/source/install/rpm.rst
@@ -97,4 +97,4 @@ Complete instructions coming soon, along with updated packages. Meantime, read a
 Configuration
 ^^^^^^^^^^^^^
 
-See  :doc:`/install/config` for more information on setting up SSH access for a user.
+See  :doc:`/config/config` for more information on setting up SSH access for a user.

--- a/docs/source/packs.rst
+++ b/docs/source/packs.rst
@@ -19,7 +19,7 @@ into any additional directories which are specified in the ``packs_base_paths`` 
 
 If user wants |st2| to look for packs in additional directories, they can do that by setting the
 value of ``packs_base_paths`` in ``st2.conf`` (typically in :github_st2:`/etc/st2/st2.conf
-</conf/st2.prod.conf>`, as described in :doc:`Configuration <install/config>`). The value must be a
+</conf/st2.prod.conf>`, as described in :doc:`Configuration <config/config>`). The value must be a
 colon delimited string of directory paths.
 
 For example:

--- a/docs/source/runners.rst
+++ b/docs/source/runners.rst
@@ -70,7 +70,7 @@ Windows command runner allows you to run you to run command-line interpreter
 (cmd) and PowerShell commands on Windows hosts.
 
 For more information on enabling and setting up the Windows runner, please see
-the following section - :doc:`./install/windows_runners`.
+the following section - :doc:`./config/windows_runners`.
 
 Runner parameters
 ^^^^^^^^^^^^^^^^^
@@ -83,7 +83,7 @@ Windows script runner (windows-script)
 Windows script runner allows you to run PowerShell scripts on Windows hosts.
 
 For more information on enabling and setting up the Windows runner, please see
-the following section - :doc:`./install/windows_runners`.
+the following section - :doc:`./config/windows_runners`.
 
 Runner parameters
 ^^^^^^^^^^^^^^^^^

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -39,7 +39,7 @@ http://hostname:8080/.
 
 Authenticate
 ----------------
-If :doc:`authentication </authentication>` enabled, obtain authentication token with ``st2 auth <username>``,
+If :doc:`authentication </config/authentication>` enabled, obtain authentication token with ``st2 auth <username>``,
 and supply it with each command using ``--token`` parameter. For convenience,
 keep credentials in CLI config file, or put it to environment variable ``ST2_AUTH_TOKEN``.
 :ref:`Details here <authentication-usage>`, a nice shortcut for now is:


### PR DESCRIPTION
Configuration related docs were moved to the config folder and broke a number of links in the docs in the process.