### PR TITLE
Display action parameters in "st2 execution get" output for workflow actions

### DIFF
--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -314,7 +314,7 @@ class ActionRunCommandMixin(object):
         action_exec_mgr = self.app.client.managers['LiveAction']
 
         instance = execution
-        options = {'attributes': ['id', 'action.ref', 'status', 'start_timestamp',
+        options = {'attributes': ['id', 'action.ref', 'parameters', 'status', 'start_timestamp',
                                   'end_timestamp']}
         options['json'] = args.json
         options['attribute_transform_functions'] = self.attribute_transform_functions


### PR DESCRIPTION
With this change we now also display action parameters by default when using "st2 execution get" on workflow actions.

This will save everyone from issuing another command or using "-d" option. It's also worth mentioning that "-d" is not exactly the same since it includes a lot of other noise and doesn't really satisfy "at a glance" requirement.

Before:

![selection_322](https://cloud.githubusercontent.com/assets/125088/12322946/dee5e934-bab7-11e5-934e-8c06c5eb3000.png)

After:

![selection_323](https://cloud.githubusercontent.com/assets/125088/12322958/f2064194-bab7-11e5-9638-51d88f8b6674.png)


I get irritated by this every time I'm debugging st2workroom test issues. I always need to execute another command to figure out if the execution refers to Ubuntu / RHEL. With this change, it will save me (and other people) that hassle.