### PR TITLE
Allow user to specify TTL via "--ttl" option when using "st2 key set" command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,8 @@ in development
 * Add new ``st2garbagecollector`` service which periodically deletes old data from the database
   as configured in the config. By default, no old data is deleted unless explicitly configured in
   the config.
+* Allow user to specify TTL when creating datastore item using CLI with the ``--ttl`` option.
+  (improvement)
 
 1.2.0 - December 07, 2015
 -------------------------

--- a/st2client/st2client/commands/keyvalue.py
+++ b/st2client/st2client/commands/keyvalue.py
@@ -82,11 +82,11 @@ class KeyValuePairListCommand(resource.ResourceListCommand):
 
 class KeyValuePairGetCommand(resource.ResourceGetCommand):
     pk_argument_name = 'name'
-    display_attributes = ['name', 'value']
+    display_attributes = ['name', 'value', 'expire_timestamp']
 
 
 class KeyValuePairSetCommand(resource.ResourceCommand):
-    display_attributes = ['name', 'value']
+    display_attributes = ['name', 'value', 'expire_timestamp']
 
     def __init__(self, resource, *args, **kwargs):
         super(KeyValuePairSetCommand, self).__init__(
@@ -99,6 +99,8 @@ class KeyValuePairSetCommand(resource.ResourceCommand):
                                  metavar='name',
                                  help='Name of the key value pair.')
         self.parser.add_argument('value', help='Value paired with the key.')
+        self.parser.add_argument('--ttl', type=int, default=None,
+                                 help='TTL for this value.')
 
     @add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
@@ -106,6 +108,10 @@ class KeyValuePairSetCommand(resource.ResourceCommand):
         instance.id = args.name  # TODO: refactor and get rid of id
         instance.name = args.name
         instance.value = args.value
+
+        if args.ttl:
+            instance.ttl = args.ttl
+
         return self.manager.update(instance, **kwargs)
 
     def run_and_print(self, args, **kwargs):

--- a/st2client/st2client/commands/keyvalue.py
+++ b/st2client/st2client/commands/keyvalue.py
@@ -99,7 +99,7 @@ class KeyValuePairSetCommand(resource.ResourceCommand):
                                  metavar='name',
                                  help='Name of the key value pair.')
         self.parser.add_argument('value', help='Value paired with the key.')
-        self.parser.add_argument('-l' ,'--ttl', dest='ttl', type=int, default=None,
+        self.parser.add_argument('-l', '--ttl', dest='ttl', type=int, default=None,
                                  help='TTL (in seconds) for this value.')
 
     @add_auth_token_to_kwargs_from_cli

--- a/st2client/st2client/commands/keyvalue.py
+++ b/st2client/st2client/commands/keyvalue.py
@@ -100,7 +100,7 @@ class KeyValuePairSetCommand(resource.ResourceCommand):
                                  help='Name of the key value pair.')
         self.parser.add_argument('value', help='Value paired with the key.')
         self.parser.add_argument('--ttl', type=int, default=None,
-                                 help='TTL for this value.')
+                                 help='TTL (in seconds) for this value.')
 
     @add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):

--- a/st2client/st2client/commands/keyvalue.py
+++ b/st2client/st2client/commands/keyvalue.py
@@ -99,7 +99,7 @@ class KeyValuePairSetCommand(resource.ResourceCommand):
                                  metavar='name',
                                  help='Name of the key value pair.')
         self.parser.add_argument('value', help='Value paired with the key.')
-        self.parser.add_argument('--ttl', type=int, default=None,
+        self.parser.add_argument('-l' ,'--ttl', dest='ttl', type=int, default=None,
                                  help='TTL (in seconds) for this value.')
 
     @add_auth_token_to_kwargs_from_cli


### PR DESCRIPTION
This pull request allows users to specify datastore item expiration (TTL) via ``--ttl`` option when using ``st2 key set`` command (e.g. ``st2 key set key1 value1 --ttl=60``).

It also updates ``key get`` and ``key set`` command to display ``expire_timestamp`` attribute.

This resolves #2343