### PR TITLE
RFR - Strip '\r' or '\r\n' chars from stdout and stderr

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,6 +46,8 @@ in development
   to match existing Fabric behavior. (bug-fix)
 * Fix CLI so it skips automatic authentication if credentials are provided in the config on "auth"
   command. (bug fix)
+* Strip the last '\r' or '\r\n' from both ``stdout`` and ``stderr`` streams from paramiko and local
+  runner output. This is done to be compatible with fabric output of those streams. (bug-fix)
 
 0.13.2 - September 09, 2015
 ---------------------------

--- a/docs/source/runners.rst
+++ b/docs/source/runners.rst
@@ -23,8 +23,8 @@ where |st2| components are running.
     ``stdout`` and ``stderr`` attributes in the runner
     result object have the last '\n' or '\r' or '\r\n' characters removed if present.
     This is done so you can more easily re-use the result of common commands such as
-    ``uptime``, ``whoami`` etc., which include a trailing line break in other actions
-    and workflows. If you have an action which requires a trailing line break character to be present, you can add it explicitly to the result, e.g. ``echo -e 'test\n'`` (this will result into two line break characters and only one of them will be stripped/removed from the result).
+    ``uptime``, ``whoami`` etc., which include a trailing line break or carriage return
+    in other actions and workflows. If you have an action which requires a trailing line break character to be present, you can add it explicitly to the result, e.g. ``echo -e 'test\n'`` (this will result into two line break characters and only one of them will be stripped/removed from the result).
 
 Runner parameters
 ^^^^^^^^^^^^^^^^^

--- a/docs/source/runners.rst
+++ b/docs/source/runners.rst
@@ -21,7 +21,10 @@ where |st2| components are running.
 .. note::
 
     ``stdout`` and ``stderr`` attributes in the runner
-    result object have the last line break (\n) character removed if present. This is done so you can more easily re-use the result of common commands such as ``uptime``, ``whoami`` etc., which include a trailing line break in other actions and workflows. If you have an action which requires a trailing line break character to be present, you can add it explicitly to the result, e.g. ``echo -e 'test\n'`` (this will result into two line break characters and only one of them will be stripped/removed from the result).
+    result object have the last '\n' or '\r' or '\r\n' characters removed if present.
+    This is done so you can more easily re-use the result of common commands such as
+    ``uptime``, ``whoami`` etc., which include a trailing line break in other actions
+    and workflows. If you have an action which requires a trailing line break character to be present, you can add it explicitly to the result, e.g. ``echo -e 'test\n'`` (this will result into two line break characters and only one of them will be stripped/removed from the result).
 
 Runner parameters
 ^^^^^^^^^^^^^^^^^

--- a/docs/source/troubleshooting/ssh.rst
+++ b/docs/source/troubleshooting/ssh.rst
@@ -29,8 +29,7 @@ To validate remote actions are working correctly, you can use the following comm
             "failed": false,
             "return_code": 0,
             "stderr": "",
-            "stdout": "stanley
-    "
+            "stdout": "stanley"
         }
     }
 
@@ -94,8 +93,7 @@ boxes as a different user, we have a way.
             "failed": false,
             "return_code": 0,
             "stderr": "",
-            "stdout": "test_user
-    "
+            "stdout": "test_user"
         }
     }
 

--- a/st2actions/st2actions/runners/localrunner.py
+++ b/st2actions/st2actions/runners/localrunner.py
@@ -28,7 +28,7 @@ from st2common.models.system.action import ShellScriptAction
 from st2common.constants.action import LIVEACTION_STATUS_SUCCEEDED
 from st2common.constants.action import LIVEACTION_STATUS_FAILED
 from st2common.constants.runners import LOCAL_RUNNER_DEFAULT_ACTION_TIMEOUT
-from st2common.util.misc import strip_last_newline_char
+from st2common.util.misc import strip_shell_chars
 from st2common.util.green.shell import run_command
 from st2common.util.shell import kill_process
 import st2common.util.jsonify as jsonify
@@ -160,8 +160,8 @@ class LocalShellRunner(ActionRunner, ShellRunnerMixin):
             'failed': not succeeded,
             'succeeded': succeeded,
             'return_code': exit_code,
-            'stdout': strip_last_newline_char(stdout),
-            'stderr': strip_last_newline_char(stderr)
+            'stdout': strip_shell_chars(stdout),
+            'stderr': strip_shell_chars(stderr)
         }
 
         if error:

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh.py
@@ -28,7 +28,7 @@ import paramiko
 # Ref: https://bugs.launchpad.net/paramiko/+bug/392973
 
 from st2common.log import logging
