### PR TITLE
Bump timeout to 120 for reload in packs.install

### DIFF
--- a/contrib/packs/actions/workflows/install.yaml
+++ b/contrib/packs/actions/workflows/install.yaml
@@ -27,6 +27,7 @@
       ref: "packs.load"
       parameters:
         register: "{{register}}"
+        timeout: 120
       on-success: "restart-sensor-container"
     -
       name: "restart-sensor-container"


### PR DESCRIPTION
The VDX pack takes roughly 80 seconds to load with 4000 actions.  Bumping this up to accommodate larger packs.