### PR TITLE
Adding ability to json load array from CLI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,8 @@ In development
   If you have an existing action definition which uses parameter with an invalid character, the
   parameter name needs to be adjusted otherwise action registration will fail. (bug fix,
   improvement)
+* Adding ability to pass complex array types via CLI by first trying to
+  seralize the array as JSON and then falling back to comma seperated array.
 
 2.0.0 - August 31, 2016
 -----------------------

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -504,10 +504,8 @@ class ActionRunCommandMixin(object):
 
         def transform_array(value):
             try:
-                print "Transforming %s" % value
                 result = json.loads(value)
             except ValueError:
-                print "Failed"
                 result = (lambda value: [v.strip() for v in value.split(',')])
             return result
 

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -506,7 +506,7 @@ class ActionRunCommandMixin(object):
             try:
                 result = json.loads(value)
             except ValueError:
-                result = (lambda value: [v.strip() for v in value.split(',')])
+                result = [v.strip() for v in value.split(',')]
             return result
 
         transformer = {

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -502,8 +502,17 @@ class ActionRunCommandMixin(object):
                     result[key] = value
             return result
 
+        def transform_array(value):
+            try:
+                print "Transforming %s" % value
+                result = json.loads(value)
+            except ValueError:
+                print "Failed"
+                result = (lambda value: [v.strip() for v in value.split(',')])
+            return result
+
         transformer = {
-            'array': (lambda cs_x: [v.strip() for v in cs_x.split(',')]),
+            'array': transform_array,
             'boolean': (lambda x: ast.literal_eval(x.capitalize())),
             'integer': int,
             'number': float,

--- a/st2client/tests/unit/test_action.py
+++ b/st2client/tests/unit/test_action.py
@@ -214,7 +214,7 @@ class ActionCommandTestCase(base.BaseCLITestCase):
                         'pluto': False,
                         'earth': True
                     }
-                    ]
+                ]
             }
         }
         httpclient.HTTPClient.post.assert_called_with('/executions', expected)
@@ -329,7 +329,7 @@ class ActionCommandTestCase(base.BaseCLITestCase):
                         'pluto': False,
                         'earth': True
                     }
-                    ]
+                ]
             }
         }
         httpclient.HTTPClient.post.assert_called_with('/executions', expected)

--- a/st2client/tests/unit/test_action.py
+++ b/st2client/tests/unit/test_action.py
@@ -33,6 +33,7 @@ RUNNER1 = {
         "int": {"type": "integer"},
         "float": {"type": "number"},
         "json": {"type": "object"},
+        "list": {"type": "array"},
         "str": {"type": "string"}
     },
     "name": "mock-runner1"
@@ -63,6 +64,7 @@ ACTION2 = {
         "int": {"type": "integer"},
         "float": {"type": "number"},
         "json": {"type": "object"},
+        "list": {"type": "array"},
         "str": {"type": "string"}
     },
     "enabled": True,
