### PR TITLE
Validate pack compatibility with running StackStorm version during packs.install

### DIFF
--- a/contrib/packs/actions/download.yaml
+++ b/contrib/packs/actions/download.yaml
@@ -17,3 +17,8 @@
     verifyssl:
       type: "boolean"
       default: true
+    force:
+      type: "boolean"
+      description: "Set to True to force install the pack and skip StackStorm version compatibility check"
+      required: false
+      default: false

--- a/contrib/packs/actions/install.meta.yaml
+++ b/contrib/packs/actions/install.meta.yaml
@@ -21,3 +21,8 @@
       type: "object"
       description: "Optional environment variables"
       required: false
+    force:
+      type: "boolean"
+      description: "Set to True to force install the pack and skip StackStorm version compatibility check"
+      required: false
+      default: false

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -176,7 +176,6 @@ class DownloadGitRepoAction(Action):
     def _verify_pack_version(pack_dir):
         pack_metadata = DownloadGitRepoAction._get_pack_metadata(pack_dir=pack_dir)
         pack_name = pack_metadata.get('name', None)
-        pack_version = pack_metadata.get('version', None)
         required_stackstorm_version = pack_metadata.get('stackstorm_version', None)
 
         # If stackstorm_version attribute is speficied, verify that the pack works with currently

--- a/contrib/packs/actions/workflows/install.yaml
+++ b/contrib/packs/actions/workflows/install.yaml
@@ -5,6 +5,7 @@
       ref: "packs.download"
       parameters:
         packs: "{{packs}}"
+        force: "{{force}}"
       on-success: "make a prerun"
     -
       name: "make a prerun"

--- a/contrib/packs/tests/fixtures/stackstorm-test/pack.yaml
+++ b/contrib/packs/tests/fixtures/stackstorm-test/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - search
   - another
   - terms
-version : "0.4"
+version : "0.4.0"
 author : st2-dev
 email : info@stackstorm.com

--- a/contrib/packs/tests/fixtures/stackstorm-test2/pack.yaml
+++ b/contrib/packs/tests/fixtures/stackstorm-test2/pack.yaml
@@ -5,6 +5,6 @@ keywords:
   - some
   - special
   - terms
-version : "0.5"
+version : "0.5.0"
 author : stanley
 email : info@stackstorm.com

--- a/contrib/packs/tests/fixtures/stackstorm-test3/pack.yaml
+++ b/contrib/packs/tests/fixtures/stackstorm-test3/pack.yaml
@@ -1,0 +1,11 @@
+---
+name : test3
+description : another st2 pack to test package management pipeline
+keywords:
+  - some
+  - special
+  - terms
+version : "0.5.0"
+stackstorm_version: ">=1.6.0, <2.2.0"
+author : stanley
+email : info@stackstorm.com

