### PR TITLE
Chatops: Make formatter return empty string if result output is disabled

### DIFF
--- a/contrib/chatops/actions/format_result.py
+++ b/contrib/chatops/actions/format_result.py
@@ -36,9 +36,9 @@ class FormatResultAction(Action):
 
             result = getattr(alias, 'result', None)
             if result:
-                enabled = result.get('enabled', True)
-
-                if enabled and 'format' in alias.result:
+                if not result.get('enabled', True):
+                    return ""
+                if 'format' in alias.result:
                     template = alias.result['format']
 
         return self.jinja.from_string(template).render(context)


### PR DESCRIPTION
Ultimately I’d like announcement not to fire at all if the body is empty, but it’s a solid first step.

Unfortunately, we can’t use Mistral at this time due to a very high overhead, so as a temporary (I hope) measure I’ll make a corresponding `hubot-stackstorm` PR to skip empty messages. 