### PR TITLE
Paramiko STDOUT/STDERR UTF-8 decode bug fix. 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,11 @@ in development
   with webhook based integrations. (new-feature)
 * Allow user to define trigger tags in sensor definition YAML files. (new feature) #2000
   [Tom Deckers]
+* Fix a bug in ``stdout`` and ``stderr`` consumption in paramiko SSH runner where reading a fixed
+  chunk byte array and decoding it could result in multi-byte UTF-8 character being read half way
+  resulting in UTF-8 decode error. This happens only when output is greater than default chunk size
+  (1024 bytes) and script produces utf-8 output. We now collect all the bytes from channel
+  and only then decode the byte stream as utf-8.
 
 0.13.2 - September 09, 2015
 ---------------------------

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh.py
@@ -421,19 +421,22 @@ class ParamikoSSHClient(object):
         Try to consume stdout data from chan if it's receive ready.
         """
 
+        out = bytearray()
         stdout = StringIO()
         if chan.recv_ready():
             data = chan.recv(self.CHUNK_SIZE)
+            out += data
 
             while data:
-                stdout.write(self._get_decoded_data(data))
                 ready = chan.recv_ready()
 
                 if not ready:
                     break
 
                 data = chan.recv(self.CHUNK_SIZE)
+                out += data
 
+        stdout.write(self._get_decoded_data(out))
         return stdout
 
     def _consume_stderr(self, chan):
@@ -441,28 +444,30 @@ class ParamikoSSHClient(object):
         Try to consume stderr data from chan if it's receive ready.
         """
 
+        out = bytearray()
         stderr = StringIO()
         if chan.recv_stderr_ready():
             data = chan.recv_stderr(self.CHUNK_SIZE)
+            out += data
 
             while data:
-                stderr.write(self._get_decoded_data(data))
                 ready = chan.recv_stderr_ready()
 
                 if not ready:
                     break
 
                 data = chan.recv_stderr(self.CHUNK_SIZE)
+                out += data
 
+        stderr.write(self._get_decoded_data(out))
         return stderr
 
     def _get_decoded_data(self, data):
-        decoded_data = str(data)
         try:
-            decoded_data = decoded_data.decode('utf-8')
+            return data.decode('utf-8')
         except:
             self.logger.warning('Non UTF-8 character found in data: %s', data)
-        return decoded_data
+            return ''
 
     def _get_pkey_object(self, key):
         """

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh.py
@@ -466,8 +466,8 @@ class ParamikoSSHClient(object):
         try:
             return data.decode('utf-8')
         except:
-            self.logger.warning('Non UTF-8 character found in data: %s', data)
-            return ''
+            self.logger.exception('Non UTF-8 character found in data: %s', data)
+            raise
 
     def _get_pkey_object(self, key):
         """

--- a/st2actions/tests/unit/test_paramiko_ssh.py
+++ b/st2actions/tests/unit/test_paramiko_ssh.py
@@ -249,11 +249,9 @@ class ParamikoSSHClientTests(unittest2.TestCase):
 
     @patch('paramiko.SSHClient', Mock)
     def test_consume_stdout(self):
-        """
-        Test utf-8 decoding of ``stdout`` still works fine when reading CHUNK_SIZE splits a
-        multi-byte utf-8 character in the middle. We should wait to collect all bytes
-        and finally decode.
-        """
+        # Test utf-8 decoding of ``stdout`` still works fine when reading CHUNK_SIZE splits a
+        # multi-byte utf-8 character in the middle. We should wait to collect all bytes
+        # and finally decode.
         conn_params = {'hostname': 'dummy.host.org',
                        'username': 'ubuntu'}
         mock = ParamikoSSHClient(**conn_params)
@@ -272,11 +270,9 @@ class ParamikoSSHClientTests(unittest2.TestCase):
 
     @patch('paramiko.SSHClient', Mock)
     def test_consume_stderr(self):
-        """
-        Test utf-8 decoding of ``stderr`` still works fine when reading CHUNK_SIZE splits a
-        multi-byte utf-8 character in the middle. We should wait to collect all bytes
-        and finally decode.
-        """
+        # Test utf-8 decoding of ``stderr`` still works fine when reading CHUNK_SIZE splits a
+        # multi-byte utf-8 character in the middle. We should wait to collect all bytes
+        # and finally decode.
         conn_params = {'hostname': 'dummy.host.org',
                        'username': 'ubuntu'}
         mock = ParamikoSSHClient(**conn_params)

--- a/st2actions/tests/unit/test_paramiko_ssh.py
+++ b/st2actions/tests/unit/test_paramiko_ssh.py
@@ -246,3 +246,49 @@ class ParamikoSSHClientTests(unittest2.TestCase):
 
         calls = [call(local_file, remote_file)]
         mock_cli.open_sftp().put.assert_has_calls(calls, any_order=True)
+
+    @patch('paramiko.SSHClient', Mock)
+    def test_consume_stdout(self):
+        """
+        Test utf-8 decoding of ``stdout`` still works fine when reading CHUNK_SIZE splits a
+        multi-byte utf-8 character in the middle. We should wait to collect all bytes
+        and finally decode.
+        """
+        conn_params = {'hostname': 'dummy.host.org',
+                       'username': 'ubuntu'}
+        mock = ParamikoSSHClient(**conn_params)
+        mock.CHUNK_SIZE = 1
+        chan = Mock()
+        chan.recv_ready.side_effect = [True, True, True, True, False]
+
+        chan.recv.side_effect = ['\xF0', '\x90', '\x8D', '\x88']
+        try:
+            '\xF0'.decode('utf-8')
+            self.fail('Test fixture is not right.')
+        except UnicodeDecodeError:
+            pass
+        stdout = mock._consume_stdout(chan)
+        self.assertEqual(u'\U00010348', stdout.getvalue())
+
+    @patch('paramiko.SSHClient', Mock)
+    def test_consume_stderr(self):
+        """
+        Test utf-8 decoding of ``stderr`` still works fine when reading CHUNK_SIZE splits a
+        multi-byte utf-8 character in the middle. We should wait to collect all bytes
+        and finally decode.
+        """
+        conn_params = {'hostname': 'dummy.host.org',
+                       'username': 'ubuntu'}
+        mock = ParamikoSSHClient(**conn_params)
+        mock.CHUNK_SIZE = 1
+        chan = Mock()
+        chan.recv_stderr_ready.side_effect = [True, True, True, True, False]
+
+        chan.recv_stderr.side_effect = ['\xF0', '\x90', '\x8D', '\x88']
+        try:
+            '\xF0'.decode('utf-8')
+            self.fail('Test fixture is not right.')
+        except UnicodeDecodeError:
+            pass
+        stderr = mock._consume_stderr(chan)
+        self.assertEqual(u'\U00010348', stderr.getvalue())


### PR DESCRIPTION
From the commit "When consuming stdout and stderr byte streams from paramiko
channel, consume all the raw bytes and then decode. Decoding
chunk as they come won't work because utf-8 is variable
length encoding. When we want to support streaming, this
is going to be a pain."