### PR TITLE
Add missing pack.yaml to examples pack

### DIFF
--- a/contrib/examples/pack.yaml
+++ b/contrib/examples/pack.yaml
@@ -1,0 +1,6 @@
+---
+name: examples
+description: Pack which contains various examples of sensors, triggers, actions and rules.
+version: 0.1.0
+author : st2-dev
+email : info@stackstorm.com


### PR DESCRIPTION
Caught by @enykeev.

(As mentioned in the other pr which adds a missing pack.yaml to default pack, not having a pack.yaml breaks all kinds of things)