### PR TITLE
New pack register CLI command syntax and various other pack register API endpoint improvements

### DIFF
--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -206,8 +206,10 @@ class DownloadGitRepoAction(Action):
         # running version of StackStorm
         if required_stackstorm_version:
             if not complex_semver_match(CURRENT_STACKSTROM_VERSION, required_stackstorm_version):
-                msg = ('Pack "%s" requires StackStorm "%s", but current version is "%s"' %
-                       (pack_name, required_stackstorm_version, CURRENT_STACKSTROM_VERSION))
+                msg = ('Pack "%s" requires StackStorm "%s", but current version is "%s". ' %
+                       (pack_name, required_stackstorm_version, CURRENT_STACKSTROM_VERSION),
+                       'You can override this restriction by providing the "force" flag, but ',
+                       'the pack is not guaranteed to work.')
                 raise ValueError(msg)
 
     @staticmethod

--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -129,17 +129,20 @@ class PackRegisterController(RestController):
 
         result = {}
 
-        if 'runner' in types or 'action' in types:
+        # Register depended resources (actions depend on runners, rules depend on rule types, etc)
+        if ('runner' in types or 'runners' in types) or ('action' in types or 'actions' in types):
             result['runners'] = runners_registrar.register_runners(experimental=True)
-        if 'rule_type' in types or 'rule' in types:
+        if ('rule_type' in types or 'rule_types' in types) or \
+           ('rule' in types or 'rules' in types):
             result['rule_types'] = rule_types_registrar.register_rule_types()
-        if 'policy_type' in types or 'policy' in types:
+        if ('policy_type' in types or 'policy_types' in types) or \
+           ('policy' in types or 'policies' in types):
             result['policy_types'] = policies_registrar.register_policy_types(st2common)
 
         use_pack_cache = False
 
         for type, (Registrar, name) in six.iteritems(ENTITIES):
-            if type in types:
+            if type in types or name in types:
                 registrar = Registrar(use_pack_cache=use_pack_cache,
                                       fail_on_failure=False)
                 if packs:

--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -60,8 +60,8 @@ ENTITIES = {
     'sensor': (SensorsRegistrar, 'sensors'),
     'rule': (RulesRegistrar, 'rules'),
     'alias': (AliasesRegistrar, 'aliases'),
-    'policy': (PolicyRegistrar, 'policy'),
-    'config': (ConfigsRegistrar, 'config')
+    'policy': (PolicyRegistrar, 'policies'),
+    'config': (ConfigsRegistrar, 'configs')
 }
 
 

--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -121,7 +121,7 @@ class PackRegisterController(RestController):
                      'policy_type', 'policy', 'config']
 
         if pack_register_request and hasattr(pack_register_request, 'packs'):
-            packs = pack_register_request.packs
+            packs = list(set(pack_register_request.packs))
         else:
             packs = None
 

--- a/st2api/tests/unit/controllers/v1/test_packs.py
+++ b/st2api/tests/unit/controllers/v1/test_packs.py
@@ -137,3 +137,20 @@ class PacksControllerTestCase(FunctionalTest):
 
         self.assertEqual(resp.status_int, 200)
         self.assertEqual(resp.json, PACK_INDEX['test2'])
+
+    def test_packs_register_endpoint(self):
+        # Register resources from all packs
+        resp = self.app.post_json('/v1/packs/register')
+
+        self.assertTrue('runners' in resp.json)
+        self.assertTrue('actions' in resp.json)
+        self.assertTrue('triggers' in resp.json)
+        self.assertTrue('sensors' in resp.json)
+        self.assertTrue('rules' in resp.json)
+        self.assertTrue('rule_types' in resp.json)
+        self.assertTrue('aliases' in resp.json)
+        self.assertTrue('policy_types' in resp.json)
+        self.assertTrue('policies' in resp.json)
+        self.assertTrue('configs' in resp.json)
+
+        self.assertTrue(resp.json['actions'] >= 1)

--- a/st2api/tests/unit/controllers/v1/test_packs.py
+++ b/st2api/tests/unit/controllers/v1/test_packs.py
@@ -169,9 +169,21 @@ class PacksControllerTestCase(FunctionalTest):
         self.assertEqual(resp.status_int, 200)
         self.assertEqual(resp.json, {'sensors': 1})
 
+        # Verify that plural name form also works
+        resp = self.app.post_json('/v1/packs/register', {'types': ['sensors']})
+
+        self.assertEqual(resp.status_int, 200)
+
         # Register specific type for a single packs
         resp = self.app.post_json('/v1/packs/register',
                                   {'packs': ['dummy_pack_1'], 'types': ['action']})
