### PR TITLE
[RFR] View controller for rules

### DIFF
--- a/st2api/st2api/controllers/v1/rules.py
+++ b/st2api/st2api/controllers/v1/rules.py
@@ -23,6 +23,7 @@ from st2common.constants.pack import DEFAULT_PACK_NAME
 from st2common.exceptions.apivalidation import ValueValidationException
 from st2common.exceptions.triggers import TriggerDoesNotExistException
 from st2api.controllers import resource
+from st2api.controllers.v1.ruleviews import RuleViewController
 from st2common.models.api.rule import RuleAPI
 from st2common.models.api.base import jsexpose
 from st2common.persistence.rule import Rule
@@ -40,6 +41,7 @@ class RuleController(resource.ContentPackResourceController):
         Implements the RESTful web endpoint that handles
         the lifecycle of Rules in the system.
     """
+    views = RuleViewController()
 
     model = RuleAPI
     access = Rule

--- a/st2api/st2api/controllers/v1/ruleviews.py
+++ b/st2api/st2api/controllers/v1/ruleviews.py
@@ -1,0 +1,108 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import six
+
+from st2common import log as logging
+from st2api.controllers import resource
+from st2common.models.api.rule import RuleViewAPI
+from st2common.models.api.base import jsexpose
+from st2common.persistence.action import Action
+from st2common.persistence.rule import Rule
+from st2common.persistence.trigger import TriggerType, Trigger
+from st2common.rbac.types import PermissionType
+from st2common.rbac.decorators import request_user_has_permission
+from st2common.rbac.decorators import request_user_has_resource_permission
+
+http_client = six.moves.http_client
+
+LOG = logging.getLogger(__name__)
+
+
+__all__ = ['RuleViewController']
+
+
+class RuleViewController(resource.ContentPackResourceController):
+
+    model = RuleViewAPI
+    access = Rule
+    supported_filters = {
+        'name': 'name',
+        'pack': 'pack'
+    }
+
+    query_options = {
+        'sort': ['pack', 'name']
+    }
+
+    include_reference = True
+
+    @request_user_has_permission(permission_type=PermissionType.RULE_VIEW)
+    @jsexpose()
+    def get_all(self, **kwargs):
+        rules = self._get_all(**kwargs)
+        return self._append_view_properties(rules)
+
+    @request_user_has_resource_permission(permission_type=PermissionType.RULE_VIEW)
+    @jsexpose(arg_types=[str])
+    def get_one(self, ref_or_id):
+        rule = self._get_one(ref_or_id)
+        return self._append_view_properties([rule])[0]
+
+    def _append_view_properties(self, rules):
+        action_by_refs, trigger_by_refs, trigger_type_by_refs = self._get_referenced_models(rules)
+
+        for rule in rules:
+            action_db = action_by_refs[rule.action['ref']]
+            rule.action['description'] = action_db.description
+
+            trigger_db = trigger_by_refs[rule.trigger['ref']]
+            rule.trigger['description'] = trigger_db.description
+
+            # If description is not found in trigger get description from triggertype
+            if not rule.trigger['description']:
+                trigger_type_db = trigger_type_by_refs[rule.trigger['type']]
+                rule.trigger['description'] = trigger_type_db.description
+
+        return rules
+
+    def _get_referenced_models(self, rules):
+        """
+        Reduces the number of queries to be made to the DB by creating sets of Actions, Triggers
+        and TriggerTypes.
+        """
+        action_refs = set()
+        trigger_refs = set()
+        trigger_type_refs = set()
+
+        for rule in rules:
+            action_refs.add(rule.action['ref'])
+            trigger_refs.add(rule.trigger['ref'])
+            trigger_type_refs.add(rule.trigger['type'])
+
+        action_by_refs = {}
+        trigger_by_refs = {}
+        trigger_type_by_refs = {}
+
+        for ref in action_refs:
+            action_by_refs[ref] = Action.get_by_ref(ref)
+
+        for ref in trigger_refs:
+            trigger_by_refs[ref] = Trigger.get_by_ref(ref)
+
+        for ref in trigger_type_refs:
+            trigger_type_by_refs[ref] = TriggerType.get_by_ref(ref)
+
+        return (action_by_refs, trigger_by_refs, trigger_type_by_refs)

--- a/st2api/st2api/controllers/v1/ruleviews.py
+++ b/st2api/st2api/controllers/v1/ruleviews.py
@@ -38,6 +38,41 @@ __all__ = ['RuleViewController']
 
 
 class RuleViewController(resource.ContentPackResourceController):
+    """
+    Add some extras to a Rule object to make it easier for UI to render a rule. The additions
+    do not necessarily belong in the Rule itself but are still valuable augmentations.
+
+    :Example:
+        {
+            "action": {
+                "description": "Action that executes an arbitrary Linux command on the localhost.",
+                "parameters": {
+                    "cmd": "echo \"{{trigger.executed_at}}\""
+                },
+                "ref": "core.local"
+            },
+            "criteria": {},
+            "description": "Sample rule using an Interval Timer.",
+            "enabled": false,
+            "id": "55ea221832ed35759cf3b312",
+            "name": "sample.with_timer",
+            "pack": "examples",
+            "ref": "examples.sample.with_timer",
+            "tags": [],
+            "trigger": {
+                "description": "Triggers on specified intervals. e.g. every 30s, 1week etc.",
+                "parameters": {
+                    "delta": 5,
+                    "unit": "seconds"
+                },
+                "ref": "core.4ad65602-6fb4-4c89-b0f2-b990d7b68bad",
+                "type": "core.st2.IntervalTimer"
+            },
+            "uid": "rule:examples:sample.with_timer"
+        }
+
+    The `description` fields in action and trigger are augmented properties.
+    """
 
     model = RuleViewAPI
     access = Rule

--- a/st2api/st2api/controllers/v1/ruleviews.py
+++ b/st2api/st2api/controllers/v1/ruleviews.py
@@ -135,9 +135,13 @@ class RuleViewController(resource.ContentPackResourceController):
         trigger_type_by_refs = {}
 
         # The functions that will return args that can used to query.
-        ref_query_args = lambda resource_ref: {'ref': resource_ref.ref}
-        name_pack_query_args = lambda resource_ref: {'name': resource_ref.name,
-                                                     'pack': resource_ref.pack}
+        def ref_query_args(ref):
+            return {'ref': ref}
+
+        def name_pack_query_args(ref):
+            resource_ref = ResourceReference.from_string_reference(ref=ref)
+            return {'name': resource_ref.name, 'pack': resource_ref.pack}
+
         action_dbs = self._get_entities(model_persistence=Action,
                                         refs=action_refs,
                                         query_args=ref_query_args)
@@ -168,11 +172,10 @@ class RuleViewController(resource.ContentPackResourceController):
         """
         q = None
         for ref in refs:
-            resource_ref = ResourceReference.from_string_reference(ref=ref)
             if not q:
-                q = Q(**query_args(resource_ref))
+                q = Q(**query_args(ref))
             else:
-                q |= Q(**query_args(resource_ref))
+                q |= Q(**query_args(ref))
         if q:
             return model_persistence._get_impl().model.objects(q)
         return []

--- a/st2api/st2api/controllers/v1/ruleviews.py
+++ b/st2api/st2api/controllers/v1/ruleviews.py
@@ -66,15 +66,15 @@ class RuleViewController(resource.ContentPackResourceController):
 
         for rule in rules:
             action_db = action_by_refs[rule.action['ref']]
-            rule.action['description'] = action_db.description
+            rule.action['description'] = action_db.description if action_db else ''
 
             trigger_db = trigger_by_refs[rule.trigger['ref']]
-            rule.trigger['description'] = trigger_db.description
+            rule.trigger['description'] = trigger_db.description if trigger_db else ''
 
             # If description is not found in trigger get description from triggertype
             if not rule.trigger['description']:
                 trigger_type_db = trigger_type_by_refs[rule.trigger['type']]
-                rule.trigger['description'] = trigger_type_db.description
+                rule.trigger['description'] = trigger_type_db.description if trigger_type_db else ''
 
         return rules
 

