### PR TITLE
Cancel subworkflow actions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,7 @@ in development
   ``TRIGGER_*`` RBAC permission constants (improvement)
 * Implement RBAC for webhooks get all and get one API endpoint. (improvement)
 * Add webhook payload to the Jinja render context when rendering Jinja variable inside rule criteria section
+* Cancel actions that are Mistral workflow when the parent workflow is cancelled. (improvement)
 
 2.2.1 - April 3, 2017
 ---------------------

--- a/contrib/examples/actions/mistral-basic.yaml
+++ b/contrib/examples/actions/mistral-basic.yaml
@@ -1,6 +1,7 @@
 ---
 description: Run a local linux command
 enabled: true
+runner_type: mistral-v2
 entry_point: workflows/mistral-basic.yaml
 name: mistral-basic
 pack: examples
@@ -8,4 +9,6 @@ parameters:
   cmd:
     required: true
     type: string
-runner_type: mistral-v2
+  timeout:
+    type: integer
+    default: 60

--- a/contrib/examples/actions/mistral-test-cancel-subworkflow-action.yaml
+++ b/contrib/examples/actions/mistral-test-cancel-subworkflow-action.yaml
@@ -1,0 +1,12 @@
+---
+description: A sample workflow used to test the cascading cancel of subworkflow action.
+enabled: true
+entry_point: workflows/mistral-test-cancel-subworkflow-action.yaml
+name: mistral-test-cancel-subworkflow-action
+pack: examples
+parameters:
+  sleep:
+    type: integer
+    required: true
+    default: 180
+runner_type: mistral-v2

--- a/contrib/examples/actions/workflows/mistral-basic.yaml
+++ b/contrib/examples/actions/workflows/mistral-basic.yaml
@@ -5,11 +5,12 @@ examples.mistral-basic:
     type: direct
     input:
         - cmd
+        - timeout
     output:
         stdout: <% $.stdout %>
     tasks:
         task1:
-            action: core.local cmd=<% $.cmd %>
+            action: core.local cmd=<% $.cmd %> timeout=<% $.timeout %>
             publish:
                 stdout: <% task(task1).result.stdout %>
                 stderr: <% task(task1).result.stderr %>

--- a/contrib/examples/actions/workflows/mistral-test-cancel-subworkflow-action.yaml
+++ b/contrib/examples/actions/workflows/mistral-test-cancel-subworkflow-action.yaml
@@ -1,0 +1,17 @@
+version: '2.0'
+
+examples.mistral-test-cancel-subworkflow-action:
+    description: A sample workflow used to test the cascading cancel of subworkflow action.
+    type: direct
+    input:
+        - sleep
+    output:
+        stdout: <% $.stdout %>
+    tasks:
+        task1:
+            action: examples.mistral-basic
+            input:
+                cmd: "date; sleep <% $.sleep %>; date"
+                timeout: <% $.sleep + 5 %>
+            publish:
+                stdout: <% task(task1).result.stdout %>

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_cancel.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_cancel.py
@@ -33,6 +33,7 @@ from mistral_v2 import MistralRunner
 from st2common.bootstrap import actionsregistrar
 from st2common.bootstrap import runnersregistrar
 from st2common.constants import action as action_constants
+from st2common.models.db.execution import ActionExecutionDB
 from st2common.models.db.liveaction import LiveActionDB
 from st2common.persistence.liveaction import LiveAction
 from st2common.runners import base as runners
@@ -54,7 +55,6 @@ PACKS = [
 ]
 
 # Action executions requirements
-MISTRAL_EXECUTION = {'id': str(uuid.uuid4()), 'state': 'RUNNING', 'workflow_name': None}
 ACTION_PARAMS = {'friend': 'Rocky'}
 NON_EMPTY_RESULT = 'non-empty'
 
