### PR TITLE
[RFR] Add the `extra` field to action aliases

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 in development
 --------------
 
+* Add ``extra`` field to the ActionAlias schema for adapter-specific parameters. (improvement)
 * Dev environment by default now uses gunicorn to spin API and AUTH processes. (improvement)
 * Allow user to pass a boolean value for the ``cacert`` st2client constructor argument. This way
   it now mimics the behavior of the ``verify`` argument of the ``requests.request`` method.

--- a/contrib/chatops/actions/format_execution_result.py
+++ b/contrib/chatops/actions/format_execution_result.py
@@ -42,8 +42,8 @@ class FormatResultAction(Action):
                     raise Exception("Output of this template is disabled.")
                 if 'format' in alias.result:
                     template = alias.result['format']
-                if 'extras' in alias.result:
-                    result['extras'] = jinja_utils.render_values(alias.result['extras'], context)
+                if 'extra' in alias.result:
+                    result['extra'] = jinja_utils.render_values(alias.result['extra'], context)
 
         result['message'] = self.jinja.from_string(template).render(context),
 

--- a/contrib/chatops/actions/format_execution_result.py
+++ b/contrib/chatops/actions/format_execution_result.py
@@ -26,6 +26,7 @@ class FormatResultAction(Action):
             'execution': execution
         }
         template = self.default_template
+        result = {}
 
         alias_id = execution['context'].get('action_alias_ref', {}).get('id', None)
         if alias_id:
@@ -35,14 +36,18 @@ class FormatResultAction(Action):
                 'alias': alias
             })
 
-            result = getattr(alias, 'result', None)
-            if result:
-                if not result.get('enabled', True):
+            result_params = getattr(alias, 'result', None)
+            if result_params:
+                if not result_params.get('enabled', True):
                     raise Exception("Output of this template is disabled.")
                 if 'format' in alias.result:
                     template = alias.result['format']
+                if 'extras' in alias.result:
+                    result['extras'] = jinja_utils.render_values(alias.result['extras'], context)
 
-        return self.jinja.from_string(template).render(context)
+        result['message'] = self.jinja.from_string(template).render(context),
+
+        return result
 
     def _get_execution(self, execution_id):
         if not execution_id:

--- a/contrib/chatops/actions/post_message.yaml
+++ b/contrib/chatops/actions/post_message.yaml
@@ -25,6 +25,6 @@ parameters:
     type: "string"
     description: "Channel to post to"
     required: true
-  extras:
+  extra:
     type: "object"
     description: "Extra adapter-specific parameters."

--- a/contrib/chatops/actions/post_message.yaml
+++ b/contrib/chatops/actions/post_message.yaml
@@ -25,6 +25,6 @@ parameters:
     type: "string"
     description: "Channel to post to"
     required: true
-  color:
-    type: "string"
-    description: "Color to use for attachment (Slack only)"
+  extras:
+    type: "object"
+    description: "Extra adapter-specific parameters."

--- a/contrib/chatops/actions/workflows/post_result.yaml
+++ b/contrib/chatops/actions/workflows/post_result.yaml
@@ -6,7 +6,8 @@ chain:
     parameters:
       execution_id: "{{execution_id}}"
     publish:
-      message: "{{format_execution_result.result}}"
+      message: "{{format_execution_result.result.message}}"
+      extras: "{{format_execution_result.result.extras}}"
     on-success: "post_message"
   -
     name: "post_message"
@@ -16,3 +17,4 @@ chain:
       channel: "{{channel}}"
       whisper: "{{whisper}}"
       message: "{{message}}"
+      extras: "{{extras}}"

--- a/contrib/chatops/actions/workflows/post_result.yaml
+++ b/contrib/chatops/actions/workflows/post_result.yaml
@@ -7,7 +7,7 @@ chain:
       execution_id: "{{execution_id}}"
     publish:
       message: "{{format_execution_result.result.message}}"
-      extras: "{{format_execution_result.result.extras}}"
+      extra: "{{format_execution_result.result.extra}}"
     on-success: "post_message"
   -
     name: "post_message"
