### PR TITLE
Allow user to specify a blacklist of attributes which are masked in the log messages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,8 @@ in development
   tokens and services use special service access tokens with no max TTL limit. (bug fix)
 
   Reported by Jiang Wei. #3314 #3315
+* Allow user to specify a custom list of attribute names which are masked in the log messages by
+  setting ``log.mask_secrets_blacklist`` config option. (improvement)
 
 2.2.1 - April 3, 2017
 ---------------------

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -177,7 +177,9 @@ def register_opts(ignore_errors=False):
         cfg.BoolOpt('redirect_stderr', default=False,
                     help='Controls if stderr should be redirected to the logs.'),
         cfg.BoolOpt('mask_secrets', default=True,
-                    help='True to mask secrets in the log files.')
+                    help='True to mask secrets in the log files.'),
+        cfg.ListOpt('mask_secrets_blacklist', default=[],
+                    help='Blacklist of additional attribute names to mask in the log messages.')
     ]
     do_register_opts(log_opts, 'log', ignore_errors)
 

--- a/st2common/st2common/logging/formatters.py
+++ b/st2common/st2common/logging/formatters.py
@@ -78,9 +78,11 @@ def process_attribute_value(key, value):
     if not cfg.CONF.log.mask_secrets:
         return value
 
+    blacklisted_attribute_names = MASKED_ATTRIBUTES_BLACKLIST + cfg.CONF.log.mask_secrets_blacklist
+
     # NOTE: This can be expensive when processing large dicts or objects
     if isinstance(value, SIMPLE_TYPES):
-        if key in MASKED_ATTRIBUTES_BLACKLIST:
+        if key in blacklisted_attribute_names:
             value = MASKED_ATTRIBUTE_VALUE
     elif isinstance(value, dict):
         # Note: We don't want to modify the original value


### PR DESCRIPTION
By default we use a static blacklist of parameter names (password, token, etc.) which are masked in the log message `extra` if `log.mask_secrets` config option is set to `True`.

This pull request allows administrator to define an additional custom list of attributes which are masked in the log messages.

Related PR https://github.com/StackStorm/st2docs/pull/459.