### PR TITLE
No more fail on error for st2ctl

### DIFF
--- a/tools/st2ctl
+++ b/tools/st2ctl
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 LOGFILE="/dev/null"
 WEBUI_LOG_FILE="/var/log/st2/st2web.log"
 COMPONENTS="st2actionrunner st2api st2auth st2sensorcontainer st2rulesengine st2web mistral st2resultstracker st2notifier"


### PR DESCRIPTION
Removes `set -e` on error, which allows services to start/stop cleanly when NG_INIT=true