### PR TITLE
API exception handling fixes, allow user to filter get all responses on multiple resources id

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,12 @@ In development
   task. (new feature) #2933
 
   Contribution by Paul Mulvihill.
+* Improve API exception handling and make sure 400 status code is returned instead of 500 on
+  mongoengine field validation error. (improvement)
+* Allow user to supply multiple resource ids using ``?id`` query parameter when filtering
+  "get all" API endpoint result set (e.g. `?id=1,2,3,4`). This allows for a better client and
+  servers performance when user is polling and interested in multiple resources such as polling on
+  multiple action executions.(improvement)
 
 2.0.1 - September 30, 2016
 --------------------------

--- a/st2api/tests/unit/controllers/v1/test_executions_simple.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_simple.py
@@ -220,6 +220,19 @@ class TestActionExecutionController(FunctionalTest):
         self.assertEqual(resp.status_int, 400)
         self.assertTrue('not a valid ObjectId' in resp.json['faultstring'])
 
+    def test_get_all_id_query_param_filtering_multiple_ids_provided(self):
+        post_resp = self._do_post(LIVE_ACTION_1)
+        self.assertEqual(post_resp.status_int, 201)
+        id_1 = self._get_actionexecution_id(post_resp)
+
+        post_resp = self._do_post(LIVE_ACTION_1)
+        self.assertEqual(post_resp.status_int, 201)
+        id_2 = self._get_actionexecution_id(post_resp)
+
+        resp = self.app.get('/v1/executions?id=%s,%s' % (id_1, id_2), expect_errors=False)
+        self.assertEqual(resp.status_int, 200)
+        self.assertEqual(len(resp.json), 2)
+
     def test_get_all(self):
         self._get_actionexecution_id(self._do_post(LIVE_ACTION_1))
         self._get_actionexecution_id(self._do_post(LIVE_ACTION_2))

--- a/st2api/tests/unit/controllers/v1/test_executions_simple.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_simple.py
@@ -205,6 +205,21 @@ class TestActionExecutionController(FunctionalTest):
         if 'end_timestamp' in get_resp:
             self.assertTrue('elapsed_seconds' in get_resp)
 
+    def test_get_all_id_query_param_filtering_success(self):
+        post_resp = self._do_post(LIVE_ACTION_1)
+        actionexecution_id = self._get_actionexecution_id(post_resp)
+        get_resp = self._do_get_one(actionexecution_id)
+        self.assertEqual(get_resp.status_int, 200)
+        self.assertEqual(self._get_actionexecution_id(get_resp), actionexecution_id)
+
+        resp = self.app.get('/v1/executions?id=%s' % (actionexecution_id), expect_errors=False)
+        self.assertEqual(resp.status_int, 200)
+
+    def test_get_all_id_query_param_filtering_invalid_id(self):
+        resp = self.app.get('/v1/executions?id=invalidid', expect_errors=True)
+        self.assertEqual(resp.status_int, 400)
+        self.assertTrue('not a valid ObjectId' in resp.json['faultstring'])
+
     def test_get_all(self):
         self._get_actionexecution_id(self._do_post(LIVE_ACTION_1))
         self._get_actionexecution_id(self._do_post(LIVE_ACTION_2))

--- a/st2common/st2common/models/api/base.py
+++ b/st2common/st2common/models/api/base.py
@@ -32,6 +32,7 @@ from st2common.util import schema as util_schema
 from st2common.util.debugging import is_enabled as is_debugging_enabled
 from st2common.util.jsonify import json_encode
 from st2common.util.api import get_exception_for_type_error
+from st2common.util.api import get_exception_for_uncaught_api_error
 from st2common import log as logging
 
 __all__ = [
@@ -283,6 +284,9 @@ def jsexpose(arg_types=None, body_cls=None, status_code=None, content_type='appl
                 result = f(*args, **kwargs)
             except TypeError as e:
                 e = get_exception_for_type_error(func=f, exc=e)
+                raise e
+            except Exception as e:
+                e = get_exception_for_uncaught_api_error(func=f, exc=e)
                 raise e
 
             if status_code:

--- a/st2common/tests/unit/test_logging.py
+++ b/st2common/tests/unit/test_logging.py
@@ -31,10 +31,7 @@ class LoggingMiscUtilsTestCase(unittest2.TestCase):
         self.assertEqual(logger_name, 'st2reactor.cmd.sensormanager')
 
         logger_name = get_logger_name_for_module(python_runner)
-        self.assertEqual(
-            logger_name,
-            'st2.contrib.runners.python_runner.python_runner'
-        )
+        self.assertTrue(logger_name.endswith('contrib.runners.python_runner.python_runner'))
 
         logger_name = get_logger_name_for_module(runners)
         self.assertEqual(logger_name, 'st2common.runners.__init__')


### PR DESCRIPTION
This pull request addresses two issues:

1. It fixes handling of `ValidationError` exception in the. Previously if exception was thrown due to an invalid ID being provided in the query string internal error was returned, not bad request error is returned.

2. It allows users to filter "get all" API responses on multiple resource ids by providing a comma delimited string value for the query parameter (e.g. `?id=1,2,3,4`).

This allows users to write more efficient clients and also reduces some overhead on the API. Previously user would either need to request all the objects and do late filtering locally or by performing multiple get one requests (one for each resource / object).

I'm personally not a fan id comma delimited string approach (HTTP already solves that by allowing client to provide the same key multiple time - `?id=1&id=2&id=3`) but sadly we already use comma delimited approach in some other places and it looks like pecan doesn't directly support multiple keys notation so I went with this approach for now.