### PR TITLE
Fix retry policy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,11 @@ in development
   Contribution by Hiroyasu OHYAMA. #3094
 * Add support for complex rendering inside of array and object types. This allows the user to
   nest Jinja variables in array and object types.
+* Fix cancellation specified in concurrency policies to cancel actions appropriately. Previously,
+  mistral workflow is orphaned and left in a running state. (bug fix)
+* If a retry policy is defined, action executions under the context of a workflow will not be
+  retried on timeout or failure. Previously, action execution will be retried but workflow is
+  terminated. (bug fix)
 
 2.1.1 - December 16, 2016
 -------------------------
@@ -57,8 +62,6 @@ in development
 * Update ``packs.load`` action to also register triggers by default. (improvement)
 * Update ``/v1/packs/register`` API endpoint so it registers resources in the correct order which
   is the same as order used in ``st2-register-content`` script. (bug fix)
-* Fix cancellation specified in concurrency policies to cancel actions appropriately. Previously, mistral
-  workflow is orphaned and left in a running state. (bug fix)
 
 2.1.0 - December 05, 2016
 -------------------------

--- a/st2actions/st2actions/policies/retry.py
+++ b/st2actions/st2actions/policies/retry.py
@@ -63,13 +63,8 @@ class ExecutionRetryPolicyApplicator(ResourcePolicyApplicator):
         self.max_retry_count = max_retry_count
         self.delay = delay or 0
 
-    def apply_before(self, target):
-        # Nothing to do here
-        target = super(ExecutionRetryPolicyApplicator, self).apply_before(target=target)
-        return target
-
     def apply_after(self, target):
-        target = super(ExecutionRetryPolicyApplicator, self).apply_before(target=target)
+        target = super(ExecutionRetryPolicyApplicator, self).apply_after(target=target)
 
         live_action_db = target
         retry_count = self._get_live_action_retry_count(live_action_db=live_action_db)

--- a/st2actions/st2actions/policies/retry.py
+++ b/st2actions/st2actions/policies/retry.py
@@ -67,6 +67,16 @@ class ExecutionRetryPolicyApplicator(ResourcePolicyApplicator):
         target = super(ExecutionRetryPolicyApplicator, self).apply_after(target=target)
 
         live_action_db = target
+
+        if self._is_live_action_part_of_workflow_action(live_action_db):
+            LOG.warning(
+                'Retry cannot be applied to this liveaction because it is executed under a '
+                'workflow. Use workflow specific retry functionality where applicable. %s',
+                live_action_db
+            )
+
+            return target
+
         retry_count = self._get_live_action_retry_count(live_action_db=live_action_db)
 
         extra = {'live_action_db': live_action_db, 'policy_ref': self._policy_ref,
@@ -111,6 +121,18 @@ class ExecutionRetryPolicyApplicator(ResourcePolicyApplicator):
             return target
 
         return target
+
+    def _is_live_action_part_of_workflow_action(self, live_action_db):
+        """
+        Retrieve parent info from context of the live action.
+
+        :rtype: ``dict``
+        """
+        context = getattr(live_action_db, 'context', {})
+        parent = context.get('parent', {})
+        is_wf_action = (parent is not None and parent != {})
+
+        return is_wf_action
 
     def _get_live_action_retry_count(self, live_action_db):
         """


### PR DESCRIPTION
Retry policy is not supported for action executions under workflows. Let specific workflow engine handles retries where applicable. Currently, action execution will retry on failure and timeout but workflow fails immediately.