### PR TITLE
Enhancement: add option to sort in descending order - ascending is default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ In development
   prevent deadlocks which may occur when using delay policies with action-chain workflows.
   (improvement)
 * Update CLI commands to make sure that all of them support ``--api-key`` option. (bug-fix)
+* Add support for sorting execution list results, allowing access to oldest items. (improvement)
 
 1.5.1 - July 13, 2016
 ---------------------

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -376,7 +376,7 @@ class ActionExecutionsController(ActionExecutionsControllerMixin, ResourceContro
         if 'timestamp_lt' in kw:
             query_options = {'sort': ['-start_timestamp', 'action.ref']}
             kw['query_options'] = query_options
-        elif 'timestamp_gt' in kw:
+        elif 'timestamp_gt' in kw or 'sort_desc' in kw:
             query_options = {'sort': ['+start_timestamp', 'action.ref']}
             kw['query_options'] = query_options
 

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -373,10 +373,10 @@ class ActionExecutionsController(ActionExecutionsControllerMixin, ResourceContro
 
         # Use a custom sort order when filtering on a timestamp so we return a correct result as
         # expected by the user
-        if 'timestamp_lt' in kw:
+        if 'timestamp_lt' in kw or 'sort_desc' in kw:
             query_options = {'sort': ['-start_timestamp', 'action.ref']}
             kw['query_options'] = query_options
-        elif 'timestamp_gt' in kw or 'sort_desc' in kw:
+        elif 'timestamp_gt' in kw or 'sort_asc' in kw:
             query_options = {'sort': ['+start_timestamp', 'action.ref']}
             kw['query_options'] = query_options
 

--- a/st2api/tests/unit/controllers/v1/test_executions_filters.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_filters.py
@@ -259,6 +259,22 @@ class TestActionExecutionFilters(FunctionalTest):
         dt2 = response.json[len(response.json) - 1]['start_timestamp']
         self.assertLess(isotime.parse(dt2), isotime.parse(dt1))
 
+    def test_ascending_sort(self):
+        response = self.app.get('/v1/executions?sort_asc=True')
+        self.assertEqual(response.status_int, 200)
+        self.assertIsInstance(response.json, list)
+        dt1 = response.json[0]['start_timestamp']
+        dt2 = response.json[len(response.json) - 1]['start_timestamp']
+        self.assertLess(isotime.parse(dt1), isotime.parse(dt2))
+
+    def test_descending_sort(self):
+        response = self.app.get('/v1/executions?sort_desc=True')
+        self.assertEqual(response.status_int, 200)
+        self.assertIsInstance(response.json, list)
+        dt1 = response.json[0]['start_timestamp']
+        dt2 = response.json[len(response.json) - 1]['start_timestamp']
+        self.assertLess(isotime.parse(dt2), isotime.parse(dt1))
+
     def test_timestamp_lt_and_gt_filter(self):
         def isoformat(timestamp):
             return isotime.format(timestamp, offset=False)
@@ -288,15 +304,15 @@ class TestActionExecutionFilters(FunctionalTest):
         self.assertEqual(len(response.json), 1)
         self.assertTrue(isotime.parse(response.json[0]['start_timestamp']) < timestamp)
 
-        # Half timestamps should be smaller
-        index = (len(self.start_timestamps) - 1)
+        # Half of the timestamps should be smaller
+        index = (len(self.start_timestamps) - 1) // 2
         timestamp = self.start_timestamps[index]
         response = self.app.get('/v1/executions?timestamp_lt=%s' % (isoformat(timestamp)))
         self.assertEqual(len(response.json), index)
         self.assertTrue(isotime.parse(response.json[0]['start_timestamp']) < timestamp)
 
-        # Half timestamps should be greater
-        index = (len(self.start_timestamps) - 1)
+        # Half of the timestamps should be greater
+        index = (len(self.start_timestamps) - 1) // 2
         timestamp = self.start_timestamps[-index]
         response = self.app.get('/v1/executions?timestamp_gt=%s' % (isoformat(timestamp)))
         self.assertEqual(len(response.json), (index - 1))

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -930,7 +930,8 @@ class ActionExecutionListCommand(ActionExecutionReadCommand):
         self.parser.add_argument('-s', '--sort', type=str, dest='sort_order',
                                  default='descending',
                                  help=('Sort %s by start timestamp, '
-                                       'asc (ascending) or desc (descending)' %
+                                       'asc|ascending (earliest first) '
+                                       'or desc|descending (latest first)' %
                                        resource.get_plural_display_name().lower()))
 
         # Filter options

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -928,6 +928,11 @@ class ActionExecutionListCommand(ActionExecutionReadCommand):
                                  help=('List N most recent %s; '
                                        'list all if 0.' %
                                        resource.get_plural_display_name().lower()))
+        self.parser.add_argument('-s', '--sort', type=str, dest='sort_order',
+                                 default='asc',
+                                 help=('Sort %s by start timestamp, '
+                                       'asc (ascending) or desc (descending)' %
+                                       resource.get_plural_display_name().lower()))
 
         # Filter options
         self.group.add_argument('--action', help='Action reference to filter the list.')
@@ -976,6 +981,9 @@ class ActionExecutionListCommand(ActionExecutionReadCommand):
             kwargs['timestamp_gt'] = args.timestamp_gt
         if args.timestamp_lt:
             kwargs['timestamp_lt'] = args.timestamp_lt
+        if args.sort_order:
+            if args.sort_order == 'desc':
+                kwargs['sort_desc'] = True
 
         # We exclude "result" and "trigger_instance" attributes which can contain a lot of data
         # since they are not displayed nor used which speeds the common operation substantially.

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -929,7 +929,7 @@ class ActionExecutionListCommand(ActionExecutionReadCommand):
                                        'list all if 0.' %
                                        resource.get_plural_display_name().lower()))
         self.parser.add_argument('-s', '--sort', type=str, dest='sort_order',
-                                 default='asc',
+                                 default='descending',
                                  help=('Sort %s by start timestamp, '
                                        'asc (ascending) or desc (descending)' %
                                        resource.get_plural_display_name().lower()))
@@ -982,7 +982,9 @@ class ActionExecutionListCommand(ActionExecutionReadCommand):
         if args.timestamp_lt:
             kwargs['timestamp_lt'] = args.timestamp_lt
         if args.sort_order:
-            if args.sort_order == 'desc':
+            if args.sort_order in ['asc', 'ascending']:
+                kwargs['sort_asc'] = True
+            elif args.sort_order in ['desc', 'descending']:
                 kwargs['sort_desc'] = True
 
         # We exclude "result" and "trigger_instance" attributes which can contain a lot of data


### PR DESCRIPTION
Add execution list sort ordering as requested in [issue 2837](https://github.com/StackStorm/st2/issues/2837) 

Added command line argument -s | --sort asc|desc (ascending is the current default sort order)

Added check for 'desc' in api (to mesh with overrides for -tg or -tl)
