### PR TITLE
Use is_debugging_enabled method to determine if debugging is enabled

### DIFF
--- a/st2common/st2common/hooks.py
+++ b/st2common/st2common/hooks.py
@@ -31,6 +31,7 @@ from st2common.exceptions import rbac as rbac_exceptions
 from st2common.exceptions.apivalidation import ValueValidationException
 from st2common.util.jsonify import json_encode
 from st2common.util.auth import validate_token, validate_api_key
+from st2common.util.debugging import is_enabled as is_debugging_enabled
 from st2common.constants.api import REQUEST_ID_HEADER
 from st2common.constants.auth import HEADER_ATTRIBUTE_NAME
 from st2common.constants.auth import QUERY_PARAM_ATTRIBUTE_NAME
@@ -268,7 +269,7 @@ class JSONErrorResponseHook(PecanHook):
         else:
             LOG.debug('API call failed: %s', error_msg, extra=extra)
 
-            if cfg.CONF.debug:
+            if is_debugging_enabled():
                 LOG.debug(traceback.format_exc())
 
         body['faultstring'] = message


### PR DESCRIPTION
Now we have two ways to enable per-service debug mode (`--debug` flag or config option) so we need to use this method to correctly determine if debugging is enabled.