### PR TITLE
Fix a regression in filtering rules by pack

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,6 +46,7 @@ in development
   configs, but in addition to the static values they can also contain dynamic values. Dynamic value
   is a value which contains a Jinja expression which is resolved to the datastore item during
   run-time. (new feature)
+* Fix a regression in filtering rules by pack with CLI. (bug-fix)
 
 1.4.0 - April 18, 2016
 ----------------------

--- a/st2client/st2client/commands/rule.py
+++ b/st2client/st2client/commands/rule.py
@@ -57,6 +57,8 @@ class RuleListCommand(resource.ContentPackResourceListCommand):
     @resource.add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
         # Filtering options
+        if args.pack:
+            kwargs['pack'] = args.pack
         if args.action:
             kwargs['action'] = args.action
         if args.trigger:


### PR DESCRIPTION
## Fixes https://github.com/StackStorm/st2/issues/2538

## Before:

```
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯ st2 --debug rule list --pack=fixtures                                   master ✭ ✱ ◼
# -------- begin 140261747512592 request ----------
curl -X GET -H  'Connection: keep-alive' -H  'Accept-Encoding: gzip, deflate' -H  'Accept: */*' -H  'User-Agent: python-requests/2.10.0' 'http://127.0.0.1:9101/v1/rules/?limit=50'

+---------------------------------+-----------+---------------------------------+---------+
| ref                             | pack      | description                     | enabled |
+---------------------------------+-----------+---------------------------------+---------+
| examples.notify_slack           | examples  | Sample rule firing on action    | True    |
|                                 |           | completion.                     |         |
| examples.sample_rule_with_actio | examples  | Sample rule firing on action    | True    |
| ntrigger                        |           | completion.                     |         |
| examples.sample_rule_with_timer | examples  | Sample rule using an Interval   | False   |
|                                 |           | Timer.                          |         |
| examples.sample_rule_with_webho | examples  | Sample rule dumping webhook     | True    |
| ok                              |           | payload to a file.              |         |
| fixtures.tests.interval_timer   | fixtures  | Test rule using an Interval     | False   |
|                                 |           | Timer.                          |         |
| issue2608.yamas2_action         | issue2608 |                                 | True    |
+---------------------------------+-----------+---------------------------------+---------+
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯
```

## After

```
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯ st2 --debug rule list --pack=fixtures                                issues/2538 ✭ ◼
# -------- begin 140455866070288 request ----------
curl -X GET -H  'Connection: keep-alive' -H  'Accept-Encoding: gzip, deflate' -H  'Accept: */*' -H  'User-Agent: python-requests/2.10.0' 'http://127.0.0.1:9101/v1/rules/?limit=50&pack=fixtures'

+-------------------------------+----------+---------------------------------+---------+
| ref                           | pack     | description                     | enabled |
+-------------------------------+----------+---------------------------------+---------+
| fixtures.tests.interval_timer | fixtures | Test rule using an Interval     | False   |
|                               |          | Timer.                          |         |
+-------------------------------+----------+---------------------------------+---------+
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯
```