### PR TITLE
Fix linting errors related to missing config section

### DIFF
--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -50,7 +50,9 @@ class ResourceController(rest.RestController):
     from_model_kwargs = {}
 
     # Maximum value of limit which can be specified by user
-    max_limit = cfg.CONF.api.max_page_size
+    @property
+    def max_limit(self):
+        return cfg.CONF.api.max_page_size
 
     # Default number of items returned per page if no limit is explicitly provided
     default_limit = 100


### PR DESCRIPTION
Problem: while working on https://github.com/StackStorm/st2/pull/2842, I've encounter strange lining issues related to missing config section (see [full traceback](https://github.com/StackStorm/st2/pull/2844#issuecomment-236864688) down below).

Per @kami proposal, I'm going to make `max_limit` a property to prevent pylint from trying to resolve it.