### PR TITLE
Publish action chain vars

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,8 +33,8 @@ in development
 * Add new ``st2garbagecollector`` service which periodically deletes old data from the database
   as configured in the config. By default, no old data is deleted unless explicitly configured in
   the config.
-* All published variables are now available in the result of ActionChain execution under the
-  ``published`` property.
+* All published variables can be available in the result of ActionChain execution under the
+  ``published`` property if ``display_published`` property is specified.
 
 1.2.0 - December 07, 2015
 -------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,8 @@ in development
 * Add new ``st2garbagecollector`` service which periodically deletes old data from the database
   as configured in the config. By default, no old data is deleted unless explicitly configured in
   the config.
+* All published variables are now available in the result of ActionChain execution under the
+  ``published`` property.
 
 1.2.0 - December 07, 2015
 -------------------------

--- a/docs/source/actionchain.rst
+++ b/docs/source/actionchain.rst
@@ -98,7 +98,7 @@ ActionChain offers the convinience of named variables. Global vars are set at th
 Tasks publish new variables with the ``publish`` keyword. Variables are handy when you need to mash up
 a reusable value from the input, globals, DataStore values, and results of multiple actions executions.
 All variables are referred with Jinja syntax. The cumulative published variables are also available in the result of an
-ActionChain execution under the ``published`` property.
+ActionChain execution under the ``published`` property is ``display_published`` property was supplied.
 
 .. code-block:: yaml
 

--- a/docs/source/actionchain.rst
+++ b/docs/source/actionchain.rst
@@ -95,9 +95,10 @@ Variables
 ~~~~~~~~~
 
 ActionChain offers the convinience of named variables. Global vars are set at the top of the definition with the ``var`` keyword.
-Tasks publish new variables with the ``publish`` keyword. Variables handy when you need to mash up
+Tasks publish new variables with the ``publish`` keyword. Variables are handy when you need to mash up
 a reusable value from the input, globals, DataStore values, and results of multiple actions executions.
-All variables are referred with Jinja syntax.
+All variables are referred with Jinja syntax. The cumulative published variables are also available in the result of an
+ActionChain execution under the ``published`` property.
 
 .. code-block:: yaml
 

--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -53,7 +53,7 @@ JINJA_START_MARKERS = [
     '{{',
     '{%'
 ]
-
+PUBLISHED_VARS_KEY = 'published'
 
 class ChainHolder(object):
 
@@ -265,7 +265,7 @@ class ActionChainRunner(ActionRunner):
             raise runnerexceptions.ActionRunnerPreRunError(e.message)
 
     def run(self, action_parameters):
-        result = {'tasks': []}  # holds final result we store
+        result = {'tasks': [], PUBLISHED_VARS_KEY: {}}  # holds final result we store
         context_result = {}  # holds result which is used for the template context purposes
         top_level_error = None  # stores a reference to a top level error
         fail = True
@@ -354,6 +354,7 @@ class ActionChainRunner(ActionRunner):
 
                 if rendered_publish_vars:
                     self.chain_holder.vars.update(rendered_publish_vars)
+                    result[PUBLISHED_VARS_KEY].update(rendered_publish_vars)
             finally:
                 # Record result and resolve a next node based on the task success or failure
                 updated_at = date_utils.get_datetime_utc_now()

--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -55,6 +55,7 @@ JINJA_START_MARKERS = [
 ]
 PUBLISHED_VARS_KEY = 'published'
 
+
 class ChainHolder(object):
 
     def __init__(self, chainspec, chainname):

--- a/st2actions/tests/unit/test_actionchain.py
+++ b/st2actions/tests/unit/test_actionchain.py
@@ -616,7 +616,7 @@ class TestActionChainRunner(DbTestCase):
         chain_runner.pre_run()
 
         action_parameters = {'action_param_1': 'test value 1'}
-        chain_runner.run(action_parameters=action_parameters)
+        _, result, _ = chain_runner.run(action_parameters=action_parameters)
 
         # We also assert that the action parameters are available in the
         # "publish" scope
@@ -627,6 +627,9 @@ class TestActionChainRunner(DbTestCase):
                           'published_action_param': action_parameters['action_param_1']}
         mock_args, _ = request.call_args
         self.assertEqual(mock_args[0].parameters, expected_value)
