### PR TITLE
Ack message formatting in AliasExecution

### DIFF
--- a/st2api/st2api/controllers/v1/aliasexecution.py
+++ b/st2api/st2api/controllers/v1/aliasexecution.py
@@ -97,8 +97,7 @@ class ActionAliasExecutionController(rest.RestController):
 
         if action_alias_db.ack and 'format' in action_alias_db.ack:
             result.update({
-                'message': render({'alias': action_alias_db.ack['format']},
-                                  {'alias': result})['alias']
+                'message': render({'alias': action_alias_db.ack['format']}, result)['alias']
             })
 
         return result

--- a/st2api/st2api/controllers/v1/aliasexecution.py
+++ b/st2api/st2api/controllers/v1/aliasexecution.py
@@ -16,9 +16,7 @@
 import jsonschema
 import pecan
 import six
-import jinja2
 from pecan import rest
-
 from st2common import log as logging
 from st2common.models.api.base import jsexpose
 from st2common.exceptions.db import StackStormDBObjectNotFoundError
@@ -34,6 +32,7 @@ from st2common.services import action as action_service
 from st2common.util import action_db as action_utils
 from st2common.util import reference
 from st2common.util.api import get_requester
+from st2common.util.jinja import render_values as render
 from st2common.rbac.types import PermissionType
 from st2common.rbac.utils import assert_request_user_has_resource_db_permission
 
@@ -97,10 +96,9 @@ class ActionAliasExecutionController(rest.RestController):
         }
 
         if action_alias_db.ack and 'format' in action_alias_db.ack:
-            jinja = jinja2.Environment(trim_blocks=True, lstrip_blocks=True)
-            jinja.tests['in'] = lambda item, list: item in list
             result.update({
-                'message': jinja.from_string(action_alias_db.ack['format']).render(result)
+                'message': render({'alias': action_alias_db.ack['format']},
+                                  {'alias': result})['alias']
             })
 
         return result

--- a/st2api/tests/unit/controllers/v1/test_alias_execution.py
+++ b/st2api/tests/unit/controllers/v1/test_alias_execution.py
@@ -16,6 +16,7 @@
 import mock
 
 from st2common.constants.action import LIVEACTION_STATUS_SUCCEEDED
+from st2common.models.db.execution import ActionExecutionDB
 from st2common.services import action as action_service
 from st2tests.fixturesloader import FixturesLoader
 from tests import FunctionalTest
@@ -32,16 +33,13 @@ TEST_LOAD_MODELS = {
     'aliases': ['alias3.yaml']
 }
 
+EXECUTION = ActionExecutionDB(id='54e657d60640fd16887d6855',
+                              status=LIVEACTION_STATUS_SUCCEEDED,
+                              result='')
+
 __all__ = [
     'AliasExecutionTestCase'
 ]
-
-
-class DummyActionExecution(object):
-    def __init__(self, id_=None, status=LIVEACTION_STATUS_SUCCEEDED, result=''):
-        self.id = id_
-        self.status = status
-        self.result = result
 
 
 class AliasExecutionTestCase(FunctionalTest):
@@ -59,29 +57,29 @@ class AliasExecutionTestCase(FunctionalTest):
         cls.alias2 = cls.models['aliases']['alias2.yaml']
 
     @mock.patch.object(action_service, 'request',
-                       return_value=(None, DummyActionExecution(id_=1)))
+                       return_value=(None, EXECUTION))
     def test_basic_execution(self, request):
         command = 'Lorem ipsum value1 dolor sit "value2 value3" amet.'
         post_resp = self._do_post(alias_execution=self.alias1, command=command)
-        self.assertEqual(post_resp.status_int, 200)
+        self.assertEqual(post_resp.status_int, 201)
         expected_parameters = {'param1': 'value1', 'param2': 'value2 value3'}
         self.assertEquals(request.call_args[0][0].parameters, expected_parameters)
 
     @mock.patch.object(action_service, 'request',
-                       return_value=(None, DummyActionExecution(id_=1)))
+                       return_value=(None, EXECUTION))
     def test_execution_with_array_type_single_value(self, request):
         command = 'Lorem ipsum value1 dolor sit value2 amet.'
         post_resp = self._do_post(alias_execution=self.alias2, command=command)
-        self.assertEqual(post_resp.status_int, 200)
+        self.assertEqual(post_resp.status_int, 201)
         expected_parameters = {'param1': 'value1', 'param3': ['value2']}
         self.assertEquals(request.call_args[0][0].parameters, expected_parameters)
 
     @mock.patch.object(action_service, 'request',
-                       return_value=(None, DummyActionExecution(id_=1)))
+                       return_value=(None, EXECUTION))
     def test_execution_with_array_type_multi_value(self, request):
         command = 'Lorem ipsum value1 dolor sit "value2, value3" amet.'
         post_resp = self._do_post(alias_execution=self.alias2, command=command)
