### PR TITLE
Fix description for 'pack install' Alias (v2.1)

### DIFF
--- a/contrib/packs/aliases/pack_install.yaml
+++ b/contrib/packs/aliases/pack_install.yaml
@@ -2,10 +2,10 @@
 name: "pack_install"
 action_ref: "packs.install"
 pack: "packs"
-description: "Install/upgrade StackStorm packs (pack = name or git URL, gitref = tag/branch/commit)."
+description: "Install/upgrade StackStorm packs."
 formats:
   - display: "pack install <pack>[,<pack>]"
-  - display: "pack install <pack>=<gitref>[,<pack>=<gitref>]"
+  - display: "pack install <gitUrl>[,<gitUrl>]"
     representation:
       - "pack install {{ packs }}"
 ack:


### PR DESCRIPTION
See original https://github.com/StackStorm/st2/pull/3066
(cherry picked from commit 928f240) for inclusion in `v2.1` branch.