### PR TITLE
Pack config schema support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,9 @@ in development
 * Add ``get_fixture_content`` method to all the base pack resource test classes. This method
   enforces fixture files location and allows user to load raw fixture content from a file on disk.
   (new feature)
+* Introduce a new concept of pack config schemas. Each pack can now contain a
+  ``config.schema.yaml`` file. This file can contain an optional schema for the pack config. In the
+  future, pack configs will be validated against the schema (if available). (new feature)
 
 1.4.0 - April 18, 2016
 ----------------------

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -204,6 +204,22 @@ class ResourceController(rest.RestController):
 
         return result
 
+    def _get_one_by_pack_ref(self, pack_ref, exclude_fields=None, from_model_kwargs=None):
+        LOG.info('GET %s with pack_ref=%s', pecan.request.path, pack_ref)
+
+        instance = self._get_by_pack_ref(pack_ref=pack_ref, exclude_fields=exclude_fields)
+
+        if not instance:
+            msg = 'Unable to identify resource with pack_ref "%s".' % (pack_ref)
+            pecan.abort(http_client.NOT_FOUND, msg)
+
+        from_model_kwargs = from_model_kwargs or {}
+        from_model_kwargs.update(self._get_from_model_kwargs_for_request(request=pecan.request))
+        result = self.model.from_model(instance, **from_model_kwargs)
+        LOG.debug('GET %s with pack_ref=%s, client_result=%s', pecan.request.path, id, result)
+
+        return result
+
     def _get_by_id(self, resource_id, exclude_fields=None):
         try:
             resource_db = self.access.get(id=resource_id, exclude_fields=exclude_fields)
@@ -216,6 +232,15 @@ class ResourceController(rest.RestController):
         try:
             resource_db = self.access.get(name=resource_name, exclude_fields=exclude_fields)
         except Exception:
+            resource_db = None
+
+        return resource_db
+
+    def _get_by_pack_ref(self, pack_ref, exclude_fields=None):
+        try:
+            resource_db = self.access.get(pack=pack_ref, exclude_fields=exclude_fields)
+        except Exception as e:
+            print e
             resource_db = None
 
         return resource_db

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -240,8 +240,11 @@ class ResourceController(rest.RestController):
         try:
             resource_db = self.access.get(pack=pack_ref, exclude_fields=exclude_fields)
         except Exception as e:
-            print e
             resource_db = None
+
+        if not resource_db:
+            msg = 'Resource with a pack_ref "%s" not found' % (pack_ref)
+            raise StackStormDBObjectNotFoundError(msg)
 
         return resource_db
 

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -59,6 +59,8 @@ class ResourceController(rest.RestController):
     filter_transform_functions = {}
 
     # Method responsible for retrieving an instance of the corresponding model DB object
+    # Note: This method should throw StackStormDBObjectNotFoundError if the corresponding DB
+    # object doesn't exist
     get_one_db_method = None
 
     def __init__(self):

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -241,7 +241,7 @@ class ResourceController(rest.RestController):
     def _get_by_pack_ref(self, pack_ref, exclude_fields=None):
         try:
             resource_db = self.access.get(pack=pack_ref, exclude_fields=exclude_fields)
-        except Exception as e:
+        except Exception:
             resource_db = None
 
         if not resource_db:

--- a/st2api/st2api/controllers/v1/pack_config_schema.py
+++ b/st2api/st2api/controllers/v1/pack_config_schema.py
@@ -1,0 +1,53 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pecan
+
+from st2common.models.api.base import jsexpose
+from st2api.controllers.resource import ResourceController
+from st2common.models.api.pack import ConfigSchemaAPI
+from st2common.persistence.pack import ConfigSchema
+from st2common.rbac.types import PermissionType
+from st2common.rbac.decorators import request_user_has_resource_db_permission
+
+
+__all__ = [
+    'PackConfigSchemaController'
+]
+
+
+class PackConfigSchemaController(ResourceController):
+    model = ConfigSchemaAPI
+    access = ConfigSchema
+    supported_filters = {}
+
+    def __init__(self):
+        super(PackConfigSchemaController, self).__init__()
+        self.get_one_db_method = self._get_by_pack_ref
+
+    @jsexpose()
+    def get_all(self, **kwargs):
+        return pecan.abort(404)
+
+    @request_user_has_resource_db_permission(permission_type=PermissionType.PACK_VIEW)
+    @jsexpose(arg_types=[str])
+    def get_one(self, pack_ref):
+        """
+            Retrieve config schema for a particular pack.
+
+            Handles requests:
+                GET /packs/config_schema/<pack_ref>
+        """
+        return self._get_one_by_pack_ref(pack_ref=pack_ref)

