### PR TITLE
Register all RMQ exchanges

### DIFF
--- a/st2common/st2common/transport/bootstrap_utils.py
+++ b/st2common/st2common/transport/bootstrap_utils.py
@@ -19,7 +19,7 @@ from st2common.transport import utils as transport_utils
 from st2common.transport.announcement import ANNOUNCEMENT_XCHG
 from st2common.transport.connection_retry_wrapper import ConnectionRetryWrapper
 from st2common.transport.execution import EXECUTION_XCHG
-from st2common.transport.liveaction import LIVEACTION_XCHG
+from st2common.transport.liveaction import LIVEACTION_XCHG, LIVEACTION_STATUS_MGMT_XCHG
 from st2common.transport.reactor import SENSOR_CUD_XCHG
 from st2common.transport.reactor import TRIGGER_CUD_XCHG, TRIGGER_INSTANCE_XCHG
 
@@ -29,8 +29,8 @@ __all__ = [
     'register_exchanges'
 ]
 
-EXCHANGES = [ANNOUNCEMENT_XCHG, EXECUTION_XCHG, LIVEACTION_XCHG, TRIGGER_CUD_XCHG,
-             TRIGGER_INSTANCE_XCHG, SENSOR_CUD_XCHG]
+EXCHANGES = [ANNOUNCEMENT_XCHG, EXECUTION_XCHG, LIVEACTION_XCHG, LIVEACTION_STATUS_MGMT_XCHG,
+             TRIGGER_CUD_XCHG, TRIGGER_INSTANCE_XCHG, SENSOR_CUD_XCHG]
 
 
 def _do_register_exchange(exchange, connection, channel, retry_wrapper):

--- a/st2common/st2common/transport/bootstrap_utils.py
+++ b/st2common/st2common/transport/bootstrap_utils.py
@@ -16,6 +16,7 @@
 from kombu import Connection
 from st2common import log as logging
 from st2common.transport import utils as transport_utils
+from st2common.transport.actionexecutionstate import ACTIONEXECUTIONSTATE_XCHG
 from st2common.transport.announcement import ANNOUNCEMENT_XCHG
 from st2common.transport.connection_retry_wrapper import ConnectionRetryWrapper
 from st2common.transport.execution import EXECUTION_XCHG
@@ -29,8 +30,9 @@ __all__ = [
     'register_exchanges'
 ]
 
-EXCHANGES = [ANNOUNCEMENT_XCHG, EXECUTION_XCHG, LIVEACTION_XCHG, LIVEACTION_STATUS_MGMT_XCHG,
-             TRIGGER_CUD_XCHG, TRIGGER_INSTANCE_XCHG, SENSOR_CUD_XCHG]
+EXCHANGES = [ACTIONEXECUTIONSTATE_XCHG, ANNOUNCEMENT_XCHG, EXECUTION_XCHG, LIVEACTION_XCHG,
+             LIVEACTION_STATUS_MGMT_XCHG, TRIGGER_CUD_XCHG, TRIGGER_INSTANCE_XCHG,
+             SENSOR_CUD_XCHG]
 
 
 def _do_register_exchange(exchange, connection, channel, retry_wrapper):


### PR DESCRIPTION
This used to work because whenever a Q is created on an exchange it ends up being registered if the exchange is not already present. However, always better to explicitly register these exchanges up-front.