### PR TITLE
Introduce Announcements

### DIFF
--- a/contrib/core/actions/announcement.yaml
+++ b/contrib/core/actions/announcement.yaml
@@ -1,0 +1,10 @@
+---
+description: Action that broadcasts the announcement to all stream consumers.
+enabled: true
+entry_point: ''
+name: announcement
+parameters:
+  message:
+    description: Message to broadcast.
+    type: string
+runner_type: announcement

--- a/contrib/core/actions/announcement.yaml
+++ b/contrib/core/actions/announcement.yaml
@@ -4,7 +4,10 @@ enabled: true
 entry_point: ''
 name: announcement
 parameters:
+  experimental:
+    immutable: true
+    default: true
   message:
     description: Message to broadcast.
-    type: string
+    type: object
 runner_type: announcement

--- a/st2actions/st2actions/runners/announcementrunner.py
+++ b/st2actions/st2actions/runners/announcementrunner.py
@@ -1,0 +1,41 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import uuid
+
+from st2actions.runners import ActionRunner
+from st2common import log as logging
+from st2common.constants.action import LIVEACTION_STATUS_SUCCEEDED
+from st2common.transport.announcement import AnnouncementDispatcher
+
+LOG = logging.getLogger(__name__)
+
+
+def get_runner():
+    return AnnouncementRunner(str(uuid.uuid4()))
+
+
+class AnnouncementRunner(ActionRunner):
+    def __init__(self, runner_id):
+        super(AnnouncementRunner, self).__init__(runner_id=runner_id)
+        self._dispatcher = AnnouncementDispatcher(LOG)
+
+    def pre_run(self):
+        LOG.debug('Entering AnnouncementRunner.pre_run() for liveaction_id="%s"',
+                  self.liveaction_id)
+
+    def run(self, action_parameters):
+        self._dispatcher.dispatch('general', payload=action_parameters)
+        return (LIVEACTION_STATUS_SUCCEEDED, {'OK': True}, None)

