### PR TITLE
Various pack management improvements

### DIFF
--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -104,7 +104,7 @@ class DownloadGitRepoAction(Action):
         if not gitref:
             valid_versions_string = DownloadGitRepoAction._get_valid_version_for_repo(repo=repo)
             valid_versions_string = ', '.join(valid_versions_string)
-            msg = ('"%s" is not a valid version, hash, tag, or branch in %s. Valid versions '
+            msg = ('"%s" is not a valid version, hash, tag, or branch in %s. Available versions '
                    'are: %s' % (ref, repo_url, valid_versions_string))
             raise ValueError(msg)
 

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -102,11 +102,17 @@ class DownloadGitRepoAction(Action):
 
         # Giving up ¯\_(ツ)_/¯
         if not gitref:
-            valid_versions_string = DownloadGitRepoAction._get_valid_version_for_repo(repo=repo)
-            valid_versions_string = ', '.join(valid_versions_string)
-            msg = ('"%s" is not a valid version, hash, tag, or branch in %s. Available versions '
-                   'are: %s' % (ref, repo_url, valid_versions_string))
-            raise ValueError(msg)
+            format_values = [ref, repo_url]
+            msg = '"%s" is not a valid version, hash, tag, or branch in %s.'
+
+            valid_versions = DownloadGitRepoAction._get_valid_version_for_repo(repo=repo)
+            if len(valid_versions) >= 1:
+                valid_versions_string = ', '.join(valid_versions)
+
+                msg += ' Available versions are: %s.'
+                format_values.append(valid_versions_string)
+
+            raise ValueError(msg % tuple(format_values))
 
         # We're trying to figure out which branch the ref is actually on,
         # since there's no direct way to check for this in git-python.

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -39,7 +39,6 @@ from st2common.util.versioning import get_stackstorm_version
 
 MANIFEST_FILE = 'pack.yaml'
 CONFIG_FILE = 'config.yaml'
-GITINFO_FILE = '.gitinfo'
 
 
 CURRENT_STACKSTROM_VERSION = get_stackstorm_version()

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -28,6 +28,7 @@ from lockfile import LockFile
 
 from st2common.runners.base_action import Action
 from st2common.content import utils
+from st2common.constants.pack import MANIFEST_FILE_NAME
 from st2common.constants.pack import PACK_RESERVED_CHARACTERS
 from st2common.constants.pack import PACK_VERSION_SEPARATOR
 from st2common.constants.pack import PACK_VERSION_REGEX
@@ -37,7 +38,6 @@ from st2common.util.green import shell
 from st2common.util.versioning import complex_semver_match
 from st2common.util.versioning import get_stackstorm_version
 
-MANIFEST_FILE = 'pack.yaml'
 CONFIG_FILE = 'config.yaml'
 
 
@@ -200,8 +200,9 @@ class DownloadGitRepoAction(Action):
                         (pack_name, character))
 
         # must contain a manifest file. Empty file is ok for now.
-        if not os.path.isfile(os.path.join(abs_pack_path, MANIFEST_FILE)):
-            return (False, 'Pack is missing a manifest file (%s).' % (MANIFEST_FILE))
+        if not os.path.isfile(os.path.join(abs_pack_path, MANIFEST_FILE_NAME)):
+            return (False, 'Pack is missing a manifest file (%s).' % (MANIFEST_FILE_NAME))
+
         return (True, '')
 
     @staticmethod
@@ -260,7 +261,7 @@ class DownloadGitRepoAction(Action):
 
     @staticmethod
     def _get_pack_metadata(pack_dir):
-        with open(os.path.join(pack_dir, MANIFEST_FILE), 'r') as fp:
+        with open(os.path.join(pack_dir, MANIFEST_FILE_NAME), 'r') as fp:
             content = fp.read()
 
         metadata = yaml.load(content)

--- a/st2common/st2common/constants/pack.py
+++ b/st2common/st2common/constants/pack.py
@@ -16,6 +16,8 @@
 __all__ = [
     'PACKS_PACK_NAME',
     'PACK_REF_WHITELIST_REGEX',
+    'PACK_RESERVED_CHARACTERS',
+    'PACK_VERSION_SEPARATOR',
     'PACK_VERSION_REGEX',
     'ST2_VERSION_REGEX',
     'SYSTEM_PACK_NAME',
@@ -34,6 +36,15 @@ PACK_REF_WHITELIST_REGEX = r'^[a-z0-9_-]+$'
 
 # Check for a valid semver string
 PACK_VERSION_REGEX = r'^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[\da-z\-]+(?:\.[\da-z\-]+)*)?(?:\+[\da-z\-]+(?:\.[\da-z\-]+)*)?$'  # noqa
+
+# Special characters which can't be used in pack names
+PACK_RESERVED_CHARACTERS = [
+    '.'
+]
+
+# Version sperator when version is supplied in pack name
+# Example: libcloud@1.0.1
+PACK_VERSION_SEPARATOR = '='
 
 # Check for st2 version in engines
 ST2_VERSION_REGEX = r'^((>?>|>=|=|<=|<?<)\s*[0-9]+\.[0-9]+\.[0-9]+?(\s*,)?\s*)+$'

--- a/st2common/st2common/services/packs.py
+++ b/st2common/st2common/services/packs.py
@@ -172,7 +172,6 @@ def search_pack_index(query, exclude=None, priority=None):
 
     matches = [[] for i in range(len(priority) + 1)]
     for pack in six.itervalues(index):
-
         for key, value in six.iteritems(pack):
             if not hasattr(value, '__contains__'):
                 value = str(value)


### PR DESCRIPTION
1. Move common code from pack actions to st2common so it can be re-used elsewhere
2. Of user specifies an invalid version (ref) when installing a pack, print available versions.

## Examples

```bash
(virtualenv)vagrant@vagrant-ubuntu-trusty-64:/data/stanley$ python ./st2client/st2client/shell.py pack  install "vsphere=1.1.2"

	[  failed   ] download pack

id: 582072430640fd7108bbca06
action.ref: packs.install
parameters: 
  packs:
  - vsphere=1.1.2
status: failed
error: Traceback (most recent call last):
  File "/data/stanley/st2common/st2common/runners/python_action_wrapper.py", line 211, in <module>
    obj.run()
  File "/data/stanley/st2common/st2common/runners/python_action_wrapper.py", line 126, in run
    output = action.run(**self._parameters)
  File "/opt/stackstorm/packs/packs/actions/pack_mgmt/download.py", line 65, in run
    verifyssl=verifyssl, ref=pack_version)
  File "/opt/stackstorm/packs/packs/actions/pack_mgmt/download.py", line 110, in _clone_repo
    raise ValueError(msg)
ValueError: "1.1.2" is not a valid version, hash, tag, or branch in https://github.com/StackStorm-Exchange/stackstorm-vsphere. Valid versions are: v0.4.2, v0.4.3

```