### PR TITLE
Improve descriptions in pack CLI

### DIFF
--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -135,8 +135,8 @@ class PackListCommand(resource.ResourceListCommand):
 
 class PackGetCommand(resource.ResourceGetCommand):
     pk_argument_name = 'ref'
-    display_attributes = ['all']
-    # attribute_display_order = [] ResourceCommand
+    display_attributes = ['name', 'version', 'author', 'email', 'keywords', 'description']
+    attribute_display_order = ['name', 'version', 'author', 'email', 'keywords', 'description']
     help_string = 'Get information about an installed pack.'
 
 

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -23,7 +23,6 @@ from st2client.models import Pack
 from st2client.models import LiveAction
 from st2client.commands import resource
 from st2client.commands.action import ActionRunCommandMixin
-from st2client.commands.noop import NoopCommand
 from st2client.formatters import table
 from st2client.exceptions.operations import OperationFailureException
 import st2client.utils.terminal as term
@@ -142,9 +141,10 @@ class PackGetCommand(resource.ResourceGetCommand):
 
 class PackShowCommand(PackResourceCommand):
     def __init__(self, resource, *args, **kwargs):
-        super(PackShowCommand, self).__init__(resource, 'show',
-              'Get information about an available %s from the index.' % resource.get_display_name().lower(),
-              *args, **kwargs)
+        help_string = ('Get information about an available %s from the index.' %
+                       resource.get_display_name().lower())
+        super(PackShowCommand, self).__init__(resource, 'show', help_string,
+                                              *args, **kwargs)
 
         self.parser.add_argument('pack',
                                  help='Name of the %s to show.' %

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -137,7 +137,7 @@ class PackGetCommand(resource.ResourceGetCommand):
     pk_argument_name = 'ref'
     display_attributes = ['all']
     # attribute_display_order = [] ResourceCommand
-    help_string = 'Get information about an installed %s.' % resource.get_display_name().lower()
+    help_string = 'Get information about an installed pack.'
 
 
 class PackShowCommand(PackResourceCommand):

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -58,14 +58,14 @@ class PackBranch(resource.ResourceBranch):
             read_only=True,
             commands={
                 'list': PackListCommand,
-                'get': NoopCommand
+                'get': PackGetCommand
             })
 
-        self.commands['register'] = PackRegisterCommand(self.resource, self.app, self.subparsers)
+        self.commands['show'] = PackShowCommand(self.resource, self.app, self.subparsers)
+        self.commands['search'] = PackSearchCommand(self.resource, self.app, self.subparsers)
         self.commands['install'] = PackInstallCommand(self.resource, self.app, self.subparsers)
         self.commands['remove'] = PackRemoveCommand(self.resource, self.app, self.subparsers)
-        self.commands['search'] = PackSearchCommand(self.resource, self.app, self.subparsers)
-        self.commands['show'] = PackShowCommand(self.resource, self.app, self.subparsers)
+        self.commands['register'] = PackRegisterCommand(self.resource, self.app, self.subparsers)
         self.commands['config'] = PackConfigCommand(self.resource, self.app, self.subparsers)
 
 
@@ -133,10 +133,17 @@ class PackListCommand(resource.ResourceListCommand):
     attribute_display_order = ['name', 'description', 'version', 'author']
 
 
+class PackGetCommand(resource.ResourceGetCommand):
+    pk_argument_name = 'ref'
+    display_attributes = ['all']
+    # attribute_display_order = [] ResourceCommand
+    help_string = 'Get information about an installed %s.' % resource.get_display_name().lower()
+
+
 class PackShowCommand(PackResourceCommand):
     def __init__(self, resource, *args, **kwargs):
         super(PackShowCommand, self).__init__(resource, 'show',
-              'Get information about a %s from the index.' % resource.get_display_name().lower(),
+              'Get information about an available %s from the index.' % resource.get_display_name().lower(),
               *args, **kwargs)
 
         self.parser.add_argument('pack',
@@ -208,8 +215,10 @@ class PackSearchCommand(resource.ResourceTableCommand):
 
     def __init__(self, resource, *args, **kwargs):
         super(PackSearchCommand, self).__init__(resource, 'search',
-            'Search for a %s in the directory.' % resource.get_display_name().lower(),
-            *args, **kwargs)
+            'Search the index for a %s with any attribute matching the query.'
+            % resource.get_display_name().lower(),
+            *args, **kwargs
+        )
 
         self.parser.add_argument('query',
                                  help='Search query.')

--- a/st2client/st2client/commands/resource.py
+++ b/st2client/st2client/commands/resource.py
@@ -295,10 +295,11 @@ class ResourceGetCommand(ResourceCommand):
 
     pk_argument_name = 'name_or_id'  # name of the attribute which stores resource PK
 
+    help_string = 'Get individual %s.' % resource.get_display_name().lower()
+
     def __init__(self, resource, *args, **kwargs):
-        super(ResourceGetCommand, self).__init__(resource, 'get',
-            'Get individual %s.' % resource.get_display_name().lower(),
-            *args, **kwargs)
+        super(ResourceGetCommand, self).__init__(resource, 'get', self.help_string,
+                                                 *args, **kwargs)
 
         argument = self.pk_argument_name
         metavar = self._get_metavar_for_argument(argument=self.pk_argument_name)

--- a/st2client/st2client/commands/resource.py
+++ b/st2client/st2client/commands/resource.py
@@ -295,11 +295,14 @@ class ResourceGetCommand(ResourceCommand):
 
     pk_argument_name = 'name_or_id'  # name of the attribute which stores resource PK
 
-    help_string = 'Get individual %s.' % resource.get_display_name().lower()
+    help_string = None
 
     def __init__(self, resource, *args, **kwargs):
-        super(ResourceGetCommand, self).__init__(resource, 'get', self.help_string,
-                                                 *args, **kwargs)
+        super(ResourceGetCommand, self).__init__(
+            resource, 'get',
+            self.help_string or 'Get individual %s.' % resource.get_display_name().lower(),
+            *args, **kwargs
+        )
 
         argument = self.pk_argument_name
         metavar = self._get_metavar_for_argument(argument=self.pk_argument_name)


### PR DESCRIPTION
```
usage: st2 pack [-h] {list,get,show,search,install,remove,register,config} ...

A group of related integration resources: actions, rules, and sensors.

positional arguments:
  {list,get,show,search,install,remove,register,config}
                        List of commands for managing packs.
    list                Get the list of packs.
    get                 Get information about an installed pack.
    show                Get information about an available pack from the
                        index.
    search              Search the index for a pack with any attribute
                        matching the query.
    install             Install new packs.
    remove              Remove packs.
    register            Register a pack: sync all file changes with DB.
    config              Configure a pack based on config schema.

optional arguments:
  -h, --help            show this help message and exit
```

The changes we've been discussing with @humblearner, @Mierdin and @lakshmi-kannan: added `st2 pack get` and updated descriptions.

@Mierdin If you want to make the descriptions better or change something else in the packs command list, let's discuss the changes here, or you can just commit into this branch. 

I'll let you run point on this: I won't merge anything before you give an explicit approval, but once you do, we're assuming `st2 pack` command names and descriptions are final.