### PR TITLE
Fix st2ctl reload so it preserves exit code from "st2-register-content" script and fails on failure by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -80,6 +80,8 @@ in development
 * Fix a bug with not being able to apply some global permission types (permissions which are global
   and not specific to a resource) such as pack install, pack remove, pack search, etc. to a role
   using ``st2-apply-rbac-definitions``. (bug fix)
+* Fix ``st2ctl reload`` command so it preserves exit code from `st2-register-content` script and
+  correctly fails on failure by default.
 
 2.1.1 - December 16, 2016
 -------------------------

--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -208,7 +208,11 @@ case ${1} in
     ;;
   reload)
     register_content ${@:2}
+    exit_code=$?
     getpids
+    # Note: We want to preserve st2-register-content "fail on failure" behavior
+    # and propagate the correct exit code and exit with non zero on failure
+    exit ${exit_code}
     ;;
   clean)
     must_be_root

--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -144,7 +144,7 @@ function register_content() {
     REGISTER_FLAGS=${flags}
   fi
 
-  echo "Registering content...[flags = ${REGISTER_FLAGS}]"
+  echo "Registering content...[flags = --config-file ${STANCONF} ${REGISTER_FLAGS}]"
   st2-register-content --config-file ${STANCONF} ${REGISTER_FLAGS}
 }
 

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -63,6 +63,8 @@ def register_opts():
                                                               'all the Python runner actions.')),
 
         # General options
+        # Note: This value should default to False since we want fail on failure behavior by
+        # default.
         cfg.BoolOpt('no-fail-on-failure', default=False,
                     help=('Don\'t exit with non-zero if some resource registration fails.')),
         # Note: Fail on failure is now a default behavior. This flag is only left here for backward

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -67,7 +67,7 @@ def register_opts():
                     help=('Don\'t exit with non-zero if some resource registration fails.')),
         # Note: Fail on failure is now a default behavior. This flag is only left here for backward
         # compatibility reasons, but it's not actually used.
-        cfg.BoolOpt('fail-on-failure', default=False,
+        cfg.BoolOpt('fail-on-failure', default=True,
                     help=('Exit with non-zero if some resource registration fails.'))
     ]
     try:


### PR DESCRIPTION
There was an inconsistency between default `st2-register-content` script and `st2ctl reload` command behavior.

The former would correctly exit on failure by default, but `st2ctl reload` wouldn't because it didn't correctly preserve and propagate the exit code from the `st2-register-content`.

Issue originally reported by tanya on Slack (good catch!)

## TODO

- [ ] Add st2tests tests - not a blocker for v2.2.0 (we already have tests for st2-register-content, but none for this specific scenario for st2ctl reload)