--- a/st2api/st2api/controllers/v1/pack_config_schema.py
+++ b/st2api/st2api/controllers/v1/pack_config_schema.py
@@ -21,6 +21,7 @@ from st2api.controllers.resource import ResourceController
 from st2common.models.api.pack import ConfigSchemaAPI
 from st2common.persistence.pack import ConfigSchema
 from st2common.rbac.types import PermissionType
+from st2common.rbac.decorators import request_user_has_permission
 from st2common.rbac.decorators import request_user_has_resource_db_permission
 
 
@@ -41,9 +42,10 @@ class PackConfigSchemaController(ResourceController):
         # this case, RBAC is checked on the parent PackDB object
         self.get_one_db_method = packs_service.get_pack_by_ref
 
+    @request_user_has_permission(permission_type=PermissionType.PACK_LIST)
     @jsexpose()
     def get_all(self, **kwargs):
-        return pecan.abort(404)
+        return super(PackConfigSchemaController, self)._get_all(**kwargs)
 
     @request_user_has_resource_db_permission(permission_type=PermissionType.PACK_VIEW)
     @jsexpose(arg_types=[str])

--- a/st2api/st2api/controllers/v1/pack_config_schema.py
+++ b/st2api/st2api/controllers/v1/pack_config_schema.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pecan
-
 from st2common.services import packs as packs_service
 from st2common.models.api.base import jsexpose
 from st2api.controllers.resource import ResourceController

--- a/st2api/st2api/controllers/v1/pack_config_schema.py
+++ b/st2api/st2api/controllers/v1/pack_config_schema.py
@@ -15,6 +15,7 @@
 
 import pecan
 
+from st2common.services import packs as packs_service
 from st2common.models.api.base import jsexpose
 from st2api.controllers.resource import ResourceController
 from st2common.models.api.pack import ConfigSchemaAPI
@@ -35,7 +36,10 @@ class PackConfigSchemaController(ResourceController):
 
     def __init__(self):
         super(PackConfigSchemaController, self).__init__()
-        self.get_one_db_method = self._get_by_pack_ref
+
+        # Note: This method is used to retrieve object for RBAC purposes and in
+        # this case, RBAC is checked on the parent PackDB object
+        self.get_one_db_method = packs_service.get_pack_by_ref
 
     @jsexpose()
     def get_all(self, **kwargs):

--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -71,35 +71,9 @@ class BasePacksController(ResourceController):
         return resource_db
 
 
-from st2common.models.api.pack import ConfigSchemaAPI
-from st2common.persistence.pack import ConfigSchema
-
-class PackConfigSchemaController(ResourceController):
-    model = ConfigSchemaAPI
-    access = ConfigSchema
-    supported_filters = {}
-
-    def __init__(self):
-        super(PackConfigSchemaController, self).__init__()
-        self.get_one_db_method = self._get_by_pack_ref
-
-    @jsexpose()
-    def get_all(self, **kwargs):
-        return pecan.abort(404)
-
-    @request_user_has_resource_db_permission(permission_type=PermissionType.PACK_VIEW)
-    @jsexpose(arg_types=[str])
-    def get_one(self, pack_ref):
-        """
-            Retrieve config schema for a particular pack.
-
-            Handles requests:
-                GET /packs/config_schema/<pack_ref>
-        """
-        return self._get_one_by_pack_ref(pack_ref=pack_ref)
-
 class PacksController(BasePacksController):
     from st2api.controllers.v1.packviews import PackViewsController
+    from st2api.controllers.v1.pack_config_schema import PackConfigSchemaController
 
     model = PackAPI
     access = Pack

--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -73,7 +73,6 @@ class BasePacksController(ResourceController):
 
 class PacksController(BasePacksController):
     from st2api.controllers.v1.packviews import PackViewsController
-    from st2api.controllers.v1.pack_config_schema import PackConfigSchemaController
 
     model = PackAPI
     access = Pack
@@ -88,7 +87,6 @@ class PacksController(BasePacksController):
 
     # Nested controllers
     views = PackViewsController()
