### PR TITLE
Look up TriggerDB objects by id / uid if available

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ In development
 
 * Fix trigger registration when using st2-register-content script with ``--register-triggers``
   flag. (bug-fix)
+* Fix an issue with CronTimer sometimes not firing due to TriggerInstance creation failure.
+  (bug-fix)
+  Reported by  Cody A. Ray
 
 1.5.0 - June 24, 2016
 ---------------------

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -169,6 +169,9 @@ class MongoDBAccess(object):
     def get_by_id(self, value):
         return self.get(id=value, raise_exception=True)
 
+    def get_by_uid(self, value):
+        return self.get(uid=value, raise_exception=True)
+
     def get_by_ref(self, value):
         return self.get(ref=value, raise_exception=True)
 

--- a/st2common/st2common/persistence/base.py
+++ b/st2common/st2common/persistence/base.py
@@ -84,6 +84,10 @@ class Access(object):
         return cls._get_impl().get_by_id(value)
 
     @classmethod
+    def get_by_uid(cls, value):
+        return cls._get_impl().get_by_uid(value)
+
+    @classmethod
     def get_by_ref(cls, value):
         return cls._get_impl().get_by_ref(value)
 

--- a/st2common/st2common/services/triggers.py
+++ b/st2common/st2common/services/triggers.py
@@ -28,6 +28,8 @@ __all__ = [
     'add_trigger_models',
 
     'get_trigger_db_by_ref',
+    'get_trigger_db_by_id',
+    'get_trigger_db_by_uid',
     'get_trigger_db_given_type_and_params',
     'get_trigger_type_db',
 
@@ -90,6 +92,42 @@ def get_trigger_db_given_type_and_params(type=None, parameters=None):
         LOG.debug('Database lookup for type="%s" parameters="%s" resulted ' +
                   'in exception : %s.', type, parameters, e, exc_info=True)
         return None
+
+
+def get_trigger_db_by_id(id):
+    """
+    Returns the trigger object from db given a trigger id.
+
+    :param ref: Reference to the trigger db object.
+    :type ref: ``str``
+
+    :rtype: ``object``
+    """
+    try:
+        return Trigger.get_by_id(id)
+    except StackStormDBObjectNotFoundError as e:
+        LOG.debug('Database lookup for id="%s" resulted in exception : %s.',
+                  id, e, exc_info=True)
+
+    return None
+
+
+def get_trigger_db_by_uid(uid):
+    """
+    Returns the trigger object from db given a trigger uid.
+
+    :param ref: Reference to the trigger db object.
+    :type ref: ``str``
+
+    :rtype: ``object``
+    """
+    try:
+        return Trigger.get_by_uid(uid)
+    except StackStormDBObjectNotFoundError as e:
+        LOG.debug('Database lookup for uid="%s" resulted in exception : %s.',
+                  uid, e, exc_info=True)
+
+    return None
 
 
 def get_trigger_db_by_ref(ref):

--- a/st2reactor/st2reactor/container/utils.py
+++ b/st2reactor/st2reactor/container/utils.py
@@ -28,11 +28,11 @@ LOG = logging.getLogger('st2reactor.sensor.container_utils')
 def create_trigger_instance(trigger, payload, occurrence_time, raise_on_no_trigger=False):
     """
     This creates a trigger instance object given trigger and payload.
-    Trigger can be just a string reference (pack.name) or a ``dict``
-    containing  'type' and 'parameters'.
+    Trigger can be just a string reference (pack.name) or a ``dict`` containing 'id' or 
+    'uid' or type' and 'parameters' keys.
 
-    :param trigger: Dictionary with trigger query filters.
-    :type trigger: ``dict``
+    :param trigger: Trigger reference or dictionary with trigger query filters.
+    :type trigger: ``str`` or ``dict``
 
     :param payload: Trigger payload.
     :type payload: ``dict``

--- a/st2reactor/st2reactor/container/utils.py
+++ b/st2reactor/st2reactor/container/utils.py
@@ -49,13 +49,18 @@ def create_trigger_instance(trigger, payload, occurrence_time, raise_on_no_trigg
         # TODO: Remove parameters dictionary look up when we can confirm each trigger dictionary
         # passed to this method always contains id or uid
         if id_:
+            LOG.debug('Looking up TriggerDB by id: %s', id)
             trigger_db = TriggerService.get_trigger_db_by_id(id=id)
         elif uid:
+            LOG.debug('Looking up TriggerDB by uid: %s', uid)
             trigger_db = TriggerService.get_trigger_db_by_uid(uid=uid)
         else:
             # Last resort - look it up by parameters
             type_ = trigger.get('type', None)
             parameters = trigger.get('parameters', {})
+
+            LOG.debug('Looking up TriggerDB by type and parameters: type=%s, parameters=%s',
+                      type_, parameters)
             trigger_db = TriggerService.get_trigger_db_given_type_and_params(type=type_,
                                                                              parameters=parameters)
 

--- a/st2reactor/st2reactor/container/utils.py
+++ b/st2reactor/st2reactor/container/utils.py
@@ -28,7 +28,7 @@ LOG = logging.getLogger('st2reactor.sensor.container_utils')
 def create_trigger_instance(trigger, payload, occurrence_time, raise_on_no_trigger=False):
     """
     This creates a trigger instance object given trigger and payload.
-    Trigger can be just a string reference (pack.name) or a ``dict`` containing 'id' or 
+    Trigger can be just a string reference (pack.name) or a ``dict`` containing 'id' or
     'uid' or type' and 'parameters' keys.
 
     :param trigger: Trigger reference or dictionary with trigger query filters.
@@ -43,25 +43,25 @@ def create_trigger_instance(trigger, payload, occurrence_time, raise_on_no_trigg
     else:
         # If id / uid is available we try to look up Trigger by id. This way we can avoid bug in
         # pymongo / mongoengine related to "parameters" dictionary lookups
-        id_ = trigger.get('id', None)
-        uid = trigger.get('uid', None)
+        trigger_id = trigger.get('id', None)
+        trigger_uid = trigger.get('uid', None)
 
         # TODO: Remove parameters dictionary look up when we can confirm each trigger dictionary
         # passed to this method always contains id or uid
-        if id_:
-            LOG.debug('Looking up TriggerDB by id: %s', id)
-            trigger_db = TriggerService.get_trigger_db_by_id(id=id)
-        elif uid:
-            LOG.debug('Looking up TriggerDB by uid: %s', uid)
-            trigger_db = TriggerService.get_trigger_db_by_uid(uid=uid)
+        if trigger_id:
+            LOG.debug('Looking up TriggerDB by id: %s', trigger_id)
+            trigger_db = TriggerService.get_trigger_db_by_id(id=trigger_id)
+        elif trigger_uid:
+            LOG.debug('Looking up TriggerDB by uid: %s', trigger_uid)
+            trigger_db = TriggerService.get_trigger_db_by_uid(uid=trigger_uid)
         else:
             # Last resort - look it up by parameters
-            type_ = trigger.get('type', None)
+            trigger_type = trigger.get('type', None)
             parameters = trigger.get('parameters', {})
 
             LOG.debug('Looking up TriggerDB by type and parameters: type=%s, parameters=%s',
-                      type_, parameters)
-            trigger_db = TriggerService.get_trigger_db_given_type_and_params(type=type_,
+                      trigger_type, parameters)
+            trigger_db = TriggerService.get_trigger_db_given_type_and_params(type=trigger_type,
                                                                              parameters=parameters)
 
     if trigger_db is None:

--- a/st2reactor/tests/unit/test_container_utils.py
+++ b/st2reactor/tests/unit/test_container_utils.py
@@ -16,14 +16,63 @@
 import mock
 
 from st2common.transport.publishers import PoolPublisher
-import st2reactor.container.utils as container_utils
+from st2reactor.container.utils import create_trigger_instance
+from st2common.persistence.trigger import Trigger
+from st2common.models.db.trigger import TriggerDB
 from st2tests.base import CleanDbTestCase
 
 
 @mock.patch.object(PoolPublisher, 'publish', mock.MagicMock())
 class ContainerUtilsTest(CleanDbTestCase):
+    def setUp(self):
+        super(ContainerUtilsTest, self).setUp()
+
+        # Insert mock TriggerDB
+        trigger_db = TriggerDB(name='name1', pack='pack1', type='type1',
+                               parameters={'a': 1, 'b': '2', 'c': 'foo'})
+        self.trigger_db = Trigger.add_or_update(trigger_db)
 
     def test_create_trigger_instance_invalid_trigger(self):
         trigger_instance = 'dummy_pack.footrigger'
-        instance = container_utils.create_trigger_instance(trigger_instance, {}, None)
+        instance = create_trigger_instance(trigger=trigger_instance, payload={},
+                                           occurrence_time=None)
         self.assertTrue(instance is None)
+
+    def test_create_trigger_instance_success(self):
+        # Here we test trigger instance creation using various ways to look up corresponding
+        # TriggerDB object
+        payload = {}
+        occurrence_time = None
+
+        # TriggerDB look up by id
+        trigger = {'id': self.trigger_db.id}
+        trigger_instance_db = create_trigger_instance(trigger=trigger, payload=payload,
+                                                      occurrence_time=occurrence_time)
+        self.assertEqual(trigger_instance_db.trigger, 'pack1.name1')
+
+        # Object doesn't exist (invalid id)
+        trigger = {'id': '5776aa2b0640fd2991b15987'}
+        trigger_instance_db = create_trigger_instance(trigger=trigger, payload=payload,
+                                                      occurrence_time=occurrence_time)
+        self.assertEqual(trigger_instance_db, None)
+
+        # TriggerDB look up by uid
+        trigger = {'uid': self.trigger_db.uid}
+        trigger_instance_db = create_trigger_instance(trigger=trigger, payload=payload,
+                                                      occurrence_time=occurrence_time)
+        self.assertEqual(trigger_instance_db.trigger, 'pack1.name1')
+
+        trigger = {'uid': 'invaliduid'}
+        trigger_instance_db = create_trigger_instance(trigger=trigger, payload=payload,
+                                                      occurrence_time=occurrence_time)
+        self.assertEqual(trigger_instance_db, None)
+
+        # TriggerDB look up by type and parameters (last resort)
+        trigger = {'type': 'pack1.name1', 'parameters': self.trigger_db.parameters}
+        trigger_instance_db = create_trigger_instance(trigger=trigger, payload=payload,
+                                                      occurrence_time=occurrence_time)
+
+        trigger = {'type': 'pack1.name1', 'parameters': {}}
+        trigger_instance_db = create_trigger_instance(trigger=trigger, payload=payload,
+                                                      occurrence_time=occurrence_time)
+        self.assertEqual(trigger_instance_db, None)


### PR DESCRIPTION
With this change we now try to look up TriggerDB objects by id / uid if either of those fields is available.

This way we can avoid lookup by type and parameters dictionary which fails in some scenarios. There are at least two bugs related "by parameters dictionary" lookup. One is related to unicode caching bug in mongoengine (I've added a nasty hack / work-around for it a while back) and the other one is yet to be tracked down.

My goal also is to confirm that id / uid field is always available so we can get rid of parameters dictionary lookup all together (that's something I wanted to do more than a year ago and I believe now it's finally possible to do that without much effort).

This hopefully resolves issue described in #2765.

## TODO

- [x] Tests
- [x] Changelog entry