### PR TITLE
Add support for file attachments in core.sendmail

### DIFF
--- a/contrib/core/actions/send_mail/send_mail
+++ b/contrib/core/actions/send_mail/send_mail
@@ -25,7 +25,13 @@ SEND_EMPTY_BODY=$1
 shift
 CONTENT_TYPE=$1
 shift
-BODY="$@"
+BODY="$1"
+shift
+IFS=',' read -ra ATTACHMENTS <<< "$@"
+
+if [[ $ATTACHMENTS == "None" ]]; then
+  ATTACHMENTS=""
+fi
 
 if [[ "${CONTENT_TYPE}" = "text/html" ]]; then
   LINE_BREAK="<br><br>"
@@ -33,19 +39,81 @@ else
   LINE_BREAK=""
 fi
 
+get_mimetype(){
+  # warning: assumes that the passed file exists
+  file --mime-type "$1" | sed 's/.*: //'
+}
+
 trimmed="${BODY// }"
 if [[ -z $trimmed && $SEND_EMPTY_BODY == 'True' ]] || [[ -n $trimmed ]]; then
-  ${MAIL} <<EOF
+
+{
+
+cat <<EOF
 TO: ${TO}
 FROM: ${FROM}
 SUBJECT: ${SUBJECT}
+EOF
+
+if [[ -n $ATTACHMENTS ]]; then
+
+  boundary="ZZ_/afg6432dfgkl.94531q"
+
+  cat <<EOF
+Content-Type: multipart/mixed; boundary="${boundary}"
+
+EOF
+
+  for file in "${ATTACHMENTS[@]}"; do
+    [ ! -f "$file" ] && echo "Warning: attachment ${file} not found, skipping" >&2 && continue
+
+    mimetype=$(get_mimetype "$file")
+
+    cat <<EOF
+--${boundary}
+Content-Type: ${mimetype}
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="$(basename $file)"
+
+EOF
+
+    base64 "$file"
+    echo
+  done
+
+  cat <<EOF
+--${boundary}
+Content-Type: ${CONTENT_TYPE}
+Content-Transfer-Encoding: 7bit
+Content-Disposition: inline
+
+EOF
+
+else
+
+  cat <<EOF
 Content-Type: ${CONTENT_TYPE}
 
+EOF
+
+fi
+
+  cat <<EOF
 ${BODY}
 ${LINE_BREAK}
 ${FOOTER}
 
 EOF
+
+if [[ -n $ATTACHMENTS ]]; then
+
+  cat <<EOF
+--${boundary}--
+EOF
+
+fi
+
+} | ${MAIL}
 
 fi
 
@@ -56,3 +124,4 @@ else
   echo "Successfully sent mail to ${TO}"
   exit 0
 fi
+

--- a/contrib/core/actions/sendmail.yaml
+++ b/contrib/core/actions/sendmail.yaml
@@ -41,5 +41,10 @@ parameters:
     type: string
   sudo:
     immutable: true
+  attachments:
+    description: Array of attachment file paths, comma-delimited.
+    position: 6
+    required: false
+    type: "string"
 
 runner_type: "local-shell-script"


### PR DESCRIPTION
For my use case, I'm writing a workflow that'll

1. query an API and write the results to a file; and
2. email the file as an attachment.

This patch enables `core.sendmail` to send file attachments. There are two things of note here:

1. The `attachments` parameter is a comma-separated `string`instead of an `array`. This can be changed when we have better support for array serialization for shell scripts. (see [discussion](https://stackstorm-community.slack.com/archives/community/p1456864311005045))
2. Only files found locally on the StackStorm host may be sent as attachments currently. We could change `core.sendmail` to a `remote-shell-script` instead of `local-shell-script` with a default host of localhost to make this more flexible. Thoughts?

```
# st2 run core.sendmail from=test to=cray@peak6.com subject="Just Testing" body="Gotta get 'em good" attachments="/tmp/image1.png,/tmp/image2.png"
..
id: 56d60990fb3b871d916f8043
status: succeeded
parameters:
  attachments: /tmp/image1.png,/tmp/image2.png
  body: Gotta get 'em good
  from: test
  subject: Just Testing
  to: cray@peak6.com
result:
  localhost:
    failed: false
    return_code: 0
    stderr: ''
    stdout: Successfully sent mail to cray@peak6.com
    succeeded: true
```

The email was received with both attachments (named image1.png and image2.png in the email).

The action still works as expected when the `attachments` parameter is omitted.

```
 st2 run core.sendmail from=test to=cray@peak6.com subject="Just Testing" body="Gotta get 'em for real"
.
id: 56d60e1dfb3b871d916f804f
status: succeeded
parameters:
  body: Gotta get 'em for real
  from: test
  subject: Just Testing
  to: cray@peak6.com
result:
  failed: false
  return_code: 0
  stderr: ''
  stdout: Successfully sent mail to cray@peak6.com
  succeeded: true
```

I followed [this guide](http://backreference.org/2013/05/22/send-email-with-attachments-from-script-or-command-line/) for attachments with sendmail.

/cc @Kami @m4dcoder 