### PR TITLE
Refactor endpoints to get rid of kwargs

### DIFF
--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -118,19 +118,22 @@ class ResourceController(object):
 
         self.get_one_db_method = self._get_by_name_or_id
 
-    def get_all(self, **kwargs):
-        return self._get_all(**kwargs)
+    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
+        return self._get_all(sort=sort,
+                             offset=offset,
+                             limit=limit,
+                             raw_filters=raw_filters)
 
     def get_one(self, id):
         return self._get_one_by_id(id=id)
 
     def _get_all(self, exclude_fields=None, sort=None, offset=0, limit=None, query_options=None,
-                 from_model_kwargs=None, **raw_filters):
+                 from_model_kwargs=None, raw_filters=None):
         """
         :param exclude_fields: A list of object fields to exclude.
         :type exclude_fields: ``list``
         """
-        raw_filters = copy.deepcopy(raw_filters)
+        raw_filters = copy.deepcopy(raw_filters) or {}
 
         exclude_fields = exclude_fields or []
         query_options = query_options if query_options else self.query_options
@@ -356,8 +359,11 @@ class ContentPackResourceController(ResourceController):
     def get_one(self, ref_or_id, from_model_kwargs=None):
         return self._get_one(ref_or_id, from_model_kwargs=from_model_kwargs)
 
-    def get_all(self, **kwargs):
-        return self._get_all(**kwargs)
+    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
+        return self._get_all(sort=sort,
+                             offset=offset,
+                             limit=limit,
+                             raw_filters=raw_filters)
 
     def _get_one(self, ref_or_id, exclude_fields=None, from_model_kwargs=None,
                  requester_user=None, permission_type=None, **kwargs):
@@ -382,8 +388,16 @@ class ContentPackResourceController(ResourceController):
 
         return Response(json=result)
 
-    def _get_all(self, **kwargs):
-        resp = super(ContentPackResourceController, self)._get_all(**kwargs)
+    def _get_all(self, exclude_fields=None, sort=None, offset=0, limit=None, query_options=None,
+                 from_model_kwargs=None, raw_filters=None):
+        resp = super(ContentPackResourceController,
+                     self)._get_all(exclude_fields=exclude_fields,
+                                    sort=sort,
+                                    offset=offset,
+                                    limit=limit,
+                                    query_options=query_options,
+                                    from_model_kwargs=from_model_kwargs,
+                                    raw_filters=raw_filters)
 
         if self.include_reference:
             result = resp.json

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -24,7 +24,6 @@ import six
 from six.moves import http_client
 
 from st2common import log as logging
-from st2common.models.system.common import InvalidResourceReferenceError
 from st2common.models.system.common import ResourceReference
 from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2common.rbac import utils as rbac_utils
@@ -126,12 +125,12 @@ class ResourceController(object):
         return self._get_one_by_id(id=id)
 
     def _get_all(self, exclude_fields=None, sort=None, offset=0, limit=None, query_options=None,
-                 from_model_kwargs=None, **kwargs):
+                 from_model_kwargs=None, **raw_filters):
         """
         :param exclude_fields: A list of object fields to exclude.
         :type exclude_fields: ``list``
         """
-        kwargs = copy.deepcopy(kwargs)
+        raw_filters = copy.deepcopy(raw_filters)
 
         exclude_fields = exclude_fields or []
         query_options = query_options if query_options else self.query_options
@@ -159,7 +158,7 @@ class ResourceController(object):
             db_sort_values.append(sort_value)
 
         default_sort_values = copy.copy(query_options.get('sort'))
-        kwargs['sort'] = db_sort_values if db_sort_values else default_sort_values
+        raw_filters['sort'] = db_sort_values if db_sort_values else default_sort_values
 
         # TODO: To protect us from DoS, we need to make max_limit mandatory
         offset = int(offset)
@@ -173,7 +172,7 @@ class ResourceController(object):
 
         filters = {}
         for k, v in six.iteritems(self.supported_filters):
-            filter_value = kwargs.get(k, None)
+            filter_value = raw_filters.get(k, None)
 
             if not filter_value:
                 continue
@@ -193,7 +192,7 @@ class ResourceController(object):
             instances = instances.limit(limit)
 
         from_model_kwargs = from_model_kwargs or {}
-        from_model_kwargs.update(self._get_from_model_kwargs_for_request(**kwargs))
+        from_model_kwargs.update(self.from_model_kwargs)
 
         result = []
         for instance in instances[offset:eop]:
@@ -229,7 +228,7 @@ class ResourceController(object):
             abort(http_client.NOT_FOUND, msg)
 
         from_model_kwargs = from_model_kwargs or {}
-        from_model_kwargs.update(self._get_from_model_kwargs_for_request(**kwargs))
+        from_model_kwargs.update(self.from_model_kwargs)
         result = self.model.from_model(instance, **from_model_kwargs)
 
         return result
@@ -253,7 +252,7 @@ class ResourceController(object):
             abort(http_client.NOT_FOUND, msg)
 
         from_model_kwargs = from_model_kwargs or {}
-        from_model_kwargs.update(self._get_from_model_kwargs_for_request(**kwargs))
+        from_model_kwargs.update(self.from_model_kwargs)
         result = self.model.from_model(instance, **from_model_kwargs)
 
         return result
