### PR TITLE
Use 127.0.0.1 instead of localhost for consistency [st2]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ compile:
 	@echo "----- Dropping all Mistral MYSQL databases -----"
 	@mysql -uroot -pStackStorm -e "DROP DATABASE IF EXISTS mistral"
 	@mysql -uroot -pStackStorm -e "CREATE DATABASE mistral"
-	@mysql -uroot -pStackStorm -e "GRANT ALL PRIVILEGES ON mistral.* TO 'mistral'@'localhost' IDENTIFIED BY 'StackStorm'"
+	@mysql -uroot -pStackStorm -e "GRANT ALL PRIVILEGES ON mistral.* TO 'mistral'@'127.0.0.1' IDENTIFIED BY 'StackStorm'"
 	@mysql -uroot -pStackStorm -e "FLUSH PRIVILEGES"
 	@/opt/openstack/mistral/.venv/bin/python /opt/openstack/mistral/tools/sync_db.py --config-file /etc/mistral/mistral.conf
 
@@ -294,7 +294,7 @@ mistral-itests: requirements .mistral-itests
 .mistral-itests:
 	@echo
 	@echo "==================== MISTRAL integration tests ===================="
-	@echo "The tests assume both st2 and mistral are running on localhost."
+	@echo "The tests assume both st2 and mistral are running on 127.0.0.1."
 	@echo
 	. $(VIRTUALENV_DIR)/bin/activate; nosetests -s -v st2tests/integration/mistral || exit 1;
 
@@ -302,7 +302,7 @@ mistral-itests: requirements .mistral-itests
 .mistral-itests-coverage-html:
 	@echo
 	@echo "==================== MISTRAL integration tests with coverage (HTML reports) ===================="
-	@echo "The tests assume both st2 and mistral are running on localhost."
+	@echo "The tests assume both st2 and mistral are running on 127.0.0.1."
 	@echo
 	. $(VIRTUALENV_DIR)/bin/activate; nosetests -s -v --with-coverage \
 		--cover-inclusive --cover-html st2tests/integration/mistral || exit 1;

--- a/conf/st2.conf.sample
+++ b/conf/st2.conf.sample
@@ -13,7 +13,7 @@ logging = conf/logging.conf
 
 [api]
 # List of origins allowed
-allow_origin = http://localhost:3000  # comma separated list allowed here.
+allow_origin = http://127.0.0.1:3000  # comma separated list allowed here.
 # location of the logging.conf file
 logging = conf/logging.conf
 # True to mask secrets in API responses

--- a/conf/st2.dev.conf
+++ b/conf/st2.dev.conf
@@ -46,7 +46,7 @@ action_executions_ttl = 30
 trigger_instances_ttl = 30
 
 [syslog]
-host = localhost
+host = 127.0.0.1
 port = 514
 facility = local7
 protocol = udp
@@ -61,7 +61,7 @@ user = stanley
 ssh_key_file = /home/vagrant/.ssh/stanley_rsa
 
 [messaging]
-url = amqp://guest:guest@localhost:5672/
+url = amqp://guest:guest@127.0.0.1:5672/
 
 [ssh_runner]
 remote_dir = /tmp

--- a/conf/st2.package.conf
+++ b/conf/st2.package.conf
@@ -52,7 +52,7 @@ api_url =
 base_path = /opt/stackstorm
 
 [syslog]
-host = localhost
+host = 127.0.0.1
 port = 514
 facility = local7
 protocol = udp
@@ -67,7 +67,7 @@ user = stanley
 ssh_key_file = /home/stanley/.ssh/stanley_rsa
 
 [messaging]
-url = amqp://guest:guest@localhost:5672/
+url = amqp://guest:guest@127.0.0.1:5672/
 
 [ssh_runner]
 remote_dir = /tmp

--- a/conf/st2.prod.conf
+++ b/conf/st2.prod.conf
@@ -42,7 +42,7 @@ logging = /etc/st2reactor/logging.garbagecollector.conf
 base_path = /opt/stackstorm
 
 [syslog]
-host = localhost
+host = 127.0.0.1
 port = 514
 facility = local7
 protocol = udp
@@ -57,7 +57,7 @@ user = stanley
 ssh_key_file = /home/stanley/.ssh/stanley_rsa
 
 [messaging]
-url = amqp://guest:guest@localhost:5672/
+url = amqp://guest:guest@127.0.0.1:5672/
 
 [ssh_runner]
 remote_dir = /tmp

--- a/conf/st2.tests.conf
+++ b/conf/st2.tests.conf
@@ -55,7 +55,7 @@ system_packs_base_path =
 packs_base_paths = st2tests/st2tests/fixtures/
 
 [syslog]
-host = localhost
+host = 127.0.0.1
 port = 514
 facility = local7
 protocol = udp
@@ -70,7 +70,7 @@ user = stanley
 ssh_key_file = /home/vagrant/.ssh/stanley_rsa
 
 [messaging]
-url = amqp://guest:guest@localhost:5672/
+url = amqp://guest:guest@127.0.0.1:5672/
 
 [ssh_runner]
 remote_dir = /tmp

--- a/conf/st2.tests1.conf
+++ b/conf/st2.tests1.conf
@@ -44,7 +44,7 @@ system_packs_base_path =
 packs_base_paths = st2tests/st2tests/fixtures/packs_1/
 
 [syslog]
-host = localhost
+host = 127.0.0.1
 port = 514
 facility = local7
 protocol = udp
@@ -59,7 +59,7 @@ user = stanley
 ssh_key_file = /home/vagrant/.ssh/stanley_rsa
 
 [messaging]
-url = amqp://guest:guest@localhost:5672/
+url = amqp://guest:guest@127.0.0.1:5672/
 
 [ssh_runner]
 remote_dir = /tmp

--- a/conf/st2rc.sample.ini
+++ b/conf/st2rc.sample.ini
@@ -1,6 +1,6 @@
 # Configuration file for the StackStorm CLI
 [general]
