### PR TITLE
Rename st2bundle to st2

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -63,7 +63,7 @@ test:
     - rsync -rv /tmp/st2-packages/ node0:~/packages/${DISTRO}:
         parallel: true
   post:
-    - .circle/docker.sh build st2bundle
+    - .circle/docker.sh build st2
     - .circle/docker.sh build st2actionrunner st2api st2auth st2exporter st2notifier st2resultstracker st2rulesengine st2sensorcontainer
     - .circle/docker.sh run st2api
     - .circle/docker.sh test st2api 'st2 --version'


### PR DESCRIPTION
Part of upstream rename https://github.com/StackStorm/st2-packages/pull/131

We also have `circle.yml` in `v1.3` and `v1.3.1` branches to fix. Do it later, once we merge upstream changes/test.