### PR TITLE
Various pack related changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -48,8 +48,13 @@ In development
   ``0.1.0``, ``2.0.0``, etc.). If version identifier is invalid, pack registration will fail.
   (improvement)
 * When a policy cancels a request due to concurrency, it leaves end_timestamp set to None which
-  the notifier expects to be a date. This causes an exception in "isotime.format()". A patch was released that catches this exception, and populates payload['end_timestamp'] with the equivalent of "datetime.now()" when the exception occurs.
+  the notifier expects to be a date. This causes an exception in "isotime.format()". A patch was
+  released that catches this exception, and populates payload['end_timestamp'] with the equivalent
+  of "datetime.now()" when the exception occurs.
 * Adding check for datastore Client expired tokens used in sensor container
+* Add new ``contributors`` field to the pack metadata file. This field can contain a list of
+  people who have contributed to the pack. The format is ``Name <email>``, e.g.
+  ``Tomaz Muraus <tomaz@stackstorm.com>`` (new feature)
 
 2.0.1 - September 30, 2016
 --------------------------

--- a/contrib/packs/actions/install.meta.yaml
+++ b/contrib/packs/actions/install.meta.yaml
@@ -12,17 +12,17 @@
       items:
         type: "string"
       required: true
-      description: "Name of the pack in Exchange or a git repo URL"
+      description: "Name of the pack in Exchange or a git repo URL."
     register:
       type: "string"
       default: "actions,aliases,sensors,triggers"
       description: "Possible options are all, triggers, sensors, actions, rules, aliases."
     env:
       type: "object"
-      description: "Optional environment variables"
+      description: "Optional environment variables."
       required: false
     force:
       type: "boolean"
-      description: "Set to True to force install the pack and skip StackStorm version compatibility check"
+      description: "Set to True to force install the pack and skip StackStorm version compatibility check and also delete and ignore lock file if one exists."
       required: false
       default: false

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -55,8 +55,19 @@ class DownloadGitRepoAction(Action):
             pack_url, pack_version = self._get_repo_url(pack)
 
             temp_dir = hashlib.md5(pack_url).hexdigest()
+            lock_file = LockFile(temp_dir)
+            lock_file_path = lock_file.lock_file
 
-            with LockFile('/tmp/%s' % (temp_dir)):
+            if force:
+                self.logger.debug('Force mode is enabled, deleting lock file...')
+
+                try:
+                    os.unlink(lock_file_path)
+                except OSError:
+                    # Lock file doesn't exist or similar
+                    pass
+
+            with lock_file:
                 try:
                     user_home = os.path.expanduser('~')
                     abs_local_path = os.path.join(user_home, temp_dir)

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -54,8 +54,8 @@ class DownloadGitRepoAction(Action):
         for pack in packs:
             pack_url, pack_version = self._get_repo_url(pack)
 
-            temp_dir = hashlib.md5(pack_url).hexdigest()
-            lock_file = LockFile(temp_dir)
+            temp_dir_name = hashlib.md5(pack_url).hexdigest()
+            lock_file = LockFile('/tmp/%s' % (temp_dir_name))
             lock_file_path = lock_file.lock_file
 
             if force:
@@ -70,7 +70,7 @@ class DownloadGitRepoAction(Action):
             with lock_file:
                 try:
                     user_home = os.path.expanduser('~')
-                    abs_local_path = os.path.join(user_home, temp_dir)
+                    abs_local_path = os.path.join(user_home, temp_dir_name)
                     self._clone_repo(temp_dir=abs_local_path, repo_url=pack_url,
                                      verifyssl=verifyssl, ref=pack_version)
 

--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -71,8 +71,11 @@ class PackInstallController(ActionExecutionsControllerMixin, RestController):
     @jsexpose(body_cls=PackInstallRequestAPI, status_code=http_client.ACCEPTED)
     def post(self, pack_install_request):
         parameters = {
-            'packs': pack_install_request.packs
+            'packs': pack_install_request.packs,
         }
