### PR TITLE
Update st2-run-pack-tests to only install global test dependencies when ST2_REPO_PATH variable is set

### DIFF
--- a/st2common/bin/st2-run-pack-tests
+++ b/st2common/bin/st2-run-pack-tests
@@ -30,6 +30,10 @@ function join { local IFS="$1"; shift; echo "$*"; }
 ###########
 
 # A list of dependencies which are installed and available to every pack tests
+# Note: Those only need to be installed when running this script standalone
+# outside of StackStorm package installation.
+# When using StackStorm package installation, those dependencies are already
+# available (they are installed by st2tests package).
 PACK_TEST_PYTHON_DEPENDENCIES=(
     'mock>=1.3.0,<2.0'
     'unittest2>=1.1.0,<2.0'
@@ -202,13 +206,13 @@ if [ "${JUST_TESTS}" = false ]; then
         echo "Installing dependencies from st2 repository..."
         pip install --cache-dir ${HOME}/.pip-cache -q -r ${ST2_REPO_PATH}/requirements.txt
         pip install --cache-dir ${HOME}/.pip-cache -q -r ${ST2_REPO_PATH}/test-requirements.txt
-    fi
 
-    # Install global test dependencies
-    echo "Installing global pack test dependencies..."
-    for dependency in ${PACK_TEST_PYTHON_DEPENDENCIES[@]}; do
-        pip install --cache-dir ${HOME}/.pip-cache ${ST2_PIP_OPTIONS} "${dependency}"
-    done
+        # Install global test dependencies
+        echo "Installing global pack test dependencies..."
+        for dependency in ${PACK_TEST_PYTHON_DEPENDENCIES[@]}; do
+            pip install --cache-dir ${HOME}/.pip-cache ${ST2_PIP_OPTIONS} "${dependency}"
+        done
+    fi
 
     # Install pack dependencies
     if [ -f ${PACK_REQUIREMENTS_FILE} ]; then

--- a/st2common/bin/st2-run-pack-tests
+++ b/st2common/bin/st2-run-pack-tests
@@ -39,7 +39,7 @@ PACK_TEST_PYTHON_DEPENDENCIES_NAMES=(
     'nose'
 )
 PACK_TEST_PYTHON_DEPENDENCIES_VERSIONS=(
-    '>=1.3.0,<2.0'
+    '>=2.0,2.1'
     '>=1.1.0,<2.0'
     '>=1.3.7'
 )
@@ -217,7 +217,7 @@ if [ "${JUST_TESTS}" = false ]; then
     INSTALLED_PIP_PACKAGES=$(pip list)
 
     echo "Installing global pack test dependencies..."
-    for((i=0; i < ${#PACK_TEST_PYTHON_DEPENDENCIES_NAMES[@]}; i++)); do
+    for((i = 0; i < ${#PACK_TEST_PYTHON_DEPENDENCIES_NAMES[@]}; i++)); do
         DEPENDENCY_NAME="${PACK_TEST_PYTHON_DEPENDENCIES_NAMES[$i]}"
         DEPENDENCY_VERSION="${PACK_TEST_PYTHON_DEPENDENCIES_VERSIONS[$i]}"
 

--- a/st2common/bin/st2-run-pack-tests
+++ b/st2common/bin/st2-run-pack-tests
@@ -30,15 +30,20 @@ function join { local IFS="$1"; shift; echo "$*"; }
 ###########
 
 # A list of dependencies which are installed and available to every pack tests
-# Note: Those only need to be installed when running this script standalone
-# outside of StackStorm package installation.
-# When using StackStorm package installation, those dependencies are already
+# Note: Those only need to be installed when running this script standalone outside of StackStorm
+# package installation. When using StackStorm package installation, those dependencies are already
 # available (they are installed by st2tests package).
-PACK_TEST_PYTHON_DEPENDENCIES=(
-    'mock>=1.3.0,<2.0'
-    'unittest2>=1.1.0,<2.0'
-    'nose>=1.3.7'
+PACK_TEST_PYTHON_DEPENDENCIES_NAMES=(
+    'mock'
+    'unittest2'
+    'nose'
 )
+PACK_TEST_PYTHON_DEPENDENCIES_VERSIONS=(
+    '>=1.3.0,<2.0'
+    '>=1.1.0,<2.0'
+    '>=1.3.7'
+)
+
 VIRTUALENVS_DIR="/tmp/st2-pack-tests-virtualenvs"
 
 ###########
@@ -206,13 +211,18 @@ if [ "${JUST_TESTS}" = false ]; then
         echo "Installing dependencies from st2 repository..."
         pip install --cache-dir ${HOME}/.pip-cache -q -r ${ST2_REPO_PATH}/requirements.txt
         pip install --cache-dir ${HOME}/.pip-cache -q -r ${ST2_REPO_PATH}/test-requirements.txt
-
-        # Install global test dependencies
-        echo "Installing global pack test dependencies..."
-        for dependency in ${PACK_TEST_PYTHON_DEPENDENCIES[@]}; do
-            pip install --cache-dir ${HOME}/.pip-cache ${ST2_PIP_OPTIONS} "${dependency}"
-        done
     fi
+
+    # Install global test dependencies
+    INSTALLED_PIP_PACKAGES=$(pip list)
+
+    echo "Installing global pack test dependencies..."
+    for((i=0; i < ${#PACK_TEST_PYTHON_DEPENDENCIES_NAMES[@]}; i++)); do
+        DEPENDENCY_NAME="${PACK_TEST_PYTHON_DEPENDENCIES_NAMES[$i]}"
+        DEPENDENCY_VERSION="${PACK_TEST_PYTHON_DEPENDENCIES_VERSIONS[$i]}"
+
+        echo ${INSTALLED_PIP_PACKAGES} | grep "${DEPENDENCY_NAME}"  > /dev/null || pip install --cache-dir ${HOME}/.pip-cache ${ST2_PIP_OPTIONS} "${DEPENDENCY_NAME}${DEPENDENCY_VERSION}"
+    done
 
     # Install pack dependencies
     if [ -f ${PACK_REQUIREMENTS_FILE} ]; then
@@ -225,7 +235,6 @@ if [ "${JUST_TESTS}" = false ]; then
         echo "Installing pack-specific test dependencies..."
         pip install --cache-dir ${HOME}/.pip-cache ${ST2_PIP_OPTIONS} -r ${PACK_TESTS_REQUIREMENTS_FILE}
     fi
-
 fi
 
 # Set PYTHONPATH, make sure it contains st2 components in PYTHONPATH


### PR DESCRIPTION
This pull request updates `st2-run-pack-tests` script to only install global pack test dependencies when `ST2_REPO_PATH` environment variable is set.

When this variable is set, it means the script is likely running standalone outside of StackStorm package installation environment.

With recent changes and improvements to this script, the script now runs out of the box on new StackStorm package based installations where those global pack test dependencies are already available (they are installed and provided by `st2tests` package).

This change speeds things up when running multiple pack tests on a box where global pack test dependencies are available (e.g. `make .pack-tests` is now 10 seconds or so faster).