### PR TITLE
RBAC for pack managemenet API endpoints

### DIFF
--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -67,6 +67,7 @@ ENTITIES = {
 
 class PackInstallController(ActionExecutionsControllerMixin, RestController):
 
+    @request_user_has_permission(permission_type=PermissionType.PACK_INSTALL)
     @jsexpose(body_cls=PackInstallRequestAPI, status_code=http_client.ACCEPTED)
     def post(self, pack_install_request):
         parameters = {
@@ -84,6 +85,7 @@ class PackInstallController(ActionExecutionsControllerMixin, RestController):
 
 class PackUninstallController(ActionExecutionsControllerMixin, RestController):
 
+    @request_user_has_permission(permission_type=PermissionType.PACK_UNINSTALL)
     @jsexpose(body_cls=PackInstallRequestAPI, arg_types=[str], status_code=http_client.ACCEPTED)
     def post(self, pack_uninstall_request, ref_or_id=None):
         if ref_or_id:
@@ -106,6 +108,7 @@ class PackUninstallController(ActionExecutionsControllerMixin, RestController):
 
 class PackRegisterController(RestController):
 
+    @request_user_has_permission(permission_type=PermissionType.PACK_REGISTER)
     @jsexpose(body_cls=PackRegisterRequestAPI)
     def post(self, pack_register_request):
         if pack_register_request and hasattr(pack_register_request, 'types'):
@@ -147,6 +150,7 @@ class PackRegisterController(RestController):
 
 class PackSearchController(RestController):
 
+    @request_user_has_permission(permission_type=PermissionType.PACK_SEARCH)
     @jsexpose(body_cls=PackSearchRequestAPI)
     def post(self, pack_search_request):
         if hasattr(pack_search_request, 'query'):

--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -163,6 +163,7 @@ class PackSearchController(RestController):
 
 class IndexHealthController(RestController):
 
+    @request_user_has_permission(permission_type=PermissionType.PACK_VIEW_INDEX_HEALTH)
     @jsexpose()
     def get(self):
         """

--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -235,6 +235,11 @@ class BasePacksController(ResourceController):
         return resource_db
 
 
+class PacksIndexController(RestController):
+    search = PackSearchController()
+    health = IndexHealthController()
+
+
 class PacksController(BasePacksController):
     from st2api.controllers.v1.packviews import PackViewsController
 
@@ -253,9 +258,8 @@ class PacksController(BasePacksController):
     install = PackInstallController()
     uninstall = PackUninstallController()
     register = PackRegisterController()
-    search = PackSearchController()
     views = PackViewsController()
-    health = IndexHealthController()
+    index = PacksIndexController()
 
     @request_user_has_permission(permission_type=PermissionType.PACK_LIST)
     @jsexpose()

--- a/st2api/tests/unit/controllers/v1/test_packs.py
+++ b/st2api/tests/unit/controllers/v1/test_packs.py
@@ -100,17 +100,17 @@ class PacksControllerTestCase(FunctionalTest):
     @mock.patch.object(pack_service, 'fetch_pack_index',
                        mock.MagicMock(return_value=(PACK_INDEX, {})))
     def test_search(self):
-        resp = self.app.post_json('/v1/packs/search', {'query': 'test'})
+        resp = self.app.post_json('/v1/packs/index/search', {'query': 'test'})
 
         self.assertEqual(resp.status_int, 200)
         self.assertEqual(resp.json, [PACK_INDEX['test'], PACK_INDEX['test2']])
 
-        resp = self.app.post_json('/v1/packs/search', {'query': 'stanley'})
+        resp = self.app.post_json('/v1/packs/index/search', {'query': 'stanley'})
 
         self.assertEqual(resp.status_int, 200)
         self.assertEqual(resp.json, [PACK_INDEX['test2']])
 
-        resp = self.app.post_json('/v1/packs/search', {'query': 'special'})
+        resp = self.app.post_json('/v1/packs/index/search', {'query': 'special'})
 
         self.assertEqual(resp.status_int, 200)
         self.assertEqual(resp.json, [PACK_INDEX['test2']])
@@ -118,12 +118,12 @@ class PacksControllerTestCase(FunctionalTest):
     @mock.patch.object(pack_service, 'fetch_pack_index',
                        mock.MagicMock(return_value=(PACK_INDEX, {})))
     def test_show(self):
-        resp = self.app.post_json('/v1/packs/search', {'pack': 'test'})
+        resp = self.app.post_json('/v1/packs/index/search', {'pack': 'test'})
 
         self.assertEqual(resp.status_int, 200)
         self.assertEqual(resp.json, PACK_INDEX['test'])
 
-        resp = self.app.post_json('/v1/packs/search', {'pack': 'test2'})
+        resp = self.app.post_json('/v1/packs/index/search', {'pack': 'test2'})
 
         self.assertEqual(resp.status_int, 200)
         self.assertEqual(resp.json, PACK_INDEX['test2'])

--- a/st2api/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
+++ b/st2api/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
@@ -142,6 +142,27 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
                 'path': '/v1/packs/dummy_pack_1',
                 'method': 'GET'
             },
+            # Pack management
+            {
+                'path': '/v1/packs/install',
+                'method': 'POST',
+                'payload': {'packs': 'libcloud'}
+            },
+            {
+                'path': '/v1/packs/uninstall',
+                'method': 'POST',
+                'payload': {'packs': 'libcloud'}
+            },
+            {
+                'path': '/v1/packs/register',
+                'method': 'POST',
+                'payload': {'types': ['actions']}
+            },
+            {
+                'path': '/v1/packs/search',
+                'method': 'POST',
+                'payload': {'query': 'cloud'}
+            },
             # Pack views
             {
                 'path': '/v1/packs/views/files/dummy_pack_1',

--- a/st2api/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
+++ b/st2api/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
@@ -159,12 +159,12 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
                 'payload': {'types': ['actions']}
             },
             {
-                'path': '/v1/packs/search',
+                'path': '/v1/packs/index/search',
                 'method': 'POST',
                 'payload': {'query': 'cloud'}
             },
             {
-                'path': '/v1/packs/health',
+                'path': '/v1/packs/index/health',
                 'method': 'GET'
             },
             # Pack views

--- a/st2api/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
+++ b/st2api/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
@@ -163,6 +163,10 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
                 'method': 'POST',
                 'payload': {'query': 'cloud'}
             },
+            {
+                'path': '/v1/packs/health',
+                'method': 'GET'
+            },
             # Pack views
             {
                 'path': '/v1/packs/views/files/dummy_pack_1',

--- a/st2common/st2common/rbac/resolvers.py
+++ b/st2common/st2common/rbac/resolvers.py
@@ -336,8 +336,15 @@ class PackPermissionsResolver(PermissionsResolver):
     resource_type = ResourceType.PACK
 
     def user_has_permission(self, user_db, permission_type):
-        assert permission_type in [PermissionType.PACK_LIST]
-        return self._user_has_list_permission(user_db=user_db, permission_type=permission_type)
+        assert permission_type in [PermissionType.PACK_LIST, PermissionType.PACK_INSTALL,
+                                   PermissionType.PACK_UNINSTALL,
+                                   PermissionType.PACK_REGISTER, PermissionType.PACK_SEARCH]
+
+        if permission_type == PermissionType.PACK_LIST:
+            return self._user_has_list_permission(user_db=user_db, permission_type=permission_type)
+        else:
+            return self._user_has_global_permission(user_db=user_db,
+                                                    permission_type=permission_type)
 
     def user_has_resource_db_permission(self, user_db, resource_db, permission_type):
         log_context = {

--- a/st2common/st2common/rbac/resolvers.py
+++ b/st2common/st2common/rbac/resolvers.py
@@ -337,8 +337,9 @@ class PackPermissionsResolver(PermissionsResolver):
 
     def user_has_permission(self, user_db, permission_type):
         assert permission_type in [PermissionType.PACK_LIST, PermissionType.PACK_INSTALL,
-                                   PermissionType.PACK_UNINSTALL,
-                                   PermissionType.PACK_REGISTER, PermissionType.PACK_SEARCH]
+                                   PermissionType.PACK_UNINSTALL, PermissionType.PACK_REGISTER,
+                                   PermissionType.PACK_SEARCH,
+                                   PermissionType.PACK_VIEW_INDEX_HEALTH]
 
         if permission_type == PermissionType.PACK_LIST:
             return self._user_has_list_permission(user_db=user_db, permission_type=permission_type)

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -42,6 +42,15 @@ class PermissionType(Enum):
     PACK_CREATE = 'pack_create'
     PACK_MODIFY = 'pack_modify'
     PACK_DELETE = 'pack_delete'
+
+    # Pack-management specific permissions
+    # Note: Right now those permissions are global and apply to all the packs.
+    # In the future we plan to support globs.
+    PACK_INSTALL = 'pack_install'
+    PACK_UNINSTALL = 'pack_uninstall'
+    PACK_REGISTER = 'pack_register'
+    PACK_SEARCH = 'pack_search'
+
     PACK_ALL = 'pack_all'
 
     # Note: Right now we only have read endpoints + update for sensors types
@@ -204,6 +213,10 @@ RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP = {
         PermissionType.PACK_CREATE,
         PermissionType.PACK_MODIFY,
         PermissionType.PACK_DELETE,
+        PermissionType.PACK_INSTALL,
+        PermissionType.PACK_UNINSTALL,
+        PermissionType.PACK_REGISTER,
+        PermissionType.PACK_SEARCH,
         PermissionType.PACK_ALL,
 
         PermissionType.SENSOR_VIEW,
@@ -300,6 +313,13 @@ PERMISION_TYPE_TO_DESCRIPTION_MAP = {
     PermissionType.PACK_VIEW: 'Ability to view a pack.',
     PermissionType.PACK_CREATE: 'Ability to create a new pack.',
     PermissionType.PACK_MODIFY: 'Ability to modify (update) an existing pack.',
+    PermissionType.PACK_DELETE: 'Ability to delete an existing pack.',
+    PermissionType.PACK_INSTALL: 'Ability to install packs.',
+    PermissionType.PACK_UNINSTALL: 'Ability to uninstall packs.',
+    PermissionType.PACK_REGISTER: 'Ability to register packs and corresponding resources.',
+    PermissionType.PACK_SEARCH: 'Ability to query registry and search packs.',
+    PermissionType.PACK_DELETE: 'Ability to delete an existing pack.',
+    PermissionType.PACK_DELETE: 'Ability to delete an existing pack.',
     PermissionType.PACK_DELETE: 'Ability to delete an existing pack.',
     PermissionType.PACK_ALL: ('Ability to perform all the supported operations on a particular '
                               'pack.'),

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -50,6 +50,7 @@ class PermissionType(Enum):
     PACK_UNINSTALL = 'pack_uninstall'
     PACK_REGISTER = 'pack_register'
     PACK_SEARCH = 'pack_search'
+    PACK_VIEW_INDEX_HEALTH = 'pack_view_index_health'
 
     PACK_ALL = 'pack_all'
 
@@ -217,6 +218,7 @@ RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP = {
         PermissionType.PACK_UNINSTALL,
         PermissionType.PACK_REGISTER,
         PermissionType.PACK_SEARCH,
+        PermissionType.PACK_VIEW_INDEX_HEALTH,
         PermissionType.PACK_ALL,
 
         PermissionType.SENSOR_VIEW,
@@ -318,9 +320,7 @@ PERMISION_TYPE_TO_DESCRIPTION_MAP = {
     PermissionType.PACK_UNINSTALL: 'Ability to uninstall packs.',
     PermissionType.PACK_REGISTER: 'Ability to register packs and corresponding resources.',
     PermissionType.PACK_SEARCH: 'Ability to query registry and search packs.',
-    PermissionType.PACK_DELETE: 'Ability to delete an existing pack.',
-    PermissionType.PACK_DELETE: 'Ability to delete an existing pack.',
-    PermissionType.PACK_DELETE: 'Ability to delete an existing pack.',
+    PermissionType.PACK_VIEW_INDEX_HEALTH: 'Ability to query health of pack registries.',
     PermissionType.PACK_ALL: ('Ability to perform all the supported operations on a particular '
                               'pack.'),
 

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -129,6 +129,11 @@ class PermissionType(Enum):
         """
         split = permission_type.split('_')
         assert len(split) >= 2
+
+        # Special case for PACK_VIEW_INDEX_HEALTH
+        if permission_type == PermissionType.PACK_VIEW_INDEX_HEALTH:
+            return split[0]
+
         return '_'.join(split[:-1])
 
     @classmethod
@@ -140,6 +145,12 @@ class PermissionType(Enum):
         """
         split = permission_type.split('_')
         assert len(split) >= 2
+
+        # Special case for PACK_VIEW_INDEX_HEALTH
+        if permission_type == PermissionType.PACK_VIEW_INDEX_HEALTH:
+            split = permission_type.split('_', 1)
+            return split[1]
+
         return split[-1]
 
     @classmethod


### PR DESCRIPTION
This introduces basic RBAC for pack management API endpoints.

Right now all the permissions are "global" which for example means that user can either install all the packs or none.

In the future we can introduce support for globs / lists or similar we can also improve this (e.g. ability to only install a set of packs, but then again for RBAC installations, you should mirror the index and only include whitelisted packages you have audited so this might be of little use).