### PR TITLE
added the function to verify that the payload format is complied with the schema of Trigger (#3077)

### DIFF
--- a/st2common/st2common/validators/api/reactor.py
+++ b/st2common/st2common/validators/api/reactor.py
@@ -22,6 +22,7 @@ from st2common.constants.triggers import SYSTEM_TRIGGER_TYPES
 from st2common.constants.triggers import CRON_TIMER_TRIGGER_REF
 from st2common.util import schema as util_schema
 import st2common.operators as criteria_operators
+from st2common.services import triggers
 
 __all__ = [
     'validate_criteria',
@@ -65,11 +66,14 @@ def validate_trigger_parameters(trigger_type_ref, parameters):
     if not trigger_type_ref:
         return None
 
-    if trigger_type_ref not in SYSTEM_TRIGGER_TYPES:
-        # Not a system trigger, skip validation for now
+    trigger_type = triggers.get_trigger_type_db(trigger_type_ref)
+    if trigger_type_ref in SYSTEM_TRIGGER_TYPES:
+        parameters_schema = SYSTEM_TRIGGER_TYPES[trigger_type_ref]['parameters_schema']
+    elif trigger_type and trigger_type.payload_schema:
+        parameters_schema = trigger_type.payload_schema
+    else:
         return None
 
-    parameters_schema = SYSTEM_TRIGGER_TYPES[trigger_type_ref]['parameters_schema']
     cleaned = util_schema.validate(instance=parameters, schema=parameters_schema,
                                    cls=util_schema.CustomValidator, use_default=True,
                                    allow_default_none=True)

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -33,6 +33,7 @@ from st2reactor.sensor.base import Sensor, PollingSensor
 from st2reactor.sensor import config
 from st2common.services.datastore import DatastoreService
 from st2common.util.monkey_patch import monkey_patch
+from st2common.services import triggers
 
 __all__ = [
     'SensorWrapper',
@@ -99,7 +100,71 @@ class SensorService(object):
         :param trace_context: Trace context to associate with Trigger.
         :type trace_context: ``st2common.api.models.api.trace.TraceContext``
         """
+        # checks specified payload comply trigger_type schema
+        if not self._check_payload_validation(trigger, payload):
+            output_msg = 'invalid payload is specified (%s)' % (payload)
+            if cfg.CONF.sensorcontainer.permit_invalid_payload:
+                self._logger.warn(output_msg)
+            else:
+                self._logger.error(output_msg)
+                return None
+
         self._dispatcher.dispatch(trigger, payload=payload, trace_context=trace_context)
+
+    # This checks that payload format is complied with schema of TriggerType
+    def _check_payload_validation(self, trigger, payload):
+        trigger_type = triggers.get_trigger_type_db(trigger)
+
+        if not trigger_type:
+            self._logger.warn("failed to get TriggerType object from the datastore")
+            return True
+
+        if not trigger_type.payload_schema:
+            # the case trigger doesn't have any properfies
+            return True
+
+        return self._do_check_payload_validation(trigger_type.payload_schema, payload)
+
+    def _do_check_payload_validation(self, schema, payload):
+        if not payload:
+            return 'default' in schema
+        elif 'type' in schema:
+            return self._is_valid_type(payload, schema, schema['type'])
+        elif 'anyOf' in schema:
+            return self._is_valid_any_of_type(payload, schema, schema['anyOf'])
+        else:
+            return True
+
+    def _is_valid_type(self, payload, schema, schema_type):
+        if schema_type in {'integer', 'number'}:
+            return isinstance(payload, int)
+
+        if schema_type == 'string':
+            return isinstance(payload, str)
+
+        if schema_type == 'boolean':
+            return isinstance(payload, bool)
+
+        if schema_type == 'array':
+            return isinstance(payload, list)
+
+        if schema_type == 'object':
+            if 'properties' not in schema:
+                return isinstance(payload, dict)
+
+            # This means payload has extend properties.
+            if set(payload.keys()) - set(schema['properties'].keys()) != set([]):
+                return False
+
+            # Tracking nested properties recursively
+            if not all([self._do_check_payload_validation(schema['properties'][k], payload[k]
+                        if k in payload else None) for k in schema['properties'].keys()]):
+                return False
+
+        return True
+
+    def _is_valid_any_of_type(self, payload, schema, schema_any_of):
+        return any([self._is_valid_type(payload, schema, x['type']) for x in schema_any_of])
 
     ##################################
     # Methods for datastore management

--- a/st2reactor/st2reactor/sensor/config.py
+++ b/st2reactor/st2reactor/sensor/config.py
@@ -55,6 +55,12 @@ def _register_sensor_container_opts(ignore_errors=False):
     ]
     st2cfg.do_register_opts(partition_opts, group='sensorcontainer', ignore_errors=ignore_errors)
 
+    validation_opts = [
+        cfg.BoolOpt('permit_invalid_payload', default=True, help='permit sensors to send payload \
+            that does not comply with payload_schema of Trigger')
+    ]
+    st2cfg.do_register_opts(validation_opts, group='sensorcontainer', ignore_errors=ignore_errors)
+
     sensor_test_opt = cfg.StrOpt('sensor-ref', help='Only run sensor with the provided reference. \
         Value is of the form pack.sensor-name.')
     st2cfg.do_register_cli_opts(sensor_test_opt, ignore_errors=ignore_errors)

--- a/st2reactor/tests/unit/test_sensor_service.py
+++ b/st2reactor/tests/unit/test_sensor_service.py
@@ -1,0 +1,124 @@
+import mock
+import unittest2
+
+from oslo_config import cfg
+
+from st2reactor.container.sensor_wrapper import SensorService
+
+
+class TriggerTypeMock(object):
+    def __init__(self, schema={}):
+        self.payload_schema = schema
+
+# This trigger has schema that uses all property types
+TRIGGER_TYPE_MOCK = TriggerTypeMock({
+    'type': 'object',
+    'properties': {
+        'age': {'type': 'integer'},
+        'name': {'type': 'string'},
+        'address': {'type': 'string', 'default': '-'},
+        'attributes': {
+            'type': 'object',
+            'properties': {
+                'career': {'type': 'array'},
+                'married': {'type': 'boolean'},
+                'awards': {'type': 'object'},
+                'income': {'anyOf': [{'type': 'integer'}, {'type': 'string'}]},
+            },
+        },
+    },
+})
+
+
+@mock.patch('st2common.services.triggers.get_trigger_type_db',
+            mock.MagicMock(return_value=TRIGGER_TYPE_MOCK))
+class SensorServiceTestCase(unittest2.TestCase):
+    def setUp(self):
+        def side_effect(trigger, payload, trace_context):
+            self._dispatched_count += 1
+
+        self.sensor_service = SensorService(mock.MagicMock())
+        self.sensor_service._dispatcher = mock.Mock()
+        self.sensor_service._dispatcher.dispatch = mock.MagicMock(side_effect=side_effect)
+        self._dispatched_count = 0
+
+    def test_dispatch_success(self):
+        # define a valid payload
+        payload = {
+            'name': 'John Doe',
+            'age': 25,
+            'attributes': {
+                'career': ['foo, Inc.', 'bar, Inc.'],
+                'married': True,
+                'awards': {'hoge prize': 2016},
+                'income': 50000,
+            },
+        }
+
+        # dispatching a trigger
+        self.sensor_service.dispatch('trigger-name', payload)
+
+        # This assumed that the target tirgger dispatched
+        self.assertEqual(self._dispatched_count, 1)
+
+        # reset payload which can have different type
+        payload['attributes']['income'] = 'secret'
+
+        self.sensor_service.dispatch('trigger-name', payload)
+        self.assertEqual(self._dispatched_count, 2)
+
+    def test_dispatch_failure_caused_by_incorrect_type(self):
+        # define a invalid payload (the type of 'age' is incorrect)
+        payload = {
+            'name': 'John Doe',
+            'age': '25',
+            'attributes': {
+                'career': ['foo, Inc.', 'bar, Inc.'],
+                'married': True,
+                'awards': {'hoge prize': 2016},
+                'income': 50000,
+            },
+        }
+
+        # set config to stop dispatching when the payload comply with target trigger_type
+        cfg.CONF.sensorcontainer.permit_invalid_payload = False
+
+        self.sensor_service.dispatch('trigger-name', payload)
+
+        # This assumed that the target tirgger doesn't dispatched
+        self.assertEqual(self._dispatched_count, 0)
+
+    def test_dispatch_failure_caused_by_lack_of_parameter(self):
+        # define a invalid payload (lack of 'attributes' property)
+        payload = {
+            'name': 'John Doe',
+            'age': 25,
+        }
+        cfg.CONF.sensorcontainer.permit_invalid_payload = False
+
+        self.sensor_service.dispatch('trigger-name', payload)
+        self.assertEqual(self._dispatched_count, 0)
+
+        # reset config to permit force dispatching
+        cfg.CONF.sensorcontainer.permit_invalid_payload = True
+
+        self.sensor_service.dispatch('trigger-name', payload)
+        self.assertEqual(self._dispatched_count, 1)
+
+    def test_dispatch_failure_caused_by_too_much_parameter(self):
+        # define a invalid payload ('hobby' is extra)
+        payload = {
+            'name': 'John Doe',
+            'age': 25,
+            'attributes': {
+                'career': ['foo, Inc.', 'bar, Inc.'],
+                'married': True,
+                'awards': {'hoge prize': 2016},
+                'income': 50000,
+                'hobby': 'programming',
+            },
+        }
+        cfg.CONF.sensorcontainer.permit_invalid_payload = False
+
+        self.sensor_service.dispatch('trigger-name', payload)
+        self.assertEqual(self._dispatched_count, 0)


### PR DESCRIPTION
This adds the function to verify that the payload format is complied with the schema of specified Trigger.
In the past, the validation checking for payload format has never been, as mentioned in #3077.

The main changes of this patch are
- adding the function to verify the payload which will be the trigger output is complied with the `payload_schema` of the corresponding Trigger.
- adding the configuration parameter of `permit_invalid_payload` to permit dispatching trigger forcibly even if the payload doesn't match the Trigger's schema.

The former is the feature for the future implementation. And the later is the one for the backward compatibility.
Even if there is a sensor that dispatch a payload which violate TriggerType, the SensorService only output warning message.

Sometime in near future, I hope that all trigger output is guaranteed that the format of payload is same with the `payload_schema` by this.

Thank you.