### PR TITLE
[RFR]: Enhancement: python action should be allowed to return status #2742

### DIFF
--- a/st2actions/st2actions/runners/python_action_wrapper.py
+++ b/st2actions/st2actions/runners/python_action_wrapper.py
@@ -16,7 +16,7 @@
 import sys
 import json
 import argparse
-
+import traceback
 from oslo_config import cfg
 
 from st2common import log as logging
@@ -133,8 +133,12 @@ class PythonActionWrapper(object):
             action_output['status'] = action_status
             print_output = json.dumps(action_output)
         else:
-            raise InvalidStatusException('Status returned from the action must'
-                                         ' either be True or False.')
+            try:
+                raise InvalidStatusException('Status returned from the action'
+                                             ' must either be True or False.')
+            except:
+                traceback.print_exc()
+                sys.exit(220)
 
         sys.stdout.write(print_output + '\n')
         sys.stdout.write(ACTION_OUTPUT_RESULT_DELIMITER)

--- a/st2actions/st2actions/runners/python_action_wrapper.py
+++ b/st2actions/st2actions/runners/python_action_wrapper.py
@@ -66,7 +66,7 @@ class ActionService(object):
 
     def set_value(self, name, value, ttl=None, local=True, scope=SYSTEM_SCOPE, encrypt=False):
         return self._datastore_service.set_value(name, value, ttl, local, scope=scope,
-            encrypt=encrypt)
+                                                 encrypt=encrypt)
 
     def delete_value(self, name, local=True, scope=SYSTEM_SCOPE):
         return self._datastore_service.delete_value(name, local)
@@ -115,8 +115,7 @@ class PythonActionWrapper(object):
         action = self._get_action_instance()
         output = action.run(**self._parameters)
         action_status = None
-
-        if type(output) is tuple and len(output) is 2:
+        if type(output) is tuple and len(output) == 2:
             action_status = output[0]
             action_result = output[1]
         else:
@@ -127,14 +126,14 @@ class PythonActionWrapper(object):
         # Print output to stdout so the parent can capture it
         sys.stdout.write(ACTION_OUTPUT_RESULT_DELIMITER)
         print_output = None
-        try:
-            if action_status:
-                action_output['status'] = action_status
-                print_output = json.dumps(action_output)
-            else:
-                print_output = json.dumps(action_output)
-        except:
-            print_output = str(action_output)
+        if action_status is None:
+            print_output = json.dumps(action_output)
+        elif type(action_status) is bool:
+            action_output['status'] = action_status
+            print_output = json.dumps(action_output)
+        else:
+            raise Exception('Status should either be True or False.')
+
         sys.stdout.write(print_output + '\n')
         sys.stdout.write(ACTION_OUTPUT_RESULT_DELIMITER)
 

--- a/st2actions/st2actions/runners/python_action_wrapper.py
+++ b/st2actions/st2actions/runners/python_action_wrapper.py
@@ -30,6 +30,7 @@ from st2common.constants.action import ACTION_OUTPUT_RESULT_DELIMITER
 from st2common.constants.keyvalue import SYSTEM_SCOPE
 from st2common.service_setup import db_setup
 from st2common.services.datastore import DatastoreService
+from st2common.exceptions.invalidstatus import InvalidStatusException
 
 __all__ = [
     'PythonActionWrapper',
@@ -132,7 +133,8 @@ class PythonActionWrapper(object):
             action_output['status'] = action_status
             print_output = json.dumps(action_output)
         else:
-            raise Exception('Status should either be True or False.')
+            raise InvalidStatusException('Status returned from the action must'
+                                         ' either be True or False.')
 
         sys.stdout.write(print_output + '\n')
         sys.stdout.write(ACTION_OUTPUT_RESULT_DELIMITER)

--- a/st2actions/st2actions/runners/python_action_wrapper.py
+++ b/st2actions/st2actions/runners/python_action_wrapper.py
@@ -28,6 +28,7 @@ from st2common.util import loader as action_loader
 from st2common.util.config_loader import ContentPackConfigLoader
 from st2common.constants.action import ACTION_OUTPUT_RESULT_DELIMITER
 from st2common.constants.keyvalue import SYSTEM_SCOPE
+from st2common.constants.error_codes import PYTHON_ACTION_INVALID_STATUS_EXIT_CODE
 from st2common.service_setup import db_setup
 from st2common.services.datastore import DatastoreService
 from st2common.exceptions.invalidstatus import InvalidStatusException
@@ -138,7 +139,7 @@ class PythonActionWrapper(object):
                                              ' must either be True or False.')
             except:
                 traceback.print_exc()
