### PR TITLE
Ignore conflict / "object already exist" errors during internal trigger types registration

### DIFF
--- a/st2api/st2api/cmd/api.py
+++ b/st2api/st2api/cmd/api.py
@@ -25,6 +25,7 @@ from st2common.service_setup import setup as common_setup
 from st2common.service_setup import teardown as common_teardown
 from st2common.util.monkey_patch import monkey_patch
 from st2api import config
+config.register_opts()
 from st2api import app
 
 __all__ = [

--- a/st2common/st2common/triggers.py
+++ b/st2common/st2common/triggers.py
@@ -73,7 +73,12 @@ def register_internal_trigger_types():
             try:
                 trigger_type_db = _register_internal_trigger_type(
                     trigger_definition=trigger_definition)
-            except:
+            except StackStormDBObjectConflictError:
+                # We ignore conflict error since this operation is idempodent and race is not an
+                # issue
+                LOG.debug('Trigger type "%s" already exists, ignoring...' %
+                          (trigger_definition['name']))
+            except Exception:
                 LOG.exception('Failed registering internal trigger: %s.', trigger_definition)
                 raise
             else:


### PR DESCRIPTION
Those operations are idempotent so we can simply ignore those errors (e.g. this could occur when using gunicorn with more than 1 worker).