### PR TITLE
Support for default config values from the config schema

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,9 @@ In development
 * Fix an issue with CronTimer sometimes not firing due to TriggerInstance creation failure.
   (bug-fix)
   Reported by  Cody A. Ray
+* Add support for default values when a new pack configuration is used. Now if a default value
+  is specified for a required config item in the config schema and a value for that item is not
+  provided in the config, default value from config schema is used. (improvement)
 
 1.5.0 - June 24, 2016
 ---------------------

--- a/st2common/st2common/util/config_loader.py
+++ b/st2common/st2common/util/config_loader.py
@@ -103,6 +103,15 @@ class ContentPackConfigLoader(object):
                 # Static value, no resolution needed
                 result[config_item_key] = config_item_value
 
+        # If config_schema is available we do a second pass and set default values for required
+        # items which values are not provided / available in the config itself
+        for schema_item_key, schema_item in six.iteritems(schema_values):
+            default_value = schema_item.get('default', None)
+            is_required = schema_item.get('required', False)
+
+            if is_required and default_value and not result.get(schema_item_key, None):
+                result[schema_item_key] = default_value
+
         return result
 
     def _get_datastore_value_for_expression(self, value, config_schema_item=None):

--- a/st2common/tests/unit/test_config_loader.py
+++ b/st2common/tests/unit/test_config_loader.py
@@ -44,7 +44,6 @@ class ContentPackConfigLoaderTestCase(DbTestCase):
     def test_get_config_some_values_overriden_in_datastore(self):
         # Test a scenario where some values are overriden in datastore via pack
         # flobal config
-
         kvp_db = set_datastore_value_for_config_key(pack_name='dummy_pack_5',
                                                     key_name='api_secret',
                                                     value='some_api_secret',
@@ -71,7 +70,21 @@ class ContentPackConfigLoaderTestCase(DbTestCase):
             'api_key': 'some_api_key',
             'api_secret': 'some_api_secret',
             'regions': ['us-west-1'],
+            'region': 'default-region-value',
             'private_key_path': 'some_private_key'
         }
 
         self.assertEqual(config, expected_config)
+
+    def test_get_config_default_value_from_config_schema_is_used(self):
+        # No value is provided for "region" in the config, default value from config schema
+        # should be used
+        loader = ContentPackConfigLoader(pack_name='dummy_pack_5')
+        config = loader.get_config()
+        self.assertEqual(config['region'], 'default-region-value')
+
+        # Here a default value is specified in schema but an explicit value is provided in the
+        # config
+        loader = ContentPackConfigLoader(pack_name='dummy_pack_1')
+        config = loader.get_config()
+        self.assertEqual(config['region'], 'us-west-1')

--- a/st2tests/st2tests/fixtures/dummy_pack_1/config.schema.yaml
+++ b/st2tests/st2tests/fixtures/dummy_pack_1/config.schema.yaml
@@ -9,4 +9,5 @@
     required: true
   region:
     type: "string"
+    required: true
     default: "lon"

--- a/st2tests/st2tests/fixtures/dummy_pack_4/config.schema.yaml
+++ b/st2tests/st2tests/fixtures/dummy_pack_4/config.schema.yaml
@@ -8,9 +8,8 @@
     secret: true
     required: true
   regions:
-      type: "list"
-      required: true
-      default: "us-east-1"
+    type: "list"
+    required: true
   private_key_path:
-      type: "string"
-      required: false
+    type: "string"
+    required: false

--- a/st2tests/st2tests/fixtures/dummy_pack_5/config.schema.yaml
+++ b/st2tests/st2tests/fixtures/dummy_pack_5/config.schema.yaml
@@ -7,9 +7,13 @@
     secret: true
     required: true
   regions:
-      type: "list"
-      required: true
-      default: "us-east-1"
+    type: "list"
+    required: true
+    default: "us-east-1"
   private_key_path:
-      type: "string"
-      required: false
+    type: "string"
+    required: false
+  region:
+    type: "string"
+    required: true
+    default: "default-region-value"


### PR DESCRIPTION
This pull request adds support for default values from config schema.

This means that if a config schema declares particular config item as "required" and that item also contains a default value and that item is not provided in the config, default value from the config schema is used. This is exactly the same behavior as we use with action parameters.

This behavior is not required to be able to utilize dynamic config values using the new config notation, but it's nice and consistent with action parameters. In addition to that, as mentioned in the blog post and other places, we plan to utilize config schema for more things (type validation, etc.) in the future.

## TODO

- [x] Tests
- [x] Changelog entry