### PR TITLE
Build el6: RHEL6/CentOS6 packages

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,7 @@ general:
 
 machine:
   environment:
-    DISTROS: "wheezy jessie trusty el7"
+    DISTROS: "wheezy jessie trusty el6 el7"
     NOTESTS: "el7"
     ST2_PACKAGES_REPO: https://github.com/StackStorm/st2-packages
     ST2_DOCKERFILES_REPO: https://github.com/StackStorm/st2-dockerfiles


### PR DESCRIPTION
Since https://github.com/StackStorm/st2-packages/pull/65 is complete, we can start building `el6` packages and deploying them to https://bintray.com/stackstorm/el6_staging.

Don't merge it yet. Needs +1 CircleCI container, see:
https://stackstorm.slack.com/archives/stackstorm/p1452692070023864