### PR TITLE
fixing in-requirements.txt for previously add mistralclient into st2api

### DIFF
--- a/st2api/in-requirements.txt
+++ b/st2api/in-requirements.txt
@@ -8,3 +8,4 @@ oslo.config
 pymongo
 six
 git+https://github.com/StackStorm/pecan.git@st2-patched#egg=pecan
+git+https://github.com/StackStorm/python-mistralclient#egg=python-mistralclient


### PR DESCRIPTION
Introducing dependencies without adding them into appropriate `in-requirements.txt` can cause inconsistency of packages in the future https://github.com/StackStorm/st2/commit/0ae8fd08bda9ff40d14bb6a79fb92f187e542a9d#diff-8d5ef5953c18fe21054d0958e6e79160R20. @m4dcoder 

New packaging has separate components which are *st2api*, *st2common*, *st2actions* etc.
These components are bundled with their own separate virtual environment, thus missing including dependency into specific `in-requirements.txt` will result in "missing module", even if the global (toplevel) `requirements.txt` contain it...
