### PR TITLE
Return entire execution object if execution is already canceled

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -60,6 +60,8 @@ In development
   install workflow. This step hasn't been needed for a while now because sensor container
   dynamically reads a list of available sensors from the database and starts the sub processes.
   (improvement)
+* Change st2api so that a full execution object is returned instead of an error message, when an
+  API client requests cancellation of an execution that is already canceled
 
 2.0.1 - September 30, 2016
 --------------------------

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -434,7 +434,10 @@ class ActionExecutionsController(ActionExecutionsControllerMixin, ResourceContro
                   'Execution object missing link to liveaction %s.' % liveaction_id)
 
         if liveaction_db.status == LIVEACTION_STATUS_CANCELED:
-            LOG.info('Action %s is already in "canceled" state; returning entire execution object to caller.' % liveaction_db.id)
+            LOG.info(
+                'Action %s already in "canceled" state; \
+                returning execution object.' % liveaction_db.id
+            )
             return execution_api
 
         if liveaction_db.status not in LIVEACTION_CANCELABLE_STATES:

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -434,7 +434,8 @@ class ActionExecutionsController(ActionExecutionsControllerMixin, ResourceContro
                   'Execution object missing link to liveaction %s.' % liveaction_id)
 
         if liveaction_db.status == LIVEACTION_STATUS_CANCELED:
-            abort(http_client.OK, 'Action is already in "canceled" state.')
+            LOG.info('Action %s is already in "canceled" state; returning entire execution object to caller.' % liveaction_db.id)
+            return execution_api
 
         if liveaction_db.status not in LIVEACTION_CANCELABLE_STATES:
             abort(http_client.OK, 'Action cannot be canceled. State = %s.' % liveaction_db.status)

--- a/st2api/tests/unit/controllers/v1/test_executions_simple.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_simple.py
@@ -302,6 +302,22 @@ class TestActionExecutionController(FunctionalTest):
         expected_result = {'message': 'Action canceled by user.', 'user': 'stanley'}
         self.assertDictEqual(delete_resp.json['result'], expected_result)
 
+    def test_post_delete_duplicate(self):
+        """Cancels an execution twice, to ensure that a full execution object
+           is returned instead of an error message
+        """
+
+        post_resp = self._do_post(LIVE_ACTION_1)
+        self.assertEqual(post_resp.status_int, 201)
+
+        # Similar to test_post_delete, only twice
+        for i in range(2):
+            delete_resp = self._do_delete(self._get_actionexecution_id(post_resp))
+            self.assertEqual(delete_resp.status_int, 200)
+            self.assertEqual(delete_resp.json['status'], 'canceled')
+            expected_result = {'message': 'Action canceled by user.', 'user': 'stanley'}
+            self.assertDictEqual(delete_resp.json['result'], expected_result)
+
     def test_post_delete_trace(self):
         LIVE_ACTION_TRACE = copy.copy(LIVE_ACTION_1)
         LIVE_ACTION_TRACE['context'] = {'trace_context': {'trace_tag': 'balleilaka'}}


### PR DESCRIPTION
This commit makes changes to the st2api so that the entire execution
object is returned to API calls that attempt to cancel execution
objects that are already cancelled, instead of returning a simple
error message.

Previously, an API call to this API would result in the following error message:

```
~>curl -X DELETE -H  'Connection: keep-alive' -H  'Accept-Encoding: gzip, deflate' -H  'Accept: */*' -H  'User-Agent: python-requests/2.11.1' -H  'X-Auth-Token: c64c7c82be38408f9dc406ceb2640d77' -H  'Content-Length: 0' http://127.0.0.1:9101/v1/executions/57fee1b6c506f479b9c58e97
{
    "faultstring": "Action is already in \"canceled\" state."
}
```

Now, the API will return a full execution object, as shown [here](https://gist.github.com/Mierdin/cf97f23ddd9ada1d4965b089b6561d24).

This fixes https://github.com/StackStorm/st2/issues/2946

Signed-off-by: Matt Oswalt <oswaldm@brocade.com>