### PR TITLE
Fixed typo in description of core.local action

### DIFF
--- a/contrib/core/actions/local.yaml
+++ b/contrib/core/actions/local.yaml
@@ -5,7 +5,7 @@ entry_point: ''
 name: local
 parameters:
   cmd:
-    description: Arbitrary Linux command to be executed on the remote host(s).
+    description: Arbitrary Linux command to be executed on the local host.
     required: true
     type: string
   sudo:


### PR DESCRIPTION
Self-explanatory - just a minor fix of the description (mistakenly refers to remote host)