### PR TITLE
Fix ?pack query param filter in /v1/triggertypes API endpoint

### DIFF
--- a/st2api/tests/unit/controllers/v1/test_triggertypes.py
+++ b/st2api/tests/unit/controllers/v1/test_triggertypes.py
@@ -65,6 +65,17 @@ class TestTriggerTypeController(FunctionalTest):
         resp = self.app.get('/v1/triggertypes')
         self.assertEqual(resp.status_int, http_client.OK)
         self.assertEqual(len(resp.json), 2, 'Get all failure.')
+
+        # ?pack query filter
+        resp = self.app.get('/v1/triggertypes?pack=doesnt-exist-invalid')
+        self.assertEqual(resp.status_int, http_client.OK)
+        self.assertEqual(len(resp.json), 0)
+
+        resp = self.app.get('/v1/triggertypes?pack=%s' % (TRIGGER_0['pack']))
+        self.assertEqual(resp.status_int, http_client.OK)
+        self.assertEqual(len(resp.json), 1)
+        self.assertEqual(resp.json[0]['pack'], TRIGGER_0['pack'])
+
         self.__do_delete(trigger_id_0)
         self.__do_delete(trigger_id_1)
 

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -3112,6 +3112,10 @@ paths:
           type: array
           items:
             type: string
+        - name: pack
+          in: query
+          description: Pack name filter
+          type: string
       responses:
         '200':
           description: List of trigger types


### PR DESCRIPTION
It looks like a small regression introduced during move to OpenAPI and we didn't have any tests for this functionality.

Resolves #3405