### PR TITLE
Execution cli params

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,6 +46,8 @@ in development
   to match existing Fabric behavior. (bug-fix)
 * Fix CLI so it skips automatic authentication if credentials are provided in the config on "auth"
   command. (bug fix)
+* Include parameters when viwewing output an execution on the CLI.
+* CLI renders parameters and output as yaml for better readability.
 
 0.13.2 - September 09, 2015
 ---------------------------

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -2,5 +2,6 @@
 jsonpath-rw>=1.3.0
 prettytable
 python-dateutil
+pyyaml<4.0,>=3.11
 requests<3.0,>=2.7.0
 six==1.9.0

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -228,7 +228,7 @@ class ActionRunCommandMixin(object):
 
         detail_arg_grp = execution_details_arg_grp.add_mutually_exclusive_group()
         detail_arg_grp.add_argument('--attr', nargs='+',
-                                    default=['id', 'status', 'result'],
+                                    default=['id', 'status', 'parameters', 'result'],
                                     help=('List of attributes to include in the '
                                           'output. "all" or unspecified will '
                                           'return all attributes.'))
@@ -933,7 +933,6 @@ class ActionExecutionGetCommand(ActionRunCommandMixin, resource.ResourceCommand)
         except resource.ResourceNotFoundError:
             self.print_not_found(args.id)
             raise OperationFailureException('Execution %s not found.' % (args.id))
-
         return self._print_execution_details(execution=execution, args=args, **kwargs)
 
 

--- a/st2client/st2client/formatters/execution.py
+++ b/st2client/st2client/formatters/execution.py
@@ -56,7 +56,7 @@ class ExecutionResult(formatters.Formatter):
                     formatted_value = yaml.safe_dump({attr: value},
                                                      default_flow_style=False,
                                                      width=sys.maxint,
-                                                     indent=2)[len(attr)+2:-1]
+                                                     indent=2)[len(attr) + 2:-1]
                     value = ('\n' if isinstance(value, dict) else '') + formatted_value
                 output += ('\n' if output else '') + '%s: %s' % \
                     (DisplayColors.colorize(attr, DisplayColors.BLUE), value)

--- a/st2client/st2client/formatters/execution.py
+++ b/st2client/st2client/formatters/execution.py
@@ -15,6 +15,8 @@
 
 import ast
 import logging
+import sys
+
 import yaml
 
 from st2client import formatters
@@ -46,12 +48,15 @@ class ExecutionResult(formatters.Formatter):
                     if type(new_value) in [dict, list]:
                         value = new_value
                 if type(value) in [dict, list]:
-                    # To get a nice overhang indent get safe_dump to generate output with
-                    # the attribute key and then remove the attribute key from the string.
-                    # Also, drop the trailing newline
+                    # 1. To get a nice overhang indent get safe_dump to generate output with
+                    #    the attribute key and then remove the attribute key from the string.
+                    # 2. Drop the trailing newline
+                    # 3. Set width to maxint so pyyaml does not split text. Anything longer
+                    #    and likely we will see other issues like storage :P.
                     formatted_value = yaml.safe_dump({attr: value},
                                                      default_flow_style=False,
-                                                     indent=4)[len(attr)+2:-1]
+                                                     width=sys.maxint,
+                                                     indent=2)[len(attr)+2:-1]
                     value = ('\n' if isinstance(value, dict) else '') + formatted_value
                 output += ('\n' if output else '') + '%s: %s' % \
                     (DisplayColors.colorize(attr, DisplayColors.BLUE), value)

--- a/st2client/st2client/formatters/execution.py
+++ b/st2client/st2client/formatters/execution.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 import ast
-import json
 import logging
+import yaml
 
 from st2client import formatters
 from st2client.utils import jsutil
@@ -46,7 +46,13 @@ class ExecutionResult(formatters.Formatter):
                     if type(new_value) in [dict, list]:
                         value = new_value
                 if type(value) in [dict, list]:
