### PR TITLE
(RFR) Reduce watcher sleep

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -69,6 +69,9 @@ in development
 * Update remote runner to include stdout and stderr which was consumed so far when a timeout
   occurs. (improvement)
 * Fix st2-self-check script to check whether to use http/https when connecting to st2, to disable Windows test by default, and to check test status correctly. (bug-fix)
+* Reduce the wait time between message consumption by TriggerWatcher to avoid latency (improvement)
+* Use exclusive messaging Qs for TriggerWatcher to avoid having to deal with old messages
+  and related migration scripts. (bug-fix)
 
 0.13.2 - September 09, 2015
 ---------------------------

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -6,7 +6,11 @@ Upgrade Notes
 * Triggers now have a `ref_count` property which must be included in Trigger objects
   created in previous versions of |st2|. A migration script is shipped in
   ${dist_packages}/st2common/bin/migrate_triggers_to_include_ref_count.py on installation.
-  The migration script is run as part of st2_deploy.sh when you upgrade from versions < 0.13 to 1.0.
+  The migration script is run as part of st2_deploy.sh when you upgrade from versions >= 0.13 to 1.0.
+* Messaging queues are now exlusive and in some cases renamed from previous versions. To
+  remove old queues run the migration script
+  ${dist_packages}/st2common/bin/migrate_messaging_setup.py on installation. The migration
+  script is run as part of st2_deploy.sh when you upgrade from versions >= 0.13 to 1.0.
 
 |st2| 0.11
 -------------

--- a/st2api/st2api/controllers/v1/webhooks.py
+++ b/st2api/st2api/controllers/v1/webhooks.py
@@ -55,7 +55,7 @@ class WebhooksController(RestController):
                                                update_handler=self._handle_update_trigger,
                                                delete_handler=self._handle_delete_trigger,
                                                trigger_types=self._trigger_types,
-                                               queue_suffix='webhooks',
+                                               queue_suffix=self.__class__.__name__,
                                                exclusive=True)
         self._trigger_watcher.start()
         self._register_webhook_trigger_types()

--- a/st2api/st2api/controllers/v1/webhooks.py
+++ b/st2api/st2api/controllers/v1/webhooks.py
@@ -55,7 +55,8 @@ class WebhooksController(RestController):
                                                update_handler=self._handle_update_trigger,
                                                delete_handler=self._handle_delete_trigger,
                                                trigger_types=self._trigger_types,
-                                               queue_suffix='webhooks')
+                                               queue_suffix='webhooks',
+                                               exclusive=True)
         self._trigger_watcher.start()
         self._register_webhook_trigger_types()
 

--- a/st2common/packaging/debian/install
+++ b/st2common/packaging/debian/install
@@ -15,5 +15,6 @@ tools/st2-setup-examples usr/lib/python2.7/dist-packages/st2common/bin/
 tools/st2-self-check usr/lib/python2.7/dist-packages/st2common/bin/
 tools/migrate_rules_to_include_pack.py usr/lib/python2.7/dist-packages/st2common/bin/
 tools/migrate_triggers_to_include_ref_count.py usr/lib/python2.7/dist-packages/st2common/bin/
+tools/migrate_messaging_setup.py usr/lib/python2.7/dist-packages/st2common/bin/
 rbac/roles/sample.yaml opt/stackstorm/rbac/roles/
 rbac/assignments/sample.yaml opt/stackstorm/rbac/assignments/

--- a/st2common/packaging/rpm/st2common-rhel6.spec
+++ b/st2common/packaging/rpm/st2common-rhel6.spec
@@ -62,7 +62,8 @@ install -m755 tools/st2ctl %{buildroot}/usr/bin/st2ctl
 install -m755 tools/st2-setup-tests %{buildroot}/usr/lib/python2.7/site-packages/st2common/bin/st2-setup-tests
 install -m755 tools/st2-setup-examples %{buildroot}/usr/lib/python2.7/site-packages/st2common/bin/st2-setup-examples
 install -m755 tools/st2-self-check %{buildroot}/usr/lib/python2.7/site-packages/st2common/bin/st2-self-check
-install -m755 tools/migrate_rules_to_include_pack.py %{buildroot}/usr/lib/python2.7/site-packages/st2common/bin/migrate_rules_to_include_pack.py
+install -m755 tools/migrate_rules_to_include_pack.py %{buildroot}/usr/lib/python2.7/site-packages/st2common/bin/
+install -m755 tools/migrate_messaging_setup.py %{buildroot}/usr/lib/python2.7/site-packages/st2common/bin/migrate_rules_to_include_pack.py
 install -m755 tools/migrate_triggers_to_include_ref_count.py %{buildroot}/usr/lib/python2.7/site-packages/st2common/bin/migrate_triggers_to_include_ref_count.py
 
 %files

