### PR TITLE
Follow Bintray repo naming for Centos/RHEL builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,8 +17,8 @@ general:
 
 machine:
   environment:
-    DISTROS: "wheezy jessie trusty centos7"
-    NOTESTS: "centos7"
+    DISTROS: "wheezy jessie trusty el7"
+    NOTESTS: "el7"
     ST2_PACKAGES_REPO: https://github.com/StackStorm/st2-packages
     ST2_DOCKERFILES_REPO: https://github.com/StackStorm/st2-dockerfiles
     BUILD_DOCKER: 1


### PR DESCRIPTION
Synchronize repo naming.
This will upload CentOS7 packages to https://bintray.com/stackstorm/el7_staging Bintray repository.

Related to https://github.com/StackStorm/st2-packages/pull/47