### PR TITLE
Rules API robustness improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,9 @@ In development
   integer, array, null) are allowed. (bug fix)
 * Upgrade pip and virtualenv libraries used by StackStorm pack virtual environments to the latest
   versions (8.1.2 and 15.0.3).
+* Allow user to list and view rules using the API even if a rule in the database references a
+  non-existent trigger. This shouldn't happen during normal usage of StackStorm, but it makes it
+  easier for the user to clean up in case database ends up in a inconsistent state. (improvement)
 
 1.6.0 - August 8, 2016
 ----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,8 @@ In development
 * Allow user to list and view rules using the API even if a rule in the database references a
   non-existent trigger. This shouldn't happen during normal usage of StackStorm, but it makes it
   easier for the user to clean up in case database ends up in a inconsistent state. (improvement)
+* Update ``packs.uninstall`` command to print a warning message if any rules in the system
+  reference a trigger from a pack which is being uninstalled. (improvement)
 
 1.6.0 - August 8, 2016
 ----------------------

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -324,14 +324,14 @@ class ContentPackResourceController(ResourceController):
         self.get_one_db_method = self._get_by_ref_or_id
 
     @jsexpose(arg_types=[str])
-    def get_one(self, ref_or_id):
-        return self._get_one(ref_or_id)
+    def get_one(self, ref_or_id, from_model_kwargs=None):
+        return self._get_one(ref_or_id, from_model_kwargs=from_model_kwargs)
 
     @jsexpose()
     def get_all(self, **kwargs):
         return self._get_all(**kwargs)
 
-    def _get_one(self, ref_or_id, exclude_fields=None):
+    def _get_one(self, ref_or_id, exclude_fields=None, from_model_kwargs=None):
         LOG.info('GET %s with ref_or_id=%s', pecan.request.path, ref_or_id)
 
         try:
@@ -341,7 +341,8 @@ class ContentPackResourceController(ResourceController):
             pecan.abort(http_client.NOT_FOUND, e.message)
             return
 
-        from_model_kwargs = self._get_from_model_kwargs_for_request(request=pecan.request)
+        from_model_kwargs = from_model_kwargs or {}
+        from_model_kwargs.update(self._get_from_model_kwargs_for_request(request=pecan.request))
         result = self.model.from_model(instance, **from_model_kwargs)
         if result and self.include_reference:
             pack = getattr(result, 'pack', None)

--- a/st2api/st2api/controllers/v1/rules.py
+++ b/st2api/st2api/controllers/v1/rules.py
@@ -76,7 +76,8 @@ class RuleController(resource.ContentPackResourceController):
     @request_user_has_resource_db_permission(permission_type=PermissionType.RULE_VIEW)
     @jsexpose(arg_types=[str])
     def get_one(self, ref_or_id):
-        return super(RuleController, self)._get_one(ref_or_id)
+        from_model_kwargs = {'ignore_missing_trigger': True}
+        return super(RuleController, self)._get_one(ref_or_id, from_model_kwargs=from_model_kwargs)
 
     @jsexpose(body_cls=RuleAPI, status_code=http_client.CREATED)
     @request_user_has_resource_api_permission(permission_type=PermissionType.RULE_CREATE)

--- a/st2api/st2api/controllers/v1/rules.py
+++ b/st2api/st2api/controllers/v1/rules.py
@@ -70,7 +70,8 @@ class RuleController(resource.ContentPackResourceController):
     @request_user_has_permission(permission_type=PermissionType.RULE_LIST)
     @jsexpose()
     def get_all(self, **kwargs):
-        return super(RuleController, self)._get_all(**kwargs)
+        from_model_kwargs = {'ignore_missing_trigger': True}
+        return super(RuleController, self)._get_all(from_model_kwargs=from_model_kwargs, **kwargs)
 
     @request_user_has_resource_db_permission(permission_type=PermissionType.RULE_VIEW)
     @jsexpose(arg_types=[str])

--- a/st2common/st2common/models/api/rule.py
+++ b/st2common/st2common/models/api/rule.py
@@ -203,18 +203,20 @@ class RuleAPI(BaseAPI, APIUIDMixin):
     }
 
     @classmethod
-    def from_model(cls, model, mask_secrets=False):
+    def from_model(cls, model, mask_secrets=False, ignore_missing_trigger=False):
         rule = cls._from_model(model, mask_secrets=mask_secrets)
         trigger_db = reference.get_model_by_resource_ref(Trigger, model.trigger)
 
-        if not trigger_db:
+        if not ignore_missing_trigger and not trigger_db:
             raise ValueError('Missing TriggerDB object for rule %s' % (rule['id']))
 
-        rule['trigger'] = {
-            'type': trigger_db.type,
-            'parameters': trigger_db.parameters,
-            'ref': model.trigger
-        }
+        if trigger_db:
+            rule['trigger'] = {
+                'type': trigger_db.type,
+                'parameters': trigger_db.parameters,
+                'ref': model.trigger
+            }
+
         rule['tags'] = TagsHelper.from_model(model.tags)
         return cls(**rule)
 

--- a/st2common/st2common/util/api.py
+++ b/st2common/st2common/util/api.py
@@ -126,10 +126,15 @@ def get_exception_for_type_error(func, exc):
         result = webob_exc.HTTPNotFound()
     elif re.search(unexpected_keyword_arg_pattern, message):
         # User passed in an unsupported query parameter
-        groups = re.match(unexpected_keyword_arg_pattern, message).groups()
-        query_param_name = groups[0]
+        match = re.match(unexpected_keyword_arg_pattern, message)
 
-        msg = 'Unsupported query parameter: %s' % (query_param_name)
+        if match:
+            groups = match.groups()
+            query_param_name = groups[0]
+
+            msg = 'Unsupported query parameter: %s' % (query_param_name)
+        else:
+            msg = 'Unknown error, please contact the administrator.'
         result = webob_exc.HTTPBadRequest(detail=msg)
     else:
         result = exc


### PR DESCRIPTION
This pull request addresses #2869 and allows users to still list and retrieve rules even if a rule in a database references a trigger which has been deleted because a pack which provides that trigger has been removed.

This is a pretty common use case which we don't handle right now - we only clean up triggers for rules which belong to the pack which is uninstalled. If there is a pack A and pack B with a rule which references a trigger inside a pack A and user uninstalls pack A, rule inside a Pack B won't be deleted (that's of course when user is working via the API and / or using `packs.uninstall` command).

One option would be to also clean up all the rules which reference a trigger from the pack which is being uninstalled (even the rules from other packs). I personally think that's a reasonable behavior for API (but not for on disk content, of course).

What do others think?