### PR TITLE
Implement re-run of task in subworkflow for mistral

### DIFF
--- a/contrib/examples/actions/mistral-test-rerun-subflow.yaml
+++ b/contrib/examples/actions/mistral-test-rerun-subflow.yaml
@@ -1,0 +1,15 @@
+---
+name: mistral-test-rerun-subflow
+description: A sample workflow used to test the rerun feature.
+pack: examples
+runner_type: mistral-v2
+entry_point: workflows/mistral-test-rerun-subflow.yaml
+enabled: true
+parameters:
+    tempfile:
+        type: string
+        required: true
+    workflow:
+        default: examples.mistral-test-rerun-subflow.main
+        immutable: true
+        type: string

--- a/contrib/examples/actions/workflows/mistral-test-rerun-subflow.yaml
+++ b/contrib/examples/actions/workflows/mistral-test-rerun-subflow.yaml
@@ -1,0 +1,25 @@
+version: '2.0'
+name: examples.mistral-test-rerun-subflow
+description: A sample workflow used to test the rerun feature.
+
+workflows:
+
+    main:
+        type: direct
+        input:
+            - tempfile
+        tasks:
+            task1:
+                workflow: subflow
+                input:
+                    tempfile: <% $.tempfile %>
+
+    subflow:
+        type: direct
+        input:
+            - tempfile
+        tasks:
+            task1:
+                action: core.local
+                input:
+                    cmd: "exit `cat <% $.tempfile %>`"

--- a/st2actions/tests/unit/test_mistral_v2_rerun.py
+++ b/st2actions/tests/unit/test_mistral_v2_rerun.py
@@ -22,6 +22,7 @@ import yaml
 
 from mistralclient.api.v2 import executions
 from mistralclient.api.v2 import tasks
+from mistralclient.api.v2 import workbooks
 from mistralclient.api.v2 import workflows
 from oslo_config import cfg
 
@@ -53,9 +54,11 @@ from tests.unit.base import MockLiveActionPublisher
 TEST_FIXTURES = {
     'workflows': [
         'workflow_v2.yaml',
+        'workbook_v2_many_workflows.yaml'
     ],
     'actions': [
         'workflow_v2.yaml',
+        'workbook_v2_many_workflows.yaml',
         'local.yaml'
     ]
 }
@@ -64,6 +67,28 @@ PACK = 'generic'
 LOADER = FixturesLoader()
 FIXTURES = LOADER.load_fixtures(fixtures_pack=PACK, fixtures_dict=TEST_FIXTURES)
 
+# Workbook with multiple workflows
+WB1_YAML_FILE_NAME = TEST_FIXTURES['workflows'][1]
+WB1_YAML_FILE_PATH = LOADER.get_fixture_file_path_abs(PACK, 'workflows', WB1_YAML_FILE_NAME)
+WB1_SPEC = FIXTURES['workflows'][WB1_YAML_FILE_NAME]
+WB1_YAML = yaml.safe_dump(WB1_SPEC, default_flow_style=False)
+WB1_NAME = '%s.%s' % (PACK, WB1_YAML_FILE_NAME.replace('.yaml', ''))
+WB1 = workbooks.Workbook(None, {'name': WB1_NAME, 'definition': WB1_YAML})
+WB1_MAIN_EXEC = {'id': str(uuid.uuid4()), 'state': 'RUNNING'}
+WB1_MAIN_EXEC['workflow_name'] = WB1_NAME + '.main'
+WB1_MAIN_EXEC_ERRORED = copy.deepcopy(WB1_MAIN_EXEC)
+WB1_MAIN_EXEC_ERRORED['state'] = 'ERROR'
+WB1_MAIN_TASK1 = {'id': str(uuid.uuid4()), 'name': 'greet', 'state': 'ERROR'}
+WB1_MAIN_TASKS = [tasks.Task(None, WB1_MAIN_TASK1)]
+WB1_MAIN_TASK_ID = WB1_MAIN_TASK1['id']
+WB1_SUB1_EXEC = {'id': str(uuid.uuid4()), 'state': 'RUNNING', 'task_execution_id': WB1_MAIN_TASK_ID}
+WB1_SUB1_EXEC['workflow_name'] = WB1_NAME + '.subflow1'
+WB1_SUB1_EXEC_ERRORED = copy.deepcopy(WB1_SUB1_EXEC)
+WB1_SUB1_EXEC_ERRORED['state'] = 'ERROR'
+WB1_SUB1_TASK1 = {'id': str(uuid.uuid4()), 'name': 'say-greeting', 'state': 'SUCCESS'}
+WB1_SUB1_TASK2 = {'id': str(uuid.uuid4()), 'name': 'say-friend', 'state': 'ERROR'}
+WB1_SUB1_TASKS = [tasks.Task(None, WB1_SUB1_TASK1), tasks.Task(None, WB1_SUB1_TASK2)]
+
 # Non-workbook with a single workflow
 WF1_YAML_FILE_NAME = TEST_FIXTURES['workflows'][0]
 WF1_YAML_FILE_PATH = LOADER.get_fixture_file_path_abs(PACK, 'workflows', WF1_YAML_FILE_NAME)
