### PR TITLE
Cache filters API response for web UI

### DIFF
--- a/st2api/in-requirements.txt
+++ b/st2api/in-requirements.txt
@@ -11,3 +11,4 @@ six
 git+https://github.com/StackStorm/pecan.git@st2-patched#egg=pecan
 git+https://github.com/StackStorm/python-mistralclient#egg=python-mistralclient
 gunicorn
+cachetools

--- a/st2api/st2api/controllers/v1/executionviews.py
+++ b/st2api/st2api/controllers/v1/executionviews.py
@@ -57,7 +57,7 @@ def csv(s):
 
 class FiltersController(RestController):
     def __init__(self, *args, **kwargs):
-        super(RestController, self).__init__(*args, **kwargs)
+        super(FiltersController, self).__init__(*args, **kwargs)
         self.cache = TTLCache(ttl=600, maxsize=10000)
 
     @jsexpose(arg_types=[csv])

--- a/st2api/st2api/controllers/v1/executionviews.py
+++ b/st2api/st2api/controllers/v1/executionviews.py
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from cachetools import TTLCache, cachedmethod
 from pecan.rest import RestController
+import operator
 import six
 
 from st2common import log as logging
@@ -54,7 +56,12 @@ def csv(s):
 
 
 class FiltersController(RestController):
+    def __init__(self, *args, **kwargs):
+        super(RestController, self).__init__(*args, **kwargs)
+        self.cache = TTLCache(ttl=600, maxsize=10000)
+
     @jsexpose(arg_types=[csv])
+    @cachedmethod(operator.attrgetter('cache'))
     def get_all(self, types=None):
         """
             List all distinct filters.


### PR DESCRIPTION
Use a TTL-based cache since we don't have a better cache invalidation mechanism here.

Hardcoded parameters and other yuck. But thought I'd get the ball rolling. It works for me. :)

Closes #2876