### PR TITLE
Fixes #3063. Stopped directly accessing dict keys to avoid KeyError

### DIFF
--- a/st2common/st2common/util/actionalias_matching.py
+++ b/st2common/st2common/util/actionalias_matching.py
@@ -39,16 +39,20 @@ def list_format_strings_from_aliases(aliases):
     for alias in aliases:
         for format_ in alias.formats:
             display, representations = normalise_alias_format_string(format_)
-            patterns.extend([(display, representation) for representation in representations])
+            if display and len(representations) == 0:
+                patterns.extend([(display, [])])
+            else:
+                patterns.extend([(display, representation) for representation in representations])
     return patterns
 
 
 def normalise_alias_format_string(alias_format):
     '''
-    StackStorm action aliases can have two types;
-        1. A simple string holding the format
-        2. A dictionary which hold numerous alias format "representation(s)"
-           With a single "display" for help about the action alias.
+    StackStorm action aliases come in two forms;
+        1. A string holding the format, which is also used as the help string.
+        2. A dictionary containing "display" and/or "representation" keys.
+           "representation": a list of numerous alias format "representation(s)"
+           "display": a help string to be displayed.
     This function processes both forms and returns a standardized form.
 
     :param alias_format: The alias format
@@ -64,8 +68,10 @@ def normalise_alias_format_string(alias_format):
         display = alias_format
         representation.append(alias_format)
     elif isinstance(alias_format, dict):
-        display = alias_format['display']
-        representation = alias_format['representation']
+        display = alias_format.get('display')
+        representation = alias_format.get('representation') or []
+        if isinstance(representation, six.string_types):
+            representation = [representation]
     else:
         raise TypeError("alias_format '%s' is neither a dictionary or string type."
                         % repr(alias_format))

--- a/st2common/tests/unit/test_util_actionalias_matching.py
+++ b/st2common/tests/unit/test_util_actionalias_matching.py
@@ -65,6 +65,34 @@ class ActionAliasTestCase(unittest2.TestCase):
         self.assertEqual(result[2][0], "How do I feel? I feel... {{status}}!")
         self.assertEqual(result[2][1], "How do I feel? I feel... {{status}}!")
 
+    def test_list_format_strings_from_aliases_with_display_only(self, mock):
+        ALIASES = [
+            MemoryActionAliasDB(name='andy', ref='the_goonies.1', formats=[
+                                {'display': 'Watch this.'}]),
+            MemoryActionAliasDB(name='andy', ref='the_goonies.2', formats=[
+                                {'display': "He's just like his {{relation}}."}])
+        ]
+        result = matching.list_format_strings_from_aliases(ALIASES)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0][0], 'Watch this.')
+        self.assertEqual(result[0][1], [])
+        self.assertEqual(result[1][0], "He's just like his {{relation}}.")
+        self.assertEqual(result[1][1], [])
+
+    def test_list_format_strings_from_aliases_with_representation_only(self, mock):
+        ALIASES = [
+            MemoryActionAliasDB(name='data', ref='the_goonies.1', formats=[
+                            {'representation': "That's okay daddy. You can't hug a {{object}}."}]),
+            MemoryActionAliasDB(name='mr_wang',  ref='the_goonies.2', formats=[
+                            {'representation': 'You are my greatest invention.'}])
+        ]
+        result = matching.list_format_strings_from_aliases(ALIASES)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0][0], None)
+        self.assertEqual(result[0][1], "That's okay daddy. You can't hug a {{object}}.")
+        self.assertEqual(result[1][0], None)
+        self.assertEqual(result[1][1], 'You are my greatest invention.')
+
     def test_normalise_alias_format_string(self, mock):
         result = matching.normalise_alias_format_string(
             'Quite an experience to live in fear, isn\'t it?')

--- a/st2common/tests/unit/test_util_actionalias_matching.py
+++ b/st2common/tests/unit/test_util_actionalias_matching.py
@@ -67,10 +67,10 @@ class ActionAliasTestCase(unittest2.TestCase):
 
     def test_list_format_strings_from_aliases_with_display_only(self, mock):
         ALIASES = [
-            MemoryActionAliasDB(name='andy', ref='the_goonies.1', formats=[
-                                {'display': 'Watch this.'}]),
-            MemoryActionAliasDB(name='andy', ref='the_goonies.2', formats=[
-                                {'display': "He's just like his {{relation}}."}])
+            MemoryActionAliasDB(name='andy',
+                                ref='the_goonies.1', formats=[{'display': 'Watch this.'}]),
+            MemoryActionAliasDB(name='andy', ref='the_goonies.2',
+                                formats=[{'display': "He's just like his {{relation}}."}])
         ]
         result = matching.list_format_strings_from_aliases(ALIASES)
         self.assertEqual(len(result), 2)
@@ -82,9 +82,9 @@ class ActionAliasTestCase(unittest2.TestCase):
     def test_list_format_strings_from_aliases_with_representation_only(self, mock):
         ALIASES = [
             MemoryActionAliasDB(name='data', ref='the_goonies.1', formats=[
-                            {'representation': "That's okay daddy. You can't hug a {{object}}."}]),
-            MemoryActionAliasDB(name='mr_wang',  ref='the_goonies.2', formats=[
-                            {'representation': 'You are my greatest invention.'}])
+                {'representation': "That's okay daddy. You can't hug a {{object}}."}]),
+            MemoryActionAliasDB(name='mr_wang', ref='the_goonies.2', formats=[
+                {'representation': 'You are my greatest invention.'}])
         ]
         result = matching.list_format_strings_from_aliases(ALIASES)
         self.assertEqual(len(result), 2)


### PR DESCRIPTION
exception and provide sane default values.  Normalised representation keys provided as strings types to be returned as list types.

Unit tests were added to test the results of display only dictionaries and representation only dictionaries.