### PR TITLE
Update the base model code to throw StackStormDBObjectNotFoundError exception if an object is not found, update affected code

### DIFF
--- a/st2common/st2common/bootstrap/aliasesregistrar.py
+++ b/st2common/st2common/bootstrap/aliasesregistrar.py
@@ -23,6 +23,7 @@ from st2common.constants.meta import ALLOWED_EXTS
 from st2common.bootstrap.base import ResourceRegistrar
 from st2common.models.api.action import ActionAliasAPI
 from st2common.persistence.actionalias import ActionAlias
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
 
 __all__ = [
     'AliasesRegistrar',
@@ -127,7 +128,7 @@ class AliasesRegistrar(ResourceRegistrar):
 
         try:
             action_alias_db.id = ActionAlias.get_by_name(action_alias_db.name).id
-        except ValueError:
+        except StackStormDBObjectNotFoundError:
             LOG.debug('ActionAlias %s not found. Creating new one.', action_alias)
 
         try:

--- a/st2common/st2common/bootstrap/base.py
+++ b/st2common/st2common/bootstrap/base.py
@@ -28,6 +28,7 @@ from st2common.models.api.pack import ConfigSchemaAPI
 from st2common.persistence.pack import Pack
 from st2common.persistence.pack import ConfigSchema
 from st2common.util.file_system import get_file_list
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
 
 __all__ = [
     'ResourceRegistrar'
@@ -157,7 +158,7 @@ class ResourceRegistrar(object):
 
         try:
             pack_db.id = Pack.get_by_ref(pack_name).id
-        except ValueError:
+        except StackStormDBObjectNotFoundError:
             LOG.debug('Pack %s not found. Creating new one.', pack_name)
 
         pack_db = Pack.add_or_update(pack_db)
@@ -179,7 +180,7 @@ class ResourceRegistrar(object):
 
         try:
             config_schema_db.id = ConfigSchema.get_by_pack(pack_name).id
-        except ValueError:
+        except StackStormDBObjectNotFoundError:
             LOG.debug('Config schema for pack %s not found. Creating new one.', pack_name)
 
         config_schema_db = ConfigSchema.add_or_update(config_schema_db)

--- a/st2common/st2common/bootstrap/policiesregistrar.py
+++ b/st2common/st2common/bootstrap/policiesregistrar.py
@@ -25,6 +25,7 @@ from st2common.constants.meta import ALLOWED_EXTS
 from st2common.bootstrap.base import ResourceRegistrar
 from st2common.models.api.policy import PolicyTypeAPI, PolicyAPI
 from st2common.persistence.policy import PolicyType, Policy
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2common.util import loader
 
 
@@ -144,7 +145,7 @@ class PolicyRegistrar(ResourceRegistrar):
 
         try:
             policy_db.id = Policy.get_by_name(policy_api.name).id
-        except ValueError:
+        except StackStormDBObjectNotFoundError:
             LOG.debug('Policy "%s" is not found. Creating new entry.', policy)
 
         try:
@@ -177,7 +178,7 @@ def register_policy_types(module):
                 existing_entry = PolicyType.get_by_ref(policy_type_db.ref)
                 if existing_entry:
                     policy_type_db.id = existing_entry.id
-            except ValueError:
+            except StackStormDBObjectNotFoundError:
                 LOG.debug('Policy type "%s" is not found. Creating new entry.',
                           policy_type_db.ref)
 

--- a/st2common/st2common/bootstrap/rulesregistrar.py
+++ b/st2common/st2common/bootstrap/rulesregistrar.py
@@ -25,6 +25,7 @@ from st2common.models.api.rule import RuleAPI
 from st2common.models.system.common import ResourceReference
 from st2common.persistence.rule import Rule
 from st2common.services.triggers import cleanup_trigger_db_for_rule, increment_trigger_ref_count
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
 import st2common.content.utils as content_utils
 
 __all__ = [
@@ -145,7 +146,7 @@ class RulesRegistrar(ResourceRegistrar):
                     if existing:
                         rule_db.id = existing.id
                         LOG.debug('Found existing rule: %s with id: %s', rule_ref, existing.id)
-                except ValueError:
+                except StackStormDBObjectNotFoundError:
                     LOG.debug('Rule %s not found. Creating new one.', rule)
 
                 try:

--- a/st2common/st2common/bootstrap/ruletypesregistrar.py
+++ b/st2common/st2common/bootstrap/ruletypesregistrar.py
@@ -19,6 +19,7 @@ from st2common import log as logging
 from st2common.constants.rules import RULE_TYPE_STANDARD, RULE_TYPE_BACKSTOP
 from st2common.models.api.rule import RuleTypeAPI
 from st2common.persistence.rule import RuleType
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
 
 __all__ = [
     'register_rule_types',
@@ -55,7 +56,7 @@ def register_rule_types():
         try:
             rule_type_db = RuleType.get_by_name(rule_type['name'])
             update = True
-        except ValueError:
+        except StackStormDBObjectNotFoundError:
             rule_type_db = None
             update = False
 

--- a/st2common/st2common/hooks.py
+++ b/st2common/st2common/hooks.py
@@ -28,6 +28,7 @@ from st2common.persistence.auth import User
 from st2common.exceptions import db as db_exceptions
 from st2common.exceptions import auth as auth_exceptions
 from st2common.exceptions import rbac as rbac_exceptions
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2common.exceptions.apivalidation import ValueValidationException
 from st2common.util.jsonify import json_encode
 from st2common.util.auth import validate_token, validate_api_key
@@ -216,7 +217,7 @@ class AuthHook(PecanHook):
 
         try:
             return User.get(user)
-        except ValueError:
+        except StackStormDBObjectNotFoundError:
             # User doesn't exist - we should probably also invalidate token/apikey if
             # this happens.
             LOG.warn('User %s not found.', user)

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -24,6 +24,7 @@ from st2common import log as logging
 from st2common.util import isotime
 from st2common.models.db import stormbase
 from st2common.models.utils.profiling import log_query_and_profile_data_for_queryset
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
 
 
 LOG = logging.getLogger(__name__)
@@ -164,7 +165,9 @@ class MongoDBAccess(object):
         log_query_and_profile_data_for_queryset(queryset=instances)
 
         if not instance and raise_exception:
-            raise ValueError('Unable to find the %s instance. %s' % (self.model.__name__, kwargs))
+            msg = 'Unable to find the %s instance. %s' % (self.model.__name__, kwargs)
+            raise StackStormDBObjectNotFoundError(msg)
+
         return instance
 
     def get_all(self, *args, **kwargs):

--- a/st2common/st2common/persistence/trigger.py
+++ b/st2common/st2common/persistence/trigger.py
@@ -15,6 +15,7 @@
 
 from st2common import log as logging
 from st2common import transport
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2common.models.db.trigger import triggertype_access, trigger_access, triggerinstance_access
 from st2common.persistence.base import (Access, ContentPackResource)
 from st2common.transport import utils as transport_utils
@@ -58,7 +59,7 @@ class Trigger(ContentPackResource):
         confirmed_delete = False
         try:
             cls.get_by_id(model_object.id)
-        except ValueError:
+        except (StackStormDBObjectNotFoundError, ValueError):
             confirmed_delete = True
 
         # Publish internal event on the message bus

--- a/st2common/st2common/services/keyvalues.py
+++ b/st2common/st2common/services/keyvalues.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from st2common.persistence.keyvalue import KeyValuePair
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
 
 
 class KeyValueLookup(object):
@@ -48,7 +49,7 @@ class KeyValueLookup(object):
         kvp = None
         try:
             kvp = KeyValuePair.get_by_name(key)
-        except ValueError:
+        except (StackStormDBObjectNotFoundError, ValueError):
             # ValueErrors are expected in case of partial lookups
             pass
         # A good default value for un-matched value is empty string since that will be used

--- a/st2common/st2common/services/packs.py
+++ b/st2common/st2common/services/packs.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 from st2common.persistence.pack import Pack
-from st2common.exceptions.db import StackStormDBObjectNotFoundError
 
 __all__ = [
     'get_pack_by_ref'
@@ -25,10 +24,5 @@ def get_pack_by_ref(pack_ref):
     """
     Retrieve PackDB by the provided reference.
     """
-
-    try:
-        pack_db = Pack.get_by_ref(pack_ref)
-    except ValueError as e:
-        raise StackStormDBObjectNotFoundError(e.message)
-
+    pack_db = Pack.get_by_ref(pack_ref)
     return pack_db

--- a/st2common/st2common/services/triggers.py
+++ b/st2common/st2common/services/triggers.py
@@ -16,6 +16,7 @@
 from st2common import log as logging
 from st2common.exceptions.sensors import TriggerTypeRegistrationException
 from st2common.exceptions.triggers import TriggerDoesNotExistException
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2common.models.api.trigger import (TriggerAPI, TriggerTypeAPI)
 from st2common.models.system.common import ResourceReference
 from st2common.persistence.trigger import (Trigger, TriggerType)
@@ -52,7 +53,7 @@ def get_trigger_db_given_type_and_params(type=None, parameters=None):
             trigger_db = Trigger.query(type=type, parameters=None).first()
 
         return trigger_db
-    except ValueError as e:
+    except StackStormDBObjectNotFoundError as e:
         LOG.debug('Database lookup for type="%s" parameters="%s" resulted ' +
                   'in exception : %s.', type, parameters, e, exc_info=True)
         return None
@@ -67,7 +68,13 @@ def get_trigger_db_by_ref(ref):
 
     :rtype trigger_type: ``object``
     """
-    return Trigger.get_by_ref(ref)
+    try:
+        return Trigger.get_by_ref(ref)
+    except StackStormDBObjectNotFoundError as e:
+        LOG.debug('Database lookup for ref="%s" resulted ' +
+                  'in exception : %s.', ref, e, exc_info=True)
+
+    return None
 
 
 def _get_trigger_db(trigger):
@@ -98,10 +105,11 @@ def get_trigger_type_db(ref):
     """
     try:
         return TriggerType.get_by_ref(ref)
-    except ValueError as e:
+    except StackStormDBObjectNotFoundError as e:
         LOG.debug('Database lookup for ref="%s" resulted ' +
                   'in exception : %s.', ref, e, exc_info=True)
-        return None
+
+    return None
 
 
 def _get_trigger_dict_given_rule(rule):

--- a/st2common/tests/unit/test_db.py
+++ b/st2common/tests/unit/test_db.py
@@ -24,6 +24,7 @@ from st2common.transport.publishers import PoolPublisher
 from st2common.util import schema as util_schema
 from st2common.util import reference
 from st2common.util import date as date_utils
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2tests import DbTestCase
 
 SKIP_DELETE = False
@@ -68,7 +69,7 @@ class ReactorModelTest(DbTestCase):
         ReactorModelTest._delete([retrieved])
         try:
             retrieved = TriggerType.get_by_id(saved.id)
-        except ValueError:
+        except StackStormDBObjectNotFoundError:
             retrieved = None
         self.assertIsNone(retrieved, 'managed to retrieve after failure.')
 
@@ -88,7 +89,7 @@ class ReactorModelTest(DbTestCase):
         ReactorModelTest._delete([retrieved, triggertype])
         try:
             retrieved = Trigger.get_by_id(saved.id)
-        except ValueError:
+        except StackStormDBObjectNotFoundError:
             retrieved = None
         self.assertIsNone(retrieved, 'managed to retrieve after failure.')
 
@@ -101,7 +102,7 @@ class ReactorModelTest(DbTestCase):
         ReactorModelTest._delete([retrieved, trigger, triggertype])
         try:
             retrieved = TriggerInstance.get_by_id(saved.id)
-        except ValueError:
+        except StackStormDBObjectNotFoundError:
             retrieved = None
         self.assertIsNone(retrieved, 'managed to retrieve after failure.')
 
@@ -123,7 +124,7 @@ class ReactorModelTest(DbTestCase):
         ReactorModelTest._delete([retrieved, trigger, action, runnertype, triggertype])
         try:
             retrieved = Rule.get_by_id(saved.id)
-        except ValueError:
+        except StackStormDBObjectNotFoundError:
             retrieved = None
         self.assertIsNone(retrieved, 'managed to retrieve after failure.')
 
@@ -288,7 +289,7 @@ class ActionModelTest(DbTestCase):
         self._delete([retrieved])
         try:
             retrieved = Action.get_by_id(saved.id)
-        except ValueError:
+        except StackStormDBObjectNotFoundError:
             retrieved = None
         self.assertIsNone(retrieved, 'managed to retrieve after failure.')
 
@@ -315,7 +316,7 @@ class ActionModelTest(DbTestCase):
         self._delete([retrieved])
         try:
             retrieved = Action.get_by_id(saved.id)
-        except ValueError:
+        except StackStormDBObjectNotFoundError:
             retrieved = None
         self.assertIsNone(retrieved, 'managed to retrieve after failure.')
 
@@ -344,7 +345,7 @@ class ActionModelTest(DbTestCase):
         self._delete([retrieved])
         try:
             retrieved = Action.get_by_id(saved.id)
-        except ValueError:
+        except StackStormDBObjectNotFoundError:
             retrieved = None
         self.assertIsNone(retrieved, 'managed to retrieve after failure.')
 
@@ -438,7 +439,7 @@ class KeyValuePairModelTest(DbTestCase):
         KeyValuePairModelTest._delete([retrieved])
         try:
             retrieved = KeyValuePair.get_by_name(saved.name)
-        except ValueError:
+        except StackStormDBObjectNotFoundError:
             retrieved = None
         self.assertIsNone(retrieved, 'managed to retrieve after failure.')
 

--- a/st2common/tests/unit/test_db_action_state.py
+++ b/st2common/tests/unit/test_db_action_state.py
@@ -2,6 +2,7 @@ import bson
 
 from st2common.models.db.executionstate import ActionExecutionStateDB
 from st2common.persistence.executionstate import ActionExecutionState
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
 
 from st2tests import DbTestCase
 
@@ -15,7 +16,7 @@ class ActionExecutionStateTests(DbTestCase):
         ActionExecutionStateTests._delete(model_objects=[retrieved])
         try:
             retrieved = ActionExecutionState.get_by_id(saved.id)
-        except ValueError:
+        except StackStormDBObjectNotFoundError:
             retrieved = None
         self.assertIsNone(retrieved, 'managed to retrieve after failure.')
 

--- a/st2common/tests/unit/test_db_liveaction.py
+++ b/st2common/tests/unit/test_db_liveaction.py
@@ -19,6 +19,7 @@ from st2common.models.db.liveaction import LiveActionDB
 from st2common.models.db.notification import NotificationSchema, NotificationSubSchema
 from st2common.persistence.liveaction import LiveAction
 from st2common.transport.publishers import PoolPublisher
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2common.util import date as date_utils
 
 from st2tests import DbTestCase
@@ -48,7 +49,7 @@ class LiveActionModelTest(DbTestCase):
         LiveActionModelTest._delete([retrieved])
         try:
             retrieved = LiveAction.get_by_id(saved.id)
-        except ValueError:
+        except StackStormDBObjectNotFoundError:
             retrieved = None
         self.assertIsNone(retrieved, 'managed to retrieve after failure.')
 

--- a/st2common/tests/unit/test_db_marker.py
+++ b/st2common/tests/unit/test_db_marker.py
@@ -15,6 +15,7 @@
 
 from st2common.models.db.marker import DumperMarkerDB
 from st2common.persistence.marker import DumperMarker
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2common.util import date as date_utils
 
 from st2tests import DbTestCase
@@ -36,7 +37,7 @@ class DumperMarkerModelTest(DbTestCase):
         DumperMarkerModelTest._delete([retrieved])
         try:
             retrieved = DumperMarker.get_by_id(saved.id)
-        except ValueError:
+        except StackStormDBObjectNotFoundError:
             retrieved = None
         self.assertIsNone(retrieved, 'managed to retrieve after failure.')
 

--- a/st2common/tests/unit/test_db_rule_enforcement.py
+++ b/st2common/tests/unit/test_db_rule_enforcement.py
@@ -19,6 +19,7 @@ import mock
 from st2common.models.db.rule_enforcement import RuleEnforcementDB
 from st2common.persistence.rule_enforcement import RuleEnforcement
 from st2common.transport.publishers import PoolPublisher
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2tests import DbTestCase
 
 SKIP_DELETE = False
@@ -45,7 +46,7 @@ class RuleEnforcementModelTest(DbTestCase):
         RuleEnforcementModelTest._delete([retrieved])
         try:
             retrieved = RuleEnforcement.get_by_id(saved.id)
-        except ValueError:
+        except StackStormDBObjectNotFoundError:
             retrieved = None
         self.assertIsNone(retrieved, 'managed to retrieve after delete.')
 

--- a/st2common/tests/unit/test_executions.py
+++ b/st2common/tests/unit/test_executions.py
@@ -23,6 +23,7 @@ from st2common.util import isotime
 from st2common.util import date as date_utils
 from st2common.persistence.execution import ActionExecution
 from st2common.models.api.execution import ActionExecutionAPI
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
 
 
 class TestActionExecutionHistoryModel(DbTestCase):
@@ -143,7 +144,7 @@ class TestActionExecutionHistoryModel(DbTestCase):
 
         # Delete the DB record.
         ActionExecution.delete(model)
-        self.assertRaises(ValueError, ActionExecution.get_by_id, obj.id)
+        self.assertRaises(StackStormDBObjectNotFoundError, ActionExecution.get_by_id, obj.id)
 
     def test_model_partial(self):
         # Create API object.
@@ -216,7 +217,7 @@ class TestActionExecutionHistoryModel(DbTestCase):
 
         # Delete the DB record.
         ActionExecution.delete(model)
-        self.assertRaises(ValueError, ActionExecution.get_by_id, obj.id)
+        self.assertRaises(StackStormDBObjectNotFoundError, ActionExecution.get_by_id, obj.id)
 
     def test_datetime_range(self):
         base = date_utils.add_utc_tz(datetime.datetime(2014, 12, 25, 0, 0, 0))

--- a/st2common/tests/unit/test_persistence.py
+++ b/st2common/tests/unit/test_persistence.py
@@ -20,6 +20,7 @@ import bson
 
 from st2tests import DbTestCase
 from st2common.util import date as date_utils
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from tests.unit.base import FakeModel, FakeModelDB
 
 
@@ -80,7 +81,8 @@ class TestPersistence(DbTestCase):
         self.assertEqual(obj1.id, obj2.id)
         self.assertEqual(obj1.name, obj2.name)
         self.assertDictEqual(obj1.context, obj2.context)
-        self.assertRaises(ValueError, self.access.get_by_id, str(bson.ObjectId()))
+        self.assertRaises(StackStormDBObjectNotFoundError,
+                          self.access.get_by_id, str(bson.ObjectId()))
 
     def test_query_by_name(self):
         obj1 = FakeModelDB(name=uuid.uuid4().hex, context={'user': 'system'})
@@ -90,7 +92,8 @@ class TestPersistence(DbTestCase):
         self.assertEqual(obj1.id, obj2.id)
         self.assertEqual(obj1.name, obj2.name)
         self.assertDictEqual(obj1.context, obj2.context)
-        self.assertRaises(ValueError, self.access.get_by_name, uuid.uuid4().hex)
+        self.assertRaises(StackStormDBObjectNotFoundError, self.access.get_by_name,
+                          uuid.uuid4().hex)
 
     def test_query_filter(self):
         obj1 = FakeModelDB(name=uuid.uuid4().hex, context={'user': 'system'})

--- a/st2common/tests/unit/test_reference.py
+++ b/st2common/tests/unit/test_reference.py
@@ -94,5 +94,5 @@ class ReferenceTest(DbTestCase):
         try:
             reference.get_model_from_ref(Trigger, {'name': 'unknown'})
             self.assertTrue(False, 'Exception expected.')
-        except ValueError:
+        except db.StackStormDBObjectNotFoundError:
             self.assertTrue(True)

--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -34,6 +34,7 @@ from st2common.exceptions.db import StackStormDBObjectConflictError
 from st2common.models.db import db_setup, db_teardown, db_ensure_indexes
 from st2common.bootstrap.base import ResourceRegistrar
 from st2common.content.utils import get_packs_base_paths
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
 import st2common.models.db.rule as rule_model
 import st2common.models.db.rule_enforcement as rule_enforcement_model
 import st2common.models.db.sensor as sensor_model
@@ -270,7 +271,8 @@ class DbModelTestCase(DbTestCase):
         # Assert instance is deleted from the database.
         retrieved = self.access_type.get_by_id(instance.id)
         retrieved.delete()
-        self.assertRaises(ValueError, self.access_type.get_by_id, instance.id)
+        self.assertRaises(StackStormDBObjectNotFoundError,
+                          self.access_type.get_by_id, instance.id)
 
     def _assert_unique_key_constraint(self, instance):
         # Assert instance is not already in the database.


### PR DESCRIPTION
I noticed this while working on some related changes.

Right now we throw `ValueError` instead of `StackStormDBObjectNotFoundError` inside base model `.get` method when object is not found. This means that in many places we need to capture this exception and then re-throw `StackStormDBObjectNotFoundError`.

This can be solved by throwing `StackStormDBObjectNotFoundError` directly. In comparison to `ValueError`, this exception is also more specific.

If the `ValueError` was selected intentionally (e.g. some other code path also throws ValueError and we want to capture all those exceptions), please let me know.