### PR TITLE
Pack search and working with pack indexes

### DIFF
--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -23,7 +23,7 @@ from git.repo import Repo
 from lockfile import LockFile
 
 from st2actions.runners.pythonrunner import Action
-from st2common.services.packs import 
+from st2common.services.packs import search_pack_index
 from st2common.util.green import shell
 
 MANIFEST_FILE = 'pack.yaml'

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -23,6 +23,7 @@ from git.repo import Repo
 from lockfile import LockFile
 
 from st2actions.runners.pythonrunner import Action
+from st2common.services.packs import 
 from st2common.util.green import shell
 
 MANIFEST_FILE = 'pack.yaml'
@@ -32,8 +33,6 @@ PACK_RESERVE_CHARACTER = '.'
 PACK_VERSION_SEPARATOR = '#'
 
 PACK_GROUP_CFG_KEY = 'pack_group'
-EXCHANGE_URL_KEY = 'exchange_url'
-EXCHANGE_PREFIX_KEY = 'exchange_prefix'
 
 
 class DownloadGitRepoAction(Action):
@@ -44,11 +43,7 @@ class DownloadGitRepoAction(Action):
         result = {}
 
         for pack in packs:
-            pack_name, pack_url, pack_version = self._get_pack_name_and_url(
-                pack,
-                self.config.get(EXCHANGE_URL_KEY, None),
-                self.config.get(EXCHANGE_PREFIX_KEY, None)
-            )
+            pack_name, pack_url, pack_version = self._get_pack_name_and_url(pack)
 
             lock_name = hashlib.md5(pack_name).hexdigest() + '.lock'
 
@@ -175,7 +170,7 @@ class DownloadGitRepoAction(Action):
         return sanitized_result
 
     @staticmethod
-    def _get_pack_name_and_url(pack, exchange_url, exchange_prefix):
+    def _get_pack_name_and_url(pack):
         try:
             name_or_url, version = pack.split(PACK_VERSION_SEPARATOR)
         except ValueError:
@@ -183,9 +178,10 @@ class DownloadGitRepoAction(Action):
             version = None
 
         if len(name_or_url.split('/')) == 1:
