### PR TITLE
Add comments to explain packs being updated to repo_name in deploy wo…

### DIFF
--- a/contrib/packs/actions/workflows/deploy.yaml
+++ b/contrib/packs/actions/workflows/deploy.yaml
@@ -31,6 +31,8 @@ workflows:
       check_for_no_subtree:
         action: core.noop
 
+        # If packs has 0 len, call publish_packs so that packs is
+        # contains the right value.
         on-complete:
           - do_manual_install: <% len($.packs) != 0 %>
           - publish_packs: <% len($.packs) = 0 %>
@@ -38,6 +40,9 @@ workflows:
       publish_packs:
         action: core.noop
 
+        # If a pack is not contained in a subtree, we should replace
+        # the empty packs array with with an array that contains the
+        # repo_name.
         publish:
           packs: [ <% $.repo_name %> ]
 


### PR DESCRIPTION
…rkflow.

As discussed with @kami and @emedvedev on PR #2581, this PR covers
when a pack has no subtree and the repo_name and packs should be the
same. However this can't be done in the alais so we handle it in the
workflow.