### PR TITLE
Fix cors middleware conflicting with logging and error handling

### DIFF
--- a/st2api/st2api/app.py
+++ b/st2api/st2api/app.py
@@ -67,9 +67,9 @@ def setup_app(config={}):
 
     app = router.as_wsgi
 
+    app = ErrorHandlingMiddleware(app)
     app = CorsMiddleware(app)
     app = LoggingMiddleware(app, router)
-    app = ErrorHandlingMiddleware(app)
     app = RequestIDMiddleware(app)
 
     return app

--- a/st2api/st2api/app.py
+++ b/st2api/st2api/app.py
@@ -67,6 +67,7 @@ def setup_app(config={}):
 
     app = router.as_wsgi
 
+    # Order is important. Check middleware for detailed explanation.
     app = ErrorHandlingMiddleware(app)
     app = CorsMiddleware(app)
     app = LoggingMiddleware(app, router)

--- a/st2auth/st2auth/app.py
+++ b/st2auth/st2auth/app.py
@@ -65,9 +65,9 @@ def setup_app(config={}):
 
     app = router.as_wsgi
 
+    app = ErrorHandlingMiddleware(app)
     app = CorsMiddleware(app)
     app = LoggingMiddleware(app, router)
-    app = ErrorHandlingMiddleware(app)
     app = RequestIDMiddleware(app)
 
     return app

--- a/st2auth/st2auth/app.py
+++ b/st2auth/st2auth/app.py
@@ -65,6 +65,7 @@ def setup_app(config={}):
 
     app = router.as_wsgi
 
+    # Order is important. Check middleware for detailed explanation.
     app = ErrorHandlingMiddleware(app)
     app = CorsMiddleware(app)
     app = LoggingMiddleware(app, router)

--- a/st2common/st2common/middleware/cors.py
+++ b/st2common/st2common/middleware/cors.py
@@ -27,6 +27,13 @@ class CorsMiddleware(object):
         self.app = app
 
     def __call__(self, environ, start_response):
+        # The middleware sets a number of headers that helps prevent a range of attacks in browser
+        # environment. It also handles OPTIONS requests used by browser as pre-flight check before
+        # the potentially insecure request is made. An absence of this headers on the response will
+        # prevent the error from ever reaching the JS layer of client-side code making it impossible
+        # to process the response or provide a human-friendly error message. Order is not important
+        # as long at this condition is met and headers not get overridden by another middleware
+        # higher up the call stack.
         request = Request(environ)
 
         def custom_start_response(status, headers, exc_info=None):

--- a/st2common/st2common/middleware/cors.py
+++ b/st2common/st2common/middleware/cors.py
@@ -19,7 +19,7 @@ from webob.headers import ResponseHeaders
 from st2common.constants.api import REQUEST_ID_HEADER
 from st2common.constants.auth import HEADER_ATTRIBUTE_NAME
 from st2common.constants.auth import HEADER_API_KEY_ATTRIBUTE_NAME
-from st2common.router import Request, Response, NotFoundException
+from st2common.router import Request, Response
 
 
 class CorsMiddleware(object):
@@ -71,10 +71,7 @@ class CorsMiddleware(object):
 
             return start_response(status, headers._items, exc_info)
 
-        try:
-            return self.app(environ, custom_start_response)
-        except NotFoundException:
-            if request.method != 'options':
-                raise
-
+        if request.method == 'OPTIONS':
             return Response()(environ, custom_start_response)
+        else:
+            return self.app(environ, custom_start_response)

--- a/st2common/st2common/middleware/error_handling.py
+++ b/st2common/st2common/middleware/error_handling.py
@@ -34,6 +34,13 @@ class ErrorHandlingMiddleware(object):
         self.app = app
 
     def __call__(self, environ, start_response):
+        # The middleware intercepts and handles all the errors happening down the call stack by
+        # converting them to valid HTTP responses with semantically meaningful status codes and
+        # predefined response structure (`{"faultstring": "..."}`). The earlier in the call stack is
+        # going to be run, the less unhandled errors could slip to the wsgi layer. Keep in mind that
+        # the middleware doesn't receive the headers that has been set down the call stack which
+        # means that things like CorsMiddleware and RequestIDMiddleware should be highier up the
+        # call stack to also apply to error responses.
         try:
             try:
                 return self.app(environ, start_response)

--- a/st2common/st2common/middleware/logging.py
+++ b/st2common/st2common/middleware/logging.py
@@ -18,7 +18,7 @@ import types
 
 from st2common.constants.api import REQUEST_ID_HEADER
 from st2common import log as logging
