### PR TITLE
Allow admin to specify an user who's context will be used when running / re-running an action

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -52,6 +52,8 @@ in development
   [Kale Blankenship]
 * Fix string parameter casting - leave actual ``None`` value as-is and don't try to cast it to a
   string which would fail. (bug-fix, improvement)
+* Allow administrator user who's context will be used when running an action or re-running an
+  action execution. (new feature)
 
 1.4.0 - April 18, 2016
 ----------------------

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -55,6 +55,7 @@ from st2common.rbac.types import PermissionType
 from st2common.rbac.decorators import request_user_has_permission
 from st2common.rbac.decorators import request_user_has_resource_db_permission
 from st2common.rbac.utils import assert_request_user_has_resource_db_permission
+from st2common.rbac.utils import assert_request_user_is_admin_if_user_query_param_is_provider
 
 __all__ = [
     'ActionExecutionsController'
@@ -117,6 +118,8 @@ class ActionExecutionsControllerMixin(BaseRestControllerMixin):
             permission_type=PermissionType.ACTION_EXECUTE)
 
         # TODO: Validate user is admin if user is provided
+        assert_request_user_is_admin_if_user_query_param_is_provider(request=pecan.request,
+                                                                     user=user)
 
         try:
             return self._schedule_execution(liveaction=liveaction, user=user)

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -258,10 +258,11 @@ class ActionExecutionReRunController(ActionExecutionsControllerMixin, ResourceCo
     ]
 
     class ExecutionSpecificationAPI(object):
-        def __init__(self, parameters=None, tasks=None, reset=None):
+        def __init__(self, parameters=None, tasks=None, reset=None, user=None):
             self.parameters = parameters or {}
             self.tasks = tasks or []
             self.reset = reset or []
+            self.user = user
 
         def validate(self):
             if (self.tasks or self.reset) and self.parameters:
@@ -325,7 +326,8 @@ class ActionExecutionReRunController(ActionExecutionsControllerMixin, ResourceCo
 
         new_liveaction = LiveActionDB(action=action_ref,
                                       context=context,
-                                      parameters=new_parameters)
+                                      parameters=new_parameters,
+                                      user=spec.user)
 
         return self._handle_schedule_execution(liveaction=new_liveaction)
 

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -36,6 +36,7 @@ from st2common.exceptions.param import ParamException
 from st2common.exceptions.apivalidation import ValueValidationException
 from st2common.exceptions.trace import TraceNotFoundException
 from st2common.models.api.action import LiveActionAPI
+from st2common.models.api.action import LiveActionCreateAPI
 from st2common.models.api.base import jsexpose
 from st2common.models.api.execution import ActionExecutionAPI
 from st2common.models.db.liveaction import LiveActionDB

--- a/st2api/st2api/controllers/v1/keyvalue.py
+++ b/st2api/st2api/controllers/v1/keyvalue.py
@@ -142,10 +142,9 @@ class KeyValuePairController(ResourceController):
         self._validate_scope(scope=scope)
 
         requester_user = get_requester()
-        is_admin = request_user_is_admin(request=pecan.request)
 
         scope = getattr(kvp, 'scope', scope)
