### PR TITLE
Filter out null from /executions/views/filters results

### DIFF
--- a/st2api/st2api/controllers/v1/executionviews.py
+++ b/st2api/st2api/controllers/v1/executionviews.py
@@ -69,8 +69,7 @@ class FiltersController(RestController):
 
         for name, field in six.iteritems(SUPPORTED_FILTERS):
             if name not in IGNORE_FILTERS and (not types or name in types):
-                filters[name] = ActionExecution.distinct(field=field)
-
+                filters[name] = ActionExecution.distinct(field=field, **{field.replace('.','__'): {"$ne": None}})
         return filters
 
 

--- a/st2api/st2api/controllers/v1/executionviews.py
+++ b/st2api/st2api/controllers/v1/executionviews.py
@@ -69,7 +69,8 @@ class FiltersController(RestController):
 
         for name, field in six.iteritems(SUPPORTED_FILTERS):
             if name not in IGNORE_FILTERS and (not types or name in types):
-                filters[name] = ActionExecution.distinct(field=field, **{field.replace('.','__'): {"$ne": None}})
+                query = {field.replace('.', '__'): {"$ne": None}} 
+                filters[name] = ActionExecution.distinct(field=field, **query)
         return filters
 
 


### PR DESCRIPTION
Fixes StackStorm/st2web#343. 

Several of the filters returned from `/executions/views/filters` contained null. Here's a sample of results from our production StackStorm setup.

```
{
  "trigger_type": [
    null,
    "event_handler",
    "st2.CronTimer",
    "st2.generic.actiontrigger"
  ],
  "rule": [
    null,
    "some_custom_rule1",
    "some_custom_rule2"
  ],
  "trigger": [
    null,
    "021a8dff-8350-497a-8072-83035cb3a887",
    "04e2bb79-8c99-4d9b-bc79-e690ba0ae551",
```

Digging into the mongo queries backing this API call, we can see that null comes from the data tier.

```
stackstorm:SECONDARY> db.action_execution_d_b.distinct("rule.name")
[
    null,
    "some_custom_rule1",
    "some_custom_rule2",
```

Looking at the action_execution_d_b documents, we have a bunch of documents without a rule.

```
stackstorm:SECONDARY> db.action_execution_d_b.find({"rule.name": null}, {"rule":1}).limit(1).pretty()
{ "_id" : ObjectId("58937871dac00704c48ad821"), "rule" : { } }
```

This appears to be a large portion of our execution history too. I'm not sure if this is true for other users or use cases, but it is for us for whatever reason.

```
stackstorm:SECONDARY> db.action_execution_d_b.find({"rule.name": null}).count()
291720
stackstorm:SECONDARY> db.action_execution_d_b.count()
334413
```

To fix this, we can update this query to exclude the null results

```
stackstorm:SECONDARY> db.action_execution_d_b.distinct("rule.name", {"rule.name": {"$ne": null}})
[
    "some_custom_rule1",
    "some_custom_rule2",
```

This commit updates `st2api` to use this same query in the distinct clause: `{"rule.name": {"$ne": null}}`.

This is a little obscure looking because
1) kwargs are passed as the mongo query (after popping `field` from the dict)
2) we need to use a dynamic field name as the keyword
3) the keyword uses dot-notation, like `rule.name`, but mongoengine needs django notation, like `rule__name`, for the query (and because you can't have dots in kwargs keywords)