### PR TITLE
Fixed heading underline length

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@ Changelog
 =========
 
 2.1.1 - December 16, 2016
-----------------------
+-------------------------
 
 * After running ``st2 pack install`` CLI command display which packs have been installed.
   (improvement)


### PR DESCRIPTION
Underline for v2.1.1 changelog not long enough, causing v2.1 doc builds to fail.