### PR TITLE
Clear error message when passphrase not supplied with encrypted private key

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -66,6 +66,8 @@ in development
 * API and CLI allow rules to be filtered by their enable state. (improvement)
 * Fix SSH bastion host support by ensuring the bastion parameter is passed to the paramiko ssh
   client. (bug-fix) #2543 [Adam Mielke]
+* Send out a clear error message when SSH private key is passphrase protected but user fails to
+  supply passphrase with private_key when running a remote SSH action. (improvement)
 
 1.4.0 - April 18, 2016
 ----------------------

--- a/st2actions/st2actions/runners/ssh/parallel_ssh.py
+++ b/st2actions/st2actions/runners/ssh/parallel_ssh.py
@@ -245,7 +245,6 @@ class ParallelSSHClient(object):
             LOG.exception(error)
             if raise_on_any_error:
                 raise
-            error = ' '.join([self.CONNECT_ERROR, str(ex)])
             error_dict = self._generate_error_result(exc=ex, message=error)
             self._bad_hosts[hostname] = error_dict
             results[hostname] = error_dict

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh.py
@@ -554,6 +554,13 @@ class ParamikoSSHClient(object):
         if self.key_files:
             conninfo['key_filename'] = self.key_files
 
+            try:
+                paramiko.RSAKey.from_private_key_file(self.key_files)
+            except paramiko.ssh_exception.PasswordRequiredException:
+                msg = ('Private key file %s is passphrase protected. Supply a passphrase!' %
+                       self.key_files)
+                raise Exception(msg)
+
             if self.passphrase:
                 # Optional passphrase for unlocking the private key
                 conninfo['password'] = self.passphrase

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh.py
@@ -554,13 +554,11 @@ class ParamikoSSHClient(object):
         if self.key_files:
             conninfo['key_filename'] = self.key_files
 
-            try:
-                paramiko.RSAKey.from_private_key_file(self.key_files)
-            except paramiko.ssh_exception.PasswordRequiredException:
+            passphrase_reqd = self._is_key_file_needs_passphrase(self.key_files)
+            if passphrase_reqd and not self.passphrase:
                 msg = ('Private key file %s is passphrase protected. Supply a passphrase.' %
                        self.key_files)
-                self.logger.exception(msg)
-                raise Exception(msg)
+                raise paramiko.ssh_exception.PasswordRequiredException(msg)
 
             if self.passphrase:
                 # Optional passphrase for unlocking the private key
@@ -586,6 +584,18 @@ class ParamikoSSHClient(object):
         client.connect(**conninfo)
 
         return client
