### PR TITLE
Change headers for cli list commands for consistency

### DIFF
--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -141,7 +141,7 @@ class ActionBranch(resource.ResourceBranch):
 
 
 class ActionListCommand(resource.ContentPackResourceListCommand):
-    display_attributes = ['uid', 'ref', 'pack', 'name', 'description']
+    display_attributes = ['ref', 'pack', 'description']
 
 
 class ActionGetCommand(resource.ContentPackResourceGetCommand):

--- a/st2client/st2client/commands/action_alias.py
+++ b/st2client/st2client/commands/action_alias.py
@@ -33,7 +33,7 @@ class ActionAliasBranch(resource.ResourceBranch):
 
 
 class ActionAliasListCommand(resource.ContentPackResourceListCommand):
-    display_attributes = ['ref', 'pack', 'name', 'description', 'enabled']
+    display_attributes = ['ref', 'pack', 'description', 'enabled']
 
 
 class ActionAliasGetCommand(resource.ContentPackResourceGetCommand):

--- a/st2client/st2client/commands/rule.py
+++ b/st2client/st2client/commands/rule.py
@@ -35,7 +35,7 @@ class RuleBranch(resource.ResourceBranch):
 
 
 class RuleListCommand(resource.ContentPackResourceListCommand):
-    display_attributes = ['uid', 'ref', 'pack', 'name', 'description']
+    display_attributes = ['ref', 'pack', 'description', 'enabled']
 
 
 class RuleGetCommand(resource.ContentPackResourceGetCommand):

--- a/st2client/st2client/commands/sensor.py
+++ b/st2client/st2client/commands/sensor.py
@@ -33,7 +33,7 @@ class SensorBranch(resource.ResourceBranch):
 
 
 class SensorListCommand(resource.ContentPackResourceListCommand):
-    display_attributes = ['uid', 'ref', 'pack', 'name', 'enabled', 'trigger_types']
+    display_attributes = ['ref', 'pack', 'description', 'enabled']
 
 
 class SensorGetCommand(resource.ContentPackResourceGetCommand):

--- a/st2client/st2client/commands/trigger.py
+++ b/st2client/st2client/commands/trigger.py
@@ -37,7 +37,7 @@ class TriggerTypeBranch(resource.ResourceBranch):
 
 
 class TriggerTypeListCommand(resource.ContentPackResourceListCommand):
-    display_attributes = ['ref', 'pack', 'name', 'description']
+    display_attributes = ['ref', 'pack', 'description']
 
 
 class TriggerTypeGetCommand(resource.ContentPackResourceGetCommand):


### PR DESCRIPTION
* Overtly verbose listing commands don't provide much value so reducing
  the headers to mostly ref, name and description. In some cases enabled
  is also included. The general idea is that the list should only be
  an overview and provide just enough information to locate an object
  quickly and for complete information dig into the objects with get
  commands.

