### PR TITLE
Make ps somewhat portable

### DIFF
--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -244,8 +244,8 @@ function st2stop(){
     fi
 
     if [ "${use_gunicorn}" = true ]; then
-        ps -e | grep "[s]t2auth/gunicorn_config.py\|[s]t2api/gunicorn_config.py" | \
-            cut -d " " -f1 | awk '{print $1}'  | xargs -L 1 kill
+        ps -ef | grep "[s]t2auth/gunicorn_config.py\|[s]t2api/gunicorn_config.py" | \
+            awk '{print $2}' | xargs -L 1 kill
     fi
 }
 


### PR DESCRIPTION
* ps -e differ on linux ubuntu14 and osx which means something that works
  in one place will not work at another. On ubuntu14 the -e only returns the
  binary name as opposed to the full command string which osx provides more
  information.
* ps -ef is more or less the same atleast in the regard we really care so
  sufficient to continue supporting both osx and u14 as development environments.