### PR TITLE
Make sure "--use-debugger" flag is taken into account in the sensor process

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,8 @@ in development
   shell-style wildcards (``*``, ``?``). (new feature)
 * Allow user to pass ``verbose`` parameter to ``linux.rm`` action. For backward compatibility
   reasons it defaults to ``true``. (improvement)
+* Make sure that sensor container child processes take into account ``--use-debugger`` flag passed
+  to the sensor container. This fixes support for remote debugging for sensor processes. (bug-fix)
 
 1.3.2 - February 12, 2016
 -------------------------

--- a/st2actions/st2actions/cmd/actionrunner.py
+++ b/st2actions/st2actions/cmd/actionrunner.py
@@ -1,4 +1,3 @@
-import eventlet
 import os
 import signal
 import sys
@@ -8,16 +7,15 @@ from st2actions import scheduler, worker
 from st2common import log as logging
 from st2common.service_setup import setup as common_setup
 from st2common.service_setup import teardown as common_teardown
+from st2common.util.monkey_patch import monkey_patch
+
+__all__ = [
+    'main'
+]
+
+monkey_patch()
 
 LOG = logging.getLogger(__name__)
-
-
-eventlet.monkey_patch(
-    os=True,
-    select=True,
-    socket=True,
-    thread=False if '--use-debugger' in sys.argv else True,
-    time=True)
 
 
 def _setup_sigterm_handler():

--- a/st2actions/st2actions/cmd/st2notifier.py
+++ b/st2actions/st2actions/cmd/st2notifier.py
@@ -5,20 +5,18 @@ import sys
 from st2common import log as logging
 from st2common.service_setup import setup as common_setup
 from st2common.service_setup import teardown as common_teardown
+from st2common.util.monkey_patch import monkey_patch
 from st2actions.notifier import config
 from st2actions.notifier import notifier
 from st2actions.notifier import scheduler
 
+__all__ = [
+    'main'
+]
+
+monkey_patch()
 
 LOG = logging.getLogger(__name__)
-
-
-eventlet.monkey_patch(
-    os=True,
-    select=True,
-    socket=True,
-    thread=False if '--use-debugger' in sys.argv else True,
-    time=True)
 
 
 def _setup():

--- a/st2actions/st2actions/cmd/st2resultstracker.py
+++ b/st2actions/st2actions/cmd/st2resultstracker.py
@@ -1,23 +1,21 @@
-import eventlet
 import os
 import sys
 
 from st2common import log as logging
 from st2common.service_setup import setup as common_setup
 from st2common.service_setup import teardown as common_teardown
+from st2common.util.monkey_patch import monkey_patch
 from st2actions.resultstracker import config
 from st2actions.resultstracker import resultstracker
 
+__all__ = [
+    'main'
+]
+
+
+monkey_patch()
 
 LOG = logging.getLogger(__name__)
-
-
-eventlet.monkey_patch(
-    os=True,
-    select=True,
-    socket=True,
-    thread=False if '--use-debugger' in sys.argv else True,
-    time=True)
 
 
 def _setup():

--- a/st2api/st2api/cmd/api.py
+++ b/st2api/st2api/cmd/api.py
@@ -23,6 +23,7 @@ from eventlet import wsgi
 from st2common import log as logging
 from st2common.service_setup import setup as common_setup
 from st2common.service_setup import teardown as common_teardown
+from st2common.util.monkey_patch import monkey_patch
 from st2common.util.wsgi import shutdown_server_kill_pending_requests
 from st2api.signal_handlers import register_api_signal_handlers
 from st2api.listener import get_listener_if_set
@@ -34,13 +35,7 @@ __all__ = [
     'main'
 ]
 
-
-eventlet.monkey_patch(
-    os=True,
-    select=True,
-    socket=True,
-    thread=False if '--use-debugger' in sys.argv else True,
-    time=True)
+monkey_patch()
 
 LOG = logging.getLogger(__name__)
 

