### PR TITLE
Import configparser from 'six' rather than stdlib

### DIFF
--- a/st2client/st2client/commands/auth.py
+++ b/st2client/st2client/commands/auth.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from configparser import ConfigParser
+from six.moves.configparser import ConfigParser
 import getpass
 import json
 import logging


### PR DESCRIPTION
Fixing an issue caused in post-merge by https://github.com/StackStorm/st2/pull/3123.

This wasn't caught by CI because that PR was done via a fork, and some CircleCI checks are disabled for forks. Submitting this to the main repo to ensure this still works.