### PR TITLE
Throw a more user-friendly exception if sensor instance fails to start due to the missing sensor class file

### DIFF
--- a/st2common/st2common/util/loader.py
+++ b/st2common/st2common/util/loader.py
@@ -35,7 +35,8 @@ PYTHON_EXTENSIONS = ('.py')
 
 def _register_plugin_path(plugin_dir_abs_path):
     if not os.path.isdir(plugin_dir_abs_path):
-        raise Exception('Directory containing plugins must be provided.')
+        raise Exception('Directory "%s" with plugins doesn\'t exist')
+
     for x in sys.path:
         if plugin_dir_abs_path in (x, x + os.sep):
             return

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -253,9 +253,14 @@ class SensorWrapper(object):
         _, filename = os.path.split(self._file_path)
         module_name, _ = os.path.splitext(filename)
 
-        sensor_class = loader.register_plugin_class(base_class=Sensor,
-                                                    file_path=self._file_path,
-                                                    class_name=self._class_name)
+        try:
+            sensor_class = loader.register_plugin_class(base_class=Sensor,
+                                                        file_path=self._file_path,
+                                                        class_name=self._class_name)
+        except Exception as e:
+            msg = ('Failed to register sensor file "%s" (sensor file most likely doesn\'t exist): '
+                   ' %s' % (self._file_path, str(e)))
+            raise ValueError(msg)
 
         if not sensor_class:
             raise ValueError('Sensor module is missing a class with name "%s"' %

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -258,8 +258,8 @@ class SensorWrapper(object):
                                                         file_path=self._file_path,
                                                         class_name=self._class_name)
         except Exception as e:
-            msg = ('Failed to register sensor file "%s" (sensor file most likely doesn\'t exist): '
-                   ' %s' % (self._file_path, str(e)))
+            msg = ('Failed to load sensor class from file "%s"'
+                   ' (sensor file most likely doesn\'t exist): %s' % (self._file_path, str(e)))
             raise ValueError(msg)
 
         if not sensor_class:

--- a/st2reactor/tests/unit/test_sensor_wrapper.py
+++ b/st2reactor/tests/unit/test_sensor_wrapper.py
@@ -91,3 +91,15 @@ class SensorWrapperTestCase(unittest2.TestCase):
         self.assertIsNotNone(wrapper._sensor_instance)
         self.assertIsInstance(wrapper._sensor_instance, PollingSensor)
         self.assertEquals(wrapper._sensor_instance._poll_interval, poll_interval)
+
+    def test_sensor_init_fails_file_doesnt_exist(self):
+        file_path = os.path.join(RESOURCES_DIR, 'test_sensor_doesnt_exist.py')
+        trigger_types = ['trigger1', 'trigger2']
+        parent_args = ['--config-file', TESTS_CONFIG_PATH]
+
+        expected_msg = 'Failed to load sensor class from file'
+        self.assertRaisesRegexp(ValueError, expected_msg, SensorWrapper,
+                                pack='core', file_path=file_path,
+                                class_name='TestSensor',
+                                trigger_types=trigger_types,
+                                parent_args=parent_args)


### PR DESCRIPTION
The error message which was reported previously was confusing and it wasn't immediately clear what is going on.

Now we throw a more specific and user-friendly error message so this should hopefully make it more obvious that either the sensor class file or the pack directory is missing.