### PR TITLE
Write webhook file to home

### DIFF
--- a/contrib/examples/rules/sample_rule_with_webhook.yaml
+++ b/contrib/examples/rules/sample_rule_with_webhook.yaml
@@ -17,4 +17,4 @@
     action:
         ref: "core.local"
         parameters:
-            cmd: "echo \"{{trigger.body}}\" >> /tmp/st2.webhook_sample.out"
+            cmd: "echo \"{{trigger.body}}\" >> ~/st2.webhook_sample.out"


### PR DESCRIPTION
* On RHEL7 writing to /tmp does not work. Not sure why but it fails causing
  test failures. Therefore writing to ~ which should always be allowed.