### PR TITLE
ChatOps: Fixing null optional arguments error

### DIFF
--- a/st2common/st2common/models/utils/action_alias_utils.py
+++ b/st2common/st2common/models/utils/action_alias_utils.py
@@ -81,7 +81,7 @@ class ActionAliasFormatParser(object):
         if matched_stream:
             values = matched_stream.groupdict()
         for param in params:
-            matched_value = values[param[0]] if matched_stream else param[1] or None
+            matched_value = values[param[0]] if matched_stream else param[1]
             if matched_value:
                 result[param[0]] = matched_value
         if extra:

--- a/st2common/st2common/models/utils/action_alias_utils.py
+++ b/st2common/st2common/models/utils/action_alias_utils.py
@@ -81,8 +81,9 @@ class ActionAliasFormatParser(object):
         if matched_stream:
             values = matched_stream.groupdict()
         for param in params:
-            matched_value = values[param[0]] if matched_stream else None
-            result[param[0]] = matched_value or param[1]
+            matched_value = values[param[0]] if matched_stream else param[1] or None
+            if matched_value:
+                result[param[0]] = matched_value
         if extra:
             for pair in kv_pairs:
                 result[pair[0]] = ''.join(pair[2:])

--- a/st2common/st2common/models/utils/action_alias_utils.py
+++ b/st2common/st2common/models/utils/action_alias_utils.py
@@ -81,9 +81,10 @@ class ActionAliasFormatParser(object):
         if matched_stream:
             values = matched_stream.groupdict()
         for param in params:
-            matched_value = values[param[0]] if matched_stream else param[1]
-            if matched_value:
-                result[param[0]] = matched_value
+            matched_value = values[param[0]] if matched_stream else None
+            matched_result = matched_value or param[1]
+            if matched_result:
+                result[param[0]] = matched_result
         if extra:
             for pair in kv_pairs:
                 result[pair[0]] = ''.join(pair[2:])

--- a/st2common/tests/unit/test_action_alias_utils.py
+++ b/st2common/tests/unit/test_action_alias_utils.py
@@ -107,7 +107,7 @@ class TestActionAliasParser(TestCase):
         param_stream = 'acl123'
         parser = ActionAliasFormatParser(alias_format, param_stream)
         extracted_values = parser.get_extracted_param_value()
-        self.assertEqual(extracted_values, {'a': ''})
+        self.assertEqual(extracted_values, {})
 
     def test_json_parsing(self):
         alias_format = 'skip {{a}} more skip.'


### PR DESCRIPTION
Fixes #2295

@pixelrebel reported a use case where an argument that’s technically not optional (i.e. doesn’t have a default value) is placed inside an optional regex group:

```
update {{hostname}}( {{count}} times)? 
```

With a string like `update google.com` our parser extracts `{{count}}` from the alias and sets the value to “” because it can’t be matched to anything. While a string like this is something you shouldn’t really do in the first place, it’s pretty easy to introduce support for it, and the use case is legit, so I suggest we go for it.

This is a small fix that doesn’t affect parser logic, so it should be fine as soon as Travis is finished, but I’ll wait for someone else to LGTM this first.