### PR TITLE
Fix pecan install issue / regression introduced in v0.13.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ kombu
 mongoengine>=0.8.7,<0.9
 oslo.config>=1.12.1,<1.13
 paramiko
--e git+https://github.com/StackStorm/pecan.git@st2-patched#egg=pecan
+git+https://github.com/StackStorm/pecan.git@st2-patched#egg=pecan
 pymongo<3.0
 python-dateutil
 python-json-logger


### PR DESCRIPTION
Using "-e" (editable) option with pip results in pip cloning a repo in the /root directory and creating a symlink from there into dist-packages.

This doesn't work well with the actions started by action runner. This manifested itself with `packs.install` action being broken (reload step failed because we failed to import pecan).

Note: This issue was originally reported by a user on slack-community channel. After a bunch of troubleshooting I managed to reproduced it on a fresh installation.

```
root@sewubuntu2:~# st2 run core.local cmd='whoami ; echo $PYTHONPATH; python -c "import pecan;print pecan;"'
.
id: 55dc738c516ea443c0aa5798
status: failed
result: 
{
    "succeeded": false, 
    "failed": true, 
    "return_code": 1, 
    "stderr": "Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: No module named pecan
", 
    "stdout": "stanley

"
}
root@sewubuntu2:~# 
```