### PR TITLE
Use mask_secrets properly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -64,6 +64,8 @@ in development
   functionality (file upload, directory upload, etc.) is not used. (improvement)
   Reported by  Cody A. Ray
 * API and CLI allow rules to be filtered by their enable state. (improvement)
+* Admins will now be able pass ``--show_secrets`` when listing apikeys to get the ``key_hash``
+  un-masked on the CLI. (new-feature)
 
 1.4.0 - April 18, 2016
 ----------------------

--- a/conf/st2.dev.conf
+++ b/conf/st2.dev.conf
@@ -5,7 +5,7 @@
 host = 0.0.0.0
 port = 9101
 logging = st2api/conf/logging.conf
-mask_secrets = False
+mask_secrets = True
 # allow_origin is required for handling CORS in st2 web UI.
 # allow_origin = http://myhost1.example.com:3000,http://myhost2.example.com:3000
 # Development vagrant VM is setup to run on 172.168.50.50.
@@ -69,7 +69,7 @@ protocol = udp
 [log]
 excludes = requests,paramiko
 redirect_stderr = False
-mask_secrets = False
+mask_secrets = True
 
 [system_user]
 user = stanley

--- a/st2api/st2api/controllers/base.py
+++ b/st2api/st2api/controllers/base.py
@@ -22,7 +22,8 @@ from st2api.controllers.controller_transforms import transform_to_bool
 from st2common.rbac.utils import request_user_is_admin
 
 __all__ = [
-    'BaseRestControllerMixin'
+    'BaseRestControllerMixin',
+    'SHOW_SECRETS_QUERY_PARAM'
 ]
 
 

--- a/st2api/st2api/controllers/base.py
+++ b/st2api/st2api/controllers/base.py
@@ -24,6 +24,9 @@ __all__ = [
 ]
 
 
+SHOW_SECRETS_QUERY_PARAM = 'show_secrets'
+
+
 class BaseRestControllerMixin(RestController):
     """
     Base REST controller class which contains various utility functions.
@@ -64,3 +67,25 @@ class BaseRestControllerMixin(RestController):
             value = transform_to_bool(value)
 
         return value
+
+    def _get_mask_secrets(self, request):
+        """
+        Return a value for mask_secrets which can be used in masking secret properties
+        to be retruned by any API. The default value is as per the config however admin
+        users have the ability to override by passing in a special query parameter
+        show_secrets.
+
+        :param request: Request object.
+
+        :rtype: ``bool``
+        """
+        mask_secrets = cfg.CONF.api.mask_secrets
+        show_secrets_param = self._get_query_param_value(request=request,
+                                                   param_name=SHOW_SECRETS_QUERY_PARAM,
+                                                   param_type='bool',
+                                                   default_value=False)
+
+        if show_secrets and request_user_is_admin(request=request):
+            mask_secrets = False
+
+        return mask_secrets

--- a/st2api/st2api/controllers/base.py
+++ b/st2api/st2api/controllers/base.py
@@ -15,6 +15,7 @@
 
 import six
 from pecan.rest import RestController
+from oslo_config import cfg
 from six.moves.urllib import parse as urlparse  # pylint: disable=import-error
 
 from st2api.controllers.controller_transforms import transform_to_bool

--- a/st2api/st2api/controllers/base.py
+++ b/st2api/st2api/controllers/base.py
@@ -19,6 +19,7 @@ from oslo_config import cfg
 from six.moves.urllib import parse as urlparse  # pylint: disable=import-error
 
 from st2api.controllers.controller_transforms import transform_to_bool
+from st2common.rbac.utils import request_user_is_admin
 
 __all__ = [
     'BaseRestControllerMixin'

--- a/st2api/st2api/controllers/base.py
+++ b/st2api/st2api/controllers/base.py
@@ -74,14 +74,14 @@ class BaseRestControllerMixin(RestController):
         Return a value for mask_secrets which can be used in masking secret properties
         to be retruned by any API. The default value is as per the config however admin
         users have the ability to override by passing in a special query parameter
-        show_secrets.
+        ?show_secrets=True.
 
         :param request: Request object.
 
         :rtype: ``bool``
         """
         mask_secrets = cfg.CONF.api.mask_secrets
