### PR TITLE
Some changes to Mistral querier to get better CPU performance

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -77,6 +77,13 @@ in development
   support non-ascii (unicode) characters. (bug fix)
 * When RBAC is enabled and action is scheduled (ran) through the API, include ``rbac`` dictionary
   with ``user`` and ``roles`` ``action_context`` attribute. (improvement)
+* Fix a bug in query base module when outstanding queries to mistral or other workflow engines 
+  could cause a tight loop without cooperative yield leading to 100% CPU usage by st2resultstracker
+  process. (bug-fix)
+* Make the query interval to third party workflow systems (including mistral) a configurable
+  value. You can now set ``query_interval`` in ``[results_tracker]`` section in ``/etc/st2/st2.conf``.
+  With this, the default query interval is set to 20s as opposed to 0.1s which was rather aggressive
+  and could cause CPU churn when there is a large number of outstanding workflows. (improvement)
 
 2.2.1 - April 3, 2017
 ---------------------

--- a/conf/st2.dev.conf
+++ b/conf/st2.dev.conf
@@ -100,3 +100,9 @@ logging = st2exporter/conf/logging.exporter.conf
 
 [content]
 pack_group = stanley
+
+[results_tracker]
+query_interval = 0.1
+
+[mistral]
+jitter_interval = 0

--- a/conf/st2.tests.conf
+++ b/conf/st2.tests.conf
@@ -89,3 +89,6 @@ logging = st2exporter/conf/logging.exporter.conf
 
 [results_tracker]
 query_interval = 0.1
+
+[mistral]
+jitter_interval = 0

--- a/conf/st2.tests.conf
+++ b/conf/st2.tests.conf
@@ -86,3 +86,6 @@ logging = st2actions/conf/logging.notifier.conf
 
 [exporter]
 logging = st2exporter/conf/logging.exporter.conf
+
+[results_tracker]
+query_interval = 0.1

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -257,7 +257,7 @@ def register_opts(ignore_errors=False):
         cfg.StrOpt('keystone_auth_url', default=None, help='Auth endpoint for Keystone.'),
         cfg.StrOpt('cacert', default=None, help='Optional certificate to validate endpoint.'),
         cfg.BoolOpt('insecure', default=False, help='Allow insecure communication with Mistral.'),
