### PR TITLE
Add missing trigger instance indexes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,7 @@ in development
 * Add tools for purging executions (also, liveactions with it) and trigger instances older than
   certain UTC timestamp from the db in bulk.
 * Fix json representation of trace in cli. (bug fix)
+* Add missing indexes on trigger_instance_d_b collection. (bug fix)
 
 1.1.1 - November 13, 2015
 -------------------------

--- a/st2common/st2common/models/db/trigger.py
+++ b/st2common/st2common/models/db/trigger.py
@@ -108,6 +108,14 @@ class TriggerInstanceDB(stormbase.StormFoundationDB):
     payload = stormbase.EscapedDictField()
     occurrence_time = me.DateTimeField()
 
+    meta = {
+        'indexes': [
+            {'fields': ['occurrence_time']},
+            {'fields': ['trigger']},
+            {'fields': ['-occurrence_time', 'trigger']}
+        ]
+    }
+
 # specialized access objects
 triggertype_access = MongoDBAccess(TriggerTypeDB)
 trigger_access = MongoDBAccess(TriggerDB)


### PR DESCRIPTION
This pull request adds missing indexes on `trigger_instances_d_b` collection (hitting GET /trigger_instances returned 500 in case there was a lot of data since no index was used).

I also applied "hot fix" on the build server.

```
db.trigger_instance_d_b.createIndex( { occurrence_time: 1 } );
db.trigger_instance_d_b.createIndex( { trigger: 1 } );
db.trigger_instance_d_b.createIndex( { occurrence_time: -1, trigger: 1 } );
```