### PR TITLE
Support single quote in actionaliasexecution

### DIFF
--- a/st2common/st2common/models/utils/action_alias_utils.py
+++ b/st2common/st2common/models/utils/action_alias_utils.py
@@ -62,9 +62,6 @@ class JsonValueParser(object):
 
 
 class StringValueParser(object):
-    start = '"'
-    end = '"'
-    escape = '\\'
 
     def __init__(self, start, end, escape):
         self.start = start

--- a/st2common/st2common/models/utils/action_alias_utils.py
+++ b/st2common/st2common/models/utils/action_alias_utils.py
@@ -66,17 +66,20 @@ class StringValueParser(object):
     end = '"'
     escape = '\\'
 
-    @staticmethod
-    def is_applicable(first_char):
-        return first_char == StringValueParser.start
+    def __init__(self, start, end, escape):
+        self.start = start
+        self.end = end
+        self.escape = escape
 
-    @staticmethod
-    def parse(start, stream):
+    def is_applicable(self, first_char):
+        return first_char == self.start
+
+    def parse(self, start, stream):
         end = 0
         char_idx = start + 1
         while not end:
             char = stream[char_idx]
-            if char == StringValueParser.end and stream[char_idx - 1] != StringValueParser.escape:
+            if char == self.end and stream[char_idx - 1] != self.escape:
                 end = char_idx
             else:
                 char_idx += 1
@@ -106,7 +109,12 @@ class DefaultParser(object):
         except IndexError:
             raise content.ParseException('What sort of messed up stream did you provide!')
 
-PARSERS = [JsonValueParser, StringValueParser, DefaultParser]
+PARSERS = [
+    JsonValueParser,
+    StringValueParser(start='"', end='"', escape='\\'),
+    StringValueParser(start='\'', end='\'', escape='\\'),
+    DefaultParser
+]
 
 
 class KeyValueActionAliasFormatParser(object):

--- a/st2common/tests/unit/test_action_alias_utils.py
+++ b/st2common/tests/unit/test_action_alias_utils.py
@@ -44,31 +44,35 @@ class TestDefaultParser(TestCase):
         self.assertEqual(value, 'value1')
 
 
-class TestStringValueParser(TestCase):
+STR_DOUBLE_QUOTE_PARSER = StringValueParser(start='"', end='"', escape='\\')
+
+
+class Test_DQ_StringValueParser(TestCase):
 
     def testStringParsing(self):
         stream = 'some meaningful "spaced value1" something else skippable "double spaced value2"' \
                  'still more skip.'
 
         start = len('some meaningful ')
-        self.assertTrue(StringValueParser.is_applicable(stream[start]), 'Should be parsable.')
-        _, value, _ = StringValueParser.parse(start, stream)
+        self.assertTrue(STR_DOUBLE_QUOTE_PARSER.is_applicable(stream[start]), 'Should be parsable.')
+        _, value, _ = STR_DOUBLE_QUOTE_PARSER.parse(start, stream)
         self.assertEqual(value, 'spaced value1')
 
         start = len('some meaningful "spaced value1" something else skippable ')
-        self.assertTrue(StringValueParser.is_applicable(stream[start]), 'Should be parsable.')
-        _, value, _ = StringValueParser.parse(start, stream)
+        self.assertTrue(STR_DOUBLE_QUOTE_PARSER.is_applicable(stream[start]), 'Should be parsable.')
+        _, value, _ = STR_DOUBLE_QUOTE_PARSER.parse(start, stream)
         self.assertEqual(value, 'double spaced value2')
 
         start = len(stream) - 2
-        self.assertFalse(StringValueParser.is_applicable(stream[start]), 'Should not be parsable.')
+        self.assertFalse(STR_DOUBLE_QUOTE_PARSER.is_applicable(stream[start]),
+                         'Should not be parsable.')
 
     def testEndStringParsing(self):
         stream = 'some meaningful "spaced value1"'
 
         start = len('some meaningful ')
-        self.assertTrue(StringValueParser.is_applicable(stream[start]), 'Should be parsable.')
-        _, value, _ = StringValueParser.parse(start, stream)
+        self.assertTrue(STR_DOUBLE_QUOTE_PARSER.is_applicable(stream[start]), 'Should be parsable.')
+        _, value, _ = STR_DOUBLE_QUOTE_PARSER.parse(start, stream)
         self.assertEqual(value, 'spaced value1')
 
     def testEscapedStringParsing(self):
@@ -76,25 +80,87 @@ class TestStringValueParser(TestCase):
                  '"double spaced value2" still more skip.'
 
         start = len('some meaningful ')
