### PR TITLE
Add support to handle re-run of with-items task for mistral workflow

### DIFF
--- a/contrib/examples/actions/mistral-test-rerun-subflow-with-items.yaml
+++ b/contrib/examples/actions/mistral-test-rerun-subflow-with-items.yaml
@@ -1,0 +1,15 @@
+---
+name: mistral-test-rerun-subflow-with-items
+description: A sample workflow used to test the rerun feature.
+pack: examples
+runner_type: mistral-v2
+entry_point: workflows/mistral-test-rerun-subflow-with-items.yaml
+enabled: true
+parameters:
+    tempfile:
+        type: string
+        required: true
+    workflow:
+        default: examples.mistral-test-rerun-subflow-with-items.main
+        immutable: true
+        type: string

--- a/contrib/examples/actions/mistral-test-rerun-with-items.yaml
+++ b/contrib/examples/actions/mistral-test-rerun-with-items.yaml
@@ -1,0 +1,11 @@
+---
+name: mistral-test-rerun-with-items
+description: A sample workflow used to test the rerun feature.
+pack: examples
+runner_type: mistral-v2
+entry_point: workflows/mistral-test-rerun-with-items.yaml
+enabled: true
+parameters:
+    tempfile:
+        type: string
+        required: true

--- a/contrib/examples/actions/workflows/mistral-test-rerun-subflow-with-items.yaml
+++ b/contrib/examples/actions/workflows/mistral-test-rerun-subflow-with-items.yaml
@@ -1,0 +1,26 @@
+version: '2.0'
+name: examples.mistral-test-rerun-subflow-with-items
+description: A sample workflow used to test the rerun feature.
+
+workflows:
+
+    main:
+        type: direct
+        input:
+            - tempfile
+        tasks:
+            task1:
+                workflow: subflow
+                input:
+                    tempfile: <% $.tempfile %>
+
+    subflow:
+        type: direct
+        input:
+            - tempfile
+        tasks:
+            task1:
+                with-items: i in [0, 1, 2, 3]
+                action: core.local
+                input:
+                    cmd: 'x=`cat <% $.tempfile %>`; y=`echo "$x * <% $.i %> % 2" | bc`; exit `echo $y`'

--- a/contrib/examples/actions/workflows/mistral-test-rerun-with-items.yaml
+++ b/contrib/examples/actions/workflows/mistral-test-rerun-with-items.yaml
@@ -1,0 +1,13 @@
+version: '2.0'
+
+examples.mistral-test-rerun-with-items:
+    description: A sample workflow used to test the rerun feature.
+    type: direct
+    input:
+        - tempfile
+    tasks:
+        task1:
+            with-items: i in [0, 1, 2, 3]
+            action: core.local
+            input:
+                cmd: 'x=`cat <% $.tempfile %>`; y=`echo "$x * <% $.i %> % 2" | bc`; exit `echo $y`'

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -1055,6 +1055,11 @@ class ActionExecutionReRunCommand(ActionRunCommandMixin, resource.ResourceComman
                                       'and optional args for the action.')
         self.parser.add_argument('--tasks', nargs='*',
                                  help='Name of the workflow tasks to re-run.')
+        self.parser.add_argument('--no-reset', dest='no_reset', nargs='*',
+                                 help='Name of the with-items tasks to not reset. This only '
+                                      'applies to Mistral workflows. By default, all iterations '
+                                      'for with-items tasks is rerun. If no reset, only failed '
+                                      ' iterations are rerun.')
         self.parser.add_argument('-a', '--async',
                                  action='store_true', dest='async',
                                  help='Do not wait for action to finish.')
@@ -1092,6 +1097,7 @@ class ActionExecutionReRunCommand(ActionRunCommandMixin, resource.ResourceComman
         execution = action_exec_mgr.re_run(execution_id=args.id,
                                            parameters=action_parameters,
                                            tasks=args.tasks,
+                                           no_reset=args.no_reset,
                                            **kwargs)
 
         execution = self._get_execution_result(execution=execution,

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -320,12 +320,19 @@ class ActionAliasResourceManager(ResourceManager):
 
 class LiveActionResourceManager(ResourceManager):
     @add_auth_token_to_kwargs_from_env
-    def re_run(self, execution_id, parameters=None, tasks=None, **kwargs):
+    def re_run(self, execution_id, parameters=None, tasks=None, no_reset=None, **kwargs):
         url = '/%s/%s/re_run' % (self.resource.get_url_path_name(), execution_id)
+
+        tasks = tasks or []
+        no_reset = no_reset or []
+
+        if list(set(no_reset) - set(tasks)):
+            raise ValueError('List of tasks to reset does not match the tasks to rerun.')
 
         data = {
             'parameters': parameters,
-            'tasks': tasks
+            'tasks': tasks,
+            'reset': list(set(tasks) - set(no_reset))
         }
 
         response = self.client.post(url, data, **kwargs)

--- a/st2client/tests/unit/test_shell.py
+++ b/st2client/tests/unit/test_shell.py
@@ -154,7 +154,8 @@ class TestShell(base.BaseCLITestCase):
             ['execution', 'get', '123', '-d'],
             ['execution', 'get', '123', '-k', 'localhost.stdout'],
             ['execution', 're-run', '123'],
-            ['execution', 're-run', '123', '--task', 'x', 'y', 'z'],
+            ['execution', 're-run', '123', '--tasks', 'x', 'y', 'z'],
+            ['execution', 're-run', '123', '--tasks', 'x', 'y', 'z', '--no-reset', 'x'],
             ['execution', 're-run', '123', 'a=1', 'b=x', 'c=True']
         ]
         self._validate_parser(args_list)


### PR DESCRIPTION
Add option to st2 execution re-run to either re-run all or only failed iterations for with-items task for mistral workflow.