### PR TITLE
Various improvements in the linux.wait_for_ssh action

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,12 @@ in development
   when using ``st2 execution get`` CLI command. (improvement)
 * Display number of seconds elapsed for all the child tasks of a workflow action when using
   ``st2 execution get`` CLI command. (improvement)
+* Various improvements in the ``linux.wait_for_ssh`` action:
+  * Support for password based authentication.
+  * Support for non-RSA SSH keys.
+  * Support for providing a non-default (22) SSH server port.
+  * Support for using default system user (stanley) ssh key if neither ``password`` nor
+    ``keyfile`` parameter is provided.
 
 1.3.2 - February 12, 2016
 -------------------------

--- a/contrib/linux/actions/wait_for_ssh.py
+++ b/contrib/linux/actions/wait_for_ssh.py
@@ -9,12 +9,14 @@ from st2actions.runners.ssh.paramiko_ssh import ParamikoSSHClient
 
 
 class BaseAction(Action):
-    def run(self, hostname, port, username, password=None, keyfile=None, ssh_timeout=30,
-            retries=10):
-        # Note: If neither password nor key file is provided, we try to use
-        # system user key file
+    def run(self, hostname, port, username, password=None, keyfile=None, ssh_timeout=5,
+            sleep_delay=20, retries=10):
+        # Note: If neither password nor key file is provided, we try to use system user 
+        # key file
         if not password and not keyfile:
             keyfile = cfg.CONF.system_user.ssh_key_file
+            self.logger.info('Neither "password" nor "keyfile" parameter provided, '
+                             'defaulting to using "%s" key file' % (keyfile))
 
         client = ParamikoSSHClient(hostname=hostname, port=port, username=username,
                                    password=password, key_files=keyfile,
@@ -28,7 +30,8 @@ class BaseAction(Action):
                 client.connect()
                 return True
             except Exception as e:
-                self.logger.info('Attempt %s failed (%s), sleeping...' % (attempt, str(e)))
-                time.sleep(ssh_timeout)
+                self.logger.info('Attempt %s failed (%s), sleeping for %s seconds...' %
+                                  (attempt, str(e), sleep_delay))
+                time.sleep(sleep_delay)
 
         raise Exception('Exceeded max retries (%s)' % (retries))

--- a/contrib/linux/actions/wait_for_ssh.py
+++ b/contrib/linux/actions/wait_for_ssh.py
@@ -11,7 +11,7 @@ from st2actions.runners.ssh.paramiko_ssh import ParamikoSSHClient
 class BaseAction(Action):
     def run(self, hostname, port, username, password=None, keyfile=None, ssh_timeout=5,
             sleep_delay=20, retries=10):
-        # Note: If neither password nor key file is provided, we try to use system user 
+        # Note: If neither password nor key file is provided, we try to use system user
         # key file
         if not password and not keyfile:
             keyfile = cfg.CONF.system_user.ssh_key_file
@@ -31,7 +31,7 @@ class BaseAction(Action):
                 return True
             except Exception as e:
                 self.logger.info('Attempt %s failed (%s), sleeping for %s seconds...' %
-                                  (attempt, str(e), sleep_delay))
+                                 (attempt, str(e), sleep_delay))
                 time.sleep(sleep_delay)
 
         raise Exception('Exceeded max retries (%s)' % (retries))

--- a/contrib/linux/actions/wait_for_ssh.py
+++ b/contrib/linux/actions/wait_for_ssh.py
@@ -2,23 +2,30 @@
 
 import time
 
-import paramiko
+from oslo_config import cfg
 
 from st2actions.runners.pythonrunner import Action
+from st2actions.runners.ssh.paramiko_ssh import ParamikoSSHClient
 
 
 class BaseAction(Action):
-    def run(self, keyfile, username, hostname, ssh_timeout, retries):
-        key = paramiko.RSAKey.from_private_key_file(keyfile)
-        client = paramiko.SSHClient()
-        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    def run(self, hostname, port, username, password=None, keyfile=None, ssh_timeout=30,
+            retries=10):
+        # Note: If neither password nor key file is provided, we try to use
+        # system user key file
+        if not password and not keyfile:
+            keyfile = cfg.CONF.system_user.ssh_key_file
+
+        client = ParamikoSSHClient(hostname=hostname, port=port, username=username,
+                                   password=password, key_files=keyfile,
+                                   timeout=ssh_timeout)
 
         for index in range(retries):
             attempt = index + 1
 
             try:
                 self.logger.debug('SSH connection attempt: %s' % (attempt))
