### PR TITLE
Do not raise delete trigger event on an update of a rule

### DIFF
--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -181,9 +181,11 @@ class MongoDBAccess(object):
         return instance.delete()
 
     def delete_by_query(self, **query):
-        result = self.model.objects.filter(**query).delete()
-        log_query_and_profile_data_for_queryset(queryset=result)
-        return result
+        qs = self.model.objects.filter(**query)
+        qs.delete()
+        log_query_and_profile_data_for_queryset(queryset=qs)
+        # mongoengine does not return anything useful so cannot return anything meaningful.
+        return None
 
     def _undo_dict_field_escape(self, instance):
         for attr, field in instance._fields.iteritems():

--- a/st2reactor/conf/logging.rulesengine.conf
+++ b/st2reactor/conf/logging.rulesengine.conf
@@ -19,7 +19,7 @@ args=(sys.stdout,)
 
 [handler_fileHandler]
 class=handlers.RotatingFileHandler
-level=INFO
+level=DEBUG
 formatter=verboseConsoleFormatter
 args=("logs/st2rulesengine.log",)
 

--- a/st2reactor/conf/logging.rulesengine.conf
+++ b/st2reactor/conf/logging.rulesengine.conf
@@ -19,7 +19,7 @@ args=(sys.stdout,)
 
 [handler_fileHandler]
 class=handlers.RotatingFileHandler
-level=DEBUG
+level=INFO
 formatter=verboseConsoleFormatter
 args=("logs/st2rulesengine.log",)
 


### PR DESCRIPTION
Turns out the check to validate if delete_by_reference actually deleted a TriggerDB was missing. Check brought in therefore should now fix the regression.