### PR TITLE
Fix CLI commands so they all support "--api-key" option

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ In development
   throughput of a single action runner when the system is not over-utilized. It can also help
   prevent deadlocks which may occur when using delay policies with action-chain workflows.
   (improvement)
+* Update CLI commands to make sure that all of them support ``--api-key`` option. (bug-fix)
 
 1.5.1 - July 13, 2016
 ---------------------

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -211,16 +211,21 @@ class ResourceManager(object):
         property_name: Name of the property
         self_deserialize: #Implies use the deserialize method implemented by this resource.
         """
-        token = None
-        if kwargs:
-            token = kwargs.pop('token', None)
+        token = kwargs.get('token', None)
+        api_key = kwargs.get('api_key', None)
 
+        if kwargs:
             url = '/%s/%s/%s/?%s' % (self.resource.get_url_path_name(), id_, property_name,
                                      urllib.parse.urlencode(kwargs))
         else:
             url = '/%s/%s/%s/' % (self.resource.get_url_path_name(), id_, property_name)
 
-        response = self.client.get(url, token=token) if token else self.client.get(url)
+        if api_key:
+            response = self.client.get(url, api_key=api_key)
+        elif api_key:
+            response = self.client.get(url, token=token)
+        else:
+            response = self.client.get(url)
 
         if response.status_code == 404:
             return None

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -220,10 +220,10 @@ class ResourceManager(object):
         else:
             url = '/%s/%s/%s/' % (self.resource.get_url_path_name(), id_, property_name)
 
-        if api_key:
-            response = self.client.get(url, api_key=api_key)
-        elif api_key:
+        if token:
             response = self.client.get(url, token=token)
+        elif api_key:
+            response = self.client.get(url, api_key=api_key)
         else:
             response = self.client.get(url)
 
@@ -260,10 +260,10 @@ class ResourceManager(object):
         url = '/%s/?%s' % (self.resource.get_url_path_name(),
                            urllib.parse.urlencode(params))
 
-        if api_key:
-            response = self.client.get(url, api_key=api_key)
-        elif api_key:
+        if token:
             response = self.client.get(url, token=token)
+        elif api_key:
+            response = self.client.get(url, api_key=api_key)
         else:
             response = self.client.get(url)
 


### PR DESCRIPTION
The problem was that `HTTPclient.query` method does some nasty stuff and wasn't updated when we added support for API keys.

I'm not a fan of the current and existing approach, but sadly there is not much I can do until we dedicate to invest enough time to totally refactor and improve the client library.

Resolves #2815.