### PR TITLE
Trace fix

### DIFF
--- a/st2actions/st2actions/notifier/notifier.py
+++ b/st2actions/st2actions/notifier/notifier.py
@@ -141,7 +141,7 @@ class Notifier(consumers.MessageHandler):
             payload['action_ref'] = liveaction.action
             payload['runner_ref'] = self._get_runner_ref(liveaction.action)
 
-            trace_context = self._get_trace_context(liveaction=liveaction)
+            trace_context = self._get_trace_context(execution_id=execution_id)
 
             failed_routes = []
             for route in routes:

--- a/st2actions/st2actions/notifier/notifier.py
+++ b/st2actions/st2actions/notifier/notifier.py
@@ -159,8 +159,9 @@ class Notifier(consumers.MessageHandler):
             if len(failed_routes) > 0:
                 raise Exception('Failed notifications to routes: %s' % ', '.join(failed_routes))
 
-    def _get_trace_context(self, liveaction):
-        _, trace_db = trace_service.get_trace_db_by_live_action(liveaction=liveaction)
+    def _get_trace_context(self, execution_id):
+        trace_db = trace_service.get_trace_db_by_action_execution(
+            action_execution_id=execution_id)
         if trace_db:
             return TraceContext(id_=str(trace_db.id), trace_tag=trace_db.trace_tag)
         # If no trace_context is found then do not create a new one here. If necessary
@@ -181,9 +182,12 @@ class Notifier(consumers.MessageHandler):
                    'runner_ref': self._get_runner_ref(liveaction.action),
                    'parameters': liveaction.get_masked_parameters(),
                    'result': liveaction.result}
-        trace_context = self._get_trace_context(liveaction=liveaction)
-        LOG.debug('POSTing %s for %s. Payload - %s.', ACTION_TRIGGER_TYPE['name'],
-                  liveaction.id, payload)
+        # Use execution_id to extract trace rather than liveaction. execution_id
+        # will look-up an exact TraceDB while liveaction depending on context
+        # may not end up going to the DB.
+        trace_context = self._get_trace_context(execution_id=execution_id)
+        LOG.debug('POSTing %s for %s. Payload - %s. TraceContext - %s',
+                  ACTION_TRIGGER_TYPE['name'], liveaction.id, payload, trace_context)
         self._trigger_dispatcher.dispatch(self._action_trigger, payload=payload,
                                           trace_context=trace_context)
 

--- a/st2common/st2common/models/api/trace.py
+++ b/st2common/st2common/models/api/trace.py
@@ -151,3 +151,6 @@ class TraceContext(object):
     def __init__(self, id_=None, trace_tag=None):
         self.id_ = id_
         self.trace_tag = trace_tag
+
+    def __str__(self):
+        return '{id_: %s, trace_tag: %s}' % (self.id_, self.trace_tag)

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -153,7 +153,7 @@ class MongoDBAccess(object):
 
     @staticmethod
     def update(instance, **kwargs):
-        instance.update(**kwargs)
+        return instance.update(**kwargs)
 
     @staticmethod
     def delete(instance):

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -152,6 +152,10 @@ class MongoDBAccess(object):
         return instance
 
     @staticmethod
+    def update(instance, **kwargs):
+        instance.update(**kwargs)
+
+    @staticmethod
     def delete(instance):
         instance.delete()
 

--- a/st2common/st2common/persistence/base.py
+++ b/st2common/st2common/persistence/base.py
@@ -152,6 +152,11 @@ class Access(object):
 
     @classmethod
     def update(cls, model_object, publish=True, dispatch_trigger=True, **kwargs):
+        """
+        Use this method when -
+        * upsert=False is desired
+        * special operators like push, push_all are to be used.
+        """
         cls._get_impl().update(model_object, **kwargs)
         # update does not return the object but a flag; likely success/fail but docs
         # are not very good on this one so ignoring. Explicitly get the object from

--- a/st2common/st2common/persistence/trace.py
+++ b/st2common/st2common/persistence/trace.py
@@ -25,6 +25,18 @@ class Trace(Access):
         return cls.impl
 
     @classmethod
+    def push_components(cls, instance, action_executions=None, rules=None, trigger_instances=None):
+        update_kwargs = {}
+        if action_executions:
+            update_kwargs['push_all__action_executions'] = action_executions
+        if rules:
+            update_kwargs['push_all__rules'] = rules
+        if trigger_instances:
+            update_kwargs['push_all__trigger_instances'] = trigger_instances
+        if update_kwargs:
+            cls._get_impl().update(instance, **update_kwargs)
+
+    @classmethod
     def push_action_execution(cls, instance, action_execution):
         return cls._get_impl().update(instance, push__action_executions=action_execution)
 