@@ -17,4 +17,4 @@ chain:
       channel: "{{channel}}"
       whisper: "{{whisper}}"
       message: "{{message}}"
-      extras: "{{extras}}"
+      extra: "{{extra}}"

--- a/st2api/st2api/controllers/v1/aliasexecution.py
+++ b/st2api/st2api/controllers/v1/aliasexecution.py
@@ -100,9 +100,9 @@ class ActionAliasExecutionController(rest.RestController):
                 result.update({
                     'message': render({'alias': action_alias_db.ack['format']}, result)['alias']
                 })
-            if 'extras' in action_alias_db.ack:
+            if 'extra' in action_alias_db.ack:
                 result.update({
-                    'extras': render(action_alias_db.ack['extras'], result)
+                    'extra': render(action_alias_db.ack['extra'], result)
                 })
 
         return result

--- a/st2api/st2api/controllers/v1/aliasexecution.py
+++ b/st2api/st2api/controllers/v1/aliasexecution.py
@@ -95,10 +95,15 @@ class ActionAliasExecutionController(rest.RestController):
             'actionalias': ActionAliasAPI.from_model(action_alias_db)
         }
 
-        if action_alias_db.ack and 'format' in action_alias_db.ack:
-            result.update({
-                'message': render({'alias': action_alias_db.ack['format']}, result)['alias']
-            })
+        if action_alias_db.ack:
+            if 'format' in action_alias_db.ack:
+                result.update({
+                    'message': render({'alias': action_alias_db.ack['format']}, result)['alias']
+                })
+            if 'extras' in action_alias_db.ack:
+                result.update({
+                    'extras': render(action_alias_db.ack['extras'], result)
+                })
 
         return result
 

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -523,6 +523,7 @@ class ActionAliasAPI(BaseAPI, APIUIDMixin):
                 "properties": {
                     "enabled": {"type": "boolean"},
                     "format": {"type": "string"},
+                    "extras": {"type": "object"},
                     "append_url": {"type": "boolean"}
                 },
                 "description": "Acknowledgement message format."
@@ -531,9 +532,14 @@ class ActionAliasAPI(BaseAPI, APIUIDMixin):
                 "type": "object",
                 "properties": {
                     "enabled": {"type": "boolean"},
-                    "format": {"type": "string"}
+                    "format": {"type": "string"},
+                    "extras": {"type": "object"}
                 },
                 "description": "Execution message format."
+            },
+            "extras": {
+                "type": "object",
+                "description": "Extra parameters, usually adapter-specific."
             }
         },
         "additionalProperties": False
@@ -550,9 +556,11 @@ class ActionAliasAPI(BaseAPI, APIUIDMixin):
         formats = alias.formats
         ack = getattr(alias, 'ack', None)
         result = getattr(alias, 'result', None)
+        extras = getattr(alias, 'extras', None)
 
-        model = cls.model(name=name, description=description, pack=pack, ref=ref, enabled=enabled,
-                          action_ref=action_ref, formats=formats, ack=ack, result=result)
+        model = cls.model(name=name, description=description, pack=pack, ref=ref,
+                          enabled=enabled, action_ref=action_ref, formats=formats,
+                          ack=ack, result=result, extras=extras)
         return model
 
 

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -523,7 +523,7 @@ class ActionAliasAPI(BaseAPI, APIUIDMixin):
                 "properties": {
                     "enabled": {"type": "boolean"},
                     "format": {"type": "string"},
-                    "extras": {"type": "object"},
+                    "extra": {"type": "object"},
                     "append_url": {"type": "boolean"}
                 },
                 "description": "Acknowledgement message format."
@@ -533,11 +533,11 @@ class ActionAliasAPI(BaseAPI, APIUIDMixin):
                 "properties": {
                     "enabled": {"type": "boolean"},
                     "format": {"type": "string"},
-                    "extras": {"type": "object"}
+                    "extra": {"type": "object"}
                 },
                 "description": "Execution message format."
             },
