### PR TITLE
ChatOps formatting: use Jinja from st2common

### DIFF
--- a/contrib/chatops/actions/format_execution_result.py
+++ b/contrib/chatops/actions/format_execution_result.py
@@ -1,9 +1,9 @@
-import jinja2
 import six
 import os
 
 from st2actions.runners.pythonrunner import Action
 from st2client.client import Client
+from st2common.util import jinja as jinja_utils
 
 
 class FormatResultAction(Action):
@@ -12,7 +12,7 @@ class FormatResultAction(Action):
         api_url = os.environ.get('ST2_ACTION_API_URL', None)
         token = os.environ.get('ST2_ACTION_AUTH_TOKEN', None)
         self.client = Client(api_url=api_url, token=token)
-        self.jinja = jinja2.Environment(trim_blocks=True, lstrip_blocks=True)
+        self.jinja = jinja_utils.get_jinja_environment()
         self.jinja.tests['in'] = lambda item, list: item in list
 
         path = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
Our ChatOps pack uses a fresh Jinja environment without our custom filters for execution results, as @emptywee pointed out. Switching to jinja_utils from st2common adds additional filters and makes the environment consistent with other places where we use Jinja across st2.

@enykeev: please test and confirm. I’m not sure why you didn’t choose to use jinja from st2common to begin with, so I’m not gonna merge without your +1.