### PR TITLE
[docs] Change sh to bash for AIO installer instructions

### DIFF
--- a/docs/source/install/all_in_one.rst
+++ b/docs/source/install/all_in_one.rst
@@ -54,7 +54,7 @@ Bring Your Own Box
 
 ::
 
-    curl -sSL https://raw.githubusercontent.com/StackStorm/st2workroom/master/script/bootstrap-st2express | sudo sh
+    curl -sSL https://raw.githubusercontent.com/StackStorm/st2workroom/master/script/bootstrap-st2express | sudo bash
 
 You will need elevated privileges in order to run this script. This will boot up a fresh |st2| installation along with the Mistral workflow engine on Ubuntu 14.04 LTS. While loading, some console output in red is expected and can be safely ignored. Once completed, you will see the following console output.
 


### PR DESCRIPTION
Tiny doc update.

As @Kami noted here: https://github.com/StackStorm/st2/issues/2083#issuecomment-149188086 AIO installer script
https://raw.githubusercontent.com/StackStorm/st2workroom/master/script/bootstrap-st2express requires `bash`.