### PR TITLE
Fix type for the headers param in the http-request runner

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,7 @@ in development
 * Deprecated ``params`` action attribute in the action chain definition in favor of the new
   ``parameters`` attribute. (improvement)
 * Fix action parameters validation so that only a selected set of attributes can be overriden for any runner parameters. (bug fix)
+* Fix type in the headers parameter for the http-request runner. (bug fix)
 
 1.2.0 - December 07, 2015
 -------------------------

--- a/docs/source/_includes/runner_parameters/http_request.rst
+++ b/docs/source/_includes/runner_parameters/http_request.rst
@@ -4,6 +4,6 @@
 * ``https_proxy`` (string) - A URL of a HTTPs proxy to use (e.g. http://10.10.1.10:3128).
 * ``url`` (string) - URL to the HTTP endpoint.
 * ``http_proxy`` (string) - A URL of a HTTP proxy to use (e.g. http://10.10.1.10:3128).
-* ``headers`` (string) - HTTP headers for the request.
+* ``headers`` (object) - HTTP headers for the request.
 * ``allow_redirects`` (boolean) - Set to True if POST/PUT/DELETE redirect following is allowed.
 * ``verify_ssl_cert`` (boolean) - Certificate for HTTPS request is verified by default using requests CA bundle which comes from Mozilla. Verification using a custom CA bundle is not yet supported. Set to False to skip verification.

--- a/st2common/st2common/bootstrap/runnersregistrar.py
+++ b/st2common/st2common/bootstrap/runnersregistrar.py
@@ -300,7 +300,7 @@ RUNNER_TYPES = [
             },
             'headers': {
                 'description': 'HTTP headers for the request.',
-                'type': 'string'
+                'type': 'object'
             },
             'cookies': {
                 'description': 'Optional cookies to send with the request.',


### PR DESCRIPTION
The type for the headers param should be object.