-base_url = http://localhost
+base_url = http://127.0.0.1
 api_version = v1
 # Path to the CA cert bundle used to validate the SSL certificates
 cacert =
@@ -18,7 +18,7 @@ username = test1
 password = testpassword
 
 [api]
-url = http://localhost:9101/v1
+url = http://127.0.0.1:9101/v1
 
 [auth]
-url = http://localhost:9100/
+url = http://127.0.0.1:9100/

--- a/scripts/travis/setup-mistral.sh
+++ b/scripts/travis/setup-mistral.sh
@@ -77,7 +77,7 @@ fi
 touch $config
 cat <<mistral_config >$config
 [database]
-connection=postgresql://mistral:StackStorm@localhost/mistral
+connection=postgresql://mistral:StackStorm@127.0.0.1/mistral
 max_pool_size=50
 
 [pecan]

--- a/st2actions/tests/unit/test_http_runner.py
+++ b/st2actions/tests/unit/test_http_runner.py
@@ -32,7 +32,7 @@ class HTTPRunnerTestCase(unittest2.TestCase):
 
     @mock.patch('st2actions.runners.httprunner.requests')
     def test_parse_response_body(self, mock_requests):
-        client = HTTPClient(url='http://localhost')
+        client = HTTPClient(url='http://127.0.0.1')
         mock_result = MockResult()
 
         # Unknown content type, body should be returned raw
@@ -88,7 +88,7 @@ class HTTPRunnerTestCase(unittest2.TestCase):
 
     @mock.patch('st2actions.runners.httprunner.requests')
     def test_https_verify(self, mock_requests):
-        url = 'https://localhost:8888'
+        url = 'https://127.0.0.1:8888'
         client = HTTPClient(url=url, verify=True)
         mock_result = MockResult()
 
@@ -108,7 +108,7 @@ class HTTPRunnerTestCase(unittest2.TestCase):
 
     @mock.patch('st2actions.runners.httprunner.requests')
     def test_https_verify_false(self, mock_requests):
-        url = 'https://localhost:8888'
+        url = 'https://127.0.0.1:8888'
         client = HTTPClient(url=url)
         mock_result = MockResult()
 

--- a/st2actions/tests/unit/test_mistral_utils.py
+++ b/st2actions/tests/unit/test_mistral_utils.py
@@ -23,12 +23,12 @@ class MistralUtilityTest(unittest2.TestCase):
     def test_get_action_execution_id_from_url(self):
         self.assertEqual(
             '12345',
-            get_action_execution_id_from_url('http://localhost:8989/v2/action_executions/12345'))
+            get_action_execution_id_from_url('http://127.0.0.1:8989/v2/action_executions/12345'))
 
         self.assertRaises(
             ValueError,
             get_action_execution_id_from_url,
-            'http://localhost:8989/v2/action_executions')
+            'http://127.0.0.1:8989/v2/action_executions')
 
         self.assertRaises(
             ValueError,
@@ -43,4 +43,4 @@ class MistralUtilityTest(unittest2.TestCase):
         self.assertRaises(
             ValueError,
             get_action_execution_id_from_url,
-            'http://localhost:8989/v2/workflows/abcde')
+            'http://127.0.0.1:8989/v2/workflows/abcde')

--- a/st2actions/tests/unit/test_mistral_v2.py
+++ b/st2actions/tests/unit/test_mistral_v2.py
@@ -607,7 +607,7 @@ class MistralRunnerTest(DbTestCase):
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(return_value=None))
     def test_callback_handler_with_result_as_text(self):
-        MistralCallbackHandler.callback('http://localhost:8989/v2/action_executions/12345', {},
+        MistralCallbackHandler.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
                                         action_constants.LIVEACTION_STATUS_SUCCEEDED,
                                         '<html></html>')
 
@@ -615,23 +615,23 @@ class MistralRunnerTest(DbTestCase):
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(return_value=None))
     def test_callback_handler_with_result_as_dict(self):
-        MistralCallbackHandler.callback('http://localhost:8989/v2/action_executions/12345', {},
+        MistralCallbackHandler.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
                                         action_constants.LIVEACTION_STATUS_SUCCEEDED, {'a': 1})
 
     @mock.patch.object(
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(return_value=None))
     def test_callback_handler_with_result_as_json_str(self):
-        MistralCallbackHandler.callback('http://localhost:8989/v2/action_executions/12345', {},
+        MistralCallbackHandler.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
                                         action_constants.LIVEACTION_STATUS_SUCCEEDED, '{"a": 1}')
-        MistralCallbackHandler.callback('http://localhost:8989/v2/action_executions/12345', {},
+        MistralCallbackHandler.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
                                         action_constants.LIVEACTION_STATUS_SUCCEEDED, "{'a': 1}")
 
     @mock.patch.object(
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(return_value=None))
     def test_callback_handler_with_result_as_list(self):
-        MistralCallbackHandler.callback('http://localhost:8989/v2/action_executions/12345', {},
+        MistralCallbackHandler.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
                                         action_constants.LIVEACTION_STATUS_SUCCEEDED,
                                         ["a", "b", "c"])
 
@@ -639,7 +639,7 @@ class MistralRunnerTest(DbTestCase):
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(return_value=None))
     def test_callback_handler_with_result_as_list_str(self):
-        MistralCallbackHandler.callback('http://localhost:8989/v2/action_executions/12345', {},
+        MistralCallbackHandler.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
                                         action_constants.LIVEACTION_STATUS_SUCCEEDED,
                                         '["a", "b", "c"]')
 
@@ -651,7 +651,7 @@ class MistralRunnerTest(DbTestCase):
             action='core.local', parameters={'cmd': 'uname -a'},
             callback={
                 'source': 'mistral',
-                'url': 'http://localhost:8989/v2/action_executions/12345'
+                'url': 'http://127.0.0.1:8989/v2/action_executions/12345'
             }
         )
 
