### PR TITLE
[WIP] Allow administrators to disable a runner

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,9 @@ in development
 * Fix for `data` is dropped if `message` is not present in notification. (bug-fix)
 * Remove now deprecated Fabric based remote runner and corresponding
   ``ssh_runner.use_paramiko_ssh_runner`` config option. (cleanup)
+* Fix support for password protected private key files in the remote runner. (bug-fix)
+* Allow user to provide a path to the private SSH key file for the remote runner ``private_key``
+  parameter. Previously only raw key material was supported. (improvement)
 
 1.4.0 - April 18, 2016
 ----------------------

--- a/st2actions/st2actions/runners/ssh/parallel_ssh.py
+++ b/st2actions/st2actions/runners/ssh/parallel_ssh.py
@@ -233,7 +233,7 @@ class ParallelSSHClient(object):
 
         client = ParamikoSSHClient(hostname, username=self._ssh_user,
                                    password=self._ssh_password,
-                                   key=self._ssh_key_file,
+                                   key_files=self._ssh_key_file,
                                    key_material=self._ssh_key_material,
                                    passphrase=self._passphrase,
                                    port=port)

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh.py
@@ -74,8 +74,10 @@ class ParamikoSSHClient(object):
 
     # Maximum number of bytes to read at once from a socket
     CHUNK_SIZE = 1024
+
     # How long to sleep while waiting for command to finish
     SLEEP_DELAY = 1.5
+
     # Connect socket timeout
     CONNECT_TIMEOUT = 60
 
@@ -110,13 +112,16 @@ class ParamikoSSHClient(object):
         self.key_files = key_files
         self.timeout = timeout or ParamikoSSHClient.CONNECT_TIMEOUT
         self.key_material = key_material
-        self.client = None
-        self.logger = logging.getLogger(__name__)
-        self.sftp = None
         self.bastion_host = bastion_host
+        self.passphrase = passphrase
+
+        self.logger = logging.getLogger(__name__)
+
+        self.client = None
+        self.sftp = None
+
         self.bastion_client = None
         self.bastion_socket = None
-        self.passphrase = passphrase
 
     def connect(self):
         """

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh_runner.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh_runner.py
@@ -20,6 +20,7 @@ import six
 
 from st2actions.runners import ShellRunnerMixin
 from st2actions.runners import ActionRunner
+from st2common.constants.runners import REMOTE_RUNNER_PRIVATE_KEY_HEADER
 from st2actions.runners.ssh.parallel_ssh import ParallelSSHClient
 from st2common import log as logging
 from st2common.constants.action import LIVEACTION_STATUS_SUCCEEDED
@@ -120,33 +121,39 @@ class BaseParallelSSHRunner(ActionRunner, ShellRunnerMixin):
             LOG.debug('Limiting parallel SSH concurrency to %d.', concurrency)
             concurrency = self._max_concurrency
 
+        client_kwargs = {
+            'hosts': self._hosts,
+            'user': self._username,
+            'port': self._ssh_port,
+            'concurrency': concurrency,
+            'bastion_host': self._bastion_host,
+            'raise_on_any_error': False,
+            'connect': True
+        }
+
         if self._password:
-            self._parallel_ssh_client = ParallelSSHClient(
-                hosts=self._hosts,
-                user=self._username, password=self._password,
-                port=self._ssh_port, concurrency=concurrency,
-                bastion_host=self._bastion_host,
-                raise_on_any_error=False,
-                connect=True
-            )
+            client_kwargs['password'] = self._password
         elif self._private_key:
-            self._parallel_ssh_client = ParallelSSHClient(
-                hosts=self._hosts,
-                user=self._username, pkey_material=self._private_key,
-                port=self._ssh_port, concurrency=concurrency,
-                bastion_host=self._bastion_host,
-                raise_on_any_error=False,
-                connect=True
-            )
+            # Determine if the private_key is a path to the key file or the raw key material
+            is_key_material = self._is_private_key_material(private_key=self._private_key)
+
+            if is_key_material:
+                # Raw key material
+                client_kwargs['pkey_material'] = self._private_key
+            else:
+                # Assume it's a path to the key file, verify the file exists
+                client_kwargs['pkey_file'] = self._private_key
+
+            if self._passphrase:
+                client_kwargs['passphrase'] = self._passphrase
         else:
-            self._parallel_ssh_client = ParallelSSHClient(
-                hosts=self._hosts,
-                user=self._username, pkey_file=self._ssh_key_file,
-                port=self._ssh_port, concurrency=concurrency,
-                bastion_host=self._bastion_host,
-                raise_on_any_error=False,
-                connect=True
-            )
+            # Default to stanley key file specified in the config
+            client_kwargs['pkey_file'] = self._ssh_key_file
+
+        self._parallel_ssh_client = ParallelSSHClient(**client_kwargs)
+
+    def _is_private_key_material(self, private_key):
+        return private_key and REMOTE_RUNNER_PRIVATE_KEY_HEADER in private_key.lower()
 
     def _get_env_vars(self):
         """

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh_runner.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh_runner.py
@@ -30,6 +30,10 @@ from st2common.constants.runners import REMOTE_RUNNER_DEFAULT_ACTION_TIMEOUT
 from st2common.exceptions.actionrunner import ActionRunnerPreRunError
 from st2common.exceptions.ssh import InvalidCredentialsException
 
