### PR TITLE
Fix executions start_timestamp_lt and start_timestamp_gt filtering

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,9 +16,11 @@ in development
 * Default to rule being disabled if the user doesn't explicitly specify ``enabled`` attribute when
   creating a rule via the API or inside the rule metadata file when registering local content
   (previously it defaulted to enabled).
-* ``private_key`` supplied for remote_actions is now used to auth correctly.
-  ``private_key`` argument should be the contents of private key file
-  (of user specified in ``username`` argument). (bug-fix)
+* ``private_key`` supplied for remote_actions is now used to auth correctly. ``private_key``
+  argument should be the contents of private key file (of user specified in ``username`` argument).
+  (bug-fix)
+* Fix ``timestamp_lt`` and ``timestamp_gt`` filtering in the `/executions` API endpoint. Now we 
+  return a correct result which is expected from a user-perspective. (bug-fix)
 
 0.13.1 - August 28, 2015
 ------------------------

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -128,7 +128,13 @@ class ResourceController(rest.RestController):
 
             filters['__'.join(v.split('.'))] = filter_value
 
-        LOG.info('GET all %s with filters=%s', pecan.request.path, filters)
+        extra = {
+            'filters': filters,
+            'sort': kwargs.get('sort', None),
+            'offset': offset,
+            'limit': limit
+        }
+        LOG.info('GET all %s with filters=%s' % (pecan.request.path, filters), extra=extra)
 
         instances = self.access.query(exclude_fields=exclude_fields, **filters)
 

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -79,6 +79,7 @@ class ResourceController(rest.RestController):
         :param exclude_fields: A list of object fields to exclude.
         :type exclude_fields: ``list``
         """
+        query_options = kwargs.get('query_options', self.query_options)
         exclude_fields = exclude_fields or []
 
         # TODO: Why do we use comma delimited string, user can just specify
@@ -103,7 +104,7 @@ class ResourceController(rest.RestController):
             sort_value = direction + self.supported_filters[sort_key]
             db_sort_values.append(sort_value)
 
-        default_sort_values = copy.copy(self.query_options.get('sort'))
+        default_sort_values = copy.copy(query_options.get('sort'))
         kwargs['sort'] = db_sort_values if db_sort_values else default_sort_values
 
         # TODO: To protect us from DoS, we need to make max_limit mandatory

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -137,6 +137,9 @@ class ResourceController(rest.RestController):
         LOG.info('GET all %s with filters=%s' % (pecan.request.path, filters), extra=extra)
 
         instances = self.access.query(exclude_fields=exclude_fields, **filters)
+        if limit == 1:
+            # Perform the filtering on the DB side
+            instances = instances.limit(limit)
 
         if limit:
             pecan.response.headers['X-Limit'] = str(limit)

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -308,6 +308,15 @@ class ActionExecutionsController(ActionExecutionsControllerMixin, ResourceContro
 
         exclude_fields = self._validate_exclude_fields(exclude_fields=exclude_fields)
 
+        # Use a custom sort order when filtering on a timestamp so we return a correct result as
+        # expected by the user
+        if 'timestamp_lt' in kw:
+            query_options = {'sort': ['-start_timestamp', 'action.ref']}
+            kw['query_options'] = query_options
+        elif 'timestamp_gt' in kw:
+            query_options = {'sort': ['+start_timestamp', 'action.ref']}
+            kw['query_options'] = query_options
+
         return self._get_action_executions(exclude_fields=exclude_fields, **kw)
 
     @jsexpose(arg_types=[str])


### PR DESCRIPTION
This issue was originally discovered by @enykeev a while ago, but I some how missed the JIRA comment - https://gist.github.com/enykeev/b535696c7ba88c2042cf.

As far as the correctness goes - the result was correct from the code and DB perspective, but not something a user would expect. The reason why was correct from the code perspective is that we did `-start_timestamp` ordering which means if you used `timestamp_gt` filter and `limit 1` we would always return first item from the result set which is always the very latest execution.

This pull request changes the behavior so it's more in line with what a user would expect:

```bash
curl http://127.0.0.1:9101/v1/executions | jq .[].start_timestamp
"2015-08-31T09:41:52.775853Z"
"2015-08-31T09:41:41.508933Z"
"2015-08-31T09:41:23.218543Z"
"2015-08-31T09:40:55.427162Z"

curl "http://127.0.0.1:9101/v1/executions?limit=1&timestamp_gt=2015-08-31T09:41:23.218543Z" | jq .[].start_timestamp
"2015-08-31T09:41:41.508933Z"

curl "http://127.0.0.1:9101/v1/executions?limit=2&timestamp_gt=2015-08-31T09:41:23.218543Z" | jq .[].start_timestamp
"2015-08-31T09:41:41.508933Z"
"2015-08-31T09:41:52.775853Z"

curl "http://127.0.0.1:9101/v1/executions?limit=1&timestamp_lt=2015-08-31T09:41:41.508933Z" | jq .[].start_timestamp
"2015-08-31T09:41:23.218543Z"

curl "http://127.0.0.1:9101/v1/executions?limit=2&timestamp_lt=2015-08-31T09:41:41.508933Z" | jq .[].start_timestamp
"2015-08-31T09:41:23.218543Z"
"2015-08-31T09:40:55.427162Z"

curl "http://127.0.0.1:9101/v1/executions?limit=2&timestamp_lt=2015-08-31T09:41:41.508933Z&timestamp_gt=2015-08-31T09:41:23.218543Z" | jq .[].start_timestamp
[]
```

TODO

- [x] Tests
- [x] Changelog