### PR TITLE
Add missing "--register-setup-virtualenvs" flag to st2ctl

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,8 +56,8 @@ in development
   specified, all the timestamps displayed by the CLI will be shown in the configured timezone
   instead of a default UTC display. (new feature)
 * Add ``attachments`` parameter to the ``core.sendmail`` action. (improvement) [Cody A. Ray]
-* Add ``--register-setup-virtualenvs`` flag to the ``register-content`` script. When this flag is
-  provided, Python virtual environments are created for all the registered packs.
+* Add ``--register-setup-virtualenvs`` flag to the ``register-content`` script and ``st2ctl``.
+  When this flag is provided, Python virtual environments are created for all the registered packs.
   This option is to be used with distributed setup where action runner services run on multiple
   hosts to ensure virtual environments exist on all those hosts. (new-feature)
 * Update ``core.st2.CronTimer`` so it supports more of the cron-like expressions (``a-b``, ``*/a``,

--- a/conf/st2.tests.conf
+++ b/conf/st2.tests.conf
@@ -39,7 +39,7 @@ backend_kwargs = {"file_path": "st2auth/conf/htpasswd_dev"}
 api_url = http://127.0.0.1:9101/
 
 [system]
-base_path = /opt/stackstorm
+base_path = /tmp
 
 [garbagecollector]
 logging = st2reactor/conf/logging.garbagecollector.conf

--- a/conf/st2.tests.conf
+++ b/conf/st2.tests.conf
@@ -39,6 +39,7 @@ backend_kwargs = {"file_path": "st2auth/conf/htpasswd_dev"}
 api_url = http://127.0.0.1:9101/
 
 [system]
+# This way integration tests can write to this directory
 base_path = /tmp
 
 [garbagecollector]

--- a/conf/st2.tests1.conf
+++ b/conf/st2.tests1.conf
@@ -36,7 +36,7 @@ backend_kwargs = {"file_path": "st2auth/conf/htpasswd_dev"}
 api_url = http://127.0.0.1:9101/
 
 [system]
-base_path = /opt/stackstorm
+base_path = /tmp
 
 [content]
 system_packs_base_path =

--- a/conf/st2.tests1.conf
+++ b/conf/st2.tests1.conf
@@ -36,6 +36,7 @@ backend_kwargs = {"file_path": "st2auth/conf/htpasswd_dev"}
 api_url = http://127.0.0.1:9101/
 
 [system]
+# This way integration tests can write to this directory
 base_path = /tmp
 
 [content]

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -70,12 +70,16 @@ def setup_virtualenvs():
     pack_dir = cfg.CONF.register.pack
     fail_on_failure = cfg.CONF.register.fail_on_failure
 
+    # Note: We need to register packs here as well
+    registrar = ResourceRegistrar()
+
     if pack_dir:
         pack_name = os.path.basename(pack_dir)
         pack_names = [pack_name]
+        registrar.register_pack(pack_name=pack_name, pack_dir=pack_dir)
     else:
-        registrar = ResourceRegistrar()
         pack_names = registrar.get_registered_packs()
+        registrar.register_packs()
 
     setup_count = 0
     for pack_name in pack_names:

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -31,6 +31,7 @@ import st2common.bootstrap.policiesregistrar as policies_registrar
 import st2common.bootstrap.runnersregistrar as runners_registrar
 import st2common.bootstrap.rulesregistrar as rules_registrar
 import st2common.bootstrap.ruletypesregistrar as rule_types_registrar
+import st2common.content.utils as content_utils
 from st2common.util.virtualenvs import setup_pack_virtualenv
 
 __all__ = [
@@ -70,16 +71,21 @@ def setup_virtualenvs():
     pack_dir = cfg.CONF.register.pack
     fail_on_failure = cfg.CONF.register.fail_on_failure
 
-    # Note: We need to register packs here as well
     registrar = ResourceRegistrar()
 
     if pack_dir:
         pack_name = os.path.basename(pack_dir)
         pack_names = [pack_name]
+
+        # 1. Register pack
         registrar.register_pack(pack_name=pack_name, pack_dir=pack_dir)
     else:
+        # 1. Register pack
+        base_dirs = content_utils.get_packs_base_paths()
+        registrar.register_packs(base_dirs=base_dirs)
+
+        # 2. Retrieve available packs (aka packs which have been registered)
         pack_names = registrar.get_registered_packs()
-        registrar.register_packs()
 
     setup_count = 0
     for pack_name in pack_names:

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -101,7 +101,7 @@ def setup_virtualenvs():
         else:
             setup_count += 1
 
-    LOG.info('Setup virtualenv for %s pack.' % (setup_count))
+    LOG.info('Setup virtualenv for %s pack(s).' % (setup_count))
 
 
 def register_sensors():

--- a/st2common/tests/integration/test_register_content_script.py
+++ b/st2common/tests/integration/test_register_content_script.py
@@ -25,7 +25,8 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 SCRIPT_PATH = os.path.join(BASE_DIR, '../../bin/st2-register-content')
 SCRIPT_PATH = os.path.abspath(SCRIPT_PATH)
 
-BASE_CMD_ARGS = [SCRIPT_PATH, '--config-file=conf/st2.tests.conf', '-v', '--register-actions']
+BASE_CMD_ARGS = [SCRIPT_PATH, '--config-file=conf/st2.tests.conf', '-v']
+BASE_REGISTER_ACTIONS_CMD_ARGS = BASE_CMD_ARGS + ['--register-actions']
 
 
 class ContentRegisterScripTestCase(IntegrationTestCase):
@@ -36,7 +37,7 @@ class ContentRegisterScripTestCase(IntegrationTestCase):
     def test_register_from_pack_success(self):
         pack_dir = os.path.join(get_fixtures_base_path(), 'dummy_pack_1')
 
-        cmd = BASE_CMD_ARGS + ['--register-pack=%s' % (pack_dir)]
+        cmd = BASE_REGISTER_ACTIONS_CMD_ARGS + ['--register-pack=%s' % (pack_dir)]
         exit_code, _, stderr = run_command(cmd=cmd)
         self.assertTrue('Registered 1 actions.' in stderr)
         self.assertEqual(exit_code, 0)
@@ -44,12 +45,13 @@ class ContentRegisterScripTestCase(IntegrationTestCase):
     def test_register_from_pack_fail_on_failure_pack_dir_doesnt_exist(self):
         # No fail on failure flag, should succeed
         pack_dir = 'doesntexistblah'
-        cmd = BASE_CMD_ARGS + ['--register-pack=%s' % (pack_dir)]
+        cmd = BASE_REGISTER_ACTIONS_CMD_ARGS + ['--register-pack=%s' % (pack_dir)]
         exit_code, _, _ = run_command(cmd=cmd)
         self.assertEqual(exit_code, 0)
 
         # Fail on failure, should fail
-        cmd = BASE_CMD_ARGS + ['--register-pack=%s' % (pack_dir), '--register-fail-on-failure']
+        cmd = BASE_REGISTER_ACTIONS_CMD_ARGS + ['--register-pack=%s' % (pack_dir),
+                                                '--register-fail-on-failure']
         exit_code, _, stderr = run_command(cmd=cmd)
         self.assertTrue('Directory "doesntexistblah" doesn\'t exist' in stderr)
         self.assertEqual(exit_code, 1)
@@ -57,14 +59,15 @@ class ContentRegisterScripTestCase(IntegrationTestCase):
     def test_register_from_pack_action_metadata_fails_validation(self):
         # No fail on failure flag, should succeed
         pack_dir = os.path.join(get_fixtures_base_path(), 'dummy_pack_4')
-        cmd = BASE_CMD_ARGS + ['--register-pack=%s' % (pack_dir)]
+        cmd = BASE_REGISTER_ACTIONS_CMD_ARGS + ['--register-pack=%s' % (pack_dir)]
         exit_code, _, stderr = run_command(cmd=cmd)
         self.assertTrue('Registered 0 actions.' in stderr)
         self.assertEqual(exit_code, 0)
 
         # Fail on failure, should fail
         pack_dir = os.path.join(get_fixtures_base_path(), 'dummy_pack_4')
-        cmd = BASE_CMD_ARGS + ['--register-pack=%s' % (pack_dir), '--register-fail-on-failure']
+        cmd = BASE_REGISTER_ACTIONS_CMD_ARGS + ['--register-pack=%s' % (pack_dir),
+                                                '--register-fail-on-failure']
         exit_code, _, stderr = run_command(cmd=cmd)
         self.assertTrue('object has no attribute \'get\'' in stderr)
         self.assertEqual(exit_code, 1)
@@ -85,4 +88,21 @@ class ContentRegisterScripTestCase(IntegrationTestCase):
         self.assertTrue('Registered 0 actions.' in stderr)
         self.assertTrue('Registered 0 sensors.' in stderr)
         self.assertTrue('Registered 0 rules.' in stderr)
+        self.assertEqual(exit_code, 0)
+
+    def test_register_setup_virtualenvs(self):
+        # Single pack
+        pack_dir = os.path.join(get_fixtures_base_path(), 'dummy_pack_1')
+
+        cmd = BASE_CMD_ARGS + ['--register-pack=%s' % (pack_dir), '--register-setup-virtualenvs']
+        exit_code, stdout, stderr = run_command(cmd=cmd)
+
+        self.assertTrue('Setting up virtualenv for pack "dummy_pack_1"' in stderr)
+        self.assertTrue('Setup virtualenv for 1 pack(s)' in stderr)
+        self.assertEqual(exit_code, 0)
+
+        # All packs
+        cmd = BASE_CMD_ARGS + ['--register-setup-virtualenvs']
+        exit_code, stdout, stderr = run_command(cmd=cmd)
+        self.assertTrue('Setup virtualenv for 4 pack(s)' in stderr)
         self.assertEqual(exit_code, 0)

--- a/tools/st2ctl
+++ b/tools/st2ctl
@@ -97,7 +97,7 @@ fi
 
 # Note: Scripts already call reload with "--register-<content>"
 if [ ${1} == "reload" -o ${1} == "clean" ]; then
-    ALLOWED_REGISTER_FLAGS=(--register-all --register-actions --register-aliases --register-policies --register-rules --register-sensors --verbose)
+    ALLOWED_REGISTER_FLAGS=(--register-all --register-actions --register-aliases --register-policies --register-rules --register-sensors --register-setup-virtualenvs --verbose)
     DEFAULT_REGISTER_FLAGS='--register-actions --register-aliases --register-sensors'
 
     if [ ! -z ${2} ]; then


### PR DESCRIPTION
I've discussed HA deployment where action runner processes run on multiple servers with @codyaray yesterday and noticed I forgot to add this flag to st2ctl in #2576.

On a related note - (afaik) we still need to document opinionated git flow and how to use this flag when using HA deployment and having action runners deployed on multiple servers.