### PR TITLE
Include original traceback when re-throwing an exception inside the sensor wrapper

### DIFF
--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -269,7 +269,8 @@ class SensorWrapper(object):
             msg = ('Failed to load sensor class from file "%s" (sensor file most likely doesn\'t '
                    'exist or contains invalid syntax): %s' % (self._file_path, str(e)))
             msg += '\n\n' + tb_msg
-            raise ValueError(msg)
+            exc_cls = type(e)
+            raise exc_cls(msg)
 
         if not sensor_class:
             raise ValueError('Sensor module is missing a class with name "%s"' %

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -17,6 +17,7 @@ import os
 import json
 import atexit
 import argparse
+import traceback
 
 from oslo_config import cfg
 
@@ -264,8 +265,10 @@ class SensorWrapper(object):
                                                         file_path=self._file_path,
                                                         class_name=self._class_name)
         except Exception as e:
-            msg = ('Failed to load sensor class from file "%s"'
-                   ' (sensor file most likely doesn\'t exist): %s' % (self._file_path, str(e)))
+            tb_msg = traceback.format_exc()
+            msg = ('Failed to load sensor class from file "%s" (sensor file most likely doesn\'t'
+                   'exist): %s' % (self._file_path, str(e)))
+            msg += '\n\n' + tb_msg
             raise ValueError(msg)
 
         if not sensor_class:

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -266,8 +266,8 @@ class SensorWrapper(object):
                                                         class_name=self._class_name)
         except Exception as e:
             tb_msg = traceback.format_exc()
-            msg = ('Failed to load sensor class from file "%s" (sensor file most likely doesn\'t'
-                   'exist): %s' % (self._file_path, str(e)))
+            msg = ('Failed to load sensor class from file "%s" (sensor file most likely doesn\'t '
+                   'exist or contains invalid syntax): %s' % (self._file_path, str(e)))
             msg += '\n\n' + tb_msg
             raise ValueError(msg)
 

--- a/st2reactor/tests/resources/test_sensor_with_typo.py
+++ b/st2reactor/tests/resources/test_sensor_with_typo.py
@@ -1,6 +1,6 @@
 from st2reactor.sensor.base import Sensor
 
-typobar
+typobar  # noqa
 
 
 class TestSensorWithTypo(Sensor):

--- a/st2reactor/tests/resources/test_sensor_with_typo.py
+++ b/st2reactor/tests/resources/test_sensor_with_typo.py
@@ -1,0 +1,23 @@
+from st2reactor.sensor.base import Sensor
+
+typobar
+
+
+class TestSensorWithTypo(Sensor):
+    def setup(self):
+        pass
+
+    def run(self):
+        pass
+
+    def cleanup(self):
+        pass
+
+    def add_trigger(self, trigger):
+        pass
+
+    def update_trigger(self, trigger):
+        pass
+
+    def remove_trigger(self, trigger):
+        pass

--- a/st2reactor/tests/unit/test_sensor_wrapper.py
+++ b/st2reactor/tests/unit/test_sensor_wrapper.py
@@ -107,8 +107,20 @@ class SensorWrapperTestCase(unittest2.TestCase):
         trigger_types = ['trigger1', 'trigger2']
         parent_args = ['--config-file', TESTS_CONFIG_PATH]
 
-        expected_msg = 'Failed to load sensor class from file'
-        self.assertRaisesRegexp(ValueError, expected_msg, SensorWrapper,
+        expected_msg = 'Failed to load sensor class from file.*? No such file or directory'
+        self.assertRaisesRegexp(IOError, expected_msg, SensorWrapper,
+                                pack='core', file_path=file_path,
+                                class_name='TestSensor',
+                                trigger_types=trigger_types,
+                                parent_args=parent_args)
+
+    def test_sensor_init_fails_sensor_code_contains_typo(self):
+        file_path = os.path.join(RESOURCES_DIR, 'test_sensor_with_typo.py')
+        trigger_types = ['trigger1', 'trigger2']
+        parent_args = ['--config-file', TESTS_CONFIG_PATH]
+
+        expected_msg = 'Failed to load sensor class from file.*? \'typobar\' is not defined'
+        self.assertRaisesRegexp(NameError, expected_msg, SensorWrapper,
                                 pack='core', file_path=file_path,
                                 class_name='TestSensor',
                                 trigger_types=trigger_types,

--- a/st2reactor/tests/unit/test_sensor_wrapper.py
+++ b/st2reactor/tests/unit/test_sensor_wrapper.py
@@ -125,3 +125,13 @@ class SensorWrapperTestCase(unittest2.TestCase):
                                 class_name='TestSensor',
                                 trigger_types=trigger_types,
                                 parent_args=parent_args)
+
+        # Verify error message also contains traceback
+        try:
+            SensorWrapper(pack='core', file_path=file_path, class_name='TestSensor',
+                          trigger_types=trigger_types, parent_args=parent_args)
+        except NameError as e:
+            self.assertTrue('Traceback (most recent call last)' in str(e))
+            self.assertTrue('line 3, in <module>' in str(e))
+        else:
+            self.fail('NameError not thrown')


### PR DESCRIPTION
When we re-throw a more user-friendly exception we didn't include the original stack trace which would make some issues harder to debug (it didn't include additional stack trace which would point user to the offending line in the sensor file and similar).

Caught by @enykeev.