### PR TITLE
Fix "PUT /v1/configs" API endpoint not working when RBAC is enabled

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -116,6 +116,8 @@ in development
 * Fix a bug with not being able to apply some global permission types (permissions which are global
   and not specific to a resource) such as pack install, pack remove, pack search, etc. to a role
   using ``st2-apply-rbac-definitions``. (bug fix)
+* Fix a bug with pack configs API endpoint (``PUT /v1/configs/``) not working when RBAC was
+  enabled. (bug fix)
 
 2.1.1 - December 16, 2016
 -------------------------

--- a/st2api/st2api/controllers/v1/pack_configs.py
+++ b/st2api/st2api/controllers/v1/pack_configs.py
@@ -79,7 +79,7 @@ class PackConfigsController(ResourceController):
         # TODO: Make sure secret values are masked
         return self._get_one_by_pack_ref(pack_ref=pack_ref)
 
-    @request_user_has_permission(permission_type=PermissionType.PACK_CREATE)
+    @request_user_has_permission(permission_type=PermissionType.PACK_CONFIG)
     @jsexpose(body_cls=ConfigUpdateRequestAPI, arg_types=[str])
     def put(self, pack_uninstall_request, pack_ref):
         """

--- a/st2api/st2api/controllers/v1/pack_configs.py
+++ b/st2api/st2api/controllers/v1/pack_configs.py
@@ -83,7 +83,7 @@ class PackConfigsController(ResourceController):
     @jsexpose(body_cls=ConfigUpdateRequestAPI, arg_types=[str])
     def put(self, pack_uninstall_request, pack_ref):
         """
-            Create a new config for the action.
+            Create a new config for a pack.
 
             Handles requests:
                 POST /configs/<pack_ref>

--- a/st2api/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
+++ b/st2api/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
@@ -185,6 +185,22 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
                 'path': '/v1/packs/views/file/dummy_pack_1/pack.yaml',
                 'method': 'GET'
             },
+            # Pack configs
+            {
+                'path': '/v1/configs/',
+                'method': 'GET'
+            },
+            {
+                'path': '/v1/configs/dummy_pack_1',
+                'method': 'GET'
+            },
+            {
+                'path': '/v1/configs/dummy_pack_1',
+                'method': 'PUT',
+                'payload': {
+                    'foo': 'bar'
+                }
+            },
             # Sensors
             {
                 'path': '/v1/sensortypes',

--- a/st2common/st2common/rbac/resolvers.py
+++ b/st2common/st2common/rbac/resolvers.py
@@ -29,6 +29,7 @@ from st2common.constants.triggers import WEBHOOK_TRIGGER_TYPE
 from st2common.rbac.types import PermissionType
 from st2common.rbac.types import ResourceType
 from st2common.rbac.types import SystemRole
+from st2common.rbac.types import GLOBAL_PACK_PERMISSION_TYPES
 from st2common.services.rbac import get_roles_for_user
 from st2common.services.rbac import get_all_permission_grants_for_user
 
@@ -336,10 +337,7 @@ class PackPermissionsResolver(PermissionsResolver):
     resource_type = ResourceType.PACK
 
     def user_has_permission(self, user_db, permission_type):
-        assert permission_type in [PermissionType.PACK_LIST, PermissionType.PACK_INSTALL,
-                                   PermissionType.PACK_UNINSTALL, PermissionType.PACK_REGISTER,
-                                   PermissionType.PACK_SEARCH,
-                                   PermissionType.PACK_VIEW_INDEX_HEALTH]
+        assert permission_type in GLOBAL_PACK_PERMISSION_TYPES
 
         if permission_type == PermissionType.PACK_LIST:
             return self._user_has_list_permission(user_db=user_db, permission_type=permission_type)

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -28,6 +28,7 @@ __all__ = [
 
     'ALL_PERMISSION_TYPES',
     'GLOBAL_PERMISSION_TYPES',
+    'GLOBAL_PACK_PERMISSION_TYPES',
     'LIST_PERMISSION_TYPES'
 ]
 
@@ -55,6 +56,7 @@ class PermissionType(Enum):
     PACK_INSTALL = 'pack_install'
     PACK_UNINSTALL = 'pack_uninstall'
     PACK_REGISTER = 'pack_register'
+    PACK_CONFIG = 'pack_config'
     PACK_SEARCH = 'pack_search'
     PACK_VIEW_INDEX_HEALTH = 'pack_view_index_health'
 
@@ -236,6 +238,7 @@ RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP = {
         PermissionType.PACK_INSTALL,
         PermissionType.PACK_UNINSTALL,
         PermissionType.PACK_REGISTER,
+        PermissionType.PACK_CONFIG,
         PermissionType.PACK_SEARCH,
         PermissionType.PACK_VIEW_INDEX_HEALTH,
         PermissionType.PACK_ALL,
@@ -340,6 +343,7 @@ GLOBAL_PERMISSION_TYPES = [
     PermissionType.PACK_UNINSTALL,
     PermissionType.PACK_CREATE,
     PermissionType.PACK_REGISTER,
+    PermissionType.PACK_CONFIG,
     PermissionType.PACK_SEARCH,
     PermissionType.PACK_VIEW_INDEX_HEALTH,
 
@@ -347,6 +351,9 @@ GLOBAL_PERMISSION_TYPES = [
     PermissionType.ACTION_ALIAS_MATCH,
     PermissionType.ACTION_ALIAS_HELP
 ] + LIST_PERMISSION_TYPES
+
+GLOBAL_PACK_PERMISSION_TYPES = [permission_type for permission_type in GLOBAL_PERMISSION_TYPES if
+                                permission_type.startswith('pack_')]
 
 
 # Maps a permission type to the corresponding description
@@ -359,6 +366,7 @@ PERMISION_TYPE_TO_DESCRIPTION_MAP = {
     PermissionType.PACK_INSTALL: 'Ability to install packs.',
     PermissionType.PACK_UNINSTALL: 'Ability to uninstall packs.',
     PermissionType.PACK_REGISTER: 'Ability to register packs and corresponding resources.',
+    PermissionType.PACK_CONFIG: 'Ability to configure a pack.',
     PermissionType.PACK_SEARCH: 'Ability to query registry and search packs.',
     PermissionType.PACK_VIEW_INDEX_HEALTH: 'Ability to query health of pack registries.',
     PermissionType.PACK_ALL: ('Ability to perform all the supported operations on a particular '


### PR DESCRIPTION
When we introduced pack configs related API endpoints (#2964) we didn't add corresponding API RBAC tests we have for every other API endpoint (`st2api/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py`) so we didn't catch an issue with pack config API endpoint not working when RBAC is enabled.

The issue has been fixed by introducing new global "pack_config" permission type which is needed to configure a pack instead of (incorrectly) using existing "pack_create".

 Resolves #3283.

Thanks again to @efenian for reporting it and @LindsayHill for confirming.