### PR TITLE
Ability to disable services

### DIFF
--- a/st2actions/st2actions/cmd/st2notifier.py
+++ b/st2actions/st2actions/cmd/st2notifier.py
@@ -2,6 +2,8 @@ import eventlet
 import os
 import sys
 
+from oslo_config import cfg
+
 from st2common import log as logging
 from st2common.service_setup import setup as common_setup
 from st2common.service_setup import teardown as common_teardown
@@ -31,16 +33,14 @@ def _run_worker():
     try:
         if cfg.CONF.scheduler.enable:
             actions_rescheduler = scheduler.get_rescheduler()
-            rescheduler_thread = eventlet.spawn(actions_rescheduler.start)
-            LOG.info('Rescheduler is enabled. Started on thread %s.', rescheduler_thread)
+            eventlet.spawn(actions_rescheduler.start)
+            LOG.info('Rescheduler is enabled.')
         actions_notifier.start(wait=True)
     except (KeyboardInterrupt, SystemExit):
         LOG.info('(PID=%s) Actions notifier stopped.', os.getpid())
         if actions_rescheduler:
             actions_rescheduler.shutdown()
         actions_notifier.shutdown()
-    except:
-        return 1
     return 0
 
 

--- a/st2actions/st2actions/cmd/st2notifier.py
+++ b/st2actions/st2actions/cmd/st2notifier.py
@@ -5,6 +5,7 @@ import sys
 from oslo_config import cfg
 
 from st2common import log as logging
+from st2common.constants.scheduler import SCHEDULER_ENABLED_LOG_LINE, SCHEDULER_DISABLED_LOG_LINE
 from st2common.service_setup import setup as common_setup
 from st2common.service_setup import teardown as common_teardown
 from st2common.util.monkey_patch import monkey_patch
@@ -34,7 +35,9 @@ def _run_worker():
         if cfg.CONF.scheduler.enable:
             actions_rescheduler = scheduler.get_rescheduler()
             eventlet.spawn(actions_rescheduler.start)
-            LOG.info('Rescheduler is enabled.')
+            LOG.info(SCHEDULER_ENABLED_LOG_LINE)
+        else:
+            LOG.info(SCHEDULER_DISABLED_LOG_LINE)
         actions_notifier.start(wait=True)
     except (KeyboardInterrupt, SystemExit):
         LOG.info('(PID=%s) Actions notifier stopped.', os.getpid())

