### PR TITLE
Fix link for installation from sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Additional documentation describing installation proceduces, action/rule/workflo
 
 ## Hacking / Contributing
 
-To set up dev environment and run StackStorm from sources, follow [these instructions](https://docs.stackstorm.com/install/sources.html).
+To set up dev environment and run StackStorm from sources, follow [these instructions](https://docs.stackstorm.com/development/sources.html).
 
 For information on how to contribute, style guide, coding conventions and more,
 please visit the [Development section](http://docs.stackstorm.com/development/index.html)


### PR DESCRIPTION
The [current link](https://docs.stackstorm.com/install/sources.html) leads to a 404.