### PR TITLE
Allow administrator to disable a runner

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,9 @@ in development
 * Fix support for password protected private key files in the remote runner. (bug-fix)
 * Allow user to provide a path to the private SSH key file for the remote runner ``private_key``
   parameter. Previously only raw key material was supported. (improvement)
+* Add new API endpoint and corresponding CLI commands (``st2 runner disable <name>``,
+  ``st2 runner enable <name>``) which allows administrator to disable (and re-enable) a runner.
+  (new feature)
 
 1.4.0 - April 18, 2016
 ----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ in development
 * Add new API endpoint and corresponding CLI commands (``st2 runner disable <name>``,
   ``st2 runner enable <name>``) which allows administrator to disable (and re-enable) a runner.
   (new feature)
+* Add RBAC support for runner types API endpoints. (improvement)
 
 1.4.0 - April 18, 2016
 ----------------------

--- a/st2actions/st2actions/container/base.py
+++ b/st2actions/st2actions/container/base.py
@@ -231,6 +231,7 @@ class RunnerContainer(object):
         resolved_entry_point = self._get_entry_point_abs_path(action_db.pack,
                                                               action_db.entry_point)
 
+        runner.runner_type_db = runnertype_db
         runner.container_service = RunnerContainerService()
         runner.action = action_db
         runner.action_name = action_db.name

