### PR TITLE
Fix validation of "type" attribute for action parameters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,9 @@ In development
 * Change Python runner action and sensor Python module loading so the module is still loaded even if
   the module name clashes with another module which is already in ``PYTHONPATH``
   (improvement)
+* Fix validation of the action parameter ``type`` attribute provided in the YAML metadata.
+  Previously we allowed any string value, now only valid types (object, string, number,
+  integer, array, null) are allowed. (bug fix)
 
 1.6.0 - August 8, 2016
 ----------------------

--- a/st2actions/tests/unit/test_actions_registrar.py
+++ b/st2actions/tests/unit/test_actions_registrar.py
@@ -83,6 +83,19 @@ class ActionsRegistrarTest(tests_base.DbTestCase):
     @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(return_value=True))
     @mock.patch.object(action_validator, '_get_runner_model',
                        mock.MagicMock(return_value=MOCK_RUNNER_TYPE_DB))
+    def test_register_action_invalid_parameter_type_attribute(self):
+        registrar = actions_registrar.ActionsRegistrar()
+        loader = fixtures_loader.FixturesLoader()
+        action_file = loader.get_fixture_file_path_abs(
+            'generic', 'actions', 'action_invalid_param_type.yaml')
+
+        expected_msg = '\'list\' is not valid under any of the given schema'
+        self.assertRaisesRegexp(jsonschema.ValidationError, expected_msg,
+                                registrar._register_action, 'dummy', action_file)
+
+    @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(return_value=True))
+    @mock.patch.object(action_validator, '_get_runner_model',
+                       mock.MagicMock(return_value=MOCK_RUNNER_TYPE_DB))
     def test_invalid_params_schema(self):
         registrar = actions_registrar.ActionsRegistrar()
         loader = fixtures_loader.FixturesLoader()

--- a/st2common/st2common/util/schema/action_params.json
+++ b/st2common/st2common/util/schema/action_params.json
@@ -135,11 +135,7 @@
         },
         "type": {
             "anyOf": [
-                { "$ref": "#/definitions/simpleTypes" },
-                {
-                    "type": "string",
-                    "items": { "$ref": "#/definitions/simpleTypes" }
-                }
+                { "$ref": "#/definitions/simpleTypes" }
             ]
         },
         "position": {

--- a/st2tests/st2tests/fixtures/generic/actions/action_invalid_param_type.yaml
+++ b/st2tests/st2tests/fixtures/generic/actions/action_invalid_param_type.yaml
@@ -1,0 +1,11 @@
+---
+description: Awesome action-1
+enabled: true
+entry_point: ''
+name: action-invalid-param-type
+pack: dummy
+parameters:
+  param1:
+    type: "list"
+    immutable: true
+runner_type: test-runner-1


### PR DESCRIPTION
This pull request fixes validation for `type` attribute of action parameters.

Existing JSON schema was incorrect so we allowed any string value and not just valid types. Since this wasn't caught before it looks like we didn't have any tests for this edge case.

This was originally discovered and reported by @LindsayHill in https://github.com/StackStorm/st2contrib/pull/532.

## TODO

- [x] Changelog entry
- [x] Tests