### PR TITLE
Fix action chain runner so vars and action parameter values support unicode characters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -73,6 +73,8 @@ in development
 * Fix a bug where keyvalue objects weren't properly cast to numeric types. (bug fix)
 * When action worker is being shutdown and action executions are being abandoned, invoke post run
   on the action executions to ensure operations such as callback is performed. (bug fix)
+* Fix action chain runner workflows so variables (vars) and parameter values
+  support non-ascii (unicode) characters. (bug fix)
 
 2.2.1 - April 3, 2017
 ---------------------

--- a/contrib/runners/action_chain_runner/tests/unit/test_actionchain_params_rendering.py
+++ b/contrib/runners/action_chain_runner/tests/unit/test_actionchain_params_rendering.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -62,3 +63,29 @@ class ActionChainRunnerResolveParamsTests(unittest2.TestCase):
             self.fail('Should have thrown an instance of %s' % ParameterRenderingFailedException)
         except ParameterRenderingFailedException:
             pass
+
+    def test_init_params_vars_with_unicode_value(self):
+        chain_spec = {
+            'vars': {
+                'unicode_var': u'٩(̾●̮̮̃̾•̃̾)۶ ٩(̾●̮̮̃̾•̃̾)۶ ćšž',
+                'unicode_var_param': u'{{ param }}'
+            },
+            'chain': [
+                {
+                    'name': 'c1',
+                    'ref': 'core.local',
+                    'parameters': {
+                        'cmd': 'echo {{ unicode_var }}'
+                    }
+                }
+            ]
+        }
+
+        chain_holder = acr.ChainHolder(chainspec=chain_spec, chainname='foo')
+        chain_holder.init_vars(action_parameters={'param': u'٩(̾●̮̮̃̾•̃̾)۶'})
+
+        expected = {
+            'unicode_var': u'٩(̾●̮̮̃̾•̃̾)۶ ٩(̾●̮̮̃̾•̃̾)۶ ćšž',
+            'unicode_var_param': u'٩(̾●̮̮̃̾•̃̾)۶'
+        }
+        self.assertEqual(chain_holder.vars, expected)

--- a/st2common/st2common/util/jinja.py
+++ b/st2common/st2common/util/jinja.py
@@ -135,7 +135,12 @@ def render_values(mapping=None, context=None, allow_undefined=False):
             v = json.dumps(v)
             reverse_json_dumps = True
         else:
-            v = to_unicode(v)
+            # Special case for text type to handle unicode
+            if isinstance(v, six.string_types):
+                v = to_unicode(v)
+            else:
+                # Other types (e.g. boolean, etc.)
+                v = str(v)
 
         try:
             LOG.info('Rendering string %s. Super context=%s', v, super_context)

--- a/st2common/st2common/util/jinja.py
+++ b/st2common/st2common/util/jinja.py
@@ -134,7 +134,8 @@ def render_values(mapping=None, context=None, allow_undefined=False):
             v = json.dumps(v)
             reverse_json_dumps = True
         else:
-            v = str(v)
+            from st2common.util.compat import to_unicode
+            v = to_unicode(v)
 
         try:
             LOG.info('Rendering string %s. Super context=%s', v, super_context)

--- a/st2common/st2common/util/jinja.py
+++ b/st2common/st2common/util/jinja.py
@@ -17,6 +17,7 @@ import json
 import six
 
 from st2common import log as logging
+from st2common.util.compat import to_unicode
 
 
 __all__ = [
@@ -134,7 +135,6 @@ def render_values(mapping=None, context=None, allow_undefined=False):
             v = json.dumps(v)
             reverse_json_dumps = True
         else:
-            from st2common.util.compat import to_unicode
             v = to_unicode(v)
 
         try:

--- a/st2common/tests/unit/test_util_jinja.py
+++ b/st2common/tests/unit/test_util_jinja.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -33,4 +34,28 @@ class JinjaUtilsRenderTestCase(unittest2.TestCase):
             context={'a': 'v1', 'b': 'v2'},
             allow_undefined=True)
         expected = {'k2': 'v2', 'k1': 'v1', 'k3': ''}
+        self.assertEqual(actual, expected)
+
+    def test_render_values_ascii_and_unicode_values(self):
+        mapping = {
+            u'k_ascii': '{{a}}',
+            u'k_unicode': '{{b}}',
+            u'k_ascii_unicode': '{{c}}'}
+        context = {
+            'a': u'some ascii value',
+            'b': u'٩(̾●̮̮̃̾•̃̾)۶ ٩(̾●̮̮̃̾•̃̾)۶ ćšž',
+            'c': u'some ascii some ٩(̾●̮̮̃̾•̃̾)۶ ٩(̾●̮̮̃̾•̃̾)۶ '
+        }
+
+        expected = {
+            'k_ascii': u'some ascii value',
+            'k_unicode': u'٩(̾●̮̮̃̾•̃̾)۶ ٩(̾●̮̮̃̾•̃̾)۶ ćšž',
+            'k_ascii_unicode': u'some ascii some ٩(̾●̮̮̃̾•̃̾)۶ ٩(̾●̮̮̃̾•̃̾)۶ '
+        }
+
+        actual = jinja_utils.render_values(
+            mapping=mapping,
+            context=context,
+            allow_undefined=True)
+
         self.assertEqual(actual, expected)


### PR DESCRIPTION
The title says it all.

This fixes the issue reported in https://github.com/StackStorm/st2/issues/3421.


```bash
st2 run examples.echochain -d
+-----------------+--------------------------------------------------------------+
| Property        | Value                                                        |
+-----------------+--------------------------------------------------------------+
| id              | 591ef4590640fd4e3d661fc8                                     |
| action.ref      | examples.echochain                                           |
| context.user    | stanley                                                      |
| parameters      |                                                              |
| status          | succeeded                                                    |
| start_timestamp | Fri, 19 May 2017 13:34:17 UTC                                |
| end_timestamp   | Fri, 19 May 2017 13:34:19 UTC                                |
| result          | {                                                            |
|                 |     "tasks": [                                               |
|                 |         {                                                    |
|                 |             "name": "c1",                                    |
|                 |             "workflow": null,                                |
|                 |             "created_at":                                    |
|                 | "2017-05-19T13:34:17.811649+00:00",                          |
|                 |             "updated_at":                                    |
|                 | "2017-05-19T13:34:19.025650+00:00",                          |
|                 |             "state": "succeeded",                            |
|                 |             "result": {                                      |
|                 |                 "succeeded": true,                           |
|                 |                 "failed": false,                             |
|                 |                 "return_code": 0,                            |
|                 |                 "stderr": "",                                |
|                 |                 "stdout": "ыыыы"                             |
|                 |             },                                               |
|                 |             "id": "c1",                                      |
|                 |             "execution_id": "591ef4590640fd4e48b71d59"       |
|                 |         }                                                    |
|                 |     ]                                                        |
|                 | }                                                            |
+-----------------+--------------------------------------------------------------+
```