### PR TITLE
Revert #2625

### DIFF
--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -32,7 +32,7 @@ function print_usage() {
     echo "  --register-aliases            Register all aliases."
     echo "  --register-policies           Register all policies."
     echo "  --register-setup-virtualenvs  Create Python virtual environments for all the registered packs."
-    echo "  --verbose                     Output additional debug and informational messages."
+    echo "  --verbose           Output additional debug and informational messages."
     echo ""
     echo "Most commands require elevated privileges."
 }
@@ -62,20 +62,12 @@ function validate_in_components() {
 
 function st2start() {
   for COM in ${COMPONENTS}; do
-    service_manager $COM status >/dev/null 2>&1;
-    if [[ "1" == $? ]]; then
-      continue
-    fi
     service_manager ${COM} start
   done
 }
 
 function st2stop() {
   for COM in ${COMPONENTS}; do
-    service_manager $COM status >/dev/null 2>&1;
-    if [[ "1" == $? ]]; then
-      continue
-    fi
     service_manager ${COM} stop
   done
 }
@@ -160,10 +152,6 @@ function getpids() {
   COMPONENTS=${COMPONENTS/mistral/mistral-server mistral-api}
 
   for COM in ${COMPONENTS}; do
-    service_manager $COM status >/dev/null 2>&1;
-    if [[ "1" == $? ]]; then
-      continue
-    fi
     PID=`ps ax | grep -v grep | grep -v st2ctl | grep "${COM}" | awk '{print $1}'`
 
     if [[ ! -z ${PID} ]]; then

--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -32,7 +32,7 @@ function print_usage() {
     echo "  --register-aliases            Register all aliases."
     echo "  --register-policies           Register all policies."
     echo "  --register-setup-virtualenvs  Create Python virtual environments for all the registered packs."
-    echo "  --verbose           Output additional debug and informational messages."
+    echo "  --verbose                     Output additional debug and informational messages."
     echo ""
     echo "Most commands require elevated privileges."
 }


### PR DESCRIPTION
This PR reverts #2625, since RHEL6 isn’t compatible. We still need a solution of the original problem (services that aren’t installed showing up as errors on st2ctl commands), but currently I don’t have a better solution than checking exit codes, and this is a blocker, so we should revert now and worry about error messages later.

I’ll wait for @DoriftoShoes before merging, hopefully he’ll have some ideas. :)