### PR TITLE
File watch sensor to utilize trigger with parameters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,9 @@ in development
   ``TRIGGER_*`` RBAC permission constants (improvement)
 * Implement RBAC for webhooks get all and get one API endpoint. (improvement)
 * Add webhook payload to the Jinja render context when rendering Jinja variable inside rule criteria section
+* Switch file_watch_sensor in Linux pack to use trigger type with parameters. Now you can add a
+  rule with `file_path` and sensor will pick up the `file_path` from the rule. A sample rule
+  is provided in contrib/examples/rules/sample_rule_file_watch.yaml. (improvement)
 
 2.2.1 - April 3, 2017
 ---------------------

--- a/contrib/examples/rules/sample_rule_file_watch.yaml
+++ b/contrib/examples/rules/sample_rule_file_watch.yaml
@@ -1,0 +1,17 @@
+---
+name: sample_rule_file_watch
+pack: "examples"
+description: Sample rule custom trigger type - add a file to be watched by file_watch_sensor in linux pack.
+enabled: false
+
+trigger:
+  parameters:
+    file_path: /var/log/dmesg
+  type: linux.file_watch.file_path
+
+criteria: {}
+
+action:
+  parameters:
+    cmd: echo "{{trigger}}"
+  ref: core.local

--- a/contrib/linux/config.yaml
+++ b/contrib/linux/config.yaml
@@ -1,2 +1,0 @@
-file_watch_sensor:
-  file_paths:

--- a/contrib/linux/sensors/file_watch_sensor.py
+++ b/contrib/linux/sensors/file_watch_sensor.py
@@ -47,7 +47,10 @@ class FileWatchSensor(Sensor):
         pass
 
     def remove_trigger(self, trigger):
-        if trigger['type'] not in ['linux.file_watch.file_path']:
+        file_path = trigger['parameters'].get('file_path', None)
+
+        if not file_path:
+            self._logger.error('Received trigger type without "file_path" field.')
             return
 
         file_path = trigger['parameters']['file_path']

--- a/contrib/linux/sensors/file_watch_sensor.py
+++ b/contrib/linux/sensors/file_watch_sensor.py
@@ -33,10 +33,12 @@ class FileWatchSensor(Sensor):
                 pass
 
     def add_trigger(self, trigger):
-        if trigger['type'] not in ['linux.file_watch.file_path']:
+        file_path = trigger['parameters'].get('file_path', None)
+
+        if not file_path:
+            self._logger.error('Received trigger type without "file_path" field.')
             return
 
-        file_path = trigger['parameters']['file_path']
         self._tail.add_file(filename=file_path)
 
         self._logger.info('Added file "%s"' % (file_path))

--- a/contrib/linux/sensors/file_watch_sensor.py
+++ b/contrib/linux/sensors/file_watch_sensor.py
@@ -53,7 +53,6 @@ class FileWatchSensor(Sensor):
             self._logger.error('Received trigger type without "file_path" field.')
             return
 
-        file_path = trigger['parameters']['file_path']
         self._tail.remove_file(filename=file_path)
 
         self._logger.info('Removed file "%s"' % (file_path))

--- a/contrib/linux/sensors/file_watch_sensor.yaml
+++ b/contrib/linux/sensors/file_watch_sensor.yaml
@@ -1,6 +1,6 @@
 ---
   class_name: "FileWatchSensor"
-  enabled: true
+  enabled: false
   entry_point: "file_watch_sensor.py"
   description: "Sensor which monitors files for new lines"
   trigger_types:

--- a/contrib/linux/sensors/file_watch_sensor.yaml
+++ b/contrib/linux/sensors/file_watch_sensor.yaml
@@ -5,6 +5,18 @@
   description: "Sensor which monitors files for new lines"
   trigger_types:
     -
+      name: "file_watch.file_path"
+      description: "Trigger which represents a file path to be monitored"
+      parameters_schema:
+        type: "object"
+        properties:
+          file_path:
+            description: "Path to the file to monitor"
+            type: "string"
+        required:
+          - "file_path"
+        additionalProperties: false
+    -
       name: "file_watch.line"
       description: "Trigger which indicates a new line has been detected"
       payload_schema:

