### PR TITLE
Implement a work-around for CronTimer rule creation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,6 +54,8 @@ in development
   string which would fail. (bug-fix, improvement)
 * Allow administrator user who's context will be used when running an action or re-running an
   action execution. (new feature)
+* Add a work-around for trigger creation which would case rule creation for CronTrigger to fail
+  under some circumstances. (workaround, bug-fix)
 
 1.4.0 - April 18, 2016
 ----------------------

--- a/st2common/st2common/services/triggers.py
+++ b/st2common/st2common/services/triggers.py
@@ -13,7 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import six
+
 from st2common import log as logging
+from st2common.constants.triggers import CRON_TIMER_TRIGGER_REF
 from st2common.exceptions.sensors import TriggerTypeRegistrationException
 from st2common.exceptions.triggers import TriggerDoesNotExistException
 from st2common.exceptions.db import StackStormDBObjectNotFoundError
@@ -45,6 +48,27 @@ def get_trigger_db_given_type_and_params(type=None, parameters=None):
                                     parameters=parameters)
 
         trigger_db = trigger_dbs[0] if len(trigger_dbs) > 0 else None
+
+        # Work around for cron-timer when in some scenarios finding an object fails when Python
+        # value types are unicode :/
+        if not trigger_db and six.PY2 and type == CRON_TIMER_TRIGGER_REF and parameters:
+            non_unicode_literal_parameters = {}
+            for key, value in six.iteritems(parameters):
+                key = key.encode('utf-8')
+                value = value.encode('utf-8')
+                non_unicode_literal_parameters[key] = value
+            parameters = non_unicode_literal_parameters
+
+            trigger_dbs = Trigger.query(type=type,
+                                        parameters=non_unicode_literal_parameters).no_cache()
+
+            # Note: We need to directly access the object, using len or accessing the query set
+            # twice won't work - there seems to bug a bug with cursor where accessing it twice
+            # will throw an exception
+            try:
+                trigger_db = trigger_dbs[0]
+            except IndexError:
+                trigger_db = None
 
         if not parameters and not trigger_db:
             # We need to do double query because some TriggeDB objects without

--- a/st2common/st2common/services/triggers.py
+++ b/st2common/st2common/services/triggers.py
@@ -49,13 +49,22 @@ def get_trigger_db_given_type_and_params(type=None, parameters=None):
 
         trigger_db = trigger_dbs[0] if len(trigger_dbs) > 0 else None
 
+        # NOTE: This is a work-around which we might be able to remove once we upgrade 
+        # pymongo and mongoengine
         # Work around for cron-timer when in some scenarios finding an object fails when Python
         # value types are unicode :/
-        if not trigger_db and six.PY2 and type == CRON_TIMER_TRIGGER_REF and parameters:
+        is_cron_trigger = (type == CRON_TIMER_TRIGGER_REF)
+        has_parameters = bool(parameters)
+
+        if not trigger_db and six.PY2 and is_cron_trigger and has_parameters:
             non_unicode_literal_parameters = {}
             for key, value in six.iteritems(parameters):
                 key = key.encode('utf-8')
-                value = value.encode('utf-8')
+
+                if isinstance(value, six.text_type):
+                    # We only encode unicode to str
+                    value = value.encode('utf-8')
+
                 non_unicode_literal_parameters[key] = value
             parameters = non_unicode_literal_parameters
 

--- a/st2common/st2common/services/triggers.py
+++ b/st2common/st2common/services/triggers.py
@@ -49,7 +49,7 @@ def get_trigger_db_given_type_and_params(type=None, parameters=None):
 
         trigger_db = trigger_dbs[0] if len(trigger_dbs) > 0 else None
 
-        # NOTE: This is a work-around which we might be able to remove once we upgrade 
+        # NOTE: This is a work-around which we might be able to remove once we upgrade
         # pymongo and mongoengine
         # Work around for cron-timer when in some scenarios finding an object fails when Python
         # value types are unicode :/


### PR DESCRIPTION
This is a terrible work-around for bug reported in #2730.

As described in that bug report, sometimes rule creation fails because finding a corresponding TriggerDB object by trigger parameters fails. I managed to track it down to an issue when unicode-literals are used for Python values (it's easy to reproduce it, check the bug report and insert debugger when trigger look up fails - if you try to look it up when parameters contain unicode literals it fails, but if you encode it to string literals it passes).

The most bizarre thing is that this doesn't happen always - sometimes dictionary can contain all unicod e literals and it works just fine - I have no idea why, but it looks like a weird bug with unicode literals and internal query cache handling in pymongo / mongoengine.

Yes, I know the work-around is terrible and I hate it, but I couldn't come up with a nicer solution. At least I tried to scope it down so we only re-run the query if trigger is not found and we are trying to find a cron trigger with parameters.