### PR TITLE
Mark execution as failed on ParamExecption

### DIFF
--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -156,7 +156,6 @@ class ActionExecutionsControllerMixin(BaseRestControllerMixin):
                 runnertype_db.runner_parameters, action_db.parameters, liveaction_db.parameters,
                 liveaction_db.context)
         except ParamException:
-            LOG.info('ParamException')
             # By this point the execution is already in the DB therefore need to mark it failed.
             _, e, tb = sys.exc_info()
             action_service.update_status(

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -16,6 +16,8 @@
 import copy
 import re
 import httplib
+import sys
+import traceback
 
 import jsonschema
 from oslo_config import cfg
@@ -28,7 +30,7 @@ from st2api.controllers.resource import ResourceController
 from st2api.controllers.v1.executionviews import ExecutionViewsController
 from st2api.controllers.v1.executionviews import SUPPORTED_FILTERS
 from st2common import log as logging
-from st2common.constants.action import LIVEACTION_STATUS_CANCELED
+from st2common.constants.action import LIVEACTION_STATUS_CANCELED, LIVEACTION_STATUS_FAILED
 from st2common.constants.action import LIVEACTION_CANCELABLE_STATES
 from st2common.exceptions.param import ParamException
 from st2common.exceptions.apivalidation import ValueValidationException
@@ -153,7 +155,14 @@ class ActionExecutionsControllerMixin(BaseRestControllerMixin):
             liveaction_db.parameters = param_utils.render_live_params(
                 runnertype_db.runner_parameters, action_db.parameters, liveaction_db.parameters,
                 liveaction_db.context)
-        except ParamException as e:
+        except ParamException:
+            LOG.info('ParamException')
+            # By this point the execution is already in the DB therefore need to mark it failed.
+            _, e, tb = sys.exc_info()
+            action_service.update_status(
+                liveaction=liveaction_db,
+                new_status=LIVEACTION_STATUS_FAILED,
+                result={'error': str(e), 'traceback': ''.join(traceback.format_tb(tb, 20))})
             raise ValueValidationException(str(e))
 
         liveaction_db = LiveAction.add_or_update(liveaction_db, publish=False)

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -163,6 +163,8 @@ class ActionExecutionsControllerMixin(BaseRestControllerMixin):
                 liveaction=liveaction_db,
                 new_status=LIVEACTION_STATUS_FAILED,
                 result={'error': str(e), 'traceback': ''.join(traceback.format_tb(tb, 20))})
+            # Might be a good idea to return the actual ActionExecution rather than bubble up
+            # the execption.
             raise ValueValidationException(str(e))
 
         liveaction_db = LiveAction.add_or_update(liveaction_db, publish=False)

--- a/st2api/tests/unit/controllers/v1/test_executions_simple.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_simple.py
@@ -284,6 +284,16 @@ class TestActionExecutionController(FunctionalTest):
         post_resp = self._do_post(execution, expect_errors=False)
         self.assertEqual(post_resp.status_int, 201)
 
+    def test_post_parameter_render_failed(self):
+        execution = copy.deepcopy(LIVE_ACTION_1)
+
+        # Runner type does not expects additional properties.
+        execution['parameters']['hosts'] = '{{ABSENT}}'
+        post_resp = self._do_post(execution, expect_errors=True)
+        self.assertEqual(post_resp.status_int, 400)
+        self.assertEqual(post_resp.json['faultstring'],
+                         'Dependecy unsatisfied in ABSENT')
+
     def test_post_with_st2_context_in_headers(self):
         resp = self._do_post(copy.deepcopy(LIVE_ACTION_1))
         self.assertEqual(resp.status_int, 201)


### PR DESCRIPTION
* Previously the execution would be left in a requested state. This way the
  execution is put in a failed state and the reasoning is provided.