### PR TITLE
Add support for Jinja template notation for default parameter values for object parameters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ In development
   ``st2 alias-execution execute``. (new feature) #2895
 
   Contributed by Anthony Shaw
+* Fix a bug with action default parameter values not supporting Jinja template
+  notation for parameters of type ``object``. (bug fix, improvement)
 
 2.0.0 - August 31, 2016
 -----------------------

--- a/st2common/st2common/util/param.py
+++ b/st2common/st2common/util/param.py
@@ -135,7 +135,7 @@ def _validate(G):
     '''
     for name in G.nodes():
         if 'value' not in G.node[name] and 'template' not in G.node[name]:
-            msg = 'Dependecy unsatisfied for parameter "%s"' % name
+            msg = 'Dependecy unsatisfied in %s' % name
             raise ParamException(msg)
 
     if not nx.is_directed_acyclic_graph(G):

--- a/st2common/st2common/util/param.py
+++ b/st2common/st2common/util/param.py
@@ -162,19 +162,33 @@ def _resolve_dependencies(G):
     for name in nx.topological_sort(G):
         node = G.node[name]
         try:
-            if 'template' in node and isinstance(node.get('template', None), list):
-                rendered_list = list()
-                for template in G.node[name]['template']:
-                    rendered_list.append(
-                        _render(dict(template=template), context)
-                    )
-                context[name] = rendered_list
+            template = node.get('template', None)
+
+            # Special case for non simple types which contains Jinja notation (lists, dicts)
+            if 'template' in node and isinstance(template, (list, dict)):
+                if isinstance(template, list):
+                    rendered_list = list()
+
+                    for template in G.node[name]['template']:
+                        rendered_list.append(
+                            _render(dict(template=template), context)
+                        )
+                    context[name] = rendered_list
+                elif isinstance(template, dict):
+                    rendered_dict = dict()
+
+                    for key, value in G.node[name]['template'].items():
+                        value = _render(dict(template=value), context)
+                        rendered_dict[key] = value
+
+                context[name] = rendered_dict
             else:
                 context[name] = _render(node, context)
         except Exception as e:
             LOG.debug('Failed to render %s: %s', name, e, exc_info=True)
             msg = 'Failed to render parameter "%s": %s' % (name, str(e))
             raise ParamException(msg)
+
     return context
 
 

--- a/st2common/st2common/util/param.py
+++ b/st2common/st2common/util/param.py
@@ -135,7 +135,7 @@ def _validate(G):
     '''
     for name in G.nodes():
         if 'value' not in G.node[name] and 'template' not in G.node[name]:
-            msg = 'Dependecy unsatisfied in %s' % name
+            msg = 'Dependecy unsatisfied for parameter "%s"' % name
             raise ParamException(msg)
 
     if not nx.is_directed_acyclic_graph(G):

--- a/st2common/st2common/util/param.py
+++ b/st2common/st2common/util/param.py
@@ -181,7 +181,7 @@ def _resolve_dependencies(G):
                         value = _render(dict(template=value), context)
                         rendered_dict[key] = value
 
-                context[name] = rendered_dict
+                    context[name] = rendered_dict
             else:
                 context[name] = _render(node, context)
         except Exception as e:

--- a/st2common/tests/unit/test_param_utils.py
+++ b/st2common/tests/unit/test_param_utils.py
@@ -459,6 +459,33 @@ class ParamsUtilsTest(DbTestCase):
                                 liveaction_parameters=params,
                                 action_context={})
 
+    def test_get_finalized_param_object_contains_template_notation_in_the_value(self):
+        runner_param_info = {'r1': {}}
+        action_param_info = {
+            'params': {
+                'type': 'object',
+                'default': {
+                    'host': '{{host}}',
+                    'port': '{{port}}',
+                    'path': '/bar'}
+            }
+        }
+        params = {
+            'host': 'lolcathost',
+            'port': 5555
+        }
+        action_context = {}
+
+        r_runner_params, r_action_params = param_utils.get_finalized_params(
+            runner_param_info, action_param_info, params, action_context)
+
+        expected_params = {
+            'host': 'lolcathost',
+            'port': '5555',
+            'path': '/bar'
+        }
+        self.assertEqual(r_action_params['params'], expected_params)
+
     def test_cast_param_referenced_action_doesnt_exist(self):
         # Make sure the function throws if the action doesnt exist
         expected_msg = 'Action with ref "foo.doesntexist" doesn\'t exist'


### PR DESCRIPTION
This pull request adds support for using Jinja notation for action default parameter values for parameters of type object.

This issue (lack of feature / support for objects) was caught and reported by @code-ape on Slack.

He had an action similar to the one below:

```yaml
---
name: example
pack: examples
description: Example
runner_type: http-request
enabled: true
parameters:
    driveraddress:
        type: string
        required: true
        default: "10.255.4.15:3000" 
    host:
        type: string
        required: true
    port:
        type: integer
        required: true
    params:
        type: object
        immutable: true
        default:
            host: "{{host}}"
            port: "{{port}}"
    url:
        type: string
        immutable: true
        default: "http://{{driveraddress}}/api/gen-payload/ve"
```

This didn't work since default values for `params` parameter was not rendered since existing code didn't support objects.

This pull request fixes that and adds support for rendering default parameter values for objects with a single level of nesting (like the one in the example above).

We don't support arbitrary level of nesting since this would increase computation time and potentially lead to resource exhaustion, infinite recursion or similar. It's the same story with lists which we already supported - we only render first level items in the list and don't support nested lists.

Not supporting objects basically means that in a scenario like the one above, user won't be able to leverage the HTTP runner, but they will need to write code for Python runner action or similar.

## TODO

- [x] Tests
- [x] Changelog