### PR TITLE
Action chain error reporting

### DIFF
--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -18,6 +18,8 @@ import traceback
 import uuid
 import datetime
 
+from jsonschema import exceptions as json_schema_exceptions
+
 from st2actions.runners import ActionRunner
 from st2common import log as logging
 from st2common.constants.action import ACTION_KV_PREFIX
@@ -234,6 +236,12 @@ class ActionChainRunner(ActionRunner):
 
         try:
             self.chain_holder = ChainHolder(chainspec, self.action_name)
+        except json_schema_exceptions.ValidationError as e:
+            # preserve the whole nasty jsonschema message as that is better to get to the
+            # root cause
+            message = str(e)
+            LOG.exception('Failed to instantiate ActionChain.')
+            raise runnerexceptions.ActionRunnerPreRunError(message)
         except Exception as e:
             message = e.message or str(e)
             LOG.exception('Failed to instantiate ActionChain.')

--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -96,6 +96,14 @@ class ChainHolder(object):
                        'task "%s".' % (on_failure_node_name, node.name))
                 raise ValueError(msg)
 
+        # check if node specified in default is valid.
+        if self.actionchain.default:
+            valid_name = self._is_valid_node_name(all_node_names=all_nodes,
+                                                  node_name=self.actionchain.default)
+            if not valid_name:
+                msg = ('Unable to find node with name "%s" referenced in "default".' %
+                       self.actionchain.default)
+                raise ValueError(msg)
         return True
 
     @staticmethod


### PR DESCRIPTION
* 	Check if name specified in default is valid. 
* 	Add more data to the error message to help get to the error faster.

Tested a few scenarios (names of chains roughly reflect the test)

1. chain_tests.bad_task_param
2. chain_tests.broken_default
3. chain_tests.broken_fail
4. chain_tests.broken_publish
5. chain_tests.broken_success
6. chain_tests.normal
7. chain_tests.incorrect_action_ref
8. chain_tests.missing_action_ref
9. chain_tests.no_default

The changes here help with `chain_tests.broken_default` and `chain_tests.missing_action_ref`