### PR TITLE
Correctly resolve parameter's required property

### DIFF
--- a/st2common/st2common/models/utils/action_param_utils.py
+++ b/st2common/st2common/models/utils/action_param_utils.py
@@ -40,7 +40,7 @@ def _merge_param_meta_values(action_meta=None, runner_meta=None):
         elif key in runner_meta_keys and key not in action_meta_keys:
             merged_meta[key] = runner_meta[key]
         else:
-            if key in ['immutable', 'required']:
+            if key in ['immutable']:
                 merged_meta[key] = runner_meta.get(key, False) or action_meta.get(key, False)
             else:
                 merged_meta[key] = action_meta.get(key)

--- a/st2common/tests/unit/test_action_param_utils.py
+++ b/st2common/tests/unit/test_action_param_utils.py
@@ -106,6 +106,18 @@ class ActionParamsUtilsTest(DbTestCase):
         # Immutability is set in action.
         self.assertEqual(merged_meta['immutable'], action_meta['immutable'])
 
+    def test_merge_param_meta_require_override(self):
+        action_meta = {
+            'required': False
+        }
+        runner_meta = {
+            'required': True
+        }
+        merged_meta = action_param_utils._merge_param_meta_values(action_meta=action_meta,
+                                                                  runner_meta=runner_meta)
+
+        self.assertEqual(merged_meta['required'], action_meta['required'])
+
     def test_validate_action_inputs(self):
         requires, unexpected = action_param_utils.validate_action_parameters(
             self.action_dbs['action-1'].ref, {'foo': 'bar'})


### PR DESCRIPTION
Back in https://github.com/StackStorm/st2/pull/690/files#diff-950f03378fda3eb80bbc01142a430fd7R31 @m4dcoder presumably decided that if certain parameter is set as required on a runner level, it should end up being required even after we add action parameters to the mix. In reality, user can set default value for this parameter on an action level and thus lift the requirement.

Strictly speaking, parameter should never have truthy values of `require` and `default` simultaneously, but that change is more on par with linting actions during registration and therefore outside the scope of this PR.

Resolves https://github.com/StackStorm/st2web/issues/307

STORM-2201