### PR TITLE
Fix description for 'pack install' Alias

### DIFF
--- a/contrib/packs/aliases/pack_install.yaml
+++ b/contrib/packs/aliases/pack_install.yaml
@@ -2,10 +2,10 @@
 name: "pack_install"
 action_ref: "packs.install"
 pack: "packs"
-description: "Install/upgrade StackStorm packs (pack = name or git URL, gitref = tag/branch/commit)."
+description: "Install/upgrade StackStorm packs."
 formats:
   - display: "pack install <pack>[,<pack>]"
-  - display: "pack install <pack>=<gitref>[,<pack>=<gitref>]"
+  - display: "pack install <gitUrl>[,<gitUrl>]"
     representation:
       - "pack install {{ packs }}"
 ack:


### PR DESCRIPTION
`=` is not acceptable in Action Alias as separator between `pack=version` because of https://docs.stackstorm.com/chatops/aliases.html#key-value-parameters

![](https://i.imgur.com/3meMhnG.png)

So adjusting description accordingly.