### PR TITLE
Fix action alias update API endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,6 +49,7 @@ in development
   put the workflow in a PAUSED state in mistral. (improvement)
 * Add support for evaluating jinja expressions in mistral workflow definition where yaql
   expressions are typically accepted. (improvement)
+* Fix action alias update API endpoint. (bug fox)
 
 2.1.1 - December 16, 2016
 -------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,7 +49,7 @@ in development
   put the workflow in a PAUSED state in mistral. (improvement)
 * Add support for evaluating jinja expressions in mistral workflow definition where yaql
   expressions are typically accepted. (improvement)
-* Fix action alias update API endpoint. (bug fox)
+* Fix action alias update API endpoint. (bug fix)
 
 2.1.1 - December 16, 2016
 -------------------------

--- a/st2api/st2api/controllers/v1/actionalias.py
+++ b/st2api/st2api/controllers/v1/actionalias.py
@@ -158,7 +158,7 @@ class ActionAliasController(resource.ContentPackResourceController):
 
     @request_user_has_resource_db_permission(permission_type=PermissionType.ACTION_ALIAS_MODIFY)
     @jsexpose(arg_types=[str], body_cls=ActionAliasAPI)
-    def put(self, action_alias_ref_or_id, action_alias):
+    def put(self, action_alias, action_alias_ref_or_id):
         action_alias_db = self._get_by_ref_or_id(ref_or_id=action_alias_ref_or_id)
         LOG.debug('PUT /actionalias/ lookup with id=%s found object: %s', action_alias_ref_or_id,
                   action_alias_db)

--- a/st2api/st2api/controllers/v1/actionalias.py
+++ b/st2api/st2api/controllers/v1/actionalias.py
@@ -156,7 +156,7 @@ class ActionAliasController(resource.ContentPackResourceController):
 
         return action_alias_api
 
-    @request_user_has_resource_db_permission(permission_type=PermissionType.ACTION_MODIFY)
+    @request_user_has_resource_db_permission(permission_type=PermissionType.ACTION_ALIAS_MODIFY)
     @jsexpose(arg_types=[str], body_cls=ActionAliasAPI)
     def put(self, action_alias_ref_or_id, action_alias):
         action_alias_db = self._get_by_ref_or_id(ref_or_id=action_alias_ref_or_id)

--- a/st2api/st2api/controllers/v1/actionalias.py
+++ b/st2api/st2api/controllers/v1/actionalias.py
@@ -163,6 +163,9 @@ class ActionAliasController(resource.ContentPackResourceController):
         LOG.debug('PUT /actionalias/ lookup with id=%s found object: %s', action_alias_ref_or_id,
                   action_alias_db)
 
+        if not hasattr(action_alias, 'id'):
+            action_alias.id = None
+
         try:
             if action_alias.id is not None and action_alias.id is not '' and \
                action_alias.id != action_alias_ref_or_id:

--- a/st2api/tests/unit/controllers/v1/test_action_alias.py
+++ b/st2api/tests/unit/controllers/v1/test_action_alias.py
@@ -90,6 +90,23 @@ class TestActionAlias(FunctionalTest):
         get_resp = self.app.get('/v1/actionalias/%s' % post_resp.json['id'], expect_errors=True)
         self.assertEqual(get_resp.status_int, 404)
 
+    def test_update_existing_alias(self):
+        post_resp = self._do_post(vars(ActionAliasAPI.from_model(self.alias3)))
+        self.assertEqual(post_resp.status_int, 201)
+        self.assertEqual(post_resp.json['name'], self.alias3['name'])
+
+        data = vars(ActionAliasAPI.from_model(self.alias3))
+        data['name'] = 'updated-alias-name'
+
+        put_resp = self.app.put_json('/v1/actionalias/%s' % post_resp.json['id'], data)
+        self.assertEqual(put_resp.json['name'], data['name'])
+
+        get_resp = self.app.get('/v1/actionalias/%s' % post_resp.json['id'])
+        self.assertEqual(get_resp.json['name'], data['name'])
+
+        del_resp = self.__do_delete(post_resp.json['id'])
+        self.assertEqual(del_resp.status_int, 204)
+
     def test_post_dup_name(self):
         post_resp = self._do_post(vars(ActionAliasAPI.from_model(self.alias3)))
         self.assertEqual(post_resp.status_int, 201)


### PR DESCRIPTION
This fixes bug reported in https://github.com/StackStorm/st2/issues/3170.

It looks like this regression was introduced as part of https://github.com/StackStorm/st2/pull/2841, but we didn't have any tests for this API endpoint so the regression wasn't caught earlier.