### PR TITLE
Improve speed of "execution list" and "execution get" commands

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,10 @@ in development
   the targeted box. (new feature, improvement) #2144, #2150 [Logan Attwood]
 * Improve speed of ``st2 execution list`` command by not requesting ``result`` and
   ``trigger_instance`` attributes. The effect of this change will be especially pronounced for
-  installations with a lot of large executions.
+  installations with a lot of large executions (large execution for this purpose is an execution
+  with a large result).
+* Improve speed of ``st2 execution get`` command by not requesting ``result`` and
+  ``trigger_instance`` attributes.
 
 1.1.0 - October 27, 2015
 ------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ in development
   with a large result).
 * Improve speed of ``st2 execution get`` command by not requesting ``result`` and
   ``trigger_instance`` attributes.
+* Now when running ``st2api`` service in debug mode (``--debug``) flag, all the JSON responses are
+  pretty indented.
 
 1.1.0 - October 27, 2015
 ------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,9 @@ in development
   for Mistral have changed. (improvement)
 * Add SSH bastion host support to the paramiko SSH runner. Utilizes same connection parameters as
   the targeted box. (new feature, improvement) #2144, #2150 [Logan Attwood]
+* Improve speed of ``st2 execution list`` command by not requesting ``result`` and
+  ``trigger_instance`` attributes. The effect of this change will be especially pronounced for
+  installations with a lot of large executions.
 
 1.1.0 - October 27, 2015
 ------------------------

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -895,6 +895,10 @@ class ActionExecutionListCommand(resource.ResourceCommand):
         if args.timestamp_lt:
             kwargs['timestamp_lt'] = args.timestamp_lt
 
+        # We exclude "result" and "trigger_instance" attributes which can contain a lot of data
+        # since they are not displayed nor used which speeds the common operation substantially.
+        kwargs['exclude_attributes'] = 'result,trigger_instance'
+
         return self.manager.query(limit=args.last, **kwargs)
 
     def run_and_print(self, args, **kwargs):

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -927,6 +927,17 @@ class ActionExecutionGetCommand(ActionRunCommandMixin, resource.ResourceCommand)
 
     @add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
+        # We exclude "result" and / or "trigger_instance" attribute if it's not explicitly
+        # requested by user either via "--attr" flag or by default.
+        exclude_attributes = []
+
+        if 'result' not in args.attr:
+            exclude_attributes.append('result')
+        if 'trigger_instance' not in args.attr:
+            exclude_attributes.append('trigger_instance')
+
+        kwargs['params'] = {'exclude_attributes': ','.join(exclude_attributes)}
+
         execution = self.get_resource_by_id(id=args.id, **kwargs)
         return execution
 

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -824,7 +824,26 @@ class ActionExecutionBranch(resource.ResourceBranch):
 POSSIBLE_ACTION_STATUS_VALUES = ('succeeded', 'running', 'scheduled', 'failed', 'canceled')
 
 
-class ActionExecutionListCommand(resource.ResourceCommand):
+class ActionExecutionReadCommand(resource.ResourceCommand):
+    """
+    Base class for read / view commands (list and get).
+    """
+
+    def _get_exclude_attributes(self, args):
+        """
+        Retrieve a list of exclude attributes for particular command line arguments.
+        """
+        exclude_attributes = []
+
+        if 'result' not in args.attr:
+            exclude_attributes.append('result')
+        if 'trigger_instance' not in args.attr:
+            exclude_attributes.append('trigger_instance')
+
+        return exclude_attributes
+
+
+class ActionExecutionListCommand(ActionExecutionReadCommand):
     display_attributes = ['id', 'action.ref', 'context.user', 'status', 'start_timestamp',
                           'end_timestamp']
     attribute_transform_functions = {
@@ -897,7 +916,9 @@ class ActionExecutionListCommand(resource.ResourceCommand):
 
         # We exclude "result" and "trigger_instance" attributes which can contain a lot of data
         # since they are not displayed nor used which speeds the common operation substantially.
-        kwargs['exclude_attributes'] = 'result,trigger_instance'
+        exclude_attributes = self._get_exclude_attributes(args=args)
+        exclude_attributes = ','.join(exclude_attributes)
+        kwargs['exclude_attributes'] = exclude_attributes
 
         return self.manager.query(limit=args.last, **kwargs)
 
@@ -909,7 +930,7 @@ class ActionExecutionListCommand(resource.ResourceCommand):
                           attribute_transform_functions=self.attribute_transform_functions)
 
 
-class ActionExecutionGetCommand(ActionRunCommandMixin, resource.ResourceCommand):
+class ActionExecutionGetCommand(ActionRunCommandMixin, ActionExecutionReadCommand):
     display_attributes = ['id', 'action.ref', 'context.user', 'parameters', 'status',
                           'start_timestamp', 'end_timestamp', 'result', 'liveaction']
 
@@ -929,14 +950,10 @@ class ActionExecutionGetCommand(ActionRunCommandMixin, resource.ResourceCommand)
     def run(self, args, **kwargs):
         # We exclude "result" and / or "trigger_instance" attribute if it's not explicitly
         # requested by user either via "--attr" flag or by default.
-        exclude_attributes = []
+        exclude_attributes = self._get_exclude_attributes(args=args)
+        exclude_attributes = ','.join(exclude_attributes)
 
