### PR TITLE
[BUGFIX] tags were not stored.  Now they are.

### DIFF
--- a/st2common/st2common/services/triggers.py
+++ b/st2common/st2common/services/triggers.py
@@ -315,6 +315,7 @@ def _add_trigger_models(trigger_type):
     parameters_schema = trigger_type['parameters_schema'] \
         if 'parameters_schema' in trigger_type else {}
     tags = trigger_type['tags']
+        if 'tags' in trigger_type else {}
     trigger_type = _create_trigger_type(
         pack=pack,
         name=trigger_type['name'],

--- a/st2common/st2common/services/triggers.py
+++ b/st2common/st2common/services/triggers.py
@@ -260,13 +260,14 @@ def create_or_update_trigger_type_db(trigger_type):
 
 
 def _create_trigger_type(pack, name, description=None, payload_schema=None,
-                         parameters_schema=None):
+                         parameters_schema=None, tags=None):
     trigger_type = {
         'name': name,
         'pack': pack,
         'description': description,
         'payload_schema': payload_schema,
-        'parameters_schema': parameters_schema
+        'parameters_schema': parameters_schema,
+	'tags': tags
     }
 
     return create_or_update_trigger_type_db(trigger_type=trigger_type)
@@ -313,13 +314,14 @@ def _add_trigger_models(trigger_type):
     payload_schema = trigger_type['payload_schema'] if 'payload_schema' in trigger_type else {}
     parameters_schema = trigger_type['parameters_schema'] \
         if 'parameters_schema' in trigger_type else {}
-
+    tags = trigger_type['tags']
     trigger_type = _create_trigger_type(
         pack=pack,
         name=trigger_type['name'],
         description=description,
         payload_schema=payload_schema,
-        parameters_schema=parameters_schema
+        parameters_schema=parameters_schema,
+	tags=tags
     )
     trigger = _create_trigger(trigger_type=trigger_type)
     return (trigger_type, trigger)

--- a/st2common/st2common/services/triggers.py
+++ b/st2common/st2common/services/triggers.py
@@ -314,7 +314,7 @@ def _add_trigger_models(trigger_type):
     payload_schema = trigger_type['payload_schema'] if 'payload_schema' in trigger_type else {}
     parameters_schema = trigger_type['parameters_schema'] \
         if 'parameters_schema' in trigger_type else {}
-    tags = trigger_type['tags']
+    tags = trigger_type['tags'] \
         if 'tags' in trigger_type else {}
     trigger_type = _create_trigger_type(
         pack=pack,


### PR DESCRIPTION
When retrieving triggers using st2 trigger get, no tags where shown even though they were define in the sensor yaml file.  With these changes tags for triggers are properly stored when registering sensors.