### PR TITLE
Rule enforcement updates

### DIFF
--- a/st2client/st2client/commands/rule_enforcement.py
+++ b/st2client/st2client/commands/rule_enforcement.py
@@ -32,10 +32,10 @@ class RuleEnforcementBranch(resource.ResourceBranch):
 
 
 class RuleEnforcementGetCommand(resource.ResourceGetCommand):
-    display_attributes = ['id', 'rule_ref', 'trigger_instance_id',
-                          'execution_id', 'enforced_at']
-    attribute_display_order = ['id', 'rule_ref', 'trigger_instance_id',
-                               'execution_id', 'enforced_at']
+    display_attributes = ['id', 'rule.ref', 'trigger_instance_id',
+                          'execution_id', 'failure_reason', 'enforced_at']
+    attribute_display_order = ['id', 'rule.ref', 'trigger_instance_id',
+                               'execution_id', 'failure_reason', 'enforced_at']
 
     pk_argument_name = 'id'
 

--- a/st2common/st2common/models/api/rule_enforcement.py
+++ b/st2common/st2common/models/api/rule_enforcement.py
@@ -56,8 +56,11 @@ class RuleEnforcementAPI(BaseAPI):
             },
             'execution_id': {
                 'description': 'ID of the action execution that was invoked as a response.',
-                'type': 'string',
-                'required': True
+                'type': 'string'
+            },
+            'failure_reason': {
+                'description': 'Reason for failure to execute the action specified in the rule.',
+                'type': 'string'
             },
             'rule': RuleReferenceSpec.schema,
             'enforced_at': {
@@ -74,6 +77,7 @@ class RuleEnforcementAPI(BaseAPI):
         trigger_instance_id = getattr(rule_enforcement, 'trigger_instance_id', None)
         execution_id = getattr(rule_enforcement, 'execution_id', None)
         enforced_at = getattr(rule_enforcement, 'enforced_at', None)
+        failure_reason = getattr(rule_enforcement, 'failure_reason', None)
 
         rule_ref_model = dict(getattr(rule_enforcement, 'rule', {}))
         rule = RuleReferenceSpecDB(ref=rule_ref_model['ref'], id=rule_ref_model['id'],
@@ -83,7 +87,7 @@ class RuleEnforcementAPI(BaseAPI):
             enforced_at = isotime.parse(enforced_at)
 
         return cls.model(trigger_instance_id=trigger_instance_id, execution_id=execution_id,
-                         enforced_at=enforced_at, rule=rule)
+                         failure_reason=failure_reason, enforced_at=enforced_at, rule=rule)
 
     @classmethod
     def from_model(cls, model, mask_secrets=False):

--- a/st2common/st2common/models/db/rule_enforcement.py
+++ b/st2common/st2common/models/db/rule_enforcement.py
@@ -46,6 +46,7 @@ class RuleEnforcementDB(stormbase.StormFoundationDB, stormbase.TagsMixin):
 
     trigger_instance_id = me.StringField(required=True)
     execution_id = me.StringField(required=False)
+    failure_reason = me.StringField(required=False)
     rule = me.EmbeddedDocumentField(RuleReferenceSpecDB, required=True)
     enforced_at = ComplexDateTimeField(
         default=date_utils.get_datetime_utc_now,

--- a/st2reactor/st2reactor/rules/enforcer.py
+++ b/st2reactor/st2reactor/rules/enforcer.py
@@ -69,7 +69,7 @@ class RuleEnforcer(object):
             'trigger_instance_db': self.trigger_instance,
             'rule_db': self.rule
         }
-
+        execution_db = None
         try:
             execution_db = self._do_enforce()
             # pylint: disable=no-member
@@ -77,7 +77,7 @@ class RuleEnforcer(object):
             extra['execution_db'] = execution_db
         except Exception as e:
             # Record the failure reason in the RuleEnforcement.
-            enforcement_db.failure_reason = e.msg
+            enforcement_db.failure_reason = e.message
             LOG.exception('Failed kicking off execution for rule %s.', self.rule, extra=extra)
         finally:
             self._update_enforcement(enforcement_db)
@@ -86,7 +86,7 @@ class RuleEnforcer(object):
         if not execution_db or execution_db.status not in EXEC_KICKED_OFF_STATES:
             LOG.audit('Rule enforcement failed. Execution of Action %s failed. '
                       'TriggerInstance: %s and Rule: %s',
-                      self.rule.action.name, self.trigger_instance, self.rule,
+                      self.rule.action.ref, self.trigger_instance, self.rule,
                       extra=extra)
         else:
             LOG.audit('Rule enforced. Execution %s, TriggerInstance %s and Rule %s.',

--- a/st2reactor/st2reactor/rules/enforcer.py
+++ b/st2reactor/st2reactor/rules/enforcer.py
@@ -72,6 +72,7 @@ class RuleEnforcer(object):
 
         try:
             execution_db = self._do_enforce()
+            # pylint: disable=no-member
             enforcement_db.execution_id = str(execution_db.id)
             extra['execution_db'] = execution_db
         except Exception as e:
@@ -81,6 +82,7 @@ class RuleEnforcer(object):
         finally:
             self._update_enforcement(enforcement_db)
 
+        # pylint: disable=no-member
         if not execution_db or execution_db.status not in EXEC_KICKED_OFF_STATES:
             LOG.audit('Rule enforcement failed. Execution of Action %s failed. '
                       'TriggerInstance: %s and Rule: %s',

--- a/st2reactor/tests/unit/test_enforce.py
+++ b/st2reactor/tests/unit/test_enforce.py
@@ -18,6 +18,7 @@ import mock
 from st2common.models.db.trigger import TriggerInstanceDB
 from st2common.models.db.execution import ActionExecutionDB
 from st2common.models.db.liveaction import LiveActionDB
+from st2common.persistence.rule_enforcement import RuleEnforcement
 from st2common.services import action as action_service
 from st2common.util import reference
 from st2common.util import date as date_utils
@@ -49,6 +50,8 @@ MOCK_LIVEACTION.status = 'requested'
 MOCK_EXECUTION = ActionExecutionDB()
 MOCK_EXECUTION.id = 'exec-test-1.id'
 MOCK_EXECUTION.status = 'requested'
+
+FAILURE_REASON = "fail!"
 
 
 class EnforceTest(DbTestCase):
@@ -83,3 +86,25 @@ class EnforceTest(DbTestCase):
         self.assertTrue(action_service.request.called)
         self.assertTrue(isinstance(action_service.request.call_args[0][0].parameters['objtype'],
                                    dict))
+
+    @mock.patch.object(action_service, 'request', mock.MagicMock(
+        return_value=(MOCK_LIVEACTION, MOCK_EXECUTION)))
+    @mock.patch.object(RuleEnforcement, 'add_or_update', mock.MagicMock())
+    def test_ruleenforcement_create_on_success(self):
+        enforcer = RuleEnforcer(MOCK_TRIGGER_INSTANCE, self.models['rules']['rule2.yaml'])
+        execution_db = enforcer.enforce()
+        self.assertTrue(execution_db is not None)
+        self.assertTrue(RuleEnforcement.add_or_update.called)
+        self.assertEqual(RuleEnforcement.add_or_update.call_args[0][0].rule.ref,
+                         self.models['rules']['rule2.yaml'].ref)
+
+    @mock.patch.object(action_service, 'request', mock.MagicMock(
+        side_effect=ValueError(FAILURE_REASON)))
+    @mock.patch.object(RuleEnforcement, 'add_or_update', mock.MagicMock())
+    def test_ruleenforcement_create_on_fail(self):
+        enforcer = RuleEnforcer(MOCK_TRIGGER_INSTANCE, self.models['rules']['rule1.yaml'])
+        execution_db = enforcer.enforce()
+        self.assertTrue(execution_db is None)
+        self.assertTrue(RuleEnforcement.add_or_update.called)
+        self.assertEqual(RuleEnforcement.add_or_update.call_args[0][0].failure_reason,
+                         FAILURE_REASON)


### PR DESCRIPTION
Record failures to enforce rules due to missing actions or parameter validation errors. A RuleEnforcement object will be created for failed enforcements that do not lead to an ActionExecution creation.

Includes CLI, API model and DB model changes apart from capturing the error message in RuleEnforcer in the `failure_reason` property.

### Sample failures

#### Missing action
```
$ st2 rule-enforcement get 56f1b4e832ed3570a924c5ff
+---------------------+--------------------------------------------+
| Property            | Value                                      |
+---------------------+--------------------------------------------+
| id                  | 56f1b4e832ed3570a924c5ff                   |
| rule.ref            | default.passive_trigger_rule_2             |
| trigger_instance_id | 56f1b4e832ed3570a924c5fa                   |
| execution_id        |                                            |
| failure_reason      | Action "core.does_not_exist" doesn't exist |
| enforced_at         | 2016-03-22T21:11:04.200402Z                |
+---------------------+--------------------------------------------+
```

#### Bad parameters
```
$ st2 rule-enforcement get 56f1b4e832ed3570a924c600
+---------------------+--------------------------------------------------------------+
| Property            | Value                                                        |
+---------------------+--------------------------------------------------------------+
| id                  | 56f1b4e832ed3570a924c600                                     |
| rule.ref            | default.passive_trigger_rule_3                               |
| trigger_instance_id | 56f1b4e832ed3570a924c5fa                                     |
| execution_id        |                                                              |
| failure_reason      | Additional properties are not allowed (u'command' was        |
|                     | unexpected)                                                  |
| enforced_at         | 2016-03-22T21:11:04.215581Z                                  |
+---------------------+--------------------------------------------------------------+
```