### PR TITLE
Fix Travis builds for Mistral

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ cache:
 install:
   - if [ ${TASK} != 'checks' ]; then pip install python-coveralls; fi
   - make requirements
-  - if [ ${TASK} = 'integration' ] || [ ${TASK} = 'mistral' ]; then sudo ./scripts/travis/prepare-integration.sh; fi
-  - if [ ${TASK} = 'mistral' ]; then sudo ./scripts/travis/setup-mistral.sh; fi
+  - if [ ${TASK} = 'integration' ] || [ ${TASK} = 'mistral' ]; then sudo -E ./scripts/travis/prepare-integration.sh; fi
+  - if [ ${TASK} = 'mistral' ]; then sudo -E ./scripts/travis/setup-mistral.sh; fi
 
 script:
   - ./scripts/travis/build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ cache:
     - $HOME/.cache/pip/
 
 install:
-  - pip install python-coveralls
+  - if [ ${TASK} != 'checks' ]; then pip install python-coveralls; fi
   - make requirements
   - if [ ${TASK} = 'integration' ] || [ ${TASK} = 'mistral' ]; then sudo ./scripts/travis/prepare-integration.sh; fi
   - if [ ${TASK} = 'mistral' ]; then sudo ./scripts/travis/setup-mistral.sh; fi
@@ -35,4 +35,4 @@ script:
   - ./scripts/travis/build.sh
 
 after_success:
-  - coveralls
+  - if [ ${TASK} != 'checks' ]; then coveralls; fi

--- a/scripts/travis/setup-mistral.sh
+++ b/scripts/travis/setup-mistral.sh
@@ -6,9 +6,39 @@ if [ "$(whoami)" != 'root' ]; then
     exit 2
 fi
 
-MISTRAL_STABLE_BRANCH="master"
+function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -V | tail -n 1)" == "$1"; }
+
+# Determine which mistral version to use
+if [[ "${TRAVIS_BRANCH}" == 'master' ]]; then
+    MISTRAL_STABLE_BRANCH='master'
+elif [[ "${TRAVIS_BRANCH}" =~ ^v[0-9] ]]; then
+    # remove 'v' prefix from version
+    VER=`echo ${TRAVIS_BRANCH} | cut -c2-`
+    if version_ge $VER "0.13"; then
+        MISTRAL_STABLE_BRANCH="st2-0.13.0"
+    elif version_ge $VER "0.9"; then
+        MISTRAL_STABLE_BRANCH="st2-0.9.0"
+    elif version_ge $VER "0.8.1"; then
+        MISTRAL_STABLE_BRANCH="st2-0.8.1"
+    elif version_ge $VER "0.8"; then
+        MISTRAL_STABLE_BRANCH="st2-0.8.0"
+    else
+        MISTRAL_STABLE_BRANCH="st2-0.5.1"
+    fi
+else
+    MISTRAL_STABLE_BRANCH="st2-0.13.0"
+fi
+
 STANCONF="${PWD}/conf/st2.dev.conf"
 TYPE="debs"
+
+
+echo "TRAVIS_BRANCH=${TRAVIS_BRANCH}"
+echo "Installing Mistral version ${MISTRAL_STABLE_BRANCH}"
+
+##############################################################
+# Copy-pasted from st2_deploy.sh
+##############################################################
 
 setup_mistral_st2_config()
 {


### PR DESCRIPTION
* Synchronize Mistral Installation script for Travis with recent `st2_deploy` changes.
* PR for st2 [`master`](https://github.com/StackStorm/st2/tree/master) branch now should use  `MISTRAL_STABLE_BRANCH="master"`
* Otherwise use `MISTRAL_STABLE_BRANCH="st2-0.13.0"`

Fixes #1925