-from st2common.util.misc import strip_last_newline_char
+from st2common.util.misc import strip_shell_chars
 from st2common.util.shell import quote_unix
 
 __all__ = [
@@ -406,8 +406,8 @@ class ParamikoSSHClient(object):
         # Receive the exit status code of the command we ran.
         status = chan.recv_exit_status()
 
-        stdout = strip_last_newline_char(stdout.getvalue())
-        stderr = strip_last_newline_char(stderr.getvalue())
+        stdout = strip_shell_chars(stdout.getvalue())
+        stderr = strip_shell_chars(stderr.getvalue())
 
         extra = {'_status': status, '_stdout': stdout, '_stderr': stderr}
         self.logger.debug('Command finished', extra=extra)

--- a/st2common/st2common/models/system/action.py
+++ b/st2common/st2common/models/system/action.py
@@ -33,7 +33,6 @@ from st2common.util.shell import quote_unix
 from st2common.constants.action import LIBS_DIR as ACTION_LIBS_DIR
 from st2common.exceptions.fabricrunner import FabricExecutionFailureException
 import st2common.util.jsonify as jsonify
-from st2common.util.misc import strip_last_newline_char
 from st2common.util.secrets import get_secret_parameters
 from st2common.util.secrets import mask_secret_parameters
 
@@ -394,8 +393,8 @@ class FabricRemoteAction(RemoteAction):
             result = self._get_error_result()
         else:
             result = {
-                'stdout': strip_last_newline_char(output.stdout),
-                'stderr': strip_last_newline_char(output.stderr),
+                'stdout': output.stdout,
+                'stderr': output.stderr,
                 'return_code': output.return_code,
                 'succeeded': output.succeeded,
                 'failed': output.failed

--- a/st2common/st2common/util/misc.py
+++ b/st2common/st2common/util/misc.py
@@ -56,9 +56,26 @@ def compare_path_file_name(file_path_a, file_path_b):
     return file_name_a < file_name_b
 
 
-def strip_last_newline_char(input_str):
+def strip_shell_chars(input_str):
     """
-    Strips the last char if its newline.
+    Strips the last '\r' or '\n' or '\r\n' string at the end of
+    the input string. This is typically used to strip ``stdout``
+    and ``stderr`` streams of those characters.
+
+    :param input_str: Input string to be stripped.
+    :type input_str: ``str``
+
+    :rtype: ``str``
+    """
+    stripped_str = rstrip_last_char(input_str, '\n')
+    stripped_str = rstrip_last_char(stripped_str, '\r')
+    return stripped_str
+
+
+def rstrip_last_char(input_str, char_to_strip):
+    """
+    Strips the last `char_to_strip` from input_str if
+    input_str ends with `char_to_strip`.
 
     :param input_str: Input string to be stripped.
     :type input_str: ``str``
@@ -68,7 +85,10 @@ def strip_last_newline_char(input_str):
     if not input_str:
         return input_str
 
-    if input_str.endswith('\n'):
-        return input_str[:-1]
+    if not char_to_strip:
+        return input_str
+
+    if input_str.endswith(char_to_strip):
+        return input_str[:-len(char_to_strip)]
 
     return input_str

--- a/st2common/tests/unit/test_misc_utils.py
+++ b/st2common/tests/unit/test_misc_utils.py
@@ -15,14 +15,31 @@
 
 import unittest2
 
-from st2common.util.misc import strip_last_newline_char
+from st2common.util.misc import rstrip_last_char, strip_shell_chars
 
 
 class MiscUtilTestCase(unittest2.TestCase):
 
-    def test_strip_last_newline_char(self):
-        self.assertEqual(strip_last_newline_char(None), None)
-        self.assertEqual(strip_last_newline_char(''), '')
-        self.assertEqual(strip_last_newline_char('foo'), 'foo')
-        self.assertEqual(strip_last_newline_char('foo\n'), 'foo')
-        self.assertEqual(strip_last_newline_char('foo\n\n'), 'foo\n')
+    def test_rstrip_last_char(self):
+        self.assertEqual(rstrip_last_char(None, '\n'), None)
+        self.assertEqual(rstrip_last_char('stuff', None), 'stuff')
+        self.assertEqual(rstrip_last_char('', '\n'), '')
+        self.assertEqual(rstrip_last_char('foo', '\n'), 'foo')
+        self.assertEqual(rstrip_last_char('foo\n', '\n'), 'foo')
+        self.assertEqual(rstrip_last_char('foo\n\n', '\n'), 'foo\n')
+        self.assertEqual(rstrip_last_char('foo\r', '\r'), 'foo')
+        self.assertEqual(rstrip_last_char('foo\r\r', '\r'), 'foo\r')
+        self.assertEqual(rstrip_last_char('foo\r\n', '\r\n'), 'foo')
+        self.assertEqual(rstrip_last_char('foo\r\r\n', '\r\n'), 'foo\r')
+        self.assertEqual(rstrip_last_char('foo\n\r', '\r\n'), 'foo\n\r')
+
+    def test_strip_shell_chars(self):
+        self.assertEqual(strip_shell_chars(None), None)
+        self.assertEqual(strip_shell_chars('foo'), 'foo')
+        self.assertEqual(strip_shell_chars('foo\r'), 'foo')
+        self.assertEqual(strip_shell_chars('fo\ro\r'), 'fo\ro')
+        self.assertEqual(strip_shell_chars('foo\n'), 'foo')
+        self.assertEqual(strip_shell_chars('fo\no\n'), 'fo\no')
+        self.assertEqual(strip_shell_chars('foo\r\n'), 'foo')
+        self.assertEqual(strip_shell_chars('fo\no\r\n'), 'fo\no')
+        self.assertEqual(strip_shell_chars('foo\r\n\r\n'), 'foo\r\n')


### PR DESCRIPTION
Found this issue by enabling paramiko on build002. 

It appears Fabric is already stripping '\r' or '\n' or '\r\n' characters from stdout and stderr. https://github.com/fabric/fabric/blob/master/fabric/io.py#L121

70808a0 removes the duplicate stripping from our fabric interface code. 

84aec38 mimics the stripping behavior in both local runner and paramiko runner. 