### PR TITLE
Fix linux.traceroute stdout formatting

### DIFF
--- a/contrib/linux/actions/traceroute.sh
+++ b/contrib/linux/actions/traceroute.sh
@@ -17,4 +17,4 @@ if [ $? -ne 0 ]; then
     exit 2
 fi
 
-exec ${TRACEROUTE} -q $MAX_QUERIES_TO_HOP -m $MAX_HOPS $HOST
+exec ${TRACEROUTE} -q ${MAX_QUERIES_TO_HOP} -m ${MAX_HOPS} ${HOST}

--- a/contrib/linux/actions/traceroute.sh
+++ b/contrib/linux/actions/traceroute.sh
@@ -17,4 +17,4 @@ if [ $? -ne 0 ]; then
     exit 2
 fi
 
-echo `${TRACEROUTE} -q $MAX_QUERIES_TO_HOP -m $MAX_HOPS $HOST`
+exec ${TRACEROUTE} -q $MAX_QUERIES_TO_HOP -m $MAX_HOPS $HOST


### PR DESCRIPTION
> Reported in Slack community by @livelace

Original `traceroute.sh` which is part of `linux.traceroute` action doesn't preserve line separators, what's confusing for users, thinking that StackStorm itself eat some line separators.

@livelace By design StackStorm shows what he get from the script via stdout, stderr and exit code.

This small change should fix `linux.traceroute` action.

### Before
```sh
./traceroute.sh google.com

traceroute to google.com (216.58.209.174), 30 hops max, 60 byte packets ...ae-3-3201.bar1.Budapest1.Level3.net (4.69.201.158) 24.733 ms 24.775 ms 24.971 ms 8 72.14.243.192 (72.14.243.192) 24.934 ms 24.892 ms 24.850 ms 9 209.85.243.119 (209.85.243.119) 45.224 ms 25.112 ms 25.077 ms 10 66.249.95.61 (66.249.95.61) 25.038 ms 25.150 ms 25.224 ms 11 bud02s21-in-f174.1e100.net (216.58.209.174) 25.183 ms 25.142 ms 24.755 ms
```

### After
```sh
$ ./traceroute.sh google.com
traceroute to google.com (216.58.209.174), 30 hops max, 60 byte packets
...
 5  * * *
 6  ae-3-3201.bar1.Budapest1.Level3.net (4.69.201.158)  25.311 ms  24.348 ms  24.289 ms
 7  ae-3-3201.bar1.Budapest1.Level3.net (4.69.201.158)  24.247 ms  24.289 ms  24.229 ms
 8  72.14.243.192 (72.14.243.192)  24.426 ms  24.139 ms  24.392 ms
 9  209.85.243.119 (209.85.243.119)  24.501 ms  25.213 ms  24.424 ms
10  66.249.95.61 (66.249.95.61)  24.581 ms  24.549 ms  24.754 ms
11  bud02s21-in-f174.1e100.net (216.58.209.174)  24.700 ms  24.708 ms  24.488 ms
```