-        user = getattr(kvp, 'user', requester_user)
+        user = getattr(kvp, 'user', requester_user) or requester_user
 
         # Validate that the authenticated user is admin if user query param is provided
         assert_request_user_is_admin_if_user_query_param_is_provider(request=pecan.request,
@@ -206,7 +205,6 @@ class KeyValuePairController(ResourceController):
 
         requester_user = get_requester()
         user = user or requester_user
-        is_admin = request_user_is_admin(request=pecan.request)
 
         # Validate that the authenticated user is admin if user query param is provided
         assert_request_user_is_admin_if_user_query_param_is_provider(request=pecan.request,

--- a/st2api/st2api/controllers/v1/keyvalue.py
+++ b/st2api/st2api/controllers/v1/keyvalue.py
@@ -32,6 +32,7 @@ from st2common.services.keyvalues import get_key_reference
 from st2common.util.api import get_requester
 from st2common.exceptions.rbac import AccessDeniedError
 from st2common.rbac.utils import request_user_is_admin
+from st2common.rbac.utils import assert_request_user_is_admin_if_user_query_param_is_provider
 
 http_client = six.moves.http_client
 
@@ -81,7 +82,8 @@ class KeyValuePairController(ResourceController):
         self._validate_decrypt_query_parameter(decrypt=decrypt, scope=scope, is_admin=is_admin)
 
         # Validate that the authenticated user is admin if user query param is provided
-        self._validate_user_query_parameter(user=user, is_admin=is_admin)
+        assert_request_user_is_admin_if_user_query_param_is_provider(request=pecan.request,
+                                                                     user=user)
 
         key_ref = get_key_reference(scope=scope, name=name, user=user)
         from_model_kwargs = {'mask_secrets': not decrypt}
@@ -146,7 +148,8 @@ class KeyValuePairController(ResourceController):
         user = getattr(kvp, 'user', requester_user)
 
         # Validate that the authenticated user is admin if user query param is provided
-        self._validate_user_query_parameter(user=user, is_admin=is_admin)
+        assert_request_user_is_admin_if_user_query_param_is_provider(request=pecan.request,
+                                                                     user=user)
 
         key_ref = get_key_reference(scope=scope, name=name, user=user)
         lock_name = self._get_lock_name_for_key(name=key_ref, scope=scope)
@@ -206,7 +209,8 @@ class KeyValuePairController(ResourceController):
         is_admin = request_user_is_admin(request=pecan.request)
 
         # Validate that the authenticated user is admin if user query param is provided
-        self._validate_user_query_parameter(user=user, is_admin=is_admin)
+        assert_request_user_is_admin_if_user_query_param_is_provider(request=pecan.request,
+                                                                     user=user)
 
         key_ref = get_key_reference(scope=scope, name=name, user=user)
         lock_name = self._get_lock_name_for_key(name=key_ref, scope=scope)
@@ -255,16 +259,6 @@ class KeyValuePairController(ResourceController):
 
         if decrypt and (scope != USER_SCOPE and not is_admin):
             msg = 'Decrypt option requires administrator access'
-            raise AccessDeniedError(message=msg, user_db=requester_user)
-
-    def _validate_user_query_parameter(self, user, is_admin):
-        """
-        Validate that the authentication user is admin if the "user" query parameter is provided.
-        """
-        requester_user = get_requester()
-
-        if user != requester_user and not is_admin:
-            msg = '"user" attribute can only be provided by admins'
             raise AccessDeniedError(message=msg, user_db=requester_user)
 
     def _validate_scope(self, scope):

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -820,6 +820,8 @@ class ActionRunCommand(ActionRunCommandMixin, resource.ResourceCommand):
                                           'which are accessible to the CLI as "env" '
                                           'parameter to the action. Note: Only works '
                                           'with python, local and remote runners.')
+            self.parser.add_argument('-u', '--user', type=str, default=None,
+                                           help='User under which to run the action (admins only).')
 
         if self.name == 'run':
             self.parser.set_defaults(async=False)
@@ -849,6 +851,7 @@ class ActionRunCommand(ActionRunCommandMixin, resource.ResourceCommand):
         execution = models.LiveAction()
         execution.action = action_ref
         execution.parameters = action_parameters
+        execution.user = args.user
 
         if not args.trace_id and args.trace_tag:
             execution.context = {'trace_context': {'trace_tag': args.trace_tag}}

--- a/st2client/tests/unit/test_action.py
+++ b/st2client/tests/unit/test_action.py
@@ -113,7 +113,7 @@ class ActionCommandTestCase(base.BaseCLITestCase):
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(LIVE_ACTION), 200, 'OK')))
     def test_runner_param_bool_conversion(self):
         self.shell.run(['run', 'mockety.mock1', 'bool=false'])
-        expected = {'action': 'mockety.mock1', 'parameters': {'bool': False}}
+        expected = {'action': 'mockety.mock1', 'user': None, 'parameters': {'bool': False}}
         httpclient.HTTPClient.post.assert_called_with('/executions', expected)
 
     @mock.patch.object(
@@ -127,7 +127,7 @@ class ActionCommandTestCase(base.BaseCLITestCase):
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(LIVE_ACTION), 200, 'OK')))
     def test_runner_param_integer_conversion(self):
         self.shell.run(['run', 'mockety.mock1', 'int=30'])
