### PR TITLE
Better tracebacks in the remote runner result object

### DIFF
--- a/st2actions/st2actions/runners/ssh/parallel_ssh.py
+++ b/st2actions/st2actions/runners/ssh/parallel_ssh.py
@@ -16,7 +16,6 @@
 import json
 import re
 import os
-import sys
 import traceback
 
 import eventlet


### PR DESCRIPTION
Before:

```bash
st2 run core.remote hosts=localhost cmd="echo 'baaaar'; sleep 10" timeout=4
...
id: 561d26ef0640fd213a4b2fd3
status: failed
parameters: 
  cmd: echo 'baaaar'; sleep 10
  hosts: localhost
  timeout: 4
result: 
  localhost:
    error: 'Failed executing command "export ST2_ACTION_PACK_NAME=core ST2_ACTION_EXECUTION_ID=561d26ef0640fd213a4b2fd3 ST2_ACTION_AUTH_TOKEN=******** ST2_ACTION_API_URL=http://127.0.0.1:9101/v1 && cd /tmp && echo ''baaaar''; sleep 10" on host "localhost": Command didn''t finish in 4 seconds'
    failed: true
    return_code: -9
    stderr: ''
    stdout: baaaar
    succeeded: false
    traceback: "  File "/data/stanley/st2actions/st2actions/runners/ssh/parallel_ssh.py", line 258, in _run_command
    (stdout, stderr, exit_code) = client.run(cmd, timeout=timeout)
  File "/data/stanley/st2actions/st2actions/runners/ssh/paramiko_ssh.py", line 404, in run
    stderr=stderr)
"
```

After:

```bash
st2 run core.remote hosts=localhost cmd="echo 'baaaar'; sleep 10" timeout=4
...
id: 561d28530640fd213a4b2fdc
status: failed
parameters: 
  cmd: echo 'baaaar'; sleep 10
  hosts: localhost
  timeout: 4
result: 
  localhost:
    error: 'Failed executing command "export ST2_ACTION_PACK_NAME=core ST2_ACTION_EXECUTION_ID=561d28530640fd213a4b2fdc ST2_ACTION_AUTH_TOKEN=******** ST2_ACTION_API_URL=http://127.0.0.1:9101/v1 && cd /tmp && echo ''baaaar''; sleep 10" on host "localhost": Command didn''t finish in 4 seconds'
    failed: true
    return_code: -9
    stderr: ''
    stdout: baaaar
    succeeded: false
    traceback: "Traceback (most recent call last):
  File "/data/stanley/st2actions/st2actions/runners/ssh/parallel_ssh.py", line 257, in _run_command
    (stdout, stderr, exit_code) = client.run(cmd, timeout=timeout)
  File "/data/stanley/st2actions/st2actions/runners/ssh/paramiko_ssh.py", line 403, in run
    stderr=stderr)
SSHCommandTimeoutError: Command didn't finish in 4 seconds
```