### PR TITLE
Throw a more friendly error message if casting a param value fails

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,7 +44,9 @@ in development
 * Fix action parameters validation so that only a selected set of attributes can be overriden for
   any runner parameters. (bug fix)
 * Fix type in the headers parameter for the http-request runner. (bug fix)
-* Fix runaway action triggers caused by state miscalculation for mistral workflow. (bug fix) 
+* Fix runaway action triggers caused by state miscalculation for mistral workflow. (bug fix)
+* Throw a more friendly error message if casting parameter value fails because the value contains
+  an invalid type or similar. (improvement)
 
 1.2.0 - December 07, 2015
 -------------------------

--- a/st2actions/tests/unit/test_actionchain.py
+++ b/st2actions/tests/unit/test_actionchain.py
@@ -665,7 +665,6 @@ class TestActionChainRunner(DbTestCase):
         else:
             self.fail('Exception was not thrown')
 
-
     @mock.patch.object(action_db_util, 'get_action_by_ref',
                        mock.MagicMock(return_value=ACTION_2))
     @mock.patch.object(action_service, 'request', return_value=(DummyActionExecution(), None))
@@ -677,7 +676,8 @@ class TestActionChainRunner(DbTestCase):
         chain_runner.pre_run()
 
         action_parameters = {}
-        expected_msg = 'Failed to cast value "stringnotanarray" for parameter "arrtype" of type "array"'
+        expected_msg = ('Failed to cast value "stringnotanarray" for parameter '
+                        '"arrtype" of type "array"')
         self.assertRaisesRegexp(ValueError, expected_msg, chain_runner.run,
                                 action_parameters=action_parameters)
 

--- a/st2common/st2common/models/utils/action_param_utils.py
+++ b/st2common/st2common/models/utils/action_param_utils.py
@@ -116,7 +116,14 @@ def cast_params(action_ref, params, cast_overrides=None):
                       parameter_type)
             continue
         LOG.debug('Casting param: %s of type %s to type: %s', v, type(v), parameter_type)
-        params[k] = cast(v)
+
+        try:
+            params[k] = cast(v)
+        except Exception:
+            msg = ('Failed to cast value "%s" for parameter "%s" of type "%s". Perhaphs the '
+                   'value is of an invalid type?' % (v, k, parameter_type))
+            raise ValueError(msg)
+
     return params
 
 

--- a/st2tests/st2tests/fixtures/generic/actionchains/chain_invalid_parameter_type_passed_to_action.yaml
+++ b/st2tests/st2tests/fixtures/generic/actionchains/chain_invalid_parameter_type_passed_to_action.yaml
@@ -1,0 +1,7 @@
+---
+chain:
+- name: c1
+  ref: wolfpack.a2
+  parameters:
+    arrtype: "stringnotanarray"
+default: c1


### PR DESCRIPTION
With this pull request we now throw a more friendly error message when casting a parameter value to the type defined in the schema fails.

Previously, if casting would fail (e.g. value doesn't contain the right type), a very cryptic error similar to the one below was returned.

```python
    return ast.literal_eval(x)
  File "/usr/lib/python2.7/ast.py", line 80, in literal_eval
    return _convert(node_or_string)
  File "/usr/lib/python2.7/ast.py", line 79, in _convert
    raise ValueError('malformed string')
ValueError: malformed string
```

Keep in mind that the actual error message could be different because it depends on the actual value (`ast.literval_eval` will throw a different error depending on the value).

Now error now includes the offending parameter name, value and type as shown below:

```python
Failed to cast value "stringnotanarray" for parameter "arrtype" of type "array"'
```

This issue was initially encountered by one of our users and reported on Slack. Because the error message was very cryptic and didn't carry enough context (parameter name, etc.) it meant we needed to waste quite a look of time to track down the actual root cause.