### PR TITLE
Support for path to the private key file for the "private_key" argument

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ in development
 * Fix for `data` is dropped if `message` is not present in notification. (bug-fix)
 * Remove now deprecated Fabric based remote runner and corresponding
   ``ssh_runner.use_paramiko_ssh_runner`` config option. (cleanup)
+* Fix support for password protected private key files in the remote runner. (bug-fix)
 
 1.4.0 - April 18, 2016
 ----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ in development
 * Remove now deprecated Fabric based remote runner and corresponding
   ``ssh_runner.use_paramiko_ssh_runner`` config option. (cleanup)
 * Fix support for password protected private key files in the remote runner. (bug-fix)
+* Allow user to provide a path to the private SSH key file for the remote runner ``private_key``
+  parameter. Previously only raw key material was supported. (improvement)
 
 1.4.0 - April 18, 2016
 ----------------------

--- a/st2actions/st2actions/runners/ssh/parallel_ssh.py
+++ b/st2actions/st2actions/runners/ssh/parallel_ssh.py
@@ -233,7 +233,7 @@ class ParallelSSHClient(object):
 
         client = ParamikoSSHClient(hostname, username=self._ssh_user,
                                    password=self._ssh_password,
-                                   key=self._ssh_key_file,
+                                   key_files=self._ssh_key_file,
                                    key_material=self._ssh_key_material,
                                    passphrase=self._passphrase,
                                    port=port)

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh.py
@@ -534,7 +534,7 @@ class ParamikoSSHClient(object):
             conninfo['password'] = self.password
 
         if self.key_files:
-            conninfo['key_filename'] = self.key_files
+            conninfo['key_files'] = self.key_files
 
         if self.key_material:
             conninfo['pkey'] = self._get_pkey_object(key_material=self.key_material,

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh.py
@@ -97,7 +97,7 @@ class ParamikoSSHClient(object):
             raise ValueError(('key_files and key_material arguments are '
                               'mutually exclusive'))
 
-        if passphrase and not (key_files and key_material):
+        if passphrase and not (key_files or key_material):
             raise ValueError('passphrase should accompany private key material')
 
         if not key_files and cfg.CONF.system_user.ssh_key_file:

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh.py
@@ -30,14 +30,13 @@ import paramiko
 from st2common.log import logging
 from st2common.util.misc import strip_shell_chars
 from st2common.util.shell import quote_unix
+from st2common.constants.runners import REMOTE_RUNNER_PRIVATE_KEY_HEADER
 
 __all__ = [
     'ParamikoSSHClient',
 
     'SSHCommandTimeoutError'
 ]
-
-PRIVATE_KEY_HEADER = 'PRIVATE KEY-----'.lower()
 
 
 class SSHCommandTimeoutError(Exception):
@@ -500,7 +499,7 @@ class ParamikoSSHClient(object):
         # If a user passes in something which looks like file path we throw a more friendly
         # exception letting the user know we expect the contents a not a path.
         # Note: We do it here and not up the stack to avoid false positives.
-        contains_header = PRIVATE_KEY_HEADER in key_material.lower()
+        contains_header = REMOTE_RUNNER_PRIVATE_KEY_HEADER in key_material.lower()
         if not contains_header and (key_material.count('/') >= 1 or key_material.count('\\') >= 1):
             msg = ('"private_key" parameter needs to contain private key data / content and not '
                    'a path')

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh.py
@@ -81,7 +81,7 @@ class ParamikoSSHClient(object):
     CONNECT_TIMEOUT = 60
 
     def __init__(self, hostname, port=22, username=None, password=None, bastion_host=None,
-                 key=None, key_files=None, key_material=None, timeout=None, passphrase=None):
+                 key_files=None, key_material=None, timeout=None, passphrase=None):
         """
         Authentication is always attempted in the following order:
 
@@ -106,8 +106,6 @@ class ParamikoSSHClient(object):
         self.password = password
         self.key = key if key else cfg.CONF.system_user.ssh_key_file
         self.key_files = key_files
-        if not self.key_files and self.key:
-            self.key_files = key  # `key` arg is deprecated.
         self.timeout = timeout or ParamikoSSHClient.CONNECT_TIMEOUT
         self.key_material = key_material
         self.client = None
@@ -535,6 +533,10 @@ class ParamikoSSHClient(object):
 
         if self.key_files:
             conninfo['key_filename'] = self.key_files
+
+            if self.passphrase:
+                # Optional passphrase for unlocking the private key
+                conninfo['password'] = self.passphrase
 
         if self.key_material:
             conninfo['pkey'] = self._get_pkey_object(key_material=self.key_material,

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh.py
@@ -100,7 +100,8 @@ class ParamikoSSHClient(object):
         if passphrase and not (key_files or key_material):
             raise ValueError('passphrase should accompany private key material')
 
-        if not key_files and cfg.CONF.system_user.ssh_key_file:
+        credentials_provided = password or key_files or key_material
+        if not credentials_provided and cfg.CONF.system_user.ssh_key_file:
             key_files = cfg.CONF.system_user.ssh_key_file
 
         self.hostname = hostname

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh.py
@@ -97,7 +97,7 @@ class ParamikoSSHClient(object):
             raise ValueError(('key_files and key_material arguments are '
                               'mutually exclusive'))
 
-        if passphrase and not key_material:
+        if passphrase and not (key_files and key_material):
             raise ValueError('passphrase should accompany private key material')
 
         if not key_files and cfg.CONF.system_user.ssh_key_file:

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh.py
@@ -534,7 +534,7 @@ class ParamikoSSHClient(object):
             conninfo['password'] = self.password
 
         if self.key_files:
-            conninfo['key_files'] = self.key_files
+            conninfo['key_filename'] = self.key_files
 
         if self.key_material:
             conninfo['pkey'] = self._get_pkey_object(key_material=self.key_material,

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh.py
@@ -100,11 +100,13 @@ class ParamikoSSHClient(object):
         if passphrase and not key_material:
             raise ValueError('passphrase should accompany private key material')
 
+        if not key_files and cfg.CONF.system_user.ssh_key_file:
+            key_files = cfg.CONF.system_user.ssh_key_file
+
         self.hostname = hostname
         self.port = port
         self.username = username if username else cfg.CONF.system_user
         self.password = password
-        self.key = key if key else cfg.CONF.system_user.ssh_key_file
         self.key_files = key_files
         self.timeout = timeout or ParamikoSSHClient.CONNECT_TIMEOUT
         self.key_material = key_material

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh_runner.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh_runner.py
@@ -144,7 +144,7 @@ class BaseParallelSSHRunner(ActionRunner, ShellRunnerMixin):
                 # Assume it's a path to the key file, verify the file exists
                 client_kwargs['pkey_file'] = self._private_key
         else:
-                client_kwargs['pkey_file'] = self._ssh_key_file
+            client_kwargs['pkey_file'] = self._ssh_key_file
 
         self._parallel_ssh_client = ParallelSSHClient(**client_kwargs)
 

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh_runner.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh_runner.py
@@ -20,6 +20,7 @@ import six
 
 from st2actions.runners import ShellRunnerMixin
 from st2actions.runners import ActionRunner
+from st2actions.runners.ssh.paramiko_ssh_runner import PRIVATE_KEY_HEADER
 from st2actions.runners.ssh.parallel_ssh import ParallelSSHClient
 from st2common import log as logging
 from st2common.constants.action import LIVEACTION_STATUS_SUCCEEDED
@@ -120,33 +121,35 @@ class BaseParallelSSHRunner(ActionRunner, ShellRunnerMixin):
             LOG.debug('Limiting parallel SSH concurrency to %d.', concurrency)
             concurrency = self._max_concurrency
 
+        client_kwargs = {
+            'hosts': self._hosts,
+            'user': self._username,
+            'port': self._ssh_port,
+            'concurrency': concurrency,
+            'bastion_host': self._bastion_host,
+            'raise_on_any_error': False,
+            'connect': True
+        }
+
         if self._password:
-            self._parallel_ssh_client = ParallelSSHClient(
-                hosts=self._hosts,
-                user=self._username, password=self._password,
-                port=self._ssh_port, concurrency=concurrency,
-                bastion_host=self._bastion_host,
-                raise_on_any_error=False,
-                connect=True
-            )
+            client_kwargs['password'] = self._password
         elif self._private_key:
-            self._parallel_ssh_client = ParallelSSHClient(
-                hosts=self._hosts,
-                user=self._username, pkey_material=self._private_key,
-                port=self._ssh_port, concurrency=concurrency,
-                bastion_host=self._bastion_host,
-                raise_on_any_error=False,
-                connect=True
-            )
+            # Determine if the private_key is a path to the key file or the raw key material
+            is_key_material = self._is_private_key_material(private_key=self._private_key)
+
+            if is_key_material:
+                # Raw key material
+                client_kwargs['pkey_material'] = self._private_key
+            else:
+                # Assume it's a path to the key file, verify the file exists
+                client_kwargs['pkey_file'] = self._private_key
         else:
-            self._parallel_ssh_client = ParallelSSHClient(
-                hosts=self._hosts,
-                user=self._username, pkey_file=self._ssh_key_file,
-                port=self._ssh_port, concurrency=concurrency,
-                bastion_host=self._bastion_host,
-                raise_on_any_error=False,
-                connect=True
-            )
+                client_kwargs['pkey_file'] = self._ssh_key_file
+
+        self._parallel_ssh_client = ParallelSSHClient(**client_kwargs)
+
+    def _is_private_key_material(self, private_key):
+        return PRIVATE_KEY_HEADER in private_key.lower()
 
     def _get_env_vars(self):
         """

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh_runner.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh_runner.py
@@ -145,7 +145,7 @@ class BaseParallelSSHRunner(ActionRunner, ShellRunnerMixin):
                 client_kwargs['pkey_file'] = self._private_key
 
             if self._passphrase:
