### PR TITLE
Pass limit 0 on in parameters to client

### DIFF
--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -172,9 +172,8 @@ class ResourceManager(object):
         user = kwargs.pop('user', None)
 
         params = kwargs.pop('params', {})
-        if limit and limit <= 0:
-            limit = None
-        if limit:
+
+        if limit is not None and limit >= 0:
             params['limit'] = limit
 
         if pack:
@@ -239,7 +238,7 @@ class ResourceManager(object):
     def query(self, **kwargs):
         if not kwargs:
             raise Exception('Query parameter is not provided.')
-        if 'limit' in kwargs and kwargs.get('limit') <= 0:
+        if 'limit' in kwargs and kwargs.get('limit') < 0:
             kwargs.pop('limit')
         token = kwargs.get('token', None)
         params = kwargs.get('params', {})

--- a/st2client/tests/unit/test_models.py
+++ b/st2client/tests/unit/test_models.py
@@ -54,35 +54,40 @@ class TestResourceManager(unittest2.TestCase):
     def test_resource_get_all_with_limit(self):
         with mock.patch.object(httpclient.HTTPClient,
                                'get',
-                               mock.MagicMock(return_value=base.FakeResponse(json.dumps(base.RESOURCES),
-                                                                             200,
-                                                                             'OK'))) as mock_client:
+                               mock.MagicMock(
+                                   return_value=base.FakeResponse(json.dumps(base.RESOURCES),
+                                                                  200,
+                                                                  'OK'))) as mock_client:
             mgr = models.ResourceManager(base.FakeResource, base.FAKE_ENDPOINT)
             resources = mgr.get_all(limit=50)
             actual = [resource.serialize() for resource in resources]
             expected = json.loads(json.dumps(base.RESOURCES))
             self.assertListEqual(actual, expected)
-            self.assertTrue(mock_client.call_args == mock.call(params={'limit': 50}, url='/fakeresources'))
+            self.assertTrue(
+                mock_client.call_args == mock.call(params={'limit': 50}, url='/fakeresources'))
 
     def test_resource_get_all_with_limit_zero(self):
         with mock.patch.object(httpclient.HTTPClient,
                                'get',
-                               mock.MagicMock(return_value=base.FakeResponse(json.dumps(base.RESOURCES),
-                                                                             200,
-                                                                             'OK'))) as mock_client:
+                               mock.MagicMock(
+                                   return_value=base.FakeResponse(json.dumps(base.RESOURCES),
+                                                                  200,
+                                                                  'OK'))) as mock_client:
             mgr = models.ResourceManager(base.FakeResource, base.FAKE_ENDPOINT)
             resources = mgr.get_all(limit=0)
             actual = [resource.serialize() for resource in resources]
             expected = json.loads(json.dumps(base.RESOURCES))
             self.assertListEqual(actual, expected)
-            self.assertTrue(mock_client.call_args == mock.call(params={'limit': 0}, url='/fakeresources'))
+            self.assertTrue(
+                mock_client.call_args == mock.call(params={'limit': 0}, url='/fakeresources'))
 
     def test_resource_get_all_with_limit_negative(self):
         with mock.patch.object(httpclient.HTTPClient,
                                'get',
-                               mock.MagicMock(return_value=base.FakeResponse(json.dumps(base.RESOURCES),
-                                                                             200,
-                                                                             'OK'))) as mock_client:
+                               mock.MagicMock(
+                                   return_value=base.FakeResponse(json.dumps(base.RESOURCES),
+                                                                  200,
+                                                                  'OK'))) as mock_client:
             mgr = models.ResourceManager(base.FakeResource, base.FAKE_ENDPOINT)
             resources = mgr.get_all(limit=-1)
             actual = [resource.serialize() for resource in resources]
@@ -135,35 +140,40 @@ class TestResourceManager(unittest2.TestCase):
     def test_resource_query_with_limit(self):
         with mock.patch.object(httpclient.HTTPClient,
                                'get',
-                               mock.MagicMock(return_value=base.FakeResponse(json.dumps(base.RESOURCES),
-                                                                             200,
-                                                                             'OK'))) as mock_client:
+                               mock.MagicMock(
+                                   return_value=base.FakeResponse(json.dumps(base.RESOURCES),
+                                                                  200,
+                                                                  'OK'))) as mock_client:
             mgr = models.ResourceManager(base.FakeResource, base.FAKE_ENDPOINT)
             resources = mgr.query(name='abc', limit=50)
             actual = [resource.serialize() for resource in resources]
             expected = json.loads(json.dumps(base.RESOURCES))
             self.assertEqual(actual, expected)