@@ -676,7 +676,7 @@ class MistralRunnerTest(DbTestCase):
             action='core.local', parameters={'cmd': 'uname -a'},
             callback={
                 'source': 'mistral',
-                'url': 'http://localhost:8989/v2/action_executions/12345'
+                'url': 'http://127.0.0.1:8989/v2/action_executions/12345'
             }
         )
 
@@ -699,7 +699,7 @@ class MistralRunnerTest(DbTestCase):
             action='core.local', parameters={'cmd': 'uname -a'},
             callback={
                 'source': 'mistral',
-                'url': 'http://localhost:8989/v2/action_executions/12345'
+                'url': 'http://127.0.0.1:8989/v2/action_executions/12345'
             }
         )
 
@@ -727,7 +727,7 @@ class MistralRunnerTest(DbTestCase):
             action='core.local', parameters={'cmd': 'uname -a'},
             callback={
                 'source': 'mistral',
-                'url': 'http://localhost:8989/v2/action_executions/12345'
+                'url': 'http://127.0.0.1:8989/v2/action_executions/12345'
             }
         )
 

--- a/st2actions/tests/unit/test_mistral_v2_auth.py
+++ b/st2actions/tests/unit/test_mistral_v2_auth.py
@@ -191,7 +191,7 @@ class MistralAuthTest(DbTestCase):
         cfg.CONF.set_default('keystone_username', 'foo', group='mistral')
         cfg.CONF.set_default('keystone_password', 'bar', group='mistral')
         cfg.CONF.set_default('keystone_project_name', 'admin', group='mistral')
-        cfg.CONF.set_default('keystone_auth_url', 'http://localhost:5000/v3', group='mistral')
+        cfg.CONF.set_default('keystone_auth_url', 'http://127.0.0.1:5000/v3', group='mistral')
 
         MistralRunner.entry_point = mock.PropertyMock(return_value=WF1_YAML_FILE_PATH)
         liveaction = LiveActionDB(action=WF1_NAME, parameters=ACTION_PARAMS)

--- a/st2actions/tests/unit/test_parallel_ssh.py
+++ b/st2actions/tests/unit/test_parallel_ssh.py
@@ -205,11 +205,11 @@ class ParallelSSHTests(unittest2.TestCase):
         return_value=(json.dumps({'foo': 'bar'}), '', 0))
     )
     def test_run_command_json_output_transformed_to_object(self):
-        hosts = ['localhost']
+        hosts = ['127.0.0.1']
         client = ParallelSSHClient(hosts=hosts,
                                    user='ubuntu',
                                    pkey_file='~/.ssh/id_rsa',
                                    connect=True)
         results = client.run('stuff', timeout=60)
-        self.assertTrue('localhost' in results)
-        self.assertDictEqual(results['localhost']['stdout'], {'foo': 'bar'})
+        self.assertTrue('127.0.0.1' in results)
+        self.assertDictEqual(results['127.0.0.1']['stdout'], {'foo': 'bar'})

--- a/st2actions/tests/unit/test_paramiko_remote_script_runner.py
+++ b/st2actions/tests/unit/test_paramiko_remote_script_runner.py
@@ -58,10 +58,10 @@ class ParamikoScriptRunnerTestCase(unittest2.TestCase):
             named_args={}, positional_args=['blank space'], env_vars={},
             on_behalf_user='svetlana', user='stanley',
             private_key='---SOME RSA KEY---',
-            remote_dir='/tmp', hosts=['localhost'], cwd='/test/cwd/'
+            remote_dir='/tmp', hosts=['127.0.0.1'], cwd='/test/cwd/'
         )
         paramiko_runner = ParamikoRemoteScriptRunner('runner_1')
