### PR TITLE
Uncomment [webui] section in st2.conf

### DIFF
--- a/conf/st2.dev.conf
+++ b/conf/st2.dev.conf
@@ -68,7 +68,7 @@ port = 514
 facility = local7
 protocol = udp
 
-# [webui]
+[webui]
 # webui_base_url = https://mywebhost.domain
 
 [log]

--- a/conf/st2.package.conf
+++ b/conf/st2.package.conf
@@ -54,7 +54,7 @@ api_url =
 [system]
 base_path = /opt/stackstorm
 
-# [webui]
+[webui]
 # webui_base_url = https://mywebhost.domain
 
 [syslog]

--- a/conf/st2.prod.conf
+++ b/conf/st2.prod.conf
@@ -50,7 +50,7 @@ port = 514
 facility = local7
 protocol = udp
 
-# [webui]
+[webui]
 # webui_base_url = https://mywebhost.domain
 
 [log]

--- a/conf/st2.tests.conf
+++ b/conf/st2.tests.conf
@@ -60,7 +60,7 @@ port = 514
 facility = local7
 protocol = udp
 
-# [webui]
+[webui]
 # webui_base_url = https://mywebhost.domain
 
 [log]

--- a/conf/st2.tests1.conf
+++ b/conf/st2.tests1.conf
@@ -49,7 +49,7 @@ port = 514
 facility = local7
 protocol = udp
 
-# [webui]
+[webui]
 # webui_base_url = https://mywebhost.domain
 
 [log]


### PR DESCRIPTION
Originally reported in #community.

User uncommented only `webui_base_url = https://mywebhost.domain` without uncommenting `[webui]` section, ex:
```ini
# [webui]
webui_base_url = https://mywebhost.domain
```
See: https://github.com/StackStorm/hubot-stackstorm/issues/129#issuecomment-262007128

With this small change it looks safer, more obvious and less error-prone default.