### PR TITLE
Allow max_page size (value of ?limit param) to be configured by the administrator

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,9 @@ In development
   prevent deadlocks which may occur when using delay policies with action-chain workflows.
   (improvement)
 * Update CLI commands to make sure that all of them support ``--api-key`` option. (bug-fix)
+* Allow administrator to configure maximum limit which can be specified using ``?limit``
+  query parameters when making API calls to get all / list endpoints. For backward compatibility
+  and safety reasons, the default value still is ``100``. (improvement)
 
 1.5.1 - July 13, 2016
 ---------------------

--- a/st2api/st2api/config.py
+++ b/st2api/st2api/config.py
@@ -69,6 +69,6 @@ def _register_app_opts():
         cfg.IntOpt('max_page_size', default=100,
                    help=('Maximum limit (page size) argument which can be specified by the user '
                          'in a query string. If a larger value is provided, it will default to  '
-                         'this value.')),
+                         'this value.'))
     ]
     CONF.register_opts(logging_opts, group='api')

--- a/st2api/st2api/config.py
+++ b/st2api/st2api/config.py
@@ -65,6 +65,10 @@ def _register_app_opts():
 
     logging_opts = [
         cfg.StrOpt('logging', default='conf/logging.conf',
-                   help='location of the logging.conf file')
+                   help='location of the logging.conf file'),
+        cfg.IntOpt('max_page_size', default=100,
+                   help=('Maximum limit (page size) argument which can be specified by the user '
+                         'in a query string. If a larger value is provided, it will default to  '
+                         'this value.')),
     ]
     CONF.register_opts(logging_opts, group='api')

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -18,6 +18,7 @@
 import abc
 import copy
 
+from oslo_config import cfg
 from mongoengine import ValidationError
 import pecan
 from pecan import rest
@@ -49,7 +50,7 @@ class ResourceController(rest.RestController):
     from_model_kwargs = {}
 
     # Maximum value of limit which can be specified by user
-    max_limit = 100
+    max_limit = cfg.CONF.api.max_page_size
 
     # Default number of items returned per page if no limit is explicitly provided
     default_limit = 100

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -123,6 +123,9 @@ class ResourceController(rest.RestController):
         offset = int(offset)
 
         if limit and int(limit) > self.max_limit:
+            # TODO: We should throw here, I don't like this.
+            LOG.info('Limit "%s" specified, defaulting to max value of "%s"',
+                     limit, self.max_limit)
             limit = self.max_limit
         eop = offset + int(limit) if limit else None
 

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -124,13 +124,12 @@ class ResourceController(rest.RestController):
 
         if limit and int(limit) > self.max_limit:
             # TODO: We should throw here, I don't like this.
-            LOG.info('Limit "%s" specified, defaulting to max value of "%s"',
-                     limit, self.max_limit)
-            limit = self.max_limit
+            msg = 'Limit "%s" specified, maximum value is "%s"' % (limit, self.max_limit)
+            raise ValueError(msg)
+
         eop = offset + int(limit) if limit else None
 
         filters = {}
-
         for k, v in six.iteritems(self.supported_filters):
             filter_value = kwargs.get(k, None)
 

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -51,6 +51,9 @@ class ResourceController(rest.RestController):
     # Maximum value of limit which can be specified by user
     max_limit = 100
 
