### PR TITLE
Fix pack permissions when running 'st2-self-check'

### DIFF
--- a/st2common/bin/st2-self-check
+++ b/st2common/bin/st2-self-check
@@ -89,9 +89,9 @@ if [ ${EXIT_CODE} -ne 0 ]; then
 fi
 
 echo "Copying asserts, fixtures, tests and examples packs."
-cp -R st2tests/packs/* /opt/stackstorm/packs/
-cp -Rf /usr/share/doc/st2/examples /opt/stackstorm/packs/
-
+chown -R root:st2packs st2tests/packs/
+cp -R --preserve st2tests/packs/* /opt/stackstorm/packs/
+cp -Rf --preserve /usr/share/doc/st2/examples /opt/stackstorm/packs/
 
 echo "Installing asserts, fixtures, tests and examples packs."
 st2 run packs.setup_virtualenv packs=examples,tests,asserts,fixtures,webui


### PR DESCRIPTION
Without correct `root:st2pack` pack permissions running workflow `examples` in `BWC` fails with API 500 error:

```sh
2017-03-30 17:22:00,115 140522965661968 ERROR hooks [-] API call failed: [Errno 13] Permission denied: u'/opt/stackstorm/packs/examples/actions/workflows/mistral-error-bad-task-transition.yaml'
Traceback (most recent call last):
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/pecan/core.py", line 631, in __call__
    self.invoke_controller(controller, args, kwargs, state)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/pecan/core.py", line 531, in invoke_controller
    result = controller(*args, **kwargs)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/rbac/decorators.py", line 122, in func_wrapper
    return func(*args, **kwargs)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/models/api/base.py", line 284, in callfunction
    raise e
IOError: [Errno 13] Permission denied: u'/opt/stackstorm/packs/examples/actions/workflows/mistral-error-bad-task-transition.yaml' (_exception_data={},_exception_class='IOError',_exception_message="[Errno 13] Permission denied: u'/opt/stackstorm/packs/examples/actions/workflows/mistral-error-bad-task-transition.yaml'")
2017-03-30 17:22:00,136 140522965661968 ERROR hooks [-] Traceback (most recent call last):
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/pecan/core.py", line 631, in __call__
    self.invoke_controller(controller, args, kwargs, state)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/pecan/core.py", line 531, in invoke_controller
    result = controller(*args, **kwargs)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/rbac/decorators.py", line 122, in func_wrapper
    return func(*args, **kwargs)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/models/api/base.py", line 284, in callfunction
    raise e
IOError: [Errno 13] Permission denied: u'/opt/stackstorm/packs/examples/actions/workflows/mistral-error-bad-task-transition.yaml'
Traceback (most recent call last):
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/pecan/core.py", line 631, in __call__
    self.invoke_controller(controller, args, kwargs, state)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/pecan/core.py", line 531, in invoke_controller
    result = controller(*args, **kwargs)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/rbac/decorators.py", line 122, in func_wrapper
    return func(*args, **kwargs)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/models/api/base.py", line 284, in callfunction
    raise e
IOError: [Errno 13] Permission denied: u'/opt/stackstorm/packs/examples/actions/workflows/mistral-error-bad-task-transition.yaml'
2017-03-30 17:22:00,136 140522965661968 INFO hooks [-] 659304d7-5e78-4af3-8233-6b9603b519ec - PUT /v1/actions/58dd26ef5d698e2eee644bcb result={
    "faultstring": "Internal Server Error"
} (result='{\n    "faultstring": "Internal Server Error"\n}',request_id='659304d7-5e78-4af3-8233-6b9603b519ec',status_code='500 Internal Server Error',remote_addr='127.0.0.1',path='/v1/actions/58dd26ef5d698e2eee644bcb',method='PUT')

```