### PR TITLE
Use and run unit and integration tests with MongoDB 2.4, 2.6 and 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_script:
   - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB}.tgz -O /tmp/mongodb.tgz
   - tar -xvf /tmp/mongodb.tgz
   - mkdir /tmp/data
-  - ${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --dbpath /tmp/data --bind_ip 127.0.0.1 --auth &> /dev/null &
+  - ${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --dbpath /tmp/data --bind_ip 127.0.0.1 &> /dev/null &
 
 install:
   - pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,18 @@ python:
   - 2.7
 
 # Note: We enable artifacts addons since we upload integration tests logs to S3
-addons:
-  artifacts:
-    s3_region: "us-west-2"
-    paths:
-      - $(ls /tmp/st2*.log | tr "\n" ":")
+#addons:
+#  artifacts:
+#    s3_region: "us-west-2"
+#    paths:
+#      - $(ls /tmp/st2*.log | tr "\n" ":")
 
 env:
   global:
     - ARTIFACTS_DEBUG=1
     - ARTIFACTS_BUCKET=st2travistestslogs
-    - secure: "2k3NMsOqDOXZLGMo+fuTSl35VqR41cm7Z4ZPSduh2ceIMyhgtnKGmElklxV7DxaZtFgl0GD0EZWLSErqlOsjDdAA0IsBMzisQRMBWl+Rqpvjsn2P0jtZBPwe/5OPDpBUqE7t/BOaPBbyTSA9vtLPMhTWdDlR4l28NifAC+k977Q="
-    - secure: "AxPXLPSPGqa8lrwysXxTFHTdEVecK4ZhH91PFu6pZ+IfrSKLek23+CM08J50tmat991swSM8qodhIUfCcvJObcqDFbl295VPYM++H4U9w1dzi571WA0VKZLs3pBhwHf6ACnBX8bzxz3s/7+vE/g2bdrqI6Z6aK3UR98POjbsdOg="
+#    - secure: "2k3NMsOqDOXZLGMo+fuTSl35VqR41cm7Z4ZPSduh2ceIMyhgtnKGmElklxV7DxaZtFgl0GD0EZWLSErqlOsjDdAA0IsBMzisQRMBWl+Rqpvjsn2P0jtZBPwe/5OPDpBUqE7t/BOaPBbyTSA9vtLPMhTWdDlR4l28NifAC+k977Q="
+#    - secure: "AxPXLPSPGqa8lrwysXxTFHTdEVecK4ZhH91PFu6pZ+IfrSKLek23+CM08J50tmat991swSM8qodhIUfCcvJObcqDFbl295VPYM++H4U9w1dzi571WA0VKZLs3pBhwHf6ACnBX8bzxz3s/7+vE/g2bdrqI6Z6aK3UR98POjbsdOg="
   matrix:
     - TASK=checks
     - TASK=unit MONGODB=2.4.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ env:
 #    - secure: "AxPXLPSPGqa8lrwysXxTFHTdEVecK4ZhH91PFu6pZ+IfrSKLek23+CM08J50tmat991swSM8qodhIUfCcvJObcqDFbl295VPYM++H4U9w1dzi571WA0VKZLs3pBhwHf6ACnBX8bzxz3s/7+vE/g2bdrqI6Z6aK3UR98POjbsdOg="
   matrix:
     - TASK=checks
-    - TASK=unit MONGODB=2.4.9
-    - TASK=integration MONGODB=2.4.9
-    - TASK=unit MONGODB=2.6.12
-    - TASK=integration MONGODB=2.6.12
+#    - TASK=unit MONGODB=2.4.9
+#    - TASK=integration MONGODB=2.4.9
+#    - TASK=unit MONGODB=2.6.12
+#    - TASK=integration MONGODB=2.6.12
     - TASK=unit MONGODB=3.2.8
     - TASK=integration MONGODB=3.2.8
     - TASK=mistral

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,13 @@ cache:
     - $HOME/.cache/pip/
 
 before_script:
+  # Note: We use ramdisk for better performance
+  - sudo mkdir /mnt/ramdisk
+  - sudo mount -t tmpfs -o size=1024m tmpfs /mnt/ramdisk
   - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB}.tgz -O /tmp/mongodb.tgz
   - tar -xvf /tmp/mongodb.tgz
   - mkdir /tmp/data
-  - ${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --dbpath /tmp/data --bind_ip 127.0.0.1 &> /dev/null &
+  - ${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --dbpath /mnt/ramdisk/mongodb --bind_ip 127.0.0.1 &> /dev/null &
 
 install:
   - pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
     - ARTIFACTS_BUCKET=st2travistestslogs
     - secure: "2k3NMsOqDOXZLGMo+fuTSl35VqR41cm7Z4ZPSduh2ceIMyhgtnKGmElklxV7DxaZtFgl0GD0EZWLSErqlOsjDdAA0IsBMzisQRMBWl+Rqpvjsn2P0jtZBPwe/5OPDpBUqE7t/BOaPBbyTSA9vtLPMhTWdDlR4l28NifAC+k977Q="
     - secure: "AxPXLPSPGqa8lrwysXxTFHTdEVecK4ZhH91PFu6pZ+IfrSKLek23+CM08J50tmat991swSM8qodhIUfCcvJObcqDFbl295VPYM++H4U9w1dzi571WA0VKZLs3pBhwHf6ACnBX8bzxz3s/7+vE/g2bdrqI6Z6aK3UR98POjbsdOg="
+    - MONGODB=3.2.8
   matrix:
     - TASK=checks
     - TASK=unit
@@ -31,13 +32,18 @@ matrix:
     - env: TASK=mistral
 
 services:
-  - mongodb
   - postgresql
   - rabbitmq
 
 cache:
   directories:
     - $HOME/.cache/pip/
+
+before_script:
+  - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB}.tgz -O /tmp/mongodb.tgz
+  - tar -xvf /tmp/mongodb.tgz
+  - mkdir /tmp/data
+  - ${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --dbpath /tmp/data --bind_ip 127.0.0.1 --auth &> /dev/null &
 
 install:
   - pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,12 +41,8 @@ cache:
 
 before_script:
   # Note: We use ramdisk for better performance
-  - sudo mkdir /mnt/ramdisk
-  - sudo mount -t tmpfs -o size=1024m tmpfs /mnt/ramdisk
-  - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB}.tgz -O /tmp/mongodb.tgz
-  - tar -xvf /tmp/mongodb.tgz
-  - mkdir /tmp/data
-  - ${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --dbpath /mnt/ramdisk/mongodb --bind_ip 127.0.0.1 &> /dev/null &
+  - sudo -E ./scripts/travis/create-and-mount-ramdisk.sh
+  - if [ ${TASK} = 'unit' ] || [ ${TASK} = 'integration' ]; then ./scripts/travis/install-and-run-mongodb.sh; fi
 
 install:
   - pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ cache:
 
 before_script:
   # Note: We use ramdisk for better performance
-  - sudo -E ./scripts/travis/create-and-mount-ramdisk.sh
+  - if [ ${TASK} = 'unit' ] || [ ${TASK} = 'integration' ]; thensudo -E ./scripts/travis/create-and-mount-ramdisk.sh; fi
   - if [ ${TASK} = 'unit' ] || [ ${TASK} = 'integration' ]; then ./scripts/travis/install-and-run-mongodb.sh; fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ cache:
 
 before_script:
   # Note: We use ramdisk for better performance
-  - if [ ${TASK} = 'unit' ] || [ ${TASK} = 'integration' ]; thensudo -E ./scripts/travis/create-and-mount-ramdisk.sh; fi
+  - if [ ${TASK} = 'unit' ] || [ ${TASK} = 'integration' ]; then sudo -E ./scripts/travis/create-and-mount-ramdisk.sh; fi
   - if [ ${TASK} = 'unit' ] || [ ${TASK} = 'integration' ]; then ./scripts/travis/install-and-run-mongodb.sh; fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,14 @@ env:
     - ARTIFACTS_BUCKET=st2travistestslogs
     - secure: "2k3NMsOqDOXZLGMo+fuTSl35VqR41cm7Z4ZPSduh2ceIMyhgtnKGmElklxV7DxaZtFgl0GD0EZWLSErqlOsjDdAA0IsBMzisQRMBWl+Rqpvjsn2P0jtZBPwe/5OPDpBUqE7t/BOaPBbyTSA9vtLPMhTWdDlR4l28NifAC+k977Q="
     - secure: "AxPXLPSPGqa8lrwysXxTFHTdEVecK4ZhH91PFu6pZ+IfrSKLek23+CM08J50tmat991swSM8qodhIUfCcvJObcqDFbl295VPYM++H4U9w1dzi571WA0VKZLs3pBhwHf6ACnBX8bzxz3s/7+vE/g2bdrqI6Z6aK3UR98POjbsdOg="
-    - MONGODB=3.2.8
   matrix:
     - TASK=checks
-    - TASK=unit
-    - TASK=integration
+    - TASK=unit MONGODB=2.4.9
+    - TASK=integration MONGODB=2.4.9
+    - TASK=unit MONGODB=2.6.12
+    - TASK=integration MONGODB=2.6.12
+    - TASK=unit MONGODB=3.2.8
+    - TASK=integration MONGODB=3.2.8
     - TASK=mistral
     - TASK=packs-tests
 

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -6,6 +6,12 @@ if [ -z ${TASK} ]; then
   exit 2
 fi
 
+# Note: We add bin directory of the MongoDB installation we use to PATH so
+# correct version of Mongo shell is used by makefile, etc.
+if [ ! -z ${MONGODB} ]; then
+  export PATH=${PATH}:${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/
+fi
+
 if [ ${TASK} == 'checks' ]; then
   # compile .py files, useful as compatibility syntax check
   make compile

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -9,7 +9,7 @@ fi
 # Note: We add bin directory of the MongoDB installation we use to PATH so
 # correct version of Mongo shell is used by makefile, etc.
 if [ ! -z ${MONGODB} ]; then
-  export PATH=${PATH}:${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/
+  export PATH=${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/:${PATH}
 fi
 
 if [ ${TASK} == 'checks' ]; then

--- a/scripts/travis/create-and-mount-ramdisk.sh
+++ b/scripts/travis/create-and-mount-ramdisk.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+mkdir /mnt/ramdisk
+mount -t tmpfs -o size=1024m tmpfs /mnt/ramdisk

--- a/scripts/travis/install-and-run-mongodb.sh
+++ b/scripts/travis/install-and-run-mongodb.sh
@@ -14,7 +14,7 @@ wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB}.tgz -O /tmp
 tar -xvf /tmp/mongodb.tgz
 mkdir -p ${DATA_DIR}
 echo "Starting MongoDB v${MONGODB}"
-${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --dbpath ${DATA_DIR} --bind_ip 127.0.0.1 &> /tmp/mongodb.log &
+${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --nojournal --dbpath ${DATA_DIR} --bind_ip 127.0.0.1 &> /tmp/mongodb.log &
 EXIT_CODE=$?
 
 if [ ${EXIT_CODE} -ne 0 ]; then

--- a/scripts/travis/install-and-run-mongodb.sh
+++ b/scripts/travis/install-and-run-mongodb.sh
@@ -4,5 +4,5 @@
 
 wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB}.tgz -O /tmp/mongodb.tgz
 tar -xvf /tmp/mongodb.tgz
-mkdir /tmp/ramdisk/mongodb
+mkdir /mnt/ramdisk/mongodb
 ${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --dbpath /mnt/ramdisk/mongodb --bind_ip 127.0.0.1 &> /dev/null &

--- a/scripts/travis/install-and-run-mongodb.sh
+++ b/scripts/travis/install-and-run-mongodb.sh
@@ -13,5 +13,14 @@ fi
 wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB}.tgz -O /tmp/mongodb.tgz
 tar -xvf /tmp/mongodb.tgz
 mkdir -p ${DATA_DIR}
+echo "Starting MongoDB v${MONGODB}"
 ${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --dbpath ${DATA_DIR} --bind_ip 127.0.0.1 &> /tmp/mongodb.log &
+EXIT_CODE=$?
+
+if [ ${EXIT_CODE} -ne 0 ]; then
+    echo "Failed to start MongoDB"
+    tail -30 /tmp/mongodb.log
+    exit 1
+fi
+
 tail -30 /tmp/mongodb.log

--- a/scripts/travis/install-and-run-mongodb.sh
+++ b/scripts/travis/install-and-run-mongodb.sh
@@ -17,6 +17,7 @@ echo "Starting MongoDB v${MONGODB}"
 ${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --nojournal --journalCommitInterval 500 \
     --syncdelay 0 --dbpath ${DATA_DIR} --bind_ip 127.0.0.1 &> /tmp/mongodb.log &
 EXIT_CODE=$?
+sleep 5
 
 if [ ${EXIT_CODE} -ne 0 ]; then
     echo "Failed to start MongoDB"

--- a/scripts/travis/install-and-run-mongodb.sh
+++ b/scripts/travis/install-and-run-mongodb.sh
@@ -13,4 +13,5 @@ fi
 wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB}.tgz -O /tmp/mongodb.tgz
 tar -xvf /tmp/mongodb.tgz
 mkdir -p ${DATA_DIR}
-${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --dbpath ${DATA_DIR} --bind_ip 127.0.0.1 &> /dev/null &
+${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --dbpath ${DATA_DIR} --bind_ip 127.0.0.1 &> /tmp/mongodb.log &
+tail -30 /tmp/mongodb.log

--- a/scripts/travis/install-and-run-mongodb.sh
+++ b/scripts/travis/install-and-run-mongodb.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Script which installs versions of MongoDB specified using an environment variable
+
+wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB}.tgz -O /tmp/mongodb.tgz
+tar -xvf /tmp/mongodb.tgz
+mkdir /tmp/ramdisk/mongodb
+${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --dbpath /mnt/ramdisk/mongodb --bind_ip 127.0.0.1 &> /dev/null &

--- a/scripts/travis/install-and-run-mongodb.sh
+++ b/scripts/travis/install-and-run-mongodb.sh
@@ -14,7 +14,8 @@ wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB}.tgz -O /tmp
 tar -xvf /tmp/mongodb.tgz
 mkdir -p ${DATA_DIR}
 echo "Starting MongoDB v${MONGODB}"
-${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --nojournal --dbpath ${DATA_DIR} --bind_ip 127.0.0.1 &> /tmp/mongodb.log &
+${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --nojournal --journalCommitInterval 500 \
+    --syncdelay 0 --dbpath ${DATA_DIR} --bind_ip 127.0.0.1 &> /tmp/mongodb.log &
 EXIT_CODE=$?
 
 if [ ${EXIT_CODE} -ne 0 ]; then

--- a/scripts/travis/install-and-run-mongodb.sh
+++ b/scripts/travis/install-and-run-mongodb.sh
@@ -2,7 +2,15 @@
 
 # Script which installs versions of MongoDB specified using an environment variable
 
+# Note: MongoDB 2.4 and 2.6 don't work with ramdisk since they don't work with
+# small files and require at least 3 GB of space
+if [ ${MONGODB} = '2.4.9' ] || [ ${MONGODB} = '2.6.12' ]; then
+    DATA_DIR=/tmp/mongodbdata
+else
+    DATA_DIR=/mnt/ramdisk/mongodb
+fi
+
 wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB}.tgz -O /tmp/mongodb.tgz
 tar -xvf /tmp/mongodb.tgz
-mkdir /mnt/ramdisk/mongodb
-${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --dbpath /mnt/ramdisk/mongodb --bind_ip 127.0.0.1 &> /dev/null &
+mkdir -p ${DATA_DIR}
+${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --dbpath ${DATA_DIR} --bind_ip 127.0.0.1 &> /dev/null &


### PR DESCRIPTION
This pull request updates Travis file so we now run unit and integration tests with MongoDB 2.4, 2.6 and 3.2.

In the future we should drop official support for versions < 3.2 since they are quite old now.

In addition to the MongoDB change, I also updated the script to create a ramdisk and use this for MongoDB data dir. In theory, this should speed things up a bit, but probably not by much since we are running on a shared environment.

Note: If it turns out that the whole build now takes too long because we run 4 additional jobs, we can update the build configuration and only run tests with MongoDB 3.2.