### PR TITLE
Control the list of filters from frontend

### DIFF
--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -55,7 +55,7 @@ __all__ = [
 LOG = logging.getLogger(__name__)
 
 # Note: We initialize filters here and not in the constructor
-SUPPORTED_EXECUTIONS_FILTERS = SUPPORTED_FILTERS
+SUPPORTED_EXECUTIONS_FILTERS = copy.deepcopy(SUPPORTED_FILTERS)
 SUPPORTED_EXECUTIONS_FILTERS.update({
     'timestamp_gt': 'start_timestamp.gt',
     'timestamp_lt': 'start_timestamp.lt'

--- a/st2api/st2api/controllers/v1/executionviews.py
+++ b/st2api/st2api/controllers/v1/executionviews.py
@@ -49,19 +49,26 @@ SUPPORTED_FILTERS = {
 IGNORE_FILTERS = ['parent', 'timestamp', 'liveaction', 'trigger_instance']
 
 
+def csv(s):
+    return s.split(',')
+
+
 class FiltersController(RestController):
-    @jsexpose()
-    def get_all(self):
+    @jsexpose(arg_types=[csv])
+    def get_all(self, types=None):
         """
             List all distinct filters.
 
             Handles requests:
-                GET /executions/views/filters
+                GET /executions/views/filters[?types=action,rule]
+
+            :param types: Comma delimited string of filter types to output.
+            :type types: ``str``
         """
         filters = {}
 
         for name, field in six.iteritems(SUPPORTED_FILTERS):
-            if name not in IGNORE_FILTERS:
+            if name not in IGNORE_FILTERS and (not types or name in types):
                 filters[name] = ActionExecution.distinct(field=field)
 
         return filters

--- a/st2api/tests/unit/controllers/v1/test_executions_filters.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_filters.py
@@ -303,5 +303,14 @@ class TestActionExecutionFilters(FunctionalTest):
         response = self.app.get('/v1/executions/views/filters')
         self.assertEqual(response.status_int, 200)
         self.assertIsInstance(response.json, dict)
-        for key, value in six.iteritems(history_views.ARTIFACTS['filters']):
+        self.assertEqual(len(response.json), len(history_views.ARTIFACTS['filters']['default']))
+        for key, value in six.iteritems(history_views.ARTIFACTS['filters']['default']):
+            self.assertEqual(set(response.json[key]), set(value))
+
+    def test_filters_view_specific_types(self):
+        response = self.app.get('/v1/executions/views/filters?types=action,user,nonexistent')
+        self.assertEqual(response.status_int, 200)
+        self.assertIsInstance(response.json, dict)
+        self.assertEqual(len(response.json), len(history_views.ARTIFACTS['filters']['specific']))
+        for key, value in six.iteritems(history_views.ARTIFACTS['filters']['specific']):
             self.assertEqual(set(response.json[key]), set(value))

--- a/st2tests/st2tests/fixtures/history_views/filters.yaml
+++ b/st2tests/st2tests/fixtures/history_views/filters.yaml
@@ -1,15 +1,24 @@
 ---
-action:
-- executions.local
-- executions.chain
-rule:
-- st2.person.joe
-runner:
-- run-local
-- action-chain
-trigger:
-- 46f67652-20cd-4bab-94e2-4615baa846d0
-trigger_type:
-- st2.webhook
-user:
-- system
+default:
+  action:
+  - executions.local
+  - executions.chain
+  rule:
+  - st2.person.joe
+  runner:
+  - run-local
+  - action-chain
+  status:
+  - succeeded
+  trigger:
+  - 46f67652-20cd-4bab-94e2-4615baa846d0
+  trigger_type:
+  - st2.webhook
+  user:
+  - system
+specific:
+  action:
+  - executions.local
+  - executions.chain
+  user:
+  - system


### PR DESCRIPTION
Since #2059 was not enough to bring filter view performance up to an expected level, we can additionally specify filters we want st2web to query.

Currently, UI only shows four types while server queries and sends nine.