### PR TITLE
String casting improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,6 +50,8 @@ in development
 * Make sure `st2-submit-debug-info` cleans up after itself and deletes a temporary directory it
   creates. (improvement) #2714
   [Kale Blankenship]
+* Fix string parameter casting - leave actual ``None`` value as-is and don't try to cast it to a
+  string which would fail. (bug-fix, improvement)
 
 1.4.0 - April 18, 2016
 ----------------------

--- a/st2actions/tests/unit/test_actionchain.py
+++ b/st2actions/tests/unit/test_actionchain.py
@@ -676,7 +676,7 @@ class TestActionChainRunner(DbTestCase):
         chain_runner.pre_run()
 
         action_parameters = {}
-        expected_msg = ('Failed to cast value "stringnotanarray" for parameter '
+        expected_msg = ('Failed to cast value "stringnotanarray" \(type: str\) for parameter '
                         '"arrtype" of type "array"')
         self.assertRaisesRegexp(ValueError, expected_msg, chain_runner.run,
                                 action_parameters=action_parameters)

--- a/st2common/st2common/models/utils/action_param_utils.py
+++ b/st2common/st2common/models/utils/action_param_utils.py
@@ -119,9 +119,11 @@ def cast_params(action_ref, params, cast_overrides=None):
 
         try:
             params[k] = cast(v)
-        except Exception:
-            msg = ('Failed to cast value "%s" for parameter "%s" of type "%s". Perhaphs the '
-                   'value is of an invalid type?' % (v, k, parameter_type))
+        except Exception as e:
+            v_type = type(v).__name__
+            msg = ('Failed to cast value "%s" (type: %s) for parameter "%s" of type "%s": %s. '
+                   'Perhaphs the value is of an invalid type?' %
+                   (v, v_type, k, parameter_type, str(e)))
             raise ValueError(msg)
 
     return params

--- a/st2common/st2common/util/casts.py
+++ b/st2common/st2common/util/casts.py
@@ -62,6 +62,12 @@ def _cast_number(x):
 
 
 def _cast_string(x):
+    if x is None:
+        # Preserve None as-is
+        return x
+
+    # TODO: Throw on non None and string value? (otherwise to_unicode will
+    # throw)
     x = to_unicode(x)
     x = _cast_none(x)
     return x

--- a/st2common/st2common/util/casts.py
+++ b/st2common/st2common/util/casts.py
@@ -66,8 +66,11 @@ def _cast_string(x):
         # Preserve None as-is
         return x
 
-    # TODO: Throw on non None and string value? (otherwise to_unicode will
-    # throw)
+    if not isinstance(x, six.string_types):
+        value_type = type(x).__name__
+        msg = 'Value "%s" must either be a string or None. Got "%s".' % (x, value_type)
+        raise ValueError(msg)
+
     x = to_unicode(x)
     x = _cast_none(x)
     return x

--- a/st2common/st2common/util/compat.py
+++ b/st2common/st2common/util/compat.py
@@ -30,6 +30,9 @@ def to_unicode(value):
 
     :rtype: ``unicode``
     """
+    if not isinstance(value, six.string_types):
+        raise ValueError('Value "%s" must be a string.' % (value))
+
     if not isinstance(value, six.text_type):
         value = six.u(value)
 

--- a/st2common/tests/unit/test_casts.py
+++ b/st2common/tests/unit/test_casts.py
@@ -21,6 +21,25 @@ from st2common.util.casts import get_cast
 
 
 class CastsTestCase(unittest2.TestCase):
+    def test_cast_string(self):
+        cast_func = get_cast('string')
+
+        value = 'test1'
+        result = cast_func(value)
+        self.assertEqual(result, 'test1')
+
+        value = u'test2'
+        result = cast_func(value)
+        self.assertEqual(result, u'test2')
+
+        value = ''
+        result = cast_func(value)
+        self.assertEqual(result, '')
+
+        value = None
+        result = cast_func(value)
+        self.assertEqual(result, None)
+
     def test_cast_array(self):
         cast_func = get_cast('array')
 

--- a/st2common/tests/unit/test_casts.py
+++ b/st2common/tests/unit/test_casts.py
@@ -36,9 +36,15 @@ class CastsTestCase(unittest2.TestCase):
         result = cast_func(value)
         self.assertEqual(result, '')
 
+        # None should be preserved
         value = None
         result = cast_func(value)
         self.assertEqual(result, None)
+
+        # Non string or non, should throw a friendly exception
+        value = []
+        expected_msg = 'Value "\[\]" must either be a string or None. Got "list"'
+        self.assertRaisesRegexp(ValueError, expected_msg, cast_func, value)
 
     def test_cast_array(self):
         cast_func = get_cast('array')


### PR DESCRIPTION
This pull request introduces some improvements in the string parameter casting:

* Treat `None` as-is and return early
* On non-string and None type, throw a more user-friendly exception (previously, `to_unicode` would throw a very cryptic exception)
* Include additional info in the existing log message

Reported by @jjm. Looking at the code and history, it looks like this bug was there for a long time, but it only manifested under specific conditions so we never noticed it before.

@jjm was also "lucky" to encounter this issue, since it would only manifest itself under a specific scenario - the way we do ChatOps string matching right now is a bit nasty (we also match a whitespace and then strip additional whitespace so for a matched parameter value of `" "` actual value of `""` would be passed in as an action parameter).