### PR TITLE
Fix "-a all" flag for "st2 execution list" command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -58,6 +58,7 @@ in development
   under some circumstances. (workaround, bug-fix)
 * Store action execution state transitions (event log) in the ``log`` attribute on the
   ActionExecution object. (new feature)
+* Make sure ``-a all`` / ``--attr=all`` flag works for ``execution list`` command (bug-fix)
 
 1.4.0 - April 18, 2016
 ----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -58,7 +58,7 @@ in development
   under some circumstances. (workaround, bug-fix)
 * Store action execution state transitions (event log) in the ``log`` attribute on the
   ActionExecution object. (new feature)
-* Make sure ``-a all`` / ``--attr=all`` flag works for ``execution list`` command (bug-fix)
+* Make sure ``-a all`` / ``--attr=all`` flag works for ``st2 execution list`` command (bug-fix)
 
 1.4.0 - April 18, 2016
 ----------------------

--- a/st2client/st2client/formatters/table.py
+++ b/st2client/st2client/formatters/table.py
@@ -100,8 +100,13 @@ class MultiColumnTable(formatters.Formatter):
 
         if not attributes or 'all' in attributes:
             entries = list(entries) if entries else []
-            attributes = sorted([attr for attr in entries[0].__dict__
-                                 if not attr.startswith('_')])
+
+            if len(entries) >= 1:
+                attributes = entries[0].__dict__.keys()
+                attributes = sorted([attr for attr in attributes if not attr.startswith('_')])
+            else:
+                # There are no entries so we can't infer available attributes
+                attributes = []
 
         # Determine table format.
         if len(attributes) == len(widths):

--- a/st2client/st2client/formatters/table.py
+++ b/st2client/st2client/formatters/table.py
@@ -99,6 +99,7 @@ class MultiColumnTable(formatters.Formatter):
                 widths.append(current_col_width)
 
         if not attributes or 'all' in attributes:
+            entries = list(entries) if entries else []
             attributes = sorted([attr for attr in entries[0].__dict__
                                  if not attr.startswith('_')])
 

--- a/st2client/tests/unit/test_shell.py
+++ b/st2client/tests/unit/test_shell.py
@@ -150,6 +150,8 @@ class TestShell(base.BaseCLITestCase):
     def test_action_execution(self):
         args_list = [
             ['execution', 'list'],
+            ['execution', 'list', '-a', 'all'],
+            ['execution', 'list', '--attr=all'],
             ['execution', 'get', '123'],
             ['execution', 'get', '123', '-d'],
             ['execution', 'get', '123', '-k', 'localhost.stdout'],


### PR DESCRIPTION
This pull request fixes bug described in #2740.