@@ -71,20 +96,12 @@ WF1_SPEC = FIXTURES['workflows'][WF1_YAML_FILE_NAME]
 WF1_YAML = yaml.safe_dump(WF1_SPEC, default_flow_style=False)
 WF1_NAME = '%s.%s' % (PACK, WF1_YAML_FILE_NAME.replace('.yaml', ''))
 WF1 = workflows.Workflow(None, {'name': WF1_NAME, 'definition': WF1_YAML})
-WF1_OLD = workflows.Workflow(None, {'name': WF1_NAME, 'definition': ''})
-WF1_EXEC = {'id': str(uuid.uuid4()), 'state': 'ERROR', 'workflow_name': 'mock'}
-WF1_EXEC['workflow_name'] = WF1_NAME
+WF1_EXEC = {'id': str(uuid.uuid4()), 'state': 'ERROR', 'workflow_name': WF1_NAME}
 WF1_EXEC_NOT_RERUNABLE = copy.deepcopy(WF1_EXEC)
 WF1_EXEC_NOT_RERUNABLE['state'] = 'PAUSED'
-
-# Mistral task objects
-TASK1 = {'id': str(uuid.uuid4()), 'name': 'say-greeting', 'state': 'SUCCESS'}
-TASK2 = {'id': str(uuid.uuid4()), 'name': 'say-friend', 'state': 'SUCCESS'}
-
-WF1_TASKS = [
-    tasks.Task(None, copy.deepcopy(TASK1)),
-    tasks.Task(None, copy.deepcopy(TASK2))
-]
+WF1_TASK1 = {'id': str(uuid.uuid4()), 'name': 'say-greeting', 'state': 'SUCCESS'}
+WF1_TASK2 = {'id': str(uuid.uuid4()), 'name': 'say-friend', 'state': 'SUCCESS'}
+WF1_TASKS = [tasks.Task(None, WF1_TASK1), tasks.Task(None, WF1_TASK2)]
 
 # Action executions requirements
 ACTION_PARAMS = {'friend': 'Rocky'}
