### PR TITLE
Some cases (e.g. core.st2.IntervalTimer) don't require sending parameters to the action

### DIFF
--- a/st2common/st2common/models/api/rule.py
+++ b/st2common/st2common/models/api/rule.py
@@ -176,7 +176,7 @@ class RuleAPI(BaseAPI):
         validator.validate_trigger_parameters(trigger_db=trigger_db)
 
         action = ActionExecutionSpecDB(ref=rule.action['ref'],
-                                       parameters=rule.action['parameters'])
+                                       parameters=rule.action.get('parameters', {}))
 
         enabled = getattr(rule, 'enabled', False)
         tags = TagsHelper.to_model(getattr(rule, 'tags', []))


### PR DESCRIPTION
As for now, in order to create a rule that doesn't send any parameters to the action, we need to specify an empty object as the parameters:

action:
        parameters: {}



