### PR TITLE
Update webhooks.rst

### DIFF
--- a/docs/source/webhooks.rst
+++ b/docs/source/webhooks.rst
@@ -74,10 +74,10 @@ Rule:
 
     ...
     trigger:
-            type: "mypack.mytrigger"
+        type: "mypack.mytrigger"
 
     criteria:
-        trigger.attribute1
+        trigger.body.payload.attribute1:
             type: "equals"
             pattern: "value1"
 


### PR DESCRIPTION
- missing colon
- the path to the attribute in the JSON object was incorrect