### PR TITLE
Validate ti rule

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ in development
   action.ref and enabled. This aligns closer the UI and also brings important information front and
   center. (improvement)
 * Action and Trigger filters for rule list (new-feature)
+* Support for object already present in the DB for ``st2-rule-tester`` (improvement)
 
 1.2.0 - December 07, 2015
 -------------------------

--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -357,7 +357,10 @@ Output:
 
 .. code-block:: bash
 
-    === RULE MATCHES ===
+    2015-12-11 14:35:03,249 INFO [-] Connecting to database "st2" @ "0.0.0.0:27017" as user "None".
+    2015-12-11 14:35:03,318 INFO [-] Validating rule irc.relayed_matched_irc_message for pubmsg.
+    2015-12-11 14:35:03,331 INFO [-] 1 rule(s) found to enforce for pubmsg.
+    2015-12-11 14:35:03,333 INFO [-] === RULE MATCHES ===
     0
 
 .. code-block:: bash
@@ -369,7 +372,17 @@ Output:
 
 .. code-block:: bash
 
-    === RULE DOES NOT MATCH ===
+    2015-12-11 14:35:57,380 INFO [-] Connecting to database "st2" @ "0.0.0.0:27017" as user "None".
+    2015-12-11 14:35:57,444 INFO [-] Validating rule irc.relayed_matched_irc_message for pubmsg.
+    2015-12-11 14:35:57,459 INFO [-] Validation for rule irc.relayed_matched_irc_message failed on -
+    {
+        "pattern": "StackStorm",
+        "type": "icontains",
+        "payload_value": "blah blah",
+        "key": "trigger.message"
+    }
+    2015-12-11 14:35:57,461 INFO [-] 0 rule(s) found to enforce for pubmsg.
+    2015-12-11 14:35:57,462 INFO [-] === RULE DOES NOT MATCH ===
     1
 
 If you are debugging and would like to see the list of trigger instances sent to |st2|,

--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -375,12 +375,10 @@ Output:
     2015-12-11 14:35:57,380 INFO [-] Connecting to database "st2" @ "0.0.0.0:27017" as user "None".
     2015-12-11 14:35:57,444 INFO [-] Validating rule irc.relayed_matched_irc_message for pubmsg.
     2015-12-11 14:35:57,459 INFO [-] Validation for rule irc.relayed_matched_irc_message failed on -
-    {
-        "pattern": "StackStorm",
-        "type": "icontains",
-        "payload_value": "blah blah",
-        "key": "trigger.message"
-    }
+      key: trigger.message
+      pattern: StackStorm
+      type: icontains
+      payload: blah blah
     2015-12-11 14:35:57,461 INFO [-] 0 rule(s) found to enforce for pubmsg.
     2015-12-11 14:35:57,462 INFO [-] === RULE DOES NOT MATCH ===
     1
@@ -403,12 +401,10 @@ Output:
     2015-12-11 15:24:16,459 INFO [-] Connecting to database "st2" @ "0.0.0.0:27017" as user "None".
     2015-12-11 15:24:16,527 INFO [-] Validating rule my_pack.fire_on_execution for st2.generic.actiontrigger.
     2015-12-11 15:24:16,542 INFO [-] Validation for rule my_pack.fire_on_execution failed on -
-    {
-        "pattern": "succeeded",
-        "type": "iequals",
-        "payload_value": "failed",
-        "key": "trigger.status"
-    }
+      key: trigger.status
+      pattern: succeeded
+      type: iequals
+      payload: failed
     2015-12-11 15:24:16,545 INFO [-] 0 rule(s) found to enforce for st2.generic.actiontrigger.
     2015-12-11 15:24:16,546 INFO [-] === RULE DOES NOT MATCH ===
 

--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -385,6 +385,36 @@ Output:
     2015-12-11 14:35:57,462 INFO [-] === RULE DOES NOT MATCH ===
     1
 