-        self.assertEqual(post_resp.status_int, 200)
+        self.assertEqual(post_resp.status_int, 201)
         expected_parameters = {'param1': 'value1', 'param3': ['value2', 'value3']}
         self.assertEquals(request.call_args[0][0].parameters, expected_parameters)
 

--- a/st2common/st2common/models/utils/action_alias_utils.py
+++ b/st2common/st2common/models/utils/action_alias_utils.py
@@ -77,7 +77,6 @@ class ActionAliasFormatParser(object):
         # "params" list if something is not present.
         matched_stream = re.match(reg, self._param_stream, re.DOTALL)
         if matched_stream:
-            print matched_stream.groupdict()
             values = matched_stream.groupdict()
         for param in params:
             matched_value = values[param[0]] if matched_stream else None

--- a/st2common/st2common/models/utils/action_alias_utils.py
+++ b/st2common/st2common/models/utils/action_alias_utils.py
@@ -44,8 +44,6 @@ class ActionAliasFormatParser(object):
         if extra:
             kv_pairs = re.findall(pairs_match,
                                   extra.group(1), re.DOTALL)
-            for pair in kv_pairs:
-                result[pair[0]] = ''.join(pair[2:])
             self._param_stream = self._param_stream.replace(extra.group(1), '')
         self._param_stream = " %s " % self._param_stream
 
@@ -75,12 +73,19 @@ class ActionAliasFormatParser(object):
         # Now we're matching param_stream against our format string regex,
         # getting a dict of values. We'll also get default values from
         # "params" list if something is not present.
+        # Priority, from lowest to highest:
+        # 1. Default parameters
+        # 2. Matched parameters
+        # 3. Extra parameters
         matched_stream = re.match(reg, self._param_stream, re.DOTALL)
         if matched_stream:
             values = matched_stream.groupdict()
         for param in params:
             matched_value = values[param[0]] if matched_stream else None
             result[param[0]] = matched_value or param[1]
+        if extra:
+            for pair in kv_pairs:
+                result[pair[0]] = ''.join(pair[2:])
 
         if self._format and not (self._param_stream.strip() or any(result.values())):
             raise content.ParseException('No value supplied and no default value found.')

--- a/st2common/st2common/util/jinja.py
+++ b/st2common/st2common/util/jinja.py
@@ -119,8 +119,11 @@ def get_jinja_environment(allow_undefined=False):
 
     '''
     undefined = jinja2.Undefined if allow_undefined else jinja2.StrictUndefined
-    env = jinja2.Environment(undefined=undefined)
+    env = jinja2.Environment(undefined=undefined,
+                             trim_blocks=True,
+                             lstrip_blocks=True)
     env.filters.update(CustomFilters.get_filters())
+    env.tests['in'] = lambda item, list: item in list
     return env
 
 

--- a/st2common/tests/unit/test_action_alias_utils.py
+++ b/st2common/tests/unit/test_action_alias_utils.py
@@ -186,3 +186,17 @@ class TestActionAliasParser(TestCase):
         expected_msg = 'No value supplied and no default value found.'
         self.assertRaisesRegexp(ParseException, expected_msg,
                                 parser.get_extracted_param_value)
+
+    def test_all_the_things(self):
+        # this is the most insane example I could come up with
+        alias_format = "{{ p0='http' }} g {{ p1=p }} a " + \
+                       "{{ url }} {{ p2={'a':'b'} }} {{ p3={{ e.i }} }}"
+        param_stream = "g a http://google.com {{ execution.id }} p4='testing' p5={'a':'c'}"
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'p0': 'http', 'p1': 'p',
+                                            'url': 'http://google.com',
+                                            'p2': '{{ execution.id }}',
+                                            'p3': '{{ e.i }}',
+                                            'p4': 'testing', 'p5': "{'a':'c'}" })
+

--- a/st2common/tests/unit/test_action_alias_utils.py
+++ b/st2common/tests/unit/test_action_alias_utils.py
@@ -198,5 +198,4 @@ class TestActionAliasParser(TestCase):
                                             'url': 'http://google.com',
                                             'p2': '{{ execution.id }}',
                                             'p3': '{{ e.i }}',
-                                            'p4': 'testing', 'p5': "{'a':'c'}" })
-
+                                            'p4': 'testing', 'p5': "{'a':'c'}"})


### PR DESCRIPTION
1. Sending HTTP 201 instead of 200.
2. Formatting ack with jinja if the format string is specified.
3. Sending more context along with the execution id and formatted string for a client to use if desired.

Tests are TBD; I’m submitting this to review and to provide context for the hubot-stackstorm PR that will follow.