### PR TITLE
Synchronize circle.yml with st2 CI process & versioning for master

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ general:
   branches:
     only:
       - master
-      - /v[0-9]+(\.[0-9]+)*/
+      - /v[0-9]+\.[0-9]+/
   build_dir: st2-packages
   artifacts:
     - ~/packages
@@ -73,7 +73,7 @@ deployment:
     owner: StackStorm
     branch:
       - master
-      - /v[0-9]+(\.[0-9]+)*/
+      - /v[0-9]+\.[0-9]+/
     commands:
       # Deploy to Bintray all artifacts for respective distros in parallel
       - |
@@ -91,4 +91,4 @@ experimental:
     branches:
       only:
         - master
-        - /v[0-9]+(\.[0-9]+)*/
+        - /v[0-9]+\.[0-9]+/


### PR DESCRIPTION
To clarify/synchronize: 

- CircleCI build is triggered only when you push changes to `master` or `vX.Y` like `v0.13` branch
- CircleCI build is never triggered when you push changes in patch `vX.Y.Z` branch like `v0.13.3`
- Package version is always obtained from local file [`st2common/st2common/__init__.py`](https://github.com/StackStorm/st2/blob/master/st2common/st2common/__init__.py#L16)
- Docker TAG is always:
   - `latest` for `master` branch
   - obtained from version [`st2common/st2common/__init__.py`](https://github.com/StackStorm/st2/blob/master/st2common/st2common/__init__.py#L16) for branches like `v0.13`
   - See: https://hub.docker.com/r/stackstorm/st2api/tags/

> Tested all the logic once again on my own `st2` fork.

Related to another change in `st2-packages` repo: https://github.com/StackStorm/st2-packages/pull/142/files

----

You don't need to delete `circle.yml` file in patch branch with this `circle.yml` version, but probably during time there will be small edits like Bintray -> Packagecloud or bugfixes.


cc @lakshmi-kannan @manasdk thanks for clarification.
The only thing I couldn't guess are patch branches. Everything else is already in sync with st2 branching/versioning.

We can include same file here: https://github.com/StackStorm/st2/pull/2451 to avoid package creation in "patch branch".