### PR TITLE
Introduce new "matchwildcard" criteria operator, update "matchregex" so dot (.) also matches new lines

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,11 @@ in development
   * Support for using default system user (stanley) ssh key if neither ``password`` nor
     ``keyfile`` parameter is provided.
 * Support for leading and trailing slashes in the webhook urls. (improvement)
+* Update ``matchregex`` rule criteria operator so it uses "dot all" mode where dot (``.``)
+  character will match any character including new lines. Previously ``*`` didn't match
+  new lines. (improvement)
+* Introduce new ``matchglob`` rule criteria matching operator. This operator provides
+  supports for Unix shell-style wildcards (``*``, ``?``). (new feature)
 
 1.3.2 - February 12, 2016
 -------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,8 +34,8 @@ in development
 * Update ``matchregex`` rule criteria operator so it uses "dot all" mode where dot (``.``)
   character will match any character including new lines. Previously ``*`` didn't match
   new lines. (improvement)
-* Introduce new ``matchglob`` rule criteria matching operator. This operator provides
-  supports for Unix shell-style wildcards (``*``, ``?``). (new feature)
+* Introduce new ``matchglob`` rule criteria operator. This operator provides supports for Unix
+  shell-style wildcards (``*``, ``?``). (new feature)
 
 1.3.2 - February 12, 2016
 -------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,7 +38,7 @@ in development
 * Update ``matchregex`` rule criteria operator so it uses "dot all" mode where dot (``.``)
   character will match any character including new lines. Previously ``*`` didn't match
   new lines. (improvement)
-* Introduce new ``matchglob`` rule criteria operator. This operator provides supports for Unix
+* Introduce new ``matchwildcard`` rule criteria operator. This operator provides supports for Unix
   shell-style wildcards (``*``, ``?``). (new feature)
 
 1.3.2 - February 12, 2016

--- a/st2common/st2common/operators.py
+++ b/st2common/st2common/operators.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import re
+import fnmatch
 
 from st2common.util import date as date_utils
 
@@ -113,6 +114,13 @@ def greater_than(value, criteria_pattern):
     return value > criteria_pattern
 
 
+def match_glob(value, criteria_pattern):
+    if criteria_pattern is None:
+        return False
+
+    return fnmatch.fnmatch(value, criteria_pattern)
+
+
 def match_regex(value, criteria_pattern):
     if criteria_pattern is None:
         return False
@@ -161,6 +169,7 @@ def nexists(value, criteria_pattern):
     return value is None
 
 # operator match strings
+MATCH_GLOB = 'matchglob'
 MATCH_REGEX = 'matchregex'
 EQUALS_SHORT = 'eq'
 EQUALS_LONG = 'equals'