-        paramiko_runner._parallel_ssh_client = ParallelSSHClient(['localhost'], 'stanley')
+        paramiko_runner._parallel_ssh_client = ParallelSSHClient(['127.0.0.1'], 'stanley')
         paramiko_runner._run_script_on_remote_host(remote_action)
         exp_cmd = "cd /test/cwd/ && /tmp/shiz_storm.py 'blank space'"
         ParallelSSHClient.run.assert_called_with(exp_cmd,
@@ -73,7 +73,7 @@ class ParamikoScriptRunnerTestCase(unittest2.TestCase):
     def test_username_only_ssh(self):
         paramiko_runner = ParamikoRemoteScriptRunner('runner_1')
 
-        paramiko_runner.runner_parameters = {'username': 'test_user', 'hosts': 'localhost'}
+        paramiko_runner.runner_parameters = {'username': 'test_user', 'hosts': '127.0.0.1'}
         self.assertRaises(InvalidCredentialsException, paramiko_runner.pre_run)
 
     def test_username_invalid_private_key(self):
@@ -81,7 +81,7 @@ class ParamikoScriptRunnerTestCase(unittest2.TestCase):
 
         paramiko_runner.runner_parameters = {
             'username': 'test_user',
-            'hosts': 'localhost',
+            'hosts': '127.0.0.1',
             'private_key': 'invalid private key',
         }
         paramiko_runner.context = {}
@@ -97,7 +97,7 @@ class ParamikoScriptRunnerTestCase(unittest2.TestCase):
 
         paramiko_runner.runner_parameters = {
             'username': 'test_user',
-            'hosts': 'localhost'
+            'hosts': '127.0.0.1'
         }
         paramiko_runner.action = ACTION_1
         paramiko_runner.liveaction_id = 'foo'

--- a/st2api/st2api/config.py
+++ b/st2api/st2api/config.py
@@ -49,7 +49,7 @@ def _register_app_opts():
     # Note "host" and "port" options are registerd as part of st2common since they are also used
     # outside st2api
     api_opts = [
-        cfg.ListOpt('allow_origin', default=['http://localhost:3000'],
+        cfg.ListOpt('allow_origin', default=['http://127.0.0.1:3000'],
                     help='List of origins allowed'),
         cfg.IntOpt('heartbeat', default=25,
                    help='Send empty message every N seconds to keep connection open'),

--- a/st2api/tests/unit/controllers/v1/test_base.py
+++ b/st2api/tests/unit/controllers/v1/test_base.py
@@ -22,7 +22,7 @@ class TestBase(FunctionalTest):
         response = self.app.get('/')
         self.assertEqual(response.status_int, 200)
         self.assertEqual(response.headers['Access-Control-Allow-Origin'],
-                         'http://localhost')
+                         'http://127.0.0.1:3000')
         self.assertEqual(response.headers['Access-Control-Allow-Methods'],
                          'GET,POST,PUT,DELETE,OPTIONS')
         self.assertEqual(response.headers['Access-Control-Allow-Headers'],
@@ -32,11 +32,11 @@ class TestBase(FunctionalTest):
 
     def test_origin(self):
         response = self.app.get('/', headers={
-            'origin': 'http://localhost:3000'
+            'origin': 'http://127.0.0.1:3000'
         })
         self.assertEqual(response.status_int, 200)
         self.assertEqual(response.headers['Access-Control-Allow-Origin'],
-                         'http://localhost:3000')
+                         'http://127.0.0.1:3000')
 
     def test_additional_origin(self):
         response = self.app.get('/', headers={

--- a/st2api/tests/unit/controllers/v1/test_executions_simple.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_simple.py
@@ -301,13 +301,13 @@ class TestActionExecutionController(FunctionalTest):
         self.assertEqual(post_resp.json['faultstring'], "'hosts' is a required property")
 
         # Runner type expects parameters "cmd" to be str.
-        execution['parameters'] = {"hosts": "localhost", "cmd": 1000}
+        execution['parameters'] = {"hosts": "127.0.0.1", "cmd": 1000}
         post_resp = self._do_post(execution, expect_errors=True)
         self.assertEqual(post_resp.status_int, 400)
         self.assertEqual(post_resp.json['faultstring'], "1000 is not of type 'string', 'null'")
 
         # Runner type expects parameters "cmd" to be str.
-        execution['parameters'] = {"hosts": "localhost", "cmd": "1000", "c": 1}
+        execution['parameters'] = {"hosts": "127.0.0.1", "cmd": "1000", "c": 1}
         post_resp = self._do_post(execution, expect_errors=True)
         self.assertEqual(post_resp.status_int, 400)
 

--- a/st2api/tests/unit/controllers/v1/test_kvps.py
+++ b/st2api/tests/unit/controllers/v1/test_kvps.py
@@ -17,7 +17,7 @@ from tests import FunctionalTest
 
 KVP = {
     'name': 'keystone_endpoint',
-    'value': 'http://localhost:5000/v3'
+    'value': 'http://127.0.0.1:5000/v3'
 }
 
 KVP_2 = {
@@ -27,7 +27,7 @@ KVP_2 = {
 
 KVP_WITH_TTL = {
     'name': 'keystone_endpoint',
-    'value': 'http://localhost:5000/v3',
+    'value': 'http://127.0.0.1:5000/v3',
     'ttl': 10
 }
 
@@ -74,7 +74,7 @@ class TestKeyValuePairController(FunctionalTest):
     def test_put(self):
         put_resp = self.__do_put('key1', KVP)
         update_input = put_resp.json
-        update_input['value'] = 'http://localhost:35357/v3'
+        update_input['value'] = 'http://127.0.0.1:35357/v3'
         put_resp = self.__do_put(self.__get_kvp_id(put_resp), update_input)
         self.assertEqual(put_resp.status_int, 200)
         self.__do_delete(self.__get_kvp_id(put_resp))

--- a/st2auth/st2auth/config.py
+++ b/st2auth/st2auth/config.py
@@ -67,7 +67,7 @@ def _register_app_opts():
     cfg.CONF.register_cli_opts(auth_opts, group='auth')
 
     api_opts = [
-        cfg.ListOpt('allow_origin', default=['http://localhost:3000'],
+        cfg.ListOpt('allow_origin', default=['http://127.0.0.1:3000'],
                     help='List of origins allowed'),
     ]
     cfg.CONF.register_cli_opts(api_opts, group='api')

--- a/st2client/README.rst
+++ b/st2client/README.rst
@@ -15,7 +15,7 @@ configuration from the environment. If no configuration is provided, the
 client will assume localhost and default ports.
 
 -  ST2\_BASE\_URL - Base URL for the StackStorm API server endpoints (i.e.
-   http://localhost). If only the base URL is provided, the client will
+   http://127.0.0.1). If only the base URL is provided, the client will
    assume default ports for the API servers are used. If any of the API
    server URL is provided, it will override the base URL and default
    port.
@@ -79,7 +79,7 @@ Python Client
 
     >>> from st2client.client import Client
     >>> from st2client import models
-    >>> client = Client(base_url='http://localhost')
+    >>> client = Client(base_url='http://127.0.0.1')
     >>> rules = client.rules.get_all()
     >>> key_value_pair = client.keys.update(models.KeyValuePair(name='k1', value='v1'))
 

--- a/st2client/tests/base.py
+++ b/st2client/tests/base.py
@@ -26,7 +26,7 @@ from st2client import models
 
 LOG = logging.getLogger(__name__)
 
-FAKE_ENDPOINT = 'http://localhost:8268'
+FAKE_ENDPOINT = 'http://127.0.0.1:8268'
 
 RESOURCES = [
     {

--- a/st2client/tests/fixtures/st2rc.full.ini
+++ b/st2client/tests/fixtures/st2rc.full.ini
@@ -1,5 +1,5 @@
 [general]
-base_url = http://localhost
+base_url = http://127.0.0.1
 api_version = v1
 cacert = cacartpath
 
@@ -12,7 +12,7 @@ username = test1
 password = test1
 
 [api]
-url = http://localhost:9101/v1
+url = http://127.0.0.1:9101/v1
 
 [auth]
-url = http://localhost:9100/
+url = http://127.0.0.1:9100/

--- a/st2client/tests/fixtures/st2rc.partial.ini
+++ b/st2client/tests/fixtures/st2rc.partial.ini
@@ -1,5 +1,5 @@
 [general]
-base_url = http://localhost
+base_url = http://127.0.0.1
 api_version = v1
 cacert = cacartpath
 
@@ -11,7 +11,7 @@ username = test1
 password = test1
 
 [api]
-url = http://localhost:9101/v1
+url = http://127.0.0.1:9101/v1
 
 [auth]
-url = http://localhost:9100/
+url = http://127.0.0.1:9100/

--- a/st2client/tests/unit/test_auth.py
+++ b/st2client/tests/unit/test_auth.py
@@ -51,7 +51,7 @@ class TestAuthToken(base.BaseCLITestCase):
         super(TestAuthToken, self).setUp()
 
         # Setup environment.
-        os.environ['ST2_BASE_URL'] = 'http://localhost'
+        os.environ['ST2_BASE_URL'] = 'http://127.0.0.1'
 
     def tearDown(self):
         super(TestAuthToken, self).tearDown()
@@ -108,7 +108,7 @@ class TestAuthToken(base.BaseCLITestCase):
         requests, 'get',
         mock.MagicMock(return_value=base.FakeResponse(json.dumps({}), 200, 'OK')))
     def test_decorate_resource_list(self):
-        url = 'http://localhost:9101/v1/rules/?limit=50'
+        url = 'http://127.0.0.1:9101/v1/rules/?limit=50'
 
         # Test without token.
         self.shell.run(['rule', 'list'])
@@ -133,7 +133,7 @@ class TestAuthToken(base.BaseCLITestCase):
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(RULE), 200, 'OK')))
     def test_decorate_resource_get(self):
         rule_ref = '%s.%s' % (RULE['pack'], RULE['name'])
-        url = 'http://localhost:9101/v1/rules/%s' % rule_ref
+        url = 'http://127.0.0.1:9101/v1/rules/%s' % rule_ref
 
         # Test without token.
         self.shell.run(['rule', 'get', rule_ref])
@@ -157,7 +157,7 @@ class TestAuthToken(base.BaseCLITestCase):
         requests, 'post',
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(RULE), 200, 'OK')))
     def test_decorate_resource_post(self):
-        url = 'http://localhost:9101/v1/rules'
+        url = 'http://127.0.0.1:9101/v1/rules'
         data = {'name': RULE['name'], 'description': RULE['description']}
 
         fd, path = tempfile.mkstemp(suffix='.json')
@@ -195,8 +195,8 @@ class TestAuthToken(base.BaseCLITestCase):
     def test_decorate_resource_put(self):
         rule_ref = '%s.%s' % (RULE['pack'], RULE['name'])
 
-        get_url = 'http://localhost:9101/v1/rules/%s' % rule_ref
-        put_url = 'http://localhost:9101/v1/rules/%s' % RULE['id']
+        get_url = 'http://127.0.0.1:9101/v1/rules/%s' % rule_ref
+        put_url = 'http://127.0.0.1:9101/v1/rules/%s' % RULE['id']
         data = {'name': RULE['name'], 'description': RULE['description'], 'pack': RULE['pack']}
 
         fd, path = tempfile.mkstemp(suffix='.json')
@@ -239,8 +239,8 @@ class TestAuthToken(base.BaseCLITestCase):
         mock.MagicMock(return_value=base.FakeResponse('', 204, 'OK')))
     def test_decorate_resource_delete(self):
         rule_ref = '%s.%s' % (RULE['pack'], RULE['name'])
-        get_url = 'http://localhost:9101/v1/rules/%s' % rule_ref
-        del_url = 'http://localhost:9101/v1/rules/%s' % RULE['id']
+        get_url = 'http://127.0.0.1:9101/v1/rules/%s' % rule_ref
+        del_url = 'http://127.0.0.1:9101/v1/rules/%s' % RULE['id']
 
         # Test without token.
         self.shell.run(['rule', 'delete', rule_ref])

--- a/st2client/tests/unit/test_config_parser.py
+++ b/st2client/tests/unit/test_config_parser.py
@@ -43,7 +43,7 @@ class CLIConfigParserTestCase(unittest2.TestCase):
         # File exists - all the options specified
         expected = {
             'general': {
-                'base_url': 'http://localhost',
+                'base_url': 'http://127.0.0.1',
                 'api_version': 'v1',
                 'cacert': 'cacartpath',
                 'silence_ssl_warnings': False
@@ -57,10 +57,10 @@ class CLIConfigParserTestCase(unittest2.TestCase):
                 'password': 'test1'
             },
             'api': {
-                'url': 'http://localhost:9101/v1'
+                'url': 'http://127.0.0.1:9101/v1'
             },
             'auth': {
-                'url': 'http://localhost:9100/'
+                'url': 'http://127.0.0.1:9100/'
             }
         }
         parser = CLIConfigParser(config_file_path=CONFIG_FILE_PATH_FULL,

--- a/st2client/tests/unit/test_ssl.py
+++ b/st2client/tests/unit/test_ssl.py
@@ -29,8 +29,8 @@ LOG = logging.getLogger(__name__)
 USERNAME = 'stanley'
 PASSWORD = 'ShhhDontTell'
 HEADERS = {'content-type': 'application/json'}
-AUTH_URL = 'https://localhost:9100/tokens'
-GET_RULES_URL = 'http://localhost:9101/v1/rules/?limit=50'
+AUTH_URL = 'https://127.0.0.1:9100/tokens'
+GET_RULES_URL = 'http://127.0.0.1:9101/v1/rules/?limit=50'
 
 
 class TestHttps(base.BaseCLITestCase):
@@ -43,8 +43,8 @@ class TestHttps(base.BaseCLITestCase):
         super(TestHttps, self).setUp()
 
         # Setup environment.
-        os.environ['ST2_BASE_URL'] = 'http://localhost'
-        os.environ['ST2_AUTH_URL'] = 'https://localhost:9100'
+        os.environ['ST2_BASE_URL'] = 'http://127.0.0.1'
+        os.environ['ST2_AUTH_URL'] = 'https://127.0.0.1:9100'
 
         if 'ST2_CACERT' in os.environ:
             del os.environ['ST2_CACERT']

--- a/st2common/st2common/hooks.py
+++ b/st2common/st2common/hooks.py
@@ -65,7 +65,7 @@ class CorsHook(PecanHook):
         public_api_url = cfg.CONF.auth.api_url
 
         # Default gulp development server WebUI URL
-        origins.add('http://localhost:3000')
+        origins.add('http://127.0.0.1:3000')
 
         # By default WebUI simple http server listens on 8080
         origins.add('http://localhost:8080')

--- a/st2common/tests/unit/services/test_action.py
+++ b/st2common/tests/unit/services/test_action.py
@@ -183,7 +183,7 @@ class TestActionExecutionService(DbTestCase):
 
     def _submit_request(self):
         context = {'user': USERNAME}
-        parameters = {'hosts': 'localhost', 'cmd': 'uname -a'}
+        parameters = {'hosts': '127.0.0.1', 'cmd': 'uname -a'}
         request = LiveActionDB(action=ACTION_REF, context=context, parameters=parameters)
         request, _ = action_service.request(request)
         execution = action_db.get_liveaction_by_id(str(request.id))
@@ -209,31 +209,31 @@ class TestActionExecutionService(DbTestCase):
                          isotime.format(request.start_timestamp, usec=False))
 
     def test_request_invalid_parameters(self):
-        parameters = {'hosts': 'localhost', 'cmd': 'uname -a', 'arg_default_value': 123}
+        parameters = {'hosts': '127.0.0.1', 'cmd': 'uname -a', 'arg_default_value': 123}
         liveaction = LiveActionDB(action=ACTION_REF, parameters=parameters)
         self.assertRaises(jsonschema.ValidationError, action_service.request, liveaction)
 
     def test_request_optional_parameter_none_value(self):
-        parameters = {'hosts': 'localhost', 'cmd': 'uname -a', 'arg_default_value': None}
+        parameters = {'hosts': '127.0.0.1', 'cmd': 'uname -a', 'arg_default_value': None}
         request = LiveActionDB(action=ACTION_REF, parameters=parameters)
         request, _ = action_service.request(request)
 
     def test_request_optional_parameter_none_value_no_default(self):
-        parameters = {'hosts': 'localhost', 'cmd': 'uname -a', 'arg_default_type': None}
+        parameters = {'hosts': '127.0.0.1', 'cmd': 'uname -a', 'arg_default_type': None}
         request = LiveActionDB(action=ACTION_REF, parameters=parameters)
         request, _ = action_service.request(request)
 
     def test_request_override_runner_parameter(self):
-        parameters = {'hosts': 'localhost', 'cmd': 'uname -a'}
+        parameters = {'hosts': '127.0.0.1', 'cmd': 'uname -a'}
         request = LiveActionDB(action=ACTION_OVR_PARAM_REF, parameters=parameters)
         request, _ = action_service.request(request)
 
-        parameters = {'hosts': 'localhost', 'cmd': 'uname -a', 'sudo': False}
+        parameters = {'hosts': '127.0.0.1', 'cmd': 'uname -a', 'sudo': False}
         request = LiveActionDB(action=ACTION_OVR_PARAM_REF, parameters=parameters)
         request, _ = action_service.request(request)
 
     def test_request_override_runner_parameter_type_attribute_value_changed(self):
-        parameters = {'hosts': 'localhost', 'cmd': 'uname -a'}
+        parameters = {'hosts': '127.0.0.1', 'cmd': 'uname -a'}
         request = LiveActionDB(action=ACTION_OVR_PARAM_BAD_ATTR_REF, parameters=parameters)
 
         with self.assertRaises(InvalidActionParameterException) as ex_ctx:
@@ -244,30 +244,30 @@ class TestActionExecutionService(DbTestCase):
         self.assertEqual(str(ex_ctx.exception), expected)
 
     def test_request_override_runner_parameter_type_attribute_no_value_changed(self):
-        parameters = {'hosts': 'localhost', 'cmd': 'uname -a'}
+        parameters = {'hosts': '127.0.0.1', 'cmd': 'uname -a'}
         request = LiveActionDB(action=ACTION_OVR_PARAM_BAD_ATTR_NOOP_REF, parameters=parameters)
         request, _ = action_service.request(request)
 
     def test_request_override_runner_parameter_mutable(self):
-        parameters = {'hosts': 'localhost', 'cmd': 'uname -a'}
+        parameters = {'hosts': '127.0.0.1', 'cmd': 'uname -a'}
         request = LiveActionDB(action=ACTION_OVR_PARAM_MUTABLE_REF, parameters=parameters)
         request, _ = action_service.request(request)
 
-        parameters = {'hosts': 'localhost', 'cmd': 'uname -a', 'sudo': True}
+        parameters = {'hosts': '127.0.0.1', 'cmd': 'uname -a', 'sudo': True}
         request = LiveActionDB(action=ACTION_OVR_PARAM_MUTABLE_REF, parameters=parameters)
         request, _ = action_service.request(request)
 
     def test_request_override_runner_parameter_immutable(self):
-        parameters = {'hosts': 'localhost', 'cmd': 'uname -a'}
+        parameters = {'hosts': '127.0.0.1', 'cmd': 'uname -a'}
         request = LiveActionDB(action=ACTION_OVR_PARAM_IMMUTABLE_REF, parameters=parameters)
         request, _ = action_service.request(request)
 
-        parameters = {'hosts': 'localhost', 'cmd': 'uname -a', 'sudo': True}
+        parameters = {'hosts': '127.0.0.1', 'cmd': 'uname -a', 'sudo': True}
         request = LiveActionDB(action=ACTION_OVR_PARAM_IMMUTABLE_REF, parameters=parameters)
         self.assertRaises(ValueError, action_service.request, request)
 
     def test_request_nonexistent_action(self):
-        parameters = {'hosts': 'localhost', 'cmd': 'uname -a'}
+        parameters = {'hosts': '127.0.0.1', 'cmd': 'uname -a'}
         action_ref = ResourceReference(name='i.action', pack='default').ref
         execution = LiveActionDB(action=action_ref, parameters=parameters)
         self.assertRaises(ValueError, action_service.request, execution)
@@ -278,7 +278,7 @@ class TestActionExecutionService(DbTestCase):
         Action.add_or_update(actiondb)
 
         try:
-            parameters = {'hosts': 'localhost', 'cmd': 'uname -a'}
+            parameters = {'hosts': '127.0.0.1', 'cmd': 'uname -a'}
             execution = LiveActionDB(action=ACTION_REF, parameters=parameters)
             self.assertRaises(ValueError, action_service.request, execution)
         except Exception as e:

--- a/st2common/tests/unit/services/test_synchronization.py
+++ b/st2common/tests/unit/services/test_synchronization.py
@@ -37,7 +37,7 @@ class SynchronizationTest(unittest2.TestCase):
         super(SynchronizationTest, cls).tearDownClass()
 
     def test_service_configured(self):
-        cfg.CONF.set_override(name='url', override='kazoo://localhost:2181', group='coordination')
+        cfg.CONF.set_override(name='url', override='kazoo://127.0.0.1:2181', group='coordination')
         self.assertTrue(coordination.configured())
 
         cfg.CONF.set_override(name='url', override='file:///tmp', group='coordination')

--- a/st2common/tests/unit/test_action_system_models.py
+++ b/st2common/tests/unit/test_action_system_models.py
@@ -25,14 +25,14 @@ class RemoteActionTestCase(unittest2.TestCase):
     def test_instantiation(self):
         action = RemoteAction(name='name', action_exec_id='aeid', command='ls -la',
                               env_vars={'a': 1}, on_behalf_user='onbehalf', user='user',
-                              hosts=['localhost'], parallel=False, sudo=True, timeout=10)
+                              hosts=['127.0.0.1'], parallel=False, sudo=True, timeout=10)
         self.assertEqual(action.name, 'name')
         self.assertEqual(action.action_exec_id, 'aeid')
         self.assertEqual(action.command, 'ls -la')
         self.assertEqual(action.env_vars, {'a': 1})
         self.assertEqual(action.on_behalf_user, 'onbehalf')
         self.assertEqual(action.user, 'user')
-        self.assertEqual(action.hosts, ['localhost'])
+        self.assertEqual(action.hosts, ['127.0.0.1'])
         self.assertEqual(action.parallel, False)
         self.assertEqual(action.sudo, True)
         self.assertEqual(action.timeout, 10)
@@ -45,7 +45,7 @@ class RemoteScriptActionTestCase(unittest2.TestCase):
                                     script_local_libs_path_abs='/tmp/sc/libs', named_args=None,
                                     positional_args=None, env_vars={'a': 1},
                                     on_behalf_user='onbehalf', user='user',
-                                    remote_dir='/home/mauser', hosts=['localhost'],
+                                    remote_dir='/home/mauser', hosts=['127.0.0.1'],
                                     parallel=False, sudo=True, timeout=10)
         self.assertEqual(action.name, 'name')
         self.assertEqual(action.action_exec_id, 'aeid')
