### PR TITLE
Add some additional tests for retry policy

### DIFF
--- a/st2actions/tests/unit/policies/test_retry_policy.py
+++ b/st2actions/tests/unit/policies/test_retry_policy.py
@@ -116,6 +116,16 @@ class RetryPolicyTestCase(CleanDbTestCase):
         self.assertEqual(action_execution_dbs[0].status, LIVEACTION_STATUS_TIMED_OUT)
         self.assertEqual(action_execution_dbs[1].status, LIVEACTION_STATUS_REQUESTED)
 
+        # Verify retried execution contains policy related context
+        original_liveaction_id = action_execution_dbs[0].liveaction['id']
+
+        context = action_execution_dbs[1].context
+        self.assertTrue('policies' in context)
+        self.assertEqual(context['policies']['retry']['retry_count'], 1)
+        self.assertEqual(context['policies']['retry']['applied_policy'], 'test_policy')
+        self.assertEqual(context['policies']['retry']['retried_liveaction_id'],
+                         original_liveaction_id)
+
         # Simulate success of second action so no it shouldn't be retried anymore
         live_action_db = live_action_dbs[1]
         live_action_db.status = LIVEACTION_STATUS_SUCCEEDED

--- a/st2common/st2common/services/executions.py
+++ b/st2common/st2common/services/executions.py
@@ -59,7 +59,7 @@ LOG = logging.getLogger(__name__)
 
 # Attributes which are stored in the "liveaction" dictionary when composing LiveActionDB object
 # into a ActionExecution compatible dictionary.
-# Those attributes are LiveAction specified and are therefore stored in a "liveaction" key
+# Those attributes are LiveAction specific and are therefore stored in a "liveaction" key
 LIVEACTION_ATTRIBUTES = [
     'id',
     'callback',


### PR DESCRIPTION
Was just looking / debugging some stuff to make sure that the execution contains policy related context and noticed we don't actually have any test which verifies that the context is present and correct so I added some.