### PR TITLE
Allow Mistral to talk to the StackStorm API using a non public URL

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,9 @@ in development
 * Add missing entry for ``st2notifier`` service to the logrotate config. (bug fix)
 * Allow action parameter values who's type is ``object`` to contain special characters such as
   ``.`` and ``$`` in the parameter value. (bug fix, improvement)
+* Allow user to specify URL which Mistral uses to talk to StackStorm API using ``mistral.api_url``
+  configuration option. If this option is not provided it defaults to the old behavior of using the
+  public API url (``auth.api_url`` setting). (improvement)
 
 1.1.0 - October 27, 2015
 ------------------------

--- a/conf/st2.conf.sample
+++ b/conf/st2.conf.sample
@@ -115,7 +115,7 @@ url = amqp://guest:guest@localhost:5672//
 cluster_urls = []
 
 [mistral]
-# URL Mistral uses to talk back to the API.If not provided it defaults to public API URL. Note: This needs to be a base URL without API version
+# URL Mistral uses to talk back to the API.If not provided it defaults to public API URL. Note: This needs to be a base URL without API version (e.g. http://127.0.0.1:9101)
 api_url = None
 # Username for authentication.
 keystone_username = None

--- a/conf/st2.conf.sample
+++ b/conf/st2.conf.sample
@@ -115,6 +115,8 @@ url = amqp://guest:guest@localhost:5672//
 cluster_urls = []
 
 [mistral]
+# URL Mistral uses to talk back to the API.If not provided it defaults to public API URL. Note: This needs to be a base URL without API version
+api_url = None
 # Username for authentication.
 keystone_username = None
 # Seconds to wait before reconnecting.

--- a/st2actions/st2actions/runners/mistral/v2.py
+++ b/st2actions/st2actions/runners/mistral/v2.py
@@ -29,6 +29,7 @@ from st2common.models.api.notification import NotificationsHelper
 from st2common.util.workflow import mistral as utils
 from st2common.util.url import get_url_without_trailing_slash
 from st2common.util.api import get_full_public_api_url
+from st2common.util.api import get_mistral_api_url
 
 
 LOG = logging.getLogger(__name__)
@@ -148,8 +149,13 @@ class MistralRunner(AsyncActionRunner):
         inputs = self.runner_parameters.get('context', dict())
         inputs.update(action_parameters)
 
-        api_url = get_full_public_api_url()
+        # This URL is used by Mistral to talk back to the API
+        api_url = get_mistral_api_url()
         endpoint = api_url + '/actionexecutions'
