### PR TITLE
Update mistral handler to use get_full_public_api_url() function

### DIFF
--- a/st2actions/st2actions/runners/mistral/v2.py
+++ b/st2actions/st2actions/runners/mistral/v2.py
@@ -30,6 +30,7 @@ from st2common import log as logging
 from st2common.models.api.notification import NotificationsHelper
 from st2common.util.workflow import mistral as utils
 from st2common.util.url import get_url_without_trailing_slash
+from st2common.util.api import get_full_public_api_url
 
 
 LOG = logging.getLogger(__name__)
@@ -144,10 +145,8 @@ class MistralRunner(AsyncActionRunner):
         inputs = self.runner_parameters.get('context', dict())
         inputs.update(action_parameters)
 
-        # If host value does not start with http, then default to http://.
-        protocol = 'http' if not cfg.CONF.api.use_ssl else 'https'
-        base_url = '%s://%s:%s' % (protocol, cfg.CONF.api.host, cfg.CONF.api.port)
-        endpoint = base_url + '/v1/actionexecutions'
+        api_url = get_full_public_api_url()
+        endpoint = api_url + '/actionexecutions'
 
         # Build context with additional information
         parent_context = {

--- a/st2actions/tests/unit/test_mistral_v2.py
+++ b/st2actions/tests/unit/test_mistral_v2.py
@@ -157,11 +157,14 @@ class MistralRunnerTest(DbTestCase):
             instance = ActionAPI(**fixture)
             Action.add_or_update(ActionAPI.to_model(instance))
 
+    def setUp(self):
+        super(MistralRunnerTest, self).setUp()
+        cfg.CONF.set_override('api_url', 'http://0.0.0.0:9101', group='auth')
+
     def tearDown(self):
         super(MistralRunnerTest, self).tearDown()
         cfg.CONF.set_default('max_attempts', 2, group='mistral')
         cfg.CONF.set_default('retry_wait', 1, group='mistral')
-        cfg.CONF.set_default('use_ssl', False, group='api')
 
     @mock.patch.object(
         workflows.WorkflowManager, 'list',
@@ -223,7 +226,7 @@ class MistralRunnerTest(DbTestCase):
         executions.ExecutionManager, 'create',
         mock.MagicMock(return_value=executions.Execution(None, WF1_EXEC)))
     def test_launch_workflow_with_st2_https(self):
-        cfg.CONF.set_default('use_ssl', True, group='api')
+        cfg.CONF.set_override('api_url', 'https://0.0.0.0:9101', group='auth')
 
         MistralRunner.entry_point = mock.PropertyMock(return_value=WF1_YAML_FILE_PATH)
         liveaction = LiveActionDB(action=WF1_NAME, parameters=ACTION_PARAMS)

--- a/st2actions/tests/unit/test_mistral_v2_auth.py
+++ b/st2actions/tests/unit/test_mistral_v2_auth.py
@@ -108,6 +108,10 @@ class MistralAuthTest(DbTestCase):
             instance = ActionAPI(**fixture)
             Action.add_or_update(ActionAPI.to_model(instance))
 
+    def setUp(self):
+        super(MistralAuthTest, self).setUp()
+        cfg.CONF.set_override('api_url', 'http://0.0.0.0:9101', group='auth')
+
     def tearDown(self):
         super(MistralAuthTest, self).tearDown()
         cfg.CONF.set_default('keystone_username', None, group='mistral')

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -138,8 +138,7 @@ def register_opts(ignore_errors=False):
     # Common API options
     api_opts = [
         cfg.StrOpt('host', default='0.0.0.0', help='StackStorm API server host'),
-        cfg.IntOpt('port', default=9101, help='StackStorm API server port'),
-        cfg.BoolOpt('use_ssl', default=False, help='Set to True if API is using SSL.')
+        cfg.IntOpt('port', default=9101, help='StackStorm API server port')
     ]
     do_register_opts(api_opts, 'api', ignore_errors)
 


### PR DESCRIPTION
This PR builds on #2002 and updates Mistral runner to use `get_full_public_api_url` function to retrieve a base URL to the API endpoint.

This function and underlying `auth.api_url` config option was added quite a while back. It's purpose was and is to serve as a single source of truth for the public base API URL (think static URL registry). All the clients which need to talk to the API endpoint on the public interface should use this value. Like other clients, Mistral is also just another API client so it should use the same value. If for some reason Mistral needs to talk on a private / different interface we should introduce a new option instead of "abusing" api.host and api.port option (one of the reasons for introducing another option in the past was that listen settings don't always directly map to the actual public URL which client uses - think API behind load balancer, etc.).

As noted in #2002, this setting needs to be configured correctly, otherwise things won't work as expected (might require st2enterprise puppet changes).

/cc @DoriftoShoes @jfryman re puppet setting