### PR TITLE
Pin astroid pylint dependency to a working version

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,8 @@
 coverage
 pep8>=1.6.0,<1.7
 flake8>=2.3.0,<2.4
-pylint>=1.4.3,<1.5
+astroid==1.3.8
+pylint==1.5.0
 pylint-plugin-utils>=0.2.3,<0.3
 ipython
 mock>=1.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@ coverage
 pep8>=1.6.0,<1.7
 flake8>=2.3.0,<2.4
 astroid==1.3.8
-pylint==1.5.0
+pylint==1.4.4
 pylint-plugin-utils>=0.2.3,<0.3
 ipython
 mock>=1.0


### PR DESCRIPTION
New version of astroid library on which pylint depends on was released. This version horribly breaks everything.

I just saved you all an hour or more of debugging time :P