### PR TITLE
Make st2tests directory a proper Python package

### DIFF
--- a/st2tests/MANIFEST.in
+++ b/st2tests/MANIFEST.in
@@ -1,0 +1,10 @@
+# https://docs.python.org/2/distutils/sourcedist.html#commands
+# Include all files under the source tree by default.
+# Another behaviour can be used in the future though.
+recursive-include st2tests *.* *
+include dist_utils.py
+include requirements.txt
+include README.rst
+include CHANGELOG.rst
+include LICENSE
+global-exclude *.pyc

--- a/st2tests/Makefile
+++ b/st2tests/Makefile
@@ -1,0 +1,93 @@
+# <<<< TO DEPRICATE
+SHELL := /bin/bash
+REPO_ROOT := ..
+VIRTUALENV_DIR=virtualenv
+RPM_ROOT=~/rpmbuild
+RPM_SOURCES_DIR := $(RPM_ROOT)/SOURCES/
+RPM_SPECS_DIR := $(RPM_ROOT)/SPECS/
+COMPONENTS := st2debug
+VER=0.4.0
+FLAKE8_CONFIG := $(REPO_ROOT)/lint-configs/python/.flake8
+
+.PHONY: clean
+clean:
+	rm -rf *.egg-info
+	rm -rf build
+	find . -name \*.pyc -type f -delete
+	find . -name \*.pyo -type f -delete
+
+.PHONY: flake8
+flake8:
+	flake8 --config $(FLAKE8_CONFIG) $(COMPONENTS)
+
+.PHONY: rpm
+rpm:
+	pushd ~ && rpmdev-setuptree && popd
+	tar --transform=s~^~$(COMPONENTS)-$(VER)/~ -czf $(RPM_SOURCES_DIR)/$(COMPONENTS).tar.gz bin $(COMPONENTS)
+	cp packaging/rpm/$(COMPONENTS).spec $(RPM_SPECS_DIR)/
+	cd $(RPM_SPECS_DIR) && rpmbuild --clean --rmsource -ba $(COMPONENTS).spec
+
+.PHONY: rhel-rpm
+rhel-rpm:
+	pushd ~ && rpmdev-setuptree && popd
+	tar --transform=s~^~$(COMPONENTS)-$(VER)/~ -czf $(RPM_SOURCES_DIR)/$(COMPONENTS).tar.gz bin $(COMPONENTS)
+	cp packaging/rpm/$(COMPONENTS)-rhel6.spec $(RPM_SPECS_DIR)/
+	cd $(RPM_SPECS_DIR) && rpmbuild --clean --rmsource -ba $(COMPONENTS)-rhel6.spec
+
+.PHONY: deb
+deb:
+	mkdir -p ~/debbuild
+	tar --transform=s~^~$(COMPONENTS)-$(VER)/~ -czf ~/$(COMPONENTS).tar.gz bin  $(COMPONENTS) packaging/debian
+	pushd ~ && tar -xzf $(COMPONENTS).tar.gz && cd $(COMPONENTS)-$(VER) && cp -Rf packaging/debian ./ && dpkg-buildpackage -us -uc -b && popd
+	cp -f ~/$(COMPONENT)*.deb ~/debbuild/
+# >>>>
+
+WHEELDIR ?= /tmp/wheelhouse
+ST2_COMPONENT := $(notdir $(CURDIR))
+ST2PKG_RELEASE ?= 1
+ST2PKG_VERSION ?= $(shell python -c "from $(ST2_COMPONENT) import __version__; print __version__,")
+
+ifneq (,$(wildcard /etc/debian_version))
+	DEBIAN := 1
+	DESTDIR ?= $(CURDIR)/debian/$(ST2_COMPONENT)
+else
+	REDHAT := 1
+endif
+
+.PHONY: all install wheelhouse
+all: install
+
+install: wheelhouse injectdeps changelog
+
+post_install: bdist_wheel
+
+populate_version: .stamp-populate_version
+.stamp-populate_version:
+	# populate version should be run before any pip/setup.py works
+	sh ../scripts/populate-version.sh
+	touch $@
+
+requirements:
+	python ../scripts/fixate-requirements.py -s in-requirements.txt -f ../fixed-requirements.txt
+
+changelog: populate_version
+ifeq ($(DEBIAN),1)
+	debchange -v $(ST2PKG_VERSION)-$(ST2PKG_RELEASE) -M "automated build version: $(ST2PKG_VERSION)"
+endif
+
+wheelhouse: .stamp-wheelhouse
+.stamp-wheelhouse: populate_version requirements
+	# Install wheels into shared location
+	pip wheel --wheel-dir=$(WHEELDIR) -r requirements.txt
+	touch $@
+
+injectdeps: .stamp-injectdeps
+.stamp-injectdeps:
+	# We can modify requirements ONLY AFTER wheelhouse has been built
+	@echo "st2common" >> requirements.txt
+	touch $@
+
+bdist_wheel: .stamp-bdist_wheel
+.stamp-bdist_wheel: populate_version
+	python setup.py bdist_wheel -d $(WHEELDIR)
+	touch $@

