### PR TITLE
Add bindir to st2actions for debian packages

### DIFF
--- a/st2actions/packaging/debian/install
+++ b/st2actions/packaging/debian/install
@@ -1,4 +1,5 @@
 st2actions usr/lib/python2.7/dist-packages/
 st2actions usr/lib/python2.7/dist-packages/
 conf/* etc/st2actions/
+bin usr/lib/python2.7/dist-packages/st2actions/
 bin/* usr/bin/


### PR DESCRIPTION
Same change as in StackStorm/st2#2077.

Accidentally added a commit I shouldn't have to #2142 , this rectifies that.