### PR TITLE
Add chatops to st2ctl

### DIFF
--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -2,7 +2,7 @@
 
 
 LOGFILE="/dev/null"
-COMPONENTS="st2actionrunner st2api st2stream st2auth st2garbagecollector st2notifier st2resultstracker st2rulesengine st2sensorcontainer mistral"
+COMPONENTS="st2actionrunner st2api st2stream st2auth st2garbagecollector st2notifier st2resultstracker st2rulesengine st2sensorcontainer st2chatops mistral"
 STANCONF="/etc/st2/st2.conf"
 
 # Ensure global environment is sourced if exists
@@ -141,6 +141,7 @@ function clean_logs() {
 function getpids() {
   echo "##### st2 components status #####"
   COMPONENTS=${COMPONENTS/mistral/mistral-server mistral-api}
+  COMPONENTS=${COMPONENTS/st2chatops/hubot}
 
   for COM in ${COMPONENTS}; do
     PID=`ps ax | grep -v grep | grep -v st2ctl | grep "${COM}" | awk '{print $1}'`


### PR DESCRIPTION
Problem: avoid managing st2chatops service as an exception. 

I bounced at this when testing chatops docs, and was about to enable the service at boot, but realized we don't want an exception here and rather manage it just like all other Stackstorm components.

Tested on ubuntu and RHEL, unfortunately it complains on "unknown service" when chatops is not installed, but I think consistency is better. Input welcome.