--- a/st2actions/st2actions/runners/__init__.py
+++ b/st2actions/st2actions/runners/__init__.py
@@ -70,6 +70,7 @@ class ActionRunner(object):
         """
         self.runner_id = runner_id
 
+        self.runner_type_db = None
         self.container_service = None
         self.runner_parameters = None
         self.action = None
@@ -85,9 +86,13 @@ class ActionRunner(object):
         self.auth_token = None
         self.rerun_ex_ref = None
 
-    @abc.abstractmethod
     def pre_run(self):
-        raise NotImplementedError()
+        runner_enabled = self.runner_type_db.enabled
+        runner_name = self.runner_type_db.name
+        if not runner_enabled:
+            msg = ('Runner "%s" has been disabled by the administrator' %
+                   (runner_name))
+            raise ValueError(msg)
 
     # Run will need to take an action argument
     # Run may need result data argument

--- a/st2actions/st2actions/runners/__init__.py
+++ b/st2actions/st2actions/runners/__init__.py
@@ -87,8 +87,8 @@ class ActionRunner(object):
         self.rerun_ex_ref = None
 
     def pre_run(self):
-        runner_enabled = self.runner_type_db.enabled
-        runner_name = self.runner_type_db.name
+        runner_enabled = getattr(self.runner_type_db, 'enabled', True)
+        runner_name = getattr(self.runner_type_db, 'name', 'unknown')
         if not runner_enabled:
             msg = ('Runner "%s" has been disabled by the administrator' %
                    (runner_name))

--- a/st2actions/st2actions/runners/actionchainrunner.py
+++ b/st2actions/st2actions/runners/actionchainrunner.py
@@ -230,6 +230,8 @@ class ActionChainRunner(ActionRunner):
         self._chain_notify = None
 
     def pre_run(self):
+        super(ActionChainRunner, self).pre_run()
+
         chainspec_file = self.entry_point
         LOG.debug('Reading action chain from %s for action %s.', chainspec_file,
                   self.action)

--- a/st2actions/st2actions/runners/announcementrunner.py
+++ b/st2actions/st2actions/runners/announcementrunner.py
@@ -35,6 +35,8 @@ class AnnouncementRunner(ActionRunner):
         self._dispatcher = AnnouncementDispatcher(LOG)
 
     def pre_run(self):
+        super(AnnouncementRunner, self).pre_run()
+
         LOG.debug('Entering AnnouncementRunner.pre_run() for liveaction_id="%s"',
                   self.liveaction_id)
 

--- a/st2actions/st2actions/runners/httprunner.py
+++ b/st2actions/st2actions/runners/httprunner.py
@@ -67,6 +67,8 @@ class HttpRunner(ActionRunner):
         self._timeout = 60
 
     def pre_run(self):
+        super(HttpRunner, self).pre_run()
+
         LOG.debug('Entering HttpRunner.pre_run() for liveaction_id="%s"', self.liveaction_id)
         self._on_behalf_user = self.runner_parameters.get(RUNNER_ON_BEHALF_USER,
                                                           self._on_behalf_user)

--- a/st2actions/st2actions/runners/localrunner.py
+++ b/st2actions/st2actions/runners/localrunner.py
@@ -71,6 +71,8 @@ class LocalShellRunner(ActionRunner, ShellRunnerMixin):
         super(LocalShellRunner, self).__init__(runner_id=runner_id)
 
     def pre_run(self):
+        super(LocalShellRunner, self).pre_run()
+
         self._sudo = self.runner_parameters.get(RUNNER_SUDO, False)
         self._on_behalf_user = self.context.get(RUNNER_ON_BEHALF_USER, LOGGED_USER_USERNAME)
         self._user = cfg.CONF.system_user.user

--- a/st2actions/st2actions/runners/nooprunner.py
+++ b/st2actions/st2actions/runners/nooprunner.py
@@ -40,7 +40,7 @@ class NoopRunner(ActionRunner):
         super(NoopRunner, self).__init__(runner_id=runner_id)
 
     def pre_run(self):
-        pass
+        super(NoopRunner, self).pre_run()
 
     def run(self, action_parameters):
 

--- a/st2actions/st2actions/runners/pythonrunner.py
+++ b/st2actions/st2actions/runners/pythonrunner.py
@@ -92,6 +92,8 @@ class PythonRunner(ActionRunner):
         self._timeout = timeout
 
     def pre_run(self):
+        super(PythonRunner, self).pre_run()
+
         # TODO :This is awful, but the way "runner_parameters" and other variables get
         # assigned on the runner instance is even worse. Those arguments should
         # be passed to the constructor.

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh_runner.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh_runner.py
@@ -85,6 +85,8 @@ class BaseParallelSSHRunner(ActionRunner, ShellRunnerMixin):
         self._max_concurrency = cfg.CONF.ssh_runner.max_parallel_actions
 
     def pre_run(self):
+        super(BaseParallelSSHRunner, self).pre_run()
+
         LOG.debug('Entering BaseParallelSSHRunner.pre_run() for liveaction_id="%s"',
                   self.liveaction_id)
         hosts = self.runner_parameters.get(RUNNER_HOSTS, '').split(',')

--- a/st2actions/st2actions/runners/windows_command_runner.py
+++ b/st2actions/st2actions/runners/windows_command_runner.py
@@ -51,6 +51,8 @@ class WindowsCommandRunner(BaseWindowsRunner):
         self._timeout = timeout
 
     def pre_run(self):
+        super(WindowsCommandRunner, self).pre_run()
+
         # TODO :This is awful, but the way "runner_parameters" and other variables get
         # assigned on the runner instance is even worse. Those arguments should
         # be passed to the constructor.

--- a/st2actions/st2actions/runners/windows_script_runner.py
+++ b/st2actions/st2actions/runners/windows_script_runner.py
@@ -75,6 +75,8 @@ class WindowsScriptRunner(BaseWindowsRunner, ShellRunnerMixin):
         self._timeout = timeout
 
     def pre_run(self):
+        super(WindowsScriptRunner, self).pre_run()
+
         # TODO :This is awful, but the way "runner_parameters" and other variables get
         # assigned on the runner instance is even worse. Those arguments should
         # be passed to the constructor.

--- a/st2actions/tests/unit/test_notifier.py
+++ b/st2actions/tests/unit/test_notifier.py
@@ -88,7 +88,7 @@ class NotifierTestCase(unittest2.TestCase):
         return_value=ActionDB(pack='core', name='local', runner_type={'name': 'run-local-cmd'},
                               parameters={})))
     @mock.patch('st2common.util.action_db.get_runnertype_by_name', mock.MagicMock(
-        return_value=RunnerTypeDB(runner_parameters={})))
+        return_value=RunnerTypeDB(name='foo', runner_parameters={})))
     @mock.patch.object(Action, 'get_by_ref', mock.MagicMock(
         return_value={'runner_type': {'name': 'run-local-cmd'}}))
     @mock.patch.object(Policy, 'query', mock.MagicMock(
@@ -115,7 +115,7 @@ class NotifierTestCase(unittest2.TestCase):
     @mock.patch('st2common.util.action_db.get_action_by_ref', mock.MagicMock(
         return_value=ActionDB(pack='core', name='local', runner_type={'name': 'run-local-cmd'})))
     @mock.patch('st2common.util.action_db.get_runnertype_by_name', mock.MagicMock(
-        return_value=RunnerTypeDB(runner_parameters={'runner_foo': 'foo'})))
+        return_value=RunnerTypeDB(name='foo', runner_parameters={'runner_foo': 'foo'})))
     @mock.patch.object(Action, 'get_by_ref', mock.MagicMock(
         return_value={'runner_type': {'name': 'run-local-cmd'}}))
     @mock.patch.object(Policy, 'query', mock.MagicMock(

--- a/st2actions/tests/unit/test_runner_container.py
+++ b/st2actions/tests/unit/test_runner_container.py
@@ -78,7 +78,7 @@ class RunnerContainerTest(DbTestCase):
         self.assertTrue(runner is not None, 'TestRunner must be valid.')
 
     def test_get_runner_module_fail(self):
-        runnertype_db = RunnerTypeDB(runner_module='absent.module')
+        runnertype_db = RunnerTypeDB(name='dummy', runner_module='absent.module')
         runner = None
         try:
             runner = get_runner(runnertype_db.runner_module)

--- a/st2actions/tests/unit/test_runner_container.py
+++ b/st2actions/tests/unit/test_runner_container.py
@@ -72,10 +72,26 @@ class RunnerContainerTest(DbTestCase):
         RunnerContainerTest.async_action_db = models['actions']['async_action1.yaml']
         RunnerContainerTest.failingaction_db = models['actions']['action-invalid-runner.yaml']
 
+    @classmethod
+    def tearDownClass(cls):
+        RunnerContainerTest.fixtures_loader.delete_fixtures_from_db(
+            fixtures_pack=FIXTURES_PACK, fixtures_dict=TEST_FIXTURES)
+        super(RunnerContainerTest, cls).tearDownClass()
+
     def test_get_runner_module(self):
         runnertype_db = RunnerContainerTest.runnertype_db
         runner = get_runner(runnertype_db.runner_module)
         self.assertTrue(runner is not None, 'TestRunner must be valid.')
+
+    def test_pre_run_runner_is_disabled(self):
+        runnertype_db = RunnerContainerTest.runnertype_db
+        runner = get_runner(runnertype_db.runner_module)
+
+        runner.runner_type_db = runnertype_db
+        runner.runner_type_db.enabled = False
+
+        expected_msg = 'Runner "test-runner-1" has been disabled by the administrator'
+        self.assertRaisesRegexp(ValueError, expected_msg, runner.pre_run)
 
     def test_get_runner_module_fail(self):
         runnertype_db = RunnerTypeDB(name='dummy', runner_module='absent.module')
@@ -203,9 +219,3 @@ class RunnerContainerTest(DbTestCase):
                                      action=action_ref, parameters=parameters,
                                      context=context)
         return liveaction_db
-
-    @classmethod
-    def tearDownClass(cls):
-        RunnerContainerTest.fixtures_loader.delete_fixtures_from_db(
-            fixtures_pack=FIXTURES_PACK, fixtures_dict=TEST_FIXTURES)
-        super(RunnerContainerTest, cls).tearDownClass()

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -230,6 +230,10 @@ class ResourceController(rest.RestController):
             # Try name
             resource_db = self._get_by_name(resource_name=name_or_id, exclude_fields=exclude_fields)
 
+        if not resource_db:
+            msg = 'Resource with a name or id "%s" not found' % (name_or_id)
+            raise StackStormDBObjectNotFoundError(msg)
+
         return resource_db
 
     def _get_from_model_kwargs_for_request(self, request):

--- a/st2api/st2api/controllers/v1/runnertypes.py
+++ b/st2api/st2api/controllers/v1/runnertypes.py
@@ -60,8 +60,9 @@ class RunnerTypesController(ResourceController):
     @request_user_has_resource_db_permission(permission_type=PermissionType.RUNNER_MODIFY)
     @jsexpose(arg_types=[str], body_cls=RunnerTypeAPI)
     def put(self, name_or_id, runner_type_api):
-        # TODO: Only allow enabled attribute to be changed
+        # Note: We only allow "enabled" attribute of the runner to be changed
         runner_type_db = self._get_by_name_or_id(name_or_id=name_or_id)
+        old_runner_type_db = runner_type_db
         LOG.debug('PUT /runnertypes/ lookup with id=%s found object: %s', name_or_id,
                   runner_type_db)
 
@@ -70,9 +71,7 @@ class RunnerTypesController(ResourceController):
                 LOG.warning('Discarding mismatched id=%s found in payload and using uri_id=%s.',
                             runner_type_api.id, name_or_id)
 
-            old_runner_type_db = runner_type_db
-            runner_type_db = RunnerTypeAPI.to_model(runner_type_api)
-            runner_type_db.id = name_or_id
+            runner_type_db.enabled = runner_type_api.enabled
             runner_type_db = RunnerType.add_or_update(runner_type_db)
         except (ValidationError, ValueError) as e:
             LOG.exception('Validation failed for runner type data=%s', runner_type_api)

--- a/st2api/st2api/controllers/v1/runnertypes.py
+++ b/st2api/st2api/controllers/v1/runnertypes.py
@@ -22,6 +22,8 @@ from st2common.models.api.base import jsexpose
 from st2common.models.api.action import RunnerTypeAPI
 from st2common.persistence.runner import RunnerType
 from st2api.controllers.resource import ResourceController
+from st2common.rbac.types import PermissionType
+from st2common.rbac.decorators import request_user_has_permission
 
 http_client = six.moves.http_client
 
@@ -44,14 +46,17 @@ class RunnerTypesController(ResourceController):
         'sort': ['name']
     }
 
+    @request_user_has_permission(permission_type=PermissionType.RUNNER_LIST)
     @jsexpose()
     def get_all(self, **kwargs):
         return super(RunnerTypesController, self)._get_all(**kwargs)
 
+    @request_user_has_permission(permission_type=PermissionType.RUNNER_VIEW)
     @jsexpose(arg_types=[str])
     def get_one(self, name_or_id):
         return super(RunnerTypesController, self)._get_one_by_name_or_id(name_or_id)
 
+    @request_user_has_permission(permission_type=PermissionType.RUNNER_MODIFY)
     @jsexpose(arg_types=[str], body_cls=RunnerTypeAPI)
     def put(self, name_or_id, runner_type_api):
         # TODO: Only allow enabled attribute to be changed

--- a/st2api/st2api/controllers/v1/runnertypes.py
+++ b/st2api/st2api/controllers/v1/runnertypes.py
@@ -24,6 +24,7 @@ from st2common.persistence.runner import RunnerType
 from st2api.controllers.resource import ResourceController
 from st2common.rbac.types import PermissionType
 from st2common.rbac.decorators import request_user_has_permission
+from st2common.rbac.decorators import request_user_has_resource_db_permission
 
 http_client = six.moves.http_client
 
@@ -51,12 +52,12 @@ class RunnerTypesController(ResourceController):
     def get_all(self, **kwargs):
         return super(RunnerTypesController, self)._get_all(**kwargs)
 
-    @request_user_has_permission(permission_type=PermissionType.RUNNER_VIEW)
+    @request_user_has_resource_db_permission(permission_type=PermissionType.RUNNER_VIEW)
     @jsexpose(arg_types=[str])
     def get_one(self, name_or_id):
         return super(RunnerTypesController, self)._get_one_by_name_or_id(name_or_id)
 
-    @request_user_has_permission(permission_type=PermissionType.RUNNER_MODIFY)
+    @request_user_has_resource_db_permission(permission_type=PermissionType.RUNNER_MODIFY)
     @jsexpose(arg_types=[str], body_cls=RunnerTypeAPI)
     def put(self, name_or_id, runner_type_api):
         # TODO: Only allow enabled attribute to be changed

--- a/st2api/tests/base.py
+++ b/st2api/tests/base.py
@@ -93,6 +93,7 @@ class APIControllerWithRBACTestCase(FunctionalTest, CleanDbTestCase):
         super(APIControllerWithRBACTestCase, self).setUp()
 
         self.users = {}
+        self.roles = {}
 
         # Run RBAC migrations
         run_all_rbac_migrations()

--- a/st2api/tests/base.py
+++ b/st2api/tests/base.py
@@ -109,6 +109,11 @@ class APIControllerWithRBACTestCase(FunctionalTest, CleanDbTestCase):
                 role=role_name)
             UserRoleAssignment.add_or_update(role_assignment_db)
 
+        # Insert a user with no permissions and role assignments
+        user_1_db = UserDB(name='no_permissions')
+        user_1_db = User.add_or_update(user_1_db)
+        self.users['no_permissions'] = user_1_db
+
     def tearDown(self):
         super(APIControllerWithRBACTestCase, self).tearDown()
 

--- a/st2api/tests/unit/controllers/v1/test_actions_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_actions_rbac.py
@@ -72,15 +72,8 @@ class ActionControllerRBACTestCase(APIControllerWithRBACTestCase):
             fixtures_dict={'actions': [file_name]})['actions'][file_name]
 
         # Insert mock users, roles and assignments
-        self = self
-        self.users = {}
-        self.roles = {}
 
         # Users
-        user_1_db = UserDB(name='no_permissions')
-        user_1_db = User.add_or_update(user_1_db)
-        self.users['no_permissions'] = user_1_db
-
         user_2_db = UserDB(name='action_create')
         user_2_db = User.add_or_update(user_2_db)
         self.users['action_create'] = user_2_db

--- a/st2api/tests/unit/controllers/v1/test_packs.py
+++ b/st2api/tests/unit/controllers/v1/test_packs.py
@@ -41,8 +41,8 @@ class PacksControllerTestCase(FunctionalTest):
         self.assertEqual(resp.status_int, 200)
         self.assertEqual(resp.json['name'], self.pack_db_1.name)
 
-        # Get by ref
-        resp = self.app.get('/v1/packs/%s' % (self.pack_db_1.ref))
+        # Get by name
+        resp = self.app.get('/v1/packs/%s' % (self.pack_db_1.name))
         self.assertEqual(resp.status_int, 200)
         self.assertEqual(resp.json['ref'], self.pack_db_1.ref)
         self.assertEqual(resp.json['name'], self.pack_db_1.name)

--- a/st2api/tests/unit/controllers/v1/test_packs.py
+++ b/st2api/tests/unit/controllers/v1/test_packs.py
@@ -23,9 +23,9 @@ class PacksControllerTestCase(FunctionalTest):
     def setUpClass(cls):
         super(PacksControllerTestCase, cls).setUpClass()
 
-        cls.pack_db_1 = PackDB(name='Pack1', description='foo', version='0.1.0', author='foo',
+        cls.pack_db_1 = PackDB(name='pack1', description='foo', version='0.1.0', author='foo',
                                email='test@example.com', ref='pack1')
-        cls.pack_db_2 = PackDB(name='Pack2', description='foo', version='0.1.0', author='foo',
+        cls.pack_db_2 = PackDB(name='pack2', description='foo', version='0.1.0', author='foo',
                                email='test@example.com', ref='pack2')
         Pack.add_or_update(cls.pack_db_1)
         Pack.add_or_update(cls.pack_db_2)
@@ -42,7 +42,7 @@ class PacksControllerTestCase(FunctionalTest):
         self.assertEqual(resp.json['name'], self.pack_db_1.name)
 
         # Get by name
-        resp = self.app.get('/v1/packs/%s' % (self.pack_db_1.name))
+        resp = self.app.get('/v1/packs/%s' % (self.pack_db_1.ref))
         self.assertEqual(resp.status_int, 200)
         self.assertEqual(resp.json['ref'], self.pack_db_1.ref)
         self.assertEqual(resp.json['name'], self.pack_db_1.name)

--- a/st2api/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
+++ b/st2api/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
@@ -42,6 +42,12 @@ TEST_FIXTURES = {
     'enforcements': ['enforcement1.yaml']
 }
 
+MOCK_RUNNER_1 = {
+    'name': 'test-runner-1',
+    'description': 'test',
+    'enabled': False
+}
+
 MOCK_ACTION_1 = {
     'name': 'ma.dummy.action',
     'pack': 'examples',
@@ -122,6 +128,20 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
         execution_model = self.models['executions']['execution1.yaml']
 
         supported_endpoints = [
+            # Runners
+            {
+                'path': '/v1/runnertypes',
+                'method': 'GET'
+            },
+            {
+                'path': '/v1/runnertypes/test-runner-1',
+                'method': 'GET'
+            },
+            {
+                'path': '/v1/runnertypes/test-runner-1',
+                'method': 'PUT',
+                'payload': MOCK_RUNNER_1
+            },
             # Packs
             {
                 'path': '/v1/packs',

--- a/st2api/tests/unit/controllers/v1/test_rules_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_rules_rbac.py
@@ -66,9 +66,6 @@ class RuleControllerRBACTestCase(APIControllerWithRBACTestCase):
             fixtures_dict={'rules': [file_name]})['rules'][file_name]
 
         # Insert mock users, roles and assignments
-        self = self
-        self.users = {}
-        self.roles = {}
 
         # Users
         user_1_db = UserDB(name='rule_create')

--- a/st2api/tests/unit/controllers/v1/test_runnertypes.py
+++ b/st2api/tests/unit/controllers/v1/test_runnertypes.py
@@ -34,9 +34,36 @@ class TestRunnerTypesController(FunctionalTest):
         self.assertEqual(resp.status_int, 200)
         self.assertTrue(len(resp.json) > 0, '/v1/runnertypes did not return correct runnertypes.')
 
-    def test_get_one_fail(self):
+    def test_get_one_fail_doesnt_exist(self):
         resp = self.app.get('/v1/runnertypes/1', expect_errors=True)
         self.assertEqual(resp.status_int, 404)
+
+    def test_put_disable_runner(self):
+        runnertype_id = 'action-chain'
+        resp = self.app.get('/v1/runnertypes/%s' % runnertype_id)
+        self.assertTrue(resp.json['enabled'])
+
+        # Disable the runner
+        update_input = resp.json
+        update_input['enabled'] = False
+        update_input['name'] = 'foobar'
+
+        put_resp = self.__do_put(runnertype_id, update_input)
+        self.assertFalse(put_resp.json['enabled'])
+
+        # Verify that the name hasn't been updated - we only allow updating
+        # enabled attribute on the runner
+        self.assertEqual(put_resp.json['name'], 'action-chain')
+
+        # Enable the runner
+        update_input = resp.json
+        update_input['enabled'] = True
+
+        put_resp = self.__do_put(runnertype_id, update_input)
+        self.assertTrue(put_resp.json['enabled'])
+
+    def __do_put(self, runner_type_id, runner_type):
+        return self.app.put_json('/v1/runnertypes/%s' % runner_type_id, runner_type, expect_errors=True)
 
     @staticmethod
     def __get_runnertype_id(resp_json):

--- a/st2api/tests/unit/controllers/v1/test_runnertypes.py
+++ b/st2api/tests/unit/controllers/v1/test_runnertypes.py
@@ -63,7 +63,8 @@ class TestRunnerTypesController(FunctionalTest):
         self.assertTrue(put_resp.json['enabled'])
 
     def __do_put(self, runner_type_id, runner_type):
-        return self.app.put_json('/v1/runnertypes/%s' % runner_type_id, runner_type, expect_errors=True)
+        return self.app.put_json('/v1/runnertypes/%s' % runner_type_id, runner_type,
+                                expect_errors=True)
 
     @staticmethod
     def __get_runnertype_id(resp_json):

--- a/st2api/tests/unit/controllers/v1/test_runnertypes_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_runnertypes_rbac.py
@@ -1,0 +1,86 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import httplib
+
+import six
+
+from st2tests.fixturesloader import FixturesLoader
+from tests.base import APIControllerWithRBACTestCase
+
+http_client = six.moves.http_client
+
+__all__ = [
+    'RunnerTypesControllerRBACTestCase'
+]
+
+FIXTURES_PACK = 'generic'
+TEST_FIXTURES = {
+    'runners': ['testrunner1.yaml'],
+    'actions': ['action1.yaml', 'local.yaml'],
+    'triggers': ['trigger1.yaml'],
+    'triggertypes': ['triggertype1.yaml']
+}
+
+
+class RunnerTypesControllerRBACTestCase(APIControllerWithRBACTestCase):
+    fixtures_loader = FixturesLoader()
+
+    def setUp(self):
+        super(RunnerTypesControllerRBACTestCase, self).setUp()
+        self.fixtures_loader.save_fixtures_to_db(fixtures_pack=FIXTURES_PACK,
+                                                 fixtures_dict=TEST_FIXTURES)
+
+    def test_get_all_and_get_one_no_permissions(self):
+        # get all
+        user_db = self.users['no_permissions']
+        self.use_user(user_db)
+
+        resp = self.app.get('/v1/runnertypes', expect_errors=True)
+        expected_msg = ('User "no_permissions" doesn\'t have required permission '
+                        '"runner_type_list"')
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertEqual(resp.json['faultstring'], expected_msg)
+
+        # get one
+        resp = self.app.get('/v1/runnertypes/test-runner-1', expect_errors=True)
+        expected_msg = ('User "no_permissions" doesn\'t have required permission '
+                        '"runner_type_view" on resource "runner_type:test-runner-1"')
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertEqual(resp.json['faultstring'], expected_msg)
+
+    def test_put_disable_runner_no_permissions(self):
+        user_db = self.users['admin']
+        self.use_user(user_db)
+
+        runnertype_id = 'test-runner-1'
+        resp = self.app.get('/v1/runnertypes/%s' % runnertype_id)
+
+        # Disable the runner
+        user_db = self.users['no_permissions']
+        self.use_user(user_db)
+
+        update_input = resp.json
+        update_input['enabled'] = False
+
+        resp = self.__do_put(runnertype_id, update_input)
+        expected_msg = ('User "no_permissions" doesn\'t have required permission '
+                        '"runner_type_modify" on resource "runner_type:test-runner-1"')
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertEqual(resp.json['faultstring'], expected_msg)
+
+    def __do_put(self, runner_type_id, runner_type):
+        return self.app.put_json('/v1/runnertypes/%s' % runner_type_id, runner_type,
+                                expect_errors=True)

--- a/st2client/st2client/commands/resource.py
+++ b/st2client/st2client/commands/resource.py
@@ -53,7 +53,8 @@ class ResourceNotFoundError(Exception):
 class ResourceBranch(commands.Branch):
 
     def __init__(self, resource, description, app, subparsers,
-                 parent_parser=None, read_only=False, commands=None):
+                 parent_parser=None, read_only=False, commands=None,
+                 has_disable=False):
 
         self.resource = resource
         super(ResourceBranch, self).__init__(
@@ -78,14 +79,25 @@ class ResourceBranch(commands.Branch):
         if 'delete' not in commands:
             commands['delete'] = ResourceDeleteCommand
 
+        if 'enable' not in commands:
+            commands['enable'] = ResourceEnableCommand
+
+        if 'disable' not in commands:
+            commands['disable'] = ResourceDisableCommand
+
         # Instantiate commands.
         args = [self.resource, self.app, self.subparsers]
         self.commands['list'] = commands['list'](*args)
         self.commands['get'] = commands['get'](*args)
+
         if not read_only:
             self.commands['create'] = commands['create'](*args)
             self.commands['update'] = commands['update'](*args)
             self.commands['delete'] = commands['delete'](*args)
+
+        if has_disable:
+            self.commands['enable'] = commands['enable'](*args)
+            self.commands['disable'] = commands['disable'](*args)
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -228,7 +228,7 @@ class Shell(object):
         self.commands['runner'] = resource.ResourceBranch(
             models.RunnerType,
             'Runner is a type of handler for a specific class of actions.',
-            self, self.subparsers, read_only=True)
+            self, self.subparsers, read_only=True, has_disable=True)
 
         self.commands['sensor'] = sensor.SensorBranch(
             'An adapter which allows you to integrate StackStorm with external system ',

--- a/st2common/st2common/bootstrap/runnersregistrar.py
+++ b/st2common/st2common/bootstrap/runnersregistrar.py
@@ -577,6 +577,11 @@ def register_runner_types(experimental=False):
                 runner_type_db = None
                 update = False
 
+            # Note: We don't want to overwrite "enabled" attribute which is already in the database
+            # (aka we don't want to re-enable runner which has been disabled by the user)
+            if runner_type_db and runner_type_db['enabled'] != runner_type['enabled']:
+                runner_type['enabled'] = runner_type_db['enabled']
+
             runner_type_api = RunnerTypeAPI(**runner_type)
             runner_type_api.validate()
             runner_type_model = RunnerTypeAPI.to_model(runner_type_api)

--- a/st2common/st2common/constants/types.py
+++ b/st2common/st2common/constants/types.py
@@ -25,6 +25,10 @@ class ResourceType(Enum):
     Enum representing a valid resource type in a system.
     """
 
