### PR TITLE
Fix parameter override in actions of linux pack

### DIFF
--- a/contrib/linux/actions/cp.yaml
+++ b/contrib/linux/actions/cp.yaml
@@ -24,7 +24,6 @@
         cmd:
             immutable: true
             default: 'cp {{args}} {{source}} {{destination}}'
-            position: 0
         args:
             description: 'Command line arguments passed to cp'
             default: '-v{% if recursive == true %} -r{% endif %}{% if force == true %} -f{% endif %}'

--- a/contrib/linux/actions/file_touch.yaml
+++ b/contrib/linux/actions/file_touch.yaml
@@ -8,7 +8,6 @@
     cmd:
       immutable: true
       default: "echo $(date +%s) > {{file}}"
-      position: 0
     file:
       type: "string"
       description: "Path of the file to be touched"

--- a/contrib/linux/actions/lsof.yaml
+++ b/contrib/linux/actions/lsof.yaml
@@ -8,7 +8,6 @@
     cmd:
       immutable: true
       default: "lsof {{args}}"
-      position: 0
     args:
       description: "Command line arguments"
       default: " "

--- a/contrib/linux/actions/lsof_pids.yaml
+++ b/contrib/linux/actions/lsof_pids.yaml
@@ -8,7 +8,6 @@
     cmd:
       immutable: true
       default: "for pid in {{pids}}; do lsof -p $pid; done"
-      position: 0
     pids:
       description: "List of pids"
       required: true

--- a/contrib/linux/actions/netstat.yaml
+++ b/contrib/linux/actions/netstat.yaml
@@ -8,7 +8,6 @@
     cmd:
       immutable: true
       default: "netstat {{args}}"
-      position: 0
     args:
       description: "Command line arguments"
       default: " "

--- a/contrib/linux/actions/netstat_grep.yaml
+++ b/contrib/linux/actions/netstat_grep.yaml
@@ -8,7 +8,6 @@
     cmd:
       immutable: true
       default: "for pid in {{pids}}; do netstat -pant | grep $pid; done; exit 0"
-      position: 0
     pids:
       description: "List of pids"
       required: true

--- a/contrib/linux/actions/pkill.yaml
+++ b/contrib/linux/actions/pkill.yaml
@@ -8,7 +8,6 @@
     cmd:
       immutable: true
       default: "pkill -e {{process}}"
-      position: 0
     process:
       type: "string"
       description: "Process name to kill"

--- a/contrib/linux/actions/rsync.yaml
+++ b/contrib/linux/actions/rsync.yaml
@@ -9,21 +9,17 @@
             type: 'string'
             description: 'List of files/directories to to be copied'
             required: true
-            position: 1
         dest_server:
             type: 'string'
             description: "Destination server for rsync'd files"
             required: true
-            position: 2
         destination:
             type: 'string'
             description: 'Destination of files/directories on target server'
             required: true
-            position: 3
         cmd:
             immutable: true
             default: 'rsync {{args}} {{source}} {{dest_server}}:{{destination}}'
-            position: 0
         connect_timeout:
             type: 'integer'
             description: 'SSH connect timeout in seconds'

--- a/contrib/linux/actions/scp.yaml
+++ b/contrib/linux/actions/scp.yaml
@@ -36,7 +36,6 @@
         cmd:
             immutable: true
             default: 'scp {{args}} -i {{keyfile}} {{source}} {{dest_server}}:{{destination}}'
-            position: 0
         args:
             description: 'Command line arguments passed to cp'
             default: '-o stricthostkeychecking=no -v{% if recursive == true %} -r{% endif %}{% if force == true %} -f{% endif %}'

--- a/contrib/linux/actions/vmstat.yaml
+++ b/contrib/linux/actions/vmstat.yaml
@@ -8,7 +8,6 @@
     cmd:
       immutable: true
       default: "vmstat {{args}}"
-      position: 0
     args:
       description: "Command line arguments"
       default: " "


### PR DESCRIPTION
The position attribute cannot be overridden for the cmd parameter in the run-remote runner.