### PR TITLE
Allow user to cancel multiple executions using st2 execution cancel command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,9 @@ In development
 * Fix a bug when jinja templates with filters (for example,
   ``st2 run core.local cmd='echo {{"1.6.0" | version_bump_minor}}'``) in parameters wasn't rendered
   correctly when executing actions. (bug-fix)
+* Allow user to cancel multiple executions using a single invocation of ``st2 execution cancel``
+  command by passing multiple ids to the command -
+  ``st2 execution cancel <id 1> <id 2> <id n>`` (improvement)
 
 1.6.0 - August 8, 2016
 ----------------------

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -1089,7 +1089,7 @@ class ActionExecutionCancelCommand(resource.ResourceCommand):
                                                    execution_id)
         else:
             message = 'Cannot cancel %s with id %s.' % (self.resource.get_display_name().lower(),
-                                                          execution_id)
+                                                        execution_id)
         print(message)
 
 


### PR DESCRIPTION
This change allows user to cancel multiple executions using a single invocation of ``st2 execution cancel`` command.

It uses the same notation as many other well known CLI commands (e.g. `git cherry-pick sha1 sha2 sha2`, etc.).

For example:

```bash
st2 execution cancel 57a9707b0640fd0a5f8b15c4 57a96e070640fd0a5f8b158e 57a96e270640fd0a5f8b1594
```

This would save me some typing yesterday when dealing with the workflows. The change itself is fully backward compatible and works the same as before when only a single execution id is provided.