### PR TITLE
Change conditional to point to username field in client config

### DIFF
--- a/st2client/st2client/base.py
+++ b/st2client/st2client/base.py
@@ -124,7 +124,7 @@ class BaseCLIApp(object):
         password = credentials.get('password', None)
         cache_token = rc_config.get('cli', {}).get('cache_token', False)
 
-        if credentials:
+        if username:
             # Credentials are provided, try to authenticate agaist the API
             try:
                 token = self._get_auth_token(client=client, username=username, password=password,


### PR DESCRIPTION
https://github.com/StackStorm/st2/pull/3219 changed the logic of when a token is retrieved from the API by looking for the 'credentials' field of the configuration.

However, when this section is missing (or when the config is omitted entirely, like it is in CI), this field is set to an empty dictionary, and then because both `username` and `password` default to None and then are added to this dict, the statement `if credentials:` will never evaluate to False, because this dict will never be empty.

In CI, this causes problems We want to skip this step when the config is missing, because in CI this is expected and other API methods will work just fine because auth is disabled. This change proposes looking at just specifically the `username` field, because even though `st2 login` omits the `password` field by default, it still writes the `username` field so can be relied upon.