### PR TITLE
Disable filewatch sensor by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,8 @@ in development
   backends can advertise functionality they support (e.g. authenticate a user, retrieve information
   about a particular user, retrieve a list of groups a particular user is a member of).
   (new feature)
+* Linux file watch sensor is now disabled by default. To enable it, set ``enabled: true`` in
+  ``/opt/stackstorm/packs/linux/sensors/file_watch_sensor.yaml``
 
 2.2.0 - February 27, 2017
 -------------------------

--- a/contrib/linux/sensors/file_watch_sensor.yaml
+++ b/contrib/linux/sensors/file_watch_sensor.yaml
@@ -1,5 +1,6 @@
 ---
   class_name: "FileWatchSensor"
+  enabled: false
   entry_point: "file_watch_sensor.py"
   description: "Sensor which monitors files for new lines"
   trigger_types:


### PR DESCRIPTION
These errors in a default installation get tedious
```
2017-03-16 02:16:11,449 140717658023568 ERROR (unknown file) [-] Traceback (most recent call last):

2017-03-16 02:16:11,449 140717658023568 ERROR (unknown file) [-]   File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2reactor/container/sensor_wrapper.py", line 357, in <module>

2017-03-16 02:16:11,450 140717658023568 ERROR (unknown file) [-]
2017-03-16 02:16:11,450 140717658023568 ERROR (unknown file) [-] obj.run()

2017-03-16 02:16:11,450 140717658023568 ERROR (unknown file) [-]   File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2reactor/container/sensor_wrapper.py", line 214, in run

2017-03-16 02:16:11,450 140717658023568 ERROR (unknown file) [-]
2017-03-16 02:16:11,450 140717658023568 ERROR (unknown file) [-] self._sensor_instance.setup()

2017-03-16 02:16:11,450 140717658023568 ERROR (unknown file) [-]   File "/opt/stackstorm/packs/linux/sensors/file_watch_sensor.py", line 20, in setup

2017-03-16 02:16:11,450 140717658023568 ERROR (unknown file) [-]
2017-03-16 02:16:11,450 140717658023568 ERROR (unknown file) [-] raise ValueError('No file_paths configured to monitor')
```

This change sets the sensor to disabled by default, so people will need to enable it.