### PR TITLE
Add "--register--setup-virtualenvs" flag to the register-content script

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,6 +53,10 @@ in development
   specified, all the timestamps displayed by the CLI will be shown in the configured timezone
   instead of a default UTC display. (new feature)
 * Add ``attachments`` parameter to the ``core.sendmail`` action. (improvement) [Cody A. Ray]
+* Add ``--register-setup-virtualenvs`` flag to the ``register-content`` script. When this flag is
+  provided, Python virtual environments are created for all the registered packs.
+  This option is to be used with distributed setup where action runner services run on multiple
+  hosts to ensure virtual environments exist on all those hosts. (new-feature)
 
 1.3.2 - February 12, 2016
 -------------------------

--- a/contrib/packs/actions/pack_mgmt/setup_virtualenv.py
+++ b/contrib/packs/actions/pack_mgmt/setup_virtualenv.py
@@ -13,19 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import re
-import shutil
-
-from oslo_config import cfg
-
-from st2common.util.shell import run_command
 from st2actions.runners.pythonrunner import Action
-from st2common.constants.pack import PACK_NAME_WHITELIST
-from st2common.constants.pack import BASE_PACK_REQUIREMENTS
-from st2common.content.utils import get_packs_base_paths
-from st2common.content.utils import get_pack_directory
-from st2common.util.shell import quote_unix
+from st2common.util.virtualenvs import setup_pack_virtualenv
+
+__all__ = [
+    'SetupVirtualEnvironmentAction'
+]
 
 
 class SetupVirtualEnvironmentAction(Action):
@@ -43,12 +36,6 @@ class SetupVirtualEnvironmentAction(Action):
     current dependencies as well as an installation of new dependencies
     """
 
-    def __init__(self, config=None, action_service=None):
-        super(SetupVirtualEnvironmentAction, self).__init__(config=config,
-                                                            action_service=action_service)
-        self._base_virtualenvs_path = os.path.join(cfg.CONF.system.base_path,
-                                                   'virtualenvs/')
-
     def run(self, packs, update=False):
         """
         :param packs: A list of packs to create the environment for.
