### PR TITLE
Execution model to contain web_url field for chatops sake

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,10 @@ In development
   concurrency policy is used and a defined threshold is reached. For backward compatibility,
   ``delay`` is a default behavior, but now user can also specify ``cancel`` and an execution will
   be canceled instead of delayed when a threshold is reached.
+* Save link to history web url in execution db model. A configuration variable in ``webui`` section
+  is now exposed to let st2 know about the location of web ui. This is used to construct the
+  web url. Chatops messages can now display the history url from the execution model they
+  get as response to API calls.
 
 1.5.1 - July 13, 2016
 ---------------------

--- a/conf/st2.conf.sample
+++ b/conf/st2.conf.sample
@@ -222,6 +222,9 @@ ssh_key_file = /home/vagrant/.ssh/stanley_rsa
 # Default system user.
 user = stanley
 
+# [webui]
+# webui_base_url = https://mywebhost.domain
+
 [timer]
 # Timezone pertaining to the location where st2 is run.
 local_timezone = America/Los_Angeles

--- a/conf/st2.dev.conf
+++ b/conf/st2.dev.conf
@@ -66,6 +66,9 @@ port = 514
 facility = local7
 protocol = udp
 
+# [webui]
+# webui_base_url = https://mywebhost.domain
+
 [log]
 excludes = requests,paramiko
 redirect_stderr = False

--- a/conf/st2.package.conf
+++ b/conf/st2.package.conf
@@ -54,6 +54,9 @@ api_url =
 [system]
 base_path = /opt/stackstorm
 
+# [webui]
+# webui_base_url = https://mywebhost.domain
+
 [syslog]
 host = 127.0.0.1
 port = 514

--- a/conf/st2.prod.conf
+++ b/conf/st2.prod.conf
@@ -50,6 +50,9 @@ port = 514
 facility = local7
 protocol = udp
 
+# [webui]
+# webui_base_url = https://mywebhost.domain
+
 [log]
 excludes = requests,paramiko
 redirect_stderr = False

--- a/conf/st2.tests.conf
+++ b/conf/st2.tests.conf
@@ -60,6 +60,9 @@ port = 514
 facility = local7
 protocol = udp
 
+# [webui]
+# webui_base_url = https://mywebhost.domain
+
 [log]
 excludes = requests,paramiko
 redirect_stderr = False

--- a/conf/st2.tests1.conf
+++ b/conf/st2.tests1.conf
@@ -49,6 +49,9 @@ port = 514
 facility = local7
 protocol = udp
 
+# [webui]
+# webui_base_url = https://mywebhost.domain
+
 [log]
 excludes = requests,paramiko
 redirect_stderr = False

--- a/contrib/chatops/actions/templates/default.j2
+++ b/contrib/chatops/actions/templates/default.j2
@@ -14,6 +14,10 @@ Action {{ execution.action.ref }} completed.
 status : {{ execution.status }}
 execution: {{ execution.id }}
 
+{% if execution.web_url -% }
+web_url: {{ execution.web_url }}
+{% endif %}
+
 {% if execution.result -%}
 result :
 --------

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import os
+import socket
 import sys
 
 from oslo_config import cfg
