### PR TITLE
RBAC for rest of the API endpoints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -48,6 +48,8 @@ in development
 * Update ``/v1/rbac/permission_types`` and ``/v1/rbac/permission_types/<resource type>`` API
   endpoint to return a dictionary which also includes a description for each available
   permission type. (improvement)
+* Require ``EXECUTION_VIEWS_FILTERS_LIST`` RBAC permission type to be able to access
+  ``/executions/views/filters`` API endpoint. (improvement)
 
 2.2.1 - April 3, 2017
 ---------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,12 +35,16 @@ in development
 * Make sure all the role assignments for a particular user are correctly deleted from the database
   after deleting an assignment file from ``/opt/stackstorm/rbac/assignments`` directory and running
   ``st2-apply-rbac-definitions`` tool. (bug fix)
+* Add webhook payload to the Jinja render context when rendering Jinja variable inside rule
+  criteria section.
 * Implement RBAC for traces API endpoints. (improvement)
 * Implement RBAC for ``API_KEY_CREATE`` permission type. (improvement)
 * Implement RBAC for timers API endpoints. Note: timers are just a type of triggers so they utilize
   ``TRIGGER_*`` RBAC permission constants (improvement)
 * Implement RBAC for webhooks get all and get one API endpoint. (improvement)
-* Add webhook payload to the Jinja render context when rendering Jinja variable inside rule criteria section
+* Implement RBAC for policy types and policies get all and get one API endpoint. (improvement)
+* Require ``ACTION_VIEW`` permission type to be able to access entry_point and parameters actions
+  view controller. (improvement)
 
 2.2.1 - April 3, 2017
 ---------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,8 +39,7 @@ in development
   criteria section.
 * Implement RBAC for traces API endpoints. (improvement)
 * Implement RBAC for ``API_KEY_CREATE`` permission type. (improvement)
-* Implement RBAC for timers API endpoints. Note: timers are just a type of triggers so they utilize
-  ``TRIGGER_*`` RBAC permission constants (improvement)
+* Implement RBAC for timers API endpoints. (improvement)
 * Implement RBAC for webhooks get all and get one API endpoint. (improvement)
 * Implement RBAC for policy types and policies get all and get one API endpoint. (improvement)
 * Require ``ACTION_VIEW`` permission type to be able to access entry_point and parameters actions

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,9 @@ in development
 * Implement RBAC for policy types and policies get all and get one API endpoint. (improvement)
 * Require ``ACTION_VIEW`` permission type to be able to access entry_point and parameters actions
   view controller. (improvement)
+* Update ``/v1/rbac/permission_types`` and ``/v1/rbac/permission_types/<resource type>`` API
+  endpoint to return a dictionary which also includes a description for each available
+  permission type. (improvement)
 
 2.2.1 - April 3, 2017
 ---------------------

--- a/st2api/st2api/controllers/v1/actionviews.py
+++ b/st2api/st2api/controllers/v1/actionviews.py
@@ -119,11 +119,11 @@ class OverviewController(resource.ContentPackResourceController):
                                                         requester_user=requester_user,
                                                         permission_type=PermissionType.ACTION_VIEW)
         action_api = ActionAPI(**resp.json)
-        result = self._transform_action_api(action_api)
+        result = self._transform_action_api(action_api=action_api, requester_user=requester_user)
         resp.json = result
         return resp
 
-    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
+    def get_all(self, sort=None, offset=0, limit=None, requester_user=None, **raw_filters):
         """
             List all actions.
 
@@ -137,14 +137,17 @@ class OverviewController(resource.ContentPackResourceController):
         result = []
         for item in resp.json:
             action_api = ActionAPI(**item)
-            result.append(self._transform_action_api(action_api))
+            result.append(self._transform_action_api(action_api=action_api,
+                                                     requester_user=requester_user))
         resp.json = result
         return resp
 
     @staticmethod
-    def _transform_action_api(action_api):
+    def _transform_action_api(action_api, requester_user):
         action_id = action_api.id
-        action_api.parameters = ParametersViewController._get_one(action_id).get('parameters')
+        result = ParametersViewController._get_one(action_id=action_id,
+                                                   requester_user=requester_user)
+        action_api.parameters = result.get('parameters', {})
         return action_api
 
 

--- a/st2api/st2api/controllers/v1/policies.py
+++ b/st2api/st2api/controllers/v1/policies.py
@@ -144,7 +144,9 @@ class PolicyController(resource.ContentPackResourceController):
                              raw_filters=raw_filters)
 
     def get_one(self, ref_or_id, requester_user):
-        return self._get_one(ref_or_id, permission_type=None, requester_user=requester_user)
+        permission_type = PermissionType.POLICY_VIEW
+        return self._get_one(ref_or_id, permission_type=permission_type,
+                             requester_user=requester_user)
 
     def post(self, instance, requester_user):
         """

--- a/st2api/st2api/controllers/v1/policies.py
+++ b/st2api/st2api/controllers/v1/policies.py
@@ -46,8 +46,8 @@ class PolicyTypeController(resource.ResourceController):
 
     include_reference = False
 
-    def get_one(self, ref_or_id):
-        return self._get_one(ref_or_id)
+    def get_one(self, ref_or_id, requester_user):
+        return self._get_one(ref_or_id, requester_user=requester_user)
 
     def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
         return self._get_all(sort=sort,
@@ -55,8 +55,14 @@ class PolicyTypeController(resource.ResourceController):
                              limit=limit,
                              raw_filters=raw_filters)
 
-    def _get_one(self, ref_or_id):
+    def _get_one(self, ref_or_id, requester_user):
         instance = self._get_by_ref_or_id(ref_or_id=ref_or_id)
+
+        permission_type = PermissionType.POLICY_TYPE_VIEW
+        rbac_utils.assert_user_has_resource_db_permission(user_db=requester_user,
+                                                          resource_db=instance,
+                                                          permission_type=permission_type)
+
         result = self.model.from_model(instance)
 
         if result and self.include_reference:

--- a/st2api/st2api/controllers/v1/rbac.py
+++ b/st2api/st2api/controllers/v1/rbac.py
@@ -20,7 +20,6 @@ from st2common.models.api.rbac import UserRoleAssignmentAPI
 from st2common.persistence.rbac import Role
 from st2common.rbac.types import get_resource_permission_types_with_descriptions
 from st2common.persistence.rbac import UserRoleAssignment
-from st2common.rbac.types import RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP
 from st2common.rbac import utils as rbac_utils
 from st2common.router import exc
 

--- a/st2api/st2api/controllers/v1/rbac.py
+++ b/st2api/st2api/controllers/v1/rbac.py
@@ -88,9 +88,7 @@ class PermissionTypesController(object):
         if permission_types is None:
             raise exc.HTTPNotFound('Invalid resource type: %s' % (resource_type))
 
-        result = {}
-        result[resource_type] = permission_types
-        return result
+        return permission_types
 
 
 roles_controller = RolesController()

--- a/st2api/st2api/controllers/v1/rbac.py
+++ b/st2api/st2api/controllers/v1/rbac.py
@@ -13,14 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import six
-
 from st2api.controllers.controller_transforms import transform_to_bool
 from st2api.controllers.resource import ResourceController
 from st2common.models.api.rbac import RoleAPI
 from st2common.persistence.rbac import Role
-from st2common.rbac.types import RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP
-from st2common.rbac.types import PERMISION_TYPE_TO_DESCRIPTION_MAP
+from st2common.rbac.types import get_resource_permission_types_with_descriptions
 from st2common.rbac import utils as rbac_utils
 from st2common.router import exc
 
@@ -73,14 +70,7 @@ class PermissionTypesController(object):
         """
         rbac_utils.assert_user_is_admin(user_db=requester_user)
 
-        result = {}
-
-        for resource_type, permission_types in six.iteritems(RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP):
-            result[resource_type] = {}
-            for permission_type in permission_types:
-                result[resource_type][permission_type] = \
-                    PERMISION_TYPE_TO_DESCRIPTION_MAP[permission_type]
-
+        result = get_resource_permission_types_with_descriptions()
         return result
 
     def get_one(self, resource_type, requester_user):
@@ -92,11 +82,15 @@ class PermissionTypesController(object):
         """
         rbac_utils.assert_user_is_admin(user_db=requester_user)
 
-        permission_types = RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP.get(resource_type, None)
+        all_permission_types = get_resource_permission_types_with_descriptions()
+        permission_types = all_permission_types.get(resource_type, None)
+
         if permission_types is None:
             raise exc.HTTPNotFound('Invalid resource type: %s' % (resource_type))
 
-        return permission_types
+        result = {}
+        result[resource_type] = permission_types
+        return result
 
 
 roles_controller = RolesController()

--- a/st2api/st2api/controllers/v1/rbac.py
+++ b/st2api/st2api/controllers/v1/rbac.py
@@ -13,13 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
+import six
 
 from st2api.controllers.controller_transforms import transform_to_bool
 from st2api.controllers.resource import ResourceController
 from st2common.models.api.rbac import RoleAPI
 from st2common.persistence.rbac import Role
 from st2common.rbac.types import RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP
+from st2common.rbac.types import PERMISION_TYPE_TO_DESCRIPTION_MAP
 from st2common.rbac import utils as rbac_utils
 from st2common.router import exc
 
@@ -72,7 +73,14 @@ class PermissionTypesController(object):
         """
         rbac_utils.assert_user_is_admin(user_db=requester_user)
 
-        result = copy.deepcopy(RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP)
+        result = {}
+
+        for resource_type, permission_types in six.iteritems(RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP):
+            result[resource_type] = {}
+            for permission_type in permission_types:
+                result[resource_type][permission_type] = \
+                    PERMISION_TYPE_TO_DESCRIPTION_MAP[permission_type]
+
         return result
 
     def get_one(self, resource_type, requester_user):

--- a/st2api/st2api/controllers/v1/rbac.py
+++ b/st2api/st2api/controllers/v1/rbac.py
@@ -80,7 +80,7 @@ class PermissionTypesController(object):
             List all the available permission types for a particular resource type.
 
             Handles requests:
-                GET /rbac/permission_types
+                GET /rbac/permission_types/<resource type>
         """
         rbac_utils.assert_user_is_admin(user_db=requester_user)
 

--- a/st2api/st2api/controllers/v1/timers.py
+++ b/st2api/st2api/controllers/v1/timers.py
@@ -95,7 +95,7 @@ class TimersController(resource.ContentPackResourceController):
     def get_one(self, ref_or_id, requester_user):
         return self._get_one(ref_or_id,
                              requester_user=requester_user,
-                             permission_type=PermissionType.TRIGGER_VIEW)
+                             permission_type=PermissionType.TIMER_VIEW)
 
     def add_trigger(self, trigger):
         # Note: Permission checking for creating and deleting a timer is done during rule

