### PR TITLE
Set default_flow_style for yaml jinja filter

### DIFF
--- a/st2common/st2common/jinja/filters/data.py
+++ b/st2common/st2common/jinja/filters/data.py
@@ -28,4 +28,5 @@ def to_json_string(value, indent=4, sort_keys=False, separators=(',', ':')):
 
 
 def to_yaml_string(value, indent=4, allow_unicode=True):
-    return yaml.safe_dump(value, indent=indent, allow_unicode=allow_unicode)
+    return yaml.safe_dump(value, indent=indent, allow_unicode=allow_unicode,
+                          default_flow_style=False)


### PR DESCRIPTION
It is my impression that this filter is mainly used to produce readable representation of the object. Unless `default_flow_style` is strictly defined, yaml dumper would pick the one it seem appropriate producing quite different formatting for pretty similar kind of input.

Flow style
```
{author: st2-dev, description: StackStorm pack management, email: info@stackstorm.com,
    name: st2, version: 0.1.2}
```
vs block style
```
author: st2-dev
description: st2 content pack containing github integrations
email: info@stackstorm.com
keywords:
- github
- git
- scm
name: github
version: 0.4.0
```