### PR TITLE
Include stderr in the error message in virtualenvs.py when the pip command fails.

### DIFF
--- a/st2common/st2common/util/virtualenvs.py
+++ b/st2common/st2common/util/virtualenvs.py
@@ -166,8 +166,8 @@ def install_requirements(virtualenv_path, requirements_file_path):
     exit_code, stdout, stderr = run_command(cmd=cmd, env=env)
 
     if exit_code != 0:
-        raise Exception('Failed to install requirements from "%s": %s' %
-                        (requirements_file_path, stdout))
+        raise Exception('Failed to install requirements from "%s": %s (stderr: %s)' %
+                        (requirements_file_path, stdout, stderr))
 
     return True
 


### PR DESCRIPTION
Include stderr in the error message in virtualenvs.py when the pip command fails.