### PR TITLE
fix bastion ssh support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -64,6 +64,8 @@ in development
   functionality (file upload, directory upload, etc.) is not used. (improvement)
   Reported by  Cody A. Ray
 * API and CLI allow rules to be filtered by their enable state. (improvement)
+* Fix SSH bastion host support by ensuring the bastion parameter is passed to the paramiko ssh
+  client. (bug-fix) #2543 [Adam Mielke]
 
 1.4.0 - April 18, 2016
 ----------------------

--- a/st2actions/st2actions/runners/ssh/parallel_ssh.py
+++ b/st2actions/st2actions/runners/ssh/parallel_ssh.py
@@ -233,6 +233,7 @@ class ParallelSSHClient(object):
 
         client = ParamikoSSHClient(hostname, username=self._ssh_user,
                                    password=self._ssh_password,
+                                   bastion_host=self._bastion_host,
                                    key_files=self._ssh_key_file,
                                    key_material=self._ssh_key_material,
                                    passphrase=self._passphrase,

--- a/st2actions/tests/unit/test_parallel_ssh.py
+++ b/st2actions/tests/unit/test_parallel_ssh.py
@@ -93,6 +93,20 @@ class ParallelSSHTests(unittest2.TestCase):
             client._hosts_client[hostname].client.connect.assert_called_once_with(**expected_conn)
 
     @patch('paramiko.SSHClient', Mock)
+    def test_connect_with_bastion(self):
+        hosts = ['localhost', '127.0.0.1']
+        client = ParallelSSHClient(hosts=hosts,
+                                   user='ubuntu',
+                                   pkey_file='~/.ssh/id_rsa',
+                                   bastion_host='testing_bastion_host',
+                                   connect=False)
+        client.connect()
+
+        for host in hosts:
+            hostname, _ = client._get_host_port_info(host)
+            self.assertEqual(client._hosts_client[hostname].bastion_host, 'testing_bastion_host')
+
+    @patch('paramiko.SSHClient', Mock)
     @patch.object(ParamikoSSHClient, 'run', MagicMock(return_value=('/home/ubuntu', '', 0)))
     def test_run_command(self):
         hosts = ['localhost', '127.0.0.1', 'st2build001']


### PR DESCRIPTION
Bastion support is currently broken because the bastion_host parameter isn't being used when creating a ParamikoSSHClient.

Fixes https://github.com/StackStorm/st2/issues/2543.