### PR TITLE
Document how to send auth token / API key in the query param

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,7 +39,7 @@ in development
   (improvement)
 * Fix validation error when None is passed explicitly to an optional argument on action
   execution. (bug fix)
-* Deprecated ``params`` action attribute in the action chain definition in favor of the new 
+* Deprecated ``params`` action attribute in the action chain definition in favor of the new
   ``parameters`` attribute. (improvement)
 
 1.2.0 - December 07, 2015

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -228,5 +228,37 @@ The following are sample API calls via curl using API Keys. ::
 
     curl https://myhost.example.com/api/v1/actions?st2-api-key=<API-KEY-VALUE>
 
+Sending authentication token or API key to the API
+--------------------------------------------------
+
+When authenticating against the |st2| API, authentication token or API key
+(but not both), should be provided in the HTTP request headers. The headers are
+named ``X-Auth-Token`` and ``St2-Api-Key`` respectively.
+
+If for some reason you can't specify auth token or API key in the headers (e.g.
+you are using a third party service to integrate with |st2| and this service
+doesn't allow you to specify custom headers), you can provide it as a query
+parameter named ``x-auth-token`` and ``st2-api-key`` respectively.
+
+Keep in mind that using HTTP header is preferred since some of the web servers
+and third party services log query parameters which are sent with each request
+which could be a security risk.
+
+Below you can find some examples on how to send authentication token and API
+key in the headers and as a query parameter using cURL.
+
+Providing it in the request headers:
+
+.. sourcecode:: bash
+
+    curl -H "X-Auth-Token: <auth token value>" https://myhost.example.com/api/v1/actions
+    curl -H "St2-Api-Key: <api key value>" https://myhost.example.com/api/v1/actions
+
+Providing it as a query parameter:
+
+.. sourcecode:: bash
+
+    curl "https://myhost.example.com/api/v1/actions?x-auth-token=<auth token value>"
+    curl "https://myhost.example.com/api/v1/actions?st2-api-key=<api key value>"
 
 .. _htpasswd: https://httpd.apache.org/docs/2.2/programs/htpasswd.html


### PR DESCRIPTION
This pull request documents previously undocumented feature which was only used by st2web.

We decide to document it, because there are more scenarios where you can't specify auth token / API key in the headers (e.g. third party services which don't allow you to send custom headers) and where this approach comes handy.

Resolves #2328.