### PR TITLE
[CircleCI Testing] Produce payload after the build for integration with st2

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,8 @@
 # DOCKER_USER
 # DOCKER_EMAIL
 # DOCKER_PASSWORD
+# ST2_HOOK_URL
+# ST2_API_KEY
 general:
   # Don't run CI for PR, only for major branches
   branches:
@@ -46,6 +48,7 @@ dependencies:
     - ~/.cache/pip
   pre:
     - sudo .circle/configure-services.sh
+    - pip install requests
     - sudo .circle/fix-cache-permissions.sh
     - sudo pip install docker-compose
     - docker-compose version
@@ -83,7 +86,7 @@ deployment:
           .circle/bintray.sh deploy ${DISTROS[$i]}_staging ~/packages/${DISTROS[$i]} &
         done
         wait
-      - echo Web Hook triggering st2 Staging box with build context payload will be here
+      - .circle/hook_st2.py ~/packages
       - .circle/docker.sh deploy st2actionrunner st2api st2auth st2exporter st2notifier st2resultstracker st2rulesengine st2sensorcontainer
 
 experimental:

--- a/circle.yml
+++ b/circle.yml
@@ -5,8 +5,6 @@
 # DOCKER_USER
 # DOCKER_EMAIL
 # DOCKER_PASSWORD
-# ST2_HOOK_URL
-# ST2_API_KEY
 general:
   # Don't run CI for PR, only for major branches
   branches:
@@ -48,7 +46,6 @@ dependencies:
     - ~/.cache/pip
   pre:
     - sudo .circle/configure-services.sh
-    - pip install requests
     - sudo .circle/fix-cache-permissions.sh
     - sudo pip install docker-compose
     - docker-compose version
@@ -86,8 +83,8 @@ deployment:
           .circle/bintray.sh deploy ${DISTROS[$i]}_staging ~/packages/${DISTROS[$i]} &
         done
         wait
-      - .circle/hook_st2.py ~/packages
       - .circle/docker.sh deploy st2actionrunner st2api st2auth st2exporter st2notifier st2resultstracker st2rulesengine st2sensorcontainer
+      - .circle/save_payload.py ~/packages
 
 experimental:
   notify:


### PR DESCRIPTION
> For code see: https://github.com/StackStorm/st2-packages/pull/42

~~Web Hook with build metadata to notify `st2 staging box`~~ (cc @lakshmi-kannan) when packages are ready/uploaded into Bintray staging repos:

> `wheezy_staging`: https://bintray.com/stackstorm/wheezy_staging
`trusty_staging`: https://bintray.com/stackstorm/trusty_staging
`jessie_staging`: https://bintray.com/stackstorm/jessie_staging

~~Required ENV variables in CircleCI WEB UI:~~
~~* `ST2_HOOK_URL`~~
~~* `ST2_API_KEY`~~

Example payload received by `st2` box (tested):
```json
{
   "packages":[
      {
         "version":"1.3dev",
         "revision":"7",
         "distro":"wheezy"
      },
      {
         "version":"1.3dev",
         "revision":"8",
         "distro":"jessie"
      },
      {
         "version":"1.3dev",
         "revision":"8",
         "distro":"trusty"
      }
   ],
   "circle":{
      "CIRCLE_BUILD_NUM":"367",
      "CI_PULL_REQUESTS":"",
      "CIRCLE_SHA1":"fdcdbc395ffc1a58e2563747d2259e701460cf58",
      "CIRCLE_USERNAME":"armab",
      "CIRCLE_PR_REPONAME":"",
      "CIRCLE_PROJECT_USERNAME":"armab",
      "CIRCLE_PR_USERNAME":"",
      "CIRCLE_COMPARE_URL":"https://github.com/armab/st2-packages/compare/6e7ef9fbef2e...fdcdbc395ffc",
      "CI_PULL_REQUEST":"",
      "CIRCLE_PROJECT_REPONAME":"st2-packages",
      "CIRCLE_BRANCH":"master",
      "CIRCLE_NODE_TOTAL":"3",
      "CIRCLE_PR_NUMBER":"",
      "CIRCLE_PREVIOUS_BUILD_NUM":"353"
   },
   "success":true,
   "reason":[],
   "build":{
      "DEPLOY_PACKAGES":"1",
      "ST2_GITURL":"https://github.com/StackStorm/st2",
      "NOTESTS":"centos7",
      "ST2_GITREV":"master",
      "DISTROS":"wheezy jessie trusty centos7"
   }
}
```

See https://circleci.com/docs/environment-variables for variables explanation.