### PR TITLE
Add "get_format_strings" utility method to the ActionAliasDB class

### DIFF
--- a/st2common/st2common/models/db/actionalias.py
+++ b/st2common/st2common/models/db/actionalias.py
@@ -86,11 +86,12 @@ class ActionAliasDB(stormbase.StormBaseDB, stormbase.ContentPackResourceMixin,
         """
         result = []
 
-        for formatstring in self.formats:
-            if isinstance(formatstring, dict) and formatstring.get('representation'):
-                result.extend(formatstring['representation'])
+        formats = getattr(self, 'formats', [])
+        for format_string in formats:
+            if isinstance(format_string, dict) and format_string.get('representation', None):
+                result.extend(format_string['representation'])
             else:
-                result.append(formatstring)
+                result.append(format_string)
 
         return result
 

--- a/st2common/st2common/models/db/actionalias.py
+++ b/st2common/st2common/models/db/actionalias.py
@@ -78,6 +78,22 @@ class ActionAliasDB(stormbase.StormBaseDB, stormbase.ContentPackResourceMixin,
         self.ref = self.get_reference().ref
         self.uid = self.get_uid()
 
+    def get_format_strings(self):
+        """
+        Return a list of all the supported format strings.
+
+        :rtype: ``list`` of ``str``
+        """
+        result = []
+
+        for formatstring in self.formats:
+            if isinstance(formatstring, dict) and formatstring.get('representation'):
+                result.extend(formatstring['representation'])
+            else:
+                result.append(formatstring)
+
+        return result
+
 
 # specialized access objects
 actionalias_access = MongoDBAccess(ActionAliasDB)

--- a/st2common/st2common/models/utils/action_alias_utils.py
+++ b/st2common/st2common/models/utils/action_alias_utils.py
@@ -129,11 +129,7 @@ def extract_parameters_for_action_alias_db(action_alias_db, format_str, param_st
     action_alias_db.formats.
     """
     formats = []
-    for formatstring in action_alias_db.formats:
-        if isinstance(formatstring, dict) and formatstring.get('representation'):
-            formats.extend(formatstring['representation'])
-        else:
-            formats.append(formatstring)
+    formats = action_alias_db.get_format_strings()
 
     if format_str not in formats:
         raise ValueError('Format string "%s" is not available on the alias "%s"' %


### PR DESCRIPTION
Discussed this with @jjm on Slack today.

This method comes handy when using `assertMatchesExactlyOneFormatString` and verifying that an alias contains no overlapping format strings which could cause issues.

When testing format strings one by one, you sadly still need to know the implementation details (is it a dict or a list) so that's not ideal and I think it would be good for us to a move to a "dict with key per format string" approach we've discussed the other day (this way inside the tests you could be like `format_string = action_alias_db.get_format_string(name='pack_with_branch')` or similar).

This would provide for a better abstraction and no need for user to know the implementation details.

/cc @emedvedev @manasdk (notably the last part aka moving to dict with key model)