### PR TITLE
ETag and Last-Modified headers for files

### DIFF
--- a/st2api/st2api/controllers/v1/packviews.py
+++ b/st2api/st2api/controllers/v1/packviews.py
@@ -188,7 +188,7 @@ class FileController(BaseFileController):
         file_size, file_mtime = self._get_file_stats(file_path=normalized_file_path)
 
         if not self._is_file_changed(file_mtime):
-            # unsure if a header is required
+            self._add_cache_headers(file_mtime)
             response.status = http_client.NOT_MODIFIED
             return response
 
@@ -199,10 +199,7 @@ class FileController(BaseFileController):
 
         content_type = mimetypes.guess_type(normalized_file_path)[0] or 'application/octet-stream'
 
-        response.headers['Cache-Control'] = 'public, max-age=90'
-        # Add both Last-Modified and ETag headers as per recommendations in RFC2616
-        response.headers['Last-Modified'] = format_date_time(file_mtime)
-        response.headers['ETag'] = repr(file_mtime)
+        self._add_cache_headers(file_mtime)
         response.headers['Content-Type'] = content_type
         response.body = self._get_file_content(file_path=normalized_file_path)
         return response
@@ -221,6 +218,12 @@ class FileController(BaseFileController):
 
         # Neither header is provided therefore assume file is changed.
         return True
+
+    def _add_cache_headers(self, file_mtime):
+        response.headers['Cache-Control'] = 'public, max-age=90'
+        # Add both Last-Modified and ETag headers as per recommendations in RFC2616
+        response.headers['Last-Modified'] = format_date_time(file_mtime)
+        response.headers['ETag'] = repr(file_mtime)
 
 
 class PackViewsController(RestController):

--- a/st2api/st2api/controllers/v1/packviews.py
+++ b/st2api/st2api/controllers/v1/packviews.py
@@ -220,7 +220,6 @@ class FileController(BaseFileController):
         return True
 
     def _add_cache_headers(self, file_mtime):
-        response.headers['Cache-Control'] = 'public, max-age=90'
         # Add both Last-Modified and ETag headers as per recommendations in RFC2616
         response.headers['Last-Modified'] = format_date_time(file_mtime)
         response.headers['ETag'] = repr(file_mtime)

--- a/st2api/st2api/gunicorn_config.py
+++ b/st2api/st2api/gunicorn_config.py
@@ -49,5 +49,6 @@ app = {
     'root': 'st2api.controllers.root.RootController',
     'modules': ['st2api'],
     'debug': cfg.CONF.api_pecan.debug,
-    'errors': {'__force_dict__': True}
+    'errors': {'__force_dict__': True},
+    'guess_content_type_from_ext': False
 }


### PR DESCRIPTION
Fixed as per https://www.keycdn.com/blog/a-guide-to-http-cache-headers/

* ETag and Cache-Control are the HTTP 1.1 way of handling intermediate caches
* Reduce the max-age to 90s from 24Hrs. This is ok since the browser will request the value but will not necessarily end up retrieving content if content has not changed. However, a backend request will still be made.