### PR TITLE
Fix a bug with default values from config schema not being used if pack doesn't have a config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,11 @@ in development
   during development where local git repository directory name doesn't match pack name) (bug fix)
 * Fix ``st2ctl reload`` command so it preserves exit code from `st2-register-content` script and
   correctly fails on failure by default.
+* Fix a bug with default values from pack config schema not being passed via config to Python
+  runner actions and sensors if pack didn't contain a config file in ``/opt/stackstorm/configs``
+  directory. (bug fix)
+
+  Reported by Jon Middleton.
 
 2.2.0 - February 27, 2017
 -------------------------

--- a/st2common/st2common/util/config_loader.py
+++ b/st2common/st2common/util/config_loader.py
@@ -20,6 +20,7 @@ import six
 from oslo_config import cfg
 
 from st2common import log as logging
+from st2common.models.db.pack import ConfigDB
 from st2common.persistence.pack import ConfigSchema
 from st2common.persistence.pack import Config
 from st2common.content import utils as content_utils
@@ -72,8 +73,10 @@ class ContentPackConfigLoader(object):
         try:
             config_db = Config.get_by_pack(value=self.pack_name)
         except StackStormDBObjectNotFoundError:
-            # Corresponding pack config doesn't exist, return early
-            return result
+            # Corresponding pack config doesn't exist. We set config_db to an empty config so
+            # that the default values from config schema are still correctly applied even if
+            # pack doesn't contain a config.
+            config_db = ConfigDB(pack=self.pack_name, values={})
 
         try:
             config_schema_db = ConfigSchema.get_by_pack(value=self.pack_name)


### PR DESCRIPTION
Before this fix, default values from pack config schema would not get applied (and as such, not passed to Python runner actions and sensors via config) if pack didn't have a config in `/opt/stackstorm/configs/` directory.

This pull request fixes that.

Thanks to @jjm for catching and reporting this.

Resolves #3258.