### PR TITLE
Preinitialize modules during route registration

### DIFF
--- a/st2common/st2common/router.py
+++ b/st2common/st2common/router.py
@@ -178,6 +178,9 @@ class Router(object):
                     for transform in transforms[filter]:
                         m.connect(None, re.sub(filter, transform, path), **connect_kw)
 
+                    module_name = endpoint['operationId'].split(':', 1)[0]
+                    __import__(module_name)
+
         for route in sorted(self.routes.matchlist, key=lambda r: r.routepath):
             LOG.debug('Route registered: %+6s %s', route.conditions['method'][0], route.routepath)
 


### PR DESCRIPTION
That was the initial intention, but it somehow slipped through the cracks.

If you don't import controller modules during server initialization, it would happen on the first request to the controller within the module. It would a) create a delay on this first request and b) cause a race on endpoints like `/webhooks` or `/stream` which require more time to properly initialize.