### PR TITLE
Add docs for the enterprise LDAP backend, enterprise version availability

### DIFF
--- a/docs/source/config/authentication.rst
+++ b/docs/source/config/authentication.rst
@@ -264,7 +264,7 @@ LDAP backend
 
 LDAP backend reads authentication information from an LDAP server.
 
-Currently there are two types of LDAP backend available - community contributed one and one
+Currently there are two types of LDAP backends available - community contributed one and one
 developed and maintained by the StackStorm team. Community contributed one can be installed
 by anyone and the StackStorm developed one is only available in the enterprise edition (for
 more information on the enterprise edition, please see https://stackstorm.com/product/#enterprise).
@@ -276,14 +276,28 @@ developed and maintained by the community.
 Enterprise LDAP backend
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Community maintained LDAP backend
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+As noted above this backend is installed and available by default in the enterprise edition.
+
+**Backend configuration options:**
+
+* ``host`` - Hostname / IP of the LDAP server.
+* ``port`` - Port of the LDAP server.
+* ``use_ssl`` - Use LDAPS to connect. Defaults to ``False``.
+* ``use_tls`` - Start TLS on LDAP to connect. Defaults to ``False``.
+* ``cacert`` - Path to the CA cert used to validate the server certificate. Defaults to
+  ``None``.
+* ``users_ou`` - OU of the user accounts.
+* ``id_attr`` - Field name of the user ID attribute.
+* ``scope`` - Search scope (base, onelevel, or subtree). Defaults to ``subtree``.
+
+Community LDAP backend
+~~~~~~~~~~~~~~~~~~~~~~
+
+Repository URL: https://github.com/StackStorm/st2-auth-backend-ldap
 
 The backend tries to bind the ldap user with given username and password. If the bind was
 successful, it tries to find the user in the given group. If the user is in the group, they will be
 authenticated.
-
-https://stackstorm.com/product/#enterprise
 
 **Backend configuration options:**
 

--- a/docs/source/config/authentication.rst
+++ b/docs/source/config/authentication.rst
@@ -262,11 +262,28 @@ Example ``auth`` section in the |st2| configuration file.
 LDAP backend
 ~~~~~~~~~~~~
 
-Repository URL: https://github.com/StackStorm/st2-auth-backend-ldap
+LDAP backend reads authentication information from an LDAP server.
 
-Backend which reads authentication information from an LDAP server. The backend tries to bind the
-ldap user with given username and password. If the bind was successful, it tries to find the user
-in the given group. If the user is in the group, they will be authenticated.
+Currently there are two types of LDAP backend available - community contributed one and one
+developed and maintained by the StackStorm team. Community contributed one can be installed
+by anyone and the StackStorm developed one is only available in the enterprise edition (for
+more information on the enterprise edition, please see https://stackstorm.com/product/#enterprise).
+
+The difference between them is that the one included in the enterprise edition is developed,
+supported, tested and maintained by the StackStorm team and the community contributed one is
+developed and maintained by the community.
+
+Enterprise LDAP backend
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Community maintained LDAP backend
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The backend tries to bind the ldap user with given username and password. If the bind was
+successful, it tries to find the user in the given group. If the user is in the group, they will be
+authenticated.
+
+https://stackstorm.com/product/#enterprise
 
 **Backend configuration options:**
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,6 +29,7 @@ Contents:
     reference/index
     development/index
     troubleshooting/index
+    tutorials/index
     changelog
     upgrade_notes
     roadmap

--- a/docs/source/rbac.rst
+++ b/docs/source/rbac.rst
@@ -1,6 +1,12 @@
 Role Based Access Control
 =========================
 
+.. note::
+
+   Role Based Access Control (RBAC) is only available in StackStorm enterprise edition. For more
+   information about enterprise edition and differences between community and enterprise edition,
+   please see this page - https://stackstorm.com/product/#enterprise.
+
 |st2| implements Role Based Access (abbreviated RBAC) control which allows system administrators
 and operators to restrict users access and limit the operations they can perform.
 

--- a/docs/source/tutorials/index.rst
+++ b/docs/source/tutorials/index.rst
@@ -1,0 +1,9 @@
+Tutorials
+=========
+
+This section contains various step by step tutorials.
+
+.. toctree::
+    :maxdepth: 1
+
+    rbac

--- a/docs/source/tutorials/rbac.rst
+++ b/docs/source/tutorials/rbac.rst
@@ -1,5 +1,5 @@
-Configuring RBAC
-================
+Getting Started With RBAC
+=========================
 
 StackStorm enterprise edition brings support for Role Based Access Control(RBAC). RBAC allows a StackStorm administrator
 control over what functions are accessible to a user within StackStorm.


### PR DESCRIPTION
This pull request adds docs for the enterprise LDAP backend and clarifies which features are only available in the enterprise edition.

Other changes:

* Moved RBAC "tutorial" from instructables/ to the new Tutorials section in the docs.