### PR TITLE
Change Python module loading code

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,9 @@ In development
 * We now execute --register-rules as part of st2ctl reload. PR raised by Vaishali:
   https://github.com/StackStorm/st2/issues/2861#issuecomment-239275641
 * Bump default timeout for ``packs.load`` command from ``60`` to ``100`` seconds. (improvement)
+* Change Python runner action and sensor Python module loading so the module is still loaded even if
+  the module name clashes with another module which is already in ``PYTHONPATH``
+  (improvement)
 
 1.6.0 - August 8, 2016
 ----------------------

--- a/st2actions/tests/unit/test_pythonrunner.py
+++ b/st2actions/tests/unit/test_pythonrunner.py
@@ -34,6 +34,9 @@ import st2tests.base as tests_base
 
 PASCAL_ROW_ACTION_PATH = os.path.join(tests_base.get_resources_path(), 'packs',
                                       'pythonactions/actions/pascal_row.py')
+TEST_ACTION_PATH = os.path.join(tests_base.get_resources_path(), 'packs',
+                                'pythonactions/actions/test.py')
+
 # Note: runner inherits parent args which doesn't work with tests since test pass additional
 # unrecognized args
 mock_sys = mock.Mock()
@@ -365,6 +368,18 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
                                             action_service=action_service)
         self.assertEqual(action3.config, config)
         self.assertEqual(action3.action_service, action_service)
+
+    def test_action_with_same_module_name_as_module_in_stdlib(self):
+        runner = pythonrunner.get_runner()
+        runner.action = self._get_mock_action_obj()
+        runner.runner_parameters = {}
+        runner.entry_point = TEST_ACTION_PATH
+        runner.container_service = service.RunnerContainerService()
+        runner.pre_run()
+        (status, output, _) = runner.run({})
+        self.assertEqual(status, LIVEACTION_STATUS_SUCCEEDED)
+        self.assertTrue(output is not None)
+        self.assertEqual(output['result'], 'test action')
 
     def _get_mock_action_obj(self):
         """

--- a/st2common/st2common/util/loader.py
+++ b/st2common/st2common/util/loader.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import importlib
+import imp
 import inspect
 import json
 import os
@@ -127,7 +127,7 @@ def register_plugin_class(base_class, file_path, class_name):
     if module_name is None:
         return None
 
-    module = importlib.import_module(module_name)
+    module = imp.load_source(module_name, file_path)
     klass = getattr(module, class_name, None)
 
     if not klass:
@@ -142,10 +142,12 @@ def register_plugin(plugin_base_class, plugin_abs_file_path):
     registered_plugins = []
     plugin_dir = os.path.dirname(os.path.realpath(plugin_abs_file_path))
     _register_plugin_path(plugin_dir)
+
     module_name = _get_plugin_module(plugin_abs_file_path)
     if module_name is None:
         return None
-    module = importlib.import_module(module_name)
+
+    module = imp.load_source(module_name, plugin_abs_file_path)
     klasses = _get_plugin_classes(module)
 
     # Try registering classes in plugin file. Some may fail.

--- a/st2tests/st2tests/resources/packs/pythonactions/actions/test.py
+++ b/st2tests/st2tests/resources/packs/pythonactions/actions/test.py
@@ -1,0 +1,9 @@
+# Python action which uses the same module name as built-in Python module
+# (test)
+
+from st2actions.runners.pythonrunner import Action
+
+
+class TestAction(Action):
+    def run(self):
+        return 'test action'


### PR DESCRIPTION
This PR changes Python plugin (module) loading code so the module is still loaded even if the module name clashes with another module which is already in `PYTHONPATH`.

The change should be fully backward compatible, but it still needs some more testing to make sure it doesn't break some existing behavior.

This change affects Python runner actions and sensors and resolves #2650.

## TODO

- [x] Tests