### PR TITLE
Fix docs mentioning 9100 and 9101 ports

### DIFF
--- a/contrib/examples/actions/workflows/mistral-env-var.yaml
+++ b/contrib/examples/actions/workflows/mistral-env-var.yaml
@@ -5,11 +5,11 @@ examples.mistral-env-var:
     type: direct
     output:
         env: <% env() %>
-        url: <% $.url %> 
+        url: <% $.url %>
     tasks:
         task1:
             action: core.local
             input:
-                cmd: echo https://127.0.0.1:9101/history/<% env().st2_execution_id %>
+                cmd: echo http://127.0.0.1:9101/executions/<% env().st2_execution_id %>
             publish:
                 url: <% $.task1.stdout %>

--- a/docs/source/actions.rst
+++ b/docs/source/actions.rst
@@ -57,10 +57,10 @@ To execute an action manually, you can use ``st2 run <action with parameters>`` 
 .. code-block:: bash
 
    # Execute action immediately and display the results
-   st2 run core.http url="http://localhost:9101"
+   st2 run core.http url="http://httpbin.org/get"
 
    # Schedule action execution
-   st2 action execute core.http url="http://localhost:9101"
+   st2 action execute core.http url="http://httpbin.org/get"
    # Obtain execution results (the command below is provided as a tip in the output of the above command):
    st2 execution get 54fc83b9e11c711106a7ae01
 
@@ -548,7 +548,7 @@ executed from the |st2| box.
 
 ::
 
-    st2 run core.http url="http://localhost:9101/v1/actions" method="GET"
+    st2 run core.http url="http://httpbin.org/get" method="GET"
 
 To see other available predefined actions, run the command below.
 

--- a/docs/source/auth_usage.rst
+++ b/docs/source/auth_usage.rst
@@ -11,7 +11,7 @@ response. ::
 
 The following is a sample API call via curl using the token. ::
 
-    curl -H "X-Auth-Token: 4d76e023841a4a91a9c66aa4541156fe" https://myhost.example.com:9101/v1/actions
+    curl -H "X-Auth-Token: 4d76e023841a4a91a9c66aa4541156fe" https://myhost.example.com/api/v1/actions
 
 The following is the equivalent for CLI. ::
 

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -34,7 +34,7 @@ to the st2 clients.
 * ``api_url`` - Authentication service also acts as a service catalog. It returns a URL to the API
   endpoint on successful authentication. This information is used by clients such as command line
   tool and web UI. The setting needs to contain a public base URL to the API endpoint (excluding
-  the API version). Example: ``https://myhost.example.com:9101/``
+  the API version). Example: ``https://myhost.example.com/api/``
 * ``enable`` - Authentication is not enabled for the |st2| API until this is set to True. If
   running |st2| on multiple servers, please ensure that this is set to True on all |st2|
   configuration files.
@@ -74,7 +74,7 @@ repo. The following is a sample auth section in the config file for the PAM back
     cert = /path/to/ssl/cert/file
     key = /path/to/ssl/key/file
     logging = /etc/st2/st2auth.logging.conf
-    api_url = https://myhost.examples.com:9101
+    api_url = https://myhost.examples.com/api/
     debug = False
 
 The following is a list of auth backends for the community edition to help get things started.
@@ -128,7 +128,7 @@ The following is a sample auth section for the LDAP backend in the st2 config fi
     cert = /path/to/mycert.crt
     key = /path/to/mycert.key
     logging = /path/to/st2auth.logging.conf
-    api_url = https://myhost.example.com:9101/
+    api_url = https://myhost.example.com/api/
     debug = False
 
 Running the Service
@@ -161,18 +161,18 @@ Run the following curl commands to test.
 .. sourcecode:: bash
 
     # If use_ssl is set to True, the following will fail because SSL is required.
-    curl -X POST http://myhost.example.com:9100/v1/tokens
+    curl -X POST http://myhost.example.com/auth/v1/tokens
 
     # The following will fail with 401 unauthorized. Please note that this is executed with "-k" to skip SSL cert verification.
-    curl -X POST -k https://myhost.example.com:9100/v1/tokens
+    curl -X POST -k https://myhost.example.com/auth/v1/tokens
 
     # The following will succeed and return a valid token. Please note that this is executed with "-k" to skip SSL cert verification.
-    curl -X POST -k -u yourusername:yourpassword https://myhost.example.com:9100/v1/tokens
+    curl -X POST -k -u yourusername:yourpassword https://myhost.example.com/auth/v1/tokens
 
     # The following will verify the SSL cert, succeed, and return a valid token.
-    curl -X POST --cacert /path/to/cacert.pem -u yourusername:yourpassword https://myhost.example.com:9100/v1/tokens
+    curl -X POST --cacert /path/to/cacert.pem -u yourusername:yourpassword https://myhost.example.com/auth/v1/tokens
 
-.. note:: Until version 0.13 of StackStorm, auth APIs were unversioned. If your version is 0.13 or below, skip v1 in the URL paths above.
+.. note:: Until version 1.2 of StackStorm, auth APIs were served from its own port. If your version is 1.1.1 or below, replace '/api' with ':9100'.
 
 .. _authentication-usage:
 
@@ -224,9 +224,9 @@ API keys are designed for API access. As of now they cannot be used via clients 
 
 The following are sample API calls via curl using API Keys. ::
 
-    curl -H "St2-Api-Key: <API-KEY-VALUE>" http://myhost.example.com:9101/v1/actions
+    curl -H "St2-Api-Key: <API-KEY-VALUE>" https://myhost.example.com/api/v1/actions
 
