### PR TITLE
Adding linux.sleep_until action

### DIFF
--- a/contrib/packs/linux/actions/sleep_until.yaml
+++ b/contrib/packs/linux/actions/sleep_until.yaml
@@ -10,7 +10,7 @@ entry_point: ""
 parameters:
   time:
     type: string
-    description: 'the time to wake up; must be parsable by "date -d"'
+    description: 'the time to wake up; must be smaller than the action timeout; must be parsable by "date -d" like "5pm today" or "Thu May 19 18:04:39 UTC 2016"'
     required: true
   cmd:
     default: 'sleep $(expr `date -d "{{ time }}" +%s` - `date -d "now" +%s`)'

--- a/contrib/packs/linux/actions/sleep_until.yaml
+++ b/contrib/packs/linux/actions/sleep_until.yaml
@@ -1,0 +1,17 @@
+---
+name: "sleep_until"
+pack: "linux"
+description: "Sleeps until a specified time"
+enabled: true
+
+runner_type: "local-shell-cmd"
+entry_point: ""
+
+parameters:
+  time:
+    type: string
+    description: 'the time to wake up; must be parsable by "date -d"'
+    required: true
+  cmd:
+    default: 'sleep $(expr `date -d "{{ time }}" +%s` - `date -d "now" +%s`)'
+    immutable: true


### PR DESCRIPTION
## Linux Pack

Added a new action that just sleeps until a specified time using the Linux `sleep` and `date` commands.

### Status 

- existing pack, new action

### Checklist (tick everything that applies)

- [X] Metadata: pack.yaml, icon, structure (required for new packs)
- [ ] Version bump (required for changed packs)
- [ ] Code linting (required, can be done after the PR checks)
- [ ] [Tests](https://docs.stackstorm.com/development/pack_testing.html) (not required but really recommended)