### PR TITLE
Deprecate {{system}} and {{user}} jinja notations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -57,6 +57,9 @@ in development
   beyond the existing `st2 auth` command and actually works with the local configuration so that
   users do not have to.
 * Fix action alias update API endpoint. (bug fix)
+* Deprecate ``{{user.}}`` and ``{{system.}}`` notations to access user and system
+  scoped items from datastore. From now on, only ``{{st2kv.user.}}`` and
+  ``{{st2kv.system.}}`` notations alone are supported. (improvement)
 
 2.1.1 - December 16, 2016
 -------------------------
@@ -134,7 +137,7 @@ in development
   seralize the array as JSON and then falling back to comma separated array.
 * Add new ``core.pause`` action. This action behaves like sleep and can be used inside the action
   chain or Mistral workflows where waiting / sleeping is desired before proceeding with a next
-  task. Contribution by Paul Mulvihill. (new feature) #2933. 
+  task. Contribution by Paul Mulvihill. (new feature) #2933.
 * When a policy cancels a request due to concurrency, it leaves end_timestamp set to None which
   the notifier expects to be a date. This causes an exception in "isotime.format()". A patch was
   released that catches this exception, and populates payload['end_timestamp'] with the equivalent

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -57,9 +57,10 @@ in development
   beyond the existing `st2 auth` command and actually works with the local configuration so that
   users do not have to.
 * Fix action alias update API endpoint. (bug fix)
-* Deprecate ``{{user.}}`` and ``{{system.}}`` notations to access user and system
-  scoped items from datastore. From now on, only ``{{st2kv.user.}}`` and
-  ``{{st2kv.system.}}`` notations alone are supported. (improvement)
+* ``{{user.}}`` and ``{{system.}}`` notations to access user and system
+  scoped items from datastore are now unsupported. Use  ``{{st2kv.user.}}``
+  and ``{{st2kv.system.}}`` instead. Please update all your content (actions, rules and
+  workflows) to use the new notation. (improvement)
 
 2.1.1 - December 16, 2016
 -------------------------

--- a/contrib/runners/action_chain_runner/action_chain_runner.py
+++ b/contrib/runners/action_chain_runner/action_chain_runner.py
@@ -193,7 +193,6 @@ class ChainHolder(object):
         if not vars:
             return {}
         context = {}
