### PR TITLE
Speed up filters aggregation

### DIFF
--- a/st2api/st2api/controllers/v1/executionviews.py
+++ b/st2api/st2api/controllers/v1/executionviews.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from itertools import chain
 from pecan.rest import RestController
 import six
 
@@ -63,21 +62,7 @@ class FiltersController(RestController):
 
         for name, field in six.iteritems(SUPPORTED_FILTERS):
             if name not in IGNORE_FILTERS:
-                if isinstance(field, six.string_types):
-                    query = '$' + field
-                else:
-                    dot_notation = list(chain.from_iterable(
-                        ('$' + item, '.') for item in field
-                    ))
-                    dot_notation.pop(-1)
-                    query = {'$concat': dot_notation}
-
-                aggregate = ActionExecution.aggregate([
-                    {'$match': {'parent': None}},
-                    {'$group': {'_id': query}}
-                ])
-
-                filters[name] = [res['_id'] for res in aggregate['result'] if res['_id']]
+                filters[name] = ActionExecution.distinct(field=field)
 
         return filters
 


### PR DESCRIPTION
Filter request times out on our staging server with half a million of execution records (more precisely, it takes him 220 seconds to complete while default http timeout is 30).

This PR reverts the changes done in 8307cf7 since we don't have compound keys anymore.