@@ -58,157 +45,8 @@ class SetupVirtualEnvironmentAction(Action):
         :type update: ``bool``
         """
         for pack_name in packs:
-            self._setup_pack_virtualenv(pack_name=pack_name, update=update)
+            setup_pack_virtualenv(pack_name=pack_name, update=update, logger=self.logger)
 
         message = ('Successfuly set up virtualenv for the following packs: %s' %
                    (', '.join(packs)))
         return message
-
-    def _setup_pack_virtualenv(self, pack_name, update=False):
-        """
-        Setup virtual environment for the provided pack.
-
-        :param pack_name: Pack name.
-        :type pack_name: ``str``
-        """
-        # Prevent directory traversal by whitelisting allowed characters in the
-        # pack name
-        if not re.match(PACK_NAME_WHITELIST, pack_name):
-            raise ValueError('Invalid pack name "%s"' % (pack_name))
-
-        self.logger.debug('Setting up virtualenv for pack "%s"' % (pack_name))
-
-        virtualenv_path = os.path.join(self._base_virtualenvs_path, quote_unix(pack_name))
-
-        # Ensure pack directory exists in one of the search paths
-        pack_path = get_pack_directory(pack_name=pack_name)
-
-        if not pack_path:
-            packs_base_paths = get_packs_base_paths()
-            search_paths = ', '.join(packs_base_paths)
-            msg = 'Pack "%s" is not installed. Looked in: %s' % (pack_name, search_paths)
-            raise Exception(msg)
-
-        if not os.path.exists(self._base_virtualenvs_path):
-            os.makedirs(self._base_virtualenvs_path)
-
-        # If we don't want to update, or if the virtualenv doesn't exist, let's create it.
-        if not update or not os.path.exists(virtualenv_path):
-            # 0. Delete virtual environment if it exists
-            self._remove_virtualenv(virtualenv_path=virtualenv_path)
-
-            # 1. Create virtual environment
-            self.logger.debug('Creating virtualenv for pack "%s" in "%s"' %
-                              (pack_name, virtualenv_path))
-            self._create_virtualenv(virtualenv_path=virtualenv_path)
-
-        # 2. Install base requirements which are common to all the packs
-        self.logger.debug('Installing base requirements')
-        for requirement in BASE_PACK_REQUIREMENTS:
-            self._install_requirement(virtualenv_path=virtualenv_path,
-                                      requirement=requirement)
-
-        # 3. Install pack-specific requirements
-        requirements_file_path = os.path.join(pack_path, 'requirements.txt')
-        has_requirements = os.path.isfile(requirements_file_path)
-
-        if has_requirements:
-            self.logger.debug('Installing pack specific requirements from "%s"' %
-                              (requirements_file_path))
-            self._install_requirements(virtualenv_path, requirements_file_path)
-        else:
-            self.logger.debug('No pack specific requirements found')
-
-        self.logger.debug('Virtualenv for pack "%s" successfully %s in "%s"' %
-                          (pack_name,
-                           'updated' if update else 'created',
-                           virtualenv_path))
-
-    def _create_virtualenv(self, virtualenv_path):
-        python_binary = cfg.CONF.actionrunner.python_binary
-        virtualenv_binary = cfg.CONF.actionrunner.virtualenv_binary
-        virtualenv_opts = cfg.CONF.actionrunner.virtualenv_opts
-
-        if not os.path.isfile(python_binary):
-            raise Exception('Python binary "%s" doesn\'t exist' % (python_binary))
-
-        if not os.path.isfile(virtualenv_binary):
-            raise Exception('Virtualenv binary "%s" doesn\'t exist.' % (virtualenv_binary))
-
-        self.logger.debug('Creating virtualenv in "%s" using Python binary "%s"' %
-                          (virtualenv_path, python_binary))
-
-        cmd = [virtualenv_binary, '-p', python_binary]
-        cmd.extend(virtualenv_opts)
-        cmd.extend([virtualenv_path])
-        self.logger.debug('Running command "%s" to create virtualenv.', ' '.join(cmd))
-
-        try:
-            exit_code, _, stderr = run_command(cmd=cmd)
-        except OSError as e:
-            raise Exception('Error executing command %s. %s.' % (' '.join(cmd),
-                                                                 e.message))
-
-        if exit_code != 0:
-            raise Exception('Failed to create virtualenv in "%s": %s' %
-                            (virtualenv_path, stderr))
-
-        return True
-
-    def _remove_virtualenv(self, virtualenv_path):
-        if not os.path.exists(virtualenv_path):
-            self.logger.info('Virtualenv path "%s" doesn\'t exist' % virtualenv_path)
-            return True
-
-        self.logger.debug('Removing virtualenv in "%s"' % virtualenv_path)
-        try:
-            shutil.rmtree(virtualenv_path)
-        except Exception as error:
-            self.logger.error('Error while removing virtualenv at "%s": "%s"' %
-                              (virtualenv_path, error))
-            raise
-        return True
-
-    def _install_requirements(self, virtualenv_path, requirements_file_path):
-        """
-        Install requirements from a file.
-        """
-        pip_path = os.path.join(virtualenv_path, 'bin/pip')
-        cmd = [pip_path, 'install', '-U', '-r', requirements_file_path]
-        env = self._get_env_for_subprocess_command()
-        exit_code, stdout, stderr = run_command(cmd=cmd, env=env)
-
-        if exit_code != 0:
-            raise Exception('Failed to install requirements from "%s": %s' %
-                            (requirements_file_path, stdout))
-
-        return True
-
-    def _install_requirement(self, virtualenv_path, requirement):
-        """
-        Install a single requirement.
-        """
-        pip_path = os.path.join(virtualenv_path, 'bin/pip')
-        cmd = [pip_path, 'install', requirement]
-        env = self._get_env_for_subprocess_command()
-        exit_code, stdout, stderr = run_command(cmd=cmd, env=env)
-
-        if exit_code != 0:
-            raise Exception('Failed to install requirement "%s": %s' %
-                            (requirement, stdout))
-
-        return True
-
-    def _get_env_for_subprocess_command(self):
-        """
-        Retrieve environment to be used with the subprocess command.
-
-        Note: We remove PYTHONPATH from the environment so the command works
-        correctly with the newely created virtualenv.
-        """
-        env = os.environ.copy()
-
-        if 'PYTHONPATH' in env:
-            del env['PYTHONPATH']
-
-        return env

--- a/st2actions/st2actions/config.py
+++ b/st2actions/st2actions/config.py
@@ -17,9 +17,6 @@
 Configuration options registration and useful routines.
 """
 
