### PR TITLE
Adjust timing in mistral concurrency test

### DIFF
--- a/contrib/examples/actions/workflows/mistral-with-items-concurrency.yaml
+++ b/contrib/examples/actions/workflows/mistral-with-items-concurrency.yaml
@@ -16,6 +16,6 @@ examples.mistral-with-items-concurrency:
             concurrency: 2
             action: core.local
             input:
-                cmd: "<% $.cmd %>; sleep 2"
+                cmd: "<% $.cmd %>; sleep 3"
             publish:
                 result: <% $.repeat.stdout %>

--- a/st2tests/integration/mistral/test_examples.py
+++ b/st2tests/integration/mistral/test_examples.py
@@ -115,9 +115,9 @@ class ExamplesTest(base.TestWorkflowExecution):
         self.assertEqual(len(execution.result['result']), inputs['count'])
 
         timestamps = [int(dt) for dt in execution.result['result']]
-        self.assertTrue(timestamps[1] - timestamps[0] <= 1)
-        self.assertTrue(timestamps[3] - timestamps[2] <= 1)
-        self.assertTrue(timestamps[2] - timestamps[1] >= 2)
+        self.assertTrue(timestamps[1] - timestamps[0] < 3)
+        self.assertTrue(timestamps[3] - timestamps[2] < 3)
+        self.assertTrue(timestamps[2] - timestamps[1] >= 3)
 
     def test_workbook_multiple_subflows(self):
         execution = self._execute_workflow('examples.mistral-workbook-multiple-subflows')


### PR DESCRIPTION
Adjust the timing in the workflow to accomodate for delayed in execution due to load.