### PR TITLE
Delete pack virtualenv directory in the st2-setup-tests script

### DIFF
--- a/tools/st2-setup-tests
+++ b/tools/st2-setup-tests
@@ -37,7 +37,7 @@ if [ -d ${TESTSPATH}/${PACK} ]; then
 fi
 
 if [ -d ${VENVSPATH}/${PACK} ]; then
-  echo -e "Deleting ${VENVPATH}/${PACK}..."
+  echo -e "Deleting ${VENVSPATH}/${PACK}..."
   rm -Rf ${VENVSPATH}/${PACK}
 fi
 
@@ -50,10 +50,10 @@ st2ctl reload
 echo -e "Bootstrapping virtualenv for ${PACK} pack..."
 if [ -f ${TESTSPATH}/${PACK}/requirements.txt ]; then
     echo "Creating virtualenv for ${PACK}..."
-    mkdir -p /opt/stackstorm/virtualenvs
-    virtualenv -p ${PY27} --system-site-packages /opt/stackstorm/virtualenvs/${PACK}
+    mkdir -p ${VENVSPATH}
+    virtualenv -p ${PY27} --system-site-packages ${VENVSPATH}/${PACK}
     echo "Installing requirements.txt for ${PACK}..."
-    source /opt/stackstorm/virtualenvs/${PACK}/bin/activate
+    source ${VENVSPATH}/${PACK}/bin/activate
     pip install -r ${TESTSPATH}/${PACK}/requirements.txt
     deactivate
 fi

--- a/tools/st2-setup-tests
+++ b/tools/st2-setup-tests
@@ -11,6 +11,7 @@ PY27=`which python2.7`
 TESTSREPO='https://github.com/StackStorm/st2tests.git'
 PACK=$1
 TESTSPATH="/opt/stackstorm/packs"
+VENVPATH="/opt/stackstorm/virtualenvs"
 TMPPATH='/tmp/st2tests'
 
 if [ -d ${TMPPATH} ]; then
@@ -32,6 +33,11 @@ fi
 if [ -d ${TESTSPATH}/${PACK} ]; then
   echo -e "Deleting ${TESTSPATH}/${PACK}..."
   rm -Rf ${TESTSPATH}/${PACK}
+fi
+
+if [ -d ${VENVPATH}/${PACK} ]; then
+  echo -e "Deleting ${VENVPATH}/${PACK}..."
+  rm -Rf ${VENVPATH}/${PACK}
 fi
 
 echo -e "Copying ${PACK} to ${TESTSPATH}..."

--- a/tools/st2-setup-tests
+++ b/tools/st2-setup-tests
@@ -7,11 +7,12 @@ if [ -z $1 ]; then
   exit 2
 fi
 
-PY27=`which python2.7`
-TESTSREPO='https://github.com/StackStorm/st2tests.git'
 PACK=$1
+PY27=`which python2.7`
+
+TESTSREPO='https://github.com/StackStorm/st2tests.git'
 TESTSPATH="/opt/stackstorm/packs"
-VENVPATH="/opt/stackstorm/virtualenvs"
+VENVSPATH="/opt/stackstorm/virtualenvs"
 TMPPATH='/tmp/st2tests'
 
 if [ -d ${TMPPATH} ]; then
@@ -35,9 +36,9 @@ if [ -d ${TESTSPATH}/${PACK} ]; then
   rm -Rf ${TESTSPATH}/${PACK}
 fi
 
-if [ -d ${VENVPATH}/${PACK} ]; then
+if [ -d ${VENVSPATH}/${PACK} ]; then
   echo -e "Deleting ${VENVPATH}/${PACK}..."
-  rm -Rf ${VENVPATH}/${PACK}
+  rm -Rf ${VENVSPATH}/${PACK}
 fi
 
 echo -e "Copying ${PACK} to ${TESTSPATH}..."


### PR DESCRIPTION
This fixes the "[Errno 40] Too many levels of symbolic links" issue we observed on the build server.

The problem was that we switched the Python binary, but we didn't re-create the whole virtualenv which would result in weirdness and failures. Now we delete and re-create virtualenv on every script invocation.