### PR TITLE
Use 127.0.0.1 instead of localhost

### DIFF
--- a/st2client/st2client/client.py
+++ b/st2client/st2client/client.py
@@ -29,7 +29,7 @@ LOG = logging.getLogger(__name__)
 DEFAULT_API_PORT = 9101
 DEFAULT_AUTH_PORT = 9100
 
-DEFAULT_BASE_URL = 'http://localhost'
+DEFAULT_BASE_URL = 'http://127.0.0.1'
 DEFAULT_API_VERSION = 'v1'
 
 

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -165,7 +165,7 @@ def register_opts(ignore_errors=False):
 
     # Mistral options
     mistral_opts = [
-        cfg.StrOpt('v2_base_url', default='http://localhost:8989/v2', help='v2 API root endpoint.'),
+        cfg.StrOpt('v2_base_url', default='http://127.0.0.1:8989/v2', help='v2 API root endpoint.'),
         cfg.IntOpt('max_attempts', default=180, help='Max attempts to reconnect.'),
         cfg.IntOpt('retry_wait', default=5, help='Seconds to wait before reconnecting.'),
         cfg.StrOpt('keystone_username', default=None, help='Username for authentication.'),

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -106,7 +106,7 @@ def register_opts(ignore_errors=False):
     messaging_opts = [
         # It would be nice to be able to deprecate url and completely switch to using
         # url. However, this will be a breaking change and will have impact so allowing both.
-        cfg.StrOpt('url', default='amqp://guest:guest@localhost:5672//',
+        cfg.StrOpt('url', default='amqp://guest:guest@127.0.0.1:5672//',
                    help='URL of the messaging server.'),
         cfg.ListOpt('cluster_urls', default=[],
                     help='URL of all the nodes in a messaging service cluster.')
@@ -114,7 +114,7 @@ def register_opts(ignore_errors=False):
     do_register_opts(messaging_opts, 'messaging', ignore_errors)
 
     syslog_opts = [
-        cfg.StrOpt('host', default='localhost',
+        cfg.StrOpt('host', default='127.0.0.1',
                    help='Host for the syslog server.'),
         cfg.IntOpt('port', default=514,
                    help='Port for the syslog server.'),

--- a/st2exporter/conf/st2exporter.dev.conf
+++ b/st2exporter/conf/st2exporter.dev.conf
@@ -2,7 +2,7 @@
 logging = st2actions/conf/logging.notifier.conf
 
 [messaging]
-url = amqp://guest:guest@localhost:5672/
+url = amqp://guest:guest@127.0.0.1:5672/
 
 [log]
 excludes = requests,paramiko


### PR DESCRIPTION
* Usually mistral binds to 127.0.0.1 and localhost may not
  re-direct to 127.0.0.1 therefore safer to use 127.0.0.1.