### PR TITLE
Update jsexpose so it knows how to handle "bool" type, various improvements and fixes

### DIFF
--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -22,6 +22,7 @@ stevedore>=1.7.0,<1.8
 bencode>=1.0,<1.1
 paramiko>=1.16.0,<1.17
 networkx==1.10
+python-keyczar==0.715
 # Note: We want to use virtualenv 13.1.2 since it uses pip 7.1.2 and versions
 # >= 14.0 use pip 8.8.0 which is incompatible with our code
 virtualenv>=13.1.2,<14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ pymongo<3.0
 python-dateutil
 python-gnupg<0.4,>=0.3.7
 python-json-logger
+python-keyczar==0.715
 pyyaml<4.0,>=3.11
 requests[security]<3.0,>=2.7.0
 retrying

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -75,7 +75,7 @@ class ResourceController(rest.RestController):
         return self._get_one_by_id(id=id)
 
     def _get_all(self, exclude_fields=None, sort=None, offset=0, limit=None, query_options=None,
-                 **kwargs):
+                 from_model_kwargs=None, **kwargs):
         """
         :param exclude_fields: A list of object fields to exclude.
         :type exclude_fields: ``list``
@@ -148,7 +148,8 @@ class ResourceController(rest.RestController):
             pecan.response.headers['X-Limit'] = str(limit)
         pecan.response.headers['X-Total-Count'] = str(instances.count())
 
-        from_model_kwargs = self._get_from_model_kwargs_for_request(request=pecan.request)
+        from_model_kwargs = from_model_kwargs or {}
+        from_model_kwargs.update(self._get_from_model_kwargs_for_request(request=pecan.request))
 
         result = []
         for instance in instances[offset:eop]:
@@ -161,7 +162,7 @@ class ResourceController(rest.RestController):
         # Note: This is here for backward compatibility reasons
         return self._get_one_by_id(id=id, exclude_fields=exclude_fields)
 
-    def _get_one_by_id(self, id, exclude_fields=None):
+    def _get_one_by_id(self, id, exclude_fields=None, from_model_kwargs=None):
         """
         :param exclude_fields: A list of object fields to exclude.
         :type exclude_fields: ``list``
@@ -175,13 +176,14 @@ class ResourceController(rest.RestController):
             msg = 'Unable to identify resource with id "%s".' % id
             pecan.abort(http_client.NOT_FOUND, msg)
 
-        from_model_kwargs = self._get_from_model_kwargs_for_request(request=pecan.request)
+        from_model_kwargs = from_model_kwargs or {}
+        from_model_kwargs.update(self._get_from_model_kwargs_for_request(request=pecan.request))
         result = self.model.from_model(instance, **from_model_kwargs)
         LOG.debug('GET %s with id=%s, client_result=%s', pecan.request.path, id, result)
 
         return result
 
-    def _get_one_by_name_or_id(self, name_or_id, exclude_fields=None):
+    def _get_one_by_name_or_id(self, name_or_id, exclude_fields=None, from_model_kwargs=None):
         """
         :param exclude_fields: A list of object fields to exclude.
         :type exclude_fields: ``list``
@@ -195,7 +197,8 @@ class ResourceController(rest.RestController):
             msg = 'Unable to identify resource with name_or_id "%s".' % (name_or_id)
             pecan.abort(http_client.NOT_FOUND, msg)
 
-        from_model_kwargs = self._get_from_model_kwargs_for_request(request=pecan.request)
+        from_model_kwargs = from_model_kwargs or {}
+        from_model_kwargs.update(self._get_from_model_kwargs_for_request(request=pecan.request))
         result = self.model.from_model(instance, **from_model_kwargs)
         LOG.debug('GET %s with name_or_id=%s, client_result=%s', pecan.request.path, id, result)
 

--- a/st2api/st2api/controllers/v1/keyvalue.py
+++ b/st2api/st2api/controllers/v1/keyvalue.py
@@ -45,20 +45,14 @@ class KeyValuePairController(RestController):
         self._coordinator = coordination.get_coordinator()
         self.get_one_db_method = self.__get_by_name
 
-    @jsexpose(arg_types=[str, str])
-    def get_one(self, name, decrypt='false'):
+    @jsexpose(arg_types=[str, bool])
+    def get_one(self, name, decrypt=False):
         """
             List key by name.
 
             Handle:
                 GET /keys/key1
         """
-
-        if not decrypt:
-            decrypt = False
-        else:
-            decrypt = (decrypt == 'true' or decrypt == 'True' or decrypt == '1')
-
         kvp_db = self.__get_by_name(name=name)
 
         if not kvp_db:
@@ -74,8 +68,8 @@ class KeyValuePairController(RestController):
 
         return kvp_api
 
-    @jsexpose(arg_types=[str])
-    def get_all(self, **kw):
+    @jsexpose(arg_types=[str, bool])
+    def get_all(self, prefix=None, decrypt=False):
         """
             List all keys.
 