-            self.assertTrue(mock_client.call_args == mock.call('/fakeresources/?limit=50&name=abc'))
+            self.assertTrue(
+                mock_client.call_args == mock.call('/fakeresources/?limit=50&name=abc'))
 
     def test_resource_query_with_limit_zero(self):
         with mock.patch.object(httpclient.HTTPClient,
                                'get',
-                               mock.MagicMock(return_value=base.FakeResponse(json.dumps(base.RESOURCES),
-                                                                             200,
-                                                                             'OK'))) as mock_client:
+                               mock.MagicMock(
+                                   return_value=base.FakeResponse(json.dumps(base.RESOURCES),
+                                                                  200,
+                                                                  'OK'))) as mock_client:
             mgr = models.ResourceManager(base.FakeResource, base.FAKE_ENDPOINT)
             resources = mgr.query(name='abc', limit=0)
             actual = [resource.serialize() for resource in resources]
             expected = json.loads(json.dumps(base.RESOURCES))
             self.assertEqual(actual, expected)
-            self.assertTrue(mock_client.call_args == mock.call('/fakeresources/?limit=0&name=abc'))
+            self.assertTrue(
+                mock_client.call_args == mock.call('/fakeresources/?limit=0&name=abc'))
 
     def test_resource_query_with_negative_limit(self):
         with mock.patch.object(httpclient.HTTPClient,
                                'get',
-                               mock.MagicMock(return_value=base.FakeResponse(json.dumps(base.RESOURCES),
-                                                                             200,
-                                                                             'OK'))) as mock_client:
+                               mock.MagicMock(
+                                   return_value=base.FakeResponse(json.dumps(base.RESOURCES),
+                                                                  200,
+                                                                  'OK'))) as mock_client:
             mgr = models.ResourceManager(base.FakeResource, base.FAKE_ENDPOINT)
             resources = mgr.query(name='abc', limit=-1)
             actual = [resource.serialize() for resource in resources]

--- a/st2client/tests/unit/test_models.py
+++ b/st2client/tests/unit/test_models.py
@@ -51,15 +51,44 @@ class TestResourceManager(unittest2.TestCase):
         expected = json.loads(json.dumps(base.RESOURCES))
         self.assertListEqual(actual, expected)
 
-    @mock.patch.object(
-        httpclient.HTTPClient, 'get',
-        mock.MagicMock(return_value=base.FakeResponse(json.dumps(base.RESOURCES), 200, 'OK')))
     def test_resource_get_all_with_limit(self):
