### PR TITLE
Add get_runner function to noop runner

### DIFF
--- a/st2actions/st2actions/runners/nooprunner.py
+++ b/st2actions/st2actions/runners/nooprunner.py
@@ -20,6 +20,13 @@ import st2common.util.jsonify as jsonify
 
 LOG = logging.getLogger(__name__)
 
+__all__ = [
+    'get_runner'
+]
+
+def get_runner():
+    return NoopRunner(str(uuid.uuid4()))
+
 
 class NoopRunner(ActionRunner):
     """

--- a/st2actions/st2actions/runners/nooprunner.py
+++ b/st2actions/st2actions/runners/nooprunner.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import uuid
 from st2common import log as logging
 from st2actions.runners import ActionRunner
 from st2common.constants.action import LIVEACTION_STATUS_SUCCEEDED

--- a/st2actions/st2actions/runners/nooprunner.py
+++ b/st2actions/st2actions/runners/nooprunner.py
@@ -25,6 +25,7 @@ __all__ = [
     'get_runner'
 ]
 
+
 def get_runner():
     return NoopRunner(str(uuid.uuid4()))
 


### PR DESCRIPTION
The noop runner is missing the get_runner function that is needed during runner import.