### PR TITLE
Include RBAC related info in action context when running action through the API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -62,6 +62,8 @@ in development
 * Update ``/v1/rbac/roles`` API endpoint so it includes corresponding permission grant objects.
   Previously it only included permission grant ids. (improvement)
 * Fix a bug where keyvalue objects weren't properly cast to numeric types. (bug fix)
+* When RBAC is enabled and action is scheduled (ran) through the API, include ``rbac`` dictionary
+  with ``user`` and ``roles`` ``action_context`` attribute. (improvement)
 
 2.2.1 - April 3, 2017
 ---------------------

--- a/st2api/tests/unit/controllers/v1/test_executions_simple.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_simple.py
@@ -34,12 +34,20 @@ from st2common.models.db.auth import UserDB
 from st2common.persistence.auth import Token
 from st2common.persistence.auth import User
 from st2common.persistence.trace import Trace
+from st2common.models.db.rbac import UserRoleAssignmentDB
+from st2common.persistence.rbac import UserRoleAssignment
 from st2common.services import trace as trace_service
 from st2common.transport.publishers import PoolPublisher
+from tests.base import APIControllerWithRBACTestCase
 from st2tests.api import SUPER_SECRET_PARAMETER
 from st2tests.api import ANOTHER_SUPER_SECRET_PARAMETER
 from st2tests.fixturesloader import FixturesLoader
 from tests import FunctionalTest
+
+__all__ = [
+    'ActionExecutionControllerTestCase',
+    'ActionExecutionRBACControllerTestCase'
+]
 
 
 ACTION_1 = {
@@ -156,6 +164,12 @@ LIVE_ACTION_4 = {
     'action': 'starterpack.st2.dummy.action4',
 }
 
+FIXTURES_PACK = 'generic'
+TEST_FIXTURES = {
+    'runners': ['testrunner1.yaml'],
+    'actions': ['action1.yaml', 'local.yaml']
+}
+
 
 class FakeResponse(object):
 
@@ -171,14 +185,119 @@ class FakeResponse(object):
         raise Exception(self.reason)
 
 
+class BaseActionExecutionControllerTestCase(object):
+
+    @staticmethod
+    def _get_actionexecution_id(resp):
+        return resp.json['id']
+
+    def _do_get_one(self, actionexecution_id, *args, **kwargs):
+        return self.app.get('/v1/executions/%s' % actionexecution_id, *args, **kwargs)
+
+    def _do_post(self, liveaction, *args, **kwargs):
+        return self.app.post_json('/v1/executions', liveaction, *args, **kwargs)
+
+    def _do_delete(self, actionexecution_id, expect_errors=False):
+        return self.app.delete('/v1/executions/%s' % actionexecution_id,
+                               expect_errors=expect_errors)
+
+
 @mock.patch.object(PoolPublisher, 'publish', mock.MagicMock())
-class TestActionExecutionController(FunctionalTest):
+class ActionExecutionRBACControllerTestCase(BaseActionExecutionControllerTestCase,
+                                            APIControllerWithRBACTestCase):
+
+    fixtures_loader = FixturesLoader()
+
+    @mock.patch.object(action_validator, 'validate_action', mock.MagicMock(
+        return_value=True))
+    def setUp(self):
+        super(ActionExecutionRBACControllerTestCase, self).setUp()
+
+        self.fixtures_loader.save_fixtures_to_db(fixtures_pack=FIXTURES_PACK,
+                                                 fixtures_dict=TEST_FIXTURES)
+
+        # Insert mock users, roles and assignments
+
+        # Users
+        user_1_db = UserDB(name='multiple_roles')
+        user_1_db = User.add_or_update(user_1_db)
+        self.users['multiple_roles'] = user_1_db
+
+        # Role assignments
+        user_db = self.users['multiple_roles']
+        role_assignment_db = UserRoleAssignmentDB(
+            user=user_db.name,
+            role='admin')
+        UserRoleAssignment.add_or_update(role_assignment_db)
+
+        user_db = self.users['multiple_roles']
+        role_assignment_db = UserRoleAssignmentDB(
+            user=user_db.name,
+            role='role_1')
+        UserRoleAssignment.add_or_update(role_assignment_db)
+
+        role_assignment_db = UserRoleAssignmentDB(
+            user=user_db.name,
+            role='role_2')
+        UserRoleAssignment.add_or_update(role_assignment_db)
+
+        role_assignment_db = UserRoleAssignmentDB(
+            user=user_db.name,
+            role='role_3')
+        UserRoleAssignment.add_or_update(role_assignment_db)
+
+    def test_post_rbac_info_in_context_success(self):
+        # When RBAC is enabled, additional RBAC related info should be included in action_context
+        data = {
+            'action': 'wolfpack.action-1',
+            'parameters': {
+                'actionstr': 'foo'
+            }
+        }
+
+        # User with one role assignment
+        user_db = self.users['admin']
+        self.use_user(user_db)
+
+        resp = self._do_post(data)
+        self.assertEqual(resp.status_int, 201)
+
+        expected_context = {
+            'user': 'admin',
+            'rbac': {
+                'user': 'admin',
+                'roles': ['admin']
+            }
+        }
+
+        self.assertEqual(resp.json['context'], expected_context)
+
+        # User with multiple role assignments
+        user_db = self.users['multiple_roles']
+        self.use_user(user_db)
+
+        resp = self._do_post(data)
+        self.assertEqual(resp.status_int, 201)
+
+        expected_context = {
+            'user': 'multiple_roles',
+            'rbac': {
+                'user': 'multiple_roles',
+                'roles': ['admin', 'role_1', 'role_2', 'role_3']
+            }
+        }
+
+        self.assertEqual(resp.json['context'], expected_context)
+
+
+@mock.patch.object(PoolPublisher, 'publish', mock.MagicMock())
+class ActionExecutionControllerTestCase(BaseActionExecutionControllerTestCase, FunctionalTest):
 
     @classmethod
     @mock.patch.object(action_validator, 'validate_action', mock.MagicMock(
         return_value=True))
     def setUpClass(cls):
-        super(TestActionExecutionController, cls).setUpClass()
+        super(BaseActionExecutionControllerTestCase, cls).setUpClass()
 
         cls.action1 = copy.deepcopy(ACTION_1)
         post_resp = cls.app.post_json('/v1/actions', cls.action1)
@@ -202,7 +321,7 @@ class TestActionExecutionController(FunctionalTest):
         cls.app.delete('/v1/actions/%s' % cls.action2['id'])
         cls.app.delete('/v1/actions/%s' % cls.action3['id'])
         cls.app.delete('/v1/actions/%s' % cls.action4['id'])
-        super(TestActionExecutionController, cls).tearDownClass()
+        super(BaseActionExecutionControllerTestCase, cls).tearDownClass()
 
     def test_get_one(self):
         post_resp = self._do_post(LIVE_ACTION_1)
@@ -671,22 +790,8 @@ class TestActionExecutionController(FunctionalTest):
                                          expect_errors=True)
         self.assertEqual(re_run_result.json['parameters']['d'], data['parameters']['d'])
 
