### PR TITLE
Fix "pkg_resources" related import issues

### DIFF
--- a/st2common/st2common/runners/python_action_wrapper.py
+++ b/st2common/st2common/runners/python_action_wrapper.py
@@ -16,13 +16,6 @@
 import os
 import sys
 
-# Note: This must be called before other imports to affect speedsup
-# We only ran it if script is ran as subprocess by action runner so we don't break the tests and
-# other code.
-if __name__ == '__main__':
-    from st2common.util.monkey_patch import monkey_patch_pkg_resources
-    monkey_patch_pkg_resources()
-
 # Note: This work-around is required to fix the issue with other Python modules which live
 # inside this directory polluting and masking sys.path for Python runner actions.
 # Since this module is ran as a Python script inside a subprocess, directory where the script


### PR DESCRIPTION
This fixes the issue inside BWC packs reported by @samirsss.

Sadly it means we need to revert one of the Python runner performance improvements. Some of the third part libraries such as paramiko and cryptography depend on `pkg_resources` functionality which is not available in much faster `entrypoints` library fork.

There are ways around that, but doing that would take me multiple days so I decided to revert the change for now. In the future, I do plan to look into it again though since it offers quite good speedups (500-600ms) for the average case where more advanced pkg_resources functionality is not used.

I will probably do something along the lines of using `entrypoints` for the common functionality which is already available in `entrypoints` and when additional more advanced functionality is requested, fall back (proxy) to `pkg_resources`. So in a sense, those will be "lazy" methods inside `entrypoints` library which lazily import original `pkg_resources` and proxy those calls to `pkg_resources`.