### PR TITLE
Update "delete_by_query" method to return a number of deleted objects

### DIFF
--- a/st2common/st2common/garbage_collection/executions.py
+++ b/st2common/st2common/garbage_collection/executions.py
@@ -70,12 +70,8 @@ def purge_executions(logger, timestamp, action_ref=None, purge_incomplete=False)
     if action_ref:
         liveaction_filters['action'] = action_ref
 
-    # TODO: Update this code to return statistics on deleted objects once we
-    # upgrade to newer version of MongoDB where delete_by_query actually returns
-    # some data
-
     try:
-        ActionExecution.delete_by_query(**exec_filters)
+        deleted_count = ActionExecution.delete_by_query(**exec_filters)
     except InvalidQueryError as e:
         msg = ('Bad query (%s) used to delete execution instances: %s'
                'Please contact support.' % (exec_filters, str(e)))
@@ -83,9 +79,11 @@ def purge_executions(logger, timestamp, action_ref=None, purge_incomplete=False)
     except:
         logger.exception('Deletion of execution models failed for query with filters: %s.',
                          exec_filters)
+    else:
+        logger.info('Deleted %s action execution objects' % (deleted_count))
 
     try:
-        LiveAction.delete_by_query(**liveaction_filters)
+        deleted_count = LiveAction.delete_by_query(**liveaction_filters)
     except InvalidQueryError as e:
         msg = ('Bad query (%s) used to delete liveaction instances: %s'
                'Please contact support.' % (liveaction_filters, str(e)))
@@ -93,6 +91,8 @@ def purge_executions(logger, timestamp, action_ref=None, purge_incomplete=False)
     except:
         logger.exception('Deletion of liveaction models failed for query with filters: %s.',
                          liveaction_filters)
+    else:
+        logger.info('Deleted %s liveaction objects' % (deleted_count))
 
     zombie_execution_instances = len(ActionExecution.query(**exec_filters))
     zombie_liveaction_instances = len(LiveAction.query(**liveaction_filters))

--- a/st2common/st2common/garbage_collection/trigger_instances.py
+++ b/st2common/st2common/garbage_collection/trigger_instances.py
@@ -40,18 +40,16 @@ def purge_trigger_instances(logger, timestamp):
 
     query_filters = {'occurrence_time__lt': isotime.parse(timestamp)}
 
-    # TODO: Update this code to return statistics on deleted objects once we
-    # upgrade to newer version of MongoDB where delete_by_query actually returns
-    # some data
-
     try:
-        TriggerInstance.delete_by_query(**query_filters)
+        deleted_count = TriggerInstance.delete_by_query(**query_filters)
     except InvalidQueryError as e:
         msg = ('Bad query (%s) used to delete trigger instances: %s'
                'Please contact support.' % (query_filters, str(e)))
         raise InvalidQueryError(msg)
     except:
         logger.exception('Deleting instances using query_filters %s failed.', query_filters)
+    else:
+        logger.info('Deleted %s trigger instance objects' % (deleted_count))
 
     # Print stats
     logger.info('All trigger instance models older than timestamp %s were deleted.', timestamp)

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -259,11 +259,14 @@ class MongoDBAccess(object):
         return instance.delete()
 
     def delete_by_query(self, **query):
+        """
+        Delete objects by query and return number of deleted objects.
+        """
         qs = self.model.objects.filter(**query)
-        qs.delete()
+        count = qs.delete()
         log_query_and_profile_data_for_queryset(queryset=qs)
-        # mongoengine does not return anything useful so cannot return anything meaningful.
-        return None
+
+        return count
 
     def _undo_dict_field_escape(self, instance):
         for attr, field in instance._fields.iteritems():


### PR DESCRIPTION
This wasn't possible in older versions of mongoengine (pymongo), but for a while now we have been using and depending on a newer version where this information is available.