### PR TITLE
Remove RBAC migration code which is not required anymore

### DIFF
--- a/st2common/st2common/rbac/migrations.py
+++ b/st2common/st2common/rbac/migrations.py
@@ -23,14 +23,12 @@ from st2common.exceptions.db import StackStormDBObjectConflictError
 __all__ = [
     'run_all',
 
-    'insert_system_roles',
-    'delete_mistyped_role'
+    'insert_system_roles'
 ]
 
 
 def run_all():
     insert_system_roles()
-    delete_mistyped_role()
 
 
 def insert_system_roles():
@@ -47,27 +45,3 @@ def insert_system_roles():
             Role.insert(role_db, log_not_unique_error_as_debug=True)
         except (StackStormDBObjectConflictError, NotUniqueError):
             pass
-
-    delete_mistyped_role()
-
-
-def delete_mistyped_role():
-    """
-    Delete " system_admin" role which was fat fingered.
-    """
-    # Note: Space is significant here since we want to remove a bad role
-    role_name = ' system_admin'
-    assert(role_name.startswith(' '))
-
-    try:
-        role_db = Role.get_by_name(role_name)
-    except:
-        return
-
-    if not role_db:
-        return
-
-    try:
-        Role.delete(role_db)
-    except:
-        return


### PR DESCRIPTION
This code is now obsolete in v1.5 and not needed anymore.