--- a/st2api/st2api/controllers/v1/ruleviews.py
+++ b/st2api/st2api/controllers/v1/ruleviews.py
@@ -15,10 +15,13 @@
 
 import six
 
+from mongoengine.queryset import Q
+
 from st2common import log as logging
 from st2api.controllers import resource
 from st2common.models.api.rule import RuleViewAPI
 from st2common.models.api.base import jsexpose
+from st2common.models.system.common import ResourceReference
 from st2common.persistence.action import Action
 from st2common.persistence.rule import Rule
 from st2common.persistence.trigger import TriggerType, Trigger
@@ -65,15 +68,15 @@ class RuleViewController(resource.ContentPackResourceController):
         action_by_refs, trigger_by_refs, trigger_type_by_refs = self._get_referenced_models(rules)
 
         for rule in rules:
-            action_db = action_by_refs[rule.action['ref']]
+            action_db = action_by_refs.get(rule.action['ref'], None)
             rule.action['description'] = action_db.description if action_db else ''
 
-            trigger_db = trigger_by_refs[rule.trigger['ref']]
+            trigger_db = trigger_by_refs.get(rule.trigger['ref'], None)
             rule.trigger['description'] = trigger_db.description if trigger_db else ''
 
             # If description is not found in trigger get description from triggertype
             if not rule.trigger['description']:
-                trigger_type_db = trigger_type_by_refs[rule.trigger['type']]
+                trigger_type_db = trigger_type_by_refs.get(rule.trigger['type'], None)
                 rule.trigger['description'] = trigger_type_db.description if trigger_type_db else ''
 
         return rules
@@ -96,13 +99,45 @@ class RuleViewController(resource.ContentPackResourceController):
         trigger_by_refs = {}
         trigger_type_by_refs = {}
 
-        for ref in action_refs:
-            action_by_refs[ref] = Action.get_by_ref(ref)
+        # The functions that will return args that can used to query.
+        ref_query_args = lambda resource_ref: {'ref': resource_ref.ref}
+        name_pack_query_args = lambda resource_ref: {'name': resource_ref.name,
+                                                     'pack': resource_ref.pack}
+        action_dbs = self._get_entities(model_persistence=Action,
+                                        refs=action_refs,
+                                        query_args=ref_query_args)
+        for action_db in action_dbs:
+            action_by_refs[action_db.ref] = action_db
 
-        for ref in trigger_refs:
-            trigger_by_refs[ref] = Trigger.get_by_ref(ref)
+        trigger_dbs = self._get_entities(model_persistence=Trigger,
+                                         refs=trigger_refs,
+                                         query_args=name_pack_query_args)
+        for trigger_db in trigger_dbs:
+            trigger_by_refs[trigger_db.get_reference().ref] = trigger_db
 
-        for ref in trigger_type_refs:
-            trigger_type_by_refs[ref] = TriggerType.get_by_ref(ref)
+        trigger_type_dbs = self._get_entities(model_persistence=TriggerType,
+                                              refs=trigger_type_refs,
+                                              query_args=name_pack_query_args)
+        for trigger_type_db in trigger_type_dbs:
+            trigger_type_by_refs[trigger_type_db.get_reference().ref] = trigger_type_db
 
         return (action_by_refs, trigger_by_refs, trigger_type_by_refs)
+
+    def _get_entities(self, model_persistence, refs, query_args):
+        """
+        Returns all the entities for the supplied refs. model_persistence is the persistence
+        object that will be used to get to the correct query method and the query_args function
+        to return the ref specific query argument.
+
+        This is such a weirdly specific method that it is likely better only in this context.
+        """
+        q = None
+        for ref in refs:
+            resource_ref = ResourceReference.from_string_reference(ref=ref)
+            if not q:
+                q = Q(**query_args(resource_ref))
+            else:
+                q |= Q(**query_args(resource_ref))
+        if q:
+            return model_persistence._get_impl().model.objects(q)
+        return []

