### PR TITLE
Allow webhooks endpoint request body to also be url encoded form data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ in development
   it now mimics the behavior of the ``verify`` argument of the ``requests.request`` method.
   (improvement)
 * Add datastore access to Python actions. (new-feature) #2396 [Kale Blankenship]
+* Allow /v1/webhooks API endpoint request body to either be JSON or url encoded form data.
+  Request body type is determined and parsed accordingly based on the value of
+  ``Content-Type`` header.
+  Note: For backward compatibility reasons we default to JSON if ``Content-Type`` header is
+  not provided. #2473 [David Pitman]
 
 1.3.0 - January 22, 2016
 ------------------------

--- a/st2api/st2api/controllers/v1/webhooks.py
+++ b/st2api/st2api/controllers/v1/webhooks.py
@@ -120,7 +120,7 @@ class WebhooksController(RestController):
             self._log_request('Parsing request body as JSON', request=pecan.request)
             body = json.loads(body)
         elif content_type in ['application/x-www-form-urlencoded', 'multipart/form-data']:
-            self._log_request('Parsing reqiest body as form encoded data', request=pecan.request)
+            self._log_request('Parsing request body as form encoded data', request=pecan.request)
             body = urlparse.parse_qs(body)
         else:
             # For backward compatibility reasons, try to parse any other content

--- a/st2api/st2api/controllers/v1/webhooks.py
+++ b/st2api/st2api/controllers/v1/webhooks.py
@@ -88,9 +88,9 @@ class WebhooksController(RestController):
 
         try:
             body = self._parse_request_body(content_type=content_type, body=body)
-        except ValueError:
+        except ValueError as e:
             self._log_request('Invalid JSON/POST body.', pecan.request)
-            msg = 'Invalid JSON/POST body: %s' % (body)
+            msg = 'Invalid request body "%s": %s' % (body, str(e))
             return pecan.abort(http_client.BAD_REQUEST, msg)
 
         headers = self._get_headers_as_dict(pecan.request.headers)

--- a/st2api/st2api/controllers/v1/webhooks.py
+++ b/st2api/st2api/controllers/v1/webhooks.py
@@ -88,8 +88,8 @@ class WebhooksController(RestController):
 
         try:
             body = self._parse_request_body(content_type=content_type, body=body)
-        except ValueError as e:
-            self._log_request('Invalid JSON/POST body.', pecan.request)
+        except Exception as e:
+            self._log_request('Invalid request body: %s.' % (str(e)), pecan.request)
             msg = 'Invalid request body "%s": %s' % (body, str(e))
             return pecan.abort(http_client.BAD_REQUEST, msg)
 

--- a/st2api/st2api/controllers/v1/webhooks.py
+++ b/st2api/st2api/controllers/v1/webhooks.py
@@ -89,8 +89,8 @@ class WebhooksController(RestController):
         try:
             body = self._parse_request_body(content_type=content_type, body=body)
         except Exception as e:
-            self._log_request('Invalid request body: %s.' % (str(e)), pecan.request)
-            msg = 'Invalid request body "%s": %s' % (body, str(e))
+            self._log_request('Failed to parse request body: %s.' % (str(e)), pecan.request)
+            msg = 'Failed to parse request body "%s": %s' % (body, str(e))
             return pecan.abort(http_client.BAD_REQUEST, msg)
 
         headers = self._get_headers_as_dict(pecan.request.headers)
@@ -123,10 +123,7 @@ class WebhooksController(RestController):
             self._log_request('Parsing request body as form encoded data', request=pecan.request)
             body = urlparse.parse_qs(body)
         else:
-            # For backward compatibility reasons, try to parse any other content
-            # type as JSON
-            self._log_request('Parsing request body as JSON', request=pecan.request)
-            body = json.loads(body)
+            raise ValueError('Unsupported Content-Type: "%s"' % (content_type))
 
         return body
 

--- a/st2api/st2api/controllers/v1/webhooks.py
+++ b/st2api/st2api/controllers/v1/webhooks.py
@@ -117,15 +117,15 @@ class WebhooksController(RestController):
 
     def _parse_request_body(self, content_type, body):
         if content_type == 'application/json':
-            self._log_request('Parsing body as JSON', request=pecan.request)
+            self._log_request('Parsing request body as JSON', request=pecan.request)
             body = json.loads(body)
         elif content_type in ['application/x-www-form-urlencoded', 'multipart/form-data']:
-            self._log_request('Parsing body as form encoded data', request=pecan.request)
+            self._log_request('Parsing reqiest body as form encoded data', request=pecan.request)
             body = urlparse.parse_qs(body)
         else:
             # For backward compatibility reasons, try to parse any other content
             # type as JSON
-            self._log_request('Parsing body as JSON', request=pecan.request)
+            self._log_request('Parsing request body as JSON', request=pecan.request)
             body = json.loads(body)
 
         return body


### PR DESCRIPTION
This pull request works on top of #2473 and adds support for determining body type based on the `Content-Type` header value.

Now that we have this code in place we could also easily add support for other Content-Types in the future if needed. (e.g. YAML or XML).