+    # System resources
+    RUNNER_TYPE = 'runner_type'
+
+    # Pack resources
     PACK = 'pack'
     ACTION = 'action'
     ACTION_ALIAS = 'action_alias'
@@ -35,6 +39,7 @@ class ResourceType(Enum):
     RULE = 'rule'
     RULE_ENFORCEMENT = 'rule_enforcement'
 
+    # Other resources
     EXECUTION = 'execution'
     KEY_VALUE_PAIR = 'key_value_pair'
 

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -58,6 +58,9 @@ class RunnerTypeAPI(BaseAPI):
                 "type": "string",
                 "default": None
             },
+            "uid": {
+                "type": "string"
+            },
             "name": {
                 "description": "The name of the action runner.",
                 "type": "string",

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -115,7 +115,7 @@ class RunnerTypeAPI(BaseAPI):
     def to_model(cls, runner_type):
         name = runner_type.name
         description = runner_type.description
-        enabled = bool(runner_type.enabled)
+        enabled = getattr(runner_type, 'enabled', True)
         runner_module = str(runner_type.runner_module)
         runner_parameters = getattr(runner_type, 'runner_parameters', dict())
         query_module = getattr(runner_type, 'query_module', None)

--- a/st2common/st2common/models/db/runner.py
+++ b/st2common/st2common/models/db/runner.py
@@ -18,6 +18,7 @@ import mongoengine as me
 from st2common import log as logging
 from st2common.models.db import MongoDBAccess
 from st2common.models.db import stormbase
+from st2common.constants.types import ResourceType
 
 __all__ = [
     'RunnerTypeDB',
@@ -29,7 +30,7 @@ LOG = logging.getLogger(__name__)
 PACK_SEPARATOR = '.'
 
 
-class RunnerTypeDB(stormbase.StormBaseDB):
+class RunnerTypeDB(stormbase.StormBaseDB, stormbase.UIDFieldMixin):
     """
     The representation of an RunnerType in the system. An RunnerType
     has a one-to-one mapping to a particular ActionRunner implementation.
@@ -43,6 +44,9 @@ class RunnerTypeDB(stormbase.StormBaseDB):
         runner_parameters: The specification for parameters for the action runner.
     """
 
+    RESOURCE_TYPE = ResourceType.RUNNER_TYPE
+    UID_FIELDS = ['name']
+
     enabled = me.BooleanField(
         required=True, default=True,
         help_text='A flag indicating whether the runner for this type is enabled.')
@@ -54,6 +58,14 @@ class RunnerTypeDB(stormbase.StormBaseDB):
     query_module = me.StringField(
         required=False,
         help_text='The python module that implements the query module for this runner.')
+
+    meta = {
+        'indexes': stormbase.UIDFieldMixin.get_indexes()
+    }
+
+    def __init__(self, *args, **values):
+        super(RunnerTypeDB, self).__init__(*args, **values)
+        self.uid = self.get_uid()
 
 # specialized access objects
 runnertype_access = MongoDBAccess(RunnerTypeDB)

--- a/st2common/st2common/rbac/resolvers.py
+++ b/st2common/st2common/rbac/resolvers.py
@@ -294,7 +294,6 @@ class RunnerPermissionsResolver(PermissionsResolver):
         return False
 
 
-
 class PackPermissionsResolver(PermissionsResolver):
     """
     Permission resolver for "pack" resource type.

--- a/st2common/st2common/rbac/resolvers.py
+++ b/st2common/st2common/rbac/resolvers.py
@@ -35,6 +35,7 @@ from st2common.services.rbac import get_all_permission_grants_for_user
 LOG = logging.getLogger(__name__)
 
 __all__ = [
+    'RunnerPermissionsResolver',
     'PackPermissionsResolver',
     'SensorPermissionsResolver',
     'ActionPermissionsResolver',
@@ -247,6 +248,51 @@ class ContentPackResourcePermissionsResolver(PermissionsResolver):
 
         self._log('No matching grants found', extra=log_context)
         return False
+
+
+class RunnerPermissionsResolver(PermissionsResolver):
+    """
+    Permission resolver for "runner_type" resource type.
+    """
+    resource_type = ResourceType.RUNNER
+
+    def user_has_permission(self, user_db, permission_type):
+        assert permission_type in [PermissionType.RUNNER_LIST]
+        return self._user_has_list_permission(user_db=user_db, permission_type=permission_type)
+
+    def user_has_resource_db_permission(self, user_db, resource_db, permission_type):
+        log_context = {
+            'user_db': user_db,
+            'resource_db': resource_db,
+            'permission_type': permission_type,
+            'resolver': self.__class__.__name__
+        }
+        self._log('Checking user resource permissions', extra=log_context)
+
+        # First check the system role permissions
+        has_system_role_permission = self._user_has_system_role_permission(
+            user_db=user_db, permission_type=permission_type)
+
+        if has_system_role_permission:
+            self._log('Found a matching grant via system role', extra=log_context)
+            return True
+
+        # Check custom roles
+        resource_uid = resource_db.get_uid()
+        resource_types = [ResourceType.RUNNER]
+        permission_types = [permission_type]
+        permission_grants = get_all_permission_grants_for_user(user_db=user_db,
+                                                               resource_uid=resource_uid,
+                                                               resource_types=resource_types,
+                                                               permission_types=permission_types)
+
+        if len(permission_grants) >= 1:
+            self._log('Found a direct grant on the runner type', extra=log_context)
+            return True
+
+        self._log('No matching grants found', extra=log_context)
+        return False
+
 
 
 class PackPermissionsResolver(PermissionsResolver):
@@ -762,7 +808,9 @@ def get_resolver_for_resource_type(resource_type):
 
     :rtype: Instance of :class:`PermissionsResolver`
     """
-    if resource_type == ResourceType.PACK:
+    if resource_type == ResourceType.RUNNER:
+        resolver_cls = RunnerPermissionsResolver
+    elif resource_type == ResourceType.PACK:
         resolver_cls = PackPermissionsResolver
     elif resource_type == ResourceType.SENSOR:
         resolver_cls = SensorPermissionsResolver

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -31,6 +31,12 @@ class PermissionType(Enum):
     Available permission types.
     """
 
+    # Note: There is no create endpoint for runner types right now
+    RUNNER_LIST = 'runner_type_list'
+    RUNNER_VIEW = 'runner_type_view'
+    RUNNER_MODIFY = 'runner_type_modify'
+    RUNNER_ALL = 'runner_type_all'
+
     PACK_LIST = 'pack_list'
     PACK_VIEW = 'pack_view'
     PACK_CREATE = 'pack_create'
@@ -160,6 +166,8 @@ class ResourceType(Enum):
     """
     Resource types on which permissions can be granted.
     """
+    RUNNER = SystemResourceType.RUNNER_TYPE
+
     PACK = SystemResourceType.PACK
     SENSOR = SystemResourceType.SENSOR_TYPE
     ACTION = SystemResourceType.ACTION

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -192,6 +192,12 @@ class SystemRole(Enum):
 
 # Maps a list of available permission types for each resource
 RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP = {
+    ResourceType.RUNNER: [
+        PermissionType.RUNNER_LIST,
+        PermissionType.RUNNER_VIEW,
+        PermissionType.RUNNER_MODIFY,
+        PermissionType.RUNNER_ALL,
+    ],
     ResourceType.PACK: [
         PermissionType.PACK_VIEW,
         PermissionType.PACK_CREATE,

--- a/st2common/tests/unit/services/test_rbac.py
+++ b/st2common/tests/unit/services/test_rbac.py
@@ -24,7 +24,7 @@ from st2common.persistence.rule import Rule
 from st2common.models.db.auth import UserDB
 from st2common.models.db.rbac import UserRoleAssignmentDB
 from st2common.models.db.rule import RuleDB
-from st2common.models.db.runner import RunnerTypeDB
+from st2common.models.db.trace import TraceDB
 
 
 class RBACServicesTestCase(CleanDbTestCase):
@@ -191,7 +191,7 @@ class RBACServicesTestCase(CleanDbTestCase):
     def test_manipulate_permission_grants_unsupported_resource_type(self):
         # Try to manipulate permissions on an unsupported resource
         role_db = self.roles['custom_role_2']
-        resource_db = RunnerTypeDB()
+        resource_db = TraceDB()
         permission_types = [PermissionType.RULE_ALL]
 
         expected_msg = 'Permissions cannot be manipulated for a resource of type'

--- a/st2common/tests/unit/test_db.py
+++ b/st2common/tests/unit/test_db.py
@@ -372,8 +372,7 @@ class ActionModelTest(DbTestCase):
 
     @staticmethod
     def _create_save_runnertype(metadata=False):
-        created = RunnerTypeDB()
-        created.name = 'python'
+        created = RunnerTypeDB(name='python')
         created.description = ''
         created.enabled = True
         if not metadata:

--- a/st2common/tests/unit/test_rbac_resolvers.py
+++ b/st2common/tests/unit/test_rbac_resolvers.py
@@ -57,6 +57,50 @@ class BasePermissionsResolverTestCase(CleanDbTestCase):
         # Insert common mock objects
         self._insert_common_mocks()
 
+    def assertUserHasResourceDbPermissions(self, resolver, user_db, resource_db, permission_types):
+        """
+        Assert that the user has all the specified permissions on the provided resource.
+
+        If permission grant is not found, an AssertionError is thrown.
+        """
+        self.assertTrue(isinstance(permission_types, (list, tuple)))
+        self.assertTrue(len(permission_types) > 1)
+
+        for permission_type in permission_types:
+            result = resolver.user_has_resource_db_permission(
+                user_db=user_db,
+                resource_db=resource_db,
+                permission_type=permission_type)
+
+            if not result:
+                msg = ('Expected permission grant "%s" for user "%s" on resource "%s", but no '
+                       'grant found' % (permission_type, user_db.name, resource_db.get_uid()))
+                raise AssertionError(msg)
+
+        return True
+
+    def assertUserDoesntHaveResourceDbPermissions(self, resolver, user_db, resource_db, permission_types):
+        """
+        Assert that the user doesn't have all the specified permissions on the provided resource.
+
+        If a permission grant which shouldn't exist is found, an AssertionError is thrown.
+        """
+        self.assertTrue(isinstance(permission_types, (list, tuple)))
+        self.assertTrue(len(permission_types) > 1)
+
+        for permission_type in permission_types:
+            result = resolver.user_has_resource_db_permission(
+                user_db=user_db,
+                resource_db=resource_db,
+                permission_type=permission_type)
+
+            if result:
+                msg = ('Found permission grant "%s" for user "%s" on resource "%s", which '
+                       'shouldn\'t exist' % (permission_type, user_db.name, resource_db.get_uid()))
+                raise AssertionError(msg)
+
+        return True
+
     def _user_has_resource_db_permissions(self, resolver, user_db, resource_db, permission_types):
         """
         Method which verifies that user has all the provided permissions.

--- a/st2common/tests/unit/test_rbac_resolvers.py
+++ b/st2common/tests/unit/test_rbac_resolvers.py
@@ -57,6 +57,35 @@ class BasePermissionsResolverTestCase(CleanDbTestCase):
         # Insert common mock objects
         self._insert_common_mocks()
 
+    def assertUserHasResourceDbPermission(self, resolver, user_db, resource_db, permission_type):
+        """
+        Assert that the user has the provided permission on the provided resource.
+        """
+        result = resolver.user_has_resource_db_permission(user_db=user_db, resource_db=resource_db,
+                                                          permission_type=permission_type)
+
+        if not result:
+                msg = ('Expected permission grant "%s" for user "%s" on resource "%s", but no '
+                       'grant was found' % (permission_type, user_db.name, resource_db.get_uid()))
+                raise AssertionError(msg)
+
+        return True
+
+    def assertUserDoesntHaveResourceDbPermission(self, resolver, user_db, resource_db,
+                                                 permission_type):
+        """
+        Assert that the user has the provided permission on the provided resource.
+        """
+        result = resolver.user_has_resource_db_permission(user_db=user_db, resource_db=resource_db,
+                                                          permission_type=permission_type)
+
+        if result:
+            msg = ('Found permission grant "%s" for user "%s" on resource "%s", which '
+                   'shouldn\'t exist' % (permission_type, user_db.name, resource_db.get_uid()))
+            raise AssertionError(msg)
+
+        return True
+
     def assertUserHasResourceDbPermissions(self, resolver, user_db, resource_db, permission_types):
         """
         Assert that the user has all the specified permissions on the provided resource.
@@ -67,15 +96,9 @@ class BasePermissionsResolverTestCase(CleanDbTestCase):
         self.assertTrue(len(permission_types) > 1)
 
         for permission_type in permission_types:
-            result = resolver.user_has_resource_db_permission(
-                user_db=user_db,
-                resource_db=resource_db,
-                permission_type=permission_type)
-
-            if not result:
-                msg = ('Expected permission grant "%s" for user "%s" on resource "%s", but no '
-                       'grant found' % (permission_type, user_db.name, resource_db.get_uid()))
-                raise AssertionError(msg)
+            self.assertUserHasResourceDbPermission(resolver=resolver, user_db=user_db,
+                                                   resource_db=resource_db,
+                                                   permission_type=permission_type)
 
         return True
 
@@ -90,15 +113,9 @@ class BasePermissionsResolverTestCase(CleanDbTestCase):
         self.assertTrue(len(permission_types) > 1)
 
         for permission_type in permission_types:
-            result = resolver.user_has_resource_db_permission(
-                user_db=user_db,
-                resource_db=resource_db,
-                permission_type=permission_type)
-
-            if result:
-                msg = ('Found permission grant "%s" for user "%s" on resource "%s", which '
-                       'shouldn\'t exist' % (permission_type, user_db.name, resource_db.get_uid()))
-                raise AssertionError(msg)
+            self.assertUserDoesntHaveResourceDbPermission(resolver=resolver, user_db=user_db,
+                                                          resource_db=resource_db,
+                                                          permission_type=permission_type)
 
         return True
 

--- a/st2common/tests/unit/test_rbac_resolvers.py
+++ b/st2common/tests/unit/test_rbac_resolvers.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import six
 import unittest2
 from oslo_config import cfg
 
@@ -57,17 +58,51 @@ class BasePermissionsResolverTestCase(CleanDbTestCase):
         # Insert common mock objects
         self._insert_common_mocks()
 
+    def assertUserHasPermission(self, resolver, user_db, permission_type):
+        """
+        Assert that the user has the provided permission.
+        """
+        self.assertTrue(isinstance(permission_type, six.string_types))
+
+        result = resolver.user_has_permission(user_db=user_db,
+                                              permission_type=permission_type)
+
+        if not result:
+            msg = ('Expected permission grant "%s" for user "%s" but no grant was found' %
+                   (permission_type, user_db.name))
+            raise AssertionError(msg)
+
+        return True
+
+    def assertUserDoesntHavePermission(self, resolver, user_db, permission_type):
+        """
+        Assert that the user has the provided permission.
+        """
+        self.assertTrue(isinstance(permission_type, six.string_types))
+
+        result = resolver.user_has_permission(user_db=user_db,
+                                              permission_type=permission_type)
+
+        if result:
+            msg = ('Found permission grant "%s" for user "%s" which shouldn\'t exist' %
+                   (permission_type, user_db.name))
+            raise AssertionError(msg)
+
+        return True
+
     def assertUserHasResourceDbPermission(self, resolver, user_db, resource_db, permission_type):
         """
         Assert that the user has the provided permission on the provided resource.
         """
+        self.assertTrue(isinstance(permission_type, six.string_types))
+
         result = resolver.user_has_resource_db_permission(user_db=user_db, resource_db=resource_db,
                                                           permission_type=permission_type)
 
         if not result:
-                msg = ('Expected permission grant "%s" for user "%s" on resource "%s", but no '
-                       'grant was found' % (permission_type, user_db.name, resource_db.get_uid()))
-                raise AssertionError(msg)
+            msg = ('Expected permission grant "%s" for user "%s" on resource DB "%s", but no '
+                   'grant was found' % (permission_type, user_db.name, resource_db.get_uid()))
+            raise AssertionError(msg)
 
         return True
 
@@ -76,11 +111,13 @@ class BasePermissionsResolverTestCase(CleanDbTestCase):
         """
         Assert that the user has the provided permission on the provided resource.
         """
+        self.assertTrue(isinstance(permission_type, six.string_types))
+
         result = resolver.user_has_resource_db_permission(user_db=user_db, resource_db=resource_db,
                                                           permission_type=permission_type)
 
         if result:
-            msg = ('Found permission grant "%s" for user "%s" on resource "%s", which '
+            msg = ('Found permission grant "%s" for user "%s" on resource DB "%s", which '
                    'shouldn\'t exist' % (permission_type, user_db.name, resource_db.get_uid()))
             raise AssertionError(msg)
 
@@ -116,6 +153,35 @@ class BasePermissionsResolverTestCase(CleanDbTestCase):
             self.assertUserDoesntHaveResourceDbPermission(resolver=resolver, user_db=user_db,
                                                           resource_db=resource_db,
                                                           permission_type=permission_type)
+
+        return True
+
+    def assertUserHasResourceApiPermission(self, resolver, user_db, resource_api, permission_type):
+        self.assertTrue(isinstance(permission_type, six.string_types))
+
+        result = resolver.user_has_resource_api_permission(user_db=user_db,
+                                                           resource_api=resource_api,
+                                                           permission_type=permission_type)
+
+        if not result:
+            msg = ('Expected permission grant "%s" for user "%s" on resource API "%s", but no '
+                   'grant was found' % (permission_type, user_db.name, resource_api.get_uid()))
+            raise AssertionError(msg)
+
+        return True
+
+    def assertUserDoesntHaveResourceApiPermission(self, resolver, user_db, resource_api,
+                                                  permission_type):
+        self.assertTrue(isinstance(permission_type, six.string_types))
+
+        result = resolver.user_has_resource_api_permission(user_db=user_db,
+                                                           resource_api=resource_api,
+                                                           permission_type=permission_type)
+
+        if result:
+            msg = ('Found permission grant "%s" for user "%s" on resource API "%s", which '
+                   'shouldn\'t exist' % (permission_type, user_db.name, resource_api.get_uid()))
+            raise AssertionError(msg)
 
         return True
 

--- a/st2common/tests/unit/test_rbac_resolvers.py
+++ b/st2common/tests/unit/test_rbac_resolvers.py
@@ -79,7 +79,8 @@ class BasePermissionsResolverTestCase(CleanDbTestCase):
 
         return True
 
-    def assertUserDoesntHaveResourceDbPermissions(self, resolver, user_db, resource_db, permission_types):
+    def assertUserDoesntHaveResourceDbPermissions(self, resolver, user_db, resource_db,
+                                                  permission_types):
         """
         Assert that the user doesn't have all the specified permissions on the provided resource.
 
@@ -119,7 +120,8 @@ class BasePermissionsResolverTestCase(CleanDbTestCase):
 
         return True
 
-    def _user_doesnt_have_resource_db_permissions(self, resolver, user_db, resource_db, permission_types):
+    def _user_doesnt_have_resource_db_permissions(self, resolver, user_db, resource_db,
+                                                  permission_types):
         """
         Method which verifies that the user doesn't have any of the specific permission.
         """

--- a/st2common/tests/unit/test_rbac_resolvers.py
+++ b/st2common/tests/unit/test_rbac_resolvers.py
@@ -185,43 +185,6 @@ class BasePermissionsResolverTestCase(CleanDbTestCase):
 
         return True
 
-    def _user_has_resource_db_permissions(self, resolver, user_db, resource_db, permission_types):
-        """
-        Method which verifies that user has all the provided permissions.
-        """
-        self.assertTrue(isinstance(permission_types, (list, tuple)))
-        self.assertTrue(len(permission_types) > 1)
-
-        for permission_type in permission_types:
-            result = resolver.user_has_resource_db_permission(
-                user_db=user_db,
-                resource_db=resource_db,
-                permission_type=permission_type)
-
-            if not result:
-                return False
-
-        return True
-
-    def _user_doesnt_have_resource_db_permissions(self, resolver, user_db, resource_db,
-                                                  permission_types):
-        """
-        Method which verifies that the user doesn't have any of the specific permission.
-        """
-        self.assertTrue(isinstance(permission_types, (list, tuple)))
-        self.assertTrue(len(permission_types) > 1)
-
-        for permission_type in permission_types:
-            result = resolver.user_has_resource_db_permission(
-                user_db=user_db,
-                resource_db=resource_db,
-                permission_type=permission_type)
-
-            if result:
-                return False
-
-        return True
-
     def _insert_common_mocks(self):
         self._insert_common_mock_users()
         self._insert_common_mock_resources()

--- a/st2common/tests/unit/test_rbac_resolvers.py
+++ b/st2common/tests/unit/test_rbac_resolvers.py
@@ -75,6 +75,24 @@ class BasePermissionsResolverTestCase(CleanDbTestCase):
 
         return True
 
+    def _user_doesnt_have_resource_db_permissions(self, resolver, user_db, resource_db, permission_types):
+        """
+        Method which verifies that the user doesn't have any of the specific permission.
+        """
+        self.assertTrue(isinstance(permission_types, (list, tuple)))
+        self.assertTrue(len(permission_types) > 1)
+
+        for permission_type in permission_types:
+            result = resolver.user_has_resource_db_permission(
+                user_db=user_db,
+                resource_db=resource_db,
+                permission_type=permission_type)
+
+            if result:
+                return False
+
+        return True
+
     def _insert_common_mocks(self):
         self._insert_common_mock_users()
         self._insert_common_mock_resources()

--- a/st2common/tests/unit/test_rbac_resolvers_action.py
+++ b/st2common/tests/unit/test_rbac_resolvers_action.py
@@ -272,28 +272,33 @@ class ActionPermissionsResolverTestCase(BasePermissionsResolverTestCase):
 
         # Admin user, should always return true
         user_db = self.users['admin']
-        self.assertTrue(resolver.user_has_permission(user_db=user_db,
-                                                     permission_type=PermissionType.ACTION_LIST))
+        self.assertUserHasPermission(resolver=resolver,
+                                     user_db=user_db,
+                                     permission_type=PermissionType.ACTION_LIST)
 
         # Observer, should always return true for VIEW permissions
         user_db = self.users['observer']
-        self.assertTrue(resolver.user_has_permission(user_db=user_db,
-                                                     permission_type=PermissionType.ACTION_LIST))
+        self.assertUserHasPermission(resolver=resolver,
+                                     user_db=user_db,
+                                     permission_type=PermissionType.ACTION_LIST)
 
         # No roles, should return false for everything
         user_db = self.users['no_roles']
-        self.assertFalse(resolver.user_has_permission(user_db=user_db,
-                                                      permission_type=PermissionType.ACTION_LIST))
+        self.assertUserDoesntHavePermission(resolver=resolver,
+                                            user_db=user_db,
+                                            permission_type=PermissionType.ACTION_LIST)
 
         # Custom role with no permission grants, should return false for everything
         user_db = self.users['1_custom_role_no_permissions']
-        self.assertFalse(resolver.user_has_permission(user_db=user_db,
-                                                      permission_type=PermissionType.ACTION_LIST))
+        self.assertUserDoesntHavePermission(resolver=resolver,
+                                            user_db=user_db,
+                                            permission_type=PermissionType.ACTION_LIST)
 
         # Custom role with "action_list" grant
         user_db = self.users['custom_role_action_list_grant']
-        self.assertTrue(resolver.user_has_permission(user_db=user_db,
-                                                     permission_type=PermissionType.ACTION_LIST))
+        self.assertUserHasPermission(resolver=resolver,
+                                     user_db=user_db,
+                                     permission_type=PermissionType.ACTION_LIST)
 
     def test_user_has_resource_api_permission(self):
         resolver = ActionPermissionsResolver()
@@ -303,80 +308,88 @@ class ActionPermissionsResolverTestCase(BasePermissionsResolverTestCase):
         resource_db = self.resources['action_1']
         resource_api = ActionAPI.from_model(resource_db)
 
-        self.assertTrue(resolver.user_has_resource_api_permission(
+        self.assertUserHasResourceApiPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_api=resource_api,
-            permission_type=PermissionType.ACTION_CREATE))
+            permission_type=PermissionType.ACTION_CREATE)
 
         # Observer, should return false
         user_db = self.users['observer']
         resource_db = self.resources['action_1']
         resource_api = ActionAPI.from_model(resource_db)
 
-        self.assertFalse(resolver.user_has_resource_api_permission(
+        self.assertUserDoesntHaveResourceApiPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_api=resource_api,
-            permission_type=PermissionType.ACTION_CREATE))
+            permission_type=PermissionType.ACTION_CREATE)
 
         # No roles, should return false
         user_db = self.users['no_roles']
         resource_db = self.resources['action_1']
         resource_api = ActionAPI.from_model(resource_db)
 
