### PR TITLE
Fix "packs.info" action

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ Changelog
 ------------
 
 * Allow user to select ``keystone`` backend in the st2auth service. (bug-fix)
+* Fix ``packs.info`` action so it correctly exists with a non-zero status code if the pack doesn't
+  exist or if it doesn't contain a valid ``.gitinfo`` file. (bug-fix)
+* Fix ``packs.info`` action so it correctly searches all the packs base dirs. (bug-fix)
 
 0.13.2 - September 09, 2015
 ---------------------------

--- a/contrib/packs/actions/pack_mgmt/info.py
+++ b/contrib/packs/actions/pack_mgmt/info.py
@@ -13,9 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from st2actions.runners.pythonrunner import Action
-import json
 import os
+import sys
+import json
+
+from st2actions.runners.pythonrunner import Action
 
 GITINFO_FILE = '.gitinfo'
 
@@ -28,4 +30,5 @@ class PackInfo(Action):
                 details = json.load(data_file)
                 return details
         except:
-            print "Unable to load git info for {}".format(pack)
+            error = 'Pack %s doesn\'t exist or it doesn\'t contain .gitinfo file' % (pack)
+            raise Exception(error)

--- a/contrib/packs/actions/pack_mgmt/info.py
+++ b/contrib/packs/actions/pack_mgmt/info.py
@@ -14,21 +14,42 @@
 # limitations under the License.
 
 import os
-import sys
 import json
 
 from st2actions.runners.pythonrunner import Action
+from st2common.content.utils import get_packs_base_paths
 
 GITINFO_FILE = '.gitinfo'
 
 
 class PackInfo(Action):
     def run(self, pack, pack_dir="/opt/stackstorm/packs"):
-        gitinfo = os.path.join(pack_dir, pack, GITINFO_FILE)
-        try:
-            with open(gitinfo) as data_file:
-                details = json.load(data_file)
-                return details
-        except:
-            error = 'Pack %s doesn\'t exist or it doesn\'t contain .gitinfo file' % (pack)
+        packs_base_paths = get_packs_base_paths()
+
+        pack_git_info_path = None
+        for packs_base_path in packs_base_paths:
+            git_info_path = os.path.join(packs_base_path, pack, GITINFO_FILE)
+
+            if os.path.isfile(git_info_path):
+                pack_git_info_path = git_info_path
+                break
+
+        error = ('Pack %s doesn\'t exist or it doesn\'t contain a valid .gitinfo file' % (pack))
+
+        if not pack_git_info_path:
             raise Exception(error)
+
+        try:
+            details = self._parse_git_info_file(git_info_path)
+        except Exception as e:
+            error = ('Pack %s doesn\'t contain a valid .gitinfo file: %s' % (pack, str(e)))
+            raise Exception(error)
+
+        return details
+
+    def _parse_git_info_file(self, file_path):
+        with open(file_path) as data_file:
+            details = json.load(data_file)
+            return details
+
+        return details

--- a/contrib/packs/actions/pack_mgmt/info.py
+++ b/contrib/packs/actions/pack_mgmt/info.py
@@ -34,9 +34,8 @@ class PackInfo(Action):
                 pack_git_info_path = git_info_path
                 break
 
-        error = ('Pack "%s" doesn\'t exist or it doesn\'t contain a valid .gitinfo file' % (pack))
-
         if not pack_git_info_path:
+            error = ('Pack "%s" doesn\'t exist or it doesn\'t contain a .gitinfo file' % (pack))
             raise Exception(error)
 
         try:

--- a/contrib/packs/actions/pack_mgmt/info.py
+++ b/contrib/packs/actions/pack_mgmt/info.py
@@ -23,7 +23,7 @@ GITINFO_FILE = '.gitinfo'
 
 
 class PackInfo(Action):
-    def run(self, pack, pack_dir="/opt/stackstorm/packs"):
+    def run(self, pack):
         packs_base_paths = get_packs_base_paths()
 
         pack_git_info_path = None
@@ -34,7 +34,7 @@ class PackInfo(Action):
                 pack_git_info_path = git_info_path
                 break
 
-        error = ('Pack %s doesn\'t exist or it doesn\'t contain a valid .gitinfo file' % (pack))
+        error = ('Pack "%s" doesn\'t exist or it doesn\'t contain a valid .gitinfo file' % (pack))
 
         if not pack_git_info_path:
             raise Exception(error)
@@ -42,7 +42,7 @@ class PackInfo(Action):
         try:
             details = self._parse_git_info_file(git_info_path)
         except Exception as e:
-            error = ('Pack %s doesn\'t contain a valid .gitinfo file: %s' % (pack, str(e)))
+            error = ('Pack "%s" doesn\'t contain a valid .gitinfo file: %s' % (pack, str(e)))
             raise Exception(error)
 
         return details


### PR DESCRIPTION
This branch fixes two issues:

1. Make sure action exits with non-zero if pack doesn't exist or if it doesn't contain a valid `.gitinfo` file
2. Correctly search all the pack search paths defined in the config. Previously we only searched ``/opt/stackstorm/packs`` which was hard coded so the action also wouldn't work if the user used a custom packs dir.

This resolves #1986