+
+        # This URL is available in the context and can be used by the users inside a workflow,
+        # similar to "ST2_ACTION_API_URL" environment variable available to actions
+        public_api_url = get_full_public_api_url()
 
         # Build context with additional information
         parent_context = {
@@ -177,6 +183,7 @@ class MistralRunner(AsyncActionRunner):
             'env': {
                 'st2_execution_id': self.execution_id,
                 'st2_liveaction_id': self.liveaction_id,
+                'st2_action_public_url': public_api_url,
                 '__actions': {
                     'st2.action': {
                         'st2_context': st2_execution_context

--- a/st2actions/st2actions/runners/mistral/v2.py
+++ b/st2actions/st2actions/runners/mistral/v2.py
@@ -183,7 +183,7 @@ class MistralRunner(AsyncActionRunner):
             'env': {
                 'st2_execution_id': self.execution_id,
                 'st2_liveaction_id': self.liveaction_id,
-                'st2_action_public_url': public_api_url,
+                'st2_action_api_url': public_api_url,
                 '__actions': {
                     'st2.action': {
                         'st2_context': st2_execution_context

--- a/st2actions/tests/unit/test_mistral_v2.py
+++ b/st2actions/tests/unit/test_mistral_v2.py
@@ -195,6 +195,7 @@ class MistralRunnerTest(DbTestCase):
         env = {
             'st2_execution_id': str(execution.id),
             'st2_liveaction_id': str(liveaction.id),
+            'st2_action_api_url': 'http://0.0.0.0:9101/v1',
             '__actions': {
                 'st2.action': {
                     'st2_context': {
@@ -244,6 +245,7 @@ class MistralRunnerTest(DbTestCase):
         env = {
             'st2_execution_id': str(execution.id),
             'st2_liveaction_id': str(liveaction.id),
+            'st2_action_api_url': 'https://0.0.0.0:9101/v1',
             '__actions': {
                 'st2.action': {
                     'st2_context': {
@@ -294,6 +296,7 @@ class MistralRunnerTest(DbTestCase):
         env = {
             'st2_execution_id': str(execution.id),
             'st2_liveaction_id': str(liveaction.id),
+            'st2_action_api_url': 'http://0.0.0.0:9101/v1',
             '__actions': {
                 'st2.action': {
                     'st2_context': {

--- a/st2actions/tests/unit/test_mistral_v2_auth.py
+++ b/st2actions/tests/unit/test_mistral_v2_auth.py
@@ -152,6 +152,7 @@ class MistralAuthTest(DbTestCase):
         env = {
             'st2_execution_id': str(execution.id),
             'st2_liveaction_id': str(liveaction.id),
+            'st2_action_api_url': 'http://0.0.0.0:9101/v1',
             '__actions': {
                 'st2.action': {
                     'st2_context': {
@@ -209,6 +210,7 @@ class MistralAuthTest(DbTestCase):
         env = {
             'st2_execution_id': str(execution.id),
             'st2_liveaction_id': str(liveaction.id),
+            'st2_action_api_url': 'http://0.0.0.0:9101/v1',
             '__actions': {
                 'st2.action': {
                     'st2_context': {

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -172,7 +172,11 @@ def register_opts(ignore_errors=False):
         cfg.StrOpt('keystone_username', default=None, help='Username for authentication.'),
         cfg.StrOpt('keystone_password', default=None, help='Password for authentication.'),
         cfg.StrOpt('keystone_project_name', default=None, help='OpenStack project scope.'),
-        cfg.StrOpt('keystone_auth_url', default=None, help='Auth endpoint for Keystone.')
+        cfg.StrOpt('keystone_auth_url', default=None, help='Auth endpoint for Keystone.'),
+
+        cfg.StrOpt('api_url', default=None, help=('URL Mistral uses to talk back to the API.'
+            'If not provided it defaults to public API URL. Note: This needs to be a base '
+            'URL without API version'))
     ]
     do_register_opts(mistral_opts, group='mistral', ignore_errors=ignore_errors)
 

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -176,7 +176,7 @@ def register_opts(ignore_errors=False):
 
         cfg.StrOpt('api_url', default=None, help=('URL Mistral uses to talk back to the API.'
             'If not provided it defaults to public API URL. Note: This needs to be a base '
-            'URL without API version'))
+            'URL without API version (e.g. http://127.0.0.1:9101)'))
     ]
     do_register_opts(mistral_opts, group='mistral', ignore_errors=ignore_errors)
 

--- a/st2common/st2common/util/api.py
+++ b/st2common/st2common/util/api.py
@@ -21,7 +21,9 @@ from st2common.util.url import get_url_without_trailing_slash
 
 __all__ = [
     'get_base_public_api_url',
-    'get_full_public_api_url'
+    'get_full_public_api_url',
+
+    'get_mistral_api_url'
 ]
 
 LOG = logging.getLogger(__name__)
@@ -52,4 +54,20 @@ def get_full_public_api_url(api_version=DEFAULT_API_VERSION):
     """
     api_url = get_base_public_api_url()
     api_url = '%s/%s' % (api_url, api_version)
+    return api_url
+
+
+def get_mistral_api_url(api_version=DEFAULT_API_VERSION):
+    """
+    Return a URL which Mistral uses to talk back to the StackStorm API.
+
+    Note: If not provided it defaults to the public API url.
+    """
+    if cfg.CONF.mistral.api_url:
+        api_url = get_url_without_trailing_slash(cfg.CONF.mistral.api_url)
+        api_url = '%s/%s' % (api_url, api_version)
+    else:
+        LOG.warn('"mistral.api_url" not set, using auth.api_url')
+        api_url = get_full_public_api_url(api_version=api_version)
+
     return api_url

--- a/st2common/tests/unit/test_util_api.py
+++ b/st2common/tests/unit/test_util_api.py
@@ -20,6 +20,7 @@ from oslo_config import cfg
 from st2common.constants.api import DEFAULT_API_VERSION
 from st2common.util.api import get_base_public_api_url
 from st2common.util.api import get_full_public_api_url
+from st2common.util.api import get_mistral_api_url
 from st2tests.config import parse_args
 parse_args()
 
@@ -66,3 +67,17 @@ class APIUtilsTestCase(unittest2.TestCase):
             cfg.CONF.auth.api_url = mock_value
             actual = get_full_public_api_url()
             self.assertEqual(actual, expected_result)
+
+    def test_get_mistral_api_url(self):
+        cfg.CONF.set_override(name='api_url', override='http://localhost:9999', group='auth')
+        cfg.CONF.set_override(name='api_url', override=None, group='mistral')
+
+        # No URL set, should fall back to auth.api_url
+        result = get_mistral_api_url()
+        self.assertEqual(result, 'http://localhost:9999/' + DEFAULT_API_VERSION)
+
+        # mistral.api_url provided, should use that
+        cfg.CONF.set_override(name='api_url', override='http://10.0.0.0:9999', group='mistral')
+
+        result = get_mistral_api_url()
+        self.assertEqual(result, 'http://10.0.0.0:9999/' + DEFAULT_API_VERSION)


### PR DESCRIPTION
This change allows operator to configure which URL Mistral uses to talk back to the StackStorm API.

For backward compatibility and by default, it uses full public API url. If needed, user can configure it to use a different URL (e.g. internal URL or local URL on single server deployments).

This should resolve #2203