### PR TITLE
Need nay must have a make target to run test without requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,12 +229,15 @@ tests: pytests
 pytests: compile requirements .flake8 .pylint .pytests-coverage
 
 .PHONY: .pytests
-.pytests: compile unit-tests itests clean
+.pytests: compile .unit-tests .itests clean
 
 .PHONY: .pytests-coverage
 .pytests-coverage: .unit-tests-coverage-html .itests-coverage-html clean
 
 .PHONY: unit-tests
+itests: requirements .unit-tests
+
+.PHONY: .unit-tests
 unit-tests:
 	@echo
 	@echo "==================== tests ===================="


### PR DESCRIPTION
* This is critical for productivity! Requirements targets are slow.

`make .pytests` - use that to run tests without requirements. 
`make pytests` - use that to run tests with requirements. This is coverage but that ain't hurting anyone.
