### PR TITLE
On packs.install only register resources from installed pack(s)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,6 +55,11 @@ In development
 * Add new ``contributors`` field to the pack metadata file. This field can contain a list of
   people who have contributed to the pack. The format is ``Name <email>``, e.g.
   ``Tomaz Muraus <tomaz@stackstorm.com>`` (new feature)
+* Update ``packs.install`` action (``pack install`` command) to only load resources from the packs
+  which are being installed. Also update it and remove "restart sensor container" step from the
+  install workflow. This step hasn't been needed for a while now because sensor container
+  dynamically reads a list of available sensors from the database and starts the sub processes.
+  (improvement)
 
 2.0.1 - September 30, 2016
 --------------------------

--- a/contrib/packs/actions/load.yaml
+++ b/contrib/packs/actions/load.yaml
@@ -9,3 +9,8 @@
       type: "string"
       default: "actions,aliases,sensors"
       description: "Possible options are all, sensors, actions, rules, aliases."
+    packs:
+      type: "array"
+      description: "A list of packs to register / load resources from."
+      items:
+        type: "string"

--- a/contrib/packs/actions/pack_mgmt/register.py
+++ b/contrib/packs/actions/pack_mgmt/register.py
@@ -55,7 +55,7 @@ class St2RegisterAction(Action):
         self._kvp = KeyValuePair
         self.client = self._get_client()
 
-    def run(self, register, **kwargs):
+    def run(self, register, packs=None):
         types = []
 
         for type in register.split(','):
@@ -67,6 +67,9 @@ class St2RegisterAction(Action):
         method_kwargs = {
             'types': types
         }
