### PR TITLE
Fix registered content counts returned by the packs register API endpoint

### DIFF
--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -15,6 +15,8 @@
 
 import re
 
+from collections import defaultdict
+
 import pecan
 from pecan.rest import RestController
 import six
@@ -127,7 +129,7 @@ class PackRegisterController(RestController):
         else:
             packs = None
 
-        result = {}
+        result = defaultdict(int)
 
         # Register depended resources (actions depend on runners, rules depend on rule types, etc)
         if ('runner' in types or 'runners' in types) or ('action' in types or 'actions' in types):
@@ -150,7 +152,8 @@ class PackRegisterController(RestController):
                         pack_path = content_utils.get_pack_base_path(pack)
 
                         try:
-                            result[name] = registrar.register_from_pack(pack_dir=pack_path)
+                            registered_count = registrar.register_from_pack(pack_dir=pack_path)
+                            result[name] += registered_count
                         except ValueError as e:
                             # Throw more user-friendly exception if requsted pack doesn't exist
                             if re.match('Directory ".*?" doesn\'t exist', str(e)):
@@ -160,7 +163,8 @@ class PackRegisterController(RestController):
                             raise e
                 else:
                     packs_base_paths = content_utils.get_packs_base_paths()
-                    result[name] = registrar.register_from_packs(base_dirs=packs_base_paths)
+                    registered_count = registrar.register_from_packs(base_dirs=packs_base_paths)
+                    result[name] += registered_count
 
         return result
 

--- a/st2api/tests/unit/controllers/v1/test_packs.py
+++ b/st2api/tests/unit/controllers/v1/test_packs.py
@@ -170,7 +170,8 @@ class PacksControllerTestCase(FunctionalTest):
         self.assertEqual(resp.json, PACK_INDEX['test2'])
 
     def test_packs_register_endpoint(self):
-        # Register resources from all packs
+        # Register resources from all packs - make sure the count values are correctly added
+        # together
         resp = self.app.post_json('/v1/packs/register')
 
         self.assertEqual(resp.status_int, 200)
@@ -184,7 +185,9 @@ class PacksControllerTestCase(FunctionalTest):
         self.assertTrue('policy_types' in resp.json)
         self.assertTrue('policies' in resp.json)
         self.assertTrue('configs' in resp.json)
-        self.assertTrue(resp.json['actions'] >= 1)
+
+        self.assertTrue(resp.json['actions'] >= 3)
+        self.assertTrue(resp.json['configs'] >= 3)
 
         # Register resources from a specific pack
         resp = self.app.post_json('/v1/packs/register', {'packs': ['dummy_pack_1']})


### PR DESCRIPTION
This fixes a bug in the result object of the packs register API endpoint.

The "registered count" values were not correctly being added together when registering multiple packs. Instead of adding the values together, the count from the last pack registered always overwrote the result.