### PR TITLE
Run "bandit" linter on the code base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,9 @@ compile:
 	find ${ROOT_DIR}/st2common/st2common/ \( -name \*.py ! -name runnersregistrar\.py \) -type f -print0 | xargs -0 cat | grep st2actions ; test $$? -eq 1
 	find ${ROOT_DIR}/st2common/st2common/ -name \*.py -type f -print0 | xargs -0 cat | grep st2api ; test $$? -eq 1
 	find ${ROOT_DIR}/st2common/st2common/ -name \*.py -type f -print0 | xargs -0 cat | grep st2auth ; test $$? -eq 1
+	find ${ROOT_DIR}/st2common/st2common/ -name \*.py -type f -print0 | xargs -0 cat | grep st2debug; test $$? -eq 1
+	find ${ROOT_DIR}/st2common/st2common/ -name \*.py -type f -print0 | xargs -0 cat | grep st2stream; test $$? -eq 1
+	find ${ROOT_DIR}/st2common/st2common/ -name \*.py -type f -print0 | xargs -0 cat | grep st2exporter; test $$? -eq 1
 
 .PHONY: .cleanmongodb
 .cleanmongodb:

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ bandit: requirements .bandit
 lint: requirements .lint
 
 .PHONY: .lint
-.lint: .flake8 .pylint
+.lint: .flake8 .pylint .bandit .st2client-dependencies-check .st2common-circular-dependencies-check
 
 .PHONY: clean
 clean: .cleanpycs

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,16 @@ flake8: requirements .flake8
 	. $(VIRTUALENV_DIR)/bin/activate; flake8 --config ./lint-configs/python/.flake8 scripts/
 	. $(VIRTUALENV_DIR)/bin/activate; flake8 --config ./lint-configs/python/.flake8 tools/
 
+.PHONY: bandit
+bandit: requirements .bandit
+
+.PHONY: .bandit
+.bandit:
+	@echo
+	@echo "==================== bandit ===================="
+	@echo
+	. $(VIRTUALENV_DIR)/bin/activate; bandit -r $(COMPONENTS) -lll
+
 .PHONY: lint
 lint: requirements .lint
 

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -9,7 +9,7 @@ fi
 if [ ${TASK} == 'checks' ]; then
   # compile .py files, useful as compatibility syntax check
   make compile
-  make pylint flake8 .st2client-dependencies-check .st2common-circular-dependencies-check
+  make pylint flake8 bandit .st2client-dependencies-check .st2common-circular-dependencies-check
 elif [ ${TASK} == 'unit' ]; then
   # compile .py files, useful as compatibility syntax check
   make compile

