### PR TITLE
Action chain validation improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,9 @@ in development
   pretty indented.
 * When using ``st2 execution list`` and ``st2 execution get`` CLI commands, display execution
   elapsed time in seconds for all the executions which are currently in "running" state.
+* Update action chain runner so it performs on-success and on-error task name validation during
+  pre_run time. This way common errors such as typos in the task names can be spotted early on
+  since there is no need to wait for the run time.
 
 1.1.0 - October 27, 2015
 ------------------------

--- a/pylint_plugins/api_models.py
+++ b/pylint_plugins/api_models.py
@@ -33,7 +33,6 @@ def transform(cls):
     if cls.name.endswith('API') or 'schema' in cls.locals:
         # This is a class which defines attributes in "schema" variable using json schema.
         # Those attributes are then assigned during run time inside the constructor
-
         fqdn = cls.qname()
         module_name, class_name = fqdn.rsplit('.', 1)
 
@@ -49,6 +48,7 @@ def transform(cls):
         properties = schema.get('properties', {}).keys()
 
         for property_name in properties:
+            property_name = property_name.replace('-', '_')  # Note: We do the same in Python code
             cls.locals[property_name] = [scoped_nodes.Class(property_name, None)]
 
 

--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -75,23 +75,25 @@ class ChainHolder(object):
         perform only simple validation during compile / create time.
         """
         all_nodes = self._get_all_nodes(action_chain=self.actionchain)
-        on_success_nodes = self._get_all_on_success_nodes(action_chain=self.actionchain)
-        on_failure_nodes = self._get_all_on_failure_nodes(action_chain=self.actionchain)
 
-        # 1. Check all the "on-success" paths
-        for node_name in on_success_nodes:
-            valid_name = self._is_valid_node_name(all_node_names=all_nodes, node_name=node_name)
+        for node in self.actionchain.chain:
+            on_success_node_name = node.on_success
+            on_failure_node_name = node.on_failure
 
+            # Check "on-success" path
+            valid_name = self._is_valid_node_name(all_node_names=all_nodes,
+                                                  node_name=on_success_node_name)
             if not valid_name:
-                msg = 'Unable to find node with name "%s".' % (node_name)
+                msg = ('Unable to find node with name "%s" referenced in "on-success" in '
+                       'task "%s".' % (on_success_node_name, node.name))
                 raise ValueError(msg)
 
-        # 2. Check all the "on-failure" paths
-        for node_name in on_failure_nodes:
-            valid_name = self._is_valid_node_name(all_node_names=all_nodes, node_name=node_name)
-
+            # Check "on-failure" path
+            valid_name = self._is_valid_node_name(all_node_names=all_nodes,
+                                                  node_name=on_failure_node_name)
             if not valid_name:
-                msg = 'Unable to find node with name "%s".' % (node_name)
+                msg = ('Unable to find node with name "%s" referenced in "on-failure" in '
+                       'task "%s".' % (on_failure_node_name, node.name))
                 raise ValueError(msg)
 
         return True

--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -410,12 +410,13 @@ class ActionChainRunner(ActionRunner):
         context.update({SYSTEM_KV_PREFIX: KeyValueLookup()})
 
         try:
-            rendered_result = jinja_utils.render_values(mapping=action_node.publish, context=context)
+            rendered_result = jinja_utils.render_values(mapping=action_node.publish,
+                                                        context=context)
         except Exception as e:
             key = getattr(e, 'key', None)
             value = getattr(e, 'value', None)
-            msg = ('Failed rendering value for publish parameter "%s" in task "%s" (template string=%s): %s' %
-                   (key, action_node.name, value, str(e)))
+            msg = ('Failed rendering value for publish parameter "%s" in task "%s" '
+                   '(template string=%s): %s' % (key, action_node.name, value, str(e)))
             raise ParameterRenderingFailedException(msg)
 
         return rendered_result
@@ -438,8 +439,8 @@ class ActionChainRunner(ActionRunner):
 
             key = getattr(e, 'key', None)
             value = getattr(e, 'value', None)
-            msg = ('Failed rendering value for parameter "%s" in task "%s" (template string=%s): %s' %
-                   (key, action_node.name, value, str(e)))
+            msg = ('Failed rendering value for action parameter "%s" in task "%s" '
+                   '(template string=%s): %s') % (key, action_node.name, value, str(e))
             raise ParameterRenderingFailedException(msg)
         LOG.debug('Rendered params: %s: Type: %s', rendered_params, type(rendered_params))
         return rendered_params

--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -97,22 +97,22 @@ class ChainHolder(object):
         return True
 
     @staticmethod
-    def _get_default(_actionchain):
+    def _get_default(action_chain):
         # default is defined
-        if _actionchain.default:
-            return _actionchain.default
+        if action_chain.default:
+            return action_chain.default
         # no nodes in chain
-        if not _actionchain.chain:
+        if not action_chain.chain:
             return None
         # The first node with no references is the default node. Assumptions
         # that support this are :
         # 1. There are no loops in the chain. Even if there are loops there is
         #    at least 1 node which does not end up in this loop.
         # 2. There are no fragments in the chain.
-        all_nodes = ChainHolder._get_all_nodes(action_chain=_actionchain)
+        all_nodes = ChainHolder._get_all_nodes(action_chain=action_chain)
         node_names = set(all_nodes)
-        on_success_nodes = ChainHolder._get_all_on_success_nodes(action_chain=_actionchain)
-        on_failure_nodes = ChainHolder._get_all_on_failure_nodes(action_chain=_actionchain)
+        on_success_nodes = ChainHolder._get_all_on_success_nodes(action_chain=action_chain)
+        on_failure_nodes = ChainHolder._get_all_on_failure_nodes(action_chain=action_chain)
         referenced_nodes = on_success_nodes | on_failure_nodes
         possible_default_nodes = node_names - referenced_nodes
         if possible_default_nodes:
@@ -122,7 +122,7 @@ class ChainHolder(object):
                 if node in possible_default_nodes:
                     return node
         # If no node is found assume the first node in the chain list to be default.
-        return _actionchain.chain[0].name
+        return action_chain.chain[0].name
 
     @staticmethod
     def _get_all_nodes(action_chain):

--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -412,8 +412,10 @@ class ActionChainRunner(ActionRunner):
         try:
             rendered_result = jinja_utils.render_values(mapping=action_node.publish, context=context)
         except Exception as e:
+            key = getattr(e, 'key', None)
+            value = getattr(e, 'value', None)
             msg = ('Failed rendering value for publish parameter "%s" in task "%s" (template string=%s): %s' %
-                   (e.key, action_node.name, e.value, str(e)))
+                   (key, action_node.name, value, str(e)))
             raise ParameterRenderingFailedException(msg)
 
         return rendered_result
@@ -434,8 +436,10 @@ class ActionChainRunner(ActionRunner):
         except Exception as e:
             LOG.exception('Jinja rendering for parameter "%s" failed.' % (e.key))
 
+            key = getattr(e, 'key', None)
+            value = getattr(e, 'value', None)
             msg = ('Failed rendering value for parameter "%s" in task "%s" (template string=%s): %s' %
-                   (e.key, action_node.name, e.value, str(e)))
+                   (key, action_node.name, value, str(e)))
             raise ParameterRenderingFailedException(msg)
         LOG.debug('Rendered params: %s: Type: %s', rendered_params, type(rendered_params))
         return rendered_params

--- a/st2actions/tests/unit/test_actionchain.py
+++ b/st2actions/tests/unit/test_actionchain.py
@@ -417,9 +417,14 @@ class TestActionChainRunner(DbTestCase):
         self.assertEqual(status, LIVEACTION_STATUS_FAILED)
         self.assertEqual(len(result['tasks']), 1)
         self.assertEqual(result['tasks'][0]['name'], 'c1')
+
+        expected_error = ('Failed rendering value for action parameter "p1" in '
+                          'task "c2" (template string={{s1}}')
+
         self.assertTrue('error' in result)
         self.assertTrue('traceback' in result)
         self.assertTrue('Failed to run task "c2". Parameter rendering failed' in result['error'])
+        self.assertTrue(expected_error in result['error'])
         self.assertTrue('Traceback' in result['traceback'])
 
     @mock.patch.object(action_db_util, 'get_action_by_ref',

--- a/st2actions/tests/unit/test_actionchain.py
+++ b/st2actions/tests/unit/test_actionchain.py
@@ -234,30 +234,6 @@ class TestActionChainRunner(DbTestCase):
         self.assertRaisesRegexp(runnerexceptions.ActionRunnerPreRunError,
                                 expected_msg, chain_runner.pre_run)
 
-
-    @mock.patch.object(action_db_util, 'get_action_by_ref',
-                       mock.MagicMock(return_value=ACTION_1))
-    @mock.patch.object(action_service, 'request',
-                       return_value=(DummyActionExecution(status=LIVEACTION_STATUS_FAILED), None))
-    def test_chain_runner_broken_fail_path_st(self, request):
-        return
-        chain_runner = acr.get_runner()
-        chain_runner.entry_point = CHAIN_BROKEN_PATH
-        chain_runner.action = ACTION_1
-        chain_runner.container_service = RunnerContainerService()
-        chain_runner.pre_run()
-        status, result, _ = chain_runner.run({})
-
-        self.assertEqual(status, LIVEACTION_STATUS_FAILED)
-        self.assertNotEqual(chain_runner.chain_holder.actionchain, None)
-
-        self.assertTrue('Failed to get next node "c1". Lookup failed:' in result['error'])
-        self.assertTrue('Unable to find node with name "c4"' in result['error'])
-        self.assertTrue('Traceback (most recent call last):' in result['traceback'])
-
-        # based on the chain the callcount is known to be 1. Not great but works.
-        self.assertEqual(request.call_count, 1)
-
     @mock.patch.object(action_db_util, 'get_action_by_ref',
                        mock.MagicMock(return_value=ACTION_1))
     @mock.patch.object(action_service, 'request', side_effect=RuntimeError('Test Failure.'))

--- a/st2actions/tests/unit/test_actionchain.py
+++ b/st2actions/tests/unit/test_actionchain.py
@@ -241,7 +241,8 @@ class TestActionChainRunner(DbTestCase):
         chain_runner.action = ACTION_1
         chain_runner.container_service = RunnerContainerService()
 
-        expected_msg = 'Unable to find node with name "c5"'
+        expected_msg = ('Unable to find node with name "c5" referenced in "on-success" '
+                        'in task "c2"')
         self.assertRaisesRegexp(runnerexceptions.ActionRunnerPreRunError,
                                 expected_msg, chain_runner.pre_run)
 
@@ -255,7 +256,8 @@ class TestActionChainRunner(DbTestCase):
         chain_runner.action = ACTION_1
         chain_runner.container_service = RunnerContainerService()
 
-        expected_msg = 'Unable to find node with name "c6"'
+        expected_msg = ('Unable to find node with name "c6" referenced in "on-failure" '
+                        'in task "c2"')
         self.assertRaisesRegexp(runnerexceptions.ActionRunnerPreRunError,
                                 expected_msg, chain_runner.pre_run)
 

--- a/st2common/st2common/log.py
+++ b/st2common/st2common/log.py
@@ -64,7 +64,19 @@ def decorate_log_method(func):
         # Prefix extra keys with underscore
         if 'extra' in kwargs:
             kwargs['extra'] = prefix_dict_keys(dictionary=kwargs['extra'], prefix='_')
-        return func(*args, **kwargs)
+
+        try:
+            return func(*args, **kwargs)
+        except TypeError as e:
+            # In some version of Python 2.7, logger.exception doesn't take any kwargs so we need
+            # this hack :/
+            # See:
+            # - https://docs.python.org/release/2.7.3/library/logging.html#logging.Logger.exception
+            # - https://docs.python.org/release/2.7.7/library/logging.html#logging.Logger.exception
+            if 'got an unexpected keyword argument \'extra\'' in str(e):
+                kwargs.pop('extra', None)
+                return func(*args, **kwargs)
+            raise e
     return func_wrapper
 
 

--- a/st2common/st2common/models/system/actionchain.py
+++ b/st2common/st2common/models/system/actionchain.py
@@ -88,6 +88,10 @@ class Node(object):
             prop = string.replace(prop, '-', '_')
             setattr(self, prop, value)
 
+    def __repr__(self):
+        return ('<Node name=%s, ref=%s, on-success=%s, on-failure=%s>' %
+                (self.name, self.ref, self.on_success, self.on_failure))
+
 
 class ActionChain(object):
 

--- a/st2common/st2common/models/utils/action_param_utils.py
+++ b/st2common/st2common/models/utils/action_param_utils.py
@@ -82,6 +82,7 @@ def get_params_view(action_db=None, runner_db=None, merged_only=False):
 def cast_params(action_ref, params, cast_overrides=None):
     """
     """
+    params = params or {}
     action_db = action_db_util.get_action_by_ref(action_ref)
 
     if not action_db:

--- a/st2common/st2common/util/jinja.py
+++ b/st2common/st2common/util/jinja.py
@@ -151,7 +151,15 @@ def render_values(mapping=None, context=None, allow_undefined=False):
             reverse_json_dumps = True
         else:
             v = str(v)
-        rendered_v = env.from_string(v).render(context)
+
+        try:
+            rendered_v = env.from_string(v).render(context)
+        except Exception as e:
+            # Attach key and value which failed the rendering
+            e.key = k
+            e.value = v
+            raise e
+
         # no change therefore no templatization so pick params from original to retain
         # original type
         if rendered_v == v:

--- a/st2tests/st2tests/fixtures/generic/actionchains/chain_action_call_no_params.yaml
+++ b/st2tests/st2tests/fixtures/generic/actionchains/chain_action_call_no_params.yaml
@@ -1,0 +1,21 @@
+---
+chain:
+- name: c1
+  on-failure: c4
+  on-success: c2
+  ref: wolfpack.a1
+- name: c2
+  on-failure: c4
+  on-success: c3
+  params:
+    p1: v1
+  ref: wolfpack.a2
+- name: c3
+  on-failure: c4
+  params: {}
+  ref: wolfpack.a3
+- name: c4
+  params:
+    actionstr: "{{action_context.parent.execution_id}}"
+  ref: wolfpack.action-4-action-context-param
+default: c1

--- a/st2tests/st2tests/fixtures/generic/actionchains/chain_broken_on_failure_path_static_task_name.yaml
+++ b/st2tests/st2tests/fixtures/generic/actionchains/chain_broken_on_failure_path_static_task_name.yaml
@@ -1,0 +1,20 @@
+---
+chain:
+  - name: c1
+    ref: wolfpack.a1
+    params:
+      p1: v1
+    on-success: c2
+    on-failure: c2
+  - name: c2
+    ref: wolfpack.a1
+    params:
+      p1: v1
+    on-success: c3
+    on-failure: c6
+  - name: c3
+    ref: wolfpack.a1
+    params:
+      p1: v1
+
+default: c1

--- a/st2tests/st2tests/fixtures/generic/actionchains/chain_broken_on_success_path_static_task_name.yaml
+++ b/st2tests/st2tests/fixtures/generic/actionchains/chain_broken_on_success_path_static_task_name.yaml
@@ -1,0 +1,20 @@
+---
+chain:
+  - name: c1
+    ref: wolfpack.a1
+    params:
+      p1: v1
+    on-success: c2
+    on-failure: c2
+  - name: c2
+    ref: wolfpack.a1
+    params:
+      p1: v1
+    on-success: c5
+    on-failure: c3
+  - name: c3
+    ref: wolfpack.a1
+    params:
+      p1: v1
+
+default: c1

--- a/st2tests/st2tests/fixtures/generic/actionchains/chain_publish_params_rendering_failure.yaml
+++ b/st2tests/st2tests/fixtures/generic/actionchains/chain_publish_params_rendering_failure.yaml
@@ -1,0 +1,22 @@
+---
+chain:
+- name: c1
+  on-failure: c4
+  on-success: c2
+  ref: wolfpack.a1
+- name: c2
+  on-failure: c4
+  on-success: c3
+  publish:
+    # We reference variable which is not defined / available in the context
+    p1: "{{ not_defined }}"
+  ref: wolfpack.a2
+- name: c3
+  on-failure: c4
+  params: {}
+  ref: wolfpack.a3
+- name: c4
+  params:
+    actionstr: "{{action_context.parent.execution_id}}"
+  ref: wolfpack.action-4-action-context-param
+default: c1


### PR DESCRIPTION
This pull request includes some action chain validation improvements.

1. Perform on-success and on-failure task name validation during run time. Previously validation happened during run time which means develop-feedback loop was very slow if user was testing workflow with long running tasks and there was, for en example, typo in the take name referenced in on-success / on-failure. This should speed up the whole develop - test loop since this issues are now detected during "pre_run" phase.
2. Throw more friendly exception when action parameter or "publish" parameter resolving fails. Now we also include task where the exception occurred, parameter name and the actual template string value.