### PR TITLE
Python runner actions datastore access changes, action unit testing fixes and lint cleanup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,9 @@ in development
 * Allow user to pass a boolean value for the ``cacert`` st2client constructor argument. This way
   it now mimics the behavior of the ``verify`` argument of the ``requests.request`` method.
   (improvement)
-* Add datastore access to Python actions. (new-feature) #2396 [Kale Blankenship]
+* Add datastore access to Python runner actions via the ``action_service`` which is available
+  to all the Python runner actions after instantiation. (new-feature) #2396 #2511
+  [Kale Blankenship]
 * Allow /v1/webhooks API endpoint request body to either be JSON or url encoded form data.
   Request body type is determined and parsed accordingly based on the value of
   ``Content-Type`` header.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ in development
 * Add datastore access to Python runner actions via the ``action_service`` which is available
   to all the Python runner actions after instantiation. (new-feature) #2396 #2511
   [Kale Blankenship]
+* Update ``st2actions.runners.pythonrunner.Action`` class so the constructor also takes
+  ``action_service`` as the second argument.
 * Allow /v1/webhooks API endpoint request body to either be JSON or url encoded form data.
   Request body type is determined and parsed accordingly based on the value of
   ``Content-Type`` header.

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,8 @@ pylint: requirements .pylint
 		. $(VIRTUALENV_DIR)/bin/activate; pylint -E --rcfile=./lint-configs/python/.pylintrc --load-plugins=pylint_plugins.api_models $$component/$$component || exit 1; \
 	done
 	# Lint Python pack management actions
-	. $(VIRTUALENV_DIR)/bin/activate; pylint -E --rcfile=./lint-configs/python/.pylintrc --load-plugins=pylint_plugins.api_models contrib/packs/actions/pack_mgmt/ || exit 1;
+	. $(VIRTUALENV_DIR)/bin/activate; pylint -E --rcfile=./lint-configs/python/.pylintrc --load-plugins=pylint_plugins.api_models contrib/packs/actions/ || exit 1;
+
 	# Lint other packs
 	. $(VIRTUALENV_DIR)/bin/activate; pylint -E --rcfile=./lint-configs/python/.pylintrc --load-plugins=pylint_plugins.api_models contrib/linux || exit 1;
 	# Lint Python scripts
@@ -84,7 +85,7 @@ flake8: requirements .flake8
 	@echo "==================== flake ===================="
 	@echo
 	. $(VIRTUALENV_DIR)/bin/activate; flake8 --config ./lint-configs/python/.flake8 $(COMPONENTS)
-	. $(VIRTUALENV_DIR)/bin/activate; flake8 --config ./lint-configs/python/.flake8 contrib/packs/actions/pack_mgmt/
+	. $(VIRTUALENV_DIR)/bin/activate; flake8 --config ./lint-configs/python/.flake8 contrib/packs/actions/
 	. $(VIRTUALENV_DIR)/bin/activate; flake8 --config ./lint-configs/python/.flake8 contrib/linux
 	. $(VIRTUALENV_DIR)/bin/activate; flake8 --config ./lint-configs/python/.flake8 scripts/
 	. $(VIRTUALENV_DIR)/bin/activate; flake8 --config ./lint-configs/python/.flake8 tools/

--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,9 @@ pylint: requirements .pylint
 	done
 	# Lint Python pack management actions
 	. $(VIRTUALENV_DIR)/bin/activate; pylint -E --rcfile=./lint-configs/python/.pylintrc --load-plugins=pylint_plugins.api_models contrib/packs/actions/ || exit 1;
-
 	# Lint other packs
 	. $(VIRTUALENV_DIR)/bin/activate; pylint -E --rcfile=./lint-configs/python/.pylintrc --load-plugins=pylint_plugins.api_models contrib/linux || exit 1;
