### PR TITLE
Add chatops pack to sandboxing constants

### DIFF
--- a/st2common/st2common/constants/pack.py
+++ b/st2common/st2common/constants/pack.py
@@ -19,6 +19,7 @@ __all__ = [
     'PACKS_PACK_NAME',
     'LINUX_PACK_NAME',
     'SYSTEM_PACK_NAMES',
+    'CHATOPS_PACK_NAME',
     'USER_PACK_NAME_BLACKLIST',
     'BASE_PACK_REQUIREMENTS',
     'MANIFEST_FILE_NAME'
@@ -39,8 +40,12 @@ LINUX_PACK_NAME = 'linux'
 # Name of the default pack
 DEFAULT_PACK_NAME = 'default'
 
+# Name of the chatops pack
+CHATOPS_PACK_NAME = 'chatops'
+
 # A list of system pack names
 SYSTEM_PACK_NAMES = [
+    CHATOPS_PACK_NAME,
     SYSTEM_PACK_NAME,
     PACKS_PACK_NAME,
     LINUX_PACK_NAME


### PR DESCRIPTION
Without the change, `chatops.format_result` throws an error

```
Virtual environment (/opt/stackstorm/virtualenvs/chatops) for pack "chatops" doesn't exist. If you haven't
installed a pack using "packs.install" command, you can create a new virtual environment using
"st2 run packs.setup_virtualenv packs=chatops" command
```