### PR TITLE
Bump timeout from 60 to 100 second for packs.load command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ In development
 * Allow user to cancel multiple executions using a single invocation of ``st2 execution cancel``
   command by passing multiple ids to the command -
   ``st2 execution cancel <id 1> <id 2> <id n>`` (improvement)
+* Bump default timeout for ``packs.load`` command from ``60`` to ``100`` seconds. (improvement)
 
 1.6.0 - August 8, 2016
 ----------------------

--- a/contrib/packs/actions/load.yaml
+++ b/contrib/packs/actions/load.yaml
@@ -16,7 +16,8 @@
       default: "actions,aliases,sensors"
       description: "Possible options are all, sensors, actions, rules, aliases."
     timeout:
-      type: "number"
+      type: "integer"
       default: 100
+      description: "Action timeout."
     kwarg_op:
       immutable: true

--- a/contrib/packs/actions/load.yaml
+++ b/contrib/packs/actions/load.yaml
@@ -15,5 +15,8 @@
       type: "string"
       default: "actions,aliases,sensors"
       description: "Possible options are all, sensors, actions, rules, aliases."
+    timeout:
+      type: "number"
+      default: 100
     kwarg_op:
       immutable: true


### PR DESCRIPTION
If there are a lot of packs and resources on disk `packs.load` with a default timeout will fail because resource registration takes longer.

This was constantly happening on the build server.

In the future we should also have a look if we can some how optimize and speed up the load process. We could perhaps batch insert stuff into database, but we first need to measure if database insertion really is the bottleneck...