### PR TITLE
Run circle for every PR

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,14 +7,6 @@
 # DOCKER_EMAIL
 # DOCKER_PASSWORD
 
-general:
-  # Don't run CI for PR, only for major branches.
-  # Remove travis and enable per PR at the same time.
-  branches:
-    only:
-      - master
-      - /v[0-9]+\.[0-9]+/
-
 notify:
   webhooks:
     - url: https://webhooks.stackstorm.net:8531/webhooks/build/events


### PR DESCRIPTION
This change is needed to start experimenting with moving away from Travis. Circle would refuse to run PRs with updated circle.yml unless we remove `branches.only` from the master version.