### PR TITLE
Fix handling of result and trigger_instance attribute in st2 execution get command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 In development
 --------------
 
+* Fix ``st2 execution get`` command so now ``--attr`` argument correctly works with child
+  properties of the ``result`` and ``trigger_instance`` dictionary (e.g. ``--attr
+  result.stdout result.stderr``). (bug fix)
+
 2.0.0 - August 31, 2016
 -----------------------
 

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -898,9 +898,21 @@ class ActionExecutionReadCommand(resource.ResourceCommand):
         """
         exclude_attributes = []
 
-        if 'result' not in args.attr:
+        result_included = False
+        trigger_instance_included = False
+
+        for attr in args.attr:
+            # Note: We do starts with check so we correct detected child attribute properties
+            # (e.g. result, result.stdout, result.stderr, etc.)
+            if attr.startswith('result'):
+                result_included = True
+
+            if attr.startswith('trigger_instance'):
+                trigger_instance_included = True
+
+        if not result_included:
             exclude_attributes.append('result')
-        if 'trigger_instance' not in args.attr:
+        if not trigger_instance_included:
             exclude_attributes.append('trigger_instance')
 
         return exclude_attributes

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -903,7 +903,7 @@ class ActionExecutionReadCommand(resource.ResourceCommand):
         trigger_instance_included = False
 
         for attr in args.attr:
-            # Note: We do starts with check so we correct detected child attribute properties
+            # Note: We perform startswith check so we correctly detected child attribute properties
             # (e.g. result, result.stdout, result.stderr, etc.)
             if attr.startswith('result'):
                 result_included = True

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -892,7 +892,8 @@ class ActionExecutionReadCommand(resource.ResourceCommand):
     Base class for read / view commands (list and get).
     """
 
-    def _get_exclude_attributes(self, args):
+    @classmethod
+    def _get_exclude_attributes(cls, args):
         """
         Retrieve a list of exclude attributes for particular command line arguments.
         """

--- a/st2client/tests/unit/test_commands.py
+++ b/st2client/tests/unit/test_commands.py
@@ -20,12 +20,19 @@ import logging
 import argparse
 import tempfile
 import unittest2
+from collections import namedtuple
 
 from tests import base
 
 from st2client import models
 from st2client.utils import httpclient
 from st2client.commands import resource
+from st2client.commands.action import ActionExecutionReadCommand
+
+__all__ = [
+    'TestResourceCommand',
+    'ActionExecutionReadCommandTestCase'
+]
 
 
 LOG = logging.getLogger(__name__)
@@ -232,3 +239,34 @@ class TestResourceCommand(unittest2.TestCase):
     def test_command_delete_failed(self):
         args = self.parser.parse_args(['fakeresource', 'delete', 'cba'])
         self.assertRaises(Exception, self.branch.commands['delete'].run, args)
+
+
+class ActionExecutionReadCommandTestCase(unittest2.TestCase):
+
+    def test_get_exclude_attributes(self):
+        cls = namedtuple('Args', 'attr')
+
+        args = cls(attr=[])
+        result = ActionExecutionReadCommand._get_exclude_attributes(args=args)
+        self.assertEqual(result, ['result', 'trigger_instance'])
+
+        args = cls(attr=['result'])
+        result = ActionExecutionReadCommand._get_exclude_attributes(args=args)
+        self.assertEqual(result, ['trigger_instance'])
+
+        args = cls(attr=['result', 'trigger_instance'])
+        result = ActionExecutionReadCommand._get_exclude_attributes(args=args)
+        self.assertEqual(result, [])
+
+        args = cls(attr=['result.stdout'])
+        result = ActionExecutionReadCommand._get_exclude_attributes(args=args)
+        self.assertEqual(result, ['trigger_instance'])
+
+        args = cls(attr=['result.stdout', 'result.stderr'])
+        result = ActionExecutionReadCommand._get_exclude_attributes(args=args)
+        self.assertEqual(result, ['trigger_instance'])
+
+        args = cls(attr=['result.stdout', 'trigger_instance.id'])
+        result = ActionExecutionReadCommand._get_exclude_attributes(args=args)
+        self.assertEqual(result, [])
+

--- a/st2client/tests/unit/test_commands.py
+++ b/st2client/tests/unit/test_commands.py
@@ -269,4 +269,3 @@ class ActionExecutionReadCommandTestCase(unittest2.TestCase):
         args = cls(attr=['result.stdout', 'trigger_instance.id'])
         result = ActionExecutionReadCommand._get_exclude_attributes(args=args)
         self.assertEqual(result, [])
-


### PR DESCRIPTION
We didn't correctly handle `exclude_attributes` API query parameter if user selected to display a child attribute of either `result` or `trigger_instance` object when using `st2 execution get` command.

For example, `--attr result` worked, but `--attr result.stdout` didn't because we incorrectly excluded `result` attribute from the API response in the second scenario.

This PR fixes that.

![selection_098](https://cloud.githubusercontent.com/assets/125088/18274783/7b8140ae-7444-11e6-88db-79d487405054.png)


Resolves #2858.