--- a/st2common/packaging/rpm/st2common.spec
+++ b/st2common/packaging/rpm/st2common.spec
@@ -60,7 +60,8 @@ install -m755 tools/st2ctl %{buildroot}/usr/bin/st2ctl
 install -m755 tools/st2-setup-tests %{buildroot}/usr/lib/python2.7/site-packages/st2common/bin/st2-setup-tests
 install -m755 tools/st2-setup-examples %{buildroot}/usr/lib/python2.7/site-packages/st2common/bin/st2-setup-examples
 install -m755 tools/st2-self-check %{buildroot}/usr/lib/python2.7/site-packages/st2common/bin/st2-self-check
-install -m755 tools/migrate_rules_to_include_pack.py %{buildroot}/usr/lib/python2.7/site-packages/st2common/bin/migrate_rules_to_include_pack.py
+install -m755 tools/migrate_rules_to_include_pack.py %{buildroot}/usr/lib/python2.7/site-packages/st2common/bin/
+install -m755 tools/migrate_messaging_setup.py %{buildroot}/usr/lib/python2.7/site-packages/st2common/bin/migrate_rules_to_include_pack.py
 install -m755 tools/migrate_triggers_to_include_ref_count.py %{buildroot}/usr/lib/python2.7/site-packages/st2common/bin/migrate_triggers_to_include_ref_count.py
 
 %files

--- a/st2common/st2common/services/triggerwatcher.py
+++ b/st2common/st2common/services/triggerwatcher.py
@@ -28,10 +28,10 @@ LOG = logging.getLogger(__name__)
 
 class TriggerWatcher(ConsumerMixin):
 
-    sleep_interval = 4  # how long to sleep after processing each message
+    sleep_interval = 0  # sleep to co-operatively yield after processing each message
 
     def __init__(self, create_handler, update_handler, delete_handler,
-                 trigger_types=None, queue_suffix=None):
+                 trigger_types=None, queue_suffix=None, exclusive=False):
         """
         :param create_handler: Function which is called on TriggerDB create event.
         :type create_handler: ``callable``
@@ -46,13 +46,18 @@ class TriggerWatcher(ConsumerMixin):
                               if the trigger in the message payload is included
                               in this list.
         :type trigger_types: ``list``
+
+        :param exclusive: If the Q is exclusive to a specific connection which is then
+                          single connection created by TriggerWatcher. When the connection
+                          breaks the Q is removed by the message broker.
+        :type exclusive: ``bool``
         """
         # TODO: Handle trigger type filtering using routing key
         self._create_handler = create_handler
         self._update_handler = update_handler
         self._delete_handler = delete_handler
         self._trigger_types = trigger_types
-        self._trigger_watch_q = self._get_queue(queue_suffix)
+        self._trigger_watch_q = self._get_queue(queue_suffix, exclusive=exclusive)
 
         self.connection = None
         self._load_thread = None
@@ -135,10 +140,10 @@ class TriggerWatcher(ConsumerMixin):
                 self._handlers[publishers.CREATE_RK](trigger)
 
     @staticmethod
-    def _get_queue(queue_suffix):
+    def _get_queue(queue_suffix, exclusive):
         if not queue_suffix:
             # pick last 10 digits of uuid. Arbitrary but unique enough for the TriggerWatcher.
             u_hex = uuid.uuid4().hex
             queue_suffix = uuid.uuid4().hex[len(u_hex) - 10:]
         queue_name = 'st2.trigger.watch.%s' % queue_suffix
-        return reactor.get_trigger_cud_queue(queue_name, routing_key='#')
+        return reactor.get_trigger_cud_queue(queue_name, routing_key='#', exclusive=exclusive)

--- a/st2common/st2common/transport/reactor.py
+++ b/st2common/st2common/transport/reactor.py
@@ -107,8 +107,8 @@ class TriggerDispatcher(object):
         self._publisher.publish_trigger(payload=payload, routing_key=routing_key)
 
 
-def get_trigger_cud_queue(name, routing_key):
-    return Queue(name, TRIGGER_CUD_XCHG, routing_key=routing_key)
+def get_trigger_cud_queue(name, routing_key, exclusive=False):
+    return Queue(name, TRIGGER_CUD_XCHG, routing_key=routing_key, exclusive=exclusive)
 
 
 def get_trigger_instances_queue(name, routing_key):

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -328,7 +328,9 @@ class SensorWrapper(object):
                                                update_handler=self._handle_update_trigger,
                                                delete_handler=self._handle_delete_trigger,
                                                trigger_types=self._trigger_types,
