### PR TITLE
Fix pip path ubuntu post python-pip installation

### DIFF
--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -465,6 +465,8 @@ install_apt() {
   # Install packages
   echo "Installing ${APT_PACKAGE_LIST}"
   apt-get install -y ${APT_PACKAGE_LIST}
+  # Now that pip is installed set PIP=`which pip` again.
+  PIP=`which pip`
   setup_rabbitmq
   install_pip
 }


### PR DESCRIPTION
Initially we set PIP=`which pip`. This is empty for ubuntu. After installation, we don't set PIP variable again. So this script was failing. 

For RHEL/Fedora etc, we set PIP=pip2.7 explicitly. So for those, we should be good. 

