### PR TITLE
Access control and other new features and improvements for the datastore API endpoints

### DIFF
--- a/st2api/st2api/controllers/v1/keyvalue.py
+++ b/st2api/st2api/controllers/v1/keyvalue.py
@@ -209,13 +209,14 @@ class KeyValuePairController(ResourceController):
         self._validate_scope(scope=scope)
 
         requester_user = get_requester()
+        user = user or requester_user
         is_admin = request_user_is_admin(request=pecan.request)
 
         if user != requester_user and not is_admin:
             msg = '"user" attribute can only be provided by admins'
             raise AccessDeniedError(message=msg, user_db=requester_user)
 
-        key_ref = get_key_reference(scope=scope, name=name, user=get_requester())
+        key_ref = get_key_reference(scope=scope, name=name, user=user)
         lock_name = self._get_lock_name_for_key(name=key_ref, scope=scope)
 
         # Note: We use lock to avoid a race

--- a/st2api/st2api/controllers/v1/keyvalue.py
+++ b/st2api/st2api/controllers/v1/keyvalue.py
@@ -91,17 +91,19 @@ class KeyValuePairController(ResourceController):
                 GET /keys/
         """
         requester_user = get_requester()
+        is_admin = request_user_is_admin(request=pecan.request)
+        is_all_scope = (scope == 'all')
 
         # Note: Decrypt option requires admin access or listing datstore values
-        # for current user( (scope == user and user == authenticated user)
-        is_admin = request_user_is_admin(request=pecan.request)
+        # for current user (scope == user and user == authenticated user)
         if decrypt and (scope != USER_SCOPE and not is_admin):
-            msg = 'decrypt option requires administrator access'
+            msg = 'Decrypt option requires administrator access'
             raise AccessDeniedError(message=msg, user_db=requester_user)
 
         from_model_kwargs = {'mask_secrets': not decrypt}
         kwargs['prefix'] = prefix
-        if scope:
+
+        if scope and scope not in ['all']:
             self._validate_scope(scope=scope)
             kwargs['scope'] = scope
 
@@ -215,7 +217,7 @@ class KeyValuePairController(ResourceController):
         return lock_name
 
     def _validate_scope(self, scope):
-        if scope not in ALLOWED_SCOPES:
+        if scope not in ['all'] + ALLOWED_SCOPES:
             msg = 'Scope %s is not in allowed scopes list: %s.' % (scope, ALLOWED_SCOPES)
             abort(http_client.BAD_REQUEST, msg)
             return

--- a/st2api/st2api/controllers/v1/keyvalue.py
+++ b/st2api/st2api/controllers/v1/keyvalue.py
@@ -77,15 +77,11 @@ class KeyValuePairController(ResourceController):
 
         key_ref = get_key_reference(scope=scope, name=name, user=get_requester())
         from_model_kwargs = {'mask_secrets': not decrypt}
-        try:
-            kvp_api = self._get_one_by_scope_and_name(
-                name=key_ref,
-                scope=scope,
-                from_model_kwargs=from_model_kwargs
-            )
-        except StackStormDBObjectNotFoundError as e:
-            abort(http_client.NOT_FOUND, e.message)
-            return
+        kvp_api = self._get_one_by_scope_and_name(
+            name=key_ref,
+            scope=scope,
+            from_model_kwargs=from_model_kwargs
+        )
 
         return kvp_api
 
@@ -191,15 +187,11 @@ class KeyValuePairController(ResourceController):
         # Note: We use lock to avoid a race
         with self._coordinator.get_lock(lock_name):
             from_model_kwargs = {'mask_secrets': True}
-            try:
-                kvp_api = self._get_one_by_scope_and_name(
-                    name=key_ref,
-                    scope=scope,
-                    from_model_kwargs=from_model_kwargs
-                )
-            except StackStormDBObjectNotFoundError as e:
-                abort(http_client.NOT_FOUND, e.message)
-                return
+            kvp_api = self._get_one_by_scope_and_name(
+                name=key_ref,
+                scope=scope,
+                from_model_kwargs=from_model_kwargs
+            )
 
             kvp_db = KeyValuePairAPI.to_model(kvp_api)
 

--- a/st2api/st2api/controllers/v1/keyvalue.py
+++ b/st2api/st2api/controllers/v1/keyvalue.py
@@ -183,8 +183,8 @@ class KeyValuePairController(ResourceController):
         kvp_api = KeyValuePairAPI.from_model(kvp_db)
         return kvp_api
 
-    @jsexpose(arg_types=[str, str], status_code=http_client.NO_CONTENT)
-    def delete(self, name, scope=SYSTEM_SCOPE):
+    @jsexpose(arg_types=[str, str, str], status_code=http_client.NO_CONTENT)
+    def delete(self, name, scope=SYSTEM_SCOPE, user=None):
         """
             Delete the key value pair.
 
