### PR TITLE
Fix ancient git EL6 bug with newer gitpython

### DIFF
--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -12,7 +12,7 @@ six==1.9.0
 pyyaml>=3.11,<4.0
 requests[security]>=2.11.1,<2.12
 apscheduler>=3.0.5,<3.1
-gitpython>=0.3.7,<1.0
+gitpython==1.0.2
 jsonschema>=2.5.0,<2.6
 mongoengine==0.10.6
 pymongo==3.2.2

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -12,7 +12,7 @@ six==1.9.0
 pyyaml>=3.11,<4.0
 requests[security]>=2.11.1,<2.12
 apscheduler>=3.0.5,<3.1
-gitpython==0.3.2.1
+gitpython>=0.3.7,<1.0
 jsonschema>=2.5.0,<2.6
 mongoengine==0.10.6
 pymongo==3.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper
 git+https://github.com/StackStorm/pecan.git@st2-patched#egg=pecan
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
-gitpython==0.3.2.1
+gitpython<1.0,>=0.3.7
 gunicorn<20.0,>=19.4.5
 ipaddr
 jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper
 git+https://github.com/StackStorm/pecan.git@st2-patched#egg=pecan
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
-gitpython<1.0,>=0.3.7
+gitpython==1.0.2
 gunicorn<20.0,>=19.4.5
 ipaddr
 jinja2


### PR DESCRIPTION
After @emedvedev fixing https://github.com/StackStorm/st2/pull/3008,
there was another one with `gitpython` library infinite loop (starting from [this line](https://github.com/StackStorm/st2/blob/ca19e2045f941196e3817eb19f5ddf15c4f6098f/contrib/packs/actions/pack_mgmt/download.py#L100)) which blocked the builds for `EL6` with timeout during the pack download.

Luckily, spending entire day with @enykeev debugging it, simple `gitpython` library upgrade worked as a last minute fix.

Let's see If this finishes [EL6 epopeya](https://github.com/StackStorm/st2-packages/issues/363).