-        self.assertFalse(resolver.user_has_resource_api_permission(
+        self.assertUserDoesntHaveResourceApiPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_api=resource_api,
-            permission_type=PermissionType.ACTION_CREATE))
+            permission_type=PermissionType.ACTION_CREATE)
 
         # Custom role with no permission grants, should return false
         user_db = self.users['1_custom_role_no_permissions']
         resource_db = self.resources['action_1']
         resource_api = ActionAPI.from_model(resource_db)
 
-        self.assertFalse(resolver.user_has_resource_api_permission(
+        self.assertUserDoesntHaveResourceApiPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_api=resource_api,
-            permission_type=PermissionType.ACTION_CREATE))
+            permission_type=PermissionType.ACTION_CREATE)
 
         # Custom role with "action_create" grant on parent pack
         user_db = self.users['action_pack_action_create_grant']
         resource_db = self.resources['action_1']
         resource_api = ActionAPI.from_model(resource_db)
 
-        self.assertTrue(resolver.user_has_resource_api_permission(
+        self.assertUserHasResourceApiPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_api=resource_api,
-            permission_type=PermissionType.ACTION_CREATE))
+            permission_type=PermissionType.ACTION_CREATE)
 
         # Custom role with "action_all" grant on the parent pack
         user_db = self.users['action_pack_action_all_grant']
         resource_db = self.resources['action_1']
         resource_api = ActionAPI.from_model(resource_db)
 
-        self.assertTrue(resolver.user_has_resource_api_permission(
+        self.assertUserHasResourceApiPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_api=resource_api,
-            permission_type=PermissionType.ACTION_CREATE))
+            permission_type=PermissionType.ACTION_CREATE)
 
         # Custom role with "action_create" grant directly on the resource
         user_db = self.users['action_action_create_grant']
         resource_db = self.resources['action_1']
         resource_api = ActionAPI.from_model(resource_db)
 
-        self.assertTrue(resolver.user_has_resource_api_permission(
+        self.assertUserHasResourceApiPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_api=resource_api,
-            permission_type=PermissionType.ACTION_CREATE))
+            permission_type=PermissionType.ACTION_CREATE)
 
         # Custom role with "action_all" grant directly on the resource
         user_db = self.users['action_action_all_grant']
         resource_db = self.resources['action_1']
         resource_api = ActionAPI.from_model(resource_db)
 
-        self.assertTrue(resolver.user_has_resource_api_permission(
+        self.assertUserHasResourceApiPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_api=resource_api,
-            permission_type=PermissionType.ACTION_CREATE))
+            permission_type=PermissionType.ACTION_CREATE)
 
     def test_user_has_resource_db_permission(self):
         resolver = ActionPermissionsResolver()
@@ -387,130 +400,144 @@ class ActionPermissionsResolverTestCase(BasePermissionsResolverTestCase):
         resource_db = self.resources['action_1']
         user_db = self.users['admin']
 
-        self.assertTrue(self._user_has_resource_db_permissions(
+        self.assertUserHasResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Observer, should always return true for VIEW permission
         user_db = self.users['observer']
-        self.assertTrue(resolver.user_has_resource_db_permission(
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['action_1'],
-            permission_type=PermissionType.ACTION_VIEW))
-        self.assertTrue(resolver.user_has_resource_db_permission(
+            permission_type=PermissionType.ACTION_VIEW)
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['action_2'],
-            permission_type=PermissionType.ACTION_VIEW))
+            permission_type=PermissionType.ACTION_VIEW)
 
-        self.assertFalse(resolver.user_has_resource_db_permission(
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['action_1'],
-            permission_type=PermissionType.ACTION_MODIFY))
-        self.assertFalse(resolver.user_has_resource_db_permission(
+            permission_type=PermissionType.ACTION_MODIFY)
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['action_2'],
-            permission_type=PermissionType.ACTION_DELETE))
+            permission_type=PermissionType.ACTION_DELETE)
 
         # No roles, should return false for everything
         user_db = self.users['no_roles']
