### PR TITLE
Support for default values on the API models

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ in development
 * Update action chain runner so it performs on-success and on-error task name validation during
   pre_run time. This way common errors such as typos in the task names can be spotted early on
   since there is no need to wait for the run time.
+* Don't allow action parameter ``type`` attribute to be an array since rest of the code doesn't 
+  support parameters with multiple types.
 
 1.1.0 - October 27, 2015
 ------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,8 +21,10 @@ in development
 * Update action chain runner so it performs on-success and on-error task name validation during
   pre_run time. This way common errors such as typos in the task names can be spotted early on
   since there is no need to wait for the run time.
-* Don't allow action parameter ``type`` attribute to be an array since rest of the code doesn't 
+* Don't allow action parameter ``type`` attribute to be an array since rest of the code doesn't
   support parameters with multiple types.
+* Fix trigger parameters validation for system triggers during rule creation - make sure we
+  validate the parameters before creating a TriggerDB object.
 
 1.1.0 - October 27, 2015
 ------------------------

--- a/pylint_plugins/api_models.py
+++ b/pylint_plugins/api_models.py
@@ -24,12 +24,20 @@ constructor.
 from astroid import MANAGER
 from astroid import scoped_nodes
 
+# A list of class names for which we want to skip the checks
+CLASS_NAME_BLACKLIST = [
+    'ExecutionParametersAPI'
+]
+
 
 def register(linter):
     pass
 
 
 def transform(cls):
+    if cls.name in CLASS_NAME_BLACKLIST:
+        return
+
     if cls.name.endswith('API') or 'schema' in cls.locals:
         # This is a class which defines attributes in "schema" variable using json schema.
         # Those attributes are then assigned during run time inside the constructor

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -245,7 +245,7 @@ class ActionExecutionReRunController(ActionExecutionsControllerMixin, ResourceCo
         'trigger_instance'
     ]
 
-    class ExecutionParameters(object):
+    class ExecutionParametersAPI(object):
         def __init__(self, parameters=None):
             self.parameters = parameters or {}
 
