### PR TITLE
Throw more user-friendly exception on invalid pack name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 in development
 --------------
 
+* Throw a more user-friendly exception when registering packs (``st2ctl reload``) if pack ref /
+  name is invalid. (improvement)
 
 2.1.0 - November 30, 2016
 -------------------------

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -168,16 +168,24 @@ class PackAPI(BaseAPI):
 
     def validate(self):
         # We wrap default validate() implementation and throw a more user-friendly exception in
-        # case pack version doesn't follow a valid semver format
+        # case pack version doesn't follow a valid semver format and other errors
         try:
             super(PackAPI, self).validate()
         except jsonschema.ValidationError as e:
             msg = str(e)
 
+            # Invalid version
             if "Failed validating 'pattern' in schema['properties']['version']" in msg:
                 new_msg = ('Pack version "%s" doesn\'t follow a valid semver format. Valid '
                            'versions and formats include: 0.1.0, 0.2.1, 1.1.0, etc.' %
                            (self.version))
+                new_msg += '\n\n' + msg
+                raise jsonschema.ValidationError(new_msg)
+
+            # Invalid ref / name
+            if "Failed validating 'pattern' in schema['properties']['ref']" in msg:
+                new_msg = ('Pack ref  name can only contain valid word characters (``a-z``, '
+                           '``0-9`` and ``_``), dashes are not allowed.')
                 new_msg += '\n\n' + msg
                 raise jsonschema.ValidationError(new_msg)
 

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -184,8 +184,8 @@ class PackAPI(BaseAPI):
 
             # Invalid ref / name
             if "Failed validating 'pattern' in schema['properties']['ref']" in msg:
-                new_msg = ('Pack ref  name can only contain valid word characters (``a-z``, '
-                           '``0-9`` and ``_``), dashes are not allowed.')
+                new_msg = ('Pack ref / name can only contain valid word characters (a-z, 0-9 and '
+                           '_), dashes are not allowed.')
                 new_msg += '\n\n' + msg
                 raise jsonschema.ValidationError(new_msg)
 

--- a/st2common/st2common/util/pack.py
+++ b/st2common/st2common/util/pack.py
@@ -57,8 +57,11 @@ def get_pack_ref_from_metadata(metadata, pack_directory_name=None):
         if re.match(PACK_REF_WHITELIST_REGEX, metadata['name']):
             pack_ref = metadata['name']
         else:
-            raise ValueError('Pack name "%s" contains invalid characters and "ref" '
-                             'attribute is not available' % (metadata['name']))
+            msg = ('Pack name "%s" contains invalid characters and "ref" attribute is not '
+                   'available. You either need to add "ref" attribute which contains only word '
+                   'characters to the pack metadata file or update name attribute to contain only'
+                   'word characters.')
+            raise ValueError(msg % (metadata['name']))
 
     return pack_ref
 

--- a/st2common/tests/unit/test_resource_registrar.py
+++ b/st2common/tests/unit/test_resource_registrar.py
@@ -39,6 +39,7 @@ PACK_PATH_9 = os.path.join(fixturesloader.get_fixtures_packs_base_path(), 'dummy
 PACK_PATH_10 = os.path.join(fixturesloader.get_fixtures_packs_base_path(), 'dummy_pack_10')
 PACK_PATH_11 = os.path.join(fixturesloader.get_fixtures_packs_base_path(), 'dummy_pack_11')
 PACK_PATH_12 = os.path.join(fixturesloader.get_fixtures_packs_base_path(), 'dummy_pack_12')
+PACK_PATH_13 = os.path.join(fixturesloader.get_fixtures_packs_base_path(), 'dummy_pack_13')
 
 
 class ResourceRegistrarTestCase(CleanDbTestCase):
@@ -104,6 +105,15 @@ class ResourceRegistrarTestCase(CleanDbTestCase):
         expected_msg = 'contains invalid characters'
         self.assertRaisesRegexp(ValueError, expected_msg, registrar._register_pack_db,
                                 pack_name=None, pack_dir=PACK_PATH_8)
+
+    def test_register_pack_invalid_ref_name_friendly_error_message(self):
+        registrar = ResourceRegistrar(use_pack_cache=False)
+
+        # Invalid ref
+        expected_msg = (r'Pack ref / name can only contain valid word characters .*?,'
+                        ' dashes are not allowed.')
+        self.assertRaisesRegexp(ValidationError, expected_msg, registrar._register_pack_db,
+                                pack_name=None, pack_dir=PACK_PATH_13)
 
     @mock.patch('st2common.models.api.pack.NORMALIZE_PACK_VERSION', False)
     def test_register_pack_invalid_semver_version_friendly_error_message(self):

--- a/st2common/tests/unit/test_resource_registrar.py
+++ b/st2common/tests/unit/test_resource_registrar.py
@@ -40,6 +40,7 @@ PACK_PATH_10 = os.path.join(fixturesloader.get_fixtures_packs_base_path(), 'dumm
 PACK_PATH_11 = os.path.join(fixturesloader.get_fixtures_packs_base_path(), 'dummy_pack_11')
 PACK_PATH_12 = os.path.join(fixturesloader.get_fixtures_packs_base_path(), 'dummy_pack_12')
 PACK_PATH_13 = os.path.join(fixturesloader.get_fixtures_packs_base_path(), 'dummy_pack_13')
+PACK_PATH_14 = os.path.join(fixturesloader.get_fixtures_packs_base_path(), 'dummy_pack_14')
 
 
 class ResourceRegistrarTestCase(CleanDbTestCase):
@@ -114,6 +115,19 @@ class ResourceRegistrarTestCase(CleanDbTestCase):
                         ' dashes are not allowed.')
         self.assertRaisesRegexp(ValidationError, expected_msg, registrar._register_pack_db,
                                 pack_name=None, pack_dir=PACK_PATH_13)
+
+        try:
+            registrar._register_pack_db(pack_name=None, pack_dir=PACK_PATH_13)
+        except ValidationError as e:
+            self.assertTrue("'invalid-has-dash' does not match '^[a-z0-9_]+$'" in str(e))
+        else:
+            self.fail('Exception not thrown')
+
+        # Pack ref not provided and name doesn't contain valid characters
+        expected_msg = (r'Pack name "dummy pack 14" contains invalid characters and "ref" '
+                        'attribute is not available. You either need to add')
+        self.assertRaisesRegexp(ValueError, expected_msg, registrar._register_pack_db,
+                                pack_name=None, pack_dir=PACK_PATH_14)
 
     @mock.patch('st2common.models.api.pack.NORMALIZE_PACK_VERSION', False)
     def test_register_pack_invalid_semver_version_friendly_error_message(self):

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_13/pack.yaml
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_13/pack.yaml
@@ -1,0 +1,7 @@
+---
+ref: invalid-has-dash
+name : dummy_pack_13
+description : dummy pack
+version : 0.1.2
+author : st2-dev
+email : info@stackstorm.com

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_14/pack.yaml
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_14/pack.yaml
@@ -1,0 +1,6 @@
+---
+name : dummy pack 14
+description : dummy pack
+version : 0.1.2
+author : st2-dev
+email : info@stackstorm.com


### PR DESCRIPTION
Default jsonschema exceptions are not that friendly so this pull request updates the code to throw a more user-friendly error in case pack ref / name contains invalid characters.

It's also worth noting that this pattern is becoming more common  in our code base (wrap original jsonschema exception and throw something more user-friendly) so we should probably come up with some kind of consistent "approach" / "conventions" for handling it consistently through the code base.