-                sys.exit(220)
+                sys.exit(PYTHON_ACTION_INVALID_STATUS_EXIT_CODE)
 
         sys.stdout.write(print_output + '\n')
         sys.stdout.write(ACTION_OUTPUT_RESULT_DELIMITER)

--- a/st2actions/st2actions/runners/pythonrunner.py
+++ b/st2actions/st2actions/runners/pythonrunner.py
@@ -166,7 +166,7 @@ class PythonRunner(ActionRunner):
         else:
             error = None
 
-        if "InvalidStatusException" in stderr:
+        if exit_code == 220:
             raise InvalidStatusException(stderr)
 
         if ACTION_OUTPUT_RESULT_DELIMITER in stdout:
@@ -186,7 +186,7 @@ class PythonRunner(ActionRunner):
             result = action_result['result']
             try:
                 action_status = action_result['status']
-            except:
+            except KeyError:
                 pass
         else:
             result = "None"

--- a/st2actions/st2actions/runners/pythonrunner.py
+++ b/st2actions/st2actions/runners/pythonrunner.py
@@ -38,6 +38,7 @@ from st2common.util.sandboxing import get_sandbox_path
 from st2common.util.sandboxing import get_sandbox_python_path
 from st2common.util.sandboxing import get_sandbox_python_binary_path
 from st2common.util.sandboxing import get_sandbox_virtualenv_path