-        self.assertFalse(self._user_has_resource_db_permissions(
+        self.assertUserDoesntHaveResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Custom role with no permission grants, should return false for everything
         user_db = self.users['1_custom_role_no_permissions']
-        self.assertFalse(self._user_has_resource_db_permissions(
+        self.assertUserDoesntHaveResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Custom role with unrelated permission grant to parent pack
         user_db = self.users['custom_role_pack_grant']
-        self.assertFalse(resolver.user_has_resource_db_permission(
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['action_1'],
-            permission_type=PermissionType.ACTION_VIEW))
-        self.assertFalse(resolver.user_has_resource_db_permission(
+            permission_type=PermissionType.ACTION_VIEW)
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['action_1'],
-            permission_type=PermissionType.ACTION_EXECUTE))
+            permission_type=PermissionType.ACTION_EXECUTE)
 
         # Custom role with with grant on the parent pack
         user_db = self.users['custom_role_action_pack_grant']
-        self.assertTrue(resolver.user_has_resource_db_permission(
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['action_1'],
-            permission_type=PermissionType.ACTION_VIEW))
-        self.assertTrue(resolver.user_has_resource_db_permission(
+            permission_type=PermissionType.ACTION_VIEW)
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['action_2'],
-            permission_type=PermissionType.ACTION_VIEW))
+            permission_type=PermissionType.ACTION_VIEW)
 
-        self.assertFalse(resolver.user_has_resource_db_permission(
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['action_2'],
-            permission_type=PermissionType.ACTION_EXECUTE))
+            permission_type=PermissionType.ACTION_EXECUTE)
 
         # Custom role with a direct grant on action
         user_db = self.users['custom_role_action_grant']
-        self.assertTrue(resolver.user_has_resource_db_permission(
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['action_3'],
-            permission_type=PermissionType.ACTION_VIEW))
+            permission_type=PermissionType.ACTION_VIEW)
 
-        self.assertFalse(resolver.user_has_resource_db_permission(
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['action_2'],
-            permission_type=PermissionType.ACTION_EXECUTE))
-        self.assertFalse(resolver.user_has_resource_db_permission(
+            permission_type=PermissionType.ACTION_EXECUTE)
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['action_3'],
-            permission_type=PermissionType.ACTION_EXECUTE))
+            permission_type=PermissionType.ACTION_EXECUTE)
 
         # Custom role - "action_all" grant on the action parent pack
         user_db = self.users['custom_role_pack_action_all_grant']
         resource_db = self.resources['action_1']
-        self.assertTrue(self._user_has_resource_db_permissions(
+        self.assertUserHasResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Custom role - "action_all" grant on the action
         user_db = self.users['custom_role_action_all_grant']
         resource_db = self.resources['action_1']
-        self.assertTrue(self._user_has_resource_db_permissions(
+        self.assertUserHasResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Custom role - "action_execute" grant on action_1
         user_db = self.users['custom_role_action_execute_grant']
         resource_db = self.resources['action_1']
-        self.assertTrue(resolver.user_has_resource_db_permission(
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_type=PermissionType.ACTION_EXECUTE))
+            permission_type=PermissionType.ACTION_EXECUTE)
 
         # "execute" also grants "view"
-        self.assertTrue(resolver.user_has_resource_db_permission(
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_type=PermissionType.ACTION_VIEW))
+            permission_type=PermissionType.ACTION_VIEW)
 
         permission_types = [
             PermissionType.ACTION_CREATE,
             PermissionType.ACTION_MODIFY,
             PermissionType.ACTION_DELETE
         ]
-        self.assertFalse(self._user_has_resource_db_permissions(
+        self.assertUserDoesntHaveResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=permission_types))
+            permission_types=permission_types)

--- a/st2common/tests/unit/test_rbac_resolvers_action_alias.py
+++ b/st2common/tests/unit/test_rbac_resolvers_action_alias.py
@@ -246,28 +246,33 @@ class ActionAliasPermissionsResolverTestCase(BasePermissionsResolverTestCase):
 
         # Admin user, should always return true
         user_db = self.users['admin']
-        self.assertTrue(resolver.user_has_permission(user_db=user_db,
-            permission_type=PermissionType.ACTION_ALIAS_LIST))
+        self.assertUserHasPermission(resolver=resolver,
+                                     user_db=user_db,
+                                     permission_type=PermissionType.ACTION_ALIAS_LIST)
 
         # Observer, should always return true for VIEW permissions
         user_db = self.users['observer']
-        self.assertTrue(resolver.user_has_permission(user_db=user_db,
-            permission_type=PermissionType.ACTION_ALIAS_LIST))
+        self.assertUserHasPermission(resolver=resolver,
+                                     user_db=user_db,
+                                     permission_type=PermissionType.ACTION_ALIAS_LIST)
 
         # No roles, should return false for everything
         user_db = self.users['no_roles']
-        self.assertFalse(resolver.user_has_permission(user_db=user_db,
-              permission_type=PermissionType.ACTION_ALIAS_LIST))
+        self.assertUserDoesntHavePermission(resolver=resolver,
+                                            user_db=user_db,
+                                            permission_type=PermissionType.ACTION_ALIAS_LIST)
 
         # Custom role with no permission grants, should return false for everything
         user_db = self.users['1_custom_role_no_permissions']
-        self.assertFalse(resolver.user_has_permission(user_db=user_db,
-              permission_type=PermissionType.ACTION_ALIAS_LIST))
+        self.assertUserDoesntHavePermission(resolver=resolver,
+                                            user_db=user_db,
+                                            permission_type=PermissionType.ACTION_ALIAS_LIST)
 
         # Custom role with "action_list" grant
         user_db = self.users['alias_list_grant']
-        self.assertTrue(resolver.user_has_permission(user_db=user_db,
-             permission_type=PermissionType.ACTION_ALIAS_LIST))
+        self.assertUserHasPermission(resolver=resolver,
+                                     user_db=user_db,
+                                     permission_type=PermissionType.ACTION_ALIAS_LIST)
 
     def test_user_has_resource_api_permission(self):
         resolver = ActionAliasPermissionsResolver()
@@ -277,80 +282,88 @@ class ActionAliasPermissionsResolverTestCase(BasePermissionsResolverTestCase):
         resource_db = self.resources['alias_1']
         resource_api = ActionAliasAPI.from_model(resource_db)
 
-        self.assertTrue(resolver.user_has_resource_api_permission(
+        self.assertUserHasResourceApiPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_api=resource_api,
-            permission_type=PermissionType.ACTION_ALIAS_CREATE))
+            permission_type=PermissionType.ACTION_ALIAS_CREATE)
 
         # Observer, should return false
         user_db = self.users['observer']
         resource_db = self.resources['alias_1']
         resource_api = ActionAliasAPI.from_model(resource_db)
 
-        self.assertFalse(resolver.user_has_resource_api_permission(
+        self.assertUserDoesntHaveResourceApiPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_api=resource_api,
-            permission_type=PermissionType.ACTION_ALIAS_CREATE))
+            permission_type=PermissionType.ACTION_ALIAS_CREATE)
 
         # No roles, should return false
         user_db = self.users['no_roles']
         resource_db = self.resources['alias_1']
         resource_api = ActionAliasAPI.from_model(resource_db)
 
-        self.assertFalse(resolver.user_has_resource_api_permission(
+        self.assertUserDoesntHaveResourceApiPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_api=resource_api,
-            permission_type=PermissionType.ACTION_ALIAS_CREATE))
+            permission_type=PermissionType.ACTION_ALIAS_CREATE)
 
         # Custom role with no permission grants, should return false
         user_db = self.users['1_custom_role_no_permissions']
         resource_db = self.resources['alias_1']
         resource_api = ActionAliasAPI.from_model(resource_db)
 
-        self.assertFalse(resolver.user_has_resource_api_permission(
+        self.assertUserDoesntHaveResourceApiPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_api=resource_api,
-            permission_type=PermissionType.ACTION_ALIAS_CREATE))
+            permission_type=PermissionType.ACTION_ALIAS_CREATE)
 
         # Custom role with "action_alias_create" grant on parent pack
         user_db = self.users['alias_pack_alias_create_grant']
         resource_db = self.resources['alias_1']
         resource_api = ActionAliasAPI.from_model(resource_db)
 
-        self.assertTrue(resolver.user_has_resource_api_permission(
+        self.assertUserHasResourceApiPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_api=resource_api,
-            permission_type=PermissionType.ACTION_ALIAS_CREATE))
+            permission_type=PermissionType.ACTION_ALIAS_CREATE)
 
         # Custom role with "action_alias_all" grant on the parent pack
         user_db = self.users['alias_pack_alias_all_grant']
         resource_db = self.resources['alias_1']
         resource_api = ActionAliasAPI.from_model(resource_db)
 
-        self.assertTrue(resolver.user_has_resource_api_permission(
+        self.assertUserHasResourceApiPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_api=resource_api,
-            permission_type=PermissionType.ACTION_ALIAS_CREATE))
+            permission_type=PermissionType.ACTION_ALIAS_CREATE)
 
         # Custom role with "action_alias_create" grant directly on the resource
         user_db = self.users['alias_alias_create_grant']
         resource_db = self.resources['alias_1']
         resource_api = ActionAliasAPI.from_model(resource_db)
 
-        self.assertTrue(resolver.user_has_resource_api_permission(
+        self.assertUserHasResourceApiPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_api=resource_api,
-            permission_type=PermissionType.ACTION_ALIAS_CREATE))
+            permission_type=PermissionType.ACTION_ALIAS_CREATE)
 
         # Custom role with "action_alias_all" grant directly on the resource
         user_db = self.users['alias_all_grant']
         resource_db = self.resources['alias_1']
         resource_api = ActionAliasAPI.from_model(resource_db)
 
-        self.assertTrue(resolver.user_has_resource_api_permission(
+        self.assertUserHasResourceApiPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_api=resource_api,
-            permission_type=PermissionType.ACTION_ALIAS_CREATE))
+            permission_type=PermissionType.ACTION_ALIAS_CREATE)
 
     def test_user_has_resource_db_permission(self):
         resolver = ActionAliasPermissionsResolver()
@@ -361,130 +374,143 @@ class ActionAliasPermissionsResolverTestCase(BasePermissionsResolverTestCase):
         resource_db = self.resources['alias_1']
         user_db = self.users['admin']
 
-        self.assertTrue(self._user_has_resource_db_permissions(
+        self.assertUserHasResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Observer, should always return true for VIEW permission
         user_db = self.users['observer']
-        self.assertTrue(resolver.user_has_resource_db_permission(
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['alias_1'],
-            permission_type=PermissionType.ACTION_ALIAS_VIEW))
-        self.assertTrue(resolver.user_has_resource_db_permission(
+            permission_type=PermissionType.ACTION_ALIAS_VIEW)
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['alias_2'],
-            permission_type=PermissionType.ACTION_ALIAS_VIEW))
+            permission_type=PermissionType.ACTION_ALIAS_VIEW)
 
-        self.assertFalse(resolver.user_has_resource_db_permission(
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['alias_1'],
-            permission_type=PermissionType.ACTION_ALIAS_MODIFY))
-        self.assertFalse(resolver.user_has_resource_db_permission(
+            permission_type=PermissionType.ACTION_ALIAS_MODIFY)
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['alias_2'],
-            permission_type=PermissionType.ACTION_ALIAS_DELETE))
+            permission_type=PermissionType.ACTION_ALIAS_DELETE)
 
         # No roles, should return false for everything
         user_db = self.users['no_roles']
-        self.assertFalse(self._user_has_resource_db_permissions(
+        self.assertUserDoesntHaveResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Custom role with no permission grants, should return false for everything
         user_db = self.users['1_custom_role_no_permissions']
-        self.assertFalse(self._user_has_resource_db_permissions(
+        self.assertUserDoesntHaveResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Custom role with unrelated permission grant to parent pack
         user_db = self.users['alias_pack_grant']
-        self.assertFalse(resolver.user_has_resource_db_permission(
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['alias_1'],
-            permission_type=PermissionType.ACTION_ALIAS_DELETE))
-        self.assertFalse(resolver.user_has_resource_db_permission(
+            permission_type=PermissionType.ACTION_ALIAS_DELETE)
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['alias_1'],
-            permission_type=PermissionType.ACTION_ALIAS_MODIFY))
+            permission_type=PermissionType.ACTION_ALIAS_MODIFY)
 
         # Custom role with with grant on the parent pack
         user_db = self.users['alias_pack_grant']
-        self.assertTrue(resolver.user_has_resource_db_permission(
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['alias_1'],
-            permission_type=PermissionType.ACTION_ALIAS_VIEW))
-        self.assertTrue(resolver.user_has_resource_db_permission(
+            permission_type=PermissionType.ACTION_ALIAS_VIEW)
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['alias_2'],
-            permission_type=PermissionType.ACTION_ALIAS_VIEW))
+            permission_type=PermissionType.ACTION_ALIAS_VIEW)
 
-        self.assertFalse(resolver.user_has_resource_db_permission(
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['alias_2'],
-            permission_type=PermissionType.ACTION_ALIAS_DELETE))
+            permission_type=PermissionType.ACTION_ALIAS_DELETE)
 
         # Custom role with a direct grant on alias
         user_db = self.users['alias_grant']
-        self.assertTrue(resolver.user_has_resource_db_permission(
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['alias_3'],
-            permission_type=PermissionType.ACTION_ALIAS_VIEW))
+            permission_type=PermissionType.ACTION_ALIAS_VIEW)
 
-        self.assertFalse(resolver.user_has_resource_db_permission(
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['alias_2'],
-            permission_type=PermissionType.ACTION_ALIAS_MODIFY))
-        self.assertFalse(resolver.user_has_resource_db_permission(
+            permission_type=PermissionType.ACTION_ALIAS_MODIFY)
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['alias_3'],
-            permission_type=PermissionType.ACTION_ALIAS_MODIFY))
+            permission_type=PermissionType.ACTION_ALIAS_MODIFY)
 
         # Custom role - "action_alias_all" grant on the parent pack
         user_db = self.users['pack_alias_all_grant']
         resource_db = self.resources['alias_1']
