### PR TITLE
Remove index.php from default nginx for st2web

### DIFF
--- a/conf/nginx/st2.conf
+++ b/conf/nginx/st2.conf
@@ -16,7 +16,7 @@ server {
        return 301 https://$host$request_uri;
   }
 
-  index  index.html index.htm index.php;
+  index  index.html;
 
   access_log /var/log/nginx/st2webui.access.log combined;
   error_log /var/log/nginx/st2webui.error.log;
@@ -35,7 +35,7 @@ server {
   ssl_ciphers               EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:ECDHE-RSA-AES128-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA128:DHE-RSA-AES128-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES128-GCM-SHA128:ECDHE-RSA-AES128-SHA384:ECDHE-RSA-AES128-SHA128:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES128-SHA128:DHE-RSA-AES128-SHA128:DHE-RSA-AES128-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA384:AES128-GCM-SHA128:AES128-SHA128:AES128-SHA128:AES128-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4;
   ssl_prefer_server_ciphers on;
 
-  index  index.html index.htm index.php;
+  index  index.html;
 
   access_log            /var/log/nginx/ssl-st2webui.access.log combined;
   error_log             /var/log/nginx/ssl-st2webui.error.log;
@@ -84,6 +84,6 @@ server {
 
   location / {
     root      /opt/stackstorm/static/webui/;
-    index     index.html index.htm index.php;
+    index     index.html;
   }
 }


### PR DESCRIPTION
`st2web` has `index.html` as index entrypoint.
Removing unneeded pieces, probably oversight with copy-paste.