### PR TITLE
Fix execution list

### DIFF
--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -127,7 +127,7 @@ class ResourceController(rest.RestController):
         for k, v in six.iteritems(self.supported_filters):
             filter_value = kwargs.get(k, None)
 
-            if filter_value is None:
+            if not filter_value:
                 continue
 
             value_transform_function = self.filter_transform_functions.get(k, None)

--- a/st2api/tests/unit/controllers/v1/test_executions_filters.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_filters.py
@@ -215,6 +215,19 @@ class TestActionExecutionFilters(FunctionalTest):
             retrieved += ids
         self.assertListEqual(sorted(retrieved), sorted(self.refs.keys()))
 
+    def test_ui_history_query(self):
+        # In this test we only care about making sure this exact query works. This query is used
+        # by the webui for the history page so it is special and breaking this is bad.
+        limit = 50
+        history_query = '/v1/executions?limit={}&parent=null&exclude_attributes=' \
+                        'result%2Ctrigger_instance&status=&action=&trigger_type=&rule=&' \
+                        'offset=0'.format(limit)
+        response = self.app.get(history_query)
+        self.assertEqual(response.status_int, 200)
+        self.assertIsInstance(response.json, list)
+        self.assertEqual(len(response.json), limit)
+        self.assertTrue(response.headers['X-Total-Count'] > limit)
+
     def test_datetime_range(self):
         dt_range = '2014-12-25T00:00:10Z..2014-12-25T00:00:19Z'
         response = self.app.get('/v1/executions?timestamp=%s' % dt_range)


### PR DESCRIPTION
Change of `falsy` check was causing some UI queries to break.