### PR TITLE
Remove temp files created by submit_debug_info

### DIFF
--- a/st2debug/st2debug/cmd/submit_debug_info.py
+++ b/st2debug/st2debug/cmd/submit_debug_info.py
@@ -241,12 +241,12 @@ class DebugInfoCollector(object):
         try:
             # 1. Create temporary directory with the final directory structure where we will move
             # files which will be processed and included in the tarball
-            temp_dir_path = self.create_temp_directories()
+            self._temp_dir_path = self.create_temp_directories()
 
             # Prepend temp_dir_path to OUTPUT_PATHS
             output_paths = {}
             for key, path in OUTPUT_PATHS.iteritems():
-                output_paths[key] = os.path.join(temp_dir_path, path)
+                output_paths[key] = os.path.join(self._temp_dir_path, path)
 
             # 2. Moves all the files to the temporary directory
             LOG.info('Collecting files...')
@@ -264,7 +264,7 @@ class DebugInfoCollector(object):
                 self.add_shell_command_output(output_paths['commands'])
 
             # 3. Create a tarball
-            return self.create_tarball(temp_dir_path)
+            return self.create_tarball(self._temp_dir_path)
 
         except Exception as e:
             LOG.exception('Failed to generate tarball', exc_info=True)
@@ -272,7 +272,7 @@ class DebugInfoCollector(object):
 
         finally:
             # Ensure temp files are removed regardless of success or failure
-            remove_dir(temp_dir_path)
+            remove_dir(self._temp_dir_path)
 
     def encrypt_archive(self, archive_file_path):
         """

--- a/st2debug/st2debug/cmd/submit_debug_info.py
+++ b/st2debug/st2debug/cmd/submit_debug_info.py
@@ -60,6 +60,7 @@ from st2debug.utils.fs import copy_files
 from st2debug.utils.fs import get_full_file_list
 from st2debug.utils.fs import get_dirs_in_path
 from st2debug.utils.fs import remove_file
+from st2debug.utils.fs import remove_dir
 from st2debug.utils.system_info import get_cpu_info
 from st2debug.utils.system_info import get_memory_info
 from st2debug.utils.system_info import get_package_list
@@ -268,6 +269,10 @@ class DebugInfoCollector(object):
         except Exception as e:
             LOG.exception('Failed to generate tarball', exc_info=True)
             raise e
+
+        finally:
+            # Ensure temp files are removed regardless of success or failure
+            remove_dir(temp_dir_path)
 
     def encrypt_archive(self, archive_file_path):
         """

--- a/st2debug/st2debug/utils/fs.py
+++ b/st2debug/st2debug/utils/fs.py
@@ -90,3 +90,20 @@ def remove_file(file_path, ignore_errors=True):
     except Exception as e:
         if not ignore_errors:
             raise e
+
+
+def remove_dir(dir_path, ignore_errors=True):
+    """
+    Recursively remove a directory.
+
+    :param dir_path: Directory to be removed.
+    :type dir_path: ``str``
+
+    :param ignore_errors: True to ignore errors during removal.
+    :type ignore_errors: ``bool``
+    """
+    try:
+        shutil.rmtree(dir_path, ignore_errors)
+    except Exception as e:
+        if not ignore_errors:
+            raise e

--- a/st2debug/tests/integration/test_submit_debug_info.py
+++ b/st2debug/tests/integration/test_submit_debug_info.py
@@ -118,6 +118,16 @@ class SubmitDebugInfoTestCase(CleanFilesTestCase):
                              extract_path=extract_path,
                              required_directories=['logs', 'configs', 'content'])
 
+    def test_create_archive_deletes_temp_dir(self):
+        debug_collector = DebugInfoCollector(include_logs=True, include_configs=True,
+                                             include_content=True,
+                                             include_system_info=True)
+        archive_path = debug_collector.create_archive()
+        self.to_delete_files.append(archive_path)
+
+        self.assertTrue(debug_collector._temp_dir_path)
+        self.assertTrue(not os.path.exists(debug_collector._temp_dir_path))
+
     def _get_yaml_config(self):
         return {
             'log_file_paths': [


### PR DESCRIPTION
Currently `submit_debug_info.py` doesn't clean up the the temp files it creates. This PR adds a finally statement to remove the temp files created by the `create_archive` function.

Added a remove_dir function to `st2debug/utils/fs.py` for consistency with the `remove_file` function.