### PR TITLE
[RFR] Ability to load apikeys from a file.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,8 @@ in development
   JSON has been deprecated in StackStorm v0.6. Now the only supported metadata file format is YAML.
 * Add ``-y`` / ``--yaml`` flag to the CLI ``list`` and ``get`` commands. If this flag is provided,
   command response will be formatted as YAML. (new feature)
+* Alias names are scoped to a pack. (bug-fix)
+* Ability to migrate api keys to new installs. (new feature)
 
 1.4.0 - April 18, 2016
 ----------------------

--- a/st2client/st2client/commands/auth.py
+++ b/st2client/st2client/commands/auth.py
@@ -194,8 +194,8 @@ class ApiKeyLoadCommand(resource.ResourceCommand):
         for res in resources:
             # pick only the meaningful properties.
             instance = {
-                'user': res['user'], # required
-                'key_hash': res['key_hash'], # required
+                'user': res['user'],  # required
+                'key_hash': res['key_hash'],  # required
                 'metadata': res.get('metadata', {}),
                 'enabled': res.get('enabled', False)
             }
@@ -210,7 +210,6 @@ class ApiKeyLoadCommand(resource.ResourceCommand):
                               attributes=ApiKeyListCommand.display_attributes,
                               widths=args.width,
                               json=args.json, yaml=args.yaml)
-
 
 
 class ApiKeyDeleteCommand(resource.ResourceDeleteCommand):

--- a/st2client/st2client/commands/auth.py
+++ b/st2client/st2client/commands/auth.py
@@ -86,6 +86,7 @@ class ApiKeyBranch(resource.ResourceBranch):
 
         self.commands['enable'] = ApiKeyEnableCommand(self.resource, self.app, self.subparsers)
         self.commands['disable'] = ApiKeyDisableCommand(self.resource, self.app, self.subparsers)
+        self.commands['load'] = ApiKeyLoadCommand(self.resource, self.app, self.subparsers)
 
 
 class ApiKeyListCommand(resource.ResourceListCommand):
@@ -163,6 +164,53 @@ class ApiKeyCreateCommand(resource.ResourceCommand):
         else:
             self.print_output(instance, table.PropertyValueTable,
                               attributes=['all'], json=args.json, yaml=args.yaml)
+
+
+class ApiKeyLoadCommand(resource.ResourceCommand):
+
+    def __init__(self, resource, *args, **kwargs):
+        super(ApiKeyLoadCommand, self).__init__(
+            resource, 'load', 'Load %s from a file.' % resource.get_display_name().lower(),
+            *args, **kwargs)
+
+        self.parser.add_argument('file',
+                                 help=('JSON/YAML file containing the %s(s) to load.'
+                                       % resource.get_display_name().lower()),
+                                 default='')
+
+        self.parser.add_argument('-w', '--width', nargs='+', type=int,
+                                 default=None,
+                                 help=('Set the width of columns in output.'))
+
+    @resource.add_auth_token_to_kwargs_from_cli
+    def run(self, args, **kwargs):
+        resources = resource.load_meta_file(args.file)
+        if not resources:
+            print('No %s found in %s.' % (self.resource.get_display_name().lower(), args.file))
+            return None
+        if not isinstance(resources, list):
+            resources = [resources]
+        instances = []
+        for res in resources:
+            # pick only the meaningful properties.
+            instance = {
+                'user': res['user'], # required
+                'key_hash': res['key_hash'], # required
+                'metadata': res.get('metadata', {}),
+                'enabled': res.get('enabled', False)
+            }
+            instance = self.resource.deserialize(instance)
+            instances.append(self.manager.create(instance, **kwargs))
+        return instances
+
+    def run_and_print(self, args, **kwargs):
+        instances = self.run(args, **kwargs)
+        if instances:
+            self.print_output(instances, table.MultiColumnTable,
+                              attributes=ApiKeyListCommand.display_attributes,
+                              widths=args.width,
+                              json=args.json, yaml=args.yaml)
+
 
 
 class ApiKeyDeleteCommand(resource.ResourceDeleteCommand):

--- a/st2client/st2client/commands/auth.py
+++ b/st2client/st2client/commands/auth.py
@@ -89,6 +89,7 @@ class ApiKeyBranch(resource.ResourceBranch):
 
 
 class ApiKeyListCommand(resource.ResourceListCommand):
+    detail_display_attributes = ['all']
     display_attributes = ['id', 'user', 'metadata']
 
     def __init__(self, resource, *args, **kwargs):
@@ -96,6 +97,8 @@ class ApiKeyListCommand(resource.ResourceListCommand):
 
         self.parser.add_argument('-u', '--user', type=str,
                                  help='Only return ApiKeys belonging to the provided user')
+        self.parser.add_argument('-d', '--detail', action='store_true',
+                                 help='Full list of attributes.')
 
     @resource.add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
@@ -103,6 +106,13 @@ class ApiKeyListCommand(resource.ResourceListCommand):
         filters['user'] = args.user
         filters.update(**kwargs)
         return self.manager.get_all(**filters)
+
+    def run_and_print(self, args, **kwargs):
+        instances = self.run(args, **kwargs)
+        attr = self.detail_display_attributes if args.detail else args.attr
+        self.print_output(instances, table.MultiColumnTable,
+                          attributes=attr, widths=args.width,
+                          json=args.json, yaml=args.yaml)
 
 
 class ApiKeyGetCommand(resource.ResourceGetCommand):

--- a/st2client/st2client/commands/resource.py
+++ b/st2client/st2client/commands/resource.py
@@ -348,7 +348,7 @@ class ResourceCreateCommand(ResourceCommand):
 
     @add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
-        data = _load_meta_file(args.file)
+        data = load_meta_file(args.file)
         instance = self.resource.deserialize(data)
         return self.manager.create(instance, **kwargs)
 
@@ -389,7 +389,7 @@ class ResourceUpdateCommand(ResourceCommand):
     def run(self, args, **kwargs):
         resource_id = getattr(args, self.pk_argument_name, None)
         instance = self.get_resource(resource_id, **kwargs)
-        data = _load_meta_file(args.file)
+        data = load_meta_file(args.file)
         modified_instance = self.resource.deserialize(data)
 
         if not getattr(modified_instance, 'id', None):
@@ -542,7 +542,7 @@ class ContentPackResourceDeleteCommand(ResourceDeleteCommand):
     pk_argument_name = 'ref_or_id'
 
 
-def _load_meta_file(file_path):
+def load_meta_file(file_path):
     if not os.path.isfile(file_path):
         raise Exception('File "%s" does not exist.' % file_path)
 


### PR DESCRIPTION
Implements feature request https://github.com/StackStorm/st2/issues/2692

### Extract API keys
`st2 apikey list -dy > apikeys.yaml`

### Load API keys
`st2 apikey load apikeys.yaml`

Note : Going with `load` instead of re-using `create` is to avoid any confusion. Creation will always create a new ApiKey while load will assume the key_hash was properly generated by a StackStorm instance and that the user already has a matching ApiKey. To preserve the distinction between a new key is desired and that an existing key is being loaded the 2 separate verbs are preferred.

Appropriate fixes made in the API layer.