### PR TITLE
WIP: Support to_human_time jinja function

### DIFF
--- a/contrib/chatops/actions/format_execution_result.py
+++ b/contrib/chatops/actions/format_execution_result.py
@@ -12,7 +12,7 @@ class FormatResultAction(Action):
         api_url = os.environ.get('ST2_ACTION_API_URL', None)
         token = os.environ.get('ST2_ACTION_AUTH_TOKEN', None)
         self.client = Client(api_url=api_url, token=token)
-        self.jinja = jinja_utils.get_jinja_environment()
+        self.jinja = jinja_utils.get_jinja_environment(allow_undefined=True)
         self.jinja.tests['in'] = lambda item, list: item in list
 
         path = os.path.dirname(os.path.realpath(__file__))
@@ -45,7 +45,7 @@ class FormatResultAction(Action):
                 if 'extra' in alias.result:
                     result['extra'] = jinja_utils.render_values(alias.result['extra'], context)
 
-        result['message'] = self.jinja.from_string(template).render(context),
+        result['message'] = self.jinja.from_string(template).render(context)
 
         return result
 

--- a/contrib/chatops/actions/templates/default.j2
+++ b/contrib/chatops/actions/templates/default.j2
@@ -18,6 +18,10 @@ execution: {{ execution.id }}
 web_url: {{ execution.web_url }}
 {% endif %}
 
+{% if execution.elapsed_seconds -%}
+Took {{execution.elapsed_seconds | to_human_time_from_seconds}} to complete.
+{% endif %}
+
 {% if execution.result -%}
 result :
 --------

--- a/contrib/chatops/tests/fixtures/remote_cmd_execution.json
+++ b/contrib/chatops/tests/fixtures/remote_cmd_execution.json
@@ -37,6 +37,7 @@
         "hosts": "localhost"
     },
     "web_url": "https://localhost.localdomain/#/history/57967f9355fc8c19a96d9e4f/general",
