### PR TITLE
Various traces API and CLI improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 In development
 --------------
 
+* Update traces list API endpoint and ``st2 trace list`` so the traces are sorted by
+  ``start_timestamp`` in descending order by default. This way it's consistent with executions
+  list and ``-n`` CLI parameter works as expected. (improvement)
+
 2.0.0 - August 31, 2016
 -----------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ In development
 * Update traces list API endpoint and ``st2 trace list`` so the traces are sorted by
   ``start_timestamp`` in descending order by default. This way it's consistent with executions
   list and ``-n`` CLI parameter works as expected. (improvement)
+* Allow users to specify sort order when listing traces using the API endpoint by specifying
+  ``?sort_desc=True|False`` query parameters and by passing ``--sort=asc|desc`` parameter to
+  the ``st2 trace list`` CLI command. (improvement)
 
 2.0.0 - August 31, 2016
 -----------------------

--- a/st2api/st2api/controllers/v1/traces.py
+++ b/st2api/st2api/controllers/v1/traces.py
@@ -16,6 +16,7 @@
 from st2api.controllers.resource import ResourceController
 from st2common.models.api.trace import TraceAPI
 from st2common.persistence.trace import Trace
+from st2common.models.api.base import jsexpose
 
 __all__ = [
     'TracesController'
@@ -35,3 +36,16 @@ class TracesController(ResourceController):
     query_options = {
         'sort': ['-start_timestamp', 'trace_tag']
     }
+
+    @jsexpose()
+    def get_all(self, **kwargs):
+        # Use a custom sort order when filtering on a timestamp so we return a correct result as
+        # expected by the user
+        if 'sort_desc' in kwargs:
+            query_options = {'sort': ['-start_timestamp', 'action.ref']}
+            kwargs['query_options'] = query_options
+        elif 'sort_asc' in kwargs:
+            query_options = {'sort': ['+start_timestamp', 'action.ref']}
+            kwargs['query_options'] = query_options
+
+        return self._get_all(**kwargs)

--- a/st2api/st2api/controllers/v1/traces.py
+++ b/st2api/st2api/controllers/v1/traces.py
@@ -33,5 +33,5 @@ class TracesController(ResourceController):
     }
 
     query_options = {
-        'sort': ['trace_tag']
+        'sort': ['-start_timestamp', 'trace_tag']
     }

--- a/st2api/tests/unit/controllers/v1/test_traces.py
+++ b/st2api/tests/unit/controllers/v1/test_traces.py
@@ -48,10 +48,11 @@ class TestTraces(FunctionalTest):
         self.assertEqual(resp.status_int, 200)
         self.assertEqual(len(resp.json), 3, '/v1/traces did not return all traces.')
 
+        # Note: traces are returned sorted by start_timestamp in descending order by default
         retrieved_trace_tags = [trace['trace_tag'] for trace in resp.json]
 
         self.assertEqual(retrieved_trace_tags,
-                         [self.trace1.trace_tag, self.trace2.trace_tag, self.trace3.trace_tag],
+                         [self.trace3.trace_tag, self.trace2.trace_tag, self.trace1.trace_tag],
                          'Incorrect traces retrieved.')
 
     def test_get_by_id(self):

--- a/st2client/st2client/commands/trace.py
+++ b/st2client/st2client/commands/trace.py
@@ -123,6 +123,12 @@ class TraceListCommand(resource.ResourceCommand, SingleTraceDisplayMixin):
                                  default=50,
                                  help=('List N most recent %s.' %
                                        resource.get_plural_display_name().lower()))
+        self.parser.add_argument('-s', '--sort', type=str, dest='sort_order',
+                                 default='descending',
+                                 help=('Sort %s by start timestamp, '
+                                       'asc|ascending (earliest first) '
+                                       'or desc|descending (latest first)' %
+                                       resource.get_plural_display_name().lower()))
 
         # Filter options
         self.group.add_argument('-c', '--trace-tag', help='Trace-tag to filter the list.')
@@ -151,6 +157,12 @@ class TraceListCommand(resource.ResourceCommand, SingleTraceDisplayMixin):
             kwargs['execution'] = args.execution
         if args.rule:
             kwargs['rule'] = args.rule
+
+        if args.sort_order:
+            if args.sort_order in ['asc', 'ascending']:
+                kwargs['sort_asc'] = True
+            elif args.sort_order in ['desc', 'descending']:
+                kwargs['sort_desc'] = True
 
         return self.manager.query(limit=args.last, **kwargs)
 

--- a/st2common/st2common/models/db/trace.py
+++ b/st2common/st2common/models/db/trace.py
@@ -79,7 +79,8 @@ class TraceDB(stormbase.StormFoundationDB):
             {'fields': ['start_timestamp']},
             {'fields': ['action_executions.object_id']},
             {'fields': ['trigger_instances.object_id']},
-            {'fields': ['rules.object_id']}
+            {'fields': ['rules.object_id']},
+            {'fields': ['-start_timestamp', 'trace_tag']},
         ]
     }
 


### PR DESCRIPTION
This pull request updates traces list API endpoint and ``st2 trace list`` CLI commands so it works in the manner user expects it to and so it's consistent with the ``st2 execution list`` command and related API endpoint:

1. Update default sort order for the API endpoint - now traces are sorted by start_timestamp (descending) first and trace_tag second
2. Fix ``-n`` parameter and make sure traces are sorted correctly (descending order) when this parameter is supplied
3. Allow user to specify sort order through the API and CLI (e.g. ``st2 trace list -n 5 --sort asc``)

Closes #2855.