@@ -189,6 +198,7 @@ KEY_NOT_EXISTS = 'nexists'
 
 # operator lookups
 operators = {
+    MATCH_GLOB: match_glob,
     MATCH_REGEX: match_regex,
     EQUALS_SHORT: equals,
     EQUALS_LONG: equals,

--- a/st2common/st2common/operators.py
+++ b/st2common/st2common/operators.py
@@ -114,7 +114,7 @@ def greater_than(value, criteria_pattern):
     return value > criteria_pattern
 
 
-def match_glob(value, criteria_pattern):
+def match_wildcard(value, criteria_pattern):
     if criteria_pattern is None:
         return False
 
@@ -169,7 +169,7 @@ def nexists(value, criteria_pattern):
     return value is None
 
 # operator match strings
-MATCH_GLOB = 'matchglob'
+MATCH_WILDCARD = 'matchwildcard'
 MATCH_REGEX = 'matchregex'
 EQUALS_SHORT = 'eq'
 EQUALS_LONG = 'equals'
@@ -198,7 +198,7 @@ KEY_NOT_EXISTS = 'nexists'
 
 # operator lookups
 operators = {
-    MATCH_GLOB: match_glob,
+    MATCH_WILDCARD: match_wildcard,
     MATCH_REGEX: match_regex,
     EQUALS_SHORT: equals,
     EQUALS_LONG: equals,

--- a/st2common/st2common/operators.py
+++ b/st2common/st2common/operators.py
@@ -116,7 +116,7 @@ def greater_than(value, criteria_pattern):
 def match_regex(value, criteria_pattern):
     if criteria_pattern is None:
         return False
-    regex = re.compile(criteria_pattern)
+    regex = re.compile(criteria_pattern, re.DOTALL)
     # check for a match and not for details of the match.
     return regex.match(value) is not None
 

--- a/st2common/tests/unit/test_operators.py
+++ b/st2common/tests/unit/test_operators.py
@@ -20,6 +20,14 @@ from st2common.util import date as date_utils
 
 
 class OperatorTest(unittest2.TestCase):
+    def test_matchglob(self):
+        op = operators.get_operator('matchglob')
+        self.assertTrue(op('v1', 'v1'), 'Failed matchglob.')
+
+        self.assertFalse(op('test foo test', 'foo'), 'Failed matchglob.')
+        self.assertTrue(op('test foo test', '*foo*'), 'Failed matchglob.')
+        self.assertTrue(op('bar', 'b*r'), 'Failed matchglob.')
+        self.assertTrue(op('bar', 'b?r'), 'Failed matchglob.')
 
     def test_matchregex(self):
         op = operators.get_operator('matchregex')

--- a/st2common/tests/unit/test_operators.py
+++ b/st2common/tests/unit/test_operators.py
@@ -20,14 +20,14 @@ from st2common.util import date as date_utils
 
 
 class OperatorTest(unittest2.TestCase):
-    def test_matchglob(self):
-        op = operators.get_operator('matchglob')
-        self.assertTrue(op('v1', 'v1'), 'Failed matchglob.')
+    def test_matchwildcard(self):
+        op = operators.get_operator('matchwildcard')
+        self.assertTrue(op('v1', 'v1'), 'Failed matchwildcard.')
 
-        self.assertFalse(op('test foo test', 'foo'), 'Failed matchglob.')
-        self.assertTrue(op('test foo test', '*foo*'), 'Failed matchglob.')
-        self.assertTrue(op('bar', 'b*r'), 'Failed matchglob.')
-        self.assertTrue(op('bar', 'b?r'), 'Failed matchglob.')
+        self.assertFalse(op('test foo test', 'foo'), 'Failed matchwildcard.')
+        self.assertTrue(op('test foo test', '*foo*'), 'Failed matchwildcard.')
+        self.assertTrue(op('bar', 'b*r'), 'Failed matchwildcard.')
+        self.assertTrue(op('bar', 'b?r'), 'Failed matchwildcard.')
 
     def test_matchregex(self):
         op = operators.get_operator('matchregex')

--- a/st2common/tests/unit/test_operators.py
+++ b/st2common/tests/unit/test_operators.py
@@ -25,6 +25,18 @@ class OperatorTest(unittest2.TestCase):
         op = operators.get_operator('matchregex')
         self.assertTrue(op('v1', 'v1$'), 'Failed matchregex.')
 
+        # Multi line string, make sure re.DOTALL is used
+        string = '''ponies
+        moar
+        foo
+        bar
+        yeah!
+        '''
+        self.assertTrue(op(string, '.*bar.*'), 'Failed matchregex.')
+
+        string = 'foo\r\nponies\nbar\nfooooo'
+        self.assertTrue(op(string, '.*ponies.*'), 'Failed matchregex.')
+
     def test_matchregex_case_variants(self):
         op = operators.get_operator('MATCHREGEX')
         self.assertTrue(op('v1', 'v1$'), 'Failed matchregex.')


### PR DESCRIPTION
This pull request includes the following changes:

1. It introduces new ``matchglob`` criteria operator which provides support for Unix shell-style wildcards (* and ?). This operator should be preferred over ``matchregex`` for simple string matches since it's a lot more straight forward.

2. Update ``matchregex`` operator so `.` character also matches new lines. In most cases where you work with multi line strings you want ``.`` character to also match new lines so that's a more sensible default behavior (people got burnt by this in the past).

This change is backward incompatible (it will make existing regexes a bit less greedy), but I will document this with examples in the upgrade notes and it's unlikely that it's going to badly affect existing regexes (in most cases it will allow users to simply existing regex patterns).


## TODO

- [x] Documentation changes
- [x] Upgrade notes changes