### PR TITLE
Various pack schema changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,15 @@ In development
   that "email" attribute (if specified) contains a valid email address. (improvement)
 * For consistency with new pack name validation changes, sample ``hello-st2`` pack has been renamed
   to ``hello_st2``.
+* Add new ``stackstorm_version`` and ``system`` fields to the pack.yaml metadata file. Value of the
+  first field can contain a specific for StackStorm version with which the pack is designed to work
+  with (e.g. ``>=1.6.0,<2.2.0`` or ``>2.0.0``). This field is checked when installing / registering
+  a pack and installation is aborted if pack doesn't support StackStorm version which is currently
+  running. Second field can contain an object with optional system / OS level dependencies.
+  (new feature)
+* Require pack metadata ``version`` attribute to contain a valid semver version identifier (e.g
+  ``0.1.0``, ``2.0.0``, etc.). If version identifier is invalid, pack registration will fail.
+  (improvement)
 
 2.0.1 - September 30, 2016
 --------------------------

--- a/st2api/tests/unit/controllers/v1/test_pack_config_schema.py
+++ b/st2api/tests/unit/controllers/v1/test_pack_config_schema.py
@@ -13,29 +13,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import glob
 
 from tests import FunctionalTest
 
-from st2tests.fixturesloader import get_fixtures_base_path
+from st2tests.fixturesloader import get_fixtures_packs_base_path
 
 __all__ = [
     'PackConfigSchemasControllerTestCase'
 ]
+
+PACKS_PATH = get_fixtures_packs_base_path()
+CONFIG_SCHEMA_COUNT = len(glob.glob('%s/*/config.schema.yaml' % (PACKS_PATH)))
+assert CONFIG_SCHEMA_COUNT > 1
 
 
 class PackConfigSchemasControllerTestCase(FunctionalTest):
     register_packs = True
 
     def test_get_all(self):
-        packs_path = os.path.join(get_fixtures_base_path(), 'packs/')
-        config_schema_count = len(glob.glob('%s/*/config.schema.yaml' % (packs_path)))
-        assert config_schema_count > 1
-
         resp = self.app.get('/v1/config_schemas')
         self.assertEqual(resp.status_int, 200)
