### PR TITLE
Change http runner to not verify ssl cert for https requests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -65,6 +65,7 @@ in development
   or as a command line argument has precedence over credentials in the CLI config. (bug fix)
 * Support versioned APIs for auth controller. For backward compatibility, unversioned API calls
   get redirected to versioned controllers by the server. (improvement)
+* Add option to verify SSL cert for HTTPS request to the core.http action. (new feature)
 
 0.13.2 - September 09, 2015
 ---------------------------

--- a/docs/source/_includes/runner_parameters/http_request.rst
+++ b/docs/source/_includes/runner_parameters/http_request.rst
@@ -6,4 +6,4 @@
 * ``http_proxy`` (string) - A URL of a HTTP proxy to use (e.g. http://10.10.1.10:3128).
 * ``headers`` (string) - HTTP headers for the request.
 * ``allow_redirects`` (boolean) - Set to True if POST/PUT/DELETE redirect following is allowed.
-* ``verify_ssl_cert`` (boolean) - SSL verification is not supported.
+* ``verify_ssl_cert`` (boolean) - Set to True to verify SSL certificate. Verification using a CA cert bundle is not yet supported.

--- a/docs/source/_includes/runner_parameters/http_request.rst
+++ b/docs/source/_includes/runner_parameters/http_request.rst
@@ -6,4 +6,4 @@
 * ``http_proxy`` (string) - A URL of a HTTP proxy to use (e.g. http://10.10.1.10:3128).
 * ``headers`` (string) - HTTP headers for the request.
 * ``allow_redirects`` (boolean) - Set to True if POST/PUT/DELETE redirect following is allowed.
-* ``verify_ssl_cert`` (boolean) - Set to True to verify SSL certificate. Verification using a CA cert bundle is not yet supported.
+* ``verify_ssl_cert`` (boolean) - Certificate for HTTPS request is verified by default using requests CA bundle which comes from Mozilla. Verification using a custom CA bundle is not yet supported. Set to False to skip verification.

--- a/docs/source/_includes/runner_parameters/http_request.rst
+++ b/docs/source/_includes/runner_parameters/http_request.rst
@@ -6,3 +6,4 @@
 * ``http_proxy`` (string) - A URL of a HTTP proxy to use (e.g. http://10.10.1.10:3128).
 * ``headers`` (string) - HTTP headers for the request.
 * ``allow_redirects`` (boolean) - Set to True if POST/PUT/DELETE redirect following is allowed.
+* ``verify_ssl_cert`` (boolean) - SSL verification is not supported.

--- a/st2actions/st2actions/runners/httprunner.py
+++ b/st2actions/st2actions/runners/httprunner.py
@@ -38,7 +38,7 @@ RUNNER_COOKIES = 'cookies'
 RUNNER_ALLOW_REDIRECTS = 'allow_redirects'
 RUNNER_HTTP_PROXY = 'http_proxy'
 RUNNER_HTTPS_PROXY = 'https_proxy'
-
+RUNNER_VERIFY_SSL_CERT = 'verify_ssl_cert'
 
 # Lookup constants for action params
 ACTION_AUTH = 'auth'
@@ -77,6 +77,7 @@ class HttpRunner(ActionRunner):
         self._allow_redirects = self.runner_parameters.get(RUNNER_ALLOW_REDIRECTS, False)
         self._http_proxy = self.runner_parameters.get(RUNNER_HTTP_PROXY, None)
         self._https_proxy = self.runner_parameters.get(RUNNER_HTTPS_PROXY, None)
+        self._verify_ssl_cert = self.runner_parameters.get(RUNNER_VERIFY_SSL_CERT, None)
 
     def run(self, action_parameters):
         client = self._get_http_client(action_parameters)
@@ -124,7 +125,7 @@ class HttpRunner(ActionRunner):
         return HTTPClient(url=self._url, method=method, body=body, params=params,
                           headers=headers, cookies=self._cookies, auth=auth,
                           timeout=timeout, allow_redirects=self._allow_redirects,
-                          proxies=proxies, files=files)
+                          proxies=proxies, files=files, verify=self._verify_ssl_cert)
 
     def _params_to_dict(self, params):
         if not params:
@@ -144,7 +145,7 @@ class HttpRunner(ActionRunner):
 class HTTPClient(object):
     def __init__(self, url=None, method=None, body='', params=None, headers=None, cookies=None,
                  auth=None, timeout=60, allow_redirects=False, proxies=None,
-                 files=None):
+                 files=None, verify=False):
         if url is None:
             raise Exception('URL must be specified.')
 
@@ -171,6 +172,7 @@ class HTTPClient(object):
         self.allow_redirects = allow_redirects
         self.proxies = proxies
         self.files = files
+        self.verify = verify
 
     def run(self):
         results = {}
@@ -201,7 +203,8 @@ class HTTPClient(object):
                 timeout=self.timeout,
                 allow_redirects=self.allow_redirects,
                 proxies=self.proxies,
-                files=self.files
+                files=self.files,
+                verify=self.verify
             )
 
             headers = dict(resp.headers)

