### PR TITLE
Create forloop chain in the example pack

### DIFF
--- a/contrib/examples/actions/chains/forloop_chain.yaml
+++ b/contrib/examples/actions/chains/forloop_chain.yaml
@@ -1,0 +1,43 @@
+---
+  chain:
+    -
+      name: "get_github_page"
+      ref: "examples.forloop_get_github_page"
+      parameters:
+        url: "{{github_organization_url}}"
+        page: "{% if increase_index_and_check_condition is defined %}{{increase_index_and_check_condition.result}}{% endif %}"
+      on-success: "parse_github_repos"
+      on-failure: "failed"
+    -
+      name: "parse_github_repos"
+      ref: "examples.forloop_parse_github_repos"
+      parameters:
+        content: "{{get_github_page.result}}"
+      on-success: "push_github_repos"
+      on-failure: "failed"
+    -
+      name: "push_github_repos"
+      ref: "examples.forloop_push_github_repos"
+      parameters:
+        data_to_push: "{{parse_github_repos.result}}"
+      on-success: "increase_index_and_check_condition"
+      on-failure: "failed"
+    -
+      name: "increase_index_and_check_condition"
+      ref: "examples.forloop_increase_index_and_check_condition"
+      parameters:
+        index: "{% if increase_index_and_check_condition is defined %}{{increase_index_and_check_condition.result}}{% endif %}"
+        pagesize: "30"
+        input: "{{parse_github_repos.result}}"
+      on-success: "get_github_page"
+      on-failure: "finished"
+    -
+      name: "finished"
+      ref: "core.local"
+      parameters:
+        cmd: "exit 0"
+    -
+      name: "failed"
+      ref: "core.local"
+      parameters:
+        cmd: "exit 1"

--- a/contrib/examples/actions/forloop_chain.yaml
+++ b/contrib/examples/actions/forloop_chain.yaml
@@ -1,0 +1,12 @@
+---
+name: "forloop_chain"
+description: "Action Chain to loop over an organization github page and get all the repositories list"
+runner_type: "action-chain"
+entry_point: "chains/forloop_chain.yaml"
+enabled: true
+parameters:
+    github_organization_url:
+      type: "string" 
+      description: "Organization url to parse data from"
+      default: "https://github.com/StackStorm-Exchange"
+      required: false

--- a/contrib/examples/actions/forloop_get_github_page.yaml
+++ b/contrib/examples/actions/forloop_get_github_page.yaml
@@ -1,0 +1,15 @@
+---
+name: "forloop_get_github_page"
+runner_type: "python-script"
+description: "Action to get the contents of a github page with support to choose the page"
+enabled: true
+entry_point: "pythonactions/forloop_get_github_page.py"
+parameters:
+  url:
+    type: "string"
+    description: "Url of the page to be requested"
+    required: true
+  page:
+    type: "string"
+    description: "Page number to request"
+    required: false

--- a/contrib/examples/actions/forloop_increase_index_and_check_condition.yaml
+++ b/contrib/examples/actions/forloop_increase_index_and_check_condition.yaml
@@ -1,0 +1,19 @@
+---
+name: "forloop_increase_index_and_check_condition"
+runner_type: "python-script"
+description: "Increase a for-loop index by a certain value and return false if condition is broken"
+enabled: true
+entry_point: "pythonactions/forloop_increase_index_and_check_condition.py"
+parameters:
+  index:
+    type: "string"
+    description: "Index to be operated on"
+    required: true
+  pagesize:
+    type: "string"
+    description: "Expected number of items on each page"
+    required: true
+  input:
+    type: object
+    description: "Dataset to compare to the pagesize"
+    required: true

--- a/contrib/examples/actions/forloop_parse_github_repos.yaml
+++ b/contrib/examples/actions/forloop_parse_github_repos.yaml
@@ -1,0 +1,11 @@
+---
+name: "forloop_parse_github_repos"
+runner_type: "python-script"
+description: "Action to parse the data and make it readable"
+enabled: true
+entry_point: "pythonactions/forloop_parse_github_repos.py"
+parameters:
+  content:
+    type: "string"
+    description: "Complete html page of the github request"
+    required: true

