### PR TITLE
[WIP] Update RBAC syncer so role assignments for users which doesn't exist in the DB are still created

### DIFF
--- a/st2common/st2common/rbac/syncer.py
+++ b/st2common/st2common/rbac/syncer.py
@@ -190,7 +190,6 @@ class RBACDefinitionsDBSyncer(object):
                 user_db = UserDB(name=username)
                 LOG.debug(('User "%s" doesn\'t exist in the DB, creating assignment anyway' %
                           (username)))
-                continue
 
             role_assignment_dbs = rbac_services.get_role_assignments_for_user(user_db=user_db)
 

--- a/st2common/st2common/rbac/syncer.py
+++ b/st2common/st2common/rbac/syncer.py
@@ -18,6 +18,7 @@ Module for syncing RBAC definitions in the database with the ones from the files
 """
 
 from st2common import log as logging
+from st2common.models.db.auth import UserDB
 from st2common.persistence.auth import User
 from st2common.persistence.rbac import Role
 from st2common.persistence.rbac import UserRoleAssignment
@@ -183,8 +184,12 @@ class RBACDefinitionsDBSyncer(object):
             user_db = username_to_user_db_map.get(username, None)
 
             if not user_db:
-                LOG.debug(('Skipping role assignments for user "%s" which doesn\'t exist in the '
-                           'database' % (username)))
+                # Note: We allow assignments to be created for the users which don't exist in the
+                # DB yet because user creation in StackStorm is lazy (we only create UserDB) object
+                # when user first logs in.
+                user_db = UserDB(name=username)
+                LOG.debug(('User "%s" doesn\'t exist in the DB, creating assignment a anyway' %
+                          (username)))
                 continue
 
             role_assignment_dbs = rbac_services.get_role_assignments_for_user(user_db=user_db)

--- a/st2common/st2common/rbac/syncer.py
+++ b/st2common/st2common/rbac/syncer.py
@@ -188,7 +188,7 @@ class RBACDefinitionsDBSyncer(object):
                 # DB yet because user creation in StackStorm is lazy (we only create UserDB) object
                 # when user first logs in.
                 user_db = UserDB(name=username)
-                LOG.debug(('User "%s" doesn\'t exist in the DB, creating assignment a anyway' %
+                LOG.debug(('User "%s" doesn\'t exist in the DB, creating assignment anyway' %
                           (username)))
                 continue
 

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -152,7 +152,7 @@ class SystemRole(Enum):
     """
     Default system roles which can't be manipulated (modified or removed).
     """
-    SYSTEM_ADMIN = ' system_admin'  # Special role which can't be revoked.
+    SYSTEM_ADMIN = 'system_admin'  # Special role which can't be revoked.
     ADMIN = 'admin'
     OBSERVER = 'observer'
 


### PR DESCRIPTION
As discussed on Slack, I'm not a big fan of this approach, but because of the way whole auth and user-creation works (lazy) that's the best option we have right now.

Ideally, eventually we would move from lazy user account creation to something else (e.g. sync defined users or similar).