+``st2-rule-tester`` further allows a kind of post-mortem debugging where you can answer the
+question ``Why did my rule not match the trigger that just fired?``. This means there is known ``Rule`` identifiable by its reference loaded in StackStorm and similarly a
+TriggerInstance with a known id.
+
+Lets say we have rule reference `my_pack.fire_on_execution` and a trigger instance `566b4be632ed352a09cd347d`
+
+.. code-block:: bash
+
+    st2-rule-tester --rule-ref=my_pack.fire_on_execution --trigger-instance-id=566b4be632ed352a09cd347d --config-file=/etc/st2/st2.conf
+    echo $?
+
+Output:
+
+.. code-block:: bash
+
+    2015-12-11 15:24:16,459 INFO [-] Connecting to database "st2" @ "0.0.0.0:27017" as user "None".
+    2015-12-11 15:24:16,527 INFO [-] Validating rule my_pack.fire_on_execution for st2.generic.actiontrigger.
+    2015-12-11 15:24:16,542 INFO [-] Validation for rule my_pack.fire_on_execution failed on -
+    {
+        "pattern": "succeeded",
+        "type": "iequals",
+        "payload_value": "failed",
+        "key": "trigger.status"
+    }
+    2015-12-11 15:24:16,545 INFO [-] 0 rule(s) found to enforce for st2.generic.actiontrigger.
+    2015-12-11 15:24:16,546 INFO [-] === RULE DOES NOT MATCH ===
+
+
+The output also identifies source of the mismatch i.e. whether it was the trigger type that did not match or one of the criteria.
+
 If you are debugging and would like to see the list of trigger instances sent to |st2|,
 you can use the CLI to do so.
 

--- a/st2reactor/st2reactor/rules/filter.py
+++ b/st2reactor/st2reactor/rules/filter.py
@@ -81,14 +81,15 @@ class RuleFilter(object):
                 criterion_k, criterion_v, payload_lookup)
             if not is_rule_applicable:
                 if self.extra_info:
-                    extra = {
-                        'key': criterion_k,
-                        'type': criterion_v['type'],
-                        'pattern': criterion_pattern,
-                        'payload_value': payload_value
-                    }
-                    LOG.info('Validation for rule %s failed on -\n%s', self.rule.ref,
-                             json.dumps(extra, indent=4))
+                    criteria_extra_info = '\n'.join([
+                        '  key: %s' % criterion_k,
+                        '  pattern: %s' % criterion_pattern,
+                        '  type: %s' % criterion_v['type'],
+                        '  payload: %s' % payload_value
+                    ])
+                    LOG.info('Validation for rule %s failed on criteria -\n%s', self.rule.ref,
+                             criteria_extra_info,
+                             extra=self._base_logger_context)
                 break
 
         if not is_rule_applicable:

--- a/st2reactor/st2reactor/rules/filter.py
+++ b/st2reactor/st2reactor/rules/filter.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import six
 from jsonpath_rw import parse
 

--- a/st2reactor/st2reactor/rules/matcher.py
+++ b/st2reactor/st2reactor/rules/matcher.py
@@ -21,15 +21,19 @@ LOG = logging.getLogger('st2reactor.rules.RulesMatcher')
 
 
 class RulesMatcher(object):
-    def __init__(self, trigger_instance, trigger, rules):
+    def __init__(self, trigger_instance, trigger, rules, extra_info=False):
         self.trigger_instance = trigger_instance
         self.trigger = trigger
         self.rules = rules
+        self.extra_info = extra_info
 
     def get_matching_rules(self):
         first_pass, second_pass = self._split_rules_into_passes()
         # first pass
