### PR TITLE
Fix execution cancellation for task of mistral workflow

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,6 +53,7 @@ in development
   caused a top level failure (e.g. copying artifacts to a remote host failed). (bug-fix)
 * Display execution parameters when using ``st2 execution get <execution id>`` CLI command for
   workflow executions. (improvement)
+* Fix execution cancellation for task of mistral workflow. (bug fix)
 
 1.2.0 - December 07, 2015
 -------------------------

--- a/st2actions/st2actions/container/base.py
+++ b/st2actions/st2actions/container/base.py
@@ -186,6 +186,10 @@ class RunnerContainer(object):
                 liveaction_db=liveaction_db)
 
             executions.update_execution(liveaction_db)
+
+            LOG.debug('Performing post_run for runner: %s', runner.runner_id)
+            runner.post_run(liveaction_db.status, {'error': 'Execution canceled by user.'})
+            runner.container_service = None
         except:
             _, ex, tb = sys.exc_info()
             # include the error message and traceback to try and provide some hints.


### PR DESCRIPTION
Cancellation of task execution was not communicated to mistral workflow which leaves the workflow execution in RUNNING state.