### PR TITLE
Throw more user-friendly exception on invalid action parameter name

### DIFF
--- a/st2actions/tests/unit/test_actions_registrar.py
+++ b/st2actions/tests/unit/test_actions_registrar.py
@@ -102,7 +102,8 @@ class ActionsRegistrarTest(tests_base.DbTestCase):
         action_file = loader.get_fixture_file_path_abs(
             'generic', 'actions', 'action_invalid_parameter_name.yaml')
 
-        expected_msg = 'Additional properties are not allowed \(\'action-name\' was unexpected\)'
+        expected_msg = ('Parameter name "action-name" is invalid. Valid characters for '
+                        'parameter name are')
         self.assertRaisesRegexp(jsonschema.ValidationError, expected_msg,
                                 registrar._register_action, 'dummy', action_file)
 

--- a/st2common/st2common/bootstrap/actionsregistrar.py
+++ b/st2common/st2common/bootstrap/actionsregistrar.py
@@ -14,8 +14,10 @@
 # limitations under the License.
 
 import os
+import re
 
 import six
+import jsonschema
 
 from st2common import log as logging
 from st2common.constants.meta import ALLOWED_EXTS
@@ -124,7 +126,24 @@ class ActionsRegistrar(ResourceRegistrar):
                             (pack, pack_field))
 
         action_api = ActionAPI(**content)
-        action_api.validate()
+
+        try:
+            action_api.validate()
+        except jsonschema.ValidationError as e:
+            # We throw a more user-friendly exception on invalid parameter name
+            msg = str(e)
+
+            is_invalid_parameter_name = 'Additional properties are not allowed' in msg
+            is_invalid_parameter_name &= 'in schema[\'properties\'][\'parameters\']' in msg
+
+            if is_invalid_parameter_name:
+                parameter_name = re.search('\'(.+?)\' was unexpected', msg).groups()[0]
+                new_msg = ('Parameter name "%s" is invalid. Valid characters for parameter name '
+                           'are [a-zA-Z0-0_]' % (parameter_name))
+                new_msg += '\n' + msg
+                raise jsonschema.ValidationError(new_msg)
+            raise e
+
         action_validator.validate_action(action_api)
         model = ActionAPI.to_model(action_api)
 

--- a/st2common/st2common/bootstrap/actionsregistrar.py
+++ b/st2common/st2common/bootstrap/actionsregistrar.py
@@ -139,8 +139,8 @@ class ActionsRegistrar(ResourceRegistrar):
             if is_invalid_parameter_name:
                 parameter_name = re.search('\'(.+?)\' was unexpected', msg).groups()[0]
                 new_msg = ('Parameter name "%s" is invalid. Valid characters for parameter name '
-                           'are [a-zA-Z0-0_]' % (parameter_name))
-                new_msg += '\n' + msg
+                           'are [a-zA-Z0-0_].' % (parameter_name))
+                new_msg += '\n\n' + msg
                 raise jsonschema.ValidationError(new_msg)
             raise e
 


### PR DESCRIPTION
This pull request builds on top of #2908 and update the exception to be more user-friendly.

Original json schema exception is very unfriendly and it's not immediately obvious what is going on (invalid parameter name).