-        self.assertTrue(self._user_has_resource_db_permissions(
+        self.assertUserHasResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Custom role - "action_alias_all" grant on the alias
         user_db = self.users['alias_all_grant']
         resource_db = self.resources['alias_1']
-        self.assertTrue(self._user_has_resource_db_permissions(
+        self.assertUserHasResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Custom role - "action_alias_modify" grant on alias_1
         user_db = self.users['alias_modify_grant']
         resource_db = self.resources['alias_1']
-        self.assertTrue(resolver.user_has_resource_db_permission(
-            user_db=user_db,
-            resource_db=resource_db,
-            permission_type=PermissionType.ACTION_ALIAS_MODIFY))
-
-        # "modify" also grants "view"
-        self.assertTrue(resolver.user_has_resource_db_permission(
-            user_db=user_db,
-            resource_db=resource_db,
-            permission_type=PermissionType.ACTION_ALIAS_VIEW))
-
-        permission_types = [
-            PermissionType.ACTION_ALIAS_CREATE,
-            PermissionType.ACTION_ALIAS_MODIFY,
-            PermissionType.ACTION_ALIAS_DELETE
-        ]
-        self.assertFalse(self._user_has_resource_db_permissions(
+        self.assertUserHasResourceDbPermission(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=permission_types))
+            permission_type=PermissionType.ACTION_ALIAS_MODIFY)
+
+        # "modify" also grants "view"
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
+            user_db=user_db,
+            resource_db=resource_db,
+            permission_type=PermissionType.ACTION_ALIAS_VIEW)
+
+        permission_types = [
+            PermissionType.ACTION_ALIAS_CREATE,
+            PermissionType.ACTION_ALIAS_DELETE
+        ]
+        self.assertUserDoesntHaveResourceDbPermissions(
+            resolver=resolver,
+            user_db=user_db,
+            resource_db=resource_db,
+            permission_types=permission_types)

--- a/st2common/tests/unit/test_rbac_resolvers_execution.py
+++ b/st2common/tests/unit/test_rbac_resolvers_execution.py
@@ -255,28 +255,33 @@ class ExecutionPermissionsResolverTestCase(BasePermissionsResolverTestCase):
 
         # Admin user, should always return true
         user_db = self.users['admin']
-        self.assertTrue(resolver.user_has_permission(user_db=user_db,
-                                                     permission_type=PermissionType.EXECUTION_LIST))
+        self.assertUserHasPermission(resolver=resolver,
+                                     user_db=user_db,
+                                     permission_type=PermissionType.EXECUTION_LIST)
 
         # Observer, should always return true for VIEW permissions
         user_db = self.users['observer']
-        self.assertTrue(resolver.user_has_permission(user_db=user_db,
-                                                     permission_type=PermissionType.EXECUTION_LIST))
+        self.assertUserHasPermission(resolver=resolver,
+                                     user_db=user_db,
+                                     permission_type=PermissionType.EXECUTION_LIST)
 
         # No roles, should return false for everything
         user_db = self.users['no_roles']
-        self.assertFalse(resolver.user_has_permission(user_db=user_db,
-            permission_type=PermissionType.EXECUTION_LIST))
+        self.assertUserDoesntHavePermission(resolver=resolver,
+                                            user_db=user_db,
+                                            permission_type=PermissionType.EXECUTION_LIST)
 
         # Custom role with no permission grants, should return false for everything
         user_db = self.users['1_custom_role_no_permissions']
-        self.assertFalse(resolver.user_has_permission(user_db=user_db,
-            permission_type=PermissionType.EXECUTION_LIST))
+        self.assertUserDoesntHavePermission(resolver=resolver,
+                                            user_db=user_db,
+                                            permission_type=PermissionType.EXECUTION_LIST)
 
         # Custom role with "execution_list" grant
         user_db = self.users['custom_role_execution_list_grant']
-        self.assertTrue(resolver.user_has_permission(user_db=user_db,
-                                                     permission_type=PermissionType.EXECUTION_LIST))
+        self.assertUserHasPermission(resolver=resolver,
+                                     user_db=user_db,
+                                     permission_type=PermissionType.EXECUTION_LIST)
 
     def test_user_has_resource_db_permission(self):
         resolver = ExecutionPermissionsResolver()
@@ -287,136 +292,143 @@ class ExecutionPermissionsResolverTestCase(BasePermissionsResolverTestCase):
         # Admin user, should always return true
         resource_db = self.resources['exec_1']
         user_db = self.users['admin']
-        self.assertTrue(self._user_has_resource_db_permissions(
+        self.assertUserHasResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Observer, should always return true for VIEW permission
         user_db = self.users['observer']
-        self.assertTrue(resolver.user_has_resource_db_permission(
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['exec_1'],
-            permission_type=PermissionType.EXECUTION_VIEW))
+            permission_type=PermissionType.EXECUTION_VIEW)
 
-        self.assertFalse(resolver.user_has_resource_db_permission(
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['exec_1'],
-            permission_type=PermissionType.EXECUTION_STOP))
-        self.assertFalse(resolver.user_has_resource_db_permission(
+            permission_type=PermissionType.EXECUTION_STOP)
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['exec_1'],
-            permission_type=PermissionType.EXECUTION_ALL))
+            permission_type=PermissionType.EXECUTION_ALL)
 
         # No roles, should return false for everything
         user_db = self.users['no_roles']
-        self.assertFalse(self._user_has_resource_db_permissions(
+        self.assertUserDoesntHaveResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Custom role with no permission grants, should return false for everything
         user_db = self.users['1_custom_role_no_permissions']
-        self.assertFalse(self._user_has_resource_db_permissions(
+        self.assertUserDoesntHaveResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Custom role with an action_view grant on unrelated pack, should return false for
         # everything
         user_db = self.users['custom_role_unrelated_pack_action_grant']
-        self.assertFalse(self._user_has_resource_db_permissions(
+        self.assertUserDoesntHaveResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Custom role with unrelated permission grant to parent pack, should return false for
         # everything
         user_db = self.users['custom_role_pack_action_grant_unrelated_permission']
-        self.assertFalse(self._user_has_resource_db_permissions(
+        self.assertUserDoesntHaveResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Custom role with "action_view" grant on the pack of the action resource belongs to
         user_db = self.users['custom_role_pack_action_view_grant']
-        self.assertTrue(resolver.user_has_resource_db_permission(
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
             permission_type=PermissionType.EXECUTION_VIEW
-        ))
+        )
 
-        self.assertFalse(resolver.user_has_resource_db_permission(
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
             permission_type=PermissionType.EXECUTION_RE_RUN
-        ))
+        )
 
         # Custom role with "action_view" grant on the action the resource belongs to
         user_db = self.users['custom_role_action_view_grant']
-        self.assertTrue(resolver.user_has_resource_db_permission(
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
             permission_type=PermissionType.EXECUTION_VIEW
-        ))
+        )
 
-        self.assertFalse(resolver.user_has_resource_db_permission(
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
             permission_type=PermissionType.EXECUTION_RE_RUN
-        ))
+        )
 
         # Custom role with "action_execute" grant on the pack of the action resource belongs to
         user_db = self.users['custom_role_pack_action_execute_grant']
         permission_types = [PermissionType.EXECUTION_RE_RUN, PermissionType.EXECUTION_STOP]
-        self.assertTrue(self._user_has_resource_db_permissions(
+        self.assertUserHasResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=permission_types))
+            permission_types=permission_types)
 
         permission_types = [PermissionType.EXECUTION_VIEW, PermissionType.EXECUTION_ALL]
-        self.assertFalse(self._user_has_resource_db_permissions(
+        self.assertUserDoesntHaveResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=permission_types))
+            permission_types=permission_types)
 
         # Custom role with "action_execute" grant on the action resource belongs to
         user_db = self.users['custom_role_action_execute_grant']
         permission_types = [PermissionType.EXECUTION_RE_RUN, PermissionType.EXECUTION_STOP]
-        self.assertTrue(self._user_has_resource_db_permissions(
+        self.assertUserHasResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=permission_types))
+            permission_types=permission_types)
 
         permission_types = [PermissionType.EXECUTION_VIEW, PermissionType.EXECUTION_ALL]
-        self.assertFalse(self._user_has_resource_db_permissions(
+        self.assertUserDoesntHaveResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=permission_types))
+            permission_types=permission_types)
 
         # Custom role - "action_all" grant on the action parent pack the execution belongs to
         user_db = self.users['custom_role_pack_action_all_grant']
         resource_db = self.resources['exec_1']
-        self.assertTrue(self._user_has_resource_db_permissions(
+        self.assertUserHasResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Custom role - "action_all" grant on the action the execution belongs to
         user_db = self.users['custom_role_action_all_grant']
         resource_db = self.resources['exec_1']
-        self.assertTrue(self._user_has_resource_db_permissions(
+        self.assertUserHasResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)

--- a/st2common/tests/unit/test_rbac_resolvers_key_value_pair.py
+++ b/st2common/tests/unit/test_rbac_resolvers_key_value_pair.py
@@ -44,8 +44,9 @@ class KeyValuePermissionsResolverTestCase(BasePermissionsResolverTestCase):
 
         permission_types = PermissionType.get_valid_permissions_for_resource_type(
             ResourceType.KEY_VALUE_PAIR)
-        for permission_type in permission_types:
-            self.assertTrue(resolver.user_has_resource_db_permission(
-                user_db=user_db,
-                resource_db=resource_db,
-                permission_type=permission_type))
+
+        self.assertUserHasResourceDbPermissions(
+            resolver=resolver,
+            user_db=user_db,
+            resource_db=resource_db,
+            permission_types=permission_types)

--- a/st2common/tests/unit/test_rbac_resolvers_rule.py
+++ b/st2common/tests/unit/test_rbac_resolvers_rule.py
@@ -271,31 +271,37 @@ class RulePermissionsResolverTestCase(BasePermissionsResolverTestCase):
 
     def test_user_has_permission(self):
         resolver = RulePermissionsResolver()
+        permission_type = PermissionType.RULE_LIST
 
         # Admin user, should always return true
         user_db = self.users['admin']
-        self.assertTrue(resolver.user_has_permission(user_db=user_db,
-                                                     permission_type=PermissionType.RULE_LIST))
+        self.assertUserHasPermission(resolver=resolver,
+                                     user_db=user_db,
+                                     permission_type=permission_type)
 
         # Observer, should always return true for VIEW permissions
         user_db = self.users['observer']
-        self.assertTrue(resolver.user_has_permission(user_db=user_db,
-                                                     permission_type=PermissionType.RULE_LIST))
+        self.assertUserHasPermission(resolver=resolver,
+                                     user_db=user_db,
+                                     permission_type=permission_type)
 
         # No roles, should return false for everything
         user_db = self.users['no_roles']
-        self.assertFalse(resolver.user_has_permission(user_db=user_db,
-                                                      permission_type=PermissionType.RULE_LIST))
+        self.assertUserDoesntHavePermission(resolver=resolver,
+                                            user_db=user_db,
+                                            permission_type=permission_type)
 
         # Custom role with no permission grants, should return false for everything
         user_db = self.users['1_custom_role_no_permissions']
-        self.assertFalse(resolver.user_has_permission(user_db=user_db,
-                                                      permission_type=PermissionType.RULE_LIST))
+        self.assertUserDoesntHavePermission(resolver=resolver,
+                                            user_db=user_db,
+                                            permission_type=permission_type)
 
         # Custom role with "rule_list" grant
         user_db = self.users['custom_role_rule_list_grant']
-        self.assertTrue(resolver.user_has_permission(user_db=user_db,
-                                                     permission_type=PermissionType.RULE_LIST))
+        self.assertUserHasPermission(resolver=resolver,
+                                     user_db=user_db,
+                                     permission_type=permission_type)
 
     def test_user_has_resource_api_permission(self):
         resolver = RulePermissionsResolver()
@@ -305,80 +311,88 @@ class RulePermissionsResolverTestCase(BasePermissionsResolverTestCase):
         resource_db = self.resources['rule_1']
         resource_api = RuleAPI.from_model(resource_db)
 
-        self.assertTrue(resolver.user_has_resource_api_permission(
+        self.assertUserHasResourceApiPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_api=resource_api,
-            permission_type=PermissionType.RULE_CREATE))
+            permission_type=PermissionType.RULE_CREATE)
 
         # Observer, should return false
         user_db = self.users['observer']
         resource_db = self.resources['rule_1']
         resource_api = RuleAPI.from_model(resource_db)
 
-        self.assertFalse(resolver.user_has_resource_api_permission(
+        self.assertUserDoesntHaveResourceApiPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_api=resource_api,
-            permission_type=PermissionType.RULE_CREATE))
+            permission_type=PermissionType.RULE_CREATE)
 
         # No roles, should return false
         user_db = self.users['no_roles']
         resource_db = self.resources['rule_1']
         resource_api = RuleAPI.from_model(resource_db)
 
-        self.assertFalse(resolver.user_has_resource_api_permission(
+        self.assertUserDoesntHaveResourceApiPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_api=resource_api,
-            permission_type=PermissionType.RULE_CREATE))
+            permission_type=PermissionType.RULE_CREATE)
 
         # Custom role with no permission grants, should return false
         user_db = self.users['1_custom_role_no_permissions']
         resource_db = self.resources['rule_1']
         resource_api = RuleAPI.from_model(resource_db)
 
-        self.assertFalse(resolver.user_has_resource_api_permission(
+        self.assertUserDoesntHaveResourceApiPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_api=resource_api,
-            permission_type=PermissionType.RULE_CREATE))
+            permission_type=PermissionType.RULE_CREATE)
 
         # Custom role with "rule_create" grant on parent pack
         user_db = self.users['rule_pack_rule_create_grant']
         resource_db = self.resources['rule_1']
         resource_api = RuleAPI.from_model(resource_db)
 
-        self.assertTrue(resolver.user_has_resource_api_permission(
+        self.assertUserHasResourceApiPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_api=resource_api,
-            permission_type=PermissionType.RULE_CREATE))
+            permission_type=PermissionType.RULE_CREATE)
 
         # Custom role with "rule_all" grant on the parent pack
         user_db = self.users['rule_pack_rule_all_grant']
         resource_db = self.resources['rule_1']
         resource_api = RuleAPI.from_model(resource_db)
 
-        self.assertTrue(resolver.user_has_resource_api_permission(
+        self.assertUserHasResourceApiPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_api=resource_api,
-            permission_type=PermissionType.RULE_CREATE))
+            permission_type=PermissionType.RULE_CREATE)
 
         # Custom role with "rule_create" grant directly on the resource
         user_db = self.users['rule_rule_create_grant']
         resource_db = self.resources['rule_1']
         resource_api = RuleAPI.from_model(resource_db)
 
-        self.assertTrue(resolver.user_has_resource_api_permission(
+        self.assertUserHasResourceApiPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_api=resource_api,
-            permission_type=PermissionType.RULE_CREATE))
+            permission_type=PermissionType.RULE_CREATE)
 
         # Custom role with "rule_all" grant directly on the resource
         user_db = self.users['rule_rule_all_grant']
         resource_db = self.resources['rule_1']
         resource_api = RuleAPI.from_model(resource_db)
 
-        self.assertTrue(resolver.user_has_resource_api_permission(
+        self.assertUserHasResourceApiPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_api=resource_api,
-            permission_type=PermissionType.RULE_CREATE))
+            permission_type=PermissionType.RULE_CREATE)
 
     def test_user_has_resource_db_permission(self):
         resolver = RulePermissionsResolver()
