### PR TITLE
Fix disabling and enabling a sensor through an API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ In development
   easier for the user to clean up in case database ends up in a inconsistent state. (improvement)
 * Update ``packs.uninstall`` command to print a warning message if any rules in the system
   reference a trigger from a pack which is being uninstalled. (improvement)
+* Fix disabling and enabling of a sensor through an API and CLI. (bug-fix)
 
 1.6.0 - August 8, 2016
 ----------------------

--- a/st2api/st2api/controllers/v1/sensors.py
+++ b/st2api/st2api/controllers/v1/sensors.py
@@ -59,7 +59,7 @@ class SensorTypeController(resource.ContentPackResourceController):
 
     @request_user_has_resource_db_permission(permission_type=PermissionType.SENSOR_MODIFY)
     @jsexpose(arg_types=[str], body_cls=SensorTypeAPI)
-    def put(self, ref_or_id, sensor_type):
+    def put(self, sensor_type, ref_or_id):
         # Note: Right now this function only supports updating of "enabled"
         # attribute on the SensorType model.
         # The reason for that is that SensorTypeAPI.to_model right now only

--- a/st2api/tests/unit/controllers/v1/test_sensortypes.py
+++ b/st2api/tests/unit/controllers/v1/test_sensortypes.py
@@ -13,19 +13,70 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
+
 import six
+import st2common.bootstrap.sensorsregistrar as sensors_registrar
 from tests import FunctionalTest
 
 http_client = six.moves.http_client
 
+__all__ = [
+    'SensorTypeControllerTestCase'
+]
 
-# TODO: Update tests once we include POST and PUT functionality
+
 class SensorTypeControllerTestCase(FunctionalTest):
+    @classmethod
+    def setUpClass(cls):
+        super(SensorTypeControllerTestCase, cls).setUpClass()
+
+        # Register local sensor and pack fixtures
+        sensors_registrar.register_sensors(use_pack_cache=False)
+
     def test_get_all(self):
         resp = self.app.get('/v1/sensortypes')
         self.assertEqual(resp.status_int, http_client.OK)
-        self.assertEqual(len(resp.json), 0)
+        self.assertEqual(len(resp.json), 1)
+        self.assertEqual(resp.json[0]['name'], 'SampleSensor')
+
+    def test_get_one_success(self):
+        resp = self.app.get('/v1/sensortypes/dummy_pack_1.SampleSensor')
+        self.assertEqual(resp.status_int, http_client.OK)
+        self.assertEqual(resp.json['name'], 'SampleSensor')
 
     def test_get_one_doesnt_exist(self):
         resp = self.app.get('/v1/sensortypes/1', expect_errors=True)
         self.assertEqual(resp.status_int, http_client.NOT_FOUND)
+
+    def test_disable_and_enable_sensor(self):
+        # Verify initial state
+        resp = self.app.get('/v1/sensortypes/dummy_pack_1.SampleSensor')
+        self.assertEqual(resp.status_int, http_client.OK)
+        self.assertTrue(resp.json['enabled'])
+
+        sensor_data = resp.json
+
+        # Disable sensor
+        data = copy.deepcopy(sensor_data)
+        data['enabled'] = False
+        put_resp = self.app.put_json('/v1/sensortypes/dummy_pack_1.SampleSensor', data)
+        self.assertEqual(put_resp.status_int, http_client.OK)
+        self.assertFalse(put_resp.json['enabled'])
+
+        # Verify sensor has been disabled
+        resp = self.app.get('/v1/sensortypes/dummy_pack_1.SampleSensor')
+        self.assertEqual(resp.status_int, http_client.OK)
+        self.assertFalse(resp.json['enabled'])
+
+        # Enable sensor
+        data = copy.deepcopy(sensor_data)
+        data['enabled'] = True
+        put_resp = self.app.put_json('/v1/sensortypes/dummy_pack_1.SampleSensor', data)
+        self.assertEqual(put_resp.status_int, http_client.OK)
+        self.assertTrue(put_resp.json['enabled'])
+
+        # Verify sensor has been enabled
+        resp = self.app.get('/v1/sensortypes/dummy_pack_1.SampleSensor')
+        self.assertEqual(resp.status_int, http_client.OK)
+        self.assertTrue(resp.json['enabled'])

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_1/sensors/my_sensor.yaml
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_1/sensors/my_sensor.yaml
@@ -1,0 +1,15 @@
+---
+  class_name: "SampleSensor"
+  entry_point: "my_sensor.py"
+  description: "Sample sensor that emits triggers."
+  trigger_types:
+    -
+      name: "event"
+      description: "An example trigger."
+      payload_schema:
+        type: "object"
+        properties:
+          executed_at:
+            type: "string"
+            format: "date-time"
+            default: "2014-07-30 05:04:24.578325"


### PR DESCRIPTION
This pull request fixes an issue reported in #2878.

We introduced a regression recently because we had no test case for a sensor disable / enable scenario (this has now also been fixed).