### PR TITLE
Fix trigger registration bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 In development
 --------------
 
+* Fix trigger registration when using st2-register-content script with ``--register-triggers``
+  flag. (bug-fix)
+
 1.5.0 - June 24, 2016
 ---------------------
 

--- a/contrib/examples/triggers/sample-trigger.yaml
+++ b/contrib/examples/triggers/sample-trigger.yaml
@@ -1,5 +1,3 @@
 ---
-payload:
-  result: 10
-  work: done
-type: st2.trigger
+name: sample_trigger
+description: Sample trigger

--- a/st2common/st2common/bootstrap/triggersregistrar.py
+++ b/st2common/st2common/bootstrap/triggersregistrar.py
@@ -21,8 +21,6 @@ from st2common import log as logging
 from st2common.constants.meta import ALLOWED_EXTS
 from st2common.bootstrap.base import ResourceRegistrar
 import st2common.content.utils as content_utils
-from st2common.models.api.trigger import TriggerTypeAPI
-from st2common.persistence.trigger import TriggerType
 from st2common.models.utils import sensor_type_utils
 
 __all__ = [

--- a/st2common/st2common/bootstrap/triggersregistrar.py
+++ b/st2common/st2common/bootstrap/triggersregistrar.py
@@ -23,6 +23,7 @@ from st2common.bootstrap.base import ResourceRegistrar
 import st2common.content.utils as content_utils
 from st2common.models.api.trigger import TriggerTypeAPI
 from st2common.persistence.trigger import TriggerType
+from st2common.models.utils import sensor_type_utils
 
 __all__ = [
     'TriggersRegistrar',
@@ -135,22 +136,9 @@ class TriggersRegistrar(ResourceRegistrar):
             raise Exception('Model is in pack "%s" but field "pack" is different: %s' %
                             (pack, pack_field))
 
-        trigger_api = TriggerTypeAPI(**content)
-        trigger_model = TriggerTypeAPI.to_model(trigger_api)
-
-        trigger_types = TriggerType.query(pack=trigger_model.pack, name=trigger_model.name)
-        if len(trigger_types) >= 1:
-            trigger_type = trigger_types[0]
-            LOG.debug('Found existing trigger id:%s with name:%s. Will update it.',
-                      trigger_type.id, trigger_type.name)
-            trigger_model.id = trigger_type.id
-
-        try:
-            trigger_model = TriggerType.add_or_update(trigger_model)
-        except:
-            LOG.exception('Failed creating trigger model for %s', trigger)
-
-        return trigger_model
+        trigger_types = [content]
+        result = sensor_type_utils.create_trigger_types(trigger_types=trigger_types)
+        return result[0] if result else None
 
 
 def register_triggers(packs_base_paths=None, pack_dir=None, use_pack_cache=True,

--- a/st2common/st2common/models/utils/sensor_type_utils.py
+++ b/st2common/st2common/models/utils/sensor_type_utils.py
@@ -22,7 +22,8 @@ from st2common.services import triggers as trigger_service
 
 __all__ = [
     'to_sensor_db_model',
-    'get_sensor_entry_point'
+    'get_sensor_entry_point',
+    'create_trigger_types'
 ]
 
 
@@ -53,7 +54,7 @@ def to_sensor_db_model(sensor_api_model=None):
     # Add pack to each trigger type item
     for trigger_type in trigger_types:
         trigger_type['pack'] = pack
-    trigger_type_refs = _create_trigger_types(trigger_types)
+    trigger_type_refs = create_trigger_types(trigger_types)
 
     return _create_sensor_type(pack=pack,
                                name=class_name,
@@ -65,7 +66,7 @@ def to_sensor_db_model(sensor_api_model=None):
                                enabled=enabled)
 
 
-def _create_trigger_types(trigger_types):
+def create_trigger_types(trigger_types):
     if not trigger_types:
         return []
 

--- a/st2common/st2common/services/triggers.py
+++ b/st2common/st2common/services/triggers.py
@@ -355,7 +355,8 @@ def _validate_trigger_type(trigger_type):
     required_fields = ['name']
     for field in required_fields:
         if field not in trigger_type:
-            raise TriggerTypeRegistrationException('Invalid trigger type. Missing field %s' % field)
+            raise TriggerTypeRegistrationException('Invalid trigger type. Missing field "%s"' %
+                                                   (field))
 
 
 def _create_trigger(trigger_type):

--- a/st2common/tests/unit/test_sensor_type_utils.py
+++ b/st2common/tests/unit/test_sensor_type_utils.py
@@ -35,7 +35,7 @@ class SensorTypeUtilsTestCase(unittest2.TestCase):
         self.assertEqual(sensor_model.artifact_uri, sensor_meta['artifact_uri'])
         self.assertListEqual(sensor_model.trigger_types, [])
 
-    @mock.patch.object(sensor_type_utils, '_create_trigger_types', mock.MagicMock(
+    @mock.patch.object(sensor_type_utils, 'create_trigger_types', mock.MagicMock(
         return_value=['mock.trigger_ref']))
     def test_to_sensor_db_model_with_trigger_types(self):
         sensor_meta = {

--- a/st2common/tests/unit/test_triggers_registrar.py
+++ b/st2common/tests/unit/test_triggers_registrar.py
@@ -16,6 +16,7 @@
 import os
 
 import st2common.bootstrap.triggersregistrar as triggers_registrar
+from st2common.persistence.trigger import Trigger
 from st2common.persistence.trigger import TriggerType
 from st2tests.base import CleanDbTestCase
 from st2tests.fixturesloader import get_fixtures_base_path
@@ -34,8 +35,11 @@ class TriggersRegistrarTestCase(CleanDbTestCase):
         count = triggers_registrar.register_triggers(packs_base_paths=[packs_base_path])
         self.assertEqual(count, 3)
 
+        # Verify TriggerTypeDB and corresponding TriggerDB objects have been created
         trigger_type_dbs = TriggerType.get_all()
+        trigger_dbs = Trigger.get_all()
         self.assertEqual(len(trigger_type_dbs), 3)
+        self.assertEqual(len(trigger_dbs), 3)
 
     def test_register_triggers_from_pack(self):
         base_path = get_fixtures_base_path()
@@ -47,10 +51,17 @@ class TriggersRegistrarTestCase(CleanDbTestCase):
         count = triggers_registrar.register_triggers(pack_dir=pack_dir)
         self.assertEqual(count, 2)
 
+        # Verify TriggerTypeDB and corresponding TriggerDB objects have been created
         trigger_type_dbs = TriggerType.get_all()
+        trigger_dbs = Trigger.get_all()
         self.assertEqual(len(trigger_type_dbs), 2)
+        self.assertEqual(len(trigger_dbs), 2)
+
         self.assertEqual(trigger_type_dbs[0].name, 'event_handler')
         self.assertEqual(trigger_type_dbs[0].pack, 'dummy_pack_1')
+        self.assertEqual(trigger_dbs[0].name, 'event_handler')
+        self.assertEqual(trigger_dbs[0].pack, 'dummy_pack_1')
+        self.assertEqual(trigger_dbs[0].type, 'dummy_pack_1.event_handler')
 
         self.assertEqual(trigger_type_dbs[1].name, 'head_sha_monitor')
         self.assertEqual(trigger_type_dbs[1].pack, 'dummy_pack_1')


### PR DESCRIPTION
This was originally reported by @codyaray in https://github.com/StackStorm/st2contrib/pull/475#issuecomment-229139710 (thanks!).

There was a bug so corresponding `TriggerDB` object was not created. I updated the code to use the same code path and function which other code which creates triggers uses. I also added a regression test case.

The function we use right now is not 100% ideal since we only operate with a single trigger type in this scenario, but we have tests now so in the future we can do a small refactor to improve it.