### PR TITLE
Fix a typo in the pack install alias

### DIFF
--- a/contrib/packs/aliases/pack_install.yaml
+++ b/contrib/packs/aliases/pack_install.yaml
@@ -5,7 +5,7 @@ pack: "packs"
 description: "Install/upgrade StackStorm packs (pack = name or git URL, gitref = tag/branch/commit)."
 formats:
   - display: "pack install <pack>[,<pack>]"
-  - display: "pack install <pack>#<gitref>[,<pack#gitref>]"
+  - display: "pack install <pack>=<gitref>[,<pack>=<gitref>]"
     representation:
       - "pack install {{ packs }}"
 ack:


### PR DESCRIPTION
Teeny tiny typo :) Or maybe not even a typo, the PR might’ve been opened when we still had `#` as a tentative version separator.