### PR TITLE
Add step to delete st2tests dir. in st2-self-check script

### DIFF
--- a/st2common/bin/st2-self-check
+++ b/st2common/bin/st2-self-check
@@ -59,25 +59,22 @@ elif [ -e "${ST2_CLI_CONFIG_FILE}" ]; then
   fi
 fi
 
-echo -n "Cloning st2tests in /tmp.."
-echo ""
-cd /tmp
+pushd ~
+echo "Cloning st2tests in `pwd`."
 git clone --depth 1 https://github.com/StackStorm/st2tests.git
 
-echo -n "Copying asserts, fixtures, tests and examples packs.."
-echo ""
+echo "Copying asserts, fixtures, tests and examples packs."
 cp -R st2tests/packs/* /opt/stackstorm/packs/
 cp -Rf /usr/share/doc/st2/examples /opt/stackstorm/packs/
 
 
-echo -n "Installing asserts, fixtures, tests and examples packs.."
-echo ""
+echo "Installing asserts, fixtures, tests and examples packs."
 st2 run packs.setup_virtualenv packs=examples,tests,asserts,fixtures,webui
 st2ctl reload --register-all
 
-echo -n "Deleting 'st2tests' directory from /tmp.."
-echo ""
-rm -R /tmp/st2tests/
+echo "Deleting 'st2tests' directory from `pwd`."
+rm -R st2tests/
+popd
 
 # Retrieve test action list
 TEST_ACTION_LIST=`st2 action list --pack=tests -w 90 | awk '{ print $2 }' | grep -v "|" | grep -v "ref"`

--- a/st2common/bin/st2-self-check
+++ b/st2common/bin/st2-self-check
@@ -59,16 +59,25 @@ elif [ -e "${ST2_CLI_CONFIG_FILE}" ]; then
   fi
 fi
 
+echo -n "Cloning st2tests in /tmp.."
+echo ""
+cd /tmp
 git clone --depth 1 https://github.com/StackStorm/st2tests.git
 
-echo -n "Installing asserts,fixtures,tests"
+echo -n "Copying asserts, fixtures, tests and examples packs.."
+echo ""
 cp -R st2tests/packs/* /opt/stackstorm/packs/
-
-echo -n "Installing examples"
 cp -Rf /usr/share/doc/st2/examples /opt/stackstorm/packs/
 
+
+echo -n "Installing asserts, fixtures, tests and examples packs.."
+echo ""
 st2 run packs.setup_virtualenv packs=examples,tests,asserts,fixtures,webui
 st2ctl reload --register-all
+
+echo -n "Deleting 'st2tests' directory from /tmp.."
+echo ""
+rm -R /tmp/st2tests/
 
 # Retrieve test action list
 TEST_ACTION_LIST=`st2 action list --pack=tests -w 90 | awk '{ print $2 }' | grep -v "|" | grep -v "ref"`


### PR DESCRIPTION
Git clone fails on second attempt as the s2tests folder is not deleted: `fatal: destination path 'st2tests' already exists and is not an empty directory.`