### PR TITLE
mistral-workbook-complex.yam: task create_vm never call

### DIFF
--- a/contrib/examples/actions/workflows/mistral-workbook-complex.yaml
+++ b/contrib/examples/actions/workflows/mistral-workbook-complex.yaml
@@ -22,7 +22,7 @@ workflows:
                     ip: "10.1.23.99"
                     status_message: "DNS for <% $.vm_name %> is registered."
                 on-success:
-                    - configure_vm
+                    - create_vm
                     - notify
             create_vm:
                 wait-before: 1


### PR DESCRIPTION
In the example, the `create_vm` task seems to be never called.
If I understand well the example, we would like to have :

  * register_dns
  * create_vm
  * configure_vm
  * ...

But currently we have `register_dns` that call `configure_vm` where as the vm is not created.

  * `register_dns` -> `configure_vm`