+
+        if pack_install_request.force:
+            parameters['force'] = True
 
         new_liveaction_api = LiveActionCreateAPI(action='packs.install',
                                                  parameters=parameters,

--- a/st2api/tests/unit/controllers/v1/test_packs.py
+++ b/st2api/tests/unit/controllers/v1/test_packs.py
@@ -88,6 +88,16 @@ class PacksControllerTestCase(FunctionalTest):
         self.assertEqual(resp.json, {'execution_id': '123'})
 
     @mock.patch.object(ActionExecutionsControllerMixin, '_handle_schedule_execution')
+    def test_install_with_force_parameter(self, _handle_schedule_execution):
+        _handle_schedule_execution.return_value = ActionExecutionAPI(id='123')
+        payload = {'packs': ['some'], 'force': True}
+
+        resp = self.app.post_json('/v1/packs/install', payload)
+
+        self.assertEqual(resp.status_int, 202)
+        self.assertEqual(resp.json, {'execution_id': '123'})
+
+    @mock.patch.object(ActionExecutionsControllerMixin, '_handle_schedule_execution')
     def test_uninstall(self, _handle_schedule_execution):
         _handle_schedule_execution.return_value = ActionExecutionAPI(id='123')
         payload = {'packs': ['some']}

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -159,10 +159,14 @@ class PackInstallCommand(PackAsyncCommand):
                                  metavar='pack',
                                  help='Name of the %s to install.' %
                                  resource.get_plural_display_name().lower())
+        self.parser.add_argument('--force',
+                                 action='store_true',
+                                 default=False,
+                                 help='Force pack installation.')
 
     @resource.add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
-        return self.manager.install(args.packs, **kwargs)
+        return self.manager.install(args.packs, force=args.force, **kwargs)
 
 
 class PackRemoveCommand(PackAsyncCommand):
@@ -179,7 +183,7 @@ class PackRemoveCommand(PackAsyncCommand):
 
     @resource.add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
-        return self.manager.remove(args.packs, **kwargs)
+        return self.manager.register(args.packs, args.types, **kwargs)
 
 
 class PackRegisterCommand(PackResourceCommand):

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -390,9 +390,13 @@ class TriggerInstanceResourceManager(ResourceManager):
 
 class PackResourceManager(ResourceManager):
     @add_auth_token_to_kwargs_from_env
-    def install(self, packs, **kwargs):
+    def install(self, packs, force=False, **kwargs):
         url = '/%s/install' % (self.resource.get_url_path_name())
-        response = self.client.post(url, {'packs': packs}, **kwargs)
+        payload = {
+            'packs': packs,
+            'force': force
+        }
+        response = self.client.post(url, payload, **kwargs)
         if response.status_code != 200:
             self.handle_error(response)
         instance = self.resource.deserialize(response.json())

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -110,9 +110,12 @@ class PackAPI(BaseAPI):
             },
             'contributors': {
                 'type': 'array',
+                'items': {
+                    'type': 'string',
+                    'maxLength': 100
+                },
                 'description': ('A list of people who have contributed to the pack. Format is: '
-                                'Name <email address> e.g. Tomaz Muraus <tomaz@stackstorm.com>.'),
-                'items': {'type': 'string'}
+                                'Name <email address> e.g. Tomaz Muraus <tomaz@stackstorm.com>.')
             },
             'files': {
                 'type': 'array',

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -108,6 +108,11 @@ class PackAPI(BaseAPI):
                 'description': 'E-mail of the pack author.',
                 'format': 'email'
             },
