### PR TITLE
Fix mistral upstream integration

### DIFF
--- a/contrib/examples/actions/mistral-jinja-st2kv-system-scope-encrypted.yaml
+++ b/contrib/examples/actions/mistral-jinja-st2kv-system-scope-encrypted.yaml
@@ -1,0 +1,9 @@
+---
+description: >
+    A sample workflow that accesses st2kv via jinja
+    to get an encrypted system scope kvp from st2.
+enabled: true
+entry_point: workflows/mistral-jinja-st2kv-system-scope-encrypted.yaml
+name: mistral-jinja-st2kv-system-scope-encrypted
+pack: examples
+runner_type: mistral-v2

--- a/contrib/examples/actions/mistral-jinja-st2kv-system-scope.yaml
+++ b/contrib/examples/actions/mistral-jinja-st2kv-system-scope.yaml
@@ -1,0 +1,9 @@
+---
+description: >
+    A sample workflow that accesses st2kv via jinja
+    to get a system scope kvp from st2.
+enabled: true
+entry_point: workflows/mistral-jinja-st2kv-system-scope.yaml
+name: mistral-jinja-st2kv-system-scope
+pack: examples
+runner_type: mistral-v2

--- a/contrib/examples/actions/workflows/mistral-jinja-st2kv-system-scope-encrypted.yaml
+++ b/contrib/examples/actions/workflows/mistral-jinja-st2kv-system-scope-encrypted.yaml
@@ -1,0 +1,14 @@
+version: '2.0'
+
+examples.mistral-jinja-st2kv-system-scope-encrypted:
+    vars:
+        foobar: unspecified
+    tasks:
+        task1:
+            action: core.local
+            input:
+                cmd: 'echo "{{ st2kv.system.foobar | decrypt_kv }}"'
+            publish:
+                foobar: <% task(task1).result.stdout %>
+            on-complete:
+                - fail: <% $.foobar != foobar %>

--- a/contrib/examples/actions/workflows/mistral-jinja-st2kv-system-scope.yaml
+++ b/contrib/examples/actions/workflows/mistral-jinja-st2kv-system-scope.yaml
@@ -1,0 +1,14 @@
+version: '2.0'
+
+examples.mistral-jinja-st2kv-system-scope:
+    vars:
+        foobar: unspecified
+    tasks:
+        task1:
+            action: core.local
+            input:
+                cmd: 'echo "{{ st2kv.system.foobar }}"'
+            publish:
+                foobar: <% task(task1).result.stdout %>
+            on-complete:
+                - fail: <% $.foobar != foobar %>

--- a/st2tests/integration/mistral/test_st2kv.py
+++ b/st2tests/integration/mistral/test_st2kv.py
@@ -18,18 +18,18 @@ from integration.mistral import base
 from st2client import models
 
 
-class CustomYaqlKeyValuePairTest(base.TestWorkflowExecution):
+class CustomKeyValuePairTest(base.TestWorkflowExecution):
     secret = None
 
     @classmethod
     def setUpClass(cls):
-        super(CustomYaqlKeyValuePairTest, cls).setUpClass()
+        super(CustomKeyValuePairTest, cls).setUpClass()
         cls.set_kvp('foobar', 'foobar', scope='system', secret=cls.secret)
         cls.set_kvp('marco', 'polo', scope='user', secret=cls.secret)
 
     @classmethod
     def tearDownClass(cls):
-        super(CustomYaqlKeyValuePairTest, cls).tearDownClass()
+        super(CustomKeyValuePairTest, cls).tearDownClass()
         cls.del_kvp('foobar')
         cls.del_kvp('marco')
 
@@ -56,29 +56,49 @@ class CustomYaqlKeyValuePairTest(base.TestWorkflowExecution):
         cls.st2client.keys.delete(kvp)
 
 
-class UnencryptedKeyValuePairTest(CustomYaqlKeyValuePairTest):
+class UnencryptedKeyValuePairTest(CustomKeyValuePairTest):
     secret = False
 