--- a/st2tests/dist_utils.py
+++ b/st2tests/dist_utils.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from pip.req import parse_requirements
+
+__all__ = [
+    'fetch_requirements',
+    'apply_vagrant_workaround'
+]
+
+
+def fetch_requirements(requirements_file_path):
+    """
+    Return a list of requirements and links by parsing the provided requirements file.
+    """
+    links = []
+    reqs = []
+    for req in parse_requirements(requirements_file_path, session=False):
+        if req.link:
+            links.append(str(req.link))
+        reqs.append(str(req.req))
+    return (reqs, links)
+
+
+def apply_vagrant_workaround():
+    """
+    Function which detects if the script is being executed inside vagrant and if it is, it deletes
+    "os.link" attribute.
+    Note: Without this workaround, setup.py sdist will fail when running inside a shared directory
+    (nfs / virtualbox shared folders).
+    """
+    if os.environ.get('USER', None) == 'vagrant':
+        del os.link

--- a/st2tests/in-requirements.txt
+++ b/st2tests/in-requirements.txt
@@ -1,0 +1,3 @@
+# Remeber to list implicit packages here, otherwise version won't be fixated!
+mock
+nosetests

--- a/st2tests/in-requirements.txt
+++ b/st2tests/in-requirements.txt
@@ -1,3 +1,5 @@
 # Remeber to list implicit packages here, otherwise version won't be fixated!
 mock
-nosetests
+unittest2
+nose
+rednose

--- a/st2tests/setup.py
+++ b/st2tests/setup.py
@@ -14,25 +14,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os.path
 
-try:
-    from setuptools import setup, find_packages
-except ImportError:
-    from ez_setup import use_setuptools
-    use_setuptools()
-    from setuptools import setup, find_packages
+from setuptools import setup, find_packages
 
+from dist_utils import fetch_requirements
+from dist_utils import apply_vagrant_workaround
+from st2tests import __version__
+
+ST2_COMPONENT = 'st2tests'
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
+
+install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
+
+apply_vagrant_workaround()
 setup(
-    name='st2tests',
-    version='0.4.0',
-    description='',
+    name=ST2_COMPONENT,
+    version=__version__,
+    description='{}'.format(ST2_COMPONENT),
     author='StackStorm',
     author_email='info@stackstorm.com',
-    install_requires=[
-        "pecan",
-    ],
-    test_suite='st2tests',
+    install_requires=install_reqs,
+    dependency_links=dep_links,
+    test_suite=ST2_COMPONENT,
     zip_safe=False,
     include_package_data=True,
-    packages=find_packages(exclude=['ez_setup'])
+    packages=find_packages(exclude=['setuptools', 'tests'])
 )

--- a/st2tests/st2tests/__init__.py
+++ b/st2tests/st2tests/__init__.py
@@ -13,6 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from st2tests.base import EventletTestCase, DbTestCase, DbModelTestCase
+from st2tests.base import EventletTestCase
+from st2tests.base import DbTestCase
+from st2tests.base import DbModelTestCase
 
-__all__ = ['EventletTestCase', 'DbTestCase', 'DbModelTestCase']
+__all__ = [
+    'EventletTestCase',
+    'DbTestCase',
+    'DbModelTestCase'
+]


### PR DESCRIPTION
This is a first step needed which will allow us to create Python package from `st2tests` and include it in the rpm / deb distributions.

Including it in those distributions, will among other things, allow users to run `st2-run-pack-tests` directly on StackStorm package based installations.