### PR TITLE
Execution log

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,7 +56,8 @@ in development
   action execution. (new feature)
 * Add a work-around for trigger creation which would case rule creation for CronTrigger to fail
   under some circumstances. (workaround, bug-fix)
-* Add event log for execution record. (new feature)
+* Store action execution state transitions (event log) in the ``log`` attribute on the
+  ActionExecution object. (new feature)
 
 1.4.0 - April 18, 2016
 ----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,6 +56,7 @@ in development
   action execution. (new feature)
 * Add a work-around for trigger creation which would case rule creation for CronTrigger to fail
   under some circumstances. (workaround, bug-fix)
+* Add event log for execution record. (new feature)
 
 1.4.0 - April 18, 2016
 ----------------------

--- a/st2common/st2common/models/api/execution.py
+++ b/st2common/st2common/models/api/execution.py
@@ -137,7 +137,7 @@ class ActionExecutionAPI(BaseAPI):
             end_timestamp = isotime.format(end_timestamp, offset=False)
             doc['end_timestamp'] = end_timestamp
 
-        for entry in doc['log']:
+        for entry in doc.get('log', []):
             entry['timestamp'] = isotime.format(entry['timestamp'], offset=False)
 
         attrs = {attr: value for attr, value in six.iteritems(doc) if value}

--- a/st2common/st2common/models/api/execution.py
+++ b/st2common/st2common/models/api/execution.py
@@ -107,6 +107,7 @@ class ActionExecutionAPI(BaseAPI):
                 "uniqueItems": True
             },
             "log": {
+                "description": "Contains information about execution state transitions.",
                 "type": "array",
                 "items": {
                     "type": "object",

--- a/st2common/st2common/models/api/execution.py
+++ b/st2common/st2common/models/api/execution.py
@@ -105,6 +105,22 @@ class ActionExecutionAPI(BaseAPI):
                 "type": "array",
                 "items": {"type": "string"},
                 "uniqueItems": True
+            },
+            "log": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "timestamp": {
+                            "type": "string",
+                            "pattern": isotime.ISO8601_UTC_REGEX
+                        },
+                        "status": {
+                            "type": "string",
+                            "enum": LIVEACTION_STATUSES
+                        }
+                    }
+                }
             }
         },
         "additionalProperties": False
@@ -120,6 +136,9 @@ class ActionExecutionAPI(BaseAPI):
         if end_timestamp:
             end_timestamp = isotime.format(end_timestamp, offset=False)
             doc['end_timestamp'] = end_timestamp
+
+        for entry in doc['log']:
+            entry['timestamp'] = isotime.format(entry['timestamp'], offset=False)
 
         attrs = {attr: value for attr, value in six.iteritems(doc) if value}
         return cls(**attrs)

--- a/st2common/st2common/models/db/execution.py
+++ b/st2common/st2common/models/db/execution.py
@@ -65,6 +65,7 @@ class ActionExecutionDB(stormbase.StormFoundationDB):
         help_text='Contextual information on the action execution.')
     parent = me.StringField()
     children = me.ListField(field=me.StringField())
