### PR TITLE
Fix token priority and precedence in the CLI commands

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -61,6 +61,8 @@ in development
   to object automatically. (bug-fix)
 * Paramiko SSH runner no longer runs a remote command with ``sudo`` if local user and remote user
   differ. (bug-fix)
+* Fix a bug with the CLI token precedence - now the auth token specified as an environment variable
+  or as a command line argument has precedence over credentials in the CLI config. (bug fix)
 
 0.13.2 - September 09, 2015
 ---------------------------

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -299,6 +299,10 @@ class Shell(object):
         if command_class_name in SKIP_AUTH_CLASSES:
             return client
 
+        # We also skip automatic authentication if token is provided via the environment variable
+        if os.environ.get('ST2_AUTH_TOKEN', None) is not None:
+            return client
+
         if username and password:
             # Credentials are provided, try to authenticate agaist the API
             try:

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -287,7 +287,10 @@ class Shell(object):
             return client
 
         # We also skip automatic authentication if token is provided via the environment variable
-        if os.environ.get('ST2_AUTH_TOKEN', None):
+        # or as a command line argument
+        env_var_token = os.environ.get('ST2_AUTH_TOKEN', None)
+        cli_argument_token = getattr(args, 'token', None)
+        if env_var_token or cli_argument_token:
             return client
 
         # If credentials are provided in the CLI config use them and try to authenticate


### PR DESCRIPTION
This bug fixes the issue with credentials in the CLI config having precedence over the token specified as en environment variable or as a command line argument.