### PR TITLE
Support arbitrary TTLs for service (system) access tokens, associate some metadata with service tokens

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -57,6 +57,14 @@ in development
   Note: This functionality is currently implemented for enterprise LDAP auth backend and only
   available in enterprise edition.
   (new feature)
+* Update the code so user can specify arbitrary default TTL for access tokens in ``st2.conf`` and
+  all the StackStorm services which rely on access tokens still work.
+
+  Previously, the lowest TTL user could specify for all the services to still work was 24 hours.
+  This has been fixed and the default TTL specified in the config now only affects user access
+  tokens and services use special service access tokens with no max TTL limit. (bug fix)
+
+  Reported by Jiang Wei. #3314 #3315
 
 2.2.0 - February 27, 2017
 -------------------------

--- a/st2actions/st2actions/container/base.py
+++ b/st2actions/st2actions/container/base.py
@@ -72,7 +72,8 @@ class RunnerContainer(object):
     def _do_run(self, runner, runnertype_db, action_db, liveaction_db):
         # Create a temporary auth token which will be available
         # for the duration of the action execution.
-        runner.auth_token = self._create_auth_token(runner.context)
+        runner.auth_token = self._create_auth_token(context=runner.context, action_db=action_db,
+                                                    liveaction_db=liveaction_db)
 
         updated_liveaction_db = None
         try:
@@ -262,13 +263,22 @@ class RunnerContainer(object):
 
         return runner
 
-    def _create_auth_token(self, context):
+    def _create_auth_token(self, context, action_db, liveaction_db):
         if not context:
             return None
+
         user = context.get('user', None)
         if not user:
             return None
-        return access.create_token(user)
+
+        metadata = {
+            'service': 'actions_container'
+            'action_name': action_db.name,
+            'live_action_id': str(liveaction_db.id)
+
+        }
+        token_db = access.create_token(username=user, metadata=metadata, service=True)
+        return token_db
 
     def _delete_auth_token(self, auth_token):
         if auth_token:

--- a/st2actions/st2actions/container/base.py
+++ b/st2actions/st2actions/container/base.py
@@ -272,7 +272,7 @@ class RunnerContainer(object):
             return None
 
         metadata = {
-            'service': 'actions_container'
+            'service': 'actions_container',
             'action_name': action_db.name,
             'live_action_id': str(liveaction_db.id)
 

--- a/st2common/st2common/models/db/auth.py
+++ b/st2common/st2common/models/db/auth.py
@@ -33,10 +33,10 @@ __all__ = [
 class UserDB(stormbase.StormFoundationDB):
     """
     An entity representing system user.
-    
+
     Attribute:
-        name: Username. Also used as a primary key and foreign key when referencing users
-              in other models.
+        name: Username. Also used as a primary key and foreign key when referencing users in other
+              models.
         is_service: True if this is a service account.
         nicknames: Nickname + origin pairs for ChatOps auth.
     """

--- a/st2common/st2common/models/db/auth.py
+++ b/st2common/st2common/models/db/auth.py
@@ -66,7 +66,7 @@ class TokenDB(stormbase.StormFoundationDB):
     expiry = me.DateTimeField(required=True)
     metadata = me.DictField(required=False,
                             help_text='Arbitrary metadata associated with this token')
-    service = me.StringField(required=True, default=False)
+    service = me.BooleanField(required=True, default=False)
 
 
 class ApiKeyDB(stormbase.StormFoundationDB, stormbase.UIDFieldMixin):

--- a/st2common/st2common/models/db/auth.py
+++ b/st2common/st2common/models/db/auth.py
@@ -51,16 +51,25 @@ class UserDB(stormbase.StormFoundationDB):
 
 
 class TokenDB(stormbase.StormFoundationDB):
+    """
+    An entity representing an access token.
+
+    Attribute:
+        user: Reference to the user this token belongs to (username).
+        token: Random access token.
+        expiry: Date when this token expires.
+        service: True if this is a service (system) token.
+    """
+
     user = me.StringField(required=True)
     token = me.StringField(required=True, unique=True)
     expiry = me.DateTimeField(required=True)
     metadata = me.DictField(required=False,
                             help_text='Arbitrary metadata associated with this token')
+    service = me.StringField(required=True, default=False)
 
 
 class ApiKeyDB(stormbase.StormFoundationDB, stormbase.UIDFieldMixin):
-    """
-    """
     RESOURCE_TYPE = ResourceType.API_KEY
     UID_FIELDS = ['key_hash']
 

--- a/st2reactor/st2reactor/container/process_container.py
+++ b/st2reactor/st2reactor/container/process_container.py
@@ -291,7 +291,7 @@ class ProcessSensorContainer(object):
 
         # Include full api URL and API token specific to that sensor
         ttl = (24 * 60 * 60)
-        temporary_token = create_token(username='sensors_container', ttl=ttl)
+        temporary_token = create_token(username='sensors_container', ttl=ttl, service=True)
 
         env[API_URL_ENV_VARIABLE_NAME] = get_full_public_api_url()
         env[AUTH_TOKEN_ENV_VARIABLE_NAME] = temporary_token.token

--- a/st2reactor/st2reactor/container/process_container.py
+++ b/st2reactor/st2reactor/container/process_container.py
@@ -291,7 +291,13 @@ class ProcessSensorContainer(object):
 
         # Include full api URL and API token specific to that sensor
         ttl = (24 * 60 * 60)
-        temporary_token = create_token(username='sensors_container', ttl=ttl, service=True)
+        metadata = {
+            'service': 'sensors_container',
+            'sensor_path': sensor['file_path'],
+            'sensor_class': sensor['class_name']
+        }
+        temporary_token = create_token(username='sensors_container', ttl=ttl, metadata=metadata,
+                                       service=True)
 
         env[API_URL_ENV_VARIABLE_NAME] = get_full_public_api_url()
         env[AUTH_TOKEN_ENV_VARIABLE_NAME] = temporary_token.token


### PR DESCRIPTION
This pull request introduces a concept of "service" (system) tokens which can have arbitrary TTL associated with them.

In addition to that it also stores some metadata with service tokens so it's easier to distinguish between service and user-level access tokens.

Previously only way to distinguish between user and service tokens in the database was by the "user" field and that approach was very fragile.

Now that we have additional metadata and "service" attribute on the token model it's easy to, for example, just purge all the user access tokens (e.g. to force all the users to re-authenticate), but leave service tokens untouched.

It resolves "issue" reported in #3314.