-    @staticmethod
-    def _get_actionexecution_id(resp):
-        return resp.json['id']
 
-    def _do_get_one(self, actionexecution_id, *args, **kwargs):
-        return self.app.get('/v1/executions/%s' % actionexecution_id, *args, **kwargs)
-
-    def _do_post(self, liveaction, *args, **kwargs):
-        return self.app.post_json('/v1/executions', liveaction, *args, **kwargs)
-
-    def _do_delete(self, actionexecution_id, expect_errors=False):
-        return self.app.delete('/v1/executions/%s' % actionexecution_id,
-                               expect_errors=expect_errors)
-
-
-# TestActionExecutionControllerAuthEnabled test section
+# ActionExecutionControllerTestCaseAuthEnabled test section
 
 NOW = date_utils.get_datetime_utc_now()
 EXPIRY = NOW + datetime.timedelta(seconds=300)
@@ -706,7 +811,7 @@ def mock_get_token(*args, **kwargs):
 
 
 @mock.patch.object(PoolPublisher, 'publish', mock.MagicMock())
-class TestActionExecutionControllerAuthEnabled(FunctionalTest):
+class ActionExecutionControllerTestCaseAuthEnabled(FunctionalTest):
 
     enable_auth = True
 
@@ -718,7 +823,7 @@ class TestActionExecutionControllerAuthEnabled(FunctionalTest):
     @mock.patch.object(action_validator, 'validate_action', mock.MagicMock(
         return_value=True))
     def setUpClass(cls):
-        super(TestActionExecutionControllerAuthEnabled, cls).setUpClass()
+        super(ActionExecutionControllerTestCaseAuthEnabled, cls).setUpClass()
         cls.action = copy.deepcopy(ACTION_1)
         headers = {'content-type': 'application/json', 'X-Auth-Token': str(SYS_TOKEN.token)}
         post_resp = cls.app.post_json('/v1/actions', cls.action, headers=headers)
@@ -734,7 +839,7 @@ class TestActionExecutionControllerAuthEnabled(FunctionalTest):
     def tearDownClass(cls):
         headers = {'content-type': 'application/json', 'X-Auth-Token': str(SYS_TOKEN.token)}
         cls.app.delete('/v1/actions/%s' % cls.action['id'], headers=headers)
-        super(TestActionExecutionControllerAuthEnabled, cls).tearDownClass()
+        super(ActionExecutionControllerTestCaseAuthEnabled, cls).tearDownClass()
 
     def _do_post(self, liveaction, *args, **kwargs):
         return self.app.post_json('/v1/executions', liveaction, *args, **kwargs)
@@ -769,11 +874,11 @@ DESCENDANTS_FIXTURES = {
 }
 
 
-class TestActionExecutionControllerDescendantsTest(FunctionalTest):
+class ActionExecutionControllerTestCaseDescendantsTest(FunctionalTest):
 
     @classmethod
     def setUpClass(cls):
-        super(TestActionExecutionControllerDescendantsTest, cls).setUpClass()
+        super(ActionExecutionControllerTestCaseDescendantsTest, cls).setUpClass()
         cls.MODELS = FixturesLoader().save_fixtures_to_db(fixtures_pack=DESCENDANTS_PACK,
                                                           fixtures_dict=DESCENDANTS_FIXTURES)
 


### PR DESCRIPTION
This pull request updates action executions handler to include user RBAC related information (username and roles) when an execution is scheduled through the API.

It was already previously possible to retrieve user roles inside the action / workflow, but it was more convoluted and involved more steps since user needed to write a custom action which hits StackStorm API to retrieve current user roles.

This also meant one additional task / action inside the workflow chain now it's possible to reference it using ``action_context`` context (e.g. ``action_context.rbac.roles``) which is available to actions and action parameters.

Example action execution context when RBAC is enabled:

```json
{
	"user": "multiple_roles",
	"rbac": {
		"user": "multiple_roles",
		"roles": ["admin", "role_1", "role_2", "role_3"]
	}
}
```

Example of using it inside action metadata definition using the Jinja notation:

```yaml
...
parameters:
...
  action_user_rbac_roles:
    default: "{{action_context.rbac.rolesd}}"
    type: array
    immutable: true
...