-        show_secrets_param = self._get_query_param_value(request=request,
+        show_secrets = self._get_query_param_value(request=request,
                                                    param_name=SHOW_SECRETS_QUERY_PARAM,
                                                    param_type='bool',
                                                    default_value=False)

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -20,7 +20,6 @@ import sys
 import traceback
 
 import jsonschema
-from oslo_config import cfg
 import pecan
 from pecan import abort
 from six.moves import http_client
@@ -44,7 +43,6 @@ from st2common.persistence.execution import ActionExecution
 from st2common.services import action as action_service
 from st2common.services import executions as execution_service
 from st2common.services import trace as trace_service
-from st2common.rbac.utils import request_user_is_admin
 from st2common.util import jsonify
 from st2common.util import isotime
 from st2common.util import action_db as action_utils

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -69,10 +69,6 @@ SUPPORTED_EXECUTIONS_FILTERS.update({
     'timestamp_lt': 'start_timestamp.lt'
 })
 
-# Name of the query parameter for toggling on the display of secrets to the admin users in the API
-# responses
-SHOW_SECRETS_QUERY_PARAM = 'show_secrets'
-
 MONITOR_THREAD_EMPTY_Q_SLEEP_TIME = 5
 MONITOR_THREAD_NO_WORKERS_SLEEP_TIME = 1
 

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -95,17 +95,7 @@ class ActionExecutionsControllerMixin(BaseRestControllerMixin):
         """
         Set mask_secrets=False if the user is an admin and provided ?show_secrets=True query param.
         """
-        from_model_kwargs = {'mask_secrets': cfg.CONF.api.mask_secrets}
-
-        show_secrets = self._get_query_param_value(request=request,
-                                                   param_name=SHOW_SECRETS_QUERY_PARAM,
-                                                   param_type='bool',
-                                                   default_value=False)
-
-        if show_secrets and request_user_is_admin(request=request):
-            from_model_kwargs['mask_secrets'] = False
-
-        return from_model_kwargs
+        return {'mask_secrets': self._get_mask_secrets(request)}
 
     def _handle_schedule_execution(self, liveaction_api):
         """

--- a/st2api/st2api/controllers/v1/auth.py
+++ b/st2api/st2api/controllers/v1/auth.py
@@ -77,7 +77,8 @@ class ApiKeyController(RestController):
             abort(http_client.NOT_FOUND, msg)
 
         try:
-            return ApiKeyAPI.from_model(api_key_db, mask_secrets=cfg.CONF.api.mask_secrets)
+            mask_secrets = self._get_mask_secrets(pecan.request)
+            return ApiKeyAPI.from_model(api_key_db, mask_secrets=mask_secrets)
         except (ValidationError, ValueError) as e:
             LOG.exception('Failed to serialize API key.')
             abort(http_client.INTERNAL_SERVER_ERROR, str(e))
@@ -91,9 +92,9 @@ class ApiKeyController(RestController):
             Handles requests:
                 GET /keys/
         """
-
+        mask_secrets = self._get_mask_secrets(pecan.request)
         api_key_dbs = ApiKey.get_all(**kw)
-        api_keys = [ApiKeyAPI.from_model(api_key_db, mask_secrets=cfg.CONF.api.mask_secrets)
+        api_keys = [ApiKeyAPI.from_model(api_key_db, mask_secrets=mask_secrets)
                     for api_key_db in api_key_dbs]
 
         return api_keys

--- a/st2api/st2api/controllers/v1/auth.py
+++ b/st2api/st2api/controllers/v1/auth.py
@@ -18,9 +18,9 @@ import six
 
 from oslo_config import cfg
 from pecan import abort
-from pecan.rest import RestController
 from mongoengine import ValidationError
 
+from st2api.controllers.base import BaseRestControllerMixin
 from st2common import log as logging
 from st2common.models.api.auth import ApiKeyAPI, ApiKeyCreateResponseAPI
 from st2common.models.api.base import jsexpose
@@ -42,7 +42,7 @@ __all__ = [
 ]
 
 
-class ApiKeyController(RestController):
+class ApiKeyController(BaseRestControllerMixin):
     """
     Implements the REST endpoint for managing the key value store.
     """

--- a/st2api/st2api/controllers/v1/auth.py
+++ b/st2api/st2api/controllers/v1/auth.py
@@ -77,7 +77,7 @@ class ApiKeyController(RestController):
             abort(http_client.NOT_FOUND, msg)
 
         try:
-            return ApiKeyAPI.from_model(api_key_db, mask_secrets=True)
+            return ApiKeyAPI.from_model(api_key_db, mask_secrets=cfg.CONF.api.mask_secrets)
         except (ValidationError, ValueError) as e:
             LOG.exception('Failed to serialize API key.')
             abort(http_client.INTERNAL_SERVER_ERROR, str(e))
@@ -93,7 +93,7 @@ class ApiKeyController(RestController):
         """
 
         api_key_dbs = ApiKey.get_all(**kw)
-        api_keys = [ApiKeyAPI.from_model(api_key_db, mask_secrets=True)
+        api_keys = [ApiKeyAPI.from_model(api_key_db, mask_secrets=cfg.CONF.api.mask_secrets)
                     for api_key_db in api_key_dbs]
 
         return api_keys

--- a/st2api/tests/unit/controllers/v1/test_auth_api_keys.py
+++ b/st2api/tests/unit/controllers/v1/test_auth_api_keys.py
@@ -19,6 +19,8 @@ import random
 import string
 import unittest
 
+from oslo_config import cfg
+
 from st2common.constants.secrets import MASKED_ATTRIBUTE_VALUE
 from st2common.models.db.auth import UserDB
 from st2common.persistence.auth import ApiKey
@@ -54,6 +56,10 @@ class TestApiKeyController(FunctionalTest):
     @classmethod
     def setUpClass(cls):
         super(TestApiKeyController, cls).setUpClass()
+
+        cfg.CONF.set_override(name='mask_secrets', override=True, group='api')
+        cfg.CONF.set_override(name='mask_secrets', override=True, group='log')
+
         models = FixturesLoader().save_fixtures_to_db(fixtures_pack=FIXTURES_PACK,
                                                       fixtures_dict=TEST_MODELS)
         cls.apikey1 = models['apikeys']['apikey1.yaml']
@@ -101,6 +107,14 @@ class TestApiKeyController(FunctionalTest):
                          'Incorrect api key retrieved.')
         self.assertEqual(resp.json['key_hash'], MASKED_ATTRIBUTE_VALUE,
                          'Key should be masked.')
+
+    def test_get_show_secrets(self):
+
+        resp = self.app.get('/v1/apikeys/?show_secrets=True')
+        self.assertEqual(resp.status_int, 200)
+        for key in resp.json:
+            self.assertNotEqual(key['key_hash'], MASKED_ATTRIBUTE_VALUE)
+            self.assertNotEqual(key['uid'], MASKED_ATTRIBUTE_VALUE)
 
     def test_post_delete_key(self):
         api_key = {

--- a/st2client/st2client/commands/auth.py
+++ b/st2client/st2client/commands/auth.py
@@ -100,12 +100,20 @@ class ApiKeyListCommand(resource.ResourceListCommand):
                                  help='Only return ApiKeys belonging to the provided user')
         self.parser.add_argument('-d', '--detail', action='store_true',
                                  help='Full list of attributes.')
+        self.parser.add_argument('--show-secrets', action='store_true',
+                                 help='Full list of attributes.')
 
     @resource.add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
         filters = {}
         filters['user'] = args.user
         filters.update(**kwargs)
+        # show_secrets is not a filter but a query param. There is some special
+        # handling for filters in the get method which reuqires this odd hack.
+        if args.show_secrets:
+            params = filters.get('params', {})
+            params['show_secrets'] = True
+            filters['params'] = params
         return self.manager.get_all(**filters)
 
     def run_and_print(self, args, **kwargs):


### PR DESCRIPTION
* Use the mask_secrets property from API config
* Provide API support for admin to override masking

Note : `--show-secrets` is not supported for `st2 apikey get`. This feature is meant to enable token export.

### CLI

With and without `--show-secrets`

```
(virtualenv)vagrant@st2dev:~/st2$ st2 apikey list -dy
-   created_at: '2016-06-17T00:08:05.555610Z'
    enabled: true
    id: 57633f65d9d7ed1fc39c019e
    key_hash: '********'
    metadata: {}
    uid: '********'
    user: stanley

(virtualenv)vagrant@st2dev:~/st2$ st2 apikey list -dy --show-secrets
-   created_at: '2016-06-17T00:08:05.555610Z'
    enabled: true
    id: 57633f65d9d7ed1fc39c019e
    key_hash: f157ebc6ae10f87af9205b31e9492d156fbd036b12686d97c69536b04d8c05327d80fc467ffc7de6f0f518b86e860a8d06aff289ed81a66bdcb160b8f23a1add
    metadata: {}
    uid: api_key:f157ebc6ae10f87af9205b31e9492d156fbd036b12686d97c69536b04d8c05327d80fc467ffc7de6f0f518b86e860a8d06aff289ed81a66bdcb160b8f23a1add
    user: stanley
```

### Todo
- [x] cli updates
- [x] tests
- [x] docs (https://github.com/StackStorm/st2docs/pull/186)