### PR TITLE
Funnel pack registration through the API

### DIFF
--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -15,6 +15,7 @@
 
 import sys
 
+from st2client.models import core
 from st2client.models import Pack
 from st2client.models import LiveAction
 from st2client.commands import resource
@@ -225,7 +226,8 @@ class PackRegisterCommand(PackResourceCommand):
 
     @resource.add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
-        return self.manager.register(args.packs, args.types, **kwargs)
+        result = self.manager.register(args.packs, args.types, **kwargs)
+        return core.Resource(**result)
 
 
 class PackSearchCommand(resource.ResourceTableCommand):

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -452,7 +452,7 @@ class PackResourceManager(ResourceManager):
         response = self.client.post(url, payload, **kwargs)
         if response.status_code != 200:
             self.handle_error(response)
-        instance = self.resource.deserialize(response.json())
+        instance = response.json()
         return instance
 
 

--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -36,6 +36,8 @@ function print_usage() {
     echo "  --register-setup-virtualenvs  Create Python virtual environments for all the registered packs."
     echo "  --register-fail-on-failure    Exit with non-zero if some resource registration fails. Deprecated. This is now a default behavior."
     echo "  --register-no-fail-on-failure Don't exit with non-zero if some resource registration fails."
+    echo "  --token                       Access token for user authentication."
+    echo "  --api-url                     Base URL to the API endpoint excluding the version."
     echo "  --verbose                     Output additional debug and informational messages."
     echo ""
     echo "Most commands require elevated privileges."
@@ -115,7 +117,7 @@ function reopen_component_log_files() {
 }
 
 function register_content() {
-  ALLOWED_REGISTER_FLAGS='--register-all --register-actions --register-aliases --register-policies --register-rules --register-sensors --register-triggers --register-configs --register-setup-virtualenvs --register-fail-on-failure --register-no-fail-on-failure --verbose'
+  ALLOWED_REGISTER_FLAGS='--register-all --register-actions --register-aliases --register-policies --register-rules --register-sensors --register-triggers --register-configs --register-setup-virtualenvs --register-fail-on-failure --register-no-fail-on-failure --verbose --token --api-url'
   DEFAULT_REGISTER_FLAGS='--register-actions --register-aliases --register-sensors --register-triggers --register-configs --register-rules'
 
   SUDO_FLAGS='--register-setup-virtualenvs'

--- a/st2common/st2common/bootstrap/ruletypesregistrar.py
+++ b/st2common/st2common/bootstrap/ruletypesregistrar.py
@@ -50,6 +50,8 @@ RULE_TYPES = [
 def register_rule_types():
     LOG.debug('Start : register default RuleTypes.')
 
+    counter = 0
+
     for rule_type in RULE_TYPES:
         rule_type = copy.deepcopy(rule_type)
 
@@ -75,9 +77,11 @@ def register_rule_types():
                 LOG.audit('RuleType updated. RuleType %s', rule_type_db, extra=extra)
             else:
                 LOG.audit('RuleType created. RuleType %s', rule_type_db, extra=extra)
+
+            counter += 1
         except Exception:
             LOG.exception('Unable to register RuleType %s.', rule_type['name'])
 
     LOG.debug('End : register default RuleTypes.')
 
-    return True
+    return counter

--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -12,8 +12,11 @@ copy_examples=false
 load_content=true
 use_ipv6=false
 
-while getopts ":r:gxcu6" o; do
+while getopts ":r:t:gxcu6" o; do
     case "${o}" in
+        t)
+            token=${OPTARG}
+            ;;
         r)
             runner_count=${OPTARG}
             ;;
@@ -262,7 +265,7 @@ function st2start(){
         echo 'Registering sensors, runners, actions, rules, aliases, and policies...'
         ./virtualenv/bin/python \
             ./st2common/bin/st2-register-content \
-            --config-file $ST2_CONF --register-all
+            --config-file $ST2_CONF --register-all --token $token
     fi
 
     # List screen sessions


### PR DESCRIPTION
Still somewhat WIP and there is a few questions unanswered, but I was hoping to get your eyes on that one as soon as possible.

With this PR we're steering towards registering all the content through API calls rather than doing it locally.

Known problems:
- registration of even a default set of content takes more than 30 seconds on devbox with nfs share. There might be a problem if user decides to run the command remotely.
- current content bootstrapping includes setting up venvs for python actions. We haven't moved this part yet and it is not clear to me how often the feature is used in the wild and whether it would be ok to keep it separate of the registration process.

By the time we're done with this PR, we're likely to merge `feature/packs`, so PR would have to be recreated against master anyway.
