### PR TITLE
Support crontab like notation for CronTimer trigger

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -57,7 +57,7 @@ in development
   provided, Python virtual environments are created for all the registered packs.
   This option is to be used with distributed setup where action runner services run on multiple
   hosts to ensure virtual environments exist on all those hosts. (new-feature)
-* Update ``core.st2.CronTimer`` so it supports more of the cron-like notation (``a-b``, ``*/a``,
+* Update ``core.st2.CronTimer`` so it supports more of the cron-like expressions (``a-b``, ``*/a``,
   ``x,y,z``, etc.). (improvement)
 
 1.3.2 - February 12, 2016

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -57,6 +57,8 @@ in development
   provided, Python virtual environments are created for all the registered packs.
   This option is to be used with distributed setup where action runner services run on multiple
   hosts to ensure virtual environments exist on all those hosts. (new-feature)
+* Update ``core.st2.CronTimer`` so it supports more of the cron-like notation (``a-b``, ``*/a``,
+  ``x,y,z``, etc.). (improvement)
 
 1.3.2 - February 12, 2016
 -------------------------

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -6,7 +6,7 @@ oslo.utils<3.1.0
 six==1.9.0
 pyyaml>=3.11,<4.0
 requests[security]>=2.7.0,<3.0
-apscheduler>=3.0.0rc1
+apscheduler>=3.0.5,<3.1
 gitpython==0.3.2.1
 jsonschema>=2.3.0
 mongoengine>=0.8.7,<0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Don't edit this file. It's generated automatically!
-apscheduler>=3.0.0rc1
+apscheduler<3.1,>=3.0.5
 bcrypt
 bencode<1.1,>=1.0
 eventlet<0.19,>=0.18.4

--- a/st2api/tests/unit/controllers/v1/test_rules.py
+++ b/st2api/tests/unit/controllers/v1/test_rules.py
@@ -77,6 +77,21 @@ class TestRuleController(FunctionalTest):
             fixtures_pack=FIXTURES_PACK,
             fixtures_dict={'rules': [file_name]})['rules'][file_name]
 
+        file_name = 'cron_timer_rule_invalid_parameters_1.yaml'
+        TestRuleController.RULE_6 = TestRuleController.fixtures_loader.load_fixtures(
+            fixtures_pack=FIXTURES_PACK,
+            fixtures_dict={'rules': [file_name]})['rules'][file_name]
+
+        file_name = 'cron_timer_rule_invalid_parameters_2.yaml'
+        TestRuleController.RULE_7 = TestRuleController.fixtures_loader.load_fixtures(
+            fixtures_pack=FIXTURES_PACK,
+            fixtures_dict={'rules': [file_name]})['rules'][file_name]
+
+        file_name = 'cron_timer_rule_invalid_parameters_3.yaml'
+        TestRuleController.RULE_8 = TestRuleController.fixtures_loader.load_fixtures(
+            fixtures_pack=FIXTURES_PACK,
+            fixtures_dict={'rules': [file_name]})['rules'][file_name]
+
     @classmethod
     def tearDownClass(cls):
         TestRuleController.fixtures_loader.delete_fixtures_from_db(
@@ -136,6 +151,25 @@ class TestRuleController(FunctionalTest):
         self.assertEqual(post_resp.status_int, http_client.BAD_REQUEST)
 
         expected_msg = '\'date\' is a required property'
+        self.assertTrue(expected_msg in post_resp.body)
+
+    def test_post_invalid_crontimer_trigger_parameters(self):
+        post_resp = self.__do_post(TestRuleController.RULE_6)
+        self.assertEqual(post_resp.status_int, http_client.BAD_REQUEST)
+
+        expected_msg = '1000 is greater than the maximum of 6'
+        self.assertTrue(expected_msg in post_resp.body)
+
+        post_resp = self.__do_post(TestRuleController.RULE_7)
+        self.assertEqual(post_resp.status_int, http_client.BAD_REQUEST)
+
+        expected_msg = 'Invalid weekday name \\"abcdef\\"'
+        self.assertTrue(expected_msg in post_resp.body)
+
+        post_resp = self.__do_post(TestRuleController.RULE_8)
+        self.assertEqual(post_resp.status_int, http_client.BAD_REQUEST)
+
+        expected_msg = 'Invalid weekday name \\"a\\"'
         self.assertTrue(expected_msg in post_resp.body)
 
     def test_post_no_enabled_attribute_disabled_by_default(self):

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -1,4 +1,5 @@
 # Remeber to list implicit packages here, otherwise version won't be fixated!
+apscheduler
 python-dateutil
 eventlet
 jinja2

--- a/st2common/st2common/constants/triggers.py
+++ b/st2common/st2common/constants/triggers.py
@@ -339,7 +339,8 @@ TIMER_PAYLOAD_SCHEMA = {
     }
 }
 