--- a/st2common/st2common/persistence/trace.py
+++ b/st2common/st2common/persistence/trace.py
@@ -23,3 +23,15 @@ class Trace(Access):
     @classmethod
     def _get_impl(cls):
         return cls.impl
+
+    @classmethod
+    def push_action_execution(cls, instance, action_execution):
+        return cls._get_impl().update(instance, push__action_executions=action_execution)
+
+    @classmethod
+    def push_rule(cls, instance, rule):
+        return cls._get_impl().update(instance, push__rules=rule)
+
+    @classmethod
+    def push_trigger_instance(cls, instance, trigger_instance):
+        return cls._get_impl().update(instance, push__trigger_instances=trigger_instance)

--- a/st2common/st2common/persistence/trace.py
+++ b/st2common/st2common/persistence/trace.py
@@ -34,16 +34,17 @@ class Trace(Access):
         if trigger_instances:
             update_kwargs['push_all__trigger_instances'] = trigger_instances
         if update_kwargs:
-            cls._get_impl().update(instance, **update_kwargs)
+            return cls.update(instance, **update_kwargs)
+        return instance
 
     @classmethod
     def push_action_execution(cls, instance, action_execution):
-        return cls._get_impl().update(instance, push__action_executions=action_execution)
+        return cls.update(instance, push__action_executions=action_execution)
 
     @classmethod
     def push_rule(cls, instance, rule):
-        return cls._get_impl().update(instance, push__rules=rule)
+        return cls.update(instance, push__rules=rule)
 
     @classmethod
     def push_trigger_instance(cls, instance, trigger_instance):
-        return cls._get_impl().update(instance, push__trigger_instances=trigger_instance)
+        return cls.update(instance, push__trigger_instances=trigger_instance)

--- a/st2common/st2common/services/trace.py
+++ b/st2common/st2common/services/trace.py
@@ -240,21 +240,23 @@ def add_or_update_given_trace_db(trace_db, action_executions=None, rules=None,
         action_executions = []
     action_executions = [TraceComponentDB(object_id=action_execution)
                          for action_execution in action_executions]
-    if trace_db.action_executions:
-        action_executions.extend(trace_db.action_executions)
 
     if not rules:
         rules = []
     rules = [TraceComponentDB(object_id=rule) for rule in rules]
-    if trace_db.rules:
-        rules.extend(trace_db.rules)
 
     if not trigger_instances:
         trigger_instances = []
     trigger_instances = [TraceComponentDB(object_id=trigger_instance)
                          for trigger_instance in trigger_instances]
-    if trace_db.trigger_instances:
-        trigger_instances.extend(trace_db.trigger_instances)
+
+    # If an id exists then this is an update and we do not want to perform
+    # an upsert so use push_components which will use the push operator.
+    if trace_db.id:
+        return Trace.push_components(trace_db,
+                                     action_executions=action_executions,
+                                     rules=rules,
+                                     trigger_instances=trigger_instances)
 
     trace_db.action_executions = action_executions
     trace_db.rules = rules

--- a/st2common/tests/unit/services/test_trace.py
+++ b/st2common/tests/unit/services/test_trace.py
@@ -16,6 +16,8 @@
 import bson
 import copy
 
+from unittest2 import TestCase
+
 from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2common.exceptions.trace import UniqueTraceNotFoundException
 from st2common.models.api.trace import TraceContext
@@ -298,3 +300,16 @@ class TestTraceService(DbTestCase):
                          'Expected updated trigger_instances.')
 
         Trace.delete(retrieved_trace_db)
+
+
+class TestTraceContext(TestCase):
+
+    def test_str_method(self):
+        trace_context = TraceContext(id_='id', trace_tag='tag')
+        self.assertTrue(str(trace_context))
+
+        trace_context = TraceContext(trace_tag='tag')
+        self.assertTrue(str(trace_context))
+
+        trace_context = TraceContext(id_='id')
+        self.assertTrue(str(trace_context))

--- a/st2common/tests/unit/test_db_trace.py
+++ b/st2common/tests/unit/test_db_trace.py
@@ -82,6 +82,29 @@ class TraceDBTest(CleanDbTestCase):
         self.assertEquals(len(retrieved[0].trigger_instances), no_trigger_instances,
                           'Failed to update trigger_instances.')
 
