### PR TITLE
Add example to file_watch_sensor

### DIFF
--- a/contrib/linux/README.md
+++ b/contrib/linux/README.md
@@ -9,6 +9,15 @@ This pack contains actions for commonly used Linux commands and tools.
   and not directories (files don't need to exist yet when the sensor is ran
   though).
 
+Example:
+
+```yaml
+---
+file_watch_sensor:
+  file_paths:
+    - /opt/data/absolute_path_to_file.log
+```
+
 ## Sensors
 
 ### FileWatchSensor


### PR DESCRIPTION
This commit adds an example of how to consume the `file_watch_sensor` in the `config.yaml` for the Pack.