+
+        self.assertEqual(resp.status_int, 200)
+        self.assertEqual(resp.json, {'actions': 1, 'runners': 11})
+
+        # Verify that plural name form also works
+        resp = self.app.post_json('/v1/packs/register',
+                                  {'packs': ['dummy_pack_1'], 'types': ['actions']})
 
         self.assertEqual(resp.status_int, 200)
         self.assertEqual(resp.json, {'actions': 1, 'runners': 11})

--- a/st2api/tests/unit/controllers/v1/test_packs.py
+++ b/st2api/tests/unit/controllers/v1/test_packs.py
@@ -142,6 +142,7 @@ class PacksControllerTestCase(FunctionalTest):
         # Register resources from all packs
         resp = self.app.post_json('/v1/packs/register')
 
+        self.assertEqual(resp.status_int, 200)
         self.assertTrue('runners' in resp.json)
         self.assertTrue('actions' in resp.json)
         self.assertTrue('triggers' in resp.json)
@@ -152,5 +153,32 @@ class PacksControllerTestCase(FunctionalTest):
         self.assertTrue('policy_types' in resp.json)
         self.assertTrue('policies' in resp.json)
         self.assertTrue('configs' in resp.json)
-
         self.assertTrue(resp.json['actions'] >= 1)
+
+        # Register resources from a specific pack
+        resp = self.app.post_json('/v1/packs/register', {'packs': ['dummy_pack_1']})
+
+        self.assertEqual(resp.status_int, 200)
+        self.assertTrue(resp.json['actions'] >= 1)
+        self.assertTrue(resp.json['sensors'] >= 1)
+        self.assertTrue(resp.json['configs'] >= 1)
+
+        # Register specific type for all packs
+        resp = self.app.post_json('/v1/packs/register', {'types': ['sensor']})
+
+        self.assertEqual(resp.status_int, 200)
+        self.assertEqual(resp.json, {'sensors': 1})
+
+        # Register specific type for a single packs
+        resp = self.app.post_json('/v1/packs/register',
+                                  {'packs': ['dummy_pack_1'], 'types': ['action']})
+
+        self.assertEqual(resp.status_int, 200)
+        self.assertEqual(resp.json, {'actions': 1, 'runners': 11})
+
+        # Register resources from a single (non-existent pack)
+        resp = self.app.post_json('/v1/packs/register', {'packs': ['doesntexist']},
+                                  expect_errors=True)
+
+        self.assertEqual(resp.status_int, 400)
+        self.assertTrue('Pack "doesntexist" not found on disk:' in resp.json['faultstring'])

--- a/st2api/tests/unit/controllers/v1/test_packs.py
+++ b/st2api/tests/unit/controllers/v1/test_packs.py
@@ -188,6 +188,15 @@ class PacksControllerTestCase(FunctionalTest):
         self.assertEqual(resp.status_int, 200)
         self.assertEqual(resp.json, {'actions': 1, 'runners': 11})
 
+        # Register single resource from a single pack specified multiple times - verify that
+        # resources from the same pack are only registered once
+        resp = self.app.post_json('/v1/packs/register',
+                                  {'packs': ['dummy_pack_1', 'dummy_pack_1', 'dummy_pack_1'],
+                                   'types': ['actions']})
+
+        self.assertEqual(resp.status_int, 200)
+        self.assertEqual(resp.json, {'actions': 1, 'runners': 11})
+
         # Register resources from a single (non-existent pack)
         resp = self.app.post_json('/v1/packs/register', {'packs': ['doesntexist']},
                                   expect_errors=True)

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -199,8 +199,9 @@ class PackRegisterCommand(PackResourceCommand):
               'Register a %s: sync all file changes with DB.' % resource.get_display_name().lower(),
               *args, **kwargs)
 
-        self.parser.add_argument('--packs',
-                                 nargs='+',
+        self.parser.add_argument('packs',
+                                 nargs='*',
+                                 metavar='pack',
                                  help='Name of the %s(s) to register.' %
                                  resource.get_display_name().lower())
 

--- a/st2common/st2common/bootstrap/ruletypesregistrar.py
+++ b/st2common/st2common/bootstrap/ruletypesregistrar.py
@@ -49,6 +49,7 @@ RULE_TYPES = [
 
 def register_rule_types():
     LOG.debug('Start : register default RuleTypes.')
+    registered_count = 0
 
     for rule_type in RULE_TYPES:
         rule_type = copy.deepcopy(rule_type)
@@ -77,7 +78,9 @@ def register_rule_types():
                 LOG.audit('RuleType created. RuleType %s', rule_type_db, extra=extra)
         except Exception:
             LOG.exception('Unable to register RuleType %s.', rule_type['name'])
+        else:
+            registered_count += 1
 
     LOG.debug('End : register default RuleTypes.')
 
-    return True
+    return registered_count


### PR DESCRIPTION
Cherry picked just the CLI syntax change from #3020.

Resolves #3001

I'm also working on some other related improvements and fixes.

# TODO

- [x] Tests for pack register API endpoint
- [x] Various other related improvements and fixes