@@ -388,141 +402,158 @@ class RulePermissionsResolverTestCase(BasePermissionsResolverTestCase):
         # Admin user, should always return true
         resource_db = self.resources['rule_1']
         user_db = self.users['admin']
-        self.assertTrue(self._user_has_resource_db_permissions(
+        self.assertUserHasResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Observer, should always return true for VIEW permission
         user_db = self.users['observer']
-        self.assertTrue(resolver.user_has_resource_db_permission(
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['rule_1'],
-            permission_type=PermissionType.RULE_VIEW))
-        self.assertTrue(resolver.user_has_resource_db_permission(
+            permission_type=PermissionType.RULE_VIEW)
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['rule_2'],
-            permission_type=PermissionType.RULE_VIEW))
+            permission_type=PermissionType.RULE_VIEW)
 
-        self.assertFalse(resolver.user_has_resource_db_permission(
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['rule_1'],
-            permission_type=PermissionType.RULE_MODIFY))
-        self.assertFalse(resolver.user_has_resource_db_permission(
+            permission_type=PermissionType.RULE_MODIFY)
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['rule_2'],
-            permission_type=PermissionType.RULE_DELETE))
+            permission_type=PermissionType.RULE_DELETE)
 
         # No roles, should return false for everything
         user_db = self.users['no_roles']
-        self.assertFalse(self._user_has_resource_db_permissions(
+        self.assertUserDoesntHaveResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Custom role with no permission grants, should return false for everything
         user_db = self.users['1_custom_role_no_permissions']
-        self.assertFalse(self._user_has_resource_db_permissions(
+        self.assertUserDoesntHaveResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Custom role with unrelated permission grant to parent pack
         user_db = self.users['custom_role_pack_grant']
-        self.assertFalse(resolver.user_has_resource_db_permission(
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['rule_1'],
-            permission_type=PermissionType.RULE_VIEW))
-        self.assertFalse(resolver.user_has_resource_db_permission(
+            permission_type=PermissionType.RULE_VIEW)
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['rule_2'],
-            permission_type=PermissionType.RULE_VIEW))
-        self.assertFalse(resolver.user_has_resource_db_permission(
+            permission_type=PermissionType.RULE_VIEW)
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['rule_3'],
-            permission_type=PermissionType.RULE_DELETE))
+            permission_type=PermissionType.RULE_DELETE)
 
         # Custom role with with grant on the parent pack
         user_db = self.users['custom_role_rule_pack_grant']
-        self.assertTrue(resolver.user_has_resource_db_permission(
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['rule_1'],
-            permission_type=PermissionType.RULE_VIEW))
-        self.assertTrue(resolver.user_has_resource_db_permission(
+            permission_type=PermissionType.RULE_VIEW)
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['rule_2'],
-            permission_type=PermissionType.RULE_VIEW))
+            permission_type=PermissionType.RULE_VIEW)
 
-        self.assertFalse(resolver.user_has_resource_db_permission(
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['rule_1'],
-            permission_type=PermissionType.RULE_DELETE))
-        self.assertFalse(resolver.user_has_resource_db_permission(
+            permission_type=PermissionType.RULE_DELETE)
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['rule_2'],
-            permission_type=PermissionType.RULE_MODIFY))
+            permission_type=PermissionType.RULE_MODIFY)
 
         # Custom role with a direct grant on rule
         user_db = self.users['custom_role_rule_grant']
-        self.assertTrue(resolver.user_has_resource_db_permission(
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['rule_3'],
-            permission_type=PermissionType.RULE_VIEW))
+            permission_type=PermissionType.RULE_VIEW)
 
-        self.assertFalse(resolver.user_has_resource_db_permission(
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['rule_3'],
-            permission_type=PermissionType.RULE_ALL))
-        self.assertFalse(resolver.user_has_resource_db_permission(
+            permission_type=PermissionType.RULE_ALL)
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['rule_3'],
-            permission_type=PermissionType.RULE_MODIFY))
-        self.assertFalse(resolver.user_has_resource_db_permission(
+            permission_type=PermissionType.RULE_MODIFY)
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['rule_3'],
-            permission_type=PermissionType.RULE_DELETE))
+            permission_type=PermissionType.RULE_DELETE)
 
         # Custom role - "rule_all" grant on the rule parent pack
         user_db = self.users['custom_role_pack_rule_all_grant']
         resource_db = self.resources['rule_1']
