### PR TITLE
Fix RBAC syncer so it correctly removes assignments for users with no assignment file on disk

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,9 @@ in development
   for fields where ``null`` is not a valid field value. (improvement)
 
   Contributed by Cody A. Ray. #3193
+* Make sure all the role assignments for a particular user are correctly deleted from the database
+  after deleting an assignment file from ``/opt/stackstorm/rbac/assignments`` directory and running
+  ``st2-apply-rbac-definitions`` tool. (bug fix)
 
 2.2.1 - April 3, 2017
 ---------------------

--- a/st2common/st2common/rbac/syncer.py
+++ b/st2common/st2common/rbac/syncer.py
@@ -188,9 +188,7 @@ class RBACDefinitionsDBSyncer(object):
 
         username_to_user_db_map = dict([(user_db.name, user_db) for user_db in user_dbs])
         username_to_role_assignment_api_map = dict([(role_assignment_api.username,
-                                                     role_assignment_api) for
-                                                     role_assignment_api in
-                                                     role_assignment_apis])
+            role_assignment_api) for role_assignment_api in role_assignment_apis])
 
         # Note: We process assignments for all the users (ones specified in the assignment files
         # and ones which are in the databse)

--- a/st2common/st2common/rbac/syncer.py
+++ b/st2common/st2common/rbac/syncer.py
@@ -191,7 +191,9 @@ class RBACDefinitionsDBSyncer(object):
             role_assignment_api) for role_assignment_api in role_assignment_apis])
 
         # Note: We process assignments for all the users (ones specified in the assignment files
-        # and ones which are in the databse)
+        # and ones which are in the databse). We want to make sure assignments are correctly
+        # deleted from the databse for users which existing in the databse, but have no assignment
+        # file on disk.
         all_usernames = (username_to_user_db_map.keys() +
                          username_to_role_assignment_api_map.keys())
         all_usernames = list(set(all_usernames))

--- a/st2common/st2common/rbac/syncer.py
+++ b/st2common/st2common/rbac/syncer.py
@@ -185,11 +185,22 @@ class RBACDefinitionsDBSyncer(object):
         LOG.info('Synchronizing users role assignments...')
 
         user_dbs = User.get_all()
+
         username_to_user_db_map = dict([(user_db.name, user_db) for user_db in user_dbs])
+        username_to_role_assignment_api_map = dict([(role_assignment_api.username,
+                                                     role_assignment_api) for
+                                                     role_assignment_api in
+                                                     role_assignment_apis])
+
+        # Note: We process assignments for all the users (ones specified in the assignment files
+        # and ones which are in the databse)
+        all_usernames = (username_to_user_db_map.keys() +
+                         username_to_role_assignment_api_map.keys())
+        all_usernames = list(set(all_usernames))
 
         results = {}
-        for role_assignment_api in role_assignment_apis:
-            username = role_assignment_api.username
+        for username in all_usernames:
+            role_assignment_api = username_to_role_assignment_api_map.get(username, None)
             user_db = username_to_user_db_map.get(username, None)
 
             if not user_db:

--- a/st2common/tests/unit/test_rbac_syncer.py
+++ b/st2common/tests/unit/test_rbac_syncer.py
@@ -53,9 +53,9 @@ class BaseRBACDefinitionsDBSyncerTestCase(CleanDbTestCase):
         user_2_db = User.add_or_update(user_2_db)
         self.users['user_2'] = user_2_db
 
-        user_2_db = UserDB(name='user_3')
-        user_2_db = User.add_or_update(user_2_db)
-        self.users['user_3'] = user_2_db
+        user_3_db = UserDB(name='user_3')
+        user_3_db = User.add_or_update(user_3_db)
+        self.users['user_3'] = user_3_db
 
 
 class RBACDefinitionsDBSyncerTestCase(BaseRBACDefinitionsDBSyncerTestCase):


### PR DESCRIPTION
This pull request fixes a bug in `st2-apply-rbac-definitions` tool.

Previously, if an existing assignment file for a user in `/opt/stackstorm/rbac/assignments/` directory was deleted and `st2-apply-rbac-definitions` tool was ran afterwards, this wasn't correctly reflected in the database - previous / old assignments would still stay in the database instead of being deleted.

This pull request fixes that.

Found this bug while working on #3351.