### PR TITLE
Rename "config" and "sensor_service" attribute on the Sensor classes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,9 @@ in development
   future, pack configs will be validated against the schema (if available). (new feature)
 * Add data model and API changes for supporting user scoped variables. (new-feature, experimental)
 * Add missing `pytz` dependency to ``st2client`` requirements file. (bug-fix)
+* For consistency with actions, ``_`` prefix has been removed from ``sensor_service`` and
+  ``config`` attribute available on the Sensor classes. Both variables are now available via
+  ``self.sensor_service`` and ``self.config``. (improvement)
 
 1.4.0 - April 18, 2016
 ----------------------

--- a/contrib/packs/actions/pack_mgmt/unload.py
+++ b/contrib/packs/actions/pack_mgmt/unload.py
@@ -27,6 +27,7 @@ from st2common.persistence.action import Action
 from st2common.persistence.action import ActionAlias
 from st2common.constants.pack import SYSTEM_PACK_NAMES
 from st2common.services.triggers import cleanup_trigger_db_for_rule
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
 
 BLOCKED_PACKS = frozenset(SYSTEM_PACK_NAMES)
 
@@ -99,7 +100,7 @@ class UnregisterPackAction(BaseAction):
     def _delete_pack_db_object(self, pack):
         try:
             pack_db = Pack.get_by_name(value=pack)
-        except ValueError:
+        except StackStormDBObjectNotFoundError:
             self.logger.exception('Pack DB object not found')
             return
 
@@ -111,7 +112,7 @@ class UnregisterPackAction(BaseAction):
     def _delete_config_schema_db_object(self, pack):
         try:
             config_schema_db = ConfigSchema.get_by_pack(value=pack)
-        except ValueError:
+        except StackStormDBObjectNotFoundError:
             self.logger.exception('ConfigSchemaDB object not found')
             return
 

--- a/st2reactor/st2reactor/sensor/base.py
+++ b/st2reactor/st2reactor/sensor/base.py
@@ -23,8 +23,20 @@ class BaseSensor(object):
         :keyword config: Sensor config.
         :type config: ``dict`` or None
         """
-        self._sensor_service = sensor_service
-        self._config = config or {}
+        self.sensor_service = sensor_service
+        self.config = config or {}
+
+    @property
+    def _sensor_service(self):
+        # Note: This is here for backward compatibility reasons. For consistency with actions,
+        # both instance variables has "_" prefix removed.
+        return self.sensor_service
+
+    @property
+    def _config(self):
+        # Note: This is here for backward compatibility reasons. For consistency with actions,
+        # both instance variables has "_" prefix removed.
+        return self.config
 
     @abc.abstractmethod
     def setup(self):

--- a/st2reactor/tests/unit/test_sensor_classes.py
+++ b/st2reactor/tests/unit/test_sensor_classes.py
@@ -1,0 +1,62 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest2
+
+from st2reactor.sensor.base import Sensor
+from st2reactor.sensor.base import PollingSensor
+
+
+class TestSensor(Sensor):
+    def setup(self):
+        pass
+
+    def run(self):
+        pass
+
+    def cleanup(self):
+        pass
+
+    def add_trigger(self, trigger):
+        pass
+
+    def update_trigger(self, trigger):
+        pass
+
+    def remove_trigger(self, trigger):
+        pass
+
+
+class TestPollingSensor(TestSensor, PollingSensor):
+    def poll(self):
+        pass
+
+
+class SensorClassesTestCase(unittest2.TestCase):
+    def test_instance_variables_backward_compatibility(self):
+        sensor1 = TestSensor(sensor_service='service', config='config')
+        sensor2 = TestPollingSensor(sensor_service='service', config='config')
+
+        # Current way
+        self.assertEqual(sensor1.sensor_service, 'service')
+        self.assertEqual(sensor1.config, 'config')
+        self.assertEqual(sensor2.sensor_service, 'service')
+        self.assertEqual(sensor2.config, 'config')
+
+        # Old way (for backward compatibility)
+        self.assertEqual(sensor1._sensor_service, 'service')
+        self.assertEqual(sensor1._config, 'config')
+        self.assertEqual(sensor2._sensor_service, 'service')
+        self.assertEqual(sensor2._config, 'config')


### PR DESCRIPTION
This was done for consistency it actions. It was something which has been bothering me for quite a while now and it looks like I'm not the only one :)

For backward compatibility reasons, users can still use old-approach to access those variable for the foreseeable future.

## TODO

- [x] Docs (upgrade notes) - https://github.com/StackStorm/st2docs/pull/158

Resolves #2694