+__all__ = [
+    'BaseParallelSSHRunner'
+]
+
 LOG = logging.getLogger(__name__)
 
 # constants to lookup in runner_parameters.

--- a/st2actions/tests/unit/test_paramiko_ssh_runner.py
+++ b/st2actions/tests/unit/test_paramiko_ssh_runner.py
@@ -1,0 +1,187 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import unittest2
+import mock
+from oslo_config import cfg
+
+from st2actions.runners.ssh.paramiko_ssh_runner import BaseParallelSSHRunner
+from st2actions.runners.ssh.paramiko_ssh_runner import RUNNER_HOSTS
+from st2actions.runners.ssh.paramiko_ssh_runner import RUNNER_USERNAME
+from st2actions.runners.ssh.paramiko_ssh_runner import RUNNER_PASSWORD
+from st2actions.runners.ssh.paramiko_ssh_runner import RUNNER_PRIVATE_KEY
+from st2actions.runners.ssh.paramiko_ssh_runner import RUNNER_PASSPHRASE
+
+import st2tests.config as tests_config
+from st2tests.fixturesloader import get_resources_base_path
+tests_config.parse_args()
+
+
+class Runner(BaseParallelSSHRunner):
+    def run(self):
+        pass
+
+
+class ParamikoSSHRunnerTestCase(unittest2.TestCase):
+    @mock.patch('st2actions.runners.ssh.paramiko_ssh_runner.ParallelSSHClient')
+    def test_pre_run(self, mock_client):
+        # Test case which verifies that ParamikoSSHClient is instantiated with the correct arguments
+        private_key_path = os.path.join(get_resources_base_path(),
+                                       'ssh', 'dummy_rsa')
+
+        with open(private_key_path, 'r') as fp:
+            private_key = fp.read()
+
+        # Username and password provided
+        runner = Runner('id')
+        runner.context = {}
+        runner_parameters = {
+            RUNNER_HOSTS: 'localhost',
+            RUNNER_USERNAME: 'someuser1',
+            RUNNER_PASSWORD: 'somepassword'
+        }
+        runner.runner_parameters = runner_parameters
+        runner.pre_run()
+
+        expected_kwargs = {
+            'hosts': ['localhost'],
+            'user': 'someuser1',
+            'password': 'somepassword',
+            'port': 22,
+            'concurrency': 1,
+            'bastion_host': None,
+            'raise_on_any_error': False,
+            'connect': True
+        }
+        mock_client.assert_called_with(**expected_kwargs)
+
+        # Private key provided as raw key material
+        runner = Runner('id')
+        runner.context = {}
+        runner_parameters = {
+            RUNNER_HOSTS: 'localhost',
+            RUNNER_USERNAME: 'someuser2',
+            RUNNER_PRIVATE_KEY: private_key
+        }
+        runner.runner_parameters = runner_parameters
+        runner.pre_run()
+
+        expected_kwargs = {
+            'hosts': ['localhost'],
+            'user': 'someuser2',
+            'pkey_material': private_key,
+            'port': 22,
+            'concurrency': 1,
+            'bastion_host': None,
+            'raise_on_any_error': False,
+            'connect': True
+        }
+        mock_client.assert_called_with(**expected_kwargs)
+
+        # Private key provided as raw key material + passphrase
+        runner = Runner('id')
+        runner.context = {}
+        runner_parameters = {
+            RUNNER_HOSTS: 'localhost21',
+            RUNNER_USERNAME: 'someuser21',
+            RUNNER_PRIVATE_KEY: private_key,
+            RUNNER_PASSPHRASE: 'passphrase21'
+        }
+        runner.runner_parameters = runner_parameters
+        runner.pre_run()
+
+        expected_kwargs = {
+            'hosts': ['localhost21'],
+            'user': 'someuser21',
+            'pkey_material': private_key,
+            'passphrase': 'passphrase21',
+            'port': 22,
+            'concurrency': 1,
+            'bastion_host': None,
+            'raise_on_any_error': False,
+            'connect': True
+        }
+        mock_client.assert_called_with(**expected_kwargs)
+
+        # Private key provided as path to the private key file
+        runner = Runner('id')
+        runner.context = {}
+        runner_parameters = {
+            RUNNER_HOSTS: 'localhost',
+            RUNNER_USERNAME: 'someuser3',
+            RUNNER_PRIVATE_KEY: private_key_path
+        }
+        runner.runner_parameters = runner_parameters
+        runner.pre_run()
+
+        expected_kwargs = {
+            'hosts': ['localhost'],
+            'user': 'someuser3',
+            'pkey_file': private_key_path,
+            'port': 22,
+            'concurrency': 1,
+            'bastion_host': None,
+            'raise_on_any_error': False,
+            'connect': True
+        }
+        mock_client.assert_called_with(**expected_kwargs)
+
+        # Private key provided as path to the private key file + passpharse
+        runner = Runner('id')
+        runner.context = {}
+        runner_parameters = {
+            RUNNER_HOSTS: 'localhost31',
+            RUNNER_USERNAME: 'someuser31',
+            RUNNER_PRIVATE_KEY: private_key_path,
+            RUNNER_PASSPHRASE: 'passphrase31'
+        }
+        runner.runner_parameters = runner_parameters
+        runner.pre_run()
+
+        expected_kwargs = {
+            'hosts': ['localhost31'],
+            'user': 'someuser31',
+            'pkey_file': private_key_path,
+            'passphrase': 'passphrase31',
+            'port': 22,
+            'concurrency': 1,
+            'bastion_host': None,
+            'raise_on_any_error': False,
+            'connect': True
+        }
+        mock_client.assert_called_with(**expected_kwargs)
+
+        # No password or private key provided, should default to system user private key
+        runner = Runner('id')
+        runner.context = {}
+        runner_parameters = {
+            RUNNER_HOSTS: 'localhost4',
+        }
+        runner.runner_parameters = runner_parameters
+        runner.pre_run()
+
+        expected_kwargs = {
+            'hosts': ['localhost4'],
+            'user': cfg.CONF.system_user.user,
+            'pkey_file': cfg.CONF.system_user.ssh_key_file,
+            'port': 22,
+            'concurrency': 1,
+            'bastion_host': None,
+            'raise_on_any_error': False,
+            'connect': True
+        }
+        mock_client.assert_called_with(**expected_kwargs)

