### PR TITLE
Modifying ActionAliasFormatParser to support more flexible chatops

### DIFF
--- a/st2common/st2common/models/utils/action_alias_utils.py
+++ b/st2common/st2common/models/utils/action_alias_utils.py
@@ -53,13 +53,13 @@ class ActionAliasFormatParser(object):
         # compiling them into a list.
         # "test {{ url = http://google.com }} {{ extra = Test }}" will become
         # [ ["url", "http://google.com"], ["extra", "Test"] ]
-        params = re.findall(r'{{\s*(.+?)\s*(?:=\s*[\'"]?(.+?)[\'"]?)?\s*}}',
+        params = re.findall(r'{{\s*(.+?)\s*(?:=\s*[\'"]?({.+?}|.+?)[\'"]?)?\s*}}',
                             self._format, re.DOTALL)
 
         # Now we're transforming our format string into a regular expression,
         # substituting {{ ... }} with regex named groups, so that param_stream
         # matched against this expression yields a dict of params with values.
-        reg = re.sub(r'\s+{{\s*(\S+)\s*=.+?}}',
+        reg = re.sub(r'\s+{{\s*(\S+)\s*=(?:{.+?}|.+?)}}',
                      r'(?:\s+[\'"]?(?P<\1>.+?)[\'"]?)?',
                      self._format)
         reg = re.sub(r'{{\s*(.+?)\s*}}',

--- a/st2common/st2common/models/utils/action_alias_utils.py
+++ b/st2common/st2common/models/utils/action_alias_utils.py
@@ -51,10 +51,7 @@ class ActionAliasFormatParser(object):
         reg = re.sub(r'{{\s*(.+?)\s*}}',
                      r'[\'"]?(?P<\1>.+?)[\'"]?',
                      reg)
-
-        # We're augmenting the expression to include an arbitrary number of
-        # optional parameters at the end.
-        reg = reg + r'(\s+)?(\s?(\S+)\s*=\s*[\'"]?(\S+)[\'"]?)*$'
+        reg = reg + r'\s*$'
 
         # Now we're matching param_stream against our format string regex,
         # getting a dict of values. We'll also get default values from
@@ -63,9 +60,10 @@ class ActionAliasFormatParser(object):
         if matched_stream:
             values = matched_stream.groupdict()
         for param in params:
-            result[param[0]] = values[param[0]] if matched_stream else param[1]
+            matched_value = values[param[0]] if matched_stream else None
+            result[param[0]] = matched_value or param[1]
 
-        if not self._param_stream and not result:
-            raise content.ParseException('No stream or defaults provided!')
+        if self._format and not (self._param_stream or any(result.values())):
+            raise content.ParseException('No value supplied and no default value found.')
 
         return result

--- a/st2common/st2common/models/utils/action_alias_utils.py
+++ b/st2common/st2common/models/utils/action_alias_utils.py
@@ -13,222 +13,52 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import shlex
-
-from st2common.exceptions import content
+import re
 
 __all__ = [
-    'JsonValueParser',
-    'StringValueParser',
-    'DefaultParser',
-
-    'KeyValueActionAliasFormatParser',
     'ActionAliasFormatParser'
 ]
 
 
-class JsonValueParser(object):
-    """
-    Sort of but not really JSON parsing. This parser only really cares if there are matching
-    braces to stop the iteration.
-
-    """
-    start = '{'
-    end = '}'
-
-    @staticmethod
-    def is_applicable(first_char):
-        return first_char == JsonValueParser.start
-
-    @staticmethod
-    def parse(start, stream):
-        end = 0
-        char_idx = start
-        message_depth = 0
-        while not end:
-            char = stream[char_idx]
-            if char == JsonValueParser.start:
-                message_depth += 1
-            elif char == JsonValueParser.end:
-                message_depth -= 1
-            if not message_depth:
-                end = char_idx
-            else:
-                char_idx += 1
-                if char_idx == len(stream):
-                    raise content.ParseException('What sort of messed up stream did you provide!')
-        # preserve the start and end chars
-        return start, stream[start:end + 1], end + 1
-
-
-class StringValueParser(object):
-
-    def __init__(self, start, end, escape):
-        self.start = start
-        self.end = end
-        self.escape = escape
-
-    def is_applicable(self, first_char):
-        return first_char == self.start
-
-    def parse(self, start, stream):
-        end = 0
-        char_idx = start + 1
-        while not end:
-            char = stream[char_idx]
-            if char == self.end and stream[char_idx - 1] != self.escape:
-                end = char_idx
-            else:
-                char_idx += 1
-                if char_idx == len(stream):
-                    raise content.ParseException('What sort of messed up stream did you provide!')
-        # skip the start and end chars
-        return start, stream[start + 1:end], end + 1
-
-
-class DefaultParser(object):
-
-    end = ' '
-
-    @staticmethod
-    def is_applicable(first_char):
-        return True
-
-    @staticmethod
-    def parse(start, stream):
-        end = stream.find(DefaultParser.end, start)
-        # if not found pick until end of stream. In this way the default parser is different
-        # from other parser as they would always requires an end marker
-        if end == -1:
-            end = len(stream)
-        try:
-            return start, stream[start:end], end
-        except IndexError:
-            raise content.ParseException('What sort of messed up stream did you provide!')
-
-PARSERS = [
-    JsonValueParser,
-    StringValueParser(start='"', end='"', escape='\\'),
-    StringValueParser(start='\'', end='\'', escape='\\'),
-    DefaultParser
-]
-
-
-class KeyValueActionAliasFormatParser(object):
-    """
-    Parser which parses action parameters in the format of "key=value" from the provided param
-    string.
-    """
-
-    delimiter = '='
-
-    def __init__(self, alias_format, param_stream=None):
-        self._format_stream = alias_format
-        self._param_stream = param_stream or ''
-
-    def parse(self):
-        result = {}
-
-        try:
-            tokens = shlex.split(self._param_stream)
-        except ValueError:
-            return result
-
-        for token in tokens:
-            split = token.split('=', 1)
-
-            if len(split) != 2:
-                continue
-
-            key, value = split
-
-            result[key] = value
-        return result
-
-
 class ActionAliasFormatParser(object):
-
-    FORMAT_MARKER_START = '{{'
-    FORMAT_MARKER_END = '}}'
-    PARAM_DEFAULT_VALUE_SEPARATOR = '='
 
     def __init__(self, alias_format=None, param_stream=None):
         self._format = alias_format or ''
         self._param_stream = param_stream or ''
-        self._alias_fmt_ptr = 0
-        self._param_strm_ptr = 0
-
-    def __iter__(self):
-        return self
-
-    def next(self):
-        try:
-            p_start, param_format, p_end = self._get_next_param_format()
-            param_name, default_value = self._get_param_name_default_value(param_format)
-        except ValueError:
-            # If we get back a ValueError then time to stop the iteration.
-            raise StopIteration()
-
-        # compute forward progress of the alias format pointer
-        v_start = p_start - self._alias_fmt_ptr + self._param_strm_ptr
-        value = None
-
-        # make sure v_start is within param_stream
-        if v_start < len(self._param_stream):
-            _, value, v_end = self._get_next_value(v_start)
-
-            # move the alias_fmt_ptr to one beyond the end of each
-            self._alias_fmt_ptr = p_end
-            self._param_strm_ptr = v_end
-        elif v_start < len(self._format):
-            # Advance in the format string
-            # Note: We still want to advance in the format string even though
-            # there is nothing left in the param stream since we support default
-            # values and param_stream can be empty
-            self._alias_fmt_ptr = p_end
-
-        if not value and not default_value:
-            raise content.ParseException('No value supplied and no default value found.')
-
-        return param_name, value if value else default_value
 
     def get_extracted_param_value(self):
+
         result = {}
 
-        # First extract format params provided in the string (if any)
-        format_params = {name: value for name, value in self}
-        result.update(format_params)
+        # As there's a lot of questions about using regular expressions,
+        # I'll try to be thorough when documenting this code.
 
-        # Second extract key=value params provided in the param string
-        kv_parser = KeyValueActionAliasFormatParser(alias_format=self._format,
-                                                    param_stream=self._param_stream)
-        kv_params = kv_parser.parse()
-        result.update(kv_params)
+        # Firstly, we'll match parameters with default values in form of
+        # {{ value = parameter }} (and all possible permutations of spaces),
+        # compiling them into a list.
+        # "test {{ url = http://google.com }} {{ extra = Test }}" will become
+        # [ ["url", "http://google.com"], ["extra", "Test"] ]
+        params_list = re.findall(r'{{\s*(.+?)\s*(?:=\s*(.+?))?\s*}}',
+                                 self._format, re.DOTALL)
+
+        # Now we're transforming our format string into a regular expression,
+        # substituting {{ ... }} with regex named groups, so that param_stream
+        # matched against this expression yields a dict of all its params.
+        reg = re.sub(r'\s+{{\s*(\S+)\s*=.+?}}', r'(?:\s+(?P<\1>.+?))?',
+                     self._format)
+        reg = re.sub(r'{{\s*(.+?)\s*}}', r'(?P<\1>.+?)', reg)
+
+        # We're augmenting the expression to include an arbitrary number of
+        # optional parameters at the end.
+        reg = reg + r'(\s+)?(\s?(\S+)\s*=\s*(\S+))*$'
+
+        # Now we're matching param_stream against our format string regex,
+        # getting a dict of values. We'll also get default values from
+        # params_list if something is not present.
+        match = re.match(reg, self._param_stream, re.DOTALL)
+        if match:
+            values_dict = match.groupdict()
+            for param in params_list:
+                result[param[0]] = values_dict[param[0]] or param[1]
 
         return result
-
-    def _get_next_param_format(self):
-        mrkr_strt_ps = self._format.index(self.FORMAT_MARKER_START, self._alias_fmt_ptr)
-        try:
-            mrkr_end_ps = self._format.index(self.FORMAT_MARKER_END, mrkr_strt_ps)
-        except ValueError:
-            # A start marker was found but end is not therefore this is a Parser exception.
-            raise content.ParseException('Expected end marker.')
-        param_format = self._format[mrkr_strt_ps + len(self.FORMAT_MARKER_START): mrkr_end_ps]
-        return mrkr_strt_ps, param_format.strip(), mrkr_end_ps + len(self.FORMAT_MARKER_END)
-
-    def _get_param_name_default_value(self, param_format):
-        if not param_format:
-            return None, None
-        values = param_format.split(self.PARAM_DEFAULT_VALUE_SEPARATOR)
-        return values[0], values[1] if len(values) > 1 else None
-
-    def _get_next_value(self, start):
-        parser = self._get_parser(self._param_stream[start])
-        return parser.parse(start, self._param_stream)
-
-    def _get_parser(self, first_char):
-        for parser in PARSERS:
-            if parser.is_applicable(first_char):
-                return parser
-        raise Exception('No parser found')

--- a/st2common/tests/unit/test_action_alias_utils.py
+++ b/st2common/tests/unit/test_action_alias_utils.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 from unittest2 import TestCase
-from st2common.exceptions import content
 from st2common.exceptions.content import ParseException
 from st2common.models.utils.action_alias_utils import ActionAliasFormatParser
 

--- a/st2common/tests/unit/test_action_alias_utils.py
+++ b/st2common/tests/unit/test_action_alias_utils.py
@@ -19,14 +19,14 @@ from st2common.models.utils.action_alias_utils import ActionAliasFormatParser
 
 
 class TestActionAliasParser(TestCase):
-    def testEmptyString(self):
+    def test_empty_string(self):
         alias_format = ''
         param_stream = ''
         parser = ActionAliasFormatParser(alias_format, param_stream)
         extracted_values = parser.get_extracted_param_value()
         self.assertEqual(extracted_values, {})
 
-    def testArbitraryPairs(self):
+    def test_arbitrary_pairs(self):
         # single-word param
         alias_format = ''
         param_stream = 'a=foobar1'
@@ -73,35 +73,35 @@ class TestActionAliasParser(TestCase):
         self.assertEqual(extracted_values, {'captain': 'Malcolm Reynolds',
                                             'weirdo': 'River Tam'})
 
-    def testSimpleParsing(self):
+    def test_simple_parsing(self):
         alias_format = 'skip {{a}} more skip {{b}} and skip more.'
         param_stream = 'skip a1 more skip b1 and skip more.'
         parser = ActionAliasFormatParser(alias_format, param_stream)
         extracted_values = parser.get_extracted_param_value()
         self.assertEqual(extracted_values, {'a': 'a1', 'b': 'b1'})
 
-    def testEndStringParsing(self):
+    def test_end_string_parsing(self):
         alias_format = 'skip {{a}} more skip {{b}}'
         param_stream = 'skip a1 more skip b1'
         parser = ActionAliasFormatParser(alias_format, param_stream)
         extracted_values = parser.get_extracted_param_value()
         self.assertEqual(extracted_values, {'a': 'a1', 'b': 'b1'})
 
-    def testSpacedParsing(self):
+    def test_spaced_parsing(self):
         alias_format = 'skip {{a}} more skip {{b}} and skip more.'
         param_stream = 'skip "a1 a2" more skip b1 and skip more.'
         parser = ActionAliasFormatParser(alias_format, param_stream)
         extracted_values = parser.get_extracted_param_value()
         self.assertEqual(extracted_values, {'a': 'a1 a2', 'b': 'b1'})
 
-    def testJsonParsing(self):
+    def test_json_parsing(self):
         alias_format = 'skip {{a}} more skip.'
         param_stream = 'skip {"a": "b", "c": "d"} more skip.'
         parser = ActionAliasFormatParser(alias_format, param_stream)
         extracted_values = parser.get_extracted_param_value()
         self.assertEqual(extracted_values, {'a': '{"a": "b", "c": "d"}'})
 
-    def testMixedParsing(self):
+    def test_mixed_parsing(self):
         alias_format = 'skip {{a}} more skip {{b}}.'
         param_stream = 'skip {"a": "b", "c": "d"} more skip x.'
         parser = ActionAliasFormatParser(alias_format, param_stream)
@@ -109,7 +109,7 @@ class TestActionAliasParser(TestCase):
         self.assertEqual(extracted_values, {'a': '{"a": "b", "c": "d"}',
                                             'b': 'x'})
 
-    def testParamSpaces(self):
+    def test_param_spaces(self):
         alias_format = 's {{a}} more {{ b }} more {{ c=99 }} more {{ d = 99 }}'
         param_stream = 's one more two more three more'
         parser = ActionAliasFormatParser(alias_format, param_stream)
@@ -117,7 +117,7 @@ class TestActionAliasParser(TestCase):
         self.assertEqual(extracted_values, {'a': 'one', 'b': 'two',
                                             'c': 'three', 'd': '99'})
 
-    def testEnclosedDefaults(self):
+    def test_enclosed_defaults(self):
         alias_format = 'skip {{ a = value }} more'
         param_stream = 'skip one more'
         parser = ActionAliasFormatParser(alias_format, param_stream)
@@ -130,7 +130,14 @@ class TestActionAliasParser(TestCase):
         extracted_values = parser.get_extracted_param_value()
         self.assertEqual(extracted_values, {'a': 'value'})
 
-    def testKeyValueCombinations(self):
+    def test_template_defaults(self):
+        alias_format = 'two by two hands of {{ color = {{ colors.default_color }} }}'
+        param_stream = 'skip one more'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'color': '{{ colors.default_color }}'})
+
+    def test_key_value_combinations(self):
         # one-word value, single extra pair
         alias_format = 'testing {{ a }}'
         param_stream = 'testing value b=value2'

--- a/st2common/tests/unit/test_action_alias_utils.py
+++ b/st2common/tests/unit/test_action_alias_utils.py
@@ -26,6 +26,53 @@ class TestActionAliasParser(TestCase):
         extracted_values = parser.get_extracted_param_value()
         self.assertEqual(extracted_values, {})
 
+    def testArbitraryPairs(self):
+        # single-word param
+        alias_format = ''
+        param_stream = 'a=foobar1'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'a': 'foobar1'})
+
+        # multi-word double-quoted param
+        alias_format = ''
+        param_stream = 'foo a="foobar2 poonies bar"'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'a': 'foobar2 poonies bar'})
+
+        # multi-word single-quoted param
+        alias_format = ''
+        param_stream = 'foo a=\'foobar2 poonies bar\''
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'a': 'foobar2 poonies bar'})
+
+        # JSON param
+        alias_format = ''
+        param_stream = 'foo a={"foobar2": "poonies"}'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'a': '{"foobar2": "poonies"}'})
+
+        # Multiple mixed params
+        alias_format = ''
+        param_stream = 'a=foobar1 b="boobar2 3 4" c=\'coobar3 4\' d={"a": "b"}'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'a': 'foobar1',
+                                            'b': 'boobar2 3 4',
+                                            'c': 'coobar3 4',
+                                            'd': '{"a": "b"}'})
+
+        # Params along with a "normal" alias format
+        alias_format = '{{ captain }} is my captain'
+        param_stream = 'Malcolm Reynolds is my captain weirdo="River Tam"'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'captain': 'Malcolm Reynolds',
+                                            'weirdo': 'River Tam'})
+
     def testSimpleParsing(self):
         alias_format = 'skip {{a}} more skip {{b}} and skip more.'
         param_stream = 'skip a1 more skip b1 and skip more.'