```
(virtualenv)manas@st2dev:~/st2$ st2 action list
+-----------------------------------------------------+----------+---------------------------------------------------------------+
| ref                                                 | pack     | description                                                   |
+-----------------------------------------------------+----------+---------------------------------------------------------------+
| core.http                                           | core     | Action that performs an http request.                         |
| core.local                                          | core     | Action that executes an arbitrary Linux command on the        |
|                                                     |          | localhost.                                                    |
| core.local_sudo                                     | core     | Action that executes an arbitrary Linux command on the        |
|                                                     |          | localhost.                                                    |
| core.remote                                         | core     | Action to execute arbitrary linux command remotely.           |
| core.remote_sudo                                    | core     | Action to execute arbitrary linux command remotely.           |
| core.sendmail                                       | core     | This sends an email                                           |
| core.stormbot_say                                   | core     | This posts a message to StormBot                              |
| core.windows_cmd                                    | core     | Action to execute arbitrary Windows command remotely.         |
| default.echochain                                   | default  | Simple Action Chain workflow                                  |
| default.parentchain                                 | default  | Simple Action Chain workflow                                  |
| default.sleepchain                                  | default  | Simple Action Chain workflow                                  |
| examples.weather                                    | examples | Look up weather.                                              |
| fixtures.streamwriter                               | fixtures | Simple python action to test output to different streams.     |
| fixtures.streamwriter-script-local                  | fixtures | Simple script action to test output to different streams.     |
| fixtures.streamwriter-script-remote                 | fixtures | Simple script action to test output to different streams.     |
| packs.delete                                        | packs    | Deletes the pack from local content repository.               |
| packs.download                                      | packs    | Downloads packs and places it in the local content            |
|                                                     |          | repository.                                                   |
| packs.info                                          | packs    | Get currently deployed pack information                       |
| packs.install                                       | packs    | Installs packs from st2-contrib into local content            |
|                                                     |          | repository. Will download pack, load the actions, sensors and |
|                                                     |          | rules from the pack. Note that install require reboot of some |
|                                                     |          | st2 services.                                                 |
| packs.load                                          | packs    | Action that reloads all st2 content.                          |
| packs.restart_component                             | packs    | Action that restarts st2 service.                             |
| packs.setup_virtualenv                              | packs    | Set up virtual environment for the provided packs             |
| packs.uninstall                                     | packs    | Uninstalls packs from local content repository. Removes pack  |
|                                                     |          | and content from st2. Note that uninstall require reboot of   |
|                                                     |          | some st2 services.                                            |
| packs.unload                                        | packs    | Unregisters all content from a pack.                          |
| packs.virtualenv_prerun                             | packs    | Transformation step to conver packs_status to list of packs.  |
+-----------------------------------------------------+----------+---------------------------------------------------------------+
(virtualenv)manas@st2dev:~/st2$ st2 rule list
+----------------------------------+----------+------------------------------------------------+---------+
| ref                              | pack     | description                                    | enabled |
+----------------------------------+----------+------------------------------------------------+---------+
| examples.examples.webhook_file   | examples | Sample rule dumping webhook payload to a file. | True    |
| examples.sample.notify_slack     | examples | Sample rule firing on action completion.       | True    |
| examples.sample.on_actiontrigger | examples | Sample rule firing on action completion.       | True    |
| examples.sample.with_timer       | examples | Sample rule using an Interval Timer.           | False   |
+----------------------------------+----------+------------------------------------------------+---------+
(virtualenv)manas@st2dev:~/st2$ st2 sensor list
+------------------------------+----------+--------------------------------------------+---------+
| ref                          | pack     | description                                | enabled |
+------------------------------+----------+--------------------------------------------+---------+
| default.SimpleSensor         | default  | Simple sensor that emits triggers.         | True    |
| fixtures.TestPassiveSensor   | fixtures | Test passive sensor                        | True    |
| examples.SimplePollingSensor | examples | Simple polling sensor that emits triggers. | True    |
| examples.SimpleSensor        | examples | Simple sensor that emits triggers.         | True    |
+------------------------------+----------+--------------------------------------------+---------+
(virtualenv)manas@st2dev:~/st2$ st2 trigger list
+--------------------------------------+----------+---------------------------------------------------------------+
| ref                                  | pack     | description                                                   |
+--------------------------------------+----------+---------------------------------------------------------------+
| default.event_test                   | default  | An example trigger.                                           |
| fixtures.test_passive_trigger.dummy  | fixtures |                                                               |
| examples.polling_event               | examples | An example trigger.                                           |
| examples.event                       | examples | An example trigger.                                           |
| core.st2.generic.actiontrigger       | core     | Trigger encapsulating the completion of an action execution.  |
| core.st2.generic.notifytrigger       | core     | Notification trigger.                                         |
| core.st2.action.file_writen          | core     | Trigger encapsulating action file being written on disk.      |
| core.st2.key_value_pair.create       | core     | Trigger encapsulating datastore item creation.                |
| core.st2.key_value_pair.update       | core     | Trigger encapsulating datastore set action.                   |
| core.st2.key_value_pair.value_change | core     | Trigger encapsulating a change of datastore item value.       |
| core.st2.key_value_pair.delete       | core     | Trigger encapsulating datastore item deletion.                |
| core.st2.sensor.process_spawn        | core     | Trigger indicating sensor process is started up.              |
| core.st2.sensor.process_exit         | core     | Trigger indicating sensor process is stopped.                 |
| core.st2.IntervalTimer               | core     | Triggers on specified intervals. e.g. every 30s, 1week etc.   |
| core.st2.DateTimer                   | core     | Triggers exactly once when the current time matches the       |
|                                      |          | specified time. e.g. timezone:UTC date:2014-12-31 23:59:59.   |
| core.st2.CronTimer                   | core     | Triggers whenever current time matches the specified time     |
|                                      |          | constaints like a UNIX cron scheduler.                        |
| core.st2.webhook                     | core     | Trigger type for registering webhooks that can consume        |
|                                      |          | arbitrary payload.                                            |
+--------------------------------------+----------+---------------------------------------------------------------+
(virtualenv)manas@st2dev:~/st2$
```