### PR TITLE
More trace improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,8 @@ in development
   identify specific issues. (new-feature)
 * Filter Trace components by model types to only view ActionExecutions, Rules or TriggerInstances.
   (new-feature)
-
+* Include ref of the most meaningful object in each trace component. (new-feature)
+* Ability to hide trigger-instance that do not yield a rule enforcement. (new-feature)
 
 1.2.0 - December 07, 2015
 -------------------------

--- a/docs/source/traces.rst
+++ b/docs/source/traces.rst
@@ -146,6 +146,24 @@ Get
 
     $ st2 trace get <trace-id>
 
+* View the causation chain in a trace for an action execution. Similarly for rule and trigger-instance.
+
+.. code-block:: bash
+
+    $ st2 trace get <trace-id> -e
+
+* View specific type in a trace.
+
+.. code-block:: bash
+
+    $ st2 trace get <trace-id> --show-executions
+
+* Hide noop trigger instances. These are trigger instances which do no lead to a rule enforcement.
+
+.. code-block:: bash
+
+    $ st2 trace get <trace-id> --hide-noop-triggers
+
 
 Is everythign traced?
 ---------------------

--- a/st2client/st2client/commands/trace.py
+++ b/st2client/st2client/commands/trace.py
@@ -196,8 +196,8 @@ class TraceGetCommand(resource.ResourceGetCommand, SingleTraceDisplayMixin):
                                               help='Only show rules.')
         self.display_filter_group.add_argument('--show-trigger-instances', action='store_true',
                                               help='Only show trigger instances.')
-        self.display_filter_group.add_argument('--hide-noop-triggers', action='store_true',
-                                              help='Hide trigger instances that lead to no execution.')
+        self.display_filter_group.add_argument('-n', '--hide-noop-triggers', action='store_true',
+                                              help='Hide noop trigger instances.')
 
     @resource.add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):

