### PR TITLE
Check if st2_deploy.sh is launched from superuser

### DIFF
--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -13,6 +13,12 @@ running StackStorm in production.
 For more information, see http://docs.stackstorm.com/install/index.html
 EOM
 
+if [[ $EUID != 0 ]]; then
+    echo 'StackStorm installation requires superuser access rights!'
+    echo 'Please run with sudo or from root user.'
+    exit 1
+fi
+
 WARNING_SLEEP_DELAY=5
 
 # Options which can be provied by the user via env variables


### PR DESCRIPTION
Community fix, covers issue when users trying to run `st2_deploy.sh` from user with insufficient rights.