### PR TITLE
Fix st2-apply-rbac-definitions debug mode

### DIFF
--- a/st2common/st2common/cmd/apply_rbac_definitions.py
+++ b/st2common/st2common/cmd/apply_rbac_definitions.py
@@ -17,8 +17,6 @@
 A script which applies RBAC definitions and role assignments stored on disk.
 """
 
-from oslo_config import cfg
-
 from st2common import config
 from st2common.script_setup import setup as common_setup
 from st2common.script_setup import teardown as common_teardown

--- a/st2common/st2common/cmd/apply_rbac_definitions.py
+++ b/st2common/st2common/cmd/apply_rbac_definitions.py
@@ -29,8 +29,6 @@ __all__ = [
     'main'
 ]
 
-cfg.CONF.register_cli_opt(cfg.BoolOpt('verbose', short='v', default=False))
-
 
 def setup(argv):
     common_setup(config=config, setup_db=True, register_mq_exchanges=True)

--- a/st2common/st2common/script_setup.py
+++ b/st2common/st2common/script_setup.py
@@ -69,6 +69,9 @@ def setup(config, setup_db=True, register_mq_exchanges=True):
     # Parse args to setup config
     config.parse_args()
 
+    if cfg.CONF.debug:
+        cfg.CONF.verbose = True
+
     # Set up logging
     log_level = stdlib_logging.DEBUG
     stdlib_logging.basicConfig(format='%(asctime)s %(levelname)s [-] %(message)s', level=log_level)


### PR DESCRIPTION
Closes: https://github.com/StackStorm/st2/issues/3323

## --verbose does get registered

```(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯ st2common/bin/st2-apply-rbac-definitions -h                issue_3323/rbac_apply_debug_mode ✭ ✱ ◼
usage: st2-apply-rbac-definitions [-h] [--config-dir DIR] [--config-file PATH]
                                  [--debug] [--nodebug] [--noprofile]
                                  [--nouse-debugger] [--profile]
                                  [--use-debugger] [--verbose] [--version]
                                  [--noverbose]

optional arguments:
  -h, --help          show this help message and exit
  --config-dir DIR    Path to a config directory to pull *.conf files from.
                      This file set is sorted, so as to provide a predictable
                      parse order if individual options are over-ridden. The
                      set is parsed after the file(s) specified via previous
                      --config-file, arguments hence over-ridden options in
                      the directory take precedence.
  --config-file PATH  Path to a config file to use. Multiple config files can
                      be specified, with values in later files taking
                      precedence. The default files used are: None.
  --debug             Enable debug mode. By default this will set all log
                      levels to DEBUG.
  --nodebug           The inverse of --debug
  --noprofile         The inverse of --profile
  --nouse-debugger    The inverse of --use-debugger
  --profile           Enable profile mode. In the profile mode all the MongoDB
                      queries and related profile data are logged.
  --use-debugger      Enables debugger. Note that using this option changes
                      how the eventlet library is used to support async IO.
                      This could result in failures that do not occur under
                      normal operation.
  --verbose, -v
  --version           show program's version number and exit
  --noverbose         The inverse of --verbose
```

## --verbose

```
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯ st2common/bin/st2-apply-rbac-definitions --verbose         issue_3323/rbac_apply_debug_mode ✭ ✱ ◼
2017-04-18 19:31:07,501 INFO [-] Connecting to database "st2" @ "0.0.0.0:27017" as user "None".
2017-04-18 19:31:07,503 DEBUG [-] Ensuring database indexes...
2017-04-18 19:31:07,617 DEBUG [-] Skipping index cleanup for blacklisted model "PermissionGrantDB"...
2017-04-18 19:31:07,662 DEBUG [-] Indexes are ensured for models: ActionAliasDB, ActionAliasDB, ActionDB, ActionExecutionDB, ActionExecutionDB, ActionExecutionStateDB, ActionExecutionStateDB, ApiKeyDB, ConfigDB, ConfigSchemaDB, GroupToRoleMappingDB, KeyValuePairDB, LiveActionDB, LiveActionDB, PackDB, PermissionGrantDB, PolicyDB, PolicyTypeDB, RoleDB, RuleDB, RuleEnforcementDB, RunnerTypeDB, RunnerTypeDB, SensorTypeDB, TokenDB, TraceDB, TriggerDB, TriggerInstanceDB, TriggerTypeDB, UserDB, UserRoleAssignmentDB
2017-04-18 19:31:07,663 DEBUG [-] Registering exchanges...
2017-04-18 19:31:07,687 DEBUG [-] Start from server, version: 0.9, properties: {u'information': u'Licensed under the MPL.  See http://www.rabbitmq.com/', u'product': u'RabbitMQ', u'copyright': u'Copyright (C) 2007-2016 Pivotal Software, Inc.', u'capabilities': {u'exchange_exchange_bindings': True, u'connection.blocked': True, u'authentication_failure_close': True, u'direct_reply_to': True, u'basic.nack': True, u'per_consumer_qos': True, u'consumer_priorities': True, u'consumer_cancel_notify': True, u'publisher_confirms': True}, u'cluster_name': u'rabbit@st2dev', u'platform': u'Erlang/OTP', u'version': u'3.6.1'}, mechanisms: [u'PLAIN', u'AMQPLAIN'], locales: [u'en_US']
2017-04-18 19:31:07,691 DEBUG [-] Open OK!
2017-04-18 19:31:07,694 DEBUG [-] using channel_id: 1
2017-04-18 19:31:07,698 DEBUG [-] Channel open
2017-04-18 19:31:07,700 DEBUG [-] registered exchange st2.actionexecutionstate.
2017-04-18 19:31:07,702 DEBUG [-] registered exchange st2.announcement.
2017-04-18 19:31:07,704 DEBUG [-] registered exchange st2.execution.
2017-04-18 19:31:07,708 DEBUG [-] registered exchange st2.liveaction.
2017-04-18 19:31:07,710 DEBUG [-] registered exchange st2.liveaction.status.
2017-04-18 19:31:07,712 DEBUG [-] registered exchange st2.trigger.
2017-04-18 19:31:07,715 DEBUG [-] registered exchange st2.trigger_instances_dispatch.
2017-04-18 19:31:07,716 DEBUG [-] registered exchange st2.sensor.
2017-04-18 19:31:07,718 DEBUG [-] Closed channel #1
2017-04-18 19:31:07,719 INFO [-] Loading role definitions from "/opt/stackstorm/rbac/roles/"
2017-04-18 19:31:07,722 INFO [-] Loading user role assignments from "/opt/stackstorm/rbac/assignments/"
2017-04-18 19:31:07,723 INFO [-] Loading group to role map definitions from "/opt/stackstorm/rbac/mappings/"
2017-04-18 19:31:07,725 INFO [-] Synchronizing roles...
2017-04-18 19:31:07,732 DEBUG [-] New roles: set([])
2017-04-18 19:31:07,733 DEBUG [-] Updated roles: set([])
2017-04-18 19:31:07,734 DEBUG [-] Removed roles: set([])
2017-04-18 19:31:07,735 DEBUG [-] Deleting 0 stale roles
2017-04-18 19:31:07,738 DEBUG [-] Deleted 0 stale roles
2017-04-18 19:31:07,742 DEBUG [-] Deleting 0 stale permission grants
2017-04-18 19:31:07,745 DEBUG [-] Deleted 0 stale permission grants
2017-04-18 19:31:07,746 DEBUG [-] Creating 0 new roles
2017-04-18 19:31:07,747 DEBUG [-] Created 0 new roles
2017-04-18 19:31:07,748 INFO [-] Roles synchronized (0 created, 0 updated, 0 removed)
2017-04-18 19:31:07,749 INFO [-] Synchronizing users role assignments...
2017-04-18 19:31:07,753 DEBUG [-] New assignments for user "sensors_container": set([])
2017-04-18 19:31:07,754 DEBUG [-] Updated assignments for user "sensors_container": set([])
2017-04-18 19:31:07,755 DEBUG [-] Removed assignments for user "sensors_container": set([])
2017-04-18 19:31:07,767 DEBUG [-] Removed 0 assignments for user "sensors_container"
2017-04-18 19:31:07,769 DEBUG [-] Created 0 new assignments for user "sensors_container"
2017-04-18 19:31:07,771 INFO [-] User role assignments synchronized
2017-04-18 19:31:07,772 INFO [-] Synchronizing group to role maps...
2017-04-18 19:31:07,777 INFO [-] Group to role map definitions synchronized.
```

## --debug option

```
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯ st2common/bin/st2-apply-rbac-definitions --debug           issue_3323/rbac_apply_debug_mode ✭ ✱ ◼
2017-04-18 19:31:11,684 INFO [-] Connecting to database "st2" @ "0.0.0.0:27017" as user "None".
2017-04-18 19:31:11,687 DEBUG [-] Ensuring database indexes...
2017-04-18 19:31:11,778 DEBUG [-] Skipping index cleanup for blacklisted model "PermissionGrantDB"...
2017-04-18 19:31:11,798 DEBUG [-] Indexes are ensured for models: ActionAliasDB, ActionAliasDB, ActionDB, ActionExecutionDB, ActionExecutionDB, ActionExecutionStateDB, ActionExecutionStateDB, ApiKeyDB, ConfigDB, ConfigSchemaDB, GroupToRoleMappingDB, KeyValuePairDB, LiveActionDB, LiveActionDB, PackDB, PermissionGrantDB, PolicyDB, PolicyTypeDB, RoleDB, RuleDB, RuleEnforcementDB, RunnerTypeDB, RunnerTypeDB, SensorTypeDB, TokenDB, TraceDB, TriggerDB, TriggerInstanceDB, TriggerTypeDB, UserDB, UserRoleAssignmentDB
2017-04-18 19:31:11,800 DEBUG [-] Registering exchanges...
2017-04-18 19:31:11,812 DEBUG [-] Start from server, version: 0.9, properties: {u'information': u'Licensed under the MPL.  See http://www.rabbitmq.com/', u'product': u'RabbitMQ', u'copyright': u'Copyright (C) 2007-2016 Pivotal Software, Inc.', u'capabilities': {u'exchange_exchange_bindings': True, u'connection.blocked': True, u'authentication_failure_close': True, u'direct_reply_to': True, u'basic.nack': True, u'per_consumer_qos': True, u'consumer_priorities': True, u'consumer_cancel_notify': True, u'publisher_confirms': True}, u'cluster_name': u'rabbit@st2dev', u'platform': u'Erlang/OTP', u'version': u'3.6.1'}, mechanisms: [u'PLAIN', u'AMQPLAIN'], locales: [u'en_US']
2017-04-18 19:31:11,814 DEBUG [-] Open OK!
2017-04-18 19:31:11,814 DEBUG [-] using channel_id: 1
2017-04-18 19:31:11,816 DEBUG [-] Channel open
2017-04-18 19:31:11,816 DEBUG [-] registered exchange st2.actionexecutionstate.
2017-04-18 19:31:11,818 DEBUG [-] registered exchange st2.announcement.
2017-04-18 19:31:11,819 DEBUG [-] registered exchange st2.execution.
2017-04-18 19:31:11,821 DEBUG [-] registered exchange st2.liveaction.
2017-04-18 19:31:11,823 DEBUG [-] registered exchange st2.liveaction.status.
2017-04-18 19:31:11,824 DEBUG [-] registered exchange st2.trigger.
2017-04-18 19:31:11,825 DEBUG [-] registered exchange st2.trigger_instances_dispatch.
2017-04-18 19:31:11,826 DEBUG [-] registered exchange st2.sensor.
2017-04-18 19:31:11,828 DEBUG [-] Closed channel #1
2017-04-18 19:31:11,830 INFO [-] Loading role definitions from "/opt/stackstorm/rbac/roles/"
2017-04-18 19:31:11,831 INFO [-] Loading user role assignments from "/opt/stackstorm/rbac/assignments/"
2017-04-18 19:31:11,831 INFO [-] Loading group to role map definitions from "/opt/stackstorm/rbac/mappings/"
2017-04-18 19:31:11,832 INFO [-] Synchronizing roles...
2017-04-18 19:31:11,833 DEBUG [-] New roles: set([])
2017-04-18 19:31:11,834 DEBUG [-] Updated roles: set([])
2017-04-18 19:31:11,834 DEBUG [-] Removed roles: set([])
2017-04-18 19:31:11,835 DEBUG [-] Deleting 0 stale roles
2017-04-18 19:31:11,838 DEBUG [-] Deleted 0 stale roles
2017-04-18 19:31:11,840 DEBUG [-] Deleting 0 stale permission grants
2017-04-18 19:31:11,841 DEBUG [-] Deleted 0 stale permission grants
2017-04-18 19:31:11,842 DEBUG [-] Creating 0 new roles
2017-04-18 19:31:11,843 DEBUG [-] Created 0 new roles
2017-04-18 19:31:11,843 INFO [-] Roles synchronized (0 created, 0 updated, 0 removed)
2017-04-18 19:31:11,844 INFO [-] Synchronizing users role assignments...
2017-04-18 19:31:11,845 DEBUG [-] New assignments for user "sensors_container": set([])
2017-04-18 19:31:11,846 DEBUG [-] Updated assignments for user "sensors_container": set([])
2017-04-18 19:31:11,847 DEBUG [-] Removed assignments for user "sensors_container": set([])
2017-04-18 19:31:11,848 DEBUG [-] Removed 0 assignments for user "sensors_container"
2017-04-18 19:31:11,851 DEBUG [-] Created 0 new assignments for user "sensors_container"
2017-04-18 19:31:11,852 INFO [-] User role assignments synchronized
2017-04-18 19:31:11,853 INFO [-] Synchronizing group to role maps...
2017-04-18 19:31:11,857 INFO [-] Group to role map definitions synchronized.
```

##  Vanilla mode

```
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯ st2common/bin/st2-apply-rbac-definitions                   issue_3323/rbac_apply_debug_mode ✭ ✱ ◼
2017-04-18 19:31:29,441 INFO [-] Connecting to database "st2" @ "0.0.0.0:27017" as user "None".
2017-04-18 19:31:29,601 INFO [-] Loading role definitions from "/opt/stackstorm/rbac/roles/"
2017-04-18 19:31:29,602 INFO [-] Loading user role assignments from "/opt/stackstorm/rbac/assignments/"
2017-04-18 19:31:29,602 INFO [-] Loading group to role map definitions from "/opt/stackstorm/rbac/mappings/"
2017-04-18 19:31:29,603 INFO [-] Synchronizing roles...
2017-04-18 19:31:29,607 INFO [-] Roles synchronized (0 created, 0 updated, 0 removed)
2017-04-18 19:31:29,607 INFO [-] Synchronizing users role assignments...
2017-04-18 19:31:29,610 INFO [-] User role assignments synchronized
2017-04-18 19:31:29,611 INFO [-] Synchronizing group to role maps...
2017-04-18 19:31:29,612 INFO [-] Group to role map definitions synchronized.
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯
```