-        self.assertEqual(len(resp.json), config_schema_count,
+        self.assertEqual(len(resp.json), CONFIG_SCHEMA_COUNT,
                          '/v1/config_schemas did not return all schemas.')
 
     def test_get_one_success(self):

--- a/st2api/tests/unit/controllers/v1/test_packs.py
+++ b/st2api/tests/unit/controllers/v1/test_packs.py
@@ -24,7 +24,7 @@ from tests import FunctionalTest
 
 PACK_INDEX = {
     "test": {
-        "version": "0.4",
+        "version": "0.4.0",
         "name": "test",
         "repo_url": "https://github.com/StackStorm-Exchange/stackstorm-test",
         "author": "st2-dev",
@@ -33,7 +33,7 @@ PACK_INDEX = {
         "description": "st2 pack to test package management pipeline"
     },
     "test2": {
-        "version": "0.5",
+        "version": "0.5.0",
         "name": "test2",
         "repo_url": "https://github.com/StackStorm-Exchange/stackstorm-test2",
         "author": "stanley",

--- a/st2common/st2common/constants/pack.py
+++ b/st2common/st2common/constants/pack.py
@@ -36,7 +36,7 @@ PACK_REF_WHITELIST_REGEX = r'^[a-z0-9_-]+$'
 PACK_VERSION_REGEX = r'^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[\da-z\-]+(?:\.[\da-z\-]+)*)?(?:\+[\da-z\-]+(?:\.[\da-z\-]+)*)?$'  # noqa
 
 # Check for st2 version in engines
-ST2_VERSION_REGEX = r'^((>?>|>=|=|<=|<?<)\s*[0-9]+\.[0-9]+(\.[0-9]+)?(\.?dev)?(\s*,)?\s*)+$'
+ST2_VERSION_REGEX = r'^((>?>|>=|=|<=|<?<)\s*[0-9]+\.[0-9]+\.[0-9]+?(\s*,)?\s*)+$'
 
 # Name used for system pack
 SYSTEM_PACK_NAME = 'core'

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -152,6 +152,23 @@ class PackAPI(BaseAPI):
 
         super(PackAPI, self).__init__(**values)
 
+    def validate(self):
+        # We wrap default validate() implementation and throw a more user-friendly exception in
+        # case pack version doesn't follow a valid semver format
+        try:
+            super(PackAPI, self).validate()
+        except jsonschema.ValidationError as e:
+            msg = str(e)
+
+            if "Failed validating 'pattern' in schema['properties']['version']" in msg:
+                new_msg = ('Pack version "%s" doesn\'t follow a valid semver format. Valid '
+                           'versions and formats include: 0.1.0, 0.2.1, 1.1.0, etc.' %
+                           (self.version))
+                new_msg += '\n' + msg
+                raise jsonschema.ValidationError(new_msg)
+
+            raise e
+
     @classmethod
     def to_model(cls, pack):
         ref = pack.ref

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -164,7 +164,7 @@ class PackAPI(BaseAPI):
                 new_msg = ('Pack version "%s" doesn\'t follow a valid semver format. Valid '
                            'versions and formats include: 0.1.0, 0.2.1, 1.1.0, etc.' %
                            (self.version))
-                new_msg += '\n' + msg
+                new_msg += '\n\n' + msg
                 raise jsonschema.ValidationError(new_msg)
 
             raise e

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -92,6 +92,12 @@ class PackAPI(BaseAPI):
                 'pattern': PACK_VERSION_REGEX,
                 'required': True
             },
+            'stackstorm_version': {
+                'type': 'string',
+                'description': 'Required StackStorm version. Examples: ">1.6", '
+                               '">=1.8dev, <2.0"',
+                'pattern': ST2_VERSION_REGEX,
+            },
             'author': {
                 'type': 'string',
                 'description': 'Pack author or authors.',
@@ -120,14 +126,7 @@ class PackAPI(BaseAPI):
                 'type': 'object',
                 'description': 'Specification for the system components and packages '
                                'required for the pack.',
-                'properties': {
-                    'stackstorm': {
-                        'type': 'string',
-                        'description': 'Required StackStorm version. Examples: ">1.6", '
-                                       '">=1.8dev, <2.0"',
-                        'pattern': ST2_VERSION_REGEX,
-                    }
-                }
+                'default': {}
             }
         }
     }
@@ -156,6 +155,7 @@ class PackAPI(BaseAPI):
                                                               new_version))
             version = new_version
 
+        stackstorm_version = getattr(pack, 'stackstorm_version', None)
         author = pack.author
         email = pack.email
         files = getattr(pack, 'files', [])
@@ -164,7 +164,8 @@ class PackAPI(BaseAPI):
 
         model = cls.model(ref=ref, name=name, description=description, keywords=keywords,
                           version=version, author=author, email=email, files=files,
-                          dependencies=dependencies, system=system)
+                          dependencies=dependencies, system=system,
+                          stackstorm_version=stackstorm_version)
         return model
 
 

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -181,7 +181,7 @@ class PackAPI(BaseAPI):
         author = pack.author
         email = pack.email
         files = getattr(pack, 'files', [])