-INTERVAL_TIMER_TRIGGER_REF = ResourceReference.to_string_reference(SYSTEM_PACK_NAME, 'st2.IntervalTimer')
+INTERVAL_TIMER_TRIGGER_REF = ResourceReference.to_string_reference(SYSTEM_PACK_NAME,
+                                                                   'st2.IntervalTimer')
 DATE_TIMER_TRIGGER_REF = ResourceReference.to_string_reference(SYSTEM_PACK_NAME, 'st2.DateTimer')
 CRON_TIMER_TRIGGER_REF = ResourceReference.to_string_reference(SYSTEM_PACK_NAME, 'st2.CronTimer')
 

--- a/st2common/st2common/constants/triggers.py
+++ b/st2common/st2common/constants/triggers.py
@@ -252,40 +252,64 @@ CRON_PARAMETERS_SCHEMA = {
             "type": "string"
         },
         "year": {
-            "type": "integer"
+            "anyOf": [
+                {"type": "string"},
+                {"type": "integer"}
+            ],
         },
         "month": {
-            "type": "integer",
+            "anyOf": [
+                {"type": "string"},
+                {"type": "integer"}
+            ],
             "minimum": 1,
             "maximum": 12
         },
         "day": {
-            "type": "integer",
+            "anyOf": [
+                {"type": "string"},
+                {"type": "integer"}
+            ],
             "minimum": 1,
             "maximum": 31
         },
         "week": {
-            "type": "integer",
+            "anyOf": [
+                {"type": "string"},
+                {"type": "integer"}
+            ],
             "minimum": 1,
             "maximum": 53
         },
         "day_of_week": {
-            "type": "integer",
+            "anyOf": [
+                {"type": "string"},
+                {"type": "integer"}
+            ],
             "minimum": 0,
             "maximum": 6
         },
         "hour": {
-            "type": "integer",
+            "anyOf": [
+                {"type": "string"},
+                {"type": "integer"}
+            ],
             "minimum": 0,
             "maximum": 23
         },
         "minute": {
-            "type": "integer",
+            "anyOf": [
+                {"type": "string"},
+                {"type": "integer"}
+            ],
             "minimum": 0,
             "maximum": 59
         },
         "second": {
-            "type": "integer",
+            "anyOf": [
+                {"type": "string"},
+                {"type": "integer"}
+            ],
             "minimum": 0,
             "maximum": 59
         }

--- a/st2common/st2common/constants/triggers.py
+++ b/st2common/st2common/constants/triggers.py
@@ -32,7 +32,11 @@ __all__ = [
     'WEBHOOK_TRIGGER_TYPES',
     'WEBHOOK_TRIGGER_TYPE',
     'INTERNAL_TRIGGER_TYPES',
-    'SYSTEM_TRIGGER_TYPES'
+    'SYSTEM_TRIGGER_TYPES',
+
+    'INTERVAL_TIMER_TRIGGER_REF',
+    'DATE_TIMER_TRIGGER_REF',
+    'CRON_TIMER_TRIGGER_REF'
 ]
 
 # Action resource triggers
@@ -335,15 +339,19 @@ TIMER_PAYLOAD_SCHEMA = {
     }
 }
 