-        if 'result' not in args.attr:
-            exclude_attributes.append('result')
-        if 'trigger_instance' not in args.attr:
-            exclude_attributes.append('trigger_instance')
-
-        kwargs['params'] = {'exclude_attributes': ','.join(exclude_attributes)}
+        kwargs['params'] = {'exclude_attributes': exclude_attributes}
 
         execution = self.get_resource_by_id(id=args.id, **kwargs)
         return execution

--- a/st2common/st2common/models/api/base.py
+++ b/st2common/st2common/models/api/base.py
@@ -24,13 +24,13 @@ import six
 from six.moves import http_client
 from webob import exc
 import pecan
-import pecan.jsonify
 import traceback
 from oslo_config import cfg
 
 from st2common.constants.pack import DEFAULT_PACK_NAME
 from st2common.util import mongoescape as util_mongodb
 from st2common.util import schema as util_schema
+from st2common.util.debugging import is_enabled as is_debugging_enabled
 from st2common.util.jsonify import json_encode
 from st2common import log as logging
 
@@ -231,7 +231,11 @@ def jsexpose(arg_types=None, body_cls=None, status_code=None, content_type='appl
             if status_code:
                 pecan.response.status = status_code
             if content_type == 'application/json':
-                return json_encode(result, indent=None)
+                if is_debugging_enabled():
+                    indent = 4
+                else:
+                    indent = None
+                return json_encode(result, indent=indent)
             else:
                 return result
 

--- a/st2common/st2common/service_setup.py
+++ b/st2common/st2common/service_setup.py
@@ -20,14 +20,12 @@ This module contains common service setup and teardown code.
 from __future__ import absolute_import
 
 import os
-import logging as stdlib_logging
 
 from oslo_config import cfg
 
 from st2common import log as logging
 from st2common.models import db
 from st2common.constants.logging import DEFAULT_LOGGING_CONF_PATH
-from st2common.logging.misc import set_log_level_for_all_loggers
 from st2common.persistence import db_init
 from st2common.transport.bootstrap_utils import register_exchanges
 from st2common.signal_handlers import register_common_signal_handlers
@@ -89,7 +87,6 @@ def setup(service, config, setup_db=True, register_mq_exchanges=True,
 
     if cfg.CONF.debug:
         enable_debugging()
-        set_log_level_for_all_loggers(level=stdlib_logging.DEBUG)
 
     # All other setup which requires config to be parsed and logging to
     # be correctly setup.

--- a/st2common/st2common/service_setup.py
+++ b/st2common/st2common/service_setup.py
@@ -31,6 +31,7 @@ from st2common.logging.misc import set_log_level_for_all_loggers
 from st2common.persistence import db_init
 from st2common.transport.bootstrap_utils import register_exchanges
 from st2common.signal_handlers import register_common_signal_handlers
+from st2common.util.debugging import enable_debugging
 from st2common.models.utils.profiling import enable_profiling
 from st2common import triggers
 
@@ -87,6 +88,7 @@ def setup(service, config, setup_db=True, register_mq_exchanges=True,
     logging.setup(logging_config_path)
 
     if cfg.CONF.debug:
+        enable_debugging()
         set_log_level_for_all_loggers(level=stdlib_logging.DEBUG)
 
     # All other setup which requires config to be parsed and logging to

--- a/st2common/st2common/util/debugging.py
+++ b/st2common/st2common/util/debugging.py
@@ -17,6 +17,10 @@
 Module containing various debugging functionality.
 """
 
+import logging as stdlib_logging
+
+from st2common.logging.misc import set_log_level_for_all_loggers
+
 __all__ = [
     'enable_debugging',
     'disable_debugging',
@@ -29,6 +33,9 @@ ENABLE_DEBUGGING = False
 def enable_debugging():
     global ENABLE_DEBUGGING
     ENABLE_DEBUGGING = True
+
+    set_log_level_for_all_loggers(level=stdlib_logging.DEBUG)
+
     return ENABLE_DEBUGGING
 
 

--- a/st2common/st2common/util/debugging.py
+++ b/st2common/st2common/util/debugging.py
@@ -1,0 +1,43 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Module containing various debugging functionality.
+"""
+
+__all__ = [
+    'enable_debugging',
+    'disable_debugging',
+    'is_enabled'
+]
+
+ENABLE_DEBUGGING = False
+
+
+def enable_debugging():
+    global ENABLE_DEBUGGING
+    ENABLE_DEBUGGING = True
+    return ENABLE_DEBUGGING
+
+
+def disable_debugging():
+    global ENABLE_DEBUGGING
+    ENABLE_DEBUGGING = False
+    return ENABLE_DEBUGGING
+
+
+def is_enabled():
+    global ENABLE_DEBUGGING
+    return ENABLE_DEBUGGING


### PR DESCRIPTION
A while back, I was debugging and checking why the output of `st2 execution list` command on our build servers is so slow.

It turns out, most of the time is spend reading data (notably the result attribute which is really large in our case since a lot of workflow actions produce tons of data) from the DB and sending all of this data over wire.

``st2 execution list`` command doesn't even display ``result`` and ``trigger_instance`` attribute by default so it makes no sense to request it.

Similar story for ``st2 execution get`` - we don't use ``trigger_instance`` by default and if user only requests one attribute using --attr option it makes no sense to also request and download other data.