--- a/st2api/st2api/controllers/v1/runnertypes.py
+++ b/st2api/st2api/controllers/v1/runnertypes.py
@@ -22,6 +22,8 @@ from st2common.models.api.base import jsexpose
 from st2common.models.api.action import RunnerTypeAPI
 from st2common.persistence.runner import RunnerType
 from st2api.controllers.resource import ResourceController
+from st2common.rbac.types import PermissionType
+from st2common.rbac.decorators import request_user_has_permission
 
 http_client = six.moves.http_client
 
@@ -44,14 +46,17 @@ class RunnerTypesController(ResourceController):
         'sort': ['name']
     }
 
+    @request_user_has_permission(permission_type=PermissionType.RUNNER_LIST)
     @jsexpose()
     def get_all(self, **kwargs):
         return super(RunnerTypesController, self)._get_all(**kwargs)
 
+    @request_user_has_permission(permission_type=PermissionType.RUNNER_VIEW)
     @jsexpose(arg_types=[str])
     def get_one(self, name_or_id):
         return super(RunnerTypesController, self)._get_one_by_name_or_id(name_or_id)
 
+    @request_user_has_permission(permission_type=PermissionType.RUNNER_MODIFY)
     @jsexpose(arg_types=[str], body_cls=RunnerTypeAPI)
     def put(self, name_or_id, runner_type_api):
         # TODO: Only allow enabled attribute to be changed

