### PR TITLE
Changing `name_or_id` back to `name` in get_by_name()

### DIFF
--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -278,14 +278,14 @@ class ResourceManager(object):
         return instances
 
     @add_auth_token_to_kwargs_from_env
-    def get_by_name(self, name_or_id, **kwargs):
-        instances = self.query(name=name_or_id, **kwargs)
+    def get_by_name(self, name, **kwargs):
+        instances = self.query(name=name, **kwargs)
         if not instances:
             return None
         else:
             if len(instances) > 1:
                 raise Exception('More than one %s named "%s" are found.' %
-                                (self.resource.__name__.lower(), name_or_id))
+                                (self.resource.__name__.lower(), name))
             return instances[0]
 
     @add_auth_token_to_kwargs_from_env


### PR DESCRIPTION
@kami: @LindsayHill updated the docs: https://github.com/StackStorm/st2docs/pull/305. But this is what changed the behavior: https://github.com/StackStorm/st2/pull/503/files#diff-212b279de225b603d0bc7fe4e00ae449R127. IMHO we should change it back to `name` otherwise it will confuse users: https://github.com/StackStorm/st2/issues/2948. Also the doc. needs more love. 
```
>>> from st2client.client import Client
>>> from st2client.models import KeyValuePair
>>> client = Client(base_url='http://localhost')
>>> client.keys.update(models.KeyValuePair(name='os_keystone_endpoint', value='http://localhost:5000/v2.0'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'models' is not defined
name 'models' is not defined
>>> client.keys.update(KeyValuePair(name='os_keystone_endpoint', value='http://localhost:5000/v2.0'))
<KeyValuePair name=os_keystone_endpoint,value=http://localhost:5000/v2.0>
>>> os_keystone_endpoint = client.keys.get_by_name(os_keystone_endpoint)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'os_keystone_endpoint' is not defined
name 'os_keystone_endpoint' is not defined
>>>
```
WDYT ? I'll update the docs accordingly.