@@ -54,7 +54,7 @@ class RemoteScriptActionTestCase(unittest2.TestCase):
         self.assertEqual(action.on_behalf_user, 'onbehalf')
         self.assertEqual(action.user, 'user')
         self.assertEqual(action.remote_dir, '/home/mauser')
-        self.assertEqual(action.hosts, ['localhost'])
+        self.assertEqual(action.hosts, ['127.0.0.1'])
         self.assertEqual(action.parallel, False)
         self.assertEqual(action.sudo, True)
         self.assertEqual(action.timeout, 10)

--- a/st2common/tests/unit/test_paramiko_command_action_model.py
+++ b/st2common/tests/unit/test_paramiko_command_action_model.py
@@ -82,7 +82,7 @@ class ParamikoRemoteComamndActionTests(unittest2.TestCase):
                                                  user='estee',
                                                  password=None,
                                                  private_key='---PRIVATE-KEY---',
-                                                 hosts='localhost',
+                                                 hosts='127.0.0.1',
                                                  parallel=True,
                                                  sudo=False,
                                                  timeout=None,

--- a/st2common/tests/unit/test_paramiko_script_action_model.py
+++ b/st2common/tests/unit/test_paramiko_script_action_model.py
@@ -133,7 +133,7 @@ class ParamikoRemoteScriptActionTests(unittest2.TestCase):
                                                    user='vagrant',
                                                    private_key='/home/vagrant/.ssh/stanley_rsa',
                                                    remote_dir='/tmp',
