### PR TITLE
[CLI] Display elapsed time for running actions / workflows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ in development
   ``trigger_instance`` attributes.
 * Now when running ``st2api`` service in debug mode (``--debug``) flag, all the JSON responses are
   pretty indented.
+* When using ``st2 execution list`` and ``st2 execution get`` CLI commands, display execution
+  elapsed time in seconds for all the executions which are currently in "running" state.
 
 1.1.0 - October 27, 2015
 ------------------------

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -135,7 +135,7 @@ def format_execution_status(instance):
     Augment instance "status" attribute with number of seconds which have elapsed for all the
     executions which are in running state.
     """
-    if instance.status == LIVEACTION_STATUS_RUNNING:
+    if instance.status == LIVEACTION_STATUS_RUNNING and instance.start_timestamp:
         start_timestamp = instance.start_timestamp
         start_timestamp = parse_isotime(start_timestamp)
         start_timestamp = calendar.timegm(start_timestamp.timetuple())

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -951,8 +951,11 @@ class ActionExecutionListCommand(ActionExecutionReadCommand):
 
     def run_and_print(self, args, **kwargs):
         instances = format_wf_instances(self.run(args, **kwargs))
-        instances = format_execution_statuses(instances)
-        # Add ellapsed time tostatus
+
+        if not args.json:
+            # Include elapsed time for running executions
+            instances = format_execution_statuses(instances)
+
         self.print_output(reversed(instances), table.MultiColumnTable,
                           attributes=args.attr, widths=args.width,
                           json=args.json,
@@ -991,7 +994,10 @@ class ActionExecutionGetCommand(ActionRunCommandMixin, ActionExecutionReadComman
     def run_and_print(self, args, **kwargs):
         try:
             execution = self.run(args, **kwargs)
-            execution = format_execution_status(execution)
+
+            if not args.json:
+                # Include elapsed time for running executions
+                execution = format_execution_status(execution)
         except resource.ResourceNotFoundError:
             self.print_not_found(args.id)
             raise OperationFailureException('Execution %s not found.' % (args.id))

--- a/st2client/st2client/formatters/table.py
+++ b/st2client/st2client/formatters/table.py
@@ -32,6 +32,14 @@ LOG = logging.getLogger(__name__)
 MIN_ID_COL_WIDTH = 26
 DEFAULT_ATTRIBUTE_DISPLAY_ORDER = ['id', 'name', 'pack', 'description']
 
+# Attributes which contain bash escape sequences - we can't split those across multiple lines
+# since things would break
+COLORIZED_ATTRIBUTES = {
+    'status': {
+        'col_width': 40
+    }
+}
+
 
 class MultiColumnTable(formatters.Formatter):
 
@@ -59,10 +67,23 @@ class MultiColumnTable(formatters.Formatter):
                 first_col_width = col_width
 
             widths = []
+            subtract = None
             for index in range(0, len(attributes)):
+                attribute_name = attributes[index]
+
                 if index == 0:
                     widths.append(first_col_width)
                 else:
+                    if attribute_name in COLORIZED_ATTRIBUTES:
+                        col_width = COLORIZED_ATTRIBUTES[attribute_name]['col_width']
+                        subtract = col_width
+                    else:
+                        if subtract:
+                            # Make sure we make the next column less wide so we account for the
+                            # fixed width columns and make sure the table is not wider than the
+                            # terminal width.
+                            col_width = (col_width - subtract)
+                            subtract = None
                     widths.append(col_width)
 
         if not attributes or 'all' in attributes:

--- a/st2client/st2client/utils/color.py
+++ b/st2client/st2client/utils/color.py
@@ -67,5 +67,19 @@ STATUS_LOOKUP = {
 
 
 def format_status(value):
-    color = STATUS_LOOKUP.get(value, DisplayColors.YELLOW)
-    return DisplayColors.colorize(value, color)
+    # Support status values with elapsed info
+    split = value.split('(', 1)
+
+    if len(split) == 2:
+        status = split[0].strip()
+        reminder = '(' + split[1]
+    else:
+        status = value
+        reminder = ''
+
+    color = STATUS_LOOKUP.get(status, DisplayColors.YELLOW)
+    result = DisplayColors.colorize(status, color)
+
+    if reminder:
+        result = result + ' ' + reminder
+    return result

--- a/st2client/st2client/utils/color.py
+++ b/st2client/st2client/utils/color.py
@@ -72,14 +72,14 @@ def format_status(value):
 
     if len(split) == 2:
         status = split[0].strip()
-        reminder = '(' + split[1]
+        remainder = '(' + split[1]
     else:
         status = value
-        reminder = ''
+        remainder = ''
 
     color = STATUS_LOOKUP.get(status, DisplayColors.YELLOW)
     result = DisplayColors.colorize(status, color)
 
-    if reminder:
-        result = result + ' ' + reminder
+    if remainder:
+        result = result + ' ' + remainder
     return result


### PR DESCRIPTION
With this change we now display elapsed time in seconds when using "execution list" and "execution get" commands for all the actions in the "running" state.

This was big annoyance for me every time I was checking things on our build server where we have a lot of long running actions - previously I would need to check current time and start timestamp, but now you can see elapsed time in a glance.

![selection_287](https://cloud.githubusercontent.com/assets/125088/10978015/e7378a56-83f4-11e5-9240-2824cd87888e.png)

![selection_288](https://cloud.githubusercontent.com/assets/125088/10978022/eabc39f6-83f4-11e5-9907-0fa7a591b08f.png)
