### PR TITLE
Fix delay caused by loading a huge set of actions

### DIFF
--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -78,8 +78,13 @@ class ActionsController(resource.ContentPackResourceController):
 
     @request_user_has_permission(permission_type=PermissionType.ACTION_LIST)
     @jsexpose()
-    def get_all(self, **kwargs):
-        return super(ActionsController, self)._get_all(**kwargs)
+    def get_all(self, exclude_attributes=None, **kwargs):
+        if exclude_attributes:
+            exclude_fields = exclude_attributes.split(',')
+        else:
+            exclude_fields = None
+
+        return super(ActionsController, self)._get_all(exclude_fields=exclude_fields, **kwargs)
 
     @request_user_has_resource_db_permission(permission_type=PermissionType.ACTION_VIEW)
     @jsexpose(arg_types=[str])


### PR DESCRIPTION
Timing graph for GET https://192.168.10.16/api/v1/actions API request that returns around 1600 actions looks like that:

![](https://s3.amazonaws.com/f.cl.ly/items/1N2X3e3W1K3A2U2l3Z3W/Screen%20Shot%202016-05-17%20at%201.48.44%20PM.png)

Applying throttling to it (Good 3G preset, 40ms latency, 1.5Mbps in, 750Kbps out) to get the picture better representing real world use:

![](https://s3.amazonaws.com/f.cl.ly/items/0R3I3t3a072p1M1L0K3F/Screen%20Shot%202016-05-17%20at%201.50.29%20PM.png)

In general, TTFB can be round down to the time server takes to prepare the answer (contact db, query data, apply transforms) and `content download` is obviously the time it takes for browser to pull this data from server. Browsers can't parse JSON from a stream so the time to first pixel rendered is always bigger than that.

By excluding fields like `parameters` and `notify`, you can reduce it to ![](https://s3.amazonaws.com/f.cl.ly/items/0B3p0i473n3l161b0L21/Screen%20Shot%202016-05-17%20at%202.36.23%20PM.png)

Personally, I'd rather prefer to use `.only()` mongo filter instead of `.exclude()` since it would help us maintain certain performance level in the long run without constantly catching up on the client side, but I guess we can solve it in a separate PR. 

Further optimization would require us to use some form of caching or pagination.

Caching is relatively easy and will only require us to track the last time we've changed an action (in simplest case, registered them) and then return proper http code. Downside is that it will still require user to download the list at least once.

Pagination on the other hand is a somewhat permanent and consistent solution, but it implies quite a lot of work both client and server side (besides the obvious "pagination" stuff, the filtering would have to be re-implemented server side).