### PR TITLE
Sensor container fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,9 +16,15 @@ in development
 * Default to rule being disabled if the user doesn't explicitly specify ``enabled`` attribute when
   creating a rule via the API or inside the rule metadata file when registering local content
   (previously it defaulted to enabled).
-* Fix ``timestamp_lt`` and ``timestamp_gt`` filtering in the `/executions` API endpoint. Now we 
+* Fix ``timestamp_lt`` and ``timestamp_gt`` filtering in the `/executions` API endpoint. Now we
   return a correct result which is expected from a user-perspective. (bug-fix)
 * Enable Mistral workflow cancellation via ``st2 execution cancel``. (improvement)
+* Fix sensor container service so the ``config`` argument is correctly passed to the sensor
+  instances in the system packs. Previously, this argument didn't get passed correctly to the
+  FileWatchSensor from the system linux pack. (bug-fix)
+* Make sure sensor processes correctly pick up parent ``--debug`` flag. This makes debugging a lot
+  easier since user simply needs to start sensor container with ``--debug`` flag and all the sensor
+  logs with level debug or higher will be routed to the container log. (improvement)
 
 0.13.1 - August 28, 2015
 ------------------------

--- a/st2common/st2common/logging/misc.py
+++ b/st2common/st2common/logging/misc.py
@@ -19,6 +19,7 @@ import logging
 
 __all__ = [
     'reopen_log_files',
+    'set_log_level_for_all_handlers',
     'set_log_level_for_all_loggers'
 ]
 
@@ -49,6 +50,19 @@ def reopen_log_files(handlers):
             handler.release()
 
 
+def set_log_level_for_all_handlers(logger, level=logging.DEBUG):
+    """
+    Set a log level for all the handlers on the provided logger.
+    """
+    logger.setLevel(level)
+
+    handlers = logger.handlers
+    for handler in handlers:
+        handler.setLevel(level)
+
+    return logger
+
+
 def set_log_level_for_all_loggers(level=logging.DEBUG):
     """
     Set a log level for all the loggers and handlers to the provided level.
@@ -61,8 +75,4 @@ def set_log_level_for_all_loggers(level=logging.DEBUG):
         if not isinstance(logger, logging.Logger):
             continue
 
-        logger.setLevel(level)
-
-        handlers = logger.handlers
-        for handler in handlers:
-            handler.setLevel(level)
+        set_log_level_for_all_handlers(logger=logger)

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -107,7 +107,6 @@ class SensorService(object):
         :param trace_context: Trace context to associate with Trigger.
         :type trace_context: ``st2common.api.models.api.trace.TraceContext``
         """
-        self._logger.debug('Dispatching trigger "%s", payload: %s' % (trigger, payload))
         self._dispatcher.dispatch(trigger, payload=payload, trace_context=trace_context)
 
     ##################################

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -18,14 +18,12 @@ import sys
 import json
 import atexit
 import argparse
-import logging as stdlib_logging
 
 import eventlet
 from oslo_config import cfg
 from st2client.client import Client
 
 from st2common import log as logging
-from st2common.logging.misc import set_log_level_for_all_handlers
 from st2common.logging.misc import set_log_level_for_all_loggers
 from st2common.models.api.trace import TraceContext
 from st2common.models.db import db_setup
@@ -35,7 +33,6 @@ from st2common.util.config_parser import ContentPackConfigParser
 from st2common.services.triggerwatcher import TriggerWatcher
 from st2reactor.sensor.base import Sensor, PollingSensor
 from st2reactor.sensor import config
-from st2common.constants.pack import SYSTEM_PACK_NAMES
 from st2common.constants.system import API_URL_ENV_VARIABLE_NAME
 from st2common.constants.system import AUTH_TOKEN_ENV_VARIABLE_NAME
 from st2client.models.keyvalue import KeyValuePair
@@ -436,7 +433,7 @@ class SensorWrapper(object):
 
         try:
             sensor_instance = sensor_class(**sensor_class_kwargs)
-        except Exception as e:
+        except Exception:
             self._logger.exception('Failed to instantiate "%s" sensor class' % (self._class_name))
             raise Exception('Failed to instantiate "%s" sensor class' % (self._class_name))
 

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -422,9 +422,7 @@ class SensorWrapper(object):
         sensor_class_kwargs['sensor_service'] = SensorService(sensor_wrapper=self)
 
         sensor_config = self._get_sensor_config()
-
-        if self._pack not in SYSTEM_PACK_NAMES:
-            sensor_class_kwargs['config'] = sensor_config
+        sensor_class_kwargs['config'] = sensor_config
 
         if self._poll_interval and issubclass(sensor_class, PollingSensor):
             sensor_class_kwargs['poll_interval'] = self._poll_interval

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -432,8 +432,8 @@ class SensorWrapper(object):
         try:
             sensor_instance = sensor_class(**sensor_class_kwargs)
         except Exception as e:
-            raise Exception('Failed to instantiate "%s" sensor class: %s' %
-                            (self._class_name, str(e)))
+            self._logger.exception('Failed to instantiate "%s" sensor class' % (self._class_name))
+            raise Exception('Failed to instantiate "%s" sensor class' % (self._class_name))
 
         return sensor_instance
 


### PR DESCRIPTION
* Fix sensor container service so the ``config`` argument is correctly passed to the sensor instances in the system packs. Previously, this argument didn't get passed correctly to the FileWatchSensor from the system linux pack.
* Make sure sensor processes correctly pick up parent ``--debug`` flag. This makes debugging a lot easier since user simply needs to start sensor container with ``--debug`` flag and all the sensor logs with level debug or higher will be routed to the container log.