-    config_schema = PackConfigSchemaController()
 
     @request_user_has_permission(permission_type=PermissionType.PACK_LIST)
     @jsexpose()

--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -71,6 +71,33 @@ class BasePacksController(ResourceController):
         return resource_db
 
 
+from st2common.models.api.pack import ConfigSchemaAPI
+from st2common.persistence.pack import ConfigSchema
+
+class PackConfigSchemaController(ResourceController):
+    model = ConfigSchemaAPI
+    access = ConfigSchema
+    supported_filters = {}
+
+    def __init__(self):
+        super(PackConfigSchemaController, self).__init__()
+        self.get_one_db_method = self._get_by_pack_ref
+
+    @jsexpose()
+    def get_all(self, **kwargs):
+        return pecan.abort(404)
+
+    @request_user_has_resource_db_permission(permission_type=PermissionType.PACK_VIEW)
+    @jsexpose(arg_types=[str])
+    def get_one(self, pack_ref):
+        """
+            Retrieve config schema for a particular pack.
+
+            Handles requests:
+                GET /packs/config_schema/<pack_ref>
+        """
+        return self._get_one_by_pack_ref(pack_ref=pack_ref)
+
 class PacksController(BasePacksController):
     from st2api.controllers.v1.packviews import PackViewsController
 
@@ -87,6 +114,7 @@ class PacksController(BasePacksController):
 
     # Nested controllers
     views = PackViewsController()
+    config_schema = PackConfigSchemaController()
 
     @request_user_has_permission(permission_type=PermissionType.PACK_LIST)
     @jsexpose()

--- a/st2api/st2api/controllers/v1/root.py
+++ b/st2api/st2api/controllers/v1/root.py
@@ -20,6 +20,7 @@ from st2api.controllers.v1.aliasexecution import ActionAliasExecutionController
 from st2api.controllers.v1.auth import ApiKeyController
 from st2api.controllers.v1.keyvalue import KeyValuePairController
 from st2api.controllers.v1.packs import PacksController
+from st2api.controllers.v1.pack_config_schema import PackConfigSchemaController
 from st2api.controllers.v1.policies import PolicyTypeController, PolicyController
 from st2api.controllers.v1.ruletypes import RuleTypesController
 from st2api.controllers.v1.rules import RuleController
@@ -39,6 +40,7 @@ __all__ = [
 
 class RootController(object):
     packs = PacksController()
+    config_schema = PackConfigSchemaController()
     actions = ActionsController()
     actionexecutions = ActionExecutionsController()
     executions = actionexecutions  # We should deprecate actionexecutions.

--- a/st2api/tests/unit/controllers/v1/test_pack_config_schema.py
+++ b/st2api/tests/unit/controllers/v1/test_pack_config_schema.py
@@ -1,0 +1,35 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from tests import FunctionalTest
+
+__all__ = [
+    'PackConfigSchemaControllerTestCase'
+]
+
+
+class PackConfigSchemaControllerTestCase(FunctionalTest):
+    register_packs = True
+
+    def test_get_all(self):
+        resp = self.app.get('/v1/config_schema')
+        self.assertEqual(resp.status_int, 200)
+        self.assertEqual(len(resp.json), 1, '/v1/config_schema did not return all schemas.')
+
+    def test_get_one(self):
+        resp = self.app.get('/v1/config_schema/dummy_pack_1')
+        self.assertEqual(resp.status_int, 200)
+        self.assertEqual(resp.json['pack'], 'dummy_pack_1')
+        self.assertEqual('api_key' in resp.json['attributes'])

--- a/st2api/tests/unit/controllers/v1/test_pack_config_schema.py
+++ b/st2api/tests/unit/controllers/v1/test_pack_config_schema.py
@@ -32,4 +32,4 @@ class PackConfigSchemaControllerTestCase(FunctionalTest):
         resp = self.app.get('/v1/config_schema/dummy_pack_1')
         self.assertEqual(resp.status_int, 200)
         self.assertEqual(resp.json['pack'], 'dummy_pack_1')
-        self.assertEqual('api_key' in resp.json['attributes'])
+        self.assertTrue('api_key' in resp.json['attributes'])

--- a/st2api/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
+++ b/st2api/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
@@ -17,8 +17,6 @@ import httplib
 
 import six
 
-from st2common.persistence.auth import User
-from st2common.models.db.auth import UserDB
 from st2tests.fixturesloader import FixturesLoader
 from tests.base import APIControllerWithRBACTestCase
 

--- a/st2api/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
+++ b/st2api/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
@@ -109,13 +109,6 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
         if self.register_packs:
             self._register_packs()
 
-        self.users = {}
-
-        # Users
-        user_1_db = UserDB(name='no_permissions')
-        user_1_db = User.add_or_update(user_1_db)
-        self.users['no_permissions'] = user_1_db
-
         # Insert mock objects - those objects are used to test get one, edit and delete operations
         self.models = self.fixtures_loader.save_fixtures_to_db(fixtures_pack=FIXTURES_PACK,
                                                                fixtures_dict=TEST_FIXTURES)

--- a/st2api/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
+++ b/st2api/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
@@ -149,6 +149,11 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
                 'path': '/v1/packs/views/files/dummy_pack_1',
                 'method': 'GET'
             },
