### PR TITLE
[CLI] Update CLI to exit with non-zero if the action fails

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,11 @@ Changelog
 in development
 --------------
 
-0.13.0 - August 24, 2015.
--------------------------
+* Update CLI so ``st2 run`` / ``st2 execution run`` and ``st2 execution re-run`` commands exit with
+  non-zero code if the action fails. (improvement)
+
+0.13.0 - August 24, 2015
+------------------------
 
 * Add new OpenStack Keystone authentication backend.
   [Itxaka Serrano]
@@ -54,8 +57,8 @@ in development
 * Make sure that the ``$PATH`` environment variable which is set for the sandboxed Python
   process contains "<virtualenv path>/bin" directory as the first entry. (bug fix)
 
-0.12.2 - August 11, 2015.
--------------------------
+0.12.2 - August 11, 2015
+------------------------
 
 * Support local ssh config file in remote runners. (feature)
 * Changes to htpasswd file used in `flat_file` auth backend do not require

--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -374,7 +374,10 @@ class ActionChainRunner(ActionRunner):
             liveaction, _ = action_service.request(liveaction)
         except:
             liveaction.status = LIVEACTION_STATUS_FAILED
-            raise Exception('Failed to schedule liveaction.')
+
+            message = 'Failed to schedule liveaction.'
+            LOG.exception(message)
+            raise Exception(message)
 
         while (wait_for_completion and
                liveaction.status != LIVEACTION_STATUS_SUCCEEDED and

--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -372,12 +372,10 @@ class ActionChainRunner(ActionRunner):
     def _run_action(self, liveaction, wait_for_completion=True):
         try:
             liveaction, _ = action_service.request(liveaction)
-        except:
+        except Exception as e:
             liveaction.status = LIVEACTION_STATUS_FAILED
-
-            message = 'Failed to schedule liveaction.'
-            LOG.exception(message)
-            raise Exception(message)
+            LOG.exception('Failed to schedule liveaction.')
+            raise e
 
         while (wait_for_completion and
                liveaction.status != LIVEACTION_STATUS_SUCCEEDED and

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -202,7 +202,11 @@ class ActionRunCommandMixin(object):
             self.print_output('To get the results, execute:\n st2 execution get %s' %
                               (execution.id), six.text_type)
         else:
-            return self._print_execution_details(execution=execution, args=args, **kwargs)
+            self._print_execution_details(execution=execution, args=args, **kwargs)
+
+        if execution.status == 'failed':
+            # Exit with non zero if the action has failed
+            sys.exit(1)
 
     def _add_common_options(self):
         root_arg_grp = self.parser.add_mutually_exclusive_group()


### PR DESCRIPTION
This pull request updates `st2 run`, `st2 execution run` and `st2 execution re-run` commands to exit with a non-zero status code when running in a non-async mode if the action failed.

I believe not exiting with non-zero code also masked the pecan regression introduced in v0.13.0. We have tests in `st2tests` for `packs.install`, but `st2 run` exited with zero so we didn't detect this issue.

@enykeev had some concerns that there might be a reason why we don't already do that. 

If there is indeed a good reason for this not being a default behavior, we can introduce a new flag (e.g. ``--exit-on-failure`` or similar), but I'm not too big of a fan of that since it's not consistent with other operations (e.g. get in-existent action).

Another concern was how to differentiate between CLI errors and API errors. We already use the same behavior in other places so I don't think this is an issue (e.g. we exit with non-zero if API returns 404 object non found) - we just need to make sure we use different / appropriate exit codes to differentaite between those error conditions.