### PR TITLE
Make sure scripts from st2common/bin/* are installed into /usr/bin

### DIFF
--- a/st2common/packaging/debian/install
+++ b/st2common/packaging/debian/install
@@ -6,6 +6,7 @@ contrib/examples usr/share/doc/st2/
 docs usr/share/doc/st2/
 st2common usr/lib/python2.7/dist-packages/
 bin usr/lib/python2.7/dist-packages/st2common/
+bin/* usr/bin/
 st2/st2.conf etc/st2
 logrotate.d/st2.conf etc/logrotate.d/
 tools/st2ctl usr/bin/

--- a/st2common/packaging/rpm/st2common-rhel6.spec
+++ b/st2common/packaging/rpm/st2common-rhel6.spec
@@ -55,6 +55,9 @@ install st2/st2.conf %{buildroot}/etc/st2/st2.conf
 install logrotate.d/st2.conf %{buildroot}/etc/logrotate.d/st2.conf
 install rbac/roles/sample.yaml %{buildroot}/opt/stackstorm/rbac/roles/sample.yaml
 install rbac/assignments/sample.yaml %{buildroot}/opt/stackstorm/rbac/assignments/sample.yaml
+install -m755 bin/st2-register-content %{buildroot}/usr/bin/st2-register-content
+install -m755 bin/st2-bootstrap-rmq %{buildroot}/usr/bin/st2-bootstrap-rmq
+install -m755 bin/st2-apply-rbac-definitions %{buildroot}/usr/bin/st2-apply-rbac-definitions
 install -m755 tools/st2ctl %{buildroot}/usr/bin/st2ctl
 install -m755 tools/st2-setup-tests %{buildroot}/usr/lib/python2.7/site-packages/st2common/bin/st2-setup-tests
 install -m755 tools/st2-setup-examples %{buildroot}/usr/lib/python2.7/site-packages/st2common/bin/st2-setup-examples

--- a/st2common/packaging/rpm/st2common.spec
+++ b/st2common/packaging/rpm/st2common.spec
@@ -53,6 +53,9 @@ install st2/st2.conf %{buildroot}/etc/st2/st2.conf
 install logrotate.d/st2.conf %{buildroot}/etc/logrotate.d/st2.conf
 install rbac/roles/sample.yaml %{buildroot}/opt/stackstorm/rbac/roles/sample.yaml
 install rbac/assignments/sample.yaml %{buildroot}/opt/stackstorm/rbac/assignments/sample.yaml
+install -m755 bin/st2-register-content %{buildroot}/usr/bin/st2-register-content
+install -m755 bin/st2-bootstrap-rmq %{buildroot}/usr/bin/st2-bootstrap-rmq
+install -m755 bin/st2-apply-rbac-definitions %{buildroot}/usr/bin/st2-apply-rbac-definitions
 install -m755 tools/st2ctl %{buildroot}/usr/bin/st2ctl
 install -m755 tools/st2-setup-tests %{buildroot}/usr/lib/python2.7/site-packages/st2common/bin/st2-setup-tests
 install -m755 tools/st2-setup-examples %{buildroot}/usr/lib/python2.7/site-packages/st2common/bin/st2-setup-examples

--- a/st2common/setup.py
+++ b/st2common/setup.py
@@ -43,6 +43,7 @@ setup(
     packages=find_packages(exclude=['setuptools', 'tests']),
     scripts=[
         'bin/st2-bootstrap-rmq',
-        'bin/st2-register-content'
+        'bin/st2-register-content',
+        'bin/st2-apply-rbac-definitions'
     ]
 )


### PR DESCRIPTION
This way it's consistent with other scripts which are already installed there (trigger-refire, etc.).

On top of that, it easier for user to execute those scripts since they don't need to know the full path.

Eventually, we can also update st2ctl and st2_deploy.sh to use scripts from /usr/bin/.

TODO (eventually):

- [ ] Only install those scripts into /usr/bin
- [ ] Update st2ctl and st2_deploy.sh to use scripts from /usr/bin