+    def test_update_via_list_push(self):
+        no_action_executions = 4
+        no_rules = 4
+        no_trigger_instances = 5
+        saved = TraceDBTest._create_save_trace(
+            trace_tag='test_trace',
+            action_executions=[str(bson.ObjectId()) for _ in range(no_action_executions)],
+            rules=[str(bson.ObjectId()) for _ in range(no_rules)],
+            trigger_instances=[str(bson.ObjectId()) for _ in range(no_trigger_instances)])
+
+        # push updates
+        Trace.push_action_execution(
+            saved, action_execution=TraceComponentDB(object_id=str(bson.ObjectId())))
+        Trace.push_rule(saved, rule=TraceComponentDB(object_id=str(bson.ObjectId())))
+        Trace.push_trigger_instance(
+            saved, trigger_instance=TraceComponentDB(object_id=str(bson.ObjectId())))
+
+        retrieved = Trace.get(id=saved.id)
+        self.assertEquals(retrieved.id, saved.id, 'Incorrect trace retrieved.')
+        self.assertEquals(len(retrieved.action_executions), no_action_executions + 1)
+        self.assertEquals(len(retrieved.rules), no_rules + 1)
+        self.assertEquals(len(retrieved.trigger_instances), no_trigger_instances + 1)
+
     @staticmethod
     def _create_save_trace(trace_tag, id_=None, action_executions=None, rules=None,
                            trigger_instances=None):

--- a/st2common/tests/unit/test_db_trace.py
+++ b/st2common/tests/unit/test_db_trace.py
@@ -105,6 +105,31 @@ class TraceDBTest(CleanDbTestCase):
         self.assertEquals(len(retrieved.rules), no_rules + 1)
         self.assertEquals(len(retrieved.trigger_instances), no_trigger_instances + 1)
 
+    def test_update_via_list_push_components(self):
+        no_action_executions = 4
+        no_rules = 4
+        no_trigger_instances = 5
+        saved = TraceDBTest._create_save_trace(
+            trace_tag='test_trace',
+            action_executions=[str(bson.ObjectId()) for _ in range(no_action_executions)],
+            rules=[str(bson.ObjectId()) for _ in range(no_rules)],
+            trigger_instances=[str(bson.ObjectId()) for _ in range(no_trigger_instances)])
+
+        Trace.push_components(
+            saved,
+            action_executions=[TraceComponentDB(object_id=str(bson.ObjectId()))
+                               for _ in range(no_action_executions)],
+            rules=[TraceComponentDB(object_id=str(bson.ObjectId()))
+                   for _ in range(no_rules)],
+            trigger_instances=[TraceComponentDB(object_id=str(bson.ObjectId()))
+                               for _ in range(no_trigger_instances)])
+
+        retrieved = Trace.get(id=saved.id)
+        self.assertEquals(retrieved.id, saved.id, 'Incorrect trace retrieved.')
+        self.assertEquals(len(retrieved.action_executions), no_action_executions * 2)
+        self.assertEquals(len(retrieved.rules), no_rules * 2)
+        self.assertEquals(len(retrieved.trigger_instances), no_trigger_instances * 2)
+
     @staticmethod
     def _create_save_trace(trace_tag, id_=None, action_executions=None, rules=None,
                            trigger_instances=None):

--- a/st2common/tests/unit/test_db_trace.py
+++ b/st2common/tests/unit/test_db_trace.py
@@ -115,7 +115,7 @@ class TraceDBTest(CleanDbTestCase):
             rules=[str(bson.ObjectId()) for _ in range(no_rules)],
             trigger_instances=[str(bson.ObjectId()) for _ in range(no_trigger_instances)])
 
-        Trace.push_components(
+        retrieved = Trace.push_components(
             saved,
             action_executions=[TraceComponentDB(object_id=str(bson.ObjectId()))
                                for _ in range(no_action_executions)],
@@ -124,7 +124,6 @@ class TraceDBTest(CleanDbTestCase):
             trigger_instances=[TraceComponentDB(object_id=str(bson.ObjectId()))
                                for _ in range(no_trigger_instances)])
 
-        retrieved = Trace.get(id=saved.id)
         self.assertEquals(retrieved.id, saved.id, 'Incorrect trace retrieved.')
         self.assertEquals(len(retrieved.action_executions), no_action_executions * 2)
         self.assertEquals(len(retrieved.rules), no_rules * 2)


### PR DESCRIPTION
* 	Ability to push an new TraceComponent into a TraceDB list property. Support for pushAll operator as that fits our usage better.

* Change service impl to update without upsert whenever possible

Testing -
* With 5 and 10 actionrunners started off the same workflow with nested workflows multiple time (10 or so). Passed in the same trace_id to the execution in order to guarantee writing to the same trace thus causing contention and previously seen racing behavior. All workflows passed and trace was updated properly.