--- a/st2common/st2common/util/jinja.py
+++ b/st2common/st2common/util/jinja.py
@@ -141,9 +141,7 @@ def get_jinja_environment(allow_undefined=False):
 
     '''
     undefined = jinja2.Undefined if allow_undefined else jinja2.StrictUndefined
-    env = jinja2.Environment(undefined=undefined,
-                             trim_blocks=True,
-                             lstrip_blocks=True)
+    env = jinja2.Environment(undefined=undefined, trim_blocks=True, lstrip_blocks=True)  # nosec
     env.filters.update(CustomFilters.get_filters())
     env.tests['in'] = lambda item, list: item in list
     return env

--- a/st2common/st2common/util/templating.py
+++ b/st2common/st2common/util/templating.py
@@ -41,7 +41,7 @@ def render_template(value, context=None):
     assert isinstance(value, six.string_types)
     context = context or {}
 
-    env = Environment(undefined=StrictUndefined)
+    env = Environment(undefined=StrictUndefined)  # nosec
     template = env.from_string(value)
     rendered = template.render(context)
 

--- a/st2tests/integration/mistral/test_wiring.py
+++ b/st2tests/integration/mistral/test_wiring.py
@@ -14,14 +14,29 @@
 # limitations under the License.
 
 import ast
-import eventlet
 import os
+import shutil
 import tempfile
+
+import eventlet
 
 from integration.mistral import base
 
 
 class WiringTest(base.TestWorkflowExecution):
+
+    temp_dir_path = None
+
+    def setUp(self):
+        super(WiringTest, self).setUp()
+
+        # Create temporary directory used by the tests
+        _, self.temp_dir_path = tempfile.mkstemp()
+        os.chmod(self.temp_dir_path, 0666)   # nosec
+
+    def tearDown(self):
+        if self.temp_dir_path and os.path.exists(self.temp_dir_path):
+            shutil.rmtree(self.temp_dir_path)
 
     def test_basic_workflow(self):
         execution = self._execute_workflow('examples.mistral-basic', {'cmd': 'date'})
@@ -100,8 +115,7 @@ class WiringTest(base.TestWorkflowExecution):
         self.assertDictEqual(ast.literal_eval(task_results[0]['state_info']), expected_state_info)
 
     def test_basic_rerun(self):
-        fd, path = tempfile.mkstemp()
-        os.chmod(path, 0666)   # nosec
+        path = self.temp_dir_path
 
         with open(path, 'w') as f:
             f.write('1')
@@ -122,8 +136,7 @@ class WiringTest(base.TestWorkflowExecution):
         self.assertNotEqual(execution.context['mistral']['execution_id'], orig_wf_ex_id)
 
     def test_basic_rerun_task(self):
-        fd, path = tempfile.mkstemp()
-        os.chmod(path, 0666)   # nosec
+        path = self.temp_dir_path
 
         with open(path, 'w') as f:
             f.write('1')
@@ -144,8 +157,7 @@ class WiringTest(base.TestWorkflowExecution):
         self.assertEqual(execution.context['mistral']['execution_id'], orig_wf_ex_id)
 
     def test_rerun_subflow_task(self):
-        fd, path = tempfile.mkstemp()
-        os.chmod(path, 0666)  # nosec
+        path = self.temp_dir_path
 
         with open(path, 'w') as f:
             f.write('1')
@@ -167,8 +179,7 @@ class WiringTest(base.TestWorkflowExecution):
         self.assertEqual(execution.context['mistral']['execution_id'], orig_wf_ex_id)
 
     def test_basic_rerun_and_reset_with_items_task(self):
-        fd, path = tempfile.mkstemp()
-        os.chmod(path, 0666)  # nosec
+        path = self.temp_dir_path
 
         with open(path, 'w') as f:
             f.write('1')
@@ -197,8 +208,7 @@ class WiringTest(base.TestWorkflowExecution):
         self.assertEqual(len(children), 4)
 
     def test_basic_rerun_and_resume_with_items_task(self):
-        fd, path = tempfile.mkstemp()
-        os.chmod(path, 0666)  # nosec
+        path = self.temp_dir_path
 
         with open(path, 'w') as f:
             f.write('1')
@@ -232,8 +242,7 @@ class WiringTest(base.TestWorkflowExecution):
         self.assertEqual(len(children), 2)
 
     def test_rerun_subflow_and_reset_with_items_task(self):
-        fd, path = tempfile.mkstemp()
-        os.chmod(path, 0666)  # nosec
+        path = self.temp_dir_path
 
         with open(path, 'w') as f:
             f.write('1')
@@ -262,8 +271,7 @@ class WiringTest(base.TestWorkflowExecution):
         self.assertEqual(len(children), 4)
 
     def test_rerun_subflow_and_resume_with_items_task(self):
-        fd, path = tempfile.mkstemp()
-        os.chmod(path, 0666)  # nosec
+        path = self.temp_dir_path
 
         with open(path, 'w') as f:
             f.write('1')

--- a/st2tests/integration/mistral/test_wiring.py
+++ b/st2tests/integration/mistral/test_wiring.py
@@ -101,7 +101,7 @@ class WiringTest(base.TestWorkflowExecution):
 
     def test_basic_rerun(self):
         fd, path = tempfile.mkstemp()
-        os.chmod(path, 0666)
+        os.chmod(path, 0666)   # nosec
 
         with open(path, 'w') as f:
             f.write('1')
@@ -123,7 +123,7 @@ class WiringTest(base.TestWorkflowExecution):
 
     def test_basic_rerun_task(self):
         fd, path = tempfile.mkstemp()
-        os.chmod(path, 0666)
+        os.chmod(path, 0666)   # nosec
 
         with open(path, 'w') as f:
             f.write('1')
@@ -145,7 +145,7 @@ class WiringTest(base.TestWorkflowExecution):
 
     def test_rerun_subflow_task(self):
         fd, path = tempfile.mkstemp()
-        os.chmod(path, 0666)
+        os.chmod(path, 0666)  # nosec
 
         with open(path, 'w') as f:
             f.write('1')
@@ -168,7 +168,7 @@ class WiringTest(base.TestWorkflowExecution):
 
     def test_basic_rerun_and_reset_with_items_task(self):
         fd, path = tempfile.mkstemp()
-        os.chmod(path, 0666)
+        os.chmod(path, 0666)  # nosec
 
         with open(path, 'w') as f:
             f.write('1')
@@ -198,7 +198,7 @@ class WiringTest(base.TestWorkflowExecution):
 
     def test_basic_rerun_and_resume_with_items_task(self):
         fd, path = tempfile.mkstemp()
-        os.chmod(path, 0666)
+        os.chmod(path, 0666)  # nosec
 
         with open(path, 'w') as f:
             f.write('1')
@@ -233,7 +233,7 @@ class WiringTest(base.TestWorkflowExecution):
 
     def test_rerun_subflow_and_reset_with_items_task(self):
         fd, path = tempfile.mkstemp()
-        os.chmod(path, 0666)
+        os.chmod(path, 0666)  # nosec
 
         with open(path, 'w') as f:
             f.write('1')
@@ -263,7 +263,7 @@ class WiringTest(base.TestWorkflowExecution):
 
     def test_rerun_subflow_and_resume_with_items_task(self):
         fd, path = tempfile.mkstemp()
-        os.chmod(path, 0666)
+        os.chmod(path, 0666)  # nosec
 
         with open(path, 'w') as f:
             f.write('1')

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,6 +4,7 @@ flake8>=2.3.0,<2.4
 astroid==1.4.5
 pylint==1.5.5
 pylint-plugin-utils>=0.2.3,<0.3
+bandit>=1.0.1,<1.1
 ipython
 mock>=1.0
 nose>=1.3.7


### PR DESCRIPTION
This pull request runs bandit security linter (https://github.com/openstack/bandit) on our code base as part of our build.

The idea behind bandit is a good one, but right now it doesn't report any real issues in our code bases (just false positives). I also have some doubts how useful it is in more "advanced" non-web based projects where most choices are deliberate, but we will see down the road.