-        self.assertTrue(StringValueParser.is_applicable(stream[start]), 'Should be parsable.')
-        _, value, _ = StringValueParser.parse(start, stream)
+        self.assertTrue(STR_DOUBLE_QUOTE_PARSER.is_applicable(stream[start]), 'Should be parsable.')
+        _, value, _ = STR_DOUBLE_QUOTE_PARSER.parse(start, stream)
         self.assertEqual(value, 'spaced \\"value1')
 
         start = len('some meaningful "spaced \\"value1" something else skippable ')
-        self.assertTrue(StringValueParser.is_applicable(stream[start]), 'Should be parsable.')
-        _, value, _ = StringValueParser.parse(start, stream)
+        self.assertTrue(STR_DOUBLE_QUOTE_PARSER.is_applicable(stream[start]), 'Should be parsable.')
+        _, value, _ = STR_DOUBLE_QUOTE_PARSER.parse(start, stream)
         self.assertEqual(value, 'double spaced value2')
 
         start = len(stream) - 2
-        self.assertFalse(StringValueParser.is_applicable(stream[start]), 'Should not be parsable.')
+        self.assertFalse(STR_DOUBLE_QUOTE_PARSER.is_applicable(stream[start]),
+                         'Should not be parsable.')
 
     def testIncompleteStringParsing(self):
         stream = 'some meaningful "spaced .'
 
         start = len('some meaningful ')
-        self.assertTrue(StringValueParser.is_applicable(stream[start]), 'Should be parsable.')
+        self.assertTrue(STR_DOUBLE_QUOTE_PARSER.is_applicable(stream[start]), 'Should be parsable.')
         try:
-            StringValueParser.parse(start, stream)
+            STR_DOUBLE_QUOTE_PARSER.parse(start, stream)
+            self.assertTrue(False, 'Parsing failure expected.')
+        except content.ParseException:
+            self.assertTrue(True)
+
+
+STR_SINGLE_QUOTE_PARSER = StringValueParser(start='\'', end='\'', escape='\\')
+
+
+class Test_SQ_StringValueParser(TestCase):
+
+    def testStringParsing(self):
+        stream = "some meaningful 'spaced value1' something else skippable 'double spaced value2'" \
+                 "still more skip."
+
+        start = len('some meaningful ')
+        self.assertTrue(STR_SINGLE_QUOTE_PARSER.is_applicable(stream[start]), 'Should be parsable.')
+        _, value, _ = STR_SINGLE_QUOTE_PARSER.parse(start, stream)
+        self.assertEqual(value, 'spaced value1')
+
+        start = len("some meaningful 'spaced value1' something else skippable ")
+        self.assertTrue(STR_SINGLE_QUOTE_PARSER.is_applicable(stream[start]), 'Should be parsable.')
+        _, value, _ = STR_SINGLE_QUOTE_PARSER.parse(start, stream)
+        self.assertEqual(value, 'double spaced value2')
+
+        start = len(stream) - 2
+        self.assertFalse(STR_SINGLE_QUOTE_PARSER.is_applicable(stream[start]),
+                         'Should not be parsable.')
+
+    def testEndStringParsing(self):
+        stream = "some meaningful 'spaced value1'"
+
+        start = len('some meaningful ')
+        self.assertTrue(STR_SINGLE_QUOTE_PARSER.is_applicable(stream[start]), 'Should be parsable.')
+        _, value, _ = STR_SINGLE_QUOTE_PARSER.parse(start, stream)
+        self.assertEqual(value, 'spaced value1')
+
+    def testEscapedStringParsing(self):
+        stream = "some meaningful 'spaced \\'value1' something else skippable " \
+                 "\'double spaced value2\' still more skip."
+
+        start = len('some meaningful ')
+        self.assertTrue(STR_SINGLE_QUOTE_PARSER.is_applicable(stream[start]), 'Should be parsable.')
+        _, value, _ = STR_SINGLE_QUOTE_PARSER.parse(start, stream)
+        self.assertEqual(value, "spaced \\'value1")
+
+        start = len("some meaningful 'spaced \\'value1' something else skippable ")
+        self.assertTrue(STR_SINGLE_QUOTE_PARSER.is_applicable(stream[start]), 'Should be parsable.')
+        _, value, _ = STR_SINGLE_QUOTE_PARSER.parse(start, stream)
+        self.assertEqual(value, 'double spaced value2')
+
+        start = len(stream) - 2
+        self.assertFalse(STR_SINGLE_QUOTE_PARSER.is_applicable(stream[start]),
+                         'Should not be parsable.')
+
+    def testIncompleteStringParsing(self):
+        stream = "some meaningful 'spaced ."
+
+        start = len('some meaningful ')
+        self.assertTrue(STR_SINGLE_QUOTE_PARSER.is_applicable(stream[start]), 'Should be parsable.')
+        try:
+            STR_SINGLE_QUOTE_PARSER.parse(start, stream)
             self.assertTrue(False, 'Parsing failure expected.')
         except content.ParseException:
             self.assertTrue(True)


### PR DESCRIPTION
* values with spaces can be represented either by single or double quotes