### PR TITLE
Fix json representation of trace in cli

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,7 @@ in development
 * Fix action chain so it doesn't end up in an infinite loop if an action which is part of the chain
   is canceled. (bug fix)
 * Allow jinja templating to be used in ``message`` and ``data`` field for notifications.(new feature)
+* Fix json representation of trace in cli. (bug fix)
 
 1.1.1 - November 13, 2015
 -------------------------

--- a/st2client/st2client/commands/trace.py
+++ b/st2client/st2client/commands/trace.py
@@ -63,13 +63,17 @@ class TraceBranch(resource.ResourceBranch):
 class SingleTraceDisplayMixin(object):
 
     def print_trace_details(self, trace, args, **kwargs):
-        options = {'attributes': TRACE_HEADER_DISPLAY_ORDER}
+        options = {'attributes': TRACE_ATTRIBUTE_DISPLAY_ORDER if args.json else TRACE_HEADER_DISPLAY_ORDER}
         options['json'] = args.json
         options['attribute_transform_functions'] = self.attribute_transform_functions
 
         formatter = execution_formatter.ExecutionResult
 
         self.print_output(trace, formatter, **options)
+
+        # Everything should be printed if we are printing json.
+        if args.json:
+          return
 
         components = []
         if any(attr in args.attr for attr in TRIGGER_INSTANCE_DISPLAY_OPTIONS):

--- a/st2client/st2client/commands/trace.py
+++ b/st2client/st2client/commands/trace.py
@@ -63,7 +63,8 @@ class TraceBranch(resource.ResourceBranch):
 class SingleTraceDisplayMixin(object):
 
     def print_trace_details(self, trace, args, **kwargs):
-        options = {'attributes': TRACE_ATTRIBUTE_DISPLAY_ORDER if args.json else TRACE_HEADER_DISPLAY_ORDER}
+        options = {'attributes': TRACE_ATTRIBUTE_DISPLAY_ORDER if args.json else
+                   TRACE_HEADER_DISPLAY_ORDER}
         options['json'] = args.json
         options['attribute_transform_functions'] = self.attribute_transform_functions
 
@@ -73,7 +74,7 @@ class SingleTraceDisplayMixin(object):
 
         # Everything should be printed if we are printing json.
         if args.json:
-          return
+            return
 
         components = []
         if any(attr in args.attr for attr in TRIGGER_INSTANCE_DISPLAY_OPTIONS):


### PR DESCRIPTION
### Before
```
$ st2 trace get 565cd03232ed3551d6e16e77 -j
{
    "id": "565cd03232ed3551d6e16e77",
    "start_timestamp": "2015-11-30T22:39:46.309136Z",
    "trace_tag": "st2.IntervalTimer-348cf727-8489-46c2-9bf6-64501dc98241"
}
[
    {
        "id": "565cd03232ed3551d6e16e76",
        "type": "trigger-instance",
        "updated_at": "2015-11-30T22:39:46.309204Z"
    }
]
```
### After
```
$ st2 trace get 565cd03232ed3551d6e16e77 -j
{
    "action_executions": [],
    "id": "565cd03232ed3551d6e16e77",
    "rules": [],
    "start_timestamp": "2015-11-30T22:39:46.309136Z",
    "trace_tag": "st2.IntervalTimer-348cf727-8489-46c2-9bf6-64501dc98241",
    "trigger_instances": [
        {
            "object_id": "565cd03232ed3551d6e16e76",
            "updated_at": "2015-11-30T22:39:46.309204Z"
        }
    ]
}
```