### PR TITLE
Fix excludes handling.

### DIFF
--- a/st2common/st2common/log.py
+++ b/st2common/st2common/log.py
@@ -184,7 +184,7 @@ def setup(config_file, redirect_stderr=True, excludes=None, disable_existing_log
                                   defaults=None,
                                   disable_existing_loggers=disable_existing_loggers)
         handlers = logging.getLoggerClass().manager.root.handlers
-        _add_exclusion_filters(handlers)
+        _add_exclusion_filters(handlers, excludes)
         if redirect_stderr:
             _redirect_stderr()
     except Exception as exc:


### PR DESCRIPTION
Need to pass `excludes` to `_add_exclusion_filters()` 

Confirmed w/ @lakshmi-kannan that this was introduced when fixing a issue with logging and config loading here: 51204cb81bf42bd4e977711f0b8444eef4704fee