### PR TITLE
Branch for testing build system fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,7 +42,7 @@ Changelog
   StackStorm now also supports using ``consul``, ``etcd`` and other new backends supported by
   tooz for coordination. (improvement)
 * Various security related improvements in the enterprise LDAP auth backend. (improvement,
-  bug fix)
+  bug fix) 
 
 2.2.0 - February 27, 2017
 -------------------------


### PR DESCRIPTION
Test branch to test the fix from - https://github.com/StackStorm/st2ci/pull/80.

The fix makes sure each st2 pr uses correct corresponding st2-packages branch. Previously all the builds used st2-packages master branch which means PR's opened against version branches would fail in case st2-packages master contained backward incompatible changes.