### PR TITLE
Fix packs.download action so it works if default repo branch is not master

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -67,6 +67,8 @@ in development
 * Update the dependencies and the code base so we now also support MongoDB 3.4. Officially
   supported MongoDB versions are now MongoDB 3.2 and 3.4. Currently default version installed by
   the installer script still is 3.2. (improvement)
+* Fix a bug with ``packs.download`` action and as such as ``pack install`` command not working with
+  Git repositories which used a default branch which was not ``master``. (bug fix)
 
 2.1.1 - December 16, 2016
 -------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Changelog
 
 in development
 --------------
+
 * Fix ``/v1/packs/views/files/<pack ref or id>`` and
   ``/v2/packs/views/files/<pack ref or id>/<file path>`` API endpoint so it
   works correctly for packs where pack name is not equal to the pack ref. (bug fix)
@@ -68,7 +69,7 @@ in development
   supported MongoDB versions are now MongoDB 3.2 and 3.4. Currently default version installed by
   the installer script still is 3.2. (improvement)
 * Fix a bug with ``packs.download`` action and as such as ``pack install`` command not working with
-  Git repositories which used a default branch which was not ``master``. (bug fix)
+  git repositories which used a default branch which was not ``master``. (bug fix)
 
 2.1.1 - December 16, 2016
 -------------------------

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -110,7 +110,7 @@ class DownloadGitRepoAction(Action):
             gitref = repo.active_branch.object
         else:
             # Try to match the reference to a branch name (i.e. "master")
-            gitref = DownloadGitRepoAction._get_gitref(repo, "origin/%s" % ref)
+            gitref = DownloadGitRepoAction._get_gitref(repo, 'origin/%s' % ref)
             if gitref:
                 use_branch = True
 
@@ -120,7 +120,7 @@ class DownloadGitRepoAction(Action):
 
         # Try to match the reference to a "vX.Y.Z" tag
         if not gitref and re.match(PACK_VERSION_REGEX, ref):
-            gitref = DownloadGitRepoAction._get_gitref(repo, "v%s" % ref)
+            gitref = DownloadGitRepoAction._get_gitref(repo, 'v%s' % ref)
 
         # Giving up ¯\_(ツ)_/¯
         if not gitref:
@@ -142,7 +142,7 @@ class DownloadGitRepoAction(Action):
         branches = branches.replace('*', '').split()
 
         if active_branch.name not in branches or use_branch:
-            branch = "origin/%s" % ref if use_branch else branches[0]
+            branch = 'origin/%s' % ref if use_branch else branches[0]
             short_branch = ref if use_branch else branches[0].split('/')[-1]
             repo.git.checkout('-b', short_branch, branch)
             branch = repo.head.reference
@@ -289,11 +289,11 @@ class DownloadGitRepoAction(Action):
         if repo_url.startswith("file://"):
             return repo_url
         else:
-            if len(repo_url.split('/')) == 2 and "git@" not in repo_url:
-                url = "https://github.com/{}".format(repo_url)
+            if len(repo_url.split('/')) == 2 and 'git@' not in repo_url:
+                url = 'https://github.com/{}'.format(repo_url)
             else:
                 url = repo_url
-            return url if url.endswith('.git') else "{}.git".format(url)
+            return url if url.endswith('.git') else '{}.git'.format(url)
 
     @staticmethod
     def _get_pack_metadata(pack_dir):

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -106,13 +106,13 @@ class DownloadGitRepoAction(Action):
 
         # Special case when a default repo branch is not "master"
         # No ref provided so we just use a default active branch
-        if not ref and repo.active_branch.object == repo.head.commit and repo.active_branch.name:
+        if (not ref or ref == active_branch.name) and repo.active_branch.object == repo.head.commit:
             gitref = repo.active_branch.object
-
-        # Try to match the reference to a branch name (i.e. "master")
-        gitref = DownloadGitRepoAction._get_gitref(repo, "origin/%s" % ref)
-        if gitref:
-            use_branch = True
+        else:
+            # Try to match the reference to a branch name (i.e. "master")
+            gitref = DownloadGitRepoAction._get_gitref(repo, "origin/%s" % ref)
+            if gitref:
+                use_branch = True
 
         # Try to match the reference to a commit hash, a tag, or "master"
         if not gitref:

--- a/contrib/packs/tests/test_action_download.py
+++ b/contrib/packs/tests/test_action_download.py
@@ -313,13 +313,14 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
             "master": "1.2.3",
             "master": "some-branch",
             "master": "default-branch",
+            "master": None,
             "default-branch": "1.2.3",
             "default-branch": "some-branch",
             "default-branch": "default-branch",
+            "default-branch": None
         }
 
         for default_branch, ref in edge_cases.items():
-
             self.repo_instance.git = mock.MagicMock(
                 branch=(lambda *args: default_branch),
                 checkout=(lambda *args: True)
@@ -327,6 +328,7 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
 
             # Set default branch
             self.repo_instance.active_branch.name = default_branch
+            self.repo_instance.active_branch.object = "aBcdef"
             self.repo_instance.head.commit = "aBcdef"
 
             # Fake gitref object
@@ -342,5 +344,11 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
             self.repo_instance.active_branch.object = gitref
 
             action = self.get_action_instance()
-            result = action.run(packs=['test=%s' % ref], abs_repo_base=self.repo_base)
+
+            if ref:
+                packs=['test=%s' % (ref)]
+            else:
+                packs=['test']
+
+            result = action.run(packs=packs, abs_repo_base=self.repo_base)
             self.assertEqual(result, {'test': 'Success.'})

--- a/contrib/packs/tests/test_action_download.py
+++ b/contrib/packs/tests/test_action_download.py
@@ -310,14 +310,14 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
         self.repo_instance.commit.side_effect = side_effect
 
         edge_cases = {
-            "master": "1.2.3",
-            "master": "some-branch",
-            "master": "default-branch",
-            "master": None,
-            "default-branch": "1.2.3",
-            "default-branch": "some-branch",
-            "default-branch": "default-branch",
-            "default-branch": None
+            'master': '1.2.3',
+            'master': 'some-branch',
+            'master': 'default-branch',
+            'master': None,
+            'default-branch': '1.2.3',
+            'default-branch': 'some-branch',
+            'default-branch': 'default-branch',
+            'default-branch': None
         }
 
         for default_branch, ref in edge_cases.items():
@@ -328,11 +328,11 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
 
             # Set default branch
             self.repo_instance.active_branch.name = default_branch
-            self.repo_instance.active_branch.object = "aBcdef"
-            self.repo_instance.head.commit = "aBcdef"
+            self.repo_instance.active_branch.object = 'aBcdef'
+            self.repo_instance.head.commit = 'aBcdef'
 
             # Fake gitref object
-            gitref = mock.MagicMock(hexsha="abcDef")
+            gitref = mock.MagicMock(hexsha='abcDef')
 
             # Fool _get_gitref into working when its ref == our ref
             def fake_commit(arg_ref):
@@ -346,9 +346,9 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
             action = self.get_action_instance()
 
             if ref:
-                packs=['test=%s' % (ref)]
+                packs = ['test=%s' % (ref)]
             else:
-                packs=['test']
+                packs = ['test']
 
             result = action.run(packs=packs, abs_repo_base=self.repo_base)
             self.assertEqual(result, {'test': 'Success.'})


### PR DESCRIPTION
packs.download and as such `pack install` command would not work if git repository uses a default branch which is not master.

This pull request fixes that.

The whole gitref and checkout code is quite convoluted so I won't accept this as done until we have good coverage for all the ref edge cases - it's possible that there are more bugs lurking in that code.

I understand the reason why the code is doing what is doing (we try to determine if ref / commit is part of a branch, but ref could also be a branch), but I will also think about it some more and see if I can simply some of that logic. Simpler logic means less chance for bugs.

This fixes a bug reported by a user in the community - https://github.com/StackStorm/st2/issues/3200.

## TODO

- [x] Tests for all the ref related edge cases (we are lacking that but we need it)
- [x] Changelog