--- a/st2client/st2client/commands/trace.py
+++ b/st2client/st2client/commands/trace.py
@@ -26,7 +26,7 @@ TRACE_ATTRIBUTE_DISPLAY_ORDER = ['id', 'trace_tag', 'action_executions', 'rules'
 
 TRACE_HEADER_DISPLAY_ORDER = ['id', 'trace_tag', 'start_timestamp']
 
-TRACE_COMPONENT_DISPLAY_LABELS = ['id', 'type', 'updated_at']
+TRACE_COMPONENT_DISPLAY_LABELS = ['id', 'type', 'ref', 'updated_at']
 
 TRACE_DISPLAY_ATTRIBUTES = ['all']
 
@@ -80,16 +80,19 @@ class SingleTraceDisplayMixin(object):
         if any(attr in args.attr for attr in TRIGGER_INSTANCE_DISPLAY_OPTIONS):
             components.extend([Resource(**{'id': trigger_instance['object_id'],
                                            'type': TriggerInstance._alias.lower(),
+                                           'ref': trigger_instance['ref'],
                                            'updated_at': trigger_instance['updated_at']})
                                for trigger_instance in trace.trigger_instances])
         if any(attr in args.attr for attr in ['all', 'rules']):
             components.extend([Resource(**{'id': rule['object_id'],
                                            'type': Rule._alias.lower(),
+                                           'ref': rule['ref'],
                                            'updated_at': rule['updated_at']})
                                for rule in trace.rules])
         if any(attr in args.attr for attr in ACTION_EXECUTION_DISPLAY_OPTIONS):
             components.extend([Resource(**{'id': execution['object_id'],
                                            'type': LiveAction._alias.lower(),
+                                           'ref': execution['ref'],
                                            'updated_at': execution['updated_at']})
                                for execution in trace.action_executions])
         if components:

--- a/st2client/tests/unit/test_trace_commands.py
+++ b/st2client/tests/unit/test_trace_commands.py
@@ -38,6 +38,7 @@ class TraceCommandTestCase(base.BaseCLITestCase):
         setattr(args, 'show_executions', False)
         setattr(args, 'show_rules', False)
         setattr(args, 'show_trigger_instances', False)
+        setattr(args, 'hide_noop_triggers', False)
 
         trace = trace_commands.TraceGetCommand._filter_trace_components(trace, args)
         self.assertEquals(len(trace.action_executions), 1)
@@ -61,6 +62,7 @@ class TraceCommandTestCase(base.BaseCLITestCase):
         setattr(args, 'show_executions', False)
         setattr(args, 'show_rules', False)
         setattr(args, 'show_trigger_instances', False)
+        setattr(args, 'hide_noop_triggers', False)
 
         trace = trace_commands.TraceGetCommand._filter_trace_components(trace, args)
         self.assertEquals(len(trace.action_executions), 0)
@@ -84,6 +86,7 @@ class TraceCommandTestCase(base.BaseCLITestCase):
         setattr(args, 'show_executions', False)
         setattr(args, 'show_rules', False)
         setattr(args, 'show_trigger_instances', False)
+        setattr(args, 'hide_noop_triggers', False)
 
         trace = trace_commands.TraceGetCommand._filter_trace_components(trace, args)
         self.assertEquals(len(trace.action_executions), 0)
@@ -100,6 +103,7 @@ class TraceCommandTestCase(base.BaseCLITestCase):
         setattr(args, 'show_executions', True)
         setattr(args, 'show_rules', False)
         setattr(args, 'show_trigger_instances', False)
+        setattr(args, 'hide_noop_triggers', False)
 
         trace = trace_commands.TraceGetCommand._apply_display_filters(trace, args)
         self.assertTrue(trace.action_executions)
@@ -116,6 +120,7 @@ class TraceCommandTestCase(base.BaseCLITestCase):
         setattr(args, 'show_executions', False)
         setattr(args, 'show_rules', True)
         setattr(args, 'show_trigger_instances', False)
+        setattr(args, 'hide_noop_triggers', False)
 
         trace = trace_commands.TraceGetCommand._apply_display_filters(trace, args)
         self.assertFalse(trace.action_executions)
@@ -132,6 +137,7 @@ class TraceCommandTestCase(base.BaseCLITestCase):
         setattr(args, 'show_executions', False)
         setattr(args, 'show_rules', False)
         setattr(args, 'show_trigger_instances', True)
+        setattr(args, 'hide_noop_triggers', False)
 
         trace = trace_commands.TraceGetCommand._apply_display_filters(trace, args)
         self.assertFalse(trace.action_executions)
@@ -148,6 +154,7 @@ class TraceCommandTestCase(base.BaseCLITestCase):
         setattr(args, 'show_executions', True)
         setattr(args, 'show_rules', True)
         setattr(args, 'show_trigger_instances', False)
+        setattr(args, 'hide_noop_triggers', False)
 
         trace = trace_commands.TraceGetCommand._apply_display_filters(trace, args)
         self.assertTrue(trace.action_executions)
@@ -164,8 +171,30 @@ class TraceCommandTestCase(base.BaseCLITestCase):
         setattr(args, 'show_executions', False)
         setattr(args, 'show_rules', False)
         setattr(args, 'show_trigger_instances', False)
+        setattr(args, 'hide_noop_triggers', False)
 
         trace = trace_commands.TraceGetCommand._apply_display_filters(trace, args)
-        self.assertTrue(trace.action_executions)
-        self.assertTrue(trace.rules)
-        self.assertTrue(trace.trigger_instances)
+        self.assertEquals(len(trace.action_executions), 1)
+        self.assertEquals(len(trace.rules), 1)
+        self.assertEquals(len(trace.trigger_instances), 1)
+
+    def test_trace_get_apply_display_filters_hide_noop(self):
+        trace = trace_models.Trace()
+        setattr(trace, 'action_executions',
+                [{'object_id': 'e1', 'caused_by': {'id': 'r1:t1', 'type': 'rule'}}])
+        setattr(trace, 'rules',
+                [{'object_id': 'r1', 'caused_by': {'id': 't1', 'type': 'trigger_instance'}}])
+        setattr(trace, 'trigger_instances',
+                [{'object_id': 't1', 'caused_by': {}},
+                 {'object_id': 't2', 'caused_by': {'id': 'e1', 'type': 'execution'}}])
+
+        args = argparse.Namespace()
+        setattr(args, 'show_executions', False)
+        setattr(args, 'show_rules', False)
+        setattr(args, 'show_trigger_instances', False)
+        setattr(args, 'hide_noop_triggers', True)
+
+        trace = trace_commands.TraceGetCommand._apply_display_filters(trace, args)
+        self.assertEquals(len(trace.action_executions), 1)
+        self.assertEquals(len(trace.rules), 1)
+        self.assertEquals(len(trace.trigger_instances), 1)

--- a/st2common/st2common/models/api/trace.py
+++ b/st2common/st2common/models/api/trace.py
@@ -26,7 +26,7 @@ TraceComponentAPISchema = {
             'description': 'Id of the component',
             'required': True
         },
-        'ref':  {
+        'ref': {
             'type': 'string',
             'description': 'ref of the component',
             'required': False

--- a/st2common/st2common/models/api/trace.py
+++ b/st2common/st2common/models/api/trace.py
@@ -23,8 +23,13 @@ TraceComponentAPISchema = {
     'properties': {
         'object_id': {
             'type': 'string',
-            'description': 'Message to use for notification',
+            'description': 'Id of the component',
             'required': True
+        },
+        'ref':  {
+            'type': 'string',
+            'description': 'ref of the component',
+            'required': False
         },
         'updated_at': {
             'description': 'The start time when the action is executed.',
@@ -98,6 +103,7 @@ class TraceAPI(BaseAPI):
     def to_component_model(cls, component):
         values = {
             'object_id': component['object_id'],
+            'ref': component['ref'],
             'caused_by': component.get('caused_by', {})
         }
         updated_at = component.get('updated_at', None)
@@ -132,6 +138,7 @@ class TraceAPI(BaseAPI):
     @classmethod
     def from_component_model(cls, component_model):
         return {'object_id': component_model.object_id,
+                'ref': component_model.ref,
                 'updated_at': isotime.format(component_model.updated_at, offset=False),
                 'caused_by': component_model.caused_by}
 

--- a/st2common/st2common/models/db/trace.py
+++ b/st2common/st2common/models/db/trace.py
@@ -31,6 +31,7 @@ class TraceComponentDB(me.EmbeddedDocument):
     """
     """
     object_id = me.StringField()
+    ref = me.StringField(default='')
     updated_at = ComplexDateTimeField(
         default=date_utils.get_datetime_utc_now,
         help_text='The timestamp when the TraceComponent was included.')

--- a/st2common/st2common/services/trace.py
+++ b/st2common/st2common/services/trace.py
@@ -289,7 +289,10 @@ def get_trace_component_for_action_execution(action_execution_db):
     """
     if not action_execution_db:
         raise ValueError('action_execution_db expected.')
-    trace_component = {'id': str(action_execution_db.id)}
+    trace_component = {
+        'id': str(action_execution_db.id),
+        'ref': str(action_execution_db.action.get('ref', ''))
+    }
     caused_by = {}
     if action_execution_db.rule and action_execution_db.trigger_instance:
         # Once RuleEnforcement is available that can be used instead.
@@ -313,7 +316,7 @@ def get_trace_component_for_rule(rule_db, trigger_instance_db):
     :rtype: ``dict``
     """
     trace_component = {}
-    trace_component = {'id': str(rule_db.id)}
+    trace_component = {'id': str(rule_db.id), 'ref': rule_db.ref}
     caused_by = {}
     if trigger_instance_db:
         # Once RuleEnforcement is available that can be used instead.
@@ -333,13 +336,15 @@ def get_trace_component_for_trigger_instance(trigger_instance_db):
     :rtype: ``dict``
     """
     trace_component = {}
-    trace_component = {'id': str(trigger_instance_db.id)}
+    trace_component = {
+        'id': str(trigger_instance_db.id),
+        'ref':trigger_instance_db.trigger
+    }
     caused_by = {}
     # Special handling for ACTION_SENSOR_TRIGGER and NOTIFY_TRIGGER where we
     # know how to maintain the links.
     if trigger_instance_db.trigger == ACTION_SENSOR_TRIGGER_REF or \
        trigger_instance_db.trigger == NOTIFY_TRIGGER_REF:
-        # Once RuleEnforcement is available that can be used instead.
         caused_by['type'] = 'action_execution'
         # For both action trigger and notidy trigger execution_id is stored in the payload.
         caused_by['id'] = trigger_instance_db.payload['execution_id']
@@ -362,6 +367,7 @@ def _to_trace_component_db(component):
         raise ValueError('Expected component to be str or dict')
 
     object_id = component if isinstance(component, basestring) else component['id']
+    ref = component.get('ref', '') if isinstance(component, dict) else ''
     caused_by = component.get('caused_by', {}) if isinstance(component, dict) else {}
 
-    return TraceComponentDB(object_id=object_id, caused_by=caused_by)
+    return TraceComponentDB(object_id=object_id, ref=ref, caused_by=caused_by)

--- a/st2common/st2common/services/trace.py
+++ b/st2common/st2common/services/trace.py
@@ -338,7 +338,7 @@ def get_trace_component_for_trigger_instance(trigger_instance_db):
     trace_component = {}
     trace_component = {
         'id': str(trigger_instance_db.id),
-        'ref':trigger_instance_db.trigger
+        'ref': trigger_instance_db.trigger
     }
     caused_by = {}
     # Special handling for ACTION_SENSOR_TRIGGER and NOTIFY_TRIGGER where we

--- a/st2tests/st2tests/fixtures/generic/traces/trace_for_test_enforce.yaml
+++ b/st2tests/st2tests/fixtures/generic/traces/trace_for_test_enforce.yaml
@@ -4,4 +4,5 @@ action_executions : []
 rules : []
 trigger_instances :
     - object_id: 'triggerinstance-test'    # value from test_enforce.py
+      ref: pack1.trigger1
       updated_at: '2014-09-01T00:00:02.000000Z'

--- a/st2tests/st2tests/fixtures/traces/traces/trace_execution.yaml
+++ b/st2tests/st2tests/fixtures/traces/traces/trace_execution.yaml
@@ -2,6 +2,7 @@
 trace_tag : traceable_execution
 action_executions :
     - object_id: 54c6bb640640fd5211edef0d
+      ref: core.local
       updated_at : '2014-09-01T00:00:02.000000Z'
 rules : []
 trigger_instances : []

--- a/st2tests/st2tests/fixtures/traces/traces/trace_multiple_components.yaml
+++ b/st2tests/st2tests/fixtures/traces/traces/trace_multiple_components.yaml
@@ -2,24 +2,34 @@
 trace_tag : test-trace-3
 action_executions :
     - object_id: '55d3a73332ed3534d41fc7b7'
+      ref: core.local
       updated_at: '2014-09-01T00:00:02.000000Z'
     - object_id: '55d3a73332ed3534d41fc7b8'
+      ref: core.remote
       updated_at: '2014-09-01T00:00:02.000000Z'
     - object_id: '55d3a73332ed3534d41fc7b9'
+      ref: core.noop
       updated_at: '2014-09-01T00:00:02.000000Z'
 rules :
     - object_id: '55d3a74b32ed3534d41fc7ba'
+      ref: pack1.rule1
       updated_at: '2014-09-01T00:00:02.000000Z'
     - object_id: '55d3a74b32ed3534d41fc7bb'
+      ref: pack1.rule2
       updated_at: '2014-09-01T00:00:02.000000Z'
     - object_id: '55d3a74b32ed3534d41fc7bc'
+      ref: pack1.rule3
       updated_at: '2014-09-01T00:00:02.000000Z'
 trigger_instances :
     - object_id: '55d3a76032ed3534d41fc7bd'
+      ref: pack1.trigger1
       updated_at: '2014-09-01T00:00:02.000000Z'
     - object_id: '55d3a76032ed3534d41fc7be'
+      ref: pack1.trigger2
       updated_at: '2014-09-01T00:00:02.000000Z'
     - object_id: '55d3a76032ed3534d41fc7bf'
+      ref: pack1.trigger3
       updated_at: '2014-09-01T00:00:02.000000Z'
     - object_id: '55d3a76032ed3534d41fc7c0'
+      ref: pack1.trigger4
       updated_at: '2014-09-01T00:00:02.000000Z'

--- a/st2tests/st2tests/fixtures/traces/traces/trace_one_each.yaml
+++ b/st2tests/st2tests/fixtures/traces/traces/trace_one_each.yaml
@@ -2,17 +2,20 @@
 trace_tag : test-trace-2
 action_executions :
     - object_id: '55d3a76032ed3534d41fc7c1'
+      ref: core.local
       updated_at: '2014-09-01T00:00:02.000000Z'
       causal_component:
         id: '55d3a76032ed3534d41fc7c2:55d3a76032ed3534d41fc7c3'
         type: 'rule'
 rules :
     - object_id: '55d3a76032ed3534d41fc7c2'
+      ref: pack1.rule1
       updated_at: '2014-09-01T00:00:02.000000Z'
       causal_component:
         id: '55d3a76032ed3534d41fc7c3'
         type: 'trigger-instance'
 trigger_instances :
     - object_id: '55d3a76032ed3534d41fc7c3'
+      ref: pack1.trigger1
       updated_at: '2014-09-01T00:00:02.000000Z'
       causal_component: {}

--- a/st2tests/st2tests/fixtures/traces/traces/trace_one_each_dup.yaml
+++ b/st2tests/st2tests/fixtures/traces/traces/trace_one_each_dup.yaml
@@ -2,10 +2,13 @@
 trace_tag : test-trace-2
 action_executions :
     - object_id: '55d3a76032ed3534d41fc7c1'
+      ref: core.local
       updated_at: '2014-09-01T00:00:02.000000Z'
 rules :
     - object_id: '55d3a76032ed3534d41fc7c2'
+      ref: pack1.rule1
       updated_at: '2014-09-01T00:00:02.000000Z'
 trigger_instances :
     - object_id: '55d3a76032ed3534d41fc7c3'
+      ref: pack1.trigger1
       updated_at: '2014-09-01T00:00:02.000000Z'


### PR DESCRIPTION
* Ability to skip noop triggers. This should help reduce noise

```
(virtualenv)manas@st2dev:~/st2$ st2 trace get 5668aea232ed353b0c46de89
id: 5668aea232ed353b0c46de89
trace_tag: trigger_instance-5668aea232ed353b0c46de88
start_timestamp: 2015-12-09T22:43:46.889177Z
+--------------------------+------------------+---------------------------+---------------------------+
| id                       | type             | ref                       | updated_at                |
+--------------------------+------------------+---------------------------+---------------------------+
| 5668aea232ed353b0c46de88 | trigger-instance | fixtures.test_passive_tri | 2015-12-09T22:43:46.88924 |
|                          |                  | gger.dummy                | 1Z                        |
| 5666295032ed355785437236 | rule             | default.passive_trigger_r | 2015-12-09T22:43:46.91876 |
|                          |                  | ule                       | 4Z                        |
| 5668aea232ed353b0c46de8b | execution        | core.local                | 2015-12-09T22:43:46.97451 |
|                          |                  |                           | 3Z                        |
| 5668aea332ed353b0c46de8d | trigger-instance | core.st2.generic.actiontr | 2015-12-09T22:43:47.15511 |
|                          |                  | igger                     | 1Z                        |
+--------------------------+------------------+---------------------------+---------------------------+
(virtualenv)manas@st2dev:~/st2$ st2 trace get 5668aea232ed353b0c46de89 --hide-noop-triggers
id: 5668aea232ed353b0c46de89
trace_tag: trigger_instance-5668aea232ed353b0c46de88
start_timestamp: 2015-12-09T22:43:46.889177Z
+--------------------------+------------------+---------------------------+---------------------------+
| id                       | type             | ref                       | updated_at                |
+--------------------------+------------------+---------------------------+---------------------------+
| 5668aea232ed353b0c46de88 | trigger-instance | fixtures.test_passive_tri | 2015-12-09T22:43:46.88924 |
|                          |                  | gger.dummy                | 1Z                        |
| 5666295032ed355785437236 | rule             | default.passive_trigger_r | 2015-12-09T22:43:46.91876 |
|                          |                  | ule                       | 4Z                        |
| 5668aea232ed353b0c46de8b | execution        | core.local                | 2015-12-09T22:43:46.97451 |
|                          |                  |                           | 3Z                        |
+--------------------------+------------------+---------------------------+---------------------------+
```

* Now ref of the most meaningful object is included so that the trace is easier to parse.