@@ -69,10 +69,23 @@ WF1_SPEC = yaml.safe_load(MistralRunner.get_workflow_definition(WF1_ENTRY_POINT_
 WF1_YAML = yaml.safe_dump(WF1_SPEC, default_flow_style=False)
 WF1 = workflows.Workflow(None, {'name': WF1_NAME, 'definition': WF1_YAML})
 WF1_OLD = workflows.Workflow(None, {'name': WF1_NAME, 'definition': ''})
-WF1_EXEC = copy.deepcopy(MISTRAL_EXECUTION)
-WF1_EXEC['workflow_name'] = WF1_NAME
+WF1_EXEC = {'id': str(uuid.uuid4()), 'state': 'RUNNING', 'workflow_name': WF1_NAME}
 WF1_EXEC_CANCELLED = copy.deepcopy(WF1_EXEC)
 WF1_EXEC_CANCELLED['state'] = 'CANCELLED'
+
+# Workflow with a subworkflow action
+WF2_META_FILE_NAME = 'workflow_v2_call_workflow_action.yaml'
+WF2_META_FILE_PATH = TEST_PACK_PATH + '/actions/' + WF2_META_FILE_NAME
+WF2_META_CONTENT = loader.load_meta_file(WF2_META_FILE_PATH)
+WF2_NAME = WF2_META_CONTENT['pack'] + '.' + WF2_META_CONTENT['name']
+WF2_ENTRY_POINT = TEST_PACK_PATH + '/actions/' + WF2_META_CONTENT['entry_point']
+WF2_ENTRY_POINT_X = WF2_ENTRY_POINT.replace(WF2_META_FILE_NAME, 'xformed_' + WF2_META_FILE_NAME)
+WF2_SPEC = yaml.safe_load(MistralRunner.get_workflow_definition(WF2_ENTRY_POINT_X))
+WF2_YAML = yaml.safe_dump(WF2_SPEC, default_flow_style=False)
+WF2 = workflows.Workflow(None, {'name': WF2_NAME, 'definition': WF2_YAML})
+WF2_EXEC = {'id': str(uuid.uuid4()), 'state': 'RUNNING', 'workflow_name': WF2_NAME}
+WF2_EXEC_CANCELLED = copy.deepcopy(WF2_EXEC)
+WF2_EXEC_CANCELLED['state'] = 'CANCELLED'
 
 
 @mock.patch.object(
@@ -147,6 +160,58 @@ class MistralRunnerCancelTest(DbTestCase):
         executions.ExecutionManager.update.assert_called_with(WF1_EXEC.get('id'), 'CANCELLED')
         liveaction = LiveAction.get_by_id(str(liveaction.id))
         self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_CANCELED)
+
+    @mock.patch.object(
+        workflows.WorkflowManager, 'list',
+        mock.MagicMock(return_value=[]))
+    @mock.patch.object(
+        workflows.WorkflowManager, 'get',
+        mock.MagicMock(side_effect=[WF2, WF1]))
+    @mock.patch.object(
+        workflows.WorkflowManager, 'create',
+        mock.MagicMock(side_effect=[[WF2], [WF1]]))
+    @mock.patch.object(
+        executions.ExecutionManager, 'create',
+        mock.MagicMock(side_effect=[
+            executions.Execution(None, WF2_EXEC),
+            executions.Execution(None, WF1_EXEC)]))
+    @mock.patch.object(
+        executions.ExecutionManager, 'update',
+        mock.MagicMock(side_effect=[
+            executions.Execution(None, WF2_EXEC_CANCELLED),
+            executions.Execution(None, WF1_EXEC_CANCELLED)]))
+    def test_cancel_subworkflow_action(self):
+        liveaction1 = LiveActionDB(action=WF2_NAME, parameters=ACTION_PARAMS)
+        liveaction1, execution1 = action_service.request(liveaction1)
+        liveaction1 = LiveAction.get_by_id(str(liveaction1.id))
+        self.assertEqual(liveaction1.status, action_constants.LIVEACTION_STATUS_RUNNING)
+
+        liveaction2 = LiveActionDB(action=WF1_NAME, parameters=ACTION_PARAMS)
+        liveaction2, execution2 = action_service.request(liveaction2)
+        liveaction2 = LiveAction.get_by_id(str(liveaction2.id))
+        self.assertEqual(liveaction2.status, action_constants.LIVEACTION_STATUS_RUNNING)
+
+        # Mock the children of the parent execution to make this
+        # test case has subworkflow execution.
+        ActionExecutionDB.children = mock.PropertyMock(return_value=[execution2.id])
+
+        mistral_context = liveaction1.context.get('mistral', None)
+        self.assertIsNotNone(mistral_context)
+        self.assertEqual(mistral_context['execution_id'], WF2_EXEC.get('id'))
+        self.assertEqual(mistral_context['workflow_name'], WF2_EXEC.get('workflow_name'))
+
+        requester = cfg.CONF.system_user.user
+        liveaction1, execution1 = action_service.request_cancellation(liveaction1, requester)
+
+        self.assertTrue(executions.ExecutionManager.update.called)
+        self.assertEqual(executions.ExecutionManager.update.call_count, 2)
+
+        calls = [
+            mock.call(WF2_EXEC.get('id'), 'CANCELLED'),
+            mock.call(WF1_EXEC.get('id'), 'CANCELLED')
+        ]
+
+        executions.ExecutionManager.update.assert_has_calls(calls, any_order=False)
 
     @mock.patch.object(
         workflows.WorkflowManager, 'list',

--- a/st2tests/st2tests/fixtures/packs/mistral_tests/actions/workflow_v2_call_workflow_action.yaml
+++ b/st2tests/st2tests/fixtures/packs/mistral_tests/actions/workflow_v2_call_workflow_action.yaml
@@ -1,0 +1,14 @@
+---
+name: workflow_v2_call_workflow_action
+pack: mistral_tests
+description: Say hi to friend!
+enabled: true
+runner_type: mistral-v2
+entry_point: workflows/workflow_v2_call_workflow_action.yaml
+parameters:
+    count:
+        default: '3'
+        type: string
+    friend:
+        required: true
+        type: string

--- a/st2tests/st2tests/fixtures/packs/mistral_tests/actions/workflows/workflow_v2_call_workflow_action.yaml
+++ b/st2tests/st2tests/fixtures/packs/mistral_tests/actions/workflows/workflow_v2_call_workflow_action.yaml
@@ -1,0 +1,13 @@
+version: '2.0'
+
+mistral_tests.workflow_v2_call_workflow_action:
+    type: direct
+    input:
+        - count
+        - friend
+    tasks:
+        task1:
+            action: mistral_tests.workflow_v2
+            input:
+                count: <% $.count %>
+                friend: <% $.friend %>

--- a/st2tests/st2tests/fixtures/packs/mistral_tests/actions/workflows/xformed_workflow_v2_call_workflow_action.yaml
+++ b/st2tests/st2tests/fixtures/packs/mistral_tests/actions/workflows/xformed_workflow_v2_call_workflow_action.yaml
@@ -1,0 +1,15 @@
+version: '2.0'
+
+mistral_tests.workflow_v2_call_workflow_action:
+    type: direct
+    input:
+        - count
+        - friend
+    tasks:
+        task1:
+            action: st2.action
+            input:
+                ref: mistral_tests.workflow_v2
+                parameters:
+                    count: <% $.count %>
+                    friend: <% $.friend %>


### PR DESCRIPTION
When a Mistral workflow is cancelled, any actions that is a Mistral workflow is also cancelled.