### PR TITLE
Fix workflow status when task is canceled

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,11 @@ Changelog
 
 in development
 --------------
+* Fix Mistral workflow status when task is canceled. Currently, when a task is canceled, the
+  workflow status is set to error. The workflow status should be set to canceled. Also, when
+  a canceled action execution completes, the action execution will be updated from canceled
+  to its new status. This should not be the case because the action execution has already been
+  canceled. (bug fix)
 
 
 2.2.0 - February 22, 2017

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_policy.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_policy.py
@@ -189,7 +189,7 @@ class MistralRunnerPolicyTest(DbTestCase):
             action_executions.ActionExecutionManager.update.assert_called_once_with(
                 '12345',
                 output='{"error": "Execution canceled by user."}',
-                state='ERROR'
+                state='CANCELLED'
             )
 
             liveaction2 = LiveAction.get_by_id(str(liveaction2.id))
@@ -256,7 +256,7 @@ class MistralRunnerPolicyTest(DbTestCase):
             action_executions.ActionExecutionManager.update.assert_called_once_with(
                 '12345',
                 output='{"error": "Execution canceled by user."}',
-                state='ERROR'
+                state='CANCELLED'
             )
 
             liveaction2 = LiveAction.get_by_id(str(liveaction2.id))

--- a/st2actions/st2actions/handlers/mistral.py
+++ b/st2actions/st2actions/handlers/mistral.py
@@ -40,7 +40,7 @@ STATUS_MAP = {
     action_constants.LIVEACTION_STATUS_TIMED_OUT: 'ERROR',
     action_constants.LIVEACTION_STATUS_ABANDONED: 'ERROR',
     action_constants.LIVEACTION_STATUS_CANCELING: 'RUNNING',
-    action_constants.LIVEACTION_STATUS_CANCELED: 'ERROR'
+    action_constants.LIVEACTION_STATUS_CANCELED: 'CANCELLED'
 }
 
 

--- a/st2common/tests/unit/test_action_db_utils.py
+++ b/st2common/tests/unit/test_action_db_utils.py
@@ -133,6 +133,60 @@ class ActionDBUtilsTestCase(DbTestCase):
         self.assertEqual(newliveaction_db.end_timestamp, now)
 
     @mock.patch.object(LiveActionPublisher, 'publish_state', mock.MagicMock())
+    def test_update_canceled_liveaction(self):
+        liveaction_db = LiveActionDB()
+        liveaction_db.status = 'initializing'
+        liveaction_db.start_timestamp = get_datetime_utc_now()
+        liveaction_db.action = ResourceReference(
+            name=ActionDBUtilsTestCase.action_db.name,
+            pack=ActionDBUtilsTestCase.action_db.pack).ref
+        params = {
+            'actionstr': 'foo',
+            'some_key_that_aint_exist_in_action_or_runner': 'bar',
+            'runnerint': 555
+        }
+        liveaction_db.parameters = params
+        liveaction_db = LiveAction.add_or_update(liveaction_db)
+        origliveaction_db = copy.copy(liveaction_db)
+
+        # Update by id.
+        newliveaction_db = action_db_utils.update_liveaction_status(
+            status='running', liveaction_id=liveaction_db.id)
+
+        # Verify id didn't change.
+        self.assertEqual(origliveaction_db.id, newliveaction_db.id)
+        self.assertEqual(newliveaction_db.status, 'running')
+
+        # Verify that state is published.
+        self.assertTrue(LiveActionPublisher.publish_state.called)
+        LiveActionPublisher.publish_state.assert_called_once_with(newliveaction_db, 'running')
+
+        # Cancel liveaction.
+        now = get_datetime_utc_now()
+        status = 'canceled'
+        newliveaction_db = action_db_utils.update_liveaction_status(
+            status=status, end_timestamp=now, liveaction_id=liveaction_db.id)
+        self.assertEqual(origliveaction_db.id, newliveaction_db.id)
+        self.assertEqual(newliveaction_db.status, status)
+        self.assertEqual(newliveaction_db.end_timestamp, now)
+
+        # Since liveaction has already been canceled, check that anymore update of
+        # status, result, context, and end timestamp are not processed.
+        now = get_datetime_utc_now()
+        status = 'succeeded'
+        result = 'Work is done.'
+        context = {'third_party_id': uuid.uuid4().hex}
+        newliveaction_db = action_db_utils.update_liveaction_status(
+            status=status, result=result, context=context, end_timestamp=now,
+            liveaction_id=liveaction_db.id)
+
+        self.assertEqual(origliveaction_db.id, newliveaction_db.id)
+        self.assertEqual(newliveaction_db.status, 'canceled')
+        self.assertNotEqual(newliveaction_db.result, result)
+        self.assertNotEqual(newliveaction_db.context, context)
+        self.assertNotEqual(newliveaction_db.end_timestamp, now)
+
+    @mock.patch.object(LiveActionPublisher, 'publish_state', mock.MagicMock())
     def test_update_liveaction_result_with_dotted_key(self):
         liveaction_db = LiveActionDB()
         liveaction_db.status = 'initializing'

--- a/st2tests/integration/mistral/base.py
+++ b/st2tests/integration/mistral/base.py
@@ -55,7 +55,7 @@ class TestWorkflowExecution(unittest2.TestCase):
 
         if expect_tasks_completed:
             tasks = execution.result['tasks']
-            self.assertTrue(all([t['state'] in ['SUCCESS', 'ERROR'] for t in tasks]))
+            self.assertTrue(all([t['state'] in ['SUCCESS', 'ERROR', 'CANCELLED'] for t in tasks]))
 
         return execution
 
@@ -77,6 +77,6 @@ class TestWorkflowExecution(unittest2.TestCase):
         tasks = execution.result.get('tasks', [])
 
         if are_tasks_completed:
-            self.assertTrue(all([t['state'] in ['SUCCESS', 'ERROR'] for t in tasks]))
+            self.assertTrue(all([t['state'] in ['SUCCESS', 'ERROR', 'CANCELLED'] for t in tasks]))
         else:
             self.assertTrue(any([t['state'] == 'RUNNING' for t in tasks]))

--- a/st2tests/integration/mistral/test_wiring.py
+++ b/st2tests/integration/mistral/test_wiring.py
@@ -116,12 +116,11 @@ class WiringTest(base.TestWorkflowExecution):
 
         self.st2client.liveactions.delete(task_executions[0])
         execution = self._wait_for_completion(execution, expect_tasks_completed=True)
-        self._assert_failure(execution)
+        self._assert_canceled(execution, are_tasks_completed=True)
 
         task_results = execution.result.get('tasks', [])
         self.assertGreater(len(task_results), 0)
-        expected_state_info = '{error: Execution canceled by user.}'
-        self.assertEqual(task_results[0]['state_info'], expected_state_info)
+        self.assertEqual(task_results[0]['state'], 'CANCELLED')
 
     def test_basic_rerun(self):
         path = self.temp_dir_path


### PR DESCRIPTION
Fix Mistral workflow status when task is canceled. Currently, when a task is canceled, the workflow status is set to error. The workflow status should be set to canceled. Also, when a canceled action execution completes, the action execution will be updated from canceled to its new status. This should not be the case because the action execution has already been canceled. Before merging this patch, please ensure mistral fork is caught up with mistral upstream master. This requires another fix from mistral upstream.