### PR TITLE
Support ancient git versions in packs.download

### DIFF
--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -119,7 +119,7 @@ class DownloadGitRepoAction(Action):
 
         # We're trying to figure out which branch the ref is actually on,
         # since there's no direct way to check for this in git-python.
-        branches = repo.git.branch('--color=never', '-a', '--contains', gitref.hexsha)
+        branches = repo.git.branch('-a', '--contains', gitref.hexsha)
         branches = branches.replace('*', '').split()
         if 'master' not in branches or use_branch:
             branch = "origin/%s" % ref if use_branch else branches[0]


### PR DESCRIPTION
Expanded all the ugly git shortcuts, this should fix RHEL6.