### PR TITLE
Rule tester improvements

### DIFF
--- a/st2reactor/st2reactor/rules/enforcer.py
+++ b/st2reactor/st2reactor/rules/enforcer.py
@@ -20,6 +20,7 @@ from st2common.constants import action as action_constants
 from st2common.constants.trace import TRACE_CONTEXT
 from st2common.models.api.trace import TraceContext
 from st2common.models.db.liveaction import LiveActionDB
+
 from st2common.models.db.rule_enforcement import RuleEnforcementDB
 from st2common.models.utils import action_param_utils
 from st2common.models.api.auth import get_system_username

--- a/st2reactor/st2reactor/rules/filter.py
+++ b/st2reactor/st2reactor/rules/filter.py
@@ -61,6 +61,8 @@ class RuleFilter(object):
                  extra=self._base_logger_context)
 
         if not self.rule.enabled:
+            if self.extra_info:
+                LOG.info('Validation failed for rule %s as it is disabled.', self.rule.ref)
             return False
 
         criteria = self.rule.criteria

--- a/st2reactor/st2reactor/rules/tester.py
+++ b/st2reactor/st2reactor/rules/tester.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import os
+import six
 
 from jinja2.exceptions import UndefinedError
 
@@ -81,8 +82,10 @@ class RuleTester(object):
         # Check if rule can be enforced
         try:
             enforcer = RuleEnforcer(trigger_instance=trigger_instance_db, rule=rule_db)
-            data = enforcer.get_resolved_parameters()
-            LOG.info('Action parameters resolved to: %s', data)
+            params = enforcer.get_resolved_parameters()
+            LOG.info('Action parameters resolved to:')
+            for param in six.iteritems(params):
+                LOG.info('\t%s: %s', param[0], param[1])
             return True
         except (UndefinedError, ValueError) as e:
             LOG.error('Failed to resolve parameters\n\tOriginal error : %s', str(e))

--- a/st2reactor/st2reactor/rules/tester.py
+++ b/st2reactor/st2reactor/rules/tester.py
@@ -119,9 +119,11 @@ class RuleTester(object):
         name = data.get('name', 'unknown')
         trigger = data['trigger']['type']
         criteria = data.get('criteria', None)
+        action = data.get('action', {})
 
