### PR TITLE
Changed default actionrunner syslog.conf to use ConfigurableSyslogHandler

### DIFF
--- a/st2actions/conf/syslog.conf
+++ b/st2actions/conf/syslog.conf
@@ -21,7 +21,7 @@ args=()
 class=st2common.log.FormatNamedFileHandler
 level=AUDIT
 formatter=jsonFormatter
-args=('logs/st2actionrunner.{pid}.audit.log',)
+args=()
 
 [formatter_syslogVerboseFormatter]
 format=st2actions[%(process)d]: %(levelname)s %(thread)s %(module)s [-] %(message)s

--- a/st2actions/conf/syslog.conf
+++ b/st2actions/conf/syslog.conf
@@ -5,7 +5,7 @@ keys=root
 keys=syslogHandler, auditHandler
 
 [formatters]
-keys=syslogVerboseFormatter, jsonFormatter
+keys=syslogVerboseFormatter
 
 [logger_root]
 level=INFO
@@ -18,15 +18,11 @@ formatter=syslogVerboseFormatter
 args=()
 
 [handler_auditHandler]
-class=st2common.log.FormatNamedFileHandler
+class=st2common.log.ConfigurableSyslogHandler
 level=AUDIT
-formatter=jsonFormatter
+formatter=syslogVerboseFormatter
 args=()
 
 [formatter_syslogVerboseFormatter]
 format=st2actions[%(process)d]: %(levelname)s %(thread)s %(module)s [-] %(message)s
 datefmt=
-
-[formatter_jsonFormatter]
-class=pythonjsonlogger.jsonlogger.JsonFormatter
-format=%(asctime) %(thread) %(levelname) %(module) %(message)


### PR DESCRIPTION
args() for the auditHandler referred to a non-existent directory. If users change `st2.conf` to use syslog.actionrunner.conf, it breaks, and st2actionrunner won't work.