### PR TITLE
Add flag to prevent parameter merging during rerun

### DIFF
--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -276,7 +276,7 @@ class ActionExecutionReRunController(ActionExecutionsControllerMixin, ResourceCo
             return self
 
     @jsexpose(body_cls=ExecutionSpecificationAPI, status_code=http_client.CREATED)
-    def post(self, spec, execution_id):
+    def post(self, spec, execution_id, no_merge=None):
         """
         Re-run the provided action execution optionally specifying override parameters.
 
@@ -290,7 +290,9 @@ class ActionExecutionReRunController(ActionExecutionsControllerMixin, ResourceCo
             raise ValueError('Task option is only supported for Mistral workflows.')
 
         # Merge in any parameters provided by the user
-        new_parameters = copy.deepcopy(getattr(existing_execution, 'parameters', {}))
+        new_parameters = {}
+        if not no_merge:
+            new_parameters.update(getattr(existing_execution, 'parameters', {}))
         new_parameters.update(spec.parameters)
 
         # Create object for the new execution


### PR DESCRIPTION
That's another way of solving https://github.com/StackStorm/st2/pull/2787 that plays much better with specifics of rerun implementation in st2web.

By avoiding the merge on an api side, user is getting full control over execution parameters without introduction of any additional special types.