+            'contributors': {
+                'type': 'string',
+                'description': ('A list of people who have contributed to the pack. Format is: '
+                                'Name <email address> e.g. Tomaz Muraus <tomaz@stackstorm.com>.')
+            },
             'files': {
                 'type': 'array',
                 'description': 'A list of files inside the pack.',

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -101,6 +101,7 @@ class PackAPI(BaseAPI):
             'author': {
                 'type': 'string',
                 'description': 'Pack author or authors.',
+                'items': {'type': 'string'},
                 'required': True
             },
             'email': {
@@ -109,7 +110,7 @@ class PackAPI(BaseAPI):
                 'format': 'email'
             },
             'contributors': {
-                'type': 'string',
+                'type': 'array',
                 'description': ('A list of people who have contributed to the pack. Format is: '
                                 'Name <email address> e.g. Tomaz Muraus <tomaz@stackstorm.com>.')
             },
@@ -172,13 +173,14 @@ class PackAPI(BaseAPI):
         stackstorm_version = getattr(pack, 'stackstorm_version', None)
         author = pack.author
         email = pack.email
+        contributors = getattr(pack, 'contributors', [])
         files = getattr(pack, 'files', [])
         dependencies = getattr(pack, 'dependencies', [])
         system = getattr(pack, 'system', {})
 
         model = cls.model(ref=ref, name=name, description=description, keywords=keywords,
-                          version=version, author=author, email=email, files=files,
-                          dependencies=dependencies, system=system,
+                          version=version, author=author, email=email, contributors=contributors,
+                          files=files, dependencies=dependencies, system=system,
                           stackstorm_version=stackstorm_version)
         return model
 

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -101,7 +101,6 @@ class PackAPI(BaseAPI):
             'author': {
                 'type': 'string',
                 'description': 'Pack author or authors.',
-                'items': {'type': 'string'},
                 'required': True
             },
             'email': {
@@ -112,7 +111,8 @@ class PackAPI(BaseAPI):
             'contributors': {
                 'type': 'array',
                 'description': ('A list of people who have contributed to the pack. Format is: '
-                                'Name <email address> e.g. Tomaz Muraus <tomaz@stackstorm.com>.')
+                                'Name <email address> e.g. Tomaz Muraus <tomaz@stackstorm.com>.'),
+                'items': {'type': 'string'}
             },
             'files': {
                 'type': 'array',

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -350,6 +350,11 @@ class PackInstallRequestAPI(BaseAPI):
         "properties": {
             "packs": {
                 "type": "array"
+            },
+            "force": {
+                "type": "boolean",
+                "description": "Force pack installation",
+                "default": False
             }
         }
     }

--- a/st2common/st2common/models/db/pack.py
+++ b/st2common/st2common/models/db/pack.py
@@ -45,6 +45,7 @@ class PackDB(stormbase.StormFoundationDB, stormbase.UIDFieldMixin,
     stackstorm_version = me.StringField(regex=ST2_VERSION_REGEX)
     author = me.StringField(required=True)
     email = me.EmailField()
+    contributors = me.ListField(field=me.StringField())
     files = me.ListField(field=me.StringField())
     dependencies = me.ListField(field=me.StringField())
     system = me.DictField()

--- a/st2common/tests/unit/test_resource_registrar.py
+++ b/st2common/tests/unit/test_resource_registrar.py
@@ -64,6 +64,9 @@ class ResourceRegistrarTestCase(CleanDbTestCase):
         self.assertEqual(len(config_schema_dbs), 1)
 
         self.assertEqual(pack_dbs[0].name, 'dummy_pack_1')
+        self.assertEqual(len(pack_dbs[0].contributors), 2)
+        self.assertEqual(pack_dbs[0].contributors[0], 'John Doe1 <john.doe1@gmail.com>')
+        self.assertEqual(pack_dbs[0].contributors[1], 'John Doe2 <john.doe2@gmail.com>')
         self.assertTrue('api_key' in config_schema_dbs[0].attributes)
         self.assertTrue('api_secret' in config_schema_dbs[0].attributes)
 
@@ -85,6 +88,7 @@ class ResourceRegistrarTestCase(CleanDbTestCase):
         # Ref is provided
         pack_db = Pack.get_by_name('dummy_pack_6')
         self.assertEqual(pack_db.ref, 'dummy_pack_6_ref')
+        self.assertEqual(len(pack_dbs[0].contributors), 0)
 
         # Ref is not provided, directory name should be used
         pack_db = Pack.get_by_name('dummy_pack_1')

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_1/pack.yaml
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_1/pack.yaml
@@ -4,3 +4,6 @@ description : dummy pack
 version : 0.1.0
 author : st2-dev
 email : info@stackstorm.com
+contributors:
+  - "John Doe1 <john.doe1@gmail.com>"
+  - "John Doe2 <john.doe2@gmail.com>"


### PR DESCRIPTION
1. Add new `contributors` field to the pack model and metadata file. This field follows the format of the same named field in the Node.js / npm package.json file. The value is optional and can contain a list of people who have contributed to the pack.

Before that, we only had an author field and a lot of pack these days have more than one contributor, but we had no good way to indicate that and give credit where credit is due.

2. Update `force` parameter in the `packs.download` and `packs.install` action to also remove the lock file if one exists. This allows user to force install a pack and clean-up a stuck lock without needing to SSH into the server in case for some reason lock wasn't correctly cleaned up / released.
3. Allow user to pass `--force` flag to `st2 pack install` command.