### PR TITLE
Don't log the response body of the file(s) controllers

### DIFF
--- a/st2common/st2common/hooks.py
+++ b/st2common/st2common/hooks.py
@@ -49,7 +49,9 @@ RESPONSE_LOGGING_METHOD_NAME_BLACKLIST = [
 RESPONSE_LOGGING_CONTROLLER_NAME_BLACKLIST = [
     'ActionExecutionChildrenController',  # action executions can be big
     'ActionExecutionAttributeController',  # result can be big
-    'ActionExecutionsController'  # action executions can be big
+    'ActionExecutionsController'  # action executions can be big,
+    'FilesController',  # files controller returns files content
+    'FileController'  # file controller returns binary file data
 ]
 
 


### PR DESCRIPTION
Response body generated by those controllers can contain a lot and / or binary data.

Resolves #2476.