### PR TITLE
Add RBAC migration for deleting a bad (mistyped) role

### DIFF
--- a/st2common/st2common/rbac/migrations.py
+++ b/st2common/st2common/rbac/migrations.py
@@ -21,8 +21,16 @@ from st2common.models.db.rbac import RoleDB
 from st2common.exceptions.db import StackStormDBObjectConflictError
 
 __all__ = [
-    'insert_system_roles'
+    'run_all',
+
+    'insert_system_roles',
+    'delete_mistyped_role'
 ]
+
+
+def run_all():
+    insert_system_roles()
+    delete_mistyped_role()
 
 
 def insert_system_roles():
@@ -39,3 +47,27 @@ def insert_system_roles():
             Role.insert(role_db, log_not_unique_error_as_debug=True)
         except (StackStormDBObjectConflictError, NotUniqueError):
             pass
+
+    delete_mistyped_role()
+
+
+def delete_mistyped_role():
+    """
+    Delete " system_admin" role which was fat fingered.
+    """
+    # Note: Space is significant here since we want to remove a bad role
+    role_name = ' system_admin'
+    assert(role_name.startswith(' '))
+
+    try:
+        role_db = Role.get_by_name(role_name)
+    except:
+        return
+
+    if not role_db:
+        return
+
+    try:
+        Role.delete(role_db)
+    except:
+        return

--- a/st2common/st2common/service_setup.py
+++ b/st2common/st2common/service_setup.py
@@ -34,7 +34,7 @@ from st2common.signal_handlers import register_common_signal_handlers
 from st2common.models.utils.profiling import enable_profiling
 from st2common import triggers
 
-from st2common.rbac.migrations import insert_system_roles
+from st2common.rbac.migrations import run_all as run_all_rbac_migrations
 
 __all__ = [
     'setup',
@@ -108,7 +108,7 @@ def setup(service, config, setup_db=True, register_mq_exchanges=True,
 
     # TODO: This is a "not so nice" workaround until we have a proper migration system in place
     if run_migrations:
-        insert_system_roles()
+        run_all_rbac_migrations()
 
     if cfg.CONF.rbac.enable and not cfg.CONF.auth.enable:
         msg = ('Authentication is not enabled. RBAC only works when authentication is enabled.'


### PR DESCRIPTION
That's about as ghetto as it gets, but until we invest in a proper schema / data migration framework that's what we are left with.