### PR TITLE
Fix integration test for mistral rerun

### DIFF
--- a/contrib/examples/actions/mistral-test-rerun.yaml
+++ b/contrib/examples/actions/mistral-test-rerun.yaml
@@ -5,3 +5,7 @@ pack: examples
 runner_type: mistral-v2
 entry_point: workflows/mistral-test-rerun.yaml
 enabled: true
+parameters:
+    tempfile:
+        type: string
+        required: true

--- a/contrib/examples/actions/workflows/mistral-test-rerun.yaml
+++ b/contrib/examples/actions/workflows/mistral-test-rerun.yaml
@@ -3,8 +3,10 @@ version: '2.0'
 examples.mistral-test-rerun:
     description: A sample workflow used to test the rerun feature.
     type: direct
+    input:
+        - tempfile
     tasks:
         task1:
             action: core.local
             input:
-                cmd: "exit `st2 key get mistral-test-rerun-switch | grep value | awk '{print $4}'`"
+                cmd: "exit `cat <% $.tempfile %>`"


### PR DESCRIPTION
Use temp file instead of st2 datastore to hold the value for the switch.