### PR TITLE
Ngnix rule for mistral_api redirect

### DIFF
--- a/conf/nginx/st2.conf
+++ b/conf/nginx/st2.conf
@@ -1,7 +1,7 @@
-# 
-# nginx configuration to expose st2 webui, redirect HTTP->HTTPS, 
+#
+# nginx configuration to expose st2 webui, redirect HTTP->HTTPS,
 # provide SSL termination, and reverse-proxy st2api and st2auth API endpoint.
-# To enable: 
+# To enable:
 #    cp ${LOCATION}/st2.conf /etc/nginx/sites-available
 #    ln -l /etc/nginx/sites-available/st2.conf /etc/nginx/sites-enabled/st2.conf
 # see https://docs.stackstorm.com/install.html for details
@@ -47,6 +47,25 @@ server {
     rewrite ^/api/(.*)  /$1 break;
 
     proxy_pass            http://127.0.0.1:9101/;
+    proxy_read_timeout    90;
+    proxy_connect_timeout 90;
+    proxy_redirect        off;
+
+    proxy_set_header      Host $host;
+    proxy_set_header      X-Real-IP $remote_addr;
+    proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
+
+    proxy_set_header Connection '';
+    chunked_transfer_encoding off;
+    proxy_buffering off;
+    proxy_cache off;
+    proxy_set_header Host $host;
+  }
+
+  location /mistral_api/ {
+    rewrite ^/mistral_api/(.*)  /$1 break;
+
+    proxy_pass            http://127.0.0.1:8989/;
     proxy_read_timeout    90;
     proxy_connect_timeout 90;
     proxy_redirect        off;


### PR DESCRIPTION
I was thinking if this is the right place for mistral ngnix configuration. Best would be to have such a thing in mistral fork and ship multiple configurations. I am not a nginx expert. It also looks like st2web configuration is here. Oh well! 

## Test
```
vagrant@pkgtestingbox:~$ http --verify=no https://192.168.1.17/mistral_api/v2/executions
HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 850
Content-Type: application/json; charset=UTF-8
Date: Fri, 05 Feb 2016 00:39:33 GMT
Front-End-Https: on
Server: nginx/1.4.6 (Ubuntu)
X-Content-Type-Options: nosniff

{
    "executions": [
        {
            "created_at": "2016-02-04 23:19:34.523955",
            "description": "",
            "id": "1c254559-a9ae-4e7e-a98a-e3b20076b495",
            "input": "{\"cmd\": \"date\"}",
            "output": "{\"stdout\": \"Thu Feb  4 15:19:35 PST 2016\"}",
            "params": "{\"env\": {\"st2_liveaction_id\": \"56b3dc855a705f396a644e64\", \"st2_execution_id\": \"56b3dc855a705f396a644e65\", \"__actions\": {\"st2.action\": {\"st2_context\": {\"auth_token\": \"98a0b5cde9ee495eb5bdd314d785c3c4\", \"endpoint\": \"http://0.0.0.0:9101/v1/actionexecutions\", \"notify\": {}, \"parent\": {\"user\": \"stanley\", \"execution_id\": \"56b3dc855a705f396a644e65\"}, \"skip_notify_tasks\": []}}}, \"st2_action_api_url\": \"http://0.0.0.0:9101/v1\"}}",
            "state": "SUCCESS",
            "state_info": null,
            "task_execution_id": null,
            "updated_at": "2016-02-04 23:19:37.085879",
            "workflow_name": "examples.mistral-basic"
        }
    ]
}

vagrant@pkgtestingbox:~$
```