### PR TITLE
Upgrade pymongo to 3.3.0 (latest stable version)

### DIFF
--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -15,7 +15,7 @@ apscheduler>=3.0.5,<3.1
 gitpython==2.1.0
 jsonschema>=2.5.0,<2.6
 mongoengine==0.10.6
-pymongo==3.2.2
+pymongo==3.3.0
 passlib>=1.6.2,<1.7
 lockfile>=0.10.2,<0.11
 python-gnupg>=0.3.7,<0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ passlib<1.7,>=1.6.2
 prettytable
 prompt-toolkit==1.0.7
 pyinotify<=0.10,>=0.9.5
-pymongo==3.2.2
+pymongo==3.3.0
 python-dateutil
 python-editor==1.0.1
 python-gnupg<0.4,>=0.3.7


### PR DESCRIPTION
This version drops support for MongoDB < 2.4, but this doesn't affect us since we install and require MongoDB > 3.0 by default for a while now.

Older StackStorm installations uses 2.4 or 2.6 which is still supported.