### PR TITLE
Fix API config for development

### DIFF
--- a/conf/st2.dev.conf
+++ b/conf/st2.dev.conf
@@ -8,6 +8,8 @@ logging = st2api/conf/logging.conf
 mask_secrets = False
 # allow_origin is required for handling CORS in st2 web UI.
 # allow_origin = http://myhost1.example.com:3000,http://myhost2.example.com:3000
+# Development vagrant VM is setup to run on 172.168.50.50.
+allow_origin = http://172.168.50.50:3000
 
 [stream]
 # Host and port to bind the API server.
@@ -16,6 +18,8 @@ port = 9102
 logging = st2stream/conf/logging.conf
 # allow_origin is required for handling CORS in st2 web UI.
 # allow_origin = http://myhost1.example.com:3000,http://myhost2.example.com:3000
+# Development vagrant VM is setup to run on 172.168.50.50.
+allow_origin = http://172.168.50.50:3000
 
 [sensorcontainer]
 logging = st2reactor/conf/logging.sensorcontainer.conf

--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -131,7 +131,7 @@ function st2start(){
         echo '  using gunicorn to run st2-api...'
         export ST2_CONFIG_PATH=${ST2_CONF}
         screen -d -m -S st2-api ./virtualenv/bin/gunicorn_pecan \
-            ./st2api/st2api/gunicorn_config.py -k eventlet -b 127.0.0.1:9101 --workers 1
+            ./st2api/st2api/gunicorn_config.py -k eventlet -b 0.0.0.0:9101 --workers 1
     else
         screen -d -m -S st2-api ./virtualenv/bin/python \
             ./st2api/bin/st2api \
@@ -143,7 +143,7 @@ function st2start(){
         echo '  using gunicorn to run st2-stream'
         export ST2_CONFIG_PATH=${ST2_CONF}
         screen -d -m -S st2-stream ./virtualenv/bin/gunicorn_pecan \
-            ./st2stream/st2stream/gunicorn_config.py -k eventlet -b 127.0.0.1:9102 --workers 1
+            ./st2stream/st2stream/gunicorn_config.py -k eventlet -b 0.0.0.0:9102 --workers 1
     else
         screen -d -m -S st2-stream ./virtualenv/bin/python \
             ./st2stream/bin/st2stream \
@@ -193,13 +193,13 @@ function st2start(){
         echo '  using uwsgi for auth...'
         export ST2_CONFIG_PATH=${ST2_CONF}
         screen -d -m -S st2-auth ./virtualenv/bin/uwsgi \
-            --http 127.0.0.1:9100 --wsgi-file ./st2auth/st2auth/wsgi.py --processes 1 --threads 10 \
+            --http 0.0.0.0:9100 --wsgi-file ./st2auth/st2auth/wsgi.py --processes 1 --threads 10 \
             --buffer-size=32768
     elif [ "${use_gunicorn}" = true ]; then
         echo '  using gunicorn to run st2-auth...'
         export ST2_CONFIG_PATH=${ST2_CONF}
         screen -d -m -S st2-auth ./virtualenv/bin/gunicorn_pecan \
-            ./st2auth/st2auth/gunicorn_config.py -k eventlet -b 127.0.0.1:9100 --workers 1
+            ./st2auth/st2auth/gunicorn_config.py -k eventlet -b 0.0.0.0:9100 --workers 1
     else
         screen -d -m -S st2-auth ./virtualenv/bin/python \
         ./st2auth/bin/st2auth \


### PR DESCRIPTION
Change the API endpoint address to 0.0.0.0 for the gunicorn config otherwise st2web will not be able to access the API endpoint. Add allow_origin entry to the development st2 configuration file.