-        rule_db = RuleDB(pack=pack, name=name, trigger=trigger, criteria=criteria, action={},
+        rule_db = RuleDB(pack=pack, name=name, trigger=trigger, criteria=criteria, action=action,
                          enabled=True)
+
         return rule_db
 
     def _get_trigger_instance_db_from_file(self, file_path):

--- a/st2reactor/tests/fixtures/rule.yaml
+++ b/st2reactor/tests/fixtures/rule.yaml
@@ -13,7 +13,7 @@
           pattern: "StackStorm"
 
   action:
-    ref: "slack.post_message"
+    ref: "wolfpack.action-1"
     parameters:
         message: "{{trigger.source.nick}} on {{trigger.channel}}: {{trigger.message}}"
         channel: "#irc-relay"

--- a/st2reactor/tests/unit/test_tester.py
+++ b/st2reactor/tests/unit/test_tester.py
@@ -36,10 +36,16 @@ TEST_MODELS_RULES = {
     'rules': ['rule1.yaml']
 }
 
+TEST_MODELS_ACTIONS = {
+    'actions': ['action1.yaml']
+}
+
 
 @mock.patch.object(PoolPublisher, 'publish', mock.MagicMock())
 class RuleTesterTestCase(CleanDbTestCase):
     def test_matching_trigger_from_file(self):
+        FixturesLoader().save_fixtures_to_db(fixtures_pack=FIXTURES_PACK,
+                                             fixtures_dict=TEST_MODELS_ACTIONS)
         rule_file_path = os.path.join(BASE_PATH, '../fixtures/rule.yaml')
         trigger_instance_file_path = os.path.join(BASE_PATH, '../fixtures/trigger_instance_1.yaml')
         tester = RuleTester(rule_file_path=rule_file_path,
@@ -56,6 +62,8 @@ class RuleTesterTestCase(CleanDbTestCase):
         self.assertFalse(matching)
 
     def test_matching_trigger_from_db(self):
+        FixturesLoader().save_fixtures_to_db(fixtures_pack=FIXTURES_PACK,
+                                             fixtures_dict=TEST_MODELS_ACTIONS)
         models = FixturesLoader().save_fixtures_to_db(fixtures_pack=FIXTURES_PACK,
                                                       fixtures_dict=TEST_MODELS_TRIGGERS)
         trigger_instance_db = models['triggerinstances']['trigger_instance_2.yaml']


### PR DESCRIPTION
### Happy path with parameter resolution -
```
$ st2reactor/bin/st2-rule-tester --rule-ref default.rule4 --trigger-instance-id 56ec763832ed35226d5b9094
2016-03-18 15:41:08,350 INFO [-] Connecting to database "st2" @ "0.0.0.0:27017" as user "None".
2016-03-18 15:41:08,383 INFO [-] Validating rule default.rule4 for st2.generic.actiontrigger.
2016-03-18 15:41:08,407 INFO [-] 1 rule(s) found to enforce for st2.generic.actiontrigger.
2016-03-18 15:41:08,413 INFO [-] Action parameters resolved to:
2016-03-18 15:41:08,414 INFO [-] 	i1: core.local
2016-03-18 15:41:08,415 INFO [-] 	i3: date
2016-03-18 15:41:08,415 INFO [-] 	i2: core.local
2016-03-18 15:41:08,416 INFO [-] === RULE MATCHES ===
```

### Parameter resolution fails -
```
$ st2reactor/bin/st2-rule-tester --rule-ref default.rule4 --trigger-instance-id 56ec763832ed35226d5b9094
2016-03-18 15:56:59,768 INFO [-] Connecting to database "st2" @ "0.0.0.0:27017" as user "None".
2016-03-18 15:56:59,798 INFO [-] Validating rule default.rule4 for st2.generic.actiontrigger.
2016-03-18 15:56:59,829 INFO [-] 1 rule(s) found to enforce for st2.generic.actiontrigger.
2016-03-18 15:56:59,837 ERROR [-] Failed to resolve parameters
	Original error : 'mongoengine.base.datastructures.BaseDict object' has no attribute 'does_not_exist'
2016-03-18 15:56:59,839 INFO [-] === RULE DOES NOT MATCH ===
```

### Action does not exist
```
$ st2reactor/bin/st2-rule-tester --rule-ref default.rule4 --trigger-instance-id 56ec763832ed35226d5b9094
2016-03-18 15:57:57,859 INFO [-] Connecting to database "st2" @ "0.0.0.0:27017" as user "None".
2016-03-18 15:57:57,892 INFO [-] Validating rule default.rule4 for st2.generic.actiontrigger.
2016-03-18 15:57:57,915 INFO [-] 1 rule(s) found to enforce for st2.generic.actiontrigger.
2016-03-18 15:57:57,916 ERROR [-] Failed to resolve parameters
	Original error : Action "core.nooop" doesn't exist
2016-03-18 15:57:57,917 INFO [-] === RULE DOES NOT MATCH ===
```

### Rule disabled
```
$ st2reactor/bin/st2-rule-tester --rule-ref default.rule4 --trigger-instance-id 56ec763832ed35226d5b9094
2016-03-18 15:58:31,804 INFO [-] Connecting to database "st2" @ "0.0.0.0:27017" as user "None".
2016-03-18 15:58:31,835 INFO [-] Validating rule default.rule4 for st2.generic.actiontrigger.
2016-03-18 15:58:31,836 INFO [-] Validation failed for rule default.rule4 as it is disabled.
2016-03-18 15:58:31,836 INFO [-] 0 rule(s) found to enforce for st2.generic.actiontrigger.
2016-03-18 15:58:31,837 INFO [-] === RULE DOES NOT MATCH ===
```