@@ -83,7 +84,7 @@ def register_opts(ignore_errors=False):
     do_register_opts(content_opts, 'content', ignore_errors)
 
     webui_opts = [
-        cfg.StrOpt('webui_base_url', default='https://localhost',
+        cfg.StrOpt('webui_base_url', default='https://%s' % socket.gethostname(),
                    help='Base https URL to access st2 Web UI. This is used to construct' +
                         'history URLs that are sent out when chatops is used to kick off ' +
                         'executions.')
@@ -109,12 +110,12 @@ def register_opts(ignore_errors=False):
         cfg.StrOpt('ssl_certfile', help='Certificate file used to identify the localconnection',
                    default=None),
         cfg.StrOpt('ssl_cert_reqs', choices='none, optional, required',
-                   help='Specifies whether a certificate is required from the other side of the \
-                         connection, and whether it will be validated if provided',
+                   help='Specifies whether a certificate is required from the other side of the ' +
+                        'connection, and whether it will be validated if provided',
                    default=None),
         cfg.StrOpt('ssl_ca_certs',
-                   help='ca_certs file contains a set of concatenated CA certificates, which are \
-                         used to validate certificates passed from MongoDB.',
+                   help='ca_certs file contains a set of concatenated CA certificates, which are' +
+                        ' used to validate certificates passed from MongoDB.',
                    default=None),
         cfg.BoolOpt('ssl_match_hostname',
                     help='If True and `ssl_cert_reqs` is not None, enables hostname verification',

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -82,6 +82,14 @@ def register_opts(ignore_errors=False):
     ]
     do_register_opts(content_opts, 'content', ignore_errors)
 
+    webui_opts = [
+        cfg.StrOpt('webui_base_url', default='https://localhost',
+                   help='Base https URL to access st2 Web UI. This is used to construct' +
+                        'history URLs that are sent out when chatops is used to kick off ' +
+                        'executions.')
+    ]
+    do_register_opts(webui_opts, 'webui', ignore_errors)
+
     db_opts = [
         cfg.StrOpt('host', default='0.0.0.0', help='host of db server'),
         cfg.IntOpt('port', default=27017, help='port of db server'),

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -84,7 +84,7 @@ def register_opts(ignore_errors=False):
     do_register_opts(content_opts, 'content', ignore_errors)
 
     webui_opts = [
-        cfg.StrOpt('webui_base_url', default='https://%s' % socket.gethostname(),
+        cfg.StrOpt('webui_base_url', default='https://%s' % socket.getfqdn(),
                    help='Base https URL to access st2 Web UI. This is used to construct' +
                         'history URLs that are sent out when chatops is used to kick off ' +
                         'executions.')

--- a/st2common/st2common/models/db/execution.py
+++ b/st2common/st2common/models/db/execution.py
@@ -66,6 +66,7 @@ class ActionExecutionDB(stormbase.StormFoundationDB):
     parent = me.StringField()
     children = me.ListField(field=me.StringField())
     log = me.ListField(field=me.DictField())
+    web_url = me.URLField(required=False, verify_exists=False)
 
     meta = {
         'indexes': [

--- a/st2common/st2common/models/db/execution.py
+++ b/st2common/st2common/models/db/execution.py
@@ -66,7 +66,8 @@ class ActionExecutionDB(stormbase.StormFoundationDB):
     parent = me.StringField()
     children = me.ListField(field=me.StringField())
     log = me.ListField(field=me.DictField())
-    web_url = me.URLField(required=False, verify_exists=False)
+    # Do not use URLField for web_url. If host doesn't have FQDN set, URLField validation blows.
+    web_url = me.StringField(required=False)
 
     meta = {
         'indexes': [

--- a/st2common/st2common/services/executions.py
+++ b/st2common/st2common/services/executions.py
@@ -28,6 +28,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from oslo_config import cfg
 import six
 
 from st2common import log as logging
@@ -122,6 +123,12 @@ def create_execution_object(liveaction, publish=True):
     attrs['log'] = [_create_execution_log_entry(liveaction['status'])]
 
     execution = ActionExecutionDB(**attrs)
+    execution = ActionExecution.add_or_update(execution, publish=False)
+
+    # Update the web_url field in execution. Unfortunately, we need
+    # the execution id for constructing the URL which we only get
+    # after the model is written to disk.
+    execution.web_url = _get_web_url_for_execution(str(execution.id))
     execution = ActionExecution.add_or_update(execution, publish=publish)
 
     if parent:
@@ -143,6 +150,11 @@ def _get_parent_execution(child_liveaction_db):
             LOG.exception('No valid execution object found in db for id: %s' % parent_id)
             return None
     return None
+
+
+def _get_web_url_for_execution(execution_id):
+    base_url = cfg.CONF.webui.webui_base_url
+    return "%s/#/history/%s/general" % (base_url, execution_id)
 
 
 def update_execution(liveaction_db, publish=True):

--- a/st2common/tests/unit/test_executions_util.py
+++ b/st2common/tests/unit/test_executions_util.py
@@ -118,6 +118,15 @@ class ExecutionsUtilTestCase(CleanDbTestCase):
         liveaction = LiveAction.get_by_id(str(liveaction.id))
         self.assertEquals(execution.liveaction['id'], str(liveaction.id))
 
+    def test_execution_creation_with_web_url(self):
+        liveaction = self.MODELS['liveactions']['liveaction1.yaml']
+        executions_util.create_execution_object(liveaction)
+        execution = self._get_action_execution(liveaction__id=str(liveaction.id),
+                                               raise_exception=True)
+        self.assertTrue(execution.web_url is not None)
+        execution_id = str(execution.id)
+        self.assertTrue(('history/%s/general' % execution_id) in execution.web_url)
+
     def test_execution_creation_chains(self):
         childliveaction = self.MODELS['liveactions']['childliveaction.yaml']
         child_exec = executions_util.create_execution_object(childliveaction)


### PR DESCRIPTION
## What? 

We want to be able to display the execution history web url in chatops messages on ACK as well as after final results. 
https://github.com/StackStorm/hubot-stackstorm/issues/120

## Context 

1. When an action is kicked off we do give out the execution id link. This is because https://github.com/StackStorm/hubot-stackstorm/blob/master/scripts/stackstorm.js#L245 but it unfortunately depends on an env variable https://github.com/StackStorm/st2chatops/blob/master/st2chatops.env#L36. So mostly we get “localhost” based URL. See  https://stackstorm.slack.com/archives/chatopsci/p1468963585000061 (private link). 

2. When an action completes, we don’t share the execution URL. This is obv looking at this https://github.com/StackStorm/st2/blob/master/contrib/chatops/actions/templates/default.j2#L15. 

So it looks like we need two changes:

1. A response for alias execution POST should include the history URL 

2. An execution model which is used in post_message should carry the URL with it for final result to show the URL. 

For both, we need the web URL generated in backend. I have no good way to get the external IP of the box from within st2. So I rely on a config parameter which defaults to https://localhost but users can change it to point to Web UI host. The execution model is now changed to contain ``web_url`` field which will then be used in both hubot-stackstorm (See https://github.com/StackStorm/hubot-stackstorm/pull/122) and post_message. 

## TODO

* [x] Tests
* [x] Docs changes https://github.com/StackStorm/st2docs/pull/215