### PR TITLE
Fix CircleCI Bintray parallel uploads

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -47,6 +47,7 @@ dependencies:
   pre:
     - sudo .circle/configure-services.sh
     - sudo .circle/fix-cache-permissions.sh
+    - sudo apt-get -y install parallel
     - sudo pip install docker-compose
     - docker-compose version
     - docker version
@@ -78,11 +79,7 @@ deployment:
       # Deploy to Bintray all artifacts for respective distros in parallel
       - |
         DISTROS=($DISTROS)
-        for i in $(seq 0 $((CIRCLE_NODE_TOTAL-1))); do
-          echo Deploying Bintray artifacts for "${DISTROS[$i]}" ...
-          .circle/bintray.sh deploy ${DISTROS[$i]}_staging ~/packages/${DISTROS[$i]} &
-        done
-        wait
+        parallel -v -j0 --line-buffer .circle/bintray.sh deploy {}_staging ~/packages/{} ::: ${DISTROS[@]::$CIRCLE_NODE_TOTAL}
       - .circle/docker.sh deploy st2actionrunner st2api st2auth st2exporter st2notifier st2resultstracker st2rulesengine st2sensorcontainer
       - .circle/save_payload.py ~/packages
 


### PR DESCRIPTION
Currently we upload packages to 5 Bintray repos in parallel.
Same we do for 7 Docker containers, uploaded to Docker Hub in parallel.
This saves time, the improvement is huge.

Existing problem described in stackstorm/st2-packages#74: when any of parallel jobs fail - we don't show failed exit code with current basic bash `& wait` implementation, which means in CI deploy task always marked as "succeeded".

Correct behavor is fixed with help of `parallel` tool, which is right way and catches exit code from all the jobs.
See: [GNU Parallel Man](https://www.gnu.org/software/parallel/man.html)

-----
Researched/experimented a bit with bashing and `xjobs`, `xargs`, `parallel`, `pexec` tools.
`parallel` is the best fit here.


See https://github.com/StackStorm/st2-packages/pull/164