### PR TITLE
Using certifi for SSL validation in st2client

### DIFF
--- a/st2client/in-requirements.txt
+++ b/st2client/in-requirements.txt
@@ -1,7 +1,8 @@
-# Remeber to list implicit packages here, otherwise version won't be fixated!
+# Remember to list implicit packages here, otherwise version won't be fixed!
 prettytable
 python-dateutil
 pyyaml
 jsonpath-rw
 requests
 six
+certifi

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -5,3 +5,4 @@ python-dateutil
 pyyaml<4.0,>=3.11
 requests<3.0,>=2.7.0
 six==1.9.0
+certifi>=2015.11.20.1

--- a/st2client/st2client/utils/httpclient.py
+++ b/st2client/st2client/utils/httpclient.py
@@ -29,7 +29,7 @@ def add_ssl_verify_to_kwargs(func):
     def decorate(*args, **kwargs):
         if isinstance(args[0], HTTPClient) and 'https' in getattr(args[0], 'root', ''):
             cacert = getattr(args[0], 'cacert', None)
-            kwargs['verify'] = cacert if cacert else False
+            kwargs['verify'] = cacert if cacert else True
         return func(*args, **kwargs)
     return decorate
 


### PR DESCRIPTION
This PR adds `certifi` to st2client dependencies and changes the SSL validation behavior to True.

To merge this, we need to make sure that our CA gets added to the `certifi` bundle; I’ll do that.