### PR TITLE
Add support for st2-packages branching (master)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,6 @@ machine:
     DISTROS: "wheezy jessie trusty el6 el7"
     NOTESTS: "el7"
     ST2_PACKAGES_REPO: https://github.com/StackStorm/st2-packages
-    ST2_PACKAGES_BRANCH: master
     ST2_DOCKERFILES_REPO: https://github.com/StackStorm/st2-dockerfiles
     BUILD_DOCKER: 0
     DEPLOY_DOCKER: 0
@@ -40,7 +39,10 @@ machine:
 
 checkout:
   post:
-    - git clone --depth 1 -b ${ST2_PACKAGES_BRANCH} ${ST2_PACKAGES_REPO} /home/ubuntu/st2/st2-packages
+    - |
+      git clone --depth 1 ${ST2_PACKAGES_REPO} /home/ubuntu/st2/st2-packages
+      cd /home/ubuntu/st2/st2-packages
+      git checkout ${CIRCLE_BRANCH} || true
     - .circle/buildenv.sh
 
 dependencies:


### PR DESCRIPTION
> Part of https://github.com/StackStorm/st2-packages/pull/227

#### What this change brings
* pushing to `master` of `st2` repo will generate packages based on `master` of `st2-packages`
* pushing to `v1.3` of `st2` repo will generate packages based on `v1.3` of `st2-packages`
  * If there is no `v1.3` branch in `st2-packages` repo, then `master` will be used as a fallback
  * ^^ This race case would happen after automating branch creation in `st2-packages` repo (`st2` branch was created, but `st2-packages` branch wasn't created yet)

----
From this point `st2` and `st2-packages` repos should have the same branches `vX.Y`.

cc @manasdk to include automated branch creation in `st2-packages` repo as part of release machinery (same as you do for `st2web`).
