### PR TITLE
JSON schema validators change - allow default value of None regardles of the attribute type

### DIFF
--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -55,7 +55,8 @@ class RunnerTypeAPI(BaseAPI):
         "properties": {
             "id": {
                 "description": "The unique identifier for the action runner.",
-                "type": "string"
+                "type": "string",
+                "default": None
             },
             "name": {
                 "description": "The name of the action runner.",
@@ -479,7 +480,8 @@ class ActionAliasAPI(BaseAPI, APIUIDMixin):
             },
             "description": {
                 "type": "string",
-                "description": "Description of the action alias."
+                "description": "Description of the action alias.",
+                "default": None
             },
             "enabled": {
                 "description": "Flag indicating of action alias is enabled.",

--- a/st2common/st2common/models/api/base.py
+++ b/st2common/st2common/models/api/base.py
@@ -81,7 +81,8 @@ class BaseAPI(object):
         attributes = vars(self)
 
         cleaned = util_schema.validate(instance=attributes, schema=schema,
-                                       cls=util_schema.CustomValidator, use_default=True)
+                                       cls=util_schema.CustomValidator, use_default=True,
+                                       allow_default_none=True)
 
         return self.__class__(**cleaned)
 

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -27,10 +27,12 @@ class PackAPI(BaseAPI):
         'type': 'object',
         'properties': {
             'id': {
-                'type': 'string'
+                'type': 'string',
+                'default': None
             },
             'ref': {
-                'type': 'string'
+                'type': 'string',
+                'default': None
             },
             "uid": {
                 "type": "string"

--- a/st2common/st2common/models/api/policy.py
+++ b/st2common/st2common/models/api/policy.py
@@ -31,7 +31,8 @@ class PolicyTypeAPI(BaseAPI):
         "type": "object",
         "properties": {
             "id": {
-                "type": "string"
+                "type": "string",
+                "default": None
             },
             "name": {
                 "type": "string",
@@ -83,7 +84,8 @@ class PolicyAPI(BaseAPI):
         "type": "object",
         "properties": {
             "id": {
-                "type": "string"
+                "type": "string",
+                "default": None
             },
             "name": {
                 "type": "string",

--- a/st2common/st2common/models/api/rbac.py
+++ b/st2common/st2common/models/api/rbac.py
@@ -113,7 +113,7 @@ class RoleDefinitionFileFormatAPI(BaseAPI):
                                 # resource type in other place
                                 'enum': PermissionType.get_valid_values()
                             },
-                            'default': None
+                            'default': []
                         }
                     }
                 }

--- a/st2common/st2common/models/api/rbac.py
+++ b/st2common/st2common/models/api/rbac.py
@@ -33,7 +33,8 @@ class RoleAPI(BaseAPI):
         'type': 'object',
         'properties': {
             'id': {
-                'type': 'string'
+                'type': 'string',
+                'default': None
             },
             'name': {
                 'type': 'string',
@@ -77,7 +78,8 @@ class RoleDefinitionFileFormatAPI(BaseAPI):
             'name': {
                 'type': 'string',
                 'description': 'Role name',
-                'required': True
+                'required': True,
+                'default': None
             },
             'description': {
                 'type': 'string',
@@ -98,7 +100,8 @@ class RoleDefinitionFileFormatAPI(BaseAPI):
                         'resource_uid': {
                             'type': 'string',
                             'description': 'UID of a resource to which this grant applies to.',
-                            'required': False
+                            'required': False,
+                            'default': None
                         },
                         'permission_types': {
                             'type': 'array',
@@ -110,7 +113,7 @@ class RoleDefinitionFileFormatAPI(BaseAPI):
                                 # resource type in other place
                                 'enum': PermissionType.get_valid_values()
                             },
-                            'default': []
+                            'default': None
                         }
                     }
                 }
@@ -161,12 +164,14 @@ class UserRoleAssignmentFileFormatAPI(BaseAPI):
             'username': {
                 'type': 'string',
                 'description': 'Username',
-                'required': True
+                'required': True,
+                'default': None
             },
             'description': {
                 'type': 'string',
                 'description': 'Assignment description',
-                'required': False
+                'required': False,
+                'default': None
             },
             'enabled': {
                 'type': 'boolean',

--- a/st2common/st2common/models/api/rule.py
+++ b/st2common/st2common/models/api/rule.py
@@ -78,7 +78,8 @@ class RuleTypeAPI(BaseAPI):
         'properties': {
             'id': {
                 'description': 'The unique identifier for the action runner.',
-                'type': 'string'
+                'type': 'string',
+                'default': None
             },
             'name': {
                 'description': 'The name of the action runner.',
@@ -142,7 +143,8 @@ class RuleAPI(BaseAPI, APIUIDMixin):
         'type': 'object',
         'properties': {
             'id': {
-                'type': 'string'
+                'type': 'string',
+                'default': None
             },
             "ref": {
                 "description": "System computed user friendly reference for the action. \

--- a/st2common/st2common/models/api/sensor.py
+++ b/st2common/st2common/models/api/sensor.py
@@ -24,7 +24,8 @@ class SensorTypeAPI(BaseAPI):
         'type': 'object',
         'properties': {
             'id': {
-                'type': 'string'
+                'type': 'string',
+                'default': None
             },
             'ref': {
                 'type': 'string'

--- a/st2common/st2common/models/api/trace.py
+++ b/st2common/st2common/models/api/trace.py
@@ -48,7 +48,8 @@ class TraceAPI(BaseAPI):
         'properties': {
             'id': {
                 'description': 'The unique identifier for a Trace.',
-                'type': 'string'
+                'type': 'string',
+                'default': None
             },
             'trace_tag': {
                 'description': 'User assigned identifier for each Trace.',

--- a/st2common/st2common/models/api/trigger.py
+++ b/st2common/st2common/models/api/trigger.py
@@ -30,7 +30,8 @@ class TriggerTypeAPI(BaseAPI):
         'type': 'object',
         'properties': {
             'id': {
-                'type': 'string'
+                'type': 'string',
+                'default': None
             },
             'ref': {
                 'type': 'string'
@@ -92,7 +93,8 @@ class TriggerAPI(BaseAPI):
         'type': 'object',
         'properties': {
             'id': {
-                'type': 'string'
+                'type': 'string',
+                'default': None
             },
             'ref': {
                 'type': 'string'
@@ -167,6 +169,7 @@ class TriggerInstanceAPI(BaseAPI):
             },
             'trigger': {
                 'type': 'string',
+                'default': None,
                 'required': True
             }
         },

--- a/st2common/st2common/models/system/actionchain.py
+++ b/st2common/st2common/models/system/actionchain.py
@@ -121,7 +121,7 @@ class ActionChain(object):
 
     def __init__(self, **kw):
         util_schema.validate(instance=kw, schema=self.schema, cls=util_schema.CustomValidator,
-                             use_default=False)
+                             use_default=False, allow_default_none=True)
 
         for prop in six.iterkeys(self.schema.get('properties', [])):
             value = kw.get(prop, None)

--- a/st2common/st2common/services/action.py
+++ b/st2common/st2common/services/action.py
@@ -72,7 +72,8 @@ def request(liveaction):
     # Validate action parameters.
     schema = util_schema.get_schema_for_action_parameters(action_db)
     validator = util_schema.get_validator()
-    util_schema.validate(liveaction.parameters, schema, validator, use_default=True)
+    util_schema.validate(liveaction.parameters, schema, validator, use_default=True,
+                         allow_default_none=True)
 
     # validate that no immutable params are being overriden. Although possible to
     # ignore the override it is safer to inform the user to avoid surprises.

--- a/st2common/st2common/util/schema/__init__.py
+++ b/st2common/st2common/util/schema/__init__.py
@@ -116,7 +116,6 @@ def assign_default_values(instance, schema):
         return instance
 
     properties = schema.get('properties', {})
-
     for property_name, property_data in six.iteritems(properties):
         has_default_value = 'default' in property_data
         default_value = property_data.get('default', None)
@@ -137,17 +136,23 @@ def assign_default_values(instance, schema):
 
         # Array
         if attribute_type == 'array' and schema_items and schema_items.get('properties', {}):
-            array_instance = instance.get(property_name, [])
+            array_instance = instance.get(property_name, None)
             array_schema = schema['properties'][property_name]['items']
-            instance[property_name] = assign_default_values(instance=array_instance,
-                                                            schema=array_schema)
+
+            if array_instance is not None:
+                # Note: We don't perform subschema assignment if no value is provided
+                instance[property_name] = assign_default_values(instance=array_instance,
+                                                                schema=array_schema)
 
         # Object
         if attribute_type == 'object' and property_data.get('properties', {}):
-            object_instance = instance.get(property_name, {})
+            object_instance = instance.get(property_name, None)
             object_schema = schema['properties'][property_name]
-            instance[property_name] = assign_default_values(instance=object_instance,
-                                                            schema=object_schema)
+
+            if object_instance is not None:
+                # Note: We don't perform subschema assignment if no value is provided
+                instance[property_name] = assign_default_values(instance=object_instance,
+                                                                schema=object_schema)
 
     return instance
 

--- a/st2common/st2common/util/schema/__init__.py
+++ b/st2common/st2common/util/schema/__init__.py
@@ -213,7 +213,7 @@ def validate(instance, schema, cls=None, use_default=True, allow_default_none=Fa
     instance_is_dict = isinstance(instance, dict)
 
     if use_default and allow_default_none:
-        schema = modify_schema_allow_default_none(schema)
+        schema = modify_schema_allow_default_none(schema=schema)
 
     if use_default and schema_type == 'object' and instance_is_dict:
         instance = assign_default_values(instance=instance, schema=schema)

--- a/st2common/st2common/util/schema/__init__.py
+++ b/st2common/st2common/util/schema/__init__.py
@@ -152,7 +152,48 @@ def assign_default_values(instance, schema):
     return instance
 
 
-def validate(instance, schema, cls=None, use_default=True, *args, **kwargs):
+def modify_schema_allow_default_none(schema):
+    """
+    Manipulate the provided schema so None is also an allowed value for each attribute which
+    defines a default value of None.
+    """
+    schema = copy.deepcopy(schema)
+
+    properties = schema.get('properties', {})
+    for property_name, property_data in six.iteritems(properties):
+        has_default_value = 'default' in property_data
+        default_value = property_data.get('default', None)
+
+        if has_default_value and default_value is None:
+            # Allow "None" to be also used as a valid attribute value
+            property_type = schema['properties'][property_name]['type']
+
+            if isinstance(property_type, list) and 'null' not in property_type:
+                schema['properties'][property_name]['type'].append('null')
+            elif isinstance(property_type, six.string_types) and 'null' not in property_type:
+                schema['properties'][property_name]['type'] = [property_type, 'null']
+
+        # Support for nested properties (array and object)
+        attribute_type = property_data.get('type', None)
+        schema_items = property_data.get('items', {})
+
+        # Array
+        if attribute_type == 'array' and schema_items and schema_items.get('properties', {}):
+            array_schema = schema_items
+            array_schema = modify_schema_allow_default_none(schema=array_schema)
+            schema['properties'][property_name]['items'] = array_schema
+
+        # Object
+        if attribute_type == 'object' and property_data.get('properties', {}):
+            object_schema = property_data
+            object_schema = modify_schema_allow_default_none(schema=object_schema)
+            schema['properties'][property_name] = object_schema
+
+    return schema
+
+
+def validate(instance, schema, cls=None, use_default=True, allow_default_none=False, *args,
+             **kwargs):
     """
     Custom validate function which supports default arguments combined with the "required"
     property.
@@ -165,6 +206,9 @@ def validate(instance, schema, cls=None, use_default=True, *args, **kwargs):
     instance = copy.deepcopy(instance)
     schema_type = schema.get('type', None)
     instance_is_dict = isinstance(instance, dict)
+
+    if use_default and allow_default_none:
+        schema = modify_schema_allow_default_none(schema)
 
     if use_default and schema_type == 'object' and instance_is_dict:
         instance = assign_default_values(instance=instance, schema=schema)
@@ -207,4 +251,5 @@ def get_schema_for_action_parameters(action_db):
         schema['type'] = 'object'
         schema['properties'] = properties
         schema['additionalProperties'] = False
+
     return schema

--- a/st2common/st2common/util/schema/__init__.py
+++ b/st2common/st2common/util/schema/__init__.py
@@ -131,14 +131,23 @@ def assign_default_values(instance, schema):
                     if instance[index].get(property_name, None) is None:
                         instance[index][property_name] = default_value
 
-        # Support for nested object / array properties
+        # Support for nested properties (array and object)
         attribute_type = property_data.get('type', None)
         schema_items = property_data.get('items', {})
+
+        # Array
         if attribute_type == 'array' and schema_items and schema_items.get('properties', {}):
             array_instance = instance.get(property_name, [])
             array_schema = schema['properties'][property_name]['items']
             instance[property_name] = assign_default_values(instance=array_instance,
                                                             schema=array_schema)
+
+        # Object
+        if attribute_type == 'object' and property_data.get('properties', {}):
+            object_instance = instance.get(property_name, {})
+            object_schema = schema['properties'][property_name]
+            instance[property_name] = assign_default_values(instance=object_instance,
+                                                            schema=object_schema)
 
     return instance
 

--- a/st2common/st2common/validators/api/reactor.py
+++ b/st2common/st2common/validators/api/reactor.py
@@ -68,5 +68,6 @@ def validate_trigger_parameters(trigger_type_ref, parameters):
 
     parameters_schema = SYSTEM_TRIGGER_TYPES[trigger_type_ref]['parameters_schema']
     cleaned = util_schema.validate(instance=parameters, schema=parameters_schema,
-                                   cls=util_schema.CustomValidator, use_default=True)
+                                   cls=util_schema.CustomValidator, use_default=True,
+                                   allow_default_none=True)
     return cleaned

--- a/st2common/tests/unit/test_api_model_validation.py
+++ b/st2common/tests/unit/test_api_model_validation.py
@@ -22,7 +22,7 @@ __all__ = [
 ]
 
 
-class MockAPIModel(BaseAPI):
+class MockAPIModel1(BaseAPI):
     model = None
     schema = {
         'title': 'MockAPIModel',
@@ -132,7 +132,7 @@ class MockAPIModel2(BaseAPI):
 class APIModelValidationTestCase(unittest2.TestCase):
     def test_validate_default_values_are_set(self):
         # no "permission_grants" attribute
-        mock_model_api = MockAPIModel(name='name')
+        mock_model_api = MockAPIModel1(name='name')
         self.assertEqual(getattr(mock_model_api, 'id', 'notset'), 'notset')
         self.assertEqual(mock_model_api.name, 'name')
         self.assertEqual(getattr(mock_model_api, 'enabled', None), None)
@@ -152,8 +152,8 @@ class APIModelValidationTestCase(unittest2.TestCase):
         self.assertEqual(mock_model_api_validated.permission_grants, [])
 
         # "permission_grants" attribute present, but child missing
-        mock_model_api = MockAPIModel(name='name', enabled=False,
-                                      permission_grants=[{}, {'description': 'test'}])
+        mock_model_api = MockAPIModel1(name='name', enabled=False,
+                                       permission_grants=[{}, {'description': 'test'}])
         self.assertEqual(mock_model_api.name, 'name')
         self.assertEqual(mock_model_api.enabled, False)
         self.assertEqual(mock_model_api.permission_grants, [{}, {'description': 'test'}])
@@ -172,6 +172,24 @@ class APIModelValidationTestCase(unittest2.TestCase):
         self.assertEqual(mock_model_api_validated.permission_grants,
                          [{'resource_uid': 'unknown', 'enabled': True},
                           {'resource_uid': 'unknown', 'enabled': True, 'description': 'test'}])
+
+    def test_validate_nested_attribute_with_default_not_provided(self):
+        mock_model_api = MockAPIModel2()
+        self.assertEqual(getattr(mock_model_api, 'id', 'notset'), 'notset')
+        self.assertEqual(getattr(mock_model_api, 'permission_grants', 'notset'), 'notset')
+        self.assertEqual(getattr(mock_model_api, 'parameters', 'notset'), 'notset')
+
+        mock_model_api_validated = mock_model_api.validate()
+
+        # Validate it doesn't modify object in place
+        self.assertEqual(getattr(mock_model_api, 'id', 'notset'), 'notset')
+        self.assertEqual(getattr(mock_model_api, 'permission_grants', 'notset'), 'notset')
+        self.assertEqual(getattr(mock_model_api, 'parameters', 'notset'), 'notset')
+
+        # Verify cleaned object
+        self.assertEqual(mock_model_api_validated.id, None)
+        self.assertEqual(mock_model_api_validated.permission_grants, [])
+        self.assertEqual(getattr(mock_model_api_validated, 'parameters', 'notset'), 'notset')
 
     def test_validate_allow_default_none_for_any_type(self):
         mock_model_api = MockAPIModel2(permission_grants=[{'description': 'test'}],

--- a/st2common/tests/unit/test_api_model_validation.py
+++ b/st2common/tests/unit/test_api_model_validation.py
@@ -131,7 +131,6 @@ class MockAPIModel2(BaseAPI):
 
 class APIModelValidationTestCase(unittest2.TestCase):
     def test_validate_default_values_are_set(self):
-        return
         # no "permission_grants" attribute
         mock_model_api = MockAPIModel(name='name')
         self.assertEqual(getattr(mock_model_api, 'id', 'notset'), 'notset')

--- a/st2reactor/st2reactor/timer/base.py
+++ b/st2reactor/st2reactor/timer/base.py
@@ -86,7 +86,8 @@ class St2Timer(object):
             util_schema.validate(instance=trigger['parameters'],
                                  schema=trigger_type['parameters_schema'],
                                  cls=util_schema.CustomValidator,
-                                 use_default=True)
+                                 use_default=True,
+                                 allow_default_none=True)
         except jsonschema.ValidationError as e:
             LOG.error('Exception scheduling timer: %s, %s',
                       trigger['parameters'], e, exc_info=True)


### PR DESCRIPTION
This pull request updates schema validation so a default value of None is allowed regardless of the attribute type. Keep in mind that this is only relevant if the attribute with a default value is not provided by the user.

For example, the following will work:

```python
    'id': {
                'description': 'The unique identifier for the action runner.',
                'type': 'string',
                'default': None
            }
```

And if user provides no value for the `id` attribute, default value of `None` will be used.

This was done for backward compatibility reasons and to make working with some common cases easier.