### PR TITLE
Using 'system' or 'user' reserved names as param names breaks execution

### DIFF
--- a/st2tests/st2tests/fixtures/generic/actions/action_system_default.yaml
+++ b/st2tests/st2tests/fixtures/generic/actions/action_system_default.yaml
@@ -11,4 +11,7 @@ parameters:
   actionstr:
     default: '{{system.actionstr}}'
     type: string
+  system:
+    default: 'this will break things'
+    type: string
 runner_type: test-runner-1

--- a/st2tests/st2tests/fixtures/generic/actions/action_user_default.yaml
+++ b/st2tests/st2tests/fixtures/generic/actions/action_user_default.yaml
@@ -8,4 +8,7 @@ parameters:
   actionstr:
     default: '{{user.foo}}'
     type: string
+  user:
+    default: 'unholy mess'
+    type: string
 runner_type: test-runner-1


### PR DESCRIPTION
It looks like even in 1.4, if you used a param name "system", it will blow up execution API because of our jinja resolution code. 

Now that we allow jinja expression like {{user.}} too with https://github.com/StackStorm/st2/pull/2763, 'user' becomes a reserved param name. 

Our chatops CI exposed this issue after we merged https://github.com/StackStorm/st2/pull/2763 (thanks @humblearner and @manasdk). We are using param 'user' in chatops.post_message https://github.com/StackStorm/st2/blob/master/contrib/chatops/actions/post_message.yaml#L13.

I amended the unit tests fixtures to include params 'system' and 'user' so they fail. See travis failure. 

## Solutions

1. We have to live with the fact that we want UX in terms of  {{system.}} and {{user.}} and disallow param names 'system' and 'user'. In this case, we would fix https://github.com/StackStorm/st2/blob/master/contrib/chatops/actions/post_message.yaml#L13.

2. If we want to allow those param names, we have to introduce alternate jinja expressions like {{system_kv.}} and {{user_kv.}}. This only reduces the chance of collision. 

