### PR TITLE
Fix mistral abandoned tasks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -71,6 +71,8 @@ in development
 * Update ``/v1/rbac/roles`` API endpoint so it includes corresponding permission grant objects.
   Previously it only included permission grant ids. (improvement)
 * Fix a bug where keyvalue objects weren't properly cast to numeric types. (bug fix)
+* When action worker is being shutdown and action executions are being abandoned, invoke post run
+  on the action executions to ensure operations such as callback is performed. (bug fix)
 
 2.2.1 - April 3, 2017
 ---------------------

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ compile:
 .st2common-circular-dependencies-check:
 	@echo "Checking st2common for circular dependencies"
 	find ${ROOT_DIR}/st2common/st2common/ -name \*.py -type f -print0 | xargs -0 cat | grep st2reactor ; test $$? -eq 1
-	find ${ROOT_DIR}/st2common/st2common/ \( -name \*.py ! -name runnersregistrar\.py ! -wholename "*runners/base.py" ! -name python_action_wrapper.py ! -wholename "*/query/base.py" \) -type f -print0 | xargs -0 cat | grep st2actions ; test $$? -eq 1
+	find ${ROOT_DIR}/st2common/st2common/ \( -name \*.py ! -name runnersregistrar\.py ! -wholename "*runners/base.py" ! -name python_action_wrapper.py ! -wholename "*/query/base.py" ! -wholename "*/runners/utils.py" \) -type f -print0 | xargs -0 cat | grep st2actions ; test $$? -eq 1
 	find ${ROOT_DIR}/st2common/st2common/ -name \*.py -type f -print0 | xargs -0 cat | grep st2api ; test $$? -eq 1
 	find ${ROOT_DIR}/st2common/st2common/ -name \*.py -type f -print0 | xargs -0 cat | grep st2auth ; test $$? -eq 1
 	find ${ROOT_DIR}/st2common/st2common/ -name \*.py -type f -print0 | xargs -0 cat | grep st2debug; test $$? -eq 1

--- a/st2actions/tests/integration/test_resultstracker.py
+++ b/st2actions/tests/integration/test_resultstracker.py
@@ -7,7 +7,9 @@ from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2common.persistence.action import Action
 from st2common.persistence.executionstate import ActionExecutionState
 from st2common.persistence.liveaction import LiveAction
+from st2common.runners import utils as runners_utils
 from st2common.services import executions
+from st2common.util import action_db as action_db_utils
 from st2tests.base import (DbTestCase, EventletTestCase)
 from st2tests.fixturesloader import FixturesLoader
 
@@ -59,8 +61,7 @@ class ResultsTrackerTests(EventletTestCase, DbTestCase):
         Action, 'get_by_ref', mock.MagicMock(return_value='foobar'))
     def test_query_process(self):
         tracker = results_tracker.get_tracker()
-        querier = tracker.get_querier('test_querymodule')
-        querier._invoke_post_run = mock.Mock(return_value=None)
+        runners_utils.invoke_post_run = mock.Mock(return_value=None)
 
         # Ensure state objects are present.
         state1 = ActionExecutionState.get_by_id(ResultsTrackerTests.states['state1.yaml'].id)
@@ -98,7 +99,7 @@ class ResultsTrackerTests(EventletTestCase, DbTestCase):
         )
 
         # Ensure invoke_post_run is called.
-        self.assertEqual(2, querier._invoke_post_run.call_count)
+        self.assertEqual(2, runners_utils.invoke_post_run.call_count)
 
     def test_start_shutdown(self):
         tracker = results_tracker.get_tracker()
@@ -245,7 +246,7 @@ class ResultsTrackerTests(EventletTestCase, DbTestCase):
         tracker = results_tracker.get_tracker()
         querier = tracker.get_querier('test_querymodule')
         querier._delete_state_object = mock.Mock(return_value=None)
-        querier._invoke_post_run = mock.Mock(return_value=None)
+        runners_utils.invoke_post_run = mock.Mock(return_value=None)
 
         # Ensure state objects are present.
         state1 = ActionExecutionState.get_by_id(ResultsTrackerTests.states['state1.yaml'].id)
@@ -273,14 +274,13 @@ class ResultsTrackerTests(EventletTestCase, DbTestCase):
         self.assertEqual(2, querier._delete_state_object.call_count)
 
         # Ensure invoke_post_run is not called.
-        querier._invoke_post_run.assert_not_called()
+        runners_utils.invoke_post_run.assert_not_called()
 
     @mock.patch.object(
         Action, 'get_by_ref', mock.MagicMock(return_value=None))
     def test_action_deleted(self):
         tracker = results_tracker.get_tracker()
-        querier = tracker.get_querier('test_querymodule')
-        querier._invoke_post_run = mock.Mock(return_value=None)
+        action_db_utils.get_runnertype_by_name = mock.Mock(return_value=None)
 
         # Ensure state objects are present.
         state1 = ActionExecutionState.get_by_id(ResultsTrackerTests.states['state1.yaml'].id)