-from st2common.router import Request
+from st2common.router import Request, NotFoundException
 
 LOG = logging.getLogger(__name__)
 
@@ -68,7 +68,10 @@ class LoggingMiddleware(object):
 
         retval = self.app(environ, custom_start_response)
 
-        endpoint, path_vars = self.router.match(request)
+        try:
+            endpoint, path_vars = self.router.match(request)
+        except NotFoundException:
+            endpoint = {}
 
         log_result = endpoint.get('x-log-result', True)
 

--- a/st2common/st2common/middleware/request_id.py
+++ b/st2common/st2common/middleware/request_id.py
@@ -26,6 +26,12 @@ class RequestIDMiddleware(object):
         self.app = app
 
     def __call__(self, environ, start_response):
+        # The middleware adds unique `X-Request-ID` header on the requests that don't have it and
+        # modifies the responses to have the same exact header as their request. The middleware
+        # helps us better track relation between request and response in places where it might not
+        # be immediately obvious (like logs for example). In general, you want to place this header
+        # as soon as possible to ensure it's present by the time it's needed. Certainly before
+        # LoggingMiddleware which relies on this header.
         request = Request(environ)
 
         if not request.headers.get(REQUEST_ID_HEADER, None):

--- a/st2stream/st2stream/app.py
+++ b/st2stream/st2stream/app.py
@@ -80,9 +80,9 @@ def setup_app(config={}):
     app = router.as_wsgi
 
     app = StreamingMiddleware(app)
+    app = ErrorHandlingMiddleware(app)
     app = CorsMiddleware(app)
     app = LoggingMiddleware(app, router)
-    app = ErrorHandlingMiddleware(app)
     app = RequestIDMiddleware(app)
 
     return app

--- a/st2stream/st2stream/app.py
+++ b/st2stream/st2stream/app.py
@@ -44,6 +44,9 @@ class StreamingMiddleware(object):
         self.app = app
 
     def __call__(self, environ, start_response):
+        # Forces eventlet to respond immediately upon receiving a new chunk from endpoint rather
+        # than buffering it until the sufficient chunk size is reached. The order for this
+        # middleware is not important since it acts as pass-through.
         environ['eventlet.minimum_write_chunk_size'] = 0
         return self.app(environ, start_response)
 
@@ -79,6 +82,7 @@ def setup_app(config={}):
 
     app = router.as_wsgi
 
+    # Order is important. Check middleware for detailed explanation.
     app = StreamingMiddleware(app)
     app = ErrorHandlingMiddleware(app)
     app = CorsMiddleware(app)

--- a/st2tests/st2tests/api.py
+++ b/st2tests/st2tests/api.py
@@ -29,8 +29,8 @@ class ResponseLeakError(ValueError):
 
 
 class TestApp(webtest.TestApp):
-    def do_request(self, *args, **kwargs):
-        res = super(TestApp, self).do_request(*args, **kwargs)
+    def do_request(self, req, **kwargs):
+        res = super(TestApp, self).do_request(req, **kwargs)
 
         if res.headers.get('Warning', None):
             raise ResponseValidationError('Endpoint produced invalid response. Make sure the '
@@ -40,5 +40,13 @@ class TestApp(webtest.TestApp):
             if SUPER_SECRET_PARAMETER in res.body or ANOTHER_SUPER_SECRET_PARAMETER in res.body:
                 raise ResponseLeakError('Endpoint response contains secret parameter. '
                                         'Find the leak.')
+
+        if 'Access-Control-Allow-Origin' not in res.headers:
+            raise ResponseValidationError('Response missing a required CORS header')
+
+        if req.environ['REQUEST_METHOD'] != 'OPTIONS':
+            # The request will then also be checked with do_request() method making sure OPTIONS
+            # response also has proper headers set.
+            self.options(req.environ['PATH_INFO'])
 
         return res


### PR DESCRIPTION
The PR solves a number of problems introduced by #2727.

First, logging middleware fails during OPTIONS preflight request due to us not defining OPTIONS requests in spec. As far as logging concerned, every request to non-existing endpoint still needs to be logged.

Second, cors and error_handling middleware both depends on each other. CORS intercepts and reraises the NotFoundException, but don't provide its headers for endpoints that don't exist (preventing browser from properly handling the error) and error_handling middleware intercepts all the errors making it impossible for cors middleware to properly handle OPTIONS requests.