### PR TITLE
Update st2-apply-rbac-definitions to remove assignments from database for users which don't exist in the database

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -71,6 +71,8 @@ in development
 * Update ``/v1/rbac/roles`` API endpoint so it includes corresponding permission grant objects.
   Previously it only included permission grant ids. (improvement)
 * Fix a bug where keyvalue objects weren't properly cast to numeric types. (bug fix)
+* Update ``st2-apply-rbac-definitions`` so it also removes assignments for users which don't exist
+  in the database. (improvement, bug fix)
 
 2.2.1 - April 3, 2017
 ---------------------

--- a/st2common/st2common/rbac/syncer.py
+++ b/st2common/st2common/rbac/syncer.py
@@ -187,6 +187,8 @@ class RBACDefinitionsDBSyncer(object):
         :return: Dictionary with created and removed role assignments for each user.
         :rtype: ``dict``
         """
+        assert isinstance(role_assignment_apis, (list, tuple))
+
         LOG.info('Synchronizing users role assignments...')
 
         # Note: We exclude remote assignments because sync tool is not supposed to manipulate
@@ -214,7 +216,6 @@ class RBACDefinitionsDBSyncer(object):
         all_usernames = list(set(all_usernames))
 
         results = {}
-
         for username in all_usernames:
             role_assignment_api = username_to_role_assignment_api_map.get(username, None)
             user_db = username_to_user_db_map.get(username, None)
@@ -229,13 +230,15 @@ class RBACDefinitionsDBSyncer(object):
 
             role_assignment_dbs = username_to_role_assignment_dbs_map.get(username, [])
 
-            # Additional safety assert to ensure we don't manipulate remote assignments
+            # Additional safety assert to ensure we don't accidentally manipulate remote
+            # assignments
             for role_assignment_db in role_assignment_dbs:
                 assert role_assignment_db.is_remote is False
 
             result = self._sync_user_role_assignments(user_db=user_db,
                                                       role_assignment_dbs=role_assignment_dbs,
                                                       role_assignment_api=role_assignment_api)
+
             results[username] = result
 
         LOG.info('User role assignments synchronized')

--- a/st2common/st2common/services/rbac.py
+++ b/st2common/st2common/services/rbac.py
@@ -32,6 +32,7 @@ __all__ = [
     'get_all_roles',
     'get_system_roles',
     'get_roles_for_user',
+    'get_all_role_assignments',
     'get_role_assignments_for_user',
     'get_role_by_name',
 
@@ -103,6 +104,26 @@ def get_roles_for_user(user_db, include_remote=True):
 
     role_names = queryset.only('role').scalar('role')
     result = Role.query(name__in=role_names)
+    return result
+
+
+def get_all_role_assignments(include_remote=True):
+    """
+    Retrieve all the UserRoleAssignmentDB objects.
+
+    :param include_remote: True to also include remote role assignments.
+    :type include_remote: ``bool``
+
+    :rtype: ``list`` of :class:`UserRoleAssignmentDB`
+    """
+    if include_remote:
+        result = UserRoleAssignment.query()
+    else:
+        # Note: We also include documents with no "is_remote" field so it also works correctly
+        # when upgrading from pre v2.3.0 when this field didn't exist yet
+        queryset_filter = (Q(is_remote=False) | Q(is_remote__exists=False))
+        result = UserRoleAssignmentDB.objects(queryset_filter)
+
     return result
 
 

--- a/st2common/tests/unit/services/test_rbac.py
+++ b/st2common/tests/unit/services/test_rbac.py
@@ -148,6 +148,16 @@ class RBACServicesTestCase(CleanDbTestCase):
         role_dbs = user_db.get_roles(include_remote=False)
         self.assertEqual(len(role_dbs), 3)
 
+    def test_get_all_role_assignments(self):
+        role_assignment_dbs = rbac_services.get_all_role_assignments(include_remote=True)
+        self.assertEqual(len(role_assignment_dbs), 5)
+
+        role_assignment_dbs = rbac_services.get_all_role_assignments(include_remote=False)
+        self.assertEqual(len(role_assignment_dbs), 4)
+
+        for role_assignment_db in role_assignment_dbs:
+            self.assertFalse(role_assignment_db.is_remote)
+
     def test_create_role_with_system_role_name(self):
         # Roles with names which match system role names can't be created
         expected_msg = '"observer" role name is blacklisted'

--- a/st2common/tests/unit/test_db_rbac.py
+++ b/st2common/tests/unit/test_db_rbac.py
@@ -29,7 +29,8 @@ from tests.unit.base import BaseDBModelCRUDTestCase
 __all__ = [
     'RoleDBModelCRUDTestCase',
     'UserRoleAssignmentDBModelCRUDTestCase',
-    'PermissionGrantDBModelCRUDTestCase'
+    'PermissionGrantDBModelCRUDTestCase',
+    'GroupToRoleMappingDBModelCRUDTestCase'
 ]
 
 

--- a/st2common/tests/unit/test_rbac_syncer.py
+++ b/st2common/tests/unit/test_rbac_syncer.py
@@ -272,7 +272,7 @@ class RBACDefinitionsDBSyncerTestCase(BaseRBACDefinitionsDBSyncerTestCase):
 
         self._insert_mock_roles()
 
-        username = 'doesntexistwhaha'
+        username = 'doesntexistwhaha_3'
 
         # Initial state, no roles
         user_db = UserDB(name=username)
@@ -297,7 +297,7 @@ class RBACDefinitionsDBSyncerTestCase(BaseRBACDefinitionsDBSyncerTestCase):
 
         self._insert_mock_roles()
 
-        username = 'doesntexistwhaha'
+        username = 'doesntexistwhaha_1'
 
         # Initial state, no roles
         user_db = UserDB(name=username)
@@ -320,6 +320,34 @@ class RBACDefinitionsDBSyncerTestCase(BaseRBACDefinitionsDBSyncerTestCase):
 
         role_dbs = get_roles_for_user(user_db=user_db)
         self.assertEqual(len(role_dbs), 0)
+
+        username = 'doesntexistwhaha_2'
+
+        # Initial state, no roles
+        user_db = UserDB(name=username)
+        self.assertEqual(len(User.query(name=username)), 0)
+        role_dbs = get_roles_for_user(user_db=user_db)
+        self.assertItemsEqual(role_dbs, [])
+
+        # Do the sync with three roles defined
+        api = UserRoleAssignmentFileFormatAPI(username=user_db.name,
+                                              roles=['role_1', 'role_2', 'role_3'])
+        syncer.sync_users_role_assignments(role_assignment_apis=[api])
+
+        role_dbs = get_roles_for_user(user_db=user_db)
+        self.assertEqual(len(role_dbs), 3)
+        self.assertEqual(role_dbs[0], self.roles['role_1'])
+        self.assertEqual(role_dbs[1], self.roles['role_2'])
+        self.assertEqual(role_dbs[2], self.roles['role_3'])
+
+        # Sync with one role on disk - two roles should be removed
+        api = UserRoleAssignmentFileFormatAPI(username=user_db.name,
+                                              roles=['role_3'])
+        syncer.sync_users_role_assignments(role_assignment_apis=[api])
+
+        role_dbs = get_roles_for_user(user_db=user_db)
+        self.assertEqual(len(role_dbs), 1)
+        self.assertEqual(role_dbs[0], self.roles['role_3'])
 
     def test_sync_remote_assignments_are_not_manipulated(self):
         # Verify remote assignments are not manipulated.

--- a/st2common/tests/unit/test_rbac_syncer.py
+++ b/st2common/tests/unit/test_rbac_syncer.py
@@ -287,6 +287,34 @@ class RBACDefinitionsDBSyncerTestCase(BaseRBACDefinitionsDBSyncerTestCase):
         self.assertEqual(role_dbs[0], self.roles['role_1'])
         self.assertEqual(role_dbs[1], self.roles['role_2'])
 
+    def test_sync_assignments_are_removed_user_doesnt_exist_in_db(self):
+        # Make sure that the assignments for the users which don't exist in the db are correctly
+        # removed
+        syncer = RBACDefinitionsDBSyncer()
+
+        self._insert_mock_roles()
+
+        # Initial state, no roles
+        user_db = UserDB(name='doesntexistwhaha')
+        role_dbs = get_roles_for_user(user_db=user_db)
+        self.assertItemsEqual(role_dbs, [])
+
+        # Do the sync with two roles defined
+        api = UserRoleAssignmentFileFormatAPI(username=user_db.name,
+                                              roles=['role_1', 'role_2'])
+        syncer.sync_users_role_assignments(role_assignment_apis=[api])
+
+        role_dbs = get_roles_for_user(user_db=user_db)
+        self.assertEqual(len(role_dbs), 2)
+        self.assertEqual(role_dbs[0], self.roles['role_1'])
+        self.assertEqual(role_dbs[1], self.roles['role_2'])
+
+        # Sync with no roles on disk - existing roles should be removed
+        syncer.sync_users_role_assignments(role_assignment_apis=[api])
+
+        role_dbs = get_roles_for_user(user_db=user_db)
+        self.assertEqual(len(role_dbs), 0)
+
     def test_sync_remote_assignments_are_not_manipulated(self):
         # Verify remote assignments are not manipulated.
         syncer = RBACDefinitionsDBSyncer()

--- a/st2common/tests/unit/test_rbac_syncer.py
+++ b/st2common/tests/unit/test_rbac_syncer.py
@@ -272,8 +272,11 @@ class RBACDefinitionsDBSyncerTestCase(BaseRBACDefinitionsDBSyncerTestCase):
 
         self._insert_mock_roles()
 
+        username = 'doesntexistwhaha'
+
         # Initial state, no roles
-        user_db = UserDB(name='doesntexistwhaha')
+        user_db = UserDB(name=username)
+        self.assertEqual(len(User.query(name=username)), 0)
         role_dbs = get_roles_for_user(user_db=user_db)
         self.assertItemsEqual(role_dbs, [])
 
@@ -294,8 +297,11 @@ class RBACDefinitionsDBSyncerTestCase(BaseRBACDefinitionsDBSyncerTestCase):
 
         self._insert_mock_roles()
 
+        username = 'doesntexistwhaha'
+
         # Initial state, no roles
-        user_db = UserDB(name='doesntexistwhaha')
+        user_db = UserDB(name=username)
+        self.assertEqual(len(User.query(name=username)), 0)
         role_dbs = get_roles_for_user(user_db=user_db)
         self.assertItemsEqual(role_dbs, [])
 

--- a/st2common/tests/unit/test_rbac_syncer.py
+++ b/st2common/tests/unit/test_rbac_syncer.py
@@ -310,7 +310,7 @@ class RBACDefinitionsDBSyncerTestCase(BaseRBACDefinitionsDBSyncerTestCase):
         self.assertEqual(role_dbs[1], self.roles['role_2'])
 
         # Sync with no roles on disk - existing roles should be removed
-        syncer.sync_users_role_assignments(role_assignment_apis=[api])
+        syncer.sync_users_role_assignments(role_assignment_apis=[])
 
         role_dbs = get_roles_for_user(user_db=user_db)
         self.assertEqual(len(role_dbs), 0)


### PR DESCRIPTION
This pull request updates `st2-apply-rbac-definitions` tools so it also removes role assignments from the database for users which don't exist in the database.

Before that change we already supported pre-creation of role assignments, meaning user could write role assignments for users which don't yet exist in the database and those assignments would get stored in the database (StackStorm user accounts are lazy created on first successful authentication with st2auth).

We didn't do that for removal (we only removed assignments for users which exist in the database) so the behavior was inconsistent (there are no negative security implications because assignments existing in the database for non-existent user is basically the same as if assignments wouldn't exist).