### PR TITLE
Add pydoc for BaseSensor

### DIFF
--- a/st2reactor/st2reactor/sensor/base.py
+++ b/st2reactor/st2reactor/sensor/base.py
@@ -16,6 +16,13 @@ class BaseSensor(object):
     """
 
     def __init__(self, sensor_service, config=None):
+        """
+        :param sensor_service: Sensor Service instance.
+        :type sensor_service: :class:``st2reactor.container.sensor_wrapper.SensorService``
+
+        :keyword config: Sensor config.
+        :type config: ``dict`` or None
+        """
         self._sensor_service = sensor_service
         self._config = config or {}
 


### PR DESCRIPTION
Very tiny cosmetic change for better IDE support when writing [new Sensors](http://docs.stackstorm.com/sensors.html#authoring-a-sensor)

![autocomplete-ide-support](https://cloud.githubusercontent.com/assets/1533818/9770383/d2d9d2c0-5727-11e5-8a10-9b07222a353b.gif)
