### PR TITLE
Make runners.sh actually work (on Jessie)

### DIFF
--- a/st2actions/bin/runners.sh
+++ b/st2actions/bin/runners.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-SYSTEMDCTL=/usr/bin/systemctl
+SYSTEMDCTL=/bin/systemctl
 UPSTARTCTL=/sbin/initctl
 SPAWNSVC=st2actionrunner
 WORKERSVC=st2actionrunner-worker


### PR DESCRIPTION
Debian keeps `systemctl` in `/bin`, CentOS/RHEL keeps it in `/usr/bin`. CentOS/RHEL symlinks `/bin` to `/usr/bin`, so this change enables Jessie compatibility.