### PR TITLE
Add "get_fixture_content" method to the base pack resource test classes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,9 @@ in development
   ``st2 runner enable <name>``) which allows administrator to disable (and re-enable) a runner.
   (new feature)
 * Add RBAC support for runner types API endpoints. (improvement)
+* Add ``get_fixture_content`` method to all the base pack resource test classes. This method
+  enforces fixture files location and allows user to load raw fixture content from a file on disk.
+  (new feature)
 
 1.4.0 - April 18, 2016
 ----------------------

--- a/st2tests/st2tests/action_aliases.py
+++ b/st2tests/st2tests/action_aliases.py
@@ -14,22 +14,20 @@
 # limitations under the License.
 
 import os
-import inspect
-
-from unittest2 import TestCase
 
 from st2common.content.loader import ContentPackLoader
 from st2common.exceptions.content import ParseException
 from st2common.bootstrap.aliasesregistrar import AliasesRegistrar
 from st2common.models.utils.action_alias_utils import extract_parameters_for_action_alias_db
 from st2common.models.utils.action_alias_utils import extract_parameters
+from st2tests.pack_resource import BasePackResourceTestCase
 
 __all__ = [
     'BaseActionAliasTestCase'
 ]
 
 
-class BaseActionAliasTestCase(TestCase):
+class BaseActionAliasTestCase(BasePackResourceTestCase):
     """
     Base class for testing action aliases.
     """
@@ -96,9 +94,7 @@ class BaseActionAliasTestCase(TestCase):
         """
         Retrieve ActionAlias DB object for the provided alias name.
         """
-        test_file_path = inspect.getfile(self.__class__)
-        base_pack_path = os.path.join(os.path.dirname(test_file_path), '..')
-        base_pack_path = os.path.abspath(base_pack_path)
+        base_pack_path = self._get_base_pack_path()
         _, pack = os.path.split(base_pack_path)
 
         pack_loader = ContentPackLoader()

--- a/st2tests/st2tests/actions.py
+++ b/st2tests/st2tests/actions.py
@@ -13,19 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest2 import TestCase
-
 from st2actions.runners.utils import get_action_class_instance
 from st2tests.mocks.action import MockActionWrapper
 from st2tests.mocks.action import MockActionService
-
+from st2tests.pack_resource import BasePackResourceTestCase
 
 __all__ = [
     'BaseActionTestCase'
 ]
 
 
-class BaseActionTestCase(TestCase):
+class BaseActionTestCase(BasePackResourceTestCase):
     """
     Base class for Python runner action tests.
     """

--- a/st2tests/st2tests/pack_resource.py
+++ b/st2tests/st2tests/pack_resource.py
@@ -1,0 +1,52 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import inspect
+
+from unittest2 import TestCase
+
+__all__ = [
+    'BasePackResourceTestCase'
+]
+
+
+class BasePackResourceTestCase(TestCase):
+    """
+    Base test class for all the pack resource test classes.
+
+    Contains some utility methods for loading fixtures from disk, etc.
+    """
+
+    def get_fixture_content(self, fixture_path):
+        """
+        Return raw fixture content for the provided fixture path.
+
+        :param fixture_path: Fixture path relative to the tests/fixtures/ directory.
+        :type fixture_path: ``str``
+        """
+        base_pack_path = self._get_base_pack_path()
+        fixtures_path = os.path.join(base_pack_path, 'tests/fixtures/')
+        fixture_path = os.path.join(fixtures_path, fixture_path)
+
+        with open(fixture_path, 'r') as fp:
+            content = fp.read()
+
+        return content
+
+    def _get_base_pack_path(self):
+        test_file_path = inspect.getfile(self.__class__)
+        base_pack_path = os.path.join(os.path.dirname(test_file_path), '..')
+        return base_pack_path

--- a/st2tests/st2tests/pack_resource.py
+++ b/st2tests/st2tests/pack_resource.py
@@ -49,4 +49,5 @@ class BasePackResourceTestCase(TestCase):
     def _get_base_pack_path(self):
         test_file_path = inspect.getfile(self.__class__)
         base_pack_path = os.path.join(os.path.dirname(test_file_path), '..')
+        base_pack_path = os.path.abspath(base_pack_path)
         return base_pack_path

--- a/st2tests/st2tests/sensors.py
+++ b/st2tests/st2tests/sensors.py
@@ -13,17 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest2 import TestCase
-
 from st2tests.mocks.sensor import MockSensorWrapper
 from st2tests.mocks.sensor import MockSensorService
+from st2tests.pack_resource import BasePackResourceTestCase
 
 __all__ = [
     'BaseSensorTestCase'
 ]
 
 
-class BaseSensorTestCase(TestCase):
+class BaseSensorTestCase(BasePackResourceTestCase):
     """
     Base class for sensor tests.
 


### PR DESCRIPTION
This PR adds "get_fixture_content" method to the base pack resource test classes. This method enforces fixture file location conventions and allows user to load raw fixture content from a fixture file on disk.

We discussed this on a st2contrib PR recently - the functionality is very simple, but we still think there is value in it since it enforces fixture file location convention (`<pack path>/tests/fixtures/`).