### PR TITLE
Remote runner improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -66,6 +66,8 @@ in development
 * Support versioned APIs for auth controller. For backward compatibility, unversioned API calls
   get redirected to versioned controllers by the server. (improvement)
 * Add option to verify SSL cert for HTTPS request to the core.http action. (new feature)
+* Update remote runner to include stdout and stderr which was consumed so far when a timeout
+  occurs. (improvement)
 
 0.13.2 - September 09, 2015
 ---------------------------

--- a/st2actions/st2actions/runners/ssh/parallel_ssh.py
+++ b/st2actions/st2actions/runners/ssh/parallel_ssh.py
@@ -14,12 +14,14 @@
 # limitations under the License.
 
 import json
+import re
 import os
 import sys
 import traceback
 
 import eventlet
 
+from st2common.constants.secrets import MASKED_ATTRIBUTE_VALUE
 from st2actions.runners.ssh.paramiko_ssh import ParamikoSSHClient
 from st2actions.runners.ssh.paramiko_ssh import SSHCommandTimeoutError
 from st2common import log as logging

--- a/st2actions/st2actions/runners/ssh/parallel_ssh.py
+++ b/st2actions/st2actions/runners/ssh/parallel_ssh.py
@@ -261,6 +261,7 @@ class ParallelSSHClient(object):
                            'succeeded': is_succeeded, 'failed': not is_succeeded}
             results[host] = jsonify.json_loads(result_dict, ParallelSSHClient.KEYS_TO_TRANSFORM)
         except:
+            cmd = self._sanitize_command_string(cmd=cmd)
             error = 'Failed executing command "%s" on host "%s"' % (cmd, host)
             LOG.exception(error)
             _, ex, tb = sys.exc_info()
@@ -320,6 +321,20 @@ class ParallelSSHClient(object):
             port = self._ssh_port
 
         return (hostname, port)
+
+    @staticmethod
+    def _sanitize_command_string(cmd):
+        """
+        Remove any potentially sensitive information from the command string.
+
+        For now we only mask the values of the sensitive environment variables.
+        """
+        if not cmd:
+            return cmd
+
+        result = re.sub('ST2_ACTION_AUTH_TOKEN=(.+?)\s+?', 'ST2_ACTION_AUTH_TOKEN=%s ' %
+                        (MASKED_ATTRIBUTE_VALUE), cmd)
+        return result
 
     @staticmethod
     def _generate_error_result(exc, tb, message):

--- a/st2actions/st2actions/runners/ssh/parallel_ssh.py
+++ b/st2actions/st2actions/runners/ssh/parallel_ssh.py
@@ -342,3 +342,7 @@ class ParallelSSHClient(object):
             'traceback': ''.join(traceback.format_tb(tb, 20)) if tb else '',
         }
         return error_dict
+
+    def __repr__(self):
+        return ('<ParallelSSHClient hosts=%s,user=%s,id=%s>' %
+                (repr(self._hosts), self._ssh_user, id(self)))

--- a/st2actions/st2actions/runners/ssh/parallel_ssh.py
+++ b/st2actions/st2actions/runners/ssh/parallel_ssh.py
@@ -329,11 +329,16 @@ class ParallelSSHClient(object):
         else:
             return_code = 255
 
+        stdout = getattr(ex, 'stdout', None) or ''
+        stderr = getattr(ex, 'stderr', None) or ''
+
         error_dict = {
-            'error': error_msg,
-            'traceback': ''.join(traceback.format_tb(tb, 20)) if tb else '',
             'failed': True,
             'succeeded': False,
-            'return_code': return_code
+            'return_code': return_code,
+            'stdout': stdout,
+            'stderr': stderr,
+            'error': error_msg,
+            'traceback': ''.join(traceback.format_tb(tb, 20)) if tb else '',
         }
         return error_dict

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh.py
@@ -513,3 +513,7 @@ class ParamikoSSHClient(object):
             msg = 'Invalid or unsupported key type'
 
         raise paramiko.ssh_exception.SSHException(msg)
+
+    def __repr__(self):
+        return ('<ParamikoSSHClient hostname=%s,port=%s,username=%s,id=%s>' %
+                (self.hostname, self.port, self.username, id(self)))

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh.py
@@ -44,9 +44,19 @@ class SSHCommandTimeoutError(Exception):
     """
     Exception which is raised when an SSH command times out.
     """
-    def __init__(self, cmd, timeout):
+
+    def __init__(self, cmd, timeout, stdout=None, stderr=None):
+        """
+        :param stdout: Stdout which was consumed until the timeout occured.
+        :type stdout: ``str``
+
+        :param stdout: Stderr which was consumed until the timeout occured.
+        :type stderr: ``str``
+        """
         self.cmd = cmd
         self.timeout = timeout
+        self.stdout = stdout
+        self.stderr = stderr
         message = 'Command didn\'t finish in %s seconds' % (timeout)
         super(SSHCommandTimeoutError, self).__init__(message)
 
@@ -387,7 +397,10 @@ class ParamikoSSHClient(object):
                 # TODO: Is this the right way to clean up?
                 chan.close()
 
-                raise SSHCommandTimeoutError(cmd=cmd, timeout=timeout)
+                stdout = strip_shell_chars(stdout.getvalue())
+                stderr = strip_shell_chars(stderr.getvalue())
+                raise SSHCommandTimeoutError(cmd=cmd, timeout=timeout, stdout=stdout,
+                                             stderr=stderr)
 
             stdout.write(self._consume_stdout(chan).getvalue())
             stderr.write(self._consume_stderr(chan).getvalue())

--- a/st2common/st2common/constants/secrets.py
+++ b/st2common/st2common/constants/secrets.py
@@ -26,7 +26,8 @@ MASKED_ATTRIBUTES_BLACKLIST = [
     'auth_token',
     'token',
     'secret',
-    'credentials'
+    'credentials',
+    'st2_auth_token'
 ]
 
 # Value with which the masked attribute values are replaced


### PR DESCRIPTION
* Set `return_code` to `-9` on command timeout - this way it's consistent with local runner and old fabric based runner
* If the timeout happens include stdout and stderr which was consumed so far
* Include original exception error message in the `error` attribute of the result object
* Strip environment variable which contains the action specific auth token for the error returned to the user