### PR TITLE
Include number of elapsed seconds for completed executions in "st2 execution get" CLI command output

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ in development
   not provided. #2473 [David Pitman]
 * Display number of seconds which have elapsed for all the executions which have completed
   when using ``st2 execution get`` CLI command. (improvement)
+* Display number of seconds elapsed for all the child tasks of a workflow action when using
+  ``st2 execution get`` CLI command. (improvement)
 
 1.3.0 - January 22, 2016
 ------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@ in development
   ``Content-Type`` header.
   Note: For backward compatibility reasons we default to JSON if ``Content-Type`` header is
   not provided. #2473 [David Pitman]
+* Display number of seconds which have elapsed for all the executions which have completed
+  when using ``st2 execution get`` CLI command. (improvement)
 
 1.3.0 - January 22, 2016
 ------------------------

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -158,8 +158,8 @@ def format_execution_status(instance):
         elapsed_seconds = (now - start_timestamp)
         instance.status = '%s (%ss elapsed)' % (instance.status, elapsed_seconds)
     elif instance.status in LIVEACTION_COMPLETED_STATES:
-        start_timestamp = instance.start_timestamp
-        end_timestamp = instance.end_timestamp
+        start_timestamp = getattr(instance, 'start_timestamp', None)
+        end_timestamp = getattr(instance, 'end_timestamp', None)
 
         if not start_timestamp or not end_timestamp:
             # start or end timestamp not available

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -738,7 +738,8 @@ class ActionRunCommandMixin(object):
             'status': task.status,
             'task': jsutil.get_value(vars(task), task_name_key),
             'action': task.action.get('ref', None),
-            'start_timestamp': task.start_timestamp
+            'start_timestamp': task.start_timestamp,
+            'end_timestamp': getattr(task, 'end_timestamp', None)
         })
 
     def _sort_parameters(self, parameters, names):

--- a/st2client/tests/fixtures/execution_get_attributes.txt
+++ b/st2client/tests/fixtures/execution_get_attributes.txt
@@ -1,2 +1,2 @@
-status: succeeded
+status: succeeded (1s elapsed)
 end_timestamp: 2014-12-02T19:56:07.000000Z

--- a/st2client/tests/fixtures/execution_get_default.txt
+++ b/st2client/tests/fixtures/execution_get_default.txt
@@ -1,5 +1,5 @@
 id: 547e19561e2e2417d3dde398
-status: succeeded
+status: succeeded (1s elapsed)
 parameters: 
   cmd: 127.0.0.1 3
 result: 

--- a/st2client/tests/fixtures/execution_get_detail.txt
+++ b/st2client/tests/fixtures/execution_get_detail.txt
@@ -7,7 +7,7 @@
 | parameters      | {                                                            |
 |                 |     "cmd": "127.0.0.1 3"                                     |
 |                 | }                                                            |
-| status          | succeeded                                                    |
+| status          | succeeded (1s elapsed)                                       |
 | start_timestamp | Tue, 02 Dec 2014 19:56:06 UTC                                |
 | end_timestamp   | Tue, 02 Dec 2014 19:56:07 UTC                                |
 | result          | {                                                            |

--- a/st2client/tests/unit/test_formatters.py
+++ b/st2client/tests/unit/test_formatters.py
@@ -15,7 +15,6 @@
 
 import six
 import os
-import re
 import sys
 import mock
 import json

--- a/st2client/tests/unit/test_formatters.py
+++ b/st2client/tests/unit/test_formatters.py
@@ -133,7 +133,6 @@ class TestExecutionResultFormatter(unittest2.TestCase):
         self._undo_console_redirect()
         with open(self.path, 'r') as fd:
             content = fd.read()
-        content = self._process_output(output=content)
         self.assertEqual(
             content, FIXTURES['results']['execution_result_has_carriage_return.txt'])
 
@@ -146,20 +145,4 @@ class TestExecutionResultFormatter(unittest2.TestCase):
         with open(self.path, 'r') as fd:
             content = fd.read()
 
-        content = self._process_output(output=content)
         return content
-
-    def _process_output(self, output):
-        # Note: We strip number of seconds elapsed from the result since we can't consistenly
-        # assert on number of seconds which have elapsed
-
-        # We only add space in table output mode
-        whitespace_count = len(' (1s elapsed)')
-
-        if '+----' in output:
-            replacement_str = (' ' * whitespace_count)
-        else:
-            replacement_str = ''
-
-        output = re.sub('\s\(\ds elapsed\)', replacement_str, output)
-        return output


### PR DESCRIPTION
The title says it all.

This should make it easier to see, at a glance, how long it took for the execution to complete and potentially adjust the action timeouts accordingly.

![screenshot from 2016-02-10 18 11 51](https://cloud.githubusercontent.com/assets/125088/12946236/d79f54a4-d02d-11e5-9a37-902b57834295.png)