-                    value = ('\n' if isinstance(value, dict) else '') + json.dumps(value, indent=4)
+                    # To get a nice overhang indent get safe_dump to generate output with
+                    # the attribute key and then remove the attribute key from the string.
+                    # Also, drop the trailing newline
+                    formatted_value = yaml.safe_dump({attr: value},
+                                                     default_flow_style=False,
+                                                     indent=4)[len(attr)+2:-1]
+                    value = ('\n' if isinstance(value, dict) else '') + formatted_value
                 output += ('\n' if output else '') + '%s: %s' % \
                     (DisplayColors.colorize(attr, DisplayColors.BLUE), value)
         return strutil.unescape(output)

--- a/st2client/tests/fixtures/execution_get_default.txt
+++ b/st2client/tests/fixtures/execution_get_default.txt
@@ -1,19 +1,24 @@
 id: 547e19561e2e2417d3dde398
 status: succeeded
+parameters: 
+  cmd: 127.0.0.1 3
 result: 
-{
-    "localhost": {
-        "failed": false, 
-        "stderr": "", 
-        "return_code": 0, 
-        "succeeded": true, 
-        "stdout": "PING 127.0.0.1 (127.0.0.1) 56(84) bytes of data.
-64 bytes from 127.0.0.1: icmp_seq=1 ttl=64 time=0.015 ms
-64 bytes from 127.0.0.1: icmp_seq=2 ttl=64 time=0.024 ms
-64 bytes from 127.0.0.1: icmp_seq=3 ttl=64 time=0.030 ms
+  localhost:
+    failed: false
+    return_code: 0
+    stderr: ''
+    stdout: 'PING 127.0.0.1 (127.0.0.1) 56(84) bytes of data.
 
---- 127.0.0.1 ping statistics ---
-3 packets transmitted, 3 received, 0% packet loss, time 1998ms
-rtt min/avg/max/mdev = 0.015/0.023/0.030/0.006 ms"
-    }
-}
+      64 bytes from 127.0.0.1: icmp_seq=1 ttl=64 time=0.015 ms
+
+      64 bytes from 127.0.0.1: icmp_seq=2 ttl=64 time=0.024 ms
+
+      64 bytes from 127.0.0.1: icmp_seq=3 ttl=64 time=0.030 ms
+
+
+      --- 127.0.0.1 ping statistics ---
+
+      3 packets transmitted, 3 received, 0% packet loss, time 1998ms
+
+      rtt min/avg/max/mdev = 0.015/0.023/0.030/0.006 ms'
+    succeeded: true

--- a/st2client/tests/unit/test_formatters.py
+++ b/st2client/tests/unit/test_formatters.py
@@ -104,7 +104,7 @@ class TestExecutionResultFormatter(unittest2.TestCase):
         argv = ['execution', 'get', EXECUTION['id'], '-j']
         content = self._get_execution(argv)
         self.assertEqual(json.loads(content),
-                         jsutil.get_kvps(EXECUTION, ['id', 'status', 'result']))
+                         jsutil.get_kvps(EXECUTION, ['id', 'status', 'parameters', 'result']))
 
     def test_execution_get_detail(self):
         argv = ['execution', 'get', EXECUTION['id'], '-d']


### PR DESCRIPTION
* Include parameters for it is annoying to not know what the parameters were; lesson learned while working with the CLI in prod
* yaml >> json

__Before__
* Run a command
```
$ st2 run core.local uname
.
id: 560d8c3932ed357fe4f1d4b5
status: succeeded
result:
{
    "failed": false,
    "stderr": "",
    "return_code": 0,
    "succeeded": true,
    "stdout": "Linux"
}
```

* View previous execution
```
$ st2 execution get 560d82b032ed357f9a189273
id: 560d82b032ed357f9a189273
status: succeeded
result:
{
    "failed": false,
    "stderr": "",
    "return_code": 0,
    "succeeded": true,
    "stdout": "Thu Oct  1 12:00:00 PDT 2015"
}
```
__After__
* Run a command
```
$ st2 run core.local uname
.
id: 560d8bc532ed357fe4f1d4b2
status: succeeded
parameters:
    cmd: uname
result:
    failed: false
    return_code: 0
    stderr: ''
    stdout: Linux
    succeeded: true
```

* View previous execution
```
$ st2 execution get 560d82b032ed357f9a189273
id: 560d82b032ed357f9a189273
status: succeeded
parameters:
    cmd: date
result:
    failed: false
    return_code: 0
    stderr: ''
    stdout: Thu Oct  1 12:00:00 PDT 2015
    succeeded: true
```