### PR TITLE
Fix mistral auth test

### DIFF
--- a/st2actions/tests/unit/test_mistral_v2_auth.py
+++ b/st2actions/tests/unit/test_mistral_v2_auth.py
@@ -231,7 +231,7 @@ class MistralAuthTest(DbTestCase):
             cfg.CONF.mistral.keystone_password,
             cfg.CONF.mistral.keystone_project_name,
             cfg.CONF.mistral.keystone_auth_url,
-            None, 'publicURL', 'workflow', None, None, None)
+            None, 'publicURL', 'workflow', None, None, None, False)
 
         executions.ExecutionManager.create.assert_called_with(
             WF1_NAME, workflow_input=workflow_input, env=env)


### PR DESCRIPTION
Fix unit test to accomdate the additional insecure flag in the authenticate method for the mistralclient.