### PR TITLE
Allow specifying color for messages posted to Slack via chatops

### DIFF
--- a/contrib/chatops/actions/post_message.yaml
+++ b/contrib/chatops/actions/post_message.yaml
@@ -25,3 +25,6 @@ parameters:
     type: "string"
     description: "Channel to post to"
     required: true
+  color:
+    type: "string"
+    description: "Color to use for attachment (Slack only)"

--- a/contrib/chatops/pack.yaml
+++ b/contrib/chatops/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name: chatops
 description: Chatops integration pack
-version: 0.1.0
+version: 0.2.0
 author: Kirill Enykeev
 email: enykeev@stackstorm.com


### PR DESCRIPTION
This commit adds the `color` parameter to the `chatops.post_message` action. This allows you to specify a particular color for the message when using Slack.