### PR TITLE
Add API key support to st2client

### DIFF
--- a/st2client/st2client/client.py
+++ b/st2client/st2client/client.py
@@ -37,7 +37,7 @@ DEFAULT_API_VERSION = 'v1'
 
 class Client(object):
     def __init__(self, base_url=None, auth_url=None, api_url=None, api_version=None, cacert=None,
-                 debug=False, token=None):
+                 debug=False, token=None, api_key=None):
         # Get CLI options. If not given, then try to get it from the environment.
         self.endpoints = dict()
 
@@ -78,6 +78,11 @@ class Client(object):
             os.environ['ST2_AUTH_TOKEN'] = token
 
         self.token = token
+
+        if api_key:
+            os.environ['ST2_API_KEY'] = api_key
+
+        self.api_key = api_key
 
         # Instantiate resource managers and assign appropriate API endpoint.
         self.managers = dict()

--- a/st2client/st2client/commands/resource.py
+++ b/st2client/st2client/commands/resource.py
@@ -39,6 +39,8 @@ def add_auth_token_to_kwargs_from_cli(func):
         ns = args[1]
         if getattr(ns, 'token', None):
             kwargs['token'] = ns.token
+        if getattr(ns, 'api_key', None):
+            kwargs['api_key'] = ns.api_key
         return func(*args, **kwargs)
     return decorate
 
@@ -117,6 +119,10 @@ class ResourceCommand(commands.Command):
             self.parser.add_argument('-t', '--token', dest='token',
                                      help='Access token for user authentication. '
                                           'Get ST2_AUTH_TOKEN from the environment '
+                                          'variables by default.')
+            self.parser.add_argument('--api-key', dest='api_key',
+                                     help='Api Key for user authentication. '
+                                          'Get ST2_API_KEY from the environment '
                                           'variables by default.')
 
         # Formatter flags

--- a/st2client/st2client/config_parser.py
+++ b/st2client/st2client/config_parser.py
@@ -79,6 +79,10 @@ CONFIG_FILE_OPTIONS = {
         'password': {
             'type': 'string',
             'default': None
+        },
+        'api_key': {
+            'type': 'string',
+            'default': None
         }
     },
     'api': {

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -32,6 +32,8 @@ def add_auth_token_to_kwargs_from_env(func):
     def decorate(*args, **kwargs):
         if not kwargs.get('token') and os.environ.get('ST2_AUTH_TOKEN', None):
             kwargs['token'] = os.environ.get('ST2_AUTH_TOKEN')
+        if not kwargs.get('api_key') and os.environ.get('ST2_API_KEY', None):
+            kwargs['api_key'] = os.environ.get('ST2_API_KEY')
         return func(*args, **kwargs)
     return decorate
 

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -308,7 +308,9 @@ class Shell(object):
         # or as a command line argument
         env_var_token = os.environ.get('ST2_AUTH_TOKEN', None)
         cli_argument_token = getattr(args, 'token', None)
-        if env_var_token or cli_argument_token:
+        env_var_api_key = os.environ.get('ST2_API_KEY', None)
+        cli_argument_api_key = getattr(args, 'api_key', None)
+        if env_var_token or cli_argument_token or env_var_api_key or cli_argument_api_key:
             return client
 
         # If credentials are provided in the CLI config use them and try to authenticate

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -79,6 +79,7 @@ CONFIG_OPTION_TO_CLIENT_KWARGS_MAP = {
     'auth_url': ['auth', 'url'],
     'api_url': ['api', 'url'],
     'api_version': ['general', 'api_version'],
+    'api_key': ['credentials', 'api_key'],
     'cacert': ['general', 'cacert'],
     'debug': ['cli', 'debug']
 }

--- a/st2client/st2client/utils/httpclient.py
+++ b/st2client/st2client/utils/httpclient.py
@@ -36,11 +36,18 @@ def add_ssl_verify_to_kwargs(func):
 
 def add_auth_token_to_headers(func):
     def decorate(*args, **kwargs):
+        headers = kwargs.get('headers', dict())
+
         token = kwargs.pop('token', None)
         if token:
-            headers = kwargs.get('headers', dict())
             headers['X-Auth-Token'] = str(token)
             kwargs['headers'] = headers
+
+        api_key = kwargs.pop('api_key', None)
+        if api_key:
+            headers['St2-Api-Key'] = str(api_key)
+            kwargs['headers'] = headers
+
         return func(*args, **kwargs)
     return decorate
 

--- a/st2client/tests/unit/test_config_parser.py
+++ b/st2client/tests/unit/test_config_parser.py
@@ -55,7 +55,8 @@ class CLIConfigParserTestCase(unittest2.TestCase):
             },
             'credentials': {
                 'username': 'test1',
-                'password': 'test1'
+                'password': 'test1',
+                'api_key': None
             },
             'api': {
                 'url': 'http://127.0.0.1:9101/v1'


### PR DESCRIPTION
As requested in https://github.com/StackStorm/st2-packages/issues/283, the PR adds support for API key to st2client and allows user to store said key in `~/.st2/config`.