-        expected = {'action': 'mockety.mock1', 'parameters': {'int': 30}}
+        expected = {'action': 'mockety.mock1', 'user': None, 'parameters': {'int': 30}}
         httpclient.HTTPClient.post.assert_called_with('/executions', expected)
 
     @mock.patch.object(
@@ -141,7 +141,7 @@ class ActionCommandTestCase(base.BaseCLITestCase):
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(LIVE_ACTION), 200, 'OK')))
     def test_runner_param_float_conversion(self):
         self.shell.run(['run', 'mockety.mock1', 'float=3.01'])
-        expected = {'action': 'mockety.mock1', 'parameters': {'float': 3.01}}
+        expected = {'action': 'mockety.mock1', 'user': None, 'parameters': {'float': 3.01}}
         httpclient.HTTPClient.post.assert_called_with('/executions', expected)
 
     @mock.patch.object(
@@ -155,7 +155,7 @@ class ActionCommandTestCase(base.BaseCLITestCase):
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(LIVE_ACTION), 200, 'OK')))
     def test_runner_param_json_conversion(self):
         self.shell.run(['run', 'mockety.mock1', 'json={"a":1}'])
-        expected = {'action': 'mockety.mock1', 'parameters': {'json': {'a': 1}}}
+        expected = {'action': 'mockety.mock1', 'user': None, 'parameters': {'json': {'a': 1}}}
         httpclient.HTTPClient.post.assert_called_with('/executions', expected)
 
     @mock.patch.object(
@@ -169,7 +169,7 @@ class ActionCommandTestCase(base.BaseCLITestCase):
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(LIVE_ACTION), 200, 'OK')))
     def test_param_bool_conversion(self):
         self.shell.run(['run', 'mockety.mock2', 'bool=false'])
-        expected = {'action': 'mockety.mock2', 'parameters': {'bool': False}}
+        expected = {'action': 'mockety.mock2', 'user': None, 'parameters': {'bool': False}}
         httpclient.HTTPClient.post.assert_called_with('/executions', expected)
 
     @mock.patch.object(
@@ -183,7 +183,7 @@ class ActionCommandTestCase(base.BaseCLITestCase):
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(LIVE_ACTION), 200, 'OK')))
     def test_param_integer_conversion(self):
         self.shell.run(['run', 'mockety.mock2', 'int=30'])
-        expected = {'action': 'mockety.mock2', 'parameters': {'int': 30}}
+        expected = {'action': 'mockety.mock2', 'user': None, 'parameters': {'int': 30}}
         httpclient.HTTPClient.post.assert_called_with('/executions', expected)
 
     @mock.patch.object(
@@ -197,7 +197,7 @@ class ActionCommandTestCase(base.BaseCLITestCase):
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(LIVE_ACTION), 200, 'OK')))
     def test_param_float_conversion(self):
         self.shell.run(['run', 'mockety.mock2', 'float=3.01'])
-        expected = {'action': 'mockety.mock2', 'parameters': {'float': 3.01}}
+        expected = {'action': 'mockety.mock2', 'user': None, 'parameters': {'float': 3.01}}
         httpclient.HTTPClient.post.assert_called_with('/executions', expected)
 
     @mock.patch.object(
@@ -211,7 +211,7 @@ class ActionCommandTestCase(base.BaseCLITestCase):
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(LIVE_ACTION), 200, 'OK')))
     def test_param_json_conversion(self):
         self.shell.run(['run', 'mockety.mock2', 'json={"a":1}'])
-        expected = {'action': 'mockety.mock2', 'parameters': {'json': {'a': 1}}}
+        expected = {'action': 'mockety.mock2', 'user': None, 'parameters': {'json': {'a': 1}}}
         httpclient.HTTPClient.post.assert_called_with('/executions', expected)
 
     @mock.patch.object(
@@ -225,6 +225,6 @@ class ActionCommandTestCase(base.BaseCLITestCase):
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(LIVE_ACTION), 200, 'OK')))
     def test_param_value_with_equal_sign(self):
         self.shell.run(['run', 'mockety.mock2', 'key=foo=bar&ponies=unicorns'])