@@ -167,6 +169,65 @@ class ActionCommandTestCase(base.BaseCLITestCase):
     @mock.patch.object(
         httpclient.HTTPClient, 'post',
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(LIVE_ACTION), 200, 'OK')))
+    def test_runner_param_array_conversion(self):
+        self.shell.run(['run', 'mockety.mock1', 'list=one,two,three'])
+        expected = {
+            'action': 'mockety.mock1',
+            'user': None,
+            'parameters': {
+                'list': [
+                    'one',
+                    'two',
+                    'three'
+                ]
+            }
+        }
+        httpclient.HTTPClient.post.assert_called_with('/executions', expected)
+
+    @mock.patch.object(
+        models.ResourceManager, 'get_by_ref_or_id',
+        mock.MagicMock(side_effect=get_by_ref))
+    @mock.patch.object(
+        models.ResourceManager, 'get_by_name',
+        mock.MagicMock(side_effect=get_by_name))
+    @mock.patch.object(
+        httpclient.HTTPClient, 'post',
+        mock.MagicMock(return_value=base.FakeResponse(json.dumps(LIVE_ACTION), 200, 'OK')))
+    def test_runner_param_array_object_conversion(self):
+        self.shell.run(
+            [
+                'run',
+                'mockety.mock1',
+                'list=[{"foo":1, "ponies":"rainbows"},{"pluto":false, "earth":true}]'
+            ]
+        )
+        expected = {
+            'action': 'mockety.mock1',
+            'user': None,
+            'parameters': {
+                'list': [
+                    {
+                        'foo': 1,
+                        'ponies': 'rainbows'
+                    },
+                    {
+                        'pluto': False,
+                        'earth': True
+                    }
+                    ]
+            }
+        }
+        httpclient.HTTPClient.post.assert_called_with('/executions', expected)
+
+    @mock.patch.object(
+        models.ResourceManager, 'get_by_ref_or_id',
+        mock.MagicMock(side_effect=get_by_ref))
+    @mock.patch.object(
+        models.ResourceManager, 'get_by_name',
+        mock.MagicMock(side_effect=get_by_name))
+    @mock.patch.object(
+        httpclient.HTTPClient, 'post',
+        mock.MagicMock(return_value=base.FakeResponse(json.dumps(LIVE_ACTION), 200, 'OK')))
     def test_param_bool_conversion(self):
         self.shell.run(['run', 'mockety.mock2', 'bool=false'])
         expected = {'action': 'mockety.mock2', 'user': None, 'parameters': {'bool': False}}
@@ -212,6 +273,65 @@ class ActionCommandTestCase(base.BaseCLITestCase):
     def test_param_json_conversion(self):
         self.shell.run(['run', 'mockety.mock2', 'json={"a":1}'])
         expected = {'action': 'mockety.mock2', 'user': None, 'parameters': {'json': {'a': 1}}}
+        httpclient.HTTPClient.post.assert_called_with('/executions', expected)
+
+    @mock.patch.object(
+        models.ResourceManager, 'get_by_ref_or_id',
+        mock.MagicMock(side_effect=get_by_ref))
+    @mock.patch.object(
+        models.ResourceManager, 'get_by_name',
+        mock.MagicMock(side_effect=get_by_name))
+    @mock.patch.object(
+        httpclient.HTTPClient, 'post',
+        mock.MagicMock(return_value=base.FakeResponse(json.dumps(LIVE_ACTION), 200, 'OK')))
+    def test_param_array_conversion(self):
+        self.shell.run(['run', 'mockety.mock2', 'list=one,two,three'])
+        expected = {
+            'action': 'mockety.mock2',
+            'user': None,
+            'parameters': {
+                'list': [
+                    'one',
+                    'two',
+                    'three'
+                ]
+            }
+        }
+        httpclient.HTTPClient.post.assert_called_with('/executions', expected)
+
+    @mock.patch.object(
+        models.ResourceManager, 'get_by_ref_or_id',
+        mock.MagicMock(side_effect=get_by_ref))
+    @mock.patch.object(
+        models.ResourceManager, 'get_by_name',
+        mock.MagicMock(side_effect=get_by_name))
+    @mock.patch.object(
+        httpclient.HTTPClient, 'post',
+        mock.MagicMock(return_value=base.FakeResponse(json.dumps(LIVE_ACTION), 200, 'OK')))
+    def test_param_array_object_conversion(self):
+        self.shell.run(
+            [
+                'run',
+                'mockety.mock2',
+                'list=[{"foo":1, "ponies":"rainbows"},{"pluto":false, "earth":true}]'
+            ]
+        )
+        expected = {
+            'action': 'mockety.mock2',
+            'user': None,
+            'parameters': {
+                'list': [
+                    {
+                        'foo': 1,
+                        'ponies': 'rainbows'
+                    },
+                    {
+                        'pluto': False,
+                        'earth': True
+                    }
+                    ]
+            }
+        }
         httpclient.HTTPClient.post.assert_called_with('/executions', expected)
 
     @mock.patch.object(


### PR DESCRIPTION
This answers #2903.

This PR allows a user to input an array of dicts or other complicated types of arrays from the CLI. It will first attempt to json load the parameter and if that fails it reverts back to separating the values by commas.