### PR TITLE
Correction to be able to pass unicode parameters to Actions

### DIFF
--- a/st2common/st2common/models/system/action.py
+++ b/st2common/st2common/models/system/action.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -236,7 +237,7 @@ class ShellScriptAction(ShellCommandAction):
                     if value is True:
                         command_parts.append(arg)
                 else:
-                    command_parts.append('%s=%s' % (quote_unix(arg), quote_unix(str(value))))
+                    command_parts.append(u'%s=%s' % (quote_unix(arg), quote_unix(unicode(value))))
 
         # add the positional args
         if positional_args:

--- a/st2common/tests/unit/test_shell_action_system_model.py
+++ b/st2common/tests/unit/test_shell_action_system_model.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -207,3 +208,13 @@ class ShellScriptActionTestCase(unittest2.TestCase):
         command = action.get_full_command_string()
         expected = self._get_fixture('escaping_test_command_2.txt')
         self.assertEqual(command, expected)
+
+    def test_unicode_parameter_specifiing(self):
+        kwargs = copy.deepcopy(self._base_kwargs)
+        kwargs['sudo'] = False
+        kwargs['user'] = LOGGED_USER_USERNAME
+        kwargs['named_args'] = {u'ｆｏｏ': u'ｂａｒ'}
+        kwargs['positional_args'] = []
+        action = ShellScriptAction(**kwargs)
+        command = action.get_full_command_string()
+        self.assertEqual(command, u"/tmp/foo.sh 'ｆｏｏ'='ｂａｒ'")


### PR DESCRIPTION
Previously, unicode parametera are unable to pass for the `local-shell-scripts` type Actions, like this.
```
[dooga@localhost ~]$ st2 action get default.test
+-------------+--------------------------+
| Property    | Value                    |
+-------------+--------------------------+
| id          | 5850f582e138233f0387c9b2 |
| uid         | action:default:test      |
| ref         | default.test             |
| pack        | default                  |
| name        | test                     |
| description |                          |
| enabled     | True                     |
| entry_point | test.sh                  |
| runner_type | local-shell-script       |
| parameters  | {                        |
|             |     "param": {           |
|             |         "type": "string" |
|             |     }                    |
|             | }                        |
| notify      |                          |
| tags        |                          |
+-------------+--------------------------+
[dooga@localhost ~]$ cat /opt/stackstorm/packs/default/actions/test.sh 
#!/bin/sh

echo $*
[dooga@localhost ~]$ st2 run default.test param='hoge'
.
id: 58510931e1382331a2d04bf1
status: succeeded
parameters: 
  param: hoge
result: 
  failed: false
  return_code: 0
  stderr: ''
  stdout: --param=hoge
  succeeded: true
[dooga@localhost ~]$ st2 run default.test param='ｈｏｇｅ'
.
id: 5851093ae1382331a2d04bf4
status: failed
parameters: 
  param: "ｈｏｇｅ"
result: 
  error: '''ascii'' codec can''t encode characters in position 0-3: ordinal not in range(128)'
  traceback: "  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2actions/container/base.py", line 99, in _do_run
    (status, result, context) = runner.run(action_params)
  File "/opt/stackstorm/runners/local_runner/local_runner.py", line 116, in run
    args = action.get_full_command_string()
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/models/system/action.py", line 179, in get_full_command_string
    return self._format_command()
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/models/system/action.py", line 183, in _format_command
    positional_args=self.positional_args)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/models/system/action.py", line 239, in _get_script_arguments
    command_parts.append('%s=%s' % (quote_unix(arg), quote_unix(str(value))))
"
[dooga@localhost ~]$

```

This is because that `ShellScriptAction` convert input parameters to `string` type, regardless of the type of the input value.
So the case of giving an unicode parameter, an encoding error would be occur.

This patch corrects for LocalShellRunner to be able to handle CLI options as unicode.

Thank you.