### PR TITLE
Add flag to register content script to fail on failure

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,9 @@ in development
   action.ref and enabled. This aligns closer the UI and also brings important information front and
   center. (improvement)
 * Action and Trigger filters for rule list (new-feature)
+* Add ``--register-fail-on-failure`` flag to ``st2-register-content`` script. If this flag is
+  provided, the script will fail and exit with non-zero status code if registering some resource
+  fails. (new feature)
 
 1.2.0 - December 07, 2015
 -------------------------

--- a/conf/st2.tests.conf
+++ b/conf/st2.tests.conf
@@ -39,6 +39,10 @@ api_url = http://127.0.0.1:9101/
 base_path = /opt/stackstorm
 admin_users = testu
 
+[content]
+system_packs_base_path =
+packs_base_paths = st2tests/st2tests/fixtures/
+
 [syslog]
 host = localhost
 port = 514

--- a/st2common/st2common/bootstrap/actionsregistrar.py
+++ b/st2common/st2common/bootstrap/actionsregistrar.py
@@ -59,7 +59,10 @@ class ActionsRegistrar(ResourceRegistrar):
                 actions = self._get_actions_from_pack(actions_dir)
                 count = self._register_actions_from_pack(pack=pack, actions=actions)
                 registered_count += count
-            except:
+            except Exception as e:
+                if self._fail_on_failure:
+                    raise e
+
                 LOG.exception('Failed registering all actions from pack: %s', actions_dir)
 
         return registered_count
@@ -88,7 +91,10 @@ class ActionsRegistrar(ResourceRegistrar):
         try:
             actions = self._get_actions_from_pack(actions_dir=actions_dir)
             registered_count = self._register_actions_from_pack(pack=pack, actions=actions)
-        except:
+        except Exception as e:
+            if self._fail_on_failure:
+                raise e
+
             LOG.exception('Failed registering all actions from pack: %s', actions_dir)
 
         return registered_count
@@ -143,7 +149,10 @@ class ActionsRegistrar(ResourceRegistrar):
             try:
                 LOG.debug('Loading action from %s.', action)
                 self._register_action(pack, action)
-            except Exception:
+            except Exception as e:
+                if self._fail_on_failure:
+                    raise e
+
                 LOG.exception('Unable to register action: %s', action)
                 continue
             else:
@@ -152,14 +161,16 @@ class ActionsRegistrar(ResourceRegistrar):
         return registered_count
 
 
-def register_actions(packs_base_paths=None, pack_dir=None, use_pack_cache=True):
+def register_actions(packs_base_paths=None, pack_dir=None, use_pack_cache=True,
+                     fail_on_failure=False):
     if packs_base_paths:
         assert isinstance(packs_base_paths, list)
 
     if not packs_base_paths:
         packs_base_paths = content_utils.get_packs_base_paths()
 
-    registrar = ActionsRegistrar(use_pack_cache=use_pack_cache)
+    registrar = ActionsRegistrar(use_pack_cache=use_pack_cache,
+                                 fail_on_failure=fail_on_failure)
 
     if pack_dir:
         result = registrar.register_actions_from_pack(pack_dir=pack_dir)

