### PR TITLE
add link to updated docs for ChatOps/Installation

### DIFF
--- a/instructables/chatops.md
+++ b/instructables/chatops.md
@@ -1,4 +1,8 @@
-Hi, and thanks for using StackStorm + ChatOps. We value your feedback, and would love to hear it. Please send us a note at `support@stackstorm.com`, or come chat with us on IRC at irc://irc.freenode.net/#stackstorm.
+# UPDATED DOCUMENTATION
+
+Thanks for coming here to give StackStorm + ChatOps a try! We have made the experience for trying out StackStorm much more streamlined with an all-in-one installer with AMIs, Vagrant images, and more. Please check out http://docs.stackstorm.com/install/all_in_one.html#all-in-one-installer for more information.
+
+This instructable has been left here as a reference for understanding the internal wiring.
 
 ## What is ChatOps
 


### PR DESCRIPTION
This PR is to redirect users who are finding their way to the ChatOps instructable to the All-in-one Installer.

This hopefully will make adoption much easier.

Reported by silopolis on stackstorm_community.