### PR TITLE
CLI per user token cache

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,9 @@ in development
   resulting in UTF-8 decode error. This happens only when output is greater than default chunk size
   (1024 bytes) and script produces utf-8 output. We now collect all the bytes from channel
   and only then decode the byte stream as utf-8.
+* Update CLI so it supports caching tokens for different users (it creates a different file for each
+  user). This means you can now use ``ST2_CONFIG_FILE`` option without disabling token cache.
+  (improvement)
 
 0.13.2 - September 09, 2015
 ---------------------------

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -409,14 +409,6 @@ class Shell(object):
 
         return token
 
-    def _get_cached_token_path_for_user(self, username):
-        """
-        Retrieve cached token path for the provided username.
-        """
-        file_name = 'token-%s' % (username)
-        result = os.path.abspath(os.path.join(ST2_CONFIG_DIRECTORY, file_name))
-        return result
-
     def _get_cached_auth_token(self, client, username, password):
         """
         Retrieve cached auth token from the file in the config directory.
@@ -461,9 +453,11 @@ class Shell(object):
 
         now = int(time.time())
         if (expire_timestamp + TOKEN_EXPIRATION_GRACE_PERIOD_SECONDS) < now:
+            LOG.debug('Cached token from file "%s" has expired' % (cached_token_path))
             # Token has expired
             return None
 
+        LOG.debug('Using cached token from file "%s"' % (cached_token_path))
         return token
 
     def _cache_auth_token(self, token_obj):
@@ -514,6 +508,7 @@ class Shell(object):
         with os.fdopen(fd, 'w') as fp:
             fp.write(data)
 
+        LOG.debug('Token has been cached in "%s"' % (cached_token_path))
         return True
 
     def _authenticate_and_retrieve_auth_token(self, client, username, password):
@@ -522,6 +517,14 @@ class Shell(object):
         instance = models.Token()
         instance = manager.create(instance, auth=(username, password))
         return instance
+
+    def _get_cached_token_path_for_user(self, username):
+        """
+        Retrieve cached token path for the provided username.
+        """
+        file_name = 'token-%s' % (username)
+        result = os.path.abspath(os.path.join(ST2_CONFIG_DIRECTORY, file_name))
+        return result
 
     def _get_config_file_path(self, args):
         """

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -451,7 +451,8 @@ class Shell(object):
             token = data['token']
             expire_timestamp = data['expire_timestamp']
         except Exception as e:
-            msg = 'File with cached token is corrupted or invalid: %s' % (str(e))
+            msg = ('File "%s" with cached token is corrupted or invalid (%s). Please delete '
+                   ' this file' % (cached_token_path, str(e)))
             raise ValueError(msg)
 
         now = int(time.time())

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -456,7 +456,7 @@ class Shell(object):
             raise ValueError(msg)
 
         now = int(time.time())