--- a/st2api/tests/unit/controllers/v1/test_action_views_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_action_views_rbac.py
@@ -1,0 +1,151 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import httplib
+
+import six
+import mock
+
+from st2common.rbac.types import PermissionType
+from st2common.rbac.types import ResourceType
+from st2common.persistence.auth import User
+from st2common.persistence.rbac import Role
+from st2common.persistence.rbac import UserRoleAssignment
+from st2common.persistence.rbac import PermissionGrant
+from st2common.models.db.auth import UserDB
+from st2common.models.db.rbac import RoleDB
+from st2common.models.db.rbac import UserRoleAssignmentDB
+from st2common.models.db.rbac import PermissionGrantDB
+from st2actions.container.service import RunnerContainerService
+from st2tests.fixturesloader import FixturesLoader
+from tests.base import APIControllerWithRBACTestCase
+
+http_client = six.moves.http_client
+
+__all__ = [
+    'ActionViewsControllerRBACTestCase'
+]
+
+FIXTURES_PACK = 'generic'
+TEST_FIXTURES = {
+    'runners': ['testrunner2.yaml'],
+    'actions': ['a1.yaml', 'a2.yaml'],
+}
+
+
+class ActionViewsControllerRBACTestCase(APIControllerWithRBACTestCase):
+    fixtures_loader = FixturesLoader()
+
+    def setUp(self):
+        super(ActionViewsControllerRBACTestCase, self).setUp()
+        self.models = self.fixtures_loader.save_fixtures_to_db(fixtures_pack=FIXTURES_PACK,
+                                                               fixtures_dict=TEST_FIXTURES)
+
+        file_name = 'a1.yaml'
+        ActionViewsControllerRBACTestCase.ACTION_1 = self.fixtures_loader.load_fixtures(
+            fixtures_pack=FIXTURES_PACK,
+            fixtures_dict={'actions': [file_name]})['actions'][file_name]
+
+        file_name = 'a2.yaml'
+        ActionViewsControllerRBACTestCase.ACTION_1 = self.fixtures_loader.load_fixtures(
+            fixtures_pack=FIXTURES_PACK,
+            fixtures_dict={'actions': [file_name]})['actions'][file_name]
+
+        # Insert mock users, roles and assignments
+
+        # Users
+        user_2_db = UserDB(name='action_view_a1')
+        user_2_db = User.add_or_update(user_2_db)
+        self.users['action_view_a1'] = user_2_db
+
+        # Roles
+
+        # action_view on a1
+        action_uid = self.models['actions']['a1.yaml'].get_uid()
+        grant_db = PermissionGrantDB(resource_uid=action_uid,
+                                     resource_type=ResourceType.ACTION,
+                                     permission_types=[PermissionType.ACTION_VIEW])
+        grant_db = PermissionGrant.add_or_update(grant_db)
+        permission_grants = [str(grant_db.id)]
+        role_1_db = RoleDB(name='action_view_a1', permission_grants=permission_grants)
+        role_1_db = Role.add_or_update(role_1_db)
+        self.roles['action_view_a1'] = role_1_db
+
+        # Role assignments
+        role_assignment_db = UserRoleAssignmentDB(
+            user=self.users['action_view_a1'].name,
+            role=self.roles['action_view_a1'].name)
+        UserRoleAssignment.add_or_update(role_assignment_db)
+
+    def test_get_entry_point_view_no_permission(self):
+        user_db = self.users['no_permissions']
+        self.use_user(user_db)
+
+        action_id = self.models['actions']['a1.yaml'].id
+        action_uid = self.models['actions']['a1.yaml'].get_uid()
+        resp = self.app.get('/v1/actions/views/entry_point/%s' % (action_id), expect_errors=True)
+        expected_msg = ('User "no_permissions" doesn\'t have required permission "action_view"'
+                        ' on resource "%s"' % (action_uid))
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertEqual(resp.json['faultstring'], expected_msg)
+
+    @mock.patch.object(RunnerContainerService, 'get_entry_point_abs_path', mock.MagicMock(
+        return_value='/path/to/file'))
+    @mock.patch('__builtin__.open', mock.mock_open(read_data='file content'), create=True)
+    def test_get_entry_point_view_success(self):
+        user_db = self.users['action_view_a1']
+        self.use_user(user_db)
+
+        # action_view on a1, but no permissions on a2
+        action_id = self.models['actions']['a1.yaml'].id
+        resp = self.app.get('/v1/actions/views/entry_point/%s' % (action_id))
+        self.assertEqual(resp.status_code, httplib.OK)
+
+        action_id = self.models['actions']['a2.yaml'].id
+        action_uid = self.models['actions']['a2.yaml'].get_uid()
+        resp = self.app.get('/v1/actions/views/entry_point/%s' % (action_id), expect_errors=True)
+        expected_msg = ('User "action_view_a1" doesn\'t have required permission "action_view"'
+                        ' on resource "%s"' % (action_uid))
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertEqual(resp.json['faultstring'], expected_msg)
+
+    def test_get_parameters_view_no_permission(self):
+        user_db = self.users['no_permissions']
+        self.use_user(user_db)
+
+        action_id = self.models['actions']['a1.yaml'].id
+        action_uid = self.models['actions']['a1.yaml'].get_uid()
+        resp = self.app.get('/v1/actions/views/parameters/%s' % (action_id), expect_errors=True)
+        expected_msg = ('User "no_permissions" doesn\'t have required permission "action_view"'
+                        ' on resource "%s"' % (action_uid))
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertEqual(resp.json['faultstring'], expected_msg)
+
+    def test_get_parameters_view_success(self):
+        user_db = self.users['action_view_a1']
+        self.use_user(user_db)
+
+        # action_view on a1, but no permissions on a2
+        action_id = self.models['actions']['a1.yaml'].id
+        resp = self.app.get('/v1/actions/views/parameters/%s' % (action_id))
+        self.assertEqual(resp.status_code, httplib.OK)
+
+        action_id = self.models['actions']['a2.yaml'].id
+        action_uid = self.models['actions']['a2.yaml'].get_uid()
+        resp = self.app.get('/v1/actions/views/parameters/%s' % (action_id), expect_errors=True)
+        expected_msg = ('User "action_view_a1" doesn\'t have required permission "action_view"'
+                        ' on resource "%s"' % (action_uid))
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertEqual(resp.json['faultstring'], expected_msg)

--- a/st2api/tests/unit/controllers/v1/test_executions_filters_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_filters_rbac.py
@@ -43,9 +43,9 @@ class ExecutionViewsFiltersControllerRBACTestCase(APIControllerWithRBACTestCase)
         # Insert mock users, roles and assignments
 
         # Users
-        user_1_db = UserDB(name='execution_view_filters_list')
+        user_1_db = UserDB(name='executions_views_filters_list')
         user_1_db = User.add_or_update(user_1_db)
-        self.users['execution_view_filters_list'] = user_1_db
+        self.users['executions_views_filters_list'] = user_1_db
 
         # Roles
         # trace_list
@@ -55,14 +55,15 @@ class ExecutionViewsFiltersControllerRBACTestCase(APIControllerWithRBACTestCase)
                                      permission_types=permission_types)
         grant_db = PermissionGrant.add_or_update(grant_db)
         permission_grants = [str(grant_db.id)]
-        role_1_db = RoleDB(name='execution_view_filters_list', permission_grants=permission_grants)
+        role_1_db = RoleDB(name='executions_views_filters_list',
+                           permission_grants=permission_grants)
         role_1_db = Role.add_or_update(role_1_db)
-        self.roles['execution_view_filters_list'] = role_1_db
+        self.roles['executions_views_filters_list'] = role_1_db
 
         # Role assignments
         role_assignment_db = UserRoleAssignmentDB(
-            user=self.users['execution_view_filters_list'].name,
-            role=self.roles['execution_view_filters_list'].name)
+            user=self.users['executions_views_filters_list'].name,
+            role=self.roles['executions_views_filters_list'].name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
     def test_get_view_filters_no_permissions(self):
@@ -71,12 +72,12 @@ class ExecutionViewsFiltersControllerRBACTestCase(APIControllerWithRBACTestCase)
 
         resp = self.app.get('/v1/executions/views/filters', expect_errors=True)
         expected_msg = ('User "no_permissions" doesn\'t have required permission '
-                        '"execution_view_filters_list"')
+                        '"executions_views_filters_list"')
         self.assertEqual(resp.status_code, httplib.FORBIDDEN)
         self.assertEqual(resp.json['faultstring'], expected_msg)
 
     def test_get_view_filters_success(self):
-        user_db = self.users['execution_view_filters_list']
+        user_db = self.users['executions_views_filters_list']
         self.use_user(user_db)
 
         resp = self.app.get('/v1/executions/views/filters')

--- a/st2api/tests/unit/controllers/v1/test_executions_filters_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_filters_rbac.py
@@ -1,0 +1,85 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import httplib
+
+import six
+
+from st2common.rbac.types import PermissionType
+from st2common.rbac.types import ResourceType
+from st2common.persistence.auth import User
+from st2common.persistence.rbac import Role
+from st2common.persistence.rbac import UserRoleAssignment
+from st2common.persistence.rbac import PermissionGrant
+from st2common.models.db.auth import UserDB
+from st2common.models.db.rbac import RoleDB
+from st2common.models.db.rbac import UserRoleAssignmentDB
+from st2common.models.db.rbac import PermissionGrantDB
+from tests.base import APIControllerWithRBACTestCase
+
+http_client = six.moves.http_client
+
+__all__ = [
+    'ExecutionViewsFiltersControllerRBACTestCase'
+]
+
+
+class ExecutionViewsFiltersControllerRBACTestCase(APIControllerWithRBACTestCase):
+    def setUp(self):
+        super(ExecutionViewsFiltersControllerRBACTestCase, self).setUp()
+
+        # Insert mock users, roles and assignments
+
+        # Users
+        user_1_db = UserDB(name='execution_view_filters_list')
+        user_1_db = User.add_or_update(user_1_db)
+        self.users['execution_view_filters_list'] = user_1_db
+
+        # Roles
+        # trace_list
+        permission_types = [PermissionType.EXECUTION_VIEWS_FILTERS_LIST]
+        grant_db = PermissionGrantDB(resource_uid=None,
+                                     resource_type=ResourceType.EXECUTION,
+                                     permission_types=permission_types)
+        grant_db = PermissionGrant.add_or_update(grant_db)
+        permission_grants = [str(grant_db.id)]
+        role_1_db = RoleDB(name='execution_view_filters_list', permission_grants=permission_grants)
+        role_1_db = Role.add_or_update(role_1_db)
+        self.roles['execution_view_filters_list'] = role_1_db
+
+        # Role assignments
+        role_assignment_db = UserRoleAssignmentDB(
+            user=self.users['execution_view_filters_list'].name,
+            role=self.roles['execution_view_filters_list'].name)
+        UserRoleAssignment.add_or_update(role_assignment_db)
+
+    def test_get_view_filters_no_permissions(self):
+        user_db = self.users['no_permissions']
+        self.use_user(user_db)
+
+        resp = self.app.get('/v1/executions/views/filters', expect_errors=True)
+        expected_msg = ('User "no_permissions" doesn\'t have required permission '
+                        '"execution_view_filters_list"')
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertEqual(resp.json['faultstring'], expected_msg)
+
+    def test_get_view_filters_success(self):
+        user_db = self.users['execution_view_filters_list']
+        self.use_user(user_db)
+
+        resp = self.app.get('/v1/executions/views/filters')
+        self.assertEqual(resp.status_code, httplib.OK)
+        self.assertTrue('status' in resp.json)
+        self.assertTrue('action' in resp.json)

--- a/st2api/tests/unit/controllers/v1/test_executions_filters_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_filters_rbac.py
@@ -43,9 +43,9 @@ class ExecutionViewsFiltersControllerRBACTestCase(APIControllerWithRBACTestCase)
         # Insert mock users, roles and assignments
 
         # Users
-        user_1_db = UserDB(name='executions_views_filters_list')
+        user_1_db = UserDB(name='execution_views_filters_list')
         user_1_db = User.add_or_update(user_1_db)
-        self.users['executions_views_filters_list'] = user_1_db
+        self.users['execution_views_filters_list'] = user_1_db
 
         # Roles
         # trace_list