-        mgr = models.ResourceManager(base.FakeResource, base.FAKE_ENDPOINT)
-        resources = mgr.get_all(limit=50)
-        actual = [resource.serialize() for resource in resources]
-        expected = json.loads(json.dumps(base.RESOURCES))
-        self.assertListEqual(actual, expected)
+        with mock.patch.object(httpclient.HTTPClient,
+                               'get',
+                               mock.MagicMock(return_value=base.FakeResponse(json.dumps(base.RESOURCES),
+                                                                             200,
+                                                                             'OK'))) as mock_client:
+            mgr = models.ResourceManager(base.FakeResource, base.FAKE_ENDPOINT)
+            resources = mgr.get_all(limit=50)
+            actual = [resource.serialize() for resource in resources]
+            expected = json.loads(json.dumps(base.RESOURCES))
+            self.assertListEqual(actual, expected)
+            self.assertTrue(mock_client.call_args == mock.call(params={'limit': 50}, url='/fakeresources'))
+
+    def test_resource_get_all_with_limit_zero(self):
+        with mock.patch.object(httpclient.HTTPClient,
+                               'get',
+                               mock.MagicMock(return_value=base.FakeResponse(json.dumps(base.RESOURCES),
+                                                                             200,
+                                                                             'OK'))) as mock_client:
+            mgr = models.ResourceManager(base.FakeResource, base.FAKE_ENDPOINT)
+            resources = mgr.get_all(limit=0)
+            actual = [resource.serialize() for resource in resources]
+            expected = json.loads(json.dumps(base.RESOURCES))
+            self.assertListEqual(actual, expected)
+            self.assertTrue(mock_client.call_args == mock.call(params={'limit': 0}, url='/fakeresources'))
+
+    def test_resource_get_all_with_limit_negative(self):
+        with mock.patch.object(httpclient.HTTPClient,
+                               'get',
+                               mock.MagicMock(return_value=base.FakeResponse(json.dumps(base.RESOURCES),
+                                                                             200,
+                                                                             'OK'))) as mock_client:
+            mgr = models.ResourceManager(base.FakeResource, base.FAKE_ENDPOINT)
+            resources = mgr.get_all(limit=-1)
+            actual = [resource.serialize() for resource in resources]
+            expected = json.loads(json.dumps(base.RESOURCES))
+            self.assertListEqual(actual, expected)
+            self.assertTrue(mock_client.call_args == mock.call(params={}, url='/fakeresources'))
 
     @mock.patch.object(
         httpclient.HTTPClient, 'get',
@@ -103,15 +132,44 @@ class TestResourceManager(unittest2.TestCase):
         expected = json.loads(json.dumps([base.RESOURCES[0]]))
         self.assertEqual(actual, expected)
 
-    @mock.patch.object(
-        httpclient.HTTPClient, 'get',
-        mock.MagicMock(return_value=base.FakeResponse(json.dumps([base.RESOURCES[0]]), 200, 'OK')))
     def test_resource_query_with_limit(self):
-        mgr = models.ResourceManager(base.FakeResource, base.FAKE_ENDPOINT)
-        resources = mgr.query(name='abc', limit=50)
-        actual = [resource.serialize() for resource in resources]
-        expected = json.loads(json.dumps([base.RESOURCES[0]]))
-        self.assertEqual(actual, expected)
+        with mock.patch.object(httpclient.HTTPClient,
+                               'get',
+                               mock.MagicMock(return_value=base.FakeResponse(json.dumps(base.RESOURCES),
+                                                                             200,
+                                                                             'OK'))) as mock_client:
+            mgr = models.ResourceManager(base.FakeResource, base.FAKE_ENDPOINT)
+            resources = mgr.query(name='abc', limit=50)
+            actual = [resource.serialize() for resource in resources]
+            expected = json.loads(json.dumps(base.RESOURCES))
+            self.assertEqual(actual, expected)
+            self.assertTrue(mock_client.call_args == mock.call('/fakeresources/?limit=50&name=abc'))
+
+    def test_resource_query_with_limit_zero(self):
+        with mock.patch.object(httpclient.HTTPClient,
+                               'get',
+                               mock.MagicMock(return_value=base.FakeResponse(json.dumps(base.RESOURCES),
+                                                                             200,
+                                                                             'OK'))) as mock_client:
+            mgr = models.ResourceManager(base.FakeResource, base.FAKE_ENDPOINT)
+            resources = mgr.query(name='abc', limit=0)
+            actual = [resource.serialize() for resource in resources]
+            expected = json.loads(json.dumps(base.RESOURCES))
+            self.assertEqual(actual, expected)
+            self.assertTrue(mock_client.call_args == mock.call('/fakeresources/?limit=0&name=abc'))
+
+    def test_resource_query_with_negative_limit(self):
+        with mock.patch.object(httpclient.HTTPClient,
+                               'get',
+                               mock.MagicMock(return_value=base.FakeResponse(json.dumps(base.RESOURCES),
+                                                                             200,
+                                                                             'OK'))) as mock_client:
+            mgr = models.ResourceManager(base.FakeResource, base.FAKE_ENDPOINT)
+            resources = mgr.query(name='abc', limit=-1)
+            actual = [resource.serialize() for resource in resources]
+            expected = json.loads(json.dumps(base.RESOURCES))
+            self.assertEqual(actual, expected)
+            self.assertTrue(mock_client.call_args == mock.call('/fakeresources/?name=abc'))
 
     @mock.patch.object(
         httpclient.HTTPClient, 'get',


### PR DESCRIPTION
I noticed in the CLI that if I ran: `st2 --debug execution list -n 0`, no limit was set in the called url, and only the last 100 executions were returned. According to the documentation if the `-n/--last` parameter is set to 0 all executions should be returned. I believe that this PR should fix this. 

I was also wondering if perhaps settling the limit to less than zero should raise an exception, but now I left the behavior as was.

Have a look and let me know what you think.