-        expected = {'action': 'mockety.mock2',
+        expected = {'action': 'mockety.mock2', 'user': None,
                     'parameters': {'key': 'foo=bar&ponies=unicorns'}}
         httpclient.HTTPClient.post.assert_called_with('/executions', expected)

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -35,6 +35,7 @@ __all__ = [
     'ActionAPI',
     'ActionCreateAPI',
     'LiveActionAPI',
+    'LiveActionCreateAPI',
     'RunnerTypeAPI'
 ]
 
@@ -410,7 +411,18 @@ class LiveActionAPI(BaseAPI):
         return model
 
 
-class ActionExecutionStateAPI(BaseAPI):
+class LiveActionCreateAPI(LiveActionAPI):
+    """
+    API model for action execution create (run action) operations.
+    """
+    schema = copy.deepcopy(LiveActionAPI.schema)
+    schema['properties']['user'] = {
+        'description': 'User context under which action should run (admins only)',
+        'type': 'string'
+    }
+
+
+class ActionExecutionStateAPI(BasePI):
     """
     System entity that represents state of an action in the system.
     This is used only in tests for now.

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -422,7 +422,7 @@ class LiveActionCreateAPI(LiveActionAPI):
     }
 
 
-class ActionExecutionStateAPI(BasePI):
+class ActionExecutionStateAPI(BaseAPI):
     """
     System entity that represents state of an action in the system.
     This is used only in tests for now.

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -418,7 +418,8 @@ class LiveActionCreateAPI(LiveActionAPI):
     schema = copy.deepcopy(LiveActionAPI.schema)
     schema['properties']['user'] = {
         'description': 'User context under which action should run (admins only)',
-        'type': 'string'
+        'type': 'string',
+        'default': None
     }
 
 

--- a/st2common/st2common/models/api/keyvalue.py
+++ b/st2common/st2common/models/api/keyvalue.py
@@ -206,5 +206,6 @@ class KeyValuePairSetAPI(KeyValuePairAPI):
     schema['properties']['user'] = {
         'description': ('User to which the value should be scoped to. Only applicable to '
                         'scope == user'),
-        'type': 'string'
+        'type': 'string',
+        'default': None
     }

--- a/st2common/st2common/rbac/utils.py
+++ b/st2common/st2common/rbac/utils.py
@@ -30,6 +30,7 @@ from st2common.rbac.types import SystemRole
 from st2common.rbac import resolvers
 from st2common.services import rbac as rbac_services
 from st2common.util import action_db as action_utils
+from st2common.util.api import get_requester
 
 __all__ = [
     'request_user_is_admin',
@@ -46,6 +47,8 @@ __all__ = [
     'assert_request_user_is_system_admin',
     'assert_request_user_has_permission',
     'assert_request_user_has_resource_db_permission',
+
+    'assert_request_user_is_admin_if_user_query_param_is_provider',
 
     'assert_request_user_has_rule_trigger_and_action_permission',
 
@@ -278,6 +281,19 @@ def assert_request_user_has_rule_trigger_and_action_permission(request, rule_api
         raise AccessDeniedError(message=msg, user_db=user_db)
 
     return True
+
+
+def assert_request_user_is_admin_if_user_query_param_is_provider(request, user):
+    """
+    Function which asserts that the request user is administator if "user" query parameter is
+    provided and doesn't match the current user.
+    """
+    requester_user = get_requester()
+    is_admin = request_user_is_admin(request=request)
+
+    if user != requester_user and not is_admin:
+        msg = '"user" attribute can only be provided by admins'
+        raise AccessDeniedError(message=msg, user_db=requester_user)
 
 
 def user_is_admin(user_db):


### PR DESCRIPTION
This ties to the pack configuration v2 story.

This pull request allows administrator to specify a user who's context will be used when running and re-running an action.

Right now inheriting a user context basically only means using datastore values for that user when using a dynamic config value, but now we have a framework in place so we can expand it in the future (e.g. it could also means inheriting that user's permissions, etc.).

I also refactored some of the RBAC code since the same logic is now used in two places so it makes sense to refactor it in some common place.

In addition to that, I also cleaned / fixed some code (One of the methods expected an API object, but in one place we passed in a DB object, it mostly worked out of pure luck because objects look mostly the same. That's just one of the left-overs from the execution -> live action change...)