### PR TITLE
Don't import module to read version string inside st2tests setup.py

### DIFF
--- a/st2tests/setup.py
+++ b/st2tests/setup.py
@@ -30,9 +30,10 @@ INIT_FILE = os.path.join(BASE_DIR, 'st2tests/__init__.py')
 
 install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 
-# Note: we can't directly import __version__ from __init__ because of aliased
-# imports in init which would result in setup.py requiring eventlet and other
-# dependencies to run
+# Note: we can't directly import __version__ from __init__ because of aliased imports in init
+# which would result in setup.py requiring eventlet and other dependencies to run.
+
+
 def get_version_string():
     with open(INIT_FILE, 'r') as fp:
         content = fp.read()
@@ -42,6 +43,7 @@ def get_version_string():
             return version_match.group(1)
 
         raise RuntimeError('Unable to find version string.')
+
 
 apply_vagrant_workaround()
 setup(

--- a/st2tests/setup.py
+++ b/st2tests/setup.py
@@ -14,24 +14,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 import os.path
 
 from setuptools import setup, find_packages
 
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
-from st2tests import __version__
 
 ST2_COMPONENT = 'st2tests'
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
+INIT_FILE = os.path.join(BASE_DIR, 'st2tests/__init__.py')
+
 
 install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
+
+# Note: we can't directly import __version__ from __init__ because of aliased
+# imports in init which would result in setup.py requiring eventlet and other
+# dependencies to run
+def get_version_string():
+    with open(INIT_FILE, 'r') as fp:
+        content = fp.read()
+        version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                                  content, re.M)
+        if version_match:
+            return version_match.group(1)
+
+        raise RuntimeError('Unable to find version string.')
 
 apply_vagrant_workaround()
 setup(
     name=ST2_COMPONENT,
-    version=__version__,
+    version=get_version_string(),
     description='{}'.format(ST2_COMPONENT),
     author='StackStorm',
     author_email='info@stackstorm.com',


### PR DESCRIPTION
Instead of importing `__version__` from `__init__` module we now read version by parsing the file as text.


Because of the aliased imports inside `__init__.py` we can't import version from there directly. If we import it, this will require all the st2common dependencies to be installed for every invocation of `setup.py` which is undesirable - those dependencies are only required during run-time, but not during "compile" time aka during setup.py invocation phase (see https://circleci.com/gh/StackStorm/st2-packages/2014?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link).

I actually wanted to refactor the code to get rid of the aliased imports in st2tests.__init__.py, but after wasting 2 hours of my precious time I decided to give up and go with this approach.

The problem with this refactor is that simply too much code depends on import ordering and config file only getting parsed once and most of the tests work out of pure luck and could and will break if some import order changes or similar.

Real solution (as discussed many times in the past already) would be refactoring the whole config reading and parsing code into a proper  application wide "bootstrap" phase where config is consistently loaded and parser. Sadly this is not something which can be done in an afternoon. It would require a lot of refactoring and moving things around and probably 2-3 weeks of work to get it really solid.

Note: This "parse version from file content" approach is actually quite common in Python world, but this doesn't mean it's ideal - usually it means code smell aka __init__.py is doing something which shouldn't be doing.