### PR TITLE
Remove formating for old packs.pack_deploy alias as it was non-functional

### DIFF
--- a/contrib/packs/aliases/pack_deploy.yaml
+++ b/contrib/packs/aliases/pack_deploy.yaml
@@ -11,8 +11,7 @@ formats:
   - display: "pack deploy <repo_name> [branch <branch=master>]"
     representation:
       - "pack deploy {{repo_name}} branch {{branch=master}}"
-      - "pack deploy {{repo_name}} {{branch=master}}"
-  - "pack deploy {{repo_name}} {{packs}} {{branch=master}}"
+      - "pack deploy {{repo_name}}"
 ack:
   enabled: true
   append_url: false


### PR DESCRIPTION
During continued use of the new deploy pack I noticed that the old formatting was not functional and all the parameters were ending up as a space separated in `{{branch}}`.

So a PR to remove the old formating and remove the unneeded `{{branch}}` from `pack deploy {{repo_name}} {{branch=master}}`.

If there is another way to achieve this, happy to update the PR.... 