### PR TITLE
Modify the mistral_examples chain to run only selected examples

### DIFF
--- a/contrib/examples/actions/chains/mistral_examples.yaml
+++ b/contrib/examples/actions/chains/mistral_examples.yaml
@@ -4,46 +4,11 @@
         name: "mistral-basic"
         ref: "examples.mistral-basic"
         params:
-          cmd: "hostname"
-        on-success: "mistral-handle-error"
-    -
-        name: "mistral-handle-error"
-        ref: "examples.mistral-handle-error"
-        params: {}
-        on-failure: "mistral-handle-retry"
-    -
-        name: "mistral-handle-retry"
-        ref: "examples.mistral-handle-retry"
-        params: {}
-        on-success: "mistral-repeat-with-items"
-    -
-        name: "mistral-repeat-with-items"
-        ref: "examples.mistral-repeat-with-items"
-        params:
-          cmds:
-            - "hostname"
-            - "date"
-        on-success: "mistral-repeat"
-    -
-        name: "mistral-repeat"
-        ref: "examples.mistral-repeat"
-        params:
-          cmd: "hostname"
-        on-success: "mistral-workbook-basic"
-    -
-        name: "mistral-workbook-basic"
-        ref: "examples.mistral-workbook-basic"
-        params:
-          cmd: "hostname"
+            cmd: "hostname"
         on-success: "mistral-workbook-complex"
     -
         name: "mistral-workbook-complex"
         ref: "examples.mistral-workbook-complex"
         params:
             vm_name: "fake-host-1"
-        on-success: "mistral-workbook-subflows"
-    -
-        name: "mistral-workbook-subflows"
-        ref: "examples.mistral-workbook-subflows"
-        params: {}
   default: "mistral-basic"

--- a/contrib/examples/actions/mistral_examples.meta.yaml
+++ b/contrib/examples/actions/mistral_examples.meta.yaml
@@ -1,7 +1,7 @@
 ---
 # Action definition metadata
 name: "mistral_examples"
-description: "Run all the Mistral examples"
+description: "Run selected Mistral examples"
 
 # `runner_type` has value `action-chain` to identify that action is an ActionChain.
 runner_type: "action-chain"


### PR DESCRIPTION
The mistral_examples WF is mostly used for health check and doesn't need to include all the mistral examples. Only selected examples are included here to test that mistral is installed and configured correctly.