### PR TITLE
Explicit kwargs pass to _get_children method

### DIFF
--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -220,7 +220,17 @@ class ActionExecutionChildrenController(BaseActionExecutionNestedController):
 
         :rtype: ``list``
         """
-        return self._get_children(id_=id, **kwargs)
+        get_children_kwargs = {}
+
+        depth = kwargs.get('depth', None)
+        if depth:
+            get_children_kwargs['depth'] = depth
+
+        request_fmt = get_children_kwargs.get('result_fmt', None)
+        if request_fmt:
+            get_children_kwargs['request_fmt'] = request_fmt
+
+        return self._get_children(id_=id, **get_children_kwargs)
 
 
 class ActionExecutionAttributeController(BaseActionExecutionNestedController):

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -213,24 +213,15 @@ class BaseActionExecutionNestedController(ActionExecutionsControllerMixin, Resou
 
 class ActionExecutionChildrenController(BaseActionExecutionNestedController):
     @request_user_has_resource_db_permission(permission_type=PermissionType.EXECUTION_VIEW)
-    @jsexpose(arg_types=[str])
-    def get(self, id, **kwargs):
+    @jsexpose(arg_types=[str, int, str])
+    def get(self, id, depth=-1, result_fmt=None, **kwargs):
         """
         Retrieve children for the provided action execution.
 
         :rtype: ``list``
         """
-        get_children_kwargs = {}
 
-        depth = kwargs.get('depth', None)
-        if depth:
-            get_children_kwargs['depth'] = depth
-
-        request_fmt = get_children_kwargs.get('result_fmt', None)
-        if request_fmt:
-            get_children_kwargs['request_fmt'] = request_fmt
-
-        return self._get_children(id_=id, **get_children_kwargs)
+        return self._get_children(id_=id, depth=depth, result_fmt=result_fmt)
 
 
 class ActionExecutionAttributeController(BaseActionExecutionNestedController):


### PR DESCRIPTION
This change https://github.com/StackStorm/st2/pull/2831/files#diff-212b279de225b603d0bc7fe4e00ae449R224 broken the controller because of kwargs abuse in both CLI https://github.com/StackStorm/st2/blob/master/st2client/st2client/utils/httpclient.py#L75 and the controller simply passing the kwargs :/

I fixed controller arguments to explicitly call out what's needed. 

Spun up an instance and hand patched to test the changes

```
vagrant@st2test:~$ st2 run packs.install packs=circle_ci
.................
id: 5797e5e955fc8c2686399ac9
action.ref: packs.install
parameters:
  packs:
  - circle_ci
status: succeeded
start_timestamp: 2016-07-26T22:36:25.183147Z
end_timestamp: 2016-07-26T22:37:00.040937Z
+--------------------------+-------------------------+--------------------------+-------------------------+-------------------------------+
| id                       | status                  | task                     | action                  | start_timestamp               |
+--------------------------+-------------------------+--------------------------+-------------------------+-------------------------------+
| 5797e5e955fc8c25cbd9feaa | succeeded (10s elapsed) | download                 | packs.download          | Tue, 26 Jul 2016 22:36:25 UTC |
| 5797e5f355fc8c25cbd9feac | succeeded (3s elapsed)  | virtualenv_prerun        | packs.virtualenv_prerun | Tue, 26 Jul 2016 22:36:35 UTC |
| 5797e5f755fc8c25cbd9feaf | succeeded (11s elapsed) | setup_virtualenv         | packs.setup_virtualenv  | Tue, 26 Jul 2016 22:36:39 UTC |
| 5797e60355fc8c25cbd9feb1 | succeeded (6s elapsed)  | reload                   | packs.load              | Tue, 26 Jul 2016 22:36:51 UTC |
| 5797e60955fc8c25cbd9feb4 | succeeded (2s elapsed)  | restart-sensor-container | packs.restart_component | Tue, 26 Jul 2016 22:36:57 UTC |
+--------------------------+-------------------------+--------------------------+-------------------------+-------------------------------+
vagrant@st2test:~$
```

TODO:

* [x] Validate UI didn't break