### PR TITLE
Fix cryptic error messages in nginx config

### DIFF
--- a/conf/nginx/st2.conf
+++ b/conf/nginx/st2.conf
@@ -1,5 +1,5 @@
 #
-# nginx configuration to expose st2 webui, redirect HTTP->HTTPS, 
+# nginx configuration to expose st2 webui, redirect HTTP->HTTPS,
 # provide SSL termination, and reverse-proxy st2api and st2auth API endpoint.
 # To enable:
 #    cp ${LOCATION}/st2.conf /etc/nginx/sites-available
@@ -62,57 +62,13 @@ server {
     proxy_set_header Host $host;
   }
 
-  location /stream/ {
-    rewrite ^/stream/(.*)  /$1 break;
-
-    proxy_pass            http://127.0.0.1:9102/;
-    proxy_read_timeout    90;
-    proxy_connect_timeout 90;
-    proxy_redirect        off;
-
-    proxy_set_header      Host $host;
-    proxy_set_header      X-Real-IP $remote_addr;
-    proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_pass_header     Authorization;
-
-    sendfile on;
-    tcp_nopush on;
-    tcp_nodelay on;
-
-    # Disable buffering and chunked encoding.
-    # In the stream case we want to receive the whole payload at once, we don't
-    # want multiple chunks.
-    proxy_set_header Connection '';
-    chunked_transfer_encoding off;
-    proxy_buffering off;
-    proxy_cache off;
-    proxy_set_header Host $host;
-  }
-
   # For backward compatibility reasons, rewrite requests from "/api/stream"
   # to "/stream/v1/stream" and "/api/v1/stream" to "/stream/v1/stream"
-  location /api/stream/ {
-    rewrite ^/api/stream/?(.*)$ /v1/stream/$1 break;
-    proxy_pass  http://127.0.0.1:9102;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  location ~* (/stream/|/api(/v\d)?/stream/?) {
+    rewrite ^/stream/(.*)  /$1 break;
+    rewrite ^/api/stream/?$ /v1/stream break;
+    rewrite ^/api(/v\d)?/stream/?$ $1/stream break;
 
-    sendfile on;
-    tcp_nopush on;
-    tcp_nodelay on;
-
-    # Disable buffering and chunked encoding.
-    # In the stream case we want to receive the whole payload at once, we don't
-    # want multiple chunks.
-    proxy_set_header Connection '';
-    chunked_transfer_encoding off;
-    proxy_buffering off;
-    proxy_cache off;
-  }
-
-  location /api/v1/stream/ {
-    rewrite ^/api/v1/stream/?(.*)$ /v1/stream/$1 break;
     proxy_pass  http://127.0.0.1:9102;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;

--- a/conf/nginx/st2.conf
+++ b/conf/nginx/st2.conf
@@ -43,7 +43,14 @@ server {
   add_header              Front-End-Https on;
   add_header              X-Content-Type-Options nosniff;
 
+  location @apiError {
+    add_header Content-Type application/json;
+    return 200 '{ "faultstring": "Nginx is unable to reach st2api. Make sure service is running." }';
+  }
+
   location /api/ {
+    error_page 502 = @apiError;
+
     rewrite ^/api/(.*)  /$1 break;
 
     proxy_pass            http://127.0.0.1:9101/;
@@ -94,7 +101,14 @@ server {
     proxy_cache off;
   }
 
+  location @authError {
+    add_header Content-Type application/json;
+    return 200 '{ "faultstring": "Nginx is unable to reach st2auth. Make sure service is running." }';
+  }
+
   location /auth/ {
+    error_page 502 = @authError;
+
     rewrite ^/auth/(.*)  /$1 break;
 
     proxy_pass            http://127.0.0.1:9100/;

--- a/conf/nginx/st2.conf
+++ b/conf/nginx/st2.conf
@@ -62,9 +62,16 @@ server {
     proxy_set_header Host $host;
   }
 
+  location @streamError {
+    add_header Content-Type text/event-stream;
+    return 200 "retry: 1000\n\n";
+  }
+
   # For backward compatibility reasons, rewrite requests from "/api/stream"
   # to "/stream/v1/stream" and "/api/v1/stream" to "/stream/v1/stream"
   location ~* (/stream/|/api(/v\d)?/stream/?) {
+    error_page 502 = @streamError;
+
     rewrite ^/stream/(.*)  /$1 break;
     rewrite ^/api/stream/?$ /v1/stream break;
     rewrite ^/api(/v\d)?/stream/?$ $1/stream break;

--- a/conf/nginx/st2.conf
+++ b/conf/nginx/st2.conf
@@ -44,8 +44,8 @@ server {
   add_header              X-Content-Type-Options nosniff;
 
   location @apiError {
-    add_header Content-Type application/json;
-    return 200 '{ "faultstring": "Nginx is unable to reach st2api. Make sure service is running." }';
+    add_header Content-Type application/json always;
+    return 503 '{ "faultstring": "Nginx is unable to reach st2api. Make sure service is running." }';
   }
 
   location /api/ {
@@ -102,8 +102,8 @@ server {
   }
 
   location @authError {
-    add_header Content-Type application/json;
-    return 200 '{ "faultstring": "Nginx is unable to reach st2auth. Make sure service is running." }';
+    add_header Content-Type application/json always;
+    return 503 '{ "faultstring": "Nginx is unable to reach st2auth. Make sure service is running." }';
   }
 
   location /auth/ {


### PR DESCRIPTION
I've also made some changes to Stream API endpoint to fix backward compatibility and make it more compact.