@@ -192,6 +192,14 @@ class KeyValuePairController(ResourceController):
                 DELETE /keys/1
         """
         self._validate_scope(scope=scope)
+
+        requester_user = get_requester()
+        is_admin = request_user_is_admin(request=pecan.request)
+
+        if user != requester_user and not is_admin:
+            msg = '"user" attribute can only be provided by admins'
+            raise AccessDeniedError(message=msg, user_db=requester_user)
+
         key_ref = get_key_reference(scope=scope, name=name, user=get_requester())
         lock_name = self._get_lock_name_for_key(name=key_ref, scope=scope)
 

--- a/st2api/st2api/controllers/v1/keyvalue.py
+++ b/st2api/st2api/controllers/v1/keyvalue.py
@@ -115,9 +115,14 @@ class KeyValuePairController(ResourceController):
             self._validate_scope(scope=scope)
             kwargs['scope'] = scope
 
-        if scope == USER_SCOPE and kwargs['prefix']:
-            kwargs['prefix'] = get_key_reference(name=kwargs['prefix'], scope=scope,
-                                                 user=requester_user)
+        if scope == USER_SCOPE:
+            # Make sure we only returned values scoped to current user
+            if kwargs['prefix']:
+                kwargs['prefix'] = get_key_reference(name=kwargs['prefix'], scope=scope,
+                                                     user=requester_user)
+            else:
+                kwargs['prefix'] = get_key_reference(name='', scope=scope,
+                                                     user=requester_user)
 
         kvp_apis = super(KeyValuePairController, self)._get_all(from_model_kwargs=from_model_kwargs,
                                                                 **kwargs)

--- a/st2api/tests/unit/controllers/v1/test_kvps_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_kvps_rbac.py
@@ -1,0 +1,282 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import httplib
+
+import six
+
+from st2common.constants.keyvalue import SYSTEM_SCOPE
+from st2common.constants.keyvalue import USER_SCOPE
+from st2common.services.keyvalues import get_key_reference
+from st2common.persistence.auth import User
+from st2common.models.db.auth import UserDB
+from st2common.models.db.keyvalue import KeyValuePairDB
+from st2common.persistence.keyvalue import KeyValuePair
+from st2common.models.api.keyvalue import KeyValuePairSetAPI
+from st2common.models.api.keyvalue import KeyValuePairAPI
+from tests.base import APIControllerWithRBACTestCase
+
+http_client = six.moves.http_client
+
+__all__ = [
+    'KeyValuesControllerRBACTestCase'
+]
+
+
+class KeyValuesControllerRBACTestCase(APIControllerWithRBACTestCase):
+    def setUp(self):
+        super(KeyValuesControllerRBACTestCase, self).setUp()
+
+        self.kvps = {}
+
+        # Insert mock users
+        user_1_db = UserDB(name='user1')
+        user_1_db = User.add_or_update(user_1_db)
+        self.users['user_1'] = user_1_db
+
+        user_2_db = UserDB(name='user2')
+        user_2_db = User.add_or_update(user_2_db)
+        self.users['user_2'] = user_2_db
+
+        # Insert mock kvp objects
+        kvp_api = KeyValuePairSetAPI(name='test_system_scope', value='value1', scope=SYSTEM_SCOPE)
+        kvp_db = KeyValuePairSetAPI.to_model(kvp_api)
+        kvp_db = KeyValuePair.add_or_update(kvp_db)
+        kvp_db = KeyValuePairAPI.from_model(kvp_db)
+        self.kvps['kvp_1'] = kvp_db
+
+        kvp_api = KeyValuePairSetAPI(name='test_system_scope_secret', value='value_secret',
+                                     scope=SYSTEM_SCOPE, secret=True)
+        kvp_db = KeyValuePairSetAPI.to_model(kvp_api)
+        kvp_db = KeyValuePair.add_or_update(kvp_db)
+        kvp_db = KeyValuePairAPI.from_model(kvp_db)
+        self.kvps['kvp_2'] = kvp_db
+
+        name = get_key_reference(scope=USER_SCOPE, name='test_user_scope_1', user='user1')
+        kvp_db = KeyValuePairDB(name=name, value='valueu12', scope=USER_SCOPE)
+        kvp_db = KeyValuePair.add_or_update(kvp_db)
+        kvp_db = KeyValuePairAPI.from_model(kvp_db)
+        self.kvps['kvp_3'] = kvp_db
+
+        name = get_key_reference(scope=USER_SCOPE, name='test_user_scope_2', user='user1')
+        kvp_api = KeyValuePairSetAPI(name=name, value='user_secret', scope=USER_SCOPE, secret=True)
+        kvp_db = KeyValuePairSetAPI.to_model(kvp_api)
+        kvp_db = KeyValuePair.add_or_update(kvp_db)
+        kvp_db = KeyValuePairAPI.from_model(kvp_db)
+        self.kvps['kvp_4'] = kvp_db
+
+        name = get_key_reference(scope=USER_SCOPE, name='test_user_scope_3', user='user2')
+        kvp_db = KeyValuePairDB(name=name, value='valueu21', scope=USER_SCOPE)
+        kvp_db = KeyValuePair.add_or_update(kvp_db)
+        kvp_db = KeyValuePairAPI.from_model(kvp_db)
+        self.kvps['kvp_5'] = kvp_db
+
+        self.system_scoped_items_count = 2
+        self.user_scoped_items_count = 3
+        self.user_scoped_items_per_user_count = {
+            'user1': 2,
+            'user2': 1
+        }
+
+    def test_get_all_system_scope_success(self):
+        # Regular user, should be able to view all the system scoped items
+        self.use_user(self.users['user_1'])
+
+        resp = self.app.get('/v1/keys')
+        self.assertEqual(resp.status_int, 200)
+        self.assertEqual(len(resp.json), self.system_scoped_items_count)
+        for item in resp.json:
+            self.assertEqual(item['scope'], SYSTEM_SCOPE)
+
+        # Verify second item is encrypted
+        self.assertTrue(resp.json[1]['secret'])
+        self.assertTrue(len(resp.json[1]['value']) > 50)
+
+    def test_get_all_user_scope_success(self):
+        # Regular user should be able to view all the items scoped to themselves
+        self.use_user(self.users['user_1'])
+
+        resp = self.app.get('/v1/keys?scope=user')
+        self.assertEqual(resp.status_int, 200)
+        self.assertEqual(len(resp.json), self.user_scoped_items_per_user_count['user1'])
+        for item in resp.json:
+            self.assertEqual(item['scope'], USER_SCOPE)
+            self.assertEqual(item['user'], 'user1')
+
+        # Verify second item is encrypted
+        self.assertTrue(resp.json[1]['secret'])
+        self.assertTrue(len(resp.json[1]['value']) > 50)
+
+    def test_get_all_scope_system_decrypt_admin_success(self):
+        # Admin should be able to view all system scoped decrypted values
+        self.use_user(self.users['admin'])
+
+        resp = self.app.get('/v1/keys?decrypt=True')
+        self.assertEqual(resp.status_int, 200)
+        self.assertEqual(len(resp.json), self.system_scoped_items_count)
+        for item in resp.json:
+            self.assertEqual(item['scope'], SYSTEM_SCOPE)
+
+        # Verify second item is decrypted
+        self.assertTrue(resp.json[1]['secret'])
+        self.assertEqual(resp.json[1]['value'], 'value_secret')
+
+    def test_get_all_scope_all_admin_decrypt_success(self):
+        # Admin users should be able to view all items (including user scoped ones) when using
+        # ?scope=all
+        self.use_user(self.users['admin'])
+
+        resp = self.app.get('/v1/keys?scope=all&decrypt=True')
+        self.assertEqual(resp.status_int, 200)
+        expected_count = (self.system_scoped_items_count + self.user_scoped_items_count)
+        self.assertEqual(len(resp.json), expected_count)
+
+        # Verify second item is decrypted
+        self.assertTrue(resp.json[1]['secret'])
+        self.assertEqual(resp.json[1]['scope'], SYSTEM_SCOPE)
+        self.assertEqual(resp.json[1]['value'], 'value_secret')
+
+        # Verify user scoped items are available and decrypted
+        self.assertTrue(resp.json[3]['secret'])
+        self.assertEqual(resp.json[3]['scope'], USER_SCOPE)
+        self.assertEqual(resp.json[3]['user'], 'user1')
+        self.assertEqual(resp.json[3]['value'], 'user_secret')
+
+        self.assertEqual(resp.json[4]['scope'], USER_SCOPE)
+        self.assertEqual(resp.json[4]['user'], 'user2')
+
+    def test_get_all_non_admin_decrypt_failure(self):
+        # Non admin shouldn't be able to view decrypted items
+        self.use_user(self.users['user_1'])
+
+        resp = self.app.get('/v1/keys?decrypt=True', expect_errors=True)
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertTrue('Decrypt option requires administrator access' in resp.json['faultstring'])
+
+    def test_get_all_scope_all_non_admin_failure(self):
+        # Non admin users can't use scope=all
+        self.use_user(self.users['user_1'])
+
+        resp = self.app.get('/v1/keys?scope=all', expect_errors=True)
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertTrue('"all" scope requires administrator access' in resp.json['faultstring'])
+
+    def test_get_one_system_scope_success(self):
+        self.use_user(self.users['user_1'])
+
+        resp = self.app.get('/v1/keys/%s' % (self.kvps['kvp_1'].name))
+        self.assertEqual(resp.json['scope'], SYSTEM_SCOPE)
+
+    def test_get_one_user_scope_success(self):
+        # Retrieving user scoped variable which is scoped to the authenticated user
+        self.use_user(self.users['user_1'])
+
+        resp = self.app.get('/v1/keys/%s?scope=user' % (self.kvps['kvp_3'].name))
+        self.assertEqual(resp.json['scope'], USER_SCOPE)
+        self.assertEqual(resp.json['user'], 'user1')
+
+    def test_get_one_user_scope_decrypt_success(self):
+        # User can request decrypted value of the item scoped to themselves
+        self.use_user(self.users['user_1'])
+
+        resp = self.app.get('/v1/keys/%s?scope=user&decrypt=True' % (self.kvps['kvp_4'].name))
+        self.assertEqual(resp.json['scope'], USER_SCOPE)
+        self.assertEqual(resp.json['user'], 'user1')
+        self.assertTrue(resp.json['secret'])
+        self.assertEqual(resp.json['value'], 'user_secret')
+
+    def test_get_one_user_scope_non_current_user_failure(self):
+        # User should only be able to retrieved user-scoped items which are scoped to themselves
+        self.use_user(self.users['user_1'])
+
+        # This item is scoped to user2
+        resp = self.app.get('/v1/keys/%s?scope=user' % (self.kvps['kvp_5'].name),
+                            expect_errors=True)
+        self.assertEqual(resp.status_code, httplib.NOT_FOUND)
+
+        # Should work fine for other user
+        self.use_user(self.users['user_2'])
+
+        resp = self.app.get('/v1/keys/%s?scope=user' % (self.kvps['kvp_5'].name))
+        self.assertEqual(resp.json['scope'], USER_SCOPE)
+        self.assertEqual(resp.json['user'], 'user2')
+
+    def test_get_one_system_scope_decrypt_non_admin_user_failure(self):
+        # Non-admin user can't access decrypted system scoped items. They can only access decrypted
+        # items which are scoped to themselves.
+        self.use_user(self.users['user_1'])
+
+        resp = self.app.get('/v1/keys/%s?decrypt=True' % (self.kvps['kvp_1'].name),
+                            expect_errors=True)
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertTrue('Decrypt option requires administrator access' in resp.json['faultstring'])
+
+    def test_set_user_scoped_item_arbitrary_user_admin_success(self):
+        # Admin user can set user-scoped items for an arbitrary user
+        self.use_user(self.users['admin'])
+
+        data = {
+            'name': 'test_new_key_1',
+            'value': 'testvalue1',
+            'scope': USER_SCOPE,
+            'user': 'user2'
+        }
+        resp = self.app.put_json('/v1/keys/test_new_key_1', data)
+        self.assertEqual(resp.status_code, httplib.OK)
+
+        # Verify item has been created
+        resp = self.app.get('/v1/keys/test_new_key_1?scope=user&user=user2')
+        self.assertEqual(resp.status_code, httplib.OK)
+        self.assertEqual(resp.json['value'], 'testvalue1')
+        self.assertEqual(resp.json['scope'], USER_SCOPE)
+        self.assertEqual(resp.json['user'], 'user2')
+
+    def test_set_user_scoped_item_arbitrary_user_non_admin_failure(self):
+        # Non admin user can't set user scoped item for arbitrary user but just for themselves
+        self.use_user(self.users['user_1'])
+
+        data = {
+            'name': 'test_new_key_2',
+            'value': 'testvalue2',
+            'scope': USER_SCOPE,
+            'user': 'user2'
+        }
+        resp = self.app.put_json('/v1/keys/test_new_key_2', data, expect_errors=True)
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertTrue('"user" attribute can only be provided by admins' in
+                        resp.json['faultstring'])
+
+        # But setting user scoped item for themselves should work
+        data = {
+            'name': 'test_new_key_3',
+            'value': 'testvalue3',
+            'scope': USER_SCOPE
+        }
+        resp = self.app.put_json('/v1/keys/test_new_key_3', data)
+        self.assertEqual(resp.status_code, httplib.OK)
+
+        resp = self.app.get('/v1/keys/test_new_key_3?scope=user')
+        self.assertEqual(resp.status_code, httplib.OK)
+        self.assertEqual(resp.json['value'], 'testvalue3')
+        self.assertEqual(resp.json['scope'], USER_SCOPE)
+        self.assertEqual(resp.json['user'], 'user1')
+
+    def test_delete_user_scope_item_aribrary_user_admin_success(self):
+        # Admin user can delete user-scoped datastore item scoped to arbitrary user
+        pass
+
+    def test_delete_user_scope_item_non_admin_failure(self):
+        # Non admin user can't delete user-scoped items which are not scoped to them
+        pass

--- a/st2client/st2client/commands/keyvalue.py
+++ b/st2client/st2client/commands/keyvalue.py
@@ -59,7 +59,7 @@ class KeyValuePairBranch(resource.ResourceBranch):
 
 
 class KeyValuePairListCommand(resource.ResourceListCommand):
-    display_attributes = ['name', 'value', 'secret', 'encrypted', 'expire_timestamp']
+    display_attributes = ['name', 'value', 'secret', 'encrypted', 'scope', 'expire_timestamp']
     attribute_transform_functions = {
         'expire_timestamp': format_isodate_for_user_timezone,
     }
@@ -135,6 +135,8 @@ class KeyValuePairSetCommand(resource.ResourceCommand):
         self.parser.add_argument('-s', '--scope', dest='scope', default=DEFAULT_SCOPE,
                                  help='Specify the scope under which you want ' +
                                       'to place the variable.')
+        self.parser.add_argument('-u', '--user', dest='user', default=None,
+                                 help='User for user scoped variables ')
 
     @add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
@@ -143,6 +145,7 @@ class KeyValuePairSetCommand(resource.ResourceCommand):
         instance.name = args.name
         instance.value = args.value
         instance.scope = args.scope
+        instance.user = args.user
 
         if args.secret:
             instance.secret = args.secret

--- a/st2client/st2client/commands/keyvalue.py
+++ b/st2client/st2client/commands/keyvalue.py
@@ -166,9 +166,21 @@ class KeyValuePairSetCommand(resource.ResourceCommand):
 class KeyValuePairDeleteCommand(resource.ResourceDeleteCommand):
     pk_argument_name = 'name'
 
+    def __init__(self, resource, *args, **kwargs):
+        super(KeyValuePairDeleteCommand, self).__init__(resource, *args, **kwargs)
+
+        self.parser.add_argument('-s', '--scope', dest='scope', default=DEFAULT_SCOPE,
+                                 help='Specify the scope under which you want ' +
+                                      'to place the variable.')
+        self.parser.add_argument('-u', '--user', dest='user', default=None,
+                                 help='User for user scoped variables ')
+
     @add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
         resource_id = getattr(args, self.pk_argument_name, None)
+        scope = getattr(args, 'scope', DEFAULT_SCOPE)
+        kwargs['params'] = {}
+        kwargs['params']['scope'] = scope
         instance = self.get_resource(resource_id, **kwargs)
 
         if not instance:

--- a/st2client/st2client/commands/keyvalue.py
+++ b/st2client/st2client/commands/keyvalue.py
@@ -59,7 +59,8 @@ class KeyValuePairBranch(resource.ResourceBranch):
 
 
 class KeyValuePairListCommand(resource.ResourceListCommand):
-    display_attributes = ['name', 'value', 'secret', 'encrypted', 'scope', 'expire_timestamp']
+    display_attributes = ['name', 'value', 'secret', 'encrypted', 'scope', 'user',
+                          'expire_timestamp']
     attribute_transform_functions = {
         'expire_timestamp': format_isodate_for_user_timezone,
     }

--- a/st2client/st2client/commands/keyvalue.py
+++ b/st2client/st2client/commands/keyvalue.py
@@ -74,7 +74,7 @@ class KeyValuePairListCommand(resource.ResourceListCommand):
         self.parser.add_argument('--decrypt', action='store_true',
                                  help='Decrypt secrets and display plain text.')
         self.parser.add_argument('-s', '--scope', default='system', dest='scope',
-                                 help='Scope variable is under. Example: "user".')
+                                 help='Scope item is under. Example: "user".')
 
     def run_and_print(self, args, **kwargs):
         if args.prefix:
@@ -102,7 +102,7 @@ class KeyValuePairGetCommand(resource.ResourceGetCommand):
         self.parser.add_argument('-d', '--decrypt', action='store_true',
                                  help='Decrypt secret if encrypted and show plain text.')
         self.parser.add_argument('-s', '--scope', default=DEFAULT_SCOPE, dest='scope',
-                                 help='Scope variable is under. Example: "user".')
+                                 help='Scope item is under. Example: "user".')
 
     @resource.add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
@@ -135,9 +135,9 @@ class KeyValuePairSetCommand(resource.ResourceCommand):
                                  help='Encrypt value before saving the value.')
         self.parser.add_argument('-s', '--scope', dest='scope', default=DEFAULT_SCOPE,
                                  help='Specify the scope under which you want ' +
-                                      'to place the variable.')
+                                      'to place the item.')
         self.parser.add_argument('-u', '--user', dest='user', default=None,
-                                 help='User for user scoped variables ')
+                                 help='User for user scoped items (admin only).')
 
     @add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
@@ -171,9 +171,9 @@ class KeyValuePairDeleteCommand(resource.ResourceDeleteCommand):
 
         self.parser.add_argument('-s', '--scope', dest='scope', default=DEFAULT_SCOPE,
                                  help='Specify the scope under which you want ' +
-                                      'to place the variable.')
+                                      'to place the item.')
         self.parser.add_argument('-u', '--user', dest='user', default=None,
-                                 help='User for user scoped variables ')
+                                 help='User for user scoped items (admin only).')
 
     @add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):

--- a/st2common/st2common/models/api/keyvalue.py
+++ b/st2common/st2common/models/api/keyvalue.py
@@ -13,8 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
 import os
+import copy
+import datetime
 
 from keyczar.keys import AesKey
 from oslo_config import cfg
@@ -185,3 +186,21 @@ class KeyValuePairAPI(BaseAPI):
                           expire_timestamp=expire_timestamp)
 
         return model
+
+
+class KeyValuePairSetAPI(KeyValuePairAPI):
+    """
+    API model for key value set operations.
+    """
+
+    schema = copy.deepcopy(KeyValuePairAPI.schema)
+    schema['properties']['ttl'] = {
+        'description': 'Items TTL',
+        'type': 'integer'
+    }
+    schema['properties']['user'] = {
+        'description': ('User to which the value should be scoped to. Only applicable to '
+                        'scope == user'),
+        'type': 'string'
+    }
+

--- a/st2common/st2common/models/api/keyvalue.py
+++ b/st2common/st2common/models/api/keyvalue.py
@@ -31,6 +31,11 @@ from st2common.models.api.base import BaseAPI
 from st2common.models.system.keyvalue import UserKeyReference
 from st2common.models.db.keyvalue import KeyValuePairDB
 
+__all__ = [
+    'KeyValuePairAPI',
+    'KeyValuePairSetAPI'
+]
+
 LOG = logging.getLogger(__name__)
 
 
@@ -203,4 +208,3 @@ class KeyValuePairSetAPI(KeyValuePairAPI):
                         'scope == user'),
         'type': 'string'
     }
-

--- a/st2common/st2common/util/api.py
+++ b/st2common/st2common/util/api.py
@@ -115,8 +115,8 @@ def get_exception_for_type_error(func, exc):
 
     # Note: Those checks are hacky, but it's better than having no checks and silently
     # accepting invalid requests
-    invalid_num_args_pattern = ('%s\(\) takes (exactly|at most) \d+ arguments \(\d+ given\)' %
-                                (func_name))
+    invalid_num_args_pattern = ('%s\(\) takes %s \d+ arguments \(\d+ given\)' %
+                                (func_name, '(exactly|at most|at least)'))
     unexpected_keyword_arg_pattern = ('%s\(\) got an unexpected keyword argument \'(.*?)\'' %
                                       (func_name))
 


### PR DESCRIPTION
This pull request includes access control and other new features, related improvements and fixes for  the datastore API endpoints.

1. Allow administrators to list all the datastore items (including user scoped ones) by specifying `all` for the `scope` query parameter.
2. When using decrypt option in the list API endpoint, require the user to be an administrator or the user is listing user-scoped items for themselves.
3. When using decrypt option in the get one API endpoint, require the user to be an administrator or the user is retrieving a user-scoped item for themselves.
4. Allow administrator to set a user-scoped item for an arbitrary user.
5. Allow administrator to delete a user-scoped item for an arbitrary user.
6. Some code cleanup (we don't need to catch `StackStormDBObjectNotFoundError` exceptions, jsexpose hooks does that and maps those errors to 404).
7. Fix get all items API endpoint - when retrieving user-scoped items, non-admin user should only be able to view / retrieve items scoped to themselves.
7. Some CLI improvements and fixes (add missing scope argument to `st2 key delete` command, etc.)
9. Various other improvements and fixes

## TODO

- [x] More tests
- [x] Some code refactor