### PR TITLE
Add option to authenticate with mistral using st2 auth token

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,6 +49,8 @@ in development
   (new feature)
 * Linux file watch sensor is now disabled by default. To enable it, set ``enabled: true`` in
   ``/opt/stackstorm/packs/linux/sensors/file_watch_sensor.yaml``
+* Add option to use st2 auth token to authenticate with mistral. Previously, OpenStack Keystone
+  is recommended for securing mistral. (improvement)
 
 2.2.0 - February 27, 2017
 -------------------------

--- a/contrib/runners/mistral_v2/callback/mistral_v2.py
+++ b/contrib/runners/mistral_v2/callback/mistral_v2.py
@@ -19,11 +19,12 @@ import re
 import retrying
 
 from oslo_config import cfg
-from mistralclient.api import client as mistral
 
 from st2common.constants import action as action_constants
 from st2common import log as logging
 from st2common.callback import base as callback
+from st2common.persistence.execution import ActionExecution
+from st2common.util import url as url_utils
 from st2common.util.workflow import mistral as utils
 
 
@@ -65,26 +66,25 @@ class MistralCallbackHandler(callback.AsyncActionExecutionCallbackHandler):
         wait_exponential_multiplier=cfg.CONF.mistral.retry_exp_msec,
         wait_exponential_max=cfg.CONF.mistral.retry_exp_max_msec,
         stop_max_delay=cfg.CONF.mistral.retry_stop_max_msec)
-    def _update_action_execution(cls, url, data):
+    def _update_action_execution(cls, url, data, auth_token):
         action_execution_id = get_action_execution_id_from_url(url)
 
         LOG.info('Sending callback to %s with data %s.', url, data)
 
-        client = mistral.client(
-            mistral_url=cfg.CONF.mistral.v2_base_url,
-            username=cfg.CONF.mistral.keystone_username,
-            api_key=cfg.CONF.mistral.keystone_password,
-            project_name=cfg.CONF.mistral.keystone_project_name,
-            auth_url=cfg.CONF.mistral.keystone_auth_url,
-            cacert=cfg.CONF.mistral.cacert,
-            insecure=cfg.CONF.mistral.insecure)
-
+        base_url = url_utils.get_url_without_trailing_slash(cfg.CONF.mistral.v2_base_url)
+        client = utils.get_client(base_url, auth_token=auth_token)
         client.action_executions.update(action_execution_id, **data)
 
     @classmethod
     def callback(cls, url, context, status, result):
         if status not in action_constants.LIVEACTION_COMPLETED_STATES:
             return
+
+        parent_ex_id = context['parent']['execution_id']
+        parent_ex = ActionExecution.get_by_id(parent_ex_id)
+        parent_ex_ctx = parent_ex.context
+        mistral_ctx = parent_ex_ctx.get('mistral', {})
+        auth_token = mistral_ctx.get('auth_token', None)
 
         try:
             if isinstance(result, basestring) and len(result) > 0 and result[0] in ['{', '[']:
@@ -95,6 +95,6 @@ class MistralCallbackHandler(callback.AsyncActionExecutionCallbackHandler):
             output = json.dumps(result) if type(result) in [dict, list] else str(result)
             data = {'state': STATUS_MAP[status], 'output': output}
 
-            cls._update_action_execution(url, data)
+            cls._update_action_execution(url, data, auth_token)
         except Exception as e:
             LOG.exception(e)

--- a/contrib/runners/mistral_v2/query/mistral_v2.py
+++ b/contrib/runners/mistral_v2/query/mistral_v2.py
@@ -11,7 +11,7 @@ from st2common.exceptions import resultstracker as exceptions
 from st2common import log as logging
 from st2common.services import action as action_service
 from st2common.util import jsonify
-from st2common.util.url import get_url_without_trailing_slash
+from st2common.util import url as url_utils
 from st2common.util.workflow import mistral as utils
 
 
