### PR TITLE
[RFR] Insert with log_error as debug flag

### DIFF
--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -142,22 +142,26 @@ class MongoDBAccess(object):
     def aggregate(self, *args, **kwargs):
         return self.model.objects(**kwargs)._collection.aggregate(*args, **kwargs)
 
-    @staticmethod
-    def add_or_update(instance):
+    def insert(self, instance):
+        instance = self.model._qs.insert(instance)
+        return self._undo_dict_field_escape(instance)
+
+    def add_or_update(self, instance):
         instance.save()
+        return self._undo_dict_field_escape(instance)
+
+    def update(self, instance, **kwargs):
+        return instance.update(**kwargs)
+
+    def delete(self, instance):
+        instance.delete()
+
+    def _undo_dict_field_escape(self, instance):
         for attr, field in instance._fields.iteritems():
             if isinstance(field, stormbase.EscapedDictField):
                 value = getattr(instance, attr)
                 setattr(instance, attr, field.to_python(value))
         return instance
-
-    @staticmethod
-    def update(instance, **kwargs):
-        return instance.update(**kwargs)
-
-    @staticmethod
-    def delete(instance):
-        instance.delete()
 
     def _process_null_filters(self, filters):
         result = copy.deepcopy(filters)

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -143,7 +143,7 @@ class MongoDBAccess(object):
         return self.model.objects(**kwargs)._collection.aggregate(*args, **kwargs)
 
     def insert(self, instance):
-        instance = self.model._qs.insert(instance)
+        instance = self.model.objects.insert(instance)
         return self._undo_dict_field_escape(instance)
 
     def add_or_update(self, instance):

--- a/st2common/st2common/rbac/migrations.py
+++ b/st2common/st2common/rbac/migrations.py
@@ -35,9 +35,7 @@ def insert_system_roles():
         description = role_name
         role_db = RoleDB(name=role_name, description=description, system=True)
 
-        # TODO: This it not ideal, we need to modify add_or_update so it allows atomic updates
-        # by non-id PK
         try:
-            Role.add_or_update(role_db)
+            Role.insert(role_db, log_not_unique_error_as_debug=True)
         except (StackStormDBObjectConflictError, NotUniqueError):
             pass

--- a/st2common/tests/unit/test_rbac.py
+++ b/st2common/tests/unit/test_rbac.py
@@ -22,6 +22,8 @@ from st2common.rbac import utils
 from st2common.rbac.types import PermissionType
 from st2common.rbac.types import ResourceType
 from st2common.models.db.auth import UserDB
+from st2common.models.db.rbac import RoleDB
+from st2common.persistence.rbac import Role
 
 
 class RBACUtilsTestCase(CleanDbTestCase):
@@ -86,3 +88,17 @@ class RBACPermissionTypeTestCase(unittest2.TestCase):
                          'all')
         self.assertEqual(PermissionType.get_permission_name(PermissionType.PACK_ALL),
                          'all')
+
+
+class RBACRoleDBTestCase(CleanDbTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(RBACRoleDBTestCase, cls).setUpClass()
+        config.parse_args()
+
+    def test_insert(self):
+        role_db = RoleDB(name='role-1', description='test role', system=True)
+        created = Role.insert(role_db)
+        retrieved = Role.get_by_id(created.id)
+        self.assertEqual(retrieved.name, role_db.name, 'Failed to save RoleDB object.')


### PR DESCRIPTION
* Implemented an insert method and used that to add Roles to the system to avoid exceptions.
* The insert method is clear but the same could've been achieved by adding the log_as_debug property to add_or_update method. 

There is already an update method but that is different from add_or_update. We may still need to iterate on the 2 methods and see which way to go. I am not motivated to invest more time here as we may be moving away from mongo anyway so why bother.