### PR TITLE
Making jsexpose more flexible

### DIFF
--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -144,7 +144,7 @@ class ActionsController(resource.ContentPackResourceController):
 
     @request_user_has_resource_db_permission(permission_type=PermissionType.ACTION_MODIFY)
     @jsexpose(arg_types=[str], body_cls=ActionCreateAPI)
-    def put(self, action_ref_or_id, action):
+    def put(self, action, action_ref_or_id):
         action_db = self._get_by_ref_or_id(ref_or_id=action_ref_or_id)
 
         # Assert permissions

--- a/st2api/st2api/controllers/v1/auth.py
+++ b/st2api/st2api/controllers/v1/auth.py
@@ -133,7 +133,7 @@ class ApiKeyController(BaseRestControllerMixin):
 
     @request_user_has_resource_db_permission(permission_type=PermissionType.API_KEY_MODIFY)
     @jsexpose(arg_types=[str], body_cls=ApiKeyAPI)
-    def put(self, api_key_id_or_key, api_key_api):
+    def put(self, api_key_api, api_key_id_or_key):
         api_key_db = ApiKey.get_by_key_or_id(api_key_id_or_key)
 
         LOG.debug('PUT /apikeys/ lookup with api_key_id_or_key=%s found object: %s',

--- a/st2api/st2api/controllers/v1/keyvalue.py
+++ b/st2api/st2api/controllers/v1/keyvalue.py
@@ -144,7 +144,7 @@ class KeyValuePairController(ResourceController):
         return kvp_apis
 
     @jsexpose(arg_types=[str, str, str], body_cls=KeyValuePairSetAPI)
-    def put(self, name, kvp, scope=SYSTEM_SCOPE):
+    def put(self, kvp, name, scope=SYSTEM_SCOPE):
         """
         Create a new entry or update an existing one.
         """

--- a/st2api/st2api/controllers/v1/policies.py
+++ b/st2api/st2api/controllers/v1/policies.py
@@ -164,7 +164,7 @@ class PolicyController(resource.ContentPackResourceController):
         return self.model.from_model(db_model)
 
     @jsexpose(arg_types=[str], body_cls=PolicyAPI)
-    def put(self, ref_or_id, instance):
+    def put(self, instance, ref_or_id):
         op = 'PUT /policies/%s/' % ref_or_id
 
         db_model = self._get_by_ref_or_id(ref_or_id=ref_or_id)

--- a/st2api/st2api/controllers/v1/rules.py
+++ b/st2api/st2api/controllers/v1/rules.py
@@ -123,7 +123,7 @@ class RuleController(resource.ContentPackResourceController):
 
     @request_user_has_resource_db_permission(permission_type=PermissionType.RULE_MODIFY)
     @jsexpose(arg_types=[str], body_cls=RuleAPI)
-    def put(self, rule_ref_or_id, rule):
+    def put(self, rule, rule_ref_or_id):
         rule_db = self._get_by_ref_or_id(rule_ref_or_id)
         LOG.debug('PUT /rules/ lookup with id=%s found object: %s', rule_ref_or_id, rule_db)
 

--- a/st2api/st2api/controllers/v1/runnertypes.py
+++ b/st2api/st2api/controllers/v1/runnertypes.py
@@ -59,7 +59,7 @@ class RunnerTypesController(ResourceController):
 
     @request_user_has_resource_db_permission(permission_type=PermissionType.RUNNER_MODIFY)
     @jsexpose(arg_types=[str], body_cls=RunnerTypeAPI)
-    def put(self, name_or_id, runner_type_api):
+    def put(self, runner_type_api, name_or_id):
         # Note: We only allow "enabled" attribute of the runner to be changed
         runner_type_db = self._get_by_name_or_id(name_or_id=name_or_id)
         old_runner_type_db = runner_type_db

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -83,7 +83,7 @@ class TriggerTypeController(resource.ContentPackResourceController):
         return triggertype_api
 
     @jsexpose(arg_types=[str], body_cls=TriggerTypeAPI)
-    def put(self, triggertype_ref_or_id, triggertype):
+    def put(self, triggertype, triggertype_ref_or_id):
         triggertype_db = self._get_by_ref_or_id(ref_or_id=triggertype_ref_or_id)
         triggertype_id = triggertype_db.id
 
@@ -238,7 +238,7 @@ class TriggerController(RestController):
         return trigger_api
 
     @jsexpose(arg_types=[str], body_cls=TriggerAPI)
-    def put(self, trigger_id, trigger):
+    def put(self, trigger, trigger_id):
         trigger_db = TriggerController.__get_by_id(trigger_id)
         try:
             if trigger.id is not None and trigger.id is not '' and trigger.id != trigger_id:

--- a/st2common/st2common/models/api/base.py
+++ b/st2common/st2common/models/api/base.py
@@ -233,15 +233,6 @@ def jsexpose(arg_types=None, body_cls=None, status_code=None, content_type='appl
                 result = cast_func(value)
                 return result
 
-            if arg_types:
-                # Cast and transform arguments based on the provided arg_types specification
-                result_args, result_kwargs = get_controller_args_for_types(func=f,
-                                                                           arg_types=arg_types,
-                                                                           args=args,
-                                                                           kwargs=kwargs)
-                more = more + result_args
-                kwargs.update(result_kwargs)
-
             if body_cls:
                 if pecan.request.body:
                     data = pecan.request.json
@@ -269,6 +260,15 @@ def jsexpose(arg_types=None, body_cls=None, status_code=None, content_type='appl
                     obj = None
 
                 more.append(obj)
+
+            if arg_types:
+                # Cast and transform arguments based on the provided arg_types specification
+                result_args, result_kwargs = get_controller_args_for_types(func=f,
+                                                                           arg_types=arg_types,
+                                                                           args=args,
+                                                                           kwargs=kwargs)
+                more = more + result_args
+                kwargs.update(result_kwargs)
 
             args = tuple(more) + tuple(args)
 

--- a/st2common/tests/unit/test_api_model_base.py
+++ b/st2common/tests/unit/test_api_model_base.py
@@ -144,26 +144,26 @@ class TestAPIModelBase(unittest.TestCase):
         APIModelMock = mock.MagicMock()
 
         @base.jsexpose(arg_types=[int], body_cls=APIModelMock)
-        def f(self, id, body, *args, **kwargs):
-            self.f(self, id, body, args, kwargs)
+        def f(self, body, id, *args, **kwargs):
+            self.f(self, body, id, args, kwargs)
 
         f(self, '11')
 
         APIModelMock.assert_called_once_with(a='b')
-        self.f.assert_called_once_with(self, 11, APIModelMock().validate(), (), {})
+        self.f.assert_called_once_with(self, APIModelMock().validate(), 11, (), {})
 
     @unittest.skip
     def test_expose_body_and_typed_arguments_unused(self):
         APIModelMock = mock.MagicMock()
 
         @base.jsexpose(arg_types=[int], body_cls=APIModelMock)
-        def f(self, id, body, *args, **kwargs):
-            self.f(self, id, body, args, kwargs)
+        def f(self, body, id, *args, **kwargs):
+            self.f(self, body, id, args, kwargs)
 
         f(self, '11', 'some')
 
         APIModelMock.assert_called_once_with(a='b')
-        self.f.assert_called_once_with(self, 11, APIModelMock().validate(), ('some', ), {})
+        self.f.assert_called_once_with(self, APIModelMock().validate(), 11, ('some', ), {})
 
     @unittest.skip
     def test_expose_body_and_typed_kw_unused(self):


### PR DESCRIPTION
Allows creating controllers with optional body and reuse the same controller for url's of any depth.

Controller with this signature
```
@jsexpose(body_cls=..., arg_types=[str, int, str])
def post(self, body, type, id, property):
```
will successfully handle all this rest calls
```
POST /document/112/header/ -> post(body=({...} or None), type='document', id=112, property='header')
POST /document/112/ -> post(body=({...} or None), type='document', id=112, property=None)
POST /document/ -> post(body=({...} or None), type='document', id=None, property=None)
```