### PR TITLE
Make pack install work with local git repo

### DIFF
--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -287,7 +287,6 @@ class DownloadGitRepoAction(Action):
                 url = repo_url
             return url if url.endswith('.git') else "{}.git".format(url)
 
-
     @staticmethod
     def _get_pack_metadata(pack_dir):
         metadata = get_pack_metadata(pack_dir=pack_dir)

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -278,12 +278,15 @@ class DownloadGitRepoAction(Action):
         """Allow passing short GitHub style URLs"""
         if not repo_url:
             raise Exception('No valid repo_url provided or could be inferred.')
-        has_git_extension = repo_url.endswith('.git')
-        if len(repo_url.split('/')) == 2 and "git@" not in repo_url:
-            url = "https://github.com/{}".format(repo_url)
+        if "file:" in repo_url:
+            return repo_url
         else:
-            url = repo_url
-        return url if has_git_extension else "{}.git".format(url)
+            if len(repo_url.split('/')) == 2 and "git@" not in repo_url:
+                url = "https://github.com/{}".format(repo_url)
+            else:
+                url = repo_url
+            return url if url.endswith('.git') else "{}.git".format(url)
+
 
     @staticmethod
     def _get_pack_metadata(pack_dir):

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -278,7 +278,7 @@ class DownloadGitRepoAction(Action):
         """Allow passing short GitHub style URLs"""
         if not repo_url:
             raise Exception('No valid repo_url provided or could be inferred.')
-        if "file:" in repo_url:
+        if repo_url.startswith("file://"):
             return repo_url
         else:
             if len(repo_url.split('/')) == 2 and "git@" not in repo_url:

--- a/contrib/packs/tests/test_action_download.py
+++ b/contrib/packs/tests/test_action_download.py
@@ -265,3 +265,27 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
         pack_mgmt.download.CURRENT_STACKSTROM_VERSION = '1.5.0'
         result = action.run(packs=['test3'], abs_repo_base=self.repo_base, force=True)
         self.assertEqual(result['test3'], 'Success.')
+
+    def test_resolve_urls(self):
+        url = DownloadGitRepoAction._eval_repo_url(
+            "https://github.com/StackStorm-Exchange/stackstorm-test")
+        self.assertEqual(url, "https://github.com/StackStorm-Exchange/stackstorm-test.git")
+
+        url = DownloadGitRepoAction._eval_repo_url(
+            "https://github.com/StackStorm-Exchange/stackstorm-test.git")
+        self.assertEqual(url, "https://github.com/StackStorm-Exchange/stackstorm-test.git")
+
+        url = DownloadGitRepoAction._eval_repo_url("StackStorm-Exchange/stackstorm-test")
+        self.assertEqual(url, "https://github.com/StackStorm-Exchange/stackstorm-test.git")
+
+        url = DownloadGitRepoAction._eval_repo_url("git://StackStorm-Exchange/stackstorm-test")
+        self.assertEqual(url, "git://StackStorm-Exchange/stackstorm-test.git")
+
+        url = DownloadGitRepoAction._eval_repo_url("git://StackStorm-Exchange/stackstorm-test.git")
+        self.assertEqual(url, "git://StackStorm-Exchange/stackstorm-test.git")
+
+        url = DownloadGitRepoAction._eval_repo_url("git@github.com:foo/bar.git")
+        self.assertEqual(url, "git@github.com:foo/bar.git")
+
+        url = DownloadGitRepoAction._eval_repo_url("file:///home/vagrant/stackstorm-test")
+        self.assertEqual(url, "file:///home/vagrant/stackstorm-test")


### PR DESCRIPTION
- Make st2 pack.install work with file:///path/to/local/git/repo.
- Add unit tests to cover permutations.