### PR TITLE
Requests verify kwarg must be True or False.

### DIFF
--- a/st2client/st2client/utils/httpclient.py
+++ b/st2client/st2client/utils/httpclient.py
@@ -29,7 +29,7 @@ def add_ssl_verify_to_kwargs(func):
     def decorate(*args, **kwargs):
         if isinstance(args[0], HTTPClient) and 'https' in getattr(args[0], 'root', ''):
             cacert = getattr(args[0], 'cacert', None)
-            kwargs['verify'] = cacert if cacert else False
+            kwargs['verify'] = True if cacert else False
         return func(*args, **kwargs)
     return decorate
 


### PR DESCRIPTION
This is the first step to addressing issue https://github.com/StackStorm/st2/issues/2242 (InsecurePlatformWarning).  

This patch along with putting the following into `~/.st2/config` will allow for a successfully verified request in the CLI.
```
[api]
# The FQDN must match the Common Name in the host cert
url = https://st2.mydomain.com:9101
[auth]
# The FQDN must match the Common Name in the host cert
url = https://st2.mydomain.com:9100
[general]
cacert  = /etc/ssl/st2/st2_ca.crt 
```
Note, even if you configure the chatops user's `.st2/config` the requests fail to verify via action_alias, chatops request.