### PR TITLE
Fix traceback duplication in ErrorHandlingMiddleware

### DIFF
--- a/st2common/st2common/middleware/error_handling.py
+++ b/st2common/st2common/middleware/error_handling.py
@@ -81,7 +81,6 @@ class ErrorHandlingMiddleware(object):
 
             if is_internal_server_error:
                 LOG.exception('API call failed: %s', error_msg, extra=extra)
-                LOG.exception(traceback.format_exc())
             else:
                 LOG.debug('API call failed: %s', error_msg, extra=extra)
 


### PR DESCRIPTION
`LOG.exception` already includes a traceback. No need to log it a second time.