--- a/st2api/st2api/controllers/v1/runnertypes.py
+++ b/st2api/st2api/controllers/v1/runnertypes.py
@@ -24,6 +24,7 @@ from st2common.persistence.runner import RunnerType
 from st2api.controllers.resource import ResourceController
 from st2common.rbac.types import PermissionType
 from st2common.rbac.decorators import request_user_has_permission
+from st2common.rbac.decorators import request_user_has_resource_db_permission
 
 http_client = six.moves.http_client
 
@@ -51,12 +52,12 @@ class RunnerTypesController(ResourceController):
     def get_all(self, **kwargs):
         return super(RunnerTypesController, self)._get_all(**kwargs)
 
-    @request_user_has_permission(permission_type=PermissionType.RUNNER_VIEW)
+    @request_user_has_resource_db_permission(permission_type=PermissionType.RUNNER_VIEW)
     @jsexpose(arg_types=[str])
     def get_one(self, name_or_id):
         return super(RunnerTypesController, self)._get_one_by_name_or_id(name_or_id)
 
-    @request_user_has_permission(permission_type=PermissionType.RUNNER_MODIFY)
+    @request_user_has_resource_db_permission(permission_type=PermissionType.RUNNER_MODIFY)
     @jsexpose(arg_types=[str], body_cls=RunnerTypeAPI)
     def put(self, name_or_id, runner_type_api):
         # TODO: Only allow enabled attribute to be changed

--- a/st2api/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
+++ b/st2api/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
@@ -42,6 +42,12 @@ TEST_FIXTURES = {
     'enforcements': ['enforcement1.yaml']
 }
 
