### PR TITLE
Pack Management CLI description adjustments

### DIFF
--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -217,7 +217,7 @@ class PackSearchCommand(resource.ResourceTableCommand):
 
     def __init__(self, resource, *args, **kwargs):
         super(PackSearchCommand, self).__init__(resource, 'search',
-            'Search for a %s in remote pack exchange directory.' % resource.get_display_name().lower(),
+            'Search for a %s in remote exchange directory.' % resource.get_display_name().lower(),
             *args, **kwargs)
 
         self.parser.add_argument('query',

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -208,7 +208,7 @@ class PackSearchCommand(resource.ResourceTableCommand):
 
     def __init__(self, resource, *args, **kwargs):
         super(PackSearchCommand, self).__init__(resource, 'search',
-            'Search for a %s in the directory.' % resource.get_display_name().lower(),
+            'Search for a %s in remote pack exchange directory.' % resource.get_display_name().lower(),
             *args, **kwargs)
 
         self.parser.add_argument('query',

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -17,6 +17,7 @@ import sys
 
 import editor
 import yaml
+import argparse
 
 from st2client.models import Config
 from st2client.models import Pack
@@ -159,6 +160,14 @@ class PackInstallCommand(PackAsyncCommand):
                                  metavar='pack',
                                  help='Name of the %s to install.' %
                                  resource.get_plural_display_name().lower())
+
+        self.parser.formatter_class = argparse.RawDescriptionHelpFormatter
+        self.parser.epilog = '''examples:
+                        st2 pack install github
+                        st2 pack install trello slack
+                        st2 pack install stackstorm/st2-mysql
+                        st2 pack install https://github.com/StackStorm/st2-kafka.git
+        '''
 
     @resource.add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):

--- a/st2client/st2client/commands/resource.py
+++ b/st2client/st2client/commands/resource.py
@@ -262,7 +262,7 @@ class ResourceTableCommand(ResourceCommand):
 class ResourceListCommand(ResourceTableCommand):
     def __init__(self, resource, *args, **kwargs):
         super(ResourceListCommand, self).__init__(resource, 'list',
-            'Get the list of %s.' % resource.get_plural_display_name().lower(),
+            'Get the list of installed %s.' % resource.get_plural_display_name().lower(),
             *args, **kwargs)
 
 


### PR DESCRIPTION
Tiny cosmetic `CLI` fixes. The following things were a bit confusing for me: 

* `st2 pack search -h`
`Search for a pack in the directory.` -> `Search for a pack in remote exchange directory.`

* `st2 pack list -h`
`Get the list of packs.` -> `Get the list of installed packs.`

* `st2 pack install -h`
Added _examples:_, because these advanced, but pretty cool things are not listed in `cli`

![st2-pack-install](https://cloud.githubusercontent.com/assets/1533818/20074925/37f00926-a543-11e6-93a0-a2fd1a6958e1.png)

@emedvedev let me know if there are any other missed tricks/examples we could add for `st2 pack install`