--- a/st2auth/st2auth/cmd/api.py
+++ b/st2auth/st2auth/cmd/api.py
@@ -23,18 +23,17 @@ from eventlet import wsgi
 from st2common import log as logging
 from st2common.service_setup import setup as common_setup
 from st2common.service_setup import teardown as common_teardown
+from st2common.util.monkey_patch import monkey_patch
 from st2common.constants.auth import VALID_MODES
 from st2auth import config
 config.register_opts()
 from st2auth import app
 
+__all__ = [
+    'main'
+]
 
-eventlet.monkey_patch(
-    os=True,
-    select=True,
-    socket=True,
-    thread=False if '--use-debugger' in sys.argv else True,
-    time=True)
+monkey_patch()
 
 LOG = logging.getLogger(__name__)
 

--- a/st2common/bin/paramiko_ssh_evenlets_tester.py
+++ b/st2common/bin/paramiko_ssh_evenlets_tester.py
@@ -18,18 +18,11 @@
 import argparse
 import os
 import pprint
-import sys
 
-import eventlet
-
+from st2common.util.monkey_patch import monkey_patch
 from st2common.ssh.parallel_ssh import ParallelSSHClient
 
-eventlet.monkey_patch(
-    os=True,
-    select=True,
-    socket=True,
-    thread=False if '--use-debugger' in sys.argv else True,
-    time=True)
+monkey_patch()
 
 
 def main(user, pkey, password, hosts_str, cmd, file_path, dir_path, delete_dir):

--- a/st2common/st2common/log.py
+++ b/st2common/st2common/log.py
@@ -153,6 +153,9 @@ class LoggingStream(object):
     def write(self, message):
         self._logger._log(self._level, message, None)
 
+    def flush(self):
+        pass
+
 
 def _audit(logger, msg, *args, **kwargs):
     if logger.isEnabledFor(logging.AUDIT):

--- a/st2common/st2common/util/monkey_patch.py
+++ b/st2common/st2common/util/monkey_patch.py
@@ -1,0 +1,56 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+#
+
+"""
+Module for performing eventlet related monkey patching.
+"""
+
+import sys
+
+import eventlet
+
+__all__ = [
+    'monkey_patch'
+]
+
+USE_DEBUGGER_FLAG = '--use-debugger'
+PARENT_ARGS_FLAG = '--parent-args='
+
+
+def monkey_patch():
+    """
+    Function which performs eventlet monkey patching and also takes into account "--use-debugger"
+    argument in the command line arguments.
+
+    If this argument is found, no monkey patching is performed for the thread module. This allows
+    user to use remote debuggers.
+    """
+    patch_thread = not is_use_debugger_flag_provided()
+    eventlet.monkey_patch(os=True, select=True, socket=True, thread=patch_thread, time=True)
+
+
+def is_use_debugger_flag_provided():
+    # 1. Check sys.argv directly
+    if USE_DEBUGGER_FLAG in sys.argv:
+        return True
+
+    # 2. Check "parent-args" arguments. This is used for spawned processes such as sensors and
+    # Python runner actions
+
+    for arg in sys.argv:
+        if arg.startswith(PARENT_ARGS_FLAG) and USE_DEBUGGER_FLAG in arg:
+            return True
+
+    return False

--- a/st2exporter/st2exporter/cmd/st2exporter_starter.py
+++ b/st2exporter/st2exporter/cmd/st2exporter_starter.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import eventlet
 import os
 import sys
 
@@ -22,17 +21,15 @@ from st2common.service_setup import setup as common_setup
 from st2common.service_setup import teardown as common_teardown
 from st2exporter import config
 from st2exporter import worker
+from st2common.util.monkey_patch import monkey_patch
 
+__all__ = [
+    'main'
+]
+
+monkey_patch()
 
 LOG = logging.getLogger(__name__)
-
-
-eventlet.monkey_patch(
-    os=True,
-    select=True,
-    socket=True,
-    thread=False if '--use-debugger' in sys.argv else True,
-    time=True)
 
 
 def _setup():

--- a/st2reactor/st2reactor/cmd/garbagecollector.py
+++ b/st2reactor/st2reactor/cmd/garbagecollector.py
@@ -16,13 +16,13 @@
 import os
 import sys
 
