### PR TITLE
Fix "get one" packs API endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ in development
   name is invalid. (improvement)
 * ``core.http`` action now also supports HTTP basic auth and digest authentication by passing
   ``username`` and ``password`` parameter to the action. (new feature)
+* Fix ``GET /v1/packs/<pack ref or id>`` API endpoint - make sure pack object is correctly returned
+  when pack ref doesn't match pack name. Previously, 404 not found was thrown. (bug fix)
 
 2.1.0 - December 05, 2016
 -------------------------

--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -43,6 +43,7 @@ from st2common.models.api.pack import PackInstallRequestAPI
 from st2common.models.api.pack import PackRegisterRequestAPI
 from st2common.models.api.pack import PackSearchRequestAPI
 from st2common.models.api.pack import PackAsyncAPI
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2common.persistence.pack import Pack
 from st2common.rbac.types import PermissionType
 from st2common.rbac.decorators import request_user_has_permission
@@ -247,6 +248,10 @@ class BasePacksController(ResourceController):
         if not resource_db:
             # Try ref
             resource_db = self._get_by_ref(ref=ref_or_id, exclude_fields=exclude_fields)
+
+        if not resource_db:
+            msg = 'Resource with a ref or id "%s" not found' % (ref_or_id)
+            raise StackStormDBObjectNotFoundError(msg)
 
         return resource_db
 

--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -284,6 +284,10 @@ class PacksController(BasePacksController):
     views = PackViewsController()
     index = PacksIndexController()
 
+    def __init__(self):
+        super(PacksController, self).__init__()
+        self.get_one_db_method = self._get_by_ref_or_id
+
     @request_user_has_permission(permission_type=PermissionType.PACK_LIST)
     @jsexpose()
     def get_all(self, **kwargs):

--- a/st2api/tests/unit/controllers/v1/test_packs.py
+++ b/st2api/tests/unit/controllers/v1/test_packs.py
@@ -53,13 +53,17 @@ class PacksControllerTestCase(FunctionalTest):
                                email='test@example.com', ref='pack1')
         cls.pack_db_2 = PackDB(name='pack2', description='foo', version='0.1.0', author='foo',
                                email='test@example.com', ref='pack2')
+        cls.pack_db_3 = PackDB(name='pack3-name', ref='pack3-ref', description='foo',
+                               version='0.1.0', author='foo',
+                               email='test@example.com')
         Pack.add_or_update(cls.pack_db_1)
         Pack.add_or_update(cls.pack_db_2)
+        Pack.add_or_update(cls.pack_db_3)
 
     def test_get_all(self):
         resp = self.app.get('/v1/packs')
         self.assertEqual(resp.status_int, 200)
-        self.assertEqual(len(resp.json), 2, '/v1/actionalias did not return all aliases.')
+        self.assertEqual(len(resp.json), 3, '/v1/actionalias did not return all packs.')
 
     def test_get_one(self):
         # Get by id
@@ -72,6 +76,11 @@ class PacksControllerTestCase(FunctionalTest):
         self.assertEqual(resp.status_int, 200)
         self.assertEqual(resp.json['ref'], self.pack_db_1.ref)
         self.assertEqual(resp.json['name'], self.pack_db_1.name)
+
+        # Get by ref (ref != name)
+        resp = self.app.get('/v1/packs/%s' % (self.pack_db_3.ref))
+        self.assertEqual(resp.status_int, 200)
+        self.assertEqual(resp.json['ref'], self.pack_db_3.ref)
 
     def test_get_one_doesnt_exist(self):
         resp = self.app.get('/v1/packs/doesntexistfoo', expect_errors=True)

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -145,8 +145,8 @@ class PackAsyncCommand(ActionRunCommandMixin, resource.ResourceCommand):
 
 
 class PackListCommand(resource.ResourceListCommand):
-    display_attributes = ['name', 'description', 'version', 'author']
-    attribute_display_order = ['name', 'description', 'version', 'author']
+    display_attributes = ['ref', 'name', 'description', 'version', 'author']
+    attribute_display_order = ['ref', 'name', 'description', 'version', 'author']
 
 
 class PackGetCommand(resource.ResourceGetCommand):


### PR DESCRIPTION
This pull request fixes "get one" packs API endpoint - it would return no items if the pack name didn't match a ref.

The method itself was fine, but the actual problem was RBAC - rbac defaulted to using "get_by_name_or_id" instead of "get_by_ref_or_id".

## TODO

- [x] Tests