### PR TITLE
Add pack back pack version normalization

### DIFF
--- a/st2common/st2common/constants/pack.py
+++ b/st2common/st2common/constants/pack.py
@@ -19,6 +19,7 @@ __all__ = [
     'PACK_RESERVED_CHARACTERS',
     'PACK_VERSION_SEPARATOR',
     'PACK_VERSION_REGEX',
+    'NORMALIZE_PACK_VERSION',
     'ST2_VERSION_REGEX',
     'SYSTEM_PACK_NAME',
     'PACKS_PACK_NAME',
@@ -36,6 +37,9 @@ PACK_REF_WHITELIST_REGEX = r'^[a-z0-9_]+$'
 
 # Check for a valid semver string
 PACK_VERSION_REGEX = r'^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[\da-z\-]+(?:\.[\da-z\-]+)*)?(?:\+[\da-z\-]+(?:\.[\da-z\-]+)*)?$'  # noqa
+
+# If True, non semver valid pack versions will be normalized on register (e.g. 0.2 -> 0.2.0)
+NORMALIZE_PACK_VERSION = True
 
 # Special characters which can't be used in pack names
 PACK_RESERVED_CHARACTERS = [

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -25,6 +25,7 @@ from st2common.constants.keyvalue import USER_SCOPE
 from st2common.constants.pack import PACK_REF_WHITELIST_REGEX
 from st2common.constants.pack import PACK_VERSION_REGEX
 from st2common.constants.pack import ST2_VERSION_REGEX
+from st2common.constants.pack import NORMALIZE_PACK_VERSION
 from st2common.persistence.pack import ConfigSchema
 from st2common.models.api.base import BaseAPI
 from st2common.models.db.pack import PackDB
@@ -153,7 +154,7 @@ class PackAPI(BaseAPI):
         # In case the version doesn't match that format, we simply append ".0" to the end (e.g.
         # 0.1 -> 0.1.0, 1.0, -> 1.0.0, etc.)
         version_seperator_count = values['version'].count('.')
-        if version_seperator_count == 1:
+        if version_seperator_count == 1 and NORMALIZE_PACK_VERSION:
             new_version = values['version'] + '.0'
             LOG.info('Pack "%s" contains invalid semver version specifer, casting it to a full '
                      'semver version specifier (%s -> %s)' % (name, values['version'],

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -33,6 +33,7 @@ from st2common.models.db.pack import ConfigSchemaDB
 from st2common.models.db.pack import ConfigDB
 from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2common.util.pack import validate_config_against_schema
+from st2common.util.pack import normalize_pack_version
 
 __all__ = [
     'PackAPI',
@@ -153,12 +154,12 @@ class PackAPI(BaseAPI):
         # Special case for old version which didn't follow semver format (e.g. 0.1, 1.0, etc.)
         # In case the version doesn't match that format, we simply append ".0" to the end (e.g.
         # 0.1 -> 0.1.0, 1.0, -> 1.0.0, etc.)
-        version_seperator_count = values['version'].count('.')
-        if version_seperator_count == 1 and NORMALIZE_PACK_VERSION:
-            new_version = values['version'] + '.0'
-            LOG.info('Pack "%s" contains invalid semver version specifer, casting it to a full '
-                     'semver version specifier (%s -> %s)' % (name, values['version'],
-                                                              new_version))
+        if NORMALIZE_PACK_VERSION:
+            new_version = normalize_pack_version(version=values['version'])
+            if new_version != values['version']:
+                LOG.info('Pack "%s" contains invalid semver version specifer, casting it to a full '
+                         'semver version specifier (%s -> %s)' % (name, values['version'],
+                                                                  new_version))
             values['version'] = new_version
 
         super(PackAPI, self).__init__(**values)

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -142,10 +142,23 @@ class PackAPI(BaseAPI):
     }
 
     def __init__(self, **values):
+        name = values.get('name', None)
+
         # Note: If some version values are not explicitly surrounded by quotes they are recognized
         # as numbers so we cast them to string
         if values.get('version', None):
             values['version'] = str(values['version'])
+
+        # Special case for old version which didn't follow semver format (e.g. 0.1, 1.0, etc.)
+        # In case the version doesn't match that format, we simply append ".0" to the end (e.g.
+        # 0.1 -> 0.1.0, 1.0, -> 1.0.0, etc.)
+        version_seperator_count = values['version'].count('.')
+        if version_seperator_count == 1:
+            new_version = values['version'] + '.0'
+            LOG.info('Pack "%s" contains invalid semver version specifer, casting it to a full '
+                     'semver version specifier (%s -> %s)' % (name, values['version'],
+                                                              new_version))
+            values['version'] = new_version
 
         super(PackAPI, self).__init__(**values)
 

--- a/st2common/st2common/util/pack.py
+++ b/st2common/st2common/util/pack.py
@@ -27,7 +27,9 @@ __all__ = [
     'get_pack_ref_from_metadata',
     'get_pack_metadata',
 
-    'validate_config_against_schema'
+    'validate_config_against_schema',
+
+    'normalize_pack_version'
 ]
 
 
@@ -105,3 +107,19 @@ def validate_config_against_schema(config_schema, config_object, config_path,
         raise jsonschema.ValidationError(msg)
 
     return cleaned
+
+
+def normalize_pack_version(version):
+    """
+    Normalize old, pre StackStorm v2.1 non valid semver version string (e.g. 0.2) to a valid
+    semver version string (0.2.0).
+
+    :rtype: ``str``
+    """
+    version = str(version)
+
+    version_seperator_count = version.count('.')
+    if version_seperator_count == 1:
+        version = version + '.0'
+
+    return version

--- a/st2common/tests/unit/test_resource_registrar.py
+++ b/st2common/tests/unit/test_resource_registrar.py
@@ -119,6 +119,21 @@ class ResourceRegistrarTestCase(CleanDbTestCase):
         self.assertRaisesRegexp(ValidationError, expected_msg, registrar._register_pack_db,
                                 pack_name=None, pack_dir=PACK_PATH_11)
 
+    def test_register_pack_old_style_non_semver_version_is_normalized_to_valid_version(self):
+        # Verify DB is empty
+        pack_dbs = Pack.get_all()
+        self.assertEqual(len(pack_dbs), 0)
+
+        registrar = ResourceRegistrar(use_pack_cache=False)
+        registrar._pack_loader.get_packs = mock.Mock()
+        registrar._pack_loader.get_packs.return_value = {'dummy_pack_11': PACK_PATH_11}
+        packs_base_paths = content_utils.get_packs_base_paths()
+        registrar.register_packs(base_dirs=packs_base_paths)
+
+        # Non-semver valid version 0.2 should be normalize to 0.2.0
+        pack_db = Pack.get_by_name('dummy_pack_11')
+        self.assertEqual(pack_db.version, '0.2.0')
+
     def test_register_pack_pack_stackstorm_version_and_future_parameters(self):
         # Verify DB is empty
         pack_dbs = Pack.get_all()

--- a/st2common/tests/unit/test_resource_registrar.py
+++ b/st2common/tests/unit/test_resource_registrar.py
@@ -105,6 +105,7 @@ class ResourceRegistrarTestCase(CleanDbTestCase):
         self.assertRaisesRegexp(ValueError, expected_msg, registrar._register_pack_db,
                                 pack_name=None, pack_dir=PACK_PATH_8)
 
+    @mock.patch('st2common.models.api.pack.NORMALIZE_PACK_VERSION', False)
     def test_register_pack_invalid_semver_version_friendly_error_message(self):
         registrar = ResourceRegistrar(use_pack_cache=False)
 

--- a/st2common/tests/unit/test_versioning_utils.py
+++ b/st2common/tests/unit/test_versioning_utils.py
@@ -16,6 +16,7 @@
 import unittest2
 
 from st2common.util.versioning import complex_semver_match
+from st2common.util.pack import normalize_pack_version
 
 
 class VersioningUtilsTestCase(unittest2.TestCase):
@@ -41,3 +42,15 @@ class VersioningUtilsTestCase(unittest2.TestCase):
         self.assertFalse(complex_semver_match('1.5.0', '>=1.6.0'))
         self.assertFalse(complex_semver_match('0.1.0', '>=1.6.0'))
         self.assertFalse(complex_semver_match('1.5.9', '>=1.6.0'))
+
+    def test_normalize_pack_version(self):
+        # Already a valid semver version string
+        self.assertEqual(normalize_pack_version('0.2.0'), '0.2.0')
+        self.assertEqual(normalize_pack_version('0.2.1'), '0.2.1')
+        self.assertEqual(normalize_pack_version('1.2.1'), '1.2.1')
+
+        # Not a valid semver version string
+        self.assertEqual(normalize_pack_version('0.2'), '0.2.0')
+        self.assertEqual(normalize_pack_version('0.3'), '0.3.0')
+        self.assertEqual(normalize_pack_version('1.3'), '1.3.0')
+        self.assertEqual(normalize_pack_version('2.0'), '2.0.0')


### PR DESCRIPTION
This adds back pack version normalization (+ extra tests, etc.) from https://github.com/StackStorm/st2/pull/2990.

This way the upgrade to v2.1.0 will be more smooth and break less backward compatibility. We will still advise users to update their pack metadata when they get a chance since non-valid semver version strings are deprecated and we will fully drop support for it in one of the next major releases.

Will cherry pick into v2.1.

