### PR TITLE
Make st2ctl ignore services that aren't installed

### DIFF
--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -71,10 +71,10 @@ function st2start() {
 
 function st2stop() {
   for COM in ${COMPONENTS}; do
-      service_manager $COM status >/dev/null 2>&1;
-      if [[ "1" == $? ]]; then
-        continue
-      fi
+    service_manager $COM status >/dev/null 2>&1;
+    if [[ "1" == $? ]]; then
+      continue
+    fi
     service_manager ${COM} stop
   done
 }

--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -2,7 +2,7 @@
 
 
 LOGFILE="/dev/null"
-COMPONENTS="st2actionrunner st2api st2stream st2auth st2garbagecollector st2notifier st2resultstracker st2rulesengine st2sensorcontainer mistral"
+COMPONENTS="st2actionrunner st2api st2stream st2auth st2garbagecollector st2notifier st2resultstracker st2rulesengine st2sensorcontainer st2chatops mistral"
 STANCONF="/etc/st2/st2.conf"
 
 # Ensure global environment is sourced if exists
@@ -61,12 +61,20 @@ function validate_in_components() {
 
 function st2start() {
   for COM in ${COMPONENTS}; do
+    service_manager $COM status >/dev/null 2>&1;
+    if [[ "1" == $? ]]; then
+      continue
+    fi
     service_manager ${COM} start
   done
 }
 
 function st2stop() {
   for COM in ${COMPONENTS}; do
+      service_manager $COM status >/dev/null 2>&1;
+      if [[ "1" == $? ]]; then
+        continue
+      fi
     service_manager ${COM} stop
   done
 }
@@ -151,6 +159,10 @@ function getpids() {
   COMPONENTS=${COMPONENTS/mistral/mistral-server mistral-api}
 
   for COM in ${COMPONENTS}; do
+    service_manager $COM status >/dev/null 2>&1;
+    if [[ "1" == $? ]]; then
+      continue
+    fi
     PID=`ps ax | grep -v grep | grep -v st2ctl | grep "${COM}" | awk '{print $1}'`
 
     if [[ ! -z ${PID} ]]; then


### PR DESCRIPTION
This is my proposed fix to the issue outlined in #2550: st2ctl will give an “unknown service” error if one of the packages (chatops in that case) wasn’t installed.

The script makes a `status` call before start/stop, and if the exit code is 1, the service is not shown in the list. I checked on RHEL6 and Ubuntu that `1` is only given when the service doesn’t exist, otherwise it gives other codes.

Can be tested by removing the st2chatops package or stopping the service and then trying to stop it again.

Includes st2chatops, so trumps #2550.