### PR TITLE
Improve output for core.sendmail when nothing sent

### DIFF
--- a/contrib/core/actions/send_mail/send_mail
+++ b/contrib/core/actions/send_mail/send_mail
@@ -120,6 +120,9 @@ fi
 if [ $? -ne 0 ]; then
   echo "Failed to send mail to ${TO}"
   exit 2
+elif [[ -z $trimmed && $SEND_EMPTY_BODY == 'False' ]]; then
+  echo "Nothing to send"
+  exit 0
 else
   echo "Successfully sent mail to ${TO}"
   exit 0


### PR DESCRIPTION
Want to be able to easily tell if an email was sent. The current message "Successfully sent mail" is misleading when we actually skip sending mail since the body is empty and we've selected not to send an empty body.

Of course, I'm open to changing the wording.