### PR TITLE
Fix trigger parameter and payload validation bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,8 @@ in development
   rule with `file_path` and sensor will pick up the `file_path` from the rule. A sample rule
   is provided in contrib/examples/rules/sample_rule_file_watch.yaml. (improvement)
 * Cancel actions that are Mistral workflow when the parent workflow is cancelled. (improvement)
+* Fixed bug where trigger parameters and payloads were being validated regardless of the relevant settings
+  in the configuration.
 
 2.2.1 - April 3, 2017
 ---------------------

--- a/st2api/tests/unit/controllers/v1/test_rules.py
+++ b/st2api/tests/unit/controllers/v1/test_rules.py
@@ -42,14 +42,18 @@ FIXTURES_PACK = 'generic'
 @mock.patch.object(PoolPublisher, 'publish', mock.MagicMock())
 class TestRuleController(FunctionalTest):
 
+    VALIDATE_TRIGGER_PAYLOAD = None
+
     fixtures_loader = FixturesLoader()
 
     @classmethod
     def setUpClass(cls):
         super(TestRuleController, cls).setUpClass()
 
-        # reset default configuration value
-        cfg.CONF.system.validate_trigger_parameters = False
+        # Previously, cfg.CONF.system.validate_trigger_payload was set to False explicitly
+        # here. Instead, we store original value so that the default is used, and if unit
+        # test modifies this, we can set it to what it was (preserve test atomicity)
+        cls.VALIDATE_TRIGGER_PAYLOAD = cfg.CONF.system.validate_trigger_parameters
 
         models = TestRuleController.fixtures_loader.save_fixtures_to_db(
             fixtures_pack=FIXTURES_PACK, fixtures_dict=TEST_FIXTURES)
@@ -110,6 +114,9 @@ class TestRuleController(FunctionalTest):
 
     @classmethod
     def tearDownClass(cls):
+        # Replace original configured value for trigger parameter validation
+        cfg.CONF.system.validate_trigger_payload = cls.VALIDATE_TRIGGER_PAYLOAD
+
         TestRuleController.fixtures_loader.delete_fixtures_from_db(
             fixtures_pack=FIXTURES_PACK, fixtures_dict=TEST_FIXTURES)
         super(TestRuleController, cls).setUpClass()
@@ -226,6 +233,13 @@ class TestRuleController(FunctionalTest):
         self.assertTrue("Failed validating u'type' in schema[u'properties'][u'param1']:" in
                         post_resp.json['faultstring'])
         self.assertTrue('12345 is not of type u\'string\'' in post_resp.json['faultstring'])
+
+    def test_post_invalid_custom_trigger_param_trigger_param_validation_disabled_default_cfg(self):
+        """Test validation does NOT take place with the default configuration.
+        """
+
+        post_resp = self.__do_post(TestRuleController.RULE_9)
+        self.assertEqual(post_resp.status_int, http_client.CREATED)
 
     def test_post_invalid_custom_trigger_parameter_trigger_param_validation_disabled(self):
         # Invalid custom trigger parameter (invalid type) and non-system trigger parameter

--- a/st2api/tests/unit/controllers/v1/test_rules.py
+++ b/st2api/tests/unit/controllers/v1/test_rules.py
@@ -112,6 +112,11 @@ class TestRuleController(FunctionalTest):
             fixtures_pack=FIXTURES_PACK,
             fixtures_dict={'rules': [file_name]})['rules'][file_name]
 
+        file_name = 'rule_invalid_trigger_parameter_type_default_cfg.yaml'
+        TestRuleController.RULE_11 = TestRuleController.fixtures_loader.load_fixtures(
+            fixtures_pack=FIXTURES_PACK,
+            fixtures_dict={'rules': [file_name]})['rules'][file_name]
+
     @classmethod
     def tearDownClass(cls):
         # Replace original configured value for trigger parameter validation
@@ -238,7 +243,7 @@ class TestRuleController(FunctionalTest):
         """Test validation does NOT take place with the default configuration.
         """
 
-        post_resp = self.__do_post(TestRuleController.RULE_9)
+        post_resp = self.__do_post(TestRuleController.RULE_11)
         self.assertEqual(post_resp.status_int, http_client.CREATED)
 
     def test_post_invalid_custom_trigger_parameter_trigger_param_validation_disabled(self):

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -75,13 +75,13 @@ def register_opts(ignore_errors=False):
         cfg.BoolOpt('debug', help='Enable debug mode.', default=False),
         cfg.StrOpt('base_path', default='/opt/stackstorm',
                    help='Base path to all st2 artifacts.'),
-        cfg.StrOpt('validate_trigger_parameters', default=False,
-                   help=('True to validate parameters for non-system trigger types when creating'
-                         'a rule. By default, only parameters for system triggers are validated')),
-        cfg.StrOpt('validate_trigger_payload', default=False,
-                   help=('True to validate payload for non-system trigger types when dispatching'
-                         'a trigger inside the sensor. By default, only payload for system '
-                         'triggers is validated.'))
+        cfg.BoolOpt('validate_trigger_parameters', default=False,
+                    help=('True to validate parameters for non-system trigger types when creating'
+                          'a rule. By default, only parameters for system triggers are validated')),
+        cfg.BoolOpt('validate_trigger_payload', default=False,
+                    help=('True to validate payload for non-system trigger types when dispatching'
+                          'a trigger inside the sensor. By default, only payload for system '
+                          'triggers is validated.'))
     ]
     do_register_opts(system_opts, 'system', ignore_errors)
 