-import os
-import sys
-
 from oslo_config import cfg
 
 import st2common.config as common_config
@@ -42,19 +39,9 @@ def _register_common_opts():
 
 
 def _register_action_runner_opts():
-    default_python_bin_path = sys.executable
-    base_dir = os.path.dirname(os.path.realpath(default_python_bin_path))
-    default_virtualenv_bin_path = os.path.join(base_dir, 'virtualenv')
     logging_opts = [
         cfg.StrOpt('logging', default='conf/logging.conf',
                    help='location of the logging.conf file'),
-        cfg.StrOpt('python_binary', default=default_python_bin_path,
-                   help='Python binary which will be used by Python actions.'),
-        cfg.StrOpt('virtualenv_binary', default=default_virtualenv_bin_path,
-                   help='Virtualenv binary which should be used to create pack virtualenvs.'),
-        cfg.ListOpt('virtualenv_opts', default=['--system-site-packages'],
-                    help='List of virtualenv options to be passsed to "virtualenv" command that ' +
-                         'creates pack virtualenv.')
     ]
     CONF.register_opts(logging_opts, group='actionrunner')
 

--- a/st2common/st2common/bootstrap/base.py
+++ b/st2common/st2common/bootstrap/base.py
@@ -77,6 +77,14 @@ class ResourceRegistrar(object):
         resources = sorted(resources)
         return resources
 
