### PR TITLE
Add groups to pack metadata

### DIFF
--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -134,6 +134,12 @@ class PackAPI(BaseAPI):
                 'items': {'type': 'string'},
                 'default': []
             },
+            'groups': {
+                'type': 'array',
+                'description': 'Groups of actions inside the pack. Reserved for future use.',
+                'items': {'type': 'object'},
+                'default': []
+            },
             'system': {
                 'type': 'object',
                 'description': 'Specification for the system components and packages '
@@ -204,12 +210,13 @@ class PackAPI(BaseAPI):
         email = pack.email
         contributors = getattr(pack, 'contributors', [])
         files = getattr(pack, 'files', [])
+        groups = getattr(pack, 'groups', {})
         dependencies = getattr(pack, 'dependencies', [])
         system = getattr(pack, 'system', {})
 
         model = cls.model(ref=ref, name=name, description=description, keywords=keywords,
                           version=version, author=author, email=email, contributors=contributors,
-                          files=files, dependencies=dependencies, system=system,
+                          files=files, dependencies=dependencies, system=system, groups=groups,
                           stackstorm_version=stackstorm_version)
         return model
 

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -210,7 +210,7 @@ class PackAPI(BaseAPI):
         email = pack.email
         contributors = getattr(pack, 'contributors', [])
         files = getattr(pack, 'files', [])
-        groups = getattr(pack, 'groups', {})
+        groups = getattr(pack, 'groups', [])
         dependencies = getattr(pack, 'dependencies', [])
         system = getattr(pack, 'system', {})
 

--- a/st2common/st2common/models/db/pack.py
+++ b/st2common/st2common/models/db/pack.py
@@ -47,6 +47,7 @@ class PackDB(stormbase.StormFoundationDB, stormbase.UIDFieldMixin,
     email = me.EmailField()
     contributors = me.ListField(field=me.StringField())
     files = me.ListField(field=me.StringField())
+    groups = me.ListField(field=me.DictField())
     dependencies = me.ListField(field=me.StringField())
     system = me.DictField()
 


### PR DESCRIPTION
This feature adds a `groups` field to `pack.yaml` for action grouping (currently used in Automation Suites).

See https://github.com/emedvedev/stackstorm-suite for an example.