### PR TITLE
Fix a bug with the top-level error reporting in the new SSH runner

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,8 @@ in development
 * Fix runaway action triggers caused by state miscalculation for mistral workflow. (bug fix)
 * Throw a more friendly error message if casting parameter value fails because the value contains
   an invalid type or similar. (improvement)
+* Fix a bug in the remote script runner which would throw an exception if a remote script action
+  caused a top level failure (e.g. copying artifacts to a remote host failed). (bug-fix)
 
 1.2.0 - December 07, 2015
 -------------------------

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh_runner.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh_runner.py
@@ -205,5 +205,3 @@ class BaseParallelSSHRunner(ActionRunner, ShellRunnerMixin):
         else:
             status = LIVEACTION_STATUS_FAILED
         return status
-
-

--- a/st2actions/tests/unit/test_paramiko_remote_script_runner.py
+++ b/st2actions/tests/unit/test_paramiko_remote_script_runner.py
@@ -22,16 +22,30 @@ import unittest2
 import st2tests.config as tests_config
 tests_config.parse_args()
 
+from st2common.util import jsonify
 from st2actions.runners.remote_script_runner import ParamikoRemoteScriptRunner
 from st2actions.runners.ssh.parallel_ssh import ParallelSSHClient
 from st2common.exceptions.ssh import InvalidCredentialsException
 from st2common.exceptions.ssh import NoHostsConnectedToException
 from st2common.models.system.paramiko_script_action import ParamikoRemoteScriptAction
-import st2common.util.jsonify as jsonify
+from st2common.constants.action import LIVEACTION_STATUS_FAILED
+from st2tests.fixturesloader import FixturesLoader
+
+__all__ = [
+    'ParamikoScriptRunnerTestCase'
+]
+
+FIXTURES_PACK = 'generic'
+TEST_MODELS = {
+    'actions': ['a1.yaml']
+}
+
+MODELS = FixturesLoader().load_models(fixtures_pack=FIXTURES_PACK,
+                                      fixtures_dict=TEST_MODELS)
+ACTION_1 = MODELS['actions']['a1.yaml']
 
 
 class ParamikoScriptRunnerTestCase(unittest2.TestCase):
-
     @patch('st2actions.runners.ssh.parallel_ssh.ParallelSSHClient', Mock)
     @patch.object(jsonify, 'json_loads', MagicMock(return_value={}))
     @patch.object(ParallelSSHClient, 'run', MagicMock(return_value={}))
@@ -72,3 +86,28 @@ class ParamikoScriptRunnerTestCase(unittest2.TestCase):
         }
         paramiko_runner.context = {}
         self.assertRaises(NoHostsConnectedToException, paramiko_runner.pre_run)
+
+    @patch('st2actions.runners.ssh.parallel_ssh.ParallelSSHClient', Mock)
+    @patch.object(ParallelSSHClient, 'run', MagicMock(return_value={}))
+    @patch.object(ParallelSSHClient, 'connect', MagicMock(return_value={}))
+    def test_top_level_error_is_correctly_reported(self):
+        # Verify that a top-level error doesn't cause an exception to be thrown.
+        # In a top-level error case, result dict doesn't contain entry per host
+        paramiko_runner = ParamikoRemoteScriptRunner('runner_1')
+
+        paramiko_runner.runner_parameters = {
+            'username': 'test_user',
+            'hosts': 'localhost'
+        }
+        paramiko_runner.action = ACTION_1
+        paramiko_runner.liveaction_id = 'foo'
+        paramiko_runner.entry_point = 'foo'
+        paramiko_runner.context = {}
+        paramiko_runner._cwd = '/tmp'
+        paramiko_runner._copy_artifacts = Mock(side_effect=Exception('fail!'))
+        status, result, _ = paramiko_runner.run(action_parameters={})
+
+        self.assertEqual(status, LIVEACTION_STATUS_FAILED)
+        self.assertEqual(result['failed'], True)
+        self.assertEqual(result['succeeded'], False)
+        self.assertTrue('Failed copying content to remote boxes' in result['error'])


### PR DESCRIPTION
Before this fix, remote script runner based on the new paramiko SSH runner would throw an exception instead of correctly reporting an error if a top-level error occurred (e.g. copying artifacts to remote hosts failed or similar).

I noticed this issue on the build server yesterday and it's quite easy to replicate it.

```bash
  error: '''bool'' object has no attribute ''get'''
  traceback: "  File "/data/stanley/st2actions/st2actions/container/base.py", line 116, in _do_run
    (status, result, context) = runner.run(action_params)
  File "/data/stanley/st2actions/st2actions/runners/remote_script_runner.py", line 97, in run
    status = self._get_result_status(result, cfg.CONF.ssh_runner.allow_partial_failure)
  File "/data/stanley/st2actions/st2actions/runners/ssh/paramiko_ssh_runner.py", line 169, in _get_result_status
    r_succeess = r.get('succeeded', False) if r else False
"
```

Note: top-level error is an error which is global and doesn't belong to a host so the result dictionary doesn't contain an entry per host.

TODO:

- [x] Tests