### PR TITLE
Don't explode if user doesn't include "enabled" attribute when creating a rule

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ in development
   default. (new feature, improvement)
 * New st2auth authentication backend for authenticating against LDAP servers -
   https://github.com/StackStorm/st2-auth-backend-ldap. (new feature)
+* Default to rule being disabled if the user doesn't explicitly specify ``enabled`` attribute when
+  creating a rule via the API or inside the rule metadata file when registering local content
+  (previously it defaulted to enabled).
 
 0.13.0 - August 24, 2015
 ------------------------

--- a/st2api/tests/unit/controllers/v1/test_rules.py
+++ b/st2api/tests/unit/controllers/v1/test_rules.py
@@ -59,6 +59,11 @@ class TestRuleController(FunctionalTest):
             fixtures_pack=FIXTURES_PACK,
             fixtures_dict={'rules': [file_name]})['rules'][file_name]
 
+        file_name = 'rule_no_enabled_attribute.yaml'
+        TestRuleController.RULE_3 = TestRuleController.fixtures_loader.load_fixtures(
+            fixtures_pack=FIXTURES_PACK,
+            fixtures_dict={'rules': [file_name]})['rules'][file_name]
+
     @classmethod
     def tearDownClass(cls):
         TestRuleController.fixtures_loader.delete_fixtures_from_db(
@@ -112,6 +117,12 @@ class TestRuleController(FunctionalTest):
 
         expected_msg = 'Additional properties are not allowed (u\'minutex\' was unexpected)'
         self.assertTrue(expected_msg in post_resp.body)
+
+    def test_post_no_enabled_attribute_disabled_by_default(self):
+        post_resp = self.__do_post(TestRuleController.RULE_3)
+        self.assertEqual(post_resp.status_int, http_client.CREATED)
+        self.assertFalse(post_resp.json['enabled'])
+        self.__do_delete(self.__get_rule_id(post_resp))
 
     def test_put(self):
         post_resp = self.__do_post(TestRuleController.RULE_1)

--- a/st2common/st2common/models/api/rule.py
+++ b/st2common/st2common/models/api/rule.py
@@ -178,7 +178,7 @@ class RuleAPI(BaseAPI):
         action = ActionExecutionSpecDB(ref=rule.action['ref'],
                                        parameters=rule.action['parameters'])
 
-        enabled = rule.enabled
+        enabled = getattr(rule, 'enabled', True)
         tags = TagsHelper.to_model(getattr(rule, 'tags', []))
 
         model = cls.model(name=name, description=description, pack=pack, ref=ref, trigger=trigger,

--- a/st2common/st2common/models/api/rule.py
+++ b/st2common/st2common/models/api/rule.py
@@ -131,7 +131,7 @@ class RuleAPI(BaseAPI):
             'action': REQUIRED_ATTR_SCHEMAS['action'],
             'enabled': {
                 'type': 'boolean',
-                'default': True
+                'default': False
             },
             "tags": {
                 "description": "User associated metadata assigned to this object.",
@@ -178,7 +178,7 @@ class RuleAPI(BaseAPI):
         action = ActionExecutionSpecDB(ref=rule.action['ref'],
                                        parameters=rule.action['parameters'])
 
-        enabled = getattr(rule, 'enabled', True)
+        enabled = getattr(rule, 'enabled', False)
         tags = TagsHelper.to_model(getattr(rule, 'tags', []))
 
         model = cls.model(name=name, description=description, pack=pack, ref=ref, trigger=trigger,

--- a/st2tests/st2tests/fixtures/generic/rules/rule_no_enabled_attribute.yaml
+++ b/st2tests/st2tests/fixtures/generic/rules/rule_no_enabled_attribute.yaml
@@ -1,0 +1,20 @@
+---
+action:
+  parameters:
+    ip1: '{{trigger.t1_p}}'
+    ip2: '{{trigger}}'
+  ref: wolfpack.action-1
+criteria:
+  t1_p:
+    pattern: t1_p_v
+    type: equals
+description: ''
+name: rule_no_enabled_attribute
+pack: wolfpack
+tags:
+- name: tag1
+  value: dont-care
+- name: tag2
+  value: dont-care
+trigger:
+  type: wolfpack.triggertype-1


### PR DESCRIPTION
I personally couldn't reproduce it since we set a default value in the RuleAPI jsonschema, so the default value (`True`) should be used.

In any case I pushed a change so we now follow the same pattern as we do for actions.