-        dependencies  = getattr(pack, 'dependencies', [])
+        dependencies = getattr(pack, 'dependencies', [])
         system = getattr(pack, 'system', {})
 
         model = cls.model(ref=ref, name=name, description=description, keywords=keywords,

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -134,30 +134,37 @@ class PackAPI(BaseAPI):
 
     @classmethod
     def to_model(cls, pack):
-        parameters = pack.__dict__
+        ref = pack.ref
+        name = pack.name
+        description = pack.description
+        keywords = getattr(pack, 'keywords', [])
+        version = str(pack.version)
 
         # Note: If some version values are not explicitly surrounded by quotes they are recognized
         # as numbers so we cast them to string
         if getattr(pack, 'version', None):
-            pack.version = str(pack['version'])
+            version = str(pack['version'])
 
         # Special case for old version which didn't follow semver format (e.g. 0.1, 1.0, etc.)
         # In case the version doesn't match that format, we simply append ".0" to the end (e.g.
         # 0.1 -> 0.1.0, 1.0, -> 1.0.0, etc.)
         dot_count = len(pack.version.split(''))
         if dot_count == 1:
-            new_version = pack.version + '.0'
+            new_version = version + '.0'
             LOG.info('Pack "%s" contains invalid semver version specifer, casting it to a full '
-                     'semver version specifier (%s -> %s)' % (pack.name, pack.version,
+                     'semver version specifier (%s -> %s)' % (name, version,
                                                               new_version))
-            pack.version = new_version
+            version = new_version
 
-        parameters['keywords'] = parameters.get('keywords', [])
-        parameters['files'] = parameters.get('files', [])
-        parameters['dependencies'] = parameters.get('dependencies', [])
-        parameters['system'] = parameters.get('system', {})
+        author = pack.author
+        email = pack.email
+        files = getattr(pack, 'files', [])
+        dependencies  = getattr(pack, 'dependencies', [])
+        system = getattr(pack, 'system', {})
 
-        model = cls.model(**parameters)
+        model = cls.model(ref=ref, name=name, description=description, keywords=keywords,
+                          version=version, author=author, email=email, files=files,
+                          dependencies=dependencies, system=system)
         return model
 
 
@@ -194,7 +201,7 @@ class ConfigSchemaAPI(BaseAPI):
         pack = config_schema.pack
         attributes = config_schema.attributes
 
-         = cls.model(pack=pack, attributes=attributes)
+        model = cls.model(pack=pack, attributes=attributes)
         return model
 
 

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -94,8 +94,8 @@ class PackAPI(BaseAPI):
             },
             'stackstorm_version': {
                 'type': 'string',
-                'description': 'Required StackStorm version. Examples: ">1.6", '
-                               '">=1.8dev, <2.0"',
+                'description': 'Required StackStorm version. Examples: ">1.6.0", '
+                               '">=1.8.0, <2.2.0"',
                 'pattern': ST2_VERSION_REGEX,
             },
             'author': {

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -142,13 +142,13 @@ class PackAPI(BaseAPI):
         # Note: If some version values are not explicitly surrounded by quotes they are recognized
         # as numbers so we cast them to string
         if getattr(pack, 'version', None):
-            version = str(pack['version'])
+            version = str(pack.version)
 
         # Special case for old version which didn't follow semver format (e.g. 0.1, 1.0, etc.)
         # In case the version doesn't match that format, we simply append ".0" to the end (e.g.
         # 0.1 -> 0.1.0, 1.0, -> 1.0.0, etc.)
-        dot_count = len(pack.version.split(''))
-        if dot_count == 1:
+        version_seperator_count = len(pack.version.split('.'))
+        if version_seperator_count == 1:
             new_version = version + '.0'
             LOG.info('Pack "%s" contains invalid semver version specifer, casting it to a full '
                      'semver version specifier (%s -> %s)' % (name, version,

--- a/st2common/st2common/models/db/pack.py
+++ b/st2common/st2common/models/db/pack.py
@@ -19,6 +19,7 @@ from st2common.models.db import MongoDBAccess
 from st2common.models.db import stormbase
 from st2common.constants.types import ResourceType
 from st2common.constants.pack import PACK_VERSION_REGEX
+from st2common.constants.pack import ST2_VERSION_REGEX
 
 __all__ = [
     'PackDB',
@@ -41,7 +42,7 @@ class PackDB(stormbase.StormFoundationDB, stormbase.UIDFieldMixin,
     description = me.StringField(required=True)
     keywords = me.ListField(field=me.StringField())
     version = me.StringField(regex=PACK_VERSION_REGEX, required=True)
-    stackstorm_version = me.StringField()
+    stackstorm_version = me.StringField(regex=ST2_VERSION_REGEX)
     author = me.StringField(required=True)
     email = me.EmailField()
     files = me.ListField(field=me.StringField())

--- a/st2common/st2common/models/db/pack.py
+++ b/st2common/st2common/models/db/pack.py
@@ -41,6 +41,7 @@ class PackDB(stormbase.StormFoundationDB, stormbase.UIDFieldMixin,
     description = me.StringField(required=True)
     keywords = me.ListField(field=me.StringField())
     version = me.StringField(regex=PACK_VERSION_REGEX, required=True)
+    stackstorm_version = me.StringField()
     author = me.StringField(required=True)
     email = me.EmailField()
     files = me.ListField(field=me.StringField())

--- a/st2common/st2common/util/versioning.py
+++ b/st2common/st2common/util/versioning.py
@@ -1,0 +1,47 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Module containing various versioning utils.
+"""
+
+import semver
+
+__all__ = [
+    'complex_semver_match'
+]
+
+
+def complex_semver_match(version, version_specifier):
+    """
+    Custom semver match function which also supports complex semver specifiers
+    such as >=1.6, <2.0, etc.
+
+    :rtype: ``bool``
+    """
+    split_version_specifier = version_specifier.split(',')
+
+    if len(split_version_specifier) == 1:
+        # No comma, we can do a simple comparision
+        return semver.match(version, version_specifier)
+    else:
+        # Compare part by part
+        for version_specifier_part in split_version_specifier:
+            version_specifier_part = version_specifier_part.strip()
+
+            if not semver.match(version, version_specifier_part):
+                return False
+
+        return True

--- a/st2common/st2common/util/versioning.py
+++ b/st2common/st2common/util/versioning.py
@@ -19,9 +19,24 @@ Module containing various versioning utils.
 
 import semver
 
+from st2common import __version__ as stackstorm_version
+
 __all__ = [
+    'get_stackstorm_version',
+
     'complex_semver_match'
 ]
+
+def get_stackstorm_version():
+    """
+    Return a valid semver version string for the currently running StackStorm version.
+    """
+    # Special handling for dev versions which are not valid semver identifiers
+    if 'dev' in stackstorm_version and stackstorm_version.count('.') == 1:
+        version = stackstorm_version.replace('dev', '.0')
+        return version
+
+    return stackstorm_version
 
 
 def complex_semver_match(version, version_specifier):

--- a/st2common/st2common/util/versioning.py
+++ b/st2common/st2common/util/versioning.py
@@ -27,6 +27,7 @@ __all__ = [
     'complex_semver_match'
 ]
 
+
 def get_stackstorm_version():
     """
     Return a valid semver version string for the currently running StackStorm version.

--- a/st2common/st2common/util/versioning.py
+++ b/st2common/st2common/util/versioning.py
@@ -41,6 +41,9 @@ def complex_semver_match(version, version_specifier):
         for version_specifier_part in split_version_specifier:
             version_specifier_part = version_specifier_part.strip()
 
+            if not version_specifier_part:
+                continue
+
             if not semver.match(version, version_specifier_part):
                 return False
 

--- a/st2common/tests/integration/test_register_content_script.py
+++ b/st2common/tests/integration/test_register_content_script.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import os
+import glob
 
 from st2tests.base import IntegrationTestCase
 from st2common.util.shell import run_command
@@ -27,6 +28,9 @@ SCRIPT_PATH = os.path.abspath(SCRIPT_PATH)
 
 BASE_CMD_ARGS = [SCRIPT_PATH, '--config-file=conf/st2.tests.conf', '-v']
 BASE_REGISTER_ACTIONS_CMD_ARGS = BASE_CMD_ARGS + ['--register-actions']
+
+PACKS_PATH = get_fixtures_packs_base_path()
+PACKS_COUNT = len(glob.glob('%s/*/pack.yaml' % (PACKS_PATH))) - 1
 
 
 class ContentRegisterScriptTestCase(IntegrationTestCase):
@@ -126,7 +130,7 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
         exit_code, stdout, stderr = run_command(cmd=cmd)
         self.assertTrue('Registering actions' in stderr)
         self.assertTrue('Registering rules' in stderr)
-        self.assertTrue('Setup virtualenv for 10 pack(s)' in stderr)
+        self.assertTrue('Setup virtualenv for %s pack(s)' % (PACKS_COUNT) in stderr)
         self.assertEqual(exit_code, 0)
 
     def test_register_setup_virtualenvs(self):
@@ -144,5 +148,5 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
         # All packs
         cmd = BASE_CMD_ARGS + ['--register-setup-virtualenvs', '--register-no-fail-on-failure']
         exit_code, stdout, stderr = run_command(cmd=cmd)
-        self.assertTrue('Setup virtualenv for 10 pack(s)' in stderr)
+        self.assertTrue('Setup virtualenv for %s pack(s)' % (PACKS_COUNT)  in stderr)
         self.assertEqual(exit_code, 0)

--- a/st2common/tests/integration/test_register_content_script.py
+++ b/st2common/tests/integration/test_register_content_script.py
@@ -148,5 +148,5 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
         # All packs
         cmd = BASE_CMD_ARGS + ['--register-setup-virtualenvs', '--register-no-fail-on-failure']
         exit_code, stdout, stderr = run_command(cmd=cmd)
-        self.assertTrue('Setup virtualenv for %s pack(s)' % (PACKS_COUNT)  in stderr)
+        self.assertTrue('Setup virtualenv for %s pack(s)' % (PACKS_COUNT) in stderr)
         self.assertEqual(exit_code, 0)

--- a/st2common/tests/unit/test_resource_registrar.py
+++ b/st2common/tests/unit/test_resource_registrar.py
@@ -109,6 +109,45 @@ class ResourceRegistrarTestCase(CleanDbTestCase):
         self.assertRaisesRegexp(ValidationError, expected_msg, registrar._register_pack_db,
                                 pack_name=None, pack_dir=PACK_PATH_12)
 
+    @mock.patch('st2common.bootstrap.base.get_stackstorm_version')
+    def test_register_pack_stackstorm_version_identifier_check(self, mock_get_stackstorm_version):
+        # Version is satisfied
+        mock_get_stackstorm_version.return_value = '2.0.0'
+
+        registrar = ResourceRegistrar(use_pack_cache=False)
+        registrar._pack_loader.get_packs = mock.Mock()
+        registrar._pack_loader.get_packs.return_value = {'dummy_pack_9': PACK_PATH_9}
+        packs_base_paths = content_utils.get_packs_base_paths()
+        registrar.register_packs(base_dirs=packs_base_paths)
+
+        pack_db = Pack.get_by_name('dummy_pack_9_deps')
+        self.assertEqual(pack_db.stackstorm_version, '>=1.6.0, <2.2.0')
+
+        # Pack requires a version which is not satisfied by current StackStorm version
+        mock_get_stackstorm_version.return_value = '2.2.0'
+        expected_msg = ('Pack "dummy_pack_9_deps" requires StackStorm ">=1.6.0, <2.2.0", but '
+                        'current version is "2.2.0"')
+        self.assertRaisesRegexp(ValueError, expected_msg, registrar._register_pack_db,
+                                pack_name=None, pack_dir=PACK_PATH_9)
+
+        mock_get_stackstorm_version.return_value = '2.3.0'
+        expected_msg = ('Pack "dummy_pack_9_deps" requires StackStorm ">=1.6.0, <2.2.0", but '
+                        'current version is "2.3.0"')
+        self.assertRaisesRegexp(ValueError, expected_msg, registrar._register_pack_db,
+                                pack_name=None, pack_dir=PACK_PATH_9)
+
+        mock_get_stackstorm_version.return_value = '1.5.9'
+        expected_msg = ('Pack "dummy_pack_9_deps" requires StackStorm ">=1.6.0, <2.2.0", but '
+                        'current version is "1.5.9"')
+        self.assertRaisesRegexp(ValueError, expected_msg, registrar._register_pack_db,
+                                pack_name=None, pack_dir=PACK_PATH_9)
+
+        mock_get_stackstorm_version.return_value = '1.5.0'
+        expected_msg = ('Pack "dummy_pack_9_deps" requires StackStorm ">=1.6.0, <2.2.0", but '
+                        'current version is "1.5.0"')
+        self.assertRaisesRegexp(ValueError, expected_msg, registrar._register_pack_db,
+                                pack_name=None, pack_dir=PACK_PATH_9)
+
     def test_register_pack_pack_stackstorm_version_and_future_parameters(self):
         # Verify DB is empty
         pack_dbs = Pack.get_all()

--- a/st2common/tests/unit/test_resource_registrar.py
+++ b/st2common/tests/unit/test_resource_registrar.py
@@ -99,7 +99,7 @@ class ResourceRegistrarTestCase(CleanDbTestCase):
         self.assertRaisesRegexp(ValueError, expected_msg, registrar._register_pack_db,
                                 pack_name=None, pack_dir=PACK_PATH_8)
 
-    def test_register_pack_future(self):
+    def test_register_pack_pack_stackstorm_version_and_future_parameters(self):
         # Verify DB is empty
         pack_dbs = Pack.get_all()
 
@@ -111,13 +111,18 @@ class ResourceRegistrarTestCase(CleanDbTestCase):
         packs_base_paths = content_utils.get_packs_base_paths()
         registrar.register_packs(base_dirs=packs_base_paths)
 
-        # Dependencies / engines / future values are ok.
+        # Dependencies, stackstorm_version and future values
         pack_db = Pack.get_by_name('dummy_pack_9_deps')
         self.assertEqual(pack_db.dependencies, ['core=0.2.0'])
-        self.assertEqual(pack_db.system, {'stackstorm': '>=1.6dev, <2.2'})
-        self.assertEqual(pack_db.future, 'arguments')
+        self.assertEqual(pack_db.stackstorm_version, '>=1.6dev, <2.2')
+        self.assertEqual(pack_db.system, {'centos': {'foo': '>= 1.0'}})
+
+        # Note: We only store paramters which are defined in the schema, all other custom user 
+        # defined attributes are ignored
+        self.assertTrue(not hasattr(pack_db, 'future'))
+        self.assertTrue(not hasattr(pack_db, 'this'))
 
         # Wrong characters in the required st2 version
-        expected_msg = "'wrongversion' does not match"
+        expected_msg = "'wrongstackstormversion' does not match"
         self.assertRaisesRegexp(ValidationError, expected_msg, registrar._register_pack_db,
                                 pack_name=None, pack_dir=PACK_PATH_10)

--- a/st2common/tests/unit/test_resource_registrar.py
+++ b/st2common/tests/unit/test_resource_registrar.py
@@ -38,6 +38,7 @@ PACK_PATH_8 = os.path.join(fixturesloader.get_fixtures_packs_base_path(), 'dummy
 PACK_PATH_9 = os.path.join(fixturesloader.get_fixtures_packs_base_path(), 'dummy_pack_9')
 PACK_PATH_10 = os.path.join(fixturesloader.get_fixtures_packs_base_path(), 'dummy_pack_10')
 PACK_PATH_11 = os.path.join(fixturesloader.get_fixtures_packs_base_path(), 'dummy_pack_11')
+PACK_PATH_12 = os.path.join(fixturesloader.get_fixtures_packs_base_path(), 'dummy_pack_12')
 
 
 class ResourceRegistrarTestCase(CleanDbTestCase):
@@ -99,6 +100,15 @@ class ResourceRegistrarTestCase(CleanDbTestCase):
         expected_msg = 'contains invalid characters'
         self.assertRaisesRegexp(ValueError, expected_msg, registrar._register_pack_db,
                                 pack_name=None, pack_dir=PACK_PATH_8)
+
+    def test_register_pack_invalid_semver_version_friendly_error_message(self):
+        registrar = ResourceRegistrar(use_pack_cache=False)
+
+        packs_base_paths = content_utils.get_packs_base_paths()
+        expected_msg = ('Pack version "0.1.2.3.4" doesn\'t follow a valid semver format. Valid '
+                        'versions and formats include: 0.1.0, 0.2.1, 1.1.0, etc.')
+        self.assertRaisesRegexp(ValidationError, expected_msg, registrar._register_pack_db,
+                                pack_name=None, pack_dir=PACK_PATH_12)
 
     def test_register_pack_pack_stackstorm_version_and_future_parameters(self):
         # Verify DB is empty

--- a/st2common/tests/unit/test_resource_registrar.py
+++ b/st2common/tests/unit/test_resource_registrar.py
@@ -104,7 +104,6 @@ class ResourceRegistrarTestCase(CleanDbTestCase):
     def test_register_pack_invalid_semver_version_friendly_error_message(self):
         registrar = ResourceRegistrar(use_pack_cache=False)
 
-        packs_base_paths = content_utils.get_packs_base_paths()
         expected_msg = ('Pack version "0.1.2.3.4" doesn\'t follow a valid semver format. Valid '
                         'versions and formats include: 0.1.0, 0.2.1, 1.1.0, etc.')
         self.assertRaisesRegexp(ValidationError, expected_msg, registrar._register_pack_db,
@@ -127,7 +126,7 @@ class ResourceRegistrarTestCase(CleanDbTestCase):
         self.assertEqual(pack_db.stackstorm_version, '>=1.6dev, <2.2')
         self.assertEqual(pack_db.system, {'centos': {'foo': '>= 1.0'}})
 
-        # Note: We only store paramters which are defined in the schema, all other custom user 
+        # Note: We only store paramters which are defined in the schema, all other custom user
         # defined attributes are ignored
         self.assertTrue(not hasattr(pack_db, 'future'))
         self.assertTrue(not hasattr(pack_db, 'this'))

--- a/st2common/tests/unit/test_resource_registrar.py
+++ b/st2common/tests/unit/test_resource_registrar.py
@@ -123,7 +123,7 @@ class ResourceRegistrarTestCase(CleanDbTestCase):
         # Dependencies, stackstorm_version and future values
         pack_db = Pack.get_by_name('dummy_pack_9_deps')
         self.assertEqual(pack_db.dependencies, ['core=0.2.0'])
-        self.assertEqual(pack_db.stackstorm_version, '>=1.6dev, <2.2')
+        self.assertEqual(pack_db.stackstorm_version, '>=1.6.0, <2.2.0')
         self.assertEqual(pack_db.system, {'centos': {'foo': '>= 1.0'}})
 
         # Note: We only store paramters which are defined in the schema, all other custom user

--- a/st2common/tests/unit/test_versioning_utils.py
+++ b/st2common/tests/unit/test_versioning_utils.py
@@ -1,0 +1,43 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest2
+
+from st2common.util.versioning import complex_semver_match
+
+
+class VersioningUtilsTestCase(unittest2.TestCase):
+    def test_complex_semver_match(self):
+        # Positive test case
+        self.assertTrue(complex_semver_match('1.6.0', '>=1.6.0, <2.2.0'))
+        self.assertTrue(complex_semver_match('1.6.1', '>=1.6.0, <2.2.0'))
+        self.assertTrue(complex_semver_match('2.0.0', '>=1.6.0, <2.2.0'))
+        self.assertTrue(complex_semver_match('2.1.0', '>=1.6.0, <2.2.0'))
+        self.assertTrue(complex_semver_match('2.1.9', '>=1.6.0, <2.2.0'))
+
+        self.assertTrue(complex_semver_match('1.6.0', '>=1.6.0'))
+        self.assertTrue(complex_semver_match('1.6.1', '>=1.6.0'))
+        self.assertTrue(complex_semver_match('2.1.0', '>=1.6.0'))
+
+        # Negative test case
+        self.assertFalse(complex_semver_match('1.5.0', '>=1.6.0, <2.2.0'))
+        self.assertFalse(complex_semver_match('0.1.0', '>=1.6.0, <2.2.0'))
+        self.assertFalse(complex_semver_match('2.2.1', '>=1.6.0, <2.2.0'))
+        self.assertFalse(complex_semver_match('2.3.0', '>=1.6.0, <2.2.0'))
+        self.assertFalse(complex_semver_match('3.0.0', '>=1.6.0, <2.2.0'))
+
+        self.assertFalse(complex_semver_match('1.5.0', '>=1.6.0'))
+        self.assertFalse(complex_semver_match('0.1.0', '>=1.6.0'))
+        self.assertFalse(complex_semver_match('1.5.9', '>=1.6.0'))

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_10/pack.yaml
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_10/pack.yaml
@@ -2,9 +2,8 @@
 name : dummy_pack_10_wrong_deps
 description : dummy pack with wrong dependencies
 version : 0.1.0
+stackstorm_version : wrongstackstormversion
 author : st2-dev
 email : info@stackstorm.com
 dependencies :
   - core=0.2.0
-system :
-  stackstorm : wrongversion

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_11/pack.yaml
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_11/pack.yaml
@@ -1,0 +1,6 @@
+---
+name : dummy_pack_11
+description : dummy pack
+version : 0.2
+author : st2-dev
+email : info@stackstorm.com

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_12/pack.yaml
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_12/pack.yaml
@@ -1,0 +1,6 @@
+---
+name : dummy_pack_12
+description : dummy pack
+version : 0.1.2.3.4
+author : st2-dev
+email : info@stackstorm.com

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_9/pack.yaml
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_9/pack.yaml
@@ -2,12 +2,14 @@
 name : dummy_pack_9_deps
 description : dummy pack with pack and engine dependencies
 version : 0.1.0
+stackstorm_version : ">=1.6dev, <2.2"
 author : st2-dev
 email : info@stackstorm.com
 dependencies :
   - core=0.2.0
 system :
-  stackstorm : ">=1.6dev, <2.2"
+  centos :
+    foo: ">= 1.0"
 this :
   is : a
   test : of

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_9/pack.yaml
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_9/pack.yaml
@@ -2,7 +2,7 @@
 name : dummy_pack_9_deps
 description : dummy pack with pack and engine dependencies
 version : 0.1.0
-stackstorm_version : ">=1.6dev, <2.2"
+stackstorm_version : ">=1.6.0, <2.2.0"
 author : st2-dev
 email : info@stackstorm.com
 dependencies :


### PR DESCRIPTION
This pull request works on top of https://github.com/StackStorm/st2/pull/2988 and makes some changes @emedvedev and I discussed.

- [x] Support for old style version specifiers which don't match semver format (e.g. 1.0). We did update all the affects packs in st2contrib, but this was done to make migration of other non-st2contrib packs easier. If such version is encountered, we simply append ".0" to the end to make it a valid semver specifier (e.g. 1.0 -> 1.0.0, 0.2 -> 0.2.0, etc.)
- [x] Throw more user-friendly exception if pack version defined in schema doesn't contain valid semver specifier
- [x] Make `stackstorm_version` attribute in pack.yaml top-level
- [x] Throw when registering a pack if the pack `stackstorm_version` property is not satisfied by currently running StackStorm version
- [x] Update changelog