-            "extras": {
+            "extra": {
                 "type": "object",
                 "description": "Extra parameters, usually adapter-specific."
             }
@@ -556,11 +556,11 @@ class ActionAliasAPI(BaseAPI, APIUIDMixin):
         formats = alias.formats
         ack = getattr(alias, 'ack', None)
         result = getattr(alias, 'result', None)
-        extras = getattr(alias, 'extras', None)
+        extra = getattr(alias, 'extra', None)
 
         model = cls.model(name=name, description=description, pack=pack, ref=ref,
                           enabled=enabled, action_ref=action_ref, formats=formats,
-                          ack=ack, result=result, extras=extras)
+                          ack=ack, result=result, extra=extra)
         return model
 
 

--- a/st2common/st2common/models/db/actionalias.py
+++ b/st2common/st2common/models/db/actionalias.py
@@ -65,8 +65,8 @@ class ActionAliasDB(stormbase.StormBaseDB, stormbase.ContentPackResourceMixin,
     result = me.DictField(
         help_text='Parameters pertaining to the execution result message.'
     )
-    extras = me.DictField(
-        help_text='Additional parameters not covered in the schema.'
+    extra = me.DictField(
+        help_text='Additional parameters (usually adapter-specific) not covered in the schema.'
     )
 
     meta = {

--- a/st2common/st2common/models/db/actionalias.py
+++ b/st2common/st2common/models/db/actionalias.py
@@ -65,6 +65,9 @@ class ActionAliasDB(stormbase.StormBaseDB, stormbase.ContentPackResourceMixin,
     result = me.DictField(
         help_text='Parameters pertaining to the execution result message.'
     )
+    extras = me.DictField(
+        help_text='Additional parameters not covered in the schema.'
+    )
 
     meta = {
         'indexes': ['name']

--- a/st2tests/st2tests/fixtures/aliases/aliases/alias1.yaml
+++ b/st2tests/st2tests/fixtures/aliases/aliases/alias1.yaml
@@ -5,3 +5,9 @@
     action_ref: "wolfpack.action1"
     formats:
         - "Lorem ipsum {{param1}} dolor sit {{param2}} amet."
+    ack:
+        extra:
+            color: "red"
+    result:
+        extra:
+            color: "red"

--- a/st2tests/st2tests/fixtures/aliases/aliases/alias2.yaml
+++ b/st2tests/st2tests/fixtures/aliases/aliases/alias2.yaml
@@ -7,3 +7,5 @@
         - display: "Help entry doesn't matter."
           representation:
               - "Lorem ipsum {{param1}} dolor sit {{param3}} amet."
+    extra:
+        color: "red"


### PR DESCRIPTION
Different chat adapters have special capabilities which are sometimes very handy and nice. Slack has attachment colors and parsing/unfurling options for better formatting; HipChat has Connect features; and so on.

It’s hard for users to add support for those right now, because you have to modify the schema and the DB connector in st2, and only then submit a PR to `hubot-stackstorm` utilizing the new parameter. More importantly, if we had a lot of requests for this, our schema would be overblown with rarely used parameters.

A solution for this,—which has been discussed some weeks ago, but I only got around to it now,—is an `extras` object inside the alias with a “free” schema. It will allow people to easily add support for extra features with relative ease and without modifying `st2` (which would imply only getting a feature out in the next `st2` release and complicating the schema). While this is not ideal architecturally (a reason the schema exists in the first place is to have order, and this breaks it a bit), I feel like pros outweigh the cons, and it’s worth to introduce this. We still maintain strict schema outside `extras`, after all.

Another neat feature this PR includes is rendering extras with Jinja, sharing the context with `ack` or `result`, depending on the placement. E.g. different colors depending on the execution status.

This can also be useful for possible usage of action aliases outside chat (e-mails, sms, tweets, and whatnot).

An example:
```
name: "tesla.honk_horn"
action_ref: "tesla.honk_horn"
description: "Honk your horn"
formats:
  - “honk-honk”
result:
  format: "**Honk Honk**"
  extras:
    color: “<% if result.succeeded %> green <% else %> red <% endif %>”
```

What do you think?