### PR TITLE
Fix a bug with CLI argument propagation in the st2 pack install, st2 pack remove and st2 pack config commands

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -74,6 +74,9 @@ in development
   just try to run the tests and it won't set up the virtual environment and install the
   dependencies. This flag can be used when virtual environment for pack tests already exists and
   when you know dependencies are already installed and up to date. (new feature)
+* Fix a bug with ``--api-token`` / ``-t`` and other CLI option values not getting correctly
+  propagated to all the API calls issued in the ``st2 pack install`` and ``st2 pack remove``
+  commands. (bug fix)
 
 2.1.1 - December 16, 2016
 -------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -75,8 +75,8 @@ in development
   dependencies. This flag can be used when virtual environment for pack tests already exists and
   when you know dependencies are already installed and up to date. (new feature)
 * Fix a bug with ``--api-token`` / ``-t`` and other CLI option values not getting correctly
-  propagated to all the API calls issued in the ``st2 pack install`` and ``st2 pack remove``
-  commands. (bug fix)
+  propagated to all the API calls issued in the ``st2 pack install``, ``st2 pack remove`` and
+  ``st2 pack config`` commands. (bug fix)
 
 2.1.1 - December 16, 2016
 -------------------------

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -188,10 +188,10 @@ class PackInstallCommand(PackAsyncCommand):
                                  default=False,
                                  help='Force pack installation.')
 
-    @resource.add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
         return self.manager.install(args.packs, force=args.force, **kwargs)
 
+    @resource.add_auth_token_to_kwargs_from_cli
     def run_and_print(self, args, **kwargs):
         instance = super(PackInstallCommand, self).run_and_print(args, **kwargs)
 
@@ -228,10 +228,10 @@ class PackRemoveCommand(PackAsyncCommand):
                                  help='Name of the %s to remove.' %
                                  resource.get_plural_display_name().lower())
 
-    @resource.add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
         return self.manager.remove(args.packs, **kwargs)
 
+    @resource.add_auth_token_to_kwargs_from_cli
     def run_and_print(self, args, **kwargs):
         all_pack_instances = self.app.client.managers['Pack'].get_all()
 
@@ -240,7 +240,7 @@ class PackRemoveCommand(PackAsyncCommand):
         packs = args.packs
 
         if len(packs) == 1:
-            pack_instance = self.app.client.managers['Pack'].get_by_ref_or_id(packs[0])
+            pack_instance = self.app.client.managers['Pack'].get_by_ref_or_id(packs[0], **kwargs)
 
             if pack_instance:
                 raise OperationFailureException('Pack %s has not been removed properly', packs[0])
@@ -252,7 +252,7 @@ class PackRemoveCommand(PackAsyncCommand):
                               attributes=args.attr, json=args.json, yaml=args.yaml,
                               attribute_display_order=self.attribute_display_order)
         else:
-            remaining_pack_instances = self.app.client.managers['Pack'].get_all()
+            remaining_pack_instances = self.app.client.managers['Pack'].get_all(**kwargs)
             pack_instances = []
 
             for pack in all_pack_instances:

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -345,7 +345,8 @@ class PackConfigCommand(resource.ResourceCommand):
         if save_dialog.read() == 'n':
             raise OperationFailureException('Interrupted')
 
-        result = self.app.client.managers['Config'].update(Config(pack=args.name, values=config))
+        config_item = Config(pack=args.name, values=config)
+        result = self.app.client.managers['Config'].update(config_item, **kwargs)
 
         return result
 

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -142,7 +142,7 @@ class PackAsyncCommand(ActionRunCommandMixin, resource.ResourceCommand):
             self._print_execution_details(execution=execution, args=args, **kwargs)
             sys.exit(1)
 
-        return self.app.client.managers['LiveAction'].get_by_id(parent_id)
+        return self.app.client.managers['LiveAction'].get_by_id(parent_id, **kwargs)
 
 
 class PackListCommand(resource.ResourceListCommand):

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -199,12 +199,12 @@ class PackInstallCommand(PackAsyncCommand):
         packs = instance.result['tasks'][1]['result']['result']
 
         if len(packs) == 1:
-            pack_instance = self.app.client.managers['Pack'].get_by_ref_or_id(packs[0])
+            pack_instance = self.app.client.managers['Pack'].get_by_ref_or_id(packs[0], **kwargs)
             self.print_output(pack_instance, table.PropertyValueTable,
                               attributes=args.attr, json=args.json, yaml=args.yaml,
                               attribute_display_order=self.attribute_display_order)
         else:
-            all_pack_instances = self.app.client.managers['Pack'].get_all()
+            all_pack_instances = self.app.client.managers['Pack'].get_all(**kwargs)
             pack_instances = []
 
             for pack in all_pack_instances:

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -234,7 +234,7 @@ class PackRemoveCommand(PackAsyncCommand):
 
     @add_auth_token_to_kwargs_from_cli
     def run_and_print(self, args, **kwargs):
-        all_pack_instances = self.app.client.managers['Pack'].get_all()
+        all_pack_instances = self.app.client.managers['Pack'].get_all(**kwargs)
 
         super(PackRemoveCommand, self).run_and_print(args, **kwargs)
 

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -22,6 +22,7 @@ from st2client.models import Config
 from st2client.models import Pack
 from st2client.models import LiveAction
 from st2client.commands import resource
+from st2client.commands.resource import add_auth_token_to_kwargs_from_cli
 from st2client.commands.action import ActionRunCommandMixin
 from st2client.formatters import table
 from st2client.exceptions.operations import OperationFailureException
@@ -100,7 +101,7 @@ class PackAsyncCommand(ActionRunCommandMixin, resource.ResourceCommand):
         detail_arg_grp.add_argument('-d', '--detail', action='store_true',
                                     help='Display full detail of the execution in table format.')
 
-    @resource.add_auth_token_to_kwargs_from_cli
+    @add_auth_token_to_kwargs_from_cli
     def run_and_print(self, args, **kwargs):
         instance = self.run(args, **kwargs)
         if not instance:
@@ -167,7 +168,7 @@ class PackShowCommand(PackResourceCommand):
                                  help='Name of the %s to show.' %
                                  resource.get_display_name().lower())
 
-    @resource.add_auth_token_to_kwargs_from_cli
+    @add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
         return self.manager.search(args, **kwargs)
 
@@ -191,7 +192,7 @@ class PackInstallCommand(PackAsyncCommand):
     def run(self, args, **kwargs):
         return self.manager.install(args.packs, force=args.force, **kwargs)
 
-    @resource.add_auth_token_to_kwargs_from_cli
+    @add_auth_token_to_kwargs_from_cli
     def run_and_print(self, args, **kwargs):
         instance = super(PackInstallCommand, self).run_and_print(args, **kwargs)
 
@@ -231,7 +232,7 @@ class PackRemoveCommand(PackAsyncCommand):
     def run(self, args, **kwargs):
         return self.manager.remove(args.packs, **kwargs)
 
-    @resource.add_auth_token_to_kwargs_from_cli
+    @add_auth_token_to_kwargs_from_cli
     def run_and_print(self, args, **kwargs):
         all_pack_instances = self.app.client.managers['Pack'].get_all()
 
@@ -283,7 +284,7 @@ class PackRegisterCommand(PackResourceCommand):
                                  nargs='+',
                                  help='Types of content to register.')
 
-    @resource.add_auth_token_to_kwargs_from_cli
+    @add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
         return self.manager.register(args.packs, args.types, **kwargs)
 
@@ -302,7 +303,7 @@ class PackSearchCommand(resource.ResourceTableCommand):
         self.parser.add_argument('query',
                                  help='Search query.')
 
-    @resource.add_auth_token_to_kwargs_from_cli
+    @add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
         return self.manager.search(args, **kwargs)
 
@@ -317,7 +318,7 @@ class PackConfigCommand(resource.ResourceCommand):
                                  help='Name of the %s(s) to configure.' %
                                       resource.get_display_name().lower())
 
-    @resource.add_auth_token_to_kwargs_from_cli
+    @add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
         schema = self.app.client.managers['ConfigSchema'].get_by_ref_or_id(args.name, **kwargs)
 


### PR DESCRIPTION
This pull request fixes a bug with ``--token`` and other CLI argument propagation in the ``st2 pack install``, ``st2 pack remove`` and ``st2 pack config`` commands.

Those commands consist of multiple API calls and previously those CLI arguments / options were only correctly propagated to the first API call and not others which means using option such as ``--token`` / ``-t`` wouldn't work correctly - only first API call would succeed, other would fail due to token not being provided.

Note: Client refactor and getting rid of all this nasty kwargs abuse can't come soon enough (some of the internal methods which manipulate kwargs even manipulate dict in place so I'm pretty sure there are other bugs related to that in the code, a ticking time bomb).

Resolves #3212.