### PR TITLE
Fix router to only check rbac on endpoints with security

### DIFF
--- a/st2api/tests/base.py
+++ b/st2api/tests/base.py
@@ -63,6 +63,8 @@ class APIControllerWithRBACTestCase(FunctionalTest, CleanDbTestCase):
     Base test case class for testing API controllers with RBAC enabled.
     """
 
+    enable_auth = True
+
     @classmethod
     def setUpClass(cls):
         super(APIControllerWithRBACTestCase, cls).setUpClass()

--- a/st2common/st2common/router.py
+++ b/st2common/st2common/router.py
@@ -278,17 +278,17 @@ class Router(object):
                 LOG.exception('API key is disabled.')
                 return abort_unauthorized(str(e))
 
-        if cfg.CONF.rbac.enable:
-            user_db = context['user']
+            if cfg.CONF.rbac.enable:
+                user_db = context['user']
 
-            permission_type = endpoint.get('x-permissions', None)
-            if permission_type:
-                resolver = resolvers.get_resolver_for_permission_type(permission_type)
-                has_permission = resolver.user_has_permission(user_db, permission_type)
+                permission_type = endpoint.get('x-permissions', None)
+                if permission_type:
+                    resolver = resolvers.get_resolver_for_permission_type(permission_type)
+                    has_permission = resolver.user_has_permission(user_db, permission_type)
 
-                if not has_permission:
-                    raise rbac_exc.ResourceTypeAccessDeniedError(user_db,
-                                                                 permission_type)
+                    if not has_permission:
+                        raise rbac_exc.ResourceTypeAccessDeniedError(user_db,
+                                                                     permission_type)
 
         # Collect parameters
         kw = {}


### PR DESCRIPTION
Auth service were raising 500 on endpoint with no security definition (`/auth/v1/tokens`) when RBAC is enabled.

Since RBAC always require auth to be enabled, no reason to check RBAC and authentication flags independently.

Also, all RBAC related tests should now flip auth flag too.