### PR TITLE
Fix bug: header value must be str

### DIFF
--- a/st2actions/st2actions/runners/httprunner.py
+++ b/st2actions/st2actions/runners/httprunner.py
@@ -157,7 +157,7 @@ class HTTPClient(object):
         headers = headers or {}
         normalized_headers = self._normalize_headers(headers=headers)
         if body and 'content-length' not in normalized_headers:
-            headers['Content-Length'] = len(body)
+            headers['Content-Length'] = str(len(body))
 
         self.url = url
         self.method = method


### PR DESCRIPTION
### environment

- OS: CentOS 7

```
[root@ac58573ad609 ~]# rpm -qa | grep st2
st2-1.7dev-19.x86_64
st2web-1.7dev-2.x86_64
st2chatops-1.7dev-1.x86_64
st2mistral-1.7dev-20.x86_64
```

### description

Starting from [requests](https://github.com/kennethreitz/requests) v2.11.0, any header values with type of other than str seems to be not accepted any more. Without this change, http_runner throughs an error if you set any body parameter:

```
[root@ac58573ad609 /]# st2 run core.http method=POST url="http://httpbin.org/post" body="hoge"
.
id: 57bd7ae1bf4c610064eda266
status: failed
parameters:
  body: hoge
  method: POST
  url: http://httpbin.org/post
result:
  error: Header value 4 must be of type str or bytes, not <type 'int'>
  traceback: "  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2actions/container/base.py", line 98, in _do_run
    (status, result, context) = runner.run(action_params)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2actions/runners/httprunner.py", line 88, in run
    result = client.run()
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2actions/runners/httprunner.py", line 206, in run
    verify=self.verify
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/requests/api.py", line 56, in request
    return session.request(method=method, url=url, **kwargs)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/requests/sessions.py", line 461, in request
    prep = self.prepare_request(req)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/requests/sessions.py", line 394, in prepare_request
    hooks=merge_hooks(request.hooks, self.hooks),
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/requests/models.py", line 295, in prepare
    self.prepare_headers(headers)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/requests/models.py", line 409, in prepare_headers
    check_header_validity(header)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/requests/utils.py", line 800, in check_header_validity
    "not %s" % (value, type(value)))
"
```