### PR TITLE
Allow "--register-all" and "--register-setup-virtualenvs" register content script flags to be used together

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ in development
   ``st2 runner enable <name>``) which allows administrator to disable (and re-enable) a runner.
   (new feature)
 * Add RBAC support for runner types API endpoints. (improvement)
+* Allow ``register-setup-virtualenvs`` flag to be used in combination with ``register-all`` in the
+  ``st2-register-content`` script.
 
 1.4.0 - April 18, 2016
 ----------------------

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -68,6 +68,11 @@ def setup_virtualenvs():
     """
     Setup Python virtual environments for all the registered or the provided pack.
     """
+
+    LOG.info('=========================================================')
+    LOG.info('########### Setting up virtual environments #############')
+    LOG.info('=========================================================')
+
     pack_dir = cfg.CONF.register.pack
     fail_on_failure = cfg.CONF.register.fail_on_failure
 
@@ -244,27 +249,28 @@ def register_policies():
 
 
 def register_content():
-    if cfg.CONF.register.all:
+    register_all = cfg.CONF.register.all
+
+    if register_all:
         register_sensors()
         register_actions()
         register_rules()
         register_aliases()
         register_policies()
-        return
 
-    if cfg.CONF.register.sensors:
+    if cfg.CONF.register.sensors and not register_all:
         register_sensors()
 
-    if cfg.CONF.register.actions:
+    if cfg.CONF.register.actions and not register_all:
         register_actions()
 
-    if cfg.CONF.register.rules:
+    if cfg.CONF.register.rules and not register_all:
         register_rules()
 
-    if cfg.CONF.register.aliases:
+    if cfg.CONF.register.aliases and not register_all:
         register_aliases()
 
-    if cfg.CONF.register.policies:
+    if cfg.CONF.register.policies and not register_all:
         register_policies()
 
     if cfg.CONF.register.setup_virtualenvs:

--- a/st2common/tests/integration/test_register_content_script.py
+++ b/st2common/tests/integration/test_register_content_script.py
@@ -90,6 +90,15 @@ class ContentRegisterScripTestCase(IntegrationTestCase):
         self.assertTrue('Registered 0 rules.' in stderr)
         self.assertEqual(exit_code, 0)
 
+    def test_register_all_and_register_setup_virtualenvs(self):
+        # Verify that --register-all works in combinations with --register-setuo-virtualenvs
+        cmd = BASE_CMD_ARGS + ['--register-all', '--register-setup-virtualenvs']
+        exit_code, stdout, stderr = run_command(cmd=cmd)
+        self.assertTrue('Registering actions' in stderr)
+        self.assertTrue('Registering rules' in stderr)
+        self.assertTrue('Setup virtualenv for 4 pack(s)' in stderr)
+        self.assertEqual(exit_code, 0)
+
     def test_register_setup_virtualenvs(self):
         # Single pack
         pack_dir = os.path.join(get_fixtures_base_path(), 'dummy_pack_1')


### PR DESCRIPTION
The title says it all.

Reported / caught by @codyaray on Slack.