### PR TITLE
Fix "decorate_log_method", make sure LogRecord attributes reflect the correct caller

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,10 @@ in development
   * Support for using default system user (stanley) ssh key if neither ``password`` nor
     ``keyfile`` parameter is provided.
 * Support for leading and trailing slashes in the webhook urls. (improvement)
+* Make sure that the ``filename``, ``module``, ``funcName`` and ``lineno`` attributes which are
+  available in the log formatter string contain the correct values. (bug-fix)
+
+  Reported by Andrew Regan.
 
 1.3.2 - February 12, 2016
 -------------------------

--- a/st2common/st2common/util/misc.py
+++ b/st2common/st2common/util/misc.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import os
+import sys
 import collections
 
 import six
@@ -108,3 +109,20 @@ def deep_update(d, u):
             d[k] = u[k]
 
     return d
+
+
+def get_normalized_file_path(file_path):
+    """
+    Return a full normalized file path for the provided path string.
+
+    :rtype: ``str``
+    """
+    if hasattr(sys, 'frozen'):  # support for py2exe
+        file_path = 'logging%s__init__%s' % (os.sep, file_path[-4:])
+    elif file_path[-4:].lower() in ['.pyc', '.pyo']:
+        file_path = file_path[:-4] + '.py'
+    else:
+        file_path = file_path
+
+    file_path = os.path.normcase(file_path)
+    return file_path


### PR DESCRIPTION
This pull request fixes issue reported in #2485.

It makes sure `filename`, `module`, `funcName` and `lineno` `LogRecord` attributes correctly point to the function / method which called the underlying logger method.

Previously they incorrectly pointed to the `log.py` file and `decorate_log_method` function.

I'm not too big of a fan of the implementation, but after doing some more research online it doesn't seem like there are any better and nicer alternatives possible :/

If it ever turns out that this adds too big of a performance overhead (unlikely since the same functionality exists and it's turned on by default in Python stdlib), we can revert this change or look into alternatives (e.g. only add caller info if the format string uses any of those log record attributes).