### PR TITLE
Fix explicit none to optional argument on action execution

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,8 @@ in development
   ``published`` property if ``display_published`` property is specified.
 * Allow user to specify TTL when creating datastore item using CLI with the ``--ttl`` option.
   (improvement)
+* Fix validation error when None is passed explicitly to an optional argument on action
+  execution. (bug fix)
 
 1.2.0 - December 07, 2015
 -------------------------

--- a/st2api/tests/unit/controllers/v1/test_executions_simple.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_simple.py
@@ -272,7 +272,7 @@ class TestActionExecutionController(FunctionalTest):
         execution['parameters'] = {"hosts": "localhost", "cmd": 1000}
         post_resp = self._do_post(execution, expect_errors=True)
         self.assertEqual(post_resp.status_int, 400)
-        self.assertEqual(post_resp.json['faultstring'], "1000 is not of type 'string'")
+        self.assertEqual(post_resp.json['faultstring'], "1000 is not of type 'string', 'null'")
 
         # Runner type expects parameters "cmd" to be str.
         execution['parameters'] = {"hosts": "localhost", "cmd": "1000", "c": 1}
@@ -293,6 +293,12 @@ class TestActionExecutionController(FunctionalTest):
         self.assertEqual(post_resp.status_int, 400)
         self.assertEqual(post_resp.json['faultstring'],
                          'Dependecy unsatisfied in ABSENT')
+
+    def test_post_parameter_validation_explicit_none(self):
+        execution = copy.deepcopy(LIVE_ACTION_1)
+        execution['parameters']['a'] = None
+        post_resp = self._do_post(execution)
+        self.assertEqual(post_resp.status_int, 201)
 
     def test_post_with_st2_context_in_headers(self):
         resp = self._do_post(copy.deepcopy(LIVE_ACTION_1))

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -289,6 +289,7 @@ class LiveActionAPI(BaseAPI):
             },
             "status": {
                 "description": "The current status of the action execution.",
+                "type": "string",
                 "enum": LIVEACTION_STATUSES
             },
             "start_timestamp": {
@@ -317,7 +318,8 @@ class LiveActionAPI(BaseAPI):
                             {"type": "integer"},
                             {"type": "number"},
                             {"type": "object"},
-                            {"type": "string"}
+                            {"type": "string"},
+                            {"type": "null"}
                         ]
                     }
                 }

