### PR TITLE
Add wait-before to mistral example to workaround known bug

### DIFF
--- a/contrib/examples/actions/workflows/mistral-workbook-complex.yaml
+++ b/contrib/examples/actions/workflows/mistral-workbook-complex.yaml
@@ -25,6 +25,7 @@ workflows:
                     - configure_vm
                     - notify
             create_vm:
+                wait-before: 1
                 workflow: create_vm
                 input:
                     name: <% $.vm_name %>


### PR DESCRIPTION
Add wait-before to one of the tasks in mistral-workbook-complex to workaround a mistral bug until it is fixed (https://bugs.launchpad.net/mistral/+bug/1530982).