### PR TITLE
[WIP] Use two BufferedDispatcher pools inside the action runner

### DIFF
--- a/st2actions/st2actions/config.py
+++ b/st2actions/st2actions/config.py
@@ -45,6 +45,15 @@ def _register_action_runner_opts():
     ]
     CONF.register_opts(logging_opts, group='actionrunner')
 
+    dispatcher_pool_opts = [
+        cfg.IntOpt('workflows_pool_size', default=50,
+                   help='Internal pool size for dispatcher used by workflow actions.'),
+        cfg.IntOpt('actions_pool_size', default=(2 * 50),
+                   help=('Internal pool size for dispatcher used by regular actions. '
+                         'It\'s recommended this pool is double the size of the workflows one'))
+    ]
+    CONF.register_opts(dispatcher_pool_opts, group='actionrunner')
+
     db_opts = [
         cfg.StrOpt('host', default='0.0.0.0', help='host of db server'),
         cfg.IntOpt('port', default=27017, help='port of db server'),

--- a/st2actions/st2actions/config.py
+++ b/st2actions/st2actions/config.py
@@ -46,11 +46,10 @@ def _register_action_runner_opts():
     CONF.register_opts(logging_opts, group='actionrunner')
 
     dispatcher_pool_opts = [
-        cfg.IntOpt('workflows_pool_size', default=50,
+        cfg.IntOpt('workflows_pool_size', default=40,
                    help='Internal pool size for dispatcher used by workflow actions.'),
-        cfg.IntOpt('actions_pool_size', default=(2 * 50),
-                   help=('Internal pool size for dispatcher used by regular actions. '
-                         'It\'s recommended this pool is double the size of the workflows one'))
+        cfg.IntOpt('actions_pool_size', default=60,
+                   help='Internal pool size for dispatcher used by regular actions.')
     ]
     CONF.register_opts(dispatcher_pool_opts, group='actionrunner')
 

--- a/st2actions/st2actions/worker.py
+++ b/st2actions/st2actions/worker.py
@@ -26,7 +26,9 @@ from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2common.models.db.liveaction import LiveActionDB
 from st2common.persistence.execution import ActionExecution
 from st2common.services import executions
-from st2common.transport import consumers, liveaction
+from st2common.transport import liveaction
+from st2common.transport.consumers import MessageHandler
+from st2common.transport.consumers import ActionsQueueConsumer
 from st2common.transport import utils as transport_utils
 from st2common.util import action_db as action_utils
 from st2common.util import system_info
@@ -41,7 +43,7 @@ ACTIONRUNNER_CANCEL_Q = liveaction.get_status_management_queue(
     'st2.actionrunner.canel', routing_key=action_constants.LIVEACTION_STATUS_CANCELING)
 
 
-class ActionExecutionDispatcher(consumers.MessageHandler):
+class ActionExecutionDispatcher(MessageHandler):
     message_type = LiveActionDB
 
     def __init__(self, connection, queues):
@@ -49,9 +51,9 @@ class ActionExecutionDispatcher(consumers.MessageHandler):
         self.container = RunnerContainer()
         self._running_liveactions = set()
 
-    def _get_queue_consumer(self, connection, queues):
+    def get_queue_consumer(self, connection, queues):
         # We want to use a special ActionsQueueConsumer which uses 2 dispatcher pools
-        return consumers.ActionsQueueConsumer(connection, queues, self)
+        return ActionsQueueConsumer(connection=connection, queues=queues, handler=self)
 
     def process(self, liveaction):
         """Dispatches the LiveAction to appropriate action runner.

--- a/st2actions/st2actions/worker.py
+++ b/st2actions/st2actions/worker.py
@@ -49,6 +49,10 @@ class ActionExecutionDispatcher(consumers.MessageHandler):
         self.container = RunnerContainer()
         self._running_liveactions = set()
 
+    def _get_queue_consumer(self, connection, queues):
+        # We want to use a special ActionsQueueConsumer which uses 2 dispatcher pools
+        return consumers.ActionsQueueConsumer(connection, queues, self)
+
     def process(self, liveaction):
         """Dispatches the LiveAction to appropriate action runner.
 

--- a/st2common/st2common/models/db/liveaction.py
+++ b/st2common/st2common/models/db/liveaction.py
@@ -59,6 +59,9 @@ class LiveActionDB(stormbase.StormFoundationDB):
     action = me.StringField(
         required=True,
         help_text='Reference to the action that has to be executed.')
+    is_action_workflow = me.BooleanField(
+        default=False,
+        help_text='A flag indicating whether the references action is a workflow.')
     parameters = stormbase.EscapedDynamicField(
         default={},
         help_text='The key-value pairs passed as to the action runner & execution.')

--- a/st2common/st2common/services/action.py
+++ b/st2common/st2common/services/action.py
@@ -98,6 +98,9 @@ def create_request(liveaction):
     liveaction.status = action_constants.LIVEACTION_STATUS_REQUESTED
     liveaction.start_timestamp = date_utils.get_datetime_utc_now()
 
+    # Set the "is_action_workflow" attribute
+    liveaction.is_action_workflow = action_db.is_workflow()
+
     # Publish creation after both liveaction and actionexecution are created.
     liveaction = LiveAction.add_or_update(liveaction, publish=False)
 

--- a/st2common/st2common/services/executions.py
+++ b/st2common/st2common/services/executions.py
@@ -59,7 +59,15 @@ LOG = logging.getLogger(__name__)
 # Attributes which are stored in the "liveaction" dictionary when composing LiveActionDB object
 # into a ActionExecution compatible dictionary.
 # Those attributes are LiveAction specified and are therefore stored in a "liveaction" key
-LIVEACTION_ATTRIBUTES = ['id', 'callback', 'action', 'runner_info', 'parameters', 'notify']
+LIVEACTION_ATTRIBUTES = [
+    'id',
+    'callback',
+    'action',
+    'is_action_workflow',
+    'runner_info',
+    'parameters',
+    'notify'
+]
 
 
 def _decompose_liveaction(liveaction_db):

--- a/st2common/st2common/transport/consumers.py
+++ b/st2common/st2common/transport/consumers.py
@@ -140,7 +140,8 @@ class MessageHandler(object):
     message_type = None
 
     def __init__(self, connection, queues):
-        self._queue_consumer = self._get_queue_consumer(connection, queues)
+        self._queue_consumer = self.get_queue_consumer(connection=connection,
+                                                       queues=queues)
         self._consumer_thread = None
 
     def start(self, wait=False):
@@ -161,8 +162,8 @@ class MessageHandler(object):
     def process(self, message):
         pass
 
-    def _get_queue_consumer(self, connection, queues):
-        return QueueConsumer(connection, queues, self)
+    def get_queue_consumer(self, connection, queues):
+        return QueueConsumer(connection=connection, queues=queues, handler=self)
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -188,5 +189,5 @@ class StagedMessageHandler(MessageHandler):
         """
         pass
 
-    def _get_queue_consumer(self, connection, queues):
-        return StagedQueueConsumer(connection, queues, self)
+    def get_queue_consumer(self, connection, queues):
+        return StagedQueueConsumer(connection=connection, queues=queues, handler=self)

--- a/st2common/st2common/util/greenpooldispatch.py
+++ b/st2common/st2common/util/greenpooldispatch.py
@@ -16,16 +16,22 @@
 import eventlet
 import Queue
 
+__all__ = [
+    'BufferedDispatcher'
+]
+
 
 class BufferedDispatcher(object):
 
     def __init__(self, dispatch_pool_size=50, monitor_thread_empty_q_sleep_time=5,
-                 monitor_thread_no_workers_sleep_time=1):
+                 monitor_thread_no_workers_sleep_time=1, name=None):
         self._pool_limit = dispatch_pool_size
         self._dispatcher_pool = eventlet.GreenPool(dispatch_pool_size)
         self._dispatch_monitor_thread = eventlet.greenthread.spawn(self._flush)
         self._monitor_thread_empty_q_sleep_time = monitor_thread_empty_q_sleep_time
         self._monitor_thread_no_workers_sleep_time = monitor_thread_no_workers_sleep_time
+        self._name = name
+
         self._work_buffer = Queue.Queue()
 
     def dispatch(self, handler, *args):
@@ -49,3 +55,11 @@ class BufferedDispatcher(object):
         while not self._work_buffer.empty() and self._dispatcher_pool.free() > 0:
             (handler, args) = self._work_buffer.get_nowait()
             self._dispatcher_pool.spawn(handler, *args)
+
+    def __repr__(self):
+        name = self._name or id(self)
+        values = (name, self._pool_limit, self._monitor_thread_empty_q_sleep_time,
+                  self._monitor_thread_no_workers_sleep_time)
+        return ('<BufferedDispatcher name=%s,dispatch_pool_size=%s,'
+                'monitor_thread_empty_q_sleep_time=%s,monitor_thread_no_workers_sleep_time=%s>' %
+                values)

--- a/st2common/st2common/util/greenpooldispatch.py
+++ b/st2common/st2common/util/greenpooldispatch.py
@@ -13,12 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
+
 import eventlet
 import Queue
+
+from st2common import log as logging
 
 __all__ = [
     'BufferedDispatcher'
 ]
+
+# If the thread pool has been occupied with no empty threads for more than this number of seconds
+# a message will be logged
+POOL_BUSY_THRESHOLD_SECONDS = 60
+
+POOL_BUSY_LOG_MESSAGE = """
+BufferedDispatcher pool "%s" has been busy with no free threads for more than %s seconds. If there \
+are server resources available, consider increasing the dispatcher pool size in the config.
+""".strip()
+
+LOG = logging.getLogger(__name__)
 
 
 class BufferedDispatcher(object):
@@ -33,6 +48,13 @@ class BufferedDispatcher(object):
         self._name = name
 
         self._work_buffer = Queue.Queue()
+
+        # Internal attributes we use to track how long the pool is busy without any free workers
+        self._pool_last_free_ts = time.time()
+
+    @property
+    def name(self):
+        return self._name or id(self)
 
     def dispatch(self, handler, *args):
         self._work_buffer.put((handler, args), block=True, timeout=1)
@@ -51,14 +73,22 @@ class BufferedDispatcher(object):
 
     def _flush_now(self):
         if self._dispatcher_pool.free() <= 0:
+            now = time.time()
+
+            if (now - self._pool_last_free_ts) >= POOL_BUSY_THRESHOLD_SECONDS:
+                LOG.info(POOL_BUSY_LOG_MESSAGE % (self.name, POOL_BUSY_THRESHOLD_SECONDS))
+
             return
+
+        # Update the time of when there were free threads available
+        self._pool_last_free_ts = time.time()
+
         while not self._work_buffer.empty() and self._dispatcher_pool.free() > 0:
             (handler, args) = self._work_buffer.get_nowait()
             self._dispatcher_pool.spawn(handler, *args)
 
     def __repr__(self):
-        name = self._name or id(self)
-        values = (name, self._pool_limit, self._monitor_thread_empty_q_sleep_time,
+        values = (self.name, self._pool_limit, self._monitor_thread_empty_q_sleep_time,
                   self._monitor_thread_no_workers_sleep_time)
         return ('<BufferedDispatcher name=%s,dispatch_pool_size=%s,'
                 'monitor_thread_empty_q_sleep_time=%s,monitor_thread_no_workers_sleep_time=%s>' %


### PR DESCRIPTION
This pull request updates action runner message handler class to utilize two `BufferedDispatcher` pools - one of regular (non-workflow) actions and one for workflow actions. Size of both of those pools is also configurable by the operator.

This will increase the safety margins and make hitting deadlocks and issues like the one described in #2814 less likely.

It's also worth pointing out again that the actual pool sizes are very much user-specific (hardware on which the action runner process runs, number of action runners processes and workload aka type of actions).

Making those pool sizes configurable will also allow users to more efficiently utilize action runners and resources - e.g. if user has many concurrent lightweight actions and server CPU, etc. is far from the upper limit, the user can now bump the pool size and receive a better throughput without needing to spin up a new action runner process (of course that also depends on the actual scenario and workload, sometimes it's better and more effective to spin up a new action runner, etc.).

In addition to that I also updated `BufferedDispatcher` class to log an INFO message if a potential deadlock has been detected (if a pool is busy with no free works for more than some pre-defined period of seconds).

Resolves #2814.

## TODO

- [ ] Documentation