@@ -203,6 +220,9 @@ class MistralRunnerTest(DbTestCase):
         workflows.WorkflowManager, 'create',
         mock.MagicMock(return_value=[WF1]))
     @mock.patch.object(
+        executions.ExecutionManager, 'list',
+        mock.MagicMock(return_value=[executions.Execution(None, WF1_EXEC)]))
+    @mock.patch.object(
         executions.ExecutionManager, 'create',
         mock.MagicMock(return_value=executions.Execution(None, WF1_EXEC)))
     @mock.patch.object(
@@ -240,6 +260,9 @@ class MistralRunnerTest(DbTestCase):
         workflows.WorkflowManager, 'create',
         mock.MagicMock(return_value=[WF1]))
     @mock.patch.object(
+        executions.ExecutionManager, 'list',
+        mock.MagicMock(return_value=[executions.Execution(None, WF1_EXEC)]))
+    @mock.patch.object(
         executions.ExecutionManager, 'create',
         mock.MagicMock(return_value=executions.Execution(None, WF1_EXEC)))
     @mock.patch.object(
@@ -262,6 +285,116 @@ class MistralRunnerTest(DbTestCase):
         }
 
         liveaction2 = LiveActionDB(action=WF1_NAME, parameters=ACTION_PARAMS, context=context)
+        liveaction2, execution2 = action_service.request(liveaction2)
+        liveaction2 = LiveAction.get_by_id(str(liveaction2.id))
+        self.assertEqual(liveaction2.status, action_constants.LIVEACTION_STATUS_FAILED)
+        self.assertIn('Unable to identify', liveaction2.result.get('error'))
+
+    @mock.patch.object(
+        workflows.WorkflowManager, 'list',
+        mock.MagicMock(return_value=[]))
+    @mock.patch.object(
+        workflows.WorkflowManager, 'get',
+        mock.MagicMock(return_value=WF1))
+    @mock.patch.object(
+        workbooks.WorkbookManager, 'create',
+        mock.MagicMock(return_value=WB1))
+    @mock.patch.object(
+        executions.ExecutionManager, 'create',
+        mock.MagicMock(return_value=executions.Execution(None, WB1_MAIN_EXEC)))
+    @mock.patch.object(
+        executions.ExecutionManager, 'get',
+        mock.MagicMock(return_value=executions.Execution(None, WB1_MAIN_EXEC_ERRORED)))
+    @mock.patch.object(
+        executions.ExecutionManager, 'list',
+        mock.MagicMock(
+            return_value=[
+                executions.Execution(None, WB1_MAIN_EXEC_ERRORED),
+                executions.Execution(None, WB1_SUB1_EXEC_ERRORED)]))
+    @mock.patch.object(
+        tasks.TaskManager, 'list',
+        mock.MagicMock(side_effect=[WB1_MAIN_TASKS, WB1_SUB1_TASKS]))
+    @mock.patch.object(
+        tasks.TaskManager, 'rerun',
+        mock.MagicMock(return_value=None))
+    def test_resume_subworkflow_task(self):
+        MistralRunner.entry_point = mock.PropertyMock(return_value=WB1_YAML_FILE_PATH)
+        liveaction1 = LiveActionDB(action=WB1_NAME, parameters=ACTION_PARAMS)
+        liveaction1, execution1 = action_service.request(liveaction1)
+
+        # Rerun the execution.
+        context = {
+            're-run': {
+                'ref': execution1.id,
+                'tasks': ['greet.say-friend']
+            }
+        }
+
+        liveaction2 = LiveActionDB(action=WB1_NAME, parameters=ACTION_PARAMS, context=context)
+        liveaction2, execution2 = action_service.request(liveaction2)
+        liveaction2 = LiveAction.get_by_id(str(liveaction2.id))
+
+        self.assertEqual(liveaction2.status, action_constants.LIVEACTION_STATUS_RUNNING)
+
+        expected_env = {
+            'st2_liveaction_id': str(liveaction2.id),
+            'st2_execution_id': str(execution2.id),
+            '__actions': {
+                'st2.action': {
+                    'st2_context': {
+                        'endpoint': 'http://0.0.0.0:9101/v1/actionexecutions',
+                        'notify': {},
+                        'parent': {
+                            're-run': context['re-run'],
+                            'execution_id': str(execution2.id)
+                        },
+                        'skip_notify_tasks': []
+                    }
+                }
+            },
+            'st2_action_api_url': 'http://0.0.0.0:9101/v1'
+        }
+
+        tasks.TaskManager.rerun.assert_called_with(WB1_SUB1_TASK2['id'], env=expected_env)
+
+    @mock.patch.object(
+        workflows.WorkflowManager, 'list',
+        mock.MagicMock(return_value=[]))
+    @mock.patch.object(
+        workflows.WorkflowManager, 'get',
+        mock.MagicMock(return_value=WF1))
+    @mock.patch.object(
+        workbooks.WorkbookManager, 'create',
+        mock.MagicMock(return_value=WB1))
+    @mock.patch.object(
+        executions.ExecutionManager, 'create',
+        mock.MagicMock(return_value=executions.Execution(None, WB1_MAIN_EXEC)))
+    @mock.patch.object(
+        executions.ExecutionManager, 'get',
+        mock.MagicMock(return_value=executions.Execution(None, WB1_MAIN_EXEC_ERRORED)))
+    @mock.patch.object(
+        executions.ExecutionManager, 'list',
+        mock.MagicMock(
+            return_value=[
+                executions.Execution(None, WB1_MAIN_EXEC_ERRORED),
+                executions.Execution(None, WB1_SUB1_EXEC_ERRORED)]))
+    @mock.patch.object(
+        tasks.TaskManager, 'list',
+        mock.MagicMock(side_effect=[WB1_MAIN_TASKS, WB1_SUB1_TASKS]))
+    def test_resume_unidentified_subworkflow_task(self):
+        MistralRunner.entry_point = mock.PropertyMock(return_value=WB1_YAML_FILE_PATH)
+        liveaction1 = LiveActionDB(action=WB1_NAME, parameters=ACTION_PARAMS)
+        liveaction1, execution1 = action_service.request(liveaction1)
+
+        # Rerun the execution.
+        context = {
+            're-run': {
+                'ref': execution1.id,
+                'tasks': ['greet.x']
+            }
+        }
+
+        liveaction2 = LiveActionDB(action=WB1_NAME, parameters=ACTION_PARAMS, context=context)
         liveaction2, execution2 = action_service.request(liveaction2)
         liveaction2 = LiveAction.get_by_id(str(liveaction2.id))
         self.assertEqual(liveaction2.status, action_constants.LIVEACTION_STATUS_FAILED)