-        context.update({SYSTEM_SCOPE: KeyValueLookup(scope=SYSTEM_SCOPE)})
         context.update({
             DATASTORE_PARENT_SCOPE: {
                 SYSTEM_SCOPE: KeyValueLookup(scope=FULL_SYSTEM_SCOPE)

--- a/contrib/runners/action_chain_runner/tests/unit/test_actionchain.py
+++ b/contrib/runners/action_chain_runner/tests/unit/test_actionchain.py
@@ -587,7 +587,6 @@ class TestActionChainRunner(DbTestCase):
             self.assertNotEqual(chain_runner.chain_holder.actionchain, None)
             expected_value = {'inttype': 1,
                               'strtype': 'two',
-                              'strtype_legacy': 'two',
                               'booltype': True}
             mock_args, _ = request.call_args
             self.assertEqual(mock_args[0].parameters, expected_value)

--- a/st2actions/st2actions/notifier/notifier.py
+++ b/st2actions/st2actions/notifier/notifier.py
@@ -200,7 +200,6 @@ class Notifier(consumers.MessageHandler):
 
     def _build_jinja_context(self, liveaction, execution):
         context = {}
-        context.update({SYSTEM_SCOPE: KeyValueLookup(scope=SYSTEM_SCOPE)})
         context.update({
             DATASTORE_PARENT_SCOPE: {
                 SYSTEM_SCOPE: KeyValueLookup(scope=FULL_SYSTEM_SCOPE)

--- a/st2common/st2common/util/param.py
+++ b/st2common/st2common/util/param.py
@@ -21,7 +21,7 @@ import networkx as nx
 from jinja2 import meta
 from st2common import log as logging
 from st2common.constants.action import ACTION_CONTEXT_KV_PREFIX
-from st2common.constants.keyvalue import DATASTORE_PARENT_SCOPE, SYSTEM_SCOPE
+from st2common.constants.keyvalue import DATASTORE_PARENT_SCOPE, SYSTEM_SCOPE, FULL_SYSTEM_SCOPE
 from st2common.exceptions.param import ParamException
 from st2common.services.keyvalues import KeyValueLookup
 from st2common.util.casts import get_cast
@@ -76,8 +76,7 @@ def _create_graph(action_context):
     Creates a generic directed graph for depencency tree and fills it with basic context variables
     '''
     G = nx.DiGraph()
-    G.add_node(SYSTEM_SCOPE, value=KeyValueLookup(scope=SYSTEM_SCOPE))
-    system_keyvalue_context = {SYSTEM_SCOPE: KeyValueLookup(scope=SYSTEM_SCOPE)}
+    system_keyvalue_context = {SYSTEM_SCOPE: KeyValueLookup(scope=FULL_SYSTEM_SCOPE)}
     G.add_node(DATASTORE_PARENT_SCOPE, value=system_keyvalue_context)
     G.add_node(ACTION_CONTEXT_KV_PREFIX, value=action_context)
     return G

--- a/st2common/st2common/util/templating.py
+++ b/st2common/st2common/util/templating.py
@@ -65,9 +65,8 @@ def render_template_with_system_context(value, context=None, prefix=None):
     :rtype: ``str``
     """
     context = context or {}
-    context[SYSTEM_SCOPE] = KeyValueLookup(prefix=prefix, scope=SYSTEM_SCOPE)
     context[DATASTORE_PARENT_SCOPE] = {
-        SYSTEM_SCOPE: KeyValueLookup(prefix=prefix, scope=SYSTEM_SCOPE)
+        SYSTEM_SCOPE: KeyValueLookup(prefix=prefix, scope=FULL_SYSTEM_SCOPE)
     }
 
     rendered = render_template(value=value, context=context)
@@ -93,8 +92,6 @@ def render_template_with_system_and_user_context(value, user, context=None, pref
     :rtype: ``str``
     """
     context = context or {}
-    context[SYSTEM_SCOPE] = KeyValueLookup(prefix=prefix, scope=SYSTEM_SCOPE)
-    context[USER_SCOPE] = UserKeyValueLookup(prefix=prefix, user=user, scope=USER_SCOPE)
     context[DATASTORE_PARENT_SCOPE] = {
         SYSTEM_SCOPE: KeyValueLookup(prefix=prefix, scope=FULL_SYSTEM_SCOPE),
         USER_SCOPE: UserKeyValueLookup(prefix=prefix, user=user, scope=FULL_USER_SCOPE)

--- a/st2common/tests/unit/test_param_utils.py
+++ b/st2common/tests/unit/test_param_utils.py
@@ -16,7 +16,6 @@
 
 import mock
 
-from st2common.constants.keyvalue import FULL_SYSTEM_SCOPE
 from st2common.exceptions.param import ParamException
 from st2common.models.system.common import ResourceReference
 from st2common.models.db.liveaction import LiveActionDB
@@ -512,28 +511,6 @@ class ParamsUtilsTest(DbTestCase):
             runner_param_info, action_param_info, params, action_context)
 
         self.assertEqual(r_action_params['cmd'], "echo 1.7.0")
-
-    def test_get_finalized_params_older_kv_scopes_backwards_compatibility(self):
-        KeyValuePair.add_or_update(KeyValuePairDB(name='cmd_to_run', value='echo MELANIA',
-                                                  scope=FULL_SYSTEM_SCOPE))
-        # k2 = KeyValuePair.add_or_update(KeyValuePairDB(name='ivanka:cmd_to_run',
-        #                                                value='echo MA DAD IS GREAT',
-        #                                                scope=USER_SCOPE))
-        params = {
-            'sys_cmd': '{{system.cmd_to_run}}',
-            # 'user_cmd': '{{user.ivanka:cmd_to_run}}' Not supported yet.
-        }
-        runner_param_info = {'r1': {}}
-        action_param_info = {
-            'sys_cmd': {}
-        }
-        action_context = {}
-
-        r_runner_params, r_action_params = param_utils.get_finalized_params(
-            runner_param_info, action_param_info, params, action_context)
-
-        self.assertEqual(r_action_params['sys_cmd'], "echo MELANIA")
-        # self.assertEqual(r_action_params['user_cmd'], "echo MA DAD IS GREAT")
 
     def test_get_finalized_params_param_rendering_failure(self):
         params = {'cmd': '{{a2.foo}}', 'a2': 'test'}

--- a/st2common/tests/unit/test_util_templating.py
+++ b/st2common/tests/unit/test_util_templating.py
@@ -51,13 +51,6 @@ class TemplatingUtilsTestCase(CleanDbTestCase):
         result = render_template_with_system_and_user_context(value=template, user=user)
         self.assertEqual(result, 'valueb')
 
-        # Backward compatibility test
-        template = '{{system.key2}}'
-        user = 'stanley'
-
-        result = render_template_with_system_and_user_context(value=template, user=user)
-        self.assertEqual(result, 'valueb')
-
         # 2. Reference to the user inside the template
         template = '{{st2kv.user.key1}}'
         user = 'stanley'
@@ -66,13 +59,6 @@ class TemplatingUtilsTestCase(CleanDbTestCase):
         self.assertEqual(result, 'valuestanley1')
 
         template = '{{st2kv.user.key1}}'
-        user = 'joe'
-
-        result = render_template_with_system_and_user_context(value=template, user=user)
-        self.assertEqual(result, 'valuejoe1')
-
-        # Backward compatibility test
-        template = '{{user.key1}}'
         user = 'joe'
 
         result = render_template_with_system_and_user_context(value=template, user=user)

--- a/st2reactor/st2reactor/rules/datatransform.py
+++ b/st2reactor/st2reactor/rules/datatransform.py
@@ -28,7 +28,6 @@ class Jinja2BasedTransformer(object):
 
     def __call__(self, mapping):
         context = copy.copy(self._payload_context)
-        context[SYSTEM_SCOPE] = KeyValueLookup(scope=SYSTEM_SCOPE)
         context.update({
             DATASTORE_PARENT_SCOPE: {
                 SYSTEM_SCOPE: KeyValueLookup(scope=FULL_SYSTEM_SCOPE)
@@ -42,7 +41,6 @@ class Jinja2BasedTransformer(object):
             return context
 
         context = context or {}
-        context[SYSTEM_SCOPE] = KeyValueLookup(scope=SYSTEM_SCOPE)
         context.update({
             DATASTORE_PARENT_SCOPE: {
                 SYSTEM_SCOPE: KeyValueLookup(scope=FULL_SYSTEM_SCOPE)

--- a/st2reactor/tests/unit/test_data_transform.py
+++ b/st2reactor/tests/unit/test_data_transform.py
@@ -73,13 +73,11 @@ class DataTransformTest(DbTestCase):
             transformer = datatransform.get_transformer(PAYLOAD)
             mapping = {'ip5': '{{trigger.k2}}-static',
                        'ip6': '{{st2kv.system.k6}}-static',
-                       'ip7': '{{st2kv.system.k7}}-static',
-                       'ip8': '{{system.k8}}-static'}
+                       'ip7': '{{st2kv.system.k7}}-static'}
             result = transformer(mapping)
             expected = {'ip5': 'v2-static',
                         'ip6': 'v6-static',
-                        'ip7': 'v7-static',
-                        'ip8': 'v8-static'}
+                        'ip7': 'v7-static'}
             self.assertEqual(result, expected)
         finally:
             KeyValuePair.delete(k5)

--- a/st2reactor/tests/unit/test_filter.py
+++ b/st2reactor/tests/unit/test_filter.py
@@ -158,7 +158,7 @@ class FilterTest(DbTestCase):
         # Using a variable in pattern, referencing an inexistent datastore value
         rule.criteria = {'trigger.p1': {
             'type': 'equals',
-            'pattern': '{{ system.inexistent_value }}'}
+            'pattern': '{{ st2kv.system.inexistent_value }}'}
         }
         f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
         self.assertFalse(f.filter())
@@ -168,7 +168,12 @@ class FilterTest(DbTestCase):
         mock_result.test_value_1 = 'non matching'
         mock_KeyValueLookup.return_value = mock_result
 
-        rule.criteria = {'trigger.p1': {'type': 'equals', 'pattern': '{{ system.test_value_1 }}'}}
+        rule.criteria = {
+            'trigger.p1': {
+                'type': 'equals',
+                'pattern': '{{ st2kv.system.test_value_1 }}'
+            }
+        }
         f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
         self.assertFalse(f.filter())
 
@@ -177,7 +182,12 @@ class FilterTest(DbTestCase):
         mock_result.test_value_2 = 'v1'
         mock_KeyValueLookup.return_value = mock_result
 
-        rule.criteria = {'trigger.p1': {'type': 'equals', 'pattern': '{{ system.test_value_2 }}'}}
+        rule.criteria = {
+            'trigger.p1': {
+                'type': 'equals',
+                'pattern': '{{ st2kv.system.test_value_2 }}'
+            }
+        }
         f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
         self.assertTrue(f.filter())
 
@@ -186,7 +196,12 @@ class FilterTest(DbTestCase):
         mock_result.test_value_3 = 'YYY'
         mock_KeyValueLookup.return_value = mock_result
 
-        rule.criteria = {'trigger.p2': {'type': 'equals', 'pattern': '{{ system.test_value_3 }}'}}
+        rule.criteria = {
+            'trigger.p2': {
+                'type': 'equals',
+                'pattern': '{{ st2kv.system.test_value_3 }}'
+            }
+        }
         f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
         self.assertFalse(f.filter())
 
@@ -195,9 +210,11 @@ class FilterTest(DbTestCase):
         mock_result.test_value_3 = 'YYY'
         mock_KeyValueLookup.return_value = mock_result
 
-        rule.criteria = {'trigger.p2': {
-            'type': 'equals',
-            'pattern': 'pre{{ system.test_value_3 }}post'}
+        rule.criteria = {
+            'trigger.p2': {
+                'type': 'equals',
+                'pattern': 'pre{{ st2kv.system.test_value_3 }}post'
+            }
         }
         f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
         self.assertTrue(f.filter())

--- a/st2tests/st2tests/fixtures/generic/actionchains/chain_with_system_vars.yaml
+++ b/st2tests/st2tests/fixtures/generic/actionchains/chain_with_system_vars.yaml
@@ -5,7 +5,6 @@ chain:
     booltype: true
     inttype: '{{inttype}}'
     strtype: '{{strtype}}'
-    strtype_legacy: '{{system.a}}'
   ref: wolfpack.a2
 default: c1
 vars:


### PR DESCRIPTION
Redo https://github.com/StackStorm/st2/pull/3164 after we decided to only deprecate {{system}} and {{user}} jinja notations. 

Deprecation notice in Upgrade Notes - https://github.com/StackStorm/st2docs/pull/367