+MOCK_RUNNER_1 = {
+    'name': 'test-runner-1',
+    'description': 'test',
+    'enabled': False
+}
+
 MOCK_ACTION_1 = {
     'name': 'ma.dummy.action',
     'pack': 'examples',
@@ -122,6 +128,20 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
         execution_model = self.models['executions']['execution1.yaml']
 
         supported_endpoints = [
+            # Runners
+            {
+                'path': '/v1/runnertypes',
+                'method': 'GET'
+            },
+            {
+                'path': '/v1/runnertypes/test-runner-1',
+                'method': 'GET'
+            },
+            {
+                'path': '/v1/runnertypes/test-runner-1',
+                'method': 'PUT',
+                'payload': MOCK_RUNNER_1
+            },
             # Packs
             {
                 'path': '/v1/packs',

--- a/st2client/st2client/commands/resource.py
+++ b/st2client/st2client/commands/resource.py
@@ -53,7 +53,8 @@ class ResourceNotFoundError(Exception):
 class ResourceBranch(commands.Branch):
 
     def __init__(self, resource, description, app, subparsers,
-                 parent_parser=None, read_only=False, commands=None):
+                 parent_parser=None, read_only=False, commands=None,
+                 has_disable=False):
 
         self.resource = resource
         super(ResourceBranch, self).__init__(
@@ -78,14 +79,25 @@ class ResourceBranch(commands.Branch):
         if 'delete' not in commands:
             commands['delete'] = ResourceDeleteCommand
 
+        if 'enable' not in commands:
+            commands['enable'] = ResourceEnableCommand
+
+        if 'disable' not in commands:
+            commands['disable'] = ResourceDisableCommand
+
         # Instantiate commands.
         args = [self.resource, self.app, self.subparsers]
         self.commands['list'] = commands['list'](*args)
         self.commands['get'] = commands['get'](*args)
+
         if not read_only:
             self.commands['create'] = commands['create'](*args)
             self.commands['update'] = commands['update'](*args)
             self.commands['delete'] = commands['delete'](*args)
+
+        if has_disable:
+            self.commands['enable'] = commands['enable'](*args)
+            self.commands['disable'] = commands['disable'](*args)
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -228,7 +228,7 @@ class Shell(object):
         self.commands['runner'] = resource.ResourceBranch(
             models.RunnerType,
             'Runner is a type of handler for a specific class of actions.',
-            self, self.subparsers, read_only=True)
+            self, self.subparsers, read_only=True, has_disable=True)
 
         self.commands['sensor'] = sensor.SensorBranch(
             'An adapter which allows you to integrate StackStorm with external system ',

--- a/st2common/st2common/bootstrap/runnersregistrar.py
+++ b/st2common/st2common/bootstrap/runnersregistrar.py
@@ -134,8 +134,8 @@ RUNNER_TYPES = [
                 'secret': True
             },
             'private_key': {
-                'description': ('Private key material to log in. Note: This needs to be actual '
-                                'private key data and NOT path.'),
+                'description': ('Private key material or path to the private key file on disk '
+                                'used to log in.'),
                 'type': 'string',
                 'required': False,
                 'secret': True

--- a/st2common/st2common/bootstrap/runnersregistrar.py
+++ b/st2common/st2common/bootstrap/runnersregistrar.py
@@ -577,6 +577,11 @@ def register_runner_types(experimental=False):
                 runner_type_db = None
                 update = False
 
+            # Note: We don't want to overwrite "enabled" attribute which is already in the database
+            # (aka we don't want to re-enable runner which has been disabled by the user)
+            if runner_type_db and runner_type_db['enabled'] != runner_type['enabled']:
+                runner_type['enabled'] = runner_type_db['enabled']
+
             runner_type_api = RunnerTypeAPI(**runner_type)
             runner_type_api.validate()
             runner_type_model = RunnerTypeAPI.to_model(runner_type_api)

--- a/st2common/st2common/constants/runners.py
+++ b/st2common/st2common/constants/runners.py
@@ -20,6 +20,7 @@ __all__ = [
 
     'REMOTE_RUNNER_DEFAULT_ACTION_TIMEOUT',
     'REMOTE_RUNNER_DEFAULT_REMOTE_DIR',
+    'REMOTE_RUNNER_PRIVATE_KEY_HEADER',
 
     'PYTHON_RUNNER_DEFAULT_ACTION_TIMEOUT',
 
@@ -39,6 +40,8 @@ try:
     REMOTE_RUNNER_DEFAULT_REMOTE_DIR = cfg.CONF.ssh_runner.remote_dir
 except:
     REMOTE_RUNNER_DEFAULT_REMOTE_DIR = '/tmp'
+
+REMOTE_RUNNER_PRIVATE_KEY_HEADER = 'PRIVATE KEY-----'.lower()
 
 # Python runner
 # Default timeout (in seconds) for actions executed by Python runner

--- a/st2common/st2common/constants/types.py
+++ b/st2common/st2common/constants/types.py
@@ -25,6 +25,10 @@ class ResourceType(Enum):
     Enum representing a valid resource type in a system.
     """
 
+    # System resources
+    RUNNER_TYPE = 'runner_type'
+
+    # Pack resources
     PACK = 'pack'
     ACTION = 'action'
     ACTION_ALIAS = 'action_alias'
@@ -35,6 +39,7 @@ class ResourceType(Enum):
     RULE = 'rule'
     RULE_ENFORCEMENT = 'rule_enforcement'
 
+    # Other resources
     EXECUTION = 'execution'
     KEY_VALUE_PAIR = 'key_value_pair'
 

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -58,6 +58,9 @@ class RunnerTypeAPI(BaseAPI):
                 "type": "string",
                 "default": None
             },
+            "uid": {
+                "type": "string"
+            },
             "name": {
                 "description": "The name of the action runner.",
                 "type": "string",

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -115,7 +115,7 @@ class RunnerTypeAPI(BaseAPI):
     def to_model(cls, runner_type):
         name = runner_type.name
         description = runner_type.description
-        enabled = bool(runner_type.enabled)
+        enabled = getattr(runner_type, 'enabled', True)
         runner_module = str(runner_type.runner_module)
         runner_parameters = getattr(runner_type, 'runner_parameters', dict())
         query_module = getattr(runner_type, 'query_module', None)

--- a/st2common/st2common/models/db/runner.py
+++ b/st2common/st2common/models/db/runner.py
@@ -18,6 +18,7 @@ import mongoengine as me
 from st2common import log as logging
 from st2common.models.db import MongoDBAccess
 from st2common.models.db import stormbase
+from st2common.constants.types import ResourceType
 
 __all__ = [
     'RunnerTypeDB',
@@ -29,7 +30,7 @@ LOG = logging.getLogger(__name__)
 PACK_SEPARATOR = '.'
 
 
-class RunnerTypeDB(stormbase.StormBaseDB):
+class RunnerTypeDB(stormbase.StormBaseDB, stormbase.UIDFieldMixin):
     """
     The representation of an RunnerType in the system. An RunnerType
     has a one-to-one mapping to a particular ActionRunner implementation.
@@ -43,6 +44,9 @@ class RunnerTypeDB(stormbase.StormBaseDB):
         runner_parameters: The specification for parameters for the action runner.
     """
 
+    RESOURCE_TYPE = ResourceType.RUNNER_TYPE
+    UID_FIELDS = ['name']
+
     enabled = me.BooleanField(
         required=True, default=True,
         help_text='A flag indicating whether the runner for this type is enabled.')
@@ -54,6 +58,14 @@ class RunnerTypeDB(stormbase.StormBaseDB):
     query_module = me.StringField(
         required=False,
         help_text='The python module that implements the query module for this runner.')
+
+    meta = {
+        'indexes': stormbase.UIDFieldMixin.get_indexes()
+    }
+
+    def __init__(self, *args, **values):
+        super(RunnerTypeDB, self).__init__(*args, **values)
+        self.uid = self.get_uid()
 
 # specialized access objects
 runnertype_access = MongoDBAccess(RunnerTypeDB)

--- a/st2common/st2common/rbac/resolvers.py
+++ b/st2common/st2common/rbac/resolvers.py
@@ -35,6 +35,7 @@ from st2common.services.rbac import get_all_permission_grants_for_user
 LOG = logging.getLogger(__name__)
 
 __all__ = [
+    'RunnerPermissionsResolver',
     'PackPermissionsResolver',
     'SensorPermissionsResolver',
     'ActionPermissionsResolver',
@@ -247,6 +248,51 @@ class ContentPackResourcePermissionsResolver(PermissionsResolver):
 
         self._log('No matching grants found', extra=log_context)
         return False
+
+
+class RunnerPermissionsResolver(PermissionsResolver):
+    """
+    Permission resolver for "runner_type" resource type.
+    """
+    resource_type = ResourceType.RUNNER
+
+    def user_has_permission(self, user_db, permission_type):
+        assert permission_type in [PermissionType.RUNNER_LIST]
+        return self._user_has_list_permission(user_db=user_db, permission_type=permission_type)
+
+    def user_has_resource_db_permission(self, user_db, resource_db, permission_type):
+        log_context = {
+            'user_db': user_db,
+            'resource_db': resource_db,
+            'permission_type': permission_type,
+            'resolver': self.__class__.__name__
+        }
+        self._log('Checking user resource permissions', extra=log_context)
+
+        # First check the system role permissions
+        has_system_role_permission = self._user_has_system_role_permission(
+            user_db=user_db, permission_type=permission_type)
+
+        if has_system_role_permission:
+            self._log('Found a matching grant via system role', extra=log_context)
+            return True
+
+        # Check custom roles
+        resource_uid = resource_db.get_uid()
+        resource_types = [ResourceType.RUNNER]
+        permission_types = [permission_type]
+        permission_grants = get_all_permission_grants_for_user(user_db=user_db,
+                                                               resource_uid=resource_uid,
+                                                               resource_types=resource_types,
+                                                               permission_types=permission_types)
+
+        if len(permission_grants) >= 1:
+            self._log('Found a direct grant on the runner type', extra=log_context)
+            return True
+
+        self._log('No matching grants found', extra=log_context)
+        return False
+
 
 
 class PackPermissionsResolver(PermissionsResolver):
@@ -762,7 +808,9 @@ def get_resolver_for_resource_type(resource_type):
 
     :rtype: Instance of :class:`PermissionsResolver`
     """
-    if resource_type == ResourceType.PACK:
+    if resource_type == ResourceType.RUNNER:
+        resolver_cls = RunnerPermissionsResolver
+    elif resource_type == ResourceType.PACK:
         resolver_cls = PackPermissionsResolver
     elif resource_type == ResourceType.SENSOR:
         resolver_cls = SensorPermissionsResolver

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -31,6 +31,12 @@ class PermissionType(Enum):
     Available permission types.
     """
 
+    # Note: There is no create endpoint for runner types right now
+    RUNNER_LIST = 'runner_type_list'
+    RUNNER_VIEW = 'runner_type_view'
+    RUNNER_MODIFY = 'runner_type_modify'
+    RUNNER_ALL = 'runner_type_all'
+
     PACK_LIST = 'pack_list'
     PACK_VIEW = 'pack_view'
     PACK_CREATE = 'pack_create'
@@ -160,6 +166,8 @@ class ResourceType(Enum):
     """
     Resource types on which permissions can be granted.
     """
+    RUNNER = SystemResourceType.RUNNER_TYPE
+
     PACK = SystemResourceType.PACK
     SENSOR = SystemResourceType.SENSOR_TYPE
     ACTION = SystemResourceType.ACTION

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -192,6 +192,12 @@ class SystemRole(Enum):
 
 # Maps a list of available permission types for each resource
 RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP = {
+    ResourceType.RUNNER: [
+        PermissionType.RUNNER_LIST,
+        PermissionType.RUNNER_VIEW,
+        PermissionType.RUNNER_MODIFY,
+        PermissionType.RUNNER_ALL,
+    ],
     ResourceType.PACK: [
         PermissionType.PACK_VIEW,
         PermissionType.PACK_CREATE,


### PR DESCRIPTION
This pull request introduces a new API and corresponding CLI commands which allows administrator to disable a particular runner.

In addition to that, it includes other related changes and improvements:

1. It ports RunnerType API endpoint to utilize `ResourceController` class. This way this API endpoint behaves the same as other API endpoints (limit works, filtering works, etc.) and means we can get rid of the duplicated code.
2. Introduces RBAC support for `RunnerType` resource. This is need because only admins (or people with an explicit permission grant) are allowed to disable / enable a runner (previously we could get away with not having RunnerType API endpoint behind RBAC wall, not we can't anymore).
3. Fixes runner registration - if user has explicitly disabled a runner through the API, runner won't get re-enabled when running register content and registering runners (aka the expected behavior).

## Background

I initially went with the config approach, but in https://github.com/StackStorm/st2/pull/2671#discussion_r62194745, @manasdk pointed out that we already have a concept for disabling a particular runner (aka `enabled` attribute on the `RunnerTypeDB` model). This attribute was there, but it wasn't hooked up and working so I hooked it up.

The whole change did require more work compared to the config approach (rbac, etc.), but imo it's worth it (RBAC is something we would eventually need to get done anyway) and this approach is generic so it applies to every runner, not just local one.

TODO:

- [ ] Update BaseRunner `pre_run` method to throw and abort action execution if a runner is disabled. Also update all the affected runner classes (aka all classes which inherit from the base class).
- [ ] Tests for RBAC permissions resolver
- [ ] Only allow "enabled" attribute of the runner to be changed through the modify / PUT API endpoint
- [ ] Tests for a disabled runner