-        self.assertTrue(self._user_has_resource_db_permissions(
+        self.assertUserHasResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Custom role - "rule_all" grant on the rule
         user_db = self.users['custom_role_rule_all_grant']
         resource_db = self.resources['rule_1']
-        self.assertTrue(self._user_has_resource_db_permissions(
+        self.assertUserHasResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Custom role - "rule_modify" grant on rule_1
         user_db = self.users['custom_role_rule_modify_grant']
         resource_db = self.resources['rule_1']
-        self.assertTrue(resolver.user_has_resource_db_permission(
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_type=PermissionType.RULE_MODIFY))
+            permission_type=PermissionType.RULE_MODIFY)
 
         # "modify" also grants "view"
-        self.assertTrue(resolver.user_has_resource_db_permission(
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_type=PermissionType.RULE_VIEW))
+            permission_type=PermissionType.RULE_VIEW)
 
         permission_types = [
             PermissionType.RULE_CREATE,
             PermissionType.RULE_DELETE
         ]
-        self.assertFalse(self._user_has_resource_db_permissions(
+        self.assertUserDoesntHaveResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=permission_types))
+            permission_types=permission_types)

--- a/st2common/tests/unit/test_rbac_resolvers_rule_enforcement.py
+++ b/st2common/tests/unit/test_rbac_resolvers_rule_enforcement.py
@@ -300,28 +300,33 @@ class RuleEnforcementPermissionsResolverTestCase(BasePermissionsResolverTestCase
         # Admin user, should always return true
         user_db = self.users['admin']
         permission_type = PermissionType.RULE_ENFORCEMENT_LIST
-        self.assertTrue(resolver.user_has_permission(user_db=user_db,
-                                                     permission_type=permission_type))
+        self.assertUserHasPermission(resolver=resolver,
+                                     user_db=user_db,
+                                     permission_type=permission_type)
 
         # Observer, should always return true for VIEW permissions
         user_db = self.users['observer']
-        self.assertTrue(resolver.user_has_permission(user_db=user_db,
-                                                     permission_type=permission_type))
+        self.assertUserHasPermission(resolver=resolver,
+                                     user_db=user_db,
+                                     permission_type=permission_type)
 
         # No roles, should return false for everything
         user_db = self.users['no_roles']
-        self.assertFalse(resolver.user_has_permission(user_db=user_db,
-                                                      permission_type=permission_type))
+        self.assertUserDoesntHavePermission(resolver=resolver,
+                                            user_db=user_db,
+                                            permission_type=permission_type)
 
         # Custom role with no permission grants, should return false for everything
         user_db = self.users['1_custom_role_no_permissions']
-        self.assertFalse(resolver.user_has_permission(user_db=user_db,
-                                                      permission_type=permission_type))
+        self.assertUserDoesntHavePermission(resolver=resolver,
+                                            user_db=user_db,
+                                            permission_type=permission_type)
 
         # Custom role with "rule_list" grant
         user_db = self.users['custom_role_rule_list_grant']
-        self.assertTrue(resolver.user_has_permission(user_db=user_db,
-                                                     permission_type=permission_type))
+        self.assertUserHasPermission(resolver=resolver,
+                                     user_db=user_db,
+                                     permission_type=permission_type)
 
     def test_user_has_resource_db_permission(self):
         resolver = RuleEnforcementPermissionsResolver()
@@ -331,92 +336,100 @@ class RuleEnforcementPermissionsResolverTestCase(BasePermissionsResolverTestCase
         # Admin user, should always return true
         resource_db = self.resources['rule_enforcement_1']
         user_db = self.users['admin']
-        self.assertTrue(self._user_has_resource_db_permissions(
+        self.assertUserHasResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Observer, should always return true for VIEW permission
         user_db = self.users['observer']
-        self.assertTrue(resolver.user_has_resource_db_permission(
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['rule_enforcement_1'],
-            permission_type=PermissionType.RULE_ENFORCEMENT_VIEW))
-        self.assertTrue(resolver.user_has_resource_db_permission(
+            permission_type=PermissionType.RULE_ENFORCEMENT_VIEW)
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['rule_enforcement_2'],
-            permission_type=PermissionType.RULE_ENFORCEMENT_VIEW))
+            permission_type=PermissionType.RULE_ENFORCEMENT_VIEW)
 
         # No roles, should return false for everything
         user_db = self.users['no_roles']
-        self.assertFalse(self._user_has_resource_db_permissions(
+        self.assertUserDoesntHaveResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Custom role with no permission grants, should return false for everything
         user_db = self.users['1_custom_role_no_permissions']
-        self.assertFalse(self._user_has_resource_db_permissions(
+        self.assertUserDoesntHaveResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Custom role with unrelated permission grant to parent pack
         user_db = self.users['custom_role_pack_grant']
-        self.assertFalse(resolver.user_has_resource_db_permission(
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['rule_enforcement_1'],
-            permission_type=PermissionType.RULE_ENFORCEMENT_VIEW))
-        self.assertFalse(resolver.user_has_resource_db_permission(
+            permission_type=PermissionType.RULE_ENFORCEMENT_VIEW)
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['rule_enforcement_2'],
-            permission_type=PermissionType.RULE_ENFORCEMENT_VIEW))
+            permission_type=PermissionType.RULE_ENFORCEMENT_VIEW)
 
         # Custom role with with grant on the parent pack
         user_db = self.users['custom_role_rule_pack_grant']
-        self.assertTrue(resolver.user_has_resource_db_permission(
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['rule_enforcement_1'],
-            permission_type=PermissionType.RULE_ENFORCEMENT_VIEW))
-        self.assertTrue(resolver.user_has_resource_db_permission(
+            permission_type=PermissionType.RULE_ENFORCEMENT_VIEW)
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['rule_enforcement_2'],
-            permission_type=PermissionType.RULE_ENFORCEMENT_VIEW))
+            permission_type=PermissionType.RULE_ENFORCEMENT_VIEW)
 
         # Custom role with a direct grant on rule
         user_db = self.users['custom_role_rule_grant']
-        self.assertTrue(resolver.user_has_resource_db_permission(
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['rule_enforcement_3'],
-            permission_type=PermissionType.RULE_ENFORCEMENT_VIEW))
+            permission_type=PermissionType.RULE_ENFORCEMENT_VIEW)
 
         # Custom role - "rule_all" grant on the rule parent pack
         user_db = self.users['custom_role_pack_rule_all_grant']
         resource_db = self.resources['rule_enforcement_1']
-        self.assertTrue(self._user_has_resource_db_permissions(
+        self.assertUserHasResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Custom role - "rule_all" grant on the rule
         user_db = self.users['custom_role_rule_all_grant']
         resource_db = self.resources['rule_enforcement_1']
-        self.assertTrue(self._user_has_resource_db_permissions(
+        self.assertUserHasResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Custom role - "rule_modify" grant on rule_1
         user_db = self.users['custom_role_rule_modify_grant']
         resource_db = self.resources['rule_enforcement_1']
 
         # "modify" also grants "view"
-        self.assertTrue(resolver.user_has_resource_db_permission(
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_type=PermissionType.RULE_ENFORCEMENT_VIEW))
+            permission_type=PermissionType.RULE_ENFORCEMENT_VIEW)

--- a/st2common/tests/unit/test_rbac_resolvers_runner.py
+++ b/st2common/tests/unit/test_rbac_resolvers_runner.py
@@ -105,28 +105,30 @@ class RunnerPermissionsResolverTestCase(BasePermissionsResolverTestCase):
         # Custom role with "runner_view" grant on runner_1
         resource_db = self.resources['runner_1']
         user_db = self.users['custom_role_runner_view_grant']
-        self.assertTrue(resolver.user_has_resource_db_permission(
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_type=PermissionType.RUNNER_VIEW))
+            permission_type=PermissionType.RUNNER_VIEW)
 
         permission_types = [
             PermissionType.RUNNER_MODIFY,
             PermissionType.RUNNER_ALL
         ]
-        self.assertFalse(self._user_has_resource_db_permissions(
+        self.assertUserDoesntHaveResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=permission_types))
+            permission_types=permission_types)
 
         # Custom role with "runner_modify" grant on runner_2
         resource_db = self.resources['runner_2']
         user_db = self.users['custom_role_runner_modify_grant']
-        self.assertTrue(resolver.user_has_resource_db_permission(
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_type=PermissionType.RUNNER_MODIFY))
+            permission_type=PermissionType.RUNNER_MODIFY)
 
         permission_types = [
             PermissionType.RUNNER_VIEW,

--- a/st2common/tests/unit/test_rbac_resolvers_runner.py
+++ b/st2common/tests/unit/test_rbac_resolvers_runner.py
@@ -1,0 +1,139 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from st2common.rbac.types import PermissionType
+from st2common.rbac.types import ResourceType
+from st2common.persistence.auth import User
+from st2common.persistence.rbac import Role
+from st2common.persistence.rbac import UserRoleAssignment
+from st2common.persistence.rbac import PermissionGrant
+from st2common.models.db.auth import UserDB
+from st2common.models.db.rbac import RoleDB
+from st2common.models.db.rbac import UserRoleAssignmentDB
+from st2common.models.db.rbac import PermissionGrantDB
+from st2common.models.db.action import RunnerTypeDB
+from st2common.rbac.resolvers import RunnerPermissionsResolver
+from tests.unit.test_rbac_resolvers import BasePermissionsResolverTestCase
+
+__all__ = [
+    'RunnerPermissionsResolverTestCase'
+]
+
+
+class RunnerPermissionsResolverTestCase(BasePermissionsResolverTestCase):
+    def setUp(self):
+        super(RunnerPermissionsResolverTestCase, self).setUp()
+
+        # Create some mock users
+        user_1_db = UserDB(name='custom_role_runner_view_grant')
+        user_1_db = User.add_or_update(user_1_db)
+        self.users['custom_role_runner_view_grant'] = user_1_db
+
+        user_2_db = UserDB(name='custom_role_runner_modify_grant')
+        user_2_db = User.add_or_update(user_2_db)
+        self.users['custom_role_runner_modify_grant'] = user_2_db
+
+        # Create some mock resources on which permissions can be granted
+        runner_1_db = RunnerTypeDB(name='runner_1')
+        self.resources['runner_1'] = runner_1_db
+
+        runner_2_db = RunnerTypeDB(name='runner_2')
+        self.resources['runner_2'] = runner_2_db
+
+        # Create some mock roles with associated permission grants
+        # Custom role - "runner_view" grant on runner_1
+        grant_db = PermissionGrantDB(resource_uid=self.resources['runner_1'].get_uid(),
+                                     resource_type=ResourceType.RUNNER,
+                                     permission_types=[PermissionType.RUNNER_VIEW])
+        grant_db = PermissionGrant.add_or_update(grant_db)
+        permission_grants = [str(grant_db.id)]
+        role_db = RoleDB(name='custom_role_runner_view_grant',
+                         permission_grants=permission_grants)
+        role_db = Role.add_or_update(role_db)
+        self.roles['custom_role_runner_view_grant'] = role_db
+
+        # Custom role - "runner_modify" grant on runner_2
+        grant_db = PermissionGrantDB(resource_uid=self.resources['runner_2'].get_uid(),
+                                     resource_type=ResourceType.RUNNER,
+                                     permission_types=[PermissionType.RUNNER_MODIFY])
+        grant_db = PermissionGrant.add_or_update(grant_db)
+        permission_grants = [str(grant_db.id)]
+        role_db = RoleDB(name='custom_role_runner_modify_grant',
+                         permission_grants=permission_grants)
+        role_db = Role.add_or_update(role_db)
+        self.roles['custom_role_runner_modify_grant'] = role_db
+
+        # Create some mock role assignments
+        user_db = self.users['custom_role_runner_view_grant']
+        role_assignment_db = UserRoleAssignmentDB(
+            user=user_db.name,
+            role=self.roles['custom_role_runner_view_grant'].name)
+        UserRoleAssignment.add_or_update(role_assignment_db)
+
+        user_db = self.users['custom_role_runner_modify_grant']
+        role_assignment_db = UserRoleAssignmentDB(
+            user=user_db.name,
+            role=self.roles['custom_role_runner_modify_grant'].name)
+        UserRoleAssignment.add_or_update(role_assignment_db)
+
+    def test_user_has_resource_db_permission(self):
+        resolver = RunnerPermissionsResolver()
+        all_permission_types = PermissionType.get_valid_permissions_for_resource_type(
+            ResourceType.RUNNER)
+
+        # Admin user, should always return true
+        resource_db = self.resources['runner_1']
+        user_db = self.users['admin']
+        self.assertTrue(self._user_has_resource_db_permissions(
+            resolver=resolver,
+            user_db=user_db,
+            resource_db=resource_db,
+            permission_types=all_permission_types))
+
+        # Custom role with "runner_view" grant on runner_1
+        resource_db = self.resources['runner_1']
+        user_db = self.users['custom_role_runner_view_grant']
+        self.assertTrue(resolver.user_has_resource_db_permission(
+            user_db=user_db,
+            resource_db=resource_db,
+            permission_type=PermissionType.RUNNER_VIEW))
+
+        permission_types = [
+            PermissionType.RUNNER_MODIFY,
+            PermissionType.RUNNER_ALL
+        ]
+        self.assertFalse(self._user_has_resource_db_permissions(
+            resolver=resolver,
+            user_db=user_db,
+            resource_db=resource_db,
+            permission_types=permission_types))
+
+        # Custom role with "runner_modify" grant on runner_2
+        resource_db = self.resources['runner_2']
+        user_db = self.users['custom_role_runner_modify_grant']
+        self.assertTrue(resolver.user_has_resource_db_permission(
+            user_db=user_db,
+            resource_db=resource_db,
+            permission_type=PermissionType.RUNNER_MODIFY))
+
+        permission_types = [
+            PermissionType.RUNNER_VIEW,
+            PermissionType.RUNNER_ALL
+        ]
+        self.assertFalse(self._user_has_resource_db_permissions(
+            resolver=resolver,
+            user_db=user_db,
+            resource_db=resource_db,
+            permission_types=permission_types))

--- a/st2common/tests/unit/test_rbac_resolvers_runner.py
+++ b/st2common/tests/unit/test_rbac_resolvers_runner.py
@@ -132,7 +132,7 @@ class RunnerPermissionsResolverTestCase(BasePermissionsResolverTestCase):
             PermissionType.RUNNER_VIEW,
             PermissionType.RUNNER_ALL
         ]
-        self.assertFalse(self._user_has_resource_db_permissions(
+        self.assertTrue(self._user_doesnt_have_resource_db_permissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,

--- a/st2common/tests/unit/test_rbac_resolvers_runner.py
+++ b/st2common/tests/unit/test_rbac_resolvers_runner.py
@@ -96,11 +96,11 @@ class RunnerPermissionsResolverTestCase(BasePermissionsResolverTestCase):
         # Admin user, should always return true
         resource_db = self.resources['runner_1']
         user_db = self.users['admin']
-        self.assertTrue(self._user_has_resource_db_permissions(
+        self.assertUserHasResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Custom role with "runner_view" grant on runner_1
         resource_db = self.resources['runner_1']
@@ -132,8 +132,8 @@ class RunnerPermissionsResolverTestCase(BasePermissionsResolverTestCase):
             PermissionType.RUNNER_VIEW,
             PermissionType.RUNNER_ALL
         ]
-        self.assertTrue(self._user_doesnt_have_resource_db_permissions(
+        self.assertUserDoesntHaveResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=permission_types))
+            permission_types=permission_types)

--- a/st2common/tests/unit/test_rbac_resolvers_sensor.py
+++ b/st2common/tests/unit/test_rbac_resolvers_sensor.py
@@ -163,28 +163,33 @@ class SensorPermissionsResolverTestCase(BasePermissionsResolverTestCase):
 
         # Admin user, should always return true
         user_db = self.users['admin']
-        self.assertTrue(resolver.user_has_permission(user_db=user_db,
-                                                     permission_type=PermissionType.SENSOR_LIST))
+        self.assertUserHasPermission(resolver=resolver,
+                                     user_db=user_db,
+                                     permission_type=PermissionType.SENSOR_LIST)
 
         # Observer, should always return true for VIEW permissions
         user_db = self.users['observer']
-        self.assertTrue(resolver.user_has_permission(user_db=user_db,
-                                                     permission_type=PermissionType.SENSOR_LIST))
+        self.assertUserHasPermission(resolver=resolver,
+                                     user_db=user_db,
+                                     permission_type=PermissionType.SENSOR_LIST)
 
         # No roles, should return false for everything
         user_db = self.users['no_roles']
-        self.assertFalse(resolver.user_has_permission(user_db=user_db,
-                                                      permission_type=PermissionType.SENSOR_LIST))
+        self.assertUserDoesntHavePermission(resolver=resolver,
+                                            user_db=user_db,
+                                            permission_type=PermissionType.SENSOR_LIST)
 
         # Custom role with no permission grants, should return false for everything
         user_db = self.users['1_custom_role_no_permissions']
-        self.assertFalse(resolver.user_has_permission(user_db=user_db,
-                                                      permission_type=PermissionType.SENSOR_LIST))
+        self.assertUserDoesntHavePermission(resolver=resolver,
+                                            user_db=user_db,
+                                            permission_type=PermissionType.SENSOR_LIST)
 
         # Custom role with "sensor_list" grant
         user_db = self.users['custom_role_sensor_list_grant']
-        self.assertTrue(resolver.user_has_permission(user_db=user_db,
-                                                     permission_type=PermissionType.SENSOR_LIST))
+        self.assertUserHasPermission(resolver=resolver,
+                                     user_db=user_db,
+                                     permission_type=PermissionType.SENSOR_LIST)
 
     def test_user_has_resource_db_permission(self):
         resolver = SensorPermissionsResolver()
@@ -194,96 +199,106 @@ class SensorPermissionsResolverTestCase(BasePermissionsResolverTestCase):
         # Admin user, should always return true
         resource_db = self.resources['sensor_1']
         user_db = self.users['admin']
-        self.assertTrue(self._user_has_resource_db_permissions(
+        self.assertUserHasResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Observer, should always return true for VIEW permission
         user_db = self.users['observer']
-        self.assertTrue(resolver.user_has_resource_db_permission(
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['sensor_1'],
-            permission_type=PermissionType.SENSOR_VIEW))
-        self.assertTrue(resolver.user_has_resource_db_permission(
+            permission_type=PermissionType.SENSOR_VIEW)
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['sensor_2'],
-            permission_type=PermissionType.SENSOR_VIEW))
+            permission_type=PermissionType.SENSOR_VIEW)
 
         # No roles, should return false for everything
         user_db = self.users['no_roles']
-        self.assertFalse(self._user_has_resource_db_permissions(
+        self.assertUserDoesntHaveResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Custom role with no permission grants, should return false for everything
         user_db = self.users['1_custom_role_no_permissions']
-        self.assertFalse(self._user_has_resource_db_permissions(
+        self.assertUserDoesntHaveResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Custom role with unrelated permission grant to parent pack
         user_db = self.users['custom_role_pack_grant']
-        self.assertFalse(resolver.user_has_resource_db_permission(
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['sensor_1'],
-            permission_type=PermissionType.SENSOR_VIEW))
-        self.assertFalse(resolver.user_has_resource_db_permission(
+            permission_type=PermissionType.SENSOR_VIEW)
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['sensor_2'],
-            permission_type=PermissionType.SENSOR_ALL))
-        self.assertFalse(resolver.user_has_resource_db_permission(
+            permission_type=PermissionType.SENSOR_ALL)
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['sensor_3'],
-            permission_type=PermissionType.SENSOR_VIEW))
+            permission_type=PermissionType.SENSOR_VIEW)
 
         # Custom role with with grant on the parent pack
         user_db = self.users['custom_role_sensor_pack_grant']
-        self.assertTrue(resolver.user_has_resource_db_permission(
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['sensor_1'],
-            permission_type=PermissionType.SENSOR_VIEW))
-        self.assertTrue(resolver.user_has_resource_db_permission(
+            permission_type=PermissionType.SENSOR_VIEW)
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['sensor_2'],
-            permission_type=PermissionType.SENSOR_VIEW))
+            permission_type=PermissionType.SENSOR_VIEW)
 
-        self.assertFalse(resolver.user_has_resource_db_permission(
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['sensor_3'],
-            permission_type=PermissionType.SENSOR_VIEW))
+            permission_type=PermissionType.SENSOR_VIEW)
 
         # Custom role with a direct grant on sensor
         user_db = self.users['custom_role_sensor_grant']
-        self.assertTrue(resolver.user_has_resource_db_permission(
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['sensor_3'],
-            permission_type=PermissionType.SENSOR_VIEW))
+            permission_type=PermissionType.SENSOR_VIEW)
 
-        self.assertFalse(resolver.user_has_resource_db_permission(
+        self.assertUserDoesntHaveResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=self.resources['sensor_3'],
-            permission_type=PermissionType.SENSOR_ALL))
+            permission_type=PermissionType.SENSOR_ALL)
 
         # Custom role - "sensor_all" grant on the sensor parent pack
         user_db = self.users['custom_role_pack_sensor_all_grant']
         resource_db = self.resources['sensor_1']
-        self.assertTrue(self._user_has_resource_db_permissions(
+        self.assertUserHasResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Custom role - "sensor_all" grant on the sensor
         user_db = self.users['custom_role_sensor_all_grant']
         resource_db = self.resources['sensor_1']
-        self.assertTrue(self._user_has_resource_db_permissions(
+        self.assertUserHasResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)

--- a/st2common/tests/unit/test_rbac_resolvers_webhook.py
+++ b/st2common/tests/unit/test_rbac_resolvers_webhook.py
@@ -72,26 +72,27 @@ class WebhookPermissionsResolverTestCase(BasePermissionsResolverTestCase):
         # Admin user, should always return true
         resource_db = self.resources['webhook_1']
         user_db = self.users['admin']
-        self.assertTrue(self._user_has_resource_db_permissions(
+        self.assertUserHasResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=all_permission_types))
+            permission_types=all_permission_types)
 
         # Custom role with "webhook_send" grant on webhook_1
         user_db = self.users['custom_role_webhook_grant']
-        self.assertTrue(resolver.user_has_resource_db_permission(
+        self.assertUserHasResourceDbPermission(
+            resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_type=PermissionType.WEBHOOK_SEND))
+            permission_type=PermissionType.WEBHOOK_SEND)
 
         permission_types = [
             PermissionType.WEBHOOK_CREATE,
             PermissionType.WEBHOOK_DELETE,
             PermissionType.WEBHOOK_ALL
         ]
-        self.assertFalse(self._user_has_resource_db_permissions(
+        self.assertUserDoesntHaveResourceDbPermissions(
             resolver=resolver,
             user_db=user_db,
             resource_db=resource_db,
-            permission_types=permission_types))
+            permission_types=permission_types)

--- a/st2tests/st2tests/mocks/runner.py
+++ b/st2tests/st2tests/mocks/runner.py
@@ -37,6 +37,7 @@ class MockActionRunner(ActionRunner):
         self.post_run_called = False
 
     def pre_run(self):
+        super(MockActionRunner, self).pre_run()
         self.pre_run_called = True
 
     def run(self, action_params):


### PR DESCRIPTION
This pull request introduces a new API and corresponding CLI commands which allows administrator to disable (and re-enable) a particular runner.

In addition to that, it includes other related changes and improvements:

1. It ports RunnerType API endpoint to utilize `ResourceController` class. This way this API endpoint behaves the same as other API endpoints (limit works, filtering works, etc.) and means we can get rid of the duplicated code.
2. Introduces RBAC support for `RunnerType` resource. This is need because only admins (or people with an explicit permission grant) are allowed to disable / enable a runner (previously we could get away with not having RunnerType API endpoint behind RBAC wall, not we can't anymore).
3. Fixes runner registration - if user has explicitly disabled a runner through the API, runner won't get re-enabled when running register content and registering runners (aka the expected behavior).
4. Introduces functionality which allows administrator to disable a runner (aka hooks up runner `enabled` attribute)

## Background

I initially went with the config approach, but in https://github.com/StackStorm/st2/pull/2671#discussion_r62194745, @manasdk pointed out that we already have a concept for disabling a particular runner (aka `enabled` attribute on the `RunnerTypeDB` model). This attribute was there, but it wasn't hooked up and working so I hooked it up.

The whole change did require more work compared to the config approach (rbac, etc.), but imo it's worth it (RBAC is something we would eventually need to get done anyway) and this approach is generic so it applies to every runner, not just local one.

TODO:

- [x] Update BaseRunner `pre_run` method to throw and abort action execution if a runner is disabled. Also update all the affected runner classes (aka all classes which inherit from the base class).
- [x] Only allow "enabled" attribute of the runner to be changed through the modify / PUT API endpoint
- [x] Tests for RBAC permissions resolver
- [x] Tests for a disabled runner