### PR TITLE
Filter out null from /executions/views/filters results (with tests)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,8 +26,8 @@ in development
   tokens and services use special service access tokens with no max TTL limit. (bug fix)
 
   Reported by Jiang Wei. #3314 #3315
-* Fix ``/executions/views/filters`` API endpoint to exclude empty (None / null) filter values.
-  (bug fix)
+* Update ``/executions/views/filters`` API endpoint so it excludes null / None from filter values
+  for fields where ``null`` is not a valid field value. (improvement)
 
   Contributed by Cody A. Ray. #3193
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,10 @@ in development
   tokens and services use special service access tokens with no max TTL limit. (bug fix)
 
   Reported by Jiang Wei. #3314 #3315
+* Fix ``/executions/views/filters`` API endpoint to exclude empty (None / null) filter values.
+  (bug fix)
+
+  Contributed by Cody A. Ray. #3193
 
 2.2.1 - April 3, 2017
 ---------------------

--- a/st2api/st2api/controllers/v1/executionviews.py
+++ b/st2api/st2api/controllers/v1/executionviews.py
@@ -42,6 +42,17 @@ SUPPORTED_FILTERS = {
     'user': 'context.user'
 }
 
+# A list of fields for which null (None) is a valid value which we include in the list of valid
+# filters.
+FILTERS_WITH_VALID_NULL_VALUES = [
+    'parent',
+    'rule',
+    'trigger',
+    'trigger_type',
+    'trigger_instance',
+    'user'
+]
+
 # List of filters that are too broad to distinct by them and are very likely to represent 1 to 1
 # relation between filter and particular history record.
 IGNORE_FILTERS = ['parent', 'timestamp', 'liveaction', 'trigger_instance']
@@ -66,7 +77,11 @@ class FiltersController(object):
 
         for name, field in six.iteritems(SUPPORTED_FILTERS):
             if name not in IGNORE_FILTERS and (not types or name in types):
-                query = {field.replace('.', '__'): {'$ne': None}}
+                if name not in FILTERS_WITH_VALID_NULL_VALUES:
+                    query = {field.replace('.', '__'): {'$ne': None}}
+                else:
+                    query = {}
+
                 filters[name] = ActionExecution.distinct(field=field, **query)
         return filters
 

--- a/st2api/st2api/controllers/v1/executionviews.py
+++ b/st2api/st2api/controllers/v1/executionviews.py
@@ -49,8 +49,7 @@ FILTERS_WITH_VALID_NULL_VALUES = [
     'rule',
     'trigger',
     'trigger_type',
-    'trigger_instance',
-    'user'
+    'trigger_instance'
 ]
 
 # List of filters that are too broad to distinct by them and are very likely to represent 1 to 1

--- a/st2api/st2api/controllers/v1/executionviews.py
+++ b/st2api/st2api/controllers/v1/executionviews.py
@@ -66,7 +66,7 @@ class FiltersController(object):
 
         for name, field in six.iteritems(SUPPORTED_FILTERS):
             if name not in IGNORE_FILTERS and (not types or name in types):
-                query = {field.replace('.', '__'): {"$ne": None}} 
+                query = {field.replace('.', '__'): {'$ne': None}}
                 filters[name] = ActionExecution.distinct(field=field, **query)
         return filters
 

--- a/st2api/tests/unit/controllers/v1/test_executions_filters.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_filters.py
@@ -338,6 +338,14 @@ class TestActionExecutionFilters(FunctionalTest):
         self.assertIsInstance(response.json, dict)
         self.assertEqual(len(response.json), len(history_views.ARTIFACTS['filters']['default']))
         for key, value in six.iteritems(history_views.ARTIFACTS['filters']['default']):
+            filter_values = response.json[key]
+
+            # Verify empty (None / null) filters are excluded
+            self.assertTrue(None not in filter_values)
+
+            if None in value:
+                value = [item for item in value if item is not None]
+
             self.assertEqual(set(response.json[key]), set(value))
 
     def test_filters_view_specific_types(self):

--- a/st2api/tests/unit/controllers/v1/test_executions_filters.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_filters.py
@@ -30,6 +30,7 @@ from st2tests.fixtures import history_views
 from st2common.util import isotime
 from st2common.util import date as date_utils
 from st2api.controllers.v1.actionexecutions import ActionExecutionsController
+from st2api.controllers.v1.executionviews import FILTERS_WITH_VALID_NULL_VALUES
 from st2common.persistence.execution import ActionExecution
 from st2common.models.api.execution import ActionExecutionAPI
 
@@ -341,12 +342,14 @@ class TestActionExecutionFilters(FunctionalTest):
             filter_values = response.json[key]
 
             # Verify empty (None / null) filters are excluded
-            self.assertTrue(None not in filter_values)
+            if key not in FILTERS_WITH_VALID_NULL_VALUES:
+                self.assertTrue(None not in filter_values)
 
-            if None in value:
+            if None in value or None in filter_values:
+                filter_values = [item for item in filter_values if item is not None]
                 value = [item for item in value if item is not None]
 
-            self.assertEqual(set(response.json[key]), set(value))
+            self.assertEqual(set(filter_values), set(value))
 
     def test_filters_view_specific_types(self):
         response = self.app.get('/v1/executions/views/filters?types=action,user,nonexistent')

--- a/st2tests/st2tests/fixtures/history_views/filters.yaml
+++ b/st2tests/st2tests/fixtures/history_views/filters.yaml
@@ -3,7 +3,7 @@ default:
   action:
   - executions.local
   - executions.chain
-  - None
+  - null
   rule:
   - st2.person.joe
   runner:
@@ -15,7 +15,7 @@ default:
   - 46f67652-20cd-4bab-94e2-4615baa846d0
   trigger_type:
   - st2.webhook
-  - None
+  - null
   user:
   - system
 specific:

--- a/st2tests/st2tests/fixtures/history_views/filters.yaml
+++ b/st2tests/st2tests/fixtures/history_views/filters.yaml
@@ -3,9 +3,12 @@ default:
   action:
   - executions.local
   - executions.chain
+  # null is not a valid value for action
   - null
   rule:
   - st2.person.joe
+  # null is a valid value for rule
+  - null
   runner:
   - run-local
   - action-chain

--- a/st2tests/st2tests/fixtures/history_views/filters.yaml
+++ b/st2tests/st2tests/fixtures/history_views/filters.yaml
@@ -3,6 +3,7 @@ default:
   action:
   - executions.local
   - executions.chain
+  - None
   rule:
   - st2.person.joe
   runner:
@@ -14,6 +15,7 @@ default:
   - 46f67652-20cd-4bab-94e2-4615baa846d0
   trigger_type:
   - st2.webhook
+  - None
   user:
   - system
 specific:


### PR DESCRIPTION
This pull request works on top of #3193 and adds tests so we can merge that change.