### PR TITLE
Deprecate {{system.}} and {{user.}} notations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,9 @@ in development
   cause a type mismatch in the API (bug fix)
 * Use the newly introduced CANCELLED state in mistral for workflow cancellation. Currently, st2
   put the workflow in a PAUSED state in mistral. (improvement)
+* Deprecate  ``{{user.}}`` and ``{{system.}}`` notations to access ``user`` and ``system``
+  scoped items from datastore. From now on, only ``{{st2kv.user.}}`` and ``{{st2kv.system.}}``
+  notations alone are supported. (improvement)
 
 2.1.1 - December 16, 2016
 -------------------------
@@ -124,7 +127,7 @@ in development
   seralize the array as JSON and then falling back to comma separated array.
 * Add new ``core.pause`` action. This action behaves like sleep and can be used inside the action
   chain or Mistral workflows where waiting / sleeping is desired before proceeding with a next
-  task. Contribution by Paul Mulvihill. (new feature) #2933. 
+  task. Contribution by Paul Mulvihill. (new feature) #2933.
 * When a policy cancels a request due to concurrency, it leaves end_timestamp set to None which
   the notifier expects to be a date. This causes an exception in "isotime.format()". A patch was
   released that catches this exception, and populates payload['end_timestamp'] with the equivalent

--- a/contrib/runners/action_chain_runner/action_chain_runner.py
+++ b/contrib/runners/action_chain_runner/action_chain_runner.py
@@ -193,7 +193,6 @@ class ChainHolder(object):
         if not vars:
             return {}
         context = {}
