### PR TITLE
ChatOps argument parsing fix

### DIFF
--- a/st2common/st2common/models/utils/action_alias_utils.py
+++ b/st2common/st2common/models/utils/action_alias_utils.py
@@ -60,7 +60,7 @@ class ActionAliasFormatParser(object):
         # matched against this expression yields a dict of params with values.
         param_match = r'["\']?(?P<\2>(?:(?<=\').+?(?=\')|(?<=").+?(?=")|{.+?}|.+?))["\']?'
         reg = re.sub(r'(\s*){{\s*([^=]+?)\s*}}(?=\s+{{[^}]+?=)',
-                     r'\s*' + param_match + r'\s+',
+                     r'\1' + param_match + r'\s*',
                      self._format)
         reg = re.sub(r'(\s*){{\s*(\S+)\s*=\s*(?:{.+?}|.+?)\s*}}(\s*)',
                      r'(?:\s*' + param_match + r'\s+)?\s*',

--- a/st2common/st2common/models/utils/action_alias_utils.py
+++ b/st2common/st2common/models/utils/action_alias_utils.py
@@ -59,14 +59,14 @@ class ActionAliasFormatParser(object):
         # substituting {{ ... }} with regex named groups, so that param_stream
         # matched against this expression yields a dict of params with values.
         param_match = r'["\']?(?P<\2>(?:(?<=\').+?(?=\')|(?<=").+?(?=")|{.+?}|.+?))["\']?'
-        reg = re.sub(r'(\s*){{\s*([^=]+?)\s*}}(?=\s+{{[^}]+?=)',
-                     r'\1' + param_match + r'\s*',
+        reg = re.sub(r'(\s*){{\s*([^=}]+?)\s*}}(?![\'"]?\s+}})',
+                     r'\1' + param_match,
                      self._format)
-        reg = re.sub(r'(\s*){{\s*(\S+)\s*=\s*(?:{.+?}|.+?)\s*}}(\s*)',
-                     r'(?:\s*' + param_match + r'\s+)?\s*',
+        reg = re.sub(r'(\s*){{\s*(\S+)\s*=\s*(?:{.+?}|.+?)\s*}}',
+                     r'(?:\1' + param_match + r')?',
                      reg)
-        reg = re.sub(r'(\s*){{\s*(.+?)\s*}}(\s*)',
-                     r'\s*' + param_match + r'\3',
+        reg = re.sub(r'(\s*){{\s*(.+?)\s*}}',
+                     r'\1' + param_match,
                      reg)
         reg = '^\s*' + reg + r'\s*$'
 

--- a/st2common/tests/unit/test_action_alias_utils.py
+++ b/st2common/tests/unit/test_action_alias_utils.py
@@ -94,6 +94,21 @@ class TestActionAliasParser(TestCase):
         extracted_values = parser.get_extracted_param_value()
         self.assertEqual(extracted_values, {'a': 'a1 a2', 'b': 'b1'})
 
+    def test_default_values(self):
+        alias_format = 'acl {{a}} {{b}} {{c}} {{d=1}}'
+        param_stream = 'acl "a1 a2" "b1" "c1"'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'a': 'a1 a2', 'b': 'b1',
+                                            'c': 'c1', 'd': '1'})
+
+    def test_spacing(self):
+        alias_format = 'acl {{a}}'
+        param_stream = 'acl123'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'a': ''})
+
     def test_json_parsing(self):
         alias_format = 'skip {{a}} more skip.'
         param_stream = 'skip {"a": "b", "c": "d"} more skip.'


### PR DESCRIPTION
Fixes #2399
Fixes another unfiled bug with parser not recognizing spaces at the
beginning of the string (where `acl {{ a }}` would match both `acl 123`
and `acl123`).

Needs a bit of testing with Hubot.