@@ -37,15 +37,7 @@ class MistralResultsQuerier(Querier):
 
     def __init__(self, id, *args, **kwargs):
         super(MistralResultsQuerier, self).__init__(*args, **kwargs)
-        self._base_url = get_url_without_trailing_slash(cfg.CONF.mistral.v2_base_url)
-        self._client = mistral.client(
-            mistral_url=self._base_url,
-            username=cfg.CONF.mistral.keystone_username,
-            api_key=cfg.CONF.mistral.keystone_password,
-            project_name=cfg.CONF.mistral.keystone_project_name,
-            auth_url=cfg.CONF.mistral.keystone_auth_url,
-            cacert=cfg.CONF.mistral.cacert,
-            insecure=cfg.CONF.mistral.insecure)
+        self._base_url = url_utils.get_url_without_trailing_slash(cfg.CONF.mistral.v2_base_url)
 
     @retrying.retry(
         retry_on_exception=utils.retry_on_exceptions,
@@ -62,14 +54,23 @@ class MistralResultsQuerier(Querier):
         :type query_context: ``objext``
         :rtype: (``str``, ``object``)
         """
-        mistral_exec_id = query_context.get('mistral', {}).get('execution_id', None)
+        mistral_qry_ctx = query_context.get('mistral', {})
+
+        if not mistral_qry_ctx.get('auth_token', None):
+            raise Exception('[%] Missing mistral auth token in query context. %s',
+                            execution_id, query_context)
+
+        client = utils.get_client(self._base_url, auth_token=mistral_qry_ctx['auth_token'])
+
+        mistral_exec_id = mistral_qry_ctx.get('execution_id', None)
+
         if not mistral_exec_id:
             raise Exception('[%s] Missing mistral workflow execution ID in query context. %s',
                             execution_id, query_context)
 
         try:
-            result = self._get_workflow_result(mistral_exec_id)
-            result['tasks'] = self._get_workflow_tasks(mistral_exec_id)
+            result = self._get_workflow_result(client, mistral_exec_id)
+            result['tasks'] = self._get_workflow_tasks(client, mistral_exec_id)
         except exceptions.ReferenceNotFoundError as exc:
             LOG.exception('[%s] Unable to find reference.', execution_id)
             return (action_constants.LIVEACTION_STATUS_FAILED, exc.message)
@@ -86,7 +87,7 @@ class MistralResultsQuerier(Querier):
 
         return (status, result)
 
-    def _get_workflow_result(self, exec_id):
+    def _get_workflow_result(self, client, exec_id):
         """
         Returns the workflow status and output. Mistral workflow status will be converted
         to st2 action status.
@@ -94,12 +95,7 @@ class MistralResultsQuerier(Querier):
         :type exec_id: ``str``
         :rtype: (``str``, ``dict``)
         """
-        try:
-            execution = self._client.executions.get(exec_id)
-        except mistralclient_base.APIException as mistral_exc:
-            if 'not found' in mistral_exc.message:
-                raise exceptions.ReferenceNotFoundError(mistral_exc.message)
-            raise mistral_exc
+        execution = client.executions.get(exec_id)
 
         result = jsonify.try_loads(execution.output) if execution.state in DONE_STATES else {}
 
@@ -110,22 +106,17 @@ class MistralResultsQuerier(Querier):
 
         return result
 
-    def _get_workflow_tasks(self, exec_id):
+    def _get_workflow_tasks(self, client, exec_id):
         """
         Returns the list of tasks for a workflow execution.
         :param exec_id: Mistral execution ID
         :type exec_id: ``str``
         :rtype: ``list``
         """
-        wf_tasks = []
-
-        try:
-            for task in self._client.tasks.list(workflow_execution_id=exec_id):
-                wf_tasks.append(self._client.tasks.get(task.id))
-        except mistralclient_base.APIException as mistral_exc:
-            if 'not found' in mistral_exc.message:
-                raise exceptions.ReferenceNotFoundError(mistral_exc.message)
-            raise mistral_exc
+        wf_tasks = [
+            client.tasks.get(task.id)
+            for task in client.tasks.list(workflow_execution_id=exec_id)
+        ]
 
         return [self._format_task_result(task=wf_task.to_dict()) for wf_task in wf_tasks]
 

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2.py
@@ -205,7 +205,9 @@ class MistralRunnerTest(DbTestCase):
             'workflow_execution_id': '135e3446-4c89-4afe-821f-6ec6a0849b27'
         }
 
-        context = MistralRunner._build_mistral_context(parent, current)
+        runner = MistralRunner(uuid.uuid4().hex)
+
+        context = runner._build_mistral_context(parent, current)
         self.assertTrue(context is not None)
         self.assertTrue('parent' in context['mistral'].keys())
 
@@ -219,7 +221,7 @@ class MistralRunnerTest(DbTestCase):
                          current['workflow_execution_id'])
 
         parent = None
-        context = MistralRunner._build_mistral_context(parent, current)
+        context = runner._build_mistral_context(parent, current)
         self.assertDictEqual(context['mistral'], current)
 
     @mock.patch.object(

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_auth.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_auth.py
@@ -164,6 +164,8 @@ class MistralAuthTest(DbTestCase):
         access_service, 'create_token',
         mock.MagicMock(return_value=TOKEN_DB))
     def test_launch_workflow_with_st2_auth(self):
+        cfg.CONF.set_override('auth_type', 'st2', group='mistral')
+
         liveaction = LiveActionDB(action=WF1_NAME, parameters=ACTION_PARAMS, context=ACTION_CONTEXT)
         liveaction, execution = action_service.request(liveaction)
         liveaction = LiveAction.get_by_id(str(liveaction.id))
@@ -216,7 +218,8 @@ class MistralAuthTest(DbTestCase):
     @mock.patch.object(
         executions.ExecutionManager, 'create',
         mock.MagicMock(return_value=executions.Execution(None, WF1_EXEC)))
-    def test_launch_workflow_with_mistral_auth(self):
+    def test_launch_workflow_with_keystone_auth(self):
+        cfg.CONF.set_override('auth_type', 'keystone', group='mistral')
         cfg.CONF.set_default('keystone_username', 'foo', group='mistral')
         cfg.CONF.set_default('keystone_password', 'bar', group='mistral')
         cfg.CONF.set_default('keystone_project_name', 'admin', group='mistral')
@@ -225,6 +228,7 @@ class MistralAuthTest(DbTestCase):
         liveaction = LiveActionDB(action=WF1_NAME, parameters=ACTION_PARAMS)
         liveaction, execution = action_service.request(liveaction)
         liveaction = LiveAction.get_by_id(str(liveaction.id))
+
         self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_RUNNING)
 
         mistral_context = liveaction.context.get('mistral', None)

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_auth.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_auth.py
@@ -43,6 +43,7 @@ from st2common.transport.publishers import CUDPublisher
 from st2common.util import isotime
 from st2common.util import date as date_utils
 from st2common.util import loader
+from st2mistral.auth import client as st2mistral
 from st2tests import DbTestCase
 from st2tests import fixturesloader
 from st2tests.mocks.liveaction import MockLiveActionPublisher
@@ -149,6 +150,12 @@ class MistralAuthTest(DbTestCase):
         cfg.CONF.set_default('keystone_auth_url', None, group='mistral')
 
     @mock.patch.object(
+        st2mistral.St2AuthHandler, 'authenticate',
+        mock.MagicMock(return_value={}))
+    @mock.patch.object(
+        keystone.KeystoneAuthHandler, 'authenticate',
+        mock.MagicMock(return_value={}))
+    @mock.patch.object(
         workflows.WorkflowManager, 'list',
         mock.MagicMock(return_value=[]))
     @mock.patch.object(
@@ -163,8 +170,9 @@ class MistralAuthTest(DbTestCase):
     @mock.patch.object(
         access_service, 'create_token',
         mock.MagicMock(return_value=TOKEN_DB))
-    def test_launch_workflow_with_st2_auth(self):
+    def test_launch_workflow_with_st2_auth_token(self):
         cfg.CONF.set_override('auth_type', 'st2', group='mistral')
+        cfg.CONF.set_override('st2_api_key', None, group='mistral')
 
         liveaction = LiveActionDB(action=WF1_NAME, parameters=ACTION_PARAMS, context=ACTION_CONTEXT)
         liveaction, execution = action_service.request(liveaction)
@@ -199,6 +207,94 @@ class MistralAuthTest(DbTestCase):
                 }
             }
         }
+
+        self.assertFalse(keystone.KeystoneAuthHandler.authenticate.called)
+
+        auth_req = {
+            'mistral_url': cfg.CONF.mistral.v2_base_url,
+            'auth_token': TOKEN_DB.token,
+            'api_key': None,
+            'insecure': False,
+            'cacert': None
+        }
+
+        st2mistral.St2AuthHandler.authenticate.assert_called_with(auth_req)
+
+        executions.ExecutionManager.create.assert_called_with(
+            WF1_NAME, workflow_input=workflow_input, env=env)
+
+    @mock.patch.object(
+        st2mistral.St2AuthHandler, 'authenticate',
+        mock.MagicMock(return_value={}))
+    @mock.patch.object(
+        keystone.KeystoneAuthHandler, 'authenticate',
+        mock.MagicMock(return_value={}))
+    @mock.patch.object(
+        workflows.WorkflowManager, 'list',
+        mock.MagicMock(return_value=[]))
+    @mock.patch.object(
+        workflows.WorkflowManager, 'get',
+        mock.MagicMock(return_value=WF1))
+    @mock.patch.object(
+        workflows.WorkflowManager, 'create',
+        mock.MagicMock(return_value=[WF1]))
+    @mock.patch.object(
+        executions.ExecutionManager, 'create',
+        mock.MagicMock(return_value=executions.Execution(None, WF1_EXEC)))
+    @mock.patch.object(
+        access_service, 'create_token',
+        mock.MagicMock(return_value=TOKEN_DB))
+    def test_launch_workflow_with_st2_api_key(self):
+        st2_api_key = uuid.uuid4().hex
+
+        cfg.CONF.set_override('auth_type', 'st2', group='mistral')
+        cfg.CONF.set_override('st2_api_key', st2_api_key, group='mistral')
+
+        liveaction = LiveActionDB(action=WF1_NAME, parameters=ACTION_PARAMS, context=ACTION_CONTEXT)
+        liveaction, execution = action_service.request(liveaction)
+        liveaction = LiveAction.get_by_id(str(liveaction.id))
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_RUNNING)
+
+        mistral_context = liveaction.context.get('mistral', None)
+        self.assertIsNotNone(mistral_context)
+        self.assertEqual(mistral_context['execution_id'], WF1_EXEC.get('id'))
+        self.assertEqual(mistral_context['workflow_name'], WF1_EXEC.get('workflow_name'))
+
+        workflow_input = copy.deepcopy(ACTION_PARAMS)
+        workflow_input.update({'count': '3'})
+
+        env = {
+            'st2_execution_id': str(execution.id),
+            'st2_liveaction_id': str(liveaction.id),
+            'st2_action_api_url': 'http://0.0.0.0:9101/v1',
+            '__actions': {
+                'st2.action': {
+                    'st2_context': {
+                        'auth_token': TOKEN_DB.token,
+                        'api_url': 'http://0.0.0.0:9101/v1',
+                        'endpoint': 'http://0.0.0.0:9101/v1/actionexecutions',
+                        'parent': {
+                            'user': liveaction.context['user'],
+                            'execution_id': str(execution.id)
+                        },
+                        'notify': {},
+                        'skip_notify_tasks': []
+                    }
+                }
+            }
+        }
+
+        self.assertFalse(keystone.KeystoneAuthHandler.authenticate.called)
+
+        auth_req = {
+            'mistral_url': cfg.CONF.mistral.v2_base_url,
+            'auth_token': TOKEN_DB.token,
+            'api_key': cfg.CONF.mistral.st2_api_key,
+            'insecure': False,
+            'cacert': None
+        }
+
+        st2mistral.St2AuthHandler.authenticate.assert_called_with(auth_req)
 
         executions.ExecutionManager.create.assert_called_with(
             WF1_NAME, workflow_input=workflow_input, env=env)

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_callback.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_callback.py
@@ -16,6 +16,7 @@
 import mock
 from mock import call
 import requests
+import uuid
 
 from mistralclient.api.v2 import action_executions
 from oslo_config import cfg
@@ -27,10 +28,13 @@ tests_config.parse_args()
 from st2common.bootstrap import actionsregistrar
 from st2common.bootstrap import runnersregistrar
 from st2common.constants import action as action_constants
+from st2common.models.db.execution import ActionExecutionDB
 from st2common.models.db.liveaction import LiveActionDB
+from st2common.persistence.execution import ActionExecution
 from st2common.persistence.liveaction import LiveAction
 from st2common.runners import base as runners
 from st2common.services import action as action_service
+from st2common.services import trace as trace_service
 from st2common.transport.liveaction import LiveActionPublisher
 from st2common.transport.publishers import CUDPublisher
 from st2common.util import loader
@@ -49,6 +53,14 @@ PACKS = [
 ]
 
 NON_EMPTY_RESULT = 'non-empty'
+
+MOCK_ACTION_EXEC_DB = ActionExecutionDB(
+    action={'ref': 'mock.workflow'},
+    runner={'ref': 'mock.runner'},
+    liveaction={'id': uuid.uuid4().hex},
+    status=action_constants.LIVEACTION_STATUS_RUNNING,
+    context={'mistral': {'auth_token': uuid.uuid4().hex}}
+)
 
 
 @mock.patch.object(
@@ -103,45 +115,87 @@ class MistralRunnerCallbackTest(DbTestCase):
                              sorted(action_constants.LIVEACTION_STATUSES))
 
     @mock.patch.object(
+        trace_service, 'get_trace_db_by_live_action',
+        mock.MagicMock(return_value=(None, None)))
+    @mock.patch.object(
+        ActionExecution, 'get_by_id',
+        mock.MagicMock(return_value=MOCK_ACTION_EXEC_DB))
+    @mock.patch.object(
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(return_value=None))
     def test_callback_handler_with_result_as_text(self):
-        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
+        self.callback_calss.callback('http://127.0.0.1:8989/v2/action_executions/12345',
+                                     {'parent': {'execution_id': uuid.uuid4().hex}},
                                      action_constants.LIVEACTION_STATUS_SUCCEEDED,
                                      '<html></html>')
 
     @mock.patch.object(
+        trace_service, 'get_trace_db_by_live_action',
+        mock.MagicMock(return_value=(None, None)))
+    @mock.patch.object(
+        ActionExecution, 'get_by_id',
+        mock.MagicMock(return_value=MOCK_ACTION_EXEC_DB))
+    @mock.patch.object(
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(return_value=None))
     def test_callback_handler_with_result_as_dict(self):
-        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
+        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345',
+                                     {'parent': {'execution_id': uuid.uuid4().hex}},
                                      action_constants.LIVEACTION_STATUS_SUCCEEDED, {'a': 1})
 
+    @mock.patch.object(
+        trace_service, 'get_trace_db_by_live_action',
+        mock.MagicMock(return_value=(None, None)))
+    @mock.patch.object(
+        ActionExecution, 'get_by_id',
+        mock.MagicMock(return_value=MOCK_ACTION_EXEC_DB))
     @mock.patch.object(
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(return_value=None))
     def test_callback_handler_with_result_as_json_str(self):
-        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
+        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345',
+                                     {'parent': {'execution_id': uuid.uuid4().hex}},
                                      action_constants.LIVEACTION_STATUS_SUCCEEDED, '{"a": 1}')
-        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
+        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345',
+                                     {'parent': {'execution_id': uuid.uuid4().hex}},
                                      action_constants.LIVEACTION_STATUS_SUCCEEDED, "{'a': 1}")
 
+    @mock.patch.object(
+        trace_service, 'get_trace_db_by_live_action',
+        mock.MagicMock(return_value=(None, None)))
+    @mock.patch.object(
+        ActionExecution, 'get_by_id',
+        mock.MagicMock(return_value=MOCK_ACTION_EXEC_DB))
     @mock.patch.object(
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(return_value=None))
     def test_callback_handler_with_result_as_list(self):
-        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
+        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345',
+                                     {'parent': {'execution_id': uuid.uuid4().hex}},
                                      action_constants.LIVEACTION_STATUS_SUCCEEDED,
                                      ["a", "b", "c"])
 
     @mock.patch.object(
+        trace_service, 'get_trace_db_by_live_action',
+        mock.MagicMock(return_value=(None, None)))
+    @mock.patch.object(
+        ActionExecution, 'get_by_id',
+        mock.MagicMock(return_value=MOCK_ACTION_EXEC_DB))
+    @mock.patch.object(
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(return_value=None))
     def test_callback_handler_with_result_as_list_str(self):
-        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
+        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345',
+                                     {'parent': {'execution_id': uuid.uuid4().hex}},
                                      action_constants.LIVEACTION_STATUS_SUCCEEDED,
                                      '["a", "b", "c"]')
 
+    @mock.patch.object(
+        trace_service, 'get_trace_db_by_live_action',
+        mock.MagicMock(return_value=(None, None)))
+    @mock.patch.object(
+        ActionExecution, 'get_by_id',
+        mock.MagicMock(return_value=MOCK_ACTION_EXEC_DB))
     @mock.patch.object(
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(return_value=None))
@@ -149,7 +203,13 @@ class MistralRunnerCallbackTest(DbTestCase):
         local_runner_cls = self.get_runner_class('local_runner')
 
         liveaction = LiveActionDB(
-            action='core.local', parameters={'cmd': 'uname -a'},
+            action='core.local',
+            parameters={'cmd': 'uname -a'},
+            context={
+                'parent': {
+                    'execution_id': uuid.uuid4().hex
+                }
+            },
             callback={
                 'source': MISTRAL_RUNNER_NAME,
                 'url': 'http://127.0.0.1:8989/v2/action_executions/12345'
@@ -166,6 +226,12 @@ class MistralRunnerCallbackTest(DbTestCase):
                 '12345', state=expected_mistral_status, output=NON_EMPTY_RESULT)
 
     @mock.patch.object(
+        trace_service, 'get_trace_db_by_live_action',
+        mock.MagicMock(return_value=(None, None)))
+    @mock.patch.object(
+        ActionExecution, 'get_by_id',
+        mock.MagicMock(return_value=MOCK_ACTION_EXEC_DB))
+    @mock.patch.object(
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(return_value=None))
     def test_callback_incomplete_state(self):
@@ -174,7 +240,13 @@ class MistralRunnerCallbackTest(DbTestCase):
         local_runner_cls.run = mock.Mock(return_value=local_run_result)
 
         liveaction = LiveActionDB(
-            action='core.local', parameters={'cmd': 'uname -a'},
+            action='core.local',
+            parameters={'cmd': 'uname -a'},
+            context={
+                'parent': {
+                    'execution_id': uuid.uuid4().hex
+                }
+            },
             callback={
                 'source': MISTRAL_RUNNER_NAME,
                 'url': 'http://127.0.0.1:8989/v2/action_executions/12345'
@@ -187,6 +259,12 @@ class MistralRunnerCallbackTest(DbTestCase):
         self.assertFalse(action_executions.ActionExecutionManager.update.called)
 
     @mock.patch.object(
+        trace_service, 'get_trace_db_by_live_action',
+        mock.MagicMock(return_value=(None, None)))
+    @mock.patch.object(
+        ActionExecution, 'get_by_id',
+        mock.MagicMock(return_value=MOCK_ACTION_EXEC_DB))
+    @mock.patch.object(
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(side_effect=[
             requests.exceptions.ConnectionError(),
@@ -197,7 +275,13 @@ class MistralRunnerCallbackTest(DbTestCase):
         local_runner_cls.run = mock.Mock(return_value=local_run_result)
 
         liveaction = LiveActionDB(
-            action='core.local', parameters={'cmd': 'uname -a'},
+            action='core.local',
+            parameters={'cmd': 'uname -a'},
+            context={
+                'parent': {
+                    'execution_id': uuid.uuid4().hex
+                }
+            },
             callback={
                 'source': MISTRAL_RUNNER_NAME,
                 'url': 'http://127.0.0.1:8989/v2/action_executions/12345'
@@ -212,6 +296,12 @@ class MistralRunnerCallbackTest(DbTestCase):
         action_executions.ActionExecutionManager.update.assert_has_calls(calls)
 
     @mock.patch.object(
+        trace_service, 'get_trace_db_by_live_action',
+        mock.MagicMock(return_value=(None, None)))
+    @mock.patch.object(
+        ActionExecution, 'get_by_id',
+        mock.MagicMock(return_value=MOCK_ACTION_EXEC_DB))
+    @mock.patch.object(
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(side_effect=[
             requests.exceptions.ConnectionError(),
@@ -225,7 +315,13 @@ class MistralRunnerCallbackTest(DbTestCase):
         local_runner_cls.run = mock.Mock(return_value=local_run_result)
 
         liveaction = LiveActionDB(
-            action='core.local', parameters={'cmd': 'uname -a'},
+            action='core.local',
+            parameters={'cmd': 'uname -a'},
+            context={
+                'parent': {
+                    'execution_id': uuid.uuid4().hex
+                }
+            },
             callback={
                 'source': MISTRAL_RUNNER_NAME,
                 'url': 'http://127.0.0.1:8989/v2/action_executions/12345'
@@ -234,6 +330,7 @@ class MistralRunnerCallbackTest(DbTestCase):
 
         liveaction, execution = action_service.request(liveaction)
         liveaction = LiveAction.get_by_id(str(liveaction.id))
+
         self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
 
         # This test initially setup mock for action_executions.ActionExecutionManager.update

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_callback.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_callback.py
@@ -124,7 +124,7 @@ class MistralRunnerCallbackTest(DbTestCase):
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(return_value=None))
     def test_callback_handler_with_result_as_text(self):
-        self.callback_calss.callback('http://127.0.0.1:8989/v2/action_executions/12345',
+        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345',
                                      {'parent': {'execution_id': uuid.uuid4().hex}},
                                      action_constants.LIVEACTION_STATUS_SUCCEEDED,
                                      '<html></html>')

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper
 git+https://github.com/StackStorm/pecan.git@st2-patched#egg=pecan
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
+git+https://github.com/StackStorm/st2mistral.git#egg=st2mistral
 gitpython==2.1.0
 gunicorn==19.6.0
 ipaddr

--- a/st2actions/in-requirements.txt
+++ b/st2actions/in-requirements.txt
@@ -5,6 +5,7 @@ eventlet
 jinja2
 kombu
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
+git+https://github.com/StackStorm/st2mistral.git#egg=st2mistral
 oslo.config
 oslo.utils
 requests

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -245,6 +245,7 @@ def register_opts(ignore_errors=False):
         cfg.IntOpt('retry_exp_msec', default=1000, help='Multiplier for the exponential backoff.'),
         cfg.IntOpt('retry_exp_max_msec', default=300000, help='Max time for each set of backoff.'),
         cfg.IntOpt('retry_stop_max_msec', default=600000, help='Max time to stop retrying.'),
+        cfg.StrOpt('auth_type', default=None, help='Type of authentication used in Mistral.'),
         cfg.StrOpt('keystone_username', default=None, help='Username for authentication.'),
         cfg.StrOpt('keystone_password', default=None, help='Password for authentication.'),
         cfg.StrOpt('keystone_project_name', default=None, help='OpenStack project scope.'),

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -246,6 +246,7 @@ def register_opts(ignore_errors=False):
         cfg.IntOpt('retry_exp_max_msec', default=300000, help='Max time for each set of backoff.'),
         cfg.IntOpt('retry_stop_max_msec', default=600000, help='Max time to stop retrying.'),
         cfg.StrOpt('auth_type', default=None, help='Type of authentication used in Mistral.'),
+        cfg.StrOpt('st2_api_key', default=None, help='The st2 API key if st2 auth type is used.'),
         cfg.StrOpt('keystone_username', default=None, help='Username for authentication.'),
         cfg.StrOpt('keystone_password', default=None, help='Password for authentication.'),
         cfg.StrOpt('keystone_project_name', default=None, help='OpenStack project scope.'),

--- a/st2common/st2common/services/access.py
+++ b/st2common/st2common/services/access.py
@@ -87,6 +87,10 @@ def create_token(username, ttl=None, metadata=None, add_missing_user=True):
     return token
 
 
+def get_token(token):
+    return Token.get(token)
+
+
 def delete_token(token):
     try:
         token_db = Token.get(token)

--- a/st2common/st2common/util/workflow/mistral.py
+++ b/st2common/st2common/util/workflow/mistral.py
@@ -20,7 +20,9 @@ import re
 import requests
 import six
 import yaml
+from mistralclient.api import client as mistral
 from mistralclient.api.base import APIException
+from oslo_config import cfg
 
 from st2common.exceptions.workflow import WorkflowDefinitionException
 from st2common import log as logging
@@ -273,3 +275,25 @@ def retry_on_exceptions(exc):
         LOG.warning('Retrying Mistral API invocation on exception type %s.', type(exc))
 
     return retrying
+
+
+def get_client(base_url, auth_token=None):
+    if cfg.CONF.mistral.auth_type and cfg.CONF.mistral.auth_type == 'st2':
+        return mistral.client(
+            mistral_url=base_url,
+            auth_type='st2',
+            auth_token=auth_token,
+            cacert=cfg.CONF.mistral.cacert,
+            insecure=cfg.CONF.mistral.insecure,
+        )
+    else:
+        return mistral.client(
+            mistral_url=base_url,
+            auth_type='keystone',
+            username=cfg.CONF.mistral.keystone_username,
+            api_key=cfg.CONF.mistral.keystone_password,
+            project_name=cfg.CONF.mistral.keystone_project_name,
+            auth_url=cfg.CONF.mistral.keystone_auth_url,
+            cacert=cfg.CONF.mistral.cacert,
+            insecure=cfg.CONF.mistral.insecure
+        )

--- a/st2common/st2common/util/workflow/mistral.py
+++ b/st2common/st2common/util/workflow/mistral.py
@@ -283,6 +283,7 @@ def get_client(base_url, auth_token=None):
             mistral_url=base_url,
             auth_type='st2',
             auth_token=auth_token,
+            api_key=cfg.CONF.mistral.st2_api_key,
             cacert=cfg.CONF.mistral.cacert,
             insecure=cfg.CONF.mistral.insecure,
         )


### PR DESCRIPTION
Mistral can now authenticate using st2 auth token. This patch adds an option to configure st2 to pass the auth token when invoking the mistral client.