### PR TITLE
Fix sending announcements through WebUI

### DIFF
--- a/st2common/st2common/transport/announcement.py
+++ b/st2common/st2common/transport/announcement.py
@@ -58,7 +58,7 @@ class AnnouncementDispatcher(object):
         :type trace_context: ``TraceContext``
         """
         assert isinstance(payload, (type(None), dict))
-        assert isinstance(trace_context, (type(None), TraceContext))
+        assert isinstance(trace_context, (type(None), dict, TraceContext))
 
         payload = {
             'payload': payload,


### PR DESCRIPTION
This PR fixes running announcements through WebUI with empty `trace-tag`. WebUI passes an empty dict into `trace_context` instead of `None`, and it can’t match the assertion in code.