### PR TITLE
RBAC for new "action alias match" API endpoint

### DIFF
--- a/st2api/st2api/controllers/v1/actionalias.py
+++ b/st2api/st2api/controllers/v1/actionalias.py
@@ -74,6 +74,7 @@ class ActionAliasController(resource.ContentPackResourceController):
     def get_one(self, ref_or_id):
         return super(ActionAliasController, self)._get_one(ref_or_id)
 
+    @request_user_has_permission(permission_type=PermissionType.ACTION_ALIAS_MATCH)
     @jsexpose(arg_types=[str], body_cls=ActionAliasMatchAPI, status_code=http_client.ACCEPTED)
     def match(self, action_alias_match_api, **kwargs):
         """
@@ -81,8 +82,6 @@ class ActionAliasController(resource.ContentPackResourceController):
 
             Handles requests:
                 POST /actionalias/match
-
-                command=hello%20world
         """
         command = action_alias_match_api.command
 

--- a/st2api/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
+++ b/st2api/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
@@ -220,6 +220,11 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
                 'path': '/v1/actionalias/aliases.alias1',
                 'method': 'DELETE'
             },
+            {
+                'path': '/v1/actionalias/match',
+                'method': 'POST',
+                'payload': {'command': 'test command string'}
+            },
             # Rules
             {
                 'path': '/v1/rules',

--- a/st2common/st2common/rbac/resolvers.py
+++ b/st2common/st2common/rbac/resolvers.py
@@ -451,7 +451,8 @@ class ActionAliasPermissionsResolver(ContentPackResourcePermissionsResolver):
         if permission_type == PermissionType.ACTION_ALIAS_LIST:
             return self._user_has_list_permission(user_db=user_db, permission_type=permission_type)
         elif permission_type == PermissionType.ACTION_ALIAS_MATCH:
-            return self._user_has_global_permission(user_db=user_db, permission_type=permission_type)
+            return self._user_has_global_permission(user_db=user_db,
+                                                    permission_type=permission_type)
         else:
             raise ValueError('Unsupported permission type: %s' % (permission_type))
 

--- a/st2common/st2common/rbac/resolvers.py
+++ b/st2common/st2common/rbac/resolvers.py
@@ -93,7 +93,41 @@ class PermissionsResolver(object):
         rules_list, action_list, etc.).
         """
         assert PermissionType.get_permission_name(permission_type) == 'list'
+        return self._user_has_global_permission(user_db=user_db, permission_type=permission_type)
 
+        log_context = {
+            'user_db': user_db,
+            'permission_type': permission_type,
+            'resolver': self.__class__.__name__
+        }
+        self._log('Checking user permissions', extra=log_context)
+
+        # First check the system role permissions
+        has_system_role_permission = self._user_has_system_role_permission(
+            user_db=user_db, permission_type=permission_type)
+
+        if has_system_role_permission:
+            self._log('Found a matching grant via system role', extra=log_context)
+            return True
+
+        # Check custom roles
+        permission_types = [permission_type]
+
+        # Check direct grants
+        permission_grants = get_all_permission_grants_for_user(user_db=user_db,
+                                                               permission_types=permission_types)
+        if len(permission_grants) >= 1:
+            self._log('Found a direct grant', extra=log_context)
+            return True
+
+        self._log('No matching grants found', extra=log_context)
+        return False
+
+    def _user_has_global_permission(self, user_db, permission_type):
+        """
+        Custom method for checking if user has a particular global permission which doesn't apply
+        to a specific resource but it's system-wide aka global permission.
+        """
         log_context = {
             'user_db': user_db,
             'permission_type': permission_type,
@@ -411,8 +445,15 @@ class ActionAliasPermissionsResolver(ContentPackResourcePermissionsResolver):
     ]
 
     def user_has_permission(self, user_db, permission_type):
-        assert permission_type in [PermissionType.ACTION_ALIAS_LIST]
-        return self._user_has_list_permission(user_db=user_db, permission_type=permission_type)
+        assert permission_type in [PermissionType.ACTION_ALIAS_LIST,
+                                   PermissionType.ACTION_ALIAS_MATCH]
+
+        if permission_type == PermissionType.ACTION_ALIAS_LIST:
+            return self._user_has_list_permission(user_db=user_db, permission_type=permission_type)
+        elif permission_type == PermissionType.ACTION_ALIAS_MATCH:
+            return self._user_has_global_permission(user_db=user_db, permission_type=permission_type)
+        else:
+            raise ValueError('Unsupported permission type: %s' % (permission_type))
 
     def user_has_resource_api_permission(self, user_db, resource_api, permission_type):
         assert permission_type in [PermissionType.ACTION_ALIAS_CREATE]

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -62,6 +62,7 @@ class PermissionType(Enum):
     ACTION_ALIAS_VIEW = 'action_alias_view'
     ACTION_ALIAS_CREATE = 'action_alias_create'
     ACTION_ALIAS_MODIFY = 'action_alias_modify'
+    ACTION_ALIAS_MATCH = 'action_alias_match'
     ACTION_ALIAS_DELETE = 'action_alias_delete'
     ACTION_ALIAS_ALL = 'action_alias_all'
 
@@ -248,6 +249,7 @@ RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP = {
         PermissionType.ACTION_ALIAS_VIEW,
         PermissionType.ACTION_ALIAS_CREATE,
         PermissionType.ACTION_ALIAS_MODIFY,
+        PermissionType.ACTION_ALIAS_MATCH,
         PermissionType.ACTION_ALIAS_DELETE,
         PermissionType.ACTION_ALIAS_ALL
     ],


### PR DESCRIPTION
This pull request updates the code so a new global "action_alias_match" permission is required to be able to call new "action alias match" API endpoint.

Part of #2895 #2904