### PR TITLE
Prevent UnicodeDecodeErrors on stdout/stderr.

### DIFF
--- a/st2common/st2common/util/virtualenvs.py
+++ b/st2common/st2common/util/virtualenvs.py
@@ -166,8 +166,12 @@ def install_requirements(virtualenv_path, requirements_file_path):
     exit_code, stdout, stderr = run_command(cmd=cmd, env=env)
 
     if exit_code != 0:
-        raise Exception('Failed to install requirements from "%s": %s (stderr: %s)' %
-                        (requirements_file_path, stdout, stderr))
+        def safetystring(s):
+            return s.decode('ascii', errors='ignore')
+        raise Exception(
+            'Failed to install requirements from "%s": %s (stderr: %s)' % (
+                requirements_file_path,
+                safetystring(stdout), safetystring(stderr)))
 
     return True
 


### PR DESCRIPTION
I have some missing dependencies when trying to build pycurl as part of the icinga2 pack install.  The build process fails and the output has a '\xe2' in it and so the output from "st2 pack install icinga2" is a UnicodeDecodeError rather than the output saying "cannot find -lidn" and the like.

This patch fixes it.