### PR TITLE
Fix st2ctl status for st2chatops

### DIFF
--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -158,6 +158,7 @@ function clean_logs() {
 function getpids() {
   echo "##### st2 components status #####"
   COMPONENTS=${COMPONENTS/mistral/mistral-server mistral-api}
+  COMPONENTS=${COMPONENTS/st2chatops/hubot}
 
   for COM in ${COMPONENTS}; do
     PID=`ps ax | grep -v grep | grep -v st2ctl | grep "${COM}" | awk '{print $1}'`


### PR DESCRIPTION
> Addresses #2779

As @LindsayHill noted, one of the fast fixes is to use `hubot` instead of `st2chatops` for pid discovery.

```
$ st2ctl status
##### st2 components status #####
st2actionrunner PID: 929
st2api PID: 843
st2api PID: 1192
st2stream PID: 846
st2stream PID: 1193
st2auth PID: 832
st2auth PID: 1191
st2garbagecollector PID: 830
st2notifier PID: 835
st2resultstracker PID: 833
st2rulesengine PID: 838
st2sensorcontainer PID: 824
hubot PID: 9907
mistral-server is not running.
mistral-api is not running.
```