### PR TITLE
Revert "Use Environment variable for webhook URL"

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ general:
 
 notify:
   webhooks:
-    - url: ${ST2_HOOK_URL}
+    - url: https://webhooks.stackstorm.net:8531/webhooks/build/events
 
 machine:
   environment:


### PR DESCRIPTION
Reverts StackStorm/st2#2587


env variable didn't worked in that section, see : 
https://circleci.com/gh/StackStorm/st2/911
![](https://i.imgur.com/Hryfu61.png)