--- a/st2reactor/tests/unit/test_sensor_service.py
+++ b/st2reactor/tests/unit/test_sensor_service.py
@@ -36,8 +36,15 @@ class SensorServiceTestCase(unittest2.TestCase):
         self.sensor_service._dispatcher.dispatch = mock.MagicMock(side_effect=side_effect)
         self._dispatched_count = 0
 
-        # reset default configuration value
-        cfg.CONF.system.validate_trigger_payload = False
+        # Previously, cfg.CONF.system.validate_trigger_payload was set to False explicitly
+        # here. Instead, we store original value so that the default is used, and if unit
+        # test modifies this, we can set it to what it was (preserve test atomicity)
+        self.validate_trigger_payload = cfg.CONF.system.validate_trigger_payload
+
+    def tearDown(self):
+
+        # Replace original configured value for payload validation
+        cfg.CONF.system.validate_trigger_payload = self.validate_trigger_payload
 
     @mock.patch('st2common.services.triggers.get_trigger_type_db',
                 mock.MagicMock(return_value=TriggerTypeMock(TEST_SCHEMA)))
@@ -57,6 +64,37 @@ class SensorServiceTestCase(unittest2.TestCase):
         self.sensor_service.dispatch('trigger-name', payload)
 
         # This assumed that the target tirgger dispatched
+        self.assertEqual(self._dispatched_count, 1)
+
+    @mock.patch('st2common.services.triggers.get_trigger_type_db',
+                mock.MagicMock(return_value=TriggerTypeMock(TEST_SCHEMA)))
+    def test_dispatch_failure_with_default_config(self):
+        """Tests for default configuration values
+
+        The previous config defition used StrOpt instead of BoolOpt for
+        cfg.CONF.system.validate_trigger_payload. This meant that even though the intention
+        was to bypass validation, the fact that this option was a string, meant it always
+        resulted in True during conditionals.the
+
+        However, the other unit tests directly modified
+        cfg.CONF.system.validate_trigger_payload before running, which
+        obscured this bug during testing.
+
+        This test (as well as resetting cfg.CONF.system.validate_trigger_payload
+        to it's original value during tearDown) will test validation does
+        NOT take place with the default configuration.
+        """
+
+        # define a invalid payload (the type of 'age' is incorrect)
+        payload = {
+            'name': 'John Doe',
+            'age': '25',
+        }
+
+        self.sensor_service.dispatch('trigger-name', payload)
+
+        # The default config is to disable validation. So, we want to make sure
+        # the dispatch actually went through.
         self.assertEqual(self._dispatched_count, 1)
 
     @mock.patch('st2common.services.triggers.get_trigger_type_db',

--- a/st2reactor/tests/unit/test_sensor_service.py
+++ b/st2reactor/tests/unit/test_sensor_service.py
@@ -42,7 +42,6 @@ class SensorServiceTestCase(unittest2.TestCase):
         self.validate_trigger_payload = cfg.CONF.system.validate_trigger_payload
 
     def tearDown(self):
-
         # Replace original configured value for payload validation
         cfg.CONF.system.validate_trigger_payload = self.validate_trigger_payload
 
@@ -68,8 +67,8 @@ class SensorServiceTestCase(unittest2.TestCase):
 
     @mock.patch('st2common.services.triggers.get_trigger_type_db',
                 mock.MagicMock(return_value=TriggerTypeMock(TEST_SCHEMA)))
-    def test_dispatch_failure_with_default_config(self):
-        """Tests for default configuration values
+    def test_dispatch_success_with_default_config_and_invalid_payload(self):
+        """Tests that an invalid payload still results in dispatch success with default config
 
         The previous config defition used StrOpt instead of BoolOpt for
         cfg.CONF.system.validate_trigger_payload. This meant that even though the intention

--- a/st2tests/st2tests/fixtures/generic/rules/rule_invalid_trigger_parameter_type_default_cfg.yaml
+++ b/st2tests/st2tests/fixtures/generic/rules/rule_invalid_trigger_parameter_type_default_cfg.yaml
@@ -1,0 +1,13 @@
+---
+name: rule_invalid_trigger_parameter_type_default_cfg
+pack: wolfpack
+action:
+  ref: wolfpack.action-1
+  parameters: {}
+enabled: true
+description: ''
+trigger:
+  type: wolfpack.triggertype_with_parameters_2
+  # param1 is not a string
+  parameters:
+      param1: 12345


### PR DESCRIPTION
This PR fixes the bug found in https://github.com/StackStorm/st2/issues/3385 by converting the trigger payload and parameter validation configuration parameters from `StrOpt` to `BoolOpt`, as well as adding unit tests for both to ensure the default configuration allows validation for both to be bypassed (which is the behavior we currently advertise).

## TODOs

- [x] Fix bug
- [x] Add test for payload validation with default config
- [x] Add test for parameter validation with default config

Closes https://github.com/StackStorm/st2/issues/3385