+    def get_registered_packs(self):
+        """
+        Return a list of registered packs.
+
+        :rype: ``list``
+        """
+        return REGISTERED_PACKS_CACHE.keys()
+
     def register_packs(self, base_dirs):
         """
         Register packs in all the provided directories.

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -44,12 +44,6 @@ def do_register_cli_opts(opt, ignore_errors=False):
 
 
 def register_opts(ignore_errors=False):
-    auth_opts = [
-        cfg.BoolOpt('enable', default=True, help='Enable authentication middleware.'),
-        cfg.IntOpt('token_ttl', default=86400, help='Access token ttl in seconds.')
-    ]
-    do_register_opts(auth_opts, 'auth', ignore_errors)
-
     rbac_opts = [
         cfg.BoolOpt('enable', default=False, help='Enable RBAC.'),
     ]
@@ -148,7 +142,9 @@ def register_opts(ignore_errors=False):
     # Common auth options
     auth_opts = [
         cfg.StrOpt('api_url', default=None,
-                   help='Base URL to the API endpoint excluding the version')
+                   help='Base URL to the API endpoint excluding the version'),
+        cfg.BoolOpt('enable', default=True, help='Enable authentication middleware.'),
+        cfg.IntOpt('token_ttl', default=86400, help='Access token ttl in seconds.')
     ]
     do_register_opts(auth_opts, 'auth', ignore_errors)
 

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import os
+import sys
 
 from oslo_config import cfg
 
@@ -150,6 +151,23 @@ def register_opts(ignore_errors=False):
                    help='Base URL to the API endpoint excluding the version')
     ]
     do_register_opts(auth_opts, 'auth', ignore_errors)
+
+    # Common action runner options
+    default_python_bin_path = sys.executable
+    base_dir = os.path.dirname(os.path.realpath(default_python_bin_path))
+    default_virtualenv_bin_path = os.path.join(base_dir, 'virtualenv')
+    action_runner_opts = [
+        cfg.StrOpt('logging', default='conf/logging.conf',
+                   help='location of the logging.conf file'),
+        cfg.StrOpt('python_binary', default=default_python_bin_path,
+                   help='Python binary which will be used by Python actions.'),
+        cfg.StrOpt('virtualenv_binary', default=default_virtualenv_bin_path,
+                   help='Virtualenv binary which should be used to create pack virtualenvs.'),
+        cfg.ListOpt('virtualenv_opts', default=['--system-site-packages'],
+                    help='List of virtualenv options to be passsed to "virtualenv" command that ' +
+                         'creates pack virtualenv.')
+    ]
+    do_register_opts(action_runner_opts, group='actionrunner')
 
     # Common options (used by action runner and sensor container)
     action_sensor_opts = [

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -263,8 +263,8 @@ def register_content():
 
 def setup(argv):
     if '--register-setup-virtualenvs' in argv:
-        # If setup-virtualenvs option is used we also want to setup config for action runner since it
-        # contains some setup virtualenv related options.
+        # If setup-virtualenvs option is used we also want to setup config for action runner since
+        # it contains some setup virtualenv related options.
         # Keep in mind that using "setup-virtualenv" only makes sense on nodes which run action
         # runners.
         # Note: This is a hack, but we can't check if that flag is provided using oslo config since
@@ -274,7 +274,7 @@ def setup(argv):
     else:
         config = common_config
 
-    common_setup(config=common_config, setup_db=True, register_mq_exchanges=True)
+    common_setup(config=config, setup_db=True, register_mq_exchanges=True)
 
 
 def teardown():

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -20,7 +20,7 @@ import logging
 from oslo_config import cfg
 
 import st2common
-from st2common import config as common_config
+from st2common import config
 from st2common.script_setup import setup as common_setup
 from st2common.script_setup import teardown as common_teardown
 from st2common.bootstrap.base import ResourceRegistrar
@@ -262,18 +262,6 @@ def register_content():
 
 
 def setup(argv):
-    if '--register-setup-virtualenvs' in argv:
-        # If setup-virtualenvs option is used we also want to setup config for action runner since
-        # it contains some setup virtualenv related options.
-        # Keep in mind that using "setup-virtualenv" only makes sense on nodes which run action
-        # runners.
-        # Note: This is a hack, but we can't check if that flag is provided using oslo config since
-        # we need to parse config first.
-        from st2actions import config as action_runner_config
-        config = action_runner_config
-    else:
-        config = common_config
-
     common_setup(config=config, setup_db=True, register_mq_exchanges=True)
 
 

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -13,15 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
+import os
 import sys
+import logging
 
 from oslo_config import cfg
 
 import st2common
-from st2common import config
+from st2common import config as common_config
 from st2common.script_setup import setup as common_setup
 from st2common.script_setup import teardown as common_teardown
+from st2common.bootstrap.base import ResourceRegistrar
 import st2common.bootstrap.sensorsregistrar as sensors_registrar
 import st2common.bootstrap.actionsregistrar as actions_registrar
 import st2common.bootstrap.aliasesregistrar as aliases_registrar
@@ -29,6 +31,7 @@ import st2common.bootstrap.policiesregistrar as policies_registrar
 import st2common.bootstrap.runnersregistrar as runners_registrar
 import st2common.bootstrap.rulesregistrar as rules_registrar
 import st2common.bootstrap.ruletypesregistrar as rule_types_registrar
+from st2common.util.virtualenvs import setup_pack_virtualenv
 
 __all__ = [
     'main'
@@ -48,6 +51,8 @@ def register_opts():
         cfg.BoolOpt('aliases', default=False, help='Register aliases.'),
         cfg.BoolOpt('policies', default=False, help='Register policies.'),
         cfg.StrOpt('pack', default=None, help='Directory to the pack to register content from.'),
+        cfg.BoolOpt('setup-virtualenvs', default=False, help=('Setup Python virtual environments '
+                                                              'all the Python runner actions.')),
         cfg.BoolOpt('fail-on-failure', default=False, help=('Exit with non-zero of resource '
                                                             'registration fails.'))
     ]
@@ -56,6 +61,37 @@ def register_opts():
     except:
         sys.stderr.write('Failed registering opts.\n')
 register_opts()
+
+
+def setup_virtualenvs():
+    """
+    Setup Python virtual environments for all the registered or the provided pack.
+    """
+    pack_dir = cfg.CONF.register.pack
+    fail_on_failure = cfg.CONF.register.fail_on_failure
+
+    if pack_dir:
+        pack_name = os.path.basename(pack_dir)
+        pack_names = [pack_name]
+    else:
+        registrar = ResourceRegistrar()
+        pack_names = registrar.get_registered_packs()
+
+    setup_count = 0
+    for pack_name in pack_names:
+        try:
+            setup_pack_virtualenv(pack_name=pack_name, update=True, logger=LOG)
+        except Exception as e:
+            exc_info = not fail_on_failure
+            LOG.warning('Failed to setup virtualenv for pack "%s": %s', pack_name, e,
+                        exc_info=exc_info)
+
+            if fail_on_failure:
+                raise e
+        else:
+            setup_count += 1
+
+    LOG.info('Setup virtualenv for %s pack.' % (setup_count))
 
 
 def register_sensors():
@@ -88,6 +124,7 @@ def register_actions():
 
     registered_count = 0
 
+    # 1. Register runner types
     try:
         LOG.info('=========================================================')
         LOG.info('############## Registering actions ######################')
@@ -98,6 +135,7 @@ def register_actions():
         LOG.warning('Not registering stock runners .')
         return
 
+    # 2. Register actions
     try:
         registered_count = actions_registrar.register_actions(pack_dir=pack_dir,
                                                               fail_on_failure=fail_on_failure)
@@ -219,9 +257,24 @@ def register_content():
     if cfg.CONF.register.policies:
         register_policies()
 
+    if cfg.CONF.register.setup_virtualenvs:
+        setup_virtualenvs()
+
 
 def setup(argv):
-    common_setup(config=config, setup_db=True, register_mq_exchanges=True)
+    if '--register-setup-virtualenvs' in argv:
+        # If setup-virtualenvs option is used we also want to setup config for action runner since it
+        # contains some setup virtualenv related options.
+        # Keep in mind that using "setup-virtualenv" only makes sense on nodes which run action
+        # runners.
+        # Note: This is a hack, but we can't check if that flag is provided using oslo config since
+        # we need to parse config first.
+        from st2actions import config as action_runner_config
+        config = action_runner_config
+    else:
+        config = common_config
+
+    common_setup(config=common_config, setup_db=True, register_mq_exchanges=True)
 
 
 def teardown():

--- a/st2common/st2common/util/virtualenvs.py
+++ b/st2common/st2common/util/virtualenvs.py
@@ -1,0 +1,205 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Pack virtual environment related utility functions.
+"""
+
+import os
+import re
+import shutil
+
+from oslo_config import cfg
+
+from st2common import log as logging
+from st2common.constants.pack import PACK_NAME_WHITELIST
+from st2common.constants.pack import BASE_PACK_REQUIREMENTS
+from st2common.util.shell import run_command
+from st2common.content.utils import get_packs_base_paths
+from st2common.content.utils import get_pack_directory
+from st2common.util.shell import quote_unix
+
+__all__ = [
+    'setup_pack_virtualenv'
+]
+
+LOG = logging.getLogger(__name__)
+
+
+def setup_pack_virtualenv(pack_name, update=False, logger=None):
+    """
+    Setup virtual environment for the provided pack.
+
+    :param pack_name: Name of the pack to setup the virtualenv for.
+    :type pack_name: ``str``
+
+    :param update: True to update dependencies inside the virtual environment.
+    :type update: ``bool``
+
+    :param logger: Optional logger instance to use. If not provided it defaults to the module
+                   level logger.
+    """
+    logger = logger or LOG
+
+    if not re.match(PACK_NAME_WHITELIST, pack_name):
+        raise ValueError('Invalid pack name "%s"' % (pack_name))
+
+    base_virtualenvs_path = os.path.join(cfg.CONF.system.base_path, 'virtualenvs/')
+
+    logger.debug('Setting up virtualenv for pack "%s"' % (pack_name))
+
+    virtualenv_path = os.path.join(base_virtualenvs_path, quote_unix(pack_name))
+
+    # Ensure pack directory exists in one of the search paths
+    pack_path = get_pack_directory(pack_name=pack_name)
+
+    if not pack_path:
+        packs_base_paths = get_packs_base_paths()
+        search_paths = ', '.join(packs_base_paths)
+        msg = 'Pack "%s" is not installed. Looked in: %s' % (pack_name, search_paths)
+        raise Exception(msg)
+
+    # 1. Create virtualenv if it doesn't exist
+    if not update or not os.path.exists(virtualenv_path):
+        # 0. Delete virtual environment if it exists
+        remove_virtualenv(virtualenv_path=virtualenv_path, logger=logger)
+
+        # 1. Create virtual environment
+        logger.debug('Creating virtualenv for pack "%s" in "%s"' % (pack_name, virtualenv_path))
+        create_virtualenv(virtualenv_path=virtualenv_path, logger=logger)
+
+    # 2. Install base requirements which are common to all the packs
+    logger.debug('Installing base requirements')
+    for requirement in BASE_PACK_REQUIREMENTS:
+        install_requirement(virtualenv_path=virtualenv_path, requirement=requirement)
+
+    # 3. Install pack-specific requirements
+    requirements_file_path = os.path.join(pack_path, 'requirements.txt')
+    has_requirements = os.path.isfile(requirements_file_path)
+
+    if has_requirements:
+        logger.debug('Installing pack specific requirements from "%s"' %
+                     (requirements_file_path))
+        install_requirements(virtualenv_path=virtualenv_path,
+                             requirements_file_path=requirements_file_path)
+    else:
+        logger.debug('No pack specific requirements found')
+
+    action = 'updated' if update else 'created'
+    logger.debug('Virtualenv for pack "%s" successfully %s in "%s"' %
+                 (pack_name, action, virtualenv_path))
+
+
+def create_virtualenv(virtualenv_path, logger=None):
+    logger = logger or LOG
+
+    python_binary = cfg.CONF.actionrunner.python_binary
+    virtualenv_binary = cfg.CONF.actionrunner.virtualenv_binary
+    virtualenv_opts = cfg.CONF.actionrunner.virtualenv_opts
+
+    if not os.path.isfile(python_binary):
+        raise Exception('Python binary "%s" doesn\'t exist' % (python_binary))
+
+    if not os.path.isfile(virtualenv_binary):
+        raise Exception('Virtualenv binary "%s" doesn\'t exist.' % (virtualenv_binary))
+
+    logger.debug('Creating virtualenv in "%s" using Python binary "%s"' %
+                 (virtualenv_path, python_binary))
+
+    cmd = [virtualenv_binary, '-p', python_binary]
+    cmd.extend(virtualenv_opts)
+    cmd.extend([virtualenv_path])
+    logger.debug('Running command "%s" to create virtualenv.', ' '.join(cmd))
+
+    try:
+        exit_code, _, stderr = run_command(cmd=cmd)
+    except OSError as e:
+        raise Exception('Error executing command %s. %s.' % (' '.join(cmd),
+                                                             e.message))
+
+    if exit_code != 0:
+        raise Exception('Failed to create virtualenv in "%s": %s' %
+                        (virtualenv_path, stderr))
+
+    return True
+
+
+def remove_virtualenv(virtualenv_path, logger=None):
+    """
+    Remove the provided virtualenv.
+    """
+    logger = logger or LOG
+
+    if not os.path.exists(virtualenv_path):
+        logger.info('Virtualenv path "%s" doesn\'t exist' % virtualenv_path)
+        return True
+
+    logger.debug('Removing virtualenv in "%s"' % virtualenv_path)
+    try:
+        shutil.rmtree(virtualenv_path)
+    except Exception as e:
+        logger.error('Error while removing virtualenv at "%s": "%s"' % (virtualenv_path, e))
+        raise e
+
+    return True
+
+
+def install_requirements(virtualenv_path, requirements_file_path):
+    """
+    Install requirements from a file.
+    """
+    pip_path = os.path.join(virtualenv_path, 'bin/pip')
+    cmd = [pip_path, 'install', '-U', '-r', requirements_file_path]
+    env = get_env_for_subprocess_command()
+    exit_code, stdout, stderr = run_command(cmd=cmd, env=env)
+
+    if exit_code != 0:
+        raise Exception('Failed to install requirements from "%s": %s' %
+                        (requirements_file_path, stdout))
+
+    return True
+
+
+def install_requirement(virtualenv_path, requirement):
+    """
+    Install a single requirement.
+
+    :param requirement: Requirement specifier.
+    """
+    pip_path = os.path.join(virtualenv_path, 'bin/pip')
+    cmd = [pip_path, 'install', requirement]
+    env = get_env_for_subprocess_command()
+    exit_code, stdout, stderr = run_command(cmd=cmd, env=env)
+
+    if exit_code != 0:
+        raise Exception('Failed to install requirement "%s": %s' %
+                        (requirement, stdout))
+
+    return True
+
+
+def get_env_for_subprocess_command():
+    """
+    Retrieve environment to be used with the subprocess command.
+
+    Note: We remove PYTHONPATH from the environment so the command works
+    correctly with the newely created virtualenv.
+    """
+    env = os.environ.copy()
+
+    if 'PYTHONPATH' in env:
+        del env['PYTHONPATH']
+
+    return env


### PR DESCRIPTION
This flag is to be used in a distributed StackStorm setup where action runner services run on multiple hosts.

In the distributed deployment context, (right now) it's up to operator to ensure register-content script with this flag is ran on every host where action runner service is running. This can be tied into the whole "content distribution" story - user can hook it up as a last step of their "deploy content to the server" story.

TODO:

- [ ] Integration tests for virtualenv creation (we can do that now that code is split out)