+    log = me.ListField(field=me.DictField())
 
     meta = {
         'indexes': [

--- a/st2common/st2common/services/executions.py
+++ b/st2common/st2common/services/executions.py
@@ -148,10 +148,14 @@ def _get_parent_execution(child_liveaction_db):
 def update_execution(liveaction_db, publish=True):
     execution = ActionExecution.get(liveaction__id=str(liveaction_db.id))
     decomposed = _decompose_liveaction(liveaction_db)
+
     kw = {}
     for k, v in six.iteritems(decomposed):
         kw['set__' + k] = v
+
     if liveaction_db.status != execution.status:
+        # Note: If the status changes we store this transition in the "log" attribute of action
+        # execution
         kw['push__log'] = _create_execution_log_entry(liveaction_db.status)
     execution = ActionExecution.update(execution, publish=publish, **kw)
     return execution

--- a/st2common/st2common/services/executions.py
+++ b/st2common/st2common/services/executions.py
@@ -56,7 +56,10 @@ __all__ = [
 
 LOG = logging.getLogger(__name__)
 
-SKIPPED = ['id', 'callback', 'action', 'runner_info', 'parameters', 'notify']
+# Attributes which are stored in the "liveaction" dictionary when composing LiveActionDB object
+# into a ActionExecution compatible dictionary.
+# Those attributes are LiveAction specified and are therefore stored in a "liveaction" key
+LIVEACTION_ATTRIBUTES = ['id', 'callback', 'action', 'runner_info', 'parameters', 'notify']
 
 
 def _decompose_liveaction(liveaction_db):
@@ -66,7 +69,7 @@ def _decompose_liveaction(liveaction_db):
     decomposed = {'liveaction': {}}
     liveaction_api = vars(LiveActionAPI.from_model(liveaction_db))
     for k in liveaction_api.keys():
-        if k in SKIPPED:
+        if k in LIVEACTION_ATTRIBUTES:
             decomposed['liveaction'][k] = liveaction_api[k]
         else:
             decomposed[k] = getattr(liveaction_db, k)
@@ -74,6 +77,9 @@ def _decompose_liveaction(liveaction_db):
 
 
 def _create_execution_log_entry(status):
+    """
+    Create execution log entry object for the provided execution status.
+    """
     return {
         'timestamp': date_utils.get_datetime_utc_now(),
         'status': status

--- a/st2common/st2common/services/executions.py
+++ b/st2common/st2common/services/executions.py
@@ -73,7 +73,7 @@ def _decompose_liveaction(liveaction_db):
     return decomposed
 
 
-def _create_timestamp(status):
+def _create_execution_log_entry(status):
     return {
         'timestamp': date_utils.get_datetime_utc_now(),
         'status': status
@@ -113,7 +113,7 @@ def create_execution_object(liveaction, publish=True):
     if parent:
         attrs['parent'] = str(parent.id)
 
-    attrs['log'] = [_create_timestamp(liveaction['status'])]
+    attrs['log'] = [_create_execution_log_entry(liveaction['status'])]
 
     execution = ActionExecutionDB(**attrs)
     execution = ActionExecution.add_or_update(execution, publish=publish)
@@ -146,7 +146,7 @@ def update_execution(liveaction_db, publish=True):
     for k, v in six.iteritems(decomposed):
         kw['set__' + k] = v
     if liveaction_db.status != execution.status:
-        kw['push__log'] = _create_timestamp(liveaction_db.status)
+        kw['push__log'] = _create_execution_log_entry(liveaction_db.status)
     execution = ActionExecution.update(execution, publish=publish, **kw)
     return execution
 

--- a/st2common/st2common/services/executions.py
+++ b/st2common/st2common/services/executions.py
@@ -56,7 +56,7 @@ __all__ = [
 
 LOG = logging.getLogger(__name__)
 
-SKIPPED = ['id', 'callback', 'action', 'runner_info', 'parameters']
+SKIPPED = ['id', 'callback', 'action', 'runner_info', 'parameters', 'notify']
 
 
 def _decompose_liveaction(liveaction_db):
@@ -142,11 +142,12 @@ def _get_parent_execution(child_liveaction_db):
 def update_execution(liveaction_db, publish=True):
     execution = ActionExecution.get(liveaction__id=str(liveaction_db.id))
     decomposed = _decompose_liveaction(liveaction_db)
-    if liveaction_db.status != execution.status:
-        execution.log.append(_create_timestamp(liveaction_db.status))
+    kw = {}
     for k, v in six.iteritems(decomposed):
-        setattr(execution, k, v)
-    execution = ActionExecution.add_or_update(execution, publish=publish)
+        kw['set__' + k] = v
+    if liveaction_db.status != execution.status:
+        kw['push__log'] = _create_timestamp(liveaction_db.status)
+    execution = ActionExecution.update(execution, publish=publish, **kw)
     return execution
 
 

--- a/st2common/tests/unit/test_executions_util.py
+++ b/st2common/tests/unit/test_executions_util.py
@@ -26,6 +26,7 @@ from st2common.persistence.execution import ActionExecution
 from st2common.transport.publishers import PoolPublisher
 import st2common.services.executions as executions_util
 import st2common.util.action_db as action_utils
+import st2common.util.date as date_utils
 
 from st2tests.base import CleanDbTestCase
 from st2tests.fixturesloader import FixturesLoader
@@ -66,7 +67,9 @@ class ExecutionsUtilTestCase(CleanDbTestCase):
 
     def test_execution_creation_manual_action_run(self):
         liveaction = self.MODELS['liveactions']['liveaction1.yaml']
+        pre_creation_timestamp = date_utils.get_datetime_utc_now()
         executions_util.create_execution_object(liveaction)
+        post_creation_timestamp = date_utils.get_datetime_utc_now()
         execution = self._get_action_execution(liveaction__id=str(liveaction.id),
                                                raise_exception=True)
         self.assertDictEqual(execution.trigger, {})
@@ -79,6 +82,10 @@ class ExecutionsUtilTestCase(CleanDbTestCase):
         self.assertDictEqual(execution.runner, vars(RunnerTypeAPI.from_model(runner)))
         liveaction = LiveAction.get_by_id(str(liveaction.id))
         self.assertEquals(execution.liveaction['id'], str(liveaction.id))
+        self.assertEquals(len(execution.log), 1)
+        self.assertEquals(execution.log[0]['status'], liveaction.status)
+        self.assertGreater(execution.log[0]['timestamp'], pre_creation_timestamp)
+        self.assertLess(execution.log[0]['timestamp'], post_creation_timestamp)
 
     def test_execution_creation_action_triggered_by_rule(self):
         # Wait for the action execution to complete and then confirm outcome.
@@ -118,6 +125,20 @@ class ExecutionsUtilTestCase(CleanDbTestCase):
         parent_execution = ActionExecution.get_by_id(parent_execution_id)
         child_execs = parent_execution.children
         self.assertTrue(str(child_exec.id) in child_execs)
+
+    def test_execution_update(self):
+        liveaction = self.MODELS['liveactions']['liveaction1.yaml']
+        executions_util.create_execution_object(liveaction)
+        liveaction.status = 'running'
+        pre_update_timestamp = date_utils.get_datetime_utc_now()
+        executions_util.update_execution(liveaction)
+        post_update_timestamp = date_utils.get_datetime_utc_now()
+        execution = self._get_action_execution(liveaction__id=str(liveaction.id),
+                                               raise_exception=True)
+        self.assertEquals(len(execution.log), 2)
+        self.assertEquals(execution.log[1]['status'], liveaction.status)
+        self.assertGreater(execution.log[1]['timestamp'], pre_update_timestamp)
+        self.assertLess(execution.log[1]['timestamp'], post_update_timestamp)
 
     @mock.patch.object(PoolPublisher, 'publish', mock.MagicMock())
     def test_abandon_executions(self):


### PR DESCRIPTION
While discussing #2706 we figured there is a few new timestamps we would like to add to execution record to improve user's understanding of the flow and make it easier to debug indeterminate set of problems (primarily performance related I would guess).

Problem is, there is quite a few execution states already and there's going to be even more if we are to focus on the problem seriously. Storing timestamps related to this state changes as a properties of the execution itself will quickly bloat the execution object beyond reason.

An obvious solution to the problem is to create another data structure that would hold this expanding set of data in a linear fashion.

The idea is, for every execution state mutation, we creating a log entry with the state execution transitions to and the timestamp when it happened. For some time, this this structure may exist in parallel to our current `state`, `start_timestamp` and `end_timestamp` to ensure backward compatibility and while providing additional context for new executions.

For now, user would have to access api directly or use st2client debug mode to get to this data, but as soon as we happy with it, we can easily add a command for it to cli and a view in web.