@@ -83,20 +77,12 @@ class KeyValuePairController(RestController):
                 GET /keys/
         """
         # Prefix filtering
-        prefix_filter = kw.get('prefix', None)
+        filters = {}
 
-        decrypt = kw.get('decrypt', None)
-        if not decrypt:
-            decrypt = False
-        else:
-            decrypt = (decrypt == 'true' or decrypt == 'True' or decrypt == '1')
-            del kw['decrypt']
+        if prefix:
+            filters['name__startswith'] = prefix
 
-        if prefix_filter:
-            kw['name__startswith'] = prefix_filter
-            del kw['prefix']
-
-        kvp_dbs = KeyValuePair.get_all(**kw)
+        kvp_dbs = KeyValuePair.get_all(**filters)
         kvps = [KeyValuePairAPI.from_model(
             kvp_db, mask_secrets=(not decrypt)) for kvp_db in kvp_dbs
         ]

--- a/st2api/st2api/controllers/v1/keyvalue.py
+++ b/st2api/st2api/controllers/v1/keyvalue.py
@@ -69,7 +69,7 @@ class KeyValuePairController(RestController):
         return kvp_api
 
     @jsexpose(arg_types=[str, bool])
-    def get_all(self, prefix=None, decrypt=False):
+    def get_all(self, prefix=None, decrypt=False, **kwargs):
         """
             List all keys.
 
@@ -78,6 +78,7 @@ class KeyValuePairController(RestController):
         """
         # Prefix filtering
         filters = {}
+        filters.update(kwargs)
 
         if prefix:
             filters['name__startswith'] = prefix

--- a/st2api/tests/unit/controllers/v1/test_jsexpose_decorator.py
+++ b/st2api/tests/unit/controllers/v1/test_jsexpose_decorator.py
@@ -1,0 +1,54 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from st2tests.fixturesloader import FixturesLoader
+from tests import FunctionalTest
+
+__all__ = [
+    'JsexposeDecoratorTestCase'
+]
+
+FIXTURES_PACK = 'aliases'
+
+TEST_MODELS = {
+    'aliases': ['alias1.yaml', 'alias2.yaml']
+}
+
+class JsexposeDecoratorTestCase(FunctionalTest):
+    """
+    Test case which tests various invalid requests and makes sure they are correctly handled by
+    the jsexpose decorator.
+    """
+
+    models = None
+    alias1 = None
+
+    @classmethod
+    def setUpClass(cls):
+        super(JsexposeDecoratorTestCase, cls).setUpClass()
+        cls.models = FixturesLoader().save_fixtures_to_db(fixtures_pack=FIXTURES_PACK,
+                                                          fixtures_dict=TEST_MODELS)
+        cls.alias1 = cls.models['aliases']['alias1.yaml']
+
+    def test_invalid_number_of_arguments_results_in_resource_not_found(self):
+        # Invalid path (additional path components after the id)
+        resp = self.app.get('/v1/actionalias/%s/some/more/args' % (self.alias1.id), expect_errors=True)
+        self.assertEqual(resp.status_int, 404)
+        self.assertEqual(resp.json['faultstring'], 'The resource could not be found.')
+
+    def test_invalid_query_param_results_in_bad_request(self):
+        resp = self.app.get('/v1/actionalias/%s?invalid=arg' % (self.alias1.id), expect_errors=True)
+        self.assertEqual(resp.status_int, 400)
+        self.assertEqual(resp.json['faultstring'], 'Unsupported query parameter: invalid')

--- a/st2api/tests/unit/controllers/v1/test_jsexpose_decorator.py
+++ b/st2api/tests/unit/controllers/v1/test_jsexpose_decorator.py
@@ -26,6 +26,7 @@ TEST_MODELS = {
     'aliases': ['alias1.yaml', 'alias2.yaml']
 }
 
+
 class JsexposeDecoratorTestCase(FunctionalTest):
     """
     Test case which tests various invalid requests and makes sure they are correctly handled by
@@ -44,7 +45,8 @@ class JsexposeDecoratorTestCase(FunctionalTest):
 
     def test_invalid_number_of_arguments_results_in_resource_not_found(self):
         # Invalid path (additional path components after the id)
-        resp = self.app.get('/v1/actionalias/%s/some/more/args' % (self.alias1.id), expect_errors=True)
+        resp = self.app.get('/v1/actionalias/%s/some/more/args' % (self.alias1.id),
+                            expect_errors=True)
         self.assertEqual(resp.status_int, 404)
         self.assertEqual(resp.json['faultstring'], 'The resource could not be found.')
 

