### PR TITLE
No more st2_startup.log

### DIFF
--- a/tools/st2ctl
+++ b/tools/st2ctl
@@ -2,7 +2,7 @@
 
 set -e
 
-LOGFILE="/tmp/st2_startup.log"
+LOGFILE="/dev/null"
 WEBUI_LOG_FILE="/var/log/st2/st2web.log"
 COMPONENTS="st2actionrunner st2api st2auth st2sensorcontainer st2rulesengine st2web mistral st2resultstracker st2notifier"
 STANCONF="/etc/st2/st2.conf"


### PR DESCRIPTION
Redirect to /dev/null instead of /tmp/st2_startup.log