+            # Pack config schema
+            {
+                'path': '/v1/config_schema/dummy_pack_1',
+                'method': 'GET'
+            },
             {
                 'path': '/v1/packs/views/file/dummy_pack_1/pack.yaml',
                 'method': 'GET'

--- a/st2common/st2common/bootstrap/base.py
+++ b/st2common/st2common/bootstrap/base.py
@@ -20,10 +20,13 @@ import six
 
 from st2common import log as logging
 from st2common.constants.pack import MANIFEST_FILE_NAME
+from st2common.constants.pack import CONFIG_SCHEMA_FILE_NAME
 from st2common.content.loader import MetaLoader
 from st2common.content.loader import ContentPackLoader
 from st2common.models.api.pack import PackAPI
+from st2common.models.api.pack import ConfigSchemaAPI
 from st2common.persistence.pack import Pack
+from st2common.persistence.pack import ConfigSchema
 from st2common.util.file_system import get_file_list
 
 __all__ = [
@@ -110,7 +113,7 @@ class ResourceRegistrar(object):
         REGISTERED_PACKS_CACHE[pack_name] = True
 
         try:
-            pack_db = self._register_pack(pack_name=pack_name, pack_dir=pack_dir)
+            pack_db, _ = self._register_pack(pack_name=pack_name, pack_dir=pack_dir)
         except Exception:
             LOG.exception('Failed to register pack "%s"' % (pack_name))
             return None
@@ -119,11 +122,21 @@ class ResourceRegistrar(object):
 
     def _register_pack(self, pack_name, pack_dir):
         """
-        Register a pack (create a DB object in the system).
+        Register a pack and corresponding pack config schema (create a DB object in the system).
 
         Note: Pack registration now happens when registering the content and not when installing
         a pack using packs.install. Eventually this will be moved to the pack management API.
         """
+        # 1. Register pack
+        pack_db = self._register_pack_db(pack_name=pack_name, pack_dir=pack_dir)
+
+        # 2. Register corresponding pack config schema
+        config_schema_db = self._register_pack_config_schema_db(pack_name=pack_name,
+                                                                pack_dir=pack_dir)
+
+        return pack_db, config_schema_db
+
+    def _register_pack_db(self, pack_name, pack_dir):
         manifest_path = os.path.join(pack_dir, MANIFEST_FILE_NAME)
 
         if not os.path.isfile(manifest_path):
@@ -150,3 +163,25 @@ class ResourceRegistrar(object):
         pack_db = Pack.add_or_update(pack_db)
         LOG.debug('Pack %s registered.' % (pack_name))
         return pack_db
+
+    def _register_pack_config_schema_db(self, pack_name, pack_dir):
+        config_schema_path = os.path.join(pack_dir, CONFIG_SCHEMA_FILE_NAME)
+
+        if not os.path.isfile(config_schema_path):
+            # Note: Config schema is optional
+            return None
+
+        content = self._meta_loader.load(config_schema_path)
+        content['pack'] = pack_name
+
+        config_schema_api = ConfigSchemaAPI(**content)
+        config_schema_db = ConfigSchemaAPI.to_model(config_schema_api)
+
+        try:
+            config_schema_db.id = ConfigSchema.get_by_ref(pack_name).id
+        except ValueError:
+            LOG.debug('Config schema for pack %s not found. Creating new one.', pack_name)
+
+        config_schema_db = ConfigSchema.add_or_update(config_schema_db)
+        LOG.debug('Config schema for pack %s registered.' % (pack_name))
+        return config_schema_db

--- a/st2common/st2common/bootstrap/base.py
+++ b/st2common/st2common/bootstrap/base.py
@@ -178,7 +178,7 @@ class ResourceRegistrar(object):
         config_schema_db = ConfigSchemaAPI.to_model(config_schema_api)
 
         try:
-            config_schema_db.id = ConfigSchema.get_by_ref(pack_name).id
+            config_schema_db.id = ConfigSchema.get_by_pack(pack_name).id
         except ValueError:
             LOG.debug('Config schema for pack %s not found. Creating new one.', pack_name)
 

--- a/st2common/st2common/constants/pack.py
+++ b/st2common/st2common/constants/pack.py
@@ -22,7 +22,8 @@ __all__ = [
     'CHATOPS_PACK_NAME',
     'USER_PACK_NAME_BLACKLIST',
     'BASE_PACK_REQUIREMENTS',
-    'MANIFEST_FILE_NAME'
+    'MANIFEST_FILE_NAME',
+    'CONFIG_SCHEMA_FILE_NAME'
 ]
 
 # A list of allowed characters for the pack name
@@ -65,3 +66,6 @@ BASE_PACK_REQUIREMENTS = [
 
 # Name of the pack manifest file
 MANIFEST_FILE_NAME = 'pack.yaml'
+
+# File name for the config schema file
+CONFIG_SCHEMA_FILE_NAME = 'config.schema.yaml'

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -13,11 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from st2common.util import schema as util_schema
 from st2common.models.api.base import BaseAPI
 from st2common.models.db.pack import PackDB
+from st2common.models.db.pack import ConfigSchemaDB
 
 __all__ = [
-    'PackAPI'
+    'PackAPI',
+    'ConfigSchemaAPI'
 ]
 
 
@@ -80,5 +83,42 @@ class PackAPI(BaseAPI):
 
         model = cls.model(name=name, description=description, ref=ref, keywords=keywords,
                           version=version, author=author, email=email, files=files)
+
+        return model
+
+
+class ConfigSchemaAPI(BaseAPI):
+    model = ConfigSchemaDB
+    schema = {
+        "title": "ConfigSchema",
+        "description": "Pack config schema.",
+        "type": "object",
+        "properties": {
+            "id": {
+                "description": "The unique identifier for the config schema.",
+                "type": "string"
+            },
+            "pack": {
+                "description": "The content pack this config schema belongs to.",
+                "type": "string"
+            },
+            "attributes": {
+                "description": "Config schema attributes.",
+                "type": "object",
+                "patternProperties": {
+                    "^\w+$": util_schema.get_action_parameters_schema()
+                },
+                "default": {}
+            }
+        },
+        "additionalProperties": False
+    }
+
+    @classmethod
+    def to_model(cls, config_schema):
+        pack = config_schema.pack
+        attributes = config_schema.attributes
+
+        model = cls.model(pack=pack, attributes=attributes)
 
         return model

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -36,6 +36,7 @@ MODEL_MODULE_NAMES = [
     'st2common.models.db.execution',
     'st2common.models.db.executionstate',
     'st2common.models.db.liveaction',
+    'st2common.models.db.pack',
     'st2common.models.db.policy',
     'st2common.models.db.rule',
     'st2common.models.db.runner',

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -149,6 +149,9 @@ class MongoDBAccess(object):
     def get_by_ref(self, value):
         return self.get(ref=value, raise_exception=True)
 
+    def get_by_pack(self, value):
+        return self.get(pack=value, raise_exception=True)
+
     def get(self, exclude_fields=None, *args, **kwargs):
         raise_exception = kwargs.pop('raise_exception', False)
 

--- a/st2common/st2common/models/db/pack.py
+++ b/st2common/st2common/models/db/pack.py
@@ -20,7 +20,8 @@ from st2common.models.db import stormbase
 from st2common.constants.types import ResourceType
 
 __all__ = [
-    'PackDB'
+    'PackDB',
+    'ConfigSchemaDB'
 ]
 
 
@@ -50,7 +51,21 @@ class PackDB(stormbase.StormFoundationDB, stormbase.UIDFieldMixin):
         self.uid = self.get_uid()
 
 
+class ConfigSchemaDB(stormbase.StormFoundationDB):
+    """
+    System entity representing a config schema for a particular pack.
+    """
+
+    pack = me.StringField(
+        required=True,
+        help_text='Name of the content pack this schema belongs to.',
+        unique=True)
+    attributes = stormbase.EscapedDynamicField(
+        help_text='The specification for config schema attributes.')
+
+
 # specialized access objects
 pack_access = MongoDBAccess(PackDB)
+config_schema_access = MongoDBAccess(ConfigSchemaDB)
 
-MODELS = [PackDB]
+MODELS = [PackDB, ConfigSchemaDB]

--- a/st2common/st2common/models/db/pack.py
+++ b/st2common/st2common/models/db/pack.py
@@ -58,8 +58,8 @@ class ConfigSchemaDB(stormbase.StormFoundationDB):
 
     pack = me.StringField(
         required=True,
-        help_text='Name of the content pack this schema belongs to.',
-        unique=True)
+        unique=True,
+        help_text='Name of the content pack this schema belongs to.')
     attributes = stormbase.EscapedDynamicField(
         help_text='The specification for config schema attributes.')
 

--- a/st2common/st2common/persistence/base.py
+++ b/st2common/st2common/persistence/base.py
@@ -88,6 +88,10 @@ class Access(object):
         return cls._get_impl().get_by_ref(value)
 
     @classmethod
+    def get_by_pack(cls, value):
+        return cls._get_impl().get_by_pack(value)
+
+    @classmethod
     def get(cls, *args, **kwargs):
         return cls._get_impl().get(*args, **kwargs)
 

--- a/st2common/st2common/persistence/pack.py
+++ b/st2common/st2common/persistence/pack.py
@@ -13,8 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from st2common.models.db.pack import pack_access
 from st2common.persistence import base
+from st2common.models.db.pack import pack_access
+from st2common.models.db.pack import config_schema_access
 
 __all__ = [
     'Pack',
@@ -31,7 +32,7 @@ class Pack(base.Access):
 
 
 class ConfigSchema(base.Access):
-    impl = pack_access
+    impl = config_schema_access
 
     @classmethod
     def _get_impl(cls):

--- a/st2common/st2common/persistence/pack.py
+++ b/st2common/st2common/persistence/pack.py
@@ -17,11 +17,20 @@ from st2common.models.db.pack import pack_access
 from st2common.persistence import base
 
 __all__ = [
-    'Pack'
+    'Pack',
+    'ConfigSchema'
 ]
 
 
 class Pack(base.Access):
+    impl = pack_access
+
+    @classmethod
+    def _get_impl(cls):
+        return cls.impl
+
+
+class ConfigSchema(base.Access):
     impl = pack_access
 
     @classmethod

--- a/st2common/st2common/rbac/decorators.py
+++ b/st2common/st2common/rbac/decorators.py
@@ -115,6 +115,7 @@ def request_user_has_resource_db_permission(permission_type):
 
             get_one_db_method = controller_instance.get_one_db_method
             resource_db = get_one_db_method(resource_id)
+            assert resource_db is not None
             utils.assert_request_user_has_resource_db_permission(request=pecan.request,
                                                                  resource_db=resource_db,
                                                                  permission_type=permission_type)

--- a/st2common/st2common/services/packs.py
+++ b/st2common/st2common/services/packs.py
@@ -1,0 +1,28 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from st2common.persistence.pack import Pack
+
+__all__ = [
+    'get_pack_by_ref'
+]
+
+
+def get_pack_by_ref(pack_ref):
+    """
+    Retrieve PackDB by the provided reference.
+    """
+    pack_db = Pack.get_by_ref(pack_ref)
+    return pack_db

--- a/st2common/tests/unit/test_resource_registrar.py
+++ b/st2common/tests/unit/test_resource_registrar.py
@@ -42,7 +42,7 @@ class ResourceRegistrarTestCase(DbTestCase):
         self.assertEqual(len(pack_dbs), 0)
         self.assertEqual(len(config_schema_dbs), 0)
 
-        registrar = ResourceRegistrar()
+        registrar = ResourceRegistrar(use_pack_cache=False)
         registrar._pack_loader.get_packs = mock.Mock()
         registrar._pack_loader.get_packs.return_value = {'dummy_pack_1': PACK_PATH}
         packs_base_paths = content_utils.get_packs_base_paths()

--- a/st2common/tests/unit/test_resource_registrar.py
+++ b/st2common/tests/unit/test_resource_registrar.py
@@ -1,0 +1,60 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import mock
+
+from st2common.content import utils as content_utils
+from st2common.bootstrap.base import ResourceRegistrar
+from st2common.persistence.pack import Pack
+from st2common.persistence.pack import ConfigSchema
+
+from st2tests import DbTestCase
+from st2tests import fixturesloader
+
+
+__all__ = [
+    'ResourceRegistrarTestCase'
+]
+
+PACK_PATH = os.path.join(fixturesloader.get_fixtures_base_path(), 'dummy_pack_1')
+
+
+class ResourceRegistrarTestCase(DbTestCase):
+    def test_register_packs(self):
+        # Verify DB is empty
+        pack_dbs = Pack.get_all()
+        config_schema_dbs = ConfigSchema.get_all()
+
+        self.assertEqual(len(pack_dbs), 0)
+        self.assertEqual(len(config_schema_dbs), 0)
+
+        registrar = ResourceRegistrar()
+        registrar._pack_loader.get_packs = mock.Mock()
+        registrar._pack_loader.get_packs.return_value = {'dummy_pack_1': PACK_PATH}
+        packs_base_paths = content_utils.get_packs_base_paths()
+        registrar.register_packs(base_dirs=packs_base_paths)
+
+        # Verify pack and schema have been registered
+        pack_dbs = Pack.get_all()
+        config_schema_dbs = ConfigSchema.get_all()
+
+        self.assertEqual(len(pack_dbs), 1)
+        self.assertEqual(len(config_schema_dbs), 1)
+
+        self.assertEqual(pack_dbs[0].name, 'dummy_pack_1')
+        self.assertTrue('api_key' in config_schema_dbs[0].attributes)
+        self.assertTrue('api_secret' in config_schema_dbs[0].attributes)

--- a/st2tests/st2tests/fixtures/dummy_pack_1/config.schema.yaml
+++ b/st2tests/st2tests/fixtures/dummy_pack_1/config.schema.yaml
@@ -1,0 +1,13 @@
+---
+  attributes:
+    api_key:
+      type: "string"
+      secret: true
+      required: true
+    api_secret:
+      type: "string"
+      secret: true
+      required: true
+    region:
+      type: "string"
+      default: "lon"

--- a/st2tests/st2tests/fixtures/pack_invalid_requirements/pack.yaml
+++ b/st2tests/st2tests/fixtures/pack_invalid_requirements/pack.yaml
@@ -1,5 +1,5 @@
 ---
-name : dummy_pack_4
+name : pack_invalid_requirements
 description : dummy pack
 version : 0.1
 author : st2-dev


### PR DESCRIPTION
This is a first iteration of the improvement pack configuration story.

It includes support for optional pack config schema. Pack configuration which will be supplied by the user (that's the second iteration of the improved pack configuration story and is TBD) will be validated against the schema provided by the pack author when loading pack configuration.

Pack schema follows action parameters format and the schema file looks like that:

```yaml
---
  attributes:
    api_key:
      type: "string"
     secret: true
     required: true
    api_secret:
      type: "string"
     secret: true
     required: true
    region:
      type: "string"
      required: false
```

(I'm open to feedback, we could rename `attributes` to something else, we could also get rid of it and have config items as top-level object, but I'm not too big of a fan of that approach.)

Schema is registered (and corresponding `ConfigSchemaDB` object is created in the database) when registering packs when running st2-register-content script.

This pull request also includes API endpoint for retrieving config schema (read-only).

## Open Questions / To Decide

- [x] Config schema file name - right now it's `config.schema.yaml`, but we could also call it `config.meta.yaml` or similar. I'm open to feedback.
- [x] API endpoint path - `/v1/packs/config_schema/<pack ref>` vs `/v1/packs/views/config_schema/<pack ref>` (ideally, it would be `/packs/<pack ref>/config_schema`, but because of our pecan abuse that's not possible right now and something we should do once we move to v2 and clean up our API).

## TODO

- [ ] Documentation
  - [ ] Basic docs on config schema format
  - [ ] Config best practices (prefer flat, avoid deeply nested objects, etc.)
- [x] Update affected `packs.uninstall` command
- [x] Tests with config schema examples fixtures
  - [x] Basic tests (registration, API retrieval)
  - [x] RBAC tests