-        cfg.IntOpt('jitter_interval', default=1,
+        cfg.FloatOpt('jitter_interval', default=1,
                    help='Jitter interval to smooth out HTTP requests ' +
                         'to mistral tasks and executions API.'),
 
@@ -272,7 +272,7 @@ def register_opts(ignore_errors=False):
     query_opts = [
         cfg.IntOpt('thread_pool_size', default=10,
                    help='Number of threads to use to query external workflow systems.'),
-        cfg.IntOpt('query_interval', default=20,
+        cfg.FloatOpt('query_interval', default=20,
                    help='Time interval between subsequent queries for a context ' +
                         'to external workflow system.')
     ]

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -257,6 +257,9 @@ def register_opts(ignore_errors=False):
         cfg.StrOpt('keystone_auth_url', default=None, help='Auth endpoint for Keystone.'),
         cfg.StrOpt('cacert', default=None, help='Optional certificate to validate endpoint.'),
         cfg.BoolOpt('insecure', default=False, help='Allow insecure communication with Mistral.'),
+        cfg.IntOpt('jitter_interval', default=1,
+                   help='Jitter interval to smooth out HTTP requests ' +
+                        'to mistral tasks and executions API.'),
 
         cfg.StrOpt('api_url', default=None, help=('URL Mistral uses to talk back to the API.'
             'If not provided it defaults to public API URL. Note: This needs to be a base '

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -264,6 +264,17 @@ def register_opts(ignore_errors=False):
     ]
     do_register_opts(mistral_opts, group='mistral', ignore_errors=ignore_errors)
 
+    # Results Tracker query module options
+    # Note that these are currently used only by mistral query module.
+    query_opts = [
+        cfg.IntOpt('thread_pool_size', default=10,
+                   help='Number of threads to use to query external workflow systems.'),
+        cfg.IntOpt('query_interval', default=20,
+                   help='Time interval between subsequent queries for a context ' +
+                        'to external workflow system.')
+    ]
+    do_register_opts(query_opts, group='results_tracker', ignore_errors=ignore_errors)
+
     # Common CLI options
     debug = cfg.BoolOpt('debug', default=False,
         help='Enable debug mode. By default this will set all log levels to DEBUG.')

--- a/st2common/st2common/query/base.py
+++ b/st2common/st2common/query/base.py
@@ -19,6 +19,8 @@ import Queue
 import six
 import time
 
+from oslo_config import cfg
+
 from st2actions.container.service import RunnerContainerService
 from st2common.runners.base import get_runner
 from st2common import log as logging
@@ -41,14 +43,14 @@ __all__ = [
 class Querier(object):
     delete_state_object_on_error = True
 
-    def __init__(self, threads_pool_size=10, query_interval=1, empty_q_sleep_time=5,
+    def __init__(self, empty_q_sleep_time=5,
                  no_workers_sleep_time=1, container_service=None):
-        self._query_threads_pool_size = threads_pool_size
+        self._query_thread_pool_size = cfg.CONF.results_tracker.thread_pool_size
+        self._query_interval = cfg.CONF.results_tracker.query_interval
         self._query_contexts = Queue.Queue()
-        self._thread_pool = eventlet.GreenPool(self._query_threads_pool_size)
+        self._thread_pool = eventlet.GreenPool(self._query_thread_pool_size)
         self._empty_q_sleep_time = empty_q_sleep_time
         self._no_workers_sleep_time = no_workers_sleep_time
-        self._query_interval = query_interval
         if not container_service:
             container_service = RunnerContainerService()
         self.container_service = container_service
@@ -62,6 +64,7 @@ class Querier(object):
             while self._thread_pool.free() <= 0:
                 eventlet.greenthread.sleep(self._no_workers_sleep_time)
             self._fire_queries()
+            eventlet.sleep(self._query_interval)
 
     def add_queries(self, query_contexts=None):
         if query_contexts is None:
@@ -76,13 +79,20 @@ class Querier(object):
     def _fire_queries(self):
         if self._thread_pool.free() <= 0:
             return
+
+        now = time.time()
+        reschedule_queries = []
+
         while not self._query_contexts.empty() and self._thread_pool.free() > 0:
             (last_query_time, query_context) = self._query_contexts.get_nowait()
-            if time.time() - last_query_time < self._query_interval:
-                self._query_contexts.put((last_query_time, query_context))
+            if now - last_query_time < self._query_interval:
+                reschedule_queries.append((last_query_time, query_context))
                 continue
             else:
                 self._thread_pool.spawn(self._query_and_save_results, query_context)
+
+        for query in reschedule_queries:
+            self._query_contexts.put((query[0], query[1]))
 
     def _query_and_save_results(self, query_context):
         execution_id = query_context.execution_id

--- a/st2common/tests/unit/test_query_base.py
+++ b/st2common/tests/unit/test_query_base.py
@@ -1,0 +1,80 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import Queue
+import time
+
+from unittest2 import TestCase
+import mock
+
+
+from st2common.constants.action import LIVEACTION_STATUS_SUCCEEDED
+from st2common.query.base import Querier
+from st2tests.config import parse_args
+parse_args()
+
+
+class QueryBaseTests(TestCase):
+
+    @mock.patch.object(
+        Querier,
+        '_query_and_save_results',
+        mock.MagicMock(return_value=True)
+    )
+    def test_fire_queries_doesnt_loop(self):
+        querier = Querier()
+
+        mock_query_state_1 = {
+            'execution_id': '59194ff9adf592042d3005bf',
+            'query_module': 'mistral_v2',
+            'query_context': {
+                'mistral': {
+                    'workflow_name': 'st2ci.st2_pkg_e2e_test',
+                    'execution_id': '6d624534-42ca-425c-aa3a-ccc676386fb2'
+                }
+            }
+        }
+
+        mock_query_state_2 = {
+            'execution_id': '59194ff9adf592042d3005bg',
+            'query_module': 'mistral_v2',
+            'query_context': {
+                'mistral': {
+                    'workflow_name': 'st2ci.st2_pkg_e2e_test',
+                    'execution_id': '6d624534-42ca-425c-aa3a-ccc676386fb3'
+                }
+            }
+        }
+
+        mock_query_state_3 = {
+            'execution_id': '59194ff9adf592042d3005bh',
+            'query_module': 'mistral_v2',
+            'query_context': {
+                'mistral': {
+                    'workflow_name': 'st2ci.st2_pkg_e2e_test',
+                    'execution_id': '6d624534-42ca-425c-aa3a-ccc676386fb4'
+                }
+            }
+        }
+
+        now = time.time()
+
+        query_contexts = Queue.Queue()
+        query_contexts.put((now + 100000, mock_query_state_1)),
+        query_contexts.put((now + 100001, mock_query_state_2)),
+        query_contexts.put((now - 200000, mock_query_state_3)),
+        querier._query_contexts = query_contexts
+        querier._fire_queries()
+        self.assertEqual(querier._query_contexts.qsize(), 2)

--- a/st2common/tests/unit/test_query_base.py
+++ b/st2common/tests/unit/test_query_base.py
@@ -20,7 +20,6 @@ from unittest2 import TestCase
 import mock
 
 
-from st2common.constants.action import LIVEACTION_STATUS_SUCCEEDED
 from st2common.query.base import Querier
 from st2tests.config import parse_args
 parse_args()

--- a/st2tests/integration/mistral/test_wiring.py
+++ b/st2tests/integration/mistral/test_wiring.py
@@ -31,7 +31,7 @@ class WiringTest(base.TestWorkflowExecution):
 
         # Create temporary directory used by the tests
         _, self.temp_dir_path = tempfile.mkstemp()
-        os.chmod(self.temp_dir_path, 0666)   # nosec
+        os.chmod(self.temp_dir_path, 0755)   # nosec
 
     def tearDown(self):
         if self.temp_dir_path and os.path.exists(self.temp_dir_path):

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -80,6 +80,7 @@ def _override_common_opts():
     CONF.set_override(name='url', override='zake://', group='coordination')
     CONF.set_override(name='lock_timeout', override=1, group='coordination')
     CONF.set_override(name='jitter_interval', override=0, group='mistral')
+    CONF.set_override(name='query_interval', override=0.1, group='results_tracker')
 
 
 def _override_api_opts():

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -79,6 +79,7 @@ def _override_common_opts():
     CONF.set_override(name='mask_secrets', override=True, group='log')
     CONF.set_override(name='url', override='zake://', group='coordination')
     CONF.set_override(name='lock_timeout', override=1, group='coordination')
+    CONF.set_override(name='jitter_interval', override=0, group='mistral')
 
 
 def _override_api_opts():

--- a/st2tests/st2tests/fixtures/packs/runners/test_querymodule/query/test_querymodule.py
+++ b/st2tests/st2tests/fixtures/packs/runners/test_querymodule/query/test_querymodule.py
@@ -11,5 +11,5 @@ class TestQuerier(Querier):
 
 
 def get_instance():
-    return TestQuerier(query_interval=0.1, empty_q_sleep_time=0.2,
+    return TestQuerier(empty_q_sleep_time=0.2,
                        no_workers_sleep_time=0.1)


### PR DESCRIPTION
## Issue:

This issue came up in st2cicd003 box where a bunch of workflows are stuck in RUNNING state (mistral <-> st2 integration bug, suspected to be addressed by https://github.com/StackStorm/st2/pull/3412). The results tracker keep querying the status of these workflows forever and doesn't bail. The CPU is constantly at 100% on the box. 

## Details

We seem to be querying mistral state over and over again for 9 workflows stuck in RUNNING. On an average, it takes some queries 3s to complete. We make a query every 1s i.e. if I query and I realized that the query didn’t clear the state, it goes back to the queue and we check if current_time - last_query_time > 1 (query_interval). If yes, we re-query. So we were constantly chugging CPU. Unfortunately, the query_interval is hard coded to 1. When I set that to something like 20s, I see the right pattern. When there are threads querying, we hit 100% CPU and then the CPU goes back to normal.

## What's the change? 

As you can see, I cleaned up the while loop. Previously, we were adding back a query to be rescheduled back in the same queue as the job queue. This meant that in this particular case, the queue was never empty and therefore the CPU kept spinning without a cooperative yield. This is a nasty oversight from my original implementation which took 3 years for us to hit it :D. I now cleaned up the code to capture the queries to be rescheduled in a different list and add it back to job queue and also cooperatively yield CPU. 

Along with this change, I also bumped the query_interval to 20s as default. This means we are introducing a delay in detecting end of workflows but with light to reasonable loads, we shouldn't see the CPU issue. This number is entirely load dependent which is why I made the interval and thread pool size configurable so people who know what they are doing can tweak it. 

The CPU profile is much better now. I'd love to share graphs but it's a WIP. 

Please register your thoughts and this IMO should be merged while we think about the callback based redesign which is WIP. /cc @dzimine @Kami @m4dcoder @bigmstone @enykeev

P.S.: The reason for the mistral queries to take 3s is because we not only query execution result but also query individual tasks for a workflow in a serial manner. Here's timing info https://stackstorm.slack.com/files/lakstorm/F5EE3HD61/timing.txt and here's the link to code where we do this serially - https://github.com/StackStorm/st2/blob/master/contrib/runners/mistral_v2/query/mistral_v2.py#L124. 