+    # Default number of items returned per page if no limit is explicitly provided
+    default_limit = 100
+
     query_options = {
         'sort': []
     }

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -458,7 +458,8 @@ class ActionExecutionsController(ActionExecutionsControllerMixin, ResourceContro
         :param exclude_fields: A list of object fields to exclude.
         :type exclude_fields: ``list``
         """
-        kw['limit'] = int(kw.get('limit', 100))
+
+        kw['limit'] = int(kw.get('limit', self.max_limit))
 
         LOG.debug('Retrieving all action executions with filters=%s', kw)
         return super(ActionExecutionsController, self)._get_all(exclude_fields=exclude_fields,

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -459,7 +459,7 @@ class ActionExecutionsController(ActionExecutionsControllerMixin, ResourceContro
         :type exclude_fields: ``list``
         """
 
-        kw['limit'] = int(kw.get('limit', self.max_limit))
+        kw['limit'] = int(kw.get('limit', self.default_limit))
 
         LOG.debug('Retrieving all action executions with filters=%s', kw)
         return super(ActionExecutionsController, self)._get_all(exclude_fields=exclude_fields,

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -395,7 +395,7 @@ class TriggerInstanceController(TriggerInstanceControllerMixin, resource.Resourc
         return trigger_instances
 
     def _get_trigger_instances(self, **kw):
-        kw['limit'] = int(kw.get('limit', 100))
+        kw['limit'] = int(kw.get('limit', self.max_limit))
 
         LOG.debug('Retrieving all trigger instances with filters=%s', kw)
         return super(TriggerInstanceController, self)._get_all(**kw)

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -395,7 +395,7 @@ class TriggerInstanceController(TriggerInstanceControllerMixin, resource.Resourc
         return trigger_instances
 
     def _get_trigger_instances(self, **kw):
-        kw['limit'] = int(kw.get('limit', self.max_limit))
+        kw['limit'] = int(kw.get('limit', self.default_limit))
 
         LOG.debug('Retrieving all trigger instances with filters=%s', kw)
         return super(TriggerInstanceController, self)._get_all(**kw)

--- a/st2api/tests/unit/controllers/v1/test_actions.py
+++ b/st2api/tests/unit/controllers/v1/test_actions.py
@@ -325,6 +325,11 @@ class TestActionController(FunctionalTest, CleanFilesTestCase):
         self.__do_delete(action_1_id)
         self.__do_delete(action_2_id)
 
+    def test_get_all_invalid_limit_too_large(self):
+        resp = self.app.get('/v1/actions?limit=1000', expect_errors=True)
+        self.assertEqual(resp.status_int, 400)
+        self.assertEqual(resp.json['faultstring'], 'Limit "1000" specified, maximum value is "100"')
+
     @mock.patch.object(action_validator, 'validate_action', mock.MagicMock(
         return_value=True))
     def test_get_all_exclude_attributes(self):

--- a/st2api/tests/unit/controllers/v1/test_executions_filters.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_filters.py
@@ -21,6 +21,9 @@ import bson
 import six
 from six.moves import http_client
 
+import st2tests.config as tests_config
+tests_config.parse_args()
+
 from tests import FunctionalTest
 from st2tests.fixtures.packs import executions as fixture
 from st2tests.fixtures import history_views

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -925,8 +925,7 @@ class ActionExecutionListCommand(ActionExecutionReadCommand):
         self.group = self.parser.add_argument_group()
         self.parser.add_argument('-n', '--last', type=int, dest='last',
                                  default=50,
-                                 help=('List N most recent %s; '
-                                       'list all if 0.' %
+                                 help=('List N most recent %s.' %
                                        resource.get_plural_display_name().lower()))
 
         # Filter options

--- a/st2client/st2client/commands/rule.py
+++ b/st2client/st2client/commands/rule.py
@@ -44,8 +44,7 @@ class RuleListCommand(resource.ContentPackResourceListCommand):
         self.group = self.parser.add_argument_group()
         self.parser.add_argument('-n', '--last', type=int, dest='last',
                                  default=50,
-                                 help=('List N most recent %s; '
-                                       'list all if 0.' %
+                                 help=('List N most recent %s.' %
                                        resource.get_plural_display_name().lower()))
         self.parser.add_argument('--iftt', action='store_true',
                                  help='Show trigger and action in display list.')

--- a/st2client/st2client/commands/rule_enforcement.py
+++ b/st2client/st2client/commands/rule_enforcement.py
@@ -64,8 +64,7 @@ class RuleEnforcementListCommand(resource.ResourceCommand):
         self.group = self.parser.add_argument_group()
         self.parser.add_argument('-n', '--last', type=int, dest='last',
                                  default=50,
-                                 help=('List N most recent %s; '
-                                       'list all if 0.' %
+                                 help=('List N most recent %s.' %
                                        resource.get_plural_display_name().lower()))
 
         # Filter options

--- a/st2client/st2client/commands/trace.py
+++ b/st2client/st2client/commands/trace.py
@@ -121,8 +121,7 @@ class TraceListCommand(resource.ResourceCommand, SingleTraceDisplayMixin):
         self.group = self.parser.add_mutually_exclusive_group()
         self.parser.add_argument('-n', '--last', type=int, dest='last',
                                  default=50,
-                                 help=('List N most recent %s; '
-                                       'list all if 0.' %
+                                 help=('List N most recent %s.' %
                                        resource.get_plural_display_name().lower()))
 
         # Filter options

--- a/st2client/st2client/commands/triggerinstance.py
+++ b/st2client/st2client/commands/triggerinstance.py
@@ -75,8 +75,7 @@ class TriggerInstanceListCommand(resource.ResourceCommand):
         self.group = self.parser.add_argument_group()
         self.parser.add_argument('-n', '--last', type=int, dest='last',
                                  default=50,
-                                 help=('List N most recent %s; '
-                                       'list all if 0.' %
+                                 help=('List N most recent %s.' %
                                        resource.get_plural_display_name().lower()))
 
         # Filter options

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -111,6 +111,14 @@ def _register_api_opts():
     ]
     _register_opts(pecan_opts, group='api_pecan')
 
+    api_opts = [
+        cfg.IntOpt('max_page_size', default=100,
+                   help=('Maximum limit (page size) argument which can be specified by the user '
+                         'in a query string. If a larger value is provided, it will default to  '
+                         'this value.'))
+    ]
+    _register_opts(api_opts, group='api')
+
     messaging_opts = [
         cfg.StrOpt('url', default='amqp://guest:guest@127.0.0.1:5672//',
                    help='URL of the messaging server.'),


### PR DESCRIPTION
As discussed in #2803 and #2806, this PR makes maximum page size aka maximum value of `?limit` query parameter configurable by the StackStorm administrator.

For backward compatibility and safety reasons (to prevent DDoS, etc.) we still default this value to `100`, but if user as a need to use a lower / higher value, they can now tune this setting.