### PR TITLE
Add more Jinja examples for Mistral

### DIFF
--- a/contrib/examples/actions/mistral-jinja-branching.yaml
+++ b/contrib/examples/actions/mistral-jinja-branching.yaml
@@ -1,0 +1,15 @@
+---
+description: Demonstrate how to use condition to select branch of execution.
+enabled: true
+entry_point: workflows/mistral-jinja-branching.yaml
+name: mistral-jinja-branching
+pack: examples
+parameters:
+  which:
+    type: string
+    required: true
+    enum:
+      - a
+      - b
+      - c
+runner_type: mistral-v2

--- a/contrib/examples/actions/mistral-jinja-env-var.yaml
+++ b/contrib/examples/actions/mistral-jinja-env-var.yaml
@@ -1,0 +1,7 @@
+---
+description: Example to return workflow's environment variable
+enabled: true
+entry_point: workflows/mistral-jinja-env-var.yaml
+name: mistral-jinja-env-var
+pack: examples
+runner_type: mistral-v2

--- a/contrib/examples/actions/mistral-jinja-repeat-with-items.yaml
+++ b/contrib/examples/actions/mistral-jinja-repeat-with-items.yaml
@@ -1,0 +1,13 @@
+---
+description: Run several linux commands in a single task.
+enabled: true
+entry_point: workflows/mistral-jinja-repeat-with-items.yaml
+name: mistral-jinja-repeat-with-items
+pack: examples
+parameters:
+  cmds:
+    items:
+      type: string
+    minItems: 1
+    type: array
+runner_type: mistral-v2

--- a/contrib/examples/actions/workflows/mistral-jinja-branching.yaml
+++ b/contrib/examples/actions/workflows/mistral-jinja-branching.yaml
@@ -1,0 +1,32 @@
+version: '2.0'
+
+examples.mistral-jinja-branching:
+    description: >
+        A sample workflow that demonstrates how to use conditions
+        to determine which path in the workflow to take.
+    type: direct
+    input:
+        - which
+    tasks:
+        t1:
+            action: core.local
+            input:
+                cmd: "echo {{ _.which }}"
+            publish:
+                path: "{{ task('t1').result.stdout }}"
+            on-success:
+                - a: "{{ _.path == 'a' }}"
+                - b: "{{ _.path == 'b' }}"
+                - c: "{{ not _.path in ['a', 'b'] }}"
+        a:
+            action: core.local
+            input:
+                cmd: "echo 'Took path A.'"
+        b:
+            action: core.local
+            input:
+                cmd: "echo 'Took path B.'"
+        c:
+            action: core.local
+            input:
+                cmd: "echo 'Took path C.'"

--- a/contrib/examples/actions/workflows/mistral-jinja-env-var.yaml
+++ b/contrib/examples/actions/workflows/mistral-jinja-env-var.yaml
@@ -1,0 +1,16 @@
+version: '2.0'
+
+examples.mistral-jinja-env-var:
+    description: A basic workflow that illustrates how to get the workflow's env vars.
+    type: direct
+    output:
+        env: "{{ env() }}"
+        url: "{{ _.url }}"
+    tasks:
+        task1:
+            action: core.local
+            input:
+                cmd: "echo http://127.0.0.1:9101/executions/{{ env().st2_execution_id }}"
+            publish:
+                url: "{{ task('task1').result.stdout }}"
+                ctx: "{{ env()['__actions']['st2.action']['st2_context'] }}"

--- a/contrib/examples/actions/workflows/mistral-jinja-repeat-with-items.yaml
+++ b/contrib/examples/actions/workflows/mistral-jinja-repeat-with-items.yaml
@@ -1,0 +1,17 @@
+version: '2.0'
+
+examples.mistral-jinja-repeat-with-items:
+    description: >
+        A sample workflow that demonstrates how to repeat a task
+        multiple times with different inputs.
+    type: direct
+    input:
+        - cmds
+    tasks:
+        repeat:
+            with-items: "cmd in {{ _.cmds }}"
+            action: core.local
+            input:
+                cmd: "{{ _.cmd }}"
+            publish:
+                result: "{{ task('repeat').result | map(attribute='stdout') | list }}"


### PR DESCRIPTION
Add examples on how to use Jinja expresssions to branch in workflow, iterate thru with-items, and access the variables returned from the env() filter.