### PR TITLE
Move sample improved pack config to examples pack

### DIFF
--- a/contrib/examples/actions/print_config.py
+++ b/contrib/examples/actions/print_config.py
@@ -1,0 +1,10 @@
+from pprint import pprint
+
+from st2actions.runners.pythonrunner import Action
+
+
+class PrintConfigAction(Action):
+    def run(self):
+        print('=========')
+        pprint(self.config)
+        print('=========')

--- a/contrib/examples/actions/print_config.yaml
+++ b/contrib/examples/actions/print_config.yaml
@@ -1,0 +1,6 @@
+---
+name: print_config
+runner_type: run-python
+description: Action which prints config values.
+enabled: true
+entry_point: print_config.py

--- a/contrib/examples/config.schema.yaml
+++ b/contrib/examples/config.schema.yaml
@@ -1,0 +1,20 @@
+---
+  api_key:
+    description: "API key"
+    type: "string"
+    secret: true
+    required: true
+  api_secret:
+    description: "API secret"
+    type: "string"
+    secret: true
+    required: true
+  region:
+    description: "API region to use"
+    type: "string"
+    required: true
+    default: "us-east-1"
+  private_key_path:
+    description: "Path to the private key file to use"
+    type: "string"
+    required: false


### PR DESCRIPTION
As suggested by @lakshmi-kannan in the blog post draft.

This works fine for now, but in case we will add more actions in the future which utilize a different config things will start to clash so we will need to figure out a better approach (e.g. move it to a separate pack or similar).