### PR TITLE
Adjust alias ordering for packs.install

### DIFF
--- a/contrib/packs/aliases/pack_deploy.yaml
+++ b/contrib/packs/aliases/pack_deploy.yaml
@@ -3,5 +3,6 @@ name: "deploy_pack"
 action_ref: "packs.install"
 description: "Download StackStorm packs via ChatOps"
 formats:
-  - "pack deploy {{packs}}"
   - "pack deploy {{packs}} from {{repo_url}}"
+  - "pack deploy {{packs}}"
+


### PR DESCRIPTION
This commit adjusts the ordering of aliases for the pack installation action, ensuring that all of the actions work properly.

Fixes #2052