### PR TITLE
Fix test for mistral example

### DIFF
--- a/st2tests/integration/mistral/test_examples.py
+++ b/st2tests/integration/mistral/test_examples.py
@@ -25,7 +25,7 @@ class ExamplesTest(base.TestWorkflowExecution):
         execution = self._wait_for_completion(execution)
         self._assert_success(execution, num_tasks=1)
         tasks = {t['name']: t for t in execution.result['tasks']}
-        expected_output = 'https://127.0.0.1:9101/history/' + execution.id
+        expected_output = 'http://127.0.0.1:9101/executions/' + execution.id
         self.assertEqual(tasks['task1']['result']['stdout'], expected_output)
 
     def test_branching(self):


### PR DESCRIPTION
The output of the mistral example was changed recently but the test is not updated.