### PR TITLE
Make config file paths which are relative to the user's home directory work inside st2 CLI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,6 +49,8 @@ in development
   put the workflow in a PAUSED state in mistral. (improvement)
 * Add support for evaluating jinja expressions in mistral workflow definition where yaql
   expressions are typically accepted. (improvement)
+* Fix ``--config-file`` st2 CLI argument not correctly expanding the provided path if the path 
+  contained a reference to the user home directory (``~``, e.g. ``~/.st2/config.ini``) (bug fix)
 
 2.1.1 - December 16, 2016
 -------------------------

--- a/st2client/st2client/base.py
+++ b/st2client/st2client/base.py
@@ -173,7 +173,7 @@ class BaseCLIApp(object):
         if args.config_file:
             path = args.config_file
 
-        path = os.path.abspath(path)
+        path = os.path.abspath(os.path.expanduser(path))
         if path != ST2_CONFIG_PATH and not os.path.isfile(path):
             raise ValueError('Config "%s" not found' % (path))
 

--- a/st2client/tests/unit/test_app.py
+++ b/st2client/tests/unit/test_app.py
@@ -1,0 +1,57 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import getpass
+
+import unittest2
+import mock
+
+from st2client.base import BaseCLIApp
+
+USER = getpass.getuser()
+
+
+class BaseCLIAppTestCase(unittest2.TestCase):
+    @mock.patch('os.path.isfile', mock.Mock())
+    def test_cli_config_file_path(self):
+        app = BaseCLIApp()
+        args = mock.Mock()
+
+        # 1. Absolute path
+        args.config_file = '/tmp/full/abs/path/config.ini'
+        result = app._get_config_file_path(args=args)
+        self.assertEqual(result, args.config_file)
+
+        args.config_file = '/home/user/st2/config.ini'
+        result = app._get_config_file_path(args=args)
+        self.assertEqual(result, args.config_file)
+
+        # 2. Path relative to user home directory, should get expanded
+        args.config_file = '~/.st2/config.ini'
+        result = app._get_config_file_path(args=args)
+        expected = '/home/%s/.st2/config.ini' % (USER)
+        self.assertEqual(result, expected)
+
+        # 3. Relative path (should get converted to absolute one)
+        args.config_file = 'config.ini'
+        result = app._get_config_file_path(args=args)
+        expected = os.path.join(os.getcwd(), 'config.ini')
+        self.assertEqual(result, expected)
+
+        args.config_file = '.st2/config.ini'
+        result = app._get_config_file_path(args=args)
+        expected = os.path.join(os.getcwd(), '.st2/config.ini')
+        self.assertEqual(result, expected)


### PR DESCRIPTION
This should fix the issue reported in https://github.com/StackStorm/st2/issues/3186.

## TODO

- [x] Tests