### PR TITLE
make sphinx vers match st2docs

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,8 +10,8 @@ mock==2.0.0
 nose>=1.3.7
 tabulate
 unittest2
-sphinx
-git+https://github.com/StackStorm/sphinx-autobuild.git@develop
+sphinx>=1.5.3,<1.6
+sphinx-autobuild
 # nosetests enhancements
 rednose
 nose-timer


### PR DESCRIPTION
Updated the sphinx and sphinx-autobuild versions in `test-requirements.txt` to match what we currently use in st2docs. 

We don't need to track our own version of sphinx-autobuild anymore, and we should pin the sphinx version.