### PR TITLE
Register oslo opts in uwsgi config for auth

### DIFF
--- a/st2auth/st2auth/wsgi.py
+++ b/st2auth/st2auth/wsgi.py
@@ -17,6 +17,7 @@ from pecan import load_app
 from oslo_config import cfg
 
 from st2auth import config  # noqa
+config.register_opts()
 from st2common import log as logging
 from st2common.persistence import db_init
 

--- a/st2auth/st2auth/wsgi.py
+++ b/st2auth/st2auth/wsgi.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 from pecan import load_app
 from oslo_config import cfg
 
@@ -22,7 +24,7 @@ from st2common import log as logging
 from st2common.persistence import db_init
 
 
-cfg.CONF(args=['--config-file', '/etc/st2/st2.conf'])
+cfg.CONF(args=['--config-file', os.environ.get('ST2_CONFIG_PATH', '/etc/st2/st2.conf')])
 
 logging.setup(cfg.CONF.auth.logging)
 

--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -181,7 +181,8 @@ function st2start(){
         echo '  using uwsgi for auth...'
         export ST2_CONFIG_PATH=${ST2_CONF}
         screen -d -m -S st2-auth ./virtualenv/bin/uwsgi \
-            --socket 127.0.0.1:9100 --wsgi-file ./st2auth/st2auth/wsgi.py --processes 1
+            --http 127.0.0.1:9100 --wsgi-file ./st2auth/st2auth/wsgi.py --processes 1 --threads 10 \
+            --buffer-size=32768
     elif [ "${use_gunicorn}" = true ]; then
         echo '  using guicorn to run st2-auth...'
         export ST2_CONFIG_PATH=${ST2_CONF}


### PR DESCRIPTION
By trying to fix a nasty import level registration in https://github.com/StackStorm/st2/pull/2437, I accidentally broke wsgi method for spinning auth. This PR fixes that. 

I also make changes to launchdev so uwsgi auth can be spun up for quick testing. With auth enabled, I am able to get token just fine. 