### PR TITLE
Fix dependency version specified in st2-run-pack-tests-tool

### DIFF
--- a/st2common/bin/st2-run-pack-tests
+++ b/st2common/bin/st2-run-pack-tests
@@ -39,7 +39,7 @@ PACK_TEST_PYTHON_DEPENDENCIES_NAMES=(
     'nose'
 )
 PACK_TEST_PYTHON_DEPENDENCIES_VERSIONS=(
-    '>=2.0,2.1'
+    '>=2.0,<2.1'
     '>=1.1.0,<2.0'
     '>=1.3.7'
 )


### PR DESCRIPTION
Noticed a small issue while testing latest v2.2.1 packages.

The issue would only affect people who directly use this tool from git master, but not people who run it on a system where StackStorm was installed using packages.

In any case, I would still propose to include this in v2.2.1.