### PR TITLE
Retry db connection

### DIFF
--- a/st2api/st2api/wsgi.py
+++ b/st2api/st2api/wsgi.py
@@ -27,8 +27,8 @@ logging.setup(cfg.CONF.api.logging)
 
 username = cfg.CONF.database.username if hasattr(cfg.CONF.database, 'username') else None
 password = cfg.CONF.database.password if hasattr(cfg.CONF.database, 'password') else None
-db.db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
-            username=username, password=password)
+db.db_setup_with_retry(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
+                       username=username, password=password)
 
 pecan_config = {
     'app': {

--- a/st2api/st2api/wsgi.py
+++ b/st2api/st2api/wsgi.py
@@ -18,7 +18,7 @@ from oslo_config import cfg
 
 from st2api import config  # noqa
 from st2common import log as logging
-from st2common.models import db
+from st2common.persistence import db_init
 
 
 cfg.CONF(args=['--config-file', '/etc/st2/st2.conf'])
@@ -27,8 +27,8 @@ logging.setup(cfg.CONF.api.logging)
 
 username = cfg.CONF.database.username if hasattr(cfg.CONF.database, 'username') else None
 password = cfg.CONF.database.password if hasattr(cfg.CONF.database, 'password') else None
-db.db_setup_with_retry(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
-                       username=username, password=password)
+db_init.db_setup_with_retry(cfg.CONF.database.db_name, cfg.CONF.database.host,
+                            cfg.CONF.database.port, username=username, password=password)
 
 pecan_config = {
     'app': {

--- a/st2auth/st2auth/wsgi.py
+++ b/st2auth/st2auth/wsgi.py
@@ -27,8 +27,8 @@ logging.setup(cfg.CONF.auth.logging)
 
 username = cfg.CONF.database.username if hasattr(cfg.CONF.database, 'username') else None
 password = cfg.CONF.database.password if hasattr(cfg.CONF.database, 'password') else None
-db.db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
-            username=username, password=password)
+db.db_setup_with_retry(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
+                       username=username, password=password)
 
 pecan_config = {
     'app': {

--- a/st2auth/st2auth/wsgi.py
+++ b/st2auth/st2auth/wsgi.py
@@ -18,7 +18,7 @@ from oslo_config import cfg
 
 from st2auth import config  # noqa
 from st2common import log as logging
-from st2common.models import db
+from st2common.persistence import db_init
 
 
 cfg.CONF(args=['--config-file', '/etc/st2/st2.conf'])
@@ -27,8 +27,8 @@ logging.setup(cfg.CONF.auth.logging)
 
 username = cfg.CONF.database.username if hasattr(cfg.CONF.database, 'username') else None
 password = cfg.CONF.database.password if hasattr(cfg.CONF.database, 'password') else None
-db.db_setup_with_retry(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
-                       username=username, password=password)
+db_init.db_setup_with_retry(cfg.CONF.database.db_name, cfg.CONF.database.host,
+                            cfg.CONF.database.port, username=username, password=password)
 
 pecan_config = {
     'app': {

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -94,6 +94,12 @@ def register_opts(ignore_errors=False):
         cfg.StrOpt('db_name', default='st2', help='name of database'),
         cfg.StrOpt('username', help='username for db login'),
         cfg.StrOpt('password', help='password for db login'),
+        cfg.IntOpt('connection_retry_max_delay_m', help='Connection retry total time (minutes).',
+                   default=3),
+        cfg.IntOpt('connection_retry_backoff_max_s', help='Connection retry backoff max (seconds).',
+                   default=10),
+        cfg.IntOpt('connection_retry_backoff_mul', help='Backoff multiplier (seconds).',
+                   default=1)
     ]
     do_register_opts(db_opts, 'database', ignore_errors)
 

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -1,3 +1,18 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import copy
 import importlib
 
@@ -29,23 +44,6 @@ MODEL_MODULE_NAMES = [
     'st2common.models.db.trigger',
 ]
 
-DB_CONNRETRY_MAX_DELAY = cfg.CONF.database.connection_retry_max_delay_m * 60 * 1000
-DB_CONNRETRY_EXP_BACK_OFF_MAX = cfg.CONF.database.connection_retry_backoff_max_s * 1000
-DB_CONNRETRY_EXP_BACK_OFF_MUL = cfg.CONF.database.connection_retry_backoff_mul * 1000
-
-
-def _retry_if_connection_error(error):
-    # Ideally we only want to retry on failure to connect to DB as opposed to
-    # bad connection details. However, mongoengine raises a ConnectionError for
-    # a few different cases and the only option would be to parse the error msg.
-    # Ideally, a special execption or atleast some exception code.
-    # If this does become an issue look for "Cannot connect to database" at the
-    # start of error msg.
-    is_connection_error = isinstance(error, mongoengine.connection.ConnectionError)
-    if is_connection_error:
-        LOG.warn('Retry on ConnectionError - %s', error)
-    return is_connection_error
-
 
 def get_model_classes():
     """
@@ -60,19 +58,6 @@ def get_model_classes():
         result.extend(model_classes)
 
     return result
-
-
-@retry(retry_on_exception=_retry_if_connection_error,
-       wait_exponential_multiplier=DB_CONNRETRY_EXP_BACK_OFF_MUL,
-       wait_exponential_max=DB_CONNRETRY_EXP_BACK_OFF_MAX,
-       stop_max_delay=DB_CONNRETRY_MAX_DELAY)
-def db_setup_with_retry(db_name, db_host, db_port, username=None, password=None,
-                        ensure_indexes=True):
-    """
-    This method is a retry version of db_setup.
-    """
-    return db_setup(db_name, db_host, db_port, username=username, password=password,
-                    ensure_indexes=ensure_indexes)
 
 
 def db_setup(db_name, db_host, db_port, username=None, password=None,

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -3,6 +3,8 @@ import importlib
 
 import six
 import mongoengine
+from oslo_config import cfg
+from retrying import retry
 
 from st2common import log as logging
 from st2common.util import isotime
@@ -27,6 +29,23 @@ MODEL_MODULE_NAMES = [
     'st2common.models.db.trigger',
 ]
 
+DB_CONNRETRY_MAX_DELAY = cfg.CONF.database.connection_retry_max_delay_m * 60 * 1000
+DB_CONNRETRY_EXP_BACK_OFF_MAX = cfg.CONF.database.connection_retry_backoff_max_s * 1000
+DB_CONNRETRY_EXP_BACK_OFF_MUL = cfg.CONF.database.connection_retry_backoff_mul * 1000
+
+
+def _retry_if_connection_error(error):
+    # Ideally we only want to retry on failure to connect to DB as opposed to
+    # bad connection details. However, mongoengine raises a ConnectionError for
+    # a few different cases and the only option would be to parse the error msg.
+    # Ideally, a special execption or atleast some exception code.
+    # If this does become an issue look for "Cannot connect to database" at the
+    # start of error msg.
+    is_connection_error = isinstance(error, mongoengine.connection.ConnectionError)
+    if is_connection_error:
+        LOG.warn('Retry on ConnectionError - %s', error)
+    return is_connection_error
+
 
 def get_model_classes():
     """
@@ -43,10 +62,23 @@ def get_model_classes():
     return result
 
 
+@retry(retry_on_exception=_retry_if_connection_error,
+       wait_exponential_multiplier=DB_CONNRETRY_EXP_BACK_OFF_MUL,
+       wait_exponential_max=DB_CONNRETRY_EXP_BACK_OFF_MAX,
+       stop_max_delay=DB_CONNRETRY_MAX_DELAY)
+def db_setup_with_retry(db_name, db_host, db_port, username=None, password=None,
+                        ensure_indexes=True):
+    """
+    This method is a retry version of db_setup.
+    """
+    return db_setup(db_name, db_host, db_port, username=username, password=password,
+                    ensure_indexes=ensure_indexes)
+
+
 def db_setup(db_name, db_host, db_port, username=None, password=None,
              ensure_indexes=True):
-    LOG.info('Connecting to database "%s" @ "%s:%s" as user "%s".' %
-             (db_name, db_host, db_port, str(username)))
+    LOG.info('Connecting to database "%s" @ "%s:%s" as user "%s".',
+             db_name, db_host, db_port, str(username))
     connection = mongoengine.connection.connect(db_name, host=db_host,
                                                 port=db_port, tz_aware=True,
                                                 username=username, password=password)

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -18,8 +18,6 @@ import importlib
 
 import six
 import mongoengine
-from oslo_config import cfg
-from retrying import retry
 
 from st2common import log as logging
 from st2common.util import isotime

--- a/st2common/st2common/persistence/db_init.py
+++ b/st2common/st2common/persistence/db_init.py
@@ -1,0 +1,58 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mongoengine
+
+from oslo_config import cfg
+from retrying import retry
+
+from st2common import log as logging
+from st2common.models.db import db_setup
+
+__all__ = [
+    'db_setup_with_retry'
+]
+
+LOG = logging.getLogger(__name__)
+
+DB_CONNRETRY_MAX_DELAY = cfg.CONF.database.connection_retry_max_delay_m * 60 * 1000
+DB_CONNRETRY_EXP_BACK_OFF_MAX = cfg.CONF.database.connection_retry_backoff_max_s * 1000
+DB_CONNRETRY_EXP_BACK_OFF_MUL = cfg.CONF.database.connection_retry_backoff_mul * 1000
+
+
+def _retry_if_connection_error(error):
+    # Ideally we only want to retry on failure to connect to DB as opposed to
+    # bad connection details. However, mongoengine raises a ConnectionError for
+    # a few different cases and the only option would be to parse the error msg.
+    # Ideally, a special execption or atleast some exception code.
+    # If this does become an issue look for "Cannot connect to database" at the
+    # start of error msg.
+    is_connection_error = isinstance(error, mongoengine.connection.ConnectionError)
+    if is_connection_error:
+        LOG.warn('Retry on ConnectionError - %s', error)
+    return is_connection_error
+
+
+@retry(retry_on_exception=_retry_if_connection_error,
+       wait_exponential_multiplier=DB_CONNRETRY_EXP_BACK_OFF_MUL,
+       wait_exponential_max=DB_CONNRETRY_EXP_BACK_OFF_MAX,
+       stop_max_delay=DB_CONNRETRY_MAX_DELAY)
+def db_setup_with_retry(db_name, db_host, db_port, username=None, password=None,
+                        ensure_indexes=True):
+    """
+    This method is a retry version of db_setup.
+    """
+    return db_setup(db_name, db_host, db_port, username=username, password=password,
+                    ensure_indexes=ensure_indexes)

--- a/st2common/st2common/persistence/db_init.py
+++ b/st2common/st2common/persistence/db_init.py
@@ -16,7 +16,7 @@
 import mongoengine
 
 from oslo_config import cfg
-from retrying import retry
+import retrying
 
 from st2common import log as logging
 from st2common.models.db import db_setup
@@ -26,10 +26,6 @@ __all__ = [
 ]
 
 LOG = logging.getLogger(__name__)
-
-DB_CONNRETRY_MAX_DELAY = cfg.CONF.database.connection_retry_max_delay_m * 60 * 1000
-DB_CONNRETRY_EXP_BACK_OFF_MAX = cfg.CONF.database.connection_retry_backoff_max_s * 1000
-DB_CONNRETRY_EXP_BACK_OFF_MUL = cfg.CONF.database.connection_retry_backoff_mul * 1000
 
 
 def _retry_if_connection_error(error):
@@ -45,14 +41,20 @@ def _retry_if_connection_error(error):
     return is_connection_error
 
 
-@retry(retry_on_exception=_retry_if_connection_error,
-       wait_exponential_multiplier=DB_CONNRETRY_EXP_BACK_OFF_MUL,
-       wait_exponential_max=DB_CONNRETRY_EXP_BACK_OFF_MAX,
-       stop_max_delay=DB_CONNRETRY_MAX_DELAY)
 def db_setup_with_retry(db_name, db_host, db_port, username=None, password=None,
                         ensure_indexes=True):
     """
     This method is a retry version of db_setup.
     """
-    return db_setup(db_name, db_host, db_port, username=username, password=password,
-                    ensure_indexes=ensure_indexes)
+    # Using as an annotation would be nice but annotations are evaluated at import
+    # time and simple ways to use the annotation means the config gets read before
+    # it is setup. Likely there is a way to use some proxies to delay the actual
+    # reading of config values however this is lesser code.
+    retrying_obj = retrying.Retrying(
+        retry_on_exception=_retry_if_connection_error,
+        wait_exponential_multiplier=cfg.CONF.database.connection_retry_backoff_mul * 1000,
+        wait_exponential_max=cfg.CONF.database.connection_retry_backoff_max_s * 1000,
+        stop_max_delay=cfg.CONF.database.connection_retry_max_delay_m * 60 * 1000
+    )
+    return retrying_obj.call(db_setup, db_name, db_host, db_port, username=username,
+                             password=password, ensure_indexes=ensure_indexes)

--- a/st2common/st2common/service_setup.py
+++ b/st2common/st2common/service_setup.py
@@ -28,6 +28,7 @@ from st2common import log as logging
 from st2common.models import db
 from st2common.constants.logging import DEFAULT_LOGGING_CONF_PATH
 from st2common.logging.misc import set_log_level_for_all_loggers
+from st2common.persistence import db_init
 from st2common.transport.bootstrap_utils import register_exchanges
 from st2common.signal_handlers import register_common_signal_handlers
 from st2common.models.utils.profiling import enable_profiling
@@ -126,7 +127,7 @@ def db_setup():
     username = getattr(cfg.CONF.database, 'username', None)
     password = getattr(cfg.CONF.database, 'password', None)
 
-    connection = db.db_setup_with_retry(
+    connection = db_init.db_setup_with_retry(
         db_name=cfg.CONF.database.db_name, db_host=cfg.CONF.database.host,
         db_port=cfg.CONF.database.port, username=username, password=password
     )

--- a/st2common/st2common/service_setup.py
+++ b/st2common/st2common/service_setup.py
@@ -126,8 +126,10 @@ def db_setup():
     username = getattr(cfg.CONF.database, 'username', None)
     password = getattr(cfg.CONF.database, 'password', None)
 
-    connection = db.db_setup(db_name=cfg.CONF.database.db_name, db_host=cfg.CONF.database.host,
-                             db_port=cfg.CONF.database.port, username=username, password=password)
+    connection = db.db_setup_with_retry(
+        db_name=cfg.CONF.database.db_name, db_host=cfg.CONF.database.host,
+        db_port=cfg.CONF.database.port, username=username, password=password
+    )
     return connection
 
 

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -26,7 +26,7 @@ from st2client.client import Client
 from st2common import log as logging
 from st2common.logging.misc import set_log_level_for_all_loggers
 from st2common.models.api.trace import TraceContext
-from st2common.models.db import db_setup_with_retry
+from st2common.persistence.db_init import db_setup_with_retry
 from st2common.transport.reactor import TriggerDispatcher
 from st2common.util import loader
 from st2common.util.config_parser import ContentPackConfigParser

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -26,7 +26,7 @@ from st2client.client import Client
 from st2common import log as logging
 from st2common.logging.misc import set_log_level_for_all_loggers
 from st2common.models.api.trace import TraceContext
-from st2common.models.db import db_setup
+from st2common.models.db import db_setup_with_retry
 from st2common.transport.reactor import TriggerDispatcher
 from st2common.util import loader
 from st2common.util.config_parser import ContentPackConfigParser
@@ -320,8 +320,8 @@ class SensorWrapper(object):
         # 2. Establish DB connection
         username = cfg.CONF.database.username if hasattr(cfg.CONF.database, 'username') else None
         password = cfg.CONF.database.password if hasattr(cfg.CONF.database, 'password') else None
-        db_setup(cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
-                 username=username, password=password)
+        db_setup_with_retry(cfg.CONF.database.db_name, cfg.CONF.database.host,
+                            cfg.CONF.database.port, username=username, password=password)
 
         # 3. Instantiate the watcher
         self._trigger_watcher = TriggerWatcher(create_handler=self._handle_create_trigger,


### PR DESCRIPTION
Initial connection to the database are a bit more resilient with some retry attempts. In some scenarios as the services are coming up it is likely that the DB has not started yet and providing some retry capabilities makes services startup a little more resilient.

Note : This changes does nothing for cases where DB goes down while services are running. That is still likely to require a restart and manifest strangely.