### PR TITLE
ChatOps pack: don't replace /n with @

### DIFF
--- a/contrib/chatops/actions/templates/default.j2
+++ b/contrib/chatops/actions/templates/default.j2
@@ -3,7 +3,7 @@
     {{ prefix }}{{ key }} : {% if value is mapping -%}
       {{ '\n' + serialize(six.iteritems(value), prefix+'  ') }}
     {%- elif value is string and (value | trim).split('\n') | length > 1 %}
-      {{ '\n' + prefix + '  ' + value | trim | replace('\n', '@')}}
+      {{ '\n' + prefix + '  ' + value | trim }}
     {% else -%}
       {{ value | trim }}
     {% endif %}


### PR DESCRIPTION
As reported in https://github.com/StackStorm/st2/issues/2456. I have no idea why that replace is even there, so I’ll test for a while and merge if nothing’s broken. If anyone knows anything about this mysterious replace, speak up, but even @enykeev does not. :P