+	. $(VIRTUALENV_DIR)/bin/activate; pylint -E --rcfile=./lint-configs/python/.pylintrc --load-plugins=pylint_plugins.api_models contrib/chatops || exit 1;
 	# Lint Python scripts
 	. $(VIRTUALENV_DIR)/bin/activate; pylint -E --rcfile=./lint-configs/python/.pylintrc --load-plugins=pylint_plugins.api_models scripts/*.py || exit 1;
 	. $(VIRTUALENV_DIR)/bin/activate; pylint -E --rcfile=./lint-configs/python/.pylintrc --load-plugins=pylint_plugins.api_models tools/*.py || exit 1;
@@ -87,6 +87,7 @@ flake8: requirements .flake8
 	. $(VIRTUALENV_DIR)/bin/activate; flake8 --config ./lint-configs/python/.flake8 $(COMPONENTS)
 	. $(VIRTUALENV_DIR)/bin/activate; flake8 --config ./lint-configs/python/.flake8 contrib/packs/actions/
 	. $(VIRTUALENV_DIR)/bin/activate; flake8 --config ./lint-configs/python/.flake8 contrib/linux
+	. $(VIRTUALENV_DIR)/bin/activate; flake8 --config ./lint-configs/python/.flake8 contrib/chatops/
 	. $(VIRTUALENV_DIR)/bin/activate; flake8 --config ./lint-configs/python/.flake8 scripts/
 	. $(VIRTUALENV_DIR)/bin/activate; flake8 --config ./lint-configs/python/.flake8 tools/
 

--- a/contrib/chatops/actions/format_execution_result.py
+++ b/contrib/chatops/actions/format_execution_result.py
@@ -7,8 +7,8 @@ from st2common.util import jinja as jinja_utils
 
 
 class FormatResultAction(Action):
-    def __init__(self, config):
-        super(FormatResultAction, self).__init__(config)
+    def __init__(self, config=None, action_service=None):
+        super(FormatResultAction, self).__init__(config=config, action_service=action_service)
         api_url = os.environ.get('ST2_ACTION_API_URL', None)
         token = os.environ.get('ST2_ACTION_AUTH_TOKEN', None)
         self.client = Client(api_url=api_url, token=token)
@@ -51,4 +51,4 @@ class FormatResultAction(Action):
         if not execution:
             return None
         excludes = ["trigger", "trigger_type", "trigger_instance", "liveaction"]
-        return execution.to_dict(exclude_attributes= excludes)
+        return execution.to_dict(exclude_attributes=excludes)

--- a/contrib/examples/actions/pythonactions/isprime.py
+++ b/contrib/examples/actions/pythonactions/isprime.py
@@ -1,12 +1,11 @@
 import math
 
+from st2actions.runners.pythonrunner import Action
 
-class PrimeChecker(object):
 
-    def __init__(self, config=None):
-        pass
-
+class PrimeCheckerAction(Action):
     def run(self, value=0):
+        self.logger.debug('value=%s' % (value))
         if math.floor(value) != value:
             raise ValueError('%s should be an integer.' % value)
         if value < 2:
@@ -17,6 +16,6 @@ class PrimeChecker(object):
         return True
 
 if __name__ == '__main__':
-    checker = PrimeChecker()
+    checker = PrimeCheckerAction()
     for i in range(0, 10):
-        print '%s : %s' % (i, checker.run(**{'value': i}))
+        print '%s : %s' % (i, checker.run(value=1))

--- a/contrib/examples/tests/test_action_isprime.py
+++ b/contrib/examples/tests/test_action_isprime.py
@@ -1,0 +1,15 @@
+from st2tests.base import BaseActionTestCase
+
+from pythonactions.isprime import PrimeCheckerAction
+
+
+class PrimeCheckerActionTestCase(BaseActionTestCase):
+    action_cls = PrimeCheckerAction
+
+    def test_run(self):
+        action = self.get_action_instance()
+        result = action.run(value=1)
+        self.assertFalse(result)
+
+        result = action.run(value=3)
+        self.assertTrue(result)

--- a/contrib/packs/actions/check_auto_deploy_repo.py
+++ b/contrib/packs/actions/check_auto_deploy_repo.py
@@ -15,16 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-import requests
-import json
-import getopt
-import argparse
-import os
-import yaml
-
-from getpass import getpass
 from st2actions.runners.pythonrunner import Action
+
 
 class CheckAutoDeployRepo(Action):
     def run(self, branch, repo_name):
@@ -42,12 +34,14 @@ class CheckAutoDeployRepo(Action):
         results = {}
 
         try:
-            results['deployment_branch'] = self.config["repositories"][repo_name]["auto_deployment"]["branch"]
-            results['notify_channel'] = self.config["repositories"][repo_name]["auto_deployment"]["notify_channel"]
+            repo_config = self.config["repositories"][repo_name]
+            results['deployment_branch'] = repo_config["auto_deployment"]["branch"]
+            results['notify_channel'] = repo_config["auto_deployment"]["notify_channel"]
         except KeyError:
             raise ValueError("No repositories or auto_deployment config for '%s'" % repo_name)
         else:
             if branch == "refs/heads/%s" % results['deployment_branch']:
                 return results
             else:
-                raise ValueError("Branch %s for %s should not be auto deployed" % (branch, repo_name))
+                raise ValueError("Branch %s for %s should not be auto deployed" %
+                                 (branch, repo_name))

--- a/contrib/packs/actions/expand_repo_name.py
+++ b/contrib/packs/actions/expand_repo_name.py
@@ -15,16 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-import requests
-import json
-import getopt
-import argparse
-import os
-import yaml
-
-from getpass import getpass
 from st2actions.runners.pythonrunner import Action
+
 
 class ExpandRepoName(Action):
     def run(self, repo_name):

--- a/contrib/packs/actions/pack_mgmt/delete.py
+++ b/contrib/packs/actions/pack_mgmt/delete.py
@@ -26,8 +26,8 @@ BLOCKED_PACKS = frozenset(SYSTEM_PACK_NAMES)
 
 
 class UninstallPackAction(Action):
-    def __init__(self, config=None):
-        super(UninstallPackAction, self).__init__(config=config)
+    def __init__(self, config=None, action_service=None):
+        super(UninstallPackAction, self).__init__(config=config, action_service=action_service)
         self._base_virtualenvs_path = os.path.join(cfg.CONF.system.base_path,
                                                    'virtualenvs/')
 

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -61,8 +61,8 @@ PACK_GROUP_CFG_KEY = 'pack_group'
 
 
 class DownloadGitRepoAction(Action):
-    def __init__(self, config=None):
-        super(DownloadGitRepoAction, self).__init__(config=config)
+    def __init__(self, config=None, action_service=None):
+        super(DownloadGitRepoAction, self).__init__(config=config, action_service=action_service)
         self._subtree = None
         self._repo_url = None
 

--- a/contrib/packs/actions/pack_mgmt/setup_virtualenv.py
+++ b/contrib/packs/actions/pack_mgmt/setup_virtualenv.py
@@ -43,8 +43,9 @@ class SetupVirtualEnvironmentAction(Action):
     current dependencies as well as an installation of new dependencies
     """
 
-    def __init__(self, config=None):
-        super(SetupVirtualEnvironmentAction, self).__init__(config=config)
+    def __init__(self, config=None, action_service=None):
+        super(SetupVirtualEnvironmentAction, self).__init__(config=config,
+                                                            action_service=action_service)
         self._base_virtualenvs_path = os.path.join(cfg.CONF.system.base_path,
                                                    'virtualenvs/')
 

--- a/contrib/packs/actions/pack_mgmt/unload.py
+++ b/contrib/packs/actions/pack_mgmt/unload.py
@@ -31,8 +31,8 @@ BLOCKED_PACKS = frozenset(SYSTEM_PACK_NAMES)
 
 
 class UnregisterPackAction(BaseAction):
-    def __init__(self, config=None):
-        super(UnregisterPackAction, self).__init__(config=config)
+    def __init__(self, config=None, action_service=None):
+        super(UnregisterPackAction, self).__init__(config=config, action_service=action_service)
         self.initialize()
 
     def initialize(self):

--- a/contrib/packs/tests/test_action_check_auto_deploy_repo.py
+++ b/contrib/packs/tests/test_action_check_auto_deploy_repo.py
@@ -32,30 +32,32 @@ repositories:
 """
 
 class CheckAutoDeployRepoActionTestCase(BaseActionTestCase):
+    action_cls = CheckAutoDeployRepo
+
     def test_run_config_blank(self):
         config = yaml.safe_load(MOCK_CONFIG_BLANK)
-        action = CheckAutoDeployRepo(config)
+        action = self.get_action_instance(config=config)
 
         self.assertRaises(Exception, action.run,
                           branch="refs/heads/master", repo_name="st2contrib")
 
     def test_run_repositories_blank(self):
         config = yaml.safe_load(MOCK_CONFIG_BLANK_REPOSITORIES)
-        action = CheckAutoDeployRepo(config)
+        action = self.get_action_instance(config=config)
 
         self.assertRaises(Exception, action.run,
                           branch="refs/heads/master", repo_name="st2contrib")
 
     def test_run_st2contrib_no_auto_deloy(self):
         config = yaml.safe_load(MOCK_CONFIG_FULL)
-        action = CheckAutoDeployRepo(config)
+        action = self.get_action_instance(config=config)
 
         self.assertRaises(Exception, action.run,
                           branch="refs/heads/dev", repo_name="st2contrib")
 
     def test_run_st2contrib_auto_deloy(self):
         config = yaml.safe_load(MOCK_CONFIG_FULL)
-        action = CheckAutoDeployRepo(config)
+        action = self.get_action_instance(config=config)
 
         expected = {'deployment_branch': 'master', 'notify_channel': 'community'}
 
@@ -72,7 +74,7 @@ class CheckAutoDeployRepoActionTestCase(BaseActionTestCase):
 
     def test_run_st2incubator_auto_deloy(self):
         config = yaml.safe_load(MOCK_CONFIG_FULL)
-        action = CheckAutoDeployRepo(config)
+        action = self.get_action_instance(config=config)
 
         expected = {'deployment_branch': 'master', 'notify_channel': 'community'}
 

--- a/contrib/packs/tests/test_action_expand_repo_name.py
+++ b/contrib/packs/tests/test_action_expand_repo_name.py
@@ -30,23 +30,25 @@ repositories:
 """
 
 class ExpandRepoNameTestCase(BaseActionTestCase):
+    action_cls = ExpandRepoName
+
     def test_run_config_blank(self):
         config = yaml.safe_load(MOCK_CONFIG_BLANK)
-        action = ExpandRepoName(config)
+        action = self.get_action_instance(config=config)
 
         self.assertRaises(Exception, action.run,
                           repo_name="st2contrib")
 
     def test_run_repositories_blank(self):
         config = yaml.safe_load(MOCK_CONFIG_BLANK_REPOSITORIES)
-        action = ExpandRepoName(config)
+        action = self.get_action_instance(config=config)
 
         self.assertRaises(Exception, action.run,
                           repo_name="st2contrib")
 
     def test_run_st2contrib_expands(self):
         config = yaml.safe_load(MOCK_CONFIG_FULL)
-        action = ExpandRepoName(config)
+        action = self.get_action_instance(config=config)
 
         expected = {'repo_url': 'https://github.com/StackStorm/st2contrib.git', 'subtree': True}
 
@@ -55,7 +57,7 @@ class ExpandRepoNameTestCase(BaseActionTestCase):
 
     def test_run_st2incubator_expands(self):
         config = yaml.safe_load(MOCK_CONFIG_FULL)
-        action = ExpandRepoName(config)
+        action = self.get_action_instance(config=config)
 
         expected = {'repo_url': 'https://github.com/StackStorm/st2incubator.git', 'subtree': True}
 

--- a/st2actions/st2actions/runners/python_action_wrapper.py
+++ b/st2actions/st2actions/runners/python_action_wrapper.py
@@ -123,20 +123,18 @@ class PythonActionWrapper(object):
         config_parser = ContentPackConfigParser(pack_name=self._pack)
         config = config_parser.get_action_config(action_file_path=self._file_path)
 
-        kwargs = {}
         if config:
             LOG.info('Using config "%s" for action "%s"' % (config.file_path,
                                                             self._file_path))
-            kwargs['config'] = config.config
+            config = config.config
         else:
             LOG.info('No config found for action "%s"' % (self._file_path))
-            kwargs['config'] = {}
+            config = None
 
         action_service = ActionService(action_wrapper=self)
-        kwargs['action_service'] = action_service
-
         action_instance = get_action_class_instance(action_cls=action_cls,
-                                                    kwargs=kwargs)
+                                                    config=config,
+                                                    action_service=action_service)
         return action_instance
 
 

--- a/st2actions/st2actions/runners/python_action_wrapper.py
+++ b/st2actions/st2actions/runners/python_action_wrapper.py
@@ -29,7 +29,8 @@ from st2common.service_setup import db_setup
 from st2common.services.datastore import DatastoreService
 
 __all__ = [
-    'PythonActionWrapper'
+    'PythonActionWrapper',
+    'ActionService'
 ]
 
 LOG = logging.getLogger(__name__)

--- a/st2actions/st2actions/runners/python_action_wrapper.py
+++ b/st2actions/st2actions/runners/python_action_wrapper.py
@@ -16,7 +16,6 @@
 import sys
 import json
 import argparse
-import logging as stdlib_logging
 
 from st2common import log as logging
 from st2actions import config
@@ -42,7 +41,7 @@ class ActionService(object):
     """
 
     def __init__(self, action_wrapper):
-        logger = get_logger_for_action(action_name=self._action_wrapper._class_name)
+        logger = get_logger_for_python_runner_action(action_name=action_wrapper._class_name)
 
         self._action_wrapper = action_wrapper
         self._datastore_service = DatastoreService(logger=logger,
@@ -136,7 +135,6 @@ class PythonActionWrapper(object):
         # Action constructor to take in additional argument (action_service).
         action_service = ActionService(action_wrapper=self)
         action_instance.setup(action_service=action_service)
-        action_instance.logger = self._set_up_logger(action_cls.__name__)
 
         return action_instance
 

--- a/st2actions/st2actions/runners/python_action_wrapper.py
+++ b/st2actions/st2actions/runners/python_action_wrapper.py
@@ -21,6 +21,7 @@ from st2common import log as logging
 from st2actions import config
 from st2actions.runners.pythonrunner import Action
 from st2actions.runners.utils import get_logger_for_python_runner_action
+from st2actions.runners.utils import get_action_class_instance
 from st2common.util import loader as action_loader
 from st2common.util.config_parser import ContentPackConfigParser
 from st2common.constants.action import ACTION_OUTPUT_RESULT_DELIMITER
@@ -121,21 +122,20 @@ class PythonActionWrapper(object):
         config_parser = ContentPackConfigParser(pack_name=self._pack)
         config = config_parser.get_action_config(action_file_path=self._file_path)
 
+        kwargs = {}
         if config:
             LOG.info('Using config "%s" for action "%s"' % (config.file_path,
                                                             self._file_path))
-
-            action_instance = action_cls(config=config.config)
+            kwargs['config'] = config.config
         else:
             LOG.info('No config found for action "%s"' % (self._file_path))
-            action_instance = action_cls(config={})
+            kwargs['config'] = {}
 
-        # Perform post instantiation action intiailization
-        # Note: This is needed since for backward compatibility reasons we can't simply update
-        # Action constructor to take in additional argument (action_service).
         action_service = ActionService(action_wrapper=self)
-        action_instance.setup(action_service=action_service)
+        kwargs['action_service'] = action_service
 
+        action_instance = get_action_class_instance(action_cls=action_cls,
+                                                    kwargs=kwargs)
         return action_instance
 
 

--- a/st2actions/st2actions/runners/pythonrunner.py
+++ b/st2actions/st2actions/runners/pythonrunner.py
@@ -69,7 +69,9 @@ class Action(object):
         :type config: ``dict``
         """
         self.config = config or {}
-        # logger and datastore are assigned in PythonActionWrapper._get_action_instance
+
+        # logger and datastore are late assigned post class instatiation in
+        # PythonActionWrapper._get_action_instance
         self.logger = None
         self.datastore = None
 

--- a/st2actions/st2actions/runners/pythonrunner.py
+++ b/st2actions/st2actions/runners/pythonrunner.py
@@ -70,7 +70,7 @@ class Action(object):
         :type config: ``dict``
         """
         self.config = config or {}
-        self.logger = get_logger_for_action(action_name=self.__class__.__name__)
+        self.logger = get_logger_for_python_runner_action(action_name=self.__class__.__name__)
 
         # action_service is late assigned post class instatiation in "setup()"
         self.datastore = None

--- a/st2actions/st2actions/runners/pythonrunner.py
+++ b/st2actions/st2actions/runners/pythonrunner.py
@@ -64,31 +64,21 @@ class Action(object):
 
     description = None
 
-    def __init__(self, config=None):
+    def __init__(self, config=None, action_service=None):
         """
         :param config: Action config.
         :type config: ``dict``
+
+        :param action_service: ActionService object.
+        :type action_service: :class:`ActionService~
         """
         self.config = config or {}
-        self.logger = get_logger_for_python_runner_action(action_name=self.__class__.__name__)
-
-        # action_service is late assigned post class instatiation in "setup()"
-        self.datastore = None
-
-        # Flag which indicates if the class has been initialized and "setup()" has been called
-        self._initialized = False
-
-    def setup(self, action_service):
-        """
-        Method which performs additional class initialization.
-        """
         self.action_service = action_service
-        self._initialized = True
+        self.logger = get_logger_for_python_runner_action(action_name=self.__class__.__name__)
 
     @abc.abstractmethod
     def run(self, **kwargs):
-        if not self._initialized:
-            raise ValueError('Class hasn\'t been initialized. Make sure setup() is called.')
+        pass
 
 
 class PythonRunner(ActionRunner):

--- a/st2actions/st2actions/runners/utils.py
+++ b/st2actions/st2actions/runners/utils.py
@@ -22,7 +22,7 @@ __all__ = [
 ]
 
 
-def get_logger_for_python_runner_action(self, action_name):
+def get_logger_for_python_runner_action(action_name):
     """
     Set up a logger which logs all the messages with level DEBUG and above to stderr.
     """

--- a/st2actions/st2actions/runners/utils.py
+++ b/st2actions/st2actions/runners/utils.py
@@ -70,8 +70,8 @@ def get_action_class_instance(action_cls, config=None, action_service=None):
         if 'unexpected keyword argument \'action_service\'' not in str(e):
             raise e
 
-        LOG.debug('Action class constructor doesn\'t take "action_service" argument, '
-                  'falling back to late assignment...')
+        LOG.debug('Action class (%s) constructor doesn\'t take "action_service" argument, '
+                  'falling back to late assignment...' % (action_cls.__class__.__name__))
 
         action_service = kwargs.pop('action_service', None)
         action_instance = action_cls(**kwargs)

--- a/st2actions/st2actions/runners/utils.py
+++ b/st2actions/st2actions/runners/utils.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
-
 import logging as stdlib_logging
 
 from st2common import log as logging
@@ -45,10 +43,23 @@ def get_logger_for_python_runner_action(action_name):
     return logger
 
 
-def get_action_class_instance(action_cls, kwargs):
+def get_action_class_instance(action_cls, config=None, action_service=None):
     """
     Instantiate and return Action class instance.
+
+    :param action_cls: Action class to instantiate.
+    :type action_cls: ``class``
+
+    :param config: Config to pass to the action class.
+    :type config: ``dict``
+
+    :param action_service: ActionService instance to pass to the class.
+    :type action_service: :class:`ActionService`
     """
+    kwargs = {}
+    kwargs['config'] = config
+    kwargs['action_service'] = action_service
+
     # Note: This is done for backward compatibility reasons. We first try to pass
     # "action_service" argument to the action class constructor, but if that doesn't work
     # (e.g. old action which hasn't been updated yet), we resort to late assignment.
@@ -61,7 +72,6 @@ def get_action_class_instance(action_cls, kwargs):
         LOG.debug('Action class constructor doesn\'t take "action_service" argument, '
                   'falling back to late assignment...')
 
-        kwargs = copy.deepcopy(kwargs)
         action_service = kwargs.pop('action_service', None)
         action_instance = action_cls(**kwargs)
         action_instance.action_service = action_service

--- a/st2actions/st2actions/runners/utils.py
+++ b/st2actions/st2actions/runners/utils.py
@@ -1,0 +1,40 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging as stdlib_logging
+
+from st2common import log as logging
+
+__all__ = [
+    'get_logger_for_python_runner_action'
+]
+
+
+def get_logger_for_python_runner_action(self, action_name):
+    """
+    Set up a logger which logs all the messages with level DEBUG and above to stderr.
+    """
+    logger_name = 'actions.python.%s' % (action_name)
+    logger = logging.getLogger(logger_name)
+
+    console = stdlib_logging.StreamHandler()
+    console.setLevel(stdlib_logging.DEBUG)
+
+    formatter = stdlib_logging.Formatter('%(name)-12s: %(levelname)-8s %(message)s')
+    console.setFormatter(formatter)
+    logger.addHandler(console)
+    logger.setLevel(stdlib_logging.DEBUG)
+
+    return logger

--- a/st2actions/st2actions/runners/utils.py
+++ b/st2actions/st2actions/runners/utils.py
@@ -61,8 +61,9 @@ def get_action_class_instance(action_cls, config=None, action_service=None):
     kwargs['action_service'] = action_service
 
     # Note: This is done for backward compatibility reasons. We first try to pass
-    # "action_service" argument to the action class constructor, but if that doesn't work
-    # (e.g. old action which hasn't been updated yet), we resort to late assignment.
+    # "action_service" argument to the action class constructor, but if that doesn't work (e.g. old
+    # action which hasn't been updated yet), we resort to late assignment post class instantiation.
+    # TODO: Remove in next major version once all the affected actions have been updated.
     try:
         action_instance = action_cls(**kwargs)
     except TypeError as e:

--- a/st2actions/tests/unit/test_pythonrunner.py
+++ b/st2actions/tests/unit/test_pythonrunner.py
@@ -211,22 +211,23 @@ class PythonRunnerTestCase(RunnerTestCase):
             def run(self):
                 pass
 
-        kwargs = {
-            'config': 'bar',
-            'action_service': 'action service'
-        }
+        config = {'a': 1, 'b': 2}
+        action_service = 'ActionService!'
 
-        action = get_action_class_instance(action_cls=Action1, kwargs=kwargs)
-        self.assertEqual(action.config, kwargs['config'])
-        self.assertEqual(action.action_service, kwargs['action_service'])
+        action1 = get_action_class_instance(action_cls=Action1, config=config,
+                                            action_service=action_service)
+        self.assertEqual(action1.config, config)
+        self.assertEqual(action1.action_service, action_service)
 
-        action = get_action_class_instance(action_cls=Action2, kwargs=kwargs)
-        self.assertEqual(action.config, kwargs['config'])
-        self.assertEqual(action.action_service, kwargs['action_service'])
+        action2 = get_action_class_instance(action_cls=Action2, config=config,
+                                            action_service=action_service)
+        self.assertEqual(action2.config, config)
+        self.assertEqual(action2.action_service, action_service)
 
-        action = get_action_class_instance(action_cls=Action3, kwargs=kwargs)
-        self.assertEqual(action.config, kwargs['config'])
-        self.assertEqual(action.action_service, kwargs['action_service'])
+        action3 = get_action_class_instance(action_cls=Action3, config=config,
+                                            action_service=action_service)
+        self.assertEqual(action3.config, config)
+        self.assertEqual(action3.action_service, action_service)
 
     def _get_mock_action_obj(self):
         """

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -35,7 +35,8 @@ from st2reactor.sensor import config
 from st2common.services.datastore import DatastoreService
 
 __all__ = [
-    'SensorWrapper'
+    'SensorWrapper',
+    'SensorService'
 ]
 
 eventlet.monkey_patch(

--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -490,6 +490,18 @@ class BaseActionTestCase(TestCase):
 
     action_cls = None
 
+    def get_action_instance(self, config=None):
+        """
+        Retrieve instance of the action class.
+        """
+        kwargs = {}
+
+        if config:
+            kwargs['config'] = config
+
+        instance = self.action_cls(**kwargs)  # pylint: disable=not-callable
+        return instance
+
 
 class FakeResponse(object):
 

--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -509,7 +509,7 @@ class BaseActionTestCase(TestCase):
             kwargs['config'] = config
 
         instance = self.action_cls(**kwargs)  # pylint: disable=not-callable
-        instance.setup(action_service=action_service)
+        instance.setup(action_service=self.action_service)
         return instance
 
 

--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -504,15 +504,10 @@ class BaseActionTestCase(TestCase):
         """
         Retrieve instance of the action class.
         """
-        kwargs = {}
-
-        if config:
-            kwargs['config'] = config
-        kwargs['action_service'] = self.action_service
-
         # pylint: disable=not-callable
-        instance = get_action_class_instance(action_cls=self.action_cls, kwargs=kwargs)
-        instance = self.action_cls(**kwargs)
+        instance = get_action_class_instance(action_cls=self.action_cls,
+                                             config=config,
+                                             action_service=self.action_service)
         return instance
 
 

--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -46,6 +46,7 @@ import st2common.models.db.executionstate as executionstate_model
 import st2common.models.db.liveaction as liveaction_model
 import st2common.models.db.actionalias as actionalias_model
 import st2common.models.db.policy as policy_model
+from st2actions.runners.utils import get_action_class_instance
 
 import st2tests.config
 from st2tests.mocks.sensor import MockSensorWrapper
@@ -507,9 +508,9 @@ class BaseActionTestCase(TestCase):
 
         if config:
             kwargs['config'] = config
+        kwargs['action_service'] = self.action_service
 
         instance = self.action_cls(**kwargs)  # pylint: disable=not-callable
-        instance.setup(action_service=self.action_service)
         return instance
 
 

--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -510,7 +510,9 @@ class BaseActionTestCase(TestCase):
             kwargs['config'] = config
         kwargs['action_service'] = self.action_service
 
-        instance = self.action_cls(**kwargs)  # pylint: disable=not-callable
+        # pylint: disable=not-callable
+        instance = get_action_class_instance(action_cls=self.action_cls, kwargs=kwargs)
+        instance = self.action_cls(**kwargs)
         return instance
 
 

--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -50,6 +50,8 @@ import st2common.models.db.policy as policy_model
 import st2tests.config
 from st2tests.mocks.sensor import MockSensorWrapper
 from st2tests.mocks.sensor import MockSensorService
+from st2tests.mocks.action import MockActionWrapper
+from st2tests.mocks.action import MockActionService
 
 
 __all__ = [
@@ -490,6 +492,13 @@ class BaseActionTestCase(TestCase):
 
     action_cls = None
 
+    def setUp(self):
+        super(BaseActionTestCase, self).setUp()
+
+        class_name = self.action_cls.__name__
+        action_wrapper = MockActionWrapper(pack='tests', class_name=class_name)
+        self.action_service = MockActionService(action_wrapper=action_wrapper)
+
     def get_action_instance(self, config=None):
         """
         Retrieve instance of the action class.
@@ -500,6 +509,7 @@ class BaseActionTestCase(TestCase):
             kwargs['config'] = config
 
         instance = self.action_cls(**kwargs)  # pylint: disable=not-callable
+        instance.setup(action_service=action_service)
         return instance
 
 

--- a/st2tests/st2tests/mocks/action.py
+++ b/st2tests/st2tests/mocks/action.py
@@ -1,0 +1,54 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Mock classes for use in pack testing.
+"""
+
+from logging import RootLogger
+
+from mock import Mock
+
+from st2actions.runners.python_action_wrapper import ActionService
+from st2tests.mocks.datastore import MockDatastoreService
+
+__all__ = [
+    'MockActionWrapper',
+    'MockActionService'
+]
+
+
+class MockActionWrapper(object):
+    def __init__(self, pack, class_name):
+        self._pack = pack
+        self._class_name = class_name
+
+
+class MockActionService(ActionService):
+    """
+    Mock ActionService for use in testing.
+    """
+
+    def __init__(self, action_wrapper):
+        self._action_wrapper = action_wrapper
+
+        # Holds a mock logger instance
+        # We use a Mock class so use can assert logger was called with particular arguments
+        self._logger = Mock(spec=RootLogger)
+
+        self._datastore_service = MockDatastoreService(logger=self._logger,
+                                                       pack_name=self._action_wrapper._pack,
+                                                       class_name=self._action_wrapper._class_name,
+                                                       api_username='action_service')


### PR DESCRIPTION
This pull request updates base `Action` class to utilize `action_service` argument and expose datastore management methods via this `action_service` instance variable.

Using `action_service` makes it consistent with sensors and also allows us to expand and add additional functionality to action service in the future.

In addition to that, it includes some other changes:

* Make sure that we pass mock action service and datastore to the Action instance which is available to action unit tests.
* Add some more test for BaseActionTestCase
* Random lint fixes and cleanup

## TODO

- [x] Update affected tests in st2contrib/ - https://github.com/StackStorm/st2contrib/pull/402
- [x] Documentation on get_action_instance - https://github.com/StackStorm/st2docs/pull/67
- [x] Update affected action docs (docs/source/actions.rst) - https://github.com/StackStorm/st2docs/pull/67
- [x] Notify plexxi about changes