### PR TITLE
Allow user to turn off verbose flag in the "linux.rm" action

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,8 @@ in development
   new lines. (improvement)
 * Introduce new ``matchwildcard`` rule criteria operator. This operator provides supports for Unix
   shell-style wildcards (``*``, ``?``). (new feature)
+* Allow user to pass ``verbose`` parameter to ``linux.rm`` action. For backward compatibility
+  reasons it defaults to ``true``. (improvement)
 
 1.3.2 - February 12, 2016
 -------------------------

--- a/contrib/linux/actions/rm.yaml
+++ b/contrib/linux/actions/rm.yaml
@@ -17,9 +17,13 @@
           type: "boolean"
           description: "Boolean flag for force"
           default: false
+      verbose:
+        type: "boolean"
+        description: "True to explain what is being done"
+        default: true
       cmd:
           immutable: true
           default: "rm {{args}} {{target}}"
       args:
           description: "Command line arguments passed to rm"
-          default: "-v{% if recursive == true %} -r{% endif %}{% if force == true %} -f{% endif %}"
+          default: "{% if verbose == true %} -v{% endif %}{% if recursive == true %} -r{% endif %}{% if force == true %} -f{% endif %}"

--- a/contrib/linux/actions/rm.yaml
+++ b/contrib/linux/actions/rm.yaml
@@ -26,4 +26,4 @@
           default: "rm {{args}} {{target}}"
       args:
           description: "Command line arguments passed to rm"
-          default: "{% if verbose == true %} -v{% endif %}{% if recursive == true %} -r{% endif %}{% if force == true %} -f{% endif %}"
+          default: "{% if verbose == true %}-v{% endif %}{% if recursive == true %} -r{% endif %}{% if force == true %} -f{% endif %}"

--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -488,7 +488,7 @@ class BaseSensorTestCase(TestCase):
 
 class BaseActionTestCase(TestCase):
     """
-    Base class for action tests.
+    Base class for Python runner action tests.
     """
 
     action_cls = None


### PR DESCRIPTION
This change makes "-v" (verbose) flag for `linux.rm` action configurable. For backward compatibility reasons it defaults to true.

I noticed `st2cd.st2workroom_st2enterprise_test` tests recently started failing with the following error - https://gist.github.com/Kami/101e707a66f54930c6cd. I believe this is related to the error @lakshmi-kannan found and worked-around in the past (we didn't fully fix it though since it would require writing our own streaming based parser which is an over kill right now).

I believe the issue pops ups because some of the file recently added to the workroom repo contains a non-ascii character in the name so a simple work-around would be to pass `verbose: false` parameter to this action in our workflows. This way what was being done (which includes file names) won't be printed to stdout.