--- a/contrib/packs/tests/test_action_download.py
+++ b/contrib/packs/tests/test_action_download.py
@@ -30,7 +30,7 @@ from pack_mgmt.download import DownloadGitRepoAction
 
 PACK_INDEX = {
     "test": {
-        "version": "0.4",
+        "version": "0.4.0",
         "name": "test",
         "repo_url": "https://github.com/StackStorm-Exchange/stackstorm-test",
         "author": "st2-dev",
@@ -39,7 +39,7 @@ PACK_INDEX = {
         "description": "st2 pack to test package management pipeline"
     },
     "test2": {
-        "version": "0.5",
+        "version": "0.5.0",
         "name": "test2",
         "repo_url": "https://github.com/StackStorm-Exchange/stackstorm-test2",
         "author": "stanley",

--- a/contrib/packs/tests/test_action_download.py
+++ b/contrib/packs/tests/test_action_download.py
@@ -26,6 +26,7 @@ from gitdb.exc import BadName
 from st2common.services import packs as pack_service
 from st2tests.base import BaseActionTestCase
 
+import pack_mgmt.download
 from pack_mgmt.download import DownloadGitRepoAction
 
 PACK_INDEX = {
@@ -42,6 +43,16 @@ PACK_INDEX = {
         "version": "0.5.0",
         "name": "test2",
         "repo_url": "https://github.com/StackStorm-Exchange/stackstorm-test2",
+        "author": "stanley",
+        "keywords": ["some", "special", "terms"],
+        "email": "info@stackstorm.com",
+        "description": "another st2 pack to test package management pipeline"
+    },
+    "test3": {
+        "version": "0.5.0",
+        "stackstorm_version": ">=1.6.0, <2.2.0",
+        "name": "test3",
+        "repo_url": "https://github.com/StackStorm-Exchange/stackstorm-test3",
         "author": "stanley",
         "keywords": ["some", "special", "terms"],
         "email": "info@stackstorm.com",
@@ -151,3 +162,36 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
         result = action.run(packs=['test=1.2.3'], abs_repo_base=self.repo_base)
 
         self.assertEqual(result, {'test': 'Success.'})
+
+    def test_download_pack_stackstorm_version_identifier_check(self):
+        action = self.get_action_instance()
+
+        # Version is satisfied
+        pack_mgmt.download.CURRENT_STACKSTROM_VERSION = '2.0.0'
+
+        result = action.run(packs=['test3'], abs_repo_base=self.repo_base)
+
+        # Pack requires a version which is not satisfied by current StackStorm version
+        pack_mgmt.download.CURRENT_STACKSTROM_VERSION = '2.2.0'
+        expected_msg = ('Pack "test3" requires StackStorm ">=1.6.0, <2.2.0", but '
+                        'current version is "2.2.0"')
+        self.assertRaisesRegexp(ValueError, expected_msg, action.run, packs=['test3'],
+                                abs_repo_base=self.repo_base)
+
+        pack_mgmt.download.CURRENT_STACKSTROM_VERSION = '2.3.0'
+        expected_msg = ('Pack "test3" requires StackStorm ">=1.6.0, <2.2.0", but '
+                        'current version is "2.3.0"')
+        self.assertRaisesRegexp(ValueError, expected_msg, action.run, packs=['test3'],
+                                abs_repo_base=self.repo_base)
+
+        pack_mgmt.download.CURRENT_STACKSTROM_VERSION = '1.5.9'
+        expected_msg = ('Pack "test3" requires StackStorm ">=1.6.0, <2.2.0", but '
+                        'current version is "1.5.9"')
+        self.assertRaisesRegexp(ValueError, expected_msg, action.run, packs=['test3'],
+                                abs_repo_base=self.repo_base)
+
+        pack_mgmt.download.CURRENT_STACKSTROM_VERSION = '1.5.0'
+        expected_msg = ('Pack "test3" requires StackStorm ">=1.6.0, <2.2.0", but '
+                        'current version is "1.5.0"')
+        self.assertRaisesRegexp(ValueError, expected_msg, action.run, packs=['test3'],
+                                abs_repo_base=self.repo_base)

--- a/contrib/packs/tests/test_action_download.py
+++ b/contrib/packs/tests/test_action_download.py
@@ -170,6 +170,7 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
         pack_mgmt.download.CURRENT_STACKSTROM_VERSION = '2.0.0'
 
         result = action.run(packs=['test3'], abs_repo_base=self.repo_base)
+        self.assertEqual(result['test3'], 'Success.')
 
         # Pack requires a version which is not satisfied by current StackStorm version
         pack_mgmt.download.CURRENT_STACKSTROM_VERSION = '2.2.0'
@@ -195,3 +196,8 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
                         'current version is "1.5.0"')
         self.assertRaisesRegexp(ValueError, expected_msg, action.run, packs=['test3'],
                                 abs_repo_base=self.repo_base)
+
+        # Version is not met, but force=true parameter is provided
+        pack_mgmt.download.CURRENT_STACKSTROM_VERSION = '1.5.0'
+        result = action.run(packs=['test3'], abs_repo_base=self.repo_base, force=True)
+        self.assertEqual(result['test3'], 'Success.')

--- a/st2common/st2common/bootstrap/base.py
+++ b/st2common/st2common/bootstrap/base.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import os
-import re
 import glob
 
 import six
@@ -30,7 +29,7 @@ from st2common.models.api.pack import ConfigSchemaAPI
 from st2common.persistence.pack import Pack
 from st2common.persistence.pack import ConfigSchema
 from st2common.util.file_system import get_file_list
-from st2common.constants.pack import PACK_REF_WHITELIST_REGEX
+from st2common.util.pack import get_pack_ref_from_metadata
 from st2common.exceptions.db import StackStormDBObjectNotFoundError
 
 __all__ = [
@@ -158,20 +157,8 @@ class ResourceRegistrar(object):
         # 2hich are in sub-directories)
         # 2. If attribute is not available, but pack name is and pack name meets the valid name
         # criteria, we use that
-        if content.get('ref', None):
-            content['ref'] = content['ref']
-        elif re.match(PACK_REF_WHITELIST_REGEX, pack_name):
-            content['ref'] = pack_name
-        else:
-            if re.match(PACK_REF_WHITELIST_REGEX, content['name']):
-                content['ref'] = content['name']
-            else:
-                raise ValueError('Pack name "%s" contains invalid characters and "ref" '
-                                 'attribute is not available' % (content['name']))
-
-        # Note: We use a ref if available, if not we fall back to pack name
-        # (pack directory name)
-        content['ref'] = content.get('ref', pack_name)
+        content['ref'] = get_pack_ref_from_metadata(metadata=content,
+                                                    pack_directory_name=pack_name)
 
         # Include a list of pack files
         pack_file_list = get_file_list(directory=pack_dir, exclude_patterns=EXCLUDE_FILE_PATTERNS)

--- a/st2common/st2common/util/pack.py
+++ b/st2common/st2common/util/pack.py
@@ -1,0 +1,52 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+
+from st2common.constants.pack import PACK_REF_WHITELIST_REGEX
+
+__all__ = [
+    'get_pack_ref_from_metadata'
+]
+
+
+def get_pack_ref_from_metadata(metadata, pack_directory_name=None):
+    """
+    Utility function which retrieves pack "ref" attribute from the pack metadata file.
+
+    If this attribute is not provided, an attempt is made to infer "ref" from the "name" attribute.
+
+    :rtype: ``str``
+    """
+    pack_ref = None
+
+    # The rules for the pack ref are as follows:
+    # 1. If ref attribute is available, we used that
+    # 2. If pack_directory_name is available we use that (this only applies to packs
+    # which are in sub-directories)
+    # 2. If attribute is not available, but pack name is and pack name meets the valid name
+    # criteria, we use that
+    if metadata.get('ref', None):
+        pack_ref = metadata['ref']
+    elif pack_directory_name and re.match(PACK_REF_WHITELIST_REGEX, pack_directory_name):
+        pack_ref = pack_directory_name
+    else:
+        if re.match(PACK_REF_WHITELIST_REGEX, metadata['name']):
+            pack_ref = metadata['name']
+        else:
+            raise ValueError('Pack name "%s" contains invalid characters and "ref" '
+                             'attribute is not available' % (metadata['name']))
+
+    return pack_ref


### PR DESCRIPTION
@emedvedev and I discussed this on Slack.

I still think all the checks should (also) happen during the pack register phase because that's the phase all the packs go through (not just the ones installed using `packs.install`, but also ones which follow opinionated git flow and skip `packs.install` all together), but that's a temporary middle group solution for now.

It's also worth nothing that even though checks should happen during register phase it's nothing wrong with also having the same check during the packs install phase - it allows us to fail faster and provide better user experience. We just need to make sure we are not duplicating code all over the place which is kinda true for `packs.install` right now which still needs refactor and robustness love.

Example output:

```bash
id: 581c74db0640fd23f797e2bb
action.ref: packs.install
parameters: 
  packs:
  - jira
status: failed
error: Traceback (most recent call last):
  File "/data/stanley/st2common/st2common/runners/python_action_wrapper.py", line 211, in <module>
    obj.run()
  File "/data/stanley/st2common/st2common/runners/python_action_wrapper.py", line 126, in run
    output = action.run(**self._parameters)
  File "/opt/stackstorm/packs/packs/actions/pack_mgmt/download.py", line 72, in run
    self._verify_pack_version(pack_dir=abs_local_path)
  File "/opt/stackstorm/packs/packs/actions/pack_mgmt/download.py", line 189, in _verify_pack_version
    raise ValueError(msg)
ValueError: Pack "jira" requires StackStorm ">=2.3.0", but current version is "2.1.0"

traceback: None
failed_on: download pack
start_timestamp: 2016-11-04T11:45:31.204757Z
end_timestamp: 2016-11-04T11:45:35.759924Z
+--------------------------+---------------------+---------------+----------------+-------------------------------+
| id                       | status              | task          | action         | start_timestamp               |
+--------------------------+---------------------+---------------+----------------+-------------------------------+
| 581c74db0640fd23f0c8f8b1 | failed (4s elapsed) | download pack | packs.download | Fri, 04 Nov 2016 11:45:31 UTC |
+--------------------------+---------------------+---------------+----------------+-------------------------------+
```

## TODO

- [x] Tests for version check