### PR TITLE
Fix/pack.unload

### DIFF
--- a/contrib/packs/actions/pack_mgmt/unload.py
+++ b/contrib/packs/actions/pack_mgmt/unload.py
@@ -94,7 +94,7 @@ class UnregisterPackAction(BaseAction):
 
         # delete rules that has an association with the pack in trigger or action.
         def _match_trigger(r):
-            return (r.trigger.split('.')[0] == pack)
+            return r.trigger.split('.')[0] == pack
 
         def _match_action(r):
             return r.action.ref.split('.')[0] == pack

--- a/contrib/packs/actions/pack_mgmt/unload.py
+++ b/contrib/packs/actions/pack_mgmt/unload.py
@@ -91,6 +91,25 @@ class UnregisterPackAction(BaseAction):
 
     def _unregister_rules(self, pack):
         deleted_rules = self._delete_pack_db_objects(pack=pack, access_cls=Rule)
+
+        # delete rules that has an association with the pack in trigger or action.
+        def _match_trigger(r):
+            return (r.trigger.split('.')[0] == pack)
+
+        def _match_action(r):
+            return r.action.ref.split('.')[0] == pack
+
+        for rule_obj in [x for x in Rule.get_all() if _match_trigger(x) or _match_action(x)]:
+            # This rule should have already been deleted.
+            if rule_obj.pack == pack:
+                continue
+
+            try:
+                Rule.delete(rule_obj)
+                deleted_rules.append(rule_obj)
+            except:
+                self.logger.exception('Failed to remove DB object %s.', rule_obj)
+
         for rule_db in deleted_rules:
             cleanup_trigger_db_for_rule(rule_db=rule_db)
 

--- a/contrib/packs/pack.yaml
+++ b/contrib/packs/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name : packs
 description : st2 content pack containing pack management functionality.
-version : 0.1.0
+version : 0.1.1
 author : st2-dev
 email : info@stackstorm.com

--- a/contrib/packs/tests/test_action_unload.py
+++ b/contrib/packs/tests/test_action_unload.py
@@ -1,0 +1,60 @@
+import mock
+
+from st2common.persistence.base import Access
+from st2common.persistence.reactor import Rule
+from st2tests.base import BaseActionTestCase
+
+from pack_mgmt.unload import UnregisterPackAction
+
+
+@mock.patch.object(Access, 'delete', mock.MagicMock(return_value=None))
+@mock.patch('pack_mgmt.unload.db_setup', mock.MagicMock(return_value=None))
+@mock.patch('pack_mgmt.unload.cleanup_trigger_db_for_rule', mock.MagicMock(return_value=None))
+class UnregisterPackActionTestCase(BaseActionTestCase):
+    action_cls = UnregisterPackAction
+
+    def _get_all_rules(self, pack=None):
+        if pack:
+            return [x for x in self.mock_rules if x.pack == pack]
+        else:
+            return self.mock_rules
+
+    def setUp(self):
+        super(UnregisterPackActionTestCase, self).setUp()
+
+        self.mock_rules = [self._MockRule('foo', 'bar.trigger', 'baz.action')]
+
+    def test_unregister_rules_of_pack(self):
+        action = self.get_action_instance()
+
+        Rule.get_all = mock.MagicMock(side_effect=self._get_all_rules)
+
+        deleted_rules = action._unregister_rules(pack='foo')
+
+        self.assertEqual(len(deleted_rules), 1)
+
+    def test_unregister_rules_of_related_pack(self):
+        action = self.get_action_instance()
+
+        Rule.get_all = mock.MagicMock(side_effect=self._get_all_rules)
+
+        deleted_rules = action._unregister_rules(pack='bar')
+        self.assertEqual(len(deleted_rules), 1)
+
+        deleted_rules = action._unregister_rules(pack='baz')
+        self.assertEqual(len(deleted_rules), 1)
+
+    def test_unregister_rules_of_unrelated_pack(self):
+        action = self.get_action_instance()
+
+        Rule.get_all = mock.MagicMock(side_effect=self._get_all_rules)
+
+        deleted_rules = action._unregister_rules(pack='hoge')
+        self.assertEqual(deleted_rules, [])
+
+    class _MockRule(object):
+        def __init__(self, pack, trigger_ref, action_ref):
+            self.pack = pack
+            self.trigger = trigger_ref
+            self.action = mock.MagicMock()
+            self.action.ref = action_ref


### PR DESCRIPTION
Hi, 

In the current processing of unload action, the only rules which are belonged to the pack are removed.
And the rules that have association with the packs in trigger or action are remained.

Both rules should be removed as mentioned in #2260.

This patch additionally remove rules that are set the pack in trigger or action.

Thank you.