### PR TITLE
Change shebang in new st2ctl

### DIFF
--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 if [ $(id -u) -ne 0 ]; then
     echo "Please run with root privileges"


### PR DESCRIPTION
Explicit `#!/bin/bash` is preferred for tests in `st2-packages`
See:
https://circleci.com/gh/armab/st2-packages/404
https://github.com/StackStorm/st2-packages/pull/64