### PR TITLE
Fix --user / -u argument when using st2 key delete command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ In development
   improvement)
 * Adding ability to pass complex array types via CLI by first trying to
   seralize the array as JSON and then falling back to comma seperated array.
+* Fix ``--user`` / ``-u`` argument in the ``st2 key delete`` CLI command.
 
 2.0.0 - August 31, 2016
 -----------------------

--- a/st2client/st2client/commands/keyvalue.py
+++ b/st2client/st2client/commands/keyvalue.py
@@ -184,6 +184,7 @@ class KeyValuePairDeleteCommand(resource.ResourceDeleteCommand):
         scope = getattr(args, 'scope', DEFAULT_SCOPE)
         kwargs['params'] = {}
         kwargs['params']['scope'] = scope
+        kwargs['params']['user'] = args.user
         instance = self.get_resource(resource_id, **kwargs)
 
         if not instance:


### PR DESCRIPTION
When a `user` argument was passed to the `st2 key delete` command it was not correctly passed to the API endpoint so it wasn't possible for an administrator to delete a user-scoped datastore item which belongs to a different user.

Resolves #2921.