### PR TITLE
Use the same registration order inside the packs register API as we do in st2-register-content

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ in development
   name is invalid. (improvement)
 * ``core.http`` action now also supports HTTP basic auth and digest authentication by passing
   ``username`` and ``password`` parameter to the action. (new feature)
+* Update ``/v1/packs/register`` API endpoint so it registers resources in the correct order which
+  is the same as order used in ``st2-register-content`` script. (bug fix)
 
 2.1.0 - December 05, 2016
 -------------------------

--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -16,6 +16,7 @@
 import re
 
 from collections import defaultdict
+from collections import OrderedDict
 
 import pecan
 from pecan.rest import RestController
@@ -58,15 +59,18 @@ __all__ = [
 
 LOG = logging.getLogger(__name__)
 
-ENTITIES = {
-    'action': (ActionsRegistrar, 'actions'),
-    'trigger': (TriggersRegistrar, 'triggers'),
-    'sensor': (SensorsRegistrar, 'sensors'),
-    'rule': (RulesRegistrar, 'rules'),
-    'alias': (AliasesRegistrar, 'aliases'),
-    'policy': (PolicyRegistrar, 'policies'),
-    'config': (ConfigsRegistrar, 'configs')
-}
+# Note: The order those are defined it's important so they are registered in the same order as
+# they are in st2-register-content.
+# We also need to use list of tuples to preserve the order.
+ENTITIES = OrderedDict([
+    ('trigger', (TriggersRegistrar, 'triggers')),
+    ('sensor', (SensorsRegistrar, 'sensors')),
+    ('action', (ActionsRegistrar, 'actions')),
+    ('rule', (RulesRegistrar, 'rules')),
+    ('alias', (AliasesRegistrar, 'aliases')),
+    ('policy', (PolicyRegistrar, 'policies')),
+    ('config', (ConfigsRegistrar, 'configs'))
+])
 
 
 class PackInstallController(ActionExecutionsControllerMixin, RestController):

--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -54,7 +54,8 @@ http_client = six.moves.http_client
 
 __all__ = [
     'PacksController',
-    'BasePacksController'
+    'BasePacksController',
+    'ENTITIES'
 ]
 
 LOG = logging.getLogger(__name__)

--- a/st2api/tests/unit/controllers/v1/test_packs.py
+++ b/st2api/tests/unit/controllers/v1/test_packs.py
@@ -198,6 +198,35 @@ class PacksControllerTestCase(FunctionalTest):
         self.assertTrue(resp.json['sensors'] >= 1)
         self.assertTrue(resp.json['configs'] >= 1)
 
+        # Registering single resource type should also cause dependent resources
+        # to be registered
+        # * actions -> runners
+        # * rules -> rule types
+        # * policies -> policy types
+        resp = self.app.post_json('/v1/packs/register', {'packs': ['dummy_pack_1'],
+                                                         'fail_on_failure': False,
+                                                         'types': ['actions']})
+
+        self.assertEqual(resp.status_int, 200)
+        self.assertTrue(resp.json['runners'] >= 1)
+        self.assertTrue(resp.json['actions'] >= 1)
+
+        resp = self.app.post_json('/v1/packs/register', {'packs': ['dummy_pack_1'],
+                                                         'fail_on_failure': False,
+                                                         'types': ['rules']})
+
+        self.assertEqual(resp.status_int, 200)
+        self.assertTrue(resp.json['rule_types'] >= 1)
+        self.assertTrue(resp.json['rules'] >= 1)
+
+        resp = self.app.post_json('/v1/packs/register', {'packs': ['dummy_pack_2'],
+                                                         'fail_on_failure': False,
+                                                         'types': ['policies']})
+
+        self.assertEqual(resp.status_int, 200)
+        self.assertTrue(resp.json['policy_types'] >= 1)
+        self.assertTrue(resp.json['policies'] >= 0)
+
         # Register specific type for all packs
         resp = self.app.post_json('/v1/packs/register', {'types': ['sensor'],
                                                          'fail_on_failure': False})

--- a/st2api/tests/unit/controllers/v1/test_packs.py
+++ b/st2api/tests/unit/controllers/v1/test_packs.py
@@ -20,6 +20,7 @@ from st2common.models.db.pack import PackDB
 from st2common.persistence.pack import Pack
 from st2common.services import packs as pack_service
 from st2api.controllers.v1.actionexecutions import ActionExecutionsControllerMixin
+from st2api.controllers.v1.packs import ENTITIES
 from tests import FunctionalTest
 
 PACK_INDEX = {
@@ -168,6 +169,22 @@ class PacksControllerTestCase(FunctionalTest):
 
         self.assertEqual(resp.status_int, 200)
         self.assertEqual(resp.json, PACK_INDEX['test2'])
+
+    def test_packs_register_endpoint_resource_register_order(self):
+        # Verify that resources are registered in the same order as they are inside
+        # st2-register-content.
+        # Note: Sadly there is no easier / better way to test this
+        resource_types = ENTITIES.keys()
+        expected_order = [
+            'trigger',
+            'sensor',
+            'action',
+            'rule',
+            'alias',
+            'policy',
+            'config'
+        ]
+        self.assertEqual(resource_types, expected_order)
 
     def test_packs_register_endpoint(self):
         # Register resources from all packs - make sure the count values are correctly added


### PR DESCRIPTION
This pull request fixes pack register API endpoint to register different resource types in the exact same order as we use in `st2-register-content`.

Not registering it in the same order can cause multiple issues:

1. Output which it not consistent with `st2-register-content`. This could be confusing because both scripts fail on failure by default, but they could fail with a different error in case a different resource register order is used (e.g. one fails with an error inside action metadata first and other fails with an error inside rule).
2. Rules could get registered before sensors / triggers which would cause an error (trigger doesn't exist).

This addresses an issue indirectly reported in https://gist.github.com/lakshmi-kannan/6493c0d303df0622145730cf6b8e2b22. @lakshmi-kannan reported an issue, but it looks like a problem lied elsewhere (it was an "old" bug unrelated to my changes) which is nevertheless still a good catch :+1: 

## TODO

- [x] Tests
- [x] Changelog entry