+INTERVAL_TIMER_TRIGGER_REF = ResourceReference.to_string_reference(SYSTEM_PACK_NAME, 'st2.IntervalTimer')
+DATE_TIMER_TRIGGER_REF = ResourceReference.to_string_reference(SYSTEM_PACK_NAME, 'st2.DateTimer')
+CRON_TIMER_TRIGGER_REF = ResourceReference.to_string_reference(SYSTEM_PACK_NAME, 'st2.CronTimer')
+
 TIMER_TRIGGER_TYPES = {
-    ResourceReference.to_string_reference(SYSTEM_PACK_NAME, 'st2.IntervalTimer'): {
+    INTERVAL_TIMER_TRIGGER_REF: {
         'name': 'st2.IntervalTimer',
         'pack': SYSTEM_PACK_NAME,
         'description': 'Triggers on specified intervals. e.g. every 30s, 1week etc.',
         'payload_schema': TIMER_PAYLOAD_SCHEMA,
         'parameters_schema': INTERVAL_PARAMETERS_SCHEMA
     },
-    ResourceReference.to_string_reference(SYSTEM_PACK_NAME, 'st2.DateTimer'): {
+    DATE_TIMER_TRIGGER_REF: {
         'name': 'st2.DateTimer',
         'pack': SYSTEM_PACK_NAME,
         'description': 'Triggers exactly once when the current time matches the specified time. '
@@ -351,7 +359,7 @@ TIMER_TRIGGER_TYPES = {
         'payload_schema': TIMER_PAYLOAD_SCHEMA,
         'parameters_schema': DATE_PARAMETERS_SCHEMA
     },
-    ResourceReference.to_string_reference(SYSTEM_PACK_NAME, 'st2.CronTimer'): {
+    CRON_TIMER_TRIGGER_REF: {
         'name': 'st2.CronTimer',
         'pack': SYSTEM_PACK_NAME,
         'description': 'Triggers whenever current time matches the specified time constaints like '

--- a/st2common/st2common/validators/api/reactor.py
+++ b/st2common/st2common/validators/api/reactor.py
@@ -15,7 +15,11 @@
 
 import six
 
+from apscheduler.triggers.cron import CronTrigger
+
 from st2common.exceptions.apivalidation import ValueValidationException
+from st2common.models.system.common import ResourceReference
+from st2common.constants.pack import SYSTEM_PACK_NAME
 from st2common.constants.triggers import SYSTEM_TRIGGER_TYPES
 from st2common.util import schema as util_schema
 import st2common.operators as criteria_operators
@@ -70,4 +74,12 @@ def validate_trigger_parameters(trigger_type_ref, parameters):
     cleaned = util_schema.validate(instance=parameters, schema=parameters_schema,
                                    cls=util_schema.CustomValidator, use_default=True,
                                    allow_default_none=True)
+
+    # Additional validation fron CronTimer
+    if trigger_type_ref == ResourceReference.to_string_reference(SYSTEM_PACK_NAME, 'st2.CronTimer'):
+        # Validate that the user provided parameters are valid. This is required since JSON schema
+        # allows arbitrary strings, but not any arbitrary string is a valid CronTrigger argument
+        # Note: Constructor throws ValueError on invalid parameters
+        time_type = CronTrigger(**parameters)
+
     return cleaned

--- a/st2common/st2common/validators/api/reactor.py
+++ b/st2common/st2common/validators/api/reactor.py
@@ -18,9 +18,8 @@ import six
 from apscheduler.triggers.cron import CronTrigger
 
 from st2common.exceptions.apivalidation import ValueValidationException
-from st2common.models.system.common import ResourceReference
-from st2common.constants.pack import SYSTEM_PACK_NAME
 from st2common.constants.triggers import SYSTEM_TRIGGER_TYPES
+from st2common.constants.triggers import CRON_TIMER_TRIGGER_REF
 from st2common.util import schema as util_schema
 import st2common.operators as criteria_operators
 
@@ -75,8 +74,9 @@ def validate_trigger_parameters(trigger_type_ref, parameters):
                                    cls=util_schema.CustomValidator, use_default=True,
                                    allow_default_none=True)
 
-    # Additional validation fron CronTimer
-    if trigger_type_ref == ResourceReference.to_string_reference(SYSTEM_PACK_NAME, 'st2.CronTimer'):
+    # Additional validation for CronTimer trigger
+    # TODO: If we need to add more checks like this we should consider abstracting this out.
+    if trigger_type_ref == CRON_TIMER_TRIGGER_REF:
         # Validate that the user provided parameters are valid. This is required since JSON schema
         # allows arbitrary strings, but not any arbitrary string is a valid CronTrigger argument
         # Note: Constructor throws ValueError on invalid parameters

--- a/st2common/st2common/validators/api/reactor.py
+++ b/st2common/st2common/validators/api/reactor.py
@@ -80,6 +80,6 @@ def validate_trigger_parameters(trigger_type_ref, parameters):
         # Validate that the user provided parameters are valid. This is required since JSON schema
         # allows arbitrary strings, but not any arbitrary string is a valid CronTrigger argument
         # Note: Constructor throws ValueError on invalid parameters
-        time_type = CronTrigger(**parameters)
+        CronTrigger(**parameters)
 
     return cleaned

--- a/st2tests/st2tests/fixtures/generic/rules/cron_timer_rule_invalid_parameters_1.yaml
+++ b/st2tests/st2tests/fixtures/generic/rules/cron_timer_rule_invalid_parameters_1.yaml
@@ -1,0 +1,18 @@
+---
+name: cron_timer_rule_invalid_parameters_1
+pack: "timer_rules"
+description: Sample rule using an Interval Timer.
+enabled: false
+
+trigger:
+  parameters:
+      day_of_week: 1000
+  type: core.st2.CronTimer
+
+criteria: {}
+
+action:
+  ref: wolfpack.action-1
+  parameters:
+    ip1: "a"
+    ip2: "b"

--- a/st2tests/st2tests/fixtures/generic/rules/cron_timer_rule_invalid_parameters_2.yaml
+++ b/st2tests/st2tests/fixtures/generic/rules/cron_timer_rule_invalid_parameters_2.yaml
@@ -1,0 +1,18 @@
+---
+name: cron_timer_rule_invalid_parameters_2
+pack: "timer_rules"
+description: Sample rule using an Interval Timer.
+enabled: false
+
+trigger:
+  parameters:
+      day_of_week: "abcdef"
+  type: core.st2.CronTimer
+
+criteria: {}
+
+action:
+  ref: wolfpack.action-1
+  parameters:
+    ip1: "a"
+    ip2: "b"

--- a/st2tests/st2tests/fixtures/generic/rules/cron_timer_rule_invalid_parameters_3.yaml
+++ b/st2tests/st2tests/fixtures/generic/rules/cron_timer_rule_invalid_parameters_3.yaml
@@ -1,0 +1,18 @@
+---
+name: cron_timer_rule_invalid_parameters_2
+pack: "timer_rules"
+description: Sample rule using an Interval Timer.
+enabled: false
+
+trigger:
+  parameters:
+      day_of_week: "a-1"
+  type: core.st2.CronTimer
+
+criteria: {}
+
+action:
+  ref: wolfpack.action-1
+  parameters:
+    ip1: "a"
+    ip2: "b"


### PR DESCRIPTION
This pull request updates our JSON schema validation code so that the CronTimer now also accepts other cron-like notation (`a-b`, `*/a`, etc.) which is supported by `CronTrigger` in apscheduler (http://apscheduler.readthedocs.org/en/3.0/modules/triggers/cron.html#api).

In addition to that, it also introduces additional validation for CronTimer parameters - this is required since we now allow arbitrary strings for parameter values, but not any arbitrary string is valid `CronTimer` argument value.

## TODO

- [x] Code refactor
- [x] Tests
- [x] Documentation changes