@@ -266,7 +265,7 @@ class ResourceController(object):
             abort(http_client.NOT_FOUND, msg)
 
         from_model_kwargs = from_model_kwargs or {}
-        from_model_kwargs.update(self._get_from_model_kwargs_for_request(**kwargs))
+        from_model_kwargs.update(self.from_model_kwargs)
         result = self.model.from_model(instance, **from_model_kwargs)
 
         return result
@@ -311,16 +310,6 @@ class ResourceController(object):
             raise StackStormDBObjectNotFoundError(msg)
 
         return resource_db
-
-    def _get_from_model_kwargs_for_request(self, **kwargs):
-        """
-        Retrieve kwargs which are passed to "LiveActionAPI.model" method.
-
-        :param request: Pecan request object.
-
-        :rtype: ``dict``
-        """
-        return self.from_model_kwargs
 
     def _get_one_by_scope_and_name(self, scope, name, from_model_kwargs=None):
         """
@@ -384,7 +373,7 @@ class ContentPackResourceController(ResourceController):
                                                           permission_type=permission_type)
 
         from_model_kwargs = from_model_kwargs or {}
-        from_model_kwargs.update(self._get_from_model_kwargs_for_request(**kwargs))
+        from_model_kwargs.update(self.from_model_kwargs)
         result = self.model.from_model(instance, **from_model_kwargs)
         if result and self.include_reference:
             pack = getattr(result, 'pack', None)
@@ -440,19 +429,3 @@ class ContentPackResourceController(ResourceController):
         resource_db = self.access.query(name=ref.name, pack=ref.pack,
                                         exclude_fields=exclude_fields).first()
         return resource_db
-
-    def _get_filters(self, **kwargs):
-        filters = copy.deepcopy(kwargs)
-        ref = filters.get('ref', None)
-
-        if ref:
-            try:
-                ref_obj = ResourceReference.from_string_reference(ref=ref)
-            except InvalidResourceReferenceError:
-                raise
-
-            filters['name'] = ref_obj.name
-            filters['pack'] = ref_obj.pack
-            del filters['ref']
-
-        return filters

--- a/st2api/st2api/controllers/v1/actionalias.py
+++ b/st2api/st2api/controllers/v1/actionalias.py
@@ -63,8 +63,11 @@ class ActionAliasController(resource.ContentPackResourceController):
             'representation': match[2]
         }
 
-    def get_all(self, **kwargs):
-        return super(ActionAliasController, self)._get_all(**kwargs)
+    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
+        return super(ActionAliasController, self)._get_all(sort=sort,
+                                                           offset=offset,
+                                                           limit=limit,
+                                                           raw_filters=raw_filters)
 
     def get_one(self, ref_or_id, requester_user):
         permission_type = PermissionType.ACTION_ALIAS_VIEW
@@ -72,7 +75,7 @@ class ActionAliasController(resource.ContentPackResourceController):
                                                            requester_user=requester_user,
                                                            permission_type=permission_type)
 
-    def match(self, action_alias_match_api, **kwargs):
+    def match(self, action_alias_match_api):
         """
             Run a chatops command
 
@@ -82,7 +85,7 @@ class ActionAliasController(resource.ContentPackResourceController):
         command = action_alias_match_api.command
         try:
             # 1. Get aliases
-            aliases_resp = super(ActionAliasController, self)._get_all(**kwargs)
+            aliases_resp = super(ActionAliasController, self)._get_all()
             aliases = [ActionAliasAPI(**alias) for alias in aliases_resp.json]
             # 2. Match alias(es) to command
             matches = match_command_to_alias(command, aliases)

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -416,7 +416,7 @@ class ActionExecutionsController(ActionExecutionsControllerMixin, ResourceContro
                                            offset=offset,
                                            limit=limit,
                                            query_options=query_options,
-                                           **raw_filters)
+                                           raw_filters=raw_filters)
 
     def get_one(self, id, requester_user, exclude_attributes=None):
         """
@@ -493,7 +493,7 @@ class ActionExecutionsController(ActionExecutionsControllerMixin, ResourceContro
         return ActionExecutionAPI.from_model(execution_db, mask_secrets=(not show_secrets))
 
     def _get_action_executions(self, exclude_fields=None, sort=None, offset=0, limit=None,
-                               query_options=None, **raw_filters):
+                               query_options=None, raw_filters=None):
         """
         :param exclude_fields: A list of object fields to exclude.
         :type exclude_fields: ``list``
@@ -510,7 +510,7 @@ class ActionExecutionsController(ActionExecutionsControllerMixin, ResourceContro
                                                                 offset=offset,
                                                                 limit=limit,
                                                                 query_options=query_options,
-                                                                **raw_filters)
+                                                                raw_filters=raw_filters)
 
 
 action_executions_controller = ActionExecutionsController()

--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -78,14 +78,18 @@ class ActionsController(resource.ContentPackResourceController):
         super(ActionsController, self).__init__(*args, **kwargs)
         self._trigger_dispatcher = TriggerDispatcher(LOG)
 
-    def get_all(self, exclude_attributes=None, **kwargs):
+    def get_all(self, exclude_attributes=None, sort=None, offset=0, limit=None, **raw_filters):
         if exclude_attributes:
             exclude_fields = exclude_attributes.split(',')
         else:
             exclude_fields = None
 
         exclude_fields = self._validate_exclude_fields(exclude_fields)
