### PR TITLE
Bug Fix: add get_logger function to MockSensorService

### DIFF
--- a/st2tests/st2tests/mocks/sensor.py
+++ b/st2tests/st2tests/mocks/sensor.py
@@ -49,7 +49,7 @@ class MockSensorService(SensorService):
 
     def get_logger(self, name):
         return None
-        
+
     def dispatch_with_context(self, trigger, payload=None, trace_context=None):
         item = {
             'trigger': trigger,

--- a/st2tests/st2tests/mocks/sensor.py
+++ b/st2tests/st2tests/mocks/sensor.py
@@ -47,6 +47,9 @@ class MockSensorService(SensorService):
         # Holds a list of triggers which were dispatched
         self.dispatched_triggers = []
 
+    def get_logger(self, name):
+        return None
+        
     def dispatch_with_context(self, trigger, payload=None, trace_context=None):
         item = {
             'trigger': trigger,


### PR DESCRIPTION
When testing a pack unit test for a sensor that calls `get_logger` in it's `__init__` method, I observed a traceback:

```
Traceback (most recent call last):
  File "/st2contrib/packs/plexxi/tests/test_plexxi_event_sensor.py", line 31, in test_run
    sensor = self.get_sensor_instance()
  File "/st2/st2tests/st2tests/base.py", line 440, in get_sensor_instance
    instance = self.sensor_cls(**kwargs)  # pylint: disable=not-callable
  File "/st2contrib/packs/plexxi/sensors/plexxi_event_sensor.py", line 78, in __init__
    self._logger = self._sensor_service.get_logger(name=self.__class__.__name__)
  File "/st2/st2reactor/st2reactor/container/sensor_wrapper.py", line 71, in get_logger
    logger_name = '%s.%s' % (self._sensor_wrapper._logger.name, name)
AttributeError: 'MockSensorWrapper' object has no attribute '_logger'
```

My sensor service init method looks like:
```
def __init__(self, sensor_service, config=None):
    super(EventSensor, self).__init__(sensor_service=sensor_service, config=config)
    self._logger = self._sensor_service.get_logger(name=self.__class__.__name__)
```


Considering that it's a mock, and I'm not interested in testing logging, I'm returning `None` for the logger instance.
