### PR TITLE
Adding info on action_context variables set by action aliases

### DIFF
--- a/docs/source/chatops/aliases.rst
+++ b/docs/source/chatops/aliases.rst
@@ -133,6 +133,13 @@ In this the action google.get_search_results would be called with the parameters
        query: StackStorm
        limit: 10
 
+Additional ChatOps parameters passed to the command
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+An execution triggered via chatops will contain variables such as ``action_context.api_user``, ``action_context.user`` and ``action_context.source_channel``. ``api_user`` is the user who's kicking off the chatops command from
+client and ``user`` is the |st2| user configured in hubot. ``source_channel`` is the channel
+in which the chatops command was kicked off.
+
 Multiple formats in single alias
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -164,4 +171,6 @@ ChatOps
 
 To see how to use aliases with your favorite Chat client and implement ChatOps in your infrastructure
 go `here <https://github.com/StackStorm/st2/blob/master/instructables/chatops.md>`_.
+
+
 


### PR DESCRIPTION
This info is part of the action documentation but I could not find it here and only learned about it after asking in the community slack channel.