### PR TITLE
Update packs.load to register triggers by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ in development
   name is invalid. (improvement)
 * ``core.http`` action now also supports HTTP basic auth and digest authentication by passing
   ``username`` and ``password`` parameter to the action. (new feature)
+* Update ``packs.load`` action to also register triggers by default. (improvement)
 
 2.1.0 - December 05, 2016
 -------------------------

--- a/contrib/packs/actions/load.yaml
+++ b/contrib/packs/actions/load.yaml
@@ -8,7 +8,7 @@
     register:
       type: "string"
       default: "actions,aliases,sensors,triggers"
-      description: "Possible options are all, sensors, actions, rules, aliases."
+      description: "Possible options are all, sensors, actions, rules, aliases, triggers, configs."
     packs:
       type: "array"
       description: "A list of packs to register / load resources from."

--- a/contrib/packs/actions/load.yaml
+++ b/contrib/packs/actions/load.yaml
@@ -7,7 +7,7 @@
   parameters:
     register:
       type: "string"
-      default: "actions,aliases,sensors"
+      default: "actions,aliases,sensors,triggers"
       description: "Possible options are all, sensors, actions, rules, aliases."
     packs:
       type: "array"


### PR DESCRIPTION
Part of https://github.com/StackStorm/st2/issues/3112.

Not loading rules by default was intentional, but not loading triggers was an oversight - we missed it when we added support for new triggers resource type.

## TODO

- [x] Tests