### PR TITLE
Sendmail Action Fixes

### DIFF
--- a/contrib/core/actions/send_mail/send_mail
+++ b/contrib/core/actions/send_mail/send_mail
@@ -18,9 +18,9 @@ SUBJECT=$1
 shift
 SEND_EMPTY_BODY=$1
 shift
-BODY="$@"
-shift
 CONTENT_TYPE=$1
+shift
+BODY="$@"
 
 if [[ "${CONTENT_TYPE}" = "text/html" ]]; then
   LINE_BREAK="<br><br>"
@@ -28,7 +28,8 @@ else
   LINE_BREAK="\n\n"
 fi
 
-if [[ -z "${BODY// }" && $SEND_EMPTY_BODY == 'True' ]] || [[ -n $BODY ]]; then
+trimmed="${BODY// }"
+if [[ -z $trimmed && $SEND_EMPTY_BODY == 'True' ]] || [[ -n $trimmed ]]; then
   ${MAIL} <<EOF
 TO: ${TO}
 FROM: ${FROM}

--- a/contrib/core/actions/sendmail.yaml
+++ b/contrib/core/actions/sendmail.yaml
@@ -20,11 +20,6 @@ parameters:
     required: false
     type: boolean
     default: True
-  body:
-    description: Body of the email.
-    position: 3
-    required: true
-    type: string
   content_type:
     type: string
     description: Content type of message to be sent
@@ -32,7 +27,12 @@ parameters:
       - "text/plain"
       - "text/html"
     default: "text/html"
+    position: 3
+  body:
+    description: Body of the email.
     position: 4
+    required: true
+    type: string
   sudo:
     immutable: true
 


### PR DESCRIPTION
In the send_mail script, BODY was grabbing everything by using $@, including the new content_type parameter. So to fix, the two parameters needed switched.

Also, it looks as though BODY was still being set, although empty, which was throwing off the send_empty_body tests. New tests have been made and verified.