### PR TITLE
Ensure st2ctl sources global env

### DIFF
--- a/tools/st2ctl
+++ b/tools/st2ctl
@@ -6,6 +6,11 @@ COMPONENTS="st2actionrunner st2api st2auth st2sensorcontainer st2rulesengine st2
 STANCONF="/etc/st2/st2.conf"
 PYTHON=`which python2.7`
 
+# Ensure global environment is sourced if exists
+# Does not happen consistently with all OSes we support.
+[ -r /etc/environment ] && . /etc/environment
+
+
 # AR is assumed to be an environment variable.
 if [ -z "$AR" ];
  then


### PR DESCRIPTION
To normalize behaviors across different OSes, this commit ensures that the environment is properly sourced.