--- a/st2tests/integration/mistral/test_wiring.py
+++ b/st2tests/integration/mistral/test_wiring.py
@@ -142,3 +142,26 @@ class WiringTest(base.TestWorkflowExecution):
         execution = self._wait_for_completion(execution)
         self._assert_success(execution, num_tasks=1)
         self.assertEqual(execution.context['mistral']['execution_id'], orig_wf_ex_id)
+
+    def test_rerun_subflow_task(self):
+        fd, path = tempfile.mkstemp()
+        os.chmod(path, 0666)
+
+        with open(path, 'w') as f:
+            f.write('1')
+
+        workflow_name = 'examples.mistral-test-rerun-subflow'
+        execution = self._execute_workflow(workflow_name, {'tempfile': path})
+        execution = self._wait_for_completion(execution)
+        self._assert_failure(execution)
+        orig_st2_ex_id = execution.id
+        orig_wf_ex_id = execution.context['mistral']['execution_id']
+
+        with open(path, 'w') as f:
+            f.write('0')
+
+        execution = self.st2client.liveactions.re_run(orig_st2_ex_id, tasks=['task1.task1'])
+        self.assertNotEqual(execution.id, orig_st2_ex_id)
+        execution = self._wait_for_completion(execution)
+        self._assert_success(execution, num_tasks=1)
+        self.assertEqual(execution.context['mistral']['execution_id'], orig_wf_ex_id)


### PR DESCRIPTION
On re-run of mistral workflow, task name can be fully qualified. The mistral runner will drill down to get the task ID in the subworkflow to initiate the re-run of the task.