--- a/st2actions/tests/unit/test_announcementrunner.py
+++ b/st2actions/tests/unit/test_announcementrunner.py
@@ -1,0 +1,93 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+
+from st2actions.runners import announcementrunner
+from st2common.constants.action import LIVEACTION_STATUS_SUCCEEDED
+from st2common.models.api.trace import TraceContext
+from base import RunnerTestCase
+import st2tests.config as tests_config
+
+
+mock_dispatcher = mock.Mock()
+
+
+@mock.patch('st2common.transport.announcement.AnnouncementDispatcher.dispatch')
+class AnnouncementRunnerTestCase(RunnerTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        tests_config.parse_args()
+
+    def test_runner_creation(self, dispatch):
+        runner = announcementrunner.get_runner()
+        self.assertTrue(runner is not None, 'Creation failed. No instance.')
+        self.assertEqual(type(runner), announcementrunner.AnnouncementRunner,
+                         'Creation failed. No instance.')
+        self.assertEqual(runner._dispatcher.dispatch, dispatch)
+
+    def test_announcement(self, dispatch):
+        runner = announcementrunner.get_runner()
+        runner.runner_parameters = {
+            'experimental': True,
+            'route': 'general'
+        }
+        runner.liveaction = mock.Mock(context={})
+
+        runner.pre_run()
+        (status, result, _) = runner.run({'test': 'passed'})
+
+        self.assertEqual(status, LIVEACTION_STATUS_SUCCEEDED)
+        self.assertTrue(result is not None)
+        self.assertEqual(result['test'], 'passed')
+        dispatch.assert_called_once_with('general', payload={'test': 'passed'},
+                                         trace_context=None)
+
+    def test_announcement_no_experimental(self, dispatch):
+        runner = announcementrunner.get_runner()
+        runner.action = mock.Mock(ref='some.thing')
+        runner.runner_parameters = {
+            'route': 'general'
+        }
+        runner.liveaction = mock.Mock(context={})
+
+        expected_msg = 'Experimental flag is missing for action some.thing'
+        self.assertRaisesRegexp(Exception, expected_msg, runner.pre_run)
+
+    @mock.patch('st2common.models.api.trace.TraceContext.__new__')
+    def test_announcement_with_trace(self, context, dispatch):
+        runner = announcementrunner.get_runner()
+        runner.runner_parameters = {
+            'experimental': True,
+            'route': 'general'
+        }
+        runner.liveaction = mock.Mock(context={
+            'trace_context': {
+                'id_': 'a',
+                'trace_tag': 'b'
+            }
+        })
+
+        runner.pre_run()
+        (status, result, _) = runner.run({'test': 'passed'})
+
+        self.assertEqual(status, LIVEACTION_STATUS_SUCCEEDED)
+        self.assertTrue(result is not None)
+        self.assertEqual(result['test'], 'passed')
+        context.assert_called_once_with(TraceContext,
+                                        **runner.liveaction.context['trace_context'])
+        dispatch.assert_called_once_with('general', payload={'test': 'passed'},
+                                         trace_context=context.return_value)

--- a/st2common/st2common/bootstrap/runnersregistrar.py
+++ b/st2common/st2common/bootstrap/runnersregistrar.py
@@ -405,6 +405,20 @@ RUNNER_TYPES = [
         'description': 'A runner for emitting an announcement event on the stream.',
         'enabled': True,
         'runner_parameters': {
+            'experimental': {
+                'description': 'Flag to indicate acknowledment of using experimental runner',
+                'type': 'boolean',
+                'required': True,
+                'default': False
+            },
+            'route': {
+                'description': ('The routing_key used to route the message to consumers. '
+                                'Might be a list of words, delimited by dots.'),
+                'type': 'string',
+                'default': 'general',
+                'minLength': 1,
+                'maxLength': 255
+            }
         },
         'runner_module': 'st2actions.runners.announcementrunner'
     },

--- a/st2common/st2common/bootstrap/runnersregistrar.py
+++ b/st2common/st2common/bootstrap/runnersregistrar.py
@@ -400,6 +400,15 @@ RUNNER_TYPES = [
 
     # Experimental runners below
     {
+        'name': 'announcement',
+        'aliases': [],
+        'description': 'A runner for emitting an announcement event on the stream.',
+        'enabled': True,
+        'runner_parameters': {
+        },
+        'runner_module': 'st2actions.runners.announcementrunner'
+    },
+    {
         'name': 'windows-cmd',
         'aliases': [],
         'description': 'A remote execution runner that executes commands'

--- a/st2common/st2common/models/api/trace.py
+++ b/st2common/st2common/models/api/trace.py
@@ -154,3 +154,6 @@ class TraceContext(object):
 
     def __str__(self):
         return '{id_: %s, trace_tag: %s}' % (self.id_, self.trace_tag)
+
+    def __json__(self):
+        return vars(self)

--- a/st2common/st2common/transport/announcement.py
+++ b/st2common/st2common/transport/announcement.py
@@ -37,19 +37,19 @@ class AnnouncementPublisher(object):
 
 class AnnouncementDispatcher(object):
     """
-    This trigger dispatcher dispatches trigger instances to a message queue (RabbitMQ).
+    This announcement dispatcher dispatches announcements to a message queue (RabbitMQ).
     """
 
     def __init__(self, logger=LOG):
         self._publisher = AnnouncementPublisher(urls=transport_utils.get_messaging_urls())
         self._logger = logger
 
-    def dispatch(self, routing_key, payload=None, trace_context=None):
+    def dispatch(self, routing_key, payload, trace_context=None):
         """
         Method which dispatches the announcement.
 
-        :param trigger: Full name / reference of the announcement.
-        :type trigger: ``str`` or ``object``
+        :param routing_key: Routing key of the announcement.
+        :type routing_key: ``str``
 
         :param payload: Announcement payload.
         :type payload: ``dict``

--- a/st2common/st2common/transport/announcement.py
+++ b/st2common/st2common/transport/announcement.py
@@ -31,7 +31,7 @@ class AnnouncementPublisher(object):
     def __init__(self, urls):
         self._publisher = publishers.PoolPublisher(urls=urls)
 
-    def publish(self, payload=None, routing_key=None):
+    def publish(self, payload, routing_key):
         self._publisher.publish(payload, ANNOUNCEMENT_XCHG, routing_key)
 
 
@@ -70,5 +70,5 @@ class AnnouncementDispatcher(object):
         self._publisher.publish(payload=payload, routing_key=routing_key)
 
 
-def get_queue(name=None, routing_key=None, exclusive=False):
+def get_queue(name=None, routing_key='#', exclusive=False):
     return Queue(name, ANNOUNCEMENT_XCHG, routing_key=routing_key, exclusive=exclusive)

--- a/st2common/st2common/transport/announcement.py
+++ b/st2common/st2common/transport/announcement.py
@@ -1,0 +1,74 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kombu import Exchange, Queue
+
+from st2common import log as logging
+from st2common.constants.trace import TRACE_CONTEXT
+from st2common.models.api.trace import TraceContext
+from st2common.transport import publishers
+from st2common.transport import utils as transport_utils
+
+LOG = logging.getLogger(__name__)
+
+# Exchange for Announcements
+ANNOUNCEMENT_XCHG = Exchange('st2.announcement', type='topic')
+
+
+class AnnouncementPublisher(object):
+    def __init__(self, urls):
+        self._publisher = publishers.PoolPublisher(urls=urls)
+
+    def publish(self, payload=None, routing_key=None):
+        self._publisher.publish(payload, ANNOUNCEMENT_XCHG, routing_key)
+
+
+class AnnouncementDispatcher(object):
+    """
+    This trigger dispatcher dispatches trigger instances to a message queue (RabbitMQ).
+    """
+
+    def __init__(self, logger=LOG):
+        self._publisher = AnnouncementPublisher(urls=transport_utils.get_messaging_urls())
+        self._logger = logger
+
+    def dispatch(self, routing_key, payload=None, trace_context=None):
+        """
+        Method which dispatches the announcement.
+
+        :param trigger: Full name / reference of the announcement.
+        :type trigger: ``str`` or ``object``
+
+        :param payload: Announcement payload.
+        :type payload: ``dict``
+
+        :param trace_context: Trace context to associate with Announcement.
+        :type trace_context: ``TraceContext``
+        """
+        assert isinstance(payload, (type(None), dict))
+        assert isinstance(trace_context, (type(None), TraceContext))
+
+        payload = {
+            'payload': payload,
+            TRACE_CONTEXT: trace_context
+        }
+
+        self._logger.debug('Dispatching announcement (routing_key=%s,payload=%s)',
+                           routing_key, payload)
+        self._publisher.publish(payload=payload, routing_key=routing_key)
+
+
+def get_queue(name=None, routing_key=None, exclusive=False):
+    return Queue(name, ANNOUNCEMENT_XCHG, routing_key=routing_key, exclusive=exclusive)


### PR DESCRIPTION
An attempt to generalize the idea of st2 posting a message to stream consumer.

It is intended to be drop-in replacement for `hubot.post_results` that will allow us to switch to using streams in hubot without redesigning the whole pipeline top to bottom.

It is also intended to be used as a general way of sending notifications to the public as opposed to `Notification` mechanic for reacting on events within st2 internally. Currently internal Notifications becoming external Announcements by means of rules. Announcements could also be called directly as a part of workflow, same way `hubot.post_message` and `slack.post_message` work right now.