### PR TITLE
Secrets in kv store phase #0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,6 +319,13 @@ packs-tests: requirements .packs-tests
 	@echo
 	. $(VIRTUALENV_DIR)/bin/activate; find ${ROOT_DIR}/contrib/* -maxdepth 0 -type d -print0 | xargs -0 -I FILENAME ./st2common/bin/st2-run-pack-tests -x -p FILENAME
 
+.PHONY: cli
+cli:
+	@echo
+	@echo "=================== Building st2 client ==================="
+	@echo
+	pushd $(CURDIR) && cd st2client && ((python setup.py develop || printf "\n\n!!! ERROR: BUILD FAILED !!!\n") || popd)
+
 .PHONY: rpms
 rpms:
 	@echo

--- a/conf/st2.dev.conf
+++ b/conf/st2.dev.conf
@@ -11,6 +11,9 @@ mask_secrets = False
 # Development vagrant VM is setup to run on 172.168.50.50.
 allow_origin = http://172.168.50.50:3000
 
+[keyvalue]
+encryption_key_path = conf/st2_kvstore_demo.crypto.key.json
+
 [stream]
 # Host and port to bind the API server.
 host = 0.0.0.0

--- a/conf/st2_kvstore_demo.crypto.key.json
+++ b/conf/st2_kvstore_demo.crypto.key.json
@@ -1,0 +1,1 @@
+{"hmacKey": {"hmacKeyString": "685EWJ8U2U_c3Ulv9ibB6aa0Y9aYm-0bCwe2mqjLJuw", "size": 256}, "aesKeyString": "eKGFrfNEUhAgX0uofaU1wQ", "mode": "CBC", "size": 128}

--- a/st2api/st2api/controllers/v1/keyvalue.py
+++ b/st2api/st2api/controllers/v1/keyvalue.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from oslo_config import cfg
 from pecan import abort
 from pecan.rest import RestController
 import six
@@ -47,19 +46,20 @@ class KeyValuePairController(RestController):
         self.get_one_db_method = self.__get_by_name
 
     @jsexpose(arg_types=[str, str])
-    def get_one(self, name, decrypt):
+    def get_one(self, name, decrypt='false'):
         """
             List key by name.
 
             Handle:
                 GET /keys/key1
         """
-        kvp_db = self.__get_by_name(name=name)
 
         if not decrypt:
             decrypt = False
         else:
             decrypt = (decrypt == 'true' or decrypt == 'True' or decrypt == '1')
+
+        kvp_db = self.__get_by_name(name=name)
 
         if not kvp_db:
             LOG.exception('Database lookup for name="%s" resulted in exception.', name)

--- a/st2api/st2api/controllers/v1/keyvalue.py
+++ b/st2api/st2api/controllers/v1/keyvalue.py
@@ -85,12 +85,21 @@ class KeyValuePairController(RestController):
         # Prefix filtering
         prefix_filter = kw.get('prefix', None)
 
+        decrypt = kw.get('decrypt', None)
+        if not decrypt:
+            decrypt = False
+        else:
+            decrypt = (decrypt == 'true' or decrypt == 'True' or decrypt == '1')
+            del kw['decrypt']
+
         if prefix_filter:
             kw['name__startswith'] = prefix_filter
             del kw['prefix']
 
         kvp_dbs = KeyValuePair.get_all(**kw)
-        kvps = [KeyValuePairAPI.from_model(kvp_db) for kvp_db in kvp_dbs]
+        kvps = [KeyValuePairAPI.from_model(
+            kvp_db, mask_secrets=(not decrypt)) for kvp_db in kvp_dbs
+        ]
 
         return kvps
 

--- a/st2api/st2api/controllers/v1/keyvalue.py
+++ b/st2api/st2api/controllers/v1/keyvalue.py
@@ -13,12 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from oslo_config import cfg
 from pecan import abort
 from pecan.rest import RestController
 import six
 from mongoengine import ValidationError
 
 from st2common import log as logging
+from st2common.exceptions.keyvalue import CryptoKeyNotSetupException
 from st2common.models.api.keyvalue import KeyValuePairAPI
 from st2common.models.api.base import jsexpose
 from st2common.persistence.keyvalue import KeyValuePair
@@ -113,7 +115,10 @@ class KeyValuePairController(RestController):
                 LOG.exception('Validation failed for key value data=%s', kvp)
                 abort(http_client.BAD_REQUEST, str(e))
                 return
-
+            except CryptoKeyNotSetupException as e:
+                LOG.exception(str(e))
+                abort(http_client.BAD_REQUEST, str(e))
+                return
         extra = {'kvp_db': kvp_db}
         LOG.audit('KeyValuePair updated. KeyValuePair.id=%s' % (kvp_db.id), extra=extra)
 

--- a/st2client/st2client/commands/resource.py
+++ b/st2client/st2client/commands/resource.py
@@ -287,7 +287,7 @@ class ResourceGetCommand(ResourceCommand):
     @add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
         resource_id = getattr(args, self.pk_argument_name, None)
-        return self.get_resource(resource_id, **kwargs)
+        return self.get_resource_by_id(resource_id, **kwargs)
 
     def run_and_print(self, args, **kwargs):
         try:

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -169,7 +169,7 @@ class ResourceManager(object):
         prefix = kwargs.pop('prefix', None)
         user = kwargs.pop('user', None)
 
-        params = {}
+        params = kwargs.pop('params', {})
         if limit and limit <= 0:
             limit = None
         if limit:

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -240,7 +240,8 @@ class ResourceManager(object):
         if 'limit' in kwargs and kwargs.get('limit') <= 0:
             kwargs.pop('limit')
         token = kwargs.get('token', None)
-        params = {}
+        params = kwargs.get('params', {})
+        print(params)
         for k, v in six.iteritems(kwargs):
             if k != 'token':
                 params[k] = v

--- a/st2client/tests/unit/test_commands.py
+++ b/st2client/tests/unit/test_commands.py
@@ -73,22 +73,8 @@ class TestResourceCommand(unittest2.TestCase):
         self.assertEqual(actual, expected)
 
     @mock.patch.object(
-        models.ResourceManager, 'get_by_name',
-        mock.MagicMock(return_value=base.FakeResource(**base.RESOURCES[0])))
-    @mock.patch.object(
-        models.ResourceManager, 'get_by_id',
-        mock.MagicMock(return_value=None))
-    def test_command_get_by_name(self):
-        args = self.parser.parse_args(['fakeresource', 'get', 'abc'])
-        self.assertEqual(args.func, self.branch.commands['get'].run_and_print)
-        instance = self.branch.commands['get'].run(args)
-        actual = instance.serialize()
-        expected = json.loads(json.dumps(base.RESOURCES[0]))
-        self.assertEqual(actual, expected)
-
-    @mock.patch.object(
         httpclient.HTTPClient, 'get',
-        mock.MagicMock(return_value=base.FakeResponse(json.dumps([base.RESOURCES[0]]), 200, 'OK')))
+        mock.MagicMock(return_value=base.FakeResponse(json.dumps(base.RESOURCES[0]), 200, 'OK')))
     def test_command_get(self):
         args = self.parser.parse_args(['fakeresource', 'get', 'abc'])
         self.assertEqual(args.func, self.branch.commands['get'].run_and_print)

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -11,6 +11,7 @@ oslo.config
 paramiko
 pyyaml
 pymongo
+python-keyczar
 requests
 retrying
 semver

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -139,6 +139,17 @@ def register_opts(ignore_errors=False):
     ]
     do_register_opts(api_opts, 'api', ignore_errors)
 
+    # Key Value store options
+    keyvalue_opts = [
+        cfg.BoolOpt('enable_encryption', default=True,
+                    help='Allow encryption of values in key value stored qualified as "secret".'),
+        cfg.StrOpt('encryption_key_path', default='conf/st2_kvstore_demo.crypto.key.json',
+                   help='Location of the symmetric encryption key for encrypting values in ' +
+                        'kvstore. This key should be in JSON and should\'ve been ' +
+                        'generated using keyczar.')
+    ]
+    do_register_opts(keyvalue_opts, group='keyvalue')
+
     # Common auth options
     auth_opts = [
         cfg.StrOpt('api_url', default=None,

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -143,7 +143,7 @@ def register_opts(ignore_errors=False):
     keyvalue_opts = [
         cfg.BoolOpt('enable_encryption', default=True,
                     help='Allow encryption of values in key value stored qualified as "secret".'),
-        cfg.StrOpt('encryption_key_path', default='conf/st2_kvstore_demo.crypto.key.json',
+        cfg.StrOpt('encryption_key_path', default='',
                    help='Location of the symmetric encryption key for encrypting values in ' +
                         'kvstore. This key should be in JSON and should\'ve been ' +
                         'generated using keyczar.')

--- a/st2common/st2common/exceptions/keyvalue.py
+++ b/st2common/st2common/exceptions/keyvalue.py
@@ -1,0 +1,24 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from st2common.exceptions import StackStormBaseException
+
+__all__ = [
+    'CryptoKeyNotSetupException',
+]
+
+
+class CryptoKeyNotSetupException(StackStormBaseException):
+    pass

--- a/st2common/st2common/models/api/keyvalue.py
+++ b/st2common/st2common/models/api/keyvalue.py
@@ -100,7 +100,7 @@ class KeyValuePairAPI(BaseAPI):
             return key
 
     @classmethod
-    def from_model(cls, model, mask_secrets=False):
+    def from_model(cls, model, mask_secrets=True):
         if not KeyValuePairAPI.crypto_setup:
             KeyValuePairAPI._setup_crypto()
 

--- a/st2common/st2common/models/api/keyvalue.py
+++ b/st2common/st2common/models/api/keyvalue.py
@@ -110,7 +110,7 @@ class KeyValuePairAPI(BaseAPI):
             del doc['id']
 
         if not mask_secrets and model.encrypted:
-            doc[value] = symmetric_decrypt(KeyValuePairAPI.crypto_key, value)
+            doc['value'] = symmetric_decrypt(KeyValuePairAPI.crypto_key, model.value)
 
         if model.expire_timestamp:
             doc['expire_timestamp'] = isotime.format(model.expire_timestamp, offset=False)

--- a/st2common/st2common/models/api/keyvalue.py
+++ b/st2common/st2common/models/api/keyvalue.py
@@ -14,16 +14,25 @@
 # limitations under the License.
 
 import datetime
+import json
+import os
 
+from keyczar.keys import AesKey
+from oslo_config import cfg
 import six
 
+from st2common.exceptions.keyvalue import CryptoKeyNotSetupException
+from st2common.log import logging
 from st2common.util import isotime
 from st2common.util import date as date_utils
+from st2common.util.crypto import symmetric_encrypt, symmetric_decrypt
 from st2common.models.api.base import BaseAPI
 from st2common.models.db.keyvalue import KeyValuePairDB
 
+LOG = logging.getLogger(__name__)
 
 class KeyValuePairAPI(BaseAPI):
+    crypto_setup = False
     model = KeyValuePairDB
     schema = {
         'type': 'object',
@@ -44,6 +53,11 @@ class KeyValuePairAPI(BaseAPI):
                 'type': 'string',
                 'required': True
             },
+            'secret': {
+                'type': 'boolean',
+                'required': False,
+                'default': False
+            },
             'expire_timestamp': {
                 'type': 'string',
                 'pattern': isotime.ISO8601_UTC_REGEX
@@ -57,12 +71,46 @@ class KeyValuePairAPI(BaseAPI):
         'additionalProperties': False
     }
 
+    @staticmethod
+    def _setup_crypto():
+        LOG.info('Checking if encryption is enabled for key-value store.')
+        KeyValuePairAPI.is_encryption_enabled = cfg.CONF.keyvalue.enable_encryption
+        LOG.debug('Encryption enabled? : %s', KeyValuePairAPI.is_encryption_enabled)
+        if KeyValuePairAPI.is_encryption_enabled:
+            KeyValuePairAPI.crypto_key_path = cfg.CONF.keyvalue.encryption_key_path
+            LOG.info('Encryption enabled. Looking for key in path %s',
+                     KeyValuePairAPI.crypto_key_path)
+            if not os.path.exists(KeyValuePairAPI.crypto_key_path):
+                msg = ('Encryption key file does not exist in path %s.' %
+                        KeyValuePairAPI.crypto_key_path)
+                LOG.exception(msg)
+                LOG.info('All API requests will now send out BAD_REQUEST ' +
+                         'if you ask to store secrets in key value store.')
+                KeyValuePairAPI.crypto_key = None
+            else:
+                KeyValuePairAPI.crypto_key = KeyValuePairAPI._read_crypto_key(
+                    KeyValuePairAPI.crypto_key_path
+                )
+        KeyValuePairAPI.crypto_setup = True
+
+    @staticmethod
+    def _read_crypto_key(key_path):
+        with open(key_path) as f:
+            key = AesKey.Read(f.read())
+            return key
+
     @classmethod
     def from_model(cls, model, mask_secrets=False):
+        if not KeyValuePairAPI.crypto_setup:
+            KeyValuePairAPI._setup_crypto()
+
         doc = cls._from_model(model, mask_secrets=mask_secrets)
 
         if 'id' in doc:
             del doc['id']
+
+        if not mask_secrets and model.encrypted:
+            doc[value] = symmetric_decrypt(KeyValuePairAPI.crypto_key, value)
 
         if model.expire_timestamp:
             doc['expire_timestamp'] = isotime.format(model.expire_timestamp, offset=False)
@@ -72,9 +120,13 @@ class KeyValuePairAPI(BaseAPI):
 
     @classmethod
     def to_model(cls, kvp):
+        if not KeyValuePairAPI.crypto_setup:
+            KeyValuePairAPI._setup_crypto()
+
         name = getattr(kvp, 'name', None)
         description = getattr(kvp, 'description', None)
         value = kvp.value
+        encrypted = False
 
         if getattr(kvp, 'ttl', None):
             expire_timestamp = (date_utils.get_datetime_utc_now() +
@@ -82,7 +134,16 @@ class KeyValuePairAPI(BaseAPI):
         else:
             expire_timestamp = None
 
+        if getattr(kvp, 'secret', False):
+            if not KeyValuePairAPI.crypto_key:
+                msg = ('Crypto key not found in %s. Unable to encrypt value for key %s.' %
+                        (KeyValuePairAPI.crypto_key_path, name))
+                raise CryptoKeyNotSetupException(msg)
+            value = symmetric_encrypt(KeyValuePairAPI.crypto_key, value)
+            encrypted = True
+
         model = cls.model(name=name, description=description, value=value,
+                          encrypted=encrypted,
                           expire_timestamp=expire_timestamp)
 
         return model

--- a/st2common/st2common/models/db/keyvalue.py
+++ b/st2common/st2common/models/db/keyvalue.py
@@ -36,7 +36,7 @@ class KeyValuePairDB(stormbase.StormBaseDB, stormbase.UIDFieldMixin):
 
     name = me.StringField(required=True, unique=True)
     value = me.StringField()
-    encrypted = me.BooleanField(default=False)
+    secret = me.BooleanField(default=False)
     expire_timestamp = me.DateTimeField()
 
     meta = {

--- a/st2common/st2common/models/db/keyvalue.py
+++ b/st2common/st2common/models/db/keyvalue.py
@@ -36,6 +36,7 @@ class KeyValuePairDB(stormbase.StormBaseDB, stormbase.UIDFieldMixin):
 
     name = me.StringField(required=True, unique=True)
     value = me.StringField()
+    encrypted = me.BooleanField(default=False)
     expire_timestamp = me.DateTimeField()
 
     meta = {

--- a/st2common/st2common/util/crypto.py
+++ b/st2common/st2common/util/crypto.py
@@ -1,0 +1,22 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def symmetric_encrypt(encrypt_key, message):
+    return encrypt_key.Encrypt(message)
+
+
+def symmetric_decrypt(decrypt_key, crypto):
+    return decrypt_key.Decrypt(crypto)

--- a/st2common/st2common/util/crypto.py
+++ b/st2common/st2common/util/crypto.py
@@ -17,8 +17,38 @@ import binascii
 
 
 def symmetric_encrypt(encrypt_key, message):
+    """
+    Encrypt the given message using the encrypt_key. Returns a UTF-8 str
+    ready to be stored in database. Note that we convert the hex notation
+    to a ASCII notation to produce a UTF-8 friendly string.
+
+    Also, this method will not return the same output on multiple invocations
+    of same method. The reason is that the Encrypt method uses a different
+    'Initialization Vector' per run and the IV is part of the output.
+
+    :param encrypt_key: Symmetric AES key to use for encryption.
+    :type encrypt_key: :class:`keyczar.keys.AesKey`
+
+    :param message: Message to be encrypted.
+    :type message: ``str``
+
+    :rtype: ``str``
+    """
     return binascii.hexlify(encrypt_key.Encrypt(message)).upper()
 
 
 def symmetric_decrypt(decrypt_key, crypto):
+    """
+    Decrypt the given crypto text into plain text. Returns the original
+    string input. Note that we first convert the string to hex notation
+    and then decrypt. This is reverse of the encrypt operation.
+
+    :param decrypt_key: Symmetric AES key to use for decryption.
+    :type decrypt_key: :class:`keyczar.keys.AesKey`
+
+    :param crypto: Crypto text to be decrypted.
+    :type crypto: ``str``
+
+    :rtype: ``str``
+    """
     return decrypt_key.Decrypt(binascii.unhexlify(crypto))

--- a/st2common/st2common/util/crypto.py
+++ b/st2common/st2common/util/crypto.py
@@ -15,6 +15,7 @@
 
 import binascii
 
+
 def symmetric_encrypt(encrypt_key, message):
     return binascii.hexlify(encrypt_key.Encrypt(message)).upper()
 

--- a/st2common/st2common/util/crypto.py
+++ b/st2common/st2common/util/crypto.py
@@ -13,10 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import binascii
 
 def symmetric_encrypt(encrypt_key, message):
-    return encrypt_key.Encrypt(message)
+    return binascii.hexlify(encrypt_key.Encrypt(message)).upper()
 
 
 def symmetric_decrypt(decrypt_key, crypto):
-    return decrypt_key.Decrypt(crypto)
+    return decrypt_key.Decrypt(binascii.unhexlify(crypto))

--- a/st2common/tests/unit/test_crypto_utils.py
+++ b/st2common/tests/unit/test_crypto_utils.py
@@ -1,0 +1,44 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the 'License'); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from keyczar.keys import AesKey
+from unittest2 import TestCase
+
+
+import st2common.util.crypto as crypto_utils
+
+
+class CryptoUtilsTestCase(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(CryptoUtilsTestCase, cls).setUpClass()
+        CryptoUtilsTestCase.test_crypto_key = AesKey.Generate()
+
+    def test_symmetric_encrypt_decrypt(self):
+        original = 'secret'
+        crypto = crypto_utils.symmetric_encrypt(CryptoUtilsTestCase.test_crypto_key, original)
+        plain = crypto_utils.symmetric_decrypt(CryptoUtilsTestCase.test_crypto_key, crypto)
+        self.assertEqual(plain, original)
+
+    def test_encrypt_output_is_diff_due_to_diff_IV(self):
+        original = 'Kami is a little boy.'
+        cryptos = set()
+
+        for _ in xrange(0, 10000):
+            crypto = crypto_utils.symmetric_encrypt(CryptoUtilsTestCase.test_crypto_key,
+                                                    original)
+            self.assertTrue(crypto not in cryptos)
+            cryptos.add(crypto)

--- a/st2common/tests/unit/test_keyvalue_lookup.py
+++ b/st2common/tests/unit/test_keyvalue_lookup.py
@@ -57,3 +57,16 @@ class TestKeyValueLookup(CleanDbTestCase):
         lookup = KeyValueLookup()
         self.assertEquals(str(lookup.missing_key), '')
         self.assertTrue(lookup.missing_key, 'Should be not none.')
+
+    def test_secret_lookup(self):
+        secret_value = '0055A2D9A09E1071931925933744965EEA7E23DCF59A8D1D7A3' + \
+                       '64338294916D37E83C4796283C584751750E39844E2FD97A3727DB5D553F638'
+        k1 = KeyValuePair.add_or_update(KeyValuePairDB(
+            name='k1', value=secret_value,
+            secret=True, encrypted=True)
+        )
+        k2 = KeyValuePair.add_or_update(KeyValuePairDB(name='k2', value='v2'))
+
+        lookup = KeyValueLookup()
+        self.assertEquals(str(lookup.k1), k1.value)
+        self.assertEquals(str(lookup.k2), k2.value)

--- a/st2tests/conf/st2_kvstore_tests.crypto.key.json
+++ b/st2tests/conf/st2_kvstore_tests.crypto.key.json
@@ -1,0 +1,1 @@
+{"hmacKey": {"hmacKeyString": "685EWJ8U2U_c3Ulv9ibB6aa0Y9aYm-0bCwe2mqjLJuw", "size": 256}, "aesKeyString": "eKGFrfNEUhAgX0uofaU1wQ", "mode": "CBC", "size": 128}

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -46,6 +46,7 @@ def _override_config_opts():
     _override_db_opts()
     _override_common_opts()
     _override_api_opts()
+    _override_keyvalue_opts()
 
 
 def _register_config_opts():
@@ -79,6 +80,12 @@ def _override_common_opts():
 def _override_api_opts():
     CONF.set_override(name='allow_origin', override=['http://127.0.0.1:3000', 'http://dev'],
                       group='api')
+
+
+def _override_keyvalue_opts():
+    CONF.set_override(name='encryption_key_path',
+                      override='st2tests/conf/st2_kvstore_tests.crypto.key.json',
+                      group='keyvalue')
 
 
 def _register_common_opts():

--- a/tools/st2-generate-symmetric-crypto-key.py
+++ b/tools/st2-generate-symmetric-crypto-key.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python
 
 import argparse
-import datetime
 import os
-import shutil
 import sys
-import traceback
 
 from keyczar.keys import AesKey
 

--- a/tools/st2-generate-symmetric-crypto-key.py
+++ b/tools/st2-generate-symmetric-crypto-key.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+import argparse
+import datetime
+import os
+import shutil
+import sys
+import traceback
+
+from keyczar.keys import AesKey
+
+
+def _backup_old_key(key_path):
+    base_path = os.path.dirname(key_path)
+    dt_str = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    bkup_file_name = os.path.basename(key_path) + '.bkup-%s' % dt_str
+    shutil.move(key_path, os.path.join(base_path, bkup_file_name))
+    print('WARNING: Backed up old key file to %s.' % bkup_file_name)
+
+
+def main(key_path, force=False):
+    base_path = os.path.dirname(key_path)
+    if not os.access(base_path, os.W_OK):
+        print('ERROR: You do not have sufficient permissions to write to path: %s.' % key_path)
+        print('Try setting up permissions correctly and then run this tool.')
+        sys.exit(1)
+
+    if os.path.exists(key_path):
+        print('You already have a key at the specified location %s!' % key_path)
+
+        if not force:
+            print('Not generating a new key. Either delete the file or re-run with --force.')
+            sys.exit(2)
+        else:
+            try:
+                _backup_old_key(key_path)
+            except:
+                traceback.print_exc()
+                print('WARNING: Failed backing up old key! Ignoring!')
+
+        print('Generating new key...')
+
+    with open(key_path, 'w') as key_file:
+        k = AesKey.Generate()
+        key_file.write(str(k))
+        key_file.flush()
+
+    msg = ('Key written to %s. ' % key_path + 'Secure the permissions so only StackStorm API ' +
+           'process and StackStorm admin access the file.')
+    print(msg)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Tool for crypto key generation.')
+    parser.add_argument('-k', '--key-path',
+                        required=True,
+                        help='Path to file to write key to. Secure permissions of file so ' +
+                        'only admin can read the crypto key.')
+    parser.add_argument('-f', '--force', action='store_true',
+                        help='Force rewrite the key file if already exists.')
+
+    args = parser.parse_args()
+    main(key_path=args.key_path, force=args.force)

--- a/tools/st2-generate-symmetric-crypto-key.py
+++ b/tools/st2-generate-symmetric-crypto-key.py
@@ -10,14 +10,6 @@ import traceback
 from keyczar.keys import AesKey
 
 
-def _backup_old_key(key_path):
-    base_path = os.path.dirname(key_path)
-    dt_str = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-    bkup_file_name = os.path.basename(key_path) + '.bkup-%s' % dt_str
-    shutil.move(key_path, os.path.join(base_path, bkup_file_name))
-    print('WARNING: Backed up old key file to %s.' % bkup_file_name)
-
-
 def main(key_path, force=False):
     base_path = os.path.dirname(key_path)
     if not os.access(base_path, os.W_OK):
@@ -31,14 +23,8 @@ def main(key_path, force=False):
         if not force:
             print('Not generating a new key. Either delete the file or re-run with --force.')
             sys.exit(2)
-        else:
-            try:
-                _backup_old_key(key_path)
-            except:
-                traceback.print_exc()
-                print('WARNING: Failed backing up old key! Ignoring!')
 
-        print('Generating new key...')
+        print('WARNING: Rewriting existing key with new key!')
 
     with open(key_path, 'w') as key_file:
         k = AesKey.Generate()


### PR DESCRIPTION
## What? 

This PR allows encrypted items to be stored in key value store. The encryption is symmetric AES256 encryption and we use keyczar to do this. The encryption key is global for all keys. So StackStorm admin can decrypt all the keys. However, with RBAC, we'll make sure only intended user (and admin) can decrypt the user's keys. 

## TODO
* [x] Encrypted values are non UTF-8. Mongoengine complains about that. 
* [x] CLI changes
  * [X] st2 keyvalue get changes 
  * [x] st2 keyvalue list changes
* [x] Tests
* [X] Tool for generating AES key in tools/ 249340e
* [X] Docs https://github.com/StackStorm/st2docs/pull/125

## CLI examples

### PUT
```
(virtualenv)vagrant@st2dev /mnt/src/storm/st2 (secrets_kv_store●●)$ st2 key set foo bar                                                                                                                                                       [ruby-1.9.3p484]
+------------------+-------+
| Property         | Value |
+------------------+-------+
| name             | foo   |
| value            | bar   |
| expire_timestamp |       |
+------------------+-------+
(virtualenv)vagrant@st2dev /mnt/src/storm/st2 (secrets_kv_store●●)$ st2 key set secret_foo secret_bar --encrypt                                                                                                                               [ruby-1.9.3p484]
+------------------+--------------------------------------------------------------+
| Property         | Value                                                        |
+------------------+--------------------------------------------------------------+
| name             | secret_foo                                                   |
| value            | 0083E1033A7C286818517F1DDD2190042C6F6161A4A6318CA7A7767B97E8 |
|                  | DCD2984F36B070A60BA3BFE0ACF0C583F6DE8233B7C842E2EAD2D6       |
| expire_timestamp |                                                              |
+------------------+--------------------------------------------------------------+
(virtualenv)vagrant@st2dev /mnt/src/storm/st2 (secrets_kv_store●●)$
```

### GET
```
(virtualenv)vagrant@st2dev /mnt/src/storm/st2 (secrets_kv_store●●)$ st2 key get secret_foo --decrypt                                                                                                                                          [ruby-1.9.3p484]
+------------------+------------+
| Property         | Value      |
+------------------+------------+
| name             | secret_foo |
| value            | secret_bar |
| secret           | True       |
| encrypted        | False      |
| expire_timestamp |            |
+------------------+------------+
(virtualenv)vagrant@st2dev /mnt/src/storm/st2 (secrets_kv_store●●)$ st2 key get secret_foo                                                                                                                                                    [ruby-1.9.3p484]
+------------------+--------------------------------------------------------------+
| Property         | Value                                                        |
+------------------+--------------------------------------------------------------+
| name             | secret_foo                                                   |
| value            | 0083E1033A90EB483B7368A414E9456928FDAB3808830B553CA63691E045 |
|                  | 3990D8B4BEB0263B3F9363F1D19CF06BF70EC9B2D81F7F7F0F6199       |
| secret           | True                                                         |
| encrypted        | True                                                         |
| expire_timestamp |                                                              |
+------------------+--------------------------------------------------------------+
(virtualenv)vagrant@st2dev /mnt/src/storm/st2 (secrets_kv_store●●)$ st2 key get foo                                                                                                                                                           [ruby-1.9.3p484]
+------------------+-------+
| Property         | Value |
+------------------+-------+
| name             | foo   |
| value            | bar   |
| secret           | False |
| encrypted        | False |
| expire_timestamp |       |
+------------------+-------+
(virtualenv)vagrant@st2dev /mnt/src/storm/st2 (secrets_kv_store●●)$
```

### List
```
(virtualenv)vagrant@st2dev /mnt/src/storm/st2 (secrets_kv_store●●)$ st2 key list --decrypt                                                                                                                                                   [ruby-1.9.3p484]

+------------+------------+--------+-----------+------------------+
| name       | value      | secret | encrypted | expire_timestamp |
+------------+------------+--------+-----------+------------------+
| secret_foo | secret_bar | True   | False     |                  |
| foo        | bar        | False  | False     |                  |
+------------+------------+--------+-----------+------------------+
(virtualenv)vagrant@st2dev /mnt/src/storm/st2 (secrets_kv_store●●)$                                                                                                                                                                          [ruby-1.9.3p484]
(virtualenv)vagrant@st2dev /mnt/src/storm/st2 (secrets_kv_store●●)$ st2 key list                                                                                                                                                             [ruby-1.9.3p484]
+------------+----------------------------------------------------+--------+-----------+------------------+
| name       | value                                              | secret | encrypted | expire_timestamp |
+------------+----------------------------------------------------+--------+-----------+------------------+
| secret_foo | 0083E1033A040EA17E5D5A61E1087675EEFED8C7A1BFF0927F | True   | True      |                  |
|            | EDEF0BE9C948044A87BE35DE9238FC67E707D377999C3FEA43 |        |           |                  |
|            | 17B4EF32371572                                     |        |           |                  |
| foo        | bar                                                | False  | False     |                  |
+------------+----------------------------------------------------+--------+-----------+------------------+
(virtualenv)vagrant@st2dev /mnt/src/storm/st2 (secrets_kv_store●●)$
```
## API examples

### No secret case

```
(virtualenv)vagrant@st2dev /mnt/src/storm/st2 (secrets_kv_store●●)$ http PUT http://127.0.0.1:9101/v1/keys/foo < kv_nosecret.json                                                                                                             [ruby-1.9.3p484]
HTTP/1.1 200 OK
Access-Control-Allow-Headers: Content-Type,Authorization,X-Auth-Token,St2-Api-Key,X-Request-ID
Access-Control-Allow-Methods: GET,POST,PUT,DELETE,OPTIONS
Access-Control-Allow-Origin: http://172.168.50.50:3000
Access-Control-Expose-Headers: Content-Type,X-Limit,X-Total-Count,X-Request-ID
Connection: keep-alive
Content-Length: 97
Content-Type: application/json; charset=UTF-8
Date: Thu, 21 Apr 2016 20:12:54 GMT
Server: gunicorn/19.4.5
X-Request-ID: 6244e7c9-bdd3-4040-9da5-2941e84391eb

{
    "encrypted": false,
    "name": "foo",
    "secret": false,
    "uid": "key_value_pair:foo",
    "value": "bar"
}

(virtualenv)vagrant@st2dev /mnt/src/storm/st2 (secrets_kv_store●●)$
```

### Secret case. No encryption key setup by admin

XXX: Note I return 400 BAD REQUEST. Opinions welcome. 

```
(virtualenv)vagrant@st2dev /mnt/src/storm/st2 (secrets_kv_store●)$ http PUT http://127.0.0.1:9101/v1/keys/secret_foo < kv.json                                                                                                               [ruby-1.9.3p484]
HTTP/1.1 400 Bad Request
Access-Control-Allow-Headers: Content-Type,Authorization,X-Auth-Token,St2-Api-Key,X-Request-ID
Access-Control-Allow-Methods: GET,POST,PUT,DELETE,OPTIONS
Access-Control-Allow-Origin: http://172.168.50.50:3000
Access-Control-Expose-Headers: Content-Type,X-Limit,X-Total-Count,X-Request-ID
Connection: keep-alive
Content-Length: 131
Content-Type: application/json
Date: Tue, 19 Apr 2016 23:43:26 GMT
Server: gunicorn/19.4.5
X-Request-ID: 14ae1cf2-f6be-472b-b1e4-8fa46b4d6148

{
    "faultstring": "Crypto key not found in conf/st2_kvstore_demo.crypto.key.json. Unable to encrypt value for key secret_foo."
}

(virtualenv)vagrant@st2dev /mnt/src/storm/st2 (secrets_kv_store●)$
```

### Secret case. Encryption key setup. 

```
(virtualenv)vagrant@st2dev /mnt/src/storm/st2 (secrets_kv_store●●)$ http PUT http://127.0.0.1:9101/v1/keys/secret_foo < kv.json                                                                                                               [ruby-1.9.3p484]
HTTP/1.1 200 OK
Access-Control-Allow-Headers: Content-Type,Authorization,X-Auth-Token,St2-Api-Key,X-Request-ID
Access-Control-Allow-Methods: GET,POST,PUT,DELETE,OPTIONS
Access-Control-Allow-Origin: http://172.168.50.50:3000
Access-Control-Expose-Headers: Content-Type,X-Limit,X-Total-Count,X-Request-ID
Connection: keep-alive
Content-Length: 220
Content-Type: application/json; charset=UTF-8
Date: Thu, 21 Apr 2016 20:13:26 GMT
Server: gunicorn/19.4.5
X-Request-ID: 41cc580c-7557-4e1b-9e32-df4672da7a63

{
    "encrypted": true,
    "name": "secret_foo",
    "secret": true,
    "uid": "key_value_pair:secret_foo",
    "value": "0083E1033A66FF9293F6715BCF5B3918E3A18E2281B6A45B08603032571E3812C6D9CEE25BD1E060DADD8E951C85E4479C1C1BE91835BACEF1"
}

(virtualenv)vagrant@st2dev /mnt/src/storm/st2 (secrets_kv_store●●)$

(virtualenv)vagrant@st2dev /mnt/src/storm/st2 (secrets_kv_store●●)$ http GET "http://127.0.0.1:9101/v1/keys/secret_foo?decrypt=False"                                                                                                         [ruby-1.9.3p484]
HTTP/1.1 200 OK
Access-Control-Allow-Headers: Content-Type,Authorization,X-Auth-Token,St2-Api-Key,X-Request-ID
Access-Control-Allow-Methods: GET,POST,PUT,DELETE,OPTIONS
Access-Control-Allow-Origin: http://172.168.50.50:3000
Access-Control-Expose-Headers: Content-Type,X-Limit,X-Total-Count,X-Request-ID
Connection: keep-alive
Content-Length: 220
Content-Type: application/json; charset=UTF-8
Date: Thu, 21 Apr 2016 20:13:58 GMT
Server: gunicorn/19.4.5
X-Request-ID: 8ee5d905-5878-47ca-98d1-118ccddc5a3d

{
    "encrypted": true,
    "name": "secret_foo",
    "secret": true,
    "uid": "key_value_pair:secret_foo",
    "value": "0083E1033A66FF9293F6715BCF5B3918E3A18E2281B6A45B08603032571E3812C6D9CEE25BD1E060DADD8E951C85E4479C1C1BE91835BACEF1"
}

(virtualenv)vagrant@st2dev /mnt/src/storm/st2 (secrets_kv_store●●)$ http GET "http://127.0.0.1:9101/v1/keys/secret_foo?decrypt=True"                                                                                                          [ruby-1.9.3p484]
HTTP/1.1 200 OK
Access-Control-Allow-Headers: Content-Type,Authorization,X-Auth-Token,St2-Api-Key,X-Request-ID
Access-Control-Allow-Methods: GET,POST,PUT,DELETE,OPTIONS
Access-Control-Allow-Origin: http://172.168.50.50:3000
Access-Control-Expose-Headers: Content-Type,X-Limit,X-Total-Count,X-Request-ID
Connection: keep-alive
Content-Length: 117
Content-Type: application/json; charset=UTF-8
Date: Thu, 21 Apr 2016 20:14:03 GMT
Server: gunicorn/19.4.5
X-Request-ID: 3a5ad5a8-bb68-472b-854f-3d3764b22b28

{
    "encrypted": false,
    "name": "secret_foo",
    "secret": true,
    "uid": "key_value_pair:secret_foo",
    "value": "secret_bar"
}

(virtualenv)vagrant@st2dev /mnt/src/storm/st2 (secrets_kv_store●●)$
```

```
> db.key_value_pair_d_b.find({'name': 'secret_foo'})
{ "_id" : ObjectId("5717e445d9d7ed0ea5b07ec7"), "uid" : "key_value_pair:secret_foo", "name" : "secret_foo", "value" : "0083E1033AE5F3D1B045398FC51F1046927971A46502A5A5BEB72ED37FB32073709569E37D081D9D38BF3E96F8A9F4D1EA5FCE349D6D18B3EB", "encrypted" : true }
>
```