-                                                   hosts=['localhost'],
+                                                   hosts=['127.0.0.1'],
                                                    parallel=True,
                                                    sudo=False,
                                                    timeout=60, cwd='/tmp')

--- a/st2common/tests/unit/test_util_api.py
+++ b/st2common/tests/unit/test_util_api.py
@@ -69,12 +69,12 @@ class APIUtilsTestCase(unittest2.TestCase):
             self.assertEqual(actual, expected_result)
 
     def test_get_mistral_api_url(self):
-        cfg.CONF.set_override(name='api_url', override='http://localhost:9999', group='auth')
+        cfg.CONF.set_override(name='api_url', override='http://127.0.0.1:9999', group='auth')
         cfg.CONF.set_override(name='api_url', override=None, group='mistral')
 
         # No URL set, should fall back to auth.api_url
         result = get_mistral_api_url()
-        self.assertEqual(result, 'http://localhost:9999/' + DEFAULT_API_VERSION)
+        self.assertEqual(result, 'http://127.0.0.1:9999/' + DEFAULT_API_VERSION)
 
         # mistral.api_url provided, should use that
         cfg.CONF.set_override(name='api_url', override='http://10.0.0.0:9999', group='mistral')

--- a/st2debug/tests/integration/fixtures/configs/mistral.conf
+++ b/st2debug/tests/integration/fixtures/configs/mistral.conf
@@ -1,5 +1,5 @@
 [database]
