### PR TITLE
Docs for enterprise license and migration

### DIFF
--- a/docs/source/install/all_in_one.rst
+++ b/docs/source/install/all_in_one.rst
@@ -1,6 +1,8 @@
 All-in-one Installer
 ********************
-|st2| provides an all-in-one installer aimed at assisting users with the initial setup and configuration. The installer comes pre-bundled in a number of different provisioning options for convenience, or can also be manually deployed and installed manually on a server.
+|st2| provides an all-in-one installer aimed at assisting users with the initial setup and configuration.
+
+.. rubric:: TL;DR
 
 That's OK! You're busy, we get it. How do you just get started? Get your own box, and run this command:
 
@@ -8,6 +10,7 @@ That's OK! You're busy, we get it. How do you just get started? Get your own box
 
    curl -sSL http://stackstorm.com/install.sh | sudo sh
 
+If you're installing *Enterprise Edition*, enter your license key when prompted. With no enterprise key, StackStorm community will be installed.
 
 .. contents:: Want to learn more? Read on! We will make it worth your while.
 
@@ -299,6 +302,7 @@ Each stable release is tagged with a Git Tag, and you can provide that tag at ru
 
    ENV=master update-system
 
+.. warning:: The update described here only applies for deployments provisioned by All-in-one installer v1.1 and above. To migrate from Scripted Installer deployments, custom deployments, or for pre v1 beta All-in-one installations, use the migration path as described in `Upgrade Notes <../upgrade_notes.html>`_.
 
 Unattended Installation
 #######################

--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -6,6 +6,8 @@ on Ubuntu/Debian or RedHat/CentOS. Skip below if you want to learn about
 :doc:`puppet` or :doc:`chef`, or other installations approaches.
 
 
+.. note:: To install Enterprise Edition, enter your license key when prompted by graphical setup, or place it in the anwser file for unattended installation. To receive a key, request a free trial or obtain a license at `stackstorm.com/product <stackstorm.com/product/#enterprise>`_. If no license provided, StackStorm Community will be installed.
+
 
 To install and run |st2| on a single Ubuntu/Debian or RedHat/CentOS box, with all dependencies,
 run the bootstrap script:

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -4,6 +4,22 @@ Upgrade Notes
 |st2| 1.1
 ---------
 
+Migrating to v1
+~~~~~~~~~~~~~~~
+The :doc:`install/st2_deploy` will upgrade v0.13 to v1.1. However we encourage to switch to :doc:`install/all_in_one`. To migrate to new All-in-one deployment from the existing pre v1.1 installations:
+
+    1. Install |st2| on a new clean box with :doc:`install/all_in_one`.
+    2. Copy the content from the previous installation to `/opt/stackstorm/packs`
+       and reload it with `st2ctl reload --register-all`.
+    3. Adjust the content according to upgrade notes below. Test and ensure your automations work.
+    4. Save the audit log files from ``/var/log/st2/*.audit.log`` for future reference.
+       We do not migrate execution history to the new installation, but all the execution data is
+       kept in these structured logs for audit purpose.
+
+    .. warning:: Don't run All-in-one installer over |st2| existing st2 deployment.
+
+Changes
+~~~~~~~
 * Triggers now have a `ref_count` property which must be included in Trigger objects
   created in previous versions of |st2|. A migration script is shipped in
   ${dist_packages}/st2common/bin/migrate_triggers_to_include_ref_count.py on installation.
@@ -15,14 +31,15 @@ Upgrade Notes
   script is run as part of st2_deploy.sh when you upgrade from versions >= 0.13 to 1.1.
 * Mistral moves to YAQL v1.0 and earlier versions of YAQL are deprecated. Expect some minor
   syntax changes to YAQL expressions.
-* Mistral has implemented new YAQL function for referencing environment variables in the data 
+* Mistral has implemented new YAQL function for referencing environment variables in the data
   context. The ``env()`` function replaces ``$.__env`` when referencing the environment variables.
   Referencing ``$.__env`` will lead to YAQL evaluation errors. Please update your workflows
   accordingly.
 * Mistral has implemented new YAQL function for referencing task result. Given task1,
   the function call ``task(task1).result``, replaces ``$.task1`` when referencing result of task1.
-  The old reference style will be fully deprecated in the next major release of Mistral, the 
+  The old reference style will be fully deprecated in the next major release of Mistral, the
   OpenStack Mitaka release cycle.
+
 
 |st2| 0.11
 -------------


### PR DESCRIPTION
* Explain that enterprise license will be entered in same all-in-one installer for users who land on installer page after getting the license.
* Put migration notes and warnings.