-        if (expire_timestamp + TOKEN_EXPIRATION_GRACE_PERIOD_SECONDS) < now:
+        if (expire_timestamp - TOKEN_EXPIRATION_GRACE_PERIOD_SECONDS) < now:
             LOG.debug('Cached token from file "%s" has expired' % (cached_token_path))
             # Token has expired
             return None

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -61,9 +61,7 @@ __all__ = [
 
 LOG = logging.getLogger(__name__)
 
-CLI_DESCRIPTION = 'CLI for StackStorm event-driven automation platform. http://stackstorm.com'
-
-CACHED_TOKEN_PATH = os.path.abspath(os.path.join(ST2_CONFIG_DIRECTORY, 'token'))
+CLI_DESCRIPTION = 'CLI for StackStorm event-driven automation platform. https://stackstorm.com'
 
 # How many seconds before the token actual expiration date we should consider the token as
 # expired. This is used to prevent the operation from failing durig the API request because the
@@ -411,6 +409,14 @@ class Shell(object):
 
         return token
 
+    def _get_cached_token_path_for_user(self, username):
+        """
+        Retrieve cached token path for the provided username.
+        """
+        file_name = 'token-%s' % (username)
+        result = os.path.abspath(os.path.join(ST2_CONFIG_DIRECTORY, file_name))
+        return result
+
     def _get_cached_auth_token(self, client, username, password):
         """
         Retrieve cached auth token from the file in the config directory.
@@ -420,27 +426,28 @@ class Shell(object):
         if not os.path.isdir(ST2_CONFIG_DIRECTORY):
             os.makedirs(ST2_CONFIG_DIRECTORY)
 
-        if not os.path.isfile(CACHED_TOKEN_PATH):
+        cached_token_path = self._get_cached_token_path_for_user(username=username)
+        if not os.path.isfile(cached_token_path):
             return None
 
         if not os.access(ST2_CONFIG_DIRECTORY, os.R_OK):
             # We don't have read access to the file with a cached token
             message = ('Unable to retrieve cached token from "%s" (user %s doesn\'t have read '
                        'access to the parent directory). Subsequent requests won\'t use a '
-                       'cached token meaning they may be slower.' % (CACHED_TOKEN_PATH,
+                       'cached token meaning they may be slower.' % (cached_token_path,
                                                                      os.getlogin()))
             LOG.warn(message)
             return None
 
-        if not os.access(CACHED_TOKEN_PATH, os.R_OK):
+        if not os.access(cached_token_path, os.R_OK):
             # We don't have read access to the file with a cached token
             message = ('Unable to retrieve cached token from "%s" (user %s doesn\'t have read '
                        'access to this file). Subsequent requests won\'t use a cached token '
-                       'meaning they may be slower.' % (CACHED_TOKEN_PATH, os.getlogin()))
+                       'meaning they may be slower.' % (cached_token_path, os.getlogin()))
             LOG.warn(message)
             return None
 
-        with open(CACHED_TOKEN_PATH) as fp:
+        with open(cached_token_path) as fp:
             data = fp.read()
 
         try:
@@ -449,7 +456,7 @@ class Shell(object):
             token = data['token']
             expire_timestamp = data['expire_timestamp']
         except Exception as e:
-            msg = 'File with cached token is corrupted: %s' % (str(e))
+            msg = 'File with cached token is corrupted or invalid: %s' % (str(e))
             raise ValueError(msg)
 
         now = int(time.time())
@@ -469,20 +476,23 @@ class Shell(object):
         if not os.path.isdir(ST2_CONFIG_DIRECTORY):
             os.makedirs(ST2_CONFIG_DIRECTORY)
 
+        username = token_obj.user
+        cached_token_path = self._get_cached_token_path_for_user(username=username)
+
         if not os.access(ST2_CONFIG_DIRECTORY, os.W_OK):
             # We don't have write access to the file with a cached token
             message = ('Unable to write token to "%s" (user %s doesn\'t have write'
                        'access to the parent directory). Subsequent requests won\'t use a '
-                       'cached token meaning they may be slower.' % (CACHED_TOKEN_PATH,
+                       'cached token meaning they may be slower.' % (cached_token_path,
                                                                      os.getlogin()))
             LOG.warn(message)
             return None
 
-        if os.path.isfile(CACHED_TOKEN_PATH) and not os.access(CACHED_TOKEN_PATH, os.W_OK):
+        if os.path.isfile(cached_token_path) and not os.access(cached_token_path, os.W_OK):
             # We don't have write access to the file with a cached token
             message = ('Unable to write token to "%s" (user %s doesn\'t have write'
                        'access to this file). Subsequent requests won\'t use a '
-                       'cached token meaning they may be slower.' % (CACHED_TOKEN_PATH,
+                       'cached token meaning they may be slower.' % (cached_token_path,
                                                                      os.getlogin()))
             LOG.warn(message)
             return None
@@ -500,7 +510,7 @@ class Shell(object):
         # open + chmod are two operations which means that during a short time frame (between
         # open and chmod) when file can potentially be read by other users if the default
         # permissions used during create allow that.
-        fd = os.open(CACHED_TOKEN_PATH, os.O_WRONLY | os.O_CREAT, 0600)
+        fd = os.open(cached_token_path, os.O_WRONLY | os.O_CREAT, 0600)
         with os.fdopen(fd, 'w') as fp:
             fp.write(data)
 

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -34,6 +34,7 @@ import requests
 
 from st2client import __version__
 from st2client import models
+from st2common.logging.misc import set_log_level_for_all_loggers
 from st2client.client import Client
 from st2client.commands import auth
 from st2client.commands import action
@@ -320,6 +321,8 @@ class Shell(object):
 
         try:
             debug = getattr(args, 'debug', False)
+            if debug:
+                set_log_level_for_all_loggers(level=logging.DEBUG)
 
             # Set up client.
             self.client = self.get_client(args=args, debug=debug)

--- a/st2client/tests/unit/test_shell.py
+++ b/st2client/tests/unit/test_shell.py
@@ -14,14 +14,19 @@
 # limitations under the License.
 
 import os
+import time
 import json
-import mock
 import logging
+import tempfile
 
-from tests import base
+import mock
+import unittest2
 
-from st2client import shell
+from st2client.shell import Shell
+from st2client.client import Client
 from st2client.utils import httpclient
+from st2common.models.db.auth import TokenDB
+from tests import base
 
 LOG = logging.getLogger(__name__)
 
@@ -35,7 +40,7 @@ class TestShell(base.BaseCLITestCase):
 
     def __init__(self, *args, **kwargs):
         super(TestShell, self).__init__(*args, **kwargs)
-        self.shell = shell.Shell()
+        self.shell = Shell()
 
     def test_endpoints_default(self):
         base_url = 'http://localhost'
@@ -253,3 +258,95 @@ class TestShell(base.BaseCLITestCase):
             ['trigger', 'delete', 'abc']
         ]
         self._validate_parser(args_list)
+
+
+class CLITokenCachingTestCase(unittest2.TestCase):
+    def setUp(self):
+        super(CLITokenCachingTestCase, self).setUp()
+        self._mock_config_directory_path = tempfile.mkdtemp()
+        self._p = mock.patch('st2client.shell.ST2_CONFIG_DIRECTORY',
+                             self._mock_config_directory_path)
+        self._p.start()
+
+    def tearDown(self):
+        super(CLITokenCachingTestCase, self).tearDown()
+        self._p.stop()
+
+    def test_get_cached_auth_token_no_token_cache_file(self):
+        client = Client()
+        shell = Shell()
+        username = 'testu'
+        password = 'testp'
+
+        result = shell._get_cached_auth_token(client=client, username=username,
+                                              password=password)
+        self.assertEqual(result, None)
+
+    def test_get_cached_auth_token_corrupted_token_cache_file(self):
+        client = Client()
+        shell = Shell()
+        username = 'testu'
+        password = 'testp'
+
+        cached_token_path = shell._get_cached_token_path_for_user(username=username)
+        with open(cached_token_path, 'w') as fp:
+            fp.write('CORRRRRUPTED!')
+
+        expected_msg = 'File (.+) with cached token is corrupted or invalid'
+        self.assertRaisesRegexp(ValueError, expected_msg, shell._get_cached_auth_token,
+                                client=client, username=username, password=password)
+
+    def test_get_cached_auth_token_expired_token_in_cache_file(self):
+        client = Client()
+        shell = Shell()
+        username = 'testu'
+        password = 'testp'
+
+        cached_token_path = shell._get_cached_token_path_for_user(username=username)
+        data = {
+            'token': 'expired',
+            'expire_timestamp': (int(time.time()) - 10)
+        }
+        with open(cached_token_path, 'w') as fp:
+            fp.write(json.dumps(data))
+
+        result = shell._get_cached_auth_token(client=client, username=username,
+                                              password=password)
+        self.assertEqual(result, None)
+
+    def test_get_cached_auth_token_valid_token_in_cache_file(self):
+        client = Client()
+        shell = Shell()
+        username = 'testu'
+        password = 'testp'
+
+        cached_token_path = shell._get_cached_token_path_for_user(username=username)
+        data = {
+            'token': 'yayvalid',
+            'expire_timestamp': (int(time.time()) + 20)
+        }
+        with open(cached_token_path, 'w') as fp:
+            fp.write(json.dumps(data))
+
+        result = shell._get_cached_auth_token(client=client, username=username,
+                                              password=password)
+        self.assertEqual(result, 'yayvalid')
+
+    def test_cache_auth_token_success(self):
+        client = Client()
+        shell = Shell()
+        username = 'testu'
+        password = 'testp'
+        expiry = '2015-09-30T17:33:49.573Z'
+
+        result = shell._get_cached_auth_token(client=client, username=username,
+                                              password=password)
+        self.assertEqual(result, None)
+
+        cached_token_path = shell._get_cached_token_path_for_user(username=username)
+        token_db = TokenDB(user=username, token='fyeah', expiry=expiry)
+        shell._cache_auth_token(token_obj=token_db)
+
+        result = shell._get_cached_auth_token(client=client, username=username,
+                                              password=password)
+        self.assertEqual(result, 'fyeah')

--- a/st2client/tests/unit/test_shell.py
+++ b/st2client/tests/unit/test_shell.py
@@ -343,7 +343,6 @@ class CLITokenCachingTestCase(unittest2.TestCase):
                                               password=password)
         self.assertEqual(result, None)
 
-        cached_token_path = shell._get_cached_token_path_for_user(username=username)
         token_db = TokenDB(user=username, token='fyeah', expiry=expiry)
         shell._cache_auth_token(token_obj=token_db)
 


### PR DESCRIPTION
This pull request improves token caching in the CLI - it now supports caching tokens for different users.

This means you can easily use multiple CLI config via `ST2_CONFIG_FILE` option or similar without disabling token cache.

On top of that it also adds some tests.