### PR TITLE
Assign expected permissions at install time.

### DIFF
--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -154,7 +154,10 @@ class DownloadGitRepoAction(Action):
 
     @staticmethod
     def _apply_pack_permissions(pack_path):
-        # mode = 770
+        """
+        Will recursively apply permission 770 to pack and its contents.
+        """
+        # These mask is same as mode = 770
         mode = stat.S_IRWXU | stat.S_IRWXG
         os.chmod(pack_path, mode)
 

--- a/st2common/packaging/debian/postinst
+++ b/st2common/packaging/debian/postinst
@@ -4,3 +4,10 @@ chmod 755 /usr/bin/st2ctl
 chmod 755 /usr/lib/python2.7/dist-packages/st2common/bin/st2-setup-tests
 chmod 755 /usr/lib/python2.7/dist-packages/st2common/bin/st2-setup-examples
 chmod 755 /usr/lib/python2.7/dist-packages/st2common/bin/st2-self-check
+
+# setup permissions on pack rather than inheriting from git repo.
+chmod -R 770 /opt/stackstorm/packs/default
+chmod -R 770 /opt/stackstorm/packs/core
+chmod -R 770 /opt/stackstorm/packs/packs
+chmod -R 770 /opt/stackstorm/packs/linux
+chmod -R 770 /opt/stackstorm/packs/examples

--- a/st2common/packaging/rpm/st2common-rhel6.spec
+++ b/st2common/packaging/rpm/st2common-rhel6.spec
@@ -39,10 +39,15 @@ mkdir -p %{buildroot}/opt/stackstorm/rbac/assignments
 mkdir -p %{buildroot}/usr/share/doc/st2
 mkdir -p %{buildroot}/usr/share/stackstorm
 cp -R contrib/default %{buildroot}/opt/stackstorm/packs/
+chmod -R 770 %{buildroot}/opt/stackstorm/packs/default
 cp -R contrib/core %{buildroot}/opt/stackstorm/packs/
+chmod -R 770 %{buildroot}/opt/stackstorm/packs/core
 cp -R contrib/packs %{buildroot}/opt/stackstorm/packs/
+chmod -R 770 %{buildroot}/opt/stackstorm/packs/packs
 cp -R contrib/linux %{buildroot}/opt/stackstorm/packs/
+chmod -R 770 %{buildroot}/opt/stackstorm/packs/linux
 cp -R contrib/examples %{buildroot}/usr/share/doc/st2/
+chmod -R 770 %{buildroot}/opt/stackstorm/packs/examples
 cp -R docs/* %{buildroot}/usr/share/doc/st2/
 cp -R st2common %{buildroot}/%{python2_sitelib}/
 cp -R bin %{buildroot}/%{python2_sitelib}/st2common/

--- a/st2common/packaging/rpm/st2common.spec
+++ b/st2common/packaging/rpm/st2common.spec
@@ -37,10 +37,15 @@ mkdir -p %{buildroot}/opt/stackstorm/rbac/assignments
 mkdir -p %{buildroot}/usr/share/doc/st2
 mkdir -p %{buildroot}/usr/share/stackstorm
 cp -R contrib/default %{buildroot}/opt/stackstorm/packs/
+chmod -R 770 %{buildroot}/opt/stackstorm/packs/default
 cp -R contrib/core %{buildroot}/opt/stackstorm/packs/
+chmod -R 770 %{buildroot}/opt/stackstorm/packs/core
 cp -R contrib/packs %{buildroot}/opt/stackstorm/packs/
+chmod -R 770 %{buildroot}/opt/stackstorm/packs/packs
 cp -R contrib/linux %{buildroot}/opt/stackstorm/packs/
+chmod -R 770 %{buildroot}/opt/stackstorm/packs/linux
 cp -R contrib/examples %{buildroot}/usr/share/doc/st2/
+chmod -R 770 %{buildroot}/opt/stackstorm/packs/examples
 cp -R docs/* %{buildroot}/usr/share/doc/st2/
 cp -R st2common %{buildroot}/%{python2_sitelib}/
 cp -R bin %{buildroot}/%{python2_sitelib}/st2common/


### PR DESCRIPTION
* The right permissions for installed packs are assigned at package
  install time. Trying to achieve this via git was a non-starter and
  likely the wrong approach anyway.