### PR TITLE
Skip virtualenv from top-level generated requirements.txt file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ requirements: virtualenv .sdist-requirements
 	$(VIRTUALENV_DIR)/bin/pip install --upgrade pip
 
 	# Generate all requirements to support current CI pipeline.
-	$(VIRTUALENV_DIR)/bin/python scripts/fixate-requirements.py -s st2*/in-requirements.txt -f fixed-requirements.txt -o requirements.txt
+	$(VIRTUALENV_DIR)/bin/python scripts/fixate-requirements.py --skip=virtualenv -s st2*/in-requirements.txt -f fixed-requirements.txt -o requirements.txt
 
 	# Install requirements
 	#

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,4 +34,3 @@ semver>=2.1.2
 six==1.9.0
 stevedore<1.8,>=1.7.0
 tooz==1.20.0
-virtualenv<14.0,>=13.1.2


### PR DESCRIPTION
#2322 was causing workroom to fail in a weird manner (I couldn't track down the root cause in a short time frame I spend debugging it).

For now, I just decided to not include `virtualenv` in top-level `requirements.txt`.

This won't affect the new packages packages since they use package / component specific `requirements.txt` file (and not the top-level one), but it will prevent workroom failures.

In the future, we should also dig in, track down the root cause and see why this is causing the workroom failure.