### PR TITLE
Fix the value of "user" attribute in the context of execution created by alias execution API endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,9 @@ in development
   validate the parameters before creating a TriggerDB object. (bug fix)
 * Update local runner so all the commands which are executed as a different user and result in
   using sudo set $HOME variable to the home directory of the target user. (improvement)
+* Fix a bug with a user inside the context of the live action which was created using alias
+  execution endpoint incorrectly being set to the system user (``stanley``) instead of the
+  authenticated user which triggered the execution. (bug fix)
 
 1.1.1 - November 13, 2015
 -------------------------

--- a/st2api/st2api/controllers/v1/aliasexecution.py
+++ b/st2api/st2api/controllers/v1/aliasexecution.py
@@ -16,7 +16,6 @@
 import jsonschema
 import pecan
 import six
-from oslo_config import cfg
 from pecan import rest
 
 from st2common import log as logging
@@ -31,6 +30,7 @@ from st2common.persistence.actionalias import ActionAlias
 from st2common.services import action as action_service
 from st2common.util import action_db as action_utils
 from st2common.util import reference
+from st2common.util.api import get_requester
 from st2common.rbac.types import PermissionType
 from st2common.rbac.utils import assert_request_user_has_resource_db_permission
 
@@ -79,7 +79,7 @@ class ActionAliasExecutionController(rest.RestController):
         context = {
             'action_alias_ref': reference.get_ref_from_model(action_alias_db),
             'api_user': payload.user,
-            'user': self._get_requester(),
+            'user': get_requester(),
             'source_channel': payload.source_channel
         }
 
@@ -89,14 +89,6 @@ class ActionAliasExecutionController(rest.RestController):
                                              context=context)
 
         return str(execution.id)
-
-    def _get_requester(self):
-        # Retrieve username of the authed user (note - if auth is disabled, user will not be
-        # set so we fall back to the system user name)
-        auth_context = pecan.request.context.get('auth', None)
-        user_db = auth_context.get('user', None) if auth_context else None
-
-        return user_db.name if user_db else cfg.CONF.system_user.user
 
     def _tokenize_alias_execution(self, alias_execution):
         tokens = alias_execution.strip().split(' ', 1)

--- a/st2api/tests/unit/controllers/v1/test_alias_execution.py
+++ b/st2api/tests/unit/controllers/v1/test_alias_execution.py
@@ -56,7 +56,7 @@ class TestAliasExecution(FunctionalTest):
 
     @mock.patch.object(action_service, 'request',
                        return_value=(None, DummyActionExecution(id_=1)))
-    def testBasicExecution(self, request):
+    def test_basic_execution(self, request):
         command = 'Lorem ipsum value1 dolor sit "value2 value3" amet.'
         post_resp = self._do_post(alias_execution=self.alias1, command=command)
         self.assertEqual(post_resp.status_int, 200)
@@ -65,7 +65,7 @@ class TestAliasExecution(FunctionalTest):
 
     @mock.patch.object(action_service, 'request',
                        return_value=(None, DummyActionExecution(id_=1)))
-    def testExecutionWithArrayTypeSingleValue(self, request):
+    def test_execution_with_array_type_single_value(self, request):
         command = 'Lorem ipsum value1 dolor sit value2 amet.'
         post_resp = self._do_post(alias_execution=self.alias2, command=command)
         self.assertEqual(post_resp.status_int, 200)
@@ -74,7 +74,7 @@ class TestAliasExecution(FunctionalTest):
 
     @mock.patch.object(action_service, 'request',
                        return_value=(None, DummyActionExecution(id_=1)))
-    def testExecutionWithArrayTypeMultiValue(self, request):
+    def test_execution_with_array_type_multi_value(self, request):
         command = 'Lorem ipsum value1 dolor sit "value2, value3" amet.'
         post_resp = self._do_post(alias_execution=self.alias2, command=command)
         self.assertEqual(post_resp.status_int, 200)

--- a/st2api/tests/unit/controllers/v1/test_alias_execution.py
+++ b/st2api/tests/unit/controllers/v1/test_alias_execution.py
@@ -32,6 +32,10 @@ TEST_LOAD_MODELS = {
     'aliases': ['alias3.yaml']
 }
 
+__all__ = [
+    'AliasExecutionTestCase'
+]
+
 
 class DummyActionExecution(object):
     def __init__(self, id_=None, status=LIVEACTION_STATUS_SUCCEEDED, result=''):
@@ -40,7 +44,7 @@ class DummyActionExecution(object):
         self.result = result
 
 
-class TestAliasExecution(FunctionalTest):
+class AliasExecutionTestCase(FunctionalTest):
 
     models = None
     alias1 = None

--- a/st2api/tests/unit/controllers/v1/test_alias_execution.py
+++ b/st2api/tests/unit/controllers/v1/test_alias_execution.py
@@ -52,7 +52,7 @@ class AliasExecutionTestCase(FunctionalTest):
 
     @classmethod
     def setUpClass(cls):
-        super(TestAliasExecution, cls).setUpClass()
+        super(AliasExecutionTestCase, cls).setUpClass()
         cls.models = FixturesLoader().save_fixtures_to_db(fixtures_pack=FIXTURES_PACK,
                                                           fixtures_dict=TEST_MODELS)
         cls.alias1 = cls.models['aliases']['alias1.yaml']