--- a/st2common/st2common/models/api/execution.py
+++ b/st2common/st2common/models/api/execution.py
@@ -60,6 +60,7 @@ class ActionExecutionAPI(BaseAPI):
             "liveaction": REQUIRED_ATTR_SCHEMAS['liveaction'],
             "status": {
                 "description": "The current status of the action execution.",
+                "type": "string",
                 "enum": LIVEACTION_STATUSES
             },
             "start_timestamp": {

--- a/st2common/tests/unit/services/test_action.py
+++ b/st2common/tests/unit/services/test_action.py
@@ -52,6 +52,9 @@ ACTION = {
         'a': {
             'type': 'string',
             'default': 'abc'
+        },
+        'b': {
+            'type': 'string'
         }
     },
     'notify': {
@@ -114,6 +117,16 @@ class TestActionExecutionService(DbTestCase):
         parameters = {'hosts': 'localhost', 'cmd': 'uname -a', 'a': 123}
         liveaction = LiveActionDB(action=ACTION_REF, parameters=parameters)
         self.assertRaises(jsonschema.ValidationError, action_service.request, liveaction)
+
+    def test_request_optional_parameter_none_value(self):
+        parameters = {'hosts': 'localhost', 'cmd': 'uname -a', 'a': None}
+        request = LiveActionDB(action=ACTION_REF, parameters=parameters)
+        request, _ = action_service.request(request)
+
+    def test_request_optional_parameter_none_value_no_default(self):
+        parameters = {'hosts': 'localhost', 'cmd': 'uname -a', 'b': None}
+        request = LiveActionDB(action=ACTION_REF, parameters=parameters)
+        request, _ = action_service.request(request)
 
     def test_request_nonexistent_action(self):
         parameters = {'hosts': 'localhost', 'cmd': 'uname -a'}

--- a/st2common/tests/unit/test_json_schema.py
+++ b/st2common/tests/unit/test_json_schema.py
@@ -24,10 +24,33 @@ TEST_SCHEMA_1 = {
     'description': 'Foo.',
     'type': 'object',
     'properties': {
-        'cmd_no_default': {
+        'arg_required_no_default': {
             'description': 'Foo',
             'required': True,
             'type': 'string'
+        },
+        'arg_optional_no_type': {
+            'description': 'Bar'
+        },
+        'arg_optional_multi_type': {
+            'description': 'Mirror mirror',
+            'type': ['string', 'boolean', 'number']
+        },
+        'arg_optional_multi_type_none': {
+            'description': 'Mirror mirror on the wall',
+            'type': ['string', 'boolean', 'number', 'null']
+        },
+        'arg_optional_type_array': {
+            'description': 'Who''s the fairest?',
+            'type': 'array'
+        },
+        'arg_optional_type_object': {
+            'description': 'Who''s the fairest of them?',
+            'type': 'object'
+        },
+        'arg_optional_multi_collection_type': {
+            'description': 'Who''s the fairest of them all?',
+            'type': ['array', 'object']
         }
     }
 }
@@ -38,11 +61,114 @@ TEST_SCHEMA_2 = {
     'description': 'Foo.',
     'type': 'object',
     'properties': {
-        'cmd_default': {
+        'arg_required_default': {
             'default': 'date',
             'description': 'Foo',
             'required': True,
             'type': 'string'
+        }
+    }
+}
+
+TEST_SCHEMA_3 = {
+    'additionalProperties': False,
+    'title': 'foo',
+    'description': 'Foo.',
+    'type': 'object',
+    'properties': {
+        'arg_optional_default': {
+            'default': 'bar',
+            'description': 'Foo',
+            'type': 'string'
+        },
+        'arg_optional_default_none': {
+            'default': None,
+            'description': 'Foo',
+            'type': 'string'
+        },
+        'arg_optional_no_default': {
+            'description': 'Foo',
+            'type': 'string'
+        }
+    }
+}
+
+TEST_SCHEMA_4 = {
+    'additionalProperties': False,
+    'title': 'foo',
+    'description': 'Foo.',
+    'type': 'object',
+    'properties': {
+        'arg_optional_default': {
+            'default': 'bar',
+            'description': 'Foo',
+            'anyOf': [
+                {'type': 'string'},
+                {'type': 'boolean'}
+            ]
+        },
+        'arg_optional_default_none': {
+            'default': None,
+            'description': 'Foo',
+            'anyOf': [
+                {'type': 'string'},
+                {'type': 'boolean'}
+            ]
+        },
+        'arg_optional_no_default': {
+            'description': 'Foo',
+            'anyOf': [
+                {'type': 'string'},
+                {'type': 'boolean'}
+            ]
+        },
+        'arg_optional_no_default_anyof_none': {
+            'description': 'Foo',
+            'anyOf': [
+                {'type': 'string'},
+                {'type': 'boolean'},
+                {'type': 'null'}
+            ]
+        }
+    }
+}
+
+TEST_SCHEMA_5 = {
+    'additionalProperties': False,
+    'title': 'foo',
+    'description': 'Foo.',
+    'type': 'object',
+    'properties': {
+        'arg_optional_default': {
+            'default': 'bar',
+            'description': 'Foo',
+            'oneOf': [
+                {'type': 'string'},
+                {'type': 'boolean'}
+            ]
+        },
+        'arg_optional_default_none': {
+            'default': None,
+            'description': 'Foo',
+            'oneOf': [
+                {'type': 'string'},
+                {'type': 'boolean'}
+            ]
+        },
+        'arg_optional_no_default': {
+            'description': 'Foo',
+            'oneOf': [
+                {'type': 'string'},
+                {'type': 'boolean'}
+            ]
+        },
+        'arg_optional_no_default_oneof_none': {
+            'description': 'Foo',
+            'oneOf': [
+                {'type': 'string'},
+                {'type': 'boolean'},
+                {'type': 'null'}
+            ]
         }
     }
 }
@@ -54,13 +180,13 @@ class JSONSchemaTestCase(TestCase):
         instance = {}
         validator = util_schema.get_validator()
 
-        expected_msg = '\'cmd_no_default\' is a required property'
+        expected_msg = '\'arg_required_no_default\' is a required property'
         self.assertRaisesRegexp(ValidationError, expected_msg, util_schema.validate,
                                 instance=instance, schema=TEST_SCHEMA_1, cls=validator,
                                 use_default=True)
 
         # No default, value provided
-        instance = {'cmd_no_default': 'foo'}
+        instance = {'arg_required_no_default': 'foo'}
         util_schema.validate(instance=instance, schema=TEST_SCHEMA_1, cls=validator,
                              use_default=True)
 
@@ -71,7 +197,175 @@ class JSONSchemaTestCase(TestCase):
                              use_default=True)
 
         # default value provided, value provided, should pass
-        instance = {'cmd_default': 'foo'}
+        instance = {'arg_required_default': 'foo'}
         validator = util_schema.get_validator()
         util_schema.validate(instance=instance, schema=TEST_SCHEMA_2, cls=validator,
                              use_default=True)
+
+    def test_allow_default_none(self):
+        # Let validator take care of default
+        validator = util_schema.get_validator()
+        util_schema.validate(instance=dict(), schema=TEST_SCHEMA_3, cls=validator,
+                             use_default=True, allow_default_none=True)
+
+    def test_allow_default_explicit_none(self):
+        # Explicitly pass None to arguments
+        instance = {
+            'arg_optional_default': None,
+            'arg_optional_default_none': None,
+            'arg_optional_no_default': None
+        }
+
+        validator = util_schema.get_validator()
+        util_schema.validate(instance=instance, schema=TEST_SCHEMA_3, cls=validator,
+                             use_default=True, allow_default_none=True)
+
+    def test_anyof_type_allow_default_none(self):
+        # Let validator take care of default
+        validator = util_schema.get_validator()
+        util_schema.validate(instance=dict(), schema=TEST_SCHEMA_4, cls=validator,
+                             use_default=True, allow_default_none=True)
+
+    def test_anyof_allow_default_explicit_none(self):
+        # Explicitly pass None to arguments
+        instance = {
+            'arg_optional_default': None,
+            'arg_optional_default_none': None,
+            'arg_optional_no_default': None,
+            'arg_optional_no_default_anyof_none': None
+        }
+
+        validator = util_schema.get_validator()
+        util_schema.validate(instance=instance, schema=TEST_SCHEMA_4, cls=validator,
+                             use_default=True, allow_default_none=True)
+
+    def test_oneof_type_allow_default_none(self):
+        # Let validator take care of default
+        validator = util_schema.get_validator()
+        util_schema.validate(instance=dict(), schema=TEST_SCHEMA_5, cls=validator,
+                             use_default=True, allow_default_none=True)
+
+    def test_oneof_allow_default_explicit_none(self):
+        # Explicitly pass None to arguments
+        instance = {
+            'arg_optional_default': None,
+            'arg_optional_default_none': None,
+            'arg_optional_no_default': None,
+            'arg_optional_no_default_oneof_none': None
+        }
+
+        validator = util_schema.get_validator()
+        util_schema.validate(instance=instance, schema=TEST_SCHEMA_5, cls=validator,
+                             use_default=True, allow_default_none=True)
+
+    def test_is_property_type_single(self):
+        typed_property = TEST_SCHEMA_1['properties']['arg_required_no_default']
+        self.assertTrue(util_schema.is_property_type_single(typed_property))
+
+        untyped_property = TEST_SCHEMA_1['properties']['arg_optional_no_type']
+        self.assertTrue(util_schema.is_property_type_single(untyped_property))
+
+        multi_typed_property = TEST_SCHEMA_1['properties']['arg_optional_multi_type']
+        self.assertFalse(util_schema.is_property_type_single(multi_typed_property))
+
+        anyof_property = TEST_SCHEMA_4['properties']['arg_optional_default']
+        self.assertFalse(util_schema.is_property_type_single(anyof_property))
+
+        oneof_property = TEST_SCHEMA_5['properties']['arg_optional_default']
+        self.assertFalse(util_schema.is_property_type_single(oneof_property))
+
+    def test_is_property_type_anyof(self):
+        anyof_property = TEST_SCHEMA_4['properties']['arg_optional_default']
+        self.assertTrue(util_schema.is_property_type_anyof(anyof_property))
+
+        typed_property = TEST_SCHEMA_1['properties']['arg_required_no_default']
+        self.assertFalse(util_schema.is_property_type_anyof(typed_property))
+
+        untyped_property = TEST_SCHEMA_1['properties']['arg_optional_no_type']
+        self.assertFalse(util_schema.is_property_type_anyof(untyped_property))
+
+        multi_typed_property = TEST_SCHEMA_1['properties']['arg_optional_multi_type']
+        self.assertFalse(util_schema.is_property_type_anyof(multi_typed_property))
+
+        oneof_property = TEST_SCHEMA_5['properties']['arg_optional_default']
+        self.assertFalse(util_schema.is_property_type_anyof(oneof_property))
+
+    def test_is_property_type_oneof(self):
+        oneof_property = TEST_SCHEMA_5['properties']['arg_optional_default']
+        self.assertTrue(util_schema.is_property_type_oneof(oneof_property))
+
+        typed_property = TEST_SCHEMA_1['properties']['arg_required_no_default']
+        self.assertFalse(util_schema.is_property_type_oneof(typed_property))
+
+        untyped_property = TEST_SCHEMA_1['properties']['arg_optional_no_type']
+        self.assertFalse(util_schema.is_property_type_oneof(untyped_property))
+
+        multi_typed_property = TEST_SCHEMA_1['properties']['arg_optional_multi_type']
+        self.assertFalse(util_schema.is_property_type_oneof(multi_typed_property))
+
+        anyof_property = TEST_SCHEMA_4['properties']['arg_optional_default']
+        self.assertFalse(util_schema.is_property_type_oneof(anyof_property))
+
+    def test_is_property_type_list(self):
+        multi_typed_property = TEST_SCHEMA_1['properties']['arg_optional_multi_type']
+        self.assertTrue(util_schema.is_property_type_list(multi_typed_property))
+
+        typed_property = TEST_SCHEMA_1['properties']['arg_required_no_default']
+        self.assertFalse(util_schema.is_property_type_list(typed_property))
+
+        untyped_property = TEST_SCHEMA_1['properties']['arg_optional_no_type']
+        self.assertFalse(util_schema.is_property_type_list(untyped_property))
+
+        anyof_property = TEST_SCHEMA_4['properties']['arg_optional_default']
+        self.assertFalse(util_schema.is_property_type_list(anyof_property))
+
+        oneof_property = TEST_SCHEMA_5['properties']['arg_optional_default']
+        self.assertFalse(util_schema.is_property_type_list(oneof_property))
+
+    def test_is_property_nullable(self):
+        multi_typed_prop_nullable = TEST_SCHEMA_1['properties']['arg_optional_multi_type_none']
+        self.assertTrue(util_schema.is_property_nullable(multi_typed_prop_nullable.get('type')))
+
+        anyof_property_nullable = TEST_SCHEMA_4['properties']['arg_optional_no_default_anyof_none']
+        self.assertTrue(util_schema.is_property_nullable(anyof_property_nullable.get('anyOf')))
+
+        oneof_property_nullable = TEST_SCHEMA_5['properties']['arg_optional_no_default_oneof_none']
+        self.assertTrue(util_schema.is_property_nullable(oneof_property_nullable.get('oneOf')))
+
+        typed_property = TEST_SCHEMA_1['properties']['arg_required_no_default']
+        self.assertFalse(util_schema.is_property_nullable(typed_property))
+
+        multi_typed_property = TEST_SCHEMA_1['properties']['arg_optional_multi_type']
+        self.assertFalse(util_schema.is_property_nullable(multi_typed_property.get('type')))
+
+        anyof_property = TEST_SCHEMA_4['properties']['arg_optional_no_default']
+        self.assertFalse(util_schema.is_property_nullable(anyof_property.get('anyOf')))
+
+        oneof_property = TEST_SCHEMA_5['properties']['arg_optional_no_default']
+        self.assertFalse(util_schema.is_property_nullable(oneof_property.get('oneOf')))
+
+    def test_is_attribute_type_array(self):
+        multi_coll_typed_prop = TEST_SCHEMA_1['properties']['arg_optional_multi_collection_type']
+        self.assertTrue(util_schema.is_attribute_type_array(multi_coll_typed_prop.get('type')))
+
+        array_type_property = TEST_SCHEMA_1['properties']['arg_optional_type_array']
+        self.assertTrue(util_schema.is_attribute_type_array(array_type_property.get('type')))
+
+        multi_non_coll_prop = TEST_SCHEMA_1['properties']['arg_optional_multi_type']
+        self.assertFalse(util_schema.is_attribute_type_array(multi_non_coll_prop.get('type')))
+
+        object_type_property = TEST_SCHEMA_1['properties']['arg_optional_type_object']
+        self.assertFalse(util_schema.is_attribute_type_array(object_type_property.get('type')))
+
+    def test_is_attribute_type_object(self):
+        multi_coll_typed_prop = TEST_SCHEMA_1['properties']['arg_optional_multi_collection_type']
+        self.assertTrue(util_schema.is_attribute_type_object(multi_coll_typed_prop.get('type')))
+
+        object_type_property = TEST_SCHEMA_1['properties']['arg_optional_type_object']
+        self.assertTrue(util_schema.is_attribute_type_object(object_type_property.get('type')))
+
+        multi_non_coll_prop = TEST_SCHEMA_1['properties']['arg_optional_multi_type']
+        self.assertFalse(util_schema.is_attribute_type_object(multi_non_coll_prop.get('type')))
+
+        array_type_property = TEST_SCHEMA_1['properties']['arg_optional_type_array']
+        self.assertFalse(util_schema.is_attribute_type_object(array_type_property.get('type')))

--- a/st2tests/st2tests/fixtures/generic/actions/local.yaml
+++ b/st2tests/st2tests/fixtures/generic/actions/local.yaml
@@ -11,4 +11,5 @@ parameters:
     type: string
   sudo:
     immutable: true
+    type: boolean
 runner_type: "local-shell-cmd"


### PR DESCRIPTION
JSON schema throws exception if None is passed explicitly to an optional parameter for an action execution.