### PR TITLE
Update jinja_filters.rst

### DIFF
--- a/docs/source/reference/jinja_filters.rst
+++ b/docs/source/reference/jinja_filters.rst
@@ -20,12 +20,12 @@ match pattern at the beginning of expression.
 
 regex_replace
 ~~~~~~~~~~~~~
-replace a pattern matching regex with supplied value
+replace a pattern matching regex with supplied value (backreferences possible)
 
 .. code-block:: bash
 
     {{value_key | regex_replace("x", "y")}}
-    {{value_key | regex_replace("(blue|white|red)", "color")}}
+    {{value_key | regex_replace("(blue|white|red)", "beautiful color \\1")}}
 
 regex_search
 ~~~~~~~~~~~~


### PR DESCRIPTION
Modified example for regex_replace to show how backreferences can be used.

So far, the documentation did not contain any backreferences, which may led users to the assumption
they cannot be used. 