-        return super(ActionsController, self)._get_all(exclude_fields=exclude_fields, **kwargs)
+        return super(ActionsController, self)._get_all(exclude_fields=exclude_fields,
+                                                       sort=sort,
+                                                       offset=offset,
+                                                       limit=limit,
+                                                       raw_filters=raw_filters)
 
     def get_one(self, ref_or_id, requester_user):
         return super(ActionsController, self)._get_one(ref_or_id, requester_user=requester_user,

--- a/st2api/st2api/controllers/v1/actionviews.py
+++ b/st2api/st2api/controllers/v1/actionviews.py
@@ -108,14 +108,17 @@ class OverviewController(resource.ContentPackResourceController):
         resp.json = result
         return resp
 
-    def get_all(self, **kwargs):
+    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
         """
             List all actions.
 
             Handles requests:
                 GET /actions/views/overview
         """
-        resp = super(OverviewController, self)._get_all(**kwargs)
+        resp = super(OverviewController, self)._get_all(sort=sort,
+                                                        offset=offset,
+                                                        limit=limit,
+                                                        raw_filters=raw_filters)
         result = []
         for item in resp.json:
             action_api = ActionAPI(**item)
@@ -136,7 +139,7 @@ class EntryPointController(resource.ContentPackResourceController):
 
     supported_filters = {}
 
-    def get_all(self, **kwargs):
+    def get_all(self):
         return abort(404)
 
     def get_one(self, ref_or_id):

--- a/st2api/st2api/controllers/v1/auth.py
+++ b/st2api/st2api/controllers/v1/auth.py
@@ -88,7 +88,7 @@ class ApiKeyController(BaseRestControllerMixin):
             LOG.exception('Failed to serialize API key.')
             abort(http_client.INTERNAL_SERVER_ERROR, str(e))
 
-    def get_all(self, requester_user, show_secrets=None, **kw):
+    def get_all(self, requester_user, show_secrets=None):
         """
             List all keys.
 
@@ -97,7 +97,7 @@ class ApiKeyController(BaseRestControllerMixin):
         """
         mask_secrets = self._get_mask_secrets(show_secrets=show_secrets,
                                               requester_user=requester_user)
-        api_key_dbs = ApiKey.get_all(**kw)
+        api_key_dbs = ApiKey.get_all()
         api_keys = [ApiKeyAPI.from_model(api_key_db, mask_secrets=mask_secrets)
                     for api_key_db in api_key_dbs]
 

--- a/st2api/st2api/controllers/v1/keyvalue.py
+++ b/st2api/st2api/controllers/v1/keyvalue.py
@@ -105,7 +105,7 @@ class KeyValuePairController(ResourceController):
         return kvp_api
 
     def get_all(self, prefix=None, scope=FULL_SYSTEM_SCOPE, user=None, requester_user=None,
-                decrypt=False, **kwargs):
+                decrypt=False, sort=None, offset=0, limit=None, **raw_filters):
         """
             List all keys.
 
@@ -141,23 +141,25 @@ class KeyValuePairController(ResourceController):
                                                              user=user)
 
         from_model_kwargs = {'mask_secrets': not decrypt}
-        kwargs['prefix'] = prefix
 
         if scope and scope not in ALL_SCOPE:
             self._validate_scope(scope=scope)
-            kwargs['scope'] = scope
+            raw_filters['scope'] = scope
 
         if scope == USER_SCOPE or scope == FULL_USER_SCOPE:
             # Make sure we only returned values scoped to current user
-            if kwargs['prefix']:
-                kwargs['prefix'] = get_key_reference(name=kwargs['prefix'], scope=scope,
-                                                     user=user)
+            if prefix:
+                prefix = get_key_reference(name=prefix, scope=scope, user=user)
             else:
-                kwargs['prefix'] = get_key_reference(name='', scope=scope,
-                                                     user=user)
+                prefix = get_key_reference(name='', scope=scope, user=user)
+
+        raw_filters['prefix'] = prefix
 
         kvp_apis = super(KeyValuePairController, self)._get_all(from_model_kwargs=from_model_kwargs,
-                                                                **kwargs)
+                                                                sort=sort,
+                                                                offset=offset,
+                                                                limit=limit,
+                                                                raw_filters=raw_filters)
         return kvp_apis
 
     def put(self, kvp, name, requester_user=None, scope=FULL_SYSTEM_SCOPE):

--- a/st2api/st2api/controllers/v1/pack_config_schemas.py
+++ b/st2api/st2api/controllers/v1/pack_config_schemas.py
@@ -40,7 +40,7 @@ class PackConfigSchemasController(ResourceController):
         # this case, RBAC is checked on the parent PackDB object
         self.get_one_db_method = packs_service.get_pack_by_ref
 
-    def get_all(self, **kwargs):
+    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
         """
         Retrieve config schema for all the packs.
 
@@ -48,7 +48,10 @@ class PackConfigSchemasController(ResourceController):
             GET /config_schema/
         """
 
-        return super(PackConfigSchemasController, self)._get_all(**kwargs)
+        return super(PackConfigSchemasController, self)._get_all(sort=sort,
+                                                                 offset=offset,
+                                                                 limit=limit,
+                                                                 raw_filters=raw_filters)
 
     def get_one(self, pack_ref, requester_user):
         """

