### PR TITLE
De-Clutter Help Output

### DIFF
--- a/st2client/st2client/commands/resource.py
+++ b/st2client/st2client/commands/resource.py
@@ -66,7 +66,7 @@ class ResourceBranch(commands.Branch):
 
         # Registers subcommands for managing the resource type.
         self.subparsers = self.parser.add_subparsers(
-            help=('List of commands for managing %s.' %
+            metavar=('List of commands for managing %s.' %
                   self.resource.get_plural_display_name().lower()))
 
         # Resolves if commands need to be overridden.

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -161,7 +161,6 @@ class Shell(BaseCLIApp):
         )
 
         # Set up list of commands and subcommands.
-        # Setting metavar to "" cuts down 
         self.subparsers = self.parser.add_subparsers(metavar="")
         self.commands = dict()
 

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -161,7 +161,8 @@ class Shell(BaseCLIApp):
         )
 
         # Set up list of commands and subcommands.
-        self.subparsers = self.parser.add_subparsers()
+        # Setting metavar to "" cuts down 
+        self.subparsers = self.parser.add_subparsers(metavar="")
         self.commands = dict()
 
         self.commands['action'] = action.ActionBranch(


### PR DESCRIPTION
I'm really just familiarizing myself with the way that the `st2client` package is put together - these changes may not be desired, but after re-familiarizing myself with the less-used features of `argparse` and with the `st2client` package, I figured I would at least post the results of my efforts.

I noticed that some of the help output contained a long, ugly line of subcommands within curly braces, right before redundantly outputting those same subcommands in a pretty tabular format:

```
vagrant@st2test:~$ st2 -h
usage: st2 [-h] [--version] [--url BASE_URL] [--auth-url AUTH_URL]
           [--api-url API_URL] [--api-version API_VERSION] [--cacert CACERT]
           [--config-file CONFIG_FILE] [--print-config] [--skip-config]
           [--debug]
           {action,action-alias,auth,apikey,execution,key,pack,policy,policy-type,rule,run,runner,sensor,trace,trigger,trigger-instance,webhook,timer,rule-enforcement}
           ...

CLI for StackStorm event-driven automation platform. https://stackstorm.com

positional arguments:
  {action,action-alias,auth,apikey,execution,key,pack,policy,policy-type,rule,run,runner,sensor,trace,trigger,trigger-instance,webhook,timer,rule-enforcement}
    action              An activity that happens as a response to the external
                        event.
    action-alias        Action aliases.

    (remainder of output omitted...)
```

This is a default behavior of the argparse library when using subcommands. The [argparse documentation](https://docs.python.org/2/library/argparse.html?highlight=add_subparsers#argparse.ArgumentParser.add_subparsers) states that this can be controlled through the "metavar" argument when running `add_subparsers()`.

So, this PR does just that - in the case of the global help output, the metavar argument for this function call in `shell.py` is set to an empty string, which removes this entirely.

There's also a call to this function in `commands/resource.py`, but in this case, the argument `help` has been removed, and what was being set there is now being passed as the `metavar` argument. This provides a more consistent output.

The result of these changes are shown below. First, to the global help output:

```
(st2client) C02RF1RYFVH8:st2client oswaldm$ st2 -h
usage: st2 [-h] [--version] [--url BASE_URL] [--auth-url AUTH_URL]
           [--api-url API_URL] [--api-version API_VERSION] [--cacert CACERT]
           [--config-file CONFIG_FILE] [--print-config] [--skip-config]
           [--debug]
           ...

CLI for StackStorm event-driven automation platform. https://stackstorm.com

positional arguments:

    action              An activity that happens as a response to the external
                        event.
    action-alias        Action aliases.

    (remainder of output omitted...)
```

In addition, any subcommand for resource management would also be affected, such as `st2 pack`:

```
(st2client) C02RF1RYFVH8:st2client oswaldm$ st2 pack -h
usage: st2 pack [-h] List of commands for managing packs. ...

A group of related integration resources: actions, rules, and sensors.

positional arguments:
  List of commands for managing packs.
    list                Get the list of packs.
    register            Register a pack: sync all file changes with DB.
    install             Install new packs.
    remove              Remove packs.
    search              Search for a pack in the directory.
    show                Get information about a pack from the index.
    config              Configure a pack based on config schema.

optional arguments:
  -h, --help            show this help message and exit
```