### PR TITLE
Fix st2-run-pack-tests script

### DIFF
--- a/st2common/bin/st2-run-pack-tests
+++ b/st2common/bin/st2-run-pack-tests
@@ -55,10 +55,11 @@ STACKSTORM_VIRTUALENV_BIN="/opt/stackstorm/st2/bin"
 ####################
 
 function usage() {
-    echo "Usage: $0 [-x] [-j] -p <path to pack>" >&2
+    echo "Usage: $0 [-x] [-j] [-v] -p <path to pack>" >&2
     echo "  -x : Do not create virtualenv, e.g. when running in existing one." >&2
     echo "  -j : Just run tests (use previously installed dependencies" >&2
     echo "       and virtualenv if any. For subsequent test runs." >&2
+    echo "  -v : Verbose mode (log debug messages to stdout)." >&2
 }
 
 while getopts ":p:xjv" o; do
@@ -180,7 +181,7 @@ else
     if [ ! -d "${VIRTUALENV_DIR}" ]; then
         echo "Virtual environment ${VIRTUALENV_DIR} doesn't exist"
         echo "Run this script without the -j flag to create it or run it with -x flag to not use" \
-             " a pack specific virtual environment."
+             "a pack specific virtual environment."
         exit 2
     fi
 

--- a/st2common/bin/st2-run-pack-tests
+++ b/st2common/bin/st2-run-pack-tests
@@ -55,7 +55,7 @@ STACKSTORM_VIRTUALENV_BIN="/opt/stackstorm/st2/bin"
 ####################
 
 function usage() {
-    echo "Usage: $0 [-x -s] -p <path to pack>" >&2
+    echo "Usage: $0 [-x] [-j] -p <path to pack>" >&2
     echo "  -x : Do not create virtualenv, e.g. when running in existing one." >&2
     echo "  -j : Just run tests (use previously installed dependencies" >&2
     echo "       and virtualenv if any. For subsequent test runs." >&2

--- a/st2common/bin/st2-run-pack-tests
+++ b/st2common/bin/st2-run-pack-tests
@@ -46,6 +46,8 @@ CREATE_VIRTUALENV=true
 JUST_TESTS=false
 VERBOSE=false
 
+VIRTUALENV_ACTIVATED=false
+
 STACKSTORM_VIRTUALENV_BIN="/opt/stackstorm/st2/bin"
 
 ####################
@@ -144,6 +146,7 @@ if [ "${CREATE_VIRTUALENV}" = false ]; then
     if [ -d "${VIRTUALENV_DIR}" ]; then
         echo "Activating virtualenv in ${VIRTUALENV_DIR}..."
         source ${VIRTUALENV_DIR}/bin/activate
+        VIRTUALENV_ACTIVATED=true
     else
         echo "Not activating virtualenv since it doesn't exist"
     fi
@@ -155,6 +158,7 @@ else
 
         # Activate the virtualenv
         source ${VIRTUALENV_DIR}/bin/activate
+        VIRTUALENV_ACTIVATED=true
 
         # Make sure virtualenv is using latest pip version
         ${VIRTUALENV_DIR}/bin/pip install --upgrade pip
@@ -169,6 +173,7 @@ else
 
     # Activate created virtualenv
     source ${VIRTUALENV_DIR}/bin/activate
+    VIRTUALENV_ACTIVATED=true
 fi
 
 # Note: If we are running outside of st2, we need to add all the st2 components
@@ -224,7 +229,7 @@ nosetests -s -v ${PACK_TESTS_PATH}
 TESTS_EXIT_CODE=$?
 
 # Clean up and unset the variables
-if [ "${CREATE_VIRTUALENV}" = true ]; then
+if [ ${VIRTUALENV_ACTIVATED} = true ]; then
     deactivate
 fi
 

--- a/st2common/bin/st2-run-pack-tests
+++ b/st2common/bin/st2-run-pack-tests
@@ -88,6 +88,12 @@ while getopts ":p:xjv" o; do
     esac
 done
 
+function verbose_log() {
+    if [ ${VERBOSE} = true ]; then
+        echo $@
+    fi
+}
+
 if [ ! ${PACK_PATH} ]; then
     # Missing required argument
     usage
@@ -218,11 +224,11 @@ fi
 # Set PYTHONPATH, make sure it contains st2 components in PATH
 export PYTHONPATH="${PYTHONPATH}:${PACK_PYTHONPATH}"
 
+verbose_log "PYTHONPATH=${PYTHONPATH}"
+verbose_log "PATH=${PATH}"
+verbose_log "Virtualenv activated=${VIRTUALENV_ACTIVATED}"
+verbose_log "Installed Python dependencies:"
 if [ ${VERBOSE} = true ]; then
-    echo "PYTHONPATH=${PYTHONPATH}"
-    echo "PATH=${PATH}"
-    echo "Virtualenv activated=${VIRTUALENV_ACTIVATED}"
-    echo "Installed Python dependencies:"
     pip list
 fi
 
@@ -232,6 +238,7 @@ TESTS_EXIT_CODE=$?
 
 # Clean up and unset the variables
 if [ ${VIRTUALENV_ACTIVATED} = true ]; then
+    verbose_log "Deactivating virtualenv ${VIRTUALENVS_DIR}"
     deactivate
 fi
 

--- a/st2common/bin/st2-run-pack-tests
+++ b/st2common/bin/st2-run-pack-tests
@@ -94,6 +94,15 @@ function verbose_log() {
     fi
 }
 
+function activate_virtualenv() {
+    # Activate virtualenv for running pack tests
+    if [ "${VIRTUALENV_ACTIVATED}" = false ]; then
+        echo "Activating virtualenv in ${VIRTUALENV_DIR}..."
+        source ${VIRTUALENV_DIR}/bin/activate
+        VIRTUALENV_ACTIVATED=true
+    fi
+}
+
 if [ ! ${PACK_PATH} ]; then
     # Missing required argument
     usage
@@ -146,14 +155,12 @@ if [ -d "${STACKSTORM_VIRTUALENV_BIN}" ]; then
     export PATH="${STACKSTORM_VIRTUALENV_BIN}:${PATH}"
 fi
 
-# Create virtualenv
+# Create virtualenv (if requested, otherwise just activate it)
 VIRTUALENV_DIR="${VIRTUALENVS_DIR}/${PACK_NAME}"
 
 if [ "${CREATE_VIRTUALENV}" = false ]; then
     if [ -d "${VIRTUALENV_DIR}" ]; then
-        echo "Activating virtualenv in ${VIRTUALENV_DIR}..."
-        source ${VIRTUALENV_DIR}/bin/activate
-        VIRTUALENV_ACTIVATED=true
+        activate_virtualenv
     else
         echo "Not activating virtualenv since it doesn't exist"
     fi
@@ -164,8 +171,7 @@ else
         virtualenv --system-site-packages ${VIRTUALENV_DIR}
 
         # Activate the virtualenv
-        source ${VIRTUALENV_DIR}/bin/activate
-        VIRTUALENV_ACTIVATED=true
+        activate_virtualenv
 
         # Make sure virtualenv is using latest pip version
         ${VIRTUALENV_DIR}/bin/pip install --upgrade pip
@@ -178,9 +184,8 @@ else
         exit 2
     fi
 
-    # Activate created virtualenv
-    source ${VIRTUALENV_DIR}/bin/activate
-    VIRTUALENV_ACTIVATED=true
+    # Make sure the virtualenv is activated
+    activate_virtualenv
 fi
 
 # Note: If we are running outside of st2, we need to add all the st2 components

--- a/st2common/bin/st2-run-pack-tests
+++ b/st2common/bin/st2-run-pack-tests
@@ -46,6 +46,8 @@ CREATE_VIRTUALENV=true
 JUST_TESTS=false
 VERBOSE=false
 
+STACKSTORM_VIRTUALENV_BIN="/opt/stackstorm/st2/bin"
+
 ####################
 # Script beings here
 ####################
@@ -130,6 +132,11 @@ PACK_TESTS_REQUIREMENTS_FILE="${PACK_PATH}/requirements-tests.txt"
 
 echo "Running tests for pack: ${PACK_NAME}"
 
+# Make sure /opt/stackstorm/bin is in PATH (for package installations)
+if [ -d "${STACKSTORM_VIRTUALENV_BIN}" ]; then
+    export PATH="${STACKSTORM_VIRTUALENV_BIN}:${PATH}"
+fi
+
 # Create virtualenv
 VIRTUALENV_DIR="${VIRTUALENVS_DIR}/${PACK_NAME}"
 
@@ -146,11 +153,13 @@ else
         mkdir -p ${VIRTUALENVS_DIR}
         virtualenv --system-site-packages ${VIRTUALENV_DIR}
 
+        # Activate the virtualenv
+        source ${VIRTUALENV_DIR}/bin/activate
+
         # Make sure virtualenv is using latest pip version
         ${VIRTUALENV_DIR}/bin/pip install --upgrade pip
     fi
 
-    # Activate created virtualenv
     if [ ! -d "${VIRTUALENV_DIR}" ]; then
         echo "Virtual environment ${VIRTUALENV_DIR} doesn't exist"
         echo "Run this script without the -j flag to create it or run it with -x flag to not use" \
@@ -158,6 +167,7 @@ else
         exit 2
     fi
 
+    # Activate created virtualenv
     source ${VIRTUALENV_DIR}/bin/activate
 fi
 
@@ -219,6 +229,7 @@ if [ "${CREATE_VIRTUALENV}" = true ]; then
 fi
 
 unset PYTHONPATH
+unset PATH
 
 # Exit
 exit ${TESTS_EXIT_CODE}

--- a/st2common/bin/st2-run-pack-tests
+++ b/st2common/bin/st2-run-pack-tests
@@ -220,6 +220,8 @@ export PYTHONPATH="${PYTHONPATH}:${PACK_PYTHONPATH}"
 
 if [ ${VERBOSE} = true ]; then
     echo "PYTHONPATH=${PYTHONPATH}"
+    echo "PATH=${PATH}"
+    echo "Virtualenv activated=${VIRTUALENV_ACTIVATED}"
     echo "Installed Python dependencies:"
     pip list
 fi

--- a/st2common/bin/st2-run-pack-tests
+++ b/st2common/bin/st2-run-pack-tests
@@ -142,6 +142,7 @@ echo "Running tests for pack: ${PACK_NAME}"
 
 # Make sure /opt/stackstorm/bin is in PATH (for package installations)
 if [ -d "${STACKSTORM_VIRTUALENV_BIN}" ]; then
+    verbose_log "Adding ${STACKSTORM_VIRTUALENV_BIN} to \$PATH"
     export PATH="${STACKSTORM_VIRTUALENV_BIN}:${PATH}"
 fi
 


### PR DESCRIPTION
This pull request fixes two issued I discovered while testing the packages:

1. Make sure we activate virtualenv before we try to upgrade pip (previously it would try to install it into global namespace).
2. Make sure we add /opt/stackstorm/st2/bin to $PATH so it works on package installations (previously this wasn't added to $PATH so the script wouldn't work out of the box on package based installations)/