-        rule_filters = [RuleFilter(self.trigger_instance, self.trigger, rule)
+        rule_filters = [RuleFilter(trigger_instance=self.trigger_instance,
+                                   trigger=self.trigger,
+                                   rule=rule,
+                                   extra_info=self.extra_info)
                         for rule in first_pass]
         matched_rules = [rule_filter.rule for rule_filter in rule_filters if rule_filter.filter()]
         LOG.debug('[1st_pass] %d rule(s) found to enforce for %s.', len(matched_rules),

--- a/st2reactor/st2reactor/rules/tester.py
+++ b/st2reactor/st2reactor/rules/tester.py
@@ -33,7 +33,8 @@ LOG = logging.getLogger(__name__)
 
 
 class RuleTester(object):
-    def __init__(self, rule_file_path, rule_ref, trigger_instance_file_path, trigger_instance_id):
+    def __init__(self, rule_file_path=None, rule_ref=None, trigger_instance_file_path=None,
+                 trigger_instance_id=None):
         """
         :param rule_file_path: Path to the file containing rule definition.
         :type rule_file_path: ``str``

--- a/st2reactor/st2reactor/rules/tester.py
+++ b/st2reactor/st2reactor/rules/tester.py
@@ -13,20 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
+from st2common import log as logging
+from st2common.content.loader import MetaLoader
 from st2common.models.db.rule import RuleDB
 from st2common.models.db.trigger import TriggerDB
 from st2common.models.db.trigger import TriggerInstanceDB
 from st2common.models.system.common import ResourceReference
-from st2common.content.loader import MetaLoader
+from st2common.persistence.reactor import Rule, TriggerInstance, Trigger
+
 from st2reactor.rules.matcher import RulesMatcher
 
 __all__ = [
     'RuleTester'
 ]
 
+LOG = logging.getLogger(__name__)
+
 
 class RuleTester(object):
-    def __init__(self, rule_file_path, trigger_instance_file_path):
+    def __init__(self, rule_file_path, rule_ref, trigger_instance_file_path, trigger_instance_id):
         """
         :param rule_file_path: Path to the file containing rule definition.
         :type rule_file_path: ``str``
@@ -35,7 +42,9 @@ class RuleTester(object):
         :type trigger_instance_file_path: ``str``
         """
         self._rule_file_path = rule_file_path
+        self._rule_ref = rule_ref
         self._trigger_instance_file_path = trigger_instance_file_path
+        self._trigger_instance_id = trigger_instance_id
         self._meta_loader = MetaLoader()
 
     def evaluate(self):
@@ -45,18 +54,41 @@ class RuleTester(object):
         :return: ``True`` if the rule matches, ``False`` otherwise.
         :rtype: ``boolean``
         """
-        rule_db = self._get_rule_db_from_file(file_path=self._rule_file_path)
-        trigger_instance_db = \
-            self._get_trigger_instance_db_from_file(file_path=self._trigger_instance_file_path)
 
-        trigger_ref = ResourceReference.from_string_reference(trigger_instance_db['trigger'])
+        rule_db = self._get_rule_db()
+        trigger_instance_db, trigger_db = self._get_trigger_instance_db()
 
-        trigger_db = TriggerDB(pack=trigger_ref.pack, name=trigger_ref.name, type=trigger_ref.ref)
+        # The trigger check needs to be performed here as that is not performed
+        # by RulesMatcher.
+        if rule_db.trigger != trigger_db.ref:
+            LOG.info('rule.trigger "%s" and trigger.ref "%s" do not match.',
+                     rule_db.trigger, trigger_db.ref)
+            return False
 
         matcher = RulesMatcher(trigger_instance=trigger_instance_db, trigger=trigger_db,
-                               rules=[rule_db])
+                               rules=[rule_db], extra_info=True)
         matching_rules = matcher.get_matching_rules()
+
         return len(matching_rules) >= 1
+
+    def _get_rule_db(self):
+        if self._rule_file_path:
+            return self._get_rule_db_from_file(
+                file_path=os.path.realpath(self._rule_file_path))
+        elif self._rule_ref:
+            return Rule.get_by_ref(self._rule_ref)
+        raise ValueError('One of _rule_file_path or _rule_ref should be specified.')
+
+    def _get_trigger_instance_db(self):
+        if self._trigger_instance_file_path:
+            return self._get_trigger_instance_db_from_file(
+                file_path=os.path.realpath(self._trigger_instance_file_path))
+        elif self._trigger_instance_id:
+            trigger_instance_db = TriggerInstance.get_by_id(self._trigger_instance_id)
+            trigger_db = Trigger.get_by_ref(trigger_instance_db.trigger)
+            return trigger_instance_db, trigger_db
+        raise ValueError('One of _trigger_instance_file_path or'
+                         '_trigger_instance_id should be specified.')
 
     def _get_rule_db_from_file(self, file_path):
         data = self._meta_loader.load(file_path=file_path)
@@ -72,4 +104,7 @@ class RuleTester(object):
     def _get_trigger_instance_db_from_file(self, file_path):
         data = self._meta_loader.load(file_path=file_path)
         instance = TriggerInstanceDB(**data)
-        return instance
+
+        trigger_ref = ResourceReference.from_string_reference(instance['trigger'])
+        trigger_db = TriggerDB(pack=trigger_ref.pack, name=trigger_ref.name, type=trigger_ref.ref)
+        return instance, trigger_db

--- a/st2reactor/tests/unit/test_tester.py
+++ b/st2reactor/tests/unit/test_tester.py
@@ -15,15 +15,31 @@
 
 import os
 
-import unittest2
+import mock
 
+from st2common.transport.publishers import PoolPublisher
+import st2reactor.container.utils as container_utils
 from st2reactor.rules.tester import RuleTester
+from st2tests.base import CleanDbTestCase
+from st2tests.fixturesloader import FixturesLoader
 
 BASE_PATH = os.path.dirname(os.path.abspath(__file__))
 
+FIXTURES_PACK = 'generic'
 
-class RuleTesterTestCase(unittest2.TestCase):
-    def test_matching_trigger(self):
+TEST_MODELS_TRIGGERS = {
+    'triggertypes': ['triggertype1.yaml', 'triggertype2.yaml'],
+    'triggers': ['trigger1.yaml', 'trigger2.yaml'],
+    'triggerinstances': ['trigger_instance_1.yaml', 'trigger_instance_2.yaml']
+}
+
+TEST_MODELS_RULES = {
+    'rules': ['rule1.yaml']
+}
+
+@mock.patch.object(PoolPublisher, 'publish', mock.MagicMock())
+class RuleTesterTestCase(CleanDbTestCase):
+    def test_matching_trigger_from_file(self):
         rule_file_path = os.path.join(BASE_PATH, '../fixtures/rule.yaml')
         trigger_instance_file_path = os.path.join(BASE_PATH, '../fixtures/trigger_instance_1.yaml')
         tester = RuleTester(rule_file_path=rule_file_path,
@@ -31,10 +47,34 @@ class RuleTesterTestCase(unittest2.TestCase):
         matching = tester.evaluate()
         self.assertTrue(matching)
 
-    def test_non_matching_trigger(self):
+    def test_non_matching_trigger_from_file(self):
         rule_file_path = os.path.join(BASE_PATH, '../fixtures/rule.yaml')
         trigger_instance_file_path = os.path.join(BASE_PATH, '../fixtures/trigger_instance_2.yaml')
         tester = RuleTester(rule_file_path=rule_file_path,
                             trigger_instance_file_path=trigger_instance_file_path)
+        matching = tester.evaluate()
+        self.assertFalse(matching)
+
+    def test_matching_trigger_from_db(self):
+        models = FixturesLoader().save_fixtures_to_db(fixtures_pack=FIXTURES_PACK,
+                                                      fixtures_dict=TEST_MODELS_TRIGGERS)
+        trigger_instance_db = models['triggerinstances']['trigger_instance_2.yaml']
+        models = FixturesLoader().save_fixtures_to_db(fixtures_pack=FIXTURES_PACK,
+                                                      fixtures_dict=TEST_MODELS_RULES)
+        rule_db = models['rules']['rule1.yaml']
+        tester = RuleTester(rule_ref=rule_db.ref,
+                            trigger_instance_id=str(trigger_instance_db.id))
+        matching = tester.evaluate()
+        self.assertTrue(matching)
+
+    def test_non_matching_trigger_from_db(self):
+        models = FixturesLoader().save_fixtures_to_db(fixtures_pack=FIXTURES_PACK,
+                                                      fixtures_dict=TEST_MODELS_TRIGGERS)
+        trigger_instance_db = models['triggerinstances']['trigger_instance_1.yaml']
+        models = FixturesLoader().save_fixtures_to_db(fixtures_pack=FIXTURES_PACK,
+                                                      fixtures_dict=TEST_MODELS_RULES)
+        rule_db = models['rules']['rule1.yaml']
+        tester = RuleTester(rule_ref=rule_db.ref,
+                            trigger_instance_id=str(trigger_instance_db.id))
         matching = tester.evaluate()
         self.assertFalse(matching)

--- a/st2reactor/tests/unit/test_tester.py
+++ b/st2reactor/tests/unit/test_tester.py
@@ -18,7 +18,6 @@ import os
 import mock
 
 from st2common.transport.publishers import PoolPublisher
-import st2reactor.container.utils as container_utils
 from st2reactor.rules.tester import RuleTester
 from st2tests.base import CleanDbTestCase
 from st2tests.fixturesloader import FixturesLoader
@@ -36,6 +35,7 @@ TEST_MODELS_TRIGGERS = {
 TEST_MODELS_RULES = {
     'rules': ['rule1.yaml']
 }
+
 
 @mock.patch.object(PoolPublisher, 'publish', mock.MagicMock())
 class RuleTesterTestCase(CleanDbTestCase):

--- a/st2tests/st2tests/fixtures/generic/rules/rule1.yaml
+++ b/st2tests/st2tests/fixtures/generic/rules/rule1.yaml
@@ -5,7 +5,7 @@ action:
     ip2: '{{trigger}}'
   ref: wolfpack.action-1
 criteria:
-  t1_p:
+  trigger.t1_p:
     pattern: t1_p_v
     type: equals
 description: ''

--- a/st2tests/st2tests/fixtures/generic/triggerinstances/trigger_instance_2.yaml
+++ b/st2tests/st2tests/fixtures/generic/triggerinstances/trigger_instance_2.yaml
@@ -1,0 +1,6 @@
+---
+occurrence_time: '2014-09-01T00:00:01.000000Z'
+payload:
+  t1_p: t1_p_v
+  t2_p: t2_p_v
+trigger: wolfpack.triggertype-1


### PR DESCRIPTION
* Rule tester now support objects already present in the DB.
* This tool now works with both objects from the file system and objects
  from the DB in any combination.
* Bringing DB support required config-file support, leading to oslo.config,
  leading to the litany of troubles with oslo config and argparse in same app.
  This has evolved into some compromises and a not so friendly help interface
  but the rule-tester is atleast more capable.
* There is some extra logging and rule_tester specific extra_info making the
  output somewhat verbose but it possibly leads to more usable tool.


#### Note
* Using DB implies config now needs to be supplied. This also means lots of ugly log statements unfortunately. Also, even if DB connection is not required the way common_setup work we will enable it anyway. Can try to work around this if is perceived as a blocker.
* Mixing and matching between DB and file system objects is possible but not highlighted.


### From DB on failure
```
./st2reactor/bin/st2-rule-tester --config-file ./conf/st2.dev.conf --rule-ref default.rule4 --trigger-instance-id 566b4be732ed352a09cd3482
2015-12-11 15:24:16,459 INFO [-] Connecting to database "st2" @ "0.0.0.0:27017" as user "None".
2015-12-11 15:24:16,527 INFO [-] Validating rule default.rule4 for st2.generic.actiontrigger.
2015-12-11 15:24:16,542 INFO [-] Validation for rule default.rule4 failed on -
{
    "pattern": "succeeded",
    "type": "iequals",
    "payload_value": "failed",
    "key": "trigger.status"
}
2015-12-11 15:24:16,545 INFO [-] 0 rule(s) found to enforce for st2.generic.actiontrigger.
2015-12-11 15:24:16,546 INFO [-] === RULE DOES NOT MATCH ===
```

### From DB on success
```
$ ./st2reactor/bin/st2-rule-tester --config-file ./conf/st2.dev.conf --rule-ref default.rule4 --trigger-instance-id 566b4be632ed352a09cd347d
2015-12-11 15:24:48,951 INFO [-] Connecting to database "st2" @ "0.0.0.0:27017" as user "None".
2015-12-11 15:24:49,017 INFO [-] Validating rule default.rule4 for st2.generic.actiontrigger.
2015-12-11 15:24:49,030 INFO [-] 1 rule(s) found to enforce for st2.generic.actiontrigger.
2015-12-11 15:24:49,031 INFO [-] === RULE MATCHES ===
```

### From filesystem on failure
```
$ ~/st2/st2reactor/bin/st2-rule-tester --rule=./my_rule.yaml --trigger-instance=./trigger_instance_2.yaml
2015-12-11 15:31:44,959 INFO [-] Connecting to database "st2" @ "0.0.0.0:27017" as user "None".
2015-12-11 15:31:45,025 INFO [-] Validating rule irc.relayed_matched_irc_message for pubmsg.
2015-12-11 15:31:45,041 INFO [-] Validation for rule irc.relayed_matched_irc_message failed on -
{
    "pattern": "StackStorm",
    "type": "icontains",
    "payload_value": "blah blah",
    "key": "trigger.message"
}
2015-12-11 15:31:45,043 INFO [-] 0 rule(s) found to enforce for pubmsg.
2015-12-11 15:31:45,044 INFO [-] === RULE DOES NOT MATCH ===
```

### From filesystem on success
```
$ ~/st2/st2reactor/bin/st2-rule-tester --rule=./my_rule.yaml --trigger-instance=./trigger_instance_1.yaml
2015-12-11 15:32:28,970 INFO [-] Connecting to database "st2" @ "0.0.0.0:27017" as user "None".
2015-12-11 15:32:29,031 INFO [-] Validating rule irc.relayed_matched_irc_message for pubmsg.
2015-12-11 15:32:29,043 INFO [-] 1 rule(s) found to enforce for pubmsg.
2015-12-11 15:32:29,043 INFO [-] === RULE MATCHES ===
```