### PR TITLE
Add proper callout box for Python dependencies section

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -11,10 +11,7 @@ http://docs.stackstorm.com/development/index.html
 Managing Python dependencies
 ----------------------------
 
-.. note::
-
-    ``requirements.txt`` files are generated automatically using
-    ``scripts/fixate-requirements.py`` script and should't be edited manually.
+    ``requirements.txt`` files are generated automatically using ``scripts/fixate-requirements.py`` script and should't be edited manually.
 
 To manage Python dependencies for each StackStorm component, we use the
 following files:


### PR DESCRIPTION
Minor fix to CONTRIBUTING.rst so that a proper callout box is shown. The sphinx-style callout doesn't show up well when viewed in Github (which presumably is the primary use case for this).