@@ -55,15 +55,15 @@ class ExecutionViewsFiltersControllerRBACTestCase(APIControllerWithRBACTestCase)
                                      permission_types=permission_types)
         grant_db = PermissionGrant.add_or_update(grant_db)
         permission_grants = [str(grant_db.id)]
-        role_1_db = RoleDB(name='executions_views_filters_list',
+        role_1_db = RoleDB(name='execution_views_filters_list',
                            permission_grants=permission_grants)
         role_1_db = Role.add_or_update(role_1_db)
-        self.roles['executions_views_filters_list'] = role_1_db
+        self.roles['execution_views_filters_list'] = role_1_db
 
         # Role assignments
         role_assignment_db = UserRoleAssignmentDB(
-            user=self.users['executions_views_filters_list'].name,
-            role=self.roles['executions_views_filters_list'].name)
+            user=self.users['execution_views_filters_list'].name,
+            role=self.roles['execution_views_filters_list'].name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
     def test_get_view_filters_no_permissions(self):
@@ -72,12 +72,12 @@ class ExecutionViewsFiltersControllerRBACTestCase(APIControllerWithRBACTestCase)
 
         resp = self.app.get('/v1/executions/views/filters', expect_errors=True)
         expected_msg = ('User "no_permissions" doesn\'t have required permission '
-                        '"executions_views_filters_list"')
+                        '"execution_views_filters_list"')
         self.assertEqual(resp.status_code, httplib.FORBIDDEN)
         self.assertEqual(resp.json['faultstring'], expected_msg)
 
     def test_get_view_filters_success(self):
-        user_db = self.users['executions_views_filters_list']
+        user_db = self.users['execution_views_filters_list']
         self.use_user(user_db)
 
         resp = self.app.get('/v1/executions/views/filters')

--- a/st2api/tests/unit/controllers/v1/test_policies_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_policies_rbac.py
@@ -1,0 +1,178 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import httplib
+
+import six
+
+from st2common.rbac.types import PermissionType
+from st2common.rbac.types import ResourceType
+from st2common.persistence.auth import User
+from st2common.persistence.rbac import Role
+from st2common.persistence.rbac import UserRoleAssignment
+from st2common.persistence.rbac import PermissionGrant
+from st2common.models.db.auth import UserDB
+from st2common.models.db.rbac import RoleDB
+from st2common.models.db.rbac import UserRoleAssignmentDB
+from st2common.models.db.rbac import PermissionGrantDB
+from st2tests.fixturesloader import FixturesLoader
+from tests.base import APIControllerWithRBACTestCase
+
+http_client = six.moves.http_client
+
+__all__ = [
+    'PolicyTypeControllerRBACTestCase'
+]
+
+FIXTURES_PACK = 'generic'
+TEST_FIXTURES = {
+    'policytypes': [
+        'fake_policy_type_1.yaml',
+        'fake_policy_type_2.yaml'
+    ],
+    'policies': [
+        'policy_1.yaml',
+        'policy_2.yaml'
+    ]
+}
+
+
+class PolicyTypeControllerRBACTestCase(APIControllerWithRBACTestCase):
+    fixtures_loader = FixturesLoader()
+
+    def setUp(self):
+        super(PolicyTypeControllerRBACTestCase, self).setUp()
+        self.models = self.fixtures_loader.save_fixtures_to_db(fixtures_pack=FIXTURES_PACK,
+                                                               fixtures_dict=TEST_FIXTURES)
+
+        file_name = 'fake_policy_type_1.yaml'
+        PolicyTypeControllerRBACTestCase.POLICY_TYPE_1 = self.fixtures_loader.load_fixtures(
+            fixtures_pack=FIXTURES_PACK,
+            fixtures_dict={'policytypes': [file_name]})['policytypes'][file_name]
+
+        file_name = 'fake_policy_type_2.yaml'
+        PolicyTypeControllerRBACTestCase.POLICY_TYPE_2 = self.fixtures_loader.load_fixtures(
+            fixtures_pack=FIXTURES_PACK,
+            fixtures_dict={'policytypes': [file_name]})['policytypes'][file_name]
+
+        # Insert mock users, roles and assignments
+
+        # Users
+        user_1_db = UserDB(name='policy_type_list')
+        user_1_db = User.add_or_update(user_1_db)
+        self.users['policy_type_list'] = user_1_db
+
+        user_2_db = UserDB(name='policy_type_view')
+        user_2_db = User.add_or_update(user_2_db)
+        self.users['policy_type_view'] = user_2_db
+
+        # Roles
+        # policy_type_list
+        grant_db = PermissionGrantDB(resource_uid=None,
+                                     resource_type=ResourceType.POLICY_TYPE,
+                                     permission_types=[PermissionType.POLICY_TYPE_LIST])
+        grant_db = PermissionGrant.add_or_update(grant_db)
+        permission_grants = [str(grant_db.id)]
+        role_1_db = RoleDB(name='policy_type_list', permission_grants=permission_grants)
+        role_1_db = Role.add_or_update(role_1_db)
+        self.roles['policy_type_list'] = role_1_db
+
+        # policy_type_view on timer 1
+        policy_type_uid = self.models['policytypes']['fake_policy_type_1.yaml'].get_uid()
+        grant_db = PermissionGrantDB(resource_uid=policy_type_uid,
+                                     resource_type=ResourceType.POLICY_TYPE,
+                                     permission_types=[PermissionType.POLICY_TYPE_VIEW])
+        grant_db = PermissionGrant.add_or_update(grant_db)
+        permission_grants = [str(grant_db.id)]
+        role_1_db = RoleDB(name='policy_type_view', permission_grants=permission_grants)
+        role_1_db = Role.add_or_update(role_1_db)
+        self.roles['policy_type_view'] = role_1_db
+
+        # Role assignments
+        role_assignment_db = UserRoleAssignmentDB(
+            user=self.users['policy_type_list'].name,
+            role=self.roles['policy_type_list'].name)
+        UserRoleAssignment.add_or_update(role_assignment_db)
+
+        role_assignment_db = UserRoleAssignmentDB(
+            user=self.users['policy_type_view'].name,
+            role=self.roles['policy_type_view'].name)
+        UserRoleAssignment.add_or_update(role_assignment_db)
+
+    def test_get_all_no_permissions(self):
+        user_db = self.users['no_permissions']
+        self.use_user(user_db)
+
+        resp = self.app.get('/v1/policytypes', expect_errors=True)
+        expected_msg = ('User "no_permissions" doesn\'t have required permission '
+                        '"policy_type_list"')
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertEqual(resp.json['faultstring'], expected_msg)
+
+    def test_get_one_no_permissions(self):
+        user_db = self.users['no_permissions']
+        self.use_user(user_db)
+
+        policy_type_id = self.models['policytypes']['fake_policy_type_1.yaml'].id
+        policy_type_uid = self.models['policytypes']['fake_policy_type_1.yaml'].get_uid()
+        resp = self.app.get('/v1/policytypes/%s' % (policy_type_id), expect_errors=True)
+        expected_msg = ('User "no_permissions" doesn\'t have required permission "policy_type_view"'
+                        ' on resource "%s"' % (policy_type_uid))
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertEqual(resp.json['faultstring'], expected_msg)
+
+    def test_get_all_permission_success_get_one_no_permission_failure(self):
+        user_db = self.users['policy_type_list']
+        self.use_user(user_db)
+
+        # policy_type_list permission, but no policy_type_view permission
+        resp = self.app.get('/v1/policytypes')
+        self.assertEqual(resp.status_code, httplib.OK)
+        self.assertEqual(len(resp.json), 2)
+
+        policy_type_id = self.models['policytypes']['fake_policy_type_1.yaml'].id
+        policy_type_uid = self.models['policytypes']['fake_policy_type_1.yaml'].get_uid()
+        resp = self.app.get('/v1/policytypes/%s' % (policy_type_id), expect_errors=True)
+        expected_msg = ('User "policy_type_list" doesn\'t have required permission '
+                        '"policy_type_view" on resource "%s"' % (policy_type_uid))
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertEqual(resp.json['faultstring'], expected_msg)
+
+    def test_get_one_permission_success_get_all_no_permission_failure(self):
+        user_db = self.users['policy_type_view']
+        self.use_user(user_db)
+
+        # policy_type_view permission, but no policy_type_list permission
+        resp = self.app.get('/v1/policytypes', expect_errors=True)
+        expected_msg = ('User "policy_type_view" doesn\'t have required permission '
+                        '"policy_type_list"')
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertEqual(resp.json['faultstring'], expected_msg)
+
+        # policy_type_view in fake_policy_type_1, but not on fake_policy_type_2
+        policy_type_id = self.models['policytypes']['fake_policy_type_1.yaml'].id
+        policy_type_uid = self.models['policytypes']['fake_policy_type_1.yaml'].get_uid()
+        resp = self.app.get('/v1/policytypes/%s' % (policy_type_id), expect_errors=True)
+        resp = self.app.get('/v1/policytypes/%s' % (policy_type_id))
+        self.assertEqual(resp.status_code, httplib.OK)
+        self.assertEqual(resp.json['uid'], policy_type_uid)
+
+        policy_type_id = self.models['policytypes']['fake_policy_type_2.yaml'].id
+        policy_type_uid = self.models['policytypes']['fake_policy_type_2.yaml'].get_uid()
+        expected_msg = ('User "policy_type_view" doesn\'t have required permission '
+                        '"policy_type_view" on resource "%s"' % (policy_type_uid))
+        resp = self.app.get('/v1/policytypes/%s' % (policy_type_id), expect_errors=True)
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertEqual(resp.json['faultstring'], expected_msg)

--- a/st2api/tests/unit/controllers/v1/test_policies_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_policies_rbac.py
@@ -189,12 +189,12 @@ class PolicyControllerRBACTestCase(APIControllerWithRBACTestCase):
                                                                fixtures_dict=TEST_FIXTURES)
 
         file_name = 'policy_1.yaml'