--- a/st2common/st2common/bootstrap/base.py
+++ b/st2common/st2common/bootstrap/base.py
@@ -46,13 +46,18 @@ EXCLUDE_FILE_PATTERNS = [
 class ResourceRegistrar(object):
     ALLOWED_EXTENSIONS = []
 
-    def __init__(self, use_pack_cache=True):
+    def __init__(self, use_pack_cache=True, fail_on_failure=False):
         """
         :param use_pack_cache: True to cache which packs have been registered in memory and making
                                 sure packs are only registered once.
         :type use_pack_cache: ``bool``
+
+        :param fail_on_failure: Throw an exception if resource registration fails.
+        :type fail_on_failure: ``bool``
         """
         self._use_pack_cache = use_pack_cache
+        self._fail_on_failure = fail_on_failure
+
         self._meta_loader = MetaLoader()
         self._pack_loader = ContentPackLoader()
 

--- a/st2common/st2common/bootstrap/policiesregistrar.py
+++ b/st2common/st2common/bootstrap/policiesregistrar.py
@@ -62,7 +62,10 @@ class PolicyRegistrar(ResourceRegistrar):
                 policies = self._get_policies_from_pack(policies_dir)
                 count = self._register_policies_from_pack(pack=pack, policies=policies)
                 registered_count += count
-            except:
+            except Exception as e:
+                if self._fail_on_failure:
+                    raise e
+
                 LOG.exception('Failed registering all policies from pack: %s', policies_dir)
 
         return registered_count
@@ -76,6 +79,7 @@ class PolicyRegistrar(ResourceRegistrar):
         """
         pack_dir = pack_dir[:-1] if pack_dir.endswith('/') else pack_dir
         _, pack = os.path.split(pack_dir)
+
         policies_dir = self._pack_loader.get_content_from_pack(pack_dir=pack_dir,
                                                                content_type='policies')
 
@@ -86,14 +90,17 @@ class PolicyRegistrar(ResourceRegistrar):
         if not policies_dir:
             return registered_count
 
-        LOG.debug('Registering policies from pack %s:, dir: %s', pack, policies_dir)
+        LOG.debug('Registering policies from pack %s, dir: %s', pack, policies_dir)
 
         try:
             policies = self._get_policies_from_pack(policies_dir=policies_dir)
             registered_count = self._register_policies_from_pack(pack=pack, policies=policies)
-        except:
+        except Exception as e:
+            if self._fail_on_failure:
+                raise e
+
             LOG.exception('Failed registering all policies from pack: %s', policies_dir)
-            return 0
+            return registered_count
 
         return registered_count
 
@@ -107,7 +114,10 @@ class PolicyRegistrar(ResourceRegistrar):
             try:
                 LOG.debug('Loading policy from %s.', policy)
                 self._register_policy(pack, policy)
-            except Exception:
+            except Exception as e:
+                if self._fail_on_failure:
+                    raise e
+
                 LOG.exception('Unable to register policy: %s', policy)
                 continue
             else:
@@ -179,14 +189,16 @@ def register_policy_types(module):
     return registered_count
 
 
-def register_policies(packs_base_paths=None, pack_dir=None):
+def register_policies(packs_base_paths=None, pack_dir=None, use_pack_cache=True,
+                     fail_on_failure=False):
     if packs_base_paths:
         assert isinstance(packs_base_paths, list)
 
     if not packs_base_paths:
         packs_base_paths = content_utils.get_packs_base_paths()
 
-    registrar = PolicyRegistrar()
+    registrar = PolicyRegistrar(use_pack_cache=use_pack_cache,
+                                fail_on_failure=fail_on_failure)
 
     if pack_dir:
         result = registrar.register_policies_from_pack(pack_dir=pack_dir)

--- a/st2common/st2common/bootstrap/sensorsregistrar.py
+++ b/st2common/st2common/bootstrap/sensorsregistrar.py
@@ -61,6 +61,9 @@ class SensorsRegistrar(ResourceRegistrar):
                 count = self._register_sensors_from_pack(pack=pack, sensors=sensors)
                 registered_count += count
             except Exception as e:
+                if self._fail_on_failure:
+                    raise e
+
                 LOG.exception('Failed registering all sensors from pack "%s": %s', sensors_dir,
                               str(e))
 
@@ -91,6 +94,9 @@ class SensorsRegistrar(ResourceRegistrar):
             sensors = self._get_sensors_from_pack(sensors_dir=sensors_dir)
             registered_count = self._register_sensors_from_pack(pack=pack, sensors=sensors)
         except Exception as e:
+            if self._fail_on_failure:
+                raise e
+
             LOG.exception('Failed registering all sensors from pack "%s": %s', sensors_dir, str(e))
 
         return registered_count
@@ -105,6 +111,9 @@ class SensorsRegistrar(ResourceRegistrar):
             try:
                 self._register_sensor_from_pack(pack=pack, sensor=sensor)
             except Exception as e:
+                if self._fail_on_failure:
+                    raise e
+
                 LOG.debug('Failed to register sensor "%s": %s', sensor, str(e))
             else:
                 LOG.debug('Sensor "%s" successfully registered', sensor)
@@ -154,14 +163,16 @@ class SensorsRegistrar(ResourceRegistrar):
         return sensor_model
 
 
-def register_sensors(packs_base_paths=None, pack_dir=None, use_pack_cache=True):
+def register_sensors(packs_base_paths=None, pack_dir=None, use_pack_cache=True,
+                     fail_on_failure=False):
     if packs_base_paths:
         assert isinstance(packs_base_paths, list)
 
     if not packs_base_paths:
         packs_base_paths = content_utils.get_packs_base_paths()
 
-    registrar = SensorsRegistrar(use_pack_cache=use_pack_cache)
+    registrar = SensorsRegistrar(use_pack_cache=use_pack_cache,
+                                 fail_on_failure=fail_on_failure)
 
     if pack_dir:
         result = registrar.register_sensors_from_pack(pack_dir=pack_dir)

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -70,10 +70,11 @@ def register_sensors():
         registered_count = sensors_registrar.register_sensors(pack_dir=pack_dir,
                                                               fail_on_failure=fail_on_failure)
     except Exception as e:
+        exc_info = not fail_on_failure
+        LOG.warning('Failed to register sensors: %s', e, exc_info=exc_info)
+
         if fail_on_failure:
             raise e
-
-        LOG.warning('Failed to register sensors: %s', e, exc_info=True)
 
     LOG.info('Registered %s sensors.' % (registered_count))
 
@@ -100,10 +101,11 @@ def register_actions():
         registered_count = actions_registrar.register_actions(pack_dir=pack_dir,
                                                               fail_on_failure=fail_on_failure)
     except Exception as e:
+        exc_info = not fail_on_failure
+        LOG.warning('Failed to register actions: %s', e, exc_info=exc_info)
+
         if fail_on_failure:
             raise e
-
-        LOG.warning('Failed to register actions: %s', e, exc_info=True)
 
     LOG.info('Registered %s actions.' % (registered_count))
 
@@ -128,10 +130,11 @@ def register_rules():
         registered_count = rules_registrar.register_rules(pack_dir=pack_dir,
                                                           fail_on_failure=fail_on_failure)
     except Exception as e:
+        exc_info = not fail_on_failure
+        LOG.warning('Failed to register rules: %s', e, exc_info=exc_info)
+
         if fail_on_failure:
             raise e
-
-        LOG.warning('Failed to register rules: %s', e, exc_info=True)
 
     LOG.info('Registered %s rules.', registered_count)
 
@@ -183,11 +186,11 @@ def register_policies():
         registered_count = policies_registrar.register_policies(pack_dir=pack_dir,
                                                                 fail_on_failure=fail_on_failure)
     except Exception as e:
-        LOG.warning('Failed to register policies.', exc_info=True)
+        exc_info = not fail_on_failure
+        LOG.warning('Failed to register policies: %s', e, exc_info=exc_info)
+
         if fail_on_failure:
             raise e
-
-        LOG.warning('Failed to register policies.', exc_info=True)
 
     LOG.info('Registered %s policies.', registered_count)
 

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -46,7 +46,9 @@ def register_opts():
         cfg.BoolOpt('rules', default=False, help='Register rules.'),
         cfg.BoolOpt('aliases', default=False, help='Register aliases.'),
         cfg.BoolOpt('policies', default=False, help='Register policies.'),
-        cfg.StrOpt('pack', default=None, help='Directory to the pack to register content from.')
+        cfg.StrOpt('pack', default=None, help='Directory to the pack to register content from.'),
+        cfg.BoolOpt('fail-on-failure', default=False, help=('Exit with non-zero of resource '
+                                                            'registration fails.'))
     ]
     try:
         cfg.CONF.register_cli_opts(content_opts, group='register')
@@ -56,14 +58,21 @@ register_opts()
 
 
 def register_sensors():
+    pack_dir = cfg.CONF.register.pack
+    fail_on_failure = cfg.CONF.register.fail_on_failure
+
     registered_count = 0
 
     try:
         LOG.info('=========================================================')
         LOG.info('############## Registering sensors ######################')
         LOG.info('=========================================================')
-        registered_count = sensors_registrar.register_sensors(pack_dir=cfg.CONF.register.pack)
+        registered_count = sensors_registrar.register_sensors(pack_dir=pack_dir,
+                                                              fail_on_failure=fail_on_failure)
     except Exception as e:
+        if fail_on_failure:
+            raise e
+
         LOG.warning('Failed to register sensors: %s', e, exc_info=True)
 
     LOG.info('Registered %s sensors.' % (registered_count))
@@ -72,6 +81,9 @@ def register_sensors():
 def register_actions():
     # Register runnertypes and actions. The order is important because actions require action
     # types to be present in the system.
+    pack_dir = cfg.CONF.register.pack
+    fail_on_failure = cfg.CONF.register.fail_on_failure
+
     registered_count = 0
 
     try:
@@ -82,17 +94,25 @@ def register_actions():
     except Exception as e:
         LOG.warning('Failed to register runner types: %s', e, exc_info=True)
         LOG.warning('Not registering stock runners .')
-    else:
-        try:
-            registered_count = actions_registrar.register_actions(pack_dir=cfg.CONF.register.pack)
-        except Exception as e:
-            LOG.warning('Failed to register actions: %s', e, exc_info=True)
+        return
+
+    try:
+        registered_count = actions_registrar.register_actions(pack_dir=pack_dir,
+                                                              fail_on_failure=fail_on_failure)
+    except Exception as e:
+        if fail_on_failure:
+            raise e
+
+        LOG.warning('Failed to register actions: %s', e, exc_info=True)
 
     LOG.info('Registered %s actions.' % (registered_count))
 
 
 def register_rules():
     # Register ruletypes and rules.
+    pack_dir = cfg.CONF.register.pack
+    fail_on_failure = cfg.CONF.register.fail_on_failure
+
     registered_count = 0
 
     try:
@@ -102,25 +122,36 @@ def register_rules():
         rule_types_registrar.register_rule_types()
     except Exception as e:
         LOG.warning('Failed to register rule types: %s', e, exc_info=True)
-    else:
-        try:
-            registered_count = rules_registrar.register_rules(pack_dir=cfg.CONF.register.pack)
-        except Exception as e:
-            LOG.warning('Failed to register rules: %s', e, exc_info=True)
+        return
+
+    try:
+        registered_count = rules_registrar.register_rules(pack_dir=pack_dir,
+                                                          fail_on_failure=fail_on_failure)
+    except Exception as e:
+        if fail_on_failure:
+            raise e
+
+        LOG.warning('Failed to register rules: %s', e, exc_info=True)
 
     LOG.info('Registered %s rules.', registered_count)
 
 
 def register_aliases():
-    # Register rules.
+    pack_dir = cfg.CONF.register.pack
+    fail_on_failure = cfg.CONF.register.fail_on_failure
+
     registered_count = 0
 
     try:
         LOG.info('=========================================================')
         LOG.info('############## Registering aliases ######################')
         LOG.info('=========================================================')
-        registered_count = aliases_registrar.register_aliases(pack_dir=cfg.CONF.register.pack)
-    except Exception:
+        registered_count = aliases_registrar.register_aliases(pack_dir=pack_dir,
+                                                              fail_on_failure=fail_on_failure)
+    except Exception as e:
+        if fail_on_failure:
+            raise e
+
         LOG.warning('Failed to register aliases.', exc_info=True)
 
     LOG.info('Registered %s aliases.', registered_count)
@@ -128,7 +159,11 @@ def register_aliases():
 
 def register_policies():
     # Register policy types and policies.
+    pack_dir = cfg.CONF.register.pack
+    fail_on_failure = cfg.CONF.register.fail_on_failure
+
     registered_type_count = 0
+
     try:
         LOG.info('=========================================================')
         LOG.info('############## Registering policy types #################')
@@ -145,8 +180,13 @@ def register_policies():
         LOG.info('=========================================================')
         LOG.info('############## Registering policies #####################')
         LOG.info('=========================================================')
-        registered_count = policies_registrar.register_policies()
-    except Exception:
+        registered_count = policies_registrar.register_policies(pack_dir=pack_dir,
+                                                                fail_on_failure=fail_on_failure)
+    except Exception as e:
+        LOG.warning('Failed to register policies.', exc_info=True)
+        if fail_on_failure:
+            raise e
+
         LOG.warning('Failed to register policies.', exc_info=True)
 
     LOG.info('Registered %s policies.', registered_count)

--- a/st2common/st2common/content/loader.py
+++ b/st2common/st2common/content/loader.py
@@ -36,6 +36,9 @@ class ContentPackLoader(object):
     Class for loading pack and pack content information from directories on disk.
     """
 
+    # TODO: Rename "get_content" methods since they don't actually return
+    # content - they just return a path
+
     ALLOWED_CONTENT_TYPES = ['sensors', 'actions', 'rules', 'aliases', 'policies']
 
     def get_packs(self, base_dirs):
@@ -186,7 +189,7 @@ class ContentPackLoader(object):
     def _get_folder(self, pack_dir, content_type):
         path = os.path.join(pack_dir, content_type)
         if not os.path.isdir(path):
-            raise ValueError('No %s found in "%s".' % (content_type, pack_dir))
+            return None
         return path
 
 

--- a/st2common/tests/integration/test_register_content_script.py
+++ b/st2common/tests/integration/test_register_content_script.py
@@ -1,0 +1,68 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from st2tests.base import IntegrationTestCase
+from st2common.util.shell import run_command
+from st2tests import config as test_config
+from st2tests.fixturesloader import get_fixtures_base_path
+
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+SCRIPT_PATH = os.path.join(BASE_DIR, '../../bin/st2-register-content')
+SCRIPT_PATH = os.path.abspath(SCRIPT_PATH)
+
+BASE_CMD_ARGS = [SCRIPT_PATH, '--config-file=conf/st2.tests.conf', '-v', '--register-actions']
+
+test_config.parse_args()
+
+
+class ContentRegisterScripTestCase(IntegrationTestCase):
+    def test_register_from_pack_success(self):
+        pack_dir = os.path.join(get_fixtures_base_path(), 'dummy_pack_1')
+
+        cmd = BASE_CMD_ARGS + ['--register-pack=%s' % (pack_dir)]
+        exit_code, _, stderr = run_command(cmd=cmd)
+        self.assertTrue('Registered 1 actions.' in stderr)
+        self.assertEqual(exit_code, 0)
+
+    def test_register_from_pack_fail_on_failure_pack_dir_doesnt_exist(self):
+        # No fail on failure flag, should succeed
+        pack_dir = 'doesntexistblah'
+        cmd = BASE_CMD_ARGS + ['--register-pack=%s' % (pack_dir)]
+        exit_code, _, _ = run_command(cmd=cmd)
+        self.assertEqual(exit_code, 0)
+
+        # Fail on failure, should fail
+        cmd = BASE_CMD_ARGS + ['--register-pack=%s' % (pack_dir), '--register-fail-on-failure']
+        exit_code, _, stderr = run_command(cmd=cmd)
+        self.assertTrue('Directory "doesntexistblah" doesn\'t exist' in stderr)
+        self.assertEqual(exit_code, 1)
+
+    def test_register_from_pack_action_metadata_fails_validation(self):
+        # No fail on failure flag, should succeed
+        pack_dir = os.path.join(get_fixtures_base_path(), 'dummy_pack_4')
+        cmd = BASE_CMD_ARGS + ['--register-pack=%s' % (pack_dir)]
+        exit_code, _, stderr = run_command(cmd=cmd)
+        self.assertTrue('Registered 0 actions.' in stderr)
+        self.assertEqual(exit_code, 0)
+
+        # Fail on failure, should fail
+        pack_dir = os.path.join(get_fixtures_base_path(), 'dummy_pack_4')
+        cmd = BASE_CMD_ARGS + ['--register-pack=%s' % (pack_dir), '--register-fail-on-failure']
+        exit_code, _, stderr = run_command(cmd=cmd)
+        self.assertTrue('object has no attribute \'get\'' in stderr)
+        self.assertEqual(exit_code, 1)

--- a/st2common/tests/unit/test_content_loader.py
+++ b/st2common/tests/unit/test_content_loader.py
@@ -36,7 +36,7 @@ class ContentLoaderTest(unittest2.TestCase):
         loader = ContentPackLoader()
         fail_pack_path = os.path.join(RESOURCES_DIR, 'packs/pack2')
         self.assertTrue(os.path.exists(fail_pack_path))
-        self.assertRaises(ValueError, loader._get_sensors, fail_pack_path)
+        self.assertEqual(loader._get_sensors(fail_pack_path), None)
 
     def test_invalid_content_type(self):
         packs_base_path = os.path.join(RESOURCES_DIR, 'packs/')
@@ -81,6 +81,5 @@ class ContentLoaderTest(unittest2.TestCase):
         loader = ContentPackLoader()
         pack_path = os.path.join(RESOURCES_DIR, 'packs/pack2')
 
-        message_regex = 'No sensors found'
-        self.assertRaisesRegexp(ValueError, message_regex, loader.get_content_from_pack,
-                                pack_dir=pack_path, content_type='sensors')
+        result = loader.get_content_from_pack(pack_dir=pack_path, content_type='sensors')
+        self.assertEqual(result, None)

--- a/st2tests/st2tests/fixtures/dummy_pack_4/pack.yaml
+++ b/st2tests/st2tests/fixtures/dummy_pack_4/pack.yaml
@@ -1,0 +1,6 @@
+---
+name : dummy_pack_4
+description : dummy pack
+version : 0.1
+author : st2-dev
+email : info@stackstorm.com


### PR DESCRIPTION
This pull request adds `--register-fail-on-failure` flag to the resource registrar script. This value defaults to `False` so it's fully backward compatible and the default behavior doesn't change.

If this flag is provided, registrar will fail and exit with non-zero if a registration of any resource fails (validation error, etc.)

This will come handy in a new st2contrib test task which I'm working on - this task will fail if any of the resource registration fails (we don't want broken definitions in the repo and we want to fail early and loudly).

P.S. Yes I know those files new more refactoring love, there is sadly still tons of duplicated code (I already did some of the refactoring in the past, but it needs a lot more love).