### PR TITLE
Ignore "index with different options already exists" mongoengine errors

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,7 +22,7 @@ dependencies:
         background: true
     # We sleep a bit to wait for the background process to start and script to
     # finish
-    - case $CIRCLE_NODE_INDEX in [1,2]) sleep 10 ;; esac:
+    - case $CIRCLE_NODE_INDEX in [1,2]) sleep 10 ;; esac
     # Tail the logs so it's easier to see what is going on. Sadly when using "background: true"
     # whole output is ignored.
     - case $CIRCLE_NODE_INDEX in [1,2]) tail -50 /tmp/mongodb-install.log ;; [3,4]) tail -50 /tmp/mongodb-install.log ;; esac

--- a/circle.yml
+++ b/circle.yml
@@ -20,6 +20,9 @@ dependencies:
     # We install and test with all the supported MongoDB versions
     - case $CIRCLE_NODE_INDEX in [1,2]) sudo service mongodb stop ; MONGODB_VERSION=3.2.12 sudo -E .circle/install-and-run-mongodb.sh > /tmp/mongodb-install.log 2>&1 ;; [3,4]) sudo service mongodb stop ; MONGODB_VERSION=3.4.2 sudo -E .circle/install-and-run-mongodb.sh > /tmp/mongodb-install.log 2>&1 ;; esac:
         background: true
+    # We sleep a bit to wait for the background process to start and script to
+    # finish
+    - case $CIRCLE_NODE_INDEX in [1,2]) sleep 10 ;; esac:
     # Tail the logs so it's easier to see what is going on. Sadly when using "background: true"
     # whole output is ignored.
     - case $CIRCLE_NODE_INDEX in [1,2]) tail -50 /tmp/mongodb-install.log ;; [3,4]) tail -50 /tmp/mongodb-install.log ;; esac

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -118,6 +118,15 @@ def db_ensure_indexes():
 
         try:
             model_class.ensure_indexes()
+        except OperationFailure as e:
+            # Note we ignore "index with different options already exists" error.
+            # Right now we can't do anything about it, one approach would be to re-create that
+            # index, but this could potentially be very expensive .and blocking
+            msg = str(e)
+            if 'already exists with different options' in msg:
+                LOG.debug('Ignoring index already exists with different options error: %s' % (msg))
+            else:
+                raise e
         except Exception as e:
             tb_msg = traceback.format_exc()
             msg = 'Failed to ensure indexes for model "%s": %s' % (class_name, str(e))

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -119,9 +119,10 @@ def db_ensure_indexes():
         try:
             model_class.ensure_indexes()
         except OperationFailure as e:
-            # Note we ignore "index with different options already exists" error.
-            # Right now we can't do anything about it, one approach would be to re-create that
-            # index, but this could potentially be very expensive .and blocking
+            # Note: We ignore "index with different options already exists" error.
+            # Right now we can't do anything about it. Correct approach would be to re-create that
+            # index, but the operation is blocking and depending on the dataset and index size,
+            # this operation could be very expensive and take a long time.
             msg = str(e)
             if 'already exists with different options' in msg:
                 LOG.debug('Ignoring index already exists with different options error: %s' % (msg))


### PR DESCRIPTION
This pull request updates the code to ignore the errors about which we can't do anything right now.

Correct solution we should eventually do is to re-creating offending indexes. The problem with re-creation is that the operation is blocking and depending on the dataset size, it could take a very long time.