### PR TITLE
Add sys.exit() to rulesengine

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,7 @@ in development
   rule with `file_path` and sensor will pick up the `file_path` from the rule. A sample rule
   is provided in contrib/examples/rules/sample_rule_file_watch.yaml. (improvement)
 * Cancel actions that are Mistral workflow when the parent workflow is cancelled. (improvement)
+* Update st2rulesengine to exit non-0 on failure (bug fix)
 
 2.2.1 - April 3, 2017
 ---------------------

--- a/st2reactor/bin/st2rulesengine
+++ b/st2reactor/bin/st2rulesengine
@@ -18,8 +18,10 @@
 #   st2 rules_engine
 #
 
+import sys
+
 from st2reactor.cmd import rulesengine
 
 
 if __name__ == '__main__':
-    rulesengine.main()
+    sys.exit(rulesengine.main())


### PR DESCRIPTION
The entry points for all of the st2 processes `sys.exit()` except for `st2rulesengine`. If `st2rulesengine` currently fails and exits it will exit successfully and won't be restarted by systemd. This change makes  `st2rulesengine` consistent with the entry points for all of the other st2 processes.