### PR TITLE
Adjust Codecov behavior

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -18,10 +18,5 @@ coverage:
         url:  "secret:8cqmX1vD14d+NVA6rkwI6rkG8oxaeF5U3WmH23ByQbxMQUqZU3wIVpFnktSoLnvucW2asoHjqpqVmUF29OJZKfEdldBdYS6WL68/JIJQi/Rk/+6NYypm9tD2dNSgiNciHmyjRBUZy2JjxFvxscQj/drg9cPAdGra1b/YLoq9UkQ="
         threshold: 1%
 
-comment:
-  layout: "header, diff, tree"
-  behavior: default
-  require_changes: false  # if true: only post the comment if coverage changes
-  branches: null
-  flags: null
-  paths: null
+# comments are useless, considering wrong coverage reports
+comment: no

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,7 +8,9 @@ coverage:
   range: 50...90      # custom range of coverage colors from red -> yellow -> green
 
   status:
-    project: yes
+    project:
+      default:
+        threshold: 2%
     patch: yes
     changes: no
 
@@ -16,7 +18,7 @@ coverage:
     slack:
       default:
         url:  "secret:8cqmX1vD14d+NVA6rkwI6rkG8oxaeF5U3WmH23ByQbxMQUqZU3wIVpFnktSoLnvucW2asoHjqpqVmUF29OJZKfEdldBdYS6WL68/JIJQi/Rk/+6NYypm9tD2dNSgiNciHmyjRBUZy2JjxFvxscQj/drg9cPAdGra1b/YLoq9UkQ="
-        threshold: 1%
+        threshold: 2%
 
 # comments are useless, considering wrong coverage reports
 comment: no


### PR DESCRIPTION
Avoid Codecov spammy behavior with inaccurate coverage% comments and wrong red GitHub PR statuses.

See https://docs.codecov.io/docs/commit-status