@@ -253,9 +253,9 @@ class ActionExecutionReRunController(ActionExecutionsControllerMixin, ResourceCo
             if self.parameters:
                 assert isinstance(self.parameters, dict)
 
-            return True
+            return self
 
-    @jsexpose(body_cls=ExecutionParameters, status_code=http_client.CREATED)
+    @jsexpose(body_cls=ExecutionParametersAPI, status_code=http_client.CREATED)
     def post(self, execution_parameters, execution_id):
         """
         Re-run the provided action execution optionally specifying override parameters.

--- a/st2api/tests/unit/controllers/v1/test_actions.py
+++ b/st2api/tests/unit/controllers/v1/test_actions.py
@@ -208,6 +208,20 @@ ACTION_12 = {
     ]
 }
 
+# Action with invalid parameter type attribute
+ACTION_13 = {
+    'name': 'st2.dummy.action2',
+    'description': 'test description',
+    'enabled': True,
+    'pack': 'dummy_pack_1',
+    'entry_point': '/tmp/test/action1.sh',
+    'runner_type': 'local-shell-script',
+    'parameters': {
+        'a': {'type': ['string', 'object'], 'default': 'A1'},
+        'b': {'type': 'string', 'default': 'B1'}
+    }
+}
+
 
 class TestActionController(FunctionalTest, CleanFilesTestCase):
     register_packs = True
@@ -324,6 +338,15 @@ class TestActionController(FunctionalTest, CleanFilesTestCase):
         self.assertDictContainsSubset({'enabled': False}, data)
 
         self.__do_delete(self.__get_action_id(post_resp))
+
+    @mock.patch.object(action_validator, 'validate_action', mock.MagicMock(
+        return_value=True))
+    def test_post_parameter_type_is_array_and_invalid(self):
+        post_resp = self.__do_post(ACTION_13, expect_errors=True)
+        self.assertEqual(post_resp.status_int, 400)
+
+        expected_error = '[u\'string\', u\'object\'] is not valid under any of the given schemas'
+        self.assertTrue(expected_error in post_resp.body)
 
     @mock.patch.object(action_validator, 'validate_action', mock.MagicMock(
         return_value=True))

--- a/st2api/tests/unit/controllers/v1/test_rules.py
+++ b/st2api/tests/unit/controllers/v1/test_rules.py
@@ -72,6 +72,11 @@ class TestRuleController(FunctionalTest):
             fixtures_pack=FIXTURES_PACK,
             fixtures_dict={'rules': [file_name]})['rules'][file_name]
 
+        file_name = 'date_timer_rule_invalid_parameters.yaml'
+        TestRuleController.RULE_5 = TestRuleController.fixtures_loader.load_fixtures(
+            fixtures_pack=FIXTURES_PACK,
+            fixtures_dict={'rules': [file_name]})['rules'][file_name]
+
     @classmethod
     def tearDownClass(cls):
         TestRuleController.fixtures_loader.delete_fixtures_from_db(
@@ -124,6 +129,13 @@ class TestRuleController(FunctionalTest):
         self.assertEqual(post_resp.status_int, http_client.BAD_REQUEST)
 
         expected_msg = 'Additional properties are not allowed (u\'minutex\' was unexpected)'
+        self.assertTrue(expected_msg in post_resp.body)
+
+    def test_post_trigger_parameter_schema_validation_fails_missing_required_param(self):
+        post_resp = self.__do_post(TestRuleController.RULE_5)
+        self.assertEqual(post_resp.status_int, http_client.BAD_REQUEST)
+
+        expected_msg = '\'date\' is a required property'
         self.assertTrue(expected_msg in post_resp.body)
 
     def test_post_no_enabled_attribute_disabled_by_default(self):

--- a/st2common/st2common/constants/triggers.py
+++ b/st2common/st2common/constants/triggers.py
@@ -185,12 +185,10 @@ WEBHOOKS_PARAMETERS_SCHEMA = {
     'type': 'object',
     'properties': {
         'url': {
-            'type': 'string'
+            'type': 'string',
+            'required': True
         }
     },
-    'required': [
-        'url'
-    ],
     'additionalProperties': False
 }
 
@@ -220,16 +218,15 @@ INTERVAL_PARAMETERS_SCHEMA = {
             "type": "string"
         },
         "unit": {
-            "enum": ["weeks", "days", "hours", "minutes", "seconds"]
+            "enum": ["weeks", "days", "hours", "minutes", "seconds"],
+            "required": True
         },
         "delta": {
-            "type": "integer"
+            "type": "integer",
+            "required": True
+
         }
     },
-    "required": [
-        "unit",
-        "delta"
-    ],
     "additionalProperties": False
 }
 
@@ -241,12 +238,10 @@ DATE_PARAMETERS_SCHEMA = {
         },
         "date": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "required": True
         }
     },
-    "required": [
-        "date"
-    ],
     "additionalProperties": False
 }
 

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -87,7 +87,7 @@ class RunnerTypeAPI(BaseAPI):
                 "description": "Input parameters for the action runner.",
                 "type": "object",
                 "patternProperties": {
-                    "^\w+$": util_schema.get_draft_schema(version='action_params')
+                    "^\w+$": util_schema.get_action_parameters_schema()
                 }
             }
         },
@@ -178,7 +178,7 @@ class ActionAPI(BaseAPI, APIUIDMixin):
                 "description": "Input parameters for the action.",
                 "type": "object",
                 "patternProperties": {
-                    "^\w+$": util_schema.get_draft_schema(version='action_params')
+                    "^\w+$": util_schema.get_action_parameters_schema()
                 },
                 "default": {}
             },

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -87,7 +87,7 @@ class RunnerTypeAPI(BaseAPI):
                 "description": "Input parameters for the action runner.",
                 "type": "object",
                 "patternProperties": {
-                    "^\w+$": util_schema.get_draft_schema()
+                    "^\w+$": util_schema.get_draft_schema(version='action_params')
                 }
             }
         },
@@ -178,7 +178,7 @@ class ActionAPI(BaseAPI, APIUIDMixin):
                 "description": "Input parameters for the action.",
                 "type": "object",
                 "patternProperties": {
-                    "^\w+$": util_schema.get_draft_schema()
+                    "^\w+$": util_schema.get_draft_schema(version='action_params')
                 },
                 "default": {}
             },

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -55,8 +55,7 @@ class RunnerTypeAPI(BaseAPI):
         "properties": {
             "id": {
                 "description": "The unique identifier for the action runner.",
-                "type": "string",
-                "default": None
+                "type": "string"
             },
             "name": {
                 "description": "The name of the action runner.",
@@ -480,8 +479,7 @@ class ActionAliasAPI(BaseAPI, APIUIDMixin):
             },
             "description": {
                 "type": "string",
-                "description": "Description of the action alias.",
-                "default": None
+                "description": "Description of the action alias."
             },
             "enabled": {
                 "description": "Flag indicating of action alias is enabled.",

--- a/st2common/st2common/models/api/base.py
+++ b/st2common/st2common/models/api/base.py
@@ -72,6 +72,10 @@ class BaseAPI(object):
     def validate(self):
         """
         Perform validation and return cleaned object on success.
+
+        Note: This method doesn't mutate this object in place, but it returns a new one.
+
+        :return: Cleaned / validated object.
         """
         schema = getattr(self, 'schema', {})
         attributes = vars(self)
@@ -79,13 +83,7 @@ class BaseAPI(object):
         cleaned = util_schema.validate(instance=attributes, schema=schema,
                                        cls=util_schema.CustomValidator, use_default=True)
 
-        # Note: For backward compatibility reasons, we re-assign attributes one the current
-        # instance instance of creating a new one
-        # return self.__class__(**cleaned)
-        for attribute_name, attribute_value in six.iteritems(cleaned):
-            setattr(self, attribute_name, attribute_value)
-
-        return self
+        return self.__class__(**cleaned)
 
     @classmethod
     def _from_model(cls, model, mask_secrets=False):
@@ -197,7 +195,7 @@ def jsexpose(arg_types=None, body_cls=None, status_code=None, content_type='appl
 
                 obj = body_cls(**data)
                 try:
-                    obj.validate()
+                    obj = obj.validate()
                 except jsonschema.ValidationError as e:
                     raise exc.HTTPBadRequest(detail=e.message,
                                              comment=traceback.format_exc())

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -27,12 +27,10 @@ class PackAPI(BaseAPI):
         'type': 'object',
         'properties': {
             'id': {
-                'type': 'string',
-                'default': None
+                'type': 'string'
             },
             'ref': {
-                'type': 'string',
-                'default': None
+                'type': 'string'
             },
             "uid": {
                 "type": "string"

--- a/st2common/st2common/models/api/policy.py
+++ b/st2common/st2common/models/api/policy.py
@@ -31,8 +31,7 @@ class PolicyTypeAPI(BaseAPI):
         "type": "object",
         "properties": {
             "id": {
-                "type": "string",
-                "default": None
+                "type": "string"
             },
             "name": {
                 "type": "string",
@@ -84,8 +83,7 @@ class PolicyAPI(BaseAPI):
         "type": "object",
         "properties": {
             "id": {
-                "type": "string",
-                "default": None
+                "type": "string"
             },
             "name": {
                 "type": "string",

--- a/st2common/st2common/models/api/rbac.py
+++ b/st2common/st2common/models/api/rbac.py
@@ -121,7 +121,7 @@ class RoleDefinitionFileFormatAPI(BaseAPI):
 
     def validate(self):
         # Parent JSON schema validation
-        super(RoleDefinitionFileFormatAPI, self).validate()
+        cleaned = super(RoleDefinitionFileFormatAPI, self).validate()
 
         # Custom validation
 
@@ -150,6 +150,8 @@ class RoleDefinitionFileFormatAPI(BaseAPI):
                         message = ('Invalid permission type "%s". Only "list" permission types '
                                    'can be used without a resource id' % (permission_type))
                         raise ValueError(message)
+
+            return cleaned
 
 
 class UserRoleAssignmentFileFormatAPI(BaseAPI):
@@ -188,7 +190,7 @@ class UserRoleAssignmentFileFormatAPI(BaseAPI):
 
     def validate(self, validate_role_exists=False):
         # Parent JSON schema validation
-        super(UserRoleAssignmentFileFormatAPI, self).validate()
+        cleaned = super(UserRoleAssignmentFileFormatAPI, self).validate()
 
         # Custom validation
         if validate_role_exists:
@@ -200,3 +202,5 @@ class UserRoleAssignmentFileFormatAPI(BaseAPI):
             for role in roles:
                 if role not in role_names:
                     raise ValueError('Role "%s" doesn\'t exist in the database' % (role))
+
+        return cleaned

--- a/st2common/st2common/models/api/rbac.py
+++ b/st2common/st2common/models/api/rbac.py
@@ -33,8 +33,7 @@ class RoleAPI(BaseAPI):
         'type': 'object',
         'properties': {
             'id': {
-                'type': 'string',
-                'default': None
+                'type': 'string'
             },
             'name': {
                 'type': 'string',
@@ -78,8 +77,7 @@ class RoleDefinitionFileFormatAPI(BaseAPI):
             'name': {
                 'type': 'string',
                 'description': 'Role name',
-                'required': True,
-                'default': None
+                'required': True
             },
             'description': {
                 'type': 'string',
@@ -100,8 +98,7 @@ class RoleDefinitionFileFormatAPI(BaseAPI):
                         'resource_uid': {
                             'type': 'string',
                             'description': 'UID of a resource to which this grant applies to.',
-                            'required': False,
-                            'default': None
+                            'required': False
                         },
                         'permission_types': {
                             'type': 'array',
@@ -113,7 +110,7 @@ class RoleDefinitionFileFormatAPI(BaseAPI):
                                 # resource type in other place
                                 'enum': PermissionType.get_valid_values()
                             },
-                            'default': None
+                            'default': []
                         }
                     }
                 }
@@ -162,14 +159,12 @@ class UserRoleAssignmentFileFormatAPI(BaseAPI):
             'username': {
                 'type': 'string',
                 'description': 'Username',
-                'required': True,
-                'default': None
+                'required': True
             },
             'description': {
                 'type': 'string',
                 'description': 'Assignment description',
-                'required': False,
-                'default': None
+                'required': False
             },
             'enabled': {
                 'type': 'boolean',

--- a/st2common/st2common/models/api/rule.py
+++ b/st2common/st2common/models/api/rule.py
@@ -78,8 +78,7 @@ class RuleTypeAPI(BaseAPI):
         'properties': {
             'id': {
                 'description': 'The unique identifier for the action runner.',
-                'type': 'string',
-                'default': None
+                'type': 'string'
             },
             'name': {
                 'description': 'The name of the action runner.',
@@ -143,8 +142,7 @@ class RuleAPI(BaseAPI, APIUIDMixin):
         'type': 'object',
         'properties': {
             'id': {
-                'type': 'string',
-                'default': None
+                'type': 'string'
             },
             "ref": {
                 "description": "System computed user friendly reference for the action. \

--- a/st2common/st2common/models/api/rule.py
+++ b/st2common/st2common/models/api/rule.py
@@ -222,12 +222,19 @@ class RuleAPI(BaseAPI, APIUIDMixin):
         kwargs['name'] = getattr(rule, 'name', None)
         kwargs['description'] = getattr(rule, 'description', None)
 
+        # Validate trigger parameters
+        # Note: This must happen before we create a trigger, otherwise create trigger could fail
+        # with a cryptic error
+        trigger = getattr(rule, 'trigger', {})
+        trigger_type_ref = trigger.get('type', None)
+        parameters = trigger.get('parameters', {})
+
+        validator.validate_trigger_parameters(trigger_type_ref=trigger_type_ref,
+                                              parameters=parameters)
+
         # Create a trigger for the provided rule
         trigger_db = TriggerService.create_trigger_db_from_rule(rule)
         kwargs['trigger'] = reference.get_str_resource_ref_from_model(trigger_db)
-
-        # Validate trigger parameters
-        validator.validate_trigger_parameters(trigger_db=trigger_db)
 
         kwargs['pack'] = getattr(rule, 'pack', DEFAULT_PACK_NAME)
         kwargs['ref'] = ResourceReference.to_string_reference(pack=kwargs['pack'],

--- a/st2common/st2common/models/api/sensor.py
+++ b/st2common/st2common/models/api/sensor.py
@@ -24,8 +24,7 @@ class SensorTypeAPI(BaseAPI):
         'type': 'object',
         'properties': {
             'id': {
-                'type': 'string',
-                'default': None
+                'type': 'string'
             },
             'ref': {
                 'type': 'string'

--- a/st2common/st2common/models/api/trace.py
+++ b/st2common/st2common/models/api/trace.py
@@ -48,8 +48,7 @@ class TraceAPI(BaseAPI):
         'properties': {
             'id': {
                 'description': 'The unique identifier for a Trace.',
-                'type': 'string',
-                'default': None
+                'type': 'string'
             },
             'trace_tag': {
                 'description': 'User assigned identifier for each Trace.',

--- a/st2common/st2common/models/api/trigger.py
+++ b/st2common/st2common/models/api/trigger.py
@@ -30,8 +30,7 @@ class TriggerTypeAPI(BaseAPI):
         'type': 'object',
         'properties': {
             'id': {
-                'type': 'string',
-                'default': None
+                'type': 'string'
             },
             'ref': {
                 'type': 'string'
@@ -93,8 +92,7 @@ class TriggerAPI(BaseAPI):
         'type': 'object',
         'properties': {
             'id': {
-                'type': 'string',
-                'default': None
+                'type': 'string'
             },
             'ref': {
                 'type': 'string'
@@ -169,7 +167,6 @@ class TriggerInstanceAPI(BaseAPI):
             },
             'trigger': {
                 'type': 'string',
-                'default': None,
                 'required': True
             }
         },

--- a/st2common/st2common/models/system/actionchain.py
+++ b/st2common/st2common/models/system/actionchain.py
@@ -19,8 +19,6 @@ import string
 from st2common.util import schema as util_schema
 from st2common.models.api.notification import NotificationSubSchemaAPI
 
-VALIDATOR = util_schema.get_validator(assign_property_default=False)
-
 
 class Node(object):
 
@@ -122,7 +120,8 @@ class ActionChain(object):
     }
 
     def __init__(self, **kw):
-        VALIDATOR(self.schema).validate(kw)
+        util_schema.validate(instance=kw, schema=self.schema, cls=util_schema.CustomValidator,
+                             use_default=False)
 
         for prop in six.iterkeys(self.schema.get('properties', [])):
             value = kw.get(prop, None)

--- a/st2common/st2common/services/action.py
+++ b/st2common/st2common/services/action.py
@@ -70,7 +70,7 @@ def request(liveaction):
         liveaction.parameters = dict()
 
     # Validate action parameters.
-    schema = util_schema.get_parameter_schema(action_db)
+    schema = util_schema.get_schema_for_action_parameters(action_db)
     validator = util_schema.get_validator()
     util_schema.validate(liveaction.parameters, schema, validator, use_default=True)
 

--- a/st2common/st2common/util/schema/__init__.py
+++ b/st2common/st2common/util/schema/__init__.py
@@ -123,8 +123,10 @@ def assign_default_values(instance, schema):
         attribute_type = property_data.get('type', None)
         schema_items = property_data.get('items', {})
         if attribute_type == 'array' and schema_items and schema_items.get('properties', {}):
-            instance[property_name] = assign_default_values(instance=instance[property_name],
-                schema=schema['properties'][property_name]['items'])
+            array_instance = instance.get(property_name, [])
+            array_schema = schema['properties'][property_name]['items']
+            instance[property_name] = assign_default_values(instance=array_instance,
+                                                            schema=array_schema)
 
     return instance
 

--- a/st2common/st2common/util/schema/__init__.py
+++ b/st2common/st2common/util/schema/__init__.py
@@ -1,3 +1,18 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import copy
 
@@ -21,10 +36,10 @@ __all__ = [
 # and draft 3 version of required.
 PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)))
 SCHEMAS = {
-    'draft4': jsonify.load_file('%s/draft4.json' % PATH),
-    'custom': jsonify.load_file('%s/custom.json' % PATH),
+    'draft4': jsonify.load_file(os.path.join(PATH, 'draft4.json')),
+    'custom': jsonify.load_file(os.path.join(PATH, 'custom.json')),
     # Custom schema for action params which doesn't allow parameter "type" attribute to be array
-    'action_params': jsonify.load_file('%s/action_params.json' % PATH)
+    'action_params': jsonify.load_file(os.path.join(PATH, 'action_params.json'))
 }
 
 SCHEMA_ANY_TYPE = {

--- a/st2common/st2common/util/schema/__init__.py
+++ b/st2common/st2common/util/schema/__init__.py
@@ -22,7 +22,9 @@ __all__ = [
 PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)))
 SCHEMAS = {
     'draft4': jsonify.load_file('%s/draft4.json' % PATH),
-    'custom': jsonify.load_file('%s/custom.json' % PATH)
+    'custom': jsonify.load_file('%s/custom.json' % PATH),
+    # Custom schema for action params which doesn't allow parameter "type" attribute to be array
+    'action_params': jsonify.load_file('%s/action_params.json' % PATH)
 }
 
 SCHEMA_ANY_TYPE = {

--- a/st2common/st2common/util/schema/__init__.py
+++ b/st2common/st2common/util/schema/__init__.py
@@ -25,6 +25,8 @@ from st2common.util import jsonify
 
 __all__ = [
     'get_validator',
+    'get_draft_schema',
+    'get_action_parameters_schema',
     'get_parameter_schema',
     'validate'
 ]
@@ -38,6 +40,7 @@ PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)))
 SCHEMAS = {
     'draft4': jsonify.load_file(os.path.join(PATH, 'draft4.json')),
     'custom': jsonify.load_file(os.path.join(PATH, 'custom.json')),
+
     # Custom schema for action params which doesn't allow parameter "type" attribute to be array
     'action_params': jsonify.load_file(os.path.join(PATH, 'action_params.json'))
 }
@@ -59,6 +62,10 @@ def get_draft_schema(version='custom', additional_properties=False):
     if additional_properties and 'additionalProperties' in schema:
         del schema['additionalProperties']
     return schema
+
+
+def get_action_parameters_schema(additional_properties=False):
+    return get_draft_schema(version='action_params', additional_properties=additional_properties)
 
 
 def extend_with_default(validator_class):
@@ -120,6 +127,9 @@ def assign_default_values(instance, schema):
     instance_is_dict = isinstance(instance, dict)
     instance_is_array = isinstance(instance, list)
 
+    if not instance_is_dict and not instance_is_array:
+        return instance
+
     properties = schema.get('properties', {})
 
     for property_name, property_data in six.iteritems(properties):
@@ -155,7 +165,7 @@ def validate(instance, schema, cls=None, use_default=True, *args, **kwargs):
 
     Note: This function returns cleaned instance with default values assigned.
 
-    :param use_default: True to support the use of the optional default property.
+    :param use_default: True to support the use of the optional "default" property.
     :type use_default: ``bool``
     """
     instance = copy.deepcopy(instance)

--- a/st2common/st2common/util/schema/__init__.py
+++ b/st2common/st2common/util/schema/__init__.py
@@ -100,6 +100,8 @@ def validate(instance, schema, cls=None, use_default=True, *args, **kwargs):
     Custom validate function which supports default arguments combined with the "required"
     property.
 
+    Note: This function returns cleaned instance with default values assigned.
+
     :param use_default: True to support the use of the optional default property.
     :type use_default: ``bool``
     """
@@ -118,8 +120,8 @@ def validate(instance, schema, cls=None, use_default=True, *args, **kwargs):
                 instance[property_name] = default_value
 
     # pylint: disable=assignment-from-no-return
-    result = jsonschema.validate(instance=instance, schema=schema, cls=cls, *args, **kwargs)
-    return result
+    jsonschema.validate(instance=instance, schema=schema, cls=cls, *args, **kwargs)
+    return instance
 
 
 VALIDATORS = {

--- a/st2common/st2common/util/schema/__init__.py
+++ b/st2common/st2common/util/schema/__init__.py
@@ -90,7 +90,7 @@ def extend_with_default(validator_class):
 
 
 CustomValidator = create(
-    meta_schema=get_draft_schema(additional_properties=True),
+    meta_schema=get_draft_schema(version='custom', additional_properties=True),
     validators={
         u"$ref": _validators.ref,
         u"additionalItems": _validators.additionalItems,
@@ -118,7 +118,7 @@ CustomValidator = create(
         u"type": _validators.type_draft4,
         u"uniqueItems": _validators.uniqueItems,
     },
-    version="action_param",
+    version="custom_validator",
 )
 
 

--- a/st2common/st2common/util/schema/__init__.py
+++ b/st2common/st2common/util/schema/__init__.py
@@ -71,24 +71,6 @@ def get_action_parameters_schema(additional_properties=False):
     return get_draft_schema(version='action_params', additional_properties=additional_properties)
 
 
-def extend_with_default(validator_class):
-    validate_properties = validator_class.VALIDATORS["properties"]
-
-    def set_defaults(validator, properties, instance, schema):
-        for error in validate_properties(
-            validator, properties, instance, schema,
-        ):
-            yield error
-
-        for property, subschema in six.iteritems(properties):
-            if "default" in subschema:
-                instance.setdefault(property, subschema["default"])
-
-    return jsonschema.validators.extend(
-        validator_class, {"properties": set_defaults},
-    )
-
-
 CustomValidator = create(
     meta_schema=get_draft_schema(version='custom', additional_properties=True),
     validators={
@@ -189,9 +171,9 @@ VALIDATORS = {
 }
 
 
-def get_validator(version='custom', assign_property_default=False):
+def get_validator(version='custom'):
     validator = VALIDATORS[version]
-    return extend_with_default(validator) if assign_property_default else validator
+    return validator
 
 
 def get_schema_for_action_parameters(action_db):

--- a/st2common/st2common/util/schema/action_params.json
+++ b/st2common/st2common/util/schema/action_params.json
@@ -1,0 +1,164 @@
+{
+    "id": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Core schema meta-schema",
+    "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#" }
+        },
+        "positiveInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "positiveIntegerDefault0": {
+            "allOf": [ { "$ref": "#/definitions/positiveInteger" }, { "default": 0 } ]
+        },
+        "simpleTypes": {
+            "enum": [ "array", "boolean", "integer", "null", "number", "object", "string" ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1,
+            "uniqueItems": true
+        }
+    },
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string",
+            "format": "uri"
+        },
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": {},
+        "multipleOf": {
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": true
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "boolean",
+            "default": false
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxLength": { "$ref": "#/definitions/positiveInteger" },
+        "minLength": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "additionalItems": {
+            "anyOf": [
+                { "type": "boolean" },
+                { "$ref": "#" }
+            ],
+            "default": {}
+        },
+        "items": {
+            "anyOf": [
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
+            ],
+            "default": {}
+        },
+        "maxItems": { "$ref": "#/definitions/positiveInteger" },
+        "minItems": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxProperties": { "$ref": "#/definitions/positiveInteger" },
+        "minProperties": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "required": {
+            "type": "boolean",
+            "default": false
+        },
+        "secret": {
+            "type": "boolean",
+            "default": false
+        },
+        "additionalProperties": {
+            "anyOf": [
+                { "type": "boolean" },
+                { "$ref": "#" }
+            ],
+            "default": {}
+        },
+        "definitions": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#" },
+                    { "$ref": "#/definitions/stringArray" }
+                ]
+            }
+        },
+        "enum": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "type": {
+            "anyOf": [
+                { "$ref": "#/definitions/simpleTypes" },
+                {
+                    "type": "string",
+                    "items": { "$ref": "#/definitions/simpleTypes" }
+                }
+            ]
+        },
+        "position": {
+            "type": "number",
+            "minimum": 0
+        },
+        "immutable": {
+            "type": "boolean",
+            "default": false
+        },
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" }
+    },
+    "dependencies": {
+        "exclusiveMaximum": [ "maximum" ],
+        "exclusiveMinimum": [ "minimum" ]
+    },
+    "default": {},
+    "additionalProperties": false
+}

--- a/st2common/st2common/validators/api/reactor.py
+++ b/st2common/st2common/validators/api/reactor.py
@@ -25,7 +25,6 @@ __all__ = [
     'validate_trigger_parameters'
 ]
 
-VALIDATOR = util_schema.get_validator(assign_property_default=False)
 allowed_operators = criteria_operators.get_allowed_operators()
 
 
@@ -68,6 +67,6 @@ def validate_trigger_parameters(trigger_db):
         return None
 
     parameters_schema = SYSTEM_TRIGGER_TYPES[trigger_type_ref]['parameters_schema']
-    VALIDATOR(parameters_schema).validate(parameters)
-
-    return True
+    cleaned = util_schema.validate(instance=parameters, schema=parameters_schema,
+                                   cls=util_schema.CustomValidator, use_default=True)
+    return cleaned

--- a/st2common/st2common/validators/api/reactor.py
+++ b/st2common/st2common/validators/api/reactor.py
@@ -46,21 +46,21 @@ def validate_criteria(criteria):
                                            'for operator ' + operator)
 
 
-def validate_trigger_parameters(trigger_db):
+def validate_trigger_parameters(trigger_type_ref, parameters):
     """
-    This function validates parameters for system triggers (e.g. timers).
+    This function validates parameters for system triggers (e.g. webhook and timers).
 
     Note: Eventually we should also validate parameters for user defined triggers which correctly
     specify JSON schema for the parameters.
 
-    :param trigger_db: Trigger DB object.
-    :type trigger_db: :class:`TriggerDB`
-    """
-    if not trigger_db:
-        return None
+    :param trigger_type_ref: Reference of a trigger type.
+    :type trigger_type_ref: ``str``
 
-    trigger_type_ref = trigger_db.type
-    parameters = trigger_db.parameters
+    :param parameters: Trigger parameters.
+    :type parameters: ``dict``
+    """
+    if not trigger_type_ref:
+        return None
 
     if trigger_type_ref not in SYSTEM_TRIGGER_TYPES:
         # Not a system trigger, skip validation for now

--- a/st2common/tests/unit/test_api_model_base.py
+++ b/st2common/tests/unit/test_api_model_base.py
@@ -35,10 +35,10 @@ class FakeModel(base.BaseAPI):
 
 @mock.patch.object(pecan, 'request', mock.MagicMock(json={'a': 'b'}))
 @mock.patch.object(pecan, 'response', mock.MagicMock())
-class TestModelBase(unittest.TestCase):
+class TestAPIModelBase(unittest.TestCase):
 
     def setUp(self):
-        super(TestModelBase, self).setUp()
+        super(TestAPIModelBase, self).setUp()
         self.f = mock.MagicMock(__name__="Name")
 
     def test_expose_decorator(self):

--- a/st2common/tests/unit/test_api_model_validation.py
+++ b/st2common/tests/unit/test_api_model_validation.py
@@ -1,0 +1,113 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest2
+
+from st2common.models.api.base import BaseAPI
+
+
+class MockAPIModel(BaseAPI):
+    model = None
+    schema = {
+        'title': 'MockAPIModel',
+        'description': 'Test',
+        'type': 'object',
+        'properties': {
+            'id': {
+                'description': 'The unique identifier for the action runner.',
+                'type': ['string', 'null'],
+                'default': None
+            },
+            'name': {
+                'description': 'The name of the action runner.',
+                'type': 'string',
+                'required': True
+            },
+            'description': {
+                'description': 'The description of the action runner.',
+                'type': 'string'
+            },
+            'enabled': {
+                'type': 'boolean',
+                'default': True
+            },
+            'parameters': {
+                'type': 'object'
+            },
+            'permission_grants': {
+                'type': 'array',
+                'items': {
+                    'type': 'object',
+                    'properties': {
+                        'resource_uid': {
+                            'type': 'string',
+                            'description': 'UID of a resource to which this grant applies to.',
+                            'required': False,
+                            'default': 'unknown'
+                        },
+                        'enabled': {
+                            'type': 'boolean',
+                            'default': True
+                        },
+                        'description': {
+                            'type': 'string',
+                            'description': 'Description',
+                            'required': False
+                        }
+                    }
+                },
+                'default': []
+            }
+        },
+        'additionalProperties': False
+    }
+
+
+class APIModelValidationTestCase(unittest2.TestCase):
+    def test_validate_default_values_are_set(self):
+        # no "permission_grants" attribute
+        mock_model_api = MockAPIModel(name='name')
+        self.assertEqual(getattr(mock_model_api, 'id', 'notset'), 'notset')
+        self.assertEqual(mock_model_api.name, 'name')
+        self.assertEqual(getattr(mock_model_api, 'enabled', None), None)
+        self.assertEqual(getattr(mock_model_api, 'permission_grants', None), None)
+
+        mock_model_api_validated = mock_model_api.validate()
+        self.assertEqual(mock_model_api.id, None)
+        self.assertEqual(mock_model_api.name, 'name')
+        self.assertEqual(mock_model_api.enabled, True)
+        self.assertEqual(mock_model_api.permission_grants, [])
+        self.assertEqual(mock_model_api_validated.name, 'name')
+        self.assertEqual(mock_model_api_validated.enabled, True)
+        self.assertEqual(mock_model_api_validated.permission_grants, [])
+
+        # "permission_grants" attribute present, but child missing
+        mock_model_api = MockAPIModel(name='name', enabled=False,
+                                      permission_grants=[{}, {'description': 'test'}])
+        self.assertEqual(mock_model_api.name, 'name')
+        self.assertEqual(mock_model_api.enabled, False)
+        self.assertEqual(mock_model_api.permission_grants, [{}, {'description': 'test'}])
+
+        mock_model_api_validated = mock_model_api.validate()
+        self.assertEqual(mock_model_api.name, 'name')
+        self.assertEqual(mock_model_api.enabled, False)
+        self.assertEqual(mock_model_api.permission_grants,
+                         [{'resource_uid': 'unknown', 'enabled': True},
+                          {'resource_uid': 'unknown', 'enabled': True, 'description': 'test'}])
+        self.assertEqual(mock_model_api_validated.name, 'name')
+        self.assertEqual(mock_model_api_validated.enabled, False)
+        self.assertEqual(mock_model_api_validated.permission_grants,
+                         [{'resource_uid': 'unknown', 'enabled': True},
+                          {'resource_uid': 'unknown', 'enabled': True, 'description': 'test'}])

--- a/st2common/tests/unit/test_api_model_validation.py
+++ b/st2common/tests/unit/test_api_model_validation.py
@@ -17,6 +17,10 @@ import unittest2
 
 from st2common.models.api.base import BaseAPI
 
+__all__ = [
+    'APIModelValidationTestCase'
+]
+
 
 class MockAPIModel(BaseAPI):
     model = None
@@ -85,10 +89,14 @@ class APIModelValidationTestCase(unittest2.TestCase):
         self.assertEqual(getattr(mock_model_api, 'permission_grants', None), None)
 
         mock_model_api_validated = mock_model_api.validate()
-        self.assertEqual(mock_model_api.id, None)
+
+        # Validate it doesn't modify object in place
+        self.assertEqual(getattr(mock_model_api, 'id', 'notset'), 'notset')
         self.assertEqual(mock_model_api.name, 'name')
-        self.assertEqual(mock_model_api.enabled, True)
-        self.assertEqual(mock_model_api.permission_grants, [])
+        self.assertEqual(getattr(mock_model_api, 'enabled', None), None)
+
+        # Verify cleaned object
+        self.assertEqual(mock_model_api_validated.id, None)
         self.assertEqual(mock_model_api_validated.name, 'name')
         self.assertEqual(mock_model_api_validated.enabled, True)
         self.assertEqual(mock_model_api_validated.permission_grants, [])
@@ -101,11 +109,14 @@ class APIModelValidationTestCase(unittest2.TestCase):
         self.assertEqual(mock_model_api.permission_grants, [{}, {'description': 'test'}])
 
         mock_model_api_validated = mock_model_api.validate()
+
+        # Validate it doesn't modify object in place
         self.assertEqual(mock_model_api.name, 'name')
         self.assertEqual(mock_model_api.enabled, False)
-        self.assertEqual(mock_model_api.permission_grants,
-                         [{'resource_uid': 'unknown', 'enabled': True},
-                          {'resource_uid': 'unknown', 'enabled': True, 'description': 'test'}])
+        self.assertEqual(mock_model_api.permission_grants, [{}, {'description': 'test'}])
+
+        # Verify cleaned object
+        self.assertEqual(mock_model_api_validated.id, None)
         self.assertEqual(mock_model_api_validated.name, 'name')
         self.assertEqual(mock_model_api_validated.enabled, False)
         self.assertEqual(mock_model_api_validated.permission_grants,

--- a/st2common/tests/unit/test_db.py
+++ b/st2common/tests/unit/test_db.py
@@ -317,7 +317,7 @@ class ActionModelTest(DbTestCase):
         retrieved = Action.get_by_id(saved.id)
 
         # validate generated schema
-        schema = util_schema.get_parameter_schema(retrieved)
+        schema = util_schema.get_schema_for_action_parameters(retrieved)
         self.assertDictEqual(schema, PARAM_SCHEMA)
         validator = util_schema.get_validator()
         validator.check_schema(schema)

--- a/st2common/tests/unit/test_model_base.py
+++ b/st2common/tests/unit/test_model_base.py
@@ -114,7 +114,7 @@ class TestModelBase(unittest.TestCase):
         f(self)
 
         APIModelMock.assert_called_once_with(a='b')
-        self.f.assert_called_once_with(self, (APIModelMock(),), {})
+        self.f.assert_called_once_with(self, (APIModelMock().validate(),), {})
 
     def test_expose_body(self):
         APIModelMock = mock.MagicMock()
@@ -126,7 +126,7 @@ class TestModelBase(unittest.TestCase):
         f(self)
 
         APIModelMock.assert_called_once_with(a='b')
-        self.f.assert_called_once_with(self, APIModelMock(), (), {})
+        self.f.assert_called_once_with(self, APIModelMock().validate(), (), {})
 
     def test_expose_body_and_arguments_unused(self):
         APIModelMock = mock.MagicMock()
@@ -138,7 +138,7 @@ class TestModelBase(unittest.TestCase):
         f(self, '11')
 
         APIModelMock.assert_called_once_with(a='b')
-        self.f.assert_called_once_with(self, APIModelMock(), ('11', ), {})
+        self.f.assert_called_once_with(self, APIModelMock().validate(), ('11', ), {})
 
     def test_expose_body_and_arguments_type_casting(self):
         APIModelMock = mock.MagicMock()
@@ -150,7 +150,7 @@ class TestModelBase(unittest.TestCase):
         f(self, '11')
 
         APIModelMock.assert_called_once_with(a='b')
-        self.f.assert_called_once_with(self, 11, APIModelMock(), (), {})
+        self.f.assert_called_once_with(self, 11, APIModelMock().validate(), (), {})
 
     @unittest.skip
     def test_expose_body_and_typed_arguments_unused(self):
@@ -163,7 +163,7 @@ class TestModelBase(unittest.TestCase):
         f(self, '11', 'some')
 
         APIModelMock.assert_called_once_with(a='b')
-        self.f.assert_called_once_with(self, 11, APIModelMock(), ('some', ), {})
+        self.f.assert_called_once_with(self, 11, APIModelMock().validate(), ('some', ), {})
 
     @unittest.skip
     def test_expose_body_and_typed_kw_unused(self):

--- a/st2reactor/st2reactor/timer/base.py
+++ b/st2reactor/st2reactor/timer/base.py
@@ -30,6 +30,7 @@ import st2common.services.triggers as trigger_services
 from st2common.services.triggerwatcher import TriggerWatcher
 from st2common.transport.reactor import TriggerDispatcher
 from st2common.util import date as date_utils
+from st2common.util import schema as util_schema
 
 LOG = logging.getLogger(__name__)
 
@@ -82,8 +83,10 @@ class St2Timer(object):
         trigger_type_ref = trigger['type']
         trigger_type = TIMER_TRIGGER_TYPES[trigger_type_ref]
         try:
-            jsonschema.validate(trigger['parameters'],
-                                trigger_type['parameters_schema'])
+            util_schema.validate(instance=trigger['parameters'],
+                                 schema=trigger_type['parameters_schema'],
+                                 cls=util_schema.CustomValidator,
+                                 use_default=True)
         except jsonschema.ValidationError as e:
             LOG.error('Exception scheduling timer: %s, %s',
                       trigger['parameters'], e, exc_info=True)

--- a/st2tests/st2tests/fixtures/generic/rules/date_timer_rule_invalid_parameters.yaml
+++ b/st2tests/st2tests/fixtures/generic/rules/date_timer_rule_invalid_parameters.yaml
@@ -1,0 +1,23 @@
+---
+action:
+  parameters:
+    ip1: '{{trigger.t1_p}}'
+    ip2: '{{rule.k1}}'
+  ref: wolfpack.action-1
+criteria:
+  t1_p:
+    pattern: t1_p_v
+    type: equals
+description: ''
+enabled: true
+name: date_timer_rule_1
+pack: timer_rules
+tags:
+- name: tag1
+  value: dont-care
+- name: tag2
+  value: dont-care
+trigger:
+  # Missing a required parameter
+  parameters: {}
+  type: core.st2.DateTimer


### PR DESCRIPTION
This pull request introduces support for default values on API model (we already support this for action parameters).

Most of the API models already defined "default" attributes in the JSON schema, but those attributes were actually ignored and not used. Not using those attributes means we need to assign default value in multiple places - you can see a bunch of `getattr` in to_model, etc. This also resulted in a lot of bugs in the past ("rule" has no property enabled, etc.).

That's obviously bad since default values needs to spread and set all around the code base. This pull request resolves this and introduces a consistent interface - default attribute will be set on the model API instance after "model.validate()" is called if the JSON schema defined a default value. This means no more nasty getattr stuff and now we know exactly when attributes are set and available.