### PR TITLE
Fix trigger-instance re-emit

### DIFF
--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -367,7 +367,7 @@ class TriggerInstanceResourceManager(ResourceManager):
     @add_auth_token_to_kwargs_from_env
     def re_emit(self, trigger_instance_id, **kwargs):
         url = '/%s/%s/re_emit' % (self.resource.get_url_path_name(), trigger_instance_id)
-        response = self.client.post(url, None)
+        response = self.client.post(url, None, **kwargs)
         if response.status_code != 200:
             self.handle_error(response)
         return response.json()


### PR DESCRIPTION
one-line fix for STORM-2263: re-emit the trigger fails with 401 because the auth token is not passed.

PS. I don't know enough of CLI unit tests to see how to get it covered, so skipping this part, sorry.