### PR TITLE
Remove config on pack unload

### DIFF
--- a/contrib/packs/actions/pack_mgmt/unload.py
+++ b/contrib/packs/actions/pack_mgmt/unload.py
@@ -19,6 +19,7 @@ from st2common.models.db import db_setup
 from st2common.runners.base_action import Action as BaseAction
 from st2common.persistence.pack import Pack
 from st2common.persistence.pack import ConfigSchema
+from st2common.persistence.pack import Config
 from st2common.persistence.reactor import SensorType
 from st2common.persistence.reactor import TriggerType
 from st2common.persistence.reactor import Trigger
@@ -64,6 +65,7 @@ class UnregisterPackAction(BaseAction):
             self._unregister_actions(pack=pack)
             self._unregister_rules(pack=pack)
             self._unregister_aliases(pack=pack)
+            self._unregister_configs(pack=pack)
             self._unregister_pack(pack=pack)
             self.logger.info('Removed pack %s.', pack)
 
@@ -98,6 +100,9 @@ class UnregisterPackAction(BaseAction):
 
     def _unregister_aliases(self, pack):
         return self._delete_pack_db_objects(pack=pack, access_cls=ActionAlias)
+
+    def _unregister_configs(self, pack):
+        return self._delete_pack_db_objects(pack=pack, access_cls=Config)
 
     def _unregister_pack(self, pack):
         # 1. Delete pack


### PR DESCRIPTION
Remove the config alongside the pack. Requested by @lakshmi-kannan.