### PR TITLE
Safe kill

### DIFF
--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -246,7 +246,9 @@ function st2stop(){
     if [ "${use_gunicorn}" = true ]; then
         pids=`ps -ef | grep "[s]t2auth/gunicorn_config.py\|[s]t2api/gunicorn_config.py" | awk '{print $2}'`
         if [ -n "$pids" ]; then
-            echo $pids | xargs -L 1 kill
+            echo 'Killing gunicorn processes'
+            # true ensures that any failure to kill a process which does not exist will not lead to failure
+            echo $pids | xargs -L 1 kill || true
         fi
     fi
 }

--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -244,8 +244,10 @@ function st2stop(){
     fi
 
     if [ "${use_gunicorn}" = true ]; then
-        ps -ef | grep "[s]t2auth/gunicorn_config.py\|[s]t2api/gunicorn_config.py" | \
-            awk '{print $2}' | xargs -L 1 kill
+        pids=`ps -ef | grep "[s]t2auth/gunicorn_config.py\|[s]t2api/gunicorn_config.py" | awk '{print $2}'`
+        if [ -n "$pids" ]; then
+            echo $pids | xargs -L 1 kill
+        fi
     fi
 }
 

--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -244,11 +244,16 @@ function st2stop(){
     fi
 
     if [ "${use_gunicorn}" = true ]; then
-        pids=`ps -ef | grep "[s]t2auth/gunicorn_config.py\|[s]t2api/gunicorn_config.py" | awk '{print $2}'`
+        pids=`ps -ef | grep "[s]t2auth/gunicorn_config.py\|[s]t2api/gunicorn_config.py" | \
+              awk '{print $2}'`
         if [ -n "$pids" ]; then
-            echo 'Killing gunicorn processes'
-            # true ensures that any failure to kill a process which does not exist will not lead to failure
-            echo $pids | xargs -L 1 kill || true
+            echo "Killing gunicorn processes"
+            # true ensures that any failure to kill a process which does not exist will not lead
+            # to failure. for loop to ensure all processes are killed even if some are missing
+            # assuming kill will fail-fast.
+            for pid in ${pids}; do
+                echo ${pid} | xargs -L 1 kill || true
+            done
         fi
     fi
 }


### PR DESCRIPTION
* There is some timing related to exit of gunicorn processes. Seems
  like killing the screen session will kill the gunicorn processes.
  Persumably the osx impl does not kill these chil processes.
  The guard makes it so that if killing the screen process does infact
  cleanup gunicorn then we do not necessarily race.