### PR TITLE
Remove old CI webhook

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,5 @@
 notify:
   webhooks:
-    - url: https://webhooks.stackstorm.net:8531/webhooks/build/events
     - url: https://ci-webhooks.stackstorm.net/webhooks/build/events
 
 machine:


### PR DESCRIPTION
Removed webhook reference to old build node, as it is not working, and generates these warnings on CircleCI:

`webhook returned http status 503, connecting to https://webhooks.stackstorm.net:8531/webhooks/build/events`