### PR TITLE
Pin requests to the latest version (v2.14.1)

### DIFF
--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -10,7 +10,7 @@ oslo.config>=1.12.1,<1.13
 oslo.utils<3.1.0
 six==1.10.0
 pyyaml>=3.12,<4.0
-requests[security]>=2.13.0,<2.14
+requests[security]>=2.14.1,<2.15
 apscheduler==3.3.1
 gitpython==2.1.3
 jsonschema>=2.5.0,<2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ python-keyczar==0.716
 pytz
 pyyaml<4.0,>=3.12
 rednose
-requests[security]<2.14,>=2.13.0
+requests[security]<2.15,>=2.14.1
 retrying<1.4,>=1.3
 routes==2.3.1
 semver==2.7.2


### PR DESCRIPTION
As per https://github.com/StackStorm/st2/pull/3372#discussion_r115702199 (thanks)

Should fix the https://github.com/shazow/urllib3/issues/1104 and broken Githubwebhooks on `st2cicd`.