### PR TITLE
RFR: Render user params (jinja) in API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -74,6 +74,8 @@ in development
   When this flag is provided, all triggers contained within a pack triggers directory are
   registered, consistent with the behavior of sensors, actions, etc. This feature allows users
   to register trigger types outside the scope of the sensors. (new-feature) [Cody A. Ray]
+* Allow user scoped variables to be used in action execution run from CLI or UI.
+  For example, you can now use ``st2 run core.local date='{{user.date_cmd}}'``. (bug-fix)
 
 1.4.0 - April 18, 2016
 ----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -74,8 +74,9 @@ in development
   When this flag is provided, all triggers contained within a pack triggers directory are
   registered, consistent with the behavior of sensors, actions, etc. This feature allows users
   to register trigger types outside the scope of the sensors. (new-feature) [Cody A. Ray]
-* Allow user scoped variables to be used in action execution run from CLI or UI.
-  For example, you can now use ``st2 run core.local date='{{user.date_cmd}}'``. (bug-fix)
+* Allow user scoped variables to be used as values for parameters in action execution API call.
+  This also means you can use user scoped variables as values for parameters when you run actions
+  from CLI or UI. For example, you can now use ``st2 run core.local date='{{user.date_cmd}}'``. (bug-fix)
 
 1.4.0 - April 18, 2016
 ----------------------

--- a/st2common/st2common/util/param.py
+++ b/st2common/st2common/util/param.py
@@ -20,8 +20,10 @@ from jinja2 import meta
 from st2common import log as logging
 from st2common.constants.action import ACTION_CONTEXT_KV_PREFIX
 from st2common.constants.keyvalue import SYSTEM_SCOPE
+from st2common.constants.keyvalue import USER_SCOPE
 from st2common.exceptions.param import ParamException
 from st2common.services.keyvalues import KeyValueLookup
+from st2common.services.keyvalues import UserKeyValueLookup
 from st2common.util.casts import get_cast
 from st2common.util.compat import to_unicode
 from st2common.util import jinja as jinja_utils
@@ -75,6 +77,10 @@ def _create_graph(action_context):
     '''
     G = nx.DiGraph()
     G.add_node(SYSTEM_SCOPE, value=KeyValueLookup(scope=SYSTEM_SCOPE))
+    user = action_context.get('user', None)
+    LOG.debug('User is: %s', user)
+    if user:
+        G.add_node(USER_SCOPE, value=UserKeyValueLookup(user=user, scope=USER_SCOPE))
     G.add_node(ACTION_CONTEXT_KV_PREFIX, value=action_context)
     return G
 

--- a/st2common/tests/unit/test_param_utils.py
+++ b/st2common/tests/unit/test_param_utils.py
@@ -119,7 +119,7 @@ class ParamsUtilsTest(DbTestCase):
         self.assertEqual(action_params.get('actionstr'), 'foo')
         self.assertEqual(action_params.get('actionnumber'), 1.0)
 
-    def test_get_finalized_parsms_user_values(self):
+    def test_get_finalized_params_user_values(self):
         KeyValuePair.add_or_update(KeyValuePairDB(name='stanley:foo', value='kabaali',
                                                   scope='user'))
         params = {

--- a/st2common/tests/unit/test_param_utils.py
+++ b/st2common/tests/unit/test_param_utils.py
@@ -32,7 +32,11 @@ from st2tests.fixturesloader import FixturesLoader
 FIXTURES_PACK = 'generic'
 
 TEST_MODELS = {
-    'actions': ['action_4_action_context_param.yaml', 'action_system_default.yaml'],
+    'actions': [
+        'action_4_action_context_param.yaml',
+        'action_system_default.yaml',
+        'action_user_default.yaml'
+    ],
     'runners': ['testrunner1.yaml']
 }
 
@@ -44,6 +48,7 @@ FIXTURES = FixturesLoader().load_models(fixtures_pack=FIXTURES_PACK,
 class ParamsUtilsTest(DbTestCase):
     action_db = FIXTURES['actions']['action_4_action_context_param.yaml']
     action_system_default_db = FIXTURES['actions']['action_system_default.yaml']
+    action_user_default_db = FIXTURES['actions']['action_user_default.yaml']
     runnertype_db = FIXTURES['runners']['testrunner1.yaml']
 
     def test_get_finalized_params(self):
@@ -113,6 +118,23 @@ class ParamsUtilsTest(DbTestCase):
         # Asserts for action params.
         self.assertEqual(action_params.get('actionstr'), 'foo')
         self.assertEqual(action_params.get('actionnumber'), 1.0)
+
+    def test_get_finalized_parsms_user_values(self):
+        KeyValuePair.add_or_update(KeyValuePairDB(name='stanley:foo', value='kabaali',
+                                                  scope='user'))
+        params = {
+            'runnerint': 555
+        }
+        liveaction_db = self._get_liveaction_model(params)
+        liveaction_db.context['user'] = 'stanley'
+
+        runner_params, action_params = param_utils.get_finalized_params(
+            ParamsUtilsTest.runnertype_db.runner_parameters,
+            ParamsUtilsTest.action_user_default_db.parameters,
+            liveaction_db.parameters,
+            liveaction_db.context)
+
+        self.assertEqual(action_params.get('actionstr'), 'kabaali')
 
     def test_get_finalized_params_action_immutable(self):
         params = {

--- a/st2tests/st2tests/fixtures/generic/actions/action_user_default.yaml
+++ b/st2tests/st2tests/fixtures/generic/actions/action_user_default.yaml
@@ -1,0 +1,11 @@
+---
+description: Awesome action-1
+enabled: true
+entry_point: ''
+name: action_user_default
+pack: wolfpack
+parameters:
+  actionstr:
+    default: '{{user.foo}}'
+    type: string
+runner_type: test-runner-1


### PR DESCRIPTION
For background, see https://stackstorm.atlassian.net/browse/STORM-2195

## Before
```
root@st2test:/home/vagrant# st2 run core.local cmd="user.date_cmd"
ERROR: 400 Client Error: Bad Request
MESSAGE: Dependecy unsatisfied in user for url: http://127.0.0.1:9101/v1/executions
root@st2test:/home/vagrant# s
```

## After

```
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯ st2 run core.local cmd="{{user.date_cmd}}"                              master ✭ ✱ ◼
.
id: 5769c625d9d7ed15e61f17eb
status: succeeded
parameters:
  cmd: '{{user.date_cmd}}'
result:
  failed: false
  return_code: 0
  stderr: ''
  stdout: Tue Jun 21 22:56:37 UTC 2016
  succeeded: true
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯
```

## TODO

* [x] tests
* [x] Changelog
* [X] Docs https://github.com/StackStorm/st2docs/pull/189