### PR TITLE
WIP: Render user params (jinja) in API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -217,6 +217,8 @@ In development
   When this flag is provided, all triggers contained within a pack triggers directory are
   registered, consistent with the behavior of sensors, actions, etc. This feature allows users
   to register trigger types outside the scope of the sensors. (new-feature) [Cody A. Ray]
+* Allow user scoped variables to be used in action execution run from CLI or UI.
+  For example, you can now use ``st2 run core.local date='{{user.date_cmd}}'``. (bug-fix)
 
 1.4.0 - April 18, 2016
 ----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ In development
   improvement)
 * Adding ability to pass complex array types via CLI by first trying to
   seralize the array as JSON and then falling back to comma seperated array.
+* Allow user scoped variables to be used in action execution run from CLI or UI.
+  For example, you can now use ``st2 run core.local date='{{user.date_cmd}}'``. (improvement)
 
 2.0.1 - September 30, 2016
 --------------------------
@@ -217,8 +219,7 @@ In development
   When this flag is provided, all triggers contained within a pack triggers directory are
   registered, consistent with the behavior of sensors, actions, etc. This feature allows users
   to register trigger types outside the scope of the sensors. (new-feature) [Cody A. Ray]
-* Allow user scoped variables to be used in action execution run from CLI or UI.
-  For example, you can now use ``st2 run core.local date='{{user.date_cmd}}'``. (bug-fix)
+
 
 1.4.0 - April 18, 2016
 ----------------------

--- a/st2common/st2common/util/param.py
+++ b/st2common/st2common/util/param.py
@@ -19,9 +19,9 @@ import networkx as nx
 from jinja2 import meta
 from st2common import log as logging
 from st2common.constants.action import ACTION_CONTEXT_KV_PREFIX
-from st2common.constants.keyvalue import DATASTORE_PARENT_SCOPE, SYSTEM_SCOPE
+from st2common.constants.keyvalue import DATASTORE_PARENT_SCOPE, SYSTEM_SCOPE, USER_SCOPE
 from st2common.exceptions.param import ParamException
-from st2common.services.keyvalues import KeyValueLookup
+from st2common.services.keyvalues import KeyValueLookup, UserKeyValueLookup
 from st2common.util.casts import get_cast
 from st2common.util.compat import to_unicode
 from st2common.util import jinja as jinja_utils
@@ -74,8 +74,17 @@ def _create_graph(action_context):
     Creates a generic directed graph for depencency tree and fills it with basic context variables
     '''
     G = nx.DiGraph()
+    user = action_context.get('user', None)
     G.add_node(SYSTEM_SCOPE, value=KeyValueLookup(scope=SYSTEM_SCOPE))
-    system_keyvalue_context = {SYSTEM_SCOPE: KeyValueLookup(scope=SYSTEM_SCOPE)}
+    system_keyvalue_context = {
+        SYSTEM_SCOPE: KeyValueLookup(scope=SYSTEM_SCOPE)
+    }
+
+    if user:
+        G.add_node(USER_SCOPE, value=UserKeyValueLookup(scope=USER_SCOPE, user=user))
+        system_keyvalue_context.update({
+            USER_SCOPE: UserKeyValueLookup(scope=USER_SCOPE, user=user)
+        })
     G.add_node(DATASTORE_PARENT_SCOPE, value=system_keyvalue_context)
     G.add_node(ACTION_CONTEXT_KV_PREFIX, value=action_context)
     return G

--- a/st2common/tests/unit/test_param_utils.py
+++ b/st2common/tests/unit/test_param_utils.py
@@ -33,7 +33,11 @@ from st2tests.fixturesloader import FixturesLoader
 FIXTURES_PACK = 'generic'
 
 TEST_MODELS = {
-    'actions': ['action_4_action_context_param.yaml', 'action_system_default.yaml'],
+    'actions': [
+        'action_4_action_context_param.yaml',
+        'action_system_default.yaml',
+        'action_user_default.yaml'
+    ],
     'runners': ['testrunner1.yaml']
 }
 
@@ -45,6 +49,7 @@ FIXTURES = FixturesLoader().load_models(fixtures_pack=FIXTURES_PACK,
 class ParamsUtilsTest(DbTestCase):
     action_db = FIXTURES['actions']['action_4_action_context_param.yaml']
     action_system_default_db = FIXTURES['actions']['action_system_default.yaml']
+    action_user_default_db = FIXTURES['actions']['action_user_default.yaml']
     runnertype_db = FIXTURES['runners']['testrunner1.yaml']
 
     def test_get_finalized_params(self):
@@ -114,6 +119,23 @@ class ParamsUtilsTest(DbTestCase):
         # Asserts for action params.
         self.assertEqual(action_params.get('actionstr'), 'foo')
         self.assertEqual(action_params.get('actionnumber'), 1.0)
+
+    def test_get_finalized_params_user_values(self):
+        KeyValuePair.add_or_update(KeyValuePairDB(name='stanley:foo', value='kabaali',
+                                                  scope='user'))
+        params = {
+            'runnerint': 555
+        }
+        liveaction_db = self._get_liveaction_model(params)
+        liveaction_db.context['user'] = 'stanley'
+
+        runner_params, action_params = param_utils.get_finalized_params(
+            ParamsUtilsTest.runnertype_db.runner_parameters,
+            ParamsUtilsTest.action_user_default_db.parameters,
+            liveaction_db.parameters,
+            liveaction_db.context)
+
+        self.assertEqual(action_params.get('actionstr'), 'kabaali')
 
     def test_get_finalized_params_action_immutable(self):
         params = {

--- a/st2tests/st2tests/fixtures/generic/actions/action_system_default.yaml
+++ b/st2tests/st2tests/fixtures/generic/actions/action_system_default.yaml
@@ -11,4 +11,7 @@ parameters:
   actionstr:
     default: '{{st2kv.system.actionstr}}'
     type: string
+  system:
+    default: 'this will break things'
+    type: string
 runner_type: test-runner-1

--- a/st2tests/st2tests/fixtures/generic/actions/action_user_default.yaml
+++ b/st2tests/st2tests/fixtures/generic/actions/action_user_default.yaml
@@ -6,7 +6,7 @@ name: action_user_default
 pack: wolfpack
 parameters:
   actionstr:
-    default: '{{user.foo}}'
+    default: '{{st2kv.user.foo}}'
     type: string
   user:
     default: 'unholy mess'

--- a/st2tests/st2tests/fixtures/generic/actions/action_user_default.yaml
+++ b/st2tests/st2tests/fixtures/generic/actions/action_user_default.yaml
@@ -1,0 +1,11 @@
+---
+description: Awesome action-1
+enabled: true
+entry_point: ''
+name: action_user_default
+pack: wolfpack
+parameters:
+  actionstr:
+    default: '{{user.foo}}'
+    type: string
+runner_type: test-runner-1

--- a/st2tests/st2tests/fixtures/generic/actions/action_user_default.yaml
+++ b/st2tests/st2tests/fixtures/generic/actions/action_user_default.yaml
@@ -8,4 +8,7 @@ parameters:
   actionstr:
     default: '{{user.foo}}'
     type: string
+  user:
+    default: 'unholy mess'
+    type: string
 runner_type: test-runner-1


### PR DESCRIPTION
See https://github.com/StackStorm/st2/pull/2772#issuecomment-228106632
https://github.com/StackStorm/st2/pull/2770

Tests will still fail because we still support {{user.}} and {{system.}} notations for backward compatibility. We should deprecate the support soon. I just opened the PR to capture the commits so I can reuse this when we deprecate {{user.}} and {{system.}}