--- a/contrib/examples/actions/forloop_push_github_repos.yaml
+++ b/contrib/examples/actions/forloop_push_github_repos.yaml
@@ -1,0 +1,11 @@
+---
+name: "forloop_push_github_repos"
+runner_type: "python-script"
+description: "Action to push the data to an external service"
+enabled: true
+entry_point: "pythonactions/forloop_push_github_repos.py"
+parameters:
+  data_to_push: 
+    type: "object"
+    description: "Dictonary of the data to be pushed"
+    required: true

--- a/contrib/examples/actions/pythonactions/forloop_get_github_page.py
+++ b/contrib/examples/actions/pythonactions/forloop_get_github_page.py
@@ -1,0 +1,10 @@
+from st2actions.runners.pythonrunner import Action
+import requests
+
+class ForloopGetGithubPage(Action):
+  def run(self, url, page="1"):
+    request = "{}?page={}".format(url, page)
+    response = requests.get(request)
+    if not response.ok:
+      return (False, "Could not request url: {}".format(request))
+    return (True, response.content)

--- a/contrib/examples/actions/pythonactions/forloop_increase_index_and_check_condition.py
+++ b/contrib/examples/actions/pythonactions/forloop_increase_index_and_check_condition.py
@@ -1,0 +1,18 @@
+from st2actions.runners.pythonrunner import Action
+
+class IncreaseIndexAndCheckCondition(Action):
+  def run(self, index, pagesize, input):
+    if pagesize and pagesize != '':
+      if len(input) < int(pagesize):
+        return (False, "Breaking out of the loop")
+    else:
+      pagesize = 0
+    if not index or index == '':
+        index = 1
+
+    print "index"
+    print type(index)
+    print "pagesize"
+    print type(pagesize)
+    return(True, int(index)+1)
+

--- a/contrib/examples/actions/pythonactions/forloop_parse_github_repos.py
+++ b/contrib/examples/actions/pythonactions/forloop_parse_github_repos.py
@@ -1,0 +1,18 @@
+from st2actions.runners.pythonrunner import Action
+from bs4 import BeautifulSoup
+
+class ParseGithubRepos(Action):
+  def run(self, content):
+    try:
+      soup = BeautifulSoup(content, 'html.parser')
+      repo_list = soup.find_all("h3")
+      output = {}
+      for each_item in repo_list:
+        repo_half_url = each_item.find("a")['href']
+        repo_name = repo_half_url.split("/")[-1]
+        repo_url = "https://github.com" + repo_half_url
+        output[repo_name] = repo_url
+    except Exception as e:
+      return (False, "Could not parse data: {}".format(e.message))
+
+    return (True, output)

--- a/contrib/examples/actions/pythonactions/forloop_push_github_repos.py
+++ b/contrib/examples/actions/pythonactions/forloop_push_github_repos.py
@@ -1,0 +1,12 @@
+from st2actions.runners.pythonrunner import Action
+
+class PushGithubRepos(Action):
+  def run(self, data_to_push):
+    try:
+      for each_item in data_to_push:
+        ## Push data to a service here
+        print str(each_item)
+    except Exception as e:
+      return (False, "Process failed: {}".format(e.message))
+
+    return (True, "Data pushed successfully")

--- a/contrib/examples/requirements.txt
+++ b/contrib/examples/requirements.txt
@@ -1,0 +1,2 @@
+requests
+beautifulsoup4


### PR DESCRIPTION
This is an example chain for a job that needs to be done in several steps because the bulk of each of the passes is bottlenecked (in the case I found, arguments between python calls cannot exceed 131072 characters). The "get_data" and the "push_data" actions can be from different packs if need be if they have support for "paging" on their requests.

If this feels valuable I could write something up more detailed as a blogpost to show how each of the steps work and post an example run and why anyone would want to use it. In this case, this is how it looks for now:

![forloop_chain](https://cloud.githubusercontent.com/assets/13749641/24627639/309f8998-187b-11e7-9507-f7e44d81d5f7.png)
