### PR TITLE
Include keystone backend as available backend, Fixes #1983

### DIFF
--- a/st2auth/st2auth/backends/__init__.py
+++ b/st2auth/st2auth/backends/__init__.py
@@ -27,7 +27,8 @@ __all__ = [
 
 BACKEND_MODULES = {
     'flat_file': 'st2auth.backends.flat_file',
-    'mongodb': 'st2auth.backends.mongodb'
+    'mongodb': 'st2auth.backends.mongodb',
+    'keystone': 'st2auth.backends.keystone'
 }
 
 VALID_BACKEND_NAMES = BACKEND_MODULES.keys()


### PR DESCRIPTION
Unable to use keystone as a backend on 0.13.x deb packages due to this issue.