### PR TITLE
fix permissions for examples

### DIFF
--- a/st2common/packaging/debian/postinst
+++ b/st2common/packaging/debian/postinst
@@ -10,3 +10,4 @@ chmod -R 775 /opt/stackstorm/packs/default
 chmod -R 775 /opt/stackstorm/packs/core
 chmod -R 775 /opt/stackstorm/packs/packs
 chmod -R 775 /opt/stackstorm/packs/linux
+chmod -R 775 /usr/share/doc/st2/examples

--- a/st2common/packaging/rpm/st2common-rhel6.spec
+++ b/st2common/packaging/rpm/st2common-rhel6.spec
@@ -47,6 +47,7 @@ chmod -R 775 %{buildroot}/opt/stackstorm/packs/packs
 cp -R contrib/linux %{buildroot}/opt/stackstorm/packs/
 chmod -R 775 %{buildroot}/opt/stackstorm/packs/linux
 cp -R contrib/examples %{buildroot}/usr/share/doc/st2/
+chmod -R 775 %{buildroot}/usr/share/doc/st2/examples
 cp -R docs/* %{buildroot}/usr/share/doc/st2/
 cp -R st2common %{buildroot}/%{python2_sitelib}/
 cp -R bin %{buildroot}/%{python2_sitelib}/st2common/

--- a/st2common/packaging/rpm/st2common.spec
+++ b/st2common/packaging/rpm/st2common.spec
@@ -45,6 +45,7 @@ chmod -R 775 %{buildroot}/opt/stackstorm/packs/packs
 cp -R contrib/linux %{buildroot}/opt/stackstorm/packs/
 chmod -R 775 %{buildroot}/opt/stackstorm/packs/linux
 cp -R contrib/examples %{buildroot}/usr/share/doc/st2/
+chmod -R 775 %{buildroot}/usr/share/doc/st2/examples
 cp -R docs/* %{buildroot}/usr/share/doc/st2/
 cp -R st2common %{buildroot}/%{python2_sitelib}/
 cp -R bin %{buildroot}/%{python2_sitelib}/st2common/


### PR DESCRIPTION
* Looks like AMI does have examples deployed by default