### PR TITLE
API status code improvements

### DIFF
--- a/st2api/tests/unit/controllers/v1/test_executions_simple.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_simple.py
@@ -519,7 +519,7 @@ class TestActionExecutionController(FunctionalTest):
         re_run_resp = self.app.post_json('/v1/executions/%s/re_run' % (execution_id),
                                          data, expect_errors=True)
 
-        self.assertEqual(re_run_resp.status_int, 500)
+        self.assertEqual(re_run_resp.status_int, 400)
         self.assertIn('not supported when re-running task(s) for a workflow',
                       re_run_resp.json['faultstring'])
 

--- a/st2common/st2common/models/api/base.py
+++ b/st2common/st2common/models/api/base.py
@@ -197,7 +197,7 @@ def jsexpose(arg_types=None, body_cls=None, status_code=None, content_type='appl
                 obj = body_cls(**data)
                 try:
                     obj = obj.validate()
-                except jsonschema.ValidationError as e:
+                except (jsonschema.ValidationError, ValueError) as e:
                     raise exc.HTTPBadRequest(detail=e.message,
                                              comment=traceback.format_exc())
                 except Exception as e:

--- a/st2common/st2common/rbac/decorators.py
+++ b/st2common/st2common/rbac/decorators.py
@@ -111,6 +111,11 @@ def request_user_has_resource_db_permission(permission_type):
         @wraps(func)
         def func_wrapper(*args, **kwargs):
             controller_instance = args[0]
+
+            if len(args) < 2:
+                # Invalid number of args, missing resource id
+                raise ValueError('Invalid path - missing resource id, name or ref')
+
             resource_id = args[1]  # Note: This can either be id, name or ref
 
             get_one_db_method = controller_instance.get_one_db_method


### PR DESCRIPTION
In a lot of scenarios before those changes, API incorrectly returned status code 500 (internal server error) instead of 400.

Fixed scenarios:

1. RBAC decorator previously threw an invalid Exception if user didn't pass a required id argument to get / put / delete controller method
2. Internal server error was incorrectly thrown if `ValueError` exception was thrown during input data object validation (`ValueError` indicates validation error).

Before:

```bash
(virtualenv)vagrant@vagrant-ubuntu-trusty-64:/data/stanley$ curl -X PUT http://127.0.0.1:9101/v1/apikeys/
{
    "faultstring": "Internal Server Error"
}(virtualenv)vagrant@vagrant-ubuntu-trusty-64:/data/stanley$ 

(virtualenv)vagrant@vagrant-ubuntu-trusty-64:/data/stanley$ python ./st2client/st2client/shell.py execution re-run 569e647a0640fd1629498976 cmd=hostname --tasks=y
ERROR: 500 Server Error: Internal Server Error
MESSAGE: Parameters override is not supported when re-running task(s) for a workflow. for url: http://127.0.0.1:9101/v1/executions/569e647a0640fd1629498976/re_run
```

After:

```bash
}(virtualenv)vagrant@vagrant-ubuntu-trusty-64:/data/stanley$ curl -X PUT http://127.0.0.1:9101/v1/apikeys/
{
    "faultstring": "Missing resource id, name or ref"
}

(virtualenv)vagrant@vagrant-ubuntu-trusty-64:/data/stanley$ python ./st2client/st2client/shell.py execution re-run 569e647a0640fd1629498976 cmd=hostname --tasks=y
ERROR: 400 Client Error: Bad Request
MESSAGE: Parameters override is not supported when re-running task(s) for a workflow. for url: http://127.0.0.1:9101/v1/executions/569e647a0640fd1629498976/re_run
````