### PR TITLE
Docs: clarify env() in upgrade notes

### DIFF
--- a/docs/source/upgrade_notes.rst
+++ b/docs/source/upgrade_notes.rst
@@ -53,7 +53,8 @@ Changes
   syntax changes to YAQL expressions.
 * Mistral has implemented new YAQL function for referencing environment variables in the data
   context. The ``env()`` function replaces ``$.__env`` when referencing the environment variables.
-  Referencing ``$.__env`` will lead to YAQL evaluation errors. Please update your workflows
+  For example, ``$.__env.st2_execution_id`` becomes ``env().st2_execution_id``.
+  **WARNING**: Referencing ``$.__env`` will lead to YAQL evaluation errors! Please update your workflows
   accordingly.
 * Mistral has implemented new YAQL function for referencing task result. Given task1,
   the function call ``task(task1).result``, replaces ``$.task1`` when referencing result of task1.


### PR DESCRIPTION
We got confused ourselves on the change of YAQL from `$.__env` to `env()`, clarifying with example.