### PR TITLE
Don't include traceback when logging "NotUnique" error as debug

### DIFF
--- a/st2common/st2common/persistence/base.py
+++ b/st2common/st2common/persistence/base.py
@@ -120,7 +120,7 @@ class Access(object):
             model_object = cls._get_impl().insert(model_object)
         except NotUniqueError as e:
             if log_not_unique_error_as_debug:
-                LOG.debug('Conflict while trying to save in DB.', exc_info=True)
+                LOG.debug('Conflict while trying to save in DB: %s.' % (str(e)))
             else:
                 LOG.exception('Conflict while trying to save in DB.')
             # On a conflict determine the conflicting object and return its id in
@@ -155,7 +155,7 @@ class Access(object):
             model_object = cls._get_impl().add_or_update(model_object)
         except NotUniqueError as e:
             if log_not_unique_error_as_debug:
-                LOG.debug('Conflict while trying to save in DB.', exc_info=True)
+                LOG.debug('Conflict while trying to save in DB: %s.' % (str(e)))
             else:
                 LOG.exception('Conflict while trying to save in DB.')
             # On a conflict determine the conflicting object and return its id in

--- a/st2common/st2common/persistence/base.py
+++ b/st2common/st2common/persistence/base.py
@@ -120,7 +120,7 @@ class Access(object):
             model_object = cls._get_impl().insert(model_object)
         except NotUniqueError as e:
             if log_not_unique_error_as_debug:
-                LOG.debug('Conflict while trying to save in DB: %s.' % (str(e)))
+                LOG.debug('Conflict while trying to save in DB: %s.', str(e))
             else:
                 LOG.exception('Conflict while trying to save in DB.')
             # On a conflict determine the conflicting object and return its id in
@@ -155,7 +155,7 @@ class Access(object):
             model_object = cls._get_impl().add_or_update(model_object)
         except NotUniqueError as e:
             if log_not_unique_error_as_debug:
-                LOG.debug('Conflict while trying to save in DB: %s.' % (str(e)))
+                LOG.debug('Conflict while trying to save in DB: %s.', str(e))
             else:
                 LOG.exception('Conflict while trying to save in DB.')
             # On a conflict determine the conflicting object and return its id in


### PR DESCRIPTION
Even though we logged the whole message (including traceback) under DEBUG log level it still confused a lot of users and made it look like a fatal error.

Before:

```bash
2016-05-02 22:33:52,529 DEBUG [-] Conflict while trying to save in DB.
Traceback (most recent call last):
  File "/data/stanley/st2common/st2common/persistence/base.py", line 120, in insert
    model_object = cls._get_impl().insert(model_object)
  File "/data/stanley/st2common/st2common/models/db/__init__.py", line 207, in insert
    instance = self.model.objects.insert(instance)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/mongoengine/queryset/base.py", line 307, in insert
    raise NotUniqueError(message % unicode(err))
NotUniqueError: Could not save document (E11000 duplicate key error index: st2.role_d_b.$name_1  dup key: { : "admin" })
```

Now:

```bash
2016-05-02 22:34:51,031 DEBUG [-] Conflict while trying to save in DB: Could not save document (E11000 duplicate key error index: st2.role_d_b.$name_1  dup key: { : "admin" }).
```