### PR TITLE
Pin kombu and amqp dependency

### DIFF
--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -1,6 +1,9 @@
 # Packages versions fixed for the whole st2 stack
 eventlet>=0.18.4,<0.19
 gunicorn>=19.4.5,<20.0
+kombu>=3.0.35,<3.1
+# Note: amqp is used by kombu
+amqp>=1.4.9,<2.0
 oslo.config>=1.12.1,<1.13
 oslo.utils<3.1.0
 six==1.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ ipaddr
 jinja2
 jsonpath-rw>=1.3.0
 jsonschema>=2.3.0
-kombu
+kombu<3.1,>=3.0.35
 lockfile<0.11,>=0.10.2
 mongoengine<0.9,>=0.8.7
 networkx==1.10


### PR DESCRIPTION
New version of amqp was released (https://pypi.python.org/pypi/amqp/2.0.0) and it appears to be breaking some end to end tests.