### PR TITLE
Add basic autocomplete support to st2 CLI client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Don't edit this file. It's generated automatically!
 apscheduler<3.1,>=3.0.5
+argcomplete
 bcrypt
 bencode<1.1,>=1.0
 eventlet<0.19,>=0.18.4

--- a/st2client/in-requirements.txt
+++ b/st2client/in-requirements.txt
@@ -1,4 +1,5 @@
 # Remeber to list implicit packages here, otherwise version won't be fixated!
+argcomplete
 prettytable
 pytz
 python-dateutil

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -24,6 +26,7 @@ import os
 import sys
 import json
 import time
+import argcomplete
 import argparse
 import calendar
 import logging
@@ -335,6 +338,9 @@ class Shell(object):
 
     def run(self, argv):
         debug = False
+
+        # Provide autocomplete for shell
+        argcomplete.autocomplete(self.parser)
 
         if '--print-config' in argv:
             # Hack because --print-config requires no command to be specified


### PR DESCRIPTION
To activate autocomplete, perform `eval "$(register-python-argcomplete st2client/st2client/shell.py)"` or `eval "$(register-python-argcomplete st2)"` in your shell (depending on how you're planning to call it).

It will become a part packaging process when we figure out we're happy with autocomplete in general.

Please note that I've added +x and hashbang to shell.py. You may have your own opinion on the matter.