### PR TITLE
Delete sensor from process container before terminating

### DIFF
--- a/st2reactor/st2reactor/container/process_container.py
+++ b/st2reactor/st2reactor/container/process_container.py
@@ -337,6 +337,10 @@ class ProcessSensorContainer(object):
         """
         process = self._processes[sensor_id]
 
+        # Delete sensor before terminating process so that it will not be
+        # respawned during termination
+        self._delete_sensor(sensor_id)
+
         # Terminate the process and wait for up to stop_timeout seconds for the
         # process to exit
         process.terminate()
@@ -356,8 +360,6 @@ class ProcessSensorContainer(object):
         if status is None:
             # Process hasn't exited yet, forcefully kill it
             process.kill()
-
-        self._delete_sensor(sensor_id)
 
     def _respawn_sensor(self, sensor_id, sensor, exit_code):
         """


### PR DESCRIPTION
* Eliminates a race condition where the process could be respawned before `_delete_sensor` is called.