### PR TITLE
Fix cast params bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@ in development
 * Fix ``timestamp_lt`` and ``timestamp_gt`` filtering in the `/executions` API endpoint. Now we
   return a correct result which is expected from a user-perspective. (bug-fix)
 * Enable Mistral workflow cancellation via ``st2 execution cancel``. (improvement)
+* Make sure that alias execution endpoint returns a correct status code and error message if the
+  referenced action doesn't exist.
 
 0.13.2 - September 09, 2015
 ---------------------------

--- a/st2actions/tests/unit/test_param_utils.py
+++ b/st2actions/tests/unit/test_param_utils.py
@@ -24,6 +24,7 @@ from st2common.models.db.keyvalue import KeyValuePairDB
 from st2common.persistence.keyvalue import KeyValuePair
 from st2common.transport.publishers import PoolPublisher
 from st2common.util import date as date_utils
+from st2common.models.utils import action_param_utils
 from st2tests import DbTestCase
 from st2tests.fixturesloader import FixturesLoader
 
@@ -333,6 +334,12 @@ class ParamsUtilsTest(DbTestCase):
                                 action_context={},
                                 runnertype_parameter_info={},
                                 action_parameter_info={})
+
+    def test_cast_param_referenced_action_doesnt_exist(self):
+        # Make sure the function throws if the action doesnt exist
+        expected_msg = 'Action with ref "foo.doesntexist" doesn\'t exist'
+        self.assertRaisesRegexp(ValueError, expected_msg, action_param_utils.cast_params,
+                                action_ref='foo.doesntexist', params={})
 
     def _get_liveaction_model(self, params):
         status = 'initializing'

--- a/st2common/st2common/models/utils/action_param_utils.py
+++ b/st2common/st2common/models/utils/action_param_utils.py
@@ -83,6 +83,10 @@ def cast_params(action_ref, params, cast_overrides=None):
     """
     """
     action_db = action_db_util.get_action_by_ref(action_ref)
+
+    if not action_db:
+        raise ValueError('Action with ref "%s" doesn\'t exist' % (action_ref))
+
     action_parameters_schema = action_db.parameters
     runnertype_db = action_db_util.get_runnertype_by_name(action_db.runner_type['name'])
     runner_parameters_schema = runnertype_db.runner_parameters


### PR DESCRIPTION
Previously, `cast_params` would explode with an unexpected error if the provided action didn't exist locally.

This pull request fixes it to throw a ValueError if the action doesn't exist.

This was discovered by @alustweiss on Slack when trying to schedule an execution using hubot and the action referenced in the alias didn't exist (https://gist.github.com/indiggio/aac040b391c0f99a2ead)