-    def test_system_kvp(self):
+    def test_yaql_system_kvp(self):
         execution = self._execute_workflow('examples.mistral-yaql-st2kv-system-scope')
         execution = self._wait_for_completion(execution)
         self._assert_success(execution, num_tasks=1)
 
-    def test_user_kvp(self):
+    def test_yaql_user_kvp(self):
         execution = self._execute_workflow('examples.mistral-yaql-st2kv-user-scope')
         execution = self._wait_for_completion(execution)
         self._assert_success(execution, num_tasks=1)
 
+    def test_jinja_system_kvp(self):
+        execution = self._execute_workflow('examples.mistral-jinja-st2kv-system-scope')
+        execution = self._wait_for_completion(execution)
+        self._assert_success(execution, num_tasks=1)
 
-class EncryptedKeyValuePairTest(CustomYaqlKeyValuePairTest):
+    def test_jinja_user_kvp(self):
+        # Pending completion of jinja rendering of user scoped variable.
+        # https://github.com/StackStorm/st2/pull/2931
+        pass
+
+
+class EncryptedKeyValuePairTest(CustomKeyValuePairTest):
     secret = True
 
-    def test_system_kvp(self):
+    def test_yaql_system_kvp(self):
         execution = self._execute_workflow('examples.mistral-yaql-st2kv-system-scope')
         execution = self._wait_for_completion(execution)
         self._assert_success(execution, num_tasks=1)
 
-    def test_user_kvp(self):
+    def test_yaql_user_kvp(self):
         execution = self._execute_workflow('examples.mistral-yaql-st2kv-user-scope')
         execution = self._wait_for_completion(execution)
         self._assert_success(execution, num_tasks=1)
+
+    def test_jinja_system_kvp(self):
+        execution = self._execute_workflow('examples.mistral-jinja-st2kv-system-scope-encrypted')
+        execution = self._wait_for_completion(execution)
+        self._assert_success(execution, num_tasks=1)
+
+    def test_jinja_user_kvp(self):
+        # Per https://docs.stackstorm.com/datastore.html#storing-secrets,
+        # decrypting user scoped variables is currently unsupported.
+        pass

--- a/st2tests/st2tests/fixtures/generic/workflows/wf_has_jinja_st2kv_post_xform.yaml
+++ b/st2tests/st2tests/fixtures/generic/workflows/wf_has_jinja_st2kv_post_xform.yaml
@@ -1,0 +1,49 @@
+version: '2.0'
+
+demo:
+    type: direct
+    input:
+        - var1
+        - var2
+    tasks:
+        task_with_no_input:
+            action: st2.action
+            input:
+                ref: wolfpack.a1
+        task_with_inputs:
+            action: st2.action
+            input:
+                ref: wolfpack.a2
+                parameters:
+                    strtype: '{% raw %}{{ st2kv.system.var1 }}{% endraw %}'
+                    inttype: '{{ foobarst2kv.system.var2 }}'
+                    arrtype:
+                        - foobar
+                        - <% $.var1 %>
+                        - '{{ _.var2 }}'
+                        - '{% raw %}{{ st2kv.system.var3 }}{% endraw %}'
+                        - '{% raw %}{{st2kv.system.var3}}{% endraw %}'
+                        - '{% raw %}{{ abc and st2kv.system.var3 }}{% endraw %}'
+                        - '{{ foobarst2kv.system.var4 }}'
+                        - '{{foobarst2kv.system.var4}}'
+                        - '{{ st2kv(var1) }}'
+                    objtype:
+                        var11: fubar
+                        var12: <% $.var1 + $.var2 %>
+                        var13: '{{ _.var1 + _.var2 }}'
+                        var14: '{% raw %}{{ st2kv.system.var5 }}{% endraw %}'
+                        var15: '{% raw %}{{st2kv.system.var5}}{% endraw %}'
+                        var16: '{% raw %}{{ abc and st2kv.system.var5 }}{% endraw %}'
+                        var17: '{{ foobarst2kv.system.var6 }}'
+                        var18: '{{foobarst2kv.system.var6}}'
+                        var19: '{{ st2kv(var1) }}'
+            publish:
+                var21: <% $.var21 %>
+                var22: <% $.var22 %>
+        task_with_inline_inputs:
+            action: st2.action
+            input:
+                ref: wolfpack.a2
+                parameters:
+                    strtype: some <% $.var1 %> string
+                    inttype: <% $.var2 %>

