### PR TITLE
Refactor mistral to support new CANCELLED status

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,8 @@ in development
   has changed in the mistral client. Fix unit test accordingly. (bug fix)
 * Fixed issue where passing a single integer member for an array parameter for an action would
   cause a type mismatch in the API (bug fix)
+* Use the newly introduced CANCELLED state in mistral for workflow cancellation. Currently, st2
+  put the workflow in a PAUSED state in mistral. (improvement)
 
 2.1.1 - December 16, 2016
 -------------------------

--- a/contrib/runners/mistral_v2/mistral_v2.py
+++ b/contrib/runners/mistral_v2/mistral_v2.py
@@ -368,7 +368,7 @@ class MistralRunner(AsyncActionRunner):
 
         # There is no cancellation state in Mistral. Pause the workflow so
         # actions that are still executing can gracefully reach completion.
-        self._client.executions.update(mistral_ctx.get('execution_id'), 'PAUSED')
+        self._client.executions.update(mistral_ctx.get('execution_id'), 'CANCELLED')
 
     @staticmethod
     def _build_mistral_context(parent, current):

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_querier_v2.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_querier_v2.py
@@ -173,7 +173,8 @@ class MistralQuerierTest(DbTestCase):
         mock.MagicMock(return_value=True))
     def test_determine_status_wf_canceled_tasks_completed(self):
         wf_id = uuid.uuid4().hex
-        status = self.querier._determine_execution_status(wf_id, 'PAUSED', MOCK_WF_TASKS_SUCCEEDED)
+        status = self.querier._determine_execution_status(
+            wf_id, 'CANCELLED', MOCK_WF_TASKS_SUCCEEDED)
         self.assertEqual(action_constants.LIVEACTION_STATUS_CANCELED, status)
 
     @mock.patch.object(
@@ -181,8 +182,8 @@ class MistralQuerierTest(DbTestCase):
         mock.MagicMock(return_value=True))
     def test_determine_status_wf_canceled_tasks_running(self):
         wf_id = uuid.uuid4().hex
-        status = self.querier._determine_execution_status(wf_id, 'PAUSED', MOCK_WF_TASKS_RUNNING)
-        self.assertEqual(action_constants.LIVEACTION_STATUS_CANCELED, status)
+        status = self.querier._determine_execution_status(wf_id, 'CANCELLED', MOCK_WF_TASKS_RUNNING)
+        self.assertEqual(action_constants.LIVEACTION_STATUS_CANCELING, status)
 
     @mock.patch.object(
         action_service, 'is_action_canceled_or_canceling',
@@ -198,14 +199,15 @@ class MistralQuerierTest(DbTestCase):
     def test_determine_status_wf_canceled_exec_running_tasks_running(self):
         wf_id = uuid.uuid4().hex
         status = self.querier._determine_execution_status(wf_id, 'RUNNING', MOCK_WF_TASKS_RUNNING)
-        self.assertEqual(action_constants.LIVEACTION_STATUS_RUNNING, status)
+        self.assertEqual(action_constants.LIVEACTION_STATUS_CANCELING, status)
 
     @mock.patch.object(
         action_service, 'is_action_canceled_or_canceling',
         mock.MagicMock(return_value=False))
     def test_determine_status_wf_running_exec_paused_tasks_completed(self):
         wf_id = uuid.uuid4().hex
-        status = self.querier._determine_execution_status(wf_id, 'PAUSED', MOCK_WF_TASKS_SUCCEEDED)
+        status = self.querier._determine_execution_status(
+            wf_id, 'PAUSED', MOCK_WF_TASKS_SUCCEEDED)
         self.assertEqual(action_constants.LIVEACTION_STATUS_RUNNING, status)
 
     @mock.patch.object(
@@ -213,7 +215,7 @@ class MistralQuerierTest(DbTestCase):
         mock.MagicMock(return_value=False))
     def test_determine_status_wf_running_exec_paused_tasks_running(self):
         wf_id = uuid.uuid4().hex
-        status = self.querier._determine_execution_status(wf_id, 'PAUSED', MOCK_WF_TASKS_RUNNING)
+        status = self.querier._determine_execution_status(wf_id, 'CANCELLED', MOCK_WF_TASKS_RUNNING)
         self.assertEqual(action_constants.LIVEACTION_STATUS_RUNNING, status)
 
     @mock.patch.object(

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2.py
@@ -132,8 +132,6 @@ WF1 = workflows.Workflow(None, {'name': WF1_NAME, 'definition': WF1_YAML})
 WF1_OLD = workflows.Workflow(None, {'name': WF1_NAME, 'definition': ''})
 WF1_EXEC = copy.deepcopy(MISTRAL_EXECUTION)
 WF1_EXEC['workflow_name'] = WF1_NAME
-WF1_EXEC_PAUSED = copy.deepcopy(WF1_EXEC)
-WF1_EXEC_PAUSED['state'] = 'PAUSED'
 
 # Non-workbook with a many workflows
 WF2_META_FILE_NAME = TEST_FIXTURES['workflows'][4]


### PR DESCRIPTION
Use the newly introduced CANCELLED state in mistral for workflow cancellation. Currently, st2 put the workflow in a PAUSED state in mistral.