### PR TITLE
Use Environment variable for webhook URL

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ general:
 
 notify:
   webhooks:
-    - url: https://webhooks.stackstorm.net:8531/webhooks/build/events
+    - url: ${ST2_HOOK_URL}
 
 machine:
   environment:


### PR DESCRIPTION
To obfuscate this a bit we'll move it to an environment variable.