### PR TITLE
Upgrade to the latest version of pymongo and mongoengine

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ In development
 * Add support for default values when a new pack configuration is used. Now if a default value
   is specified for a required config item in the config schema and a value for that item is not
   provided in the config, default value from config schema is used. (improvement)
+* Upgrade to pymongo 3.2.2 and mongoengine 0.10.6 so StackStorm now also supports and works with
+  MongoDB 3.x. (improvement)
 
 1.5.0 - June 24, 2016
 ---------------------

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ pylint: requirements .pylint
 	# Lint Python scripts
 	. $(VIRTUALENV_DIR)/bin/activate; pylint -E --rcfile=./lint-configs/python/.pylintrc --load-plugins=pylint_plugins.api_models scripts/*.py || exit 1;
 	. $(VIRTUALENV_DIR)/bin/activate; pylint -E --rcfile=./lint-configs/python/.pylintrc --load-plugins=pylint_plugins.api_models tools/*.py || exit 1;
+	. $(VIRTUALENV_DIR)/bin/activate; pylint -E --rcfile=./lint-configs/python/.pylintrc pylint_plugins/*.py || exit 1;
 
 .PHONY: flake8
 flake8: requirements .flake8
@@ -97,6 +98,7 @@ flake8: requirements .flake8
 	. $(VIRTUALENV_DIR)/bin/activate; flake8 --config ./lint-configs/python/.flake8 contrib/chatops/
 	. $(VIRTUALENV_DIR)/bin/activate; flake8 --config ./lint-configs/python/.flake8 scripts/
 	. $(VIRTUALENV_DIR)/bin/activate; flake8 --config ./lint-configs/python/.flake8 tools/
+	. $(VIRTUALENV_DIR)/bin/activate; flake8 --config ./lint-configs/python/.flake8 pylint_plugins/
 
 .PHONY: lint
 lint: requirements .lint

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ pylint: requirements .pylint
 		echo "==========================================================="; \
 		echo "Running pylint on" $$component; \
 		echo "==========================================================="; \
-		. $(VIRTUALENV_DIR)/bin/activate; pylint -E --rcfile=./lint-configs/python/.pylintrc --load-plugins=pylint_plugins.api_models $$component/$$component || exit 1; \
+		. $(VIRTUALENV_DIR)/bin/activate; pylint -E --rcfile=./lint-configs/python/.pylintrc --load-plugins=pylint_plugins.api_models --load-plugins=pylint_plugins.db_models $$component/$$component || exit 1; \
 	done
 	# Lint Python pack management actions
 	. $(VIRTUALENV_DIR)/bin/activate; pylint -E --rcfile=./lint-configs/python/.pylintrc --load-plugins=pylint_plugins.api_models contrib/packs/actions/ || exit 1;

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -12,8 +12,8 @@ requests[security]>=2.7.0,<3.0
 apscheduler>=3.0.5,<3.1
 gitpython==0.3.2.1
 jsonschema>=2.3.0
-mongoengine>=0.8.7,<0.9
-pymongo<3.0
+mongoengine==0.10.6
+pymongo==3.2.2
 passlib>=1.6.2,<1.7
 lockfile>=0.10.2,<0.11
 python-gnupg>=0.3.7,<0.4

--- a/pylint_plugins/db_models.py
+++ b/pylint_plugins/db_models.py
@@ -1,0 +1,43 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Plugin which tells Pylint how to handle mongoengine document classes.
+"""
+
+from astroid import MANAGER
+from astroid import scoped_nodes
+
+# A list of class names for which we want to skip the checks
+CLASS_NAME_BLACKLIST = [
+]
+
+
+def register(linter):
+    pass
+
+
+def transform(cls):
+    if cls.name in CLASS_NAME_BLACKLIST:
+        return
+
+    if cls.name.endswith('DB'):
+        # mongoengine explicitly declared "id" field on each class so we teach pylint about that
+        property_name = 'id'
+        node = scoped_nodes.Class(property_name, None)
+        cls.locals[property_name] = [node]
+
+
+MANAGER.register_transform(scoped_nodes.Class, transform)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ jsonpath-rw>=1.3.0
 jsonschema>=2.3.0
 kombu<3.1,>=3.0.35
 lockfile<0.11,>=0.10.2
-mongoengine<0.9,>=0.8.7
+mongoengine==0.10.6
 networkx==1.10
 oslo.config<1.13,>=1.12.1
 oslo.utils<3.1.0
@@ -24,7 +24,7 @@ paramiko<1.17,>=1.16.0
 passlib<1.7,>=1.6.2
 prettytable
 pyinotify<=0.10,>=0.9.5
-pymongo<3.0
+pymongo==3.2.2
 python-dateutil
 python-gnupg<0.4,>=0.3.7
 python-json-logger

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -246,7 +246,7 @@ class ActionAPI(BaseAPI, APIUIDMixin):
             # to use an empty document.
             notify = NotificationsHelper.to_model({})
 
-        model = cls.model(name=name, description=description, enable=enabled, enabled=enabled,
+        model = cls.model(name=name, description=description, enabled=enabled,
                           entry_point=entry_point, pack=pack, runner_type=runner_type,
                           tags=tags, parameters=parameters, notify=notify,
                           ref=ref)
@@ -378,8 +378,6 @@ class LiveActionAPI(BaseAPI):
 
     @classmethod
     def to_model(cls, live_action):
-        name = getattr(live_action, 'name', None)
-        description = getattr(live_action, 'description', None)
         action = live_action.action
 
         if getattr(live_action, 'start_timestamp', None):
@@ -403,7 +401,7 @@ class LiveActionAPI(BaseAPI):
         else:
             notify = None
 
-        model = cls.model(name=name, description=description, action=action,
+        model = cls.model(action=action,
                           start_timestamp=start_timestamp, end_timestamp=end_timestamp,
                           status=status, parameters=parameters, context=context,
                           callback=callback, result=result, notify=notify)

--- a/st2common/st2common/models/db/stormbase.py
+++ b/st2common/st2common/models/db/stormbase.py
@@ -55,10 +55,9 @@ class StormFoundationDB(me.Document, DictSerializableClassMixin):
     # We explicitly assign the manager so pylint know what type objects is
     objects = me.queryset.QuerySetManager()
 
-    # ObjectIdField should be not have any constraints like required,
-    # unique etc for it to be auto-generated.
-    # TODO: Work out how we can mark this as a unique primary key.
-    id = me.ObjectIdField()
+    # Note: In mongoengine >= 0.10 "id" field is automatically declared on all
+    # the documents and declaring it ourselves causes a lot of issues so we
+    # don't do that
 
     # see http://docs.mongoengine.org/guide/defining-documents.html#abstract-classes
     meta = {

--- a/st2common/st2common/models/db/stormbase.py
+++ b/st2common/st2common/models/db/stormbase.py
@@ -65,6 +65,13 @@ class StormFoundationDB(me.Document, DictSerializableClassMixin):
         'abstract': True
     }
 
+    def __init__(self, *args, **kwargs):
+        # Work around for mongoengine 10.x which doesn't recognize _id anymore
+        # Note: We simply set "id" field value to the value of "_id" field, if provided
+        if '_id' in kwargs:
+            kwargs['id'] = kwargs.pop('_id')
+        super(StormFoundationDB, self).__init__(*args, **kwargs)
+
     def __str__(self):
         attrs = list()
         for k in sorted(self._fields.keys()):

--- a/st2common/st2common/models/db/stormbase.py
+++ b/st2common/st2common/models/db/stormbase.py
@@ -64,13 +64,6 @@ class StormFoundationDB(me.Document, DictSerializableClassMixin):
         'abstract': True
     }
 
-    def __init__(self, *args, **kwargs):
-        # Work around for mongoengine 10.x which doesn't recognize _id anymore
-        # Note: We simply set "id" field value to the value of "_id" field, if provided
-        if '_id' in kwargs:
-            kwargs['id'] = kwargs.pop('_id')
-        super(StormFoundationDB, self).__init__(*args, **kwargs)
-
     def __str__(self):
         attrs = list()
         for k in sorted(self._fields.keys()):

--- a/st2common/st2common/services/rbac.py
+++ b/st2common/st2common/services/rbac.py
@@ -236,7 +236,7 @@ def create_permission_grant(role_db, resource_uid, resource_type, permission_typ
     permission_grant_db = PermissionGrant.add_or_update(permission_grant_db)
 
     # Add assignment to the role
-    role_db.update(push__permission_grants=permission_grant_db.id)
+    role_db.update(push__permission_grants=str(permission_grant_db.id))
 
     return permission_grant_db
 
@@ -260,7 +260,7 @@ def remove_permission_grant_for_resource_db(role_db, resource_db, permission_typ
                                               permission_types=permission_types)
 
     # Remove assignment from a role
-    role_db.update(pull__permission_grants=permission_grant_db.id)
+    role_db.update(pull__permission_grants=str(permission_grant_db.id))
 
     return permission_grant_db
 

--- a/st2common/tests/unit/test_db.py
+++ b/st2common/tests/unit/test_db.py
@@ -25,6 +25,10 @@ from st2common.util import schema as util_schema
 from st2common.util import reference
 from st2common.util import date as date_utils
 from st2common.exceptions.db import StackStormDBObjectNotFoundError
+from st2common.models.db.trigger import TriggerTypeDB, TriggerDB, TriggerInstanceDB
+from st2common.models.db.rule import RuleDB, ActionExecutionSpecDB
+from st2common.persistence.rule import Rule
+from st2common.persistence.trigger import TriggerType, Trigger, TriggerInstance
 from st2tests import DbTestCase
 
 SKIP_DELETE = False
@@ -42,12 +46,6 @@ class DbConnectionTest(DbTestCase):
 
         expected_str = "host=['%s:%s']" % (cfg.CONF.database.host, cfg.CONF.database.port)
         self.assertTrue(expected_str in str(client), 'Not connected to desired host.')
-
-
-from st2common.models.db.trigger import TriggerTypeDB, TriggerDB, TriggerInstanceDB
-from st2common.models.db.rule import RuleDB, ActionExecutionSpecDB
-from st2common.persistence.rule import Rule
-from st2common.persistence.trigger import TriggerType, Trigger, TriggerInstance
 
 
 @mock.patch.object(PoolPublisher, 'publish', mock.MagicMock())

--- a/st2common/tests/unit/test_db.py
+++ b/st2common/tests/unit/test_db.py
@@ -39,10 +39,9 @@ class DbConnectionTest(DbTestCase):
         running.
         """
         client = mongoengine.connection.get_connection()
-        self.assertEqual(client.host, cfg.CONF.database.host,
-                         'Not connected to desired host.')
-        self.assertEqual(client.port, cfg.CONF.database.port,
-                         'Not connected to desired port.')
+
+        expected_str = "host=['%s:%s']" % (cfg.CONF.database.host, cfg.CONF.database.port)
+        self.assertTrue(expected_str in str(client), 'Not connected to desired host.')
 
 
 from st2common.models.db.trigger import TriggerTypeDB, TriggerDB, TriggerInstanceDB

--- a/st2common/tests/unit/test_db_model_uids.py
+++ b/st2common/tests/unit/test_db_model_uids.py
@@ -34,7 +34,7 @@ class DBModelUIDFieldTestCase(unittest2.TestCase):
         sensor_type_db = SensorTypeDB(name='sname', pack='spack')
         self.assertEqual(sensor_type_db.get_uid(), 'sensor_type:spack:sname')
 
-        action_db = ActionDB(name='aname', pack='apack', runner_info={})
+        action_db = ActionDB(name='aname', pack='apack', runner_type={})
         self.assertEqual(action_db.get_uid(), 'action:apack:aname')
 
         rule_db = RuleDB(name='rname', pack='rpack')

--- a/st2common/tests/unit/test_keyvalue_lookup.py
+++ b/st2common/tests/unit/test_keyvalue_lookup.py
@@ -118,12 +118,12 @@ class TestKeyValueLookup(CleanDbTestCase):
                        '64338294916D37E83C4796283C584751750E39844E2FD97A3727DB5D553F638'
         k1 = KeyValuePair.add_or_update(KeyValuePairDB(
             name='k1', value=secret_value,
-            secret=True, encrypted=True)
+            secret=True)
         )
         k2 = KeyValuePair.add_or_update(KeyValuePairDB(name='k2', value='v2'))
         k3 = KeyValuePair.add_or_update(KeyValuePairDB(
             name='stanley:k3', value=secret_value, scope=USER_SCOPE,
-            secret=True, encrypted=True)
+            secret=True)
         )
 
         lookup = KeyValueLookup()


### PR DESCRIPTION
This pull request upgrades to latest version of `pymongo` and `mongoengine`.

We wanted to do this many times before, but there are some backward incompatible changes in the newer versions and we never spent enough time digging in and addressing those issues so it never happened.

With the latest version of those libraries, StackStorm now also supports MongoDB 3.x. I think this is very important since MongoDB 3.x addresses and improves a lot of things (especially with a new storage engine). In the near future we should recommend MongoDB 3.x for new users, install MongoDB 3.x with the installer and come up with an upgrade scenario and document for an existing users which want to upgrade from 2.x to 3.x (there are some backward incompatible changes which require some work on the user side).

## Mongoengine Strict Mode

New version of mongoengine now ships with a "strict" mode which is enabled by default. When this mode is enabled, document constructor method will throw an exception if an argument / field which is not declared on the model definition is passed in.

For example:
    
```python
class MyModel(me.Document):
    field1 = me.StringField()

instance = MyModel(field1='foo', field2='bar')
```

This snippet would throw `FieldDoesNotExist` exception because `MyModel` doesn't declare that field.

I of course left this thing enabled because it's a good thing - it will allow us to more easily catch programmer errors and typos. If you check the diff you can see we had some issues like that in our code, but previous versions of mongoengine didn't throw an exception so those issues were silently ignored.

# Roll out scenario

All the tests pass locally, but I would still prefer to roll this out gradually and I want us to first test / run it on our build servers for a while.

As far as StackStorm version goes, I propose to ship v1.5.1 with the current bug-fixes from master and then ship and include this change in v1.6.0.

## TODO

- [ ] Update installer documentation and scripts to install MongoDB 3.2 for new installations (not part of this PR)