### PR TITLE
Fix st2 login and st2 whoami commands to work

### DIFF
--- a/st2client/st2client/commands/auth.py
+++ b/st2client/st2client/commands/auth.py
@@ -175,7 +175,7 @@ class WhoamiCommand(resource.ResourceCommand):
         config = ConfigParser()
         config.read(config_file)
 
-        return config['credentials']['username']
+        return config.get('credentials', 'username')
 
     def run_and_print(self, args, **kwargs):
         try:

--- a/st2client/st2client/commands/auth.py
+++ b/st2client/st2client/commands/auth.py
@@ -123,17 +123,17 @@ class LoginCommand(resource.ResourceCommand):
         config.read(config_file)
 
         # Modify config (and optionally populate with password)
-        if 'credentials' not in config:
+        if not config.has_section('credentials'):
             config.add_section('credentials')
-            config['credentials'] = {}
-        config['credentials']['username'] = args.username
+
+        config.set('credentials', 'username', args.username)
         if args.write_password:
-            config['credentials']['password'] = args.password
+            config.set('credentials', 'password', args.password)
         else:
             # Remove any existing password from config
-            config['credentials'].pop('password', None)
+            config.remove_option('credentials', 'password')
 
-        with open(config_file, "w") as cfg_file_out:
+        with open(config_file, 'w') as cfg_file_out:
             config.write(cfg_file_out)
 
         return manager

--- a/st2client/st2client/commands/auth.py
+++ b/st2client/st2client/commands/auth.py
@@ -13,10 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from six.moves.configparser import ConfigParser
 import getpass
 import json
 import logging
+
+from six.moves.configparser import ConfigParser
 
 from st2client.base import BaseCLIApp
 from st2client import config_parser

--- a/st2client/tests/base.py
+++ b/st2client/tests/base.py
@@ -89,6 +89,10 @@ class BaseCLITestCase(unittest2.TestCase):
         os.environ['ST2_CLI_SKIP_CONFIG'] = '1'
 
         if self.capture_output:
+            # Make sure we reset it for each test class instance
+            self.stdout = six.moves.StringIO()
+            self.stderr = six.moves.StringIO()
+
             sys.stdout = self.stdout
             sys.stderr = self.stderr
 

