### PR TITLE
Fix overrides of runner parameter attributes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,7 @@ in development
   execution. (bug fix)
 * Deprecated ``params`` action attribute in the action chain definition in favor of the new 
   ``parameters`` attribute. (improvement)
+* Fix action parameters validation so that only a selected set of attributes can be overriden for any runner parameters. (bug fix)
 
 1.2.0 - December 07, 2015
 -------------------------

--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -28,6 +28,7 @@ from st2api.controllers import resource
 from st2api.controllers.v1.actionviews import ActionViewsController
 from st2common import log as logging
 from st2common.constants.triggers import ACTION_FILE_WRITTEN_TRIGGER
+from st2common.exceptions.action import InvalidActionParameterException
 from st2common.exceptions.apivalidation import ValueValidationException
 from st2common.models.api.base import jsexpose
 from st2common.persistence.action import Action
@@ -94,9 +95,16 @@ class ActionsController(resource.ContentPackResourceController):
             Handles requests:
                 POST /actions/
         """
-        # Perform validation
-        validate_not_part_of_system_pack(action)
-        action_validator.validate_action(action)
+
+        try:
+            # Perform validation
+            validate_not_part_of_system_pack(action)
+            action_validator.validate_action(action)
+        except (ValidationError, ValueError,
+                ValueValidationException, InvalidActionParameterException) as e:
+            LOG.exception('Unable to create action data=%s', action)
+            abort(http_client.BAD_REQUEST, str(e))
+            return
 
         # Write pack data files to disk (if any are provided)
         data_files = getattr(action, 'data_files', [])

--- a/st2api/tests/unit/controllers/v1/test_actions.py
+++ b/st2api/tests/unit/controllers/v1/test_actions.py
@@ -222,6 +222,34 @@ ACTION_13 = {
     }
 }
 
+ACTION_14 = {
+    'name': 'st2.dummy.action14',
+    'description': 'test description',
+    'enabled': True,
+    'pack': 'dummy_pack_1',
+    'entry_point': '/tmp/test/action1.sh',
+    'runner_type': 'local-shell-script',
+    'parameters': {
+        'a': {'type': 'string', 'default': 'A1'},
+        'b': {'type': 'string', 'default': 'B1'},
+        'sudo': {'type': 'string'}
+    }
+}
+
+ACTION_15 = {
+    'name': 'st2.dummy.action15',
+    'description': 'test description',
+    'enabled': True,
+    'pack': 'dummy_pack_1',
+    'entry_point': '/tmp/test/action1.sh',
+    'runner_type': 'local-shell-script',
+    'parameters': {
+        'a': {'type': 'string', 'default': 'A1'},
+        'b': {'type': 'string', 'default': 'B1'},
+        'sudo': {'default': True, 'immutable': True}
+    }
+}
+
 
 class TestActionController(FunctionalTest, CleanFilesTestCase):
     register_packs = True
@@ -432,6 +460,15 @@ class TestActionController(FunctionalTest, CleanFilesTestCase):
     def test_post_invalid_runner_type(self):
         post_resp = self.__do_post(ACTION_5, expect_errors=True)
         self.assertEqual(post_resp.status_int, 400)
+
+    def test_post_override_runner_param_not_allowed(self):
+        post_resp = self.__do_post(ACTION_14, expect_errors=True)
+        self.assertEqual(post_resp.status_int, 400)
+        self.assertIn('cannot be overridden', post_resp.json.get('faultstring'))
+
+    def test_post_override_runner_param_allowed(self):
+        post_resp = self.__do_post(ACTION_15)
+        self.assertEqual(post_resp.status_int, 201)
 
     @mock.patch.object(action_validator, 'validate_action', mock.MagicMock(
         return_value=True))

--- a/st2common/st2common/exceptions/action.py
+++ b/st2common/st2common/exceptions/action.py
@@ -13,14 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from st2common.exceptions import StackStormBaseException
+
 __all__ = [
-    'ParameterRenderingFailedException'
+    'ParameterRenderingFailedException',
+    'InvalidActionReferencedException',
+    'InvalidActionParameterException'
 ]
 
 
-class ParameterRenderingFailedException(Exception):
+class ParameterRenderingFailedException(StackStormBaseException):
     pass
 
 
-class InvalidActionReferencedException(Exception):
+class InvalidActionReferencedException(StackStormBaseException):
+    pass
+
+
+class InvalidActionParameterException(StackStormBaseException):
     pass

--- a/st2common/tests/unit/services/test_action.py
+++ b/st2common/tests/unit/services/test_action.py
@@ -13,11 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
 import jsonschema
+import mock
+import six
 
 from st2actions.container.base import RunnerContainer
 from st2common.constants import action as action_constants
+from st2common.exceptions.action import InvalidActionParameterException
 from st2common.models.db.liveaction import LiveActionDB
 from st2common.models.api.action import RunnerTypeAPI, ActionAPI
 from st2common.models.system.common import ResourceReference
@@ -36,7 +38,8 @@ RUNNER = {
     'enabled': True,
     'runner_parameters': {
         'hosts': {'type': 'string'},
-        'cmd': {'type': 'string'}
+        'cmd': {'type': 'string'},
+        'sudo': {'type': 'boolean', 'default': False}
     },
     'runner_module': 'st2actions.runners.fabricrunner'
 }
@@ -49,12 +52,11 @@ ACTION = {
     'pack': 'default',
     'runner_type': 'local-shell-script',
     'parameters': {
-        'a': {
+        'arg_default_value': {
             'type': 'string',
             'default': 'abc'
         },
-        'b': {
-            'type': 'string'
+        'arg_default_type': {
         }
     },
     'notify': {
@@ -65,7 +67,85 @@ ACTION = {
     }
 }
 
-ACTION_REF = ResourceReference(name='my.action', pack='default').ref
+ACTION_OVR_PARAM = {
+    'name': 'my.sudo.default.action',
+    'description': 'my test',
+    'enabled': True,
+    'entry_point': '/tmp/test/action.sh',
+    'pack': 'default',
+    'runner_type': 'local-shell-script',
+    'parameters': {
+        'sudo': {
+            'default': True
+        }
+    }
+}
+
+ACTION_OVR_PARAM_MUTABLE = {
+    'name': 'my.sudo.mutable.action',
+    'description': 'my test',
+    'enabled': True,
+    'entry_point': '/tmp/test/action.sh',
+    'pack': 'default',
+    'runner_type': 'local-shell-script',
+    'parameters': {
+        'sudo': {
+            'immutable': False
+        }
+    }
+}
+
+ACTION_OVR_PARAM_IMMUTABLE = {
+    'name': 'my.sudo.immutable.action',
+    'description': 'my test',
+    'enabled': True,
+    'entry_point': '/tmp/test/action.sh',
+    'pack': 'default',
+    'runner_type': 'local-shell-script',
+    'parameters': {
+        'sudo': {
+            'immutable': True
+        }
+    }
+}
+
+ACTION_OVR_PARAM_BAD_ATTR = {
+    'name': 'my.sudo.invalid.action',
+    'description': 'my test',
+    'enabled': True,
+    'entry_point': '/tmp/test/action.sh',
+    'pack': 'default',
+    'runner_type': 'local-shell-script',
+    'parameters': {
+        'sudo': {
+            'type': 'number'
+        }
+    }
+}
+
+ACTION_OVR_PARAM_BAD_ATTR_NOOP = {
+    'name': 'my.sudo.invalid.noop.action',
+    'description': 'my test',
+    'enabled': True,
+    'entry_point': '/tmp/test/action.sh',
+    'pack': 'default',
+    'runner_type': 'local-shell-script',
+    'parameters': {
+        'sudo': {
+            'type': 'boolean'
+        }
+    }
+}
+
+PACK = 'default'
+ACTION_REF = ResourceReference(name='my.action', pack=PACK).ref
+ACTION_OVR_PARAM_REF = ResourceReference(name='my.sudo.default.action', pack=PACK).ref
+ACTION_OVR_PARAM_MUTABLE_REF = ResourceReference(name='my.sudo.mutable.action', pack=PACK).ref
+ACTION_OVR_PARAM_IMMUTABLE_REF = ResourceReference(name='my.sudo.immutable.action', pack=PACK).ref
+ACTION_OVR_PARAM_BAD_ATTR_REF = ResourceReference(name='my.sudo.invalid.action', pack=PACK).ref
+ACTION_OVR_PARAM_BAD_ATTR_NOOP_REF = ResourceReference(
+    name='my.sudo.invalid.noop.action', pack=PACK).ref
+
 USERNAME = 'stanley'
 
 
@@ -77,14 +157,28 @@ class TestActionExecutionService(DbTestCase):
         super(TestActionExecutionService, cls).setUpClass()
         cls.runner = RunnerTypeAPI(**RUNNER)
         cls.runnerdb = RunnerType.add_or_update(RunnerTypeAPI.to_model(cls.runner))
-        cls.action = ActionAPI(**ACTION)
-        cls.actiondb = Action.add_or_update(ActionAPI.to_model(cls.action))
+
+        cls.actions = {
+            ACTION['name']: ActionAPI(**ACTION),
+            ACTION_OVR_PARAM['name']: ActionAPI(**ACTION_OVR_PARAM),
+            ACTION_OVR_PARAM_MUTABLE['name']: ActionAPI(**ACTION_OVR_PARAM_MUTABLE),
+            ACTION_OVR_PARAM_IMMUTABLE['name']: ActionAPI(**ACTION_OVR_PARAM_IMMUTABLE),
+            ACTION_OVR_PARAM_BAD_ATTR['name']: ActionAPI(**ACTION_OVR_PARAM_BAD_ATTR),
+            ACTION_OVR_PARAM_BAD_ATTR_NOOP['name']: ActionAPI(**ACTION_OVR_PARAM_BAD_ATTR_NOOP)
+        }
+
+        cls.actiondbs = {name: Action.add_or_update(ActionAPI.to_model(action))
+                         for name, action in six.iteritems(cls.actions)}
+
         cls.container = RunnerContainer()
 
     @classmethod
     def tearDownClass(cls):
-        Action.delete(cls.actiondb)
+        for actiondb in cls.actiondbs.values():
+            Action.delete(actiondb)
+
         RunnerType.delete(cls.runnerdb)
+
         super(TestActionExecutionService, cls).tearDownClass()
 
     def _submit_request(self):
@@ -101,10 +195,11 @@ class TestActionExecutionService(DbTestCase):
         return execution
 
     def test_request(self):
+        actiondb = self.actiondbs[ACTION['name']]
         request, execution = self._submit_request()
         self.assertIsNotNone(execution)
         self.assertEqual(execution.id, request.id)
-        self.assertEqual(execution.action, '.'.join([self.actiondb.pack, self.actiondb.name]))
+        self.assertEqual(execution.action, '.'.join([actiondb.pack, actiondb.name]))
         self.assertEqual(execution.context['user'], request.context['user'])
         self.assertDictEqual(execution.parameters, request.parameters)
         self.assertEqual(execution.status, action_constants.LIVEACTION_STATUS_REQUESTED)
@@ -114,19 +209,56 @@ class TestActionExecutionService(DbTestCase):
                          isotime.format(request.start_timestamp, usec=False))
 
     def test_request_invalid_parameters(self):
-        parameters = {'hosts': 'localhost', 'cmd': 'uname -a', 'a': 123}
+        parameters = {'hosts': 'localhost', 'cmd': 'uname -a', 'arg_default_value': 123}
         liveaction = LiveActionDB(action=ACTION_REF, parameters=parameters)
         self.assertRaises(jsonschema.ValidationError, action_service.request, liveaction)
 
     def test_request_optional_parameter_none_value(self):
-        parameters = {'hosts': 'localhost', 'cmd': 'uname -a', 'a': None}
+        parameters = {'hosts': 'localhost', 'cmd': 'uname -a', 'arg_default_value': None}
         request = LiveActionDB(action=ACTION_REF, parameters=parameters)
         request, _ = action_service.request(request)
 
     def test_request_optional_parameter_none_value_no_default(self):
-        parameters = {'hosts': 'localhost', 'cmd': 'uname -a', 'b': None}
+        parameters = {'hosts': 'localhost', 'cmd': 'uname -a', 'arg_default_type': None}
         request = LiveActionDB(action=ACTION_REF, parameters=parameters)
         request, _ = action_service.request(request)
+
+    def test_request_override_runner_parameter(self):
+        parameters = {'hosts': 'localhost', 'cmd': 'uname -a'}
+        request = LiveActionDB(action=ACTION_OVR_PARAM_REF, parameters=parameters)
+        request, _ = action_service.request(request)
+
+        parameters = {'hosts': 'localhost', 'cmd': 'uname -a', 'sudo': False}
+        request = LiveActionDB(action=ACTION_OVR_PARAM_REF, parameters=parameters)
+        request, _ = action_service.request(request)
+
+    def test_request_override_runner_parameter_type_attribute_value_changed(self):
+        parameters = {'hosts': 'localhost', 'cmd': 'uname -a'}
+        request = LiveActionDB(action=ACTION_OVR_PARAM_BAD_ATTR_REF, parameters=parameters)
+        self.assertRaises(InvalidActionParameterException, action_service.request, request)
+
+    def test_request_override_runner_parameter_type_attribute_no_value_changed(self):
+        parameters = {'hosts': 'localhost', 'cmd': 'uname -a'}
+        request = LiveActionDB(action=ACTION_OVR_PARAM_BAD_ATTR_NOOP_REF, parameters=parameters)
+        request, _ = action_service.request(request)
+
+    def test_request_override_runner_parameter_mutable(self):
+        parameters = {'hosts': 'localhost', 'cmd': 'uname -a'}
+        request = LiveActionDB(action=ACTION_OVR_PARAM_MUTABLE_REF, parameters=parameters)
+        request, _ = action_service.request(request)
+
+        parameters = {'hosts': 'localhost', 'cmd': 'uname -a', 'sudo': True}
+        request = LiveActionDB(action=ACTION_OVR_PARAM_MUTABLE_REF, parameters=parameters)
+        request, _ = action_service.request(request)
+
+    def test_request_override_runner_parameter_immutable(self):
+        parameters = {'hosts': 'localhost', 'cmd': 'uname -a'}
+        request = LiveActionDB(action=ACTION_OVR_PARAM_IMMUTABLE_REF, parameters=parameters)
+        request, _ = action_service.request(request)
+
+        parameters = {'hosts': 'localhost', 'cmd': 'uname -a', 'sudo': True}
+        request = LiveActionDB(action=ACTION_OVR_PARAM_IMMUTABLE_REF, parameters=parameters)
+        self.assertRaises(ValueError, action_service.request, request)
 
     def test_request_nonexistent_action(self):
         parameters = {'hosts': 'localhost', 'cmd': 'uname -a'}
@@ -135,13 +267,19 @@ class TestActionExecutionService(DbTestCase):
         self.assertRaises(ValueError, action_service.request, execution)
 
     def test_request_disabled_action(self):
-        self.actiondb.enabled = False
-        Action.add_or_update(self.actiondb)
-        parameters = {'hosts': 'localhost', 'cmd': 'uname -a'}
-        execution = LiveActionDB(action=ACTION_REF, parameters=parameters)
-        self.assertRaises(ValueError, action_service.request, execution)
-        self.actiondb.enabled = True
-        Action.add_or_update(self.actiondb)
+        actiondb = self.actiondbs[ACTION['name']]
+        actiondb.enabled = False
+        Action.add_or_update(actiondb)
+
+        try:
+            parameters = {'hosts': 'localhost', 'cmd': 'uname -a'}
+            execution = LiveActionDB(action=ACTION_REF, parameters=parameters)
+            self.assertRaises(ValueError, action_service.request, execution)
+        except Exception as e:
+            raise e
+        finally:
+            actiondb.enabled = True
+            Action.add_or_update(actiondb)
 
     def test_request_cancellation(self):
         request, execution = self._submit_request()

--- a/st2tests/st2tests/fixtures/generic/actions/action1.yaml
+++ b/st2tests/st2tests/fixtures/generic/actions/action1.yaml
@@ -21,12 +21,9 @@ parameters:
   runnerdummy:
     default: actiondummy
     immutable: true
-    type: string
   runnerfoo:
     default: FOO
     immutable: true
-    type: string
   runnerimmutable:
     default: failed_override
-    type: string
 runner_type: test-runner-1

--- a/st2tests/st2tests/fixtures/generic/actions/action2.yaml
+++ b/st2tests/st2tests/fixtures/generic/actions/action2.yaml
@@ -21,12 +21,9 @@ parameters:
   runnerdummy:
     default: actiondummy
     immutable: true
-    type: string
   runnerfoo:
     default: FOO
     immutable: true
-    type: string
   runnerimmutable:
     default: failed_override
-    type: string
 runner_type: test-runner-1

--- a/st2tests/st2tests/fixtures/generic/actions/action3.yaml
+++ b/st2tests/st2tests/fixtures/generic/actions/action3.yaml
@@ -6,7 +6,6 @@ name: action-3
 pack: wolfpack
 parameters:
   k2:
-    type: string
     required: true
     default: bar
 runner_type: test-runner-3

--- a/st2tests/st2tests/fixtures/generic/actions/action_4_action_context_param.yaml
+++ b/st2tests/st2tests/fixtures/generic/actions/action_4_action_context_param.yaml
@@ -23,18 +23,13 @@ parameters:
   runnerdummy:
     default: actiondummy
     immutable: true
-    type: string
   runnerfoo:
     default: FOO
     immutable: true
-    type: string
   runnerimmutable:
     default: failed_override
-    type: string
   runnerdefaultint:
     default: 0
-    description: Falsey integer param, overrides runner default. Covers timeout 0 issue
-    type: integer
   defaults_ovverriden_by_execution:
     default: 1
     description: Overrides runner default. Will be overriden by live action

--- a/st2tests/st2tests/fixtures/generic/actions/async_action1.yaml
+++ b/st2tests/st2tests/fixtures/generic/actions/async_action1.yaml
@@ -17,8 +17,6 @@ parameters:
     type: string
   runnerdummy:
     default: actiondummy
-    type: string
   runnerimmutable:
     default: failed_override
-    type: string
 runner_type: test-async-runner-1

--- a/st2tests/st2tests/fixtures/generic/actions/local.yaml
+++ b/st2tests/st2tests/fixtures/generic/actions/local.yaml
@@ -6,9 +6,7 @@ name: local
 pack: core
 parameters:
   cmd:
-    description: Arbitrary Linux command to be executed on the remote host(s).
     required: true
-    type: string
   sudo:
     immutable: true
     type: boolean

--- a/st2tests/st2tests/fixtures/generic/actions/workbook_v2_many_workflows.yaml
+++ b/st2tests/st2tests/fixtures/generic/actions/workbook_v2_many_workflows.yaml
@@ -14,5 +14,4 @@ parameters:
   workflow:
     default: generic.workbook_v2_many_workflows.main
     immutable: true
-    type: string
 runner_type: mistral-v2


### PR DESCRIPTION
Validate that only a selected set of attributes can be overriden for any runner parameters. It does't make sense to let an action parameter override the type in the runner parameter. Also, this will fix a bug where a partial dict in the action parameter will completely override the runner parameter. In the case where type is not defined in the action parameter, the runner parameter will no longer have a type after the override.