### PR TITLE
cwd for remote_script should use cwd runner param

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,6 @@ in development
 --------------
 
 * Add YAQL v1.0 support to Mistral. Earlier versions are deprecated. (improvement)
-* cwd for paramiko script runner should use cwd provided as runner parameter. (bug-fix)
 
 0.13.0 - August 24, 2015.
 -------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ in development
 --------------
 
 * Add YAQL v1.0 support to Mistral. Earlier versions are deprecated. (improvement)
+* cwd for paramiko script runner should use cwd provided as runner parameter. (bug-fix)
 
 0.13.0 - August 24, 2015.
 -------------------------

--- a/st2actions/st2actions/runners/remote_script_runner.py
+++ b/st2actions/st2actions/runners/remote_script_runner.py
@@ -159,7 +159,7 @@ class ParamikoRemoteScriptRunner(BaseParallelSSHRunner):
         command = remote_action.get_full_command_string()
         LOG.info('Command to run: %s', command)
         results = self._parallel_ssh_client.run(command, timeout=remote_action.get_timeout(),
-                                                cwd=remote_action.get_remote_base_dir())
+                                                cwd=remote_action.get_cwd())
         LOG.debug('Results from script: %s', results)
         return results
 

--- a/st2actions/tests/unit/test_paramiko_remote_script_runner.py
+++ b/st2actions/tests/unit/test_paramiko_remote_script_runner.py
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import bson
+from mock import patch, Mock, MagicMock
+import unittest2
+
+# XXX: There is an import dependency. Config needs to setup
+# before importing remote_script_runner classes.
+import st2tests.config as tests_config
+tests_config.parse_args()
+
+from st2actions.runners.remote_script_runner import ParamikoRemoteScriptRunner
+from st2actions.runners.ssh.parallel_ssh import ParallelSSHClient
+from st2common.models.system.action import RemoteScriptAction
+import st2common.util.jsonify as jsonify
+
+
+class ParamikoScriptRunnerTestCase(unittest2.TestCase):
+
+    @patch('st2actions.runners.ssh.parallel_ssh.ParallelSSHClient', Mock)
+    @patch.object(jsonify, 'json_loads', MagicMock(return_value={}))
+    @patch.object(ParallelSSHClient, 'run', MagicMock(return_value={}))
+    @patch.object(ParallelSSHClient, 'connect', MagicMock(return_value={}))
+    def test_cwd_used_correctly(self):
+        remote_action = RemoteScriptAction(
+            'foo-script', bson.ObjectId(),
+            script_local_path_abs='/home/stanley/shiz_storm.py',
+            script_local_libs_path_abs=None,
+            named_args={}, positional_args=['blank space'], env_vars={},
+            on_behalf_user='svetlana', user='stanley',
+            private_key='/home/stanley/.ssh/stanley_rsa',
+            remote_dir='/tmp', hosts=['localhost'], cwd='/test/cwd/'
+        )
+        paramiko_runner = ParamikoRemoteScriptRunner('runner_1')
+        paramiko_runner._parallel_ssh_client = ParallelSSHClient(['localhost'], 'stanley')
+        paramiko_runner._run_script_on_remote_host(remote_action)
+        ParallelSSHClient.run.assert_called_with("/tmp/shiz_storm.py 'blank space'",
+                                                 cwd='/test/cwd/', timeout=None)

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -52,6 +52,7 @@ def _register_config_opts():
     _register_api_opts()
     _register_auth_opts()
     _register_action_sensor_opts()
+    _register_ssh_runner_opts()
     _register_mistral_opts()
     _register_cloudslang_opts()
     _register_scheduler_opts()
@@ -158,6 +159,28 @@ def _register_action_sensor_opts():
                    help='Amount of time to wait prior to retrying a request.')
     ]
     _register_opts(action_sensor_opts, group='action_sensor')
+
+
+def _register_ssh_runner_opts():
+    ssh_runner_opts = [
+        cfg.BoolOpt('use_ssh_config', default=False,
+                    help='Use the .ssh/config file. Useful to override ports etc.'),
+        cfg.StrOpt('remote_dir',
+                   default='/tmp',
+                   help='Location of the script on the remote filesystem.'),
+        cfg.BoolOpt('allow_partial_failure',
+                    default=False,
+                    help='How partial success of actions run on multiple nodes ' +
+                         'should be treated.'),
+        cfg.BoolOpt('use_paramiko_ssh_runner',
+                    default=False,
+                    help='Use Paramiko based SSH runner as the default remote runner. ' +
+                         'EXPERIMENTAL!!! USE AT YOUR OWN RISK.'),
+        cfg.IntOpt('max_parallel_actions', default=50,
+                   help='Max number of parallel remote SSH actions that should be run.  ' +
+                        'Works only with Paramiko SSH runner.'),
+    ]
+    _register_opts(ssh_runner_opts, group='ssh_runner')
 
 
 def _register_mistral_opts():


### PR DESCRIPTION
Noticed this issue in st2build001. To use the new runner in st2build001, we need this patch in 0.13.1. 