### PR TITLE
Allow user to specify a boolean for a "cacert" argument value

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 in development
 --------------
 
+* Allow user to pass a boolean value for the ``cacert`` st2client constructor argument. This way
+  it now mimics the behavior of the ``verify`` argument of the ``requests.request`` method.
+  (improvement)
+
 1.3.0 - January 22, 2016
 ------------------------
 

--- a/st2client/st2client/client.py
+++ b/st2client/st2client/client.py
@@ -16,6 +16,8 @@
 import os
 import logging
 
+import six
+
 from st2client import models
 from st2client.models.core import ResourceManager
 from st2client.models.core import ActionAliasResourceManager
@@ -59,12 +61,14 @@ class Client(object):
             self.endpoints['auth'] = os.environ.get(
                 'ST2_AUTH_URL', '%s:%s' % (self.endpoints['base'], DEFAULT_AUTH_PORT))
 
-        if cacert:
+        if cacert is not None:
             self.cacert = cacert
         else:
             self.cacert = os.environ.get('ST2_CACERT', None)
 
-        if self.cacert and not os.path.isfile(self.cacert):
+        # Note: boolean is also a valid value for "cacert"
+        is_cacert_string = isinstance(self.cacert, six.string_types)
+        if (self.cacert and is_cacert_string and not os.path.isfile(self.cacert)):
             raise ValueError('CA cert file "%s" does not exist.' % (self.cacert))
 
         self.debug = debug

--- a/st2client/st2client/utils/httpclient.py
+++ b/st2client/st2client/utils/httpclient.py
@@ -29,7 +29,7 @@ def add_ssl_verify_to_kwargs(func):
     def decorate(*args, **kwargs):
         if isinstance(args[0], HTTPClient) and 'https' in getattr(args[0], 'root', ''):
             cacert = getattr(args[0], 'cacert', None)
-            kwargs['verify'] = cacert if cacert else False
+            kwargs['verify'] = cacert if cacert is not None else False
         return func(*args, **kwargs)
     return decorate
 

--- a/st2client/tests/unit/test_client.py
+++ b/st2client/tests/unit/test_client.py
@@ -88,6 +88,32 @@ class TestClientEndpoints(unittest2.TestCase):
         self.assertEqual(endpoints['base'], base_url)
         self.assertEqual(endpoints['api'], api_url)
 
+    def test_cacert_arg(self):
+        # Valid value, boolean True
+        base_url = 'http://www.stackstorm.com'
+        api_url = 'http://www.st2.com:9101/v1'
+
+        client = Client(base_url=base_url, api_url=api_url, cacert=True)
+        self.assertEqual(client.cacert, True)
+
+        # Valid value, boolean False
+        base_url = 'http://www.stackstorm.com'
+        api_url = 'http://www.st2.com:9101/v1'
+
+        client = Client(base_url=base_url, api_url=api_url, cacert=False)
+        self.assertEqual(client.cacert, False)
+
+        # Valid value, existing path to a CA bundle
+        cacert = os.path.abspath(__file__)
+        client = Client(base_url=base_url, api_url=api_url, cacert=cacert)
+        self.assertEqual(client.cacert, cacert)
+
+        # Invalid value, path to the bundle doesn't exist
+        cacert = os.path.abspath(__file__)
+        expected_msg = 'CA cert file "doesntexist" does not exist'
+        self.assertRaisesRegexp(ValueError, expected_msg, Client, base_url=base_url,
+                                api_url=api_url, cacert='doesntexist')
+
     def test_args_base_only(self):
         base_url = 'http://www.stackstorm.com'
         api_url = 'http://www.stackstorm.com:9101/v1'


### PR DESCRIPTION
Right now we only allow user to pass a string (path to the CA bundle) as a value for the `cacert` argument.

`requests` also allows user to pass in a boolean, but we don't support this use case right now. If boolean `Rrue` is passed for the `verify` argument requests will use bundled CA bundle or CA bundle from the system store (http://docs.python-requests.org/en/latest/user/advanced/#ca-certificates).

I know that the argument is named `cacert` so also allowing user to pass in boolean values makes for a bit of a confusing API, but I don't have many other options right now which don't require bigger refactoring.

Related to https://github.com/StackStorm/st2contrib/pull/376