### PR TITLE
Fix typo in the CLI help output

### DIFF
--- a/st2client/st2client/commands/action_alias.py
+++ b/st2client/st2client/commands/action_alias.py
@@ -98,7 +98,8 @@ class ActionAliasExecuteCommand(resource.ResourceCommand):
     def __init__(self, resource, *args, **kwargs):
         super(ActionAliasExecuteCommand, self).__init__(
             resource, 'execute',
-            'Execute the command text by finding a matching ActionAlias.',
+            ('Execute the command text by finding a matching %s.' %
+            resource.get_display_name().lower()),
             *args, **kwargs)
 
         self.parser.add_argument('command_text',

--- a/st2client/st2client/models/action_alias.py
+++ b/st2client/st2client/models/action_alias.py
@@ -25,7 +25,7 @@ class ActionAlias(core.Resource):
     _alias = 'Action-Alias'
     _display_name = 'Action Alias'
     _plural = 'ActionAliases'
-    _plural_display_name = 'Runners'
+    _plural_display_name = 'Action Aliases'
     _url_path = 'actionalias'
     _repr_attributes = ['name', 'pack', 'action_ref']
 


### PR DESCRIPTION
Fixes a small typo caught by @LindsayHill in #3165.