-import eventlet
 from oslo_config import cfg
 
 from st2common import log as logging
 from st2common.logging.misc import get_logger_name_for_module
 from st2common.service_setup import setup as common_setup
 from st2common.service_setup import teardown as common_teardown
+from st2common.util.monkey_patch import monkey_patch
 from st2common.constants.exit_codes import FAILURE_EXIT_CODE
 from st2reactor.garbage_collector import config
 from st2reactor.garbage_collector.base import GarbageCollectorService
@@ -31,12 +31,8 @@ __all__ = [
     'main'
 ]
 
-eventlet.monkey_patch(
-    os=True,
-    select=True,
-    socket=True,
-    thread=False if '--use-debugger' in sys.argv else True,
-    time=True)
+monkey_patch()
+
 
 LOGGER_NAME = get_logger_name_for_module(sys.modules[__name__])
 LOG = logging.getLogger(LOGGER_NAME)

--- a/st2reactor/st2reactor/cmd/rulesengine.py
+++ b/st2reactor/st2reactor/cmd/rulesengine.py
@@ -23,16 +23,13 @@ from st2common import log as logging
 from st2common.logging.misc import get_logger_name_for_module
 from st2common.service_setup import setup as common_setup
 from st2common.service_setup import teardown as common_teardown
+from st2common.util.monkey_patch import monkey_patch
 from st2reactor.rules import config
 from st2reactor.rules import worker
 from st2reactor.timer.base import St2Timer
 
-eventlet.monkey_patch(
-    os=True,
-    select=True,
-    socket=True,
-    thread=False if '--use-debugger' in sys.argv else True,
-    time=True)
+monkey_patch()
+
 
 LOGGER_NAME = get_logger_name_for_module(sys.modules[__name__])
 LOG = logging.getLogger(LOGGER_NAME)

--- a/st2reactor/st2reactor/cmd/sensormanager.py
+++ b/st2reactor/st2reactor/cmd/sensormanager.py
@@ -16,12 +16,11 @@
 import os
 import sys
 
-import eventlet
-
 from st2common import log as logging
 from st2common.logging.misc import get_logger_name_for_module
 from st2common.service_setup import setup as common_setup
 from st2common.service_setup import teardown as common_teardown
+from st2common.util.monkey_patch import monkey_patch
 from st2common.exceptions.sensors import SensorNotFoundException
 from st2common.constants.exit_codes import FAILURE_EXIT_CODE
 from st2reactor.sensor import config
@@ -32,13 +31,7 @@ __all__ = [
     'main'
 ]
 
-eventlet.monkey_patch(
-    os=True,
-    select=True,
-    socket=True,
-    thread=False if '--use-debugger' in sys.argv else True,
-    time=True)
-
+monkey_patch()
 
 LOGGER_NAME = get_logger_name_for_module(sys.modules[__name__])
 LOG = logging.getLogger(LOGGER_NAME)

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -33,18 +33,14 @@ from st2common.services.triggerwatcher import TriggerWatcher
 from st2reactor.sensor.base import Sensor, PollingSensor
 from st2reactor.sensor import config
 from st2common.services.datastore import DatastoreService
+from st2common.util.monkey_patch import monkey_patch
 
 __all__ = [
     'SensorWrapper',
     'SensorService'
 ]
 
-eventlet.monkey_patch(
-    os=True,
-    select=True,
-    socket=True,
-    thread=False if '--use-debugger' in sys.argv else True,
-    time=True)
+monkey_patch()
 
 
 class SensorService(object):

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -14,12 +14,10 @@
 # limitations under the License.
 
 import os
-import sys
 import json
 import atexit
 import argparse
 
-import eventlet
 from oslo_config import cfg
 
 from st2common import log as logging

