### PR TITLE
Workaround for correctly casting None values to None type in rule action parameters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -97,6 +97,10 @@ in development
 * Fix alias executions API endpoint and make sure an exception is thrown if the user provided
   command string doesn't match the provided format string. Previously, a non-match was silently
   ignored. (bug fix)
+* Add custom ``use_none`` Jinja template filter which can be used inside rules when invoking an
+  action. This filter ensures that ``None`` values are correctly serialized and is to be used when
+  TriggerInstance payload value can be ``None`` and ``None`` is also a valid value for a particular
+  action parameter. (improvement, workaround)
 
 1.3.2 - February 12, 2016
 -------------------------

--- a/st2common/st2common/util/casts.py
+++ b/st2common/st2common/util/casts.py
@@ -46,9 +46,9 @@ def _cast_boolean(x):
 
 
 def _cast_string(x):
-    result = to_unicode(x)
-    result = _cast_none(result)
-    return result
+    x = to_unicode(x)
+    x = _cast_none(x)
+    return x
 
 
 def _cast_none(x):

--- a/st2common/st2common/util/casts.py
+++ b/st2common/st2common/util/casts.py
@@ -20,6 +20,7 @@ import json
 import six
 
 from st2common.util.compat import to_unicode
+from st2common.util.jinja import NONE_MAGIC_VALUE
 
 
 def _cast_object(x):
@@ -44,6 +45,23 @@ def _cast_boolean(x):
     return x
 
 