--- a/st2api/st2api/controllers/v1/pack_configs.py
+++ b/st2api/st2api/controllers/v1/pack_configs.py
@@ -53,7 +53,7 @@ class PackConfigsController(ResourceController):
         # this case, RBAC is checked on the parent PackDB object
         self.get_one_db_method = packs_service.get_pack_by_ref
 
-    def get_all(self, **kwargs):
+    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
         """
         Retrieve configs for all the packs.
 
@@ -62,7 +62,10 @@ class PackConfigsController(ResourceController):
         """
         # TODO: Make sure secret values are masked
 
-        return super(PackConfigsController, self)._get_all(**kwargs)
+        return super(PackConfigsController, self)._get_all(sort=sort,
+                                                           offset=offset,
+                                                           limit=limit,
+                                                           raw_filters=raw_filters)
 
     def get_one(self, pack_ref, requester_user):
         """

--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -232,8 +232,7 @@ class BasePacksController(ResourceController):
             abort(http_client.NOT_FOUND, msg)
             return
 
-        from_model_kwargs = self._get_from_model_kwargs_for_request()
-        result = self.model.from_model(instance, **from_model_kwargs)
+        result = self.model.from_model(instance, **self.from_model_kwargs)
 
         return result
 

--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -287,8 +287,11 @@ class PacksController(BasePacksController):
         super(PacksController, self).__init__()
         self.get_one_db_method = self._get_by_ref_or_id
 
-    def get_all(self, **kwargs):
-        return super(PacksController, self)._get_all(**kwargs)
+    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
+        return super(PacksController, self)._get_all(sort=sort,
+                                                     offset=offset,
+                                                     limit=limit,
+                                                     raw_filters=raw_filters)
 
     def get_one(self, ref_or_id, requester_user):
         return self._get_one_by_ref_or_id(ref_or_id=ref_or_id, requester_user=requester_user)

--- a/st2api/st2api/controllers/v1/packviews.py
+++ b/st2api/st2api/controllers/v1/packviews.py
@@ -61,7 +61,7 @@ class BaseFileController(BasePacksController):
     supported_filters = {}
     query_options = {}
 
-    def get_all(self, **kwargs):
+    def get_all(self):
         return abort(404)
 
     def _get_file_size(self, file_path):

--- a/st2api/st2api/controllers/v1/packviews.py
+++ b/st2api/st2api/controllers/v1/packviews.py
@@ -172,7 +172,8 @@ class FileController(BaseFileController):
     Controller which allows user to retrieve content of a specific file in a pack.
     """
 
-    def get_one(self, ref_or_id, file_path, requester_user, **kwargs):
+    def get_one(self, ref_or_id, file_path, requester_user, if_none_match=None,
+                if_modified_since=None):
         """
             Outputs the content of a specific file in a pack.
 
@@ -206,7 +207,9 @@ class FileController(BaseFileController):
 
         response = Response()
 
-        if not self._is_file_changed(file_mtime, **kwargs):
+        if not self._is_file_changed(file_mtime,
+                                     if_none_match=if_none_match,
+                                     if_modified_since=if_modified_since):
             response.status = http_client.NOT_MODIFIED
         else:
             if file_size is not None and file_size > MAX_FILE_SIZE:
@@ -225,10 +228,7 @@ class FileController(BaseFileController):
 
         return response
 
-    def _is_file_changed(self, file_mtime, **kwargs):
-        if_none_match = kwargs.get('if-none-match', None)
-        if_modified_since = kwargs.get('if-modified-since', None)
-
+    def _is_file_changed(self, file_mtime, if_none_match=None, if_modified_since=None):
         # For if_none_match check against what would be the ETAG value
         if if_none_match:
             return repr(file_mtime) != if_none_match

--- a/st2api/st2api/controllers/v1/policies.py
+++ b/st2api/st2api/controllers/v1/policies.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
-
 from mongoengine import ValidationError
 from six.moves import http_client
 
@@ -23,7 +21,6 @@ from st2common import log as logging
 from st2common.exceptions.apivalidation import ValueValidationException
 from st2common.models.api.policy import PolicyTypeAPI, PolicyAPI
 from st2common.models.db.policy import PolicyTypeReference
-from st2common.models.system.common import InvalidReferenceError
 from st2common.persistence.policy import PolicyType, Policy
 from st2common.validators.api.misc import validate_not_part_of_system_pack
 from st2common.exceptions.db import StackStormDBObjectNotFoundError
@@ -105,22 +102,6 @@ class PolicyTypeController(resource.ResourceController):
 
         resource_db = self.access.query(name=ref.name, resource_type=ref.resource_type).first()
         return resource_db
-
-    def _get_filters(self, **kwargs):
-        filters = copy.deepcopy(kwargs)
-        ref = filters.get('ref', None)
-
-        if ref:
-            try:
-                ref_obj = PolicyTypeReference.from_string_reference(ref=ref)
-            except InvalidReferenceError:
-                raise
-
-            filters['name'] = ref_obj.name
-            filters['resource_type'] = ref_obj.resource_type
-            del filters['ref']
-
-        return filters
 
 
 class PolicyController(resource.ContentPackResourceController):

--- a/st2api/st2api/controllers/v1/policies.py
+++ b/st2api/st2api/controllers/v1/policies.py
@@ -47,8 +47,11 @@ class PolicyTypeController(resource.ResourceController):
     def get_one(self, ref_or_id):
         return self._get_one(ref_or_id)
 
-    def get_all(self, **kwargs):
-        return self._get_all(**kwargs)
+    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
+        return self._get_all(sort=sort,
+                             offset=offset,
+                             limit=limit,
+                             raw_filters=raw_filters)
 
     def _get_one(self, ref_or_id):
         instance = self._get_by_ref_or_id(ref_or_id=ref_or_id)
@@ -61,8 +64,16 @@ class PolicyTypeController(resource.ResourceController):
 
         return result
 
-    def _get_all(self, **kwargs):
-        resp = super(PolicyTypeController, self)._get_all(**kwargs)
+    def _get_all(self, exclude_fields=None, sort=None, offset=0, limit=None, query_options=None,
+                 from_model_kwargs=None, raw_filters=None):
+
+        resp = super(PolicyTypeController, self)._get_all(exclude_fields=exclude_fields,
+                                                          sort=sort,
+                                                          offset=offset,
+                                                          limit=limit,
+                                                          query_options=query_options,
+                                                          from_model_kwargs=from_model_kwargs,
+                                                          raw_filters=raw_filters)
 
         if self.include_reference:
             result = resp.json
@@ -121,8 +132,11 @@ class PolicyController(resource.ContentPackResourceController):
     def get_one(self, ref_or_id):
         return self._get_one(ref_or_id)
 
-    def get_all(self, **kwargs):
-        return self._get_all(**kwargs)
+    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
+        return self._get_all(sort=sort,
+                             offset=offset,
+                             limit=limit,
+                             raw_filters=raw_filters)
 
     def post(self, instance):
         """