--- a/st2api/tests/unit/controllers/v1/test_alias_execution_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_alias_execution_rbac.py
@@ -1,0 +1,73 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+
+from st2common.services import action as action_service
+from st2tests.fixturesloader import FixturesLoader
+from tests.base import APIControllerWithRBACTestCase
+from tests.unit.controllers.v1.test_alias_execution import DummyActionExecution
+
+FIXTURES_PACK = 'aliases'
+
+TEST_MODELS = {
+    'aliases': ['alias1.yaml', 'alias2.yaml'],
+    'actions': ['action1.yaml'],
+    'runners': ['runner1.yaml']
+}
+
+TEST_LOAD_MODELS = {
+    'aliases': ['alias3.yaml']
+}
+
+__all__ = [
+    'AliasExecutionWithRBACTestCase'
+]
+
+
+class AliasExecutionWithRBACTestCase(APIControllerWithRBACTestCase):
+
+    def setUp(self):
+        super(AliasExecutionWithRBACTestCase, self).setUp()
+
+        self.models = FixturesLoader().save_fixtures_to_db(fixtures_pack=FIXTURES_PACK,
+                                                          fixtures_dict=TEST_MODELS)
+        self.alias1 = self.models['aliases']['alias1.yaml']
+        self.alias2 = self.models['aliases']['alias2.yaml']
+
+    @mock.patch.object(action_service, 'request',
+                       return_value=(None, DummyActionExecution(id_=1)))
+    def test_live_action_context_user_is_set_to_authenticated_user(self, request):
+        # Verify that the user inside the context of live action is set to authenticated user
+        # which hit the endpoint. This is important for RBAC and many other things.
+        user_db = self.users['admin']
+        self.use_user(user_db)
+
+        command = 'Lorem ipsum value1 dolor sit "value2, value3" amet.'
+        post_resp = self._do_post(alias_execution=self.alias2, command=command)
+        self.assertEqual(post_resp.status_int, 200)
+
+        live_action_db = request.call_args[0][0]
+        self.assertEquals(live_action_db.context['user'], 'admin')
+
+    def _do_post(self, alias_execution, command, expect_errors=False):
+        execution = {'name': alias_execution.name,
+                     'format': alias_execution.formats[0],
+                     'command': command,
+                     'user': 'stanley',
+                     'source_channel': 'test',
+                     'notification_route': 'test'}
+        return self.app.post_json('/v1/aliasexecution', execution,
+                                  expect_errors=expect_errors)

--- a/st2common/st2common/util/api.py
+++ b/st2common/st2common/util/api.py
@@ -86,7 +86,7 @@ def get_requester():
     auth_context = pecan.request.context.get('auth', None)
     user_db = auth_context.get('user', None) if auth_context else None
 
-    if cfg.CONF.auth.enable and not user_db:
+    if not user_db:
         LOG.warn('auth is disabled, falling back to system_user')
         username = cfg.CONF.system_user.user
     else:

--- a/st2common/st2common/util/api.py
+++ b/st2common/st2common/util/api.py
@@ -86,4 +86,10 @@ def get_requester():
     auth_context = pecan.request.context.get('auth', None)
     user_db = auth_context.get('user', None) if auth_context else None
 
-    return user_db.name if user_db else cfg.CONF.system_user.user
+    if cfg.CONF.auth.enable and not user_db:
+        LOG.warn('auth is disabled, falling back to system_user')
+        username = cfg.CONF.system_user.user
+    else:
+        username = user_db.name
+
+    return username

--- a/st2common/st2common/util/api.py
+++ b/st2common/st2common/util/api.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pecan
+
 from oslo_config import cfg
 
 from st2common import log as logging
@@ -22,8 +24,9 @@ from st2common.util.url import get_url_without_trailing_slash
 __all__ = [
     'get_base_public_api_url',
     'get_full_public_api_url',
+    'get_mistral_api_url',
 
-    'get_mistral_api_url'
+    'get_requester'
 ]
 
 LOG = logging.getLogger(__name__)
@@ -71,3 +74,16 @@ def get_mistral_api_url(api_version=DEFAULT_API_VERSION):
         api_url = get_full_public_api_url(api_version=api_version)
 
     return api_url
+
+
+def get_requester():
+    """
+    Retrieve username of the authed user (note - if auth is disabled, user will not be
+    set so we fall back to the system user name)
+
+    :rtype: ``str``
+    """
+    auth_context = pecan.request.context.get('auth', None)
+    user_db = auth_context.get('user', None) if auth_context else None
+
+    return user_db.name if user_db else cfg.CONF.system_user.user


### PR DESCRIPTION
This pull request fixes the value of "user" attribute in the "context" of live action created by the alias execution API.

Previously, ``user`` was incorrectly set to system user (``stanley``) instead of the authenticated user which triggered the execution. Not setting the user correctly means RBAC and some other things won't work correctly - token which gets created by the action runner and is available for the duration of the action execution will be tied to the system user (which has no permissions by default) instead of the authenticated user (in workroom case, we create a special use which is used for ChatOps by hubot and we grant that user admin role).

This issue was spotted by @enykeev.