### PR TITLE
Let querier plugin decide to delete state object on error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,6 +49,9 @@ in development
   put the workflow in a PAUSED state in mistral. (improvement)
 * Add support for evaluating jinja expressions in mistral workflow definition where yaql
   expressions are typically accepted. (improvement)
+* Let querier plugin decide whether to delete state object on error. Mistral querier will
+  delete state object on workflow completion or when the workflow or task references no
+  longer exists. (improvement)
 
 2.1.1 - December 16, 2016
 -------------------------

--- a/contrib/runners/mistral_v2/query/mistral_v2.py
+++ b/contrib/runners/mistral_v2/query/mistral_v2.py
@@ -117,11 +117,11 @@ class MistralResultsQuerier(Querier):
         :type exec_id: ``str``
         :rtype: ``list``
         """
+        wf_tasks = []
+
         try:
-            wf_tasks = [
-                self._client.tasks.get(task.id)
-                for task in self._client.tasks.list(workflow_execution_id=exec_id)
-            ]
+            for task in self._client.tasks.list(workflow_execution_id=exec_id):
+                wf_tasks.append(self._client.tasks.get(task.id))
         except mistralclient_base.APIException as mistral_exc:
             if 'not found' in mistral_exc.message:
                 raise exceptions.ReferenceNotFoundError(mistral_exc.message)

--- a/contrib/runners/mistral_v2/query/mistral_v2.py
+++ b/contrib/runners/mistral_v2/query/mistral_v2.py
@@ -71,7 +71,7 @@ class MistralResultsQuerier(Querier):
             result = self._get_workflow_result(mistral_exec_id)
             result['tasks'] = self._get_workflow_tasks(mistral_exec_id)
         except exceptions.ReferenceNotFoundError as exc:
-            LOG.exception('[%s] Unable to find reference. %s', execution_id, exc.message)
+            LOG.exception('[%s] Unable to find reference.', execution_id)
             return (action_constants.LIVEACTION_STATUS_FAILED, exc.message)
         except Exception:
             LOG.exception('[%s] Unable to fetch mistral workflow result and tasks. %s',
@@ -100,8 +100,6 @@ class MistralResultsQuerier(Querier):
             if 'not found' in mistral_exc.message:
                 raise exceptions.ReferenceNotFoundError(mistral_exc.message)
             raise mistral_exc
-        except Exception:
-            raise
 
         result = jsonify.try_loads(execution.output) if execution.state in DONE_STATES else {}
 
@@ -128,8 +126,6 @@ class MistralResultsQuerier(Querier):
             if 'not found' in mistral_exc.message:
                 raise exceptions.ReferenceNotFoundError(mistral_exc.message)
             raise mistral_exc
-        except Exception:
-            raise
 
         return [self._format_task_result(task=wf_task.to_dict()) for wf_task in wf_tasks]
 

--- a/st2actions/tests/integration/test_resultstracker.py
+++ b/st2actions/tests/integration/test_resultstracker.py
@@ -1,45 +1,97 @@
 import eventlet
+import mock
 
 import st2actions.resultstracker.resultstracker as results_tracker
+from st2common.constants import action as action_constants
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
+from st2common.persistence.action import Action
 from st2common.persistence.executionstate import ActionExecutionState
 from st2common.persistence.liveaction import LiveAction
+from st2common.services import executions
 from st2tests.base import (DbTestCase, EventletTestCase)
 from st2tests.fixturesloader import FixturesLoader
 
+
+FIXTURES_LOADER = FixturesLoader()
 FIXTURES_PACK = 'generic'
-FIXTURES = {'actionstates': ['state1.yaml', 'state2.yaml'],
-            'liveactions': ['liveaction1.yaml', 'liveaction2.yaml']}
-loader = FixturesLoader()
+FIXTURES = {
+    'actionstates': ['state1.yaml', 'state2.yaml'],
+    'liveactions': ['liveaction1.yaml', 'liveaction2.yaml']
+}
 
 
+@mock.patch.object(
+    executions, 'update_execution', mock.MagicMock(return_value=None))
+@mock.patch.object(
+    LiveAction, 'publish_update', mock.MagicMock(return_value=None))
 class ResultsTrackerTests(EventletTestCase, DbTestCase):
     states = None
     models = None
     liveactions = None
 
-    @classmethod
-    def setUpClass(cls):
-        super(ResultsTrackerTests, cls).setUpClass()
+    def setUp(self):
+        super(ResultsTrackerTests, self).setUp()
         DbTestCase.setUpClass()
-        ResultsTrackerTests.models = loader.save_fixtures_to_db(fixtures_pack=FIXTURES_PACK,
-                                                                fixtures_dict=FIXTURES)
+        ResultsTrackerTests.models = FIXTURES_LOADER.save_fixtures_to_db(
+            fixtures_pack=FIXTURES_PACK, fixtures_dict=FIXTURES)
         ResultsTrackerTests.states = ResultsTrackerTests.models['actionstates']
         ResultsTrackerTests.liveactions = ResultsTrackerTests.models['liveactions']
         ResultsTrackerTests._update_state_models()
-
-    def test_bootstrap(self):
         tracker = results_tracker.get_tracker()
+        querier = tracker.get_querier('test_querymodule')
+        querier.delete_state_object_on_error = True
+
+    def tearDown(self):
+        FIXTURES_LOADER.delete_models_from_db(ResultsTrackerTests.models)
+        super(ResultsTrackerTests, self).tearDown()
+
+    @classmethod
+    def _update_state_models(cls):
+        states = ResultsTrackerTests.states
+        state1 = ActionExecutionState.get_by_id(states['state1.yaml'].id)
+        state1.execution_id = ResultsTrackerTests.liveactions['liveaction1.yaml'].id
+        state2 = ActionExecutionState.get_by_id(states['state2.yaml'].id)
+        state2.execution_id = ResultsTrackerTests.liveactions['liveaction2.yaml'].id
+        ResultsTrackerTests.states['state1.yaml'] = ActionExecutionState.add_or_update(state1)
+        ResultsTrackerTests.states['state2.yaml'] = ActionExecutionState.add_or_update(state2)
+
+    @mock.patch.object(
+        Action, 'get_by_ref', mock.MagicMock(return_value='foobar'))
+    def test_query_process(self):
+        tracker = results_tracker.get_tracker()
+        querier = tracker.get_querier('test_querymodule')
+        querier._invoke_post_run = mock.Mock(return_value=None)
+
         tracker._bootstrap()
-        eventlet.sleep(0.2)
+        eventlet.sleep(1)
+
         exec_id = str(ResultsTrackerTests.states['state1.yaml'].execution_id)
         exec_db = LiveAction.get_by_id(exec_id)
         self.assertTrue(exec_db.result['called_with'][exec_id] is not None,
                         exec_db.result)
+
         exec_id = str(ResultsTrackerTests.states['state2.yaml'].execution_id)
         exec_db = LiveAction.get_by_id(exec_id)
         self.assertTrue(exec_db.result['called_with'][exec_id] is not None,
                         exec_db.result)
+
         tracker.shutdown()
+
+        # Ensure state objects are deleted
+        self.assertRaises(
+            StackStormDBObjectNotFoundError,
+            ActionExecutionState.get_by_id,
+            ResultsTrackerTests.states['state1.yaml'].id
+        )
+
+        self.assertRaises(
+            StackStormDBObjectNotFoundError,
+            ActionExecutionState.get_by_id,
+            ResultsTrackerTests.states['state2.yaml'].id
+        )
+
+        # Ensure invoke_post_run is called.
+        self.assertEqual(2, querier._invoke_post_run.call_count)
 
     def test_start_shutdown(self):
         tracker = results_tracker.get_tracker()
@@ -58,16 +110,168 @@ class ResultsTrackerTests(EventletTestCase, DbTestCase):
         eventlet.sleep(0.1)
         self.assertTrue(querier.is_started(), 'querier must have been started.')
 
-    @classmethod
-    def tearDownClass(cls):
-        loader.delete_models_from_db(ResultsTrackerTests.models)
+    def test_delete_state_object_on_error_at_query(self):
+        tracker = results_tracker.get_tracker()
+        querier = tracker.get_querier('test_querymodule')
+        querier._delete_state_object = mock.Mock(return_value=None)
 
-    @classmethod
-    def _update_state_models(cls):
-        states = ResultsTrackerTests.states
-        state1 = ActionExecutionState.get_by_id(states['state1.yaml'].id)
-        state1.execution_id = ResultsTrackerTests.liveactions['liveaction1.yaml'].id
-        state2 = ActionExecutionState.get_by_id(states['state2.yaml'].id)
-        state2.execution_id = ResultsTrackerTests.liveactions['liveaction2.yaml'].id
-        ResultsTrackerTests.states['state1.yaml'] = ActionExecutionState.add_or_update(state1)
-        ResultsTrackerTests.states['state2.yaml'] = ActionExecutionState.add_or_update(state2)
+        with mock.patch.object(
+                querier.__class__, 'query',
+                mock.MagicMock(side_effect=Exception('Mock query exception.'))):
+            tracker._bootstrap()
+            eventlet.sleep(1)
+
+            exec_id = str(ResultsTrackerTests.states['state1.yaml'].execution_id)
+            exec_db = LiveAction.get_by_id(exec_id)
+            self.assertDictEqual(exec_db.result, {})
+
+            exec_id = str(ResultsTrackerTests.states['state2.yaml'].execution_id)
+            exec_db = LiveAction.get_by_id(exec_id)
+            self.assertDictEqual(exec_db.result, {})
+
+            tracker.shutdown()
+
+        # Ensure deletes are called.
+        self.assertEqual(2, querier._delete_state_object.call_count)
+
+    def test_keep_state_object_on_error_at_query(self):
+        tracker = results_tracker.get_tracker()
+        querier = tracker.get_querier('test_querymodule')
+        querier._delete_state_object = mock.Mock(return_value=None)
+        querier.delete_state_object_on_error = False
+
+        with mock.patch.object(
+                querier.__class__, 'query',
+                mock.MagicMock(side_effect=Exception('Mock query exception.'))):
+            tracker._bootstrap()
+            eventlet.sleep(1)
+
+            exec_id = str(ResultsTrackerTests.states['state1.yaml'].execution_id)
+            exec_db = LiveAction.get_by_id(exec_id)
+            self.assertDictEqual(exec_db.result, {})
+
+            exec_id = str(ResultsTrackerTests.states['state2.yaml'].execution_id)
+            exec_db = LiveAction.get_by_id(exec_id)
+            self.assertDictEqual(exec_db.result, {})
+
+            tracker.shutdown()
+
+        # Ensure deletes are not called.
+        querier._delete_state_object.assert_not_called()
+
+    def test_delete_state_object_on_error_at_update_result(self):
+        tracker = results_tracker.get_tracker()
+        querier = tracker.get_querier('test_querymodule')
+        querier._delete_state_object = mock.Mock(return_value=None)
+
+        with mock.patch.object(
+                querier.__class__, '_update_action_results',
+                mock.MagicMock(side_effect=Exception('Mock update exception.'))):
+            tracker._bootstrap()
+            eventlet.sleep(1)
+
+            exec_id = str(ResultsTrackerTests.states['state1.yaml'].execution_id)
+            exec_db = LiveAction.get_by_id(exec_id)
+            self.assertDictEqual(exec_db.result, {})
+
+            exec_id = str(ResultsTrackerTests.states['state2.yaml'].execution_id)
+            exec_db = LiveAction.get_by_id(exec_id)
+            self.assertDictEqual(exec_db.result, {})
+
+            tracker.shutdown()
+
+        # Ensure deletes are called.
+        self.assertEqual(2, querier._delete_state_object.call_count)
+
+    def test_keep_state_object_on_error_at_update_result(self):
+        tracker = results_tracker.get_tracker()
+        querier = tracker.get_querier('test_querymodule')
+        querier._delete_state_object = mock.Mock(return_value=None)
+        querier.delete_state_object_on_error = False
+
+        with mock.patch.object(
+                querier.__class__, '_update_action_results',
+                mock.MagicMock(side_effect=Exception('Mock update exception.'))):
+            tracker._bootstrap()
+            eventlet.sleep(1)
+
+            exec_id = str(ResultsTrackerTests.states['state1.yaml'].execution_id)
+            exec_db = LiveAction.get_by_id(exec_id)
+            self.assertDictEqual(exec_db.result, {})
+
+            exec_id = str(ResultsTrackerTests.states['state2.yaml'].execution_id)
+            exec_db = LiveAction.get_by_id(exec_id)
+            self.assertDictEqual(exec_db.result, {})
+
+            tracker.shutdown()
+
+        # Ensure deletes are not called.
+        querier._delete_state_object.assert_not_called()
+
+    @mock.patch.object(
+        Action, 'get_by_ref', mock.MagicMock(return_value='foobar'))
+    def test_execution_cancellation(self):
+        tracker = results_tracker.get_tracker()
+        querier = tracker.get_querier('test_querymodule')
+        querier._delete_state_object = mock.Mock(return_value=None)
+        querier._invoke_post_run = mock.Mock(return_value=None)
+
+        with mock.patch.object(
+                querier.__class__, 'query',
+                mock.MagicMock(return_value=(action_constants.LIVEACTION_STATUS_CANCELED, {}))):
+            tracker._bootstrap()
+            eventlet.sleep(1)
+
+            exec_id = str(ResultsTrackerTests.states['state1.yaml'].execution_id)
+            exec_db = LiveAction.get_by_id(exec_id)
+            self.assertDictEqual(exec_db.result, {})
+
+            exec_id = str(ResultsTrackerTests.states['state2.yaml'].execution_id)
+            exec_db = LiveAction.get_by_id(exec_id)
+            self.assertDictEqual(exec_db.result, {})
+
+            tracker.shutdown()
+
+        # Ensure deletes are called.
+        self.assertEqual(2, querier._delete_state_object.call_count)
+
+        # Ensure invoke_post_run is not called.
+        querier._invoke_post_run.assert_not_called()
+
+    @mock.patch.object(
+        Action, 'get_by_ref', mock.MagicMock(return_value=None))
+    def test_action_deleted(self):
+        tracker = results_tracker.get_tracker()
+        querier = tracker.get_querier('test_querymodule')
+        querier._invoke_post_run = mock.Mock(return_value=None)
+
+        tracker._bootstrap()
+        eventlet.sleep(1)
+
+        exec_id = str(ResultsTrackerTests.states['state1.yaml'].execution_id)
+        exec_db = LiveAction.get_by_id(exec_id)
+        self.assertTrue(exec_db.result['called_with'][exec_id] is not None,
+                        exec_db.result)
+
+        exec_id = str(ResultsTrackerTests.states['state2.yaml'].execution_id)
+        exec_db = LiveAction.get_by_id(exec_id)
+        self.assertTrue(exec_db.result['called_with'][exec_id] is not None,
+                        exec_db.result)
+
+        tracker.shutdown()
+
+        # Ensure state objects are deleted
+        self.assertRaises(
+            StackStormDBObjectNotFoundError,
+            ActionExecutionState.get_by_id,
+            ResultsTrackerTests.states['state1.yaml'].id
+        )
+
+        self.assertRaises(
+            StackStormDBObjectNotFoundError,
+            ActionExecutionState.get_by_id,
+            ResultsTrackerTests.states['state2.yaml'].id
+        )
+
+        # Ensure invoke_post_run is not called.
+        querier._invoke_post_run.assert_not_called()

--- a/st2actions/tests/integration/test_resultstracker.py
+++ b/st2actions/tests/integration/test_resultstracker.py
@@ -62,6 +62,13 @@ class ResultsTrackerTests(EventletTestCase, DbTestCase):
         querier = tracker.get_querier('test_querymodule')
         querier._invoke_post_run = mock.Mock(return_value=None)
 
+        # Ensure state objects are present.
+        state1 = ActionExecutionState.get_by_id(ResultsTrackerTests.states['state1.yaml'].id)
+        state2 = ActionExecutionState.get_by_id(ResultsTrackerTests.states['state2.yaml'].id)
+        self.assertIsNotNone(state1)
+        self.assertIsNotNone(state2)
+
+        # Process the state objects.
         tracker._bootstrap()
         eventlet.sleep(1)
 
@@ -77,7 +84,7 @@ class ResultsTrackerTests(EventletTestCase, DbTestCase):
 
         tracker.shutdown()
 
-        # Ensure state objects are deleted
+        # Ensure state objects are deleted.
         self.assertRaises(
             StackStormDBObjectNotFoundError,
             ActionExecutionState.get_by_id,
@@ -115,6 +122,12 @@ class ResultsTrackerTests(EventletTestCase, DbTestCase):
         querier = tracker.get_querier('test_querymodule')
         querier._delete_state_object = mock.Mock(return_value=None)
 
+        # Ensure state objects are present.
+        state1 = ActionExecutionState.get_by_id(ResultsTrackerTests.states['state1.yaml'].id)
+        state2 = ActionExecutionState.get_by_id(ResultsTrackerTests.states['state2.yaml'].id)
+        self.assertIsNotNone(state1)
+        self.assertIsNotNone(state2)
+
         with mock.patch.object(
                 querier.__class__, 'query',
                 mock.MagicMock(side_effect=Exception('Mock query exception.'))):
@@ -140,6 +153,12 @@ class ResultsTrackerTests(EventletTestCase, DbTestCase):
         querier._delete_state_object = mock.Mock(return_value=None)
         querier.delete_state_object_on_error = False
 
+        # Ensure state objects are present.
+        state1 = ActionExecutionState.get_by_id(ResultsTrackerTests.states['state1.yaml'].id)
+        state2 = ActionExecutionState.get_by_id(ResultsTrackerTests.states['state2.yaml'].id)
+        self.assertIsNotNone(state1)
+        self.assertIsNotNone(state2)
+
         with mock.patch.object(
                 querier.__class__, 'query',
                 mock.MagicMock(side_effect=Exception('Mock query exception.'))):
@@ -163,6 +182,12 @@ class ResultsTrackerTests(EventletTestCase, DbTestCase):
         tracker = results_tracker.get_tracker()
         querier = tracker.get_querier('test_querymodule')
         querier._delete_state_object = mock.Mock(return_value=None)
+
+        # Ensure state objects are present.
+        state1 = ActionExecutionState.get_by_id(ResultsTrackerTests.states['state1.yaml'].id)
+        state2 = ActionExecutionState.get_by_id(ResultsTrackerTests.states['state2.yaml'].id)
+        self.assertIsNotNone(state1)
+        self.assertIsNotNone(state2)
 
         with mock.patch.object(
                 querier.__class__, '_update_action_results',
@@ -188,6 +213,12 @@ class ResultsTrackerTests(EventletTestCase, DbTestCase):
         querier = tracker.get_querier('test_querymodule')
         querier._delete_state_object = mock.Mock(return_value=None)
         querier.delete_state_object_on_error = False
+
+        # Ensure state objects are present.
+        state1 = ActionExecutionState.get_by_id(ResultsTrackerTests.states['state1.yaml'].id)
+        state2 = ActionExecutionState.get_by_id(ResultsTrackerTests.states['state2.yaml'].id)
+        self.assertIsNotNone(state1)
+        self.assertIsNotNone(state2)
 
         with mock.patch.object(
                 querier.__class__, '_update_action_results',
@@ -215,6 +246,12 @@ class ResultsTrackerTests(EventletTestCase, DbTestCase):
         querier = tracker.get_querier('test_querymodule')
         querier._delete_state_object = mock.Mock(return_value=None)
         querier._invoke_post_run = mock.Mock(return_value=None)
+
+        # Ensure state objects are present.
+        state1 = ActionExecutionState.get_by_id(ResultsTrackerTests.states['state1.yaml'].id)
+        state2 = ActionExecutionState.get_by_id(ResultsTrackerTests.states['state2.yaml'].id)
+        self.assertIsNotNone(state1)
+        self.assertIsNotNone(state2)
 
         with mock.patch.object(
                 querier.__class__, 'query',
@@ -245,6 +282,13 @@ class ResultsTrackerTests(EventletTestCase, DbTestCase):
         querier = tracker.get_querier('test_querymodule')
         querier._invoke_post_run = mock.Mock(return_value=None)
 
+        # Ensure state objects are present.
+        state1 = ActionExecutionState.get_by_id(ResultsTrackerTests.states['state1.yaml'].id)
+        state2 = ActionExecutionState.get_by_id(ResultsTrackerTests.states['state2.yaml'].id)
+        self.assertIsNotNone(state1)
+        self.assertIsNotNone(state2)
+
+        # Process the state objects.
         tracker._bootstrap()
         eventlet.sleep(1)
 
@@ -260,7 +304,7 @@ class ResultsTrackerTests(EventletTestCase, DbTestCase):
 
         tracker.shutdown()
 
-        # Ensure state objects are deleted
+        # Ensure state objects are deleted.
         self.assertRaises(
             StackStormDBObjectNotFoundError,
             ActionExecutionState.get_by_id,

--- a/st2common/st2common/exceptions/resultstracker.py
+++ b/st2common/st2common/exceptions/resultstracker.py
@@ -1,0 +1,20 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from st2common.exceptions import StackStormBaseException
+
+
+class ReferenceNotFoundError(StackStormBaseException):
+    pass


### PR DESCRIPTION
Add option in querier plugin to specify whether state object should be deleted if an error occur during query. This allows querier to recover in case of unexpected environment related exceptions. Mistral querier is refactored to delete state object on workflow completion or when the workflow or task references no longer exists.