### PR TITLE
Sensor Logging Fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ in development
   ``Content-Type`` header.
   Note: For backward compatibility reasons we default to JSON if ``Content-Type`` header is
   not provided. #2473 [David Pitman]
+* Bug fixes to allow Sensors to have their own log files. #2487 [Andrew Regan]
 
 1.3.0 - January 22, 2016
 ------------------------

--- a/st2common/st2common/log.py
+++ b/st2common/st2common/log.py
@@ -94,8 +94,14 @@ def decorate_logger_methods(logger):
 
 
 def getLogger(name):
-    logger_name = 'st2.{}'.format(name)
-    logger = logging.getLogger(logger_name)
+    # make sure that prefix isn't appended multiple times to preserve logging name hierarchy
+    prefix = 'st2.'
+    if name.startswith(prefix):
+        logger = logging.getLogger(name)
+    else:
+        logger_name = '{}{}'.format(prefix, name)
+        logger = logging.getLogger(logger_name)
+
     logger = decorate_logger_methods(logger=logger)
     return logger
 

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -175,8 +175,8 @@ class SensorWrapper(object):
                                                exclusive=True)
 
         # 4. Set up logging
-        self._logger = logging.getLogger('SensorWrapper.%s' %
-                                         (self._class_name))
+        self._logger = logging.getLogger('SensorWrapper.%s.%s' %
+                                         (self._pack, self._class_name))
         logging.setup(cfg.CONF.sensorcontainer.logging)
 
         if '--debug' in parent_args:


### PR DESCRIPTION
__Updates__
* Make sure the `getLogger()` call does not append more then one `st2.` prefix to the logger name to preserve the logging name hierarchy. This code from `st2reactor/st2reactor/container/sensor_wrapper.py` was creating loggers prefixed with `st2.st2.` because `self._sensor_wrapper._logger.name` is already prefixed with `st2.` and the call to `getLogger` would prefix an additional `st2.`:
```
    def get_logger(self, name):
        """
        Retrieve an instance of a logger to be used by the sensor class.
        """
        logger_name = '%s.%s' % (self._sensor_wrapper._logger.name, name)
        logger = logging.getLogger(logger_name)
        logger.propagate = True

        return logger
```
* Include the pack name in the logger named used by sensors since `self._class_name` does not have to be unique across packs

The current default logging setup shares the `st2sensorcontainer.log` across multiple processes which isn't really suppored. Using these changes its possible to break out individual log files per sensor via the `logging.sensorcontainer.conf`. Example changes:

```
[loggers]
keys=root,vSphereEventSensor

...

[logger_vSphereEventSensor]
level=DEBUG
handlers=consoleHandler, vSphereEventSensorFileHandler, vSphereEventSensorAuditHandler
propagate=0
qualname=st2.SensorWrapper.vsphere.EventSensor

...

[handler_vSphereEventSensorFileHandler]
class=handlers.RotatingFileHandler
level=DEBUG
formatter=verboseConsoleFormatter
args=("logs/vsphere_event_sensor.log",)
```
