### PR TITLE
Add indexes for distinct fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -73,6 +73,8 @@ In development
   schema file. (new-feature)
 * Upgrade various internal Python library dependencies to the latest stable versions (gunicorn,
   kombu, six, appscheduler, passlib, python-gnupg, semver, paramiko, python-keyczar, virtualenv).
+* Improve performance of ``GET /executions/views/filters`` by creating additional indexes on
+  executions collection
 
 2.0.1 - September 30, 2016
 --------------------------

--- a/st2common/st2common/models/db/execution.py
+++ b/st2common/st2common/models/db/execution.py
@@ -78,6 +78,11 @@ class ActionExecutionDB(stormbase.StormFoundationDB):
             {'fields': ['end_timestamp']},
             {'fields': ['status']},
             {'fields': ['parent']},
+            {'fields': ['rule.name']},
+            {'fields': ['runner.name']},
+            {'fields': ['trigger.name']},
+            {'fields': ['trigger_type.name']},
+            {'fields': ['context.user']},
             {'fields': ['-start_timestamp', 'action.ref', 'status']}
         ]
     }


### PR DESCRIPTION
Fixes #2876 

Dramatically improves TTFB of the /executions/views/filters request by preparing indexes for the fields ahead of time.

For our production set of 99k executions, before the change:
```
$ curl -w "@curl-format.txt" -o /dev/null -s 172.168.50.50:9101/v1/executions/views/filters

            time_namelookup:  0.000
               time_connect:  0.000
            time_appconnect:  0.000
           time_pretransfer:  0.000
              time_redirect:  0.000
         time_starttransfer:  60.616
                            ----------
                 time_total:  60.616
```

after

```
$ curl -w "@curl-format.txt" -o /dev/null -s 172.168.50.50:9101/v1/executions/views/filters

            time_namelookup:  0.000
               time_connect:  0.000
            time_appconnect:  0.000
           time_pretransfer:  0.000
              time_redirect:  0.000
         time_starttransfer:  0.080
                            ----------
                 time_total:  0.080
```

The change has very tiny footprint comparing to collection size
```
> db.action_execution_d_b.stats()
{
	"ns" : "st2.action_execution_d_b",
	"count" : 99086,
	"size" : 5165258272,
	"avgObjSize" : 52129,
	"numExtents" : 21,
	"storageSize" : 5791203328,
	"lastExtentSize" : 1513054208,
	"paddingFactor" : 1,
	"paddingFactorNote" : "paddingFactor is unused and unmaintained in 3.0. It remains hard coded to 1.0 for compatibility only.",
	"userFlags" : 0,
	"capped" : false,
	"nindexes" : 14,
	"totalIndexSize" : 68596640,
	"indexSizes" : {
		"_id_" : 5576032,
		"rule.ref_1" : 3630144,
		"action.ref_1" : 6491744,
		"liveaction.id_1" : 8118768,
		"start_timestamp_1" : 4815664,
		"end_timestamp_1" : 4987360,
		"status_1" : 5363456,
		"parent_1" : 7513744,
		"start_timestamp_-1_action.ref_1_status_1" : 11029424,
		"rule.name_1" : 1831424,
		"runner.name_1" : 3123232,
		"trigger.name_1" : 1831424,
		"trigger_type.name_1" : 1806896,
		"context.user_1" : 2477328
	},
	"ok" : 1
}
```

It might have some impact on the write speed, but unlikely to break the bank by any stretch of imagination.