-                                               queue_suffix='sensorwrapper')
+                                               queue_suffix='sensorwrapper_%s_%s' %
+                                               (self._pack, self._class_name),
+                                               exclusive=True)
 
         # 4. Set up logging
         self._logger = logging.getLogger('SensorWrapper.%s' %

--- a/st2reactor/st2reactor/timer/base.py
+++ b/st2reactor/st2reactor/timer/base.py
@@ -47,7 +47,8 @@ class St2Timer(object):
                                                update_handler=self._handle_update_trigger,
                                                delete_handler=self._handle_delete_trigger,
                                                trigger_types=self._trigger_types,
-                                               queue_suffix='timers')
+                                               queue_suffix='timers',
+                                               exclusive=True)
         self._trigger_dispatcher = TriggerDispatcher(LOG)
 
     def start(self):

--- a/st2reactor/st2reactor/timer/base.py
+++ b/st2reactor/st2reactor/timer/base.py
@@ -47,7 +47,7 @@ class St2Timer(object):
                                                update_handler=self._handle_update_trigger,
                                                delete_handler=self._handle_delete_trigger,
                                                trigger_types=self._trigger_types,
-                                               queue_suffix='timers',
+                                               queue_suffix=self.__class__.__name__,
                                                exclusive=True)
         self._trigger_dispatcher = TriggerDispatcher(LOG)
 

--- a/tools/migrate_messaging_setup.py
+++ b/tools/migrate_messaging_setup.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A migration script that cleans up old queues.
+"""
+
+import traceback
+
+from kombu import Connection
+from st2common import config
+from st2common.transport import reactor
+from st2common.transport import utils as transport_utils
+
+
+class Migrate_0_13_x_to_1_1_0(object):
+    """
+    Handles migration of messaging setup from 0.13.x to 1.1.
+    """
+
+    # All these queues are either not required due to name
+    # changes or changes in durability proeprties.
+    OLD_QS = [
+        # Name changed in 1.1
+        reactor.get_trigger_cud_queue('st2.trigger.watch.timers', routing_key='#'),
+        # Split to multiple queues in 1.1
+        reactor.get_trigger_cud_queue('st2.trigger.watch.sensorwrapper', routing_key='#'),
+        # Name changed in 1.1
+        reactor.get_trigger_cud_queue('st2.trigger.watch.webhooks', routing_key='#')
+    ]
+
+    def migrate(self):
+        self._cleanup_old_queues()
+
+    def _cleanup_old_queues(self):
+        with Connection(transport_utils.get_messaging_urls()) as connection:
+            for q in self.OLD_QS:
+                bound_q = q(connection.default_channel)
+                try:
+                    bound_q.delete()
+                except:
+                    print('Failed to delete %s.' % q.name)
+                    traceback.print_exc()
+
+
+def main():
+    try:
+        migrator = Migrate_0_13_x_to_1_1_0()
+        migrator.migrate()
+    except:
+        print('Messaging setup migration failed.')
+        traceback.print_exc()
+
+
+if __name__ == '__main__':
+    config.parse_args(args={})
+    main()

--- a/tools/st2_deploy.sh
+++ b/tools/st2_deploy.sh
@@ -982,6 +982,12 @@ migrate_triggers() {
   $PYTHON ${PYTHONPACK}/st2common/bin/migrate_triggers_to_include_ref_count.py
 }
 
+migrate_messaging_setup() {
+  echo "###########################################################################################"
+  echo "# Migrating messaging setup."
+  $PYTHON ${PYTHONPACK}/st2common/bin/migrate_messaging_setup.py
+}
+
 register_content() {
   echo "###########################################################################################"
   echo "# Registering all content"
@@ -1106,6 +1112,7 @@ fi
 
 if version_ge $VER "1.0"; then
   migrate_triggers
+  migrate_messaging_setup
 fi
 
 register_content


### PR DESCRIPTION
* Sleeping for 4s between message retrievals causes unnecessary latency.
  Reducing to 0 since this is for co-oprative yields anyway so length
  should not matter. If it does I promise you we have a much larger problem.
* An ability to define Qs as exclusive to a connection.

* Processing old messages leads to unpredicatable behavior. With the
  TriggerWatcher consumers the idea is to 1st read from DB and then
  start consuming messages. However, non exclusive Qs cause old messages
  to be consumed leading to bugs and unpredicatbale behavior. e.g. and
  old create/update/delete might be processed.
* SensorWrapper should not share Qs. This would mean that the messages
  end up being distributed across sensor_wrappers. Each sensor_wrapper
  should get all messages and choose to process them or not.

Testing -
1. Validate passive sensor
2. Validated polling sensor