--- a/contrib/linux/sensors/file_watch_sensor.yaml
+++ b/contrib/linux/sensors/file_watch_sensor.yaml
@@ -1,23 +1,24 @@
 ---
   class_name: "FileWatchSensor"
-  enabled: false
+  enabled: true
   entry_point: "file_watch_sensor.py"
   description: "Sensor which monitors files for new lines"
   trigger_types:
     -
       name: "file_watch.file_path"
+      pack: "linux"
       description: "Trigger which represents a file path to be monitored"
       parameters_schema:
         type: "object"
         properties:
-          file_path:
+          file_path:  # User ``st2`` should have permissions to be able to read this file.
             description: "Path to the file to monitor"
             type: "string"
-        required:
-          - "file_path"
+            required: true
         additionalProperties: false
     -
       name: "file_watch.line"
+      pack: "linux"
       description: "Trigger which indicates a new line has been detected"
       payload_schema:
         type: "object"


### PR DESCRIPTION
Cherry-picked https://github.com/StackStorm/st2/pull/1291

Then, I made the following changes:
* I enabled the file_watch_sensor by default. 
* I edited the sensor YAML file to reflect pack name explicitly
* I added a sample rule which would register a trigger with parameter (file_path). Sensor automatically picks up the file name from rule and starts to listen to file and emit lines from file.

To test, do the following:

* Spin st2 up and place the linux pack from this branch to /opt/stackstorm/packs
* Register contents of linux pack - st2ctl reload --register-all
* Restart st2 so file_watch_sensor is run - st2ctl restart
* Verify file_watch_sensor is running and enabled
```
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯ ps auxww | grep file_watch | grep -v grep                                      tt_with_params ✭ ◼
vagrant  15142  0.1  2.0 111104 42520 pts/5    S+   07:19   0:04 /mnt/src/storm/st2/virtualenv/bin/python /mnt/src/storm/st2/st2reactor/st2reactor/container/sensor_wrapper.py --pack=linux --file-path=/opt/stackstorm/packs/linux/sensors/file_watch_sensor.py --class-name=FileWatchSensor --trigger-type-refs=linux.file_watch.file_path,linux.file_watch.line --parent-args=["--config-file", "/mnt/src/storm/st2/tools/../conf/st2.dev.conf"]
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯
```

```
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯ st2 sensor list --pack=linux                                                   tt_with_params ✭ ◼
+-----------------------+-------+-------------------------------------+---------+
| ref                   | pack  | description                         | enabled |
+-----------------------+-------+-------------------------------------+---------+
| linux.FileWatchSensor | linux | Sensor which monitors files for new | True    |
|                       |       | lines                               |         |
+-----------------------+-------+-------------------------------------+---------+
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯
```
* Now copy sample rule that will register the rule 
```
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯ st2 rule create /opt/stackstorm/packs/examples/rules/sample_rule_file_watch.yaml
+-------------+-----------------------------------------------------------+
| Property    | Value                                                     |
+-------------+-----------------------------------------------------------+
| id          | 58f620c6d9d7ed3af4554f4d                                  |
| name        | sample_rule_file_watch                                    |
| pack        | examples                                                  |
| description | Sample rule customer trigger type.                        |
| action      | {                                                         |
|             |     "ref": "core.local",                                  |
|             |     "parameters": {                                       |
|             |         "cmd": "echo "{{trigger}}""                       |
|             |     }                                                     |
|             | }                                                         |
| criteria    |                                                           |
| enabled     | False                                                     |
| ref         | examples.sample_rule_file_watch                           |
| tags        |                                                           |
| trigger     | {                                                         |
|             |     "type": "linux.file_watch.file_path",                 |
|             |     "ref": "linux.1c65e441-fd18-4217-bc53-8ac616a31074",  |
|             |     "parameters": {                                       |
|             |         "file_path": "/var/log/dmesg"                     |
|             |     }                                                     |
|             | }                                                         |
| type        | {                                                         |
|             |     "ref": "standard",                                    |
|             |     "parameters": {}                                      |
|             | }                                                         |
| uid         | rule:examples:sample_rule_file_watch                      |
+-------------+-----------------------------------------------------------+
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯
```
