### PR TITLE
Add a regression test case for register content script

### DIFF
--- a/conf/st2.tests1.conf
+++ b/conf/st2.tests1.conf
@@ -1,0 +1,75 @@
+# Config file used by integration tests
+#
+[api]
+# Host and port to bind the API server.
+host = 0.0.0.0
+port = 9101
+logging = st2tests/conf/logging.api.conf
+mask_secrets = False
+# allow_origin is required for handling CORS in st2 web UI.
+# allow_origin = http://myhost1.example.com:3000,http://myhost2.example.com:3000
+
+[sensorcontainer]
+logging = st2tests/conf/logging.sensorcontainer.conf
+sensor_node_name = sensornode1
+partition_provider = name:default
+
+[rulesengine]
+logging = st2reactor/conf/logging.rulesengine.conf
+
+[actionrunner]
+logging = st2actions/conf/logging.conf
+
+[auth]
+host = 0.0.0.0
+port = 9100
+use_ssl = False
+debug = False
+enable = False
+logging = st2tests/conf/logging.auth.conf
+
+mode = standalone
+backend = flat_file
+backend_kwargs = {"file_path": "st2auth/conf/htpasswd_dev"}
+
+# Base URL to the API endpoint excluding the version (e.g. http://myhost.net:9101/)
+api_url = http://127.0.0.1:9101/
+
+[system]
+base_path = /opt/stackstorm
+admin_users = testu
+
+[content]
+system_packs_base_path =
+packs_base_paths = st2tests/st2tests/fixtures/packs_1/
+
+[syslog]
+host = localhost
+port = 514
+facility = local7
+protocol = udp
+
+[log]
+excludes = requests,paramiko
+redirect_stderr = False
+mask_secrets = False
+
+[system_user]
+user = stanley
+ssh_key_file = /home/vagrant/.ssh/stanley_rsa
+
+[messaging]
+url = amqp://guest:guest@localhost:5672/
+
+[ssh_runner]
+remote_dir = /tmp
+use_paramiko_ssh_runner = True
+
+[resultstracker]
+logging = st2actions/conf/logging.resultstracker.conf
+
+[notifier]
+logging = st2actions/conf/logging.notifier.conf
+
+[exporter]
+logging = st2exporter/conf/logging.exporter.conf

--- a/st2common/tests/integration/test_register_content_script.py
+++ b/st2common/tests/integration/test_register_content_script.py
@@ -27,10 +27,12 @@ SCRIPT_PATH = os.path.abspath(SCRIPT_PATH)
 
 BASE_CMD_ARGS = [SCRIPT_PATH, '--config-file=conf/st2.tests.conf', '-v', '--register-actions']
 
-test_config.parse_args()
-
 
 class ContentRegisterScripTestCase(IntegrationTestCase):
+    def setUp(self):
+        super(ContentRegisterScripTestCase, self).setUp()
+        test_config.parse_args()
+
     def test_register_from_pack_success(self):
         pack_dir = os.path.join(get_fixtures_base_path(), 'dummy_pack_1')
 
@@ -66,3 +68,21 @@ class ContentRegisterScripTestCase(IntegrationTestCase):
         exit_code, _, stderr = run_command(cmd=cmd)
         self.assertTrue('object has no attribute \'get\'' in stderr)
         self.assertEqual(exit_code, 1)
+
+    def test_register_from_packs_doesnt_throw_on_missing_pack_resource_folder(self):
+        # dummy_pack_4 only has actions folder, make sure it doesn't throw when
+        # sensors and other resource folders are missing
+
+        # Note: We want to use a different config which sets fixtures/packs_1/
+        # dir as packs_base_paths
+        cmd = [SCRIPT_PATH, '--config-file=conf/st2.tests1.conf', '-v', '--register-sensors']
+        exit_code, _, stderr = run_command(cmd=cmd)
+        self.assertTrue('Registered 0 sensors.' in stderr)
+        self.assertEqual(exit_code, 0)
+
+        cmd = [SCRIPT_PATH, '--config-file=conf/st2.tests1.conf', '-v', '--register-all']
+        exit_code, _, stderr = run_command(cmd=cmd)
+        self.assertTrue('Registered 0 actions.' in stderr)
+        self.assertTrue('Registered 0 sensors.' in stderr)
+        self.assertTrue('Registered 0 rules.' in stderr)
+        self.assertEqual(exit_code, 0)

--- a/st2tests/st2tests/fixtures/packs_1/dummy_pack_4/pack.yaml
+++ b/st2tests/st2tests/fixtures/packs_1/dummy_pack_4/pack.yaml
@@ -1,0 +1,6 @@
+---
+name : dummy_pack_4
+description : dummy pack
+version : 0.1
+author : st2-dev
+email : info@stackstorm.com


### PR DESCRIPTION
This PR adds a regression test case for this scenario - https://github.com/StackStorm/st2/pull/2298.

It makes sure the script doesn't throw if a pack directory is missing directory for some resource which is to be registered (sensors/, etc.).