### PR TITLE
Adding connection retry for RabbitMQ

### DIFF
--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -129,7 +129,11 @@ def register_opts(ignore_errors=False):
         cfg.StrOpt('url', default='amqp://guest:guest@127.0.0.1:5672//',
                    help='URL of the messaging server.'),
         cfg.ListOpt('cluster_urls', default=[],
-                    help='URL of all the nodes in a messaging service cluster.')
+                    help='URL of all the nodes in a messaging service cluster.'),
+        cfg.IntOpt('connection_retries', default=10,
+                    help='On initial connection how many times should we retry connection before failing.'),
+        cfg.IntOpt('connection_retry_wait', default=10000,
+                    help='On initial connection how long should we wait between connection retries.')
     ]
     do_register_opts(messaging_opts, 'messaging', ignore_errors)
 

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -131,9 +131,9 @@ def register_opts(ignore_errors=False):
         cfg.ListOpt('cluster_urls', default=[],
                     help='URL of all the nodes in a messaging service cluster.'),
         cfg.IntOpt('connection_retries', default=10,
-                    help='On initial connection how many times should we retry connection before failing.'),
+                   help='How many times should we retry connection before failing.'),
         cfg.IntOpt('connection_retry_wait', default=10000,
-                    help='On initial connection how long should we wait between connection retries.')
+                   help='How long should we wait between connection retries.')
     ]
     do_register_opts(messaging_opts, 'messaging', ignore_errors)
 

--- a/st2common/st2common/script_setup.py
+++ b/st2common/st2common/script_setup.py
@@ -30,7 +30,7 @@ from st2common import log as logging
 from st2common.service_setup import db_setup
 from st2common.service_setup import db_teardown
 from st2common.logging.filters import LogLevelFilter
-from st2common.transport.bootstrap_utils import register_exchanges
+from st2common.transport.bootstrap_utils import register_exchanges_with_retry
 
 __all__ = [
     'setup',
@@ -86,7 +86,7 @@ def setup(config, setup_db=True, register_mq_exchanges=True):
         db_setup()
 
     if register_mq_exchanges:
-        register_exchanges()
+        register_exchanges_with_retry()
 
 
 def teardown():

--- a/st2common/st2common/service_setup.py
+++ b/st2common/st2common/service_setup.py
@@ -27,7 +27,7 @@ from st2common import log as logging
 from st2common.models import db
 from st2common.constants.logging import DEFAULT_LOGGING_CONF_PATH
 from st2common.persistence import db_init
-from st2common.transport.bootstrap_utils import register_exchanges
+from st2common.transport.bootstrap_utils import register_exchanges_with_retry
 from st2common.signal_handlers import register_common_signal_handlers
 from st2common.util.debugging import enable_debugging
 from st2common.models.utils.profiling import enable_profiling
@@ -99,7 +99,7 @@ def setup(service, config, setup_db=True, register_mq_exchanges=True,
         db_setup()
 
     if register_mq_exchanges:
-        register_exchanges()
+        register_exchanges_with_retry()
 
     if register_signal_handlers:
         register_common_signal_handlers()

--- a/st2common/st2common/transport/bootstrap.py
+++ b/st2common/st2common/transport/bootstrap.py
@@ -16,7 +16,7 @@
 import logging
 import st2common.config as config
 
-from st2common.transport.bootstrap_utils import register_exchanges
+from st2common.transport.bootstrap_utils import register_exchanges_with_retry
 
 
 def _setup():
@@ -29,7 +29,7 @@ def _setup():
 
 def main():
     _setup()
-    register_exchanges()
+    register_exchanges_with_retry()
 
 
 # The scripts sets up Exchanges in RabbitMQ.

--- a/st2common/st2common/transport/bootstrap_utils.py
+++ b/st2common/st2common/transport/bootstrap_utils.py
@@ -59,7 +59,7 @@ def _do_register_exchange(exchange, connection, channel, retry_wrapper):
         LOG.exception('Failed to register exchange : %s.', exchange.name)
 
 
-def _register_exchanges():
+def register_exchanges():
     LOG.debug('Registering exchanges...')
     connection_urls = transport_utils.get_messaging_urls()
     with Connection(connection_urls) as conn:
@@ -74,10 +74,10 @@ def _register_exchanges():
         retry_wrapper.run(connection=conn, wrapped_callback=wrapped_register_exchanges)
 
 
-def register_exchanges():
+def register_exchanges_with_retry():
     retrying_obj = retrying.Retrying(
         retry_on_exception=socket.error,
         wait_fixed=cfg.CONF.messaging.connection_retry_wait,
         stop_max_attempt_number=cfg.CONF.messaging.connection_retries
     )
-    return retrying_obj.call(_register_exchanges)
+    return retrying_obj.call(register_exchanges)

--- a/st2common/st2common/transport/bootstrap_utils.py
+++ b/st2common/st2common/transport/bootstrap_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import retrying
 from kombu import Connection
 from st2common import log as logging
 from st2common.transport import utils as transport_utils
@@ -56,6 +57,9 @@ def _do_register_exchange(exchange, connection, channel, retry_wrapper):
         LOG.exception('Failed to register exchange : %s.', exchange.name)
 
 
+@retrying.retry(
+    wait_fixed=10000,
+    stop_max_attempt_number=10)
 def register_exchanges():
     LOG.debug('Registering exchanges...')
     connection_urls = transport_utils.get_messaging_urls()


### PR DESCRIPTION
This PR adds connection retry to RabbitMQ transport. This will recover from issues where RabbitMQ is unavailable immediately on startup.

- [x] Add config options for parameters.