-        context.update({SYSTEM_SCOPE: KeyValueLookup(scope=SYSTEM_SCOPE)})
         context.update({
             DATASTORE_PARENT_SCOPE: {
                 SYSTEM_SCOPE: KeyValueLookup(scope=FULL_SYSTEM_SCOPE)

--- a/contrib/runners/action_chain_runner/tests/unit/test_actionchain.py
+++ b/contrib/runners/action_chain_runner/tests/unit/test_actionchain.py
@@ -587,7 +587,6 @@ class TestActionChainRunner(DbTestCase):
             self.assertNotEqual(chain_runner.chain_holder.actionchain, None)
             expected_value = {'inttype': 1,
                               'strtype': 'two',
-                              'strtype_legacy': 'two',
                               'booltype': True}
             mock_args, _ = request.call_args
             self.assertEqual(mock_args[0].parameters, expected_value)

--- a/st2actions/st2actions/notifier/notifier.py
+++ b/st2actions/st2actions/notifier/notifier.py
@@ -200,7 +200,6 @@ class Notifier(consumers.MessageHandler):
 
     def _build_jinja_context(self, liveaction, execution):
         context = {}
-        context.update({SYSTEM_SCOPE: KeyValueLookup(scope=SYSTEM_SCOPE)})
         context.update({
             DATASTORE_PARENT_SCOPE: {
                 SYSTEM_SCOPE: KeyValueLookup(scope=FULL_SYSTEM_SCOPE)

--- a/st2api/st2api/controllers/v1/keyvalue.py
+++ b/st2api/st2api/controllers/v1/keyvalue.py
@@ -21,7 +21,7 @@ from mongoengine import ValidationError
 from st2api.controllers.resource import ResourceController
 from st2common import log as logging
 from st2common.constants.keyvalue import ALL_SCOPE, FULL_SYSTEM_SCOPE
-from st2common.constants.keyvalue import FULL_USER_SCOPE, USER_SCOPE, ALLOWED_SCOPES
+from st2common.constants.keyvalue import FULL_USER_SCOPE, ALLOWED_SCOPES
 from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2common.exceptions.keyvalue import CryptoKeyNotSetupException, InvalidScopeException
 from st2common.models.api.keyvalue import KeyValuePairAPI
@@ -139,7 +139,7 @@ class KeyValuePairController(ResourceController):
             self._validate_scope(scope=scope)
             kwargs['scope'] = scope
 
-        if scope == USER_SCOPE or scope == FULL_USER_SCOPE:
+        if scope == FULL_USER_SCOPE:
             # Make sure we only returned values scoped to current user
             if kwargs['prefix']:
                 kwargs['prefix'] = get_key_reference(name=kwargs['prefix'], scope=scope,
@@ -280,7 +280,7 @@ class KeyValuePairController(ResourceController):
         """
         requester_user = get_requester()
 
-        is_user_scope = (scope == USER_SCOPE or scope == FULL_USER_SCOPE)
+        is_user_scope = (scope == FULL_USER_SCOPE)
         if decrypt and (not is_user_scope and not is_admin):
             msg = 'Decrypt option requires administrator access'
             raise AccessDeniedError(message=msg, user_db=requester_user)

--- a/st2common/st2common/models/api/keyvalue.py
+++ b/st2common/st2common/models/api/keyvalue.py
@@ -134,7 +134,7 @@ class KeyValuePairAPI(BaseAPI):
             doc['value'] = symmetric_decrypt(KeyValuePairAPI.crypto_key, model.value)
             encrypted = False
 
-        scope = getattr(model, 'scope', SYSTEM_SCOPE)
+        scope = getattr(model, 'scope', FULL_SYSTEM_SCOPE)
         if scope:
             doc['scope'] = scope
 

--- a/st2common/st2common/models/api/keyvalue.py
+++ b/st2common/st2common/models/api/keyvalue.py
@@ -21,7 +21,6 @@ from oslo_config import cfg
 import six
 
 from st2common.constants.keyvalue import FULL_SYSTEM_SCOPE, FULL_USER_SCOPE, ALLOWED_SCOPES
-from st2common.constants.keyvalue import USER_SCOPE
 from st2common.exceptions.keyvalue import CryptoKeyNotSetupException, InvalidScopeException
 from st2common.log import logging
 from st2common.util import isotime
@@ -139,7 +138,7 @@ class KeyValuePairAPI(BaseAPI):
             doc['scope'] = scope
 
         key = doc.get('name', None)
-        if (scope == USER_SCOPE or scope == FULL_USER_SCOPE) and key:
+        if (scope == FULL_USER_SCOPE) and key:
             doc['user'] = UserKeyReference.get_user(key)
             doc['name'] = UserKeyReference.get_name(key)
 

--- a/st2common/st2common/models/api/keyvalue.py
+++ b/st2common/st2common/models/api/keyvalue.py
@@ -21,7 +21,7 @@ from oslo_config import cfg
 import six
 
 from st2common.constants.keyvalue import FULL_SYSTEM_SCOPE, FULL_USER_SCOPE, ALLOWED_SCOPES
-from st2common.constants.keyvalue import SYSTEM_SCOPE, USER_SCOPE
+from st2common.constants.keyvalue import USER_SCOPE
 from st2common.exceptions.keyvalue import CryptoKeyNotSetupException, InvalidScopeException
 from st2common.log import logging
 from st2common.util import isotime

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -20,8 +20,8 @@ from oslo_config import cfg
 
 from st2common import log as logging
 from st2common.util import schema as util_schema
-from st2common.constants.keyvalue import SYSTEM_SCOPE
-from st2common.constants.keyvalue import USER_SCOPE
+from st2common.constants.keyvalue import FULL_SYSTEM_SCOPE
+from st2common.constants.keyvalue import FULL_USER_SCOPE
 from st2common.constants.pack import PACK_REF_WHITELIST_REGEX
 from st2common.constants.pack import PACK_VERSION_REGEX
 from st2common.constants.pack import ST2_VERSION_REGEX
@@ -345,10 +345,10 @@ class ConfigItemSetAPI(BaseAPI):
             "scope": {
                 "description": "Config item scope (system / user)",
                 "type": "string",
-                "default": SYSTEM_SCOPE,
+                "default": FULL_SYSTEM_SCOPE,
                 "enum": [
-                    SYSTEM_SCOPE,
-                    USER_SCOPE
+                    FULL_SYSTEM_SCOPE,
+                    FULL_USER_SCOPE
                 ]
             },
             "user": {

--- a/st2common/st2common/runners/python_action_wrapper.py
+++ b/st2common/st2common/runners/python_action_wrapper.py
@@ -42,7 +42,7 @@ from st2common.runners.utils import get_action_class_instance
 from st2common.util import loader as action_loader
 from st2common.util.config_loader import ContentPackConfigLoader
 from st2common.constants.action import ACTION_OUTPUT_RESULT_DELIMITER
-from st2common.constants.keyvalue import SYSTEM_SCOPE
+from st2common.constants.keyvalue import FULL_SYSTEM_SCOPE
 from st2common.constants.runners import PYTHON_RUNNER_INVALID_ACTION_STATUS_EXIT_CODE
 from st2common.database_setup import db_setup
 
@@ -96,14 +96,14 @@ class ActionService(object):
     def list_values(self, local=True, prefix=None):
         return self.datastore_service.list_values(local, prefix)
 
-    def get_value(self, name, local=True, scope=SYSTEM_SCOPE, decrypt=False):
+    def get_value(self, name, local=True, scope=FULL_SYSTEM_SCOPE, decrypt=False):
         return self.datastore_service.get_value(name, local, scope=scope, decrypt=decrypt)
 
-    def set_value(self, name, value, ttl=None, local=True, scope=SYSTEM_SCOPE, encrypt=False):
+    def set_value(self, name, value, ttl=None, local=True, scope=FULL_SYSTEM_SCOPE, encrypt=False):
         return self.datastore_service.set_value(name, value, ttl, local, scope=scope,
                                                 encrypt=encrypt)
 
-    def delete_value(self, name, local=True, scope=SYSTEM_SCOPE):
+    def delete_value(self, name, local=True, scope=FULL_SYSTEM_SCOPE):
         return self.datastore_service.delete_value(name, local)
 
 

--- a/st2common/st2common/services/datastore.py
+++ b/st2common/st2common/services/datastore.py
@@ -19,7 +19,7 @@ from st2client.models import KeyValuePair
 from st2common.services.access import create_token
 from st2common.util.api import get_full_public_api_url
 from st2common.util.date import get_datetime_utc_now
-from st2common.constants.keyvalue import DATASTORE_KEY_SEPARATOR, SYSTEM_SCOPE
+from st2common.constants.keyvalue import DATASTORE_KEY_SEPARATOR, FULL_SYSTEM_SCOPE
 
 
 class DatastoreService(object):
@@ -61,7 +61,7 @@ class DatastoreService(object):
         kvps = client.keys.get_all(prefix=key_prefix)
         return kvps
 
-    def get_value(self, name, local=True, scope=SYSTEM_SCOPE, decrypt=False):
+    def get_value(self, name, local=True, scope=FULL_SYSTEM_SCOPE, decrypt=False):
         """
         Retrieve a value from the datastore for the provided key.
 
@@ -82,7 +82,7 @@ class DatastoreService(object):
 
         :rtype: ``str`` or ``None``
         """
-        if scope != SYSTEM_SCOPE:
+        if scope != FULL_SYSTEM_SCOPE:
             raise ValueError('Scope %s is unsupported.' % scope)
 
         name = self._get_full_key_name(name=name, local=local)
@@ -106,7 +106,7 @@ class DatastoreService(object):
 
         return None
 
-    def set_value(self, name, value, ttl=None, local=True, scope=SYSTEM_SCOPE, encrypt=False):
+    def set_value(self, name, value, ttl=None, local=True, scope=FULL_SYSTEM_SCOPE, encrypt=False):
         """
         Set a value for the provided key.
 
@@ -134,7 +134,7 @@ class DatastoreService(object):
         :return: ``True`` on success, ``False`` otherwise.
         :rtype: ``bool``
         """
-        if scope != SYSTEM_SCOPE:
+        if scope != FULL_SYSTEM_SCOPE:
             raise ValueError('Scope %s is unsupported.', scope)
 
         name = self._get_full_key_name(name=name, local=local)
@@ -158,7 +158,7 @@ class DatastoreService(object):
         client.keys.update(instance=instance)
         return True
 
-    def delete_value(self, name, local=True, scope=SYSTEM_SCOPE):
+    def delete_value(self, name, local=True, scope=FULL_SYSTEM_SCOPE):
         """
         Delete the provided key.
 
@@ -177,7 +177,7 @@ class DatastoreService(object):
         :return: ``True`` on success, ``False`` otherwise.
         :rtype: ``bool``
         """
-        if scope != SYSTEM_SCOPE:
+        if scope != FULL_SYSTEM_SCOPE:
             raise ValueError('Scope %s is unsupported.', scope)
 
         name = self._get_full_key_name(name=name, local=local)

--- a/st2common/st2common/services/keyvalues.py
+++ b/st2common/st2common/services/keyvalues.py
@@ -15,8 +15,8 @@
 
 from st2common import log as logging
 
-from st2common.constants.keyvalue import SYSTEM_SCOPE, FULL_SYSTEM_SCOPE
-from st2common.constants.keyvalue import USER_SCOPE, FULL_USER_SCOPE
+from st2common.constants.keyvalue import FULL_SYSTEM_SCOPE
+from st2common.constants.keyvalue import FULL_USER_SCOPE
 from st2common.constants.keyvalue import ALLOWED_SCOPES
 from st2common.constants.keyvalue import DATASTORE_KEY_SEPARATOR
 from st2common.exceptions.keyvalue import InvalidScopeException, InvalidUserException
@@ -71,9 +71,6 @@ class KeyValueLookup(object):
         if not scope:
             scope = FULL_SYSTEM_SCOPE
 
-        if scope == SYSTEM_SCOPE:
-            scope = FULL_SYSTEM_SCOPE
-
         self._prefix = prefix
         self._key_prefix = key_prefix or ''
         self._value_cache = cache or {}
@@ -122,9 +119,6 @@ class UserKeyValueLookup(object):
 
     def __init__(self, user, prefix=None, key_prefix=None, cache=None, scope=FULL_USER_SCOPE):
         if not scope:
-            scope = FULL_USER_SCOPE
-
-        if scope == USER_SCOPE:
             scope = FULL_USER_SCOPE
 
         self._prefix = prefix
@@ -182,9 +176,9 @@ def get_key_reference(scope, name, user=None):
 
     :rtype: ``str``
     """
-    if (scope == SYSTEM_SCOPE or scope == FULL_SYSTEM_SCOPE):
+    if scope == FULL_SYSTEM_SCOPE:
         return name
-    elif (scope == USER_SCOPE or scope == FULL_USER_SCOPE):
+    elif scope == FULL_USER_SCOPE:
         if not user:
             raise InvalidUserException('A valid user must be specified for user key ref.')
         return UserKeyReference(name=name, user=user).ref

--- a/st2common/st2common/util/param.py
+++ b/st2common/st2common/util/param.py
@@ -76,7 +76,6 @@ def _create_graph(action_context):
     Creates a generic directed graph for depencency tree and fills it with basic context variables
     '''
     G = nx.DiGraph()
-    G.add_node(SYSTEM_SCOPE, value=KeyValueLookup(scope=SYSTEM_SCOPE))
     system_keyvalue_context = {SYSTEM_SCOPE: KeyValueLookup(scope=SYSTEM_SCOPE)}
     G.add_node(DATASTORE_PARENT_SCOPE, value=system_keyvalue_context)
     G.add_node(ACTION_CONTEXT_KV_PREFIX, value=action_context)

--- a/st2common/st2common/util/param.py
+++ b/st2common/st2common/util/param.py
@@ -21,7 +21,7 @@ import networkx as nx
 from jinja2 import meta
 from st2common import log as logging
 from st2common.constants.action import ACTION_CONTEXT_KV_PREFIX
-from st2common.constants.keyvalue import DATASTORE_PARENT_SCOPE, SYSTEM_SCOPE
+from st2common.constants.keyvalue import DATASTORE_PARENT_SCOPE, SYSTEM_SCOPE, FULL_SYSTEM_SCOPE
 from st2common.exceptions.param import ParamException
 from st2common.services.keyvalues import KeyValueLookup
 from st2common.util.casts import get_cast
@@ -76,7 +76,7 @@ def _create_graph(action_context):
     Creates a generic directed graph for depencency tree and fills it with basic context variables
     '''
     G = nx.DiGraph()
-    system_keyvalue_context = {SYSTEM_SCOPE: KeyValueLookup(scope=SYSTEM_SCOPE)}
+    system_keyvalue_context = {SYSTEM_SCOPE: KeyValueLookup(scope=FULL_SYSTEM_SCOPE)}
     G.add_node(DATASTORE_PARENT_SCOPE, value=system_keyvalue_context)
     G.add_node(ACTION_CONTEXT_KV_PREFIX, value=action_context)
     return G

--- a/st2common/st2common/util/templating.py
+++ b/st2common/st2common/util/templating.py
@@ -92,7 +92,6 @@ def render_template_with_system_and_user_context(value, user, context=None, pref
     :rtype: ``str``
     """
     context = context or {}
-    context[USER_SCOPE] = UserKeyValueLookup(prefix=prefix, user=user, scope=USER_SCOPE)
     context[DATASTORE_PARENT_SCOPE] = {
         SYSTEM_SCOPE: KeyValueLookup(prefix=prefix, scope=FULL_SYSTEM_SCOPE),
         USER_SCOPE: UserKeyValueLookup(prefix=prefix, user=user, scope=FULL_USER_SCOPE)

--- a/st2common/st2common/util/templating.py
+++ b/st2common/st2common/util/templating.py
@@ -65,9 +65,8 @@ def render_template_with_system_context(value, context=None, prefix=None):
     :rtype: ``str``
     """
     context = context or {}
-    context[SYSTEM_SCOPE] = KeyValueLookup(prefix=prefix, scope=SYSTEM_SCOPE)
     context[DATASTORE_PARENT_SCOPE] = {
-        SYSTEM_SCOPE: KeyValueLookup(prefix=prefix, scope=SYSTEM_SCOPE)
+        SYSTEM_SCOPE: KeyValueLookup(prefix=prefix, scope=FULL_SYSTEM_SCOPE)
     }
 
     rendered = render_template(value=value, context=context)
@@ -93,7 +92,6 @@ def render_template_with_system_and_user_context(value, user, context=None, pref
     :rtype: ``str``
     """
     context = context or {}
-    context[SYSTEM_SCOPE] = KeyValueLookup(prefix=prefix, scope=SYSTEM_SCOPE)
     context[USER_SCOPE] = UserKeyValueLookup(prefix=prefix, user=user, scope=USER_SCOPE)
     context[DATASTORE_PARENT_SCOPE] = {
         SYSTEM_SCOPE: KeyValueLookup(prefix=prefix, scope=FULL_SYSTEM_SCOPE),

--- a/st2common/tests/unit/services/test_keyvalue.py
+++ b/st2common/tests/unit/services/test_keyvalue.py
@@ -15,7 +15,7 @@
 
 import unittest2
 
-from st2common.constants.keyvalue import SYSTEM_SCOPE, USER_SCOPE
+from st2common.constants.keyvalue import FULL_SYSTEM_SCOPE, FULL_USER_SCOPE
 from st2common.exceptions.keyvalue import InvalidScopeException, InvalidUserException
 from st2common.services.keyvalues import get_key_reference
 
@@ -23,14 +23,14 @@ from st2common.services.keyvalues import get_key_reference
 class KeyValueServicesTest(unittest2.TestCase):
 
     def test_get_key_reference_system_scope(self):
-        ref = get_key_reference(scope=SYSTEM_SCOPE, name='foo')
+        ref = get_key_reference(scope=FULL_SYSTEM_SCOPE, name='foo')
         self.assertEqual(ref, 'foo')
 
     def test_get_key_reference_user_scope(self):
-        ref = get_key_reference(scope=USER_SCOPE, name='foo', user='stanley')
+        ref = get_key_reference(scope=FULL_USER_SCOPE, name='foo', user='stanley')
         self.assertEqual(ref, 'stanley:foo')
         self.assertRaises(InvalidUserException, get_key_reference,
-                          scope=USER_SCOPE, name='foo', user='')
+                          scope=FULL_USER_SCOPE, name='foo', user='')
 
     def test_get_key_reference_invalid_scope_raises_exception(self):
         self.assertRaises(InvalidScopeException, get_key_reference,

--- a/st2common/tests/unit/test_datastore.py
+++ b/st2common/tests/unit/test_datastore.py
@@ -19,7 +19,7 @@ from st2common.util.date import get_datetime_utc_now
 
 import mock
 
-from st2common.constants.keyvalue import SYSTEM_SCOPE
+from st2common.constants.keyvalue import FULL_SYSTEM_SCOPE
 from st2common.services.datastore import DatastoreService
 from st2client.models.keyvalue import KeyValuePair
 from st2tests import DbTestCase
@@ -101,7 +101,7 @@ class DatastoreServiceTestCase(DbTestCase):
         self.assertTrue(value)
         kvp = mock_api_client.keys.update.call_args[1]['instance']
         self.assertEquals(kvp.value, 'foo')
-        self.assertEquals(kvp.scope, SYSTEM_SCOPE)
+        self.assertEquals(kvp.scope, FULL_SYSTEM_SCOPE)
 
     def test_datastore_operations_delete_value(self):
         mock_api_client = mock.Mock()
@@ -121,7 +121,7 @@ class DatastoreServiceTestCase(DbTestCase):
         kvp = mock_api_client.keys.update.call_args[1]['instance']
         self.assertEquals(kvp.value, 'foo')
         self.assertTrue(kvp.secret)
-        self.assertEquals(kvp.scope, SYSTEM_SCOPE)
+        self.assertEquals(kvp.scope, FULL_SYSTEM_SCOPE)
 
     def test_datastore_unsupported_scope(self):
         self.assertRaises(ValueError, self._datastore_service.get_value, name='test1',

--- a/st2common/tests/unit/test_keyvalue_lookup.py
+++ b/st2common/tests/unit/test_keyvalue_lookup.py
@@ -15,7 +15,6 @@
 
 from st2tests.base import CleanDbTestCase
 from st2common.constants.keyvalue import FULL_SYSTEM_SCOPE, FULL_USER_SCOPE
-from st2common.constants.keyvalue import SYSTEM_SCOPE, USER_SCOPE
 from st2common.models.db.keyvalue import KeyValuePairDB
 from st2common.persistence.keyvalue import KeyValuePair
 from st2common.services.keyvalues import KeyValueLookup, UserKeyValueLookup
@@ -89,17 +88,6 @@ class TestKeyValueLookup(CleanDbTestCase):
         self.assertEquals(str(lookup['r']['i']['p']), '')
         user_lookup = UserKeyValueLookup(scope=FULL_USER_SCOPE, user='stanley')
         self.assertEquals(str(user_lookup['r']['i']['p']), k4.value)
-
-    def test_lookups_older_scope_names_backward_compatibility(self):
-        k1 = KeyValuePair.add_or_update(KeyValuePairDB(name='a.b', value='v1',
-                                                       scope=FULL_SYSTEM_SCOPE))
-        lookup = KeyValueLookup(scope=SYSTEM_SCOPE)
-        self.assertEquals(str(lookup['a']['b']), k1.value)
-
-        k2 = KeyValuePair.add_or_update(KeyValuePairDB(name='stanley:r.i.p', value='v4',
-                                                       scope=FULL_USER_SCOPE))
-        user_lookup = UserKeyValueLookup(scope=USER_SCOPE, user='stanley')
-        self.assertEquals(str(user_lookup['r']['i']['p']), k2.value)
 
     def test_user_scope_lookups_dot_in_user(self):
         KeyValuePair.add_or_update(KeyValuePairDB(name='first.last:r.i.p', value='v4',

--- a/st2common/tests/unit/test_param_utils.py
+++ b/st2common/tests/unit/test_param_utils.py
@@ -16,7 +16,6 @@
 
 import mock
 
-from st2common.constants.keyvalue import FULL_SYSTEM_SCOPE
 from st2common.exceptions.param import ParamException
 from st2common.models.system.common import ResourceReference
 from st2common.models.db.liveaction import LiveActionDB
@@ -512,28 +511,6 @@ class ParamsUtilsTest(DbTestCase):
             runner_param_info, action_param_info, params, action_context)
 
         self.assertEqual(r_action_params['cmd'], "echo 1.7.0")
-
-    def test_get_finalized_params_older_kv_scopes_backwards_compatibility(self):
-        KeyValuePair.add_or_update(KeyValuePairDB(name='cmd_to_run', value='echo MELANIA',
-                                                  scope=FULL_SYSTEM_SCOPE))
-        # k2 = KeyValuePair.add_or_update(KeyValuePairDB(name='ivanka:cmd_to_run',
-        #                                                value='echo MA DAD IS GREAT',
-        #                                                scope=USER_SCOPE))
-        params = {
-            'sys_cmd': '{{st2kv.system.cmd_to_run}}',
-            # 'user_cmd': '{{user.ivanka:cmd_to_run}}' Not supported yet.
-        }
-        runner_param_info = {'r1': {}}
-        action_param_info = {
-            'sys_cmd': {}
-        }
-        action_context = {}
-
-        r_runner_params, r_action_params = param_utils.get_finalized_params(
-            runner_param_info, action_param_info, params, action_context)
-
-        self.assertEqual(r_action_params['sys_cmd'], "echo MELANIA")
-        # self.assertEqual(r_action_params['user_cmd'], "echo MA DAD IS GREAT")
 
     def test_get_finalized_params_param_rendering_failure(self):
         params = {'cmd': '{{a2.foo}}', 'a2': 'test'}

--- a/st2common/tests/unit/test_param_utils.py
+++ b/st2common/tests/unit/test_param_utils.py
@@ -520,7 +520,7 @@ class ParamsUtilsTest(DbTestCase):
         #                                                value='echo MA DAD IS GREAT',
         #                                                scope=USER_SCOPE))
         params = {
-            'sys_cmd': '{{system.cmd_to_run}}',
+            'sys_cmd': '{{st2kv.system.cmd_to_run}}',
             # 'user_cmd': '{{user.ivanka:cmd_to_run}}' Not supported yet.
         }
         runner_param_info = {'r1': {}}

--- a/st2common/tests/unit/test_util_templating.py
+++ b/st2common/tests/unit/test_util_templating.py
@@ -63,10 +63,3 @@ class TemplatingUtilsTestCase(CleanDbTestCase):
 
         result = render_template_with_system_and_user_context(value=template, user=user)
         self.assertEqual(result, 'valuejoe1')
-
-        # Backward compatibility test
-        template = '{{user.key1}}'
-        user = 'joe'
-
-        result = render_template_with_system_and_user_context(value=template, user=user)
-        self.assertEqual(result, 'valuejoe1')

--- a/st2common/tests/unit/test_util_templating.py
+++ b/st2common/tests/unit/test_util_templating.py
@@ -51,13 +51,6 @@ class TemplatingUtilsTestCase(CleanDbTestCase):
         result = render_template_with_system_and_user_context(value=template, user=user)
         self.assertEqual(result, 'valueb')
 
-        # Backward compatibility test
-        template = '{{system.key2}}'
-        user = 'stanley'
-
-        result = render_template_with_system_and_user_context(value=template, user=user)
-        self.assertEqual(result, 'valueb')
-
         # 2. Reference to the user inside the template
         template = '{{st2kv.user.key1}}'
         user = 'stanley'

--- a/st2reactor/st2reactor/rules/datatransform.py
+++ b/st2reactor/st2reactor/rules/datatransform.py
@@ -28,7 +28,6 @@ class Jinja2BasedTransformer(object):
 
     def __call__(self, mapping):
         context = copy.copy(self._payload_context)
-        context[SYSTEM_SCOPE] = KeyValueLookup(scope=SYSTEM_SCOPE)
         context.update({
             DATASTORE_PARENT_SCOPE: {
                 SYSTEM_SCOPE: KeyValueLookup(scope=FULL_SYSTEM_SCOPE)
@@ -42,7 +41,6 @@ class Jinja2BasedTransformer(object):
             return context
 
         context = context or {}
-        context[SYSTEM_SCOPE] = KeyValueLookup(scope=SYSTEM_SCOPE)
         context.update({
             DATASTORE_PARENT_SCOPE: {
                 SYSTEM_SCOPE: KeyValueLookup(scope=FULL_SYSTEM_SCOPE)

--- a/st2reactor/tests/unit/test_data_transform.py
+++ b/st2reactor/tests/unit/test_data_transform.py
@@ -73,13 +73,11 @@ class DataTransformTest(DbTestCase):
             transformer = datatransform.get_transformer(PAYLOAD)
             mapping = {'ip5': '{{trigger.k2}}-static',
                        'ip6': '{{st2kv.system.k6}}-static',
-                       'ip7': '{{st2kv.system.k7}}-static',
-                       'ip8': '{{system.k8}}-static'}
+                       'ip7': '{{st2kv.system.k7}}-static'}
             result = transformer(mapping)
             expected = {'ip5': 'v2-static',
                         'ip6': 'v6-static',
-                        'ip7': 'v7-static',
-                        'ip8': 'v8-static'}
+                        'ip7': 'v7-static'}
             self.assertEqual(result, expected)
         finally:
             KeyValuePair.delete(k5)

--- a/st2reactor/tests/unit/test_filter.py
+++ b/st2reactor/tests/unit/test_filter.py
@@ -168,7 +168,12 @@ class FilterTest(DbTestCase):
         mock_result.test_value_1 = 'non matching'
         mock_KeyValueLookup.return_value = mock_result
 
-        rule.criteria = {'trigger.p1': {'type': 'equals', 'pattern': '{{ st2kv.system.test_value_1 }}'}}
+        rule.criteria = {
+            'trigger.p1': {
+                'type': 'equals',
+                'pattern': '{{ st2kv.system.test_value_1 }}'
+            }
+        }
         f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
         self.assertFalse(f.filter())
 
@@ -177,7 +182,12 @@ class FilterTest(DbTestCase):
         mock_result.test_value_2 = 'v1'
         mock_KeyValueLookup.return_value = mock_result
 
-        rule.criteria = {'trigger.p1': {'type': 'equals', 'pattern': '{{ st2kv.system.test_value_2 }}'}}
+        rule.criteria = {
+            'trigger.p1': {
+                'type': 'equals',
+                'pattern': '{{ st2kv.system.test_value_2 }}'
+            }
+        }
         f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
         self.assertTrue(f.filter())
 
@@ -186,7 +196,12 @@ class FilterTest(DbTestCase):
         mock_result.test_value_3 = 'YYY'
         mock_KeyValueLookup.return_value = mock_result
 
-        rule.criteria = {'trigger.p2': {'type': 'equals', 'pattern': '{{ st2kv.system.test_value_3 }}'}}
+        rule.criteria = {
+            'trigger.p2': {
+                'type': 'equals',
+                'pattern': '{{ st2kv.system.test_value_3 }}'
+            }
+        }
         f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
         self.assertFalse(f.filter())
 
@@ -195,9 +210,11 @@ class FilterTest(DbTestCase):
         mock_result.test_value_3 = 'YYY'
         mock_KeyValueLookup.return_value = mock_result
 
-        rule.criteria = {'trigger.p2': {
-            'type': 'equals',
-            'pattern': 'pre{{ st2kv.system.test_value_3 }}post'}
+        rule.criteria = {
+            'trigger.p2': {
+                'type': 'equals',
+                'pattern': 'pre{{ st2kv.system.test_value_3 }}post'
+            }
         }
         f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
         self.assertTrue(f.filter())

--- a/st2reactor/tests/unit/test_filter.py
+++ b/st2reactor/tests/unit/test_filter.py
@@ -158,7 +158,7 @@ class FilterTest(DbTestCase):
         # Using a variable in pattern, referencing an inexistent datastore value
         rule.criteria = {'trigger.p1': {
             'type': 'equals',
-            'pattern': '{{ system.inexistent_value }}'}
+            'pattern': '{{ st2kv.system.inexistent_value }}'}
         }
         f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
         self.assertFalse(f.filter())
@@ -168,7 +168,7 @@ class FilterTest(DbTestCase):
         mock_result.test_value_1 = 'non matching'
         mock_KeyValueLookup.return_value = mock_result
 
-        rule.criteria = {'trigger.p1': {'type': 'equals', 'pattern': '{{ system.test_value_1 }}'}}
+        rule.criteria = {'trigger.p1': {'type': 'equals', 'pattern': '{{ st2kv.system.test_value_1 }}'}}
         f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
         self.assertFalse(f.filter())
 
@@ -177,7 +177,7 @@ class FilterTest(DbTestCase):
         mock_result.test_value_2 = 'v1'
         mock_KeyValueLookup.return_value = mock_result
 
-        rule.criteria = {'trigger.p1': {'type': 'equals', 'pattern': '{{ system.test_value_2 }}'}}
+        rule.criteria = {'trigger.p1': {'type': 'equals', 'pattern': '{{ st2kv.system.test_value_2 }}'}}
         f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
         self.assertTrue(f.filter())
 
@@ -186,7 +186,7 @@ class FilterTest(DbTestCase):
         mock_result.test_value_3 = 'YYY'
         mock_KeyValueLookup.return_value = mock_result
 
-        rule.criteria = {'trigger.p2': {'type': 'equals', 'pattern': '{{ system.test_value_3 }}'}}
+        rule.criteria = {'trigger.p2': {'type': 'equals', 'pattern': '{{ st2kv.system.test_value_3 }}'}}
         f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
         self.assertFalse(f.filter())
 
@@ -197,7 +197,7 @@ class FilterTest(DbTestCase):
 
         rule.criteria = {'trigger.p2': {
             'type': 'equals',
-            'pattern': 'pre{{ system.test_value_3 }}post'}
+            'pattern': 'pre{{ st2kv.system.test_value_3 }}post'}
         }
         f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
         self.assertTrue(f.filter())

--- a/st2tests/st2tests/fixtures/generic/actionchains/chain_with_system_vars.yaml
+++ b/st2tests/st2tests/fixtures/generic/actionchains/chain_with_system_vars.yaml
@@ -5,7 +5,6 @@ chain:
     booltype: true
     inttype: '{{inttype}}'
     strtype: '{{strtype}}'
-    strtype_legacy: '{{system.a}}'
   ref: wolfpack.a2
 default: c1
 vars:

--- a/st2tests/st2tests/mocks/datastore.py
+++ b/st2tests/st2tests/mocks/datastore.py
@@ -17,7 +17,7 @@
 Mock classes for use in pack testing.
 """
 
-from st2common.constants.keyvalue import SYSTEM_SCOPE
+from st2common.constants.keyvalue import FULL_SYSTEM_SCOPE
 from st2common.services.datastore import DatastoreService
 from st2client.models.keyvalue import KeyValuePair
 
@@ -54,7 +54,7 @@ class MockDatastoreService(DatastoreService):
 
         return result
 
-    def get_value(self, name, local=True, scope=SYSTEM_SCOPE, decrypt=False):
+    def get_value(self, name, local=True, scope=FULL_SYSTEM_SCOPE, decrypt=False):
         """
         Return a particular value stored in a dictionary which is local to this class.
         """
@@ -66,7 +66,7 @@ class MockDatastoreService(DatastoreService):
         kvp = self._datastore_items[name]
         return kvp.value
 
-    def set_value(self, name, value, ttl=None, local=True, scope=SYSTEM_SCOPE, encrypt=False):
+    def set_value(self, name, value, ttl=None, local=True, scope=FULL_SYSTEM_SCOPE, encrypt=False):
         """
         Store a value in a dictionary which is local to this class.
         """
@@ -83,7 +83,7 @@ class MockDatastoreService(DatastoreService):
         self._datastore_items[name] = instance
         return True
 
-    def delete_value(self, name, local=True, scope=SYSTEM_SCOPE):
+    def delete_value(self, name, local=True, scope=FULL_SYSTEM_SCOPE):
         """
         Delete a value from a dictionary which is local to this class.
         """


### PR DESCRIPTION
With this PR, we are deprecating {{user.}} and {{system.}} notations for accessing items from datastore. We only support {{st2kv.user.}} and {{st2kv.system.}} notations. 

## TODO

* [x] Deprecate {{user.}}
* [X] Fix docs (https://github.com/StackStorm/st2docs/pull/367)
* [X] Deprecation notice in Upgrade Notes (https://github.com/StackStorm/st2docs/pull/367)
* [x] Changelog