### PR TITLE
Fix a bug with gunicorn master process not shutting down

### DIFF
--- a/st2api/st2api/app.py
+++ b/st2api/st2api/app.py
@@ -14,9 +14,7 @@
 # limitations under the License.
 
 import os
-import sys
 
-import eventlet
 import pecan
 from oslo_config import cfg
 from pecan.middleware.static import StaticFileMiddleware
@@ -24,6 +22,7 @@ from pecan.middleware.static import StaticFileMiddleware
 from st2api import config as st2api_config
 from st2common import hooks
 from st2common import log as logging
+from st2common.util.monkey_patch import monkey_patch
 from st2common.constants.system import VERSION_STRING
 from st2common.service_setup import setup as common_setup
 
@@ -57,12 +56,7 @@ def setup_app(config=None):
         # Note: We need to perform monkey patching in the worker. If we do it in
         # the master process (gunicorn_config.py), it breaks tons of things
         # including shutdown
-        eventlet.monkey_patch(
-            os=True,
-            select=True,
-            socket=True,
-            thread=False if '--use-debugger' in sys.argv else True,
-            time=True)
+        monkey_patch()
 
         st2api_config.register_opts()
         # This should be called in gunicorn case because we only want

--- a/st2api/st2api/gunicorn_config.py
+++ b/st2api/st2api/gunicorn_config.py
@@ -21,20 +21,10 @@ st2api configuration / wsgi entry point file for gunicorn.
 from __future__ import absolute_import
 
 import os
-import sys
-
-import eventlet
 
 __all__ = [
     'app'
 ]
-
-eventlet.monkey_patch(
-    os=True,
-    select=True,
-    socket=True,
-    thread=False if '--use-debugger' in sys.argv else True,
-    time=True)
 
 bind = '127.0.0.1:9101'
 

--- a/st2auth/st2auth/app.py
+++ b/st2auth/st2auth/app.py
@@ -13,15 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-
-import eventlet
 import pecan
 from oslo_config import cfg
 
 from st2auth import config as st2auth_config
 from st2common import hooks
 from st2common import log as logging
+from st2common.util.monkey_patch import monkey_patch
 from st2common.constants.system import VERSION_STRING
 from st2common.service_setup import setup as common_setup
 
@@ -50,12 +48,7 @@ def setup_app(config=None):
         # Note: We need to perform monkey patching in the worker. If we do it in
         # the master process (gunicorn_config.py), it breaks tons of things
         # including shutdown
-        eventlet.monkey_patch(
-            os=True,
-            select=True,
-            socket=True,
-            thread=False if '--use-debugger' in sys.argv else True,
-            time=True)
+        monkey_patch()
 
         # This should be called in gunicorn case because we only want
         # workers to connect to db, rabbbitmq etc. In standalone HTTP

--- a/st2auth/st2auth/gunicorn_config.py
+++ b/st2auth/st2auth/gunicorn_config.py
@@ -21,20 +21,10 @@ st2auth configuration / wsgi entry point file for gunicorn.
 from __future__ import absolute_import
 
 import os
-import sys
-
-import eventlet
 
 __all__ = [
     'app'
 ]
-
-eventlet.monkey_patch(
-    os=True,
-    select=True,
-    socket=True,
-    thread=False if '--use-debugger' in sys.argv else True,
-    time=True)
 
 bind = '127.0.0.1:9100'
 

--- a/st2stream/st2stream/app.py
+++ b/st2stream/st2stream/app.py
@@ -23,7 +23,9 @@ Note: This app doesn't need access to MongoDB, just RabbitMQ.
 """
 
 import os
+import sys
 
+import eventlet
 import pecan
 from oslo_config import cfg
 
@@ -56,6 +58,13 @@ def setup_app(config=None):
 
     is_gunicorn = getattr(config, 'is_gunicorn', False)
     if is_gunicorn:
+        eventlet.monkey_patch(
+            os=True,
+            select=True,
+            socket=True,
+            thread=False if '--use-debugger' in sys.argv else True,
+            time=True)
+
         st2stream_config.register_opts()
         # This should be called in gunicorn case because we only want
         # workers to connect to db, rabbbitmq etc. In standalone HTTP

--- a/st2stream/st2stream/gunicorn_config.py
+++ b/st2stream/st2stream/gunicorn_config.py
@@ -21,20 +21,10 @@ st2stream configuration / wsgi entry point file for gunicorn.
 from __future__ import absolute_import
 
 import os
-import sys
-
-import eventlet
 
 __all__ = [
     'app'
 ]
-
-eventlet.monkey_patch(
-    os=True,
-    select=True,
-    socket=True,
-    thread=False if '--use-debugger' in sys.argv else True,
-    time=True)
 
 bind = '127.0.0.1:9101'
 


### PR DESCRIPTION
The problem was that we performed eventlet monkey patching inside master instead
of only inside workers which broke signal handling (master never received
signals so it never shut down).