### PR TITLE
Fix workflow task result in mistral querier

### DIFF
--- a/st2actions/st2actions/query/mistral/v2.py
+++ b/st2actions/st2actions/query/mistral/v2.py
@@ -102,7 +102,10 @@ class MistralResultsQuerier(Querier):
         :type exec_id: ``str``
         :rtype: ``list``
         """
-        wf_tasks = tasks.TaskManager(self._client).list(workflow_execution_id=exec_id)
+        wf_tasks = [
+            tasks.TaskManager(self._client).get(task.id)
+            for task in tasks.TaskManager(self._client).list(workflow_execution_id=exec_id)
+        ]
 
         return [self._format_task_result(task=wf_task.to_dict()) for wf_task in wf_tasks]
 


### PR DESCRIPTION
Task list no longer includes task result. The mistral querier is updated to use task get to fetch task result for each tasks in the list.
