### PR TITLE
Append_url parameter in ack messages

### DIFF
--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -516,7 +516,8 @@ class ActionAliasAPI(BaseAPI, APIUIDMixin):
                 "type": "object",
                 "properties": {
                     "enabled": {"type": "boolean"},
-                    "format": {"type": "string"}
+                    "format": {"type": "string"},
+                    "append_url": {"type": "boolean"}
                 },
                 "description": "Acknowledgement message format."
             },


### PR DESCRIPTION
Discussed this with @jfryman yesterday: StackStorm execution details URL will be appended to the end of the ack message by default unless specifically disabled with `append_url: false`.