--- a/st2api/st2api/controllers/v1/rule_enforcements.py
+++ b/st2api/st2api/controllers/v1/rule_enforcements.py
@@ -57,8 +57,11 @@ class RuleEnforcementController(resource.ResourceController):
         'enforced_at_lt': lambda value: isotime.parse(value=value)
     }
 
-    def get_all(self, **kwargs):
-        return super(RuleEnforcementController, self)._get_all(**kwargs)
+    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
+        return super(RuleEnforcementController, self)._get_all(sort=sort,
+                                                               offset=offset,
+                                                               limit=limit,
+                                                               raw_filters=raw_filters)
 
     def get_one(self, id, requester_user):
         return super(RuleEnforcementController,

--- a/st2api/st2api/controllers/v1/rule_enforcements.py
+++ b/st2api/st2api/controllers/v1/rule_enforcements.py
@@ -60,10 +60,10 @@ class RuleEnforcementController(resource.ResourceController):
     def get_all(self, **kwargs):
         return super(RuleEnforcementController, self)._get_all(**kwargs)
 
-    def get_one(self, ref_or_id, requester_user):
+    def get_one(self, id, requester_user):
         return super(RuleEnforcementController,
-                     self)._get_one(ref_or_id, requester_user=requester_user,
-                                    permission_type=PermissionType.RULE_ENFORCEMENT_VIEW)
+                     self)._get_one_by_id(id, requester_user=requester_user,
+                                          permission_type=PermissionType.RULE_ENFORCEMENT_VIEW)
 
 
 rule_enforcements_controller = RuleEnforcementController()

--- a/st2api/st2api/controllers/v1/rules.py
+++ b/st2api/st2api/controllers/v1/rules.py
@@ -65,9 +65,13 @@ class RuleController(resource.ContentPackResourceController):
 
     include_reference = True
 
-    def get_all(self, **kwargs):
+    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
         from_model_kwargs = {'ignore_missing_trigger': True}
-        return super(RuleController, self)._get_all(from_model_kwargs=from_model_kwargs, **kwargs)
+        return super(RuleController, self)._get_all(from_model_kwargs=from_model_kwargs,
+                                                    sort=sort,
+                                                    offset=offset,
+                                                    limit=limit,
+                                                    raw_filters=raw_filters)
 
     def get_one(self, ref_or_id, requester_user):
         from_model_kwargs = {'ignore_missing_trigger': True}

--- a/st2api/st2api/controllers/v1/ruletypes.py
+++ b/st2api/st2api/controllers/v1/ruletypes.py
@@ -60,14 +60,14 @@ class RuleTypesController(object):
         ruletype_api = RuleTypeAPI.from_model(ruletype_db)
         return ruletype_api
 
-    def get_all(self, **kw):
+    def get_all(self):
         """
             List all RuleType objects.
 
             Handles requests:
                 GET /ruletypes/
         """
-        ruletype_dbs = RuleType.get_all(**kw)
+        ruletype_dbs = RuleType.get_all()
         ruletype_apis = [RuleTypeAPI.from_model(runnertype_db)
                          for runnertype_db in ruletype_dbs]
         return ruletype_apis

--- a/st2api/st2api/controllers/v1/ruleviews.py
+++ b/st2api/st2api/controllers/v1/ruleviews.py
@@ -83,8 +83,11 @@ class RuleViewController(resource.ContentPackResourceController):
 
     include_reference = True
 