-            return (name_or_url, "{}/{}-{}.git".format(exchange_url, exchange_prefix,
-                                                       name_or_url),
-                    version)
+            pack = search_pack_index(pack=name_or_url)
+            if not pack:
+                raise Exception('No record of the "%s" pack in the index.' % name_or_url)
+            return (pack.name, pack.repo_url, version)
         else:
             return (DownloadGitRepoAction._eval_repo_name(name_or_url),
                     DownloadGitRepoAction._eval_repo_url(name_or_url),

--- a/contrib/packs/config.yaml
+++ b/contrib/packs/config.yaml
@@ -1,7 +1,5 @@
 ---
 pack_group: st2packs
-exchange_url: https://github.com/StackStorm-Exchange
-exchange_prefix: stackstorm
 
 repositories:
 

--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -37,6 +37,7 @@ from st2common.models.api.action import LiveActionCreateAPI
 from st2common.models.api.pack import PackAPI
 from st2common.models.api.pack import PackInstallRequestAPI
 from st2common.models.api.pack import PackRegisterRequestAPI
+from st2common.models.api.pack import PackSearchRequestAPI
 from st2common.models.api.pack import PackAsyncAPI
 from st2common.persistence.pack import Pack
 from st2common.rbac.types import PermissionType
@@ -133,11 +134,12 @@ class PackRegisterController(RestController):
 
         return result
 
+
 class PackSearchController(RestController):
 
     @jsexpose(body_cls=PackSearchRequestAPI)
     def post(self, pack_search_request):
-        return search_pack_index(pack_search_request.query, 
+        return search_pack_index(pack_search_request.query,
                                  pack_search_request.pack)
 
 

--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -42,6 +42,7 @@ from st2common.persistence.pack import Pack
 from st2common.rbac.types import PermissionType
 from st2common.rbac.decorators import request_user_has_permission
 from st2common.rbac.decorators import request_user_has_resource_db_permission
+from st2common.services.packs import search_pack_index
 
 http_client = six.moves.http_client
 
@@ -132,6 +133,13 @@ class PackRegisterController(RestController):
 
         return result
 
+class PackSearchController(RestController):
+
+    @jsexpose(body_cls=PackSearchRequestAPI)
+    def post(self, pack_search_request):
+        return search_pack_index(pack_search_request.query, 
+                                 pack_search_request.pack)
+
 
 class BasePacksController(ResourceController):
     model = PackAPI
@@ -189,6 +197,7 @@ class PacksController(BasePacksController):
     install = PackInstallController()
     uninstall = PackUninstallController()
     register = PackRegisterController()
+    search = PackSearchController()
     views = PackViewsController()
 
     @request_user_has_permission(permission_type=PermissionType.PACK_LIST)

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -58,6 +58,7 @@ class PackBranch(resource.ResourceBranch):
         self.commands['install'] = PackInstallCommand(self.resource, self.app, self.subparsers)
         self.commands['remove'] = PackRemoveCommand(self.resource, self.app, self.subparsers)
         self.commands['search'] = PackSearchCommand(self.resource, self.app, self.subparsers)
+        self.commands['show'] = PackShowCommand(self.resource, self.app, self.subparsers)
 
 
 class PackResourceCommand(resource.ResourceCommand):
@@ -105,6 +106,21 @@ class PackAsyncCommand(ActionRunCommandMixin, resource.ResourceCommand):
 class PackListCommand(resource.ResourceListCommand):
     display_attributes = ['name', 'description', 'version', 'author']
     attribute_display_order = ['name', 'description', 'version', 'author']
+
+
+class PackShowCommand(PackResourceCommand):
+    def __init__(self, resource, *args, **kwargs):
+        super(PackShowCommand, self).__init__(resource, 'show',
+              'Get information about a %s from the index.' % resource.get_display_name().lower(),
+              *args, **kwargs)
+
+        self.parser.add_argument('name',
+                                 help='Name of the %s to show.' %
+                                 resource.get_display_name().lower())
+
+    @resource.add_auth_token_to_kwargs_from_cli
+    def run(self, args, **kwargs):
+        return self.manager.search(args, **kwargs)
 
 
 class PackInstallCommand(PackAsyncCommand):
@@ -186,4 +202,4 @@ class PackSearchCommand(resource.ResourceTableCommand):
 
     @resource.add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
-        return self.manager.search(args.query, **kwargs)
+        return self.manager.search(args, **kwargs)

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -172,7 +172,10 @@ class PackRegisterCommand(PackResourceCommand):
         return self.manager.register(args.types, **kwargs)
 
 
-class PackSearchCommand(PackListCommand):
+class PackSearchCommand(resource.ResourceTableCommand):
+    display_attributes = ['name', 'description', 'version', 'author']
+    attribute_display_order = ['name', 'description', 'version', 'author']
+
     def __init__(self, resource, *args, **kwargs):
         super(PackSearchCommand, self).__init__(resource, 'search',
             'Search for a %s in the directory.' % resource.get_display_name().lower(),

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -172,7 +172,7 @@ class PackRegisterCommand(PackResourceCommand):
         return self.manager.register(args.types, **kwargs)
 
 
-class PackSearchCommand(PackResourceCommand):
+class PackSearchCommand(PackListCommand):
     def __init__(self, resource, *args, **kwargs):
         super(PackSearchCommand, self).__init__(resource, 'search',
             'Search for a %s in the directory.' % resource.get_display_name().lower(),

--- a/st2client/st2client/commands/resource.py
+++ b/st2client/st2client/commands/resource.py
@@ -236,13 +236,12 @@ class ResourceCommand(commands.Command):
         return result
 
 
-class ResourceListCommand(ResourceCommand):
+class ResourceTableCommand(ResourceCommand):
     display_attributes = ['id', 'name', 'description']
 
-    def __init__(self, resource, *args, **kwargs):
-        super(ResourceListCommand, self).__init__(resource, 'list',
-            'Get the list of %s.' % resource.get_plural_display_name().lower(),
-            *args, **kwargs)
+    def __init__(self, resource, name, description, *args, **kwargs):
+        super(ResourceTableCommand, self).__init__(resource, name, description,
+                                                   *args, **kwargs)
 
         self.parser.add_argument('-a', '--attr', nargs='+',
                                  default=self.display_attributes,
@@ -262,6 +261,13 @@ class ResourceListCommand(ResourceCommand):
         self.print_output(instances, table.MultiColumnTable,
                           attributes=args.attr, widths=args.width,
                           json=args.json, yaml=args.yaml)
+
+
+class ResourceListCommand(ResourceTableCommand):
+    def __init__(self, resource, *args, **kwargs):
+        super(ResourceListCommand, self).__init__(resource, 'list',
+            'Get the list of %s.' % resource.get_plural_display_name().lower(),
+            *args, **kwargs)
 
 
 class ContentPackResourceListCommand(ResourceListCommand):

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -417,9 +417,13 @@ class PackResourceManager(ResourceManager):
         return instance
 
     @add_auth_token_to_kwargs_from_env
-    def search(self, query, **kwargs):
+    def search(self, args, **kwargs):
         url = '/%s/search' % (self.resource.get_url_path_name())
-        response = self.client.post(url, {'query': query})
+        if getattr(args, 'query'):
+            payload = {'query': args.query}
+        else:
+            payload = {'name': args.name}
+        response = self.client.post(url, payload)
         if response.status_code != 200:
             self.handle_error(response)
         instance = self.resource.deserialize(response.json())

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -79,7 +79,11 @@ def register_opts(ignore_errors=False):
         cfg.StrOpt('system_packs_base_path', default=system_packs_base_path,
                    help='Path to the directory which contains system packs.'),
         cfg.StrOpt('packs_base_paths', default=None,
-                   help='Paths which will be searched for integration packs.')
+                   help='Paths which will be searched for integration packs.'),
+        cfg.ListOpt('index_url', default='https://exchange.stackstorm.org/index/v1/index.json',
+                    help=('A URL pointing to the pack index. StackStorm Exchange is used by '
+                          'default. Use a comma-separated list for multiple indexes if you '
+                          'want to get other packs discovered with "st2 pack search".')),
     ]
     do_register_opts(content_opts, 'content', ignore_errors)
 

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -288,7 +288,7 @@ class PackSearchRequestAPI(BaseAPI):
                 },
                 "required": ["query"],
                 "additionalProperties": False,
-            }, 
+            },
             {
                 "properties": {
                     "pack": {

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -37,6 +37,7 @@ __all__ = [
 
     'PackInstallRequestAPI',
     'PackRegisterRequestAPI',
+    'PackSearchRequestAPI',
     'PackAsyncAPI'
 ]
 
@@ -278,13 +279,26 @@ class PackRegisterRequestAPI(BaseAPI):
 class PackSearchRequestAPI(BaseAPI):
     schema = {
         "type": "object",
-        "properties": {
-            "query": {
-                "type": "string",
-                "required": True
-            }
-        },
-        "additionalProperties": False
+        "oneOf": [
+            {
+                "properties": {
+                    "query": {
+                        "type": "string",
+                    },
+                },
+                "required": ["query"],
+                "additionalProperties": False,
+            }, 
+            {
+                "properties": {
+                    "pack": {
+                        "type": "string",
+                    },
+                },
+                "required": ["pack"],
+                "additionalProperties": False,
+            },
+        ]
     }
 
 

--- a/st2common/st2common/services/packs.py
+++ b/st2common/st2common/services/packs.py
@@ -39,9 +39,9 @@ def fetch_pack_index(index_url=None):
     """
     if not index_url:
         index_urls = cfg.CONF.content.index_url
-    else if isinstance(index_url, str):
+    elif isinstance(index_url, str):
         index_urls = [index_url]
-    else if hasattr(index_url, '__iter__'):
+    elif hasattr(index_url, '__iter__'):
         index_urls = index_url
     else:
         raise TypeError('"index_url" should either be a string or an iterable object.')
@@ -72,5 +72,5 @@ def search_pack_index(query=None, pack=None):
             if query in value:
                 matches.append(pack)
                 break
-                
+
     return matches

--- a/st2common/st2common/services/packs.py
+++ b/st2common/st2common/services/packs.py
@@ -32,6 +32,7 @@ def get_pack_by_ref(pack_ref):
     pack_db = Pack.get_by_ref(pack_ref)
     return pack_db
 
+
 def fetch_pack_index(index_url=None):
     """
     Fetch the pack indexes (either from the config or provided as an argument)
@@ -45,26 +46,27 @@ def fetch_pack_index(index_url=None):
         index_urls = index_url
     else:
         raise TypeError('"index_url" should either be a string or an iterable object.')
-        
+
     result = {}
     for index_url in index_urls:
         result.update(requests.get(index_url).json())
     return result
 
+
 def search_pack_index(query=None, pack=None):
     """
     Search the pack index either by pack name or by query.
-    Returns a pack object if the pack name is specified, otherwise returns 
+    Returns a pack object if the pack name is specified, otherwise returns
     a list of matches for a query.
     """
     if (not query and not pack) or (query and pack):
         raise ValueError("Either a query or a pack name must be specified.")
-    
+
     index = fetch_pack_index()
-    
+
     if pack:
         return index.get(pack, None)
-    
+
     pack_list = index.values()
     matches = []
     for pack in pack_list:

--- a/st2common/st2common/services/packs.py
+++ b/st2common/st2common/services/packs.py
@@ -13,10 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from oslo_config import cfg
+import requests
+
 from st2common.persistence.pack import Pack
 
 __all__ = [
-    'get_pack_by_ref'
+    'get_pack_by_ref',
+    'fetch_pack_index',
+    'search_pack_index'
 ]
 
 
@@ -26,3 +31,46 @@ def get_pack_by_ref(pack_ref):
     """
     pack_db = Pack.get_by_ref(pack_ref)
     return pack_db
+
+def fetch_pack_index(index_url=None):
+    """
+    Fetch the pack indexes (either from the config or provided as an argument)
+    and return the object.
+    """
+    if not index_url:
+        index_urls = cfg.CONF.content.index_url
+    else if isinstance(index_url, str):
+        index_urls = [index_url]
+    else if hasattr(index_url, '__iter__'):
+        index_urls = index_url
+    else:
+        raise TypeError('"index_url" should either be a string or an iterable object.')
+        
+    result = {}
+    for index_url in index_urls:
+        result.update(requests.get(index_url).json())
+    return result
+
+def search_pack_index(query=None, pack=None):
+    """
+    Search the pack index either by pack name or by query.
+    Returns a pack object if the pack name is specified, otherwise returns 
+    a list of matches for a query.
+    """
+    if (not query and not pack) or (query and pack):
+        raise ValueError("Either a query or a pack name must be specified.")
+    
+    index = fetch_pack_index()
+    
+    if pack:
+        return index.get(pack, None)
+    
+    pack_list = index.values()
+    matches = []
+    for pack in pack_list:
+        for value in pack.values():
+            if query in value:
+                matches.append(pack)
+                break
+                
+    return matches


### PR DESCRIPTION
This PR adds:

1. A config entry that allows you to specify a pack index or a list of indexes. It defaults to our main index in the Exchange, but if there's some security concerns in a large enterprise, they can maintain their own index, or even a local one on the same host, or use both at the same time and have both their own packs and Exchange packs available for discovery. (Oh boy, @armab will geek out about the multiple indexes part.)

2. Helper functions in `st2common` for (1) fetching and combining the indexes, and (2) the index search.

3. The `pack/search` API endpoint that supports getting a single pack object by its name, or listing all packs matching a query.

4. The corresponding CLI commands (`st2 pack search <query>` and `st2 pack show <pack>`).

5. Changes to the `packs.download` action, which is the cool part. Now, if you want to download a pack by its short name, the action won't just assume the pack is hosted on the Exchange github org: it will query the index instead. This has the added benefit of using local indexes, or enterprise-only indexes, or listing external packs in our own index in the future, and the end user won't need the full URL to install any of them via CLI or `packs.install`. Of course, the full URLs are still supported, since maintaining an index is unnecessary in most cases.