### PR TITLE
Switch packs to 775

### DIFF
--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -157,8 +157,8 @@ class DownloadGitRepoAction(Action):
         """
         Will recursively apply permission 770 to pack and its contents.
         """
-        # These mask is same as mode = 770
-        mode = stat.S_IRWXU | stat.S_IRWXG
+        # These mask is same as mode = 775
+        mode = stat.S_IRWXU | stat.S_IRWXG | stat.S_IROTH | stat.S_IXOTH
         os.chmod(pack_path, mode)
 
         # Yuck! Since os.chmod does not support chmod -R walk manually.

--- a/st2common/packaging/debian/postinst
+++ b/st2common/packaging/debian/postinst
@@ -6,7 +6,7 @@ chmod 755 /usr/lib/python2.7/dist-packages/st2common/bin/st2-setup-examples
 chmod 755 /usr/lib/python2.7/dist-packages/st2common/bin/st2-self-check
 
 # setup permissions on pack rather than inheriting from git repo.
-chmod -R 770 /opt/stackstorm/packs/default
-chmod -R 770 /opt/stackstorm/packs/core
-chmod -R 770 /opt/stackstorm/packs/packs
-chmod -R 770 /opt/stackstorm/packs/linux
+chmod -R 775 /opt/stackstorm/packs/default
+chmod -R 775 /opt/stackstorm/packs/core
+chmod -R 775 /opt/stackstorm/packs/packs
+chmod -R 775 /opt/stackstorm/packs/linux

--- a/st2common/packaging/rpm/st2common-rhel6.spec
+++ b/st2common/packaging/rpm/st2common-rhel6.spec
@@ -39,13 +39,13 @@ mkdir -p %{buildroot}/opt/stackstorm/rbac/assignments
 mkdir -p %{buildroot}/usr/share/doc/st2
 mkdir -p %{buildroot}/usr/share/stackstorm
 cp -R contrib/default %{buildroot}/opt/stackstorm/packs/
-chmod -R 770 %{buildroot}/opt/stackstorm/packs/default
+chmod -R 775 %{buildroot}/opt/stackstorm/packs/default
 cp -R contrib/core %{buildroot}/opt/stackstorm/packs/
-chmod -R 770 %{buildroot}/opt/stackstorm/packs/core
+chmod -R 775 %{buildroot}/opt/stackstorm/packs/core
 cp -R contrib/packs %{buildroot}/opt/stackstorm/packs/
-chmod -R 770 %{buildroot}/opt/stackstorm/packs/packs
+chmod -R 775 %{buildroot}/opt/stackstorm/packs/packs
 cp -R contrib/linux %{buildroot}/opt/stackstorm/packs/
-chmod -R 770 %{buildroot}/opt/stackstorm/packs/linux
+chmod -R 775 %{buildroot}/opt/stackstorm/packs/linux
 cp -R contrib/examples %{buildroot}/usr/share/doc/st2/
 cp -R docs/* %{buildroot}/usr/share/doc/st2/
 cp -R st2common %{buildroot}/%{python2_sitelib}/

--- a/st2common/packaging/rpm/st2common.spec
+++ b/st2common/packaging/rpm/st2common.spec
@@ -37,13 +37,13 @@ mkdir -p %{buildroot}/opt/stackstorm/rbac/assignments
 mkdir -p %{buildroot}/usr/share/doc/st2
 mkdir -p %{buildroot}/usr/share/stackstorm
 cp -R contrib/default %{buildroot}/opt/stackstorm/packs/
-chmod -R 770 %{buildroot}/opt/stackstorm/packs/default
+chmod -R 775 %{buildroot}/opt/stackstorm/packs/default
 cp -R contrib/core %{buildroot}/opt/stackstorm/packs/
-chmod -R 770 %{buildroot}/opt/stackstorm/packs/core
+chmod -R 775 %{buildroot}/opt/stackstorm/packs/core
 cp -R contrib/packs %{buildroot}/opt/stackstorm/packs/
-chmod -R 770 %{buildroot}/opt/stackstorm/packs/packs
+chmod -R 775 %{buildroot}/opt/stackstorm/packs/packs
 cp -R contrib/linux %{buildroot}/opt/stackstorm/packs/
-chmod -R 770 %{buildroot}/opt/stackstorm/packs/linux
+chmod -R 775 %{buildroot}/opt/stackstorm/packs/linux
 cp -R contrib/examples %{buildroot}/usr/share/doc/st2/
 cp -R docs/* %{buildroot}/usr/share/doc/st2/
 cp -R st2common %{buildroot}/%{python2_sitelib}/


### PR DESCRIPTION
* 770 is restrictive and causes local scripts to fail. Switching to 775 should unblock those features. We can work out how to properly support this so that packs can be more secure.