+        # Assert that the variables are correctly published
+        self.assertEqual(result['published'],
+                         {'published_action_param': u'test value 1', 'o1': u'published'})
 
     @mock.patch.object(action_db_util, 'get_action_by_ref',
                        mock.MagicMock(return_value=ACTION_1))

--- a/st2actions/tests/unit/test_actionchain.py
+++ b/st2actions/tests/unit/test_actionchain.py
@@ -613,6 +613,7 @@ class TestActionChainRunner(DbTestCase):
         chain_runner.entry_point = CHAIN_WITH_PUBLISH
         chain_runner.action = ACTION_2
         chain_runner.container_service = RunnerContainerService()
+        chain_runner.runner_parameters = {'display_published': True}
         chain_runner.pre_run()
 
         action_parameters = {'action_param_1': 'test value 1'}

--- a/st2common/st2common/bootstrap/runnersregistrar.py
+++ b/st2common/st2common/bootstrap/runnersregistrar.py
@@ -373,6 +373,11 @@ RUNNER_TYPES = [
                 'description': 'List of tasks to skip notifications for.',
                 'type': 'array',
                 'default': []
+            },
+            'display_published': {
+                'description': 'Intermediate published variables will be stored and displayed.',
+                'type': 'boolean',
+                'default': False
             }
         },
         'runner_module': 'st2actions.runners.actionchainrunner'

--- a/st2common/st2common/util/jinja.py
+++ b/st2common/st2common/util/jinja.py
@@ -144,6 +144,13 @@ def render_values(mapping=None, context=None, allow_undefined=False):
     if not context or not mapping:
         return mapping
 
+    # Add in special __context variable that provides an easy way to get access to entire context.
+    # This mean __context is a reserve key word although backwards compat is preserved by making
+    # sure that real context is updated later and therefore will override the __context value.
+    super_context = {}
+    super_context['__context'] = context
+    super_context.update(context)
+
     env = get_jinja_environment(allow_undefined=allow_undefined)
     rendered_mapping = {}
     for k, v in six.iteritems(mapping):
@@ -156,7 +163,7 @@ def render_values(mapping=None, context=None, allow_undefined=False):
             v = str(v)
 
         try:
-            rendered_v = env.from_string(v).render(context)
+            rendered_v = env.from_string(v).render(super_context)
         except Exception as e:
             # Attach key and value which failed the rendering
             e.key = k


### PR DESCRIPTION
* Action chain vars are published in the result of an action chain under the `published` property.
* Also, added support for a special `__context` property that can be used in ActionChain, Rules, AliasExecution and Notification sections. This property will help with debugging.

### Sample ActionChain
```
---
    chain:
        -
            name: "c1"
            ref: "core.local"
            params:
                cmd: "date"
            publish:
                date: "{{c1.stdout}}"
            on-success: "c2"
            on-failure: "c4"
        -
            name: "c2"
            ref: "core.local"
            params:
                cmd: "echo \"c2: parent exec is {{action_context.parent.execution_id}}.\""
            publish:
                context: "{{__context}}"
            on-success: "c3"
            on-failure: "c4"
        -
            name: "c3"
            ref: "core.local"
            params:
                cmd: "echo c3"
            on-failure: "c4"
        -
            name: "c4"
            ref: "core.local"
            params:
                cmd: "echo fail c4"
    default: "c1"
```
### Results of an execution
```
"result": {
        "published": {
            "context": "{'date': u'Mon Jan  4 16:06:59 PST 2016', '__results': {'c2': {u'failed': False, u'stderr': u'', u'return_code': 0, u'succeeded': True, u'stdout': u'c2: parent exec is 568b092332ed354a1d2d19ea.'}, 'c1': {u'failed': False, u'stderr': u'', u'return_code': 0, u'succeeded': True, u'stdout': u'Mon Jan  4 16:06:59 PST 2016'}}, u'i1': u'hi', 'c2': {u'failed': False, u'stderr': u'', u'return_code': 0, u'succeeded': True, u'stdout': u'c2: parent exec is 568b092332ed354a1d2d19ea.'}, 'c1': {u'failed': False, u'stderr': u'', u'return_code': 0, u'succeeded': True, u'stdout': u'Mon Jan  4 16:06:59 PST 2016'}, 'system': <st2common.services.keyvalues.KeyValueLookup object at 0x7f6bfc2c0b90>}",
            "date": "Mon Jan  4 16:06:59 PST 2016"
        },
        "tasks": [
           ...
        ]
    }
```

Fixes https://github.com/StackStorm/st2/issues/2344