### PR TITLE
Re-enable pylint, lint and docs checks on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - 2.7
 
 env:
+  - TASK=checks
   - TASK=unit
   - TASK=integration
   - TASK=mistral

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -6,7 +6,11 @@ if [ -z ${TASK} ]; then
   exit 2
 fi
 
-if [ ${TASK} == 'unit' ]; then
+if [ ${TASK} == 'checks' ]; then
+  # compile .py files, useful as compatibility syntax check
+  make compile
+  make pylint flake8 docs
+elif [ ${TASK} == 'unit' ]; then
   # compile .py files, useful as compatibility syntax check
   make compile
   make .unit-tests-coverage-html


### PR DESCRIPTION
Sadly Scrutinizer gets stuck too many times or fails with errors unrelated to our changes :/