### PR TITLE
Upgrade paramiko to v1.16.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -89,6 +89,8 @@ in development
 * Mistral has deprecated the use of task name (i.e. ``$.task1``) to reference task result. It is
   replaced with a ``task`` function that returns attributes of the task such as id, state, result,
   and additional information (i.e. ``task(task1).result``).
+* Add support for additional SSH key exchange algorithms to the remote runner via upgrade to
+  paramiko 1.16.0. (new feature)
 
 1.3.2 - February 12, 2016
 -------------------------

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -20,7 +20,7 @@ semver>=2.1.2
 tooz==1.20.0
 stevedore>=1.7.0,<1.8
 bencode>=1.0,<1.1
-paramiko>=1.15.2,<1.16
+paramiko>=1.16.0,<1.17
 networkx==1.10
 # Note: We want to use virtualenv 13.1.2 since it uses pip 7.1.2 and versions
 # >= 14.0 use pip 8.8.0 which is incompatible with our code

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ mongoengine<0.9,>=0.8.7
 networkx==1.10
 oslo.config<1.13,>=1.12.1
 oslo.utils<3.1.0
-paramiko<1.16,>=1.15.2
+paramiko<1.17,>=1.16.0
 passlib<1.7,>=1.6.2
 prettytable
 pyinotify<=0.10,>=0.9.5


### PR DESCRIPTION
This new features includes support for additional key exchanges algorithms. In addition to that it also includes various improvements and bug fixes (http://www.paramiko.org/changelog.html).

I have deployed the same change to st2build002 to make sure it doesn't introduce any regressions.

Resolves #2614.