--- a/st2client/tests/unit/test_auth.py
+++ b/st2client/tests/unit/test_auth.py
@@ -69,12 +69,11 @@ class TestLoginBase(base.BaseCLITestCase):
     """
 
     DOTST2_PATH = os.path.expanduser('~/.st2/')
+    CONFIG_FILE = '/tmp/logintest.cfg'
+    CONFIG_CONTENTS = None
 
-    def __init__(self, config_file='~/.st2/config', config_contents=None):
-        super(TestLoginBase, self).__init__()
-
-        self.config_file = config_file
-        self.config_contents = config_contents
+    def __init__(self, *args, **kwargs):
+        super(TestLoginBase, self).__init__(*args, **kwargs)
 
         self.parser = argparse.ArgumentParser()
         self.parser.add_argument('-t', '--token', dest='token')
@@ -85,13 +84,13 @@ class TestLoginBase(base.BaseCLITestCase):
         super(TestLoginBase, self).setUp()
 
         # Remove any existing config file
-        if os.path.isfile(self.config_file):
-            os.remove(self.config_file)
+        if os.path.isfile(self.CONFIG_FILE):
+            os.remove(self.CONFIG_FILE)
 
-        with open(self.config_file, 'w') as cfg:
+        with open(self.CONFIG_FILE, 'w') as cfg:
             # If a test passes in it's own config, we write that instead
-            if self.config_contents:
-                for line in self.config_contents.split('\n'):
+            if self.CONFIG_CONTENTS:
+                for line in self.CONFIG_CONTENTS.split('\n'):
                     cfg.write("%s\n" % line.strip())
             else:
 
@@ -105,7 +104,7 @@ class TestLoginBase(base.BaseCLITestCase):
         super(TestLoginBase, self).tearDown()
 
         # Clean up config file
-        os.remove(self.config_file)
+        os.remove(self.CONFIG_FILE)
 
         # Clean up tokens
         for file in [f for f in os.listdir(self.DOTST2_PATH) if 'token-' in f]:
@@ -124,10 +123,6 @@ class TestLoginPasswordAndConfig(TestLoginBase):
         'metadata': {}
     }
 
-    def __init__(self, *args, **kwargs):
-        super(TestLoginPasswordAndConfig, self).__init__(
-            config_file=self.CONFIG_FILE)
-
     @mock.patch.object(
         requests, 'post',
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(TOKEN), 200, 'OK')))
@@ -142,7 +137,6 @@ class TestLoginPasswordAndConfig(TestLoginBase):
         self.shell.run(args)
 
         with open(self.CONFIG_FILE, 'r') as config_file:
-
             for line in config_file.readlines():
 
                 # Make sure certain values are not present
@@ -168,10 +162,6 @@ class TestLoginIntPwdAndConfig(TestLoginBase):
         'id': '589e607532ed3535707f10eb',
         'metadata': {}
     }
-
-    def __init__(self, *args, **kwargs):
-        super(TestLoginIntPwdAndConfig, self).__init__(
-            config_file=self.CONFIG_FILE)
 
     @mock.patch.object(
         requests, 'post',
@@ -216,10 +206,6 @@ class TestLoginWritePwdOkay(TestLoginBase):
         'metadata': {}
     }
 
-    def __init__(self, *args, **kwargs):
-        super(TestLoginWritePwdOkay, self).__init__(
-            config_file=self.CONFIG_FILE)
-
     @mock.patch.object(
         requests, 'post',
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(TOKEN), 200, 'OK')))
@@ -261,10 +247,6 @@ class TestLoginUncaughtException(TestLoginBase):
         'metadata': {}
     }
 
-    def __init__(self, *args, **kwargs):
-        super(TestLoginUncaughtException, self).__init__(
-            config_file=self.CONFIG_FILE)
-
     @mock.patch.object(
         requests, 'post',
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(TOKEN), 200, 'OK')))
@@ -292,15 +274,11 @@ class TestWhoami(TestLoginBase):
 
     USERNAME = 'st2foouser'
 
-    CONFIG_CONTENT = """
+    CONFIG_CONTENTS = """
     [credentials]
     username = %s
     password = Password1!
     """ % USERNAME