-        PolicyTypeControllerRBACTestCase.POLICY_1 = self.fixtures_loader.load_fixtures(
+        PolicyControllerRBACTestCase.POLICY_1 = self.fixtures_loader.load_fixtures(
             fixtures_pack=FIXTURES_PACK,
             fixtures_dict={'policies': [file_name]})['policies'][file_name]
 
         file_name = 'policy_2.yaml'
-        PolicyTypeControllerRBACTestCase.POLICY_TYPE_2 = self.fixtures_loader.load_fixtures(
+        PolicyControllerRBACTestCase.POLICY_TYPE_2 = self.fixtures_loader.load_fixtures(
             fixtures_pack=FIXTURES_PACK,
             fixtures_dict={'policies': [file_name]})['policies'][file_name]
 
@@ -343,5 +343,42 @@ class PolicyControllerRBACTestCase(APIControllerWithRBACTestCase):
         resp = self.app.get('/v1/policies/%s' % (policy_id), expect_errors=True)
         expected_msg = ('User "policy_view_policy8_parent_pack" doesn\'t have required permission'
                         ' "policy_view" on resource "%s"' % (policy_uid))
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertEqual(resp.json['faultstring'], expected_msg)
+
+    def test_policy_create_no_permissions(self):
+        user_db = self.users['no_permissions']
+        self.use_user(user_db)
+
+        policy_uid = self.models['policies']['policy_1.yaml'].get_uid()
+        data = self.POLICY_1
+        resp = self.app.post_json('/v1/policies', data, expect_errors=True)
+        expected_msg = ('User "no_permissions" doesn\'t have required permission "policy_create" '
+                        'on resource "%s"' % (policy_uid))
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertEqual(resp.json['faultstring'], expected_msg)
+
+    def test_policy_update_no_permissions(self):
+        user_db = self.users['no_permissions']
+        self.use_user(user_db)
+
+        policy_id = self.models['policies']['policy_1.yaml'].id
+        policy_uid = self.models['policies']['policy_1.yaml'].get_uid()
+        data = self.POLICY_1
+        resp = self.app.put_json('/v1/policies/%s' % (policy_id), data, expect_errors=True)
+        expected_msg = ('User "no_permissions" doesn\'t have required permission "policy_modify"'
+                        ' on resource "%s"' % (policy_uid))
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertEqual(resp.json['faultstring'], expected_msg)
+
+    def test_policy_delete_no_permissions(self):
+        user_db = self.users['no_permissions']
+        self.use_user(user_db)
+
+        policy_id = self.models['policies']['policy_1.yaml'].id
+        policy_uid = self.models['policies']['policy_1.yaml'].get_uid()
+        resp = self.app.delete('/v1/policies/%s' % (policy_id), expect_errors=True)
+        expected_msg = ('User "no_permissions" doesn\'t have required permission "policy_delete"'
+                        ' on resource "%s"' % (policy_uid))
         self.assertEqual(resp.status_code, httplib.FORBIDDEN)
         self.assertEqual(resp.json['faultstring'], expected_msg)

--- a/st2api/tests/unit/controllers/v1/test_policies_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_policies_rbac.py
@@ -33,7 +33,8 @@ from tests.base import APIControllerWithRBACTestCase
 http_client = six.moves.http_client
 
 __all__ = [
-    'PolicyTypeControllerRBACTestCase'
+    'PolicyTypeControllerRBACTestCase',
+    'PolicyControllerRBACTestCase'
 ]
 
 FIXTURES_PACK = 'generic'
@@ -44,7 +45,8 @@ TEST_FIXTURES = {
     ],
     'policies': [
         'policy_1.yaml',
-        'policy_2.yaml'
+        'policy_2.yaml',
+        'policy_8.yaml'
     ]
 }
 
@@ -174,5 +176,172 @@ class PolicyTypeControllerRBACTestCase(APIControllerWithRBACTestCase):
         expected_msg = ('User "policy_type_view" doesn\'t have required permission '
                         '"policy_type_view" on resource "%s"' % (policy_type_uid))
         resp = self.app.get('/v1/policytypes/%s' % (policy_type_id), expect_errors=True)
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertEqual(resp.json['faultstring'], expected_msg)
+
+
+class PolicyControllerRBACTestCase(APIControllerWithRBACTestCase):
+    fixtures_loader = FixturesLoader()
+
+    def setUp(self):
+        super(PolicyControllerRBACTestCase, self).setUp()
+        self.models = self.fixtures_loader.save_fixtures_to_db(fixtures_pack=FIXTURES_PACK,
+                                                               fixtures_dict=TEST_FIXTURES)
+
+        file_name = 'policy_1.yaml'
+        PolicyTypeControllerRBACTestCase.POLICY_1 = self.fixtures_loader.load_fixtures(
+            fixtures_pack=FIXTURES_PACK,
+            fixtures_dict={'policies': [file_name]})['policies'][file_name]
+
+        file_name = 'policy_2.yaml'
+        PolicyTypeControllerRBACTestCase.POLICY_TYPE_2 = self.fixtures_loader.load_fixtures(
+            fixtures_pack=FIXTURES_PACK,
+            fixtures_dict={'policies': [file_name]})['policies'][file_name]
+
+        # Insert mock users, roles and assignments
+
+        # Users
+        user_1_db = UserDB(name='policy_list')
+        user_1_db = User.add_or_update(user_1_db)
+        self.users['policy_list'] = user_1_db
+
+        user_2_db = UserDB(name='policy_view_direct_policy1')
+        user_2_db = User.add_or_update(user_2_db)
+        self.users['policy_view_direct_policy1'] = user_2_db
+
+        user_3_db = UserDB(name='policy_view_policy8_parent_pack')
+        user_3_db = User.add_or_update(user_3_db)
+        self.users['policy_view_policy8_parent_pack'] = user_3_db
+
+        # Roles
+        # policy_list
+        grant_db = PermissionGrantDB(resource_uid=None,
+                                     resource_type=ResourceType.POLICY,
+                                     permission_types=[PermissionType.POLICY_LIST])
+        grant_db = PermissionGrant.add_or_update(grant_db)
+        permission_grants = [str(grant_db.id)]
+        role_1_db = RoleDB(name='policy_list', permission_grants=permission_grants)
+        role_1_db = Role.add_or_update(role_1_db)
+        self.roles['policy_list'] = role_1_db
+
+        # policy_view directly on policy1
+        policy_type_uid = self.models['policies']['policy_1.yaml'].get_uid()
+        grant_db = PermissionGrantDB(resource_uid=policy_type_uid,
+                                     resource_type=ResourceType.POLICY,
+                                     permission_types=[PermissionType.POLICY_VIEW])
+        grant_db = PermissionGrant.add_or_update(grant_db)
+        permission_grants = [str(grant_db.id)]
+        role_1_db = RoleDB(name='policy_view_direct_policy1', permission_grants=permission_grants)
+        role_1_db = Role.add_or_update(role_1_db)
+        self.roles['policy_view_direct_policy1'] = role_1_db
+
+        # policy_view on a parent pack of policy 8
+        policy_pack_uid = self.models['policies']['policy_8.yaml'].get_pack_uid()
+        grant_db = PermissionGrantDB(resource_uid=policy_pack_uid,
+                                     resource_type=ResourceType.PACK,
+                                     permission_types=[PermissionType.POLICY_VIEW])
+        grant_db = PermissionGrant.add_or_update(grant_db)
+        permission_grants = [str(grant_db.id)]
+        role_1_db = RoleDB(name='policy_view_policy8_parent_pack',
+                           permission_grants=permission_grants)
+        role_1_db = Role.add_or_update(role_1_db)
+        self.roles['policy_view_policy8_parent_pack'] = role_1_db
+
+        # Role assignments
+        role_assignment_db = UserRoleAssignmentDB(
+            user=self.users['policy_list'].name,
+            role=self.roles['policy_list'].name)
+        UserRoleAssignment.add_or_update(role_assignment_db)
+
+        role_assignment_db = UserRoleAssignmentDB(
+            user=self.users['policy_view_direct_policy1'].name,
+            role=self.roles['policy_view_direct_policy1'].name)
+        UserRoleAssignment.add_or_update(role_assignment_db)
+
+        role_assignment_db = UserRoleAssignmentDB(
+            user=self.users['policy_view_policy8_parent_pack'].name,
+            role=self.roles['policy_view_policy8_parent_pack'].name)
+        UserRoleAssignment.add_or_update(role_assignment_db)
+
+    def test_get_all_no_permissions(self):
+        user_db = self.users['no_permissions']
+        self.use_user(user_db)
+
+        resp = self.app.get('/v1/policies', expect_errors=True)
+        expected_msg = ('User "no_permissions" doesn\'t have required permission '
+                        '"policy_list"')
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertEqual(resp.json['faultstring'], expected_msg)
+
+    def test_get_one_no_permissions(self):
+        user_db = self.users['no_permissions']
+        self.use_user(user_db)
+
+        policy_id = self.models['policies']['policy_1.yaml'].id
+        policy_uid = self.models['policies']['policy_1.yaml'].get_uid()
+        resp = self.app.get('/v1/policies/%s' % (policy_id), expect_errors=True)
+        expected_msg = ('User "no_permissions" doesn\'t have required permission "policy_view"'
+                        ' on resource "%s"' % (policy_uid))
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertEqual(resp.json['faultstring'], expected_msg)
+
+    def test_get_all_permission_success_get_one_no_permission_failure(self):
+        user_db = self.users['policy_list']
+        self.use_user(user_db)
+
+        # policy_list permission, but no policy_view permission
+        resp = self.app.get('/v1/policies')
+        self.assertEqual(resp.status_code, httplib.OK)
+        self.assertEqual(len(resp.json), 3)
+
+        policy_id = self.models['policies']['policy_1.yaml'].id
+        policy_uid = self.models['policies']['policy_1.yaml'].get_uid()
+        resp = self.app.get('/v1/policies/%s' % (policy_id), expect_errors=True)
+        expected_msg = ('User "policy_list" doesn\'t have required permission "policy_view"'
+                        ' on resource "%s"' % (policy_uid))
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertEqual(resp.json['faultstring'], expected_msg)
+
+    def test_get_one_permission_success_get_all_no_permission_failure(self):
+        user_db = self.users['policy_view_direct_policy1']
+        self.use_user(user_db)
+
+        # policy_view permission, but no policy_type_list permission
+        resp = self.app.get('/v1/policies', expect_errors=True)
+        expected_msg = ('User "policy_view_direct_policy1" doesn\'t have required permission '
+                        '"policy_list"')
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertEqual(resp.json['faultstring'], expected_msg)
+
+        # policy_view in policy_1, but not on policy_2
+        policy_id = self.models['policies']['policy_1.yaml'].id
+        policy_uid = self.models['policies']['policy_1.yaml'].get_uid()
+        resp = self.app.get('/v1/policies/%s' % (policy_id))
+        self.assertEqual(resp.status_code, httplib.OK)
+        self.assertEqual(resp.json['uid'], policy_uid)
+
+        policy_id = self.models['policies']['policy_2.yaml'].id
+        policy_uid = self.models['policies']['policy_2.yaml'].get_uid()
+        resp = self.app.get('/v1/policies/%s' % (policy_id), expect_errors=True)
+        expected_msg = ('User "policy_view_direct_policy1" doesn\'t have required permission'
+                        ' "policy_view" on resource "%s"' % (policy_uid))
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertEqual(resp.json['faultstring'], expected_msg)
+
+        # policy_view on parent pack of policy8, but not on policy1
+        user_db = self.users['policy_view_policy8_parent_pack']
+        self.use_user(user_db)
+
+        policy_id = self.models['policies']['policy_8.yaml'].id
+        policy_uid = self.models['policies']['policy_8.yaml'].get_uid()
+        resp = self.app.get('/v1/policies/%s' % (policy_id))
+        self.assertEqual(resp.status_code, httplib.OK)
+        self.assertEqual(resp.json['uid'], policy_uid)
+
+        policy_id = self.models['policies']['policy_1.yaml'].id
+        policy_uid = self.models['policies']['policy_1.yaml'].get_uid()
+        resp = self.app.get('/v1/policies/%s' % (policy_id), expect_errors=True)
+        expected_msg = ('User "policy_view_policy8_parent_pack" doesn\'t have required permission'
+                        ' "policy_view" on resource "%s"' % (policy_uid))
         self.assertEqual(resp.status_code, httplib.FORBIDDEN)
         self.assertEqual(resp.json['faultstring'], expected_msg)

--- a/st2api/tests/unit/controllers/v1/test_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_rbac.py
@@ -91,15 +91,12 @@ class TestRbacController(APIControllerWithRBACTestCase):
     def test_permission_type_get_one(self):
         self.use_user(self.users['admin'])
 
-        list_resp = self.app.get('/v1/rbac/permission_types')
-        self.assertEqual(list_resp.status_int, 200)
-        self.assertTrue(len(list(list_resp.json)) > 0,
-                        '/v1/rbac/permission_types did not return correct permission types.')
-        resource_type = list(list_resp.json)[0]
+        resource_type = ResourceType.RULE
         get_resp = self.app.get('/v1/rbac/permission_types/%s' % resource_type)
         self.assertEqual(get_resp.status_int, 200)
         self.assertTrue(len(get_resp.json) > 0,
                         '/v1/rbac/permission_types did not return correct permission types.')
+        self.assertTrue(PermissionType.RULE_ALL in get_resp.json)
 
     def test_permission_type_get_all(self):
         self.use_user(self.users['admin'])

--- a/st2api/tests/unit/controllers/v1/test_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_rbac.py
@@ -106,6 +106,8 @@ class TestRbacController(APIControllerWithRBACTestCase):
 
         resp = self.app.get('/v1/rbac/permission_types')
         self.assertEqual(resp.status_int, 200)
+        self.assertTrue(ResourceType.ACTION in resp.json)
+        self.assertTrue(PermissionType.ACTION_LIST in resp.json[ResourceType.ACTION])
         self.assertTrue(len(list(resp.json)) > 0,
                         '/v1/rbac/permission_types did not return correct permission types.')
 

--- a/st2api/tests/unit/controllers/v1/test_timers_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_timers_rbac.py
@@ -92,8 +92,8 @@ class TimerControllerRBACTestCase(APIControllerWithRBACTestCase):
         trigger_db = self.models['triggers']['cron1.yaml']
         timer_uid = TimerDB(name=trigger_db.name, pack=trigger_db.pack).get_uid()
         grant_db = PermissionGrantDB(resource_uid=timer_uid,
-                                     resource_type=ResourceType.TRIGGER,
-                                     permission_types=[PermissionType.TRIGGER_VIEW])
+                                     resource_type=ResourceType.TIMER,
+                                     permission_types=[PermissionType.TIMER_VIEW])
         grant_db = PermissionGrant.add_or_update(grant_db)
         permission_grants = [str(grant_db.id)]
         role_1_db = RoleDB(name='timer_view', permission_grants=permission_grants)

