### PR TITLE
Register ANNOUNCEMENT_XCHG in bootstrap_utils.py

### DIFF
--- a/st2common/st2common/transport/bootstrap_utils.py
+++ b/st2common/st2common/transport/bootstrap_utils.py
@@ -16,11 +16,12 @@
 from kombu import Connection
 from st2common import log as logging
 from st2common.transport import utils as transport_utils
+from st2common.transport.announcement import ANNOUNCEMENT_XCHG
 from st2common.transport.connection_retry_wrapper import ConnectionRetryWrapper
 from st2common.transport.execution import EXECUTION_XCHG
 from st2common.transport.liveaction import LIVEACTION_XCHG
-from st2common.transport.reactor import TRIGGER_CUD_XCHG, TRIGGER_INSTANCE_XCHG
 from st2common.transport.reactor import SENSOR_CUD_XCHG
+from st2common.transport.reactor import TRIGGER_CUD_XCHG, TRIGGER_INSTANCE_XCHG
 
 LOG = logging.getLogger('st2common.transport.bootstrap')
 
@@ -28,8 +29,8 @@ __all__ = [
     'register_exchanges'
 ]
 
-EXCHANGES = [EXECUTION_XCHG, LIVEACTION_XCHG, TRIGGER_CUD_XCHG, TRIGGER_INSTANCE_XCHG,
-             SENSOR_CUD_XCHG]
+EXCHANGES = [ANNOUNCEMENT_XCHG, EXECUTION_XCHG, LIVEACTION_XCHG, TRIGGER_CUD_XCHG,
+             TRIGGER_INSTANCE_XCHG, SENSOR_CUD_XCHG]
 
 
 def _do_register_exchange(exchange, connection, channel, retry_wrapper):


### PR DESCRIPTION
This exchange was not being registered with rabbitmq, causing "no exchange s2.announcement in vhost" errors.