### PR TITLE
Move auth enable check to the hook itself

### DIFF
--- a/st2api/st2api/app.py
+++ b/st2api/st2api/app.py
@@ -82,9 +82,7 @@ def setup_app(config=None):
     active_hooks = [hooks.RequestIDHook(), hooks.JSONErrorResponseHook(),
                     hooks.LoggingHook()]
 
-    if cfg.CONF.auth.enable:
-        active_hooks.append(hooks.AuthHook())
-
+    active_hooks.append(hooks.AuthHook())
     active_hooks.append(hooks.CorsHook())
 
     app = pecan.make_app(app_conf.pop('root'),

--- a/st2common/st2common/hooks.py
+++ b/st2common/st2common/hooks.py
@@ -123,13 +123,14 @@ class AuthHook(PecanHook):
                 re.search(AUTH_TOKENS_URL_REGEX, state.request.path)):
             return
 
-        user_db = self._validate_creds_and_get_user(request=state.request)
+        if cfg.CONF.auth.enable:
+            user_db = self._validate_creds_and_get_user(request=state.request)
 
-        # Store related user object in the context. The token is not passed
-        # along any longer as that should only be used in the auth domain.
-        state.request.context['auth'] = {
-            'user': user_db
-        }
+            # Store related user object in the context. The token is not passed
+            # along any longer as that should only be used in the auth domain.
+            state.request.context['auth'] = {
+                'user': user_db
+            }
 
         if QUERY_PARAM_ATTRIBUTE_NAME in state.arguments.keywords:
             del state.arguments.keywords[QUERY_PARAM_ATTRIBUTE_NAME]

--- a/st2stream/st2stream/app.py
+++ b/st2stream/st2stream/app.py
@@ -86,9 +86,7 @@ def setup_app(config=None):
     active_hooks = [hooks.RequestIDHook(), hooks.JSONErrorResponseHook(),
                     hooks.LoggingHook()]
 
-    if cfg.CONF.auth.enable:
-        active_hooks.append(hooks.AuthHook())
-
+    active_hooks.append(hooks.AuthHook())
     active_hooks.append(hooks.CorsHook())
 
     app = pecan.make_app(app_conf.pop('root'),


### PR DESCRIPTION
There's an inconsistency in handling the `x-auth-token` query param when sending it to the server with disabled auth makes /stream endpoint return 400 due to different controller signature.
