### PR TITLE
Formatting fix for the chatops message

### DIFF
--- a/contrib/chatops/actions/workflows/post_result.yaml
+++ b/contrib/chatops/actions/workflows/post_result.yaml
@@ -7,7 +7,7 @@ chain:
       execution_id: "{{execution_id}}"
     publish:
       message: "{{format_execution_result.result.message}}"
-      extra: "{{format_execution_result.result.extra}}"
+      extra: "{% if 'extra' in format_execution_result.result %}{{format_execution_result.result.extra}}{% else %}{}{% endif %}"
     on-success: "post_message"
   -
     name: "post_message"

--- a/contrib/chatops/actions/workflows/post_result.yaml
+++ b/contrib/chatops/actions/workflows/post_result.yaml
@@ -6,7 +6,7 @@ chain:
     parameters:
       execution_id: "{{execution_id}}"
     publish:
-      message: "{{format_execution_result.result.message}}"
+      message: "{{format_execution_result.result.message[0]}}"
       extra: "{% if 'extra' in format_execution_result.result %}{{format_execution_result.result.extra}}{% else %}{}{% endif %}"
     on-success: "post_message"
   -


### PR DESCRIPTION
There’s a bug where Jinja renderer returns a list instead of a string, resulting in a formatting glitch. 

Reported by Tracy Teague on the community channel.