### PR TITLE
Modifying the ActionAlias schema

### DIFF
--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -537,7 +537,7 @@ class ActionAliasAPI(BaseAPI, APIUIDMixin):
         result = alias.result
 
         model = cls.model(name=name, description=description, pack=pack, ref=ref, enabled=enabled,
-                          action_ref=action_ref, formats=formats, aliases=aliases, ack=ack, 
+                          action_ref=action_ref, formats=formats, aliases=aliases, ack=ack,
                           result=result)
         return model
 

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -496,7 +496,7 @@ class ActionAliasAPI(BaseAPI, APIUIDMixin):
             "formats": {
                 "type": "array",
                 "items": {
-                    "anyOf": [ 
+                    "anyOf": [
                         {"type": "string"},
                         {
                             "type": "object",

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -495,13 +495,22 @@ class ActionAliasAPI(BaseAPI, APIUIDMixin):
             },
             "formats": {
                 "type": "array",
-                "items": {"type": "string"},
+                "items": {
+                    "anyOf": [ 
+                        {"type": "string"},
+                        {
+                            "type": "object",
+                            "properties": {
+                                "display": {"type": "string"},
+                                "representation": {
+                                    "type": "array",
+                                    "items": {"type": "string"}
+                                }
+                            }
+                        }
+                    ]
+                },
                 "description": "Possible parameter format."
-            },
-            "aliases": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": "Parameter format hidden from public list."
             },
             "ack": {
                 "type": "object",
@@ -532,13 +541,11 @@ class ActionAliasAPI(BaseAPI, APIUIDMixin):
         enabled = getattr(alias, 'enabled', True)
         action_ref = alias.action_ref
         formats = alias.formats
-        aliases = getattr(alias, 'aliases', None)
         ack = getattr(alias, 'ack', None)
         result = getattr(alias, 'result', None)
 
         model = cls.model(name=name, description=description, pack=pack, ref=ref, enabled=enabled,
-                          action_ref=action_ref, formats=formats, aliases=aliases, ack=ack,
-                          result=result)
+                          action_ref=action_ref, formats=formats, ack=ack, result=result)
         return model
 
 

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -532,9 +532,9 @@ class ActionAliasAPI(BaseAPI, APIUIDMixin):
         enabled = getattr(alias, 'enabled', True)
         action_ref = alias.action_ref
         formats = alias.formats
-        aliases = alias.aliases if hasattr(alias, 'aliases') else None
-        ack = alias.ack
-        result = alias.result
+        aliases = getattr(alias, 'aliases', None)
+        ack = getattr(alias, 'ack', None)
+        result = getattr(alias, 'result', None)
 
         model = cls.model(name=name, description=description, pack=pack, ref=ref, enabled=enabled,
                           action_ref=action_ref, formats=formats, aliases=aliases, ack=ack,

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -506,7 +506,7 @@ class ActionAliasAPI(BaseAPI, APIUIDMixin):
             "ack": {
                 "type": "object",
                 "properties": {
-                    "disabled": {"type": "boolean"},
+                    "enabled": {"type": "boolean"},
                     "format": {"type": "string"}
                 },
                 "description": "Acknowledgement message format."
@@ -514,7 +514,7 @@ class ActionAliasAPI(BaseAPI, APIUIDMixin):
             "result": {
                 "type": "object",
                 "properties": {
-                    "disabled": {"type": "boolean"},
+                    "enabled": {"type": "boolean"},
                     "format": {"type": "string"}
                 },
                 "description": "Execution message format."

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -497,6 +497,27 @@ class ActionAliasAPI(BaseAPI, APIUIDMixin):
                 "type": "array",
                 "items": {"type": "string"},
                 "description": "Possible parameter format."
+            },
+            "aliases": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Parameter format hidden from public list."
+            },
+            "ack": {
+                "type": "object",
+                "properties": {
+                    "disabled": {"type": "boolean"},
+                    "format": {"type": "string"}
+                },
+                "description": "Acknowledgement message format."
+            },
+            "result": {
+                "type": "object",
+                "properties": {
+                    "disabled": {"type": "boolean"},
+                    "format": {"type": "string"}
+                },
+                "description": "Execution message format."
             }
         },
         "additionalProperties": False
@@ -511,9 +532,13 @@ class ActionAliasAPI(BaseAPI, APIUIDMixin):
         enabled = getattr(alias, 'enabled', True)
         action_ref = alias.action_ref
         formats = alias.formats
+        aliases = alias.aliases if hasattr(alias, 'aliases') else None
+        ack = alias.ack
+        result = alias.result
 
         model = cls.model(name=name, description=description, pack=pack, ref=ref, enabled=enabled,
-                          action_ref=action_ref, formats=formats)
+                          action_ref=action_ref, formats=formats, aliases=aliases, ack=ack, 
+                          result=result)
         return model
 
 

--- a/st2common/st2common/models/db/actionalias.py
+++ b/st2common/st2common/models/db/actionalias.py
@@ -60,6 +60,15 @@ class ActionAliasDB(stormbase.StormBaseDB, stormbase.ContentPackResourceMixin,
     formats = me.ListField(
         field=me.StringField(),
         help_text='Possible parameter formats that an alias supports.')
+    aliases = me.ListField(
+        field=me.StringField(),
+        help_text='Parameter formats hidden from a public list.')
+    ack = me.DictField(
+        help_text='Parameters pertaining to the acknowledgement message.'
+    )
+    result = me.DictField(
+        help_text='Parameters pertaining to the execution result message.'
+    )
 
     meta = {
         'indexes': ['name']

--- a/st2common/st2common/models/db/actionalias.py
+++ b/st2common/st2common/models/db/actionalias.py
@@ -58,11 +58,7 @@ class ActionAliasDB(stormbase.StormBaseDB, stormbase.ContentPackResourceMixin,
         required=True,
         help_text='Reference of the Action map this alias.')
     formats = me.ListField(
-        field=me.StringField(),
         help_text='Possible parameter formats that an alias supports.')
-    aliases = me.ListField(
-        field=me.StringField(),
-        help_text='Parameter formats hidden from a public list.')
     ack = me.DictField(
         help_text='Parameters pertaining to the acknowledgement message.'
     )


### PR DESCRIPTION
Extending the ChatOps schema, as discussed: 
1. Support custom ack and result parameters.
2. Support aliases.

This PR is complete, but I'm putting it on hold until the changes in hubot-stackstorm are ready to merge as well.