+
+        if packs:
+            method_kwargs['packs'] = packs
 
         result = self._run_client_method(method=self.client.packs.register,
                                          method_kwargs=method_kwargs,

--- a/contrib/packs/actions/workflows/install.yaml
+++ b/contrib/packs/actions/workflows/install.yaml
@@ -25,6 +25,7 @@
       ref: "packs.load"
       parameters:
         register: "{{register}}"
+        packs: "{{ __results['make a prerun'].result }}"
       on-success: "restart sensor container"
     -
       name: "restart sensor container"

--- a/contrib/packs/actions/workflows/install.yaml
+++ b/contrib/packs/actions/workflows/install.yaml
@@ -26,11 +26,5 @@
       parameters:
         register: "{{register}}"
         packs: "{{ __results['make a prerun'].result }}"
-      on-success: "restart sensor container"
-    -
-      name: "restart sensor container"
-      ref: "packs.restart_component"
-      parameters:
-        servicename: "st2sensorcontainer"
 
   default: "download pack"

--- a/contrib/packs/actions/workflows/uninstall.yaml
+++ b/contrib/packs/actions/workflows/uninstall.yaml
@@ -11,11 +11,5 @@
       ref: "packs.delete"
       parameters:
         packs: "{{packs}}"
-      on-success: "restart sensor container"
-    -
-      name: "restart sensor container"
-      ref: "packs.restart_component"
-      parameters:
-        servicename: "st2sensorcontainer"
 
   default: "unregister packs"

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -183,7 +183,7 @@ class PackRemoveCommand(PackAsyncCommand):
 
     @resource.add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
-        return self.manager.register(args.packs, args.types, **kwargs)
+        return self.manager.remove(args.packs, **kwargs)
 
 
 class PackRegisterCommand(PackResourceCommand):


### PR DESCRIPTION
This pull request updates `packs.install` and `packs.register` action to only register resources from packs which are being installed.

Before that, we registered resources from all the packs on install. This could take a very long time in case user had a lot of packs and resources locally. This new change makes the user experience better since the whole process completes faster.

Before:

```bash
(virtualenv)vagrant@vagrant-ubuntu-trusty-64:/data/stanley$ time python ./st2client/st2client/shell.py pack install datadog consul
2016-11-10 10:02:06,123  WARNING - Auth API server is not available, skipping authentication.

	[ succeeded ] download pack
	[ succeeded ] make a prerun
	[ succeeded ] install pack dependencies
	[ succeeded ] register pack
	[  failed   ] restart sensor container

id: 5824459e0640fd53f1cde673
action.ref: packs.install
parameters: 
  packs:
  - datadog
  - consul
status: failed
error: bash: /usr/bin/st2ctl: Permission denied
traceback: None
failed_on: restart sensor container
start_timestamp: 2016-11-10T10:02:06.161971Z
end_timestamp: 2016-11-10T10:03:15.211736Z
+--------------------------+-------------------------+---------------------------+-------------------------+-------------------------------+
| id                       | status                  | task                      | action                  | start_timestamp               |
+--------------------------+-------------------------+---------------------------+-------------------------+-------------------------------+
| 5824459e0640fd53ec23ac12 | succeeded (7s elapsed)  | download pack             | packs.download          | Thu, 10 Nov 2016 10:02:06 UTC |
| 582445a50640fd53ec23ac15 | succeeded (3s elapsed)  | make a prerun             | packs.virtualenv_prerun | Thu, 10 Nov 2016 10:02:13 UTC |
| 582445a90640fd53ec23ac18 | succeeded (14s elapsed) | install pack dependencies | packs.setup_virtualenv  | Thu, 10 Nov 2016 10:02:17 UTC |
| 582445b80640fd53ec23ac1b | succeeded (41s elapsed) | register pack             | packs.load              | Thu, 10 Nov 2016 10:02:32 UTC |
| 582445e10640fd53ec23ac1e | failed (1s elapsed)     | restart sensor container  | packs.restart_component | Thu, 10 Nov 2016 10:03:13 UTC |
+--------------------------+-------------------------+---------------------------+-------------------------+-------------------------------+

real	1m11.403s
user	0m2.357s
```

After:

```bash
(virtualenv)vagrant@vagrant-ubuntu-trusty-64:/data/stanley$ time python ./st2client/st2client/shell.py pack install datadog consul
2016-11-10 10:00:18,205  WARNING - Auth API server is not available, skipping authentication.

	[ succeeded ] download pack
	[ succeeded ] make a prerun
	[ succeeded ] install pack dependencies
	[ succeeded ] register pack
	[  failed   ] restart sensor container

id: 582445320640fd53f1cde670
action.ref: packs.install
parameters: 
  packs:
  - datadog
  - consul
status: failed
error: bash: /usr/bin/st2ctl: Permission denied
traceback: None
failed_on: restart sensor container
start_timestamp: 2016-11-10T10:00:18.227732Z
end_timestamp: 2016-11-10T10:00:46.795525Z
+--------------------------+-------------------------+---------------------------+-------------------------+-------------------------------+
| id                       | status                  | task                      | action                  | start_timestamp               |
+--------------------------+-------------------------+---------------------------+-------------------------+-------------------------------+
| 582445320640fd53ec23ac02 | succeeded (7s elapsed)  | download pack             | packs.download          | Thu, 10 Nov 2016 10:00:18 UTC |
| 582445390640fd53ec23ac05 | succeeded (3s elapsed)  | make a prerun             | packs.virtualenv_prerun | Thu, 10 Nov 2016 10:00:25 UTC |
| 5824453d0640fd53ec23ac08 | succeeded (10s elapsed) | install pack dependencies | packs.setup_virtualenv  | Thu, 10 Nov 2016 10:00:29 UTC |
| 582445480640fd53ec23ac0b | succeeded (4s elapsed)  | register pack             | packs.load              | Thu, 10 Nov 2016 10:00:40 UTC |
| 5824454d0640fd53ec23ac0e | failed (1s elapsed)     | restart sensor container  | packs.restart_component | Thu, 10 Nov 2016 10:00:45 UTC |
+--------------------------+-------------------------+---------------------------+-------------------------+-------------------------------+

real	0m30.134s
user	0m1.921s
sys	0m0.561s
```