### PR TITLE
Handle exception if trigger registration fails

### DIFF
--- a/st2common/st2common/triggers.py
+++ b/st2common/st2common/triggers.py
@@ -71,8 +71,13 @@ def register_internal_trigger_types():
             is_action_trigger = trigger_definition['name'] == ACTION_SENSOR_TRIGGER['name']
             if is_action_trigger and not action_sensor_enabled:
                 continue
-
-            trigger_type_db = _register_internal_trigger_type(trigger_definition=trigger_definition)
-            registered_trigger_types_db.append(trigger_type_db)
+            try:
+                trigger_type_db = _register_internal_trigger_type(
+                    trigger_definition=trigger_definition)
+            except:
+                LOG.warning('Failed registering internal trigger: %s.', trigger_definition,
+                            exc_info=True)
+            else:
+                registered_trigger_types_db.append(trigger_type_db)
 
     return registered_trigger_types_db


### PR DESCRIPTION
It looks like if there is a conflict in trigger type registration, we simply bubbled up the exception to the point the API process shut down. Now we catch the exception, log as a warning and move on. 

This should address intermittent build failures in circle ci such as https://circleci.com/gh/StackStorm/st2-packages/310