### PR TITLE
submit-debug-info: pass the `output_path` as the shell command working directory

### DIFF
--- a/st2debug/st2debug/cmd/submit_debug_info.py
+++ b/st2debug/st2debug/cmd/submit_debug_info.py
@@ -424,7 +424,7 @@ class DebugInfoCollector(object):
         LOG.debug('Including the required shell commands output files')
         for cmd in self.shell_commands:
             output_file = os.path.join(output_path, '%s.txt' % self.format_output_filename(cmd))
-            exit_code, stdout, stderr = run_command(cmd=cmd, shell=True)
+            exit_code, stdout, stderr = run_command(cmd=cmd, shell=True, cwd=output_path)
             with open(output_file, 'w') as fp:
                 fp.write('[BEGIN STDOUT]\n')
                 fp.write(stdout)


### PR DESCRIPTION
In addition to log files and stdout/stderr, I had the need to run a shell script as a `shell_command` when running submit_debug_info.py to generate a debug bundle.  The use case for the shell script is to create and then collect various additional files outside of the purview of st2 and place them in the tmp****** directory to be included in the archive. 

In order to do so effectively, I needed the shell script to reliably know the path to the temporary directory.  This change sets the `output_path` as the working directory of the subprocess which executes the shell command.  Ex: `/tmp/tmpp0qiO5/commands`