-connection=mysql://mistral:StackStorm@localhost/mistral
+connection=mysql://mistral:StackStorm@127.0.0.1/mistral
 
 [pecan]
 auth_enable=false

--- a/st2debug/tests/integration/fixtures/configs/st2.conf
+++ b/st2debug/tests/integration/fixtures/configs/st2.conf
@@ -41,7 +41,7 @@ api_url =
 base_path = /opt/stackstorm
 
 [syslog]
-host = localhost
+host = 127.0.0.1
 port = 514
 facility = local7
 protocol = udp
@@ -55,14 +55,14 @@ user = stanley
 ssh_key_file = /vagrant/.ssh/stanley_rsa
 
 [messaging]
-url = amqp://guest:guest@localhost:5672/
+url = amqp://guest:guest@127.0.0.1:5672/
 
 [ssh_runner]
 remote_dir = /tmp
 
 [action_sensor]
-triggers_base_url = http://localhost:9101/triggertypes/
-webhook_sensor_base_url = http://localhost:6000/webhooks/st2/
+triggers_base_url = http://127.0.0.1:9101/triggertypes/
+webhook_sensor_base_url = http://127.0.0.1:6000/webhooks/st2/
 
 [history]
 logging = st2actions/conf/logging.history.conf

--- a/st2tests/conf/st2.conf
+++ b/st2tests/conf/st2.conf
@@ -30,7 +30,7 @@ logging = st2auth/conf/logging.conf
 base_path = /opt/stackstorm
 
 [syslog]
