### PR TITLE
Fix / update linux.scp action #1236

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,9 @@ in development
   tokens and services use special service access tokens with no max TTL limit. (bug fix)
 
   Reported by Jiang Wei. #3314 #3315
+* Issue #1236 - The ``destination_server`` field has been removed from the
+  ``linux.scp`` action. Going forward simply specify the server as part of the
+  ``source`` and/or ``destination`` arguments.
 
 2.2.1 - April 3, 2017
 ---------------------

--- a/contrib/linux/actions/scp.yaml
+++ b/contrib/linux/actions/scp.yaml
@@ -13,10 +13,6 @@
             type: 'string'
             description: 'Destination of files/directories'
             required: true
-        dest_server:
-            type: 'string'
-            description: 'Destination of files/directories'
-            required: true
         recursive:
             type: 'boolean'
             description: 'Boolean flag for recursive copy'
@@ -35,7 +31,7 @@
             default: '/home/stanley/.ssh/stanley_rsa'
         cmd:
             immutable: true
-            default: 'scp {{args}} -i {{keyfile}} {{source}} {{dest_server}}:{{destination}}'
+            default: 'scp {{args}} -i {{keyfile}} {{source}} {{destination}}'
         args:
             description: 'Command line arguments passed to cp'
             default: '-o stricthostkeychecking=no -v{% if recursive == true %} -r{% endif %}{% if force == true %} -f{% endif %}'

--- a/contrib/linux/actions/scp.yaml
+++ b/contrib/linux/actions/scp.yaml
@@ -7,11 +7,11 @@
     parameters:
         source:
             type: 'string'
-            description: 'List of files/directories to to be copied'
+            description: 'List of files/directories to be copied. This can be either a local path (example: "/path/to/file") or remote path (example: "server.fqdn:/path/to/file"). Paths can also be relative (examples: "folder/a.txt" or "server.fqdn:folder/a.txt") or absolute (Examples: "/etc/hosts" or "server.fqdn:/etc/hosts"). Lists of multiple files/directories should be separated by a spaces (example: "file1.txt file2.txt otherserver.domain.com:file3.txt")'
             required: true
         destination:
             type: 'string'
-            description: 'Destination of files/directories'
+            description: 'Destination of files/directories. This can be either a local path (example: "/path/to/file") or remote path (example: "server.fqdn:/path/to/file"). Paths can also be relative (examples: "folder/a.txt" or "server.fqdn:folder/a.txt") or absolute (Examples: "/etc/hosts" or "server.fqdn:/etc/hosts").'
             required: true
         recursive:
             type: 'boolean'


### PR DESCRIPTION
PR to fix #1236

I liked Kami's approach 1). In my mind this is more flexible because the author using the ```linux.scp``` action may not know if this will be an "upload" or a "download" or potentially a "transfer" (```scp user@host1:a.txt user@host2:```).

By using ``` source``` and ```destination```  this accounts of all scenarios and allows for each to be accomplished using the same action. Also, this mimics the way that a user would interact with ```scp``` on the command line.

Now, i know this breaks backwards compatibility. Is this OK, or should i mark ```dest_server``` as  ```required: false``` for the time being and some Jinja logic to insert it in the command if it's specified?

Thoughts?