### PR TITLE
RFR: Add --always-copy option to create_virtualenv method for pack virtual…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,7 +44,9 @@ in development
 * Fix action parameters validation so that only a selected set of attributes can be overriden for
   any runner parameters. (bug fix)
 * Fix type in the headers parameter for the http-request runner. (bug fix)
-* Fix runaway action triggers caused by state miscalculation for mistral workflow. (bug fix) 
+* Fix runaway action triggers caused by state miscalculation for mistral workflow. (bug fix)
+* Use ``--always-copy`` option when creating virtualenv for packs from packs.setup_virtualenv action. This is required when st2actionrunner is kicked off
+from python within a virtualenv.
 
 1.2.0 - December 07, 2015
 -------------------------

--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,7 @@ requirements: virtualenv .sdist-requirements
 
 	# Make sure we use latest version of pip
 	$(VIRTUALENV_DIR)/bin/pip install --upgrade pip
+	$(VIRTUALENV_DIR)/bin/pip install virtualenv  # Required for packs.install in dev envs.
 
 	# Generate all requirements to support current CI pipeline.
 	$(VIRTUALENV_DIR)/bin/python scripts/fixate-requirements.py --skip=virtualenv -s st2*/in-requirements.txt -f fixed-requirements.txt -o requirements.txt

--- a/conf/st2.conf.sample
+++ b/conf/st2.conf.sample
@@ -13,7 +13,7 @@ logging = conf/logging.conf
 
 [api]
 # List of origins allowed
-allow_origin = ['http://localhost:3000']
+allow_origin = http://localhost:3000  # comma separated list allowed here.
 # location of the logging.conf file
 logging = conf/logging.conf
 # True to mask secrets in API responses
@@ -114,7 +114,7 @@ collection_interval = 600
 # Controls if stderr should be redirected to the logs.
 redirect_stderr = False
 # Exclusion list of loggers to omit.
-excludes = 
+excludes =
 # True to mask secrets in the log files.
 mask_secrets = True
 
@@ -122,7 +122,7 @@ mask_secrets = True
 # URL of the messaging server.
 url = amqp://guest:guest@127.0.0.1:5672//
 # URL of all the nodes in a messaging service cluster.
-cluster_urls = []
+cluster_urls = # comma separated list or URLs allowed here.
 
 [mistral]
 # URL Mistral uses to talk back to the API.If not provided it defaults to public API URL. Note: This needs to be a base URL without API version (e.g. http://127.0.0.1:9101)

--- a/conf/st2.package.conf
+++ b/conf/st2.package.conf
@@ -17,6 +17,7 @@ logging = /etc/st2/logging.rulesengine.conf
 
 [actionrunner]
 logging = /etc/st2/logging.actionrunner.conf
+virtualenv_opts = --always-copy
 
 [resultstracker]
 logging = /etc/st2/logging.resultstracker.conf

--- a/contrib/packs/actions/pack_mgmt/setup_virtualenv.py
+++ b/contrib/packs/actions/pack_mgmt/setup_virtualenv.py
@@ -125,6 +125,8 @@ class SetupVirtualEnvironmentAction(Action):
 
     def _create_virtualenv(self, virtualenv_path):
         python_binary = cfg.CONF.actionrunner.python_binary
+        virtualenv_binary = cfg.CONF.actionrunner.virtualenv_binary
+        virtualenv_opts = cfg.CONF.actionrunner.virtualenv_opts
 
         if not os.path.isfile(python_binary):
             raise Exception('Python binary "%s" doesn\'t exist' % (python_binary))
@@ -132,8 +134,15 @@ class SetupVirtualEnvironmentAction(Action):
         self.logger.debug('Creating virtualenv in "%s" using Python binary "%s"' %
                           (virtualenv_path, python_binary))
 
-        cmd = ['virtualenv', '-p', python_binary, '--system-site-packages', virtualenv_path]
-        exit_code, _, stderr = run_command(cmd=cmd)
+        cmd = [virtualenv_binary, '-p', python_binary]
+        cmd.extend(virtualenv_opts)
+        cmd.extend([virtualenv_path])
+        self.logger.debug('Running command "%s" to create virtualenv.', ' '.join(cmd))
+
+        try:
+            exit_code, _, stderr = run_command(cmd=cmd)
+        except OSError:
+            raise Exception('Virtualenv binary "%s" doesn\'t exist.' % virtualenv_binary)
 
         if exit_code != 0:
             raise Exception('Failed to create virtualenv in "%s": %s' %

--- a/contrib/packs/actions/pack_mgmt/setup_virtualenv.py
+++ b/contrib/packs/actions/pack_mgmt/setup_virtualenv.py
@@ -131,6 +131,9 @@ class SetupVirtualEnvironmentAction(Action):
         if not os.path.isfile(python_binary):
             raise Exception('Python binary "%s" doesn\'t exist' % (python_binary))
 
+        if not os.path.isfile(virtualenv_binary):
+            raise Exception('Virtualenv binary "%s" doesn\'t exist.' % (virtualenv_binary))
+
         self.logger.debug('Creating virtualenv in "%s" using Python binary "%s"' %
                           (virtualenv_path, python_binary))
 
@@ -141,8 +144,9 @@ class SetupVirtualEnvironmentAction(Action):
 
         try:
             exit_code, _, stderr = run_command(cmd=cmd)
-        except OSError:
-            raise Exception('Virtualenv binary "%s" doesn\'t exist.' % virtualenv_binary)
+        except OSError as e:
+            raise Exception('Error executing command %s. %s.' % (' '.join(cmd),
+                                                                 e.message))
 
         if exit_code != 0:
             raise Exception('Failed to create virtualenv in "%s": %s' %

--- a/st2actions/st2actions/config.py
+++ b/st2actions/st2actions/config.py
@@ -17,6 +17,7 @@
 Configuration options registration and useful routines.
 """
 
+import os
 import sys
 
 from oslo_config import cfg
@@ -41,11 +42,19 @@ def _register_common_opts():
 
 
 def _register_action_runner_opts():
+    default_python_bin_path = sys.executable
+    base_dir = os.path.dirname(os.path.realpath(default_python_bin_path))
+    default_virtualenv_bin_path = os.path.join(base_dir, 'virtualenv')
     logging_opts = [
         cfg.StrOpt('logging', default='conf/logging.conf',
                    help='location of the logging.conf file'),
-        cfg.StrOpt('python_binary', default=sys.executable,
-                   help='Python binary which will be used by Python actions.')
+        cfg.StrOpt('python_binary', default=default_python_bin_path,
+                   help='Python binary which will be used by Python actions.'),
+        cfg.StrOpt('virtualenv_binary', default=default_virtualenv_bin_path,
+                   help='Virtualenv binary which should be used to create pack virtualenvs.'),
+        cfg.ListOpt('virtualenv_opts', default=['--always-copy', '--system-site-packages'],
+                    help='List of virtualenv options to be passsed to "virtualenv" command that ' +
+                         'creates pack virtualenv.')
     ]
     CONF.register_opts(logging_opts, group='actionrunner')
 


### PR DESCRIPTION
…envs

See https://github.com/StackStorm/st2-packages/issues/53 for details. 

I anyways added config options for virtualenv_binary and virtualenv_opts in case we want to play around with these in the future so it's easier. The only legit change that fixed anything was `--always-copy`. 

This works on my dev env as well. Meanwhile, @Kami, @DoriftoShoes, @dennybaa and @armab please take a look at my comment on https://github.com/StackStorm/st2-packages/issues/53 and this change. 

TODO

* - [ ] Docs changes --> Not sure where to document this!
* - [X] Changelog