### PR TITLE
Prevent UnicodeDecodeErrors on stdout/stderr when packs.setup_virtualenv fails

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -71,6 +71,9 @@ in development
 * Update ``/v1/rbac/roles`` API endpoint so it includes corresponding permission grant objects.
   Previously it only included permission grant ids. (improvement)
 * Fix a bug where keyvalue objects weren't properly cast to numeric types. (bug fix)
+* Ignore unicode related encoding errors which could occur in some circumstances when
+  ``packs.setup_virtualenv`` fails due to a missing dependency or similar. (improvement, bug fix)
+  #3337 [Sean Reifschneider]
 
 2.2.1 - April 3, 2017
 ---------------------

--- a/st2common/st2common/util/compat.py
+++ b/st2common/st2common/util/compat.py
@@ -17,7 +17,8 @@
 import six
 
 __all__ = [
-    'to_unicode'
+    'to_unicode',
+    'to_ascii'
 ]
 
 
@@ -37,3 +38,11 @@ def to_unicode(value):
         value = six.u(value)
 
     return value
+
+
+def to_ascii(value):
+    """
+    Function which encodes the provided bytes / string to ASCII encoding ignoring any errors
+    which could come up when trying to encode a non-ascii value.
+    """
+    return value.decode('ascii', errors='ignore')

--- a/st2common/st2common/util/virtualenvs.py
+++ b/st2common/st2common/util/virtualenvs.py
@@ -28,7 +28,7 @@ from st2common.constants.pack import PACK_REF_WHITELIST_REGEX
 from st2common.constants.pack import BASE_PACK_REQUIREMENTS
 from st2common.util.shell import run_command
 from st2common.util.shell import quote_unix
-from st2common.util.compact import to_ascii
+from st2common.util.compat import to_ascii
 from st2common.content.utils import get_packs_base_paths
 from st2common.content.utils import get_pack_directory
 

--- a/st2common/st2common/util/virtualenvs.py
+++ b/st2common/st2common/util/virtualenvs.py
@@ -27,9 +27,10 @@ from st2common import log as logging
 from st2common.constants.pack import PACK_REF_WHITELIST_REGEX
 from st2common.constants.pack import BASE_PACK_REQUIREMENTS
 from st2common.util.shell import run_command
+from st2common.util.shell import quote_unix
+from st2common.util.compact import to_ascii
 from st2common.content.utils import get_packs_base_paths
 from st2common.content.utils import get_pack_directory
-from st2common.util.shell import quote_unix
 
 __all__ = [
     'setup_pack_virtualenv'
@@ -166,12 +167,11 @@ def install_requirements(virtualenv_path, requirements_file_path):
     exit_code, stdout, stderr = run_command(cmd=cmd, env=env)
 
     if exit_code != 0:
-        def safetystring(s):
-            return s.decode('ascii', errors='ignore')
-        raise Exception(
-            'Failed to install requirements from "%s": %s (stderr: %s)' % (
-                requirements_file_path,
-                safetystring(stdout), safetystring(stderr)))
+        stdout = to_ascii(stdout)
+        stderr = to_ascii(stderr)
+
+        raise Exception('Failed to install requirements from "%s": %s (stderr: %s)' %
+                        (requirements_file_path, stdout, stderr))
 
     return True
 

--- a/st2common/tests/unit/test_util_compact.py
+++ b/st2common/tests/unit/test_util_compact.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest2
+
+from st2common.util.compat import to_ascii
+
+__all__ = [
+    'CompatUtilsTestCase'
+]
+
+
+class CompatUtilsTestCase(unittest2.TestCase):
+    def test_to_ascii(self):
+        expected_values = [
+            ('already ascii', 'already ascii'),
+            (u'foo', 'foo'),
+            ('٩(̾●̮̮̃̾•̃̾)۶', '()'),
+            ('\xd9\xa9', '')
+        ]
+
+        for input_value, expected_value in expected_values:
+            result = to_ascii(input_value)
+            self.assertEqual(result, expected_value)


### PR DESCRIPTION
This pull request works on top of #3338 and adds / changes:

* Moves utility function into `st2common.util.compat` module
* Adds test case for it
* Adds changelog entry