### PR TITLE
Fix heading underline

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@ Changelog
 =========
 
 2.2.1 - April 3, 2017
-----------------
+---------------------
 
 * Fix ``st2ctl reload`` command so it preserves exit code from `st2-register-content` script and
   correctly fails on failure by default.


### PR DESCRIPTION
Small formatting issue which could cause documentation build to fail when strict mode is enabled.