### PR TITLE
Various fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ In development
 * Add support for default values when a new pack configuration is used. Now if a default value
   is specified for a required config item in the config schema and a value for that item is not
   provided in the config, default value from config schema is used. (improvement)
+* Allow user to prevent execution parameter merging when re-running an execution by passing
+  ``?no_merge=true`` query parameter to the execution re-run API endpoint. (improvement)
 
 1.5.0 - June 24, 2016
 ---------------------

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -37,6 +37,7 @@ from st2common.exceptions.trace import TraceNotFoundException
 from st2common.models.api.action import LiveActionAPI
 from st2common.models.api.action import LiveActionCreateAPI
 from st2common.models.api.base import jsexpose
+from st2common.models.api.base import cast_argument_value
 from st2common.models.api.execution import ActionExecutionAPI
 from st2common.persistence.liveaction import LiveAction
 from st2common.persistence.execution import ActionExecution
@@ -276,7 +277,7 @@ class ActionExecutionReRunController(ActionExecutionsControllerMixin, ResourceCo
             return self
 
     @jsexpose(body_cls=ExecutionSpecificationAPI, status_code=http_client.CREATED)
-    def post(self, spec, execution_id, no_merge=None):
+    def post(self, spec_api, execution_id, no_merge=False):
         """
         Re-run the provided action execution optionally specifying override parameters.
 
@@ -284,16 +285,17 @@ class ActionExecutionReRunController(ActionExecutionsControllerMixin, ResourceCo
 
             POST /executions/<id>/re_run
         """
+        no_merge = cast_argument_value(value_type=bool, value=no_merge)
         existing_execution = self._get_one(id=execution_id, exclude_fields=self.exclude_fields)
 
-        if spec.tasks and existing_execution.runner['name'] != 'mistral-v2':
+        if spec_api.tasks and existing_execution.runner['name'] != 'mistral-v2':
             raise ValueError('Task option is only supported for Mistral workflows.')
 
         # Merge in any parameters provided by the user
         new_parameters = {}
         if not no_merge:
             new_parameters.update(getattr(existing_execution, 'parameters', {}))
-        new_parameters.update(spec.parameters)
+        new_parameters.update(spec_api.parameters)
 
         # Create object for the new execution
         action_ref = existing_execution.action['ref']
@@ -305,11 +307,11 @@ class ActionExecutionReRunController(ActionExecutionsControllerMixin, ResourceCo
             }
         }
 
-        if spec.tasks:
-            context['re-run']['tasks'] = spec.tasks
+        if spec_api.tasks:
+            context['re-run']['tasks'] = spec_api.tasks
 
-        if spec.reset:
-            context['re-run']['reset'] = spec.reset
+        if spec_api.reset:
+            context['re-run']['reset'] = spec_api.reset
 
         # Add trace to the new execution
         trace = trace_service.get_trace_db_by_action_execution(
@@ -321,7 +323,7 @@ class ActionExecutionReRunController(ActionExecutionsControllerMixin, ResourceCo
         new_liveaction_api = LiveActionCreateAPI(action=action_ref,
                                                  context=context,
                                                  parameters=new_parameters,
-                                                 user=spec.user)
+                                                 user=spec_api.user)
 
         return self._handle_schedule_execution(liveaction_api=new_liveaction_api)
 

--- a/st2api/tests/unit/controllers/v1/test_base.py
+++ b/st2api/tests/unit/controllers/v1/test_base.py
@@ -65,3 +65,12 @@ class TestBase(FunctionalTest):
         self.assertEqual(response.status_int, 200)
         self.assertEqual(response.headers['Access-Control-Allow-Origin'],
                          '*')
+
+    def test_valid_status_code_is_returned_on_invalid_path(self):
+        # TypeError: get_all() takes exactly 1 argument (2 given)
+        resp = self.app.get('/v1/executions/577f775b0640fd1451f2030b/re_run', expect_errors=True)
+        self.assertEqual(resp.status_int, 404)
+
+        # get_one() takes exactly 2 arguments (4 given)
+        resp = self.app.get('/v1/executions/577f775b0640fd1451f2030b/re_run/a/b', expect_errors=True)
+        self.assertEqual(resp.status_int, 404)

--- a/st2api/tests/unit/controllers/v1/test_base.py
+++ b/st2api/tests/unit/controllers/v1/test_base.py
@@ -72,5 +72,6 @@ class TestBase(FunctionalTest):
         self.assertEqual(resp.status_int, 404)
 
         # get_one() takes exactly 2 arguments (4 given)
-        resp = self.app.get('/v1/executions/577f775b0640fd1451f2030b/re_run/a/b', expect_errors=True)
+        resp = self.app.get('/v1/executions/577f775b0640fd1451f2030b/re_run/a/b',
+                            expect_errors=True)
         self.assertEqual(resp.status_int, 404)

--- a/st2common/st2common/util/api.py
+++ b/st2common/st2common/util/api.py
@@ -115,7 +115,7 @@ def get_exception_for_type_error(func, exc):
 
     # Note: Those checks are hacky, but it's better than having no checks and silently
     # accepting invalid requests
-    invalid_num_args_pattern = ('%s\(\) takes %s \d+ arguments \(\d+ given\)' %
+    invalid_num_args_pattern = ('%s\(\) takes %s \d+ arguments? \(\d+ given\)' %
                                 (func_name, '(exactly|at most|at least)'))
     unexpected_keyword_arg_pattern = ('%s\(\) got an unexpected keyword argument \'(.*?)\'' %
                                       (func_name))


### PR DESCRIPTION
- Correctly cast `no_merge` query param to boolean
- Update regular expression so we correctly handle some more pecan edge cases and return 404 instead of 500 on invalid paths