### PR TITLE
Add missing entry for st2notifier service to logrotate config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ in development
   could be respawned before it exited. (bug fix) #2187 [Kale Blankenship]
 * Update local runner so all the commands which are executed as a different user and result in
   using sudo set $HOME variable to the home directory of the target user. (improvement)
+* Add missing entry for ``st2notifier`` service to the logrotate config. (bug fix)
 
 1.1.0 - October 27, 2015
 ------------------------

--- a/conf/logrotate.conf
+++ b/conf/logrotate.conf
@@ -46,6 +46,15 @@ notifempty
   endscript
 }
 
+## Notifier
+/var/log/st2/st2notifier*.log {
+  daily
+  rotate 5
+  postrotate
+    st2ctl reopen-log-files st2notifier
+  endscript
+}
+
 ## Sensor Containers
 /var/log/st2/st2sensorcontainer*.log {
   daily


### PR DESCRIPTION
The title says it all.

```bash
-rw-r--r-- 1 root root  14G Nov 10 21:44 st2notifier.log
```

:P

Will cherry pick onto v1.1.1.