### PR TITLE
Exclude parameters during rerun to fallback to default value

### DIFF
--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -22,6 +22,7 @@ import traceback
 import jsonschema
 import pecan
 from pecan import abort
+import six
 from six.moves import http_client
 
 from st2api.controllers.base import BaseRestControllerMixin
@@ -291,7 +292,12 @@ class ActionExecutionReRunController(ActionExecutionsControllerMixin, ResourceCo
 
         # Merge in any parameters provided by the user
         new_parameters = copy.deepcopy(getattr(existing_execution, 'parameters', {}))
-        new_parameters.update(spec.parameters)
+
+        for (name, value) in six.iteritems(spec.parameters):
+            if value is not None:
+                new_parameters[name] = value
+            else:
+                new_parameters.pop(name, None)
 
         # Create object for the new execution
         action_ref = existing_execution.action['ref']


### PR DESCRIPTION
Currently, if the initial action was executed with particular parameter, there is no way to remove this parameter during rerun. Best you can do is to replace it with default value manually.

Since it seems like in practice we don't really have another use for parameter's `null` value, I'm proposing to use it as an indicator to fallback to default value during rerun. This way, execution with parameters

```yaml
a: 'b'
c: 'd'
```

being rerun with parameters

```yaml
c: null
```

will result in a new execution with parameters

```yaml
a: 'b'
```

which would be later resolved as if it was an initial execution run (with default value of `c` potentially being resolved). In practice, this is how it works today. The change only ensures resulting execution having proper set of parameters instead of

```yaml
a: 'b'
c: null
```

UI changes are pending.

