### PR TITLE
Remove newline characters in sendmail

### DIFF
--- a/contrib/core/actions/send_mail/send_mail
+++ b/contrib/core/actions/send_mail/send_mail
@@ -30,7 +30,7 @@ BODY="$@"
 if [[ "${CONTENT_TYPE}" = "text/html" ]]; then
   LINE_BREAK="<br><br>"
 else
-  LINE_BREAK="\n\n"
+  LINE_BREAK=""
 fi
 
 trimmed="${BODY// }"


### PR DESCRIPTION
In text/plain version, the newline characters show literally in the body of the email.  This solution achieves the desired "double-spaced" formatting.