-host = localhost
+host = 127.0.0.1
 port = 514
 facility = local7
 protocol = udp
@@ -43,7 +43,7 @@ user = vagrant
 ssh_key_file = /vagrant/.ssh/id_rsa
 
 [messaging]
-url = amqp://guest:guest@localhost:5672/
+url = amqp://guest:guest@127.0.0.1:5672/
 
 [ssh_runner]
 remote_dir = /tmp

--- a/st2tests/integration/mistral/base.py
+++ b/st2tests/integration/mistral/base.py
@@ -24,7 +24,7 @@ class TestWorkflowExecution(unittest2.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.st2client = st2.Client(base_url='http://localhost')
+        cls.st2client = st2.Client(base_url='http://127.0.0.1')
 
     def _execute_workflow(self, action, parameters=None):
         if parameters is None:

--- a/st2tests/integration/run-ssh-tests.sh
+++ b/st2tests/integration/run-ssh-tests.sh
@@ -83,7 +83,7 @@ function sshtest(){
     # Run script test.
     for i in `seq 1 ${loop_count}`; do
         echo "Running test: $i"
-        output=`st2 run check.loadavg period=all hosts=localhost --json`
+        output=`st2 run check.loadavg period=all hosts=127.0.0.1 --json`
         # altoutput=`st2 run local date --json | python -mjson.tool`
         status=$(echo "$output" | grep -Po '"status":.*?[^\\]",' | awk '{print $2}' | cut -d ',' -f 1 | tr -d '"')
         if [ $status != "succeeded" ]; then

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -68,7 +68,7 @@ def _override_common_opts():
     CONF.set_override(name='base_path', override=packs_base_path, group='system')
     CONF.set_override(name='system_packs_base_path', override=packs_base_path, group='content')
     CONF.set_override(name='packs_base_paths', override=packs_base_path, group='content')
-    CONF.set_override(name='api_url', override='http://localhost', group='auth')
+    CONF.set_override(name='api_url', override='http://127.0.0.1', group='auth')
     CONF.set_override(name='admin_users', override=['admin_user'], group='system')
     CONF.set_override(name='mask_secrets', override=True, group='log')
     CONF.set_override(name='url', override='zake://', group='coordination')
@@ -84,7 +84,7 @@ def _register_common_opts():
 
 def _register_api_opts():
     api_opts = [
-        cfg.ListOpt('allow_origin', default=['http://localhost:3000', 'http://dev'],
+        cfg.ListOpt('allow_origin', default=['http://127.0.0.1:3000', 'http://dev'],
                     help='List of origins allowed'),
         cfg.IntOpt('heartbeat', default=25,
                    help='Send empty message every N seconds to keep connection open'),
@@ -148,7 +148,7 @@ def _register_action_sensor_opts():
         cfg.BoolOpt('enable', default=True,
                     help='Whether to enable or disable the ability ' +
                          'to post a trigger on action.'),
-        cfg.StrOpt('triggers_base_url', default='http://localhost:9101/v1/triggertypes/',
+        cfg.StrOpt('triggers_base_url', default='http://127.0.0.1:9101/v1/triggertypes/',
                    help='URL for action sensor to post TriggerType.'),
         cfg.IntOpt('request_timeout', default=1,
                    help='Timeout value of all httprequests made by action sensor.'),

--- a/tools/db_cleanup.sh
+++ b/tools/db_cleanup.sh
@@ -9,7 +9,7 @@ mongo st2 --eval "db.dropDatabase();"
 echo "Cleaning Mistral Database..."
 SQL_QUERY="DROP DATABASE IF EXISTS mistral; \
   CREATE DATABASE mistral; \
-  GRANT ALL PRIVILEGES ON mistral.* TO 'mistral'@'localhost' IDENTIFIED BY '$ROOT_PASSWORD'; \
+  GRANT ALL PRIVILEGES ON mistral.* TO 'mistral'@'127.0.0.1' IDENTIFIED BY '$ROOT_PASSWORD'; \
   FLUSH PRIVILEGES;"
 
 mysql -uroot -p$ROOT_PASSWORD -e $SQL_QUERY


### PR DESCRIPTION
> Adresses https://github.com/StackStorm/st2-packages/issues/157

Mixing `localhost` vs `127.0.0.1` in configs can lead to bugs/connection problems with some specific configurations in `/etc/hosts`.

Use `127.0.0.1` where possible and follow that for consistency.