-    def get_all(self, **kwargs):
-        rules = self._get_all(**kwargs)
+    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
+        rules = self._get_all(sort=sort,
+                              offset=offset,
+                              limit=limit,
+                              raw_filters=raw_filters)
         result = self._append_view_properties(rules.json)
         rules.json = result
         return rules

--- a/st2api/st2api/controllers/v1/runnertypes.py
+++ b/st2api/st2api/controllers/v1/runnertypes.py
@@ -45,8 +45,11 @@ class RunnerTypesController(ResourceController):
         'sort': ['name']
     }
 
-    def get_all(self, **kwargs):
-        return super(RunnerTypesController, self)._get_all(**kwargs)
+    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
+        return super(RunnerTypesController, self)._get_all(sort=sort,
+                                                           offset=offset,
+                                                           limit=limit,
+                                                           raw_filters=raw_filters)
 
     def get_one(self, name_or_id, requester_user):
         return self._get_one_by_name_or_id(name_or_id,

--- a/st2api/st2api/controllers/v1/sensors.py
+++ b/st2api/st2api/controllers/v1/sensors.py
@@ -45,8 +45,11 @@ class SensorTypeController(resource.ContentPackResourceController):
 
     include_reference = True
 
-    def get_all(self, **kwargs):
-        return super(SensorTypeController, self)._get_all(**kwargs)
+    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
+        return super(SensorTypeController, self)._get_all(sort=sort,
+                                                          offset=offset,
+                                                          limit=limit,
+                                                          raw_filters=raw_filters)
 
     def get_one(self, ref_or_id, requester_user):
         permission_type = PermissionType.SENSOR_VIEW

--- a/st2api/st2api/controllers/v1/traces.py
+++ b/st2api/st2api/controllers/v1/traces.py
@@ -36,16 +36,20 @@ class TracesController(ResourceController):
         'sort': ['-start_timestamp', 'trace_tag']
     }
 
-    def get_all(self, **kwargs):
+    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
         # Use a custom sort order when filtering on a timestamp so we return a correct result as
         # expected by the user
         query_options = None
-        if 'sort_desc' in kwargs:
+        if 'sort_desc' in raw_filters:
             query_options = {'sort': ['-start_timestamp', 'action.ref']}
-        elif 'sort_asc' in kwargs:
+        elif 'sort_asc' in raw_filters:
             query_options = {'sort': ['+start_timestamp', 'action.ref']}
 
-        return self._get_all(query_options=query_options, **kwargs)
+        return self._get_all(sort=sort,
+                             offset=offset,
+                             limit=limit,
+                             query_options=query_options,
+                             raw_filters=raw_filters)
 
 
 traces_controller = TracesController()

--- a/st2api/st2api/controllers/v1/traces.py
+++ b/st2api/st2api/controllers/v1/traces.py
@@ -39,14 +39,13 @@ class TracesController(ResourceController):
     def get_all(self, **kwargs):
         # Use a custom sort order when filtering on a timestamp so we return a correct result as
         # expected by the user
+        query_options = None
         if 'sort_desc' in kwargs:
             query_options = {'sort': ['-start_timestamp', 'action.ref']}
-            kwargs['query_options'] = query_options
         elif 'sort_asc' in kwargs:
             query_options = {'sort': ['+start_timestamp', 'action.ref']}
-            kwargs['query_options'] = query_options
 