-                client_kwargs['passphrase'] = passphrase
+                client_kwargs['passphrase'] = self._passphrase
         else:
             client_kwargs['pkey_file'] = self._ssh_key_file
 

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh_runner.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh_runner.py
@@ -147,6 +147,7 @@ class BaseParallelSSHRunner(ActionRunner, ShellRunnerMixin):
             if self._passphrase:
                 client_kwargs['passphrase'] = self._passphrase
         else:
+            # Default to stanley key file specified in the config
             client_kwargs['pkey_file'] = self._ssh_key_file
 
         self._parallel_ssh_client = ParallelSSHClient(**client_kwargs)

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh_runner.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh_runner.py
@@ -143,6 +143,9 @@ class BaseParallelSSHRunner(ActionRunner, ShellRunnerMixin):
             else:
                 # Assume it's a path to the key file, verify the file exists
                 client_kwargs['pkey_file'] = self._private_key
+
+            if self._passphrase:
+                client_kwargs['passphrase'] = passphrase
         else:
             client_kwargs['pkey_file'] = self._ssh_key_file
 

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh_runner.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh_runner.py
@@ -20,7 +20,7 @@ import six
 
 from st2actions.runners import ShellRunnerMixin
 from st2actions.runners import ActionRunner
-from st2actions.runners.ssh.paramiko_ssh_runner import PRIVATE_KEY_HEADER
+from st2common.constants.runners import REMOTE_RUNNER_PRIVATE_KEY_HEADER
 from st2actions.runners.ssh.parallel_ssh import ParallelSSHClient
 from st2common import log as logging
 from st2common.constants.action import LIVEACTION_STATUS_SUCCEEDED