@@ -317,5 +317,5 @@ class ResultsTrackerTests(EventletTestCase, DbTestCase):
             ResultsTrackerTests.states['state2.yaml'].id
         )
 
-        # Ensure invoke_post_run is not called.
-        querier._invoke_post_run.assert_not_called()
+        # Ensure get_runnertype_by_name in invoke_post_run is not called.
+        action_db_utils.get_runnertype_by_name.assert_not_called()

--- a/st2common/st2common/services/executions.py
+++ b/st2common/st2common/services/executions.py
@@ -44,6 +44,8 @@ from st2common.models.api.action import RunnerTypeAPI, ActionAPI, LiveActionAPI
 from st2common.models.api.rule import RuleAPI
 from st2common.models.api.trigger import TriggerTypeAPI, TriggerAPI, TriggerInstanceAPI
 from st2common.models.db.execution import ActionExecutionDB
+from st2common.runners import utils as runners_utils
+
 
 __all__ = [
     'create_execution_object',
@@ -189,17 +191,26 @@ def abandon_execution_if_incomplete(liveaction_id, publish=True):
     is certain it can no longer determine status of an execution.
     """
     liveaction_db = action_utils.get_liveaction_by_id(liveaction_id)
+
     # No need to abandon and already complete action
     if liveaction_db.status in action_constants.LIVEACTION_COMPLETED_STATES:
         raise ValueError('LiveAction %s already in a completed state %s.' %
                          (liveaction_id, liveaction_db.status))
+
+    # Update status to reflect execution being abandoned.
     liveaction_db = action_utils.update_liveaction_status(
         status=action_constants.LIVEACTION_STATUS_ABANDONED,
         liveaction_db=liveaction_db,
         result={})
+
     execution_db = update_execution(liveaction_db, publish=publish)
+
     LOG.info('Marked execution %s as %s.', execution_db.id,
              action_constants.LIVEACTION_STATUS_ABANDONED)
+
+    # Invoke post run on the action to execute post run operations such as callback.
+    runners_utils.invoke_post_run(liveaction_db)
+
     return execution_db
 
 

--- a/st2common/tests/unit/test_runners_utils.py
+++ b/st2common/tests/unit/test_runners_utils.py
@@ -1,0 +1,71 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+
+from st2common.runners import utils
+from st2common.services import executions as exe_svc
+from st2common.util import action_db as action_db_utils
+from st2tests import base
+from st2tests import fixturesloader
+
+
+from st2tests import config as tests_config
+tests_config.parse_args()
+
+
+FIXTURES_PACK = 'generic'
+
+TEST_FIXTURES = {
+    'liveactions': ['liveaction1.yaml'],
+    'actions': ['local.yaml'],
+    'executions': ['execution1.yaml'],
+    'runners': ['run-local.yaml']
+}
+
+
+class RunnersUtilityTests(base.CleanDbTestCase):
+    def __init__(self, *args, **kwargs):
+        super(RunnersUtilityTests, self).__init__(*args, **kwargs)
+        self.models = None
+
+    def setUp(self):
+        super(RunnersUtilityTests, self).setUp()
+
+        loader = fixturesloader.FixturesLoader()
+
+        self.models = loader.save_fixtures_to_db(
+            fixtures_pack=FIXTURES_PACK,
+            fixtures_dict=TEST_FIXTURES
+        )
+
+        self.liveaction_db = self.models['liveactions']['liveaction1.yaml']
+        exe_svc.create_execution_object(self.liveaction_db)
+        self.action_db = action_db_utils.get_action_by_ref(self.liveaction_db.action)
+
+    @mock.patch.object(action_db_utils, 'get_action_by_ref', mock.MagicMock(return_value=None))
+    def test_invoke_post_run_action_provided(self):
+        utils.invoke_post_run(self.liveaction_db, action_db=self.action_db)
+        action_db_utils.get_action_by_ref.assert_not_called()
+
+    def test_invoke_post_run_action_exists(self):
+        utils.invoke_post_run(self.liveaction_db)
+
+    @mock.patch.object(action_db_utils, 'get_action_by_ref', mock.MagicMock(return_value=None))
+    @mock.patch.object(action_db_utils, 'get_runnertype_by_name', mock.MagicMock(return_value=None))
+    def test_invoke_post_run_action_does_not_exist(self):
+        utils.invoke_post_run(self.liveaction_db)
+        action_db_utils.get_action_by_ref.assert_called_once()
+        action_db_utils.get_runnertype_by_name.assert_not_called()


### PR DESCRIPTION
When action runner is shutdown, any liveactions that are still running will be abandoned. On abandon, the runner's post run method is not called so operations such as callback is not performed. In the case of Mistral, since callback is not performed, Mistral does not know that the task has completed and so the workflow is stuck in running state.