+
+    @staticmethod
+    def _is_key_file_needs_passphrase(file):
+        for cls in [paramiko.RSAKey, paramiko.DSSKey, paramiko.ECDSAKey]:
+            try:
+                cls.from_private_key_file(file, password=None)
+            except paramiko.ssh_exception.PasswordRequiredException:
+                return True
+            except paramiko.ssh_exception.SSHException:
+                continue
+
+        return False
 
     def __repr__(self):
         return ('<ParamikoSSHClient hostname=%s,port=%s,username=%s,id=%s>' %

--- a/st2actions/st2actions/runners/ssh/paramiko_ssh.py
+++ b/st2actions/st2actions/runners/ssh/paramiko_ssh.py
@@ -557,8 +557,9 @@ class ParamikoSSHClient(object):
             try:
                 paramiko.RSAKey.from_private_key_file(self.key_files)
             except paramiko.ssh_exception.PasswordRequiredException:
-                msg = ('Private key file %s is passphrase protected. Supply a passphrase!' %
+                msg = ('Private key file %s is passphrase protected. Supply a passphrase.' %
                        self.key_files)
+                self.logger.exception(msg)
                 raise Exception(msg)
 
             if self.passphrase:

--- a/st2actions/tests/unit/test_parallel_ssh.py
+++ b/st2actions/tests/unit/test_parallel_ssh.py
@@ -29,6 +29,8 @@ tests_config.parse_args()
 class ParallelSSHTests(unittest2.TestCase):
 
     @patch('paramiko.SSHClient', Mock)
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     def test_connect_with_password(self):
         hosts = ['localhost', '127.0.0.1']
         client = ParallelSSHClient(hosts=hosts,
@@ -49,6 +51,8 @@ class ParallelSSHTests(unittest2.TestCase):
             client._hosts_client[host].client.connect.assert_called_once_with(**expected_conn)
 
     @patch('paramiko.SSHClient', Mock)
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     def test_connect_with_random_ports(self):
         hosts = ['localhost:22', '127.0.0.1:55', 'st2build001']
         client = ParallelSSHClient(hosts=hosts,
@@ -71,6 +75,8 @@ class ParallelSSHTests(unittest2.TestCase):
             client._hosts_client[hostname].client.connect.assert_called_once_with(**expected_conn)
 
     @patch('paramiko.SSHClient', Mock)
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     def test_connect_with_key(self):
         hosts = ['localhost', '127.0.0.1', 'st2build001']
         client = ParallelSSHClient(hosts=hosts,
@@ -93,6 +99,8 @@ class ParallelSSHTests(unittest2.TestCase):
             client._hosts_client[hostname].client.connect.assert_called_once_with(**expected_conn)
 
     @patch('paramiko.SSHClient', Mock)
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     def test_connect_with_bastion(self):
         hosts = ['localhost', '127.0.0.1']
         client = ParallelSSHClient(hosts=hosts,
@@ -108,6 +116,8 @@ class ParallelSSHTests(unittest2.TestCase):
 
     @patch('paramiko.SSHClient', Mock)
     @patch.object(ParamikoSSHClient, 'run', MagicMock(return_value=('/home/ubuntu', '', 0)))
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     def test_run_command(self):
         hosts = ['localhost', '127.0.0.1', 'st2build001']
         client = ParallelSSHClient(hosts=hosts,
@@ -123,6 +133,8 @@ class ParallelSSHTests(unittest2.TestCase):
             client._hosts_client[hostname].run.assert_called_with('pwd', **expected_kwargs)
 
     @patch('paramiko.SSHClient', Mock)
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     def test_run_command_timeout(self):
         # Make sure stdout and stderr is included on timeout
         hosts = ['localhost', '127.0.0.1', 'st2build001']
@@ -149,6 +161,8 @@ class ParallelSSHTests(unittest2.TestCase):
     @patch('paramiko.SSHClient', Mock)
     @patch.object(ParamikoSSHClient, 'put', MagicMock(return_value={}))
     @patch.object(os.path, 'exists', MagicMock(return_value=True))
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     def test_put(self):
         hosts = ['localhost', '127.0.0.1', 'st2build001']
         client = ParallelSSHClient(hosts=hosts,
@@ -167,6 +181,8 @@ class ParallelSSHTests(unittest2.TestCase):
 
     @patch('paramiko.SSHClient', Mock)
     @patch.object(ParamikoSSHClient, 'delete_file', MagicMock(return_value={}))
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     def test_delete_file(self):
         hosts = ['localhost', '127.0.0.1', 'st2build001']
         client = ParallelSSHClient(hosts=hosts,
@@ -180,6 +196,8 @@ class ParallelSSHTests(unittest2.TestCase):
 
     @patch('paramiko.SSHClient', Mock)
     @patch.object(ParamikoSSHClient, 'delete_dir', MagicMock(return_value={}))
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     def test_delete_dir(self):
         hosts = ['localhost', '127.0.0.1', 'st2build001']
         client = ParallelSSHClient(hosts=hosts,
@@ -197,6 +215,8 @@ class ParallelSSHTests(unittest2.TestCase):
                                                                          **expected_kwargs)
 
     @patch('paramiko.SSHClient', Mock)
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     def test_host_port_info(self):
         client = ParallelSSHClient(hosts=['dummy'],
                                    user='ubuntu',
@@ -218,6 +238,8 @@ class ParallelSSHTests(unittest2.TestCase):
     @patch.object(ParamikoSSHClient, 'run', MagicMock(
         return_value=(json.dumps({'foo': 'bar'}), '', 0))
     )
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     def test_run_command_json_output_transformed_to_object(self):
         hosts = ['127.0.0.1']
         client = ParallelSSHClient(hosts=hosts,

--- a/st2actions/tests/unit/test_paramiko_ssh.py
+++ b/st2actions/tests/unit/test_paramiko_ssh.py
@@ -44,6 +44,8 @@ class ParamikoSSHClientTests(unittest2.TestCase):
         self.ssh_cli = ParamikoSSHClient(**conn_params)
 
     @patch('paramiko.SSHClient', Mock)
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     def test_create_with_password(self):
         conn_params = {'hostname': 'dummy.host.org',
                        'username': 'ubuntu',
@@ -61,6 +63,8 @@ class ParamikoSSHClientTests(unittest2.TestCase):
         mock.client.connect.assert_called_once_with(**expected_conn)
 
     @patch('paramiko.SSHClient', Mock)
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     def test_deprecated_key_argument(self):
         conn_params = {'hostname': 'dummy.host.org',
                        'username': 'ubuntu',
@@ -89,6 +93,8 @@ class ParamikoSSHClientTests(unittest2.TestCase):
                                 ParamikoSSHClient, **conn_params)
 
     @patch('paramiko.SSHClient', Mock)
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     def test_key_material_argument(self):
         path = os.path.join(get_resources_base_path(),
                             'ssh', 'dummy_rsa')
@@ -113,6 +119,8 @@ class ParamikoSSHClientTests(unittest2.TestCase):
         mock.client.connect.assert_called_once_with(**expected_conn)
 
     @patch('paramiko.SSHClient', Mock)
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     def test_key_material_argument_invalid_key(self):
         conn_params = {'hostname': 'dummy.host.org',
                        'username': 'ubuntu',
@@ -125,6 +133,8 @@ class ParamikoSSHClientTests(unittest2.TestCase):
                                 expected_msg, mock.connect)
 
     @patch('paramiko.SSHClient', Mock)
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=True))
     def test_passphrase_no_key_provided(self):
         conn_params = {'hostname': 'dummy.host.org',
                        'username': 'ubuntu',
@@ -135,6 +145,18 @@ class ParamikoSSHClientTests(unittest2.TestCase):
                                 **conn_params)
 
     @patch('paramiko.SSHClient', Mock)
+    def test_passphrase_not_provided_for_encrypted_key_file(self):
+        path = os.path.join(get_resources_base_path(),
+                            'ssh', 'dummy_rsa_passphrase')
+        conn_params = {'hostname': 'dummy.host.org',
+                       'username': 'ubuntu',
+                       'key_files': path}
+        mock = ParamikoSSHClient(**conn_params)
+        self.assertRaises(paramiko.ssh_exception.PasswordRequiredException, mock.connect)
+
+    @patch('paramiko.SSHClient', Mock)
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=True))
     def test_key_with_passphrase_success(self):
         path = os.path.join(get_resources_base_path(),
                             'ssh', 'dummy_rsa_passphrase')
@@ -179,6 +201,8 @@ class ParamikoSSHClientTests(unittest2.TestCase):
         mock.client.connect.assert_called_once_with(**expected_conn)
 
     @patch('paramiko.SSHClient', Mock)
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=True))
     def test_passphrase_and_no_key(self):
         conn_params = {'hostname': 'dummy.host.org',
                        'username': 'ubuntu',
@@ -189,6 +213,8 @@ class ParamikoSSHClientTests(unittest2.TestCase):
                                 ParamikoSSHClient, **conn_params)
 
     @patch('paramiko.SSHClient', Mock)
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=True))
     def test_incorrect_passphrase(self):
         path = os.path.join(get_resources_base_path(),
                             'ssh', 'dummy_rsa_passphrase')
@@ -207,6 +233,8 @@ class ParamikoSSHClientTests(unittest2.TestCase):
                                 expected_msg, mock.connect)
 
     @patch('paramiko.SSHClient', Mock)
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     def test_key_material_contains_path_not_contents(self):
         conn_params = {'hostname': 'dummy.host.org',
                        'username': 'ubuntu'}
@@ -228,6 +256,8 @@ class ParamikoSSHClientTests(unittest2.TestCase):
                                     expected_msg, mock.connect)
 
     @patch('paramiko.SSHClient', Mock)
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     def test_create_with_key(self):
         conn_params = {'hostname': 'dummy.host.org',
                        'username': 'ubuntu',
@@ -245,6 +275,8 @@ class ParamikoSSHClientTests(unittest2.TestCase):
         mock.client.connect.assert_called_once_with(**expected_conn)
 
     @patch('paramiko.SSHClient', Mock)
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     def test_create_with_key_via_bastion(self):
         conn_params = {'hostname': 'dummy.host.org',
                        'bastion_host': 'bastion.host.org',
@@ -273,6 +305,8 @@ class ParamikoSSHClientTests(unittest2.TestCase):
         mock.client.connect.assert_called_once_with(**expected_conn)
 
     @patch('paramiko.SSHClient', Mock)
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     def test_create_with_password_and_key(self):
         conn_params = {'hostname': 'dummy.host.org',
                        'username': 'ubuntu',
@@ -292,6 +326,8 @@ class ParamikoSSHClientTests(unittest2.TestCase):
         mock.client.connect.assert_called_once_with(**expected_conn)
 
     @patch('paramiko.SSHClient', Mock)
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     def test_create_without_credentials(self):
         """
         Initialize object with no credentials.
@@ -313,6 +349,8 @@ class ParamikoSSHClientTests(unittest2.TestCase):
         mock.client.connect.assert_called_once_with(**expected_conn)
 
     @patch('paramiko.SSHClient', Mock)
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     def test_create_without_credentials_use_default_key(self):
         # No credentials are provided by default stanley ssh key exists so it should use that
         cfg.CONF.set_override(name='ssh_key_file', override='stanley_rsa', group='system_user')
@@ -338,6 +376,8 @@ class ParamikoSSHClientTests(unittest2.TestCase):
                   MagicMock(return_value=StringIO('')))
     @patch.object(os.path, 'exists', MagicMock(return_value=True))
     @patch.object(os, 'stat', MagicMock(return_value=None))
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     def test_basic_usage_absolute_path(self):
         """
         Basic execution.
@@ -370,6 +410,8 @@ class ParamikoSSHClientTests(unittest2.TestCase):
         mock.close()
 
     @patch('paramiko.SSHClient', Mock)
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     def test_delete_script(self):
         """
         Provide a basic test with 'delete' action.
@@ -387,6 +429,8 @@ class ParamikoSSHClientTests(unittest2.TestCase):
         mock.close()
 
     @patch('paramiko.SSHClient', Mock)
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     @patch.object(ParamikoSSHClient, 'exists', return_value=False)
     def test_put_dir(self, *args):
         mock = self.ssh_cli
@@ -410,6 +454,8 @@ class ParamikoSSHClientTests(unittest2.TestCase):
         mock_cli.open_sftp().put.assert_has_calls(calls, any_order=True)
 
     @patch('paramiko.SSHClient', Mock)
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     def test_consume_stdout(self):
         # Test utf-8 decoding of ``stdout`` still works fine when reading CHUNK_SIZE splits a
         # multi-byte utf-8 character in the middle. We should wait to collect all bytes
@@ -431,6 +477,8 @@ class ParamikoSSHClientTests(unittest2.TestCase):
         self.assertEqual(u'\U00010348', stdout.getvalue())
 
     @patch('paramiko.SSHClient', Mock)
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     def test_consume_stderr(self):
         # Test utf-8 decoding of ``stderr`` still works fine when reading CHUNK_SIZE splits a
         # multi-byte utf-8 character in the middle. We should wait to collect all bytes
@@ -458,6 +506,8 @@ class ParamikoSSHClientTests(unittest2.TestCase):
                   MagicMock(return_value=StringIO('')))
     @patch.object(os.path, 'exists', MagicMock(return_value=True))
     @patch.object(os, 'stat', MagicMock(return_value=None))
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
     def test_sftp_connection_is_only_established_if_required(self):
         # Verify that SFTP connection is lazily established only if and when needed.
         conn_params = {'hostname': 'dummy.host.org',


### PR DESCRIPTION
## Before

```
vagrant@st2test:~$ st2 run core.remote hosts=localhost cmd=date username=vagrant private_key=/home/vagrant/.ssh/test_rsa_pp
.
id: 5763024955fc8c18adf74f00
status: failed
parameters:
  cmd: date
  hosts: localhost
  private_key: '********'
  username: vagrant
result:
  error: "Unable to connect to any one of the hosts: [u'localhost'].

 connect_errors={
  "localhost": {
    "failed": true,
    "traceback": "Traceback (most recent call last):\n  File \"/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2actions/runners/ssh/parallel_ssh.py\", line 241, in _connect\n    client.connect()\n  File \"/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2actions/runners/ssh/paramiko_ssh.py\", line 144, in connect\n    self.client = self._connect(host=self.hostname, socket=self.bastion_socket)\n  File \"/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2actions/runners/ssh/paramiko_ssh.py\", line 578, in _connect\n    client.connect(**conninfo)\n  File \"/opt/stackstorm/st2/local/lib/python2.7/site-packages/paramiko/client.py\", line 380, in connect\n    look_for_keys, gss_auth, gss_kex, gss_deleg_creds, gss_host)\n  File \"/opt/stackstorm/st2/local/lib/python2.7/site-packages/paramiko/client.py\", line 597, in _auth\n    raise saved_exception\nSSHException: not a valid EC private key file\n",
    "timeout": false,
    "succeeded": false,
    "stdout": "",
    "stderr": "",
    "error": "Cannot connect to host. not a valid EC private key file: not a valid EC private key file",
    "return_code": 255
  }
}"
  traceback: "  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2actions/container/base.py", line 89, in _do_run
    runner.pre_run()
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2actions/runners/ssh/paramiko_ssh_runner.py", line 159, in pre_run
    self._parallel_ssh_client = ParallelSSHClient(**client_kwargs)
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2actions/runners/ssh/parallel_ssh.py", line 60, in __init__
    connect_results = self.connect(raise_on_any_error=raise_on_any_error)
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2actions/runners/ssh/parallel_ssh.py", line 90, in connect
    raise NoHostsConnectedToException(msg)
"
vagrant@st2test:~$
```

## After

```
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯ st2 run core.remote hosts=localhost username=vagrant private_key=/home/vagrant/.ssh/test_rsa_pp cmd=date
.
id: 57633ad7d9d7ed1889ad2098
status: failed
parameters:
  cmd: date
  hosts: localhost
  private_key: /home/vagrant/.ssh/test_rsa_pp
  username: vagrant
result:
  error: "Unable to connect to any one of the hosts: [u'localhost'].

 connect_errors={
  "localhost": {
    "failed": true,
    "traceback": "Traceback (most recent call last):\n  File \"/mnt/src/storm/st2/st2actions/st2actions/runners/ssh/parallel_ssh.py\", line 241, in _connect\n    client.connect()\n  File \"/mnt/src/storm/st2/st2actions/st2actions/runners/ssh/paramiko_ssh.py\", line 144, in connect\n    self.client = self._connect(host=self.hostname, socket=self.bastion_socket)\n  File \"/mnt/src/storm/st2/st2actions/st2actions/runners/ssh/paramiko_ssh.py\", line 549, in _connect\n    raise Exception(msg)\nException: Private key file /home/vagrant/.ssh/test_rsa_pp is passphrase protected. Supply a passphrase!\n",
    "timeout": false,
    "succeeded": false,
    "stdout": "",
    "stderr": "",
    "error": "Failed connecting to host localhost.: Private key file /home/vagrant/.ssh/test_rsa_pp is passphrase protected. Supply a passphrase!",
    "return_code": 255
  }
}"
  traceback: "  File "/mnt/src/storm/st2/st2actions/st2actions/container/base.py", line 89, in _do_run
    runner.pre_run()
  File "/mnt/src/storm/st2/st2actions/st2actions/runners/ssh/paramiko_ssh_runner.py", line 159, in pre_run
    self._parallel_ssh_client = ParallelSSHClient(**client_kwargs)
  File "/mnt/src/storm/st2/st2actions/st2actions/runners/ssh/parallel_ssh.py", line 60, in __init__
    connect_results = self.connect(raise_on_any_error=raise_on_any_error)
  File "/mnt/src/storm/st2/st2actions/st2actions/runners/ssh/parallel_ssh.py", line 90, in connect
    raise NoHostsConnectedToException(msg)
"
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯
```