### PR TITLE
st2 packaging updates

### DIFF
--- a/st2actions/Makefile
+++ b/st2actions/Makefile
@@ -45,7 +45,7 @@ deb:
 WHEELDIR ?= /tmp/wheelhouse
 ST2_COMPONENT := $(notdir $(CURDIR))
 ST2PKG_RELEASE ?= 1
-ST2PKG_VERSION ?= 0.1.0
+ST2PKG_VERSION ?= $(shell python -c "from $(ST2_COMPONENT) import __version__; print __version__,")
 
 ifneq (,$(wildcard /etc/debian_version))
 	DEBIAN := 1

--- a/st2api/Makefile
+++ b/st2api/Makefile
@@ -45,7 +45,7 @@ deb:
 WHEELDIR ?= /tmp/wheelhouse
 ST2_COMPONENT := $(notdir $(CURDIR))
 ST2PKG_RELEASE ?= 1
-ST2PKG_VERSION ?= 0.1.0
+ST2PKG_VERSION ?= $(shell python -c "from $(ST2_COMPONENT) import __version__; print __version__,")
 
 ifneq (,$(wildcard /etc/debian_version))
 	DEBIAN := 1

--- a/st2auth/Makefile
+++ b/st2auth/Makefile
@@ -45,7 +45,7 @@ deb:
 WHEELDIR ?= /tmp/wheelhouse
 ST2_COMPONENT := $(notdir $(CURDIR))
 ST2PKG_RELEASE ?= 1
-ST2PKG_VERSION ?= 0.1.0
+ST2PKG_VERSION ?= $(shell python -c "from $(ST2_COMPONENT) import __version__; print __version__,")
 
 ifneq (,$(wildcard /etc/debian_version))
 	DEBIAN := 1

--- a/st2client/Makefile
+++ b/st2client/Makefile
@@ -37,7 +37,7 @@ deb:
 WHEELDIR ?= /tmp/wheelhouse
 ST2_COMPONENT := $(notdir $(CURDIR))
 ST2PKG_RELEASE ?= 1
-ST2PKG_VERSION ?= 0.1.0
+ST2PKG_VERSION ?= $(shell python -c "from $(ST2_COMPONENT) import __version__; print __version__,")
 
 ifneq (,$(wildcard /etc/debian_version))
 	DEBIAN := 1

--- a/st2common/Makefile
+++ b/st2common/Makefile
@@ -46,7 +46,7 @@ deb:
 WHEELDIR ?= /tmp/wheelhouse
 ST2_COMPONENT := $(notdir $(CURDIR))
 ST2PKG_RELEASE ?= 1
-ST2PKG_VERSION ?= 0.1.0
+ST2PKG_VERSION ?= $(shell python -c "from $(ST2_COMPONENT) import __version__; print __version__,")
 
 ifneq (,$(wildcard /etc/debian_version))
 	DEBIAN := 1

--- a/st2debug/Makefile
+++ b/st2debug/Makefile
@@ -45,7 +45,7 @@ deb:
 WHEELDIR ?= /tmp/wheelhouse
 ST2_COMPONENT := $(notdir $(CURDIR))
 ST2PKG_RELEASE ?= 1
-ST2PKG_VERSION ?= 0.1.0
+ST2PKG_VERSION ?= $(shell python -c "from $(ST2_COMPONENT) import __version__; print __version__,")
 
 ifneq (,$(wildcard /etc/debian_version))
 	DEBIAN := 1

--- a/st2exporter/Makefile
+++ b/st2exporter/Makefile
@@ -1,7 +1,7 @@
 WHEELDIR ?= /tmp/wheelhouse
 ST2_COMPONENT := $(notdir $(CURDIR))
 ST2PKG_RELEASE ?= 1
-ST2PKG_VERSION ?= 0.1.0
+ST2PKG_VERSION ?= $(shell python -c "from $(ST2_COMPONENT) import __version__; print __version__,")
 
 ifneq (,$(wildcard /etc/debian_version))
 	DEBIAN := 1

--- a/st2reactor/Makefile
+++ b/st2reactor/Makefile
@@ -31,7 +31,7 @@ deb:
 WHEELDIR ?= /tmp/wheelhouse
 ST2_COMPONENT := $(notdir $(CURDIR))
 ST2PKG_RELEASE ?= 1
-ST2PKG_VERSION ?= 0.1.0
+ST2PKG_VERSION ?= $(shell python -c "from $(ST2_COMPONENT) import __version__; print __version__,")
 
 ifneq (,$(wildcard /etc/debian_version))
 	DEBIAN := 1


### PR DESCRIPTION
make ST2PKG_VERSION lazily parsed from __init__.py if not defined