### PR TITLE
Change `packs.install` meta action to require pack

### DIFF
--- a/contrib/packs/actions/install.meta.yaml
+++ b/contrib/packs/actions/install.meta.yaml
@@ -11,8 +11,7 @@
       type: "array"
       items:
         type: "string"
-      default:
-        - "*"
+      required: true
     repo_url:
       type: "string"
       default: "StackStorm/st2contrib"


### PR DESCRIPTION
This commit changes the `packs.install` action metadata from * to `None` with `required: true`. This forces the user to explicitly download packs they want/need versus accidentally getting everything.