### PR TITLE
Various improvements for new st2ctl

### DIFF
--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -76,7 +76,7 @@ function st2stop() {
 function service_manager() {
   if [ -d /run/systemd/system ]; then
     systemctl "${2}" "${1}"
-  elif command -v service 2>/dev/null; then
+  elif command -v service > /dev/null 2>&1; then
     service "${1}" "${2}"
   else
     echo -e "\e[31mError: Unsupported service manager in the system! \e[0m\n"

--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -2,8 +2,7 @@
 
 
 LOGFILE="/dev/null"
-COMPONENTS="st2actionrunner st2api st2auth st2garbagecollector st2notifier st2resultstracker "
-COMPONENTS+="st2rulesengine st2sensorcontainer st2web mistral mistral-api"
+COMPONENTS="st2actionrunner st2api st2auth st2garbagecollector st2notifier st2resultstracker st2rulesengine st2sensorcontainer st2web mistral"
 STANCONF="/etc/st2/st2.conf"
 WEBUI_PORT=${WEBUI_PORT:-8080}
 
@@ -140,12 +139,11 @@ function clean_logs() {
 
 function getpids() {
   echo "##### st2 components status #####"
+  COMPONENTS=${COMPONENTS/mistral/mistral-server mistral-api}
 
   for COM in ${COMPONENTS}; do
     if [[ "${COM}" == "st2web" && -z "${ST2_DISABLE_HTTPSERVER}" ]]; then
       PID=`ps ax | grep -v grep | egrep "SimpleHTTPServer $WEBUI_PORT\$" | awk '{print $1}'`
-    elif [[ "${COM}" == "mistral" ]]; then
-      PID=`ps ax | grep -v grep | grep -v postgres | grep "${COM}" | awk '{print $1}'`
     else
       PID=`ps ax | grep -v grep | grep -v st2ctl | grep "${COM}" | awk '{print $1}'`
     fi

--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -72,10 +72,14 @@ function st2stop() {
 }
 
 function service_manager() {
-  if [ -d /run/systemd/system ]; then
+  if [ ! -f /etc/init/${1}.conf ] && [ ! -x /etc/init.d/${1} ]; then
+    echo "[info] ${1}: service is not installed"
+  elif [ -d /run/systemd/system ]; then
     systemctl "${2}" "${1}"
   elif command -v service > /dev/null 2>&1; then
     service "${1}" "${2}"
+  elif [ -x /etc/init.d/${1} ]; then
+    /etc/init.d/${1} "${2}"
   else
     echo -e "\e[31mError: Unsupported service manager in the system! \e[0m\n"
     exit 1

--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -2,7 +2,7 @@
 
 
 LOGFILE="/dev/null"
-COMPONENTS="st2actionrunner st2api st2auth st2garbagecollector st2notifier st2resultstracker st2rulesengine st2sensorcontainer st2web mistral"
+COMPONENTS="st2actionrunner st2api st2auth st2garbagecollector st2notifier st2resultstracker st2rulesengine st2sensorcontainer mistral"
 STANCONF="/etc/st2/st2.conf"
 
 # Ensure global environment is sourced if exists
@@ -72,9 +72,7 @@ function st2stop() {
 }
 
 function service_manager() {
-  if [ ! -f /etc/init/${1}.conf ] && [ ! -x /etc/init.d/${1} ]; then
-    echo "[info] ${1}: service is not installed"
-  elif [ -d /run/systemd/system ]; then
+  if [ -d /run/systemd/system ]; then
     systemctl "${2}" "${1}"
   elif command -v service > /dev/null 2>&1; then
     service "${1}" "${2}"

--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -4,7 +4,6 @@
 LOGFILE="/dev/null"
 COMPONENTS="st2actionrunner st2api st2auth st2garbagecollector st2notifier st2resultstracker st2rulesengine st2sensorcontainer st2web mistral"
 STANCONF="/etc/st2/st2.conf"
-WEBUI_PORT=${WEBUI_PORT:-8080}
 
 # Ensure global environment is sourced if exists
 # Does not happen consistently with all OSes we support.
@@ -142,11 +141,7 @@ function getpids() {
   COMPONENTS=${COMPONENTS/mistral/mistral-server mistral-api}
 
   for COM in ${COMPONENTS}; do
-    if [[ "${COM}" == "st2web" && -z "${ST2_DISABLE_HTTPSERVER}" ]]; then
-      PID=`ps ax | grep -v grep | egrep "SimpleHTTPServer $WEBUI_PORT\$" | awk '{print $1}'`
-    else
-      PID=`ps ax | grep -v grep | grep -v st2ctl | grep "${COM}" | awk '{print $1}'`
-    fi
+    PID=`ps ax | grep -v grep | grep -v st2ctl | grep "${COM}" | awk '{print $1}'`
 
     if [[ ! -z ${PID} ]]; then
       for p in ${PID}; do
@@ -170,7 +165,7 @@ case ${1} in
     st2stop
     ;;
   restart)
-    must_be_root  
+    must_be_root
     st2stop
     sleep 1
     st2start


### PR DESCRIPTION
Testing `st2`/`st2ctl` under Docker with different distros. Part of https://github.com/StackStorm/st2/issues/2409 checks. Fixes: 

#### 1.) `mistral-api` is not a service to start/stop
Debian wheezy Docker: 
![st2ctl](https://cloud.githubusercontent.com/assets/1533818/13010275/b6488320-d1a9-11e5-9b6d-db85eeb65015.gif)
As said before https://github.com/StackStorm/st2/pull/2445, both `mistral-api` and `mistral-server` are handled by `service mistral`.
Instead of `service mistral-api restart` the correct command is `service mistral restart` which handles both.
Instead of adding them in components to start/stop, show `mistral-server` and `mistral-api` statuses separated in `st2ctl status`:
```sh
# st2ctl status
##### st2 components status #####
...
mistral-server PID: 16318
mistral-api PID: 16305
mistral-api PID: 16327
mistral-api PID: 16332
```

#### 2.) Cosmetic fixes with `/dev/null` & output
Debian Wheezy Docker:
![st2ctl-2](https://cloud.githubusercontent.com/assets/1533818/13010314/ecde6b2a-d1a9-11e5-8c64-1c0b3637b590.gif)
https://gist.github.com/lakshmi-kannan/890933d2823b541701e7 cc @lakshmi-kannan


#### 3.) Remove obsolete `WEBUI_PORT` and `SimpleHTTPServer` from new `st2ctl`

#### 4.) Ubuntu trusty + Docker
`initctl: Unable to connect to Upstart: Failed to connect to socket /com/ubuntu/upstart: Connection refused`

#### 5.) Add a fallback to `/etc/init.d/service-name` as last step
Just in case, handle various distros/Docker cases

#### 6.) Testing in different Distros/Docker containers