### PR TITLE
Improved CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -27,10 +27,3 @@ test:
   post:
     - case $CIRCLE_NODE_INDEX in [1,2]) codecov ;; esac:
         parallel: true
-
-experimental:
-  notify:
-    branches:
-      only:
-        - master
-        - /v[0-9]+\.[0-9]+/


### PR DESCRIPTION
~This is the last piece of the improved CI puzzle. As soon as it in place, the whole thing should start moving.~ Apparently, CircleCI does not support this experimental option any longer, so stuff started moving ahead of schedule. I'll use this PR to explain and illustrate how improved CI is going to work from now on (expect further edits). 

The PR built with updated ciecleci.yml would produce an event triggering `st2ci.build_pkgs_branch_on_pytests` rule which in turn will initiate a package build for this branch and ensure the packages would not end up in staging repo. Notification from the packaging build will in turn trigger `st2ci.st2_pkg_test_unstable_u14_dev` rule (and alike) that would install packages from CircleCI artifacts on a vm and run e2e tests against it.