--- a/tools/diff-db-disk.py
+++ b/tools/diff-db-disk.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 """
 
 Tags: Ops tool.
@@ -26,12 +25,11 @@ A utility script that diffs models registered in st2 db versus what's on disk.
 import difflib
 import json
 import os
-import sys
 
-import eventlet
 from oslo_config import cfg
 
 from st2common import config
+from st2common.util.monkey_patch import monkey_patch
 from st2common.constants.pack import DEFAULT_PACK_NAME
 from st2common.content.loader import ContentPackLoader
 from st2common.content.loader import MetaLoader
@@ -72,15 +70,6 @@ def do_register_cli_opts(opts, ignore_errors=False):
         except:
             if not ignore_errors:
                 raise
-
-
-def _monkey_patch():
-    eventlet.monkey_patch(
-        os=True,
-        select=True,
-        socket=True,
-        thread=False if '--use-debugger' in sys.argv else True,
-        time=True)
 
 
 def _get_api_models_from_db(persistence_model, pack_dir=None):
@@ -236,7 +225,7 @@ def _diff_rules(pack_dir=None, verbose=True, content_diff=True):
 
 
 def main():
-    _monkey_patch()
+    monkey_patch()
 
     cli_opts = [
         cfg.BoolOpt('sensors', default=False,

--- a/tools/st2-analyze-links.py
+++ b/tools/st2-analyze-links.py
@@ -29,14 +29,13 @@ To run :
 The command must run on a StackStorm box.
 """
 
-import eventlet
 import os
 import sets
-import sys
 
 from oslo_config import cfg
 
 from st2common import config
+from st2common.util.monkey_patch import monkey_patch
 from st2common.persistence.rule import Rule
 from st2common.service_setup import db_setup
 
@@ -55,15 +54,6 @@ def do_register_cli_opts(opts, ignore_errors=False):
         except:
             if not ignore_errors:
                 raise
-
-
-def _monkey_patch():
-    eventlet.monkey_patch(
-        os=True,
-        select=True,
-        socket=True,
-        thread=False if '--use-debugger' in sys.argv else True,
-        time=True)
 
 
 class RuleLink(object):
@@ -155,7 +145,7 @@ class Grapher(object):
 
 
 def main():
-    _monkey_patch()
+    monkey_patch()
 
     cli_opts = [
         cfg.StrOpt('action_ref', default=None,

--- a/tools/st2-inject-trigger-instances.py
+++ b/tools/st2-inject-trigger-instances.py
@@ -28,13 +28,13 @@ meaningful work.
 
 import os
 import random
-import sys
 
 import eventlet
 from oslo_config import cfg
 import yaml
 
 from st2common import config
+from st2common.util.monkey_patch import monkey_patch
 from st2common.util import date as date_utils
 from st2common.transport.reactor import TriggerDispatcher
 
@@ -46,15 +46,6 @@ def do_register_cli_opts(opts, ignore_errors=False):
         except:
             if not ignore_errors:
                 raise
-
-
-def _monkey_patch():
-    eventlet.monkey_patch(
-        os=True,
-        select=True,
-        socket=True,
-        thread=False if '--use-debugger' in sys.argv else True,
-        time=True)
 
 
 def _inject_instances(trigger, rate_per_trigger, duration, payload={}):
@@ -75,7 +66,7 @@ def _inject_instances(trigger, rate_per_trigger, duration, payload={}):
 
 
 def main():
-    _monkey_patch()
+    monkey_patch()
 
     cli_opts = [
         cfg.IntOpt('rate', default=100,


### PR DESCRIPTION
Previously, `--use-debugger` flag was not correctly propagated and checked in the child sensor processes which means `thread` module was still patched and this broke remote debugging support (some remote debugger like the pydev and pycharm one rely on thread module not being patched).

Some references:

* https://ask.openstack.org/en/question/815/how-do-i-debug-nova-service-with-eclipse-and-pydev/
* http://debugopenstack.blogspot.si/

I didn't test this end to end since I don't have PyDev installed locally, but I tested it using netcat and it seems to be working. In any case, I will ask Ethan or someone with PyDev to test those changes.

This was reported by Ethan on the IRC.

I also asked Ethan to write a guest blog post on remote debugging sensors with PyDev once this issue has been resolved since having such post / article would be great.