### PR TITLE
Clean up the ChatOps aliases pack deployment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 in development
 --------------
 
+* Improvements to ChatOps deployments of packs via ``pack deploy`` [Jon Middleton]
 * Add ``extra`` field to the ActionAlias schema for adapter-specific parameters. (improvement)
 * Dev environment by default now uses gunicorn to spin API and AUTH processes. (improvement)
 * Allow user to pass a boolean value for the ``cacert`` st2client constructor argument. This way

--- a/contrib/packs/actions/deploy.yaml
+++ b/contrib/packs/actions/deploy.yaml
@@ -19,11 +19,11 @@
     branch:
       type: "string"
       description: "The Branch to deploy."
-      required: true
+      default: "master"
     packs:
       type: "array"
       description: "The Pack(s) to deploy."
-      required: true
+      default: []
     auto_deploy:
       type: "boolean"
       description: "Should this pack and branch be evulated for auto deployment."

--- a/contrib/packs/actions/workflows/deploy.yaml
+++ b/contrib/packs/actions/workflows/deploy.yaml
@@ -26,7 +26,23 @@ workflows:
 
         on-complete:
           - do_auto_install: <% $.auto_deploy = true %>
-          - do_manual_install: <% $.auto_deploy = false %>
+          - check_for_no_subtree: <% $.auto_deploy = false %>
+
+      check_for_no_subtree:
+        action: core.noop
+
+        on-complete:
+          - do_manual_install: <% len($.packs) != 0 %>
+          - publish_packs: <% len($.packs) = 0 %>
+
+      publish_packs:
+        action: core.noop
+
+        publish:
+          packs: [ <% $.repo_name %> ]
+
+        on-complete:
+          - do_manual_install
 
       do_manual_install:
         workflow: install

--- a/contrib/packs/aliases/pack_deploy.yaml
+++ b/contrib/packs/aliases/pack_deploy.yaml
@@ -4,6 +4,14 @@ action_ref: "packs.deploy"
 pack: "packs"
 description: "Download StackStorm packs via ChatOps"
 formats:
+  - display: "pack deploy <repo_name> [packs <packs>] [branch <branch=master>]"
+    representation:
+      - "pack deploy {{repo_name}} packs {{packs}} branch {{branch}}"
+      - "pack deploy {{repo_name}} packs {{packs}}"
+  - display: "pack deploy <repo_name> [branch <branch=master>]"
+    representation:
+      - "pack deploy {{repo_name}} branch {{branch=master}}"
+      - "pack deploy {{repo_name}} {{branch=master}}"
   - "pack deploy {{repo_name}} {{packs}} {{branch=master}}"
 ack:
   enabled: true
@@ -13,7 +21,8 @@ result:
   format: |
     {% if execution.status == "succeeded" %}
     Successful deployment of {% for pack in execution.result.packs %}*{{pack}}* {% endfor %}!{~}
-    from {{ execution.result.repo_url }} (branch: _{{ execution.parameters.branch }}_).
+    from {{ execution.result.repo_url }} (branch: _{{ execution.result.branch }}_).
     {% else %}
-    Deployment failed of {% for pack in execution.parameters.packs %}*{{pack}}* {% endfor %}, from *{{execution.parameters.repo_name}}*. Please check {{ execution.id }} for details. {~}
+    Deployment failed of packs from *{{execution.parameters.repo_name}}*.{~}
+    Please check {{ execution.id }} for details.
     {% endif %}


### PR DESCRIPTION
A clean up to the ChatOps aliases for pack deployment in the packs pack.

The current way turned out to be a little hard of the fingers when deploying a pack which had no subtree. As you need to type `my-pack` twice. This removes this requirement.