### PR TITLE
Get rid of mutually exclusive args in re-run

### DIFF
--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -1050,14 +1050,11 @@ class ActionExecutionReRunCommand(ActionRunCommandMixin, resource.ResourceComman
         self.parser.add_argument('id', nargs='?',
                                  metavar='id',
                                  help='ID of action execution to re-run ')
-
-        group = self.parser.add_mutually_exclusive_group()
-        group.add_argument('--parameters', nargs='*',
-                           help='List of keyword args, positional args, '
-                                'and optional args for the action.')
-        group.add_argument('--tasks', nargs='*',
-                           help='Name of the workflow tasks to re-run.')
-
+        self.parser.add_argument('parameters', nargs='*',
+                                 help='List of keyword args, positional args, '
+                                      'and optional args for the action.')
+        self.parser.add_argument('--tasks', nargs='*',
+                                 help='Name of the workflow tasks to re-run.')
         self.parser.add_argument('-a', '--async',
                                  action='store_true', dest='async',
                                  help='Do not wait for action to finish.')

--- a/st2client/tests/unit/test_shell.py
+++ b/st2client/tests/unit/test_shell.py
@@ -155,16 +155,13 @@ class TestShell(base.BaseCLITestCase):
             ['execution', 'get', '123', '-k', 'localhost.stdout'],
             ['execution', 're-run', '123'],
             ['execution', 're-run', '123', '--task', 'x', 'y', 'z'],
-            ['execution', 're-run', '123', '--parameters', 'a=1', 'b=x', 'c=True']
+            ['execution', 're-run', '123', 'a=1', 'b=x', 'c=True']
         ]
         self._validate_parser(args_list)
 
         # Test mutually exclusive argument groups
         self.assertRaises(SystemExit, self._validate_parser,
                           [['execution', 'get', '123', '-d', '-k', 'localhost.stdout']])
-
-        self.assertRaises(SystemExit, self._validate_parser,
-                          [['execution', 're-run', '123', '--task', 'x', '--parameters', 'y=1']])
 
     def test_key(self):
         args_list = [


### PR DESCRIPTION
Get rid of mutually exclusive args since positional parameters cannot exist in mutually exclusives.

Doing so also means that a user can provide `--task` and `--parameters` together. The API guards against this condition by throwing back an error so that nothing bad actually happens.

Perhaps a better approach would be to have a standalone `st2 execution re-run-workflow --tasks <task-name>` however that is a much bigger change and could be handled later.

In case parameters and tasks are mixed -
```
$ st2 execution re-run 569f2c7932ed352e386fc284 cmd=hostname --tasks y
ERROR: 500 Server Error: Internal Server Error
MESSAGE: Parameters override is not supported when re-running task(s) for a workflow. for url: http://127.0.0.1:9101/v1/executions/569f2c7932ed352e386fc284/re_run
```