### PR TITLE
Throw more user-friendly exception if uses passes path, not content for the "private_key" parameter

### DIFF
--- a/docs/source/_includes/runner_parameters/remote_shell_cmd.rst
+++ b/docs/source/_includes/runner_parameters/remote_shell_cmd.rst
@@ -1,7 +1,7 @@
 .. NOTE: This file has been generated automatically, don't manually edit it
 
 * ``username`` (string) - Username used to log-in. If not provided, default username from config is used.
-* ``private_key`` (string) - Private key material to log in.
+* ``private_key`` (string) - Private key material to log in. Note: This needs to be actual private key data and NOT path.
 * ``timeout`` (integer) - Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds.
 * ``sudo`` (boolean) - The remote command will be executed with sudo.
 * ``kwarg_op`` (string) - Operator to use in front of keyword args i.e. "--" or "-".

--- a/docs/source/_includes/runner_parameters/remote_shell_script.rst
+++ b/docs/source/_includes/runner_parameters/remote_shell_script.rst
@@ -1,7 +1,7 @@
 .. NOTE: This file has been generated automatically, don't manually edit it
 
 * ``username`` (string) - Username used to log-in. If not provided, default username from config is used.
-* ``private_key`` (string) - Private key material to log in.
+* ``private_key`` (string) - Private key material to log in. Note: This needs to be actual private key data and NOT path.
 * ``env`` (object) - Environment variables which will be available to the script(e.g. key1=val1,key2=val2)
 * ``sudo`` (boolean) - The remote command will be executed with sudo.
 * ``kwarg_op`` (string) - Operator to use in front of keyword args i.e. "--" or "-".

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh.py
@@ -37,6 +37,8 @@ __all__ = [
     'SSHCommandTimeoutError'
 ]
 
+PRIVATE_KEY_HEADER = 'PRIVATE KEY-----'.lower()
+
 
 class SSHCommandTimeoutError(Exception):
     """
@@ -483,5 +485,14 @@ class ParamikoSSHClient(object):
             else:
                 return key
 
-        msg = 'Invalid or unsupported key type'
+        # If a user passes in something which looks like file path we throw a more friendly
+        # exception letting the user know we expect the contents a not a path.
+        # Note: We do it here and not up the stack to avoid false positives.
+        contains_header = PRIVATE_KEY_HEADER in key.lower()
+        if not contains_header and (key.count('/') >= 1 or key.count('\\') >= 1):
+            msg = ('"private_key" parameter needs to contain private key data / content and not '
+                   'a path')
+        else:
+            msg = 'Invalid or unsupported key type'
+
         raise paramiko.ssh_exception.SSHException(msg)

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh.py
@@ -121,7 +121,7 @@ class ParamikoSSHClient(object):
             conninfo['key_filename'] = self.key_files
 
         if self.key_material:
-            conninfo['pkey'] = self._get_pkey_object(key=self.key_material)
+            conninfo['pkey'] = self._get_pkey_object(key_material=self.key_material)
 
         if not self.password and not (self.key_files or self.key_material):
             conninfo['allow_agent'] = True
@@ -471,14 +471,14 @@ class ParamikoSSHClient(object):
             self.logger.exception('Non UTF-8 character found in data: %s', data)
             raise
 
-    def _get_pkey_object(self, key):
+    def _get_pkey_object(self, key_material):
         """
         Try to detect private key type and return paramiko.PKey object.
         """
 
         for cls in [paramiko.RSAKey, paramiko.DSSKey, paramiko.ECDSAKey]:
             try:
-                key = cls.from_private_key(StringIO(key))
+                key = cls.from_private_key(StringIO(key_material))
             except paramiko.ssh_exception.SSHException:
                 # Invalid key, try other key type
                 pass
@@ -488,8 +488,8 @@ class ParamikoSSHClient(object):
         # If a user passes in something which looks like file path we throw a more friendly
         # exception letting the user know we expect the contents a not a path.
         # Note: We do it here and not up the stack to avoid false positives.
-        contains_header = PRIVATE_KEY_HEADER in key.lower()
-        if not contains_header and (key.count('/') >= 1 or key.count('\\') >= 1):
+        contains_header = PRIVATE_KEY_HEADER in key_material.lower()
+        if not contains_header and (key_material.count('/') >= 1 or key_material.count('\\') >= 1):
             msg = ('"private_key" parameter needs to contain private key data / content and not '
                    'a path')
         else:

--- a/st2actions/tests/unit/test_paramiko_ssh.py
+++ b/st2actions/tests/unit/test_paramiko_ssh.py
@@ -119,6 +119,27 @@ class ParamikoSSHClientTests(unittest2.TestCase):
                                 expected_msg, mock.connect)
 
     @patch('paramiko.SSHClient', Mock)
+    def test_key_material_contains_path_not_contents(self):
+        conn_params = {'hostname': 'dummy.host.org',
+                       'username': 'ubuntu'}
+        key_materials = [
+            '~/.ssh/id_rsa',
+            '/tmp/id_rsa',
+            'C:\\id_rsa'
+        ]
+
+        expected_msg = ('"private_key" parameter needs to contain private key data / content and '
+                        'not a path')
+
+        for key_material in key_materials:
+            conn_params = conn_params.copy()
+            conn_params['key_material'] = key_material
+            mock = ParamikoSSHClient(**conn_params)
+
+            self.assertRaisesRegexp(paramiko.ssh_exception.SSHException,
+                                    expected_msg, mock.connect)
+
+    @patch('paramiko.SSHClient', Mock)
     def test_create_with_key(self):
         conn_params = {'hostname': 'dummy.host.org',
                        'username': 'ubuntu',

--- a/st2common/st2common/bootstrap/runnersregistrar.py
+++ b/st2common/st2common/bootstrap/runnersregistrar.py
@@ -134,7 +134,8 @@ RUNNER_TYPES = [
                 'secret': True
             },
             'private_key': {
-                'description': ('Private key material to log in.'),
+                'description': ('Private key material to log in. Note: This needs to be actual '
+                                'private key data and NOT path.'),
                 'type': 'string',
                 'required': False,
                 'secret': True
@@ -218,7 +219,8 @@ RUNNER_TYPES = [
                 'secret': True
             },
             'private_key': {
-                'description': ('Private key material to log in.'),
+                'description': ('Private key material to log in. Note: This needs to be actual '
+                                'private key data and NOT path.'),
                 'type': 'string',
                 'required': False,
                 'secret': True


### PR DESCRIPTION
The title says it all.

We already have documentation which clarifies that this parameter needs to contain key material and not a path, and we also have docs with examples which show how to use `@` CLI notation, but users are still stumbling on this so we should do something to mitigate this and save both (ourselves and them) some time.