### PR TITLE
Minor fix to mistral itests

### DIFF
--- a/st2tests/integration/mistral/test_errors.py
+++ b/st2tests/integration/mistral/test_errors.py
@@ -68,12 +68,12 @@ class ExceptionHandlingTest(base.TestWorkflowExecution):
 
     def test_bad_with_items(self):
         execution = self._execute_workflow('examples.mistral-error-bad-with-items', {})
-        execution = self._wait_for_completion(execution)
+        execution = self._wait_for_completion(execution, expect_tasks=False)
         self._assert_failure(execution, expect_tasks_failure=False)
         self.assertIn('Wrong input format', execution.result['extra']['state_info'])
 
     def test_bad_with_items_yaql(self):
         execution = self._execute_workflow('examples.mistral-error-bad-with-items-yaql', {})
-        execution = self._wait_for_completion(execution)
+        execution = self._wait_for_completion(execution, expect_tasks=False)
         self._assert_failure(execution, expect_tasks_failure=False)
         self.assertIn('Can not evaluate YAQL expression', execution.result['extra']['state_info'])

--- a/st2tests/integration/mistral/test_wiring.py
+++ b/st2tests/integration/mistral/test_wiring.py
@@ -114,7 +114,7 @@ class WiringTest(base.TestWorkflowExecution):
     def test_cancellation_cascade_subworkflow_action(self):
         execution = self._execute_workflow(
             'examples.mistral-test-cancel-subworkflow-action',
-            {'sleep': 10}
+            {'sleep': 30}
         )
 
         execution = self._wait_for_state(execution, ['running'])


### PR DESCRIPTION
Increase sleep time in one of the test to ensure there's enough time for the test to cancel the sub-workflow.