### PR TITLE
st2-submit-debug-info #2529 Follow Up

### DIFF
--- a/st2debug/st2debug/cmd/submit_debug_info.py
+++ b/st2debug/st2debug/cmd/submit_debug_info.py
@@ -596,6 +596,8 @@ def main():
                         help='Specify an existing file to operate on')
     args = parser.parse_args()
 
+    setup_logging()
+
     # Ensure that not all options have been excluded
     abort = True
     for arg_name in ARG_NAMES:
@@ -607,8 +609,16 @@ def main():
 
     # Get setting overrides from yaml file if specified
     if args.config:
-        with open(args.config, 'r') as yaml_file:
-            config_file = yaml.load(yaml_file)
+        try:
+            with open(args.config, 'r') as yaml_file:
+                config_file = yaml.safe_load(yaml_file)
+        except Exception as e:
+            LOG.error('Failed to parse config file: %s' % e)
+            sys.exit(1)
+
+        if not isinstance(config_file, dict):
+            LOG.error('Unrecognized config file format')
+            sys.exit(1)
     else:
         config_file = {}
 
@@ -652,7 +662,6 @@ def main():
             user_info['email'] = six.moves.input('Email: ')
             user_info['comment'] = six.moves.input('Comment: ')
 
-    setup_logging()
 
     debug_collector = DebugInfoCollector(include_logs=not args.exclude_logs,
                                          include_configs=not args.exclude_configs,

--- a/st2debug/st2debug/cmd/submit_debug_info.py
+++ b/st2debug/st2debug/cmd/submit_debug_info.py
@@ -396,6 +396,12 @@ class DebugInfoCollector(object):
             fp.write(system_information)
 
     def add_user_info(self, output_path):
+        """
+        Write user info to output path as YAML.
+
+        :param output_path: Path where user info will be written.
+        :type output_path: ``str``
+        """
         LOG.debug('Including user info')
         user_info = yaml.dump(self.user_info, default_flow_style=False)
 

--- a/st2debug/st2debug/cmd/submit_debug_info.py
+++ b/st2debug/st2debug/cmd/submit_debug_info.py
@@ -168,7 +168,7 @@ class DebugInfoCollector(object):
         self.st2_config_file_path = config_file.get('st2_config_file_path', ST2_CONFIG_FILE_PATH)
         self.mistral_config_file_path = config_file.get('mistral_config_file_path',
                                                         MISTRAL_CONFIG_FILE_PATH)
-        self.log_files_paths = config_file.get('log_files_paths', LOG_FILE_PATHS[:])
+        self.log_file_paths = config_file.get('log_file_paths', LOG_FILE_PATHS[:])
         self.gpg_key = config_file.get('gpg_key', GPG_KEY)
         self.gpg_key_fingerprint = config_file.get('gpg_key_fingerprint', GPG_KEY_FINGERPRINT)
         self.s3_bucket_url = config_file.get('s3_bucket_url', S3_BUCKET_URL)
@@ -333,7 +333,7 @@ class DebugInfoCollector(object):
         :type output_path: ``str``
         """
         LOG.debug('Including log files')
-        for file_path_glob in self.log_files_paths:
+        for file_path_glob in self.log_file_paths:
             log_file_list = get_full_file_list(file_path_glob=file_path_glob)
             copy_files(file_paths=log_file_list, destination=output_path)
 

--- a/st2debug/st2debug/cmd/submit_debug_info.py
+++ b/st2debug/st2debug/cmd/submit_debug_info.py
@@ -668,7 +668,6 @@ def main():
             user_info['email'] = six.moves.input('Email: ')
             user_info['comment'] = six.moves.input('Comment: ')
 
-
     debug_collector = DebugInfoCollector(include_logs=not args.exclude_logs,
                                          include_configs=not args.exclude_configs,
                                          include_content=not args.exclude_content,

--- a/st2debug/tests/integration/test_submit_debug_info.py
+++ b/st2debug/tests/integration/test_submit_debug_info.py
@@ -192,13 +192,13 @@ class SubmitDebugInfoTestCase(CleanFilesTestCase):
         self.assertTrue('echobar12.txt' in command_files)
 
         # Verify file contents
-        with open(os.path.join(commands_path, 'echofoo.txt')) as echofoo:
+        with open(os.path.join(commands_path, 'echofoo.txt')) as f:
             expected_content = '[BEGIN STDOUT]\nfoo\n[END STDOUT]\n[BEGIN STDERR]\n[END STDERR]'
-            self.assertEqual(expected_content, echofoo.read())
+            self.assertEqual(expected_content, f.read())
 
-        with open(os.path.join(commands_path, 'echobar12.txt')) as echofoo:
+        with open(os.path.join(commands_path, 'echobar12.txt')) as f:
             expected_content = '[BEGIN STDOUT]\n[END STDOUT]\n[BEGIN STDERR]\nbar\n[END STDERR]'
-            self.assertEqual(expected_content, echofoo.read())
+            self.assertEqual(expected_content, f.read())
 
     def test_create_archive_exclusion(self):
         # Verify only system info file is included

--- a/st2debug/tests/integration/test_submit_debug_info.py
+++ b/st2debug/tests/integration/test_submit_debug_info.py
@@ -120,7 +120,7 @@ class SubmitDebugInfoTestCase(CleanFilesTestCase):
 
     def _get_yaml_config(self):
         return {
-            'log_files_paths': [
+            'log_file_paths': [
                 os.path.join(FIXTURES_DIR, 'logs/st2*.log')
             ],
             'st2_config_file_path': os.path.join(FIXTURES_DIR, 'configs/st2.conf'),
@@ -137,7 +137,7 @@ class SubmitDebugInfoTestCase(CleanFilesTestCase):
 
     def test_config_option_overrides_defaults(self):
         config = {
-            'log_files_paths': [
+            'log_file_paths': [
                 'log/path/1',
                 'log/path/1'
             ],
@@ -158,7 +158,7 @@ class SubmitDebugInfoTestCase(CleanFilesTestCase):
                                              include_content=True,
                                              include_system_info=True,
                                              config_file=config)
-        self.assertEqual(debug_collector.log_files_paths, ['log/path/1', 'log/path/1'])
+        self.assertEqual(debug_collector.log_file_paths, ['log/path/1', 'log/path/1'])
         self.assertEqual(debug_collector.st2_config_file_path, 'st2/config/path')
         self.assertEqual(debug_collector.st2_config_file_name, 'path')
         self.assertEqual(debug_collector.mistral_config_file_path, 'mistral/config/path')


### PR DESCRIPTION
Follow up for PR #2529, as requested by @Kami.

* Following errors are handled when specify a custom config:
    * Config file does not exist
    * Config file is not valid YAML
    * YAML is not a dict
* Changed `yaml.load` to `yaml.safe_load` to avoid potential for privilege escalation when a non-privileged user is allowed to execute the script as root.
* Added missing docstring for `add_user_info`.
* Added tests to verify that shell command files are created and that the output is correctly written to the files.
* Added tests to verify that custom config does override default options.

Let me know if there are any other test cases you'd like added.