### PR TITLE
Refine Installation/Vagrant

### DIFF
--- a/docs/source/install/vagrant.rst
+++ b/docs/source/install/vagrant.rst
@@ -1,7 +1,7 @@
 Vagrant
 =======
 
-|st2| provides pre-built Vagrant boxes for both `VirtualBox <https://www.virtualbox.org>` and `VMWare <https://www.vmware.com>` providers. By default, the setup will install the lastest stable release of |st2|. These boxes are hosted on the `Hashicorp Atlas <https://atlas.hashicorp.com/stackstorm/boxes/st2>` website.
+|st2| provides pre-built Vagrant boxes for both `VirtualBox <https://www.virtualbox.org>`_ and `VMWare <https://www.vmware.com>`_ providers. By default, the setup will install the lastest stable release of |st2|. These boxes are hosted on the `Hashicorp Atlas <https://atlas.hashicorp.com/stackstorm/boxes/st2>`_ website.
 
 Using these vagrant images, it is possible to setup:
 
@@ -9,8 +9,12 @@ Using these vagrant images, it is possible to setup:
 * Spin up a development environment to work with StackStorm (`st2dev`)
 * Begin building infrastructure patterns using pre-configured Config Management tools
 
-Quick Start
------------
+You can also create your own Vagrant VM and run :doc:<all_in_one>.
+
+NOTE: the `st2express/Vagrant <https://github.com/StackStorm/st2express>`__ is deprecated in _v0.13_.
+
+Quick Start with st2workroom
+----------------------------
 
 If you are new to Vagrant, or to StackStorm, we have made a repository all setup with the necessary configuration to run a Vagrant box. This includes pre-configured virtual machine settings out of the box. This is a great way to get started quickly and easily.
 
@@ -40,10 +44,11 @@ Once installed, you have the option of logging into the virtual machine with thi
 
 Likewise, you have the option to run the All-in-one GUI setup. Using this tool, you can quickly configure your StackStorm system including user accounts, ChatOps support, and enable Enterprise Features. Refer to :ref:`all_in_one-running_the_setup` section of :doc:`./all_in_one` for more information.
 
-NOTE: the `st2express/Vagrant <https://github.com/StackStorm/st2express>`__ is deprecated in _v0.13_.
 
+Run Vagrant with All-In-One Installer
+-------------------------------------
 Requirements
-------------
+~~~~~~~~~~~~
 
 In order to successfully deploy StackStorm to a Vagrant environment, you must ensure the following conditions are satisified. Namely:
 
@@ -53,7 +58,7 @@ In order to successfully deploy StackStorm to a Vagrant environment, you must en
 Once setup, the next step is to run the StackStorm installer. This will pull down and setup all the necessary items to run StackStorm Using this tool, you can quickly configure your StackStorm system including user accounts, ChatOps support, and enable Enterprise Features. Refer to :ref:`all_in_one-running_the_setup` section of :doc:`./all_in_one` for more information.
 
 Supported Baseboxes
--------------------
+~~~~~~~~~~~~~~~~~~~
 
 We have currently done testing and certified that StackStorm Installer works properly on the following Vagrant Baseboxes:
 
@@ -66,18 +71,11 @@ It is very possible that other baseboxes with the same OS will work just fine. H
 We are constantly striving to ensure that we have compatability with as many platforms as we can. However, if you find a basebox that doesn't work, please let us know and we'll be glad to take a look. We also love Pull Requests from the community, and might have some goodies if you help us out!
 
 Sample Vagrantfile
-------------------
+~~~~~~~~~~~~~~~~~~
 
-Below is an an example of a Vagrantfile capable of loading StackStorm. This minimal Vagrantfile will load up a machine and provision a clean StackStorm installation.This configuration also includes a `public_network` setting, which is necessary to allow your host environment to access the StackStorm guest machine. If you choose not to use this configuration, make sure that you have an interface configured that you can access via the Host Machine.
+Below is an an example of a Vagrantfile capable of loading StackStorm. This Vagrantfile will load up a machine and provision a clean StackStorm installation. This configuration also includes a `public_network` setting, which is necessary to allow your host environment to access the StackStorm guest machine. If you choose not to use this configuration, make sure that you have an interface configured that you can access via the Host Machine.
 
-::
+.. literalinclude:: ../../../scripts/Vagrantfile
+   :language: ruby
 
-    Vagrant.configure(2) do |config|
-      config.vm.network "public_network"
-      config.vm.box = "puppetlabs/ubuntu-14.04-64-nocm"
-      config.vm.provider "virtualbox" do |v|
-        v.memory = 1024
-      end
-      config.vm.provision "shell",
-          inline: "curl -sSL http://stackstorm.com/install.sh | sudo su"
-    end
+

--- a/scripts/Vagrantfile
+++ b/scripts/Vagrantfile
@@ -1,0 +1,37 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+hostname = ENV['HOSTNAME'] ? ENV['HOSTNAME'] : 'st2test'
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+    config.vm.network "public_network"
+    # config.vm.network "private_network", ip: "172.168.90.65"
+    config.vm.hostname = "#{hostname}"
+
+    config.vm.define "u14" do |u14|
+      u14.vm.box = 'puppetlabs/ubuntu-14.04-64-nocm'
+    end
+
+    config.vm.define "el6" do |el6|
+      el6.vm.box = 'puppetlabs/centos-6.6-64-nocm'
+    end
+
+    config.vm.define "el7" do |el7|
+      el7.vm.box = 'puppetlabs/centos-7.0-64-nocm'
+    end
+
+    config.vm.provider :virtualbox do |vb|
+      vb.name = "#{hostname}"
+      vb.memory = 2048
+      vb.cpus = 2
+    end
+
+    # Configure a private network
+
+    config.vm.provision "shell", inline: "curl -sSL http://stackstorm.com/install.sh | sudo su"
+
+end


### PR DESCRIPTION
* Clarify separation between st2workroom and all-in-one on Vagrant box
* Take Manas' Vagrant file as example, and keep it with source.

@jfryman pls take a look. Except links fixes, these are optional adjustments. Also, while I like having a real Vagrantfile, if you people think it's a wrong place and we don't have a good place, ok to copy it literally, or revert to simplistic one. 