### PR TITLE
Fix pip version temporary for make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ requirements: virtualenv .sdist-requirements
 	@echo
 
 	# Make sure we use latest version of pip
-	$(VIRTUALENV_DIR)/bin/pip install --upgrade pip
+	$(VIRTUALENV_DIR)/bin/pip install --upgrade 'pip<8.0.0'
 	$(VIRTUALENV_DIR)/bin/pip install virtualenv  # Required for packs.install in dev envs.
 
 	# Generate all requirements to support current CI pipeline.


### PR DESCRIPTION
The latest pip version 8.0.0 is causing problem on making requirements.