### PR TITLE
Fix typo in CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -11,7 +11,7 @@ http://docs.stackstorm.com/development/index.html
 Managing Python dependencies
 ----------------------------
 
-    ``requirements.txt`` files are generated automatically using ``scripts/fixate-requirements.py`` script and should't be edited manually.
+    ``requirements.txt`` files are generated automatically using ``scripts/fixate-requirements.py`` script and shouldn't be edited manually.
 
 To manage Python dependencies for each StackStorm component, we use the
 following files:


### PR DESCRIPTION
@LindsayHill's eagle eyes spotted a typo that I overlooked in my previous patch:
https://github.com/StackStorm/st2/pull/2984

This fixes that.

Signed-off-by: Matt Oswalt <oswaldm@brocade.com>