### PR TITLE
Fix notification model logging to show routes

### DIFF
--- a/st2common/st2common/models/db/notification.py
+++ b/st2common/st2common/models/db/notification.py
@@ -39,8 +39,8 @@ class NotificationSubSchema(me.EmbeddedDocument):
         result.append(str(id(self)))
         result.append('(message="%s", ' % str(self.message))
         result.append('data="%s", ' % str(self.data))
-        result.append('routes="%s")' % str(self.channels))
-        result.append('(**deprecated**) channels="%s")' % str(self.channels))
+        result.append('routes="%s", ' % str(self.routes))
+        result.append('[**deprecated**]channels="%s")' % str(self.channels))
         return ''.join(result)
 
 


### PR DESCRIPTION
https://github.com/StackStorm/st2/issues/2018

Fixes this log line which is horribly confusing!

```
on_complete="NotificationSubSchema@140374782839888(message="None", data="{u'user': u'lakstorm', u'source_channel': u'chatops_ci'}", routes="[u'notify.default']")(**deprecated**) channels="[u'notify.default']")"
```