@@ -152,7 +152,7 @@ class BaseParallelSSHRunner(ActionRunner, ShellRunnerMixin):
         self._parallel_ssh_client = ParallelSSHClient(**client_kwargs)
 
     def _is_private_key_material(self, private_key):
-        return PRIVATE_KEY_HEADER in private_key.lower()
+        return private_key and REMOTE_RUNNER_PRIVATE_KEY_HEADER in private_key.lower()
 
     def _get_env_vars(self):
         """

--- a/st2actions/tests/unit/test_paramiko_ssh.py
+++ b/st2actions/tests/unit/test_paramiko_ssh.py
@@ -36,7 +36,7 @@ class ParamikoSSHClientTests(unittest2.TestCase):
         conn_params = {'hostname': 'dummy.host.org',
                        'port': 8822,
                        'username': 'ubuntu',
-                       'key': '~/.ssh/ubuntu_ssh',
+                       'key_files': '~/.ssh/ubuntu_ssh',
                        'timeout': '600'}
         self.ssh_cli = ParamikoSSHClient(**conn_params)
 
@@ -61,7 +61,7 @@ class ParamikoSSHClientTests(unittest2.TestCase):
     def test_deprecated_key_argument(self):
         conn_params = {'hostname': 'dummy.host.org',
                        'username': 'ubuntu',
-                       'key': 'id_rsa'}
+                       'key_files': 'id_rsa'}
         mock = ParamikoSSHClient(**conn_params)
         mock.connect()
 
@@ -245,7 +245,7 @@ class ParamikoSSHClientTests(unittest2.TestCase):
         conn_params = {'hostname': 'dummy.host.org',
                        'username': 'ubuntu',
                        'password': 'ubuntu',
-                       'key': 'id_rsa'}
+                       'key_files': 'id_rsa'}
         mock = ParamikoSSHClient(**conn_params)
         mock.connect()
 

--- a/st2actions/tests/unit/test_paramiko_ssh.py
+++ b/st2actions/tests/unit/test_paramiko_ssh.py
@@ -122,7 +122,17 @@ class ParamikoSSHClientTests(unittest2.TestCase):
                                 expected_msg, mock.connect)
 
     @patch('paramiko.SSHClient', Mock)
-    def test_key_with_passphrase(self):
+    def test_passphrase_no_key_provided(self):
+        conn_params = {'hostname': 'dummy.host.org',
+                       'username': 'ubuntu',
+                       'passphrase': 'testphrase'}
+
+        expected_msg = 'passphrase should accompany private key material'
+        self.assertRaisesRegexp(ValueError, expected_msg, ParamikoSSHClient,
+                                **conn_params)
+
+    @patch('paramiko.SSHClient', Mock)
+    def test_key_with_passphrase_success(self):
         path = os.path.join(get_resources_base_path(),
                             'ssh', 'dummy_rsa_passphrase')
 

--- a/st2actions/tests/unit/test_paramiko_ssh.py
+++ b/st2actions/tests/unit/test_paramiko_ssh.py
@@ -129,6 +129,7 @@ class ParamikoSSHClientTests(unittest2.TestCase):
         with open(path, 'r') as fp:
             private_key = fp.read()
 
+        # Key material provided
         conn_params = {'hostname': 'dummy.host.org',
                        'username': 'ubuntu',
                        'key_material': private_key,
@@ -142,6 +143,24 @@ class ParamikoSSHClientTests(unittest2.TestCase):
                          'hostname': 'dummy.host.org',
                          'look_for_keys': False,
                          'pkey': pkey,
+                         'timeout': 60,
+                         'port': 22}
+        mock.client.connect.assert_called_once_with(**expected_conn)
+
+        # Path to private key file provided
+        conn_params = {'hostname': 'dummy.host.org',
+                       'username': 'ubuntu',
+                       'key_files': path,
+                       'passphrase': 'testphrase'}
+        mock = ParamikoSSHClient(**conn_params)
+        mock.connect()
+
+        expected_conn = {'username': 'ubuntu',
+                         'allow_agent': False,
+                         'hostname': 'dummy.host.org',
+                         'look_for_keys': False,
+                         'key_filename': path,
+                         'password': 'testphrase',
                          'timeout': 60,
                          'port': 22}
         mock.client.connect.assert_called_once_with(**expected_conn)

--- a/st2actions/tests/unit/test_paramiko_ssh_runner.py
+++ b/st2actions/tests/unit/test_paramiko_ssh_runner.py
@@ -1,0 +1,137 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import unittest2
+import mock
+from oslo_config import cfg
+
+from st2actions.runners.ssh.paramiko_ssh_runner import BaseParallelSSHRunner
+from st2actions.runners.ssh.paramiko_ssh_runner import RUNNER_HOSTS
+from st2actions.runners.ssh.paramiko_ssh_runner import RUNNER_USERNAME
+from st2actions.runners.ssh.paramiko_ssh_runner import RUNNER_PASSWORD
+from st2actions.runners.ssh.paramiko_ssh_runner import RUNNER_PRIVATE_KEY
+
+import st2tests.config as tests_config
+from st2tests.fixturesloader import get_resources_base_path
+tests_config.parse_args()
+
+
+class Runner(BaseParallelSSHRunner):
+    def run(self):
+        pass
+
+
+class ParamikoSSHRunnerTestCase(unittest2.TestCase):
+    @mock.patch('st2actions.runners.ssh.paramiko_ssh_runner.ParallelSSHClient')
+    def test_pre_run(self, mock_client):
+        # Test case which verifies that ParamikoSSHClient is instantiated with the correct arguments
+
+        # Username and password provided
+        runner = Runner('id')
+        runner.context = {}
+        runner_parameters = {
+            RUNNER_HOSTS: 'localhost',
+            RUNNER_USERNAME: 'someuser1',
+            RUNNER_PASSWORD: 'somepassword'
+        }
+        runner.runner_parameters = runner_parameters
+        runner.pre_run()
+
+        expected_kwargs = {
+            'hosts': ['localhost'],
+            'user': 'someuser1',
+            'password': 'somepassword',
+            'port': 22,
+            'concurrency': 1,
+            'bastion_host': None,
+            'raise_on_any_error': False,
+            'connect': True
+        }
+        mock_client.assert_called_with(**expected_kwargs)
+
+        # Private key provided as raw key material
+        path = os.path.join(get_resources_base_path(),
+                            'ssh', 'dummy_rsa')
+
+        with open(path, 'r') as fp:
+            private_key = fp.read()
+
+        runner = Runner('id')
+        runner.context = {}
+        runner_parameters = {
+            RUNNER_HOSTS: 'localhost',
+            RUNNER_USERNAME: 'someuser2',
+            RUNNER_PRIVATE_KEY: private_key
+        }
+        runner.runner_parameters = runner_parameters
+        runner.pre_run()
+
+        expected_kwargs = {
+            'hosts': ['localhost'],
+            'user': 'someuser2',
+            'pkey_material': private_key,
+            'port': 22,
+            'concurrency': 1,
+            'bastion_host': None,
+            'raise_on_any_error': False,
+            'connect': True
+        }
+        mock_client.assert_called_with(**expected_kwargs)
+
+        # Private key provided as path to the private key file
+        runner = Runner('id')
+        runner.context = {}
+        runner_parameters = {
+            RUNNER_HOSTS: 'localhost',
+            RUNNER_USERNAME: 'someuser3',
+            RUNNER_PRIVATE_KEY: path
+        }
+        runner.runner_parameters = runner_parameters
+        runner.pre_run()
+
+        expected_kwargs = {
+            'hosts': ['localhost'],
+            'user': 'someuser3',
+            'pkey_file': path,
+            'port': 22,
+            'concurrency': 1,
+            'bastion_host': None,
+            'raise_on_any_error': False,
+            'connect': True
+        }
+        mock_client.assert_called_with(**expected_kwargs)
+
+        # No password or private key provided, should default to system user private key
+        runner = Runner('id')
+        runner.context = {}
+        runner_parameters = {
+            RUNNER_HOSTS: 'localhost4',
+        }
+        runner.runner_parameters = runner_parameters
+        runner.pre_run()
+
+        expected_kwargs = {
+            'hosts': ['localhost4'],
+            'user': cfg.CONF.system_user.user,
+            'pkey_file': cfg.CONF.system_user.ssh_key_file,
+            'port': 22,
+            'concurrency': 1,
+            'bastion_host': None,
+            'raise_on_any_error': False,
+            'connect': True
+        }
+        mock_client.assert_called_with(**expected_kwargs)

--- a/st2actions/tests/unit/test_paramiko_ssh_runner.py
+++ b/st2actions/tests/unit/test_paramiko_ssh_runner.py
@@ -24,6 +24,7 @@ from st2actions.runners.ssh.paramiko_ssh_runner import RUNNER_HOSTS
 from st2actions.runners.ssh.paramiko_ssh_runner import RUNNER_USERNAME
 from st2actions.runners.ssh.paramiko_ssh_runner import RUNNER_PASSWORD
 from st2actions.runners.ssh.paramiko_ssh_runner import RUNNER_PRIVATE_KEY
+from st2actions.runners.ssh.paramiko_ssh_runner import RUNNER_PASSPHRASE
 
 import st2tests.config as tests_config
 from st2tests.fixturesloader import get_resources_base_path
@@ -39,6 +40,11 @@ class ParamikoSSHRunnerTestCase(unittest2.TestCase):
     @mock.patch('st2actions.runners.ssh.paramiko_ssh_runner.ParallelSSHClient')
     def test_pre_run(self, mock_client):
         # Test case which verifies that ParamikoSSHClient is instantiated with the correct arguments
+        private_key_path = os.path.join(get_resources_base_path(),
+                                       'ssh', 'dummy_rsa')
+
+        with open(private_key_path, 'r') as fp:
+            private_key = fp.read()
 
         # Username and password provided
         runner = Runner('id')
@@ -64,12 +70,6 @@ class ParamikoSSHRunnerTestCase(unittest2.TestCase):
         mock_client.assert_called_with(**expected_kwargs)
 
         # Private key provided as raw key material
-        path = os.path.join(get_resources_base_path(),
-                            'ssh', 'dummy_rsa')
-
-        with open(path, 'r') as fp:
-            private_key = fp.read()
-
         runner = Runner('id')
         runner.context = {}
         runner_parameters = {
@@ -92,13 +92,38 @@ class ParamikoSSHRunnerTestCase(unittest2.TestCase):
         }
         mock_client.assert_called_with(**expected_kwargs)
 
+        # Private key provided as raw key material + passphrase
+        runner = Runner('id')
+        runner.context = {}
+        runner_parameters = {
+            RUNNER_HOSTS: 'localhost21',
+            RUNNER_USERNAME: 'someuser21',
+            RUNNER_PRIVATE_KEY: private_key,
+            RUNNER_PASSPHRASE: 'passphrase21'
+        }
+        runner.runner_parameters = runner_parameters
+        runner.pre_run()
+
+        expected_kwargs = {
+            'hosts': ['localhost21'],
+            'user': 'someuser21',
+            'pkey_material': private_key,
+            'passphrase': 'passphrase21',
+            'port': 22,
+            'concurrency': 1,
+            'bastion_host': None,
+            'raise_on_any_error': False,
+            'connect': True
+        }
+        mock_client.assert_called_with(**expected_kwargs)
+
         # Private key provided as path to the private key file
         runner = Runner('id')
         runner.context = {}
         runner_parameters = {
             RUNNER_HOSTS: 'localhost',
             RUNNER_USERNAME: 'someuser3',
-            RUNNER_PRIVATE_KEY: path
+            RUNNER_PRIVATE_KEY: private_key_path
         }
         runner.runner_parameters = runner_parameters
         runner.pre_run()
@@ -106,7 +131,32 @@ class ParamikoSSHRunnerTestCase(unittest2.TestCase):
         expected_kwargs = {
             'hosts': ['localhost'],
             'user': 'someuser3',
-            'pkey_file': path,
+            'pkey_file': private_key_path,
+            'port': 22,
+            'concurrency': 1,
+            'bastion_host': None,
+            'raise_on_any_error': False,
+            'connect': True
+        }
+        mock_client.assert_called_with(**expected_kwargs)
+
+        # Private key provided as path to the private key file + passpharse
+        runner = Runner('id')
+        runner.context = {}
+        runner_parameters = {
+            RUNNER_HOSTS: 'localhost31',
+            RUNNER_USERNAME: 'someuser31',
+            RUNNER_PRIVATE_KEY: private_key_path,
+            RUNNER_PASSPHRASE: 'passphrase31'
+        }
+        runner.runner_parameters = runner_parameters
+        runner.pre_run()
+
+        expected_kwargs = {
+            'hosts': ['localhost31'],
+            'user': 'someuser31',
+            'pkey_file': private_key_path,
+            'passphrase': 'passphrase31',
             'port': 22,
             'concurrency': 1,
             'bastion_host': None,

--- a/st2common/st2common/bootstrap/runnersregistrar.py
+++ b/st2common/st2common/bootstrap/runnersregistrar.py
@@ -134,8 +134,8 @@ RUNNER_TYPES = [
                 'secret': True
             },
             'private_key': {
-                'description': ('Private key material to log in. Note: This needs to be actual '
-                                'private key data and NOT path.'),
+                'description': ('Private key material or path to the private key file on disk '
+                                'used to log in.'),
                 'type': 'string',
                 'required': False,
                 'secret': True

--- a/st2common/st2common/constants/runners.py
+++ b/st2common/st2common/constants/runners.py
@@ -20,6 +20,7 @@ __all__ = [
 
     'REMOTE_RUNNER_DEFAULT_ACTION_TIMEOUT',
     'REMOTE_RUNNER_DEFAULT_REMOTE_DIR',
+    'REMOTE_RUNNER_PRIVATE_KEY_HEADER',
 
     'PYTHON_RUNNER_DEFAULT_ACTION_TIMEOUT',
 
@@ -39,6 +40,8 @@ try:
     REMOTE_RUNNER_DEFAULT_REMOTE_DIR = cfg.CONF.ssh_runner.remote_dir
 except:
     REMOTE_RUNNER_DEFAULT_REMOTE_DIR = '/tmp'
+
+REMOTE_RUNNER_PRIVATE_KEY_HEADER = 'PRIVATE KEY-----'.lower()
 
 # Python runner
 # Default timeout (in seconds) for actions executed by Python runner


### PR DESCRIPTION
Note: This PR is based on #2666.

This pull request updates remote runner so user can now also specify a path to the private key file for the `private_key` remote runner argument.

This resolves security concerns from #2662.

We are currently working on secrets in datastore story which goal is to solve some of the issues like that, but I still see value in allowing users to specify a path to the key file. A lot of organizations already have a code / configuration management in place or managing secret files on disk so it makes sense to allow users to re-use that functionality instead of forcing them to use datastore secrets which is StackStorm specific functionality.

In addition to that, I also fixed support for password protected keys (see https://github.com/StackStorm/st2/pull/2596#issuecomment-216768910 for details) and removed support for the deprecated `key` argument since the whole logic for that was kinda convoluted and made it hard to follow / understand.

## TODO:

- [x] Docs
- [x] Tests