--- a/st2tests/st2tests/fixtures/generic/workflows/wf_has_jinja_st2kv_pre_xform.yaml
+++ b/st2tests/st2tests/fixtures/generic/workflows/wf_has_jinja_st2kv_pre_xform.yaml
@@ -1,0 +1,40 @@
+version: '2.0'
+
+demo:
+    type: direct
+    input:
+        - var1
+        - var2
+    tasks:
+        task_with_no_input:
+            action: wolfpack.a1
+        task_with_inputs:
+            action: wolfpack.a2
+            input:
+                strtype: '{{ st2kv.system.var1 }}'
+                inttype: '{{ foobarst2kv.system.var2 }}'
+                arrtype:
+                    - foobar
+                    - <% $.var1 %>
+                    - '{{ _.var2 }}'
+                    - '{{ st2kv.system.var3 }}'
+                    - '{{st2kv.system.var3}}'
+                    - '{{ abc and st2kv.system.var3 }}'
+                    - '{{ foobarst2kv.system.var4 }}'
+                    - '{{foobarst2kv.system.var4}}'
+                    - '{{ st2kv(var1) }}'
+                objtype:
+                    var11: fubar
+                    var12: <% $.var1 + $.var2 %>
+                    var13: '{{ _.var1 + _.var2 }}'
+                    var14: '{{ st2kv.system.var5 }}'
+                    var15: '{{st2kv.system.var5}}'
+                    var16: '{{ abc and st2kv.system.var5 }}'
+                    var17: '{{ foobarst2kv.system.var6 }}'
+                    var18: '{{foobarst2kv.system.var6}}'
+                    var19: '{{ st2kv(var1) }}'
+            publish:
+                var21: <% $.var21 %>
+                var22: <% $.var22 %>
+        task_with_inline_inputs:
+            action: wolfpack.a2 strtype="some <% $.var1 %> string" inttype=<% $.var2 %>

--- a/st2tests/st2tests/fixtures/generic/workflows/wf_jinja_mixed_context_ref1.yaml
+++ b/st2tests/st2tests/fixtures/generic/workflows/wf_jinja_mixed_context_ref1.yaml
@@ -1,0 +1,20 @@
+version: '2.0'
+
+demo:
+    type: direct
+    input:
+        - var1
+        - var2
+    tasks:
+        task_with_no_input:
+            action: wolfpack.a1
+        task_with_inputs:
+            action: wolfpack.a2
+            input:
+                strtype: '{{ st2kv.system.var1a }} and {{ _.var1b }}'
+                inttype: '{{ st2kv.user.var2 }}'
+            publish:
+                var3: <% $.var3 %>
+                var4: <% $.var4 %>
+        task_with_inline_inputs:
+            action: wolfpack.a2 strtype="some <% $.var1 %> string" inttype=<% $.var2 %>

--- a/st2tests/st2tests/fixtures/generic/workflows/wf_jinja_mixed_context_ref2.yaml
+++ b/st2tests/st2tests/fixtures/generic/workflows/wf_jinja_mixed_context_ref2.yaml
@@ -1,0 +1,20 @@
+version: '2.0'
+
+demo:
+    type: direct
+    input:
+        - var1
+        - var2
+    tasks:
+        task_with_no_input:
+            action: wolfpack.a1
+        task_with_inputs:
+            action: wolfpack.a2
+            input:
+                strtype: '{{ st2kv.system.var1 }}'
+                inttype: '{{ st2kv.user.var2a + _.var2b }}'
+            publish:
+                var3: <% $.var3 %>
+                var4: <% $.var4 %>
+        task_with_inline_inputs:
+            action: wolfpack.a2 strtype="some <% $.var1 %> string" inttype=<% $.var2 %>


### PR DESCRIPTION
Mistral added jinja evaluation and breaks st2kv rendering via jinja. This patch wraps any jinja as raw if there is any st2kv reference.