--- a/st2actions/st2actions/notifier/config.py
+++ b/st2actions/st2actions/notifier/config.py
@@ -47,6 +47,7 @@ def _register_notifier_opts():
     CONF.register_opts(notifier_opts, group='notifier')
 
     scheduler_opts = [
+        cfg.BoolOpt('enable', default=True, help='Specify to enable actions rescheduler.'),
         cfg.IntOpt('delayed_execution_recovery', default=600,
                    help='The time in seconds to wait before recovering delayed action executions.'),
         cfg.IntOpt('rescheduling_interval', default=300,

--- a/st2actions/tests/integration/test_notifier.py
+++ b/st2actions/tests/integration/test_notifier.py
@@ -24,7 +24,7 @@ from st2tests.base import IntegrationTestCase
 from st2tests.base import CleanDbTestCase
 
 __all__ = [
-    'TimerEnableDisableTestCase'
+    'SchedulerEnableDisableTestCase'
 ]
 
 
@@ -96,7 +96,6 @@ class SchedulerEnableDisableTestCase(IntegrationTestCase, CleanDbTestCase):
             if SCHEDULER_ENABLED_LOG_LINE in line:
                 self.assertTrue(True)
                 break
-
 
     def test_scheduler_disable_explicit(self):
         self._append_to_cfg_file(cfg_path=self.cfg_path, content='\n[scheduler]\nenable = False')

--- a/st2actions/tests/integration/test_notifier.py
+++ b/st2actions/tests/integration/test_notifier.py
@@ -16,7 +16,6 @@ import os
 import signal
 import tempfile
 
-import eventlet
 from eventlet.green import subprocess
 
 from st2common.constants.scheduler import SCHEDULER_ENABLED_LOG_LINE, SCHEDULER_DISABLED_LOG_LINE
@@ -60,63 +59,51 @@ class SchedulerEnableDisableTestCase(IntegrationTestCase, CleanDbTestCase):
         process = None
         try:
             process = self._start_notifier(cmd=self.cmd)
-            eventlet.sleep(1)
+            lines = 0
+            while lines < 100:
+                line = process.stdout.readline()
+                lines += 1
+                if SCHEDULER_ENABLED_LOG_LINE in line:
+                    self.assertTrue(True)
+                    break
         finally:
             if process:
                 process.send_signal(signal.SIGKILL)
                 self.remove_process(process=process)
-
-        lines = 0
-        while lines < 100:
-            line = process.stdout.readline()
-            if not line:
-                self.assertTrue(False, 'Scheduler enabled not found.')
-            lines += 1
-            if SCHEDULER_ENABLED_LOG_LINE in line:
-                self.assertTrue(True)
-                break
 
     def test_scheduler_enable_explicit(self):
         self._append_to_cfg_file(cfg_path=self.cfg_path, content='\n[scheduler]\nenable = True')
         process = None
         try:
             process = self._start_notifier(cmd=self.cmd)
-            eventlet.sleep(1)
+            lines = 0
+            while lines < 100:
+                line = process.stdout.readline()
+                lines += 1
+                if SCHEDULER_ENABLED_LOG_LINE in line:
+                    self.assertTrue(True)
+                    break
         finally:
             if process:
                 process.send_signal(signal.SIGKILL)
                 self.remove_process(process=process)
-
-        lines = 0
-        while lines < 100:
-            line = process.stdout.readline()
-            if not line:
-                self.assertTrue(False, 'Scheduler enabled not found.')
-            lines += 1
-            if SCHEDULER_ENABLED_LOG_LINE in line:
-                self.assertTrue(True)
-                break
 
     def test_scheduler_disable_explicit(self):
         self._append_to_cfg_file(cfg_path=self.cfg_path, content='\n[scheduler]\nenable = False')
         process = None
         try:
             process = self._start_notifier(cmd=self.cmd)
-            eventlet.sleep(1)
+            lines = 0
+            while lines < 100:
+                line = process.stdout.readline()
+                lines += 1
+                if SCHEDULER_DISABLED_LOG_LINE in line:
+                    self.assertTrue(True)
+                    break
         finally:
             if process:
                 process.send_signal(signal.SIGKILL)
                 self.remove_process(process=process)
-
-        max_lines = 0
-        while max_lines < 100:
-            line = process.stdout.readline()
-            if not line:
-                self.assertTrue(False, 'Scheduler disabled not found.')
-            max_lines += 1
-            if SCHEDULER_DISABLED_LOG_LINE in line:
-                self.assertTrue(True)
-                break
 
     def _start_notifier(self, cmd):
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,

--- a/st2actions/tests/integration/test_notifier.py
+++ b/st2actions/tests/integration/test_notifier.py
@@ -1,0 +1,134 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import os
+import signal
+import tempfile
+
+import eventlet
+from eventlet.green import subprocess
+
+from st2common.constants.scheduler import SCHEDULER_ENABLED_LOG_LINE, SCHEDULER_DISABLED_LOG_LINE
+from st2tests.base import IntegrationTestCase
+from st2tests.base import CleanDbTestCase
+
+__all__ = [
+    'TimerEnableDisableTestCase'
+]
+
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+ST2_CONFIG_PATH = os.path.join(BASE_DIR, '../../../conf/st2.tests.conf')
+ST2_CONFIG_PATH = os.path.abspath(ST2_CONFIG_PATH)
+BINARY = os.path.join(BASE_DIR, '../../../st2actions/bin/st2notifier')
+BINARY = os.path.abspath(BINARY)
+CMD = [BINARY, '--config-file']
+
+
+class SchedulerEnableDisableTestCase(IntegrationTestCase, CleanDbTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(SchedulerEnableDisableTestCase, cls).setUpClass()
+
+    def setUp(self):
+        super(SchedulerEnableDisableTestCase, self).setUp()
+        config_text = open(ST2_CONFIG_PATH).read()
+        self.cfg_fd, self.cfg_path = tempfile.mkstemp()
+        with open(self.cfg_path, 'w') as f:
+            f.write(config_text)
+        self.cmd = []
+        self.cmd.extend(CMD)
+        self.cmd.append(self.cfg_path)
+
+    def tearDown(self):
+        self.cmd = None
+        self._remove_tempfile(self.cfg_fd, self.cfg_path)
+        super(SchedulerEnableDisableTestCase, self).tearDown()
+
+    def test_scheduler_enable_implicit(self):
+        process = None
+        try:
+            process = self._start_notifier(cmd=self.cmd)
+            eventlet.sleep(1)
+        finally:
+            if process:
+                process.send_signal(signal.SIGKILL)
+                self.remove_process(process=process)
+
+        lines = 0
+        while lines < 100:
+            line = process.stdout.readline()
+            if not line:
+                self.assertTrue(False, 'Scheduler enabled not found.')
+            lines += 1
+            if SCHEDULER_ENABLED_LOG_LINE in line:
+                self.assertTrue(True)
+                break
+
+    def test_scheduler_enable_explicit(self):
+        self._append_to_cfg_file(cfg_path=self.cfg_path, content='\n[scheduler]\nenable = True')
+        process = None
+        try:
+            process = self._start_notifier(cmd=self.cmd)
+            eventlet.sleep(1)
+        finally:
+            if process:
+                process.send_signal(signal.SIGKILL)
+                self.remove_process(process=process)
+
+        lines = 0
+        while lines < 100:
+            line = process.stdout.readline()
+            if not line:
+                self.assertTrue(False, 'Scheduler enabled not found.')
+            lines += 1
+            if SCHEDULER_ENABLED_LOG_LINE in line:
+                self.assertTrue(True)
+                break
+
+
+    def test_scheduler_disable_explicit(self):
+        self._append_to_cfg_file(cfg_path=self.cfg_path, content='\n[scheduler]\nenable = False')
+        process = None
+        try:
+            process = self._start_notifier(cmd=self.cmd)
+            eventlet.sleep(1)
+        finally:
+            if process:
+                process.send_signal(signal.SIGKILL)
+                self.remove_process(process=process)
+
+        max_lines = 0
+        while max_lines < 100:
+            line = process.stdout.readline()
+            if not line:
+                self.assertTrue(False, 'Scheduler disabled not found.')
+            max_lines += 1
+            if SCHEDULER_DISABLED_LOG_LINE in line:
+                self.assertTrue(True)
+                break
+
+    def _start_notifier(self, cmd):
+        process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                   shell=False, preexec_fn=os.setsid)
+        self.add_process(process=process)
+        return process
+
+    def _append_to_cfg_file(self, cfg_path, content):
+        with open(cfg_path, 'a') as f:
+            f.write(content)
+
+    def _remove_tempfile(self, fd, path):
+        os.close(fd)
+        os.unlink(path)

--- a/st2common/st2common/constants/scheduler.py
+++ b/st2common/st2common/constants/scheduler.py
@@ -1,0 +1,21 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = ['SCHEDULER_ENABLED_LOG_LINE', 'SCHEDULER_DISABLED_LOG_LINE']
+
+
+# Integration tests look for these loglines to validate scheduler enable/disable
+SCHEDULER_ENABLED_LOG_LINE = 'Scheduler is enabled.'
+SCHEDULER_DISABLED_LOG_LINE = 'Scheduler is disabled.'

--- a/st2common/st2common/constants/timer.py
+++ b/st2common/st2common/constants/timer.py
@@ -1,0 +1,21 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = ['TIMER_ENABLED_LOG_LINE', 'TIMER_DISABLED_LOG_LINE']
+
+
+# Integration tests look for these loglines to validate timer enable/disable
+TIMER_ENABLED_LOG_LINE = 'Timer is enabled.'
+TIMER_DISABLED_LOG_LINE = 'Timer is disabled.'

--- a/st2reactor/st2reactor/cmd/rulesengine.py
+++ b/st2reactor/st2reactor/cmd/rulesengine.py
@@ -20,6 +20,7 @@ import eventlet
 from oslo_config import cfg
 
 from st2common import log as logging
+from st2common.constants.timer import TIMER_ENABLED_LOG_LINE, TIMER_DISABLED_LOG_LINE
 from st2common.logging.misc import get_logger_name_for_module
 from st2common.service_setup import setup as common_setup
 from st2common.service_setup import teardown as common_teardown
@@ -33,7 +34,6 @@ monkey_patch()
 
 LOGGER_NAME = get_logger_name_for_module(sys.modules[__name__])
 LOG = logging.getLogger(LOGGER_NAME)
-
 
 def _setup():
     common_setup(service='rulesengine', config=config, setup_db=True, register_mq_exchanges=True,
@@ -59,7 +59,9 @@ def _run_worker():
         if cfg.CONF.timer.enable:
             timer = St2Timer(local_timezone=cfg.CONF.timer.local_timezone)
             timer_thread = eventlet.spawn(_kickoff_timer, timer)
-            LOG.info('Timer is enabled.')
+            LOG.info(TIMER_ENABLED_LOG_LINE)
+        else:
+            LOG.info(TIMER_DISABLED_LOG_LINE)
         rules_engine_worker.start()
         if timer:
             return timer_thread.wait() and rules_engine_worker.wait()

--- a/st2reactor/st2reactor/cmd/rulesengine.py
+++ b/st2reactor/st2reactor/cmd/rulesengine.py
@@ -59,7 +59,7 @@ def _run_worker():
         if cfg.CONF.timer.enable:
             timer = St2Timer(local_timezone=cfg.CONF.timer.local_timezone)
             timer_thread = eventlet.spawn(_kickoff_timer, timer)
-            LOG.info('Timer is enabled. Started on thread %s', timer_thread)
+            LOG.info('Timer is enabled.')
         rules_engine_worker.start()
         if timer:
             return timer_thread.wait() and rules_engine_worker.wait()

--- a/st2reactor/st2reactor/cmd/rulesengine.py
+++ b/st2reactor/st2reactor/cmd/rulesengine.py
@@ -35,6 +35,7 @@ monkey_patch()
 LOGGER_NAME = get_logger_name_for_module(sys.modules[__name__])
 LOG = logging.getLogger(LOGGER_NAME)
 
+
 def _setup():
     common_setup(service='rulesengine', config=config, setup_db=True, register_mq_exchanges=True,
                  register_signal_handlers=True)

--- a/st2reactor/st2reactor/rules/config.py
+++ b/st2reactor/st2reactor/rules/config.py
@@ -48,7 +48,8 @@ def _register_rules_engine_opts():
 
     timer_opts = [
         cfg.StrOpt('local_timezone', default='America/Los_Angeles',
-                   help='Timezone pertaining to the location where st2 is run.')
+                   help='Timezone pertaining to the location where st2 is run.'),
+        cfg.BoolOpt('enable', default=True, help='Specify to enable Timer.')
     ]
     CONF.register_opts(timer_opts, group='timer')
 

--- a/st2reactor/tests/integration/test_rules_engine.py
+++ b/st2reactor/tests/integration/test_rules_engine.py
@@ -1,0 +1,134 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import os
+import signal
+import tempfile
+
+import eventlet
+from eventlet.green import subprocess
+
+from st2common.constants.timer import TIMER_ENABLED_LOG_LINE, TIMER_DISABLED_LOG_LINE
+from st2tests.base import IntegrationTestCase
+from st2tests.base import CleanDbTestCase
+
+__all__ = [
+    'TimerEnableDisableTestCase'
+]
+
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+ST2_CONFIG_PATH = os.path.join(BASE_DIR, '../../../conf/st2.tests.conf')
+ST2_CONFIG_PATH = os.path.abspath(ST2_CONFIG_PATH)
+BINARY = os.path.join(BASE_DIR, '../../../st2reactor/bin/st2rulesengine')
+BINARY = os.path.abspath(BINARY)
+CMD = [BINARY, '--config-file']
+
+
+class TimerEnableDisableTestCase(IntegrationTestCase, CleanDbTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TimerEnableDisableTestCase, cls).setUpClass()
+
+    def setUp(self):
+        super(TimerEnableDisableTestCase, self).setUp()
+        config_text = open(ST2_CONFIG_PATH).read()
+        self.cfg_fd, self.cfg_path = tempfile.mkstemp()
+        with open(self.cfg_path, 'w') as f:
+            f.write(config_text)
+        self.cmd = []
+        self.cmd.extend(CMD)
+        self.cmd.append(self.cfg_path)
+
+    def tearDown(self):
+        self.cmd = None
+        self._remove_tempfile(self.cfg_fd, self.cfg_path)
+        super(TimerEnableDisableTestCase, self).tearDown()
+
+    def test_timer_enable_implicit(self):
+        process = None
+        try:
+            process = self._start_rules_engine(cmd=self.cmd)
+            eventlet.sleep(1)
+        finally:
+            if process:
+                process.send_signal(signal.SIGKILL)
+                self.remove_process(process=process)
+
+        lines = 0
+        while lines < 100:
+            line = process.stdout.readline()
+            if not line:
+                self.assertTrue(False, 'Timer enabled not found.')
+            lines += 1
+            if TIMER_ENABLED_LOG_LINE in line:
+                self.assertTrue(True)
+                break
+
+    def test_timer_enable_explicit(self):
+        self._append_to_cfg_file(cfg_path=self.cfg_path, content='\n[timer]\nenable = True')
+        process = None
+        try:
+            process = self._start_rules_engine(cmd=self.cmd)
+            eventlet.sleep(1)
+        finally:
+            if process:
+                process.send_signal(signal.SIGKILL)
+                self.remove_process(process=process)
+
+        lines = 0
+        while lines < 100:
+            line = process.stdout.readline()
+            if not line:
+                self.assertTrue(False, 'Timer enabled not found.')
+            lines += 1
+            if TIMER_ENABLED_LOG_LINE in line:
+                self.assertTrue(True)
+                break
+
+
+    def test_timer_disable_explicit(self):
+        self._append_to_cfg_file(cfg_path=self.cfg_path, content='\n[timer]\nenable = False')
+        process = None
+        try:
+            process = self._start_rules_engine(cmd=self.cmd)
+            eventlet.sleep(1)
+        finally:
+            if process:
+                process.send_signal(signal.SIGKILL)
+                self.remove_process(process=process)
+
+        max_lines = 0
+        while max_lines < 100:
+            line = process.stdout.readline()
+            if not line:
+                self.assertTrue(False, 'Timer disabled not found.')
+            max_lines += 1
+            if TIMER_DISABLED_LOG_LINE in line:
+                self.assertTrue(True)
+                break
+
+    def _start_rules_engine(self, cmd):
+        process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                   shell=False, preexec_fn=os.setsid)
+        self.add_process(process=process)
+        return process
+
+    def _append_to_cfg_file(self, cfg_path, content):
+        with open(cfg_path, 'a') as f:
+            f.write(content)
+
+    def _remove_tempfile(self, fd, path):
+        os.close(fd)
+        os.unlink(path)

--- a/st2reactor/tests/integration/test_rules_engine.py
+++ b/st2reactor/tests/integration/test_rules_engine.py
@@ -16,7 +16,6 @@ import os
 import signal
 import tempfile
 
-import eventlet
 from eventlet.green import subprocess
 
 from st2common.constants.timer import TIMER_ENABLED_LOG_LINE, TIMER_DISABLED_LOG_LINE
@@ -60,63 +59,51 @@ class TimerEnableDisableTestCase(IntegrationTestCase, CleanDbTestCase):
         process = None
         try:
             process = self._start_rules_engine(cmd=self.cmd)
-            eventlet.sleep(1)
+            lines = 0
+            while lines < 100:
+                line = process.stdout.readline()
+                lines += 1
+                if TIMER_ENABLED_LOG_LINE in line:
+                    self.assertTrue(True)
+                    break
         finally:
             if process:
                 process.send_signal(signal.SIGKILL)
                 self.remove_process(process=process)
-
-        lines = 0
-        while lines < 100:
-            line = process.stdout.readline()
-            if not line:
-                self.assertTrue(False, 'Timer enabled not found.')
-            lines += 1
-            if TIMER_ENABLED_LOG_LINE in line:
-                self.assertTrue(True)
-                break
 
     def test_timer_enable_explicit(self):
         self._append_to_cfg_file(cfg_path=self.cfg_path, content='\n[timer]\nenable = True')
         process = None
         try:
             process = self._start_rules_engine(cmd=self.cmd)
-            eventlet.sleep(1)
+            lines = 0
+            while lines < 100:
+                line = process.stdout.readline()
+                lines += 1
+                if TIMER_ENABLED_LOG_LINE in line:
+                    self.assertTrue(True)
+                    break
         finally:
             if process:
                 process.send_signal(signal.SIGKILL)
                 self.remove_process(process=process)
-
-        lines = 0
-        while lines < 100:
-            line = process.stdout.readline()
-            if not line:
-                self.assertTrue(False, 'Timer enabled not found.')
-            lines += 1
-            if TIMER_ENABLED_LOG_LINE in line:
-                self.assertTrue(True)
-                break
 
     def test_timer_disable_explicit(self):
         self._append_to_cfg_file(cfg_path=self.cfg_path, content='\n[timer]\nenable = False')
         process = None
         try:
             process = self._start_rules_engine(cmd=self.cmd)
-            eventlet.sleep(1)
+            lines = 0
+            while lines < 100:
+                line = process.stdout.readline()
+                lines += 1
+                if TIMER_DISABLED_LOG_LINE in line:
+                    self.assertTrue(True)
+                    break
         finally:
             if process:
                 process.send_signal(signal.SIGKILL)
                 self.remove_process(process=process)
-
-        max_lines = 0
-        while max_lines < 100:
-            line = process.stdout.readline()
-            if not line:
-                self.assertTrue(False, 'Timer disabled not found.')
-            max_lines += 1
-            if TIMER_DISABLED_LOG_LINE in line:
-                self.assertTrue(True)
-                break
 
     def _start_rules_engine(self, cmd):
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,

--- a/st2reactor/tests/integration/test_rules_engine.py
+++ b/st2reactor/tests/integration/test_rules_engine.py
@@ -97,7 +97,6 @@ class TimerEnableDisableTestCase(IntegrationTestCase, CleanDbTestCase):
                 self.assertTrue(True)
                 break
 
-
     def test_timer_disable_explicit(self):
         self._append_to_cfg_file(cfg_path=self.cfg_path, content='\n[timer]\nenable = False')
         process = None


### PR DESCRIPTION
Ways to disable timer and action rescheduler. This is useful in HA scenarios where these services that are hosted in shared containers do not scale the same way as co-services.

e.g. timer and rulesengine run in the same process st2rulesengine. Timer pretty much needs to be singleton but rulesengine are designed to share the work. The short term solution is to be able to disable timer in certain st2rulesengine containers.

Note : By default there will be no change.
