### PR TITLE
Support --register-fail-on-failure in st2ctl

### DIFF
--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -33,6 +33,7 @@ function print_usage() {
     echo "  --register-policies           Register all policies."
     echo "  --register-configs            Register all configuration files."
     echo "  --register-setup-virtualenvs  Create Python virtual environments for all the registered packs."
+    echo "  --register-fail-on-failure    Exit with non-zero if resource registration fails."
     echo "  --verbose                     Output additional debug and informational messages."
     echo ""
     echo "Most commands require elevated privileges."
@@ -112,7 +113,7 @@ function reopen_component_log_files() {
 }
 
 function register_content() {
-  ALLOWED_REGISTER_FLAGS='--register-all --register-actions --register-aliases --register-policies --register-rules --register-sensors --register-configs --register-setup-virtualenvs --verbose'
+  ALLOWED_REGISTER_FLAGS='--register-all --register-actions --register-aliases --register-policies --register-rules --register-sensors --register-configs --register-setup-virtualenvs --register-fail-on-failure --verbose'
   DEFAULT_REGISTER_FLAGS='--register-actions --register-aliases --register-sensors --register-configs'
   flags="${@}"
 

--- a/tools/st2ctl
+++ b/tools/st2ctl
@@ -58,6 +58,7 @@ function print_usage() {
     echo "  --register-policies           Register all policies."
     echo "  --register-configs            Register all configuration files."
     echo "  --register-setup-virtualenvs  Create Python virtual environments for all the registered packs."
+    echo "  --register-fail-on-failure    Exit with non-zero if resource registration fails."
     echo "  --verbose                     Output additional debug and informational messages."
     echo ""
 }
@@ -100,7 +101,7 @@ fi
 
 # Note: Scripts already call reload with "--register-<content>"
 if [ ${1} == "reload" -o ${1} == "clean" ]; then
-    ALLOWED_REGISTER_FLAGS=(--register-all --register-actions --register-aliases --register-policies --register-rules --register-sensors --register-setup-virtualenvs --verbose)
+    ALLOWED_REGISTER_FLAGS=(--register-all --register-actions --register-aliases --register-policies --register-rules --register-sensors --register-setup-virtualenvs --register-fail-on-failure --verbose)
     DEFAULT_REGISTER_FLAGS='--register-actions --register-aliases --register-sensors --register-configs'
 
     if [ ! -z ${2} ]; then


### PR DESCRIPTION
The `--register-fail-on-failure` option that I [learned about yesterday|https://stackstorm-community.slack.com/archives/community/p1465382685000395] is pretty useful. We should expose this option through `st2ctl reload`.

Our content management story currently deploys packs with ansible and triggers `st2ctl reload --register-all` (and in some playbooks `--register-setup-virtualenvs` as well). So right now it fails silently if the content can't be loaded. Would be nice if we could just pass this flag through directly so it returns the error to ansible to display. 

Or you can say, no, just use the `st2-register-content` script directly for more flags. That's fine too. :)