+    "elapsed_seconds": 1.576789,
     "result": {
         "localhost": {
             "failed": false,

--- a/contrib/chatops/tests/test_format_result.py
+++ b/contrib/chatops/tests/test_format_result.py
@@ -22,7 +22,10 @@ class FormatResultActionTestCase(BaseActionTestCase):
         action._get_execution = mock.MagicMock(
             return_value=remote_shell_cmd_execution_model
         )
-        self.assertTrue(action.run(execution_id='57967f9355fc8c19a96d9e4f'))
+        result = action.run(execution_id='57967f9355fc8c19a96d9e4f')
+        self.assertTrue(result)
+        self.assertTrue('web_url' in result['message'], result['message'])
+        self.assertTrue('Took 2s to complete' in result['message'], result['message'])
 
     def test_rendering_local_shell_cmd(self):
         local_shell_cmd_execution_model = json.loads(

--- a/contrib/examples/actions/chains/data_jinja_filter.yaml
+++ b/contrib/examples/actions/chains/data_jinja_filter.yaml
@@ -1,0 +1,19 @@
+---
+  chain:
+    -
+      name: "c1"
+      ref: "examples.object_return"
+      parameters: {}
+      on-success: "c2"
+    -
+      name: "c2"
+      ref: "examples.json_string_to_object"
+      parameters:
+        json_str: "{{c1.result | to_json_string}}"
+      on-success: "c3"
+    -
+      name: "c3"
+      ref: "examples.yaml_string_to_object"
+      parameters:
+        yaml_str: "{{ c1.result | to_yaml_string}}"
+

--- a/contrib/examples/actions/chains/time_jinja_filter.yaml
+++ b/contrib/examples/actions/chains/time_jinja_filter.yaml
@@ -1,0 +1,7 @@
+---
+  chain:
+    -
+      name: "c1"
+      ref: "core.local"
+      parameters:
+        cmd: "echo '{{12345 | to_human_time_from_seconds}}'"

--- a/contrib/examples/actions/chains/version_jinja_filter.yaml
+++ b/contrib/examples/actions/chains/version_jinja_filter.yaml
@@ -1,0 +1,35 @@
+---
+  chain:
+    -
+      name: "c1"
+      ref: "core.local"
+      parameters:
+        cmd: "echo {{'1.6.0' | version_bump_minor}}"
+      on-success: "c2"
+    -
+      name: "c2"
+      ref: "core.local"
+      parameters:
+        cmd: "echo {{c1.stdout | version_bump_major}}"
+      on-success: "c3"
+    -
+      name: "c3"
+      ref: "core.local"
+      parameters:
+        cmd: "echo {{c1.stdout | version_compare('1.6.0')}}"
+      on-success: "c4"
+    -
+      name: "c4"
+      ref: "core.local"
+      parameters:
+        cmd: "echo {{c1.stdout | version_strip_patch}}"
+      on-success: "c5"
+    -
+      name: "c5"
+      ref: "core.local"
+      parameters:
+        cmd: "echo {{c1.stdout | version_match('>=1.7.0')}}"
+
+
+
+

--- a/contrib/examples/actions/data_jinja_filter.meta.yaml
+++ b/contrib/examples/actions/data_jinja_filter.meta.yaml
@@ -1,0 +1,12 @@
+---
+name: "data_jinja_filter"
+description: "Simple Action Chain workflow showing how to use jinja data filters in st2."
+
+# `runner_type` has value `action-chain` to identify that action is an ActionChain.
+runner_type: "action-chain"
+
+# `entry_point` path to the ActionChain definition file, relative to the pack's action directory.
+entry_point: "chains/data_jinja_filter.yaml"
+
+enabled: true
+parameters: {}

--- a/contrib/examples/actions/json_string_to_object.meta.yaml
+++ b/contrib/examples/actions/json_string_to_object.meta.yaml
@@ -1,0 +1,9 @@
+---
+description: Convert JSON str to object.
+enabled: true
+entry_point: pythonactions/json_string_to_object.py
+name: json_string_to_object
+parameters:
+  json_str:
+    type: string
+runner_type: "python-script"

--- a/contrib/examples/actions/object_return.meta.yaml
+++ b/contrib/examples/actions/object_return.meta.yaml
@@ -1,0 +1,7 @@
+---
+description: Just an example action that returns an object.
+enabled: true
+entry_point: pythonactions/object_return.py
+name: object_return
+parameters: {}
+runner_type: "python-script"

--- a/contrib/examples/actions/pythonactions/json_string_to_object.py
+++ b/contrib/examples/actions/pythonactions/json_string_to_object.py
@@ -1,0 +1,9 @@
+import json
+
+from st2actions.runners.pythonrunner import Action
+
+
+class JsonStringToObject(Action):
+
+    def run(self, json_str):
+        return json.loads(json_str)

--- a/contrib/examples/actions/pythonactions/object_return.py
+++ b/contrib/examples/actions/pythonactions/object_return.py
@@ -1,0 +1,7 @@
+from st2actions.runners.pythonrunner import Action
+
+
+class ObjectReturnAction(Action):
+
+    def run(self):
+        return {'a': 'b', 'c': {'d': 'e', 'f': 1, 'g': True}}

--- a/contrib/examples/actions/pythonactions/yaml_string_to_object.py
+++ b/contrib/examples/actions/pythonactions/yaml_string_to_object.py
@@ -1,0 +1,9 @@
+import yaml
+
+from st2actions.runners.pythonrunner import Action
+
+
+class YamlStringToObject(Action):
+
+    def run(self, yaml_str):
+        return yaml.safe_load(yaml_str)

--- a/contrib/examples/actions/time_jinja_filter.meta.yaml
+++ b/contrib/examples/actions/time_jinja_filter.meta.yaml
@@ -1,0 +1,12 @@
+---
+name: "time_jinja_filter"
+description: "Simple Action Chain workflow showing how to use jinja time filters in st2."
+
+# `runner_type` has value `action-chain` to identify that action is an ActionChain.
+runner_type: "action-chain"
+
+# `entry_point` path to the ActionChain definition file, relative to the pack's action directory.
+entry_point: "chains/time_jinja_filter.yaml"
+
+enabled: true
+parameters: {}

--- a/contrib/examples/actions/version_jinja_filter.meta.yaml
+++ b/contrib/examples/actions/version_jinja_filter.meta.yaml
@@ -1,0 +1,12 @@
+---
+name: "version_jinja_filter"
+description: "Simple Action Chain workflow showing how to use jinja version filters in st2."
+
+# `runner_type` has value `action-chain` to identify that action is an ActionChain.
+runner_type: "action-chain"
+
+# `entry_point` path to the ActionChain definition file, relative to the pack's action directory.
+entry_point: "chains/version_jinja_filter.yaml"
+
+enabled: true
+parameters: {}

--- a/contrib/examples/actions/yaml_string_to_object.meta.yaml
+++ b/contrib/examples/actions/yaml_string_to_object.meta.yaml
@@ -1,0 +1,9 @@
+---
+description: Convert YAML str to object.
+enabled: true
+entry_point: pythonactions/yaml_string_to_object.py
+name: yaml_string_to_object
+parameters:
+  yaml_str:
+    type: string
+runner_type: "python-script"

--- a/st2common/st2common/jinja/filters/data.py
+++ b/st2common/st2common/jinja/filters/data.py
@@ -1,0 +1,41 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import yaml
+
+__all__ = [
+    'to_json_string',
+    'to_yaml_string',
+    'from_json_string',
+    'from_yaml_string'
+]
+
+
+def to_json_string(value, indent=4, sort_keys=False, separators=(',', ':')):
+    return json.dumps(value, indent=indent, separators=separators,
+                      sort_keys=sort_keys)
+
+
+def to_yaml_string(value, indent=4, allow_unicode=True):
+    return yaml.safe_dump(value, indent=indent, allow_unicode=allow_unicode)
+
+
+def from_json_string(value):
+    return json.loads(value)
+
+
+def from_yaml_string(value):
+    return yaml.safe_load(value)

--- a/st2common/st2common/jinja/filters/data.py
+++ b/st2common/st2common/jinja/filters/data.py
@@ -19,8 +19,6 @@ import yaml
 __all__ = [
     'to_json_string',
     'to_yaml_string',
-    'from_json_string',
-    'from_yaml_string'
 ]
 
 

--- a/st2common/st2common/jinja/filters/regex.py
+++ b/st2common/st2common/jinja/filters/regex.py
@@ -1,0 +1,49 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import six
+
+__all__ = [
+    'regex_match',
+    'regex_replace',
+    'regex_search'
+]
+
+
+def _get_regex_flags(ignorecase=False):
+    return re.I if ignorecase else 0
+
+
+def regex_match(value, pattern='', ignorecase=False):
+    if not isinstance(value, six.string_types):
+        value = str(value)
+    flags = _get_regex_flags(ignorecase)
+    return bool(re.match(pattern, value, flags))
+
+
+def regex_replace(value='', pattern='', replacement='', ignorecase=False):
+    if not isinstance(value, six.string_types):
+        value = str(value)
+    flags = _get_regex_flags(ignorecase)
+    regex = re.compile(pattern, flags)
+    return regex.sub(replacement, value)
+
+
+def regex_search(value, pattern='', ignorecase=False):
+    if not isinstance(value, six.string_types):
+        value = str(value)
+    flags = _get_regex_flags(ignorecase)
+    return bool(re.search(pattern, value, flags))

--- a/st2common/st2common/jinja/filters/time.py
+++ b/st2common/st2common/jinja/filters/time.py
@@ -30,8 +30,8 @@ def to_human_time_from_seconds(seconds):
 
     :rtype: ``str``
     """
-    assert (isinstance(seconds, int) or isinstance(seconds, long)
-            or isinstance(seconds, float))
+    assert (isinstance(seconds, int) or isinstance(seconds, long) or
+            isinstance(seconds, float))
 
     return _get_human_time(seconds)
 

--- a/st2common/st2common/jinja/filters/time.py
+++ b/st2common/st2common/jinja/filters/time.py
@@ -16,11 +16,11 @@
 import datetime
 
 __all__ = [
-    'to_human_time'
+    'to_human_time_from_seconds'
 ]
 
 
-def to_human_time(time_seconds):
+def to_human_time_from_seconds(time_seconds):
     """
     Given a time value in seconds, this function returns
     a fuzzy version like 3m5s.

--- a/st2common/st2common/jinja/filters/time.py
+++ b/st2common/st2common/jinja/filters/time.py
@@ -1,0 +1,50 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+
+__all__ = [
+    'to_human_time'
+]
+
+
+def to_human_time(time_seconds):
+    """
+    Given a time value in seconds, this function returns
+    a fuzzy version like 3m5s.
+
+    :param time_seconds: Time specified in seconds.
+    :type time_seconds: ``int`` or ``long``
+
+    :rtype: ``str``
+    """
+    assert time_seconds is int or time_seconds is long
+    timedelta_str = datetime.timedelta(seconds=time_seconds)  # Returns 'hh:mm:ss'
+    return _get_human_time(timedelta_str)
+
+
+def _get_human_time(timedelta_str):
+    """
+    Takes a timedelta string of form '01:03:05' and returns a string
+    of form '1h3m5s'.
+
+    :param timedelta_str: Timedelta in string format.
+    :type timedelta_str: ``str``
+
+    :rtype: ``str``
+    """
+    time_parts = timedelta_str.split(':')
+    time_parts = [part.lstrip("0") for part in time_parts]
+    return '%sh%sm%ss' % (tuple(time_parts))

--- a/st2common/st2common/jinja/filters/time.py
+++ b/st2common/st2common/jinja/filters/time.py
@@ -56,7 +56,7 @@ def _get_human_time(seconds):
         return '%s\u03BCs' % seconds  # Microseconds
 
     if isinstance(seconds, float):
-        seconds = long(seconds)  # Let's lose microseconds.
+        seconds = long(round(seconds))  # Let's lose microseconds.
 
     timedelta = datetime.timedelta(seconds=seconds)
     offset_date = datetime.datetime(1, 1, 1) + timedelta

--- a/st2common/st2common/jinja/filters/version.py
+++ b/st2common/st2common/jinja/filters/version.py
@@ -1,0 +1,62 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import semver
+
+__all__ = [
+    'version_compare',
+    'version_more_than',
+    'version_less_than',
+    'version_equal',
+    'version_match',
+    'version_bump_major',
+    'version_bump_minor'
+]
+
+
+def version_compare(value, pattern):
+    return semver.compare(value, pattern)
+
+
+def version_more_than(value, pattern):
+    return semver.compare(value, pattern) == 1
+
+
+def version_less_than(value, pattern):
+    return semver.compare(value, pattern) == -1
+
+
+def version_equal(value, pattern):
+    return semver.compare(value, pattern) == 0
+
+
+def version_match(value, pattern):
+    return semver.match(value, pattern)
+
+
+def version_bump_major(value):
+    return semver.bump_major(value)
+
+
+def version_bump_minor(value):
+    return semver.bump_minor(value)
+
+
+def version_bump_patch(value):
+    return semver.bump_patch(value)
+
+
+def version_strip_patch(value):
+    return "{major}.{minor}".format(**semver.parse(value))

--- a/st2common/st2common/util/jinja.py
+++ b/st2common/st2common/util/jinja.py
@@ -57,7 +57,7 @@ def get_filters():
         'regex_replace': regex.regex_replace,
         'regex_search': regex.regex_search,
 
-        'to_human_time': time.to_human_time,
+        'to_human_time_from_seconds': time.to_human_time_from_seconds,
 
         'version_compare': version.version_compare,
         'version_more_than': version.version_more_than,

--- a/st2common/st2common/util/jinja.py
+++ b/st2common/st2common/util/jinja.py
@@ -18,6 +18,7 @@ import six
 
 import jinja2
 
+from st2common.jinja.filters import data
 from st2common.jinja.filters import regex
 from st2common.jinja.filters import time
 from st2common.jinja.filters import version
@@ -47,6 +48,11 @@ def use_none(value):
 
 def get_filters():
     return {
+        'to_json_string': data.to_json_string,
+        'from_json_string': data.from_json_string,
+        'to_yaml_string': data.to_yaml_string,
+        'from_yaml_string': data.from_yaml_string,
+
         'regex_match': regex.regex_match,
         'regex_replace': regex.regex_replace,
         'regex_search': regex.regex_search,

--- a/st2common/st2common/util/jinja.py
+++ b/st2common/st2common/util/jinja.py
@@ -75,11 +75,11 @@ def get_jinja_environment(allow_undefined=False, trim_blocks=True, lstrip_blocks
 
     '''
     undefined = jinja2.Undefined if allow_undefined else jinja2.StrictUndefined
-    env = jinja2.Environment(
+    env = jinja2.Environment(  # nosec
         undefined=undefined,
         trim_blocks=trim_blocks,
         lstrip_blocks=lstrip_blocks
-    )  # nosec
+    )
     env.filters.update(get_filters())
     env.tests['in'] = lambda item, list: item in list
     return env

--- a/st2common/st2common/util/jinja.py
+++ b/st2common/st2common/util/jinja.py
@@ -15,10 +15,13 @@
 
 import json
 import six
-import re
 
-import semver
 import jinja2
+
+from st2common.jinja.filters import regex
+from st2common.jinja.filters import time
+from st2common.jinja.filters import version
+
 
 __all__ = [
     'get_jinja_environment',
@@ -35,104 +38,35 @@ JINJA_EXPRESSIONS_START_MARKERS = [
 ]
 
 
-class CustomFilters(object):
-    '''
-    Collection of CustomFilters for jinja2
-    '''
+def use_none(value):
+    if value is None:
+        return NONE_MAGIC_VALUE
 
-    ###############
-    # regex filters
-    @staticmethod
-    def _get_regex_flags(ignorecase=False):
-        return re.I if ignorecase else 0
-
-    @staticmethod
-    def _regex_match(value, pattern='', ignorecase=False):
-        if not isinstance(value, six.string_types):
-            value = str(value)
-        flags = CustomFilters._get_regex_flags(ignorecase)
-        return bool(re.match(pattern, value, flags))
-
-    @staticmethod
-    def _regex_replace(value='', pattern='', replacement='', ignorecase=False):
-        if not isinstance(value, six.string_types):
-            value = str(value)
-        flags = CustomFilters._get_regex_flags(ignorecase)
-        regex = re.compile(pattern, flags)
-        return regex.sub(replacement, value)
-
-    @staticmethod
-    def _regex_search(value, pattern='', ignorecase=False):
-        if not isinstance(value, six.string_types):
-            value = str(value)
-        flags = CustomFilters._get_regex_flags(ignorecase)
-        return bool(re.search(pattern, value, flags))
-
-    #################
-    # version filters
-    @staticmethod
-    def _version_compare(value, pattern):
-        return semver.compare(value, pattern)
-
-    @staticmethod
-    def _version_more_than(value, pattern):
-        return semver.compare(value, pattern) == 1
-
-    @staticmethod
-    def _version_less_than(value, pattern):
-        return semver.compare(value, pattern) == -1
-
-    @staticmethod
-    def _version_equal(value, pattern):
-        return semver.compare(value, pattern) == 0
-
-    @staticmethod
-    def _version_match(value, pattern):
-        return semver.match(value, pattern)
-
-    @staticmethod
-    def _version_bump_major(value):
-        return semver.bump_major(value)
-
-    @staticmethod
-    def _version_bump_minor(value):
-        return semver.bump_minor(value)
-
-    @staticmethod
-    def _version_bump_patch(value):
-        return semver.bump_patch(value)
-
-    @staticmethod
-    def _version_strip_patch(value):
-        return "{major}.{minor}".format(**semver.parse(value))
-
-    @staticmethod
-    def _use_none(value):
-        if value is None:
-            return NONE_MAGIC_VALUE
-
-        return value
-
-    @staticmethod
-    def get_filters():
-        return {
-            'regex_match': CustomFilters._regex_match,
-            'regex_replace': CustomFilters._regex_replace,
-            'regex_search': CustomFilters._regex_search,
-            'version_compare': CustomFilters._version_compare,
-            'version_more_than': CustomFilters._version_more_than,
-            'version_less_than': CustomFilters._version_less_than,
-            'version_equal': CustomFilters._version_equal,
-            'version_match': CustomFilters._version_match,
-            'version_bump_major': CustomFilters._version_bump_major,
-            'version_bump_minor': CustomFilters._version_bump_minor,
-            'version_bump_patch': CustomFilters._version_bump_patch,
-            'version_strip_patch': CustomFilters._version_strip_patch,
-            'use_none': CustomFilters._use_none
-        }
+    return value
 
 
-def get_jinja_environment(allow_undefined=False):
+def get_filters():
+    return {
+        'regex_match': regex.regex_match,
+        'regex_replace': regex.regex_replace,
+        'regex_search': regex.regex_search,
+
+        'to_human_time': time.to_human_time,
+
+        'version_compare': version.version_compare,
+        'version_more_than': version.version_more_than,
+        'version_less_than': version.version_less_than,
+        'version_equal': version.version_equal,
+        'version_match': version.version_match,
+        'version_bump_major': version.version_bump_major,
+        'version_bump_minor': version.version_bump_minor,
+        'version_bump_patch': version.version_bump_patch,
+        'version_strip_patch': version.version_strip_patch,
+        'use_none': use_none
+    }
+
+
+def get_jinja_environment(allow_undefined=False, trim_blocks=True, lstrip_blocks=True):
     '''
     jinja2.Environment object that is setup with right behaviors and custom filters.
 
@@ -141,8 +75,12 @@ def get_jinja_environment(allow_undefined=False):
 
     '''
     undefined = jinja2.Undefined if allow_undefined else jinja2.StrictUndefined
-    env = jinja2.Environment(undefined=undefined, trim_blocks=True, lstrip_blocks=True)  # nosec
-    env.filters.update(CustomFilters.get_filters())
+    env = jinja2.Environment(
+        undefined=undefined,
+        trim_blocks=trim_blocks,
+        lstrip_blocks=lstrip_blocks
+    )  # nosec
+    env.filters.update(get_filters())
     env.tests['in'] = lambda item, list: item in list
     return env
 

--- a/st2common/st2common/util/jinja.py
+++ b/st2common/st2common/util/jinja.py
@@ -49,9 +49,7 @@ def use_none(value):
 def get_filters():
     return {
         'to_json_string': data.to_json_string,
-        'from_json_string': data.from_json_string,
         'to_yaml_string': data.to_yaml_string,
-        'from_yaml_string': data.from_yaml_string,
 
         'regex_match': regex.regex_match,
         'regex_replace': regex.regex_replace,

--- a/st2common/st2common/util/templating.py
+++ b/st2common/st2common/util/templating.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 import six
-from jinja2 import Environment, StrictUndefined
 
+from st2common.util.jinja import get_jinja_environment
 from st2common.constants.keyvalue import SYSTEM_SCOPE
 from st2common.constants.keyvalue import USER_SCOPE
 from st2common.services.keyvalues import KeyValueLookup
@@ -41,7 +41,7 @@ def render_template(value, context=None):
     assert isinstance(value, six.string_types)
     context = context or {}
 
-    env = Environment(undefined=StrictUndefined)  # nosec
+    env = get_jinja_environment(allow_undefined=False)  # nosec
     template = env.from_string(value)
     rendered = template.render(context)
 

--- a/st2common/tests/unit/test_jinja_render_data_filters.py
+++ b/st2common/tests/unit/test_jinja_render_data_filters.py
@@ -13,24 +13,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import unittest2
+import yaml
 
 from st2common.util import jinja as jinja_utils
 
 
-class JinjaUtilsRenderTestCase(unittest2.TestCase):
+class JinjaUtilsDataFilterTestCase(unittest2.TestCase):
 
-    def test_render_values(self):
-        actual = jinja_utils.render_values(
-            mapping={'k1': '{{a}}', 'k2': '{{b}}'},
-            context={'a': 'v1', 'b': 'v2'})
-        expected = {'k2': 'v2', 'k1': 'v1'}
-        self.assertEqual(actual, expected)
+    def test_filter_to_json_string(self):
+        env = jinja_utils.get_jinja_environment()
+        obj = {'a': 'b', 'c': {'d': 'e', 'f': 1, 'g': True}}
 
-    def test_render_values_skip_missing(self):
-        actual = jinja_utils.render_values(
-            mapping={'k1': '{{a}}', 'k2': '{{b}}', 'k3': '{{c}}'},
-            context={'a': 'v1', 'b': 'v2'},
-            allow_undefined=True)
-        expected = {'k2': 'v2', 'k1': 'v1', 'k3': ''}
-        self.assertEqual(actual, expected)
+        template = '{{k1 | to_json_string}}'
+
+        obj_json_str = env.from_string(template).render({'k1': obj})
+        actual_obj = json.loads(obj_json_str)
+        self.assertDictEqual(obj, actual_obj)
+
+    def test_filter_to_yaml_string(self):
+        env = jinja_utils.get_jinja_environment()
+        obj = {'a': 'b', 'c': {'d': 'e', 'f': 1, 'g': True}}
+
+        template = '{{k1 | to_yaml_string}}'
+        obj_yaml_str = env.from_string(template).render({'k1': obj})
+        actual_obj = yaml.load(obj_yaml_str)
+        self.assertDictEqual(obj, actual_obj)

--- a/st2common/tests/unit/test_jinja_render_regex_filters.py
+++ b/st2common/tests/unit/test_jinja_render_regex_filters.py
@@ -1,0 +1,70 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest2
+
+from st2common.util import jinja as jinja_utils
+
+
+class JinjaUtilsRegexFilterTestCase(unittest2.TestCase):
+
+    def test_filters_regex_match(self):
+        env = jinja_utils.get_jinja_environment()
+
+        template = '{{k1 | regex_match("x")}}'
+        actual = env.from_string(template).render({'k1': 'xyz'})
+        expected = 'True'
+        self.assertEqual(actual, expected)
+
+        template = '{{k1 | regex_match("y")}}'
+        actual = env.from_string(template).render({'k1': 'xyz'})
+        expected = 'False'
+        self.assertEqual(actual, expected)
+
+        template = '{{k1 | regex_match("^v(\\d+\\.)?(\\d+\\.)?(\\*|\\d+)$")}}'
+        actual = env.from_string(template).render({'k1': 'v0.10.1'})
+        expected = 'True'
+        self.assertEqual(actual, expected)
+
+    def test_filters_regex_replace(self):
+        env = jinja_utils.get_jinja_environment()
+
+        template = '{{k1 | regex_replace("x", "y")}}'
+        actual = env.from_string(template).render({'k1': 'xyz'})
+        expected = 'yyz'
+        self.assertEqual(actual, expected)
+
+        template = '{{k1 | regex_replace("(blue|white|red)", "color")}}'
+        actual = env.from_string(template).render({'k1': 'blue socks and red shoes'})
+        expected = 'color socks and color shoes'
+        self.assertEqual(actual, expected)
+
+    def test_filters_regex_search(self):
+        env = jinja_utils.get_jinja_environment()
+
+        template = '{{k1 | regex_search("x")}}'
+        actual = env.from_string(template).render({'k1': 'xyz'})
+        expected = 'True'
+        self.assertEqual(actual, expected)
+
+        template = '{{k1 | regex_search("y")}}'
+        actual = env.from_string(template).render({'k1': 'xyz'})
+        expected = 'True'
+        self.assertEqual(actual, expected)
+
+        template = '{{k1 | regex_search("^v(\\d+\\.)?(\\d+\\.)?(\\*|\\d+)$")}}'
+        actual = env.from_string(template).render({'k1': 'v0.10.1'})
+        expected = 'True'
+        self.assertEqual(actual, expected)

--- a/st2common/tests/unit/test_jinja_render_time_filters.py
+++ b/st2common/tests/unit/test_jinja_render_time_filters.py
@@ -13,21 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
-import yaml
+import unittest2
 
-__all__ = [
-    'to_json_string',
-    'to_yaml_string',
-    'from_json_string',
-    'from_yaml_string'
-]
+from st2common.util import jinja as jinja_utils
 
 
-def to_json_string(value, indent=4, sort_keys=False, separators=(',', ':')):
-    return json.dumps(value, indent=indent, separators=separators,
-                      sort_keys=sort_keys)
+class JinjaUtilsTimeFilterTestCase(unittest2.TestCase):
 
+    def test_to_human_time_filter(self):
+        env = jinja_utils.get_jinja_environment()
 
-def to_yaml_string(value, indent=4, allow_unicode=True):
-    return yaml.safe_dump(value, indent=indent, allow_unicode=allow_unicode)
+        template = '{{k1 | to_human_time_from_seconds}}'
+        actual = env.from_string(template).render({'k1': 12345})
+        self.assertEqual(actual, '3h25m45s')
+
+        actual = env.from_string(template).render({'k1': 0})
+        self.assertEqual(actual, '0s')
+
+        self.assertRaises(AssertionError, env.from_string(template).render,
+                          {'k1': 'stuff'})

--- a/st2common/tests/unit/test_jinja_render_version_filters.py
+++ b/st2common/tests/unit/test_jinja_render_version_filters.py
@@ -1,0 +1,153 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import unittest2
+
+from st2common.util import jinja as jinja_utils
+
+
+class JinjaUtilsVersionsFilterTestCase(unittest2.TestCase):
+
+    def test_version_compare(self):
+        env = jinja_utils.get_jinja_environment()
+
+        template = '{{version | version_compare("0.10.0")}}'
+        actual = env.from_string(template).render({'version': '0.9.0'})
+        expected = '-1'
+        self.assertEqual(actual, expected)
+
+        template = '{{version | version_compare("0.10.0")}}'
+        actual = env.from_string(template).render({'version': '0.10.1'})
+        expected = '1'
+        self.assertEqual(actual, expected)
+
+        template = '{{version | version_compare("0.10.0")}}'
+        actual = env.from_string(template).render({'version': '0.10.0'})
+        expected = '0'
+        self.assertEqual(actual, expected)
+
+    def test_version_more_than(self):
+        env = jinja_utils.get_jinja_environment()
+
+        template = '{{version | version_more_than("0.10.0")}}'
+        actual = env.from_string(template).render({'version': '0.9.0'})
+        expected = 'False'
+        self.assertEqual(actual, expected)
+
+        template = '{{version | version_more_than("0.10.0")}}'
+        actual = env.from_string(template).render({'version': '0.10.1'})
+        expected = 'True'
+        self.assertEqual(actual, expected)
+
+        template = '{{version | version_more_than("0.10.0")}}'
+        actual = env.from_string(template).render({'version': '0.10.0'})
+        expected = 'False'
+        self.assertEqual(actual, expected)
+
+    def test_version_less_than(self):
+        env = jinja_utils.get_jinja_environment()
+
+        template = '{{version | version_less_than("0.10.0")}}'
+        actual = env.from_string(template).render({'version': '0.9.0'})
+        expected = 'True'
+        self.assertEqual(actual, expected)
+
+        template = '{{version | version_less_than("0.10.0")}}'
+        actual = env.from_string(template).render({'version': '0.10.1'})
+        expected = 'False'
+        self.assertEqual(actual, expected)
+
+        template = '{{version | version_less_than("0.10.0")}}'
+        actual = env.from_string(template).render({'version': '0.10.0'})
+        expected = 'False'
+        self.assertEqual(actual, expected)
+
+    def test_version_equal(self):
+        env = jinja_utils.get_jinja_environment()
+
+        template = '{{version | version_equal("0.10.0")}}'
+        actual = env.from_string(template).render({'version': '0.9.0'})
+        expected = 'False'
+        self.assertEqual(actual, expected)
+
+        template = '{{version | version_equal("0.10.0")}}'
+        actual = env.from_string(template).render({'version': '0.10.1'})
+        expected = 'False'
+        self.assertEqual(actual, expected)
+
+        template = '{{version | version_equal("0.10.0")}}'
+        actual = env.from_string(template).render({'version': '0.10.0'})
+        expected = 'True'
+        self.assertEqual(actual, expected)
+
+    def test_version_match(self):
+        env = jinja_utils.get_jinja_environment()
+
+        template = '{{version | version_match(">0.10.0")}}'
+        actual = env.from_string(template).render({'version': '0.10.1'})
+        expected = 'True'
+        self.assertEqual(actual, expected)
+        actual = env.from_string(template).render({'version': '0.1.1'})
+        expected = 'False'
+        self.assertEqual(actual, expected)
+
+        template = '{{version | version_match("<0.10.0")}}'
+        actual = env.from_string(template).render({'version': '0.1.0'})
+        expected = 'True'
+        self.assertEqual(actual, expected)
+        actual = env.from_string(template).render({'version': '1.1.0'})
+        expected = 'False'
+        self.assertEqual(actual, expected)
+
+        template = '{{version | version_match("==0.10.0")}}'
+        actual = env.from_string(template).render({'version': '0.10.0'})
+        expected = 'True'
+        self.assertEqual(actual, expected)
+        actual = env.from_string(template).render({'version': '0.10.1'})
+        expected = 'False'
+        self.assertEqual(actual, expected)
+
+    def test_version_bump_major(self):
+        env = jinja_utils.get_jinja_environment()
+
+        template = '{{version | version_bump_major}}'
+        actual = env.from_string(template).render({'version': '0.10.1'})
+        expected = '1.0.0'
+        self.assertEqual(actual, expected)
+
+    def test_version_bump_minor(self):
+        env = jinja_utils.get_jinja_environment()
+
+        template = '{{version | version_bump_minor}}'
+        actual = env.from_string(template).render({'version': '0.10.1'})
+        expected = '0.11.0'
+        self.assertEqual(actual, expected)
+
+    def test_version_bump_patch(self):
+        env = jinja_utils.get_jinja_environment()
+
+        template = '{{version | version_bump_patch}}'
+        actual = env.from_string(template).render({'version': '0.10.1'})
+        expected = '0.10.2'
+        self.assertEqual(actual, expected)
+
+    def test_version_strip_patch(self):
+        env = jinja_utils.get_jinja_environment()
+
+        template = '{{version | version_strip_patch}}'
+        actual = env.from_string(template).render({'version': '0.10.1'})
+        expected = '0.10'
+        self.assertEqual(actual, expected)

--- a/st2common/tests/unit/test_param_utils.py
+++ b/st2common/tests/unit/test_param_utils.py
@@ -435,6 +435,17 @@ class ParamsUtilsTest(DbTestCase):
         self.assertEqual(r_runner_params, {'r1': '{{ missing }}'})
         self.assertEqual(r_action_params, {})
 
+    def test_get_finalized_params_jinja_filters(self):
+        params = {'cmd': 'echo {{"1.6.0" | version_bump_minor}}'}
+        runner_param_info = {'r1': {}}
+        action_param_info = {'cmd': {}}
+        action_context = {}
+
+        r_runner_params, r_action_params = param_utils.get_finalized_params(
+            runner_param_info, action_param_info, params, action_context)
+
+        self.assertEqual(r_action_params['cmd'], "echo 1.7.0")
+
     def test_get_finalized_params_param_rendering_failure(self):
         params = {'cmd': '{{a2.foo}}', 'a2': 'test'}
         action_param_info = {'cmd': {}, 'a2': {}}

--- a/st2common/tests/unit/test_time_jinja_filters.py
+++ b/st2common/tests/unit/test_time_jinja_filters.py
@@ -1,0 +1,32 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the 'License'); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest2 import TestCase
+
+from st2common.jinja.filters import time
+
+
+class TestTimeJinjaFilters(TestCase):
+
+    def test_to_human_time_from_seconds(self):
+        self.assertEqual('0s', time.to_human_time_from_seconds(seconds=0))
+        self.assertEqual('0.1\u03BCs', time.to_human_time_from_seconds(seconds=0.1))
+        self.assertEqual('56s', time.to_human_time_from_seconds(seconds=56))
+        self.assertEqual('56s', time.to_human_time_from_seconds(seconds=56.2))
+        self.assertEqual('7m36s', time.to_human_time_from_seconds(seconds=456))
+        self.assertEqual('1h16m0s', time.to_human_time_from_seconds(seconds=4560))
+        self.assertEqual('1y12d16h36m37s', time.to_human_time_from_seconds(seconds=45678997))
+        self.assertRaises(AssertionError, time.to_human_time_from_seconds,
+                          seconds='stuff')

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -19,4 +19,4 @@ nose-timer
 pyyaml
 RandomWords
 gunicorn>=19.3.0,<19.4
-psutil>=3.2.2,<3.3
+psutil


### PR DESCRIPTION
## What? 

Include a ``to_human_time`` jinja function that can be used to fuzzy render time value in seconds. 
For example {{ elapsed_seconds || to_human_time }} will convert an integer (or long) 181 to string '3m1s'.

## Why?
See https://github.com/StackStorm/hubot-stackstorm/issues/123

## TODO

- [X] Refactor existing jinja filters to own files
- [X] Add a to_human_time method (** I think I'll need to_human_time_from_secs to be explicit)
- [X] Fix a bug in jinja rendering where jinja filter expressions weren't detected to be jinja renderable (See https://gist.github.com/lakshmi-kannan/0af3004652c12eaa9d5002cb0903a058, eaa7420, refactored 8c95a6d)
- [x] Unit tests
- [x] Documentation for jinja filters (https://github.com/StackStorm/st2docs/pull/228)
- [ ] Changelog


