### PR TITLE
Workaround for Python action runner subprocess sys.path pollution (take 2)

### DIFF
--- a/st2common/st2common/runners/python_action_wrapper.py
+++ b/st2common/st2common/runners/python_action_wrapper.py
@@ -13,17 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import sys
 
 # Note: This work-around is required to fix the issue with other Python modules which live
 # inside this directory polluting and masking sys.path for Python runner actions.
 # Since this module is ran as a Python script inside a subprocess, directory where the script
 # lives gets added to sys.path and we don't want that.
+# Note: We need to use just the suffix, because full path is different depending if the process
+# is ran in virtualenv or not
+RUNNERS_PATH_SUFFIX = 'st2common/runners'
 if __name__ == '__main__':
-    BASE_DIR = os.path.dirname(os.path.abspath(__file__))
     script_path = sys.path[0]
-    if BASE_DIR in script_path:
+    if RUNNERS_PATH_SUFFIX in script_path:
         sys.path.pop(0)
 
 import sys


### PR DESCRIPTION
This pull request works on top of https://github.com/StackStorm/st2/pull/3075.

The work-around in that PR worked fine locally, but not with actual packages inside production. The problem was that I used a very safe, but also a very restrictive path check which works locally, but not with packages which use a virtualenv  for st2 so paths are different.

Here is an example of actual BASE_DIR and SCRIPT_PATH with packages:

* /opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/runners
* /opt/stackstorm/st2/lib/python2.7/site-packages/st2common/runners

Luckily we now also have en end to end test in addition to unit test which caught this.