-
-    def __init__(self, *args, **kwargs):
-        super(TestWhoami, self).__init__(
-            config_contents=self.CONFIG_CONTENT, config_file=self.CONFIG_FILE)
 
     @mock.patch.object(
         requests, 'post',
@@ -320,14 +298,10 @@ class TestWhoamiMissingUser(TestLoginBase):
 
     CONFIG_FILE = '/tmp/logintest.cfg'
 
-    CONFIG_CONTENT = ("""
+    CONFIG_CONTENTS = ("""
     [credentials]
     foo = bar
     """)
-
-    def __init__(self, *args, **kwargs):
-        super(TestWhoamiMissingUser, self).__init__(
-            config_contents=self.CONFIG_CONTENT, config_file=self.CONFIG_FILE)
 
     @mock.patch.object(
         requests, 'post',
@@ -347,14 +321,10 @@ class TestWhoamiMissingCreds(TestLoginBase):
 
     CONFIG_FILE = '/tmp/logintest.cfg'
 
-    CONFIG_CONTENT = ("""
+    CONFIG_CONTENTS = ("""
     [nonsense]
     foo = bar
     """)
-
-    def __init__(self, *args, **kwargs):
-        super(TestWhoamiMissingCreds, self).__init__(
-            config_contents=self.CONFIG_CONTENT, config_file=self.CONFIG_FILE)
 
     @mock.patch.object(
         requests, 'post',
@@ -376,15 +346,11 @@ class TestWhoamiUncaughtException(TestLoginBase):
 
     USERNAME = 'st2foouser'
 
-    CONFIG_CONTENT = ("""
+    CONFIG_CONTENTS = ("""
     [credentials]
     username = %s
     password = Password1!
     """ % USERNAME)
-
-    def __init__(self, *args, **kwargs):
-        super(TestWhoamiUncaughtException, self).__init__(
-            config_contents=self.CONFIG_CONTENT, config_file=self.CONFIG_FILE)
 
     @mock.patch.object(
         requests, 'post',

--- a/st2client/tests/unit/test_auth.py
+++ b/st2client/tests/unit/test_auth.py
@@ -69,7 +69,7 @@ class TestLoginBase(base.BaseCLITestCase):
     """
 
     DOTST2_PATH = os.path.expanduser('~/.st2/')
-    CONFIG_FILE = '/tmp/logintest.cfg'
+    CONFIG_FILE = tempfile.mkstemp(suffix='st2.conf')
     CONFIG_CONTENTS = None
 
     def __init__(self, *args, **kwargs):

--- a/st2client/tests/unit/test_auth.py
+++ b/st2client/tests/unit/test_auth.py
@@ -70,7 +70,11 @@ class TestLoginBase(base.BaseCLITestCase):
 
     DOTST2_PATH = os.path.expanduser('~/.st2/')
     CONFIG_FILE = tempfile.mkstemp(suffix='st2.conf')
-    CONFIG_CONTENTS = None
+    CONFIG_CONTENTS = """
+    [credentials]
+    username = olduser
+    password = Password1!
+    """
 
     def __init__(self, *args, **kwargs):
         super(TestLoginBase, self).__init__(*args, **kwargs)
@@ -88,17 +92,8 @@ class TestLoginBase(base.BaseCLITestCase):
             os.remove(self.CONFIG_FILE)
 
         with open(self.CONFIG_FILE, 'w') as cfg:
-            # If a test passes in it's own config, we write that instead
-            if self.CONFIG_CONTENTS:
-                for line in self.CONFIG_CONTENTS.split('\n'):
-                    cfg.write("%s\n" % line.strip())
-            else:
-
-                # Default config for most tests
-                cfg.write('[credentials]\n')
-                # Using 'olduser' so we can assert this has changed at the end
-                cfg.write('username = olduser\n')
-                cfg.write('password = Password1!\n')
+            for line in self.CONFIG_CONTENTS.split('\n'):
+                cfg.write('%s\n' % line.strip())
 
     def tearDown(self):
         super(TestLoginBase, self).tearDown()

--- a/st2client/tests/unit/test_auth.py
+++ b/st2client/tests/unit/test_auth.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import os
 import uuid
 import json
@@ -21,8 +22,8 @@ import tempfile
 import requests
 import argparse
 import logging
-from cStringIO import StringIO
-import sys
+
+from six import StringIO
 
 from tests import base
 from st2client import shell

--- a/st2debug/st2debug/processors.py
+++ b/st2debug/st2debug/processors.py
@@ -15,7 +15,7 @@
 
 import os
 
-from ConfigParser import ConfigParser
+from six.moves.configparser import ConfigParser
 
 __all__ = [
     'process_st2_config',


### PR DESCRIPTION
Randomly noticed it's not working while testing it - https://gist.github.com/Kami/f03360208e2e8599f42d3152df054842

It looks like the problem is that code tries to work with the `ConfigParser` object as a dictionary, but `ConfigParser` object doesn't behave and support dictionary-like access notation.

Edit: Looked at the tests and it looks like they didn't catch this issue because the hide it because they mock `ConfigParser` instance. I know that's not always possible, but we should try to avoid mocking as much as possible because many times we end up mocking too much and we actually end up testing mocks and not the actual code...

## TODO

- [x] Tests (and figure out why existing tests passed, maybe they mock too much. Imo, better and safer approach would be to use actual config file fixtures from disk - this way we don't need to mock stuff.)