-        return self._get_all(**kwargs)
+        return self._get_all(query_options=query_options, **kwargs)
 
 
 traces_controller = TracesController()

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -377,21 +377,24 @@ class TriggerInstanceController(TriggerInstanceControllerMixin, resource.Resourc
         """
         return self._get_one_by_id(instance_id)
 
-    def get_all(self, **kw):
+    def get_all(self, limit=None, **kw):
         """
             List all triggerinstances.
 
             Handles requests:
                 GET /triggerinstances/
         """
-        trigger_instances = self._get_trigger_instances(**kw)
+        trigger_instances = self._get_trigger_instances(limit=limit, **kw)
         return trigger_instances
 
-    def _get_trigger_instances(self, **kw):
-        kw['limit'] = int(kw.get('limit') or self.default_limit)
+    def _get_trigger_instances(self, limit=None, **kw):
+        if limit is None:
+            limit = self.default_limit
+
+        limit = int(limit)
 
         LOG.debug('Retrieving all trigger instances with filters=%s', kw)
-        return super(TriggerInstanceController, self)._get_all(**kw)
+        return super(TriggerInstanceController, self)._get_all(limit=limit, **kw)
 
 
 triggertype_controller = TriggerTypeController()

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -326,7 +326,7 @@ class TriggerInstanceResendController(TriggerInstanceControllerMixin, resource.R
             POST /triggerinstance/<id>/re_send
         """
         # Note: We only really need parameters here
-        existing_trigger_instance = self._get_one(id=trigger_instance_id)
+        existing_trigger_instance = self._get_one_by_id(id=trigger_instance_id)
 
         new_payload = copy.deepcopy(existing_trigger_instance.payload)
         new_payload['__context'] = {
@@ -375,7 +375,7 @@ class TriggerInstanceController(TriggerInstanceControllerMixin, resource.Resourc
             Handle:
                 GET /triggerinstances/1
         """
-        return self._get_one(instance_id)
+        return self._get_one_by_id(instance_id)
 
     def get_all(self, **kw):
         """

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -204,14 +204,14 @@ class TriggerController(object):
         trigger_api = TriggerAPI.from_model(trigger_db)
         return trigger_api
 
-    def get_all(self, **kw):
+    def get_all(self):
         """
             List all triggers.
 
             Handles requests:
                 GET /triggers/
         """
-        trigger_dbs = Trigger.get_all(**kw)
+        trigger_dbs = Trigger.get_all()
         trigger_apis = [TriggerAPI.from_model(trigger_db) for trigger_db in trigger_dbs]
         return trigger_apis
 
@@ -377,24 +377,30 @@ class TriggerInstanceController(TriggerInstanceControllerMixin, resource.Resourc
         """
         return self._get_one_by_id(instance_id)
 
-    def get_all(self, limit=None, **kw):
+    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
         """
             List all triggerinstances.
 
             Handles requests:
                 GET /triggerinstances/
         """
-        trigger_instances = self._get_trigger_instances(limit=limit, **kw)
+        trigger_instances = self._get_trigger_instances(sort=sort,
+                                                        offset=offset,
+                                                        limit=limit,
+                                                        raw_filters=raw_filters)
         return trigger_instances
 
-    def _get_trigger_instances(self, limit=None, **kw):
+    def _get_trigger_instances(self, sort=None, offset=0, limit=None, raw_filters=None):
         if limit is None:
             limit = self.default_limit
 
         limit = int(limit)
 
-        LOG.debug('Retrieving all trigger instances with filters=%s', kw)
-        return super(TriggerInstanceController, self)._get_all(limit=limit, **kw)
+        LOG.debug('Retrieving all trigger instances with filters=%s', raw_filters)
+        return super(TriggerInstanceController, self)._get_all(sort=sort,
+                                                               offset=offset,
+                                                               limit=limit,
+                                                               raw_filters=raw_filters)
 
 
 triggertype_controller = TriggerTypeController()

--- a/st2api/st2api/controllers/v1/webhooks.py
+++ b/st2api/st2api/controllers/v1/webhooks.py
@@ -109,7 +109,6 @@ class WebhooksController(object):
         # For demonstration purpose return 1st
         return triggers[0]
 
-    # @request_user_has_webhook_permission(permission_type=PermissionType.WEBHOOK_SEND)
     def post(self, hook, body, headers, requester_user):
         body = vars(body)
 

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -669,6 +669,7 @@ paths:
           type: boolean
         - name: st2-context
           in: header
+          x-as: context_string
           description: Additional execution context
           type: string
       x-parameters:
@@ -2467,14 +2468,14 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-  /api/v1/ruleenforcements/{ref_or_id}:
+  /api/v1/ruleenforcements/{id}:
     get:
       operationId: st2api.controllers.v1.rule_enforcements:rule_enforcements_controller.get_one
       description: Return a specific rule enforcement based on id.
       parameters:
-        - name: ref_or_id
+        - name: id
           in: path
-          description: entities id
+          description: Entity id
           type: string
       x-parameters:
         - name: user

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -934,6 +934,20 @@ paths:
           in: query
           description: Entity owner
           type: string
+        - name: limit
+          in: query
+          description: Number of actions to get
+          type: integer
+          default: 100
+        - name: offset
+          in: query
+          description: Number of actions offset
+          type: integer
+          default: 0
+        - name: sort
+          in: query
+          description: Comma-separated list of fields to sort by
+          type: string
         - name: id
           in: query
           description: Entity id filter
@@ -1071,13 +1085,33 @@ paths:
       x-permissions: {{ PERMISSION_TYPE.PACK_LIST }}
       description: Get list of installed packs.
       parameters:
+        - name: limit
+          in: query
+          description: Number of actions to get
+          type: integer
+          default: 100
+        - name: offset
+          in: query
+          description: Number of actions offset
+          type: integer
+          default: 0
+        - name: sort
+          in: query
+          description: Comma-separated list of fields to sort by
+          type: string
+        - name: id
+          in: query
+          description: Entity id filter
+          type: array
+          items:
+            type: string
         - name: name
           in: query
-          description: Name of a pack
+          description: Entity name filter
           type: string
         - name: ref
           in: query
-          description: ref for a pack
+          description: Entity ref filter
           type: string
       responses:
         '200':
@@ -1320,6 +1354,33 @@ paths:
       operationId: st2api.controllers.v1.pack_configs:pack_configs_controller.get_all
       x-permissions: {{ PERMISSION_TYPE.PACK_LIST }}
       description: Retrieve configs for all the packs.
+      parameters:
+        - name: limit
+          in: query
+          description: Number of actions to get
+          type: integer
+          default: 100
+        - name: offset
+          in: query
+          description: Number of actions offset
+          type: integer
+          default: 0
+        - name: sort
+          in: query
+          description: Comma-separated list of fields to sort by
+          type: string
+        - name: id
+          in: query
+          description: Entity id filter
+          type: array
+          items:
+            type: string
+        - name: name
+          in: query
+          description: Entity name filter
+          type: array
+          items:
+            type: string
       responses:
         '200':
           description: Get packs config.
@@ -1397,6 +1458,33 @@ paths:
       operationId: st2api.controllers.v1.pack_config_schemas:pack_config_schema_controller.get_all
       x-permissions: {{ PERMISSION_TYPE.PACK_LIST }}
       description: Retrieve config schema for all the packs.
+      parameters:
+        - name: limit
+          in: query
+          description: Number of actions to get
+          type: integer
+          default: 100
+        - name: offset
+          in: query
+          description: Number of actions offset
+          type: integer
+          default: 0
+        - name: sort
+          in: query
+          description: Comma-separated list of fields to sort by
+          type: string
+        - name: id
+          in: query
+          description: Entity id filter
+          type: array
+          items:
+            type: string
+        - name: name
+          in: query
+          description: Entity name filter
+          type: array
+          items:
+            type: string
       responses:
         '200':
           description: Get packs config schema.
@@ -1449,10 +1537,32 @@ paths:
           in: query
           description: Policy type resource type
           type: string
+        - name: limit
+          in: query
+          description: Number of actions to get
+          type: integer
+          default: 100
+        - name: offset
+          in: query
+          description: Number of actions offset
+          type: integer
+          default: 0
+        - name: sort
+          in: query
+          description: Comma-separated list of fields to sort by
+          type: string
+        - name: id
+          in: query
+          description: Entity id filter
+          type: array
+          items:
+            type: string
         - name: name
           in: query
-          description: Policy type name
-          type: string
+          description: Entity name filter
+          type: array
+          items:
+            type: string
       responses:
         '200':
           description: List of policy types
@@ -2045,8 +2155,18 @@ paths:
           required: false
         - name: limit
           in: query
-          description: Number of entities to get
+          description: Number of actions to get
           type: integer
+          default: 100
+        - name: offset
+          in: query
+          description: Number of actions offset
+          type: integer
+          default: 0
+        - name: sort
+          in: query
+          description: Comma-separated list of fields to sort by
+          type: string
         - name: id
           in: query
           description: Entity id filter
@@ -2056,23 +2176,9 @@ paths:
         - name: name
           in: query
           description: Entity name filter
-          type: string
-        - name: pack
-          in: query
-          description: Entity pack name filter
-          type: string
-        - name: action
-          in: query
-          description: Action ref filter
-          type: string
-        - name: trigger
-          in: query
-          description: Trigger filter
-          type: string
-        - name: enabled
-          in: query
-          description: Enabled filter
-          type: string
+          type: array
+          items:
+            type: string
       responses:
         '200':
           description: List of rules
@@ -2427,6 +2533,27 @@ paths:
           description: List N most recent rule enforcements.
           type: string
           default: 50
+        - name: offset
+          in: query
+          description: Number of actions offset
+          type: integer
+          default: 0
+        - name: sort
+          in: query
+          description: Comma-separated list of fields to sort by
+          type: string
+        - name: id
+          in: query
+          description: Entity id filter
+          type: array
+          items:
+            type: string
+        - name: name
+          in: query
+          description: Entity name filter
+          type: array
+          items:
+            type: string
         - name: execution
           in: query
           description: Execution to filter the list.
@@ -2554,10 +2681,30 @@ paths:
       parameters:
         - name: limit
           in: query
-          description: Limit number of traces.
+          description: Number of actions to get
           type: integer
-          # required: true
-          # default: 50
+          default: 100
+        - name: offset
+          in: query
+          description: Number of actions offset
+          type: integer
+          default: 0
+        - name: sort
+          in: query
+          description: Comma-separated list of fields to sort by
+          type: string
+        - name: id
+          in: query
+          description: Entity id filter
+          type: array
+          items:
+            type: string
+        - name: name
+          in: query
+          description: Entity name filter
+          type: array
+          items:
+            type: string
         - name: trace_tag
           in: query
           description: Trace-tag to filter the list.
@@ -2854,6 +3001,28 @@ paths:
           in: query
           description: Number of actions to get
           type: integer
+          default: 100
+        - name: offset
+          in: query
+          description: Number of actions offset
+          type: integer
+          default: 0
+        - name: sort
+          in: query
+          description: Comma-separated list of fields to sort by
+          type: string
+        - name: id
+          in: query
+          description: Entity id filter
+          type: array
+          items:
+            type: string
+        - name: name
+          in: query
+          description: Entity name filter
+          type: array
+          items:
+            type: string
         - name: trigger
           in: query
           description: Trigger filter

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -1293,10 +1293,12 @@ paths:
           required: true
         - name: if-none-match
           in: header
+          x-as: if_none_match
           description: ETag to compare to.
           type: string
         - name: if-modified-since
           in: header
+          x-as: if_modified_since
           description: Date of last known modification.
           type: string
       x-parameters:


### PR DESCRIPTION
As @Kami pointed in https://github.com/StackStorm/st2/pull/2727#discussion_r103643612, using `**kwargs` in controllers require user to constantly keep in mind the list of parameters available for the particular controller or get back and forth between code and spec.

Luckily, as it turns out, we no longer need to use `**kwargs` in most cases and it's just a matter of refactoring.

The point of this PR is to replace the use of kwargs in every controller it is possible to do and justify it's use in the rest of them.