### PR TITLE
PXPSE-422

### DIFF
--- a/st2common/st2common/log.py
+++ b/st2common/st2common/log.py
@@ -94,8 +94,14 @@ def decorate_logger_methods(logger):
 
 
 def getLogger(name):
-    logger_name = 'st2.{}'.format(name)
-    logger = logging.getLogger(logger_name)
+    # make sure that prefix isn't appended multiple times to preserve logging name hierarchy
+    prefix = 'st2.'
+    if name.startswith(prefix):
+        logger = logging.getLogger(name)
+    else:
+        logger_name = '{}{}'.format(prefix, name)
+        logger = logging.getLogger(logger_name)
+
     logger = decorate_logger_methods(logger=logger)
     return logger
 

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -175,8 +175,8 @@ class SensorWrapper(object):
                                                exclusive=True)
 
         # 4. Set up logging
-        self._logger = logging.getLogger('SensorWrapper.%s' %
-                                         (self._class_name))
+        self._logger = logging.getLogger('SensorWrapper.%s.%s' %
+                                         (self._pack, self._class_name))
         logging.setup(cfg.CONF.sensorcontainer.logging)
 
         if '--debug' in parent_args:


### PR DESCRIPTION
Ignore...just PRing to let the automated tests run.

__Updates__

* Ensure that 'st2.' is not prefixed to logger names multiple times to preserve the correct logging hierarchy.
* Include the pack name in the logger name retrieved in SensorWrapper.