--- a/st2api/tests/unit/controllers/v1/test_timers_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_timers_rbac.py
@@ -124,11 +124,12 @@ class TimerControllerRBACTestCase(APIControllerWithRBACTestCase):
         user_db = self.users['no_permissions']
         self.use_user(user_db)
 
-        trigger_id = self.models['triggers']['cron1.yaml'].id
-        trigger_uid = self.models['triggers']['cron1.yaml'].get_uid()
+        trigger_db = self.models['triggers']['cron1.yaml']
+        trigger_id = trigger_db.id
+        timer_uid = TimerDB(name=trigger_db.name, pack=trigger_db.pack).get_uid()
         resp = self.app.get('/v1/timers/%s' % (trigger_id), expect_errors=True)
         expected_msg = ('User "no_permissions" doesn\'t have required permission "timer_view"'
-                        ' on resource "%s"' % (trigger_uid))
+                        ' on resource "%s"' % (timer_uid))
         self.assertEqual(resp.status_code, httplib.FORBIDDEN)
         self.assertEqual(resp.json['faultstring'], expected_msg)
 
@@ -141,11 +142,12 @@ class TimerControllerRBACTestCase(APIControllerWithRBACTestCase):
         self.assertEqual(resp.status_code, httplib.OK)
         self.assertEqual(len(resp.json), 5)
 
-        trigger_id = self.models['triggers']['cron1.yaml'].id
-        trigger_uid = self.models['triggers']['cron1.yaml'].get_uid()
+        trigger_db = self.models['triggers']['cron1.yaml']
+        trigger_id = trigger_db.id
+        timer_uid = TimerDB(name=trigger_db.name, pack=trigger_db.pack).get_uid()
         resp = self.app.get('/v1/timers/%s' % (trigger_id), expect_errors=True)
         expected_msg = ('User "timer_list" doesn\'t have required permission "timer_view"'
-                        ' on resource "%s"' % (trigger_uid))
+                        ' on resource "%s"' % (timer_uid))
         self.assertEqual(resp.status_code, httplib.FORBIDDEN)
         self.assertEqual(resp.json['faultstring'], expected_msg)
 
@@ -154,8 +156,9 @@ class TimerControllerRBACTestCase(APIControllerWithRBACTestCase):
         self.use_user(user_db)
 
         # timer_view permission, but no timer_list permission
-        trigger_id = self.models['triggers']['cron1.yaml'].id
-        trigger_uid = self.models['triggers']['cron1.yaml'].get_uid()
+        trigger_db = self.models['triggers']['cron1.yaml']
+        trigger_id = trigger_db.id
+        trigger_uid = trigger_db.get_uid()
         resp = self.app.get('/v1/timers/%s' % (trigger_id))
         self.assertEqual(resp.status_code, httplib.OK)
         self.assertEqual(resp.json['uid'], trigger_uid)

--- a/st2api/tests/unit/controllers/v1/test_timers_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_timers_rbac.py
@@ -27,6 +27,7 @@ from st2common.models.db.auth import UserDB
 from st2common.models.db.rbac import RoleDB
 from st2common.models.db.rbac import UserRoleAssignmentDB
 from st2common.models.db.rbac import PermissionGrantDB
+from st2common.models.db.timer import TimerDB
 from st2tests.fixturesloader import FixturesLoader
 from tests.base import APIControllerWithRBACTestCase
 
@@ -68,45 +69,46 @@ class TimerControllerRBACTestCase(APIControllerWithRBACTestCase):
         # Insert mock users, roles and assignments
 
         # Users
-        user_1_db = UserDB(name='trigger_list')
+        user_1_db = UserDB(name='timer_list')
         user_1_db = User.add_or_update(user_1_db)
-        self.users['trigger_list'] = user_1_db
+        self.users['timer_list'] = user_1_db
 
-        user_2_db = UserDB(name='trigger_view')
+        user_2_db = UserDB(name='timer_view')
         user_2_db = User.add_or_update(user_2_db)
-        self.users['trigger_view'] = user_2_db
+        self.users['timer_view'] = user_2_db
 
         # Roles
-        # trigger_list
+        # timer_list
         grant_db = PermissionGrantDB(resource_uid=None,
-                                     resource_type=ResourceType.TRIGGER,
-                                     permission_types=[PermissionType.TRIGGER_LIST])
+                                     resource_type=ResourceType.TIMER,
+                                     permission_types=[PermissionType.TIMER_LIST])
         grant_db = PermissionGrant.add_or_update(grant_db)
         permission_grants = [str(grant_db.id)]
-        role_1_db = RoleDB(name='trigger_list', permission_grants=permission_grants)
+        role_1_db = RoleDB(name='timer_list', permission_grants=permission_grants)
         role_1_db = Role.add_or_update(role_1_db)
-        self.roles['trigger_list'] = role_1_db
+        self.roles['timer_list'] = role_1_db
 
