### PR TITLE
Add missing MockSensorService.get_logger method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,9 @@ in development
 * Add ``--register-fail-on-failure`` flag to ``st2-register-content`` script. If this flag is
   provided, the script will fail and exit with non-zero status code if registering some resource
   fails. (new feature)
+* Add a missing ``getLogger`` method to the `MockSensorService``. This method now returns an
+  instance of ``Mock`` class which allows user to assert that a particular message has been 
+  logged. [Tim Ireland, Tomaz Muraus]
 
 1.2.0 - December 07, 2015
 -------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,8 +24,8 @@ in development
 * Add ``--register-fail-on-failure`` flag to ``st2-register-content`` script. If this flag is
   provided, the script will fail and exit with non-zero status code if registering some resource
   fails. (new feature)
-* Add a missing ``getLogger`` method to the `MockSensorService``. This method now returns an
-  instance of ``Mock`` class which allows user to assert that a particular message has been 
+* Add a missing ``get_logger`` method to the `MockSensorService``. This method now returns an
+  instance of ``Mock`` class which allows user to assert that a particular message has been
   logged. [Tim Ireland, Tomaz Muraus]
 
 1.2.0 - December 07, 2015

--- a/docs/source/development/pack_testing.rst
+++ b/docs/source/development/pack_testing.rst
@@ -59,8 +59,8 @@ in the tests.
   from the ``run`` method.
 * ``st2tests.mocks.sensor.MockSensorWrapper`` - Mock ``SensorWrapper`` class.
 * ``st2tests.mocks.sensor.MockSensorService`` - Mock ``SensorService`` class.
-  This class mock methods which operate on the datastore items (``list_values``,
-  ``get_value``, ``set_value``, ``delete_value``).
+  This class mock methods which operate on the datastore items (``get_logger`,
+  ``list_values``, ``get_value``, ``set_value``, ``delete_value``).
 
 Dependencies
 ------------
@@ -90,7 +90,7 @@ Running Tests
 -------------
 
 To run all the tests in a particular pack you can use the ``st2-run-pack-tests``
-script (``st2common/bin/st2-run-pack-tests``) from the ``st2`` repository as 
+script (``st2common/bin/st2-run-pack-tests``) from the ``st2`` repository as
 shown below.
 
 .. sourcecode:: bash
@@ -116,6 +116,14 @@ If you are running this script inside a development VM (st2express /
 st2workroom), you can safely pass ``-x`` flag to the script since a virtual
 environment should already be created and all the necessary |st2| dependencies
 should be available in ``PYTHONPATH``.
+
+Sample Tests
+------------
+
+You can find some sample tests on the links below.
+
+* Sensor - `test_sensor_docker_sensor <https://github.com/StackStorm/st2contrib/blob/master/packs/docker/tests/test_sensor_docker_sensor.py>`_
+* Action - `test_action_parse <https://github.com/StackStorm/st2contrib/blob/master/packs/csv/tests/test_action_parse.py>`_
 
 Continous Integration
 ---------------------

--- a/st2common/tests/unit/test_unit_testing_mocks.py
+++ b/st2common/tests/unit/test_unit_testing_mocks.py
@@ -55,6 +55,24 @@ class MockSensorServiceTestCase(unittest2.TestCase):
     def setUp(self):
         self._mock_sensor_wrapper = MockSensorWrapper(pack='dummy', class_name='test')
 
+    def test_get_logger(self):
+        sensor_service = MockSensorService(sensor_wrapper=self._mock_sensor_wrapper)
+        logger = sensor_service.get_logger('test')
+        logger.info('test info')
+        logger.debug('test debug')
+
+        self.assertEqual(len(logger.method_calls), 2)
+
+        method_name, method_args, method_kwargs = tuple(logger.method_calls[0])
+        self.assertEqual(method_name, 'info')
+        self.assertEqual(method_args, ('test info',))
+        self.assertEqual(method_kwargs, {})
+
+        method_name, method_args, method_kwargs = tuple(logger.method_calls[1])
+        self.assertEqual(method_name, 'debug')
+        self.assertEqual(method_args, ('test debug',))
+        self.assertEqual(method_kwargs, {})
+
     def test_list_set_get_delete_values(self):
         sensor_service = MockSensorService(sensor_wrapper=self._mock_sensor_wrapper)
 

--- a/st2tests/st2tests/mocks/sensor.py
+++ b/st2tests/st2tests/mocks/sensor.py
@@ -17,6 +17,10 @@
 Mock classes for use in pack testing.
 """
 
+from logging import RootLogger
+
+from mock import Mock
+
 from st2reactor.container.sensor_wrapper import SensorService
 from st2client.models.keyvalue import KeyValuePair
 
@@ -40,6 +44,10 @@ class MockSensorService(SensorService):
     def __init__(self, sensor_wrapper):
         self._sensor_wrapper = sensor_wrapper
 
+        # Holds a mock logger instance
+        # We use a Mock class so use can assert logger was called with particular arguments
+        self._logger = Mock(spec=RootLogger)
+
         # Holds mock KeyValuePair objects
         # Key is a KeyValuePair name and value is the KeyValuePair object
         self._datastore_items = {}
@@ -48,7 +56,7 @@ class MockSensorService(SensorService):
         self.dispatched_triggers = []
 
     def get_logger(self, name):
-        return None
+        return self._logger
 
     def dispatch_with_context(self, trigger, payload=None, trace_context=None):
         item = {

--- a/st2tests/st2tests/mocks/sensor.py
+++ b/st2tests/st2tests/mocks/sensor.py
@@ -56,6 +56,13 @@ class MockSensorService(SensorService):
         self.dispatched_triggers = []
 
     def get_logger(self, name):
+        """
+        Return mock logger instance.
+
+        Keep in mind that this method returns Mock class instance which means you can use all the
+        usual Mock class methods to assert that a particular message has been logged / logger has
+        been called with particular arguments.
+        """
         return self._logger
 
     def dispatch_with_context(self, trigger, payload=None, trace_context=None):
@@ -67,6 +74,9 @@ class MockSensorService(SensorService):
         self.dispatched_triggers.append(item)
 
     def list_values(self, local=True, prefix=None):
+        """
+        Return a list of all values stored in a dictionary which is local to this class.
+        """
         key_prefix = self._get_full_key_prefix(local=local, prefix=prefix)
 
         if not key_prefix:
@@ -80,6 +90,9 @@ class MockSensorService(SensorService):
         return result
 
     def get_value(self, name, local=True):
+        """
+        Return a particular value stored in a dictionary which is local to this class.
+        """
         name = self._get_full_key_name(name=name, local=local)
 
         if name not in self._datastore_items:
@@ -89,6 +102,9 @@ class MockSensorService(SensorService):
         return kvp.value
 
     def set_value(self, name, value, ttl=None, local=True):
+        """
+        Store a value in a dictionary which is local to this class.
+        """
         if ttl:
             raise ValueError('MockSensorService.set_value doesn\'t support "ttl" argument')
 
@@ -103,6 +119,9 @@ class MockSensorService(SensorService):
         return True
 
     def delete_value(self, name, local=True):
+        """
+        Delete a value from a dictionary which is local to this class.
+        """
         name = self._get_full_key_name(name=name, local=local)
 
         if name not in self._datastore_items:


### PR DESCRIPTION
This pull request updates `MockSensorService.get_logger` method to return an instance of `Mock` class. This allows user to assert that a particular message has been logged / logger method has been called with particular arguments (you can find an example of how to do that in the tests below).

The reason why I have decided to simply use Mock class instead of re-inventing the wheel is that it does the job and it exposes a familiar Mock interface.