### PR TITLE
Fix base action alias test case so it works if local pack directory name doesn't match the pack name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 in development
 --------------
 
+* Fix base action alias test class (``BaseActionAliasTestCase``) so it also works if the local pack
+  directory name doesn't match the pack name (this might be the case with new pack management
+  during development where local git repository directory name doesn't match pack name) (bug fix)
 
 2.2.0 - February 22, 2017
 -------------------------

--- a/st2tests/st2tests/fixtures/packs/pack_dir_name_doesnt_match_ref/aliases/alias1.yaml
+++ b/st2tests/st2tests/fixtures/packs/pack_dir_name_doesnt_match_ref/aliases/alias1.yaml
@@ -1,0 +1,13 @@
+---
+    name: "alias1"
+    pack: "pack_name_not_the_same_as_dir_name"
+    description: "DON'T CARE"
+    action_ref: "wolfpack.action1"
+    formats:
+        - "Lorem ipsum {{param1}} dolor sit {{param2}} amet."
+    ack:
+        extra:
+            color: "red"
+    result:
+        extra:
+            color: "red"

--- a/st2tests/st2tests/fixtures/packs/pack_dir_name_doesnt_match_ref/pack.yaml
+++ b/st2tests/st2tests/fixtures/packs/pack_dir_name_doesnt_match_ref/pack.yaml
@@ -1,4 +1,6 @@
 ref: pack_name_not_the_same_as_dir_name
 name: pack_name_not_the_same_as_dir_name
+description: "test pack"
 author: Dummy
+email: "dev@stackstorm.com"
 version: 0.1.1

--- a/st2tests/st2tests/fixtures/packs/pack_dir_name_doesnt_match_ref/pack.yaml
+++ b/st2tests/st2tests/fixtures/packs/pack_dir_name_doesnt_match_ref/pack.yaml
@@ -1,0 +1,4 @@
+ref: pack_name_not_the_same_as_dir_name
+name: pack_name_not_the_same_as_dir_name
+author: Dummy
+version: 0.1.1


### PR DESCRIPTION
This pull request fixes a bug which would cause action alias tests to fail when local pack directory name doesn't match `pack` attribute in different resource metadata files.

This can be the case with the new pack management when you are locally developing a pack and local git repository directory name is not the same as `pack` / `ref` attribute (e.g. `stackstorm-network_utils` vs `network_utils`).

Again, this only affects local development and not actual StackStorm installations when packs are installed into `/opt/stackstorm/packs`. When pack is downloaded (git clone), correct directory name is used (one which matches `pack` / `ref` attribute) - if you run tests on `/opt/stackstorm/packs/<pack>` directory, they will work just fine.

Resolves https://github.com/StackStorm/st2/issues/3250 (https://github.com/StackStorm-Exchange/stackstorm-networking_utils/pull/1#issuecomment-282509188).

Thanks to @jjm for catching and reporting this issue.

## TODO

- [x] Tests