### PR TITLE
Fail on runner registration, cleanup configs

### DIFF
--- a/st2common/st2common/bootstrap/runnersregistrar.py
+++ b/st2common/st2common/bootstrap/runnersregistrar.py
@@ -31,17 +31,14 @@ __all__ = [
 LOG = logging.getLogger(__name__)
 
 
-def register_runners(runner_dir=None, experimental=False, fail_on_failure=True):
+def register_runners(runner_dirs=None, experimental=False, fail_on_failure=True):
     """ Register runners
     """
     LOG.debug('Start : register runners')
     runner_count = 0
     runner_loader = RunnersLoader()
 
-    if runner_dir:
-        assert isinstance(runner_dir, list)
-
-    if not runner_dir:
+    if not runner_dirs:
         runner_dirs = content_utils.get_runners_base_paths()
 
     runners = runner_loader.get_runners(runner_dirs)

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -176,7 +176,7 @@ def register_runners():
         LOG.info('=========================================================')
         LOG.info('############## Registering runners ######################')
         LOG.info('=========================================================')
-        registered_count = runners_registrar.register_runners(runner_dir=runner_dir,
+        registered_count = runners_registrar.register_runners(runner_dirs=[runner_dir],
                                                               fail_on_failure=fail_on_failure,
                                                               experimental=False)
     except Exception as error:
@@ -345,7 +345,11 @@ def register_content():
         register_runners()
 
     if cfg.CONF.register.actions and not register_all:
-        register_runners()
+        # If --register-runners is passed, registering runners again would be duplicate.
+        # If it's not passed, we still want to register runners. Otherwise, actions will complain
+        # about runners not being registered.
+        if not cfg.CONF.register.runners:
+            register_runners()
         register_actions()
 
     if cfg.CONF.register.rules and not register_all:

--- a/st2common/tests/integration/test_register_content_script.py
+++ b/st2common/tests/integration/test_register_content_script.py
@@ -29,16 +29,20 @@ BASE_CMD_ARGS = [SCRIPT_PATH, '--config-file=conf/st2.tests.conf', '-v']
 BASE_REGISTER_ACTIONS_CMD_ARGS = BASE_CMD_ARGS + ['--register-actions']
 
 
-class ContentRegisterScripTestCase(IntegrationTestCase):
+class ContentRegisterScriptTestCase(IntegrationTestCase):
     def setUp(self):
-        super(ContentRegisterScripTestCase, self).setUp()
+        super(ContentRegisterScriptTestCase, self).setUp()
         test_config.parse_args()
 
     def test_register_from_pack_success(self):
         pack_dir = os.path.join(get_fixtures_packs_base_path(), 'dummy_pack_1')
+        runner_dirs = os.path.join(get_fixtures_packs_base_path(), 'runners')
 
-        cmd = BASE_REGISTER_ACTIONS_CMD_ARGS + ['--register-pack=%s' % (pack_dir)]
-        print('Command to run: %s' % cmd)
+        opts = [
+            '--register-pack=%s' % (pack_dir),
+            '--register-runner-dir=%s' % (runner_dirs),
+        ]
+        cmd = BASE_REGISTER_ACTIONS_CMD_ARGS + opts
         exit_code, _, stderr = run_command(cmd=cmd)
         self.assertTrue('Registered 1 actions.' in stderr)
         self.assertEqual(exit_code, 0)
@@ -46,14 +50,24 @@ class ContentRegisterScripTestCase(IntegrationTestCase):
     def test_register_from_pack_fail_on_failure_pack_dir_doesnt_exist(self):
         # No fail on failure flag, should succeed
         pack_dir = 'doesntexistblah'
-        cmd = BASE_REGISTER_ACTIONS_CMD_ARGS + ['--register-pack=%s' % (pack_dir),
-                                                '--register-no-fail-on-failure']
+        runner_dirs = os.path.join(get_fixtures_packs_base_path(), 'runners')
+
+        opts = [
+            '--register-pack=%s' % (pack_dir),
+            '--register-runner-dir=%s' % (runner_dirs),
+            '--register-no-fail-on-failure'
+        ]
+        cmd = BASE_REGISTER_ACTIONS_CMD_ARGS + opts
         exit_code, _, _ = run_command(cmd=cmd)
         self.assertEqual(exit_code, 0)
 
         # Fail on failure, should fail
-        cmd = BASE_REGISTER_ACTIONS_CMD_ARGS + ['--register-pack=%s' % (pack_dir),
-                                                '--register-fail-on-failure']
+        opts = [
+            '--register-pack=%s' % (pack_dir),
+            '--register-runner-dir=%s' % (runner_dirs),
+            '--register-fail-on-failure'
+        ]
+        cmd = BASE_REGISTER_ACTIONS_CMD_ARGS + opts
         exit_code, _, stderr = run_command(cmd=cmd)
         self.assertTrue('Directory "doesntexistblah" doesn\'t exist' in stderr)
         self.assertEqual(exit_code, 1)
@@ -61,16 +75,27 @@ class ContentRegisterScripTestCase(IntegrationTestCase):
     def test_register_from_pack_action_metadata_fails_validation(self):
         # No fail on failure flag, should succeed
         pack_dir = os.path.join(get_fixtures_packs_base_path(), 'dummy_pack_4')
-        cmd = BASE_REGISTER_ACTIONS_CMD_ARGS + ['--register-pack=%s' % (pack_dir),
-                                                '--register-no-fail-on-failure']
+        runner_dirs = os.path.join(get_fixtures_packs_base_path(), 'runners')
+
+        opts = [
+            '--register-pack=%s' % (pack_dir),
+            '--register-no-fail-on-failure',
+            '--register-runner-dir=%s' % (runner_dirs),
+        ]
+
+        cmd = BASE_REGISTER_ACTIONS_CMD_ARGS + opts
         exit_code, _, stderr = run_command(cmd=cmd)
         self.assertTrue('Registered 0 actions.' in stderr)
         self.assertEqual(exit_code, 0)
 
         # Fail on failure, should fail
         pack_dir = os.path.join(get_fixtures_packs_base_path(), 'dummy_pack_4')
-        cmd = BASE_REGISTER_ACTIONS_CMD_ARGS + ['--register-pack=%s' % (pack_dir),
-                                                '--register-fail-on-failure']
+        opts = [
+            '--register-pack=%s' % (pack_dir),
+            '--register-fail-on-failure',
+            '--register-runner-dir=%s' % (runner_dirs),
+        ]
+        cmd = BASE_REGISTER_ACTIONS_CMD_ARGS + opts
         exit_code, _, stderr = run_command(cmd=cmd)
         self.assertTrue('object has no attribute \'get\'' in stderr)
         self.assertEqual(exit_code, 1)

--- a/st2common/tests/integration/test_register_content_script.py
+++ b/st2common/tests/integration/test_register_content_script.py
@@ -38,6 +38,7 @@ class ContentRegisterScripTestCase(IntegrationTestCase):
         pack_dir = os.path.join(get_fixtures_packs_base_path(), 'dummy_pack_1')
 
         cmd = BASE_REGISTER_ACTIONS_CMD_ARGS + ['--register-pack=%s' % (pack_dir)]
+        print('Command to run: %s' % cmd)
         exit_code, _, stderr = run_command(cmd=cmd)
         self.assertTrue('Registered 1 actions.' in stderr)
         self.assertEqual(exit_code, 0)


### PR DESCRIPTION
```
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯ nosetests -sv st2common/tests/integration/test_register_content_script.py
test_register_all_and_register_setup_virtualenvs (tests.integration.test_register_content_script.ContentRegisterScriptTestCase) ... ok
test_register_from_pack_action_metadata_fails_validation (tests.integration.test_register_content_script.ContentRegisterScriptTestCase) ... ok
test_register_from_pack_fail_on_failure_pack_dir_doesnt_exist (tests.integration.test_register_content_script.ContentRegisterScriptTestCase) ... ok
test_register_from_pack_success (tests.integration.test_register_content_script.ContentRegisterScriptTestCase) ... ok
test_register_from_packs_doesnt_throw_on_missing_pack_resource_folder (tests.integration.test_register_content_script.ContentRegisterScriptTestCase) ... ok
test_register_setup_virtualenvs (tests.integration.test_register_content_script.ContentRegisterScriptTestCase) ... ok

----------------------------------------------------------------------
Ran 6 tests in 39.879s

OK
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯
```