### PR TITLE
RFR: When notify is not specified, mongoengine requires an empty doc

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -58,6 +58,8 @@ in development
 * The ``--tasks`` option in the CLI for ``st2 execution get`` and ``st2 run`` will be renamed to
   ``--show-tasks`` to avoid conflict with the tasks option in st2 execution re-run.
 * Add option to rerun one or more tasks in mistral workflow that has errored. (new-feature)
+* Fix a bug when removing notify section from an action meta and registering it never removed
+  the notify section from the db. (bug fix)
 
 1.2.0 - December 07, 2015
 -------------------------

--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -155,8 +155,10 @@ class ActionsController(resource.ContentPackResourceController):
 
         try:
             action_db = ActionAPI.to_model(action)
+            LOG.debug('/actions/ PUT incoming action: %s', action_db)
             action_db.id = action_id
             action_db = Action.add_or_update(action_db)
+            LOG.debug('/actions/ PUT after add_or_update: %s', action_db)
         except (ValidationError, ValueError) as e:
             LOG.exception('Unable to update action data=%s', action)
             abort(http_client.BAD_REQUEST, str(e))

--- a/st2api/tests/unit/controllers/v1/test_actions.py
+++ b/st2api/tests/unit/controllers/v1/test_actions.py
@@ -521,7 +521,7 @@ class TestActionController(FunctionalTest, CleanFilesTestCase):
         # Now post the same action with no notify
         ACTION_WITHOUT_NOTIFY = copy.copy(ACTION_WITH_NOTIFY)
         del ACTION_WITHOUT_NOTIFY['notify']
-        put_resp = self.__do_put(action_id, ACTION_WITHOUT_NOTIFY)
+        self.__do_put(action_id, ACTION_WITHOUT_NOTIFY)
         # Validate that notify section has vanished
         get_resp = self.__do_get_one(action_id)
         self.assertEqual(get_resp.json['notify'], {})

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -236,6 +236,9 @@ class ActionAPI(BaseAPI, APIUIDMixin):
         if getattr(action, 'notify', None):
             notify = NotificationsHelper.to_model(action.notify)
         else:
+            # We use embedded document model for ``notify`` in action model. If notify is
+            # unspecified, we set notify to None. Mongoengine interprets None as unmodified
+            # field therefore doesn't delete the embedded document.
             notify = NotificationsHelper.to_model({})
 
         model = cls.model(name=name, description=description, enable=enabled, enabled=enabled,

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -236,7 +236,7 @@ class ActionAPI(BaseAPI, APIUIDMixin):
         if getattr(action, 'notify', None):
             notify = NotificationsHelper.to_model(action.notify)
         else:
-            notify = None
+            notify = NotificationsHelper.to_model({})
 
         model = cls.model(name=name, description=description, enable=enabled, enabled=enabled,
                           entry_point=entry_point, pack=pack, runner_type=runner_type,

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -237,8 +237,9 @@ class ActionAPI(BaseAPI, APIUIDMixin):
             notify = NotificationsHelper.to_model(action.notify)
         else:
             # We use embedded document model for ``notify`` in action model. If notify is
-            # unspecified, we set notify to None. Mongoengine interprets None as unmodified
-            # field therefore doesn't delete the embedded document.
+            # set notify to None, Mongoengine interprets ``None`` as unmodified
+            # field therefore doesn't delete the embedded document. Therefore, we need
+            # to use an empty document.
             notify = NotificationsHelper.to_model({})
 
         model = cls.model(name=name, description=description, enable=enabled, enabled=enabled,

--- a/st2common/st2common/models/api/notification.py
+++ b/st2common/st2common/models/api/notification.py
@@ -85,6 +85,10 @@ class NotificationsHelper(object):
         if getattr(notify_model, 'on_failure', None):
             notify['on-failure'] = NotificationsHelper._from_model_sub_schema(
                 notify_model.on_failure)
+
+        if not notify:
+            return None
+
         return notify
 
     @staticmethod

--- a/st2common/st2common/models/api/notification.py
+++ b/st2common/st2common/models/api/notification.py
@@ -86,9 +86,6 @@ class NotificationsHelper(object):
             notify['on-failure'] = NotificationsHelper._from_model_sub_schema(
                 notify_model.on_failure)
 
-        if not notify:
-            return None
-
         return notify
 
     @staticmethod

--- a/st2common/tests/unit/test_db.py
+++ b/st2common/tests/unit/test_db.py
@@ -303,6 +303,12 @@ class ActionModelTest(DbTestCase):
         retrieved = Action.get_by_id(saved.id)
         self.assertEqual(retrieved.notify.on_complete.message, on_complete.message)
 
+        # Now reset notify in action to empty and validate it's gone.
+        retrieved.notify = NotificationSchema(on_complete=None)
+        saved = Action.add_or_update(retrieved)
+        retrieved = Action.get_by_id(saved.id)
+        self.assertEqual(retrieved.notify.on_complete, None)
+
         # cleanup
         self._delete([retrieved])
         try:

--- a/st2common/tests/unit/test_notification_helper.py
+++ b/st2common/tests/unit/test_notification_helper.py
@@ -22,6 +22,14 @@ class NotificationsHelperTestCase(unittest2.TestCase):
 
     def test_model_transformations(self):
         notify = {}
+
+        notify_model = NotificationsHelper.to_model(notify)
+        self.assertEqual(notify_model.on_success, None)
+        self.assertEqual(notify_model.on_failure, None)
+        self.assertEqual(notify_model.on_complete, None)
+        notify_api = NotificationsHelper.from_model(notify_model)
+        self.assertEqual(notify_api, {})
+
         notify['on-complete'] = {
             'message': 'Action completed.',
             'data': {


### PR DESCRIPTION
Original bug: https://github.com/StackStorm/st2/issues/2378 (Thanks @ charlottestjohn).

Summary:

1. Register action with notify
2. Remove notify section from meta. Register notify again.
3. Check action. You'll still see notify section 

Repro: 
See https://gist.github.com/lakshmi-kannan/3891705755dbafa8b82c for repro. 

What happened?

We use embedded document model for notify in action model. If notify is unspecified, we set notify to None. Mongoengine interprets `None` as unmodified field therefore doesn't delete the embedded document. 

Solution: We now explicitly set the embedded document to {} instead of None. 

TODO:

- [X] Tests
- [x] Changelog


