### PR TITLE
Add symlinks for flake8 and pylint rc files

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,1 @@
+./lint-configs/python/.flake8

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,1 @@
+./lint-configs/python/.pylintrc


### PR DESCRIPTION
This change would allow pylint and flake8 to utilize our rc files automatically by leveraging their existing search path. This allows developers to leave their existing rc files untouched and use these "automatically" for the ST2 project.