### PR TITLE
Fix Hubot restart command

### DIFF
--- a/docs/source/chatops/chatops.rst
+++ b/docs/source/chatops/chatops.rst
@@ -144,7 +144,7 @@ reload Hubot. Do this with the following commands:
 ::
 
     $ sudo st2ctl reload
-    $ sudo /etc/init.d/docker-hubot restart
+    $ sudo service docker-hubot restart
 
 This will register the aliases we created, and tell Hubot to go and
 refresh its command list.

--- a/docs/source/chatops/chatops.rst
+++ b/docs/source/chatops/chatops.rst
@@ -144,7 +144,7 @@ reload Hubot. Do this with the following commands:
 ::
 
     $ sudo st2ctl reload
-    $ sudo service hubot restart
+    $ sudo /etc/init.d/docker-hubot restart
 
 This will register the aliases we created, and tell Hubot to go and
 refresh its command list.


### PR DESCRIPTION
In my ST2 installation (Ubuntu 14.04, using 'curl -sSL https://install.stackstorm.com/ | sudo sh'), the Hubot instance runs in a Docker container, and is controlled via /etc/init.d/docker-hubot.