--- a/st2api/tests/unit/controllers/v1/test_rule_views.py
+++ b/st2api/tests/unit/controllers/v1/test_rule_views.py
@@ -1,0 +1,83 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import six
+
+from st2common.models.system.common import ResourceReference
+from st2tests.fixturesloader import FixturesLoader
+from tests import FunctionalTest
+
+http_client = six.moves.http_client
+
+TEST_FIXTURES = {
+    'runners': ['testrunner1.yaml'],
+    'actions': ['action1.yaml'],
+    'triggers': ['trigger1.yaml'],
+    'triggertypes': ['triggertype1.yaml']
+}
+
+TEST_FIXTURES_RULES = {
+    'rules': ['rule1.yaml']
+}
+
+FIXTURES_PACK = 'generic'
+
+
+class TestRuleViewController(FunctionalTest):
+
+    fixtures_loader = FixturesLoader()
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestRuleViewController, cls).setUpClass()
+        models = TestRuleViewController.fixtures_loader.save_fixtures_to_db(
+            fixtures_pack=FIXTURES_PACK, fixtures_dict=TEST_FIXTURES)
+        TestRuleViewController.RUNNER_TYPE = models['runners']['testrunner1.yaml']
+        TestRuleViewController.ACTION = models['actions']['action1.yaml']
+        TestRuleViewController.TRIGGER = models['triggers']['trigger1.yaml']
+
+        file_name = 'rule1.yaml'
+        rules = TestRuleViewController.fixtures_loader.save_fixtures_to_db(
+            fixtures_pack=FIXTURES_PACK, fixtures_dict=TEST_FIXTURES_RULES)['rules']
+        TestRuleViewController.RULE_1 = rules[file_name]
+
+    def test_get_all(self):
+        resp = self.app.get('/v1/rules/views')
+        self.assertEqual(resp.status_int, http_client.OK)
+
+    def test_get_one_by_id(self):
+        rule_id = str(TestRuleViewController.RULE_1.id)
+        get_resp = self.__do_get_one(rule_id)
+        self.assertEqual(get_resp.status_int, http_client.OK)
+        self.assertEqual(self.__get_rule_id(get_resp), rule_id)
+
+    def test_get_one_by_ref(self):
+        rule_name = TestRuleViewController.RULE_1.name
+        rule_pack = TestRuleViewController.RULE_1.pack
+        ref = ResourceReference.to_string_reference(name=rule_name, pack=rule_pack)
+        get_resp = self.__do_get_one(ref)
+        self.assertEqual(get_resp.json['name'], rule_name)
+        self.assertEqual(get_resp.status_int, http_client.OK)
+
+    def test_get_one_fail(self):
+        resp = self.app.get('/v1/rules/1', expect_errors=True)
+        self.assertEqual(resp.status_int, http_client.NOT_FOUND)
+
+    @staticmethod
+    def __get_rule_id(resp):
+        return resp.json['id']
+
+    def __do_get_one(self, rule_id):
+        return self.app.get('/v1/rules/views/%s' % rule_id, expect_errors=True)

--- a/st2api/tests/unit/controllers/v1/test_rule_views.py
+++ b/st2api/tests/unit/controllers/v1/test_rule_views.py
@@ -23,13 +23,13 @@ http_client = six.moves.http_client
 
 TEST_FIXTURES = {
     'runners': ['testrunner1.yaml'],
-    'actions': ['action1.yaml'],
+    'actions': ['action1.yaml', 'action2.yaml'],
     'triggers': ['trigger1.yaml'],
     'triggertypes': ['triggertype1.yaml']
 }
 
 TEST_FIXTURES_RULES = {
-    'rules': ['rule1.yaml']
+    'rules': ['rule1.yaml', 'rule4.yaml', 'rule5.yaml']
 }
 
 FIXTURES_PACK = 'generic'
