### PR TITLE
Remove enum to allow for extra content-type arguments, like charset

### DIFF
--- a/contrib/core/actions/sendmail.yaml
+++ b/contrib/core/actions/sendmail.yaml
@@ -30,9 +30,6 @@ parameters:
   content_type:
     type: string
     description: Content type of message to be sent
-    enum:
-      - "text/plain"
-      - "text/html"
     default: "text/html"
     position: 4
   body:


### PR DESCRIPTION
Having `enum` in the `content_type` schema, restricts users from adding extras like `text/plain; charset="utf-8"`  

If we want to keep the restriction, I suppose we could add a `charset` argument to the send_mail script?