+from st2common.exceptions.invalidstatus import InvalidStatusException
 
 
 __all__ = [
@@ -164,6 +165,9 @@ class PythonRunner(ActionRunner):
             error = 'Action failed to complete in %s seconds' % (self._timeout)
         else:
             error = None
+
+        if "InvalidStatusException" in stderr:
+            raise InvalidStatusException(stderr)
 
         if ACTION_OUTPUT_RESULT_DELIMITER in stdout:
             split = stdout.split(ACTION_OUTPUT_RESULT_DELIMITER)

--- a/st2actions/st2actions/runners/pythonrunner.py
+++ b/st2actions/st2actions/runners/pythonrunner.py
@@ -29,6 +29,7 @@ from st2common.constants.action import ACTION_OUTPUT_RESULT_DELIMITER
 from st2common.constants.action import LIVEACTION_STATUS_SUCCEEDED
 from st2common.constants.action import LIVEACTION_STATUS_FAILED
 from st2common.constants.action import LIVEACTION_STATUS_TIMED_OUT
+from st2common.constants.error_codes import PYTHON_ACTION_INVALID_STATUS_EXIT_CODE
 from st2common.constants.error_messages import PACK_VIRTUALENV_DOESNT_EXIST
 from st2common.constants.runners import PYTHON_RUNNER_DEFAULT_ACTION_TIMEOUT
 from st2common.constants.system import API_URL_ENV_VARIABLE_NAME
@@ -166,7 +167,7 @@ class PythonRunner(ActionRunner):
         else:
             error = None
 
-        if exit_code == 220:
+        if exit_code == PYTHON_ACTION_INVALID_STATUS_EXIT_CODE:
             raise InvalidStatusException(stderr)
 
         if ACTION_OUTPUT_RESULT_DELIMITER in stdout:

--- a/st2actions/tests/unit/test_pythonrunner.py
+++ b/st2actions/tests/unit/test_pythonrunner.py
@@ -69,7 +69,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         runner.entry_point = PASCAL_ROW_ACTION_PATH
         runner.container_service = service.RunnerContainerService()
         runner.pre_run()
-        (status, output, _) = runner.run({'row_index':'b'})
+        (status, output, _) = runner.run({'row_index': 'b'})
         self.assertEqual(status, LIVEACTION_STATUS_SUCCEEDED)
         self.assertTrue(output is not None)
         self.assertEqual(output['exit_code'], 0)

--- a/st2actions/tests/unit/test_pythonrunner.py
+++ b/st2actions/tests/unit/test_pythonrunner.py
@@ -22,6 +22,7 @@ from st2actions.runners.python_action_wrapper import PythonActionWrapper
 from st2actions.runners.pythonrunner import Action
 from st2actions.container import service
 from st2actions.runners.utils import get_action_class_instance
+from st2common.exceptions import invalidstatus
 from st2common.services import config as config_service
 from st2common.constants.action import ACTION_OUTPUT_RESULT_DELIMITER
 from st2common.constants.action import LIVEACTION_STATUS_SUCCEEDED, LIVEACTION_STATUS_FAILED
@@ -125,6 +126,16 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         self.assertEqual(status, LIVEACTION_STATUS_FAILED)
         self.assertTrue(output is not None)
         self.assertEqual(output['result'], None)
+
+    def test_exception_in_simple_action_with_invalid_status(self):
+        runner = pythonrunner.get_runner()
+        runner.action = self._get_mock_action_obj()
+        runner.runner_parameters = {}
+        runner.entry_point = PASCAL_ROW_ACTION_PATH
+        runner.container_service = service.RunnerContainerService()
+        runner.pre_run()
+        self.assertRaises(invalidstatus.InvalidStatusException,
+                          runner.run, action_parameters={'row_index': 'd'})
 
     def test_simple_action_config_value_provided_overriden_in_datastore(self):
         wrapper = PythonActionWrapper(pack='dummy_pack_5', file_path=PASCAL_ROW_ACTION_PATH,

--- a/st2actions/tests/unit/test_pythonrunner.py
+++ b/st2actions/tests/unit/test_pythonrunner.py
@@ -31,9 +31,8 @@ from st2tests.base import CleanDbTestCase
 import st2tests.base as tests_base
 
 
-PACAL_ROW_ACTION_PATH = os.path.join(tests_base.get_resources_path(), 'packs',
-                                     'pythonactions/actions/pascal_row.py')
-
+PASCAL_ROW_ACTION_PATH = os.path.join(tests_base.get_resources_path(), 'packs',
+                                      'pythonactions/actions/pascal_row.py')
 # Note: runner inherits parent args which doesn't work with tests since test pass additional
 # unrecognized args
 mock_sys = mock.Mock()
@@ -50,20 +49,56 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         self.assertTrue(runner is not None, 'Creation failed. No instance.')
         self.assertEqual(type(runner), pythonrunner.PythonRunner, 'Creation failed. No instance.')
 
-    def test_simple_action(self):
+    def test_simple_action_without_status(self):
         runner = pythonrunner.get_runner()
         runner.action = self._get_mock_action_obj()
         runner.runner_parameters = {}
-        runner.entry_point = PACAL_ROW_ACTION_PATH
+        runner.entry_point = PASCAL_ROW_ACTION_PATH
         runner.container_service = service.RunnerContainerService()
         runner.pre_run()
-        (status, result, _) = runner.run({'row_index': 4})
+        (status, output, _) = runner.run({'row_index': 5})
         self.assertEqual(status, LIVEACTION_STATUS_SUCCEEDED)
-        self.assertTrue(result is not None)
-        self.assertEqual(result['result'], [1, 4, 6, 4, 1])
+        self.assertTrue(output is not None)
+        self.assertEqual(output['result'], [1, 5, 10, 10, 5, 1])
+
+    def test_simple_action_with_status_succeeded(self):
+        runner = pythonrunner.get_runner()
+        runner.action = self._get_mock_action_obj()
+        runner.runner_parameters = {}
+        runner.entry_point = PASCAL_ROW_ACTION_PATH
+        runner.container_service = service.RunnerContainerService()
+        runner.pre_run()
+        (status, output, _) = runner.run({'row_index': 4})
+        self.assertEqual(status, LIVEACTION_STATUS_SUCCEEDED)
+        self.assertTrue(output is not None)
+        self.assertEqual(output['result'], [1, 4, 6, 4, 1])
+
+    def test_simple_action_with_status_failed(self):
+        runner = pythonrunner.get_runner()
+        runner.action = self._get_mock_action_obj()
+        runner.runner_parameters = {}
+        runner.entry_point = PASCAL_ROW_ACTION_PATH
+        runner.container_service = service.RunnerContainerService()
+        runner.pre_run()
+        (status, output, _) = runner.run({'row_index': 'a'})
+        self.assertEqual(status, LIVEACTION_STATUS_FAILED)
+        self.assertTrue(output is not None)
+        self.assertEqual(output['result'], "This is suppose to fail don't worry!!")
+
+    def test_simple_action_with_status_failed_result_none(self):
+        runner = pythonrunner.get_runner()
+        runner.action = self._get_mock_action_obj()
+        runner.runner_parameters = {}
+        runner.entry_point = PASCAL_ROW_ACTION_PATH
+        runner.container_service = service.RunnerContainerService()
+        runner.pre_run()
+        (status, output, _) = runner.run({'row_index': 'b'})
+        self.assertEqual(status, LIVEACTION_STATUS_FAILED)
+        self.assertTrue(output is not None)
+        self.assertEqual(output['result'], 'None')
 
     def test_simple_action_config_value_provided_overriden_in_datastore(self):
-        wrapper = PythonActionWrapper(pack='dummy_pack_5', file_path=PACAL_ROW_ACTION_PATH,
+        wrapper = PythonActionWrapper(pack='dummy_pack_5', file_path=PASCAL_ROW_ACTION_PATH,
                                       user='joe')
 
         # No values provided in the datastore
@@ -95,7 +130,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         runner = pythonrunner.get_runner()
         runner.action = self._get_mock_action_obj()
         runner.runner_parameters = {}
-        runner.entry_point = PACAL_ROW_ACTION_PATH
+        runner.entry_point = PASCAL_ROW_ACTION_PATH
         runner.container_service = service.RunnerContainerService()
         runner.pre_run()
         (status, result, _) = runner.run({'row_index': '4'})
@@ -134,7 +169,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         runner = pythonrunner.get_runner()
         runner.action = self._get_mock_action_obj()
         runner.runner_parameters = {'env': env_vars}
-        runner.entry_point = PACAL_ROW_ACTION_PATH
+        runner.entry_point = PASCAL_ROW_ACTION_PATH
         runner.container_service = service.RunnerContainerService()
         runner.pre_run()
         (_, _, _) = runner.run({'row_index': 4})
@@ -164,7 +199,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         runner = pythonrunner.get_runner()
         runner.action = self._get_mock_action_obj()
         runner.runner_parameters = {}
-        runner.entry_point = PACAL_ROW_ACTION_PATH
+        runner.entry_point = PASCAL_ROW_ACTION_PATH
         runner.container_service = service.RunnerContainerService()
         runner.pre_run()
         (_, output, _) = runner.run({'row_index': 4})
@@ -174,26 +209,48 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         self.assertEqual(output['result'], 'None')
         self.assertEqual(output['exit_code'], 0)
 
-        # Output to stdout and no result (implicit None)
+        # Output to stdout, no result (implicit None),return_code 1 and status
+        # failed
+        mock_stdout = 'pre result%(delimiter)sNone%(delimiter)spost result' % values
+        mock_stderr = 'foo stderr'
+        mock_process = mock.Mock()
+        mock_process.communicate.return_value = (mock_stdout, mock_stderr)
+        mock_process.returncode = 1
+        mock_popen.return_value = mock_process
+
+        runner = pythonrunner.get_runner()
+        runner.action = self._get_mock_action_obj()
+        runner.runner_parameters = {}
+        runner.entry_point = PASCAL_ROW_ACTION_PATH
+        runner.container_service = service.RunnerContainerService()
+        runner.pre_run()
+        (status, output, _) = runner.run({'row_index': 4})
+        self.assertEqual(output['stdout'], 'pre resultpost result')
+        self.assertEqual(output['stderr'], mock_stderr)
+        self.assertEqual(output['result'], 'None')
+        self.assertEqual(output['exit_code'], 1)
+        self.assertEqual(status, 'failed')
+
+        # Output to stdout, no result (implicit None), return_code 1 and status
+        # succedded
         mock_stdout = 'pre result%(delimiter)sNone%(delimiter)spost result' % values
         mock_stderr = 'foo stderr'
         mock_process = mock.Mock()
         mock_process.communicate.return_value = (mock_stdout, mock_stderr)
         mock_process.returncode = 0
         mock_popen.return_value = mock_process
-
         runner = pythonrunner.get_runner()
         runner.action = self._get_mock_action_obj()
         runner.runner_parameters = {}
-        runner.entry_point = PACAL_ROW_ACTION_PATH
+        runner.entry_point = PASCAL_ROW_ACTION_PATH
         runner.container_service = service.RunnerContainerService()
         runner.pre_run()
-        (_, output, _) = runner.run({'row_index': 4})
-
+        (status, output, _) = runner.run({'row_index': 4})
         self.assertEqual(output['stdout'], 'pre resultpost result')
         self.assertEqual(output['stderr'], mock_stderr)
         self.assertEqual(output['result'], 'None')
         self.assertEqual(output['exit_code'], 0)
+        self.assertEqual(status, 'succeeded')
 
     @mock.patch('st2common.util.green.shell.subprocess.Popen')
     def test_common_st2_env_vars_are_available_to_the_action(self, mock_popen):
@@ -206,7 +263,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         runner.auth_token.token = 'ponies'
         runner.action = self._get_mock_action_obj()
         runner.runner_parameters = {}
-        runner.entry_point = PACAL_ROW_ACTION_PATH
+        runner.entry_point = PASCAL_ROW_ACTION_PATH
         runner.container_service = service.RunnerContainerService()
         runner.pre_run()
         (_, _, _) = runner.run({'row_index': 4})

--- a/st2common/st2common/constants/error_codes.py
+++ b/st2common/st2common/constants/error_codes.py
@@ -1,0 +1,16 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+PYTHON_ACTION_INVALID_STATUS_EXIT_CODE = 220

--- a/st2common/st2common/exceptions/invalidstatus.py
+++ b/st2common/st2common/exceptions/invalidstatus.py
@@ -1,0 +1,20 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from st2common.exceptions import StackStormBaseException
+
+
+class InvalidStatusException(StackStormBaseException):
+    pass

--- a/st2tests/st2tests/resources/packs/pythonactions/actions/pascal_row.py
+++ b/st2tests/st2tests/resources/packs/pythonactions/actions/pascal_row.py
@@ -11,17 +11,19 @@ class PascalRowAction(Action):
     @staticmethod
     def _compute_pascal_row(row_index=0):
         if row_index == 'a':
-            return "Failed", "This is suppose to fail don't worry!!"
+            return False, "This is suppose to fail don't worry!!"
+
+        elif row_index == 'b':
+            return None
 
         elif row_index == 'c':
-            return "Failed", None
+            return False, None
 
         elif row_index == 5:
             return [math.factorial(row_index) /
                     (math.factorial(i) * math.factorial(row_index - i))
                     for i in range(row_index + 1)]
-
         else:
-            return "Succeeded", [math.factorial(row_index) /
-                                 (math.factorial(i) * math.factorial(row_index - i))
-                                 for i in range(row_index + 1)]
+            return True, [math.factorial(row_index) /
+                          (math.factorial(i) * math.factorial(row_index - i))
+                          for i in range(row_index + 1)]

--- a/st2tests/st2tests/resources/packs/pythonactions/actions/pascal_row.py
+++ b/st2tests/st2tests/resources/packs/pythonactions/actions/pascal_row.py
@@ -19,6 +19,9 @@ class PascalRowAction(Action):
         elif row_index == 'c':
             return False, None
 
+        elif row_index == 'd':
+            return "succeeded", [1, 2, 3, 4]
+
         elif row_index == 5:
             return [math.factorial(row_index) /
                     (math.factorial(i) * math.factorial(row_index - i))

--- a/st2tests/st2tests/resources/packs/pythonactions/actions/pascal_row.py
+++ b/st2tests/st2tests/resources/packs/pythonactions/actions/pascal_row.py
@@ -10,5 +10,18 @@ class PascalRowAction(Action):
 
     @staticmethod
     def _compute_pascal_row(row_index=0):
-        return [math.factorial(row_index) / (math.factorial(i) * math.factorial(row_index - i))
-                for i in range(row_index + 1)]
+        if row_index == 'a':
+            return "Failed", "This is suppose to fail don't worry!!"
+
+        elif row_index == 'c':
+            return "Failed", None
+
+        elif row_index == 5:
+            return [math.factorial(row_index) /
+                    (math.factorial(i) * math.factorial(row_index - i))
+                    for i in range(row_index + 1)]
+
+        else:
+            return "Succeeded", [math.factorial(row_index) /
+                                 (math.factorial(i) * math.factorial(row_index - i))
+                                 for i in range(row_index + 1)]


### PR DESCRIPTION
**Changed files:**
- st2actions/st2actions/runners/python_action_wrapper.py
- st2actions/st2actions/runners/pythonrunner.py
- st2tests/st2tests/resources/packs/pythonactions/actions/pascal_row.py
- st2actions/tests/unit/test_pythonrunner.py
 

**Test Cases:**
_Modified_:
- test_simple_action_without_status
- test_stdout_interception_and_parsing

_New_:
- test_simple_action_with_status_succeeded
- test_simple_action_with_status_failed
- test_simple_action_with_status_failed_result_none

**Caveats:**
~~- Assumption: User must provide status as "succeeded" or "failed" (case insensitive). It may fail otherwise. No check for this.~~