### PR TITLE
Fix param dependency override regression

### DIFF
--- a/st2common/st2common/util/param.py
+++ b/st2common/st2common/util/param.py
@@ -106,8 +106,11 @@ def _process_defaults(G, schemas):
     '''
     for schema in schemas:
         for name, value in six.iteritems(schema):
-            if name not in G.node or value.get('immutable', False):
-                _process(G, name, value.get('default', None))
+            absent = name not in G.node
+            is_none = G.node.get(name, {}).get('value') is None
+            immutable = value.get('immutable', False)
+            if absent or is_none or immutable:
+                _process(G, name, value.get('default'))
 
 
 def _validate(G):

--- a/st2common/tests/unit/test_param_utils.py
+++ b/st2common/tests/unit/test_param_utils.py
@@ -276,6 +276,14 @@ class ParamsUtilsTest(DbTestCase):
         self.assertEqual(r_runner_params, {'r1': None, 'r2': u'r2', 'r3': u'a3'})
         self.assertEqual(r_action_params, {'a1': None, 'a2': u'a2'})
 
+        params = {}
+        runner_param_info = {'r1': {}, 'r2': {'default': 'r2'}, 'r3': {}}
+        action_param_info = {'r1': {}, 'r2': {}, 'r3': {'default': 'a3'}}
+        action_context = {'api_user': 'noob'}
+        r_runner_params, r_action_params = param_utils.get_finalized_params(
+            runner_param_info, action_param_info, params, action_context)
+        self.assertEqual(r_runner_params, {'r1': None, 'r2': u'r2', 'r3': u'a3'})
+
     def test_get_finalized_params_non_existent_template_key_in_action_context(self):
         params = {
             'r1': 'foo',


### PR DESCRIPTION
As a result of #2288, we have a regression when action parameter without default `p1: {}` overrides runner parameter with default value `p1: {default: '...'}` resulting in a final parameter rendering as `None` instead of runner parameter default.

Kudos to @manasdk 

STORM-1924 #resolve