### PR TITLE
Only allow word characters and don't allow slashes in action parameter names

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,12 @@ In development
   Contributed by Anthony Shaw
 * Fix a bug with action default parameter values not supporting Jinja template
   notation for parameters of type ``object``. (bug fix, improvement)
+* Only allow valid word characters (``a-z``, ``0-9`` and ``_``) to be used for action parameter
+  names. Previously, due to bug in the code, any character was allowed.
+
+  If you have an existing action definition which uses parameter with an invalid character, the
+  parameter name needs to be adjusted otherwise action registration will fail. (bug fix,
+  improvement)
 
 2.0.0 - August 31, 2016
 -----------------------

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -13,7 +13,7 @@ pyyaml>=3.11,<4.0
 requests[security]>=2.11.1,<2.12
 apscheduler>=3.0.5,<3.1
 gitpython==0.3.2.1
-jsonschema>=2.3.0
+jsonschema>=2.5.0,<2.6
 mongoengine==0.10.6
 pymongo==3.2.2
 passlib>=1.6.2,<1.7

--- a/st2actions/tests/unit/test_actions_registrar.py
+++ b/st2actions/tests/unit/test_actions_registrar.py
@@ -96,6 +96,19 @@ class ActionsRegistrarTest(tests_base.DbTestCase):
     @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(return_value=True))
     @mock.patch.object(action_validator, '_get_runner_model',
                        mock.MagicMock(return_value=MOCK_RUNNER_TYPE_DB))
+    def test_register_action_invalid_parameter_name(self):
+        registrar = actions_registrar.ActionsRegistrar()
+        loader = fixtures_loader.FixturesLoader()
+        action_file = loader.get_fixture_file_path_abs(
+            'generic', 'actions', 'action_invalid_parameter_name.yaml')
+
+        expected_msg = 'Additional properties are not allowed \(\'action-name\' was unexpected\)'
+        self.assertRaisesRegexp(jsonschema.ValidationError, expected_msg,
+                                registrar._register_action, 'dummy', action_file)
+
+    @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(return_value=True))
+    @mock.patch.object(action_validator, '_get_runner_model',
+                       mock.MagicMock(return_value=MOCK_RUNNER_TYPE_DB))
     def test_invalid_params_schema(self):
         registrar = actions_registrar.ActionsRegistrar()
         loader = fixtures_loader.FixturesLoader()

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -97,7 +97,8 @@ class RunnerTypeAPI(BaseAPI):
                 "type": "object",
                 "patternProperties": {
                     "^\w+$": util_schema.get_action_parameters_schema()
-                }
+                },
+                'additionalProperties': False
             }
         },
         "additionalProperties": False
@@ -189,6 +190,7 @@ class ActionAPI(BaseAPI, APIUIDMixin):
                 "patternProperties": {
                     "^\w+$": util_schema.get_action_parameters_schema()
                 },
+                'additionalProperties': False,
                 "default": {}
             },
             "tags": {
@@ -334,7 +336,8 @@ class LiveActionAPI(BaseAPI):
                             {"type": "null"}
                         ]
                     }
-                }
+                },
+                'additionalProperties': False
             },
             "result": {
                 "anyOf": [{"type": "array"},

--- a/st2common/st2common/models/api/execution.py
+++ b/st2common/st2common/models/api/execution.py
@@ -97,7 +97,8 @@ class ActionExecutionAPI(BaseAPI):
                             {"type": "string"}
                         ]
                     }
-                }
+                },
+                'additionalProperties': False
             },
             "context": {
                 "type": "object"

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -120,6 +120,7 @@ class ConfigSchemaAPI(BaseAPI):
                 "patternProperties": {
                     "^\w+$": util_schema.get_action_parameters_schema()
                 },
+                'additionalProperties': False,
                 "default": {}
             }
         },

--- a/st2common/st2common/models/api/policy.py
+++ b/st2common/st2common/models/api/policy.py
@@ -61,7 +61,8 @@ class PolicyTypeAPI(BaseAPI):
                 "type": "object",
                 "patternProperties": {
                     "^\w+$": util_schema.get_draft_schema()
-                }
+                },
+                'additionalProperties': False
             }
         },
         "additionalProperties": False
@@ -126,7 +127,9 @@ class PolicyAPI(BaseAPI):
                             {"type": "string"}
                         ]
                     }
-                }
+                },
+                'additionalProperties': False
+
             }
         },
         "additionalProperties": False

--- a/st2tests/st2tests/fixtures/generic/actions/action_invalid_parameter_name.yaml
+++ b/st2tests/st2tests/fixtures/generic/actions/action_invalid_parameter_name.yaml
@@ -1,0 +1,16 @@
+---
+  name: "invalid_parameter_name"
+  runner_type: "action-chain"
+  description: "Upgrades an existing st2 installation"
+  enabled: true
+  entry_point: "workflows/st2_upgrade.yaml"
+  parameters:
+    hostname:
+      type: "string"
+      description: "Host to upgrade st2 on"
+      required: true
+    # Note: This parameter name is invalid because we don't support dashes in the parameter names
+    action-name:
+      type: "string"
+      description: "Action to run after upgrade"
+      default: "core.local"


### PR DESCRIPTION
While looking into #2907 I noticed our code is broken / incorrect everywhere where we use `patternProperties` functionally of json schema.

We limit valid names for property to any valid word character (`\w` - `a-Z0-0_`), but we don't specify `'additionalProperties': False`. Not specifying that means that any other name which doesn't fall into that (e.g. parameter name which contains a dash or any other character which falls outside of `\w`) will be considered as additional property and no validation will be performed for that property/

For one, this means we allow dashes and other special characters which causes issue because for example, Jinja doesn't support dashes in the variable names, etc. In addition to that, it's dangerous (and not user-friendly) since we don't perform any validation for those attributes.

Since this change is potentially backward incompatible, I propose to include it in v2.1. We should also go over st2contrib and make sure we don't have any parameters with invalid names.


Resolves #2907.

## TODO

- [x] Tests
- [x] Changelog entry
- [ ] Upgrade notes entry