--- a/st2common/st2common/models/api/base.py
+++ b/st2common/st2common/models/api/base.py
@@ -146,7 +146,7 @@ class APIUIDMixin(object):
 
 def jsexpose(arg_types=None, body_cls=None, status_code=None, content_type='application/json'):
     """
-    :param arg_types: A list of types for the function arguments.
+    :param arg_types: A list of types for the function arguments (e.g. [str, str, int, bool]).
     :type arg_types: ``list``
 
     :param body_cls: Request body class. If provided, this class will be used to create an instance

--- a/st2common/st2common/models/api/base.py
+++ b/st2common/st2common/models/api/base.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import abc
-import copy
 import functools
 import inspect
 
@@ -160,6 +159,8 @@ def get_controller_args_for_types(func, arg_types, args, kwargs):
     """
     Build a list of arguments and dictionary of keyword arguments which are passed to the
     controller method based on the arg_types specification.
+
+    Note: args argument is mutated in place.
     """
     result_args = []
     result_kwargs = {}

--- a/st2common/st2common/util/api.py
+++ b/st2common/st2common/util/api.py
@@ -13,9 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pecan
+import re
 
+import pecan
 from oslo_config import cfg
+from webob import exc as webob_exc
 
 from st2common import log as logging
 from st2common.constants.api import DEFAULT_API_VERSION
@@ -26,7 +28,9 @@ __all__ = [
     'get_full_public_api_url',
     'get_mistral_api_url',
 
-    'get_requester'
+    'get_requester',
+    'get_exception_for_type_error'
+
 ]
 
 LOG = logging.getLogger(__name__)
@@ -93,3 +97,39 @@ def get_requester():
         username = user_db.name
 
     return username
+
+
+def get_exception_for_type_error(func, exc):
+    """
+    Method which translates TypeError thrown by the controller method and intercepted inside
+    jsexpose decorator and returns a better exception for it.
+
+    :param func: Controller function / method.
+    :type func: ``callable``
+
+    :param exc: Exception intercepted by jsexpose.
+    :type exc: :class:`Exception`
+    """
+    message = str(exc)
+    func_name = func.__name__
+
+    # Note: Those checks are hacky, but it's better than having no checks and silently
+    # accepting invalid requests
+    invalid_num_args_pattern = ('%s\(\) takes (exactly|at most) \d+ arguments \(\d+ given\)' %
+                                (func_name))
+    unexpected_keyword_arg_pattern = ('%s\(\) got an unexpected keyword argument \'(.*?)\'' %
+                                      (func_name))
+
+    if (re.search(invalid_num_args_pattern, message)):
+        # Invalid number of arguments passed to the function meaning invalid path was
+        # requested
+        result = webob_exc.HTTPNotFound()
+    elif re.search(unexpected_keyword_arg_pattern, message):
+        # User passed in an unsupported query parameter
+        groups = re.match(unexpected_keyword_arg_pattern, message).groups()
+        query_param_name = groups[0]
+        result = ValueError('Unsupported query parameter: %s' % (query_param_name))
+    else:
+        result = exc
+
+    return result

--- a/st2common/st2common/util/api.py
+++ b/st2common/st2common/util/api.py
@@ -128,7 +128,9 @@ def get_exception_for_type_error(func, exc):
         # User passed in an unsupported query parameter
         groups = re.match(unexpected_keyword_arg_pattern, message).groups()
         query_param_name = groups[0]
-        result = ValueError('Unsupported query parameter: %s' % (query_param_name))
+
+        msg = 'Unsupported query parameter: %s' % (query_param_name)
+        result = webob_exc.HTTPBadRequest(detail=msg)
     else:
         result = exc
 


### PR DESCRIPTION
Looks like @lakshmi-kannan missed or ignored my comments in the secrets PR so I decided to make some improvements to `jsexpose` myself :P

1. Update jsexpose so it knows how to handle `bool` type. Perhaps better and more explicit name for this argument would be `cast_funcs`, but that's something we can rename in the future aka separate PR.
2. Update jsexpose so it always consumes keyword arguments first. This way it works correctly if not all of the arguments are provided and we don't need to abuse "**kwargs" in the method signature.
3. Update jsexpose to handle more edge cases and invalid HTTP requests. The code which performs those checks is hacky, but it's better than not having anything and silently swallowing and ignoring invalid requests. As mentioned below, proper solution is moving away from jsexpose to something better and more sane.

Note: As I mentioned many times before already, I hate `jsexpose`. It's a huge hack and a mess, but I'm trying to improve it one step at a time. Ideally though, we could totally get rid of it and replace it with something more strict, correct and less fragile in the future.

## TODO

- [x] Test cases for all the jsexponse (edge) cases with arg_types
- [x] Code refactor (refactor some of the code from jsexpose into standalone utility functions)