-    curl https://myhost.example.com:9101/v1/actions?st2-api-key=<API-KEY-VALUE>
+    curl https://myhost.example.com/api/v1/actions?st2-api-key=<API-KEY-VALUE>
 
 
 .. _htpasswd: https://httpd.apache.org/docs/2.2/programs/htpasswd.html

--- a/docs/source/chatops/chatops.rst
+++ b/docs/source/chatops/chatops.rst
@@ -144,7 +144,7 @@ reload Hubot. Do this with the following commands:
 ::
 
     $ sudo st2ctl reload
-    $ sudo service hubot restart
+    $ sudo service docker-hubot restart
 
 This will register the aliases we created, and tell Hubot to go and
 refresh its command list.

--- a/docs/source/chatops/chatops.rst
+++ b/docs/source/chatops/chatops.rst
@@ -76,9 +76,9 @@ StackStorm installation, you will need to set the following environment
 variables:
 
 -  ``ST2_API`` - FQDN + port to StackStorm endpoint. Typically:
-   ``http://<host>:9101``
+   ``https://<host>:443/api``
 -  ``ST2_AUTH_URL`` - FQDN + port to StackStorm Auth endpoint:
-   ``http://<host>:9100``
+   ``https://<host>:443/auth``
 -  ``ST2_AUTH_USERNAME`` - StackStorm installation username
 -  ``ST2_AUTH_PASSWORD`` - StackStorm installation password
 

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -154,7 +154,7 @@ Sample rule: :github_st2:`sample_rule_with_webhook.yaml
 The rule definition is a YAML with three sections: trigger, criteria, and action. This example is
 setup to react on a webhook trigger and applies filtering criteria on the content of the trigger.
 The webhook in this example is setup to listen on the ``sample`` sub-url at
-``https://{host}:9101/v1/webhooks/sample``. When a POST is made on this URL, the trigger
+``https://{host}/api/v1/webhooks/sample``. When a POST is made on this URL, the trigger
 fires. If the criteria matches, value in payload is ``st2`` in this case, the payload will be
 appended to the file st2.webhook_sample.out in the home directory of the user setup to run |st2|.
 By default, ``stanley`` is the default user and the file will be located at
@@ -197,13 +197,13 @@ Deploy Rule
     # Get the rule that was just created
     st2 rule get examples.sample_rule_with_webhook
 
-Once the rule is created, the webhook begins to listen on ``https://{host}:9101/v1/webhooks/{url}``.
+Once the rule is created, the webhook begins to listen on ``https://{host}/api/v1/webhooks/{url}``.
 Fire the POST, check out the file and see that it appends the payload if the name=Joe.
 
 .. code-block:: bash
 
     # Post to the webhook
-    curl -k https://localhost:9101/v1/webhooks/sample -d '{"foo": "bar", "name": "st2"}' -H 'Content-Type: application/json' -H 'X-Auth-Token: put_token_here'
+    curl -k https://localhost/api/v1/webhooks/sample -d '{"foo": "bar", "name": "st2"}' -H 'Content-Type: application/json' -H 'X-Auth-Token: put_token_here'
 
     # Check if the action got executed (this shows last action)
     st2 execution list -n 1
@@ -212,7 +212,7 @@ Fire the POST, check out the file and see that it appends the payload if the nam
     sudo tail /home/stanley/st2.webhook_sample.out
 
     # And for fun, same post with |st2|
-    st2 run core.http method=POST body='{"you": "too", "name": "st2"}' url=https://localhost:9101/v1/webhooks/sample headers='x-auth-token=put_token_here;content-type=application/json' verify_ssl_cert=False
+    st2 run core.http method=POST body='{"you": "too", "name": "st2"}' url=https://localhost/api/v1/webhooks/sample headers='x-auth-token=put_token_here;content-type=application/json' verify_ssl_cert=False
 
     # Check that the rule worked. By default, st2 runs as the stanley user.
     sudo tail /home/stanley/st2.webhook_sample.out
@@ -273,4 +273,3 @@ For more information on datastore, check :doc:`datastore`
 
 
 .. include:: engage.rst
-

--- a/st2client/README.rst
+++ b/st2client/README.rst
@@ -20,7 +20,7 @@ client will assume localhost and default ports.
    server URL is provided, it will override the base URL and default
    port.
 -  ST2\_API\_URL - Endpoint for the Action REST API (i.e.
-   http://localhost:9101) for managing actions, executions, triggers,
+   https://example.com/api) for managing actions, executions, triggers,
    rules and reusable configuration data.
 
 The default endpoint configuration can be explicitly specified at the


### PR DESCRIPTION
There will be a lot of confusion next couple of month related to this new schema and how port and path corelate and when you should use one or the other.

The rule of thumb I used while making this commit and suggesting you should use when in doubt is rather simple:

> `https://example.org/api` is a public url and should be used for external services talking to st2 (webhooks, browsers, off-server or potentially off-server running services like hubot).

>`http://localhost:9101/` is a private url and should be used for testing or wiring between internal components (so it is ok to use it as a mock in tests, example when testing custom auth is properly set up or to route the request from nginx to st2api).

There's a ton of potentially tricky situations where it's not immediately clear whether it should be private or public url and we'll have to deal with each of them on a case by case basis.

And yeah, if you can avoid mentioning st2api url in examples that are not directly tied to wiring up the system, use some other url instead. http://httpbin.org/get is a nice general purpose example url.