### PR TITLE
Change headers and params core.http action parameters type to object

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ in development
 * Update action chain runner so it performs on-success and on-error task name validation during
   pre_run time. This way common errors such as typos in the task names can be spotted early on
   since there is no need to wait for the run time.
+* Change ``headers`` and ``params`` ``core.http`` action paramer type from ``string`` to
+  ``object``.
 
 1.1.0 - October 27, 2015
 ------------------------

--- a/contrib/core/actions/http.yaml
+++ b/contrib/core/actions/http.yaml
@@ -25,8 +25,8 @@ parameters:
     description: Path to the file to upload
     type: string
   headers:
-    description: 'HTTP headers to use with the request. Example: ''content-type=application/json&x-foo=bar''.'
-    type: string
+    description: 'HTTP headers to use with the request.'
+    type: object
   method:
     description: HTTP method to use.
     enum:
@@ -36,9 +36,8 @@ parameters:
     - PUT
     - DELETE
   params:
-    description: Query params to be used with the HTTP request. This can be of the
-      form 'foo=bar&baz=1'.
-    type: string
+    description: Query params to be used with the HTTP request.
+    type: object
   timeout:
     default: 60
     description: Timeout for the HTTP request.

--- a/docs/source/runners.rst
+++ b/docs/source/runners.rst
@@ -111,6 +111,9 @@ Runner parameters
 
 .. include:: _includes/runner_parameters/http_request.rst
 
+Keep in mind that other parameters such as ``body``, ``method``, ``headers``, etc. are defined
+as part of the ``core.http`` action.
+
 Runner result
 ~~~~~~~~~~~~~
 

--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -7,6 +7,9 @@ Upgrade Notes
 * Refactor retries in the Mistral action runner to use exponential backoff. Configuration options
   for Mistral have changed. The options ``max_attempts`` and ``retry_wait`` are deprecated. Please
   refer to the configuration section of docs for more details.
+* Change ``headers`` and ``params`` parameters in the ``core.http`` action from ``string`` to
+  ``object``. If you have any code or rules which calls this action, you need to update it to
+  pass in a new and correct type.
 
 |st2| 1.1
 ---------

--- a/st2actions/st2actions/runners/httprunner.py
+++ b/st2actions/st2actions/runners/httprunner.py
@@ -20,7 +20,6 @@ import uuid
 
 import requests
 from oslo_config import cfg
-from six.moves.urllib import parse as urlparse
 
 from st2actions.runners import ActionRunner
 from st2common import __version__ as st2_version
@@ -124,15 +123,6 @@ class HttpRunner(ActionRunner):
                           headers=headers, cookies=self._cookies, auth=auth,
                           timeout=timeout, allow_redirects=self._allow_redirects,
                           proxies=proxies, files=files, verify=self._verify_ssl_cert)
-
-    def _params_to_dict(self, params):
-        if not params:
-            return {}
-
-        if isinstance(params, dict):
-            return params
-
-        return dict(urlparse.parse_qsl(params, keep_blank_values=True, strict_parsing=True))
 
     @staticmethod
     def _get_result_status(status_code):

--- a/st2actions/st2actions/runners/httprunner.py
+++ b/st2actions/st2actions/runners/httprunner.py
@@ -71,7 +71,6 @@ class HttpRunner(ActionRunner):
                                                           self._on_behalf_user)
         self._url = self.runner_parameters.get(RUNNER_URL, None)
         self._headers = self.runner_parameters.get(RUNNER_HEADERS, {})
-        self._headers = self._params_to_dict(self._headers)
 
         self._cookies = self.runner_parameters.get(RUNNER_COOKIES, None)
         self._allow_redirects = self.runner_parameters.get(RUNNER_ALLOW_REDIRECTS, False)
@@ -90,7 +89,6 @@ class HttpRunner(ActionRunner):
         timeout = float(action_parameters.get(ACTION_TIMEOUT, self._timeout))
         method = action_parameters.get(ACTION_METHOD, None)
         params = action_parameters.get(ACTION_QUERY_PARAMS, None)
-        params = self._params_to_dict(params)
         auth = action_parameters.get(ACTION_AUTH, {})
 
         file_name = action_parameters.get(FILE_NAME, None)


### PR DESCRIPTION
This changes the type of headers and params ``core.http`` action parameters type from ``string`` to ``object``.

I assume the action was defined before CLI supported complex type so action defined type as string instead of object. This is invalid and incorrect use of the types - the type should indeed be object (dict) since the runner shouldn't be responsible of figuring out and parsing the parameters.

This change is backward incompatible, but I think it's fine. I wanted to make it backward compatible since we support list for parameter `type` attribute but things broke, horrible. I got the CLI to work, but everything else broke down.

On a related note - I think we should also make a change so user can't specify a list for action parameter `type` attribute since things (parameter casting, etc.) break horribly and we don't support it.