### PR TITLE
Makefiles update: publish st2* wheels into the wheelhouse

### DIFF
--- a/st2actions/Makefile
+++ b/st2actions/Makefile
@@ -59,7 +59,7 @@ all: install
 
 install: wheelhouse changelog
 
-post_install:
+post_install: bdist_wheel
 	# post_install is triggered debian/rules file, don't call it from install target!
 	# We don't want anything like below to be postinst
 	install conf/logging.conf $(DESTDIR)/etc/st2/logging.actionrunner.conf
@@ -86,4 +86,9 @@ wheelhouse: .stamp-wheelhouse
 	pip wheel --wheel-dir=$(WHEELDIR) -r requirements.txt
 	# We can modify requirements ONLY AFTER wheelhouse has been built
 	@echo "st2common" >> requirements.txt
+	touch $@
+
+bdist_wheel: .stamp-bdist_wheel
+.stamp-bdist_wheel: populate_version
+	python setup.py bdist_wheel -d $(WHEELDIR)
 	touch $@

--- a/st2api/Makefile
+++ b/st2api/Makefile
@@ -59,7 +59,7 @@ all: install
 
 install: wheelhouse changelog
 
-post_install:
+post_install: bdist_wheel
 	# post_install is triggered debian/rules file, don't call it from install target!
 	# We don't want anything like below to be postinst
 	install conf/logging.conf $(DESTDIR)/etc/st2/logging.api.conf
@@ -86,4 +86,9 @@ wheelhouse: .stamp-wheelhouse
 	pip wheel --wheel-dir=$(WHEELDIR) -r requirements.txt
 	# We can modify requirements ONLY AFTER wheelhouse has been built
 	@echo "st2common" >> requirements.txt
+	touch $@
+
+bdist_wheel: .stamp-bdist_wheel
+.stamp-bdist_wheel: populate_version
+	python setup.py bdist_wheel -d $(WHEELDIR)
 	touch $@

--- a/st2auth/Makefile
+++ b/st2auth/Makefile
@@ -59,7 +59,7 @@ all: install
 
 install: wheelhouse changelog
 
-post_install:
+post_install: bdist_wheel
 	# post_install is triggered debian/rules file, don't call it from install target!
 	# We don't want anything like below to be postinst
 	install conf/logging.conf $(DESTDIR)/etc/st2/logging.auth.conf
@@ -86,4 +86,9 @@ wheelhouse: .stamp-wheelhouse
 	pip wheel --wheel-dir=$(WHEELDIR) -r requirements.txt
 	# We can modify requirements ONLY AFTER wheelhouse has been built
 	@echo "st2common" >> requirements.txt
+	touch $@
+
+bdist_wheel: .stamp-bdist_wheel
+.stamp-bdist_wheel: populate_version
+	python setup.py bdist_wheel -d $(WHEELDIR)
 	touch $@

--- a/st2client/Makefile
+++ b/st2client/Makefile
@@ -51,7 +51,7 @@ all: install
 
 install: wheelhouse changelog
 
-post_install: ;
+post_install: bdist_wheel
 
 populate_version: .stamp-populate_version
 .stamp-populate_version:
@@ -73,4 +73,9 @@ wheelhouse: .stamp-wheelhouse
 	pip wheel --wheel-dir=$(WHEELDIR) -r requirements.txt
 	# We can modify requirements ONLY AFTER wheelhouse has been built
 	@echo "st2common" >> requirements.txt
+	touch $@
+
+bdist_wheel: .stamp-bdist_wheel
+.stamp-bdist_wheel: populate_version
+	python setup.py bdist_wheel -d $(WHEELDIR)
 	touch $@

--- a/st2common/Makefile
+++ b/st2common/Makefile
@@ -83,7 +83,5 @@ wheelhouse: .stamp-wheelhouse
 
 bdist_wheel: .stamp-bdist_wheel
 .stamp-bdist_wheel: populate_version
-	# All other components depend on st2common, so we create st2common
-	# in the shared WHEELHOUSE directory.
 	python setup.py bdist_wheel -d $(WHEELDIR)
 	touch $@

--- a/st2debug/Makefile
+++ b/st2debug/Makefile
@@ -59,7 +59,7 @@ all: install
 
 install: wheelhouse changelog
 
-post_install: ;
+post_install: bdist_wheel
 
 populate_version: .stamp-populate_version
 .stamp-populate_version:
@@ -81,4 +81,9 @@ wheelhouse: .stamp-wheelhouse
 	pip wheel --wheel-dir=$(WHEELDIR) -r requirements.txt
 	# We can modify requirements ONLY AFTER wheelhouse has been built
 	@echo "st2common" >> requirements.txt
+	touch $@
+
+bdist_wheel: .stamp-bdist_wheel
+.stamp-bdist_wheel: populate_version
+	python setup.py bdist_wheel -d $(WHEELDIR)
 	touch $@

--- a/st2exporter/Makefile
+++ b/st2exporter/Makefile
@@ -15,7 +15,7 @@ all: install
 
 install: wheelhouse changelog
 
-post_install:
+post_install: bdist_wheel
 	# post_install is triggered debian/rules file, don't call it from install target!
 	# We don't want anything like below to be postinst
 	sed -i -r "/args\s*=\s*/s%logs%/var/log/st2%g" $(DESTDIR)/etc/st2/logging.*conf
@@ -40,4 +40,9 @@ wheelhouse: .stamp-wheelhouse
 	pip wheel --wheel-dir=$(WHEELDIR) -r requirements.txt
 	# We can modify requirements ONLY AFTER wheelhouse has been built
 	@echo "st2common" >> requirements.txt
+	touch $@
+
+bdist_wheel: .stamp-bdist_wheel
+.stamp-bdist_wheel: populate_version
+	python setup.py bdist_wheel -d $(WHEELDIR)
 	touch $@

--- a/st2reactor/Makefile
+++ b/st2reactor/Makefile
@@ -45,7 +45,7 @@ all: install
 
 install: wheelhouse changelog
 
-post_install:
+post_install: bdist_wheel
 	# post_install is triggered debian/rules file, don't call it from install target!
 	# We don't want anything like below to be postinst
 	sed -i -r "/args\s*=\s*/s%logs%/var/log/st2%g" $(DESTDIR)/etc/st2/logging.*conf
@@ -70,4 +70,9 @@ wheelhouse: .stamp-wheelhouse
 	pip wheel --wheel-dir=$(WHEELDIR) -r requirements.txt
 	# We can modify requirements ONLY AFTER wheelhouse has been built
 	@echo "st2common" >> requirements.txt
+	touch $@
+
+bdist_wheel: .stamp-bdist_wheel
+.stamp-bdist_wheel: populate_version
+	python setup.py bdist_wheel -d $(WHEELDIR)
 	touch $@


### PR DESCRIPTION
We need local wheels for each of the components so that "st2bundle" can be created.