### PR DESCRIPTION
We have several problems with the way ActionAliasFormatParser is implemented now:
1. In hubot we have a regex pattern matching for chatops commands, which in some edge cases isn't caught by the back-end parser. This results in hubot sending a legitimate command which is not recognized or executed. 
2. The parser doesn't match multi-word commands if they aren't quoted or multi-line commands ever. It limits user's flexibility in passing long arguments or making a bot more responsive and, again, "human-like".
3. It would be nice to have full support for regexes in aliases in general: we'll be able to create more flexible commands.
4. @enykeev's catch: there's no support for default params in the middle of the string (his example was `st2 list {{ limit=999 }} actions`).

This PR solves all of the above by trying a different take on the parser: instead of iterating over a string catching values, we're transforming our format string into a regex (which is not new, because it's exactly the approach we take in `hubot-stackstorm`) and build a parameter list. Since the format becomes a regex, it also allows much greater flexibility and degree of control. It also simplifies parser greatly, because there's no need for specialized value parsers or an iterator anymore (this is why this PR has 10x more deletions than it has additions).

There's one thing on which I'll need input from @manasdk: in our parser we support matching of arbitrary key-value pairs without a format string, which is something I don't see the use case for, not even in theory. With the current approach it will not work, because we'll need a format string to match any parameters, but then again, I don't see why it existed in the first place. @manasdk, @Kami: let's discuss this.

To be clear, I'm talking about something like this case I found in tests:
```
alias_format = ''
param_stream = 'mixed a=foobar1 some more b=boobar2 text c=coobar3 yeah'
```
Why is it here? Do we use it? Do we plan to? If we do, I'd like to know where and, in all honesty, why. If not, it should be safe to merge this PR.

cc @enykeev @dzimine 