### PR TITLE
Fix old git syntax compatibility

### DIFF
--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -116,7 +116,7 @@ class DownloadGitRepoAction(Action):
 
         # We're trying to figure out which branch the ref is actually on,
         # since there's no direct way to check for this in git-python.
-        branches = repo.git.branch('--color=never', '--all', '--contains', gitref.hexsha)
+        branches = repo.git.branch('--color=never', '-a', '--contains', gitref.hexsha)
         branches = branches.replace('*', '').split()
         if 'master' not in branches:
             branch = branches[0]


### PR DESCRIPTION
> Fixes bug described in StackStorm/st2-packages#363

`--all` flag is not available for older `git` versions shipped with `EL6`, so use `-a` instead.

* git version 1.7.1 (`CentOS6`):
```sh
    -a                    list both remote-tracking and local branches
```

* version 2.7.4:
```sh
      -a, --all
           List both remote-tracking branches and local branches.
```
