### PR TITLE
Setup insecure and cacert properties for mistral

### DIFF
--- a/st2actions/st2actions/handlers/mistral.py
+++ b/st2actions/st2actions/handlers/mistral.py
@@ -76,7 +76,9 @@ class MistralCallbackHandler(handlers.ActionExecutionCallbackHandler):
             username=cfg.CONF.mistral.keystone_username,
             api_key=cfg.CONF.mistral.keystone_password,
             project_name=cfg.CONF.mistral.keystone_project_name,
-            auth_url=cfg.CONF.mistral.keystone_auth_url)
+            auth_url=cfg.CONF.mistral.keystone_auth_url,
+            cacert=cfg.CONF.mistral.cacert,
+            insecure=cfg.CONF.mistral.insecure)
 
         manager = action_executions.ActionExecutionManager(client)
         manager.update(action_execution_id, **data)

--- a/st2actions/st2actions/query/mistral/v2.py
+++ b/st2actions/st2actions/query/mistral/v2.py
@@ -36,7 +36,9 @@ class MistralResultsQuerier(Querier):
             username=cfg.CONF.mistral.keystone_username,
             api_key=cfg.CONF.mistral.keystone_password,
             project_name=cfg.CONF.mistral.keystone_project_name,
-            auth_url=cfg.CONF.mistral.keystone_auth_url)
+            auth_url=cfg.CONF.mistral.keystone_auth_url,
+            cacert=cfg.CONF.mistral.cacert,
+            insecure=cfg.CONF.mistral.insecure)
 
     @retrying.retry(
         retry_on_exception=utils.retry_on_exceptions,

--- a/st2actions/st2actions/runners/mistral/v2.py
+++ b/st2actions/st2actions/runners/mistral/v2.py
@@ -53,7 +53,9 @@ class MistralRunner(AsyncActionRunner):
             username=cfg.CONF.mistral.keystone_username,
             api_key=cfg.CONF.mistral.keystone_password,
             project_name=cfg.CONF.mistral.keystone_project_name,
-            auth_url=cfg.CONF.mistral.keystone_auth_url)
+            auth_url=cfg.CONF.mistral.keystone_auth_url,
+            cacert=cfg.CONF.mistral.cacert,
+            insecure=cfg.CONF.mistral.insecure)
 
     def pre_run(self):
         if getattr(self, 'liveaction', None):

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -175,6 +175,8 @@ def register_opts(ignore_errors=False):
         cfg.StrOpt('keystone_password', default=None, help='Password for authentication.'),
         cfg.StrOpt('keystone_project_name', default=None, help='OpenStack project scope.'),
         cfg.StrOpt('keystone_auth_url', default=None, help='Auth endpoint for Keystone.'),
+        cfg.StrOpt('cacert', default=None, help='Optional certificate to validate endpoint.'),
+        cfg.BoolOpt('insecure', default=False, help='Allow insecure communication with Mistral.'),
 
         cfg.StrOpt('api_url', default=None, help=('URL Mistral uses to talk back to the API.'
             'If not provided it defaults to public API URL. Note: This needs to be a base '

--- a/st2common/st2common/validators/workflow/mistral/v2.py
+++ b/st2common/st2common/validators/workflow/mistral/v2.py
@@ -45,7 +45,9 @@ class MistralWorkflowValidator(WorkflowValidator):
             username=cfg.CONF.mistral.keystone_username,
             api_key=cfg.CONF.mistral.keystone_password,
             project_name=cfg.CONF.mistral.keystone_project_name,
-            auth_url=cfg.CONF.mistral.keystone_auth_url)
+            auth_url=cfg.CONF.mistral.keystone_auth_url,
+            cacert=cfg.CONF.mistral.cacert,
+            insecure=cfg.CONF.mistral.insecure)
 
     @staticmethod
     def parse(message):


### PR DESCRIPTION
Follow up to https://review.openstack.org/#/c/286942/3

This will allow StackStorm to use mistral-api with a self signed SSL cert