### PR TITLE
Detect service manager for new st2ctl

### DIFF
--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -68,12 +68,12 @@ function st2stop() {
 }
 
 function service_manager() {
-  if command -v systemctl 2>/dev/null; then
+  if [ -d /run/systemd/system ]; then
     systemctl "${2}" "${1}"
   elif command -v service 2>/dev/null; then
     service "${1}" "${2}"
   else
-    echo -e "\e[31mError: Unknown service manager in the system! \e[0m\n"
+    echo -e "\e[31mError: Unsupported service manager in the system! \e[0m\n"
     exit 1
   fi
 }

--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -57,14 +57,25 @@ function validate_in_components() {
 
 function st2start() {
   for COM in ${COMPONENTS}; do
-    service ${COM} start
+    service_manager ${COM} start
   done
 }
 
 function st2stop() {
   for COM in ${COMPONENTS}; do
-    service ${COM} stop
+    service_manager ${COM} stop
   done
+}
+
+function service_manager() {
+  if command -v systemctl 2>/dev/null; then
+    systemctl "${2}" "${1}"
+  elif command -v service 2>/dev/null; then
+    service "${1}" "${2}"
+  else
+    echo -e "\e[31mError: Unknown service manager in the system! \e[0m\n"
+    exit 1
+  fi
 }
 
 # Next candidate for removal


### PR DESCRIPTION
Provides fix for https://github.com/StackStorm/st2/pull/2367/files#r49736848
![](https://camo.githubusercontent.com/2eb6927a2be193f1a09496f4f817716e9fc800c5/68747470733a2f2f692e6779617a6f2e636f6d2f38396564396530363133336463373637356133383132646166363164643264642e706e67)
when `service` command is not available under `CentOS7` (replaced by `systemctl`).

Tested/Verified.