### PR TITLE
Add missing pytz dependency to st2client

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ in development
   ``config.schema.yaml`` file. This file can contain an optional schema for the pack config. In the
   future, pack configs will be validated against the schema (if available). (new feature)
 * Add data model and API changes for supporting user scoped variables. (new-feature, experimental)
+* Add missing `pytz` dependency to ``st2client`` requirements file. (bug-fix)
 
 1.4.0 - April 18, 2016
 ----------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ python-dateutil
 python-gnupg<0.4,>=0.3.7
 python-json-logger
 python-keyczar==0.715
+pytz
 pyyaml<4.0,>=3.11
 requests[security]<3.0,>=2.7.0
 retrying

--- a/st2client/in-requirements.txt
+++ b/st2client/in-requirements.txt
@@ -1,5 +1,6 @@
 # Remeber to list implicit packages here, otherwise version won't be fixated!
 prettytable
+pytz
 python-dateutil
 pyyaml
 jsonpath-rw

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -2,6 +2,7 @@
 jsonpath-rw>=1.3.0
 prettytable
 python-dateutil
+pytz
 pyyaml<4.0,>=3.11
 requests<3.0,>=2.7.0
 six==1.9.0


### PR DESCRIPTION
Originally reported in #2689 (thanks!).

We never encountered this issue (and tests didn't catch it) since when using package installation method, `st2client` uses the same virtual environment as other components and `appscheduler` (used by `st2reactor`) depends on `pytz` so the dependency was also satisfied for `st2client`.

The issue would only manifest itself if user manually installed `st2client` outside st2 virtual environment.