+def _cast_string(x):
+    result = to_unicode(x)
+    result = _cast_none(result)
+    return result
+
+
+def _cast_none(x):
+    """
+    Cast function which serialized special magic string value for None type to
+    None.
+    """
+    if isinstance(x, six.string_types) and x == NONE_MAGIC_VALUE:
+        return None
+
+    return x
+
+
 # These types as they appear in json schema.
 CASTS = {
     'array': _cast_object,
@@ -51,7 +69,7 @@ CASTS = {
     'integer': int,
     'number': float,
     'object': _cast_object,
-    'string': to_unicode
+    'string': _cast_string
 }
 
 

--- a/st2common/st2common/util/casts.py
+++ b/st2common/st2common/util/casts.py
@@ -29,6 +29,8 @@ def _cast_object(x):
 
     Note: String can be either serialized as JSON or a raw Python output.
     """
+    x = _cast_none(x)
+
     if isinstance(x, six.string_types):
         try:
             return json.loads(x)
@@ -39,9 +41,23 @@ def _cast_object(x):
 
 
 def _cast_boolean(x):
+    x = _cast_none(x)
+
     if isinstance(x, six.string_types):
         return ast.literal_eval(x.capitalize())
 
+    return x
+
+
+def _cast_integer(x):
+    x = _cast_none(x)
+    x = int(x)
+    return x
+
+
+def _cast_number(x):
+    x = _cast_none(x)
+    x = float(x)
     return x
 
 
@@ -53,8 +69,7 @@ def _cast_string(x):
 
 def _cast_none(x):
     """
-    Cast function which serialized special magic string value for None type to
-    None.
+    Cast function which serializes special magic string value which indicate "None" to None type.
     """
     if isinstance(x, six.string_types) and x == NONE_MAGIC_VALUE:
         return None
@@ -66,8 +81,8 @@ def _cast_none(x):
 CASTS = {
     'array': _cast_object,
     'boolean': _cast_boolean,
-    'integer': int,
-    'number': float,
+    'integer': _cast_integer,
+    'number': _cast_number,
     'object': _cast_object,
     'string': _cast_string
 }

--- a/st2common/st2common/util/jinja.py
+++ b/st2common/st2common/util/jinja.py
@@ -26,7 +26,7 @@ __all__ = [
 ]
 
 # Magic string to which None type is serialized when using use_none filter
-NONE_MAGIC_VALUE = '%__%NONE%__%'
+NONE_MAGIC_VALUE = '%*****__%NONE%__*****%'
 
 
 class CustomFilters(object):

--- a/st2common/st2common/util/jinja.py
+++ b/st2common/st2common/util/jinja.py
@@ -20,6 +20,14 @@ import re
 
 import semver
 
+__all__ = [
+    'get_jinja_environment',
+    'render_values'
+]
+
+# Magic string to which None type is serialized when using use_none filter
+NONE_MAGIC_VALUE = '%__%NONE%__%'
+
 
 class CustomFilters(object):
     '''
@@ -93,6 +101,13 @@ class CustomFilters(object):
         return "{major}.{minor}".format(**semver.parse(value))
 
     @staticmethod
+    def _use_none(value):
+        if value is None:
+            return NONE_MAGIC_VALUE
+
+        return value
+
+    @staticmethod
     def get_filters():
         return {
             'regex_match': CustomFilters._regex_match,
@@ -106,7 +121,8 @@ class CustomFilters(object):
             'version_bump_major': CustomFilters._version_bump_major,
             'version_bump_minor': CustomFilters._version_bump_minor,
             'version_bump_patch': CustomFilters._version_bump_patch,
-            'version_strip_patch': CustomFilters._version_strip_patch
+            'version_strip_patch': CustomFilters._version_strip_patch,
+            'use_none': CustomFilters._use_none
         }
 
 

--- a/st2tests/st2tests/fixtures/generic/rules/rule_none_no_use_none_filter.yaml
+++ b/st2tests/st2tests/fixtures/generic/rules/rule_none_no_use_none_filter.yaml
@@ -1,0 +1,21 @@
+---
+action:
+  parameters:
+    actionstr: '{{trigger.t1_p}}-{{trigger.t2_p}}'
+    ip2: '{{trigger}}'
+  ref: wolfpack.action-1
+criteria:
+  t1_p:
+    pattern: t1_p_v
+    type: equals
+description: ''
+enabled: true
+name: rule_none_no_use_none_filter
+pack: wolfpack
+tags:
+- name: tag1
+  value: dont-care
+- name: tag2
+  value: dont-care
+trigger:
+  type: wolfpack.triggertype-1

--- a/st2tests/st2tests/fixtures/generic/rules/rule_use_none_filter.yaml
+++ b/st2tests/st2tests/fixtures/generic/rules/rule_use_none_filter.yaml
@@ -1,0 +1,21 @@
+---
+action:
+  parameters:
+    actionstr: '{{trigger.t1_p | use_none}}'
+    ip2: '{{trigger}}'
+  ref: wolfpack.action-1
+criteria:
+  t1_p:
+    pattern: t1_p_v
+    type: equals
+description: ''
+enabled: true
+name: rule_use_none_filter
+pack: wolfpack
+tags:
+- name: tag1
+  value: dont-care
+- name: tag2
+  value: dont-care
+trigger:
+  type: wolfpack.triggertype-1

--- a/st2tests/st2tests/fixtures/generic/traces/trace_for_test_enforce_2.yaml
+++ b/st2tests/st2tests/fixtures/generic/traces/trace_for_test_enforce_2.yaml
@@ -1,0 +1,8 @@
+---
+trace_tag : trace_for_test_enforce
+action_executions : []
+rules : []
+trigger_instances :
+    - object_id: 'triggerinstance-test2'    # value from test_enforce.py
+      ref: pack1.trigger1
+      updated_at: '2014-09-01T00:00:02.000000Z'

--- a/st2tests/st2tests/fixtures/generic/traces/trace_for_test_enforce_3.yaml
+++ b/st2tests/st2tests/fixtures/generic/traces/trace_for_test_enforce_3.yaml
@@ -1,0 +1,8 @@
+---
+trace_tag : trace_for_test_enforce
+action_executions : []
+rules : []
+trigger_instances :
+    - object_id: 'triggerinstance-test3'    # value from test_enforce.py
+      ref: pack1.trigger1
+      updated_at: '2014-09-01T00:00:02.000000Z'

--- a/st2tests/st2tests/fixturesloader.py
+++ b/st2tests/st2tests/fixturesloader.py
@@ -167,12 +167,16 @@ class FixturesLoader(object):
 
         db_models = {}
         for fixture_type, fixtures in six.iteritems(fixtures_dict):
-
             API_MODEL = FIXTURE_API_MODEL.get(fixture_type, None)
             PERSISTENCE_MODEL = FIXTURE_PERSISTENCE_MODEL.get(fixture_type, None)
 
             loaded_fixtures = {}
             for fixture in fixtures:
+                # Guard against copy and type and similar typos
+                if fixture in loaded_fixtures:
+                    msg = 'Fixture "%s" is specified twice, probably a typo.' % (fixture)
+                    raise ValueError(msg)
+
                 fixture_dict = self.meta_loader.load(
                     self._get_fixture_file_path_abs(fixtures_pack_path, fixture_type, fixture))
                 api_model = API_MODEL(**fixture_dict)


### PR DESCRIPTION
This is a work-around for issue described at #2621.

This is a short-term workaround until we switch from Jinja to a better system which supports types which means we won't need to do nasty and potentially error prone casting anymore.


## TODO

- [x] Docs - https://github.com/StackStorm/st2docs/pull/116

/cc @jjm 