### PR TITLE
Pack management: branch checkouts

### DIFF
--- a/contrib/packs/tests/test_action_download.py
+++ b/contrib/packs/tests/test_action_download.py
@@ -139,8 +139,13 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
         def side_effect(ref):
             if ref[0] != 'v':
                 raise BadName()
+            return mock.MagicMock(hexsha='abcdef')
 
         self.repo_instance.commit.side_effect = side_effect
+        self.repo_instance.git = mock.MagicMock(
+            branch=(lambda *args: 'master'),
+            checkout=(lambda *args: True)
+        )
 
         action = self.get_action_instance()
         result = action.run(packs=['test=1.2.3'], abs_repo_base=self.repo_base)

--- a/contrib/packs/tests/test_action_download.py
+++ b/contrib/packs/tests/test_action_download.py
@@ -143,6 +143,6 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
         self.repo_instance.commit.side_effect = side_effect
 
         action = self.get_action_instance()
-        result = action.run(packs=['test=1.2.0'], abs_repo_base=self.repo_base)
+        result = action.run(packs=['test=1.2.3'], abs_repo_base=self.repo_base)
 
         self.assertEqual(result, {'test': 'Success.'})

--- a/contrib/packs/tests/test_action_download.py
+++ b/contrib/packs/tests/test_action_download.py
@@ -90,11 +90,9 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
         result = action.run(packs=['test'], abs_repo_base=self.repo_base)
         temp_dir = hashlib.md5(PACK_INDEX['test']['repo_url']).hexdigest()
 
-
         self.assertEqual(result, {'test': 'Success.'})
         self.clone_from.assert_called_once_with(PACK_INDEX['test']['repo_url'],
-                                           os.path.join(os.path.expanduser('~'), temp_dir),
-                                           branch='master')
+                                                os.path.join(os.path.expanduser('~'), temp_dir))
         self.assertTrue(os.path.isfile(os.path.join(self.repo_base, 'test/pack.yaml')))
 
     def test_run_pack_download_existing_pack(self):
@@ -116,11 +114,9 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
 
         self.assertEqual(result, {'test': 'Success.', 'test2': 'Success.'})
         self.clone_from.assert_any_call(PACK_INDEX['test']['repo_url'],
-                                        os.path.join(os.path.expanduser('~'), temp_dirs[0]),
-                                        branch='master')
+                                        os.path.join(os.path.expanduser('~'), temp_dirs[0]))
         self.clone_from.assert_any_call(PACK_INDEX['test2']['repo_url'],
-                                        os.path.join(os.path.expanduser('~'), temp_dirs[1]),
-                                        branch='master')
+                                        os.path.join(os.path.expanduser('~'), temp_dirs[1]))
         self.assertEqual(self.clone_from.call_count, 2)
         self.assertTrue(os.path.isfile(os.path.join(self.repo_base, 'test/pack.yaml')))
         self.assertTrue(os.path.isfile(os.path.join(self.repo_base, 'test2/pack.yaml')))
@@ -147,6 +143,6 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
         self.repo_instance.commit.side_effect = side_effect
 
         action = self.get_action_instance()
-        result = action.run(packs=['test=1.2.3'], abs_repo_base=self.repo_base)
+        result = action.run(packs=['test=1.2.0'], abs_repo_base=self.repo_base)
 
         self.assertEqual(result, {'test': 'Success.'})


### PR DESCRIPTION
Two changes here:
1. Versions can also point to branches now (i.e. `st2 pack install sensu=development`).
2. Checking out commits / tags that aren't tips of the branches will not detach HEAD. Instead it will put you on the right branch and point to N commits back. 

(2) is important to figure out where in the history you actually are. If I checked out a specific version, `Your branch is behind 'origin/master' by 3 commits` is a pretty useful message. `HEAD detached at c46a25c` is not a useful message.

It also helps you work with your pack more effectively, since it's pretty easy to update your pack with fast-forwarding or even start a new branch from that particular commit if you want to. Detached HEAD would require you to figure out which branch it belonged to, do a merge or a checkout to master, or make commits that are gonna be garbage-collected if you forget to create a new branch.

In other words, working with packs as repos (navigating, editing, etc.) is much easier now.
