### PR TITLE
Fix handling of global RBAC permission types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -77,6 +77,9 @@ in development
 * Fix a bug with ``--api-token`` / ``-t`` and other CLI option values not getting correctly
   propagated to all the API calls issued in the ``st2 pack install``, ``st2 pack remove`` and
   ``st2 pack config`` commands. (bug fix)
+* Fix a bug with not being apply to apply some global permission types (permission which are global
+  and not specific to a resource) such as pack install, pack remove, pack search, etc. to a role
+  using ``st2-apply-rbac-definitions``. (bug fix)
 
 2.1.1 - December 16, 2016
 -------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -77,7 +77,7 @@ in development
 * Fix a bug with ``--api-token`` / ``-t`` and other CLI option values not getting correctly
   propagated to all the API calls issued in the ``st2 pack install``, ``st2 pack remove`` and
   ``st2 pack config`` commands. (bug fix)
-* Fix a bug with not being apply to apply some global permission types (permission which are global
+* Fix a bug with not being able to apply some global permission types (permissions which are global
   and not specific to a resource) such as pack install, pack remove, pack search, etc. to a role
   using ``st2-apply-rbac-definitions``. (bug fix)
 

--- a/st2common/st2common/models/api/rbac.py
+++ b/st2common/st2common/models/api/rbac.py
@@ -17,6 +17,7 @@ from st2common.models.api.base import BaseAPI
 from st2common.models.db.pack import PackDB
 from st2common.services.rbac import get_all_roles
 from st2common.rbac.types import PermissionType
+from st2common.rbac.types import GLOBAL_PERMISSION_TYPES
 from st2common.util.uid import parse_uid
 
 __all__ = [
@@ -146,9 +147,11 @@ class RoleDefinitionFileFormatAPI(BaseAPI):
                 # Right now we only support single permission type (list) which is global and
                 # doesn't apply to a resource
                 for permission_type in permission_types:
-                    if not permission_type.endswith('_list'):
-                        message = ('Invalid permission type "%s". Only "list" permission types '
-                                   'can be used without a resource id' % (permission_type))
+                    if permission_type not in GLOBAL_PERMISSION_TYPES:
+                        valid_global_permission_types = ', '.join(GLOBAL_PERMISSION_TYPES)
+                        message = ('Invalid permission type "%s". Valid global permission types '
+                                   'which can be used without a resource id are: %s' %
+                                   (permission_type, valid_global_permission_types))
                         raise ValueError(message)
 
             return cleaned

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -335,12 +335,17 @@ LIST_PERMISSION_TYPES = [permission_type for permission_type in ALL_PERMISSION_T
 
 # List of global permissions (ones which don't apply to a specific resource)
 GLOBAL_PERMISSION_TYPES = [
+    # Pack global permission types
     PermissionType.PACK_INSTALL,
     PermissionType.PACK_UNINSTALL,
     PermissionType.PACK_CREATE,
     PermissionType.PACK_REGISTER,
     PermissionType.PACK_SEARCH,
-    PermissionType.PACK_VIEW_INDEX_HEALTH
+    PermissionType.PACK_VIEW_INDEX_HEALTH,
+
+    # Action alias global permission types
+    PermissionType.ACTION_ALIAS_MATCH,
+    PermissionType.ACTION_ALIAS_HELP
 ] + LIST_PERMISSION_TYPES
 
 

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -228,6 +228,7 @@ RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP = {
         PermissionType.RUNNER_ALL,
     ],
     ResourceType.PACK: [
+        PermissionType.PACK_LIST,
         PermissionType.PACK_VIEW,
         PermissionType.PACK_CREATE,
         PermissionType.PACK_MODIFY,

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -337,6 +337,7 @@ LIST_PERMISSION_TYPES = [permission_type for permission_type in ALL_PERMISSION_T
 GLOBAL_PERMISSION_TYPES = [
     PermissionType.PACK_INSTALL,
     PermissionType.PACK_UNINSTALL,
+    PermissionType.PACK_CREATE,
     PermissionType.PACK_REGISTER,
     PermissionType.PACK_SEARCH,
     PermissionType.PACK_VIEW_INDEX_HEALTH

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
+
 from st2common.util.enum import Enum
 from st2common.constants.types import ResourceType as SystemResourceType
 
@@ -22,7 +24,11 @@ __all__ = [
     'ResourceType',
 
     'RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP',
-    'PERMISION_TYPE_TO_DESCRIPTION_MAP'
+    'PERMISION_TYPE_TO_DESCRIPTION_MAP',
+
+    'ALL_PERMISSION_TYPES',
+    'GLOBAL_PERMISSION_TYPES',
+    'LIST_PERMISSION_TYPES'
 ]
 
 
@@ -320,6 +326,20 @@ RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP = {
         PermissionType.API_KEY_ALL
     ]
 }
+
+ALL_PERMISSION_TYPES = RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP.values()
+ALL_PERMISSION_TYPES = list(itertools.chain(*ALL_PERMISSION_TYPES))
+LIST_PERMISSION_TYPES = [permission_type for permission_type in ALL_PERMISSION_TYPES if
+                         permission_type.endswith('_list')]
+
+# List of global permissions (ones which don't apply to a specific resource)
+GLOBAL_PERMISSION_TYPES = [
+    PermissionType.PACK_INSTALL,
+    PermissionType.PACK_UNINSTALL,
+    PermissionType.PACK_REGISTER,
+    PermissionType.PACK_SEARCH,
+    PermissionType.PACK_VIEW_INDEX_HEALTH
+] + LIST_PERMISSION_TYPES
 
 
 # Maps a permission type to the corresponding description

--- a/st2common/tests/unit/test_rbac_loader.py
+++ b/st2common/tests/unit/test_rbac_loader.py
@@ -71,8 +71,8 @@ class RBACDefinitionsLoaderTestCase(unittest2.TestCase):
 
         # Only list permissions can be used without a resource_uid
         file_path = os.path.join(get_fixtures_base_path(), 'rbac_invalid/roles/role_four.yaml')
-        expected_msg = ('Invalid permission type "action_create". Only "list" permission types '
-                        'can be used without a resource id')
+        expected_msg = ('Invalid permission type "action_create". Valid global '
+                        'permission types which can be used without a resource id are:')
         self.assertRaisesRegexp(ValueError, expected_msg,
                                 loader.load_role_definition_from_file, file_path=file_path)
 

--- a/st2common/tests/unit/test_rbac_loader.py
+++ b/st2common/tests/unit/test_rbac_loader.py
@@ -76,6 +76,14 @@ class RBACDefinitionsLoaderTestCase(unittest2.TestCase):
         self.assertRaisesRegexp(ValueError, expected_msg,
                                 loader.load_role_definition_from_file, file_path=file_path)
 
+    def test_load_role_definition_with_all_global_permission_types(self):
+        loader = RBACDefinitionsLoader()
+
+        file_path = os.path.join(get_fixtures_base_path(), 'rbac/roles/role_seven.yaml')
+        role_definition_api = loader.load_role_definition_from_file(file_path=file_path)
+
+        self.assertEqual(role_definition_api.name, 'role_seven')
+
     def test_load_user_role_assignments_success(self):
         loader = RBACDefinitionsLoader()
 

--- a/st2tests/st2tests/fixtures/rbac/roles/role_seven.yaml
+++ b/st2tests/st2tests/fixtures/rbac/roles/role_seven.yaml
@@ -1,0 +1,16 @@
+---
+    name: "role_seven"
+    description: "Role which grants all the available global permissions"
+    permission_grants:
+        -
+            permission_types:
+               - "pack_list"
+               - "action_list"
+               - "pack_create"
+               - "pack_install"
+               - "pack_uninstall"
+               - "pack_register"
+               - "pack_search"
+               - "pack_view_index_health"
+               - "action_alias_match"
+               - "action_alias_help"


### PR DESCRIPTION
The code incorrectly assumed that the only global permission types (the ones which are global and don't apply to a specific resource) are just _list permissions.

This pull request fixes that. It was originally reported by a community member saying that they can't apply "pack_install" and some other pack-related global permissions using `st2-apply-rbac-definitions`.
## TODO

- [x] More tests