### PR TITLE
Throw more user-friendly exception when instantiating auth backend

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,9 @@ in development
 * If a retry policy is defined, action executions under the context of a workflow will not be
   retried on timeout or failure. Previously, action execution will be retried but workflow is
   terminated. (bug fix)
+* Update ``st2auth`` service so it includes more context and throws a more user-friendly exception
+  when retrieving an auth backend instance fails. This makes it easier to debug and spot various
+  auth backend issues related to typos, misconfiguration and similar. (improvement)
 
 2.1.1 - December 16, 2016
 -------------------------

--- a/st2auth/st2auth/backends/__init__.py
+++ b/st2auth/st2auth/backends/__init__.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import traceback
 import json
 
 from oslo_config import cfg
@@ -43,9 +44,14 @@ def get_available_backends():
 
 def get_backend_instance(name):
     """
+    Retrieve a class instance for the provided auth backend.
+
     :param name: Backend name.
     :type name: ``str``
     """
+
+    LOG.debug('Retrieving backend instance for backend "%s"' % (name))
+
     try:
         manager = DriverManager(namespace=BACKENDS_NAMESPACE, name=name,
                                 invoke_on_load=False)
@@ -60,10 +66,21 @@ def get_backend_instance(name):
         try:
             kwargs = json.loads(backend_kwargs)
         except ValueError as e:
-            raise ValueError('Failed to JSON parse backend settings: %s' % (str(e)))
+            raise ValueError('Failed to JSON parse backend settings for backend "%s": %s' %
+                             (name, str(e)))
     else:
         kwargs = {}
 
     cls = manager.driver
-    cls_instance = cls(**kwargs)
+
+    try:
+        cls_instance = cls(**kwargs)
+    except Exception as e:
+        tb_msg = traceback.format_exc()
+        msg = ('Failed to instantiate auth backend "%s" with backend settings "%s": %s' %
+               (name, str(kwargs), str(e)))
+        msg += '\n\n' + tb_msg
+        exc_cls = type(e)
+        raise exc_cls(msg)
+
     return cls_instance

--- a/st2auth/st2auth/backends/__init__.py
+++ b/st2auth/st2auth/backends/__init__.py
@@ -77,8 +77,9 @@ def get_backend_instance(name):
         cls_instance = cls(**kwargs)
     except Exception as e:
         tb_msg = traceback.format_exc()
-        msg = ('Failed to instantiate auth backend "%s" with backend settings "%s": %s' %
-               (name, str(kwargs), str(e)))
+        class_name = cls.__name__
+        msg = ('Failed to instantiate auth backend "%s" (class %s) with backend settings '
+               '"%s": %s' % (name, class_name, str(kwargs), str(e)))
         msg += '\n\n' + tb_msg
         exc_cls = type(e)
         raise exc_cls(msg)


### PR DESCRIPTION
This pull request updates `get_backend_instance` method to include more context and throw a more user-friendly exception when retrieving an auth backend instance fails.

Previously, the error didn't include configured auth backend name, etc. which made it harder and more time consuming to debug issues such as typos, misconfiguration and similar in the st2 config.

Before:

```bash
2017-01-06 13:21:23,210 INFO [-] Creating st2auth: StackStorm v2.2dev as Pecan app.
2017-01-06 13:21:23,328 DEBUG [-] found extension EntryPoint.parse('flat_file = st2auth_flat_file_backend.flat_file:FlatFileAuthenticationBackend')
2017-01-06 13:21:23,329 ERROR [-] (PID=14210) ST2 Auth API quit due to exception.
Traceback (most recent call last):
  File "/data/stanley/st2auth/st2auth/cmd/api.py", line 87, in main
    return _run_server()
  File "/data/stanley/st2auth/st2auth/cmd/api.py", line 76, in _run_server
    wsgi.server(socket, app.setup_app())
  File "/data/stanley/st2auth/st2auth/app.py", line 78, in setup_app
    **app_conf
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/pecan/__init__.py", line 83, in make_app
    app = Pecan(root, **kw)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/pecan/core.py", line 760, in __init__
    super(Pecan, self).__init__(*args, **kw)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/pecan/core.py", line 219, in __init__
    root = self.__translate_root__(root)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/pecan/core.py", line 254, in __translate_root__
    module = __import__(name, fromlist=fromlist)
  File "/data/stanley/st2auth/st2auth/controllers/root.py", line 18, in <module>
    import st2auth.controllers.v1.root as v1_root
  File "/data/stanley/st2auth/st2auth/controllers/v1/root.py", line 19, in <module>
    class RootController(object):
  File "/data/stanley/st2auth/st2auth/controllers/v1/root.py", line 20, in RootController
    tokens = auth.TokenController()
  File "/data/stanley/st2auth/st2auth/controllers/v1/auth.py", line 66, in __init__
    self.handler = HANDLER_MAPPINGS[cfg.CONF.auth.mode]()
  File "/data/stanley/st2auth/st2auth/handlers.py", line 123, in __init__
    self._auth_backend = get_backend_instance(name=cfg.CONF.auth.backend)
  File "/data/stanley/st2auth/st2auth/backends/__init__.py", line 68, in get_backend_instance
    cls_instance = cls(**kwargs)
TypeError: __init__() got an unexpected keyword argument 'filee_path'
```

After:

```bash
2017-01-06 13:21:48,575 INFO [-] Creating st2auth: StackStorm v2.2dev as Pecan app.
2017-01-06 13:21:48,679 DEBUG [-] Retrieving backend instance for backend "flat_file"
2017-01-06 13:21:48,679 DEBUG [-] found extension EntryPoint.parse('flat_file = st2auth_flat_file_backend.flat_file:FlatFileAuthenticationBackend')
2017-01-06 13:21:48,681 ERROR [-] (PID=14224) ST2 Auth API quit due to exception.
Traceback (most recent call last):
  File "/data/stanley/st2auth/st2auth/cmd/api.py", line 87, in main
    return _run_server()
  File "/data/stanley/st2auth/st2auth/cmd/api.py", line 76, in _run_server
    wsgi.server(socket, app.setup_app())
  File "/data/stanley/st2auth/st2auth/app.py", line 78, in setup_app
    **app_conf
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/pecan/__init__.py", line 83, in make_app
    app = Pecan(root, **kw)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/pecan/core.py", line 760, in __init__
    super(Pecan, self).__init__(*args, **kw)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/pecan/core.py", line 219, in __init__
    root = self.__translate_root__(root)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/pecan/core.py", line 254, in __translate_root__
    module = __import__(name, fromlist=fromlist)
  File "/data/stanley/st2auth/st2auth/controllers/root.py", line 18, in <module>
    import st2auth.controllers.v1.root as v1_root
  File "/data/stanley/st2auth/st2auth/controllers/v1/root.py", line 19, in <module>
    class RootController(object):
  File "/data/stanley/st2auth/st2auth/controllers/v1/root.py", line 20, in RootController
    tokens = auth.TokenController()
  File "/data/stanley/st2auth/st2auth/controllers/v1/auth.py", line 66, in __init__
    self.handler = HANDLER_MAPPINGS[cfg.CONF.auth.mode]()
  File "/data/stanley/st2auth/st2auth/handlers.py", line 123, in __init__
    self._auth_backend = get_backend_instance(name=cfg.CONF.auth.backend)
  File "/data/stanley/st2auth/st2auth/backends/__init__.py", line 84, in get_backend_instance
    raise exc_cls(msg)
TypeError: Failed to instantiate auth backend "flat_file" with backend settings "{u'filee_path': u'st2auth/conf/htpasswd_dev'}": __init__() got an unexpected keyword argument 'filee_path'

Traceback (most recent call last):
  File "/data/stanley/st2auth/st2auth/backends/__init__.py", line 77, in get_backend_instance
    cls_instance = cls(**kwargs)
TypeError: __init__() got an unexpected keyword argument 'filee_path'

```

Reported by Vishnu Kumar on Slack.