--- a/st2actions/tests/unit/test_http_runner.py
+++ b/st2actions/tests/unit/test_http_runner.py
@@ -87,6 +87,26 @@ class HTTPRunnerTestCase(unittest2.TestCase):
         self.assertEqual(result['body'], mock_result.text)
 
     @mock.patch('st2actions.runners.httprunner.requests')
+    def test_https_verify(self, mock_requests):
+        url = 'https://localhost:8888'
+        client = HTTPClient(url=url, verify=True)
+        mock_result = MockResult()
+
+        mock_result.text = 'foo bar ponies'
+        mock_result.headers = {'Content-Type': 'text/html'}
+        mock_result.status_code = 200
+
+        mock_requests.request.return_value = mock_result
+        client.run()
+
+        self.assertTrue(client.verify)
+
+        mock_requests.request.assert_called_with(
+            'GET', url, allow_redirects=False, auth=None, cookies=None,
+            data='', files=None, headers={}, params=None, proxies=None,
+            timeout=60, verify=True)
+
+    @mock.patch('st2actions.runners.httprunner.requests')
     def test_https_verify_false(self, mock_requests):
         url = 'https://localhost:8888'
         client = HTTPClient(url=url)

--- a/st2actions/tests/unit/test_http_runner.py
+++ b/st2actions/tests/unit/test_http_runner.py
@@ -85,3 +85,23 @@ class HTTPRunnerTestCase(unittest2.TestCase):
 
         self.assertFalse(isinstance(result['body'], dict))
         self.assertEqual(result['body'], mock_result.text)
+
+    @mock.patch('st2actions.runners.httprunner.requests')
+    def test_https_verify_false(self, mock_requests):
+        url = 'https://localhost:8888'
+        client = HTTPClient(url=url)
+        mock_result = MockResult()
+
+        mock_result.text = 'foo bar ponies'
+        mock_result.headers = {'Content-Type': 'text/html'}
+        mock_result.status_code = 200
+
+        mock_requests.request.return_value = mock_result
+        client.run()
+
+        self.assertFalse(client.verify)
+
+        mock_requests.request.assert_called_with(
+            'GET', url, allow_redirects=False, auth=None, cookies=None,
+            data='', files=None, headers={}, params=None, proxies=None,
+            timeout=60, verify=False)

--- a/st2common/st2common/bootstrap/runnersregistrar.py
+++ b/st2common/st2common/bootstrap/runnersregistrar.py
@@ -305,6 +305,12 @@ RUNNER_TYPES = [
                 'type': 'boolean',
                 'default': False
             },
+            'verify_ssl_cert': {
+                'description': 'SSL verification is not supported.',
+                'type': 'boolean',
+                'default': False,
+                'immutable': True
+            }
         },
         'runner_module': 'st2actions.runners.httprunner'
     },

--- a/st2common/st2common/bootstrap/runnersregistrar.py
+++ b/st2common/st2common/bootstrap/runnersregistrar.py
@@ -306,10 +306,10 @@ RUNNER_TYPES = [
                 'default': False
             },
             'verify_ssl_cert': {
-                'description': 'SSL verification is not supported.',
+                'description': 'Set to True to verify SSL certificate. Verification '
+                               'using a CA cert bundle is not yet supported.',
                 'type': 'boolean',
-                'default': False,
-                'immutable': True
+                'default': True
             }
         },
         'runner_module': 'st2actions.runners.httprunner'

--- a/st2common/st2common/bootstrap/runnersregistrar.py
+++ b/st2common/st2common/bootstrap/runnersregistrar.py
@@ -306,8 +306,10 @@ RUNNER_TYPES = [
                 'default': False
             },
             'verify_ssl_cert': {
-                'description': 'Set to True to verify SSL certificate. Verification '
-                               'using a CA cert bundle is not yet supported.',
+                'description': 'Certificate for HTTPS request is verified by default using '
+                               'requests CA bundle which comes from Mozilla. Verification '
+                               'using a custom CA bundle is not yet supported. Set to False '
+                               'to skip verification.',
                 'type': 'boolean',
                 'default': True
             }


### PR DESCRIPTION
Add an immutable runner parameter named verify_ssl_cert for the http runner and set it to False so the user knows that for HTTPS requests SSL cert is not verified. Pass the value to requests.reqest in the HTTPClient.