-                client.connect(hostname=hostname, username=username, pkey=key)
+                client.connect()
                 return True
             except Exception as e:
                 self.logger.info('Attempt %s failed (%s), sleeping...' % (attempt, str(e)))

--- a/contrib/linux/actions/wait_for_ssh.yaml
+++ b/contrib/linux/actions/wait_for_ssh.yaml
@@ -1,23 +1,34 @@
 ---
   name: "wait_for_ssh"
   runner_type: "python-script"
-  description: "Wait for SSH"
+  description: "Action which waits for a SSH server to become accessible. By default if no credentials are explicitly provided, this action will try to authenticate using system user username and password."
   enabled: true
   entry_point: "wait_for_ssh.py"
-  parameters: 
-    keyfile: 
-      default: "/home/stanley/.ssh/stanley_rsa"
-      required: true
-    username: 
-      description: "Command line arguments"
-      required: true
-      default: "stanley"
-    hostname: 
+  parameters:
+    hostname:
+      description: "Remote hostname"
       type: "string"
       required: true
-    ssh_timeout: 
+    port:
+      description: "Remote SSH port."
+      type: "integer"
+      default: 22
+    username:
+      description: "Username used to authenticate."
+      required: true
+      default: "stanley"
+    password:
+      description: "Password used to authenticate."
+      required: false
+    keyfile:
+      description: "SSH key file used to authenticate."
+      required: false
+    # TODO: We should really rename this to sleep delay or similar
+    ssh_timeout:
+      description: "Sleep delay after each connection attempt."
       type: "integer"
       default: 30
-    retries: 
+    retries:
+      description: "Maximum number of retries."
       type: "integer"
       default: 10

--- a/contrib/linux/actions/wait_for_ssh.yaml
+++ b/contrib/linux/actions/wait_for_ssh.yaml
@@ -1,17 +1,18 @@
 ---
   name: "wait_for_ssh"
   runner_type: "python-script"
-  description: "Action which waits for a SSH server to become accessible. By default if no credentials are explicitly provided, this action will try to authenticate using system user username and password."
+  description: "Action which waits for a SSH server to become accessible. By default, if no credentials are provided, this action will try to authenticate using the system user username and key file."
   enabled: true
   entry_point: "wait_for_ssh.py"
   parameters:
     hostname:
-      description: "Remote hostname"
+      description: "Remote hostname."
       type: "string"
       required: true
     port:
       description: "Remote SSH port."
       type: "integer"
+      required: true
       default: 22
     username:
       description: "Username used to authenticate."

--- a/contrib/linux/actions/wait_for_ssh.yaml
+++ b/contrib/linux/actions/wait_for_ssh.yaml
@@ -23,12 +23,19 @@
     keyfile:
       description: "SSH key file used to authenticate."
       required: false
-    # TODO: We should really rename this to sleep delay or similar
     ssh_timeout:
-      description: "Sleep delay after each connection attempt."
+      description: "SSH connection connect timeout (in seconds)."
       type: "integer"
-      default: 30
+      default: 5
+    sleep_delay:
+      description: "How long to sleep / wait (in seconds) after each failed connection attempt."
+      type: "integer"
+      default: 20
     retries:
       description: "Maximum number of retries."
       type: "integer"
       default: 10
+    timeout:
+      # Note: timeout needs to be >= ((ssh_timeout + sleep_delay) * retries) so we override a
+      # default Python runner action timeout with a larger value
+      default: 400


### PR DESCRIPTION
@jon-middleton originally reported on the Slack community channel that this action uses an incorrect path to the default SSH key file used to authenticate.

The problem is that path is hard-coded in the action parameter default value while it should really be read from the config file since the path is user-configurable and installation specific.

In addition to that, I noticed this action needs some love so I also made some other improvements which make this action more generic and generally usable.

1. Support for password based authentication (previously only key based authentication was supported)
2. Support for non-default SSH ports (previously only 22 was supported)
3. Support for non RSA key types (previously only RSA keys were supported)
4. If neither `password` nor `keyfile` argument is explicitly provided, action will try to use path to the key file from the system user. That's the default behavior to keep the action backward compatible.
5. Refactor the code to utilize the new `ParamikoSSHClient` class which is also used by the remote runner.
6. Add new `sleep_delay` parameter which represents number of seconds to sleep / wait before each failed connection timeout and actually utilize existing `ssh_timeout` argument for the SSH connection timeout.

Resolves #2507.