### PR TITLE
Fix cancellation of actions in non-running state

### DIFF
--- a/st2api/tests/unit/controllers/v1/test_executions_simple.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_simple.py
@@ -232,7 +232,7 @@ class TestActionExecutionController(FunctionalTest):
         self.assertEqual(post_resp.status_int, 201)
         delete_resp = self._do_delete(self._get_actionexecution_id(post_resp))
         self.assertEqual(delete_resp.status_int, 200)
-        self.assertEqual(delete_resp.json['status'], 'canceling')
+        self.assertEqual(delete_resp.json['status'], 'canceled')
         expected_result = {'message': 'Action canceled by user.', 'user': 'stanley'}
         self.assertDictEqual(delete_resp.json['result'], expected_result)
 
@@ -243,14 +243,14 @@ class TestActionExecutionController(FunctionalTest):
         self.assertEqual(post_resp.status_int, 201)
         delete_resp = self._do_delete(self._get_actionexecution_id(post_resp))
         self.assertEqual(delete_resp.status_int, 200)
-        self.assertEqual(delete_resp.json['status'], 'canceling')
+        self.assertEqual(delete_resp.json['status'], 'canceled')
         trace_id = str(Trace.get_all()[0].id)
         LIVE_ACTION_TRACE['context'] = {'trace_context': {'id_': trace_id}}
         post_resp = self._do_post(LIVE_ACTION_TRACE)
         self.assertEqual(post_resp.status_int, 201)
         delete_resp = self._do_delete(self._get_actionexecution_id(post_resp))
         self.assertEqual(delete_resp.status_int, 200)
-        self.assertEqual(delete_resp.json['status'], 'canceling')
+        self.assertEqual(delete_resp.json['status'], 'canceled')
 
     def test_post_parameter_validation_failed(self):
         execution = copy.deepcopy(LIVE_ACTION_1)

--- a/st2common/st2common/services/action.py
+++ b/st2common/st2common/services/action.py
@@ -179,7 +179,12 @@ def request_cancellation(liveaction, requester):
         'user': requester
     }
 
-    update_status(liveaction, action_constants.LIVEACTION_STATUS_CANCELING, result=result)
+    # There is real work only when liveaction is still running.
+    status = (action_constants.LIVEACTION_STATUS_CANCELING
+              if liveaction.status == action_constants.LIVEACTION_STATUS_RUNNING
+              else action_constants.LIVEACTION_STATUS_CANCELED)
+
+    update_status(liveaction, status, result=result)
 
     execution = ActionExecution.get(liveaction__id=str(liveaction.id))
 

--- a/st2common/tests/unit/services/test_action.py
+++ b/st2common/tests/unit/services/test_action.py
@@ -158,3 +158,13 @@ class TestActionExecutionService(DbTestCase):
 
         # Request cancellation.
         self.assertRaises(Exception, action_service.request_cancellation, execution)
+
+    def test_request_cancellation_on_idle_execution(self):
+        request, execution = self._submit_request()
+        self.assertIsNotNone(execution)
+        self.assertEqual(execution.id, request.id)
+        self.assertEqual(execution.status, action_constants.LIVEACTION_STATUS_REQUESTED)
+
+        # Request cancellation.
+        execution = self._submit_cancellation(execution)
+        self.assertEqual(execution.status, action_constants.LIVEACTION_STATUS_CANCELED)


### PR DESCRIPTION
This bug only manifests currently for the mistral runner. Since the action is in requested state, the workflow execution has not started. The container service invokes cancel for a workflow that doesn't exists and fails.