### PR TITLE
docs/install: reference correct stack

### DIFF
--- a/docs/source/install/all_in_one.rst
+++ b/docs/source/install/all_in_one.rst
@@ -88,14 +88,14 @@ Vagrant
 
    git clone https://github.com/StackStorm/st2workroom.git st2workroom
    cd st2workroom
-   vagrant up st2express
+   vagrant up st2
 
 
 If you have previously used deployed |st2| and downloaded the st2express box it might be a good idea to update the box. If this is your absolute first install of |st2| then skip this step.
 
 ::
 
-  vagrant box update st2express
+  vagrant box update st2
 
 
 This will boot up a fresh |st2| installation along with the Mistral workflow engine on Ubuntu 14.04 LTS. While loading, some console output in red is expected and can be safely ignored. Once completed, you will see the following console output.


### PR DESCRIPTION
https://github.com/StackStorm/st2workroom/blob/master/stacks/st2.yaml#L21 has no stack `st2express`, but does have `st2`.

Fixes the following first install issue:

```
[logikal] git clone https://github.com/StackStorm/st2workroom.git st2workroom
cd st2workroom
vagrant up st2expressCloning into 'st2workroom'...
remote: Counting objects: 6520, done.
remote: Compressing objects: 100% (49/49), done.
remote: Total 6520 (delta 18), reused 0 (delta 0), pack-reused 6471
Receiving objects: 100% (6520/6520), 14.98 MiB | 1.10 MiB/s, done.
Resolving deltas: 100% (3880/3880), done.
Checking connectivity... done.
[logikal] cd st2workroom
[st2workroom] vagrant up st2express                                                                                                      master
Installing the 'dotenv' plugin. This can take a few minutes...
Installed the plugin 'dotenv (2.0.2)'!
Installing the 'deep_merge' plugin. This can take a few minutes...
Installed the plugin 'deep_merge (1.0.1)'!
The machine with the name 'st2express' was not found configured for
this Vagrant environment.
vagrant up st2express  27.32s user 4.50s system 48% cpu 1:06.07 total