@@ -44,9 +44,8 @@ class TestRuleViewController(FunctionalTest):
         super(TestRuleViewController, cls).setUpClass()
         models = TestRuleViewController.fixtures_loader.save_fixtures_to_db(
             fixtures_pack=FIXTURES_PACK, fixtures_dict=TEST_FIXTURES)
-        TestRuleViewController.RUNNER_TYPE = models['runners']['testrunner1.yaml']
-        TestRuleViewController.ACTION = models['actions']['action1.yaml']
-        TestRuleViewController.TRIGGER = models['triggers']['trigger1.yaml']
+        TestRuleViewController.ACTION_1 = models['actions']['action1.yaml']
+        TestRuleViewController.TRIGGER_TYPE_1 = models['triggertypes']['triggertype1.yaml']
 
         file_name = 'rule1.yaml'
         rules = TestRuleViewController.fixtures_loader.save_fixtures_to_db(
@@ -56,12 +55,17 @@ class TestRuleViewController(FunctionalTest):
     def test_get_all(self):
         resp = self.app.get('/v1/rules/views')
         self.assertEqual(resp.status_int, http_client.OK)
+        self.assertEqual(len(resp.json), 3)
 
     def test_get_one_by_id(self):
         rule_id = str(TestRuleViewController.RULE_1.id)
         get_resp = self.__do_get_one(rule_id)
         self.assertEqual(get_resp.status_int, http_client.OK)
         self.assertEqual(self.__get_rule_id(get_resp), rule_id)
+        self.assertEqual(get_resp.json['action']['description'],
+                         TestRuleViewController.ACTION_1.description)
+        self.assertEqual(get_resp.json['trigger']['description'],
+                         TestRuleViewController.TRIGGER_TYPE_1.description)
 
     def test_get_one_by_ref(self):
         rule_name = TestRuleViewController.RULE_1.name

--- a/st2common/st2common/models/api/rule.py
+++ b/st2common/st2common/models/api/rule.py
@@ -19,7 +19,6 @@ import six
 
 from st2common.constants.pack import DEFAULT_PACK_NAME
 from st2common.models.api.base import BaseAPI
-from st2common.models.api.trigger import TriggerAPI
 from st2common.models.api.tag import TagsHelper
 from st2common.models.db.rule import RuleDB, ActionExecutionSpecDB
 from st2common.models.system.common import ResourceReference

--- a/st2common/st2common/models/api/rule.py
+++ b/st2common/st2common/models/api/rule.py
@@ -149,10 +149,11 @@ class RuleAPI(BaseAPI):
 
         if not trigger_db:
             raise ValueError('Missing TriggerDB object for rule %s' % (rule['id']))
-
-        rule['trigger'] = vars(TriggerAPI.from_model(trigger_db))
-        del rule['trigger']['id']
-        del rule['trigger']['name']
+        rule['trigger'] = {
+            'type': trigger_db.type,
+            'parameters': trigger_db.parameters,
+            'ref': model.trigger
+        }
         rule['tags'] = TagsHelper.from_model(model.tags)
         return cls(**rule)
 
@@ -184,3 +185,20 @@ class RuleAPI(BaseAPI):
         model = cls.model(name=name, description=description, pack=pack, ref=ref, trigger=trigger,
                           criteria=criteria, action=action, enabled=enabled, tags=tags)
         return model
+
+
+class RuleViewAPI(RuleAPI):
+
+    # Always deep-copy to avoid breaking the original.
+    schema = copy.deepcopy(RuleAPI.schema)
+    # Update the schema to include the description properties
+    schema['properties']['action'].update({
+        'description': {
+            'type': 'string'
+        }
+    })
+    schema['properties']['trigger'].update({
+        'description': {
+            'type': 'string'
+        }
+    })

--- a/st2tests/st2tests/fixtures/generic/actions/action2.yaml
+++ b/st2tests/st2tests/fixtures/generic/actions/action2.yaml
@@ -1,0 +1,32 @@
+---
+description: Awesome action-2
+enabled: true
+entry_point: ''
+name: action-2
+pack: wolfpack
+parameters:
+  actionimmutable:
+    default: actionimmutable
+    immutable: true
+    type: string
+  actionint:
+    default: 10
+    type: number
+  actionstr:
+    required: true
+    type: string
+  async_test:
+    default: false
+    type: boolean
+  runnerdummy:
+    default: actiondummy
+    immutable: true
+    type: string
+  runnerfoo:
+    default: FOO
+    immutable: true
+    type: string
+  runnerimmutable:
+    default: failed_override
+    type: string
+runner_type: test-runner-1

--- a/st2tests/st2tests/fixtures/generic/rules/rule4.yaml
+++ b/st2tests/st2tests/fixtures/generic/rules/rule4.yaml
@@ -1,0 +1,21 @@
+---
+action:
+  parameters:
+    ip1: '{{trigger.t1_p}}'
+    ip2: '{{trigger}}'
+  ref: wolfpack.action-2
+criteria:
+  t1_p:
+    pattern: t1_p_v
+    type: equals
+description: ''
+enabled: true
+name: rule4
+pack: wolfpack
+tags:
+- name: tag1
+  value: dont-care
+- name: tag2
+  value: dont-care
+trigger:
+  type: wolfpack.triggertype-1

--- a/st2tests/st2tests/fixtures/generic/rules/rule5.yaml
+++ b/st2tests/st2tests/fixtures/generic/rules/rule5.yaml
@@ -1,0 +1,21 @@
+---
+action:
+  parameters:
+    ip1: '{{trigger.t1_p}}'
+    ip2: '{{trigger}}'
+  ref: wolfpack.action-1
+criteria:
+  t1_p:
+    pattern: t1_p_v
+    type: equals
+description: ''
+enabled: true
+name: rule5
+pack: wolfpack
+tags:
+- name: tag1
+  value: dont-care
+- name: tag2
+  value: dont-care
+trigger:
+  type: wolfpack.triggertype-1

--- a/st2tests/st2tests/fixtures/generic/triggertypes/triggertype1.yaml
+++ b/st2tests/st2tests/fixtures/generic/triggertypes/triggertype1.yaml
@@ -1,5 +1,6 @@
 ---
 name: triggertype-1
+description: awesome trigger-1
 pack: wolfpack
 parameters_schema: {}
 payload_schema: {}


### PR DESCRIPTION
* Adds extra properties for UI display purpose and returns a RuleViewAPI object

**[API] rules/views**
```
$ http localhost:9101/rules/views/default.rule-99
{
    "action": {
        "description": "Action that executes an arbitrary Linux command on the localhost.",
        "parameters": {
            "cmd": "date"
        },
        "ref": "core.local"
    },
    "criteria": {},
    "enabled": true,
    "id": "55e93d6732ed3558db7790df",
    "name": "rule-99",
    "pack": "default",
    "ref": "default.rule-99",
    "tags": [],
    "trigger": {
        "description": "Notification trigger.",
        "parameters": {},
        "ref": "core.st2.generic.notifytrigger",
        "type": "core.st2.generic.notifytrigger"
    },
    "uid": "rule:default:rule-99"
}
```

**[API] rules**
```
$ time http localhost:9101/rules/default.rule-99

{
    "action": {
        "parameters": {
            "cmd": "date"
        },
        "ref": "core.local"
    },
    "criteria": {},
    "enabled": true,
    "id": "55e93d6732ed3558db7790df",
    "name": "rule-99",
    "pack": "default",
    "ref": "default.rule-99",
    "tags": [],
    "trigger": {
        "parameters": {},
        "ref": "core.st2.generic.notifytrigger",
        "type": "core.st2.generic.notifytrigger"
    },
    "uid": "rule:default:rule-99"
}
```