### PR TITLE
Don't print "Logged in as x" on failed st2 login attempt

### DIFF
--- a/st2client/st2client/commands/auth.py
+++ b/st2client/st2client/commands/auth.py
@@ -147,6 +147,8 @@ class LoginCommand(resource.ResourceCommand):
             if self.app.client.debug:
                 raise
 
+            return
+
         print('Logged in as %s' % (args.username))
 
         if not args.write_password:

--- a/st2client/tests/unit/test_auth.py
+++ b/st2client/tests/unit/test_auth.py
@@ -262,6 +262,7 @@ class TestLoginUncaughtException(TestLoginBase):
         retcode = self.shell.run(args)
 
         self.assertTrue('Failed to log in as %s' % expected_username in self.stdout.getvalue())
+        self.assertTrue('Logged in as' not in self.stdout.getvalue())
         self.assertEqual(retcode, 0)
 
 


### PR DESCRIPTION
Small fix so we don't print "Logged in as x" on failed log in attempt.