### PR TITLE
Fix mistral integration test for state_info

### DIFF
--- a/st2tests/integration/mistral/test_wiring.py
+++ b/st2tests/integration/mistral/test_wiring.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ast
 import os
 import shutil
 import tempfile
@@ -121,8 +120,8 @@ class WiringTest(base.TestWorkflowExecution):
 
         task_results = execution.result.get('tasks', [])
         self.assertGreater(len(task_results), 0)
-        expected_state_info = {'error': 'Execution canceled by user.'}
-        self.assertDictEqual(ast.literal_eval(task_results[0]['state_info']), expected_state_info)
+        expected_state_info = '{error: Execution canceled by user.}'
+        self.assertEqual(task_results[0]['state_info'], expected_state_info)
 
     def test_basic_rerun(self):
         path = self.temp_dir_path


### PR DESCRIPTION
The format of state_info has been changed. A bug report has been filed at launchpad. This is a temporary fix to get CI to pass. https://bugs.launchpad.net/mistral/+bug/1662350