### PR TITLE
Add new entries to mistral status map

### DIFF
--- a/st2actions/st2actions/handlers/mistral.py
+++ b/st2actions/st2actions/handlers/mistral.py
@@ -31,12 +31,17 @@ from st2common.util.workflow import mistral as utils
 LOG = logging.getLogger(__name__)
 
 
-STATUS_MAP = dict()
-STATUS_MAP[action_constants.LIVEACTION_STATUS_REQUESTED] = 'RUNNING'
-STATUS_MAP[action_constants.LIVEACTION_STATUS_SCHEDULED] = 'RUNNING'
-STATUS_MAP[action_constants.LIVEACTION_STATUS_RUNNING] = 'RUNNING'
-STATUS_MAP[action_constants.LIVEACTION_STATUS_SUCCEEDED] = 'SUCCESS'
-STATUS_MAP[action_constants.LIVEACTION_STATUS_FAILED] = 'ERROR'
+STATUS_MAP = {
+    action_constants.LIVEACTION_STATUS_REQUESTED: 'RUNNING',
+    action_constants.LIVEACTION_STATUS_SCHEDULED: 'RUNNING',
+    action_constants.LIVEACTION_STATUS_DELAYED: 'RUNNING',
+    action_constants.LIVEACTION_STATUS_RUNNING: 'RUNNING',
+    action_constants.LIVEACTION_STATUS_SUCCEEDED: 'SUCCESS',
+    action_constants.LIVEACTION_STATUS_FAILED: 'ERROR',
+    action_constants.LIVEACTION_STATUS_TIMED_OUT: 'ERROR',
+    action_constants.LIVEACTION_STATUS_CANCELING: 'RUNNING',
+    action_constants.LIVEACTION_STATUS_CANCELED: 'ERROR'
+}
 
 
 def get_handler():
@@ -77,8 +82,7 @@ class MistralCallbackHandler(handlers.ActionExecutionCallbackHandler):
 
     @classmethod
     def callback(cls, url, context, status, result):
-        if status not in [action_constants.LIVEACTION_STATUS_SUCCEEDED,
-                          action_constants.LIVEACTION_STATUS_FAILED]:
+        if status not in action_constants.LIVEACTION_COMPLETED_STATES:
             return
 
         try:
@@ -92,5 +96,4 @@ class MistralCallbackHandler(handlers.ActionExecutionCallbackHandler):
 
             cls._update_action_execution(url, data)
         except Exception as e:
-            print str(e)
             LOG.exception(e)

--- a/st2actions/tests/unit/test_mistral_v2.py
+++ b/st2actions/tests/unit/test_mistral_v2.py
@@ -40,6 +40,7 @@ cfg.CONF.set_override('retry_stop_max_msec', 200, group='mistral')
 
 import st2common.bootstrap.runnersregistrar as runners_registrar
 from st2actions.handlers.mistral import MistralCallbackHandler
+from st2actions.handlers.mistral import STATUS_MAP as mistral_status_map
 from st2actions.runners.localrunner import LocalShellRunner
 from st2actions.runners.mistral.v2 import MistralRunner
 from st2common.constants import action as action_constants
@@ -142,9 +143,6 @@ ACTION_PARAMS = {'friend': 'Rocky'}
 NON_EMPTY_RESULT = 'non-empty'
 
 
-@mock.patch.object(LocalShellRunner, 'run', mock.
-                   MagicMock(return_value=(action_constants.LIVEACTION_STATUS_SUCCEEDED,
-                                           NON_EMPTY_RESULT, None)))
 @mock.patch.object(CUDPublisher, 'publish_update', mock.MagicMock(return_value=None))
 @mock.patch.object(CUDPublisher, 'publish_create',
                    mock.MagicMock(side_effect=MockLiveActionPublisher.publish_create))
@@ -600,6 +598,11 @@ class MistralRunnerTest(DbTestCase):
         self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_FAILED)
         self.assertIn('Name of the workbook must be the same', liveaction.result['error'])
 
+    def test_callback_handler_status_map(self):
+        # Ensure all StackStorm status are mapped otherwise leads to zombie workflow.
+        self.assertListEqual(sorted(mistral_status_map.keys()),
+                             sorted(action_constants.LIVEACTION_STATUSES))
+
     @mock.patch.object(
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(return_value=None))
@@ -652,12 +655,40 @@ class MistralRunnerTest(DbTestCase):
             }
         )
 
+        for status in action_constants.LIVEACTION_COMPLETED_STATES:
+            expected_mistral_status = mistral_status_map[status]
+            LocalShellRunner.run = mock.Mock(return_value=(status, NON_EMPTY_RESULT, None))
+            liveaction, execution = action_service.request(liveaction)
+            liveaction = LiveAction.get_by_id(str(liveaction.id))
+            self.assertEqual(liveaction.status, status)
+            action_executions.ActionExecutionManager.update.assert_called_with(
+                '12345', state=expected_mistral_status, output=NON_EMPTY_RESULT)
+
+    @mock.patch.object(
+        LocalShellRunner, 'run',
+        mock.MagicMock(return_value=(action_constants.LIVEACTION_STATUS_RUNNING,
+                                     NON_EMPTY_RESULT, None)))
+    @mock.patch.object(
+        action_executions.ActionExecutionManager, 'update',
+        mock.MagicMock(return_value=None))
+    def test_callback_incomplete_state(self):
+        liveaction = LiveActionDB(
+            action='core.local', parameters={'cmd': 'uname -a'},
+            callback={
+                'source': 'mistral',
+                'url': 'http://localhost:8989/v2/action_executions/12345'
+            }
+        )
+
         liveaction, execution = action_service.request(liveaction)
         liveaction = LiveAction.get_by_id(str(liveaction.id))
-        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
-        action_executions.ActionExecutionManager.update.assert_called_with(
-            '12345', state='SUCCESS', output=NON_EMPTY_RESULT)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_RUNNING)
+        self.assertFalse(action_executions.ActionExecutionManager.update.called)
 
+    @mock.patch.object(
+        LocalShellRunner, 'run',
+        mock.MagicMock(return_value=(action_constants.LIVEACTION_STATUS_SUCCEEDED,
+                                     NON_EMPTY_RESULT, None)))
     @mock.patch.object(
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(side_effect=[
@@ -679,6 +710,10 @@ class MistralRunnerTest(DbTestCase):
         calls = [call('12345', state='SUCCESS', output=NON_EMPTY_RESULT) for i in range(0, 2)]
         action_executions.ActionExecutionManager.update.assert_has_calls(calls)
 
+    @mock.patch.object(
+        LocalShellRunner, 'run',
+        mock.MagicMock(return_value=(action_constants.LIVEACTION_STATUS_SUCCEEDED,
+                                     NON_EMPTY_RESULT, None)))
     @mock.patch.object(
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(side_effect=[


### PR DESCRIPTION
The new timeout status causes zombie mistral workflows because the callback handler did not know how to handle the new state.