-        # trigger_view on timer 1
-        trigger_uid = self.models['triggers']['cron1.yaml'].get_uid()
-        grant_db = PermissionGrantDB(resource_uid=trigger_uid,
+        # timer_View on timer 1
+        trigger_db = self.models['triggers']['cron1.yaml']
+        timer_uid = TimerDB(name=trigger_db.name, pack=trigger_db.pack).get_uid()
+        grant_db = PermissionGrantDB(resource_uid=timer_uid,
                                      resource_type=ResourceType.TRIGGER,
                                      permission_types=[PermissionType.TRIGGER_VIEW])
         grant_db = PermissionGrant.add_or_update(grant_db)
         permission_grants = [str(grant_db.id)]
-        role_1_db = RoleDB(name='trigger_view', permission_grants=permission_grants)
+        role_1_db = RoleDB(name='timer_view', permission_grants=permission_grants)
         role_1_db = Role.add_or_update(role_1_db)
-        self.roles['trigger_view'] = role_1_db
+        self.roles['timer_view'] = role_1_db
 
         # Role assignments
         role_assignment_db = UserRoleAssignmentDB(
-            user=self.users['trigger_list'].name,
-            role=self.roles['trigger_list'].name)
+            user=self.users['timer_list'].name,
+            role=self.roles['timer_list'].name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         role_assignment_db = UserRoleAssignmentDB(
-            user=self.users['trigger_view'].name,
-            role=self.roles['trigger_view'].name)
+            user=self.users['timer_view'].name,
+            role=self.roles['timer_view'].name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
     def test_get_all_no_permissions(self):
@@ -114,7 +116,7 @@ class TimerControllerRBACTestCase(APIControllerWithRBACTestCase):
         self.use_user(user_db)
 
         resp = self.app.get('/v1/timers', expect_errors=True)
-        expected_msg = ('User "no_permissions" doesn\'t have required permission "trigger_list"')
+        expected_msg = ('User "no_permissions" doesn\'t have required permission "timer_list"')
         self.assertEqual(resp.status_code, httplib.FORBIDDEN)
         self.assertEqual(resp.json['faultstring'], expected_msg)
 
@@ -125,16 +127,16 @@ class TimerControllerRBACTestCase(APIControllerWithRBACTestCase):
         trigger_id = self.models['triggers']['cron1.yaml'].id
         trigger_uid = self.models['triggers']['cron1.yaml'].get_uid()
         resp = self.app.get('/v1/timers/%s' % (trigger_id), expect_errors=True)
-        expected_msg = ('User "no_permissions" doesn\'t have required permission "trigger_view"'
+        expected_msg = ('User "no_permissions" doesn\'t have required permission "timer_view"'
                         ' on resource "%s"' % (trigger_uid))
         self.assertEqual(resp.status_code, httplib.FORBIDDEN)
         self.assertEqual(resp.json['faultstring'], expected_msg)
 
     def test_get_all_permission_success_get_one_no_permission_failure(self):
-        user_db = self.users['trigger_list']
+        user_db = self.users['timer_list']
         self.use_user(user_db)
 
-        # trigger_list permission, but no trigger_view permission
+        # timer_list permission, but no timer_view permission
         resp = self.app.get('/v1/timers')
         self.assertEqual(resp.status_code, httplib.OK)
         self.assertEqual(len(resp.json), 5)
@@ -142,16 +144,16 @@ class TimerControllerRBACTestCase(APIControllerWithRBACTestCase):
         trigger_id = self.models['triggers']['cron1.yaml'].id
         trigger_uid = self.models['triggers']['cron1.yaml'].get_uid()
         resp = self.app.get('/v1/timers/%s' % (trigger_id), expect_errors=True)
-        expected_msg = ('User "trigger_list" doesn\'t have required permission "trigger_view"'
+        expected_msg = ('User "timer_list" doesn\'t have required permission "timer_view"'
                         ' on resource "%s"' % (trigger_uid))
         self.assertEqual(resp.status_code, httplib.FORBIDDEN)
         self.assertEqual(resp.json['faultstring'], expected_msg)
 
     def test_get_one_permission_success_get_all_no_permission_failure(self):
-        user_db = self.users['trigger_view']
+        user_db = self.users['timer_view']
         self.use_user(user_db)
 
-        # trigger_view permission, but no trigger_list permission
+        # timer_view permission, but no timer_list permission
         trigger_id = self.models['triggers']['cron1.yaml'].id
         trigger_uid = self.models['triggers']['cron1.yaml'].get_uid()
         resp = self.app.get('/v1/timers/%s' % (trigger_id))
@@ -159,6 +161,6 @@ class TimerControllerRBACTestCase(APIControllerWithRBACTestCase):
         self.assertEqual(resp.json['uid'], trigger_uid)
 
         resp = self.app.get('/v1/timers', expect_errors=True)
-        expected_msg = ('User "trigger_view" doesn\'t have required permission "trigger_list"')
+        expected_msg = ('User "timer_view" doesn\'t have required permission "timer_list"')
         self.assertEqual(resp.status_code, httplib.FORBIDDEN)
         self.assertEqual(resp.json['faultstring'], expected_msg)

--- a/st2common/st2common/constants/types.py
+++ b/st2common/st2common/constants/types.py
@@ -38,6 +38,8 @@ class ResourceType(Enum):
     TRIGGER_INSTANCE = 'trigger_instance'
     RULE = 'rule'
     RULE_ENFORCEMENT = 'rule_enforcement'
+    POLICY_TYPE = 'policy_type'
+    POLICY = 'policy'
 
     # Other resources
     EXECUTION = 'execution'

--- a/st2common/st2common/constants/types.py
+++ b/st2common/st2common/constants/types.py
@@ -48,6 +48,7 @@ class ResourceType(Enum):
     KEY_VALUE_PAIR = 'key_value_pair'
 
     WEBHOOK = 'webhook'
+    TIMER = 'timer'
     API_KEY = 'api_key'
     TRACE = 'trace'
     TIMER = 'timer'

--- a/st2common/st2common/constants/types.py
+++ b/st2common/st2common/constants/types.py
@@ -38,6 +38,8 @@ class ResourceType(Enum):
     TRIGGER_INSTANCE = 'trigger_instance'
     RULE = 'rule'
     RULE_ENFORCEMENT = 'rule_enforcement'
+
+    # Note: Policy type is a global resource and policy belong to a pack
     POLICY_TYPE = 'policy_type'
     POLICY = 'policy'
 

--- a/st2common/st2common/models/api/policy.py
+++ b/st2common/st2common/models/api/policy.py
@@ -15,6 +15,7 @@
 
 from st2common.persistence.policy import PolicyType
 from st2common.models.api.base import BaseAPI
+from st2common.models.api.base import APIUIDMixin
 from st2common.models.db.policy import PolicyTypeDB, PolicyDB
 from st2common import log as logging
 from st2common.util import schema as util_schema
@@ -25,7 +26,7 @@ __all__ = ['PolicyTypeAPI']
 LOG = logging.getLogger(__name__)
 
 
-class PolicyTypeAPI(BaseAPI):
+class PolicyTypeAPI(BaseAPI, APIUIDMixin):
     model = PolicyTypeDB
     schema = {
         "title": "Policy Type",
@@ -34,6 +35,9 @@ class PolicyTypeAPI(BaseAPI):
             "id": {
                 "type": "string",
                 "default": None
+            },
+            'uid': {
+                'type': 'string'
             },
             "name": {
                 "type": "string",
@@ -79,7 +83,7 @@ class PolicyTypeAPI(BaseAPI):
                          parameters=getattr(instance, 'parameters', dict()))
 
 
-class PolicyAPI(BaseAPI):
+class PolicyAPI(BaseAPI, APIUIDMixin):
     model = PolicyDB
     schema = {
         "title": "Policy",
@@ -88,6 +92,9 @@ class PolicyAPI(BaseAPI):
             "id": {
                 "type": "string",
                 "default": None
+            },
+            'uid': {
+                'type': 'string'
             },
             "name": {
                 "type": "string",

--- a/st2common/st2common/models/db/policy.py
+++ b/st2common/st2common/models/db/policy.py
@@ -113,7 +113,7 @@ class PolicyTypeDB(stormbase.StormBaseDB, stormbase.UIDFieldMixin):
         module: The python module that implements the policy for this type.
         parameters: The specification for parameters for the policy type.
     """
-    ResourceType = ResourceType.POLICY_TYPE
+    RESOURCE_TYPE = ResourceType.POLICY_TYPE
     UID_FIELDS = ['resource_type', 'name']
 
     ref = me.StringField(required=True)

--- a/st2common/st2common/models/db/policy.py
+++ b/st2common/st2common/models/db/policy.py
@@ -133,6 +133,7 @@ class PolicyTypeDB(stormbase.StormBaseDB, stormbase.UIDFieldMixin):
 
     def __init__(self, *args, **kwargs):
         super(PolicyTypeDB, self).__init__(*args, **kwargs)
+        self.uid = self.get_uid()
         self.ref = PolicyTypeReference.to_string_reference(resource_type=self.resource_type,
                                                            name=self.name)
 
@@ -183,6 +184,7 @@ class PolicyDB(stormbase.StormFoundationDB, stormbase.ContentPackResourceMixin,
 
     def __init__(self, *args, **kwargs):
         super(PolicyDB, self).__init__(*args, **kwargs)
+        self.uid = self.get_uid()
         self.ref = common_models.ResourceReference.to_string_reference(pack=self.pack,
                                                                        name=self.name)
 

--- a/st2common/st2common/models/db/policy.py
+++ b/st2common/st2common/models/db/policy.py
@@ -19,6 +19,7 @@ from st2common import log as logging
 from st2common.constants import pack as pack_constants
 from st2common.models.db import stormbase
 from st2common.models.system import common as common_models
+from st2common.constants.types import ResourceType
 
 
 __all__ = ['PolicyTypeReference',
@@ -99,7 +100,7 @@ class PolicyTypeReference(object):
                 (self.__class__.__name__, self.resource_type, self.name, self.ref))
 
 
-class PolicyTypeDB(stormbase.StormBaseDB):
+class PolicyTypeDB(stormbase.StormBaseDB, stormbase.UIDFieldMixin):
     """
     The representation of an PolicyType in the system.
 
@@ -112,6 +113,9 @@ class PolicyTypeDB(stormbase.StormBaseDB):
         module: The python module that implements the policy for this type.
         parameters: The specification for parameters for the policy type.
     """
+    ResourceType = ResourceType.POLICY_TYPE
+    UID_FIELDS = ['resource_type', 'name']
+
     ref = me.StringField(required=True)
     resource_type = me.StringField(
         required=True,
@@ -141,7 +145,8 @@ class PolicyTypeDB(stormbase.StormBaseDB):
         return PolicyTypeReference(resource_type=self.resource_type, name=self.name)
 
 
-class PolicyDB(stormbase.StormFoundationDB, stormbase.ContentPackResourceMixin):
+class PolicyDB(stormbase.StormFoundationDB, stormbase.ContentPackResourceMixin,
+               stormbase.UIDFieldMixin):
     """
     The representation for a policy in the system.
 
@@ -151,6 +156,9 @@ class PolicyDB(stormbase.StormFoundationDB, stormbase.ContentPackResourceMixin):
         policy_type: The type of policy.
         parameters: The specification of input parameters for the policy.
     """
+    RESOURCE_TYPE = ResourceType.POLICY
+    UID_FIELDS = ['pack', 'name']
+
     name = me.StringField(required=True)
     ref = me.StringField(required=True)
     pack = me.StringField(

--- a/st2common/st2common/models/db/timer.py
+++ b/st2common/st2common/models/db/timer.py
@@ -1,0 +1,40 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mongoengine as me
+
+from st2common.models.db import stormbase
+from st2common.constants.types import ResourceType
+
+
+class TimerDB(stormbase.StormFoundationDB, stormbase.UIDFieldMixin):
+    """
+    Note: Right now timer is a meta model which is not persisted in the database (it's only used
+    for RBAC purposes).
+
+    Attribute:
+        name: Timer name - maps to the URL path (e.g. st2/ or my/webhook/one).
+    """
+
+    RESOURCE_TYPE = ResourceType.TIMER
+    UID_FIELDS = ['pack', 'name']
+
+    name = me.StringField(required=True)
+    type = me.StringField()
+    parameters = me.DictField()
+
+    def __init__(self, *args, **values):
+        super(TimerDB, self).__init__(*args, **values)
+        self.uid = self.get_uid()

--- a/st2common/st2common/models/db/timer.py
+++ b/st2common/st2common/models/db/timer.py
@@ -32,6 +32,7 @@ class TimerDB(stormbase.StormFoundationDB, stormbase.UIDFieldMixin):
     UID_FIELDS = ['pack', 'name']
 
     name = me.StringField(required=True)
+    pack = me.StringField(required=True, unique_with='name')
     type = me.StringField()
     parameters = me.DictField()
 

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -2881,7 +2881,7 @@ paths:
   /api/v1/timers:
     get:
       operationId: st2api.controllers.v1.timers:timers_controller.get_all
-      x-permissions: {{ PERMISSION_TYPE.TRIGGER_LIST }}
+      x-permissions: {{ PERMISSION_TYPE.TIMER_LIST }}
       description: Returns a list of all the timers.
       parameters:
         - name: timer_type

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -2011,19 +2011,6 @@ paths:
           description: Dictionary of permission types by resource types.
           schema:
             type: object
-          examples:
-            application/json:
-              runner_type:
-                - runner_type_list
-                - runner_type_view
-                - runner_type_modify
-                - runner_type_all
-              pack:
-                - pack_list
-                - pack_view
-                - pack_create
-                - pack_modify
-                - pack_delete
         default:
           description: Unexpected error
           schema:
@@ -2047,15 +2034,7 @@ paths:
         '200':
           description: List of permission types.
           schema:
-            type: array
-            items:
-              type: string
-          examples:
-            application/json:
-              - runner_type_list
-              - runner_type_view
-              - runner_type_modify
-              - runner_type_all
+            type: object
         default:
           description: Unexpected error
           schema:

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -1493,7 +1493,7 @@ paths:
   /api/v1/packs/index/health:
     get:
       operationId: st2api.controllers.v1.packs:packs_controller.index.get
-      x-permissions: {{ PERMISSION_TYPE.PACK_VIEW_INDEX_HEALTH }}
+      x-permissions: {{ PERMISSION_TYPE.PACK_VIEWS_INDEX_HEALTH }}
       description: To get the state of all indexes used by your StackStorm instance.
       responses:
         '200':

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -4036,6 +4036,7 @@ definitions:
   PolicyList:
     type: object
   PolicyCreate:
+    x-api-model: st2common.models.api.policy:PolicyAPI
     type: object
   RunnerType:
     type: object

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -387,6 +387,11 @@ paths:
           description: Entity id
           type: string
           required: true
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: An object containing action parameters
@@ -486,6 +491,11 @@ paths:
           description: Entity reference or id
           type: string
           required: true
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: Entry point code
@@ -1099,6 +1109,7 @@ paths:
   /api/v1/executions/views/filters:
     get:
       operationId: st2api.controllers.v1.executionviews:filters_controller.get_all
+      x-permissions: {{ PERMISSION_TYPE.EXECUTION_VIEWS_FILTERS_LIST }}
       description: |
         Get a list of distinct values for the execution filters.
       parameters:

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -1761,6 +1761,7 @@ paths:
   /api/v1/policytypes:
     get:
       operationId: st2api.controllers.v1.policies:policy_type_controller.get_all
+      x-permissions: {{ PERMISSION_TYPE.POLICY_TYPE_LIST }}
       description: Returns a list of all the policy types.
       parameters:
         - name: resource_type
@@ -1834,6 +1835,7 @@ paths:
   /api/v1/policies:
     get:
       operationId: st2api.controllers.v1.policies:policy_controller.get_all
+      x-permissions: {{ PERMISSION_TYPE.POLICY_LIST }}
       description: |
         List of policies
       parameters:
@@ -1871,6 +1873,11 @@ paths:
           schema:
             $ref: '#/definitions/PolicyCreate'
           required: true
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: Policy created successfully.
@@ -1895,6 +1902,11 @@ paths:
           description: Entity reference or id.
           type: string
           required: true
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: Policy found.
@@ -1924,6 +1936,11 @@ paths:
           schema:
             $ref: '#/definitions/PolicyCreate'
           required: true
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: Policy updated successfully.
@@ -1947,6 +1964,11 @@ paths:
           description: Entity reference or id.
           type: string
           required: true
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '204':
           description: Policy deleted

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -436,6 +436,11 @@ paths:
           in: query
           description: Action pack name filter
           type: string
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of actions

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -1819,6 +1819,11 @@ paths:
           description: Entity reference or id.
           type: string
           required: true
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: Specific policy type.

--- a/st2common/st2common/rbac/resolvers.py
+++ b/st2common/st2common/rbac/resolvers.py
@@ -646,7 +646,8 @@ class ExecutionPermissionsResolver(PermissionsResolver):
     resource_type = ResourceType.EXECUTION
 
     def user_has_permission(self, user_db, permission_type):
-        assert permission_type in [PermissionType.EXECUTION_LIST]
+        assert permission_type in [PermissionType.EXECUTION_LIST,
+                                   PermissionType.EXECUTION_VIEWS_FILTERS_LIST]
         return self._user_has_list_permission(user_db=user_db, permission_type=permission_type)
 
     def user_has_resource_db_permission(self, user_db, resource_db, permission_type):

--- a/st2common/st2common/rbac/resolvers.py
+++ b/st2common/st2common/rbac/resolvers.py
@@ -911,7 +911,7 @@ class PolicyTypePermissionsResolver(PermissionsResolver):
     resource_type = ResourceType.POLICY_TYPE
 
     def user_has_permission(self, user_db, permission_type):
-        assert permission_type in [PermissionType.POLICY_TYPE]
+        assert permission_type in [PermissionType.POLICY_TYPE_LIST]
         return self._user_has_list_permission(user_db=user_db, permission_type=permission_type)
 
     def user_has_resource_db_permission(self, user_db, resource_db, permission_type):
@@ -955,7 +955,7 @@ class PolicyPermissionsResolver(ContentPackResourcePermissionsResolver):
     Permission resolver for "policy" resource type.
     """
 
-    resource_type = ResourceType.Policy
+    resource_type = ResourceType.POLICY
     view_grant_permission_types = [
         PermissionType.POLICY_ALL,
         PermissionType.POLICY_CREATE,

--- a/st2common/st2common/rbac/resolvers.py
+++ b/st2common/st2common/rbac/resolvers.py
@@ -684,6 +684,8 @@ class ExecutionPermissionsResolver(PermissionsResolver):
             action_permission_type = PermissionType.ACTION_EXECUTE
         elif permission_type == PermissionType.EXECUTION_ALL:
             action_permission_type = PermissionType.ACTION_ALL
+        elif permission_type == PermissionType.EXECUTION_VIEWS_FILTERS_LIST:
+            action_permission_type = PermissionType.EXECUTION_VIEWS_FILTERS_LIST
         else:
             raise ValueError('Invalid permission type: %s' % (permission_type))
 

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -118,6 +118,10 @@ class PermissionType(Enum):
     WEBHOOK_DELETE = 'webhook_delete'
     WEBHOOK_ALL = 'webhook_all'
 
+    TIMER_LIST = 'timer_list'
+    TIMER_VIEW = 'timer_view'
+    TIMER_ALL = 'timer_all'
+
     API_KEY_LIST = 'api_key_list'
     API_KEY_VIEW = 'api_key_view'
     API_KEY_CREATE = 'api_key_create'
@@ -242,6 +246,7 @@ class ResourceType(Enum):
     EXECUTION = SystemResourceType.EXECUTION
     KEY_VALUE_PAIR = SystemResourceType.KEY_VALUE_PAIR
     WEBHOOK = SystemResourceType.WEBHOOK
+    TIMER = SystemResourceType.TIMER
     API_KEY = SystemResourceType.API_KEY
     TRACE = SystemResourceType.TRACE
     TRIGGER = SystemResourceType.TRIGGER
@@ -358,6 +363,11 @@ RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP = {
         PermissionType.WEBHOOK_SEND,
         PermissionType.WEBHOOK_DELETE,
         PermissionType.WEBHOOK_ALL
+    ],
+    ResourceType.TIMER: [
+        PermissionType.TIMER_LIST,
+        PermissionType.TIMER_VIEW,
+        PermissionType.TIMER_ALL
     ],
     ResourceType.API_KEY: [
         PermissionType.API_KEY_LIST,
@@ -512,6 +522,10 @@ PERMISION_TYPE_TO_DESCRIPTION_MAP = {
     PermissionType.WEBHOOK_DELETE: ('Ability to delete an existing webhook.'),
     PermissionType.WEBHOOK_ALL: ('Ability to perform all the supported operations on a particular '
                                  'webhook.'),
+
+    PermissionType.TIMER_LIST: 'Ability to list (view all) timers.',
+    PermissionType.TIMER_VIEW: ('Ability to view a timer.'),
+    PermissionType.TIMER_ALL: ('Ability to perform all the supported operations on timers'),
 
     PermissionType.API_KEY_LIST: 'Ability to list (view all) API keys.',
     PermissionType.API_KEY_VIEW: ('Ability to view an API Key.'),

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -61,7 +61,7 @@ class PermissionType(Enum):
     PACK_REGISTER = 'pack_register'
     PACK_CONFIG = 'pack_config'
     PACK_SEARCH = 'pack_search'
-    PACK_VIEW_INDEX_HEALTH = 'pack_view_index_health'
+    PACK_VIEWS_INDEX_HEALTH = 'pack_views_index_health'
 
     PACK_ALL = 'pack_all'
 
@@ -94,7 +94,7 @@ class PermissionType(Enum):
     EXECUTION_RE_RUN = 'execution_rerun'
     EXECUTION_STOP = 'execution_stop'
     EXECUTION_ALL = 'execution_all'
-    EXECUTION_VIEWS_FILTERS_LIST = 'execution_view_filters_list'
+    EXECUTION_VIEWS_FILTERS_LIST = 'execution_views_filters_list'
 
     RULE_LIST = 'rule_list'
     RULE_VIEW = 'rule_view'
@@ -168,9 +168,9 @@ class PermissionType(Enum):
         :rtype: ``str``
         """
         # Special case for:
-        # * PACK_VIEW_INDEX_HEALTH
+        # * PACK_VIEWS_INDEX_HEALTH
         # * EXECUTION_VIEWS_FILTERS_LIST
-        if permission_type == PermissionType.PACK_VIEW_INDEX_HEALTH:
+        if permission_type == PermissionType.PACK_VIEWS_INDEX_HEALTH:
             return ResourceType.PACK
         elif permission_type == PermissionType.EXECUTION_VIEWS_FILTERS_LIST:
             return ResourceType.EXECUTION
@@ -190,8 +190,8 @@ class PermissionType(Enum):
         split = permission_type.split('_')
         assert len(split) >= 2
 
-        # Special case for PACK_VIEW_INDEX_HEALTH
-        if permission_type == PermissionType.PACK_VIEW_INDEX_HEALTH:
+        # Special case for PACK_VIEWS_INDEX_HEALTH
+        if permission_type == PermissionType.PACK_VIEWS_INDEX_HEALTH:
             split = permission_type.split('_', 1)
             return split[1]
 
@@ -280,7 +280,7 @@ RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP = {
         PermissionType.PACK_REGISTER,
         PermissionType.PACK_CONFIG,
         PermissionType.PACK_SEARCH,
-        PermissionType.PACK_VIEW_INDEX_HEALTH,
+        PermissionType.PACK_VIEWS_INDEX_HEALTH,
         PermissionType.PACK_ALL,
 
         PermissionType.SENSOR_VIEW,
@@ -416,7 +416,7 @@ GLOBAL_PERMISSION_TYPES = [
     PermissionType.PACK_REGISTER,
     PermissionType.PACK_CONFIG,
     PermissionType.PACK_SEARCH,
-    PermissionType.PACK_VIEW_INDEX_HEALTH,
+    PermissionType.PACK_VIEWS_INDEX_HEALTH,
 
     # Action alias global permission types
     PermissionType.ACTION_ALIAS_MATCH,
@@ -448,7 +448,7 @@ PERMISION_TYPE_TO_DESCRIPTION_MAP = {
     PermissionType.PACK_REGISTER: 'Ability to register packs and corresponding resources.',
     PermissionType.PACK_CONFIG: 'Ability to configure a pack.',
     PermissionType.PACK_SEARCH: 'Ability to query registry and search packs.',
-    PermissionType.PACK_VIEW_INDEX_HEALTH: 'Ability to query health of pack registries.',
+    PermissionType.PACK_VIEWS_INDEX_HEALTH: 'Ability to query health of pack registries.',
     PermissionType.PACK_ALL: ('Ability to perform all the supported operations on a particular '
                               'pack.'),
 

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -131,6 +131,17 @@ class PermissionType(Enum):
     TRIGGER_VIEW = 'trigger_view'
     TRIGGER_ALL = 'trigger_all'
 
+    POLICY_TYPE_LIST = 'policy_type_list'
+    POLICY_TYPE_VIEW = 'policy_type_view'
+    POLICY_TYPE_ALL = 'policy_type_all'
+
+    POLICY_LIST = 'policy_list'
+    POLICY_VIEW = 'policy_view'
+    POLICY_CREATE = 'policy_create'
+    POLICY_MODIFY = 'policy_modify'
+    POLICY_DELETE = 'policy_delete'
+    POLICY_ALL = 'policy_all'
+
     @classmethod
     def get_valid_permissions_for_resource_type(cls, resource_type):
         """
@@ -347,11 +358,26 @@ RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP = {
     ],
     ResourceType.TRACE: [
         PermissionType.TRACE_LIST,
-        PermissionType.TRACE_VIEW
+        PermissionType.TRACE_VIEW,
+        PermissionType.TRACE_ALL
     ],
     ResourceType.TRIGGER: [
         PermissionType.TRIGGER_LIST,
-        PermissionType.TRIGGER_VIEW
+        PermissionType.TRIGGER_VIEW,
+        PermissionType.TRIGGER_ALL
+    ],
+    ResourceType.POLICY_TYPE: [
+        PermissionType.POLICY_TYPE_LIST,
+        PermissionType.POLICY_TYPE_VIEW,
+        PermissionType.POLICY_TYPE_ALL,
+    ],
+    ResourceType.POLICY: [
+        PermissionType.POLICY_LIST,
+        PermissionType.POLICY_VIEW,
+        PermissionType.POLICY_CREATE,
+        PermissionType.POLICY_MODIFY,
+        PermissionType.POLICY_DELETE,
+        PermissionType.POLICY_ALL,
     ]
 }
 
@@ -376,7 +402,10 @@ GLOBAL_PERMISSION_TYPES = [
     PermissionType.ACTION_ALIAS_HELP,
 
     # API key global permission types
-    PermissionType.API_KEY_CREATE
+    PermissionType.API_KEY_CREATE,
+
+    # Policy global permission types
+    PermissionType.POLICY_CREATE
 ] + LIST_PERMISSION_TYPES
 
 GLOBAL_PACK_PERMISSION_TYPES = [permission_type for permission_type in GLOBAL_PERMISSION_TYPES if

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -518,4 +518,17 @@ PERMISION_TYPE_TO_DESCRIPTION_MAP = {
     PermissionType.TRIGGER_LIST: ('Ability to list (view all) triggers.'),
     PermissionType.TRIGGER_VIEW: ('Ability to view a trigger.'),
     PermissionType.TRIGGER_ALL: ('Ability to perform all the supported operations on triggers.'),
+
+    PermissionType.POLICY_TYPE_LIST: ('Ability to list (view all) policy types.'),
+    PermissionType.POLICY_TYPE_VIEW: ('Ability to view a policy types.'),
+    PermissionType.POLICY_TYPE_ALL: ('Ability to perform all the supported operations on policy'
+                                     ' types.'),
+
+    PermissionType.POLICY_LIST: 'Ability to list (view all) policies.',
+    PermissionType.POLICY_VIEW: ('Ability to view a policy.'),
+    PermissionType.POLICY_CREATE: ('Ability to create a new policy.'),
+    PermissionType.POLICY_MODIFY: ('Ability to modify an existing policy.'),
+    PermissionType.POLICY_DELETE: ('Ability to delete an existing policy.'),
+    PermissionType.POLICY_ALL: ('Ability to perform all the supported operations on a particular '
+                                'policy.')
 }

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -481,7 +481,7 @@ PERMISION_TYPE_TO_DESCRIPTION_MAP = {
     PermissionType.ACTION_ALIAS_MATCH: ('Ability to use action alias match API endpoint.'),
     PermissionType.ACTION_ALIAS_HELP: ('Ability to use action alias help API endpoint.'),
     PermissionType.ACTION_ALIAS_DELETE: ('Ability to delete an existing action alias. Also '
-                                         'imples "action_alias_view" permission.'),
+                                         'implies "action_alias_view" permission.'),
     PermissionType.ACTION_ALIAS_ALL: ('Ability to perform all the supported operations on a '
                                       'particular action alias.'),
 
@@ -491,7 +491,7 @@ PERMISION_TYPE_TO_DESCRIPTION_MAP = {
     PermissionType.EXECUTION_STOP: 'Ability to stop (cancel) a running execution.',
     PermissionType.EXECUTION_ALL: ('Ability to perform all the supported operations on a '
                                    'particular execution.'),
-    PermissionType.EXECUTION_VIEWS_FILTERS_LIST: ('Ability vew all the distinct execution '
+    PermissionType.EXECUTION_VIEWS_FILTERS_LIST: ('Ability view all the distinct execution '
                                                   'filters.'),
 
     PermissionType.RULE_LIST: 'Ability to list (view all) rules.',

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -228,6 +228,8 @@ class ResourceType(Enum):
     ACTION_ALIAS = SystemResourceType.ACTION_ALIAS
     RULE = SystemResourceType.RULE
     RULE_ENFORCEMENT = SystemResourceType.RULE_ENFORCEMENT
+    POLICY_TYPE = SystemResourceType.POLICY_TYPE
+    POLICY = SystemResourceType.POLICY
 
     EXECUTION = SystemResourceType.EXECUTION
     KEY_VALUE_PAIR = SystemResourceType.KEY_VALUE_PAIR

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -94,6 +94,7 @@ class PermissionType(Enum):
     EXECUTION_RE_RUN = 'execution_rerun'
     EXECUTION_STOP = 'execution_stop'
     EXECUTION_ALL = 'execution_all'
+    EXECUTION_VIEW_FILTERS_LIST = 'execution_view_filters_list'
 
     RULE_LIST = 'rule_list'
     RULE_VIEW = 'rule_view'
@@ -410,7 +411,10 @@ GLOBAL_PERMISSION_TYPES = [
     PermissionType.API_KEY_CREATE,
 
     # Policy global permission types
-    PermissionType.POLICY_CREATE
+    PermissionType.POLICY_CREATE,
+
+    # Execution
+    PermissionType.EXECUTION_VIEW_FILTERS_LIST
 ] + LIST_PERMISSION_TYPES
 
 GLOBAL_PACK_PERMISSION_TYPES = [permission_type for permission_type in GLOBAL_PERMISSION_TYPES if
@@ -472,6 +476,7 @@ PERMISION_TYPE_TO_DESCRIPTION_MAP = {
     PermissionType.EXECUTION_STOP: 'Ability to stop (cancel) a running execution.',
     PermissionType.EXECUTION_ALL: ('Ability to perform all the supported operations on a '
                                    'particular execution.'),
+    PermissionType.EXECUTION_VIEW_FILTERS_LIST: ('Ability vew all the distinct execution filters'),
 
     PermissionType.RULE_LIST: 'Ability to list (view all) rules.',
     PermissionType.RULE_VIEW: 'Ability to view a rule.',

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import six
 import itertools
 
 from st2common.util.enum import Enum
@@ -29,7 +30,9 @@ __all__ = [
     'ALL_PERMISSION_TYPES',
     'GLOBAL_PERMISSION_TYPES',
     'GLOBAL_PACK_PERMISSION_TYPES',
-    'LIST_PERMISSION_TYPES'
+    'LIST_PERMISSION_TYPES',
+
+    'get_resource_permission_types_with_descriptions'
 ]
 
 
@@ -532,3 +535,20 @@ PERMISION_TYPE_TO_DESCRIPTION_MAP = {
     PermissionType.POLICY_ALL: ('Ability to perform all the supported operations on a particular '
                                 'policy.')
 }
+
+
+def get_resource_permission_types_with_descriptions():
+    """
+    Return available permission types for each resource types with corresponding descriptions.
+
+    :rtype: ``dict`
+    """
+    result = {}
+
+    for resource_type, permission_types in six.iteritems(RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP):
+        result[resource_type] = {}
+        for permission_type in permission_types:
+            result[resource_type][permission_type] = \
+                PERMISION_TYPE_TO_DESCRIPTION_MAP[permission_type]
+
+    return result

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -94,7 +94,7 @@ class PermissionType(Enum):
     EXECUTION_RE_RUN = 'execution_rerun'
     EXECUTION_STOP = 'execution_stop'
     EXECUTION_ALL = 'execution_all'
-    EXECUTION_VIEW_FILTERS_LIST = 'execution_view_filters_list'
+    EXECUTION_VIEWS_FILTERS_LIST = 'execution_view_filters_list'
 
     RULE_LIST = 'rule_list'
     RULE_VIEW = 'rule_view'
@@ -169,6 +169,8 @@ class PermissionType(Enum):
         # Special case for PACK_VIEW_INDEX_HEALTH
         if permission_type == PermissionType.PACK_VIEW_INDEX_HEALTH:
             return split[0]
+        elif permission_type == PermissionType.EXECUTION_VIEWS_FILTERS_LIST:
+            return ResourceType.EXECUTION
 
         return '_'.join(split[:-1])
 
@@ -340,6 +342,7 @@ RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP = {
         PermissionType.EXECUTION_RE_RUN,
         PermissionType.EXECUTION_STOP,
         PermissionType.EXECUTION_ALL,
+        PermissionType.EXECUTION_VIEWS_FILTERS_LIST,
     ],
     ResourceType.KEY_VALUE_PAIR: [
         PermissionType.KEY_VALUE_VIEW,
@@ -414,7 +417,7 @@ GLOBAL_PERMISSION_TYPES = [
     PermissionType.POLICY_CREATE,
 
     # Execution
-    PermissionType.EXECUTION_VIEW_FILTERS_LIST
+    PermissionType.EXECUTION_VIEWS_FILTERS_LIST
 ] + LIST_PERMISSION_TYPES
 
 GLOBAL_PACK_PERMISSION_TYPES = [permission_type for permission_type in GLOBAL_PERMISSION_TYPES if
@@ -476,7 +479,8 @@ PERMISION_TYPE_TO_DESCRIPTION_MAP = {
     PermissionType.EXECUTION_STOP: 'Ability to stop (cancel) a running execution.',
     PermissionType.EXECUTION_ALL: ('Ability to perform all the supported operations on a '
                                    'particular execution.'),
-    PermissionType.EXECUTION_VIEW_FILTERS_LIST: ('Ability vew all the distinct execution filters'),
+    PermissionType.EXECUTION_VIEWS_FILTERS_LIST: ('Ability vew all the distinct execution '
+                                                  'filters.'),
 
     PermissionType.RULE_LIST: 'Ability to list (view all) rules.',
     PermissionType.RULE_VIEW: 'Ability to view a rule.',

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -163,14 +163,16 @@ class PermissionType(Enum):
 
         :rtype: ``str``
         """
-        split = permission_type.split('_')
-        assert len(split) >= 2
-
-        # Special case for PACK_VIEW_INDEX_HEALTH
+        # Special case for:
+        # * PACK_VIEW_INDEX_HEALTH
+        # * EXECUTION_VIEWS_FILTERS_LIST
         if permission_type == PermissionType.PACK_VIEW_INDEX_HEALTH:
-            return split[0]
+            return ResourceType.PACK
         elif permission_type == PermissionType.EXECUTION_VIEWS_FILTERS_LIST:
             return ResourceType.EXECUTION
+
+        split = permission_type.split('_')
+        assert len(split) >= 2
 
         return '_'.join(split[:-1])
 

--- a/st2common/tests/unit/test_db_model_uids.py
+++ b/st2common/tests/unit/test_db_model_uids.py
@@ -24,6 +24,8 @@ from st2common.models.db.action import ActionDB
 from st2common.models.db.rule import RuleDB
 from st2common.models.db.trigger import TriggerTypeDB
 from st2common.models.db.trigger import TriggerDB
+from st2common.models.db.policy import PolicyTypeDB
+from st2common.models.db.policy import PolicyDB
 
 __all__ = [
     'DBModelUIDFieldTestCase'
@@ -70,3 +72,9 @@ class DBModelUIDFieldTestCase(unittest2.TestCase):
         parameters = OrderedDict({'c': [1, 2, 3], 'b': u'unicode', 'd': {'h': 2, 'g': 1}, 'a': 1})
         trigger_db = TriggerDB(name='tname', pack='tpack', parameters=parameters)
         self.assertEqual(trigger_db.get_uid(), 'trigger:tpack:tname:%s' % (paramers_hash))
+
+        policy_type_db = PolicyTypeDB(resource_type='action', name='concurrency')
+        self.assertEqual(policy_type_db.get_uid(), 'policy_type:action:concurrency')
+
+        policy_db = PolicyDB(pack='dummy', name='policy1')
+        self.assertEqual(policy_db.get_uid(), 'policy:dummy:policy1')

--- a/st2tests/st2tests/fixtures/generic/actions/a1.yaml
+++ b/st2tests/st2tests/fixtures/generic/actions/a1.yaml
@@ -1,7 +1,7 @@
 ---
 description: test description
 enabled: true
-entry_point: /tmp/test/action1.sh
+entry_point: test/action1.sh
 name: a1
 pack: wolfpack
 parameters: {}

--- a/st2tests/st2tests/fixtures/generic/policies/policy_8.yaml
+++ b/st2tests/st2tests/fixtures/generic/policies/policy_8.yaml
@@ -1,0 +1,12 @@
+---
+name: action-8.concurrency.attr.cancel
+pack: wolfpack2
+description: Limits the concurrent executions for the fake action by actionstr.
+enabled: true
+resource_ref: wolfpack2.action-8
+policy_type: action.concurrency.attr
+parameters:
+    action: cancel
+    threshold: 3
+    attributes:
+        - actionstr

--- a/st2tests/st2tests/fixtures/rbac/roles/role_seven.yaml
+++ b/st2tests/st2tests/fixtures/rbac/roles/role_seven.yaml
@@ -11,6 +11,6 @@
                - "pack_uninstall"
                - "pack_register"
                - "pack_search"
-               - "pack_view_index_health"
+               - "pack_views_index_health"
                - "action_alias_match"
                - "action_alias_help"


### PR DESCRIPTION
This pull request implements RBAC for rest of the API endpoints which were missing it:

- [x] Policy type (get all, get one)
- [x] Policy (get all, get one, create, update, delete)
- [x] Action entry_point view
- [x] Action parameters view
- [x] Rule views
- [x] Introduce new ephemeral "Timer" model which is only used for permission grants (same as we do for webhooks)