### PR TITLE
Normalize url in trigger parameters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ in development
   * Support for providing a non-default (22) SSH server port.
   * Support for using default system user (stanley) ssh key if neither ``password`` nor
     ``keyfile`` parameter is provided.
+* Support for leading and trailing slashes in the webhook urls. (improvement)
 
 1.3.2 - February 12, 2016
 -------------------------

--- a/st2api/st2api/controllers/v1/webhooks.py
+++ b/st2api/st2api/controllers/v1/webhooks.py
@@ -176,10 +176,10 @@ class WebhooksController(RestController):
             del self._hooks[url]
 
     def _get_normalized_url(self, trigger):
-        '''
-        remove the trailing and leading "/" so that the hook url and those coming
+        """
+        remove the trailing and leading / so that the hook url and those coming
         from trigger parameters end up being the same.
-        '''
+        """
         return trigger['parameters']['url'].strip('/')
 
     def _get_headers_as_dict(self, headers):

--- a/st2api/st2api/controllers/v1/webhooks.py
+++ b/st2api/st2api/controllers/v1/webhooks.py
@@ -80,7 +80,7 @@ class HooksHolder(object):
     def get_all(self):
         triggers = []
         for values in six.itervalues(self._triggers_by_hook):
-            triggers.extend(triggers)
+            triggers.extend(values)
         return triggers
 
 

--- a/st2api/st2api/controllers/v1/webhooks.py
+++ b/st2api/st2api/controllers/v1/webhooks.py
@@ -159,7 +159,7 @@ class WebhooksController(RestController):
     def add_trigger(self, trigger):
         # Note: Permission checking for creating and deleting a webhook is done during rule
         # creation
-        url = trigger['parameters']['url']
+        url = self._get_normalized_url(trigger)
         LOG.info('Listening to endpoint: %s', urljoin(self._base_url, url))
         self._hooks[url] = trigger
 
@@ -169,11 +169,18 @@ class WebhooksController(RestController):
     def remove_trigger(self, trigger):
         # Note: Permission checking for creating and deleting a webhook is done during rule
         # creation
-        url = trigger['parameters']['url']
+        url = self._get_normalized_url(trigger)
 
         if url in self._hooks:
             LOG.info('Stop listening to endpoint: %s', urljoin(self._base_url, url))
             del self._hooks[url]
+
+    def _get_normalized_url(self, trigger):
+        '''
+        remove the trailing and leading "/" so that the hook url and those coming
+        from trigger parameters end up being the same.
+        '''
+        return trigger['parameters']['url'].strip('/')
 
     def _get_headers_as_dict(self, headers):
         headers_dict = {}

--- a/st2api/tests/unit/controllers/v1/test_webhooks.py
+++ b/st2api/tests/unit/controllers/v1/test_webhooks.py
@@ -174,7 +174,7 @@ class TestWebhooksController(FunctionalTest):
         # the url containing all kinds of slashes the normalized version still work.
         # The part which does not get tested is integration with pecan since # that will
         # require hacking into the test app and force dependency on pecan internals.
-        # TLDR; sorry for the ghetto test. Not sure how to do this as a unit.
+        # TLDR; sorry for the ghetto test. Not sure how else to test this as a unit test.
         def get_webhook_trigger(name, url):
             trigger = TriggerDB(name=name, pack='test')
             trigger.type = WEBHOOK_TRIGGER_TYPES.keys()[0]

--- a/st2api/tests/unit/controllers/v1/test_webhooks.py
+++ b/st2api/tests/unit/controllers/v1/test_webhooks.py
@@ -19,7 +19,7 @@ import mock
 import six
 from tests import FunctionalTest
 
-from st2api.controllers.v1.webhooks import WebhooksController
+from st2api.controllers.v1.webhooks import WebhooksController, HooksHolder
 from st2common.constants.triggers import WEBHOOK_TRIGGER_TYPES
 from st2common.models.db.trigger import TriggerDB
 from st2common.transport.reactor import TriggerInstancePublisher
@@ -48,8 +48,8 @@ class TestWebhooksController(FunctionalTest):
         return_value=True))
     @mock.patch.object(WebhooksController, '_is_valid_hook', mock.MagicMock(
         return_value=True))
-    @mock.patch.object(WebhooksController, '_get_trigger_for_hook', mock.MagicMock(
-        return_value=DUMMY_TRIGGER))
+    @mock.patch.object(HooksHolder, 'get_triggers_for_hook', mock.MagicMock(
+        return_value=[DUMMY_TRIGGER]))
     @mock.patch('st2common.transport.reactor.TriggerDispatcher.dispatch')
     def test_post(self, dispatch_mock):
         post_resp = self.__do_post('git', WEBHOOK_1, expect_errors=False)
@@ -60,8 +60,8 @@ class TestWebhooksController(FunctionalTest):
         return_value=True))
     @mock.patch.object(WebhooksController, '_is_valid_hook', mock.MagicMock(
         return_value=True))
-    @mock.patch.object(WebhooksController, '_get_trigger_for_hook', mock.MagicMock(
-        return_value=DUMMY_TRIGGER))
+    @mock.patch.object(HooksHolder, 'get_triggers_for_hook', mock.MagicMock(
+        return_value=[DUMMY_TRIGGER]))
     @mock.patch('st2common.transport.reactor.TriggerDispatcher.dispatch')
     def test_post_with_trace(self, dispatch_mock):
         post_resp = self.__do_post('git', WEBHOOK_1, expect_errors=False,
@@ -105,8 +105,8 @@ class TestWebhooksController(FunctionalTest):
         return_value=True))
     @mock.patch.object(WebhooksController, '_is_valid_hook', mock.MagicMock(
         return_value=True))
-    @mock.patch.object(WebhooksController, '_get_trigger_for_hook', mock.MagicMock(
-        return_value=DUMMY_TRIGGER))
+    @mock.patch.object(HooksHolder, 'get_triggers_for_hook', mock.MagicMock(
+        return_value=[DUMMY_TRIGGER]))
     @mock.patch('st2common.transport.reactor.TriggerDispatcher.dispatch')
     def test_json_request_body(self, dispatch_mock):
         # 1. Send JSON using application/json content type
@@ -142,8 +142,8 @@ class TestWebhooksController(FunctionalTest):
         return_value=True))
     @mock.patch.object(WebhooksController, '_is_valid_hook', mock.MagicMock(
         return_value=True))
-    @mock.patch.object(WebhooksController, '_get_trigger_for_hook', mock.MagicMock(
-        return_value=DUMMY_TRIGGER))
+    @mock.patch.object(HooksHolder, 'get_triggers_for_hook', mock.MagicMock(
+        return_value=[DUMMY_TRIGGER]))
     @mock.patch('st2common.transport.reactor.TriggerDispatcher.dispatch')
     def test_form_encoded_request_body(self, dispatch_mock):
         # Send request body as form urlencoded data

--- a/st2api/tests/unit/controllers/v1/test_webhooks.py
+++ b/st2api/tests/unit/controllers/v1/test_webhooks.py
@@ -22,7 +22,6 @@ from tests import FunctionalTest
 from st2api.controllers.v1.webhooks import WebhooksController
 from st2common.constants.triggers import WEBHOOK_TRIGGER_TYPES
 from st2common.models.db.trigger import TriggerDB
-from st2common.persistence.trigger import Trigger
 from st2common.transport.reactor import TriggerInstancePublisher
 
 http_client = six.moves.http_client

--- a/st2api/tests/unit/controllers/v1/test_webhooks.py
+++ b/st2api/tests/unit/controllers/v1/test_webhooks.py
@@ -192,9 +192,8 @@ class TestWebhooksController(FunctionalTest):
         for trigger in test_triggers:
             controller.add_trigger(trigger)
 
-        get_webhook_trigger('with_mixed_slash', '/with/mixed/slash/')
-
         self.assertTrue(controller._is_valid_hook('no_slash'))
+        self.assertFalse(controller._is_valid_hook('/no_slash'))
         self.assertTrue(controller._is_valid_hook('with_leading_slash'))
         self.assertTrue(controller._is_valid_hook('with_trailing_slash'))
         self.assertTrue(controller._is_valid_hook('with_leading_trailing_slash'))


### PR DESCRIPTION
* Leading or trailing slashes in the url coming from the rule
  would cause the API to reject webhook requests.
* Normailzing the url to not include trailing or leading / means
  that the match is / agnostic and StackStorm does not end tripping
  over some silly /.
* URL normalization basically mean multiple version of the URL map
  to the same URL.
* Each unique URL gets it own Trigger. Even though the controller
  treats `sample`, `/sample` and `sample/` different it still
  represents 3 different triggers. Therefore it is necessary to
  match the normalized version to all 3 triggers. This is done by
  holding a match between normalized to a list of triggers.