### PR TITLE
Fix rule criteria comparison for falsy criteria pattern values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -75,8 +75,10 @@ in development
 * Fix ``linux.traceroute`` action. (bug fix)
 * Fix a bug with positional argument handling in the local script runner. Now the arguments with a
   no value or value of ``None`` are correctly passed to the script. (bug fix)
-* Fix rule criteria comparison and make sure that falsy criteria pattern values such as integer /
-  number ``0`` are handled correctly. (bug-fix)
+* Fix rule criteria comparison and make sure that falsy criteria pattern values such as integer
+  ``0`` are handled correctly. (bug-fix)
+
+  Reported by Igor Cherkaev.
 
 1.3.2 - February 12, 2016
 -------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -75,6 +75,8 @@ in development
 * Fix ``linux.traceroute`` action. (bug fix)
 * Fix a bug with positional argument handling in the local script runner. Now the arguments with a
   no value or value of ``None`` are correctly passed to the script. (bug fix)
+* Fix rule criteria comparison and make sure that falsy criteria pattern values such as integer /
+  number ``0`` are handled correctly. (bug-fix)
 
 1.3.2 - February 12, 2016
 -------------------------

--- a/st2reactor/st2reactor/rules/filter.py
+++ b/st2reactor/st2reactor/rules/filter.py
@@ -139,6 +139,8 @@ class RuleFilter(object):
         return result, payload_value, criteria_pattern
 
     def _render_criteria_pattern(self, criteria_pattern):
+        # Note: Here we want to use strict comparison to None to make sure that
+        # other falsy values such as integer 0 are handled correctly.
         if criteria_pattern is None:
             return None
 

--- a/st2reactor/st2reactor/rules/filter.py
+++ b/st2reactor/st2reactor/rules/filter.py
@@ -139,7 +139,7 @@ class RuleFilter(object):
         return result, payload_value, criteria_pattern
 
     def _render_criteria_pattern(self, criteria_pattern):
-        if not criteria_pattern:
+        if criteria_pattern is None:
             return None
 
         if not isinstance(criteria_pattern, six.string_types):

--- a/st2reactor/tests/unit/test_filter.py
+++ b/st2reactor/tests/unit/test_filter.py
@@ -133,6 +133,18 @@ class FilterTest(DbTestCase):
         f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
         self.assertTrue(f.filter(), '"floattt" key ain\'t exist in trigger. Should return true.')
 
+    def test_gt_lt_falsy_pattern(self):
+        # Make sure that the falsy value (number 0) is handled correctly
+        rule = MOCK_RULE_1
+
+        rule.criteria = {'trigger.int': {'type': 'gt', 'pattern': 0}}
+        f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
+        self.assertTrue(f.filter(), 'trigger value is gt than 0 but didn\'t match')
+
+        rule.criteria = {'trigger.int': {'type': 'lt', 'pattern': 0}}
+        f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
+        self.assertFalse(f.filter(), 'trigger value is gt than 0 but didn\'t fail')
+
     @mock.patch('st2common.util.templating.KeyValueLookup')
     def test_criteria_pattern_references_a_datastore_item(self, mock_KeyValueLookup):
         class MockResultLookup(object):


### PR DESCRIPTION
This pull request fixes a bug with criteria comparison of falsy pattern values.

Previously, if a falsy value was provided for a pattern (e.g. number 0), comparison would fail since we incorrectly assumed criteria pattern is not provided and cast it to `None`.

This fixes bug described in #2600.