### PR TITLE
Pin requests to a more specific version

### DIFF
--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -10,7 +10,7 @@ oslo.config>=1.12.1,<1.13
 oslo.utils<3.1.0
 six==1.9.0
 pyyaml>=3.11,<4.0
-requests[security]>=2.7.0,<3.0
+requests[security]>=2.11.1,<2.12
 apscheduler>=3.0.5,<3.1
 gitpython==0.3.2.1
 jsonschema>=2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ python-json-logger
 python-keyczar==0.715
 pytz
 pyyaml<4.0,>=3.11
-requests[security]<3.0,>=2.7.0
+requests[security]>=2.11.1,<2.12
 retrying<1.4,>=1.3
 semver>=2.1.2
 six==1.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ python-json-logger
 python-keyczar==0.715
 pytz
 pyyaml<4.0,>=3.11
-requests[security]>=2.11.1,<2.12
+requests[security]<2.12,>=2.11.1
 retrying<1.4,>=1.3
 semver>=2.1.2
 six==1.9.0


### PR DESCRIPTION
Something we should have done before to avoid backward incompatible changes related issues such as this one - https://github.com/StackStorm/st2/pull/2880.