### PR TITLE
Fix duplicate remove from running liveactions set

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -97,6 +97,8 @@ in development
 * Add new ``examples.forloop_chain`` action-chain workflow to the examples pack which demonstrates
   how to iterate over multiple pages inside a workflow. #3328
   [Carles Figuerola]
+* Fix a bug where action runner throws KeyError on abandoning action executions
+  during process shutdown. (bug fix)
 
 2.2.1 - April 3, 2017
 ---------------------

--- a/st2actions/st2actions/worker.py
+++ b/st2actions/st2actions/worker.py
@@ -145,7 +145,11 @@ class ActionExecutionDispatcher(MessageHandler):
             executions.update_execution(liveaction_db)
             raise
         finally:
-            self._running_liveactions.remove(liveaction_db.id)
+            # In the case of worker shutdown, the items are removed from _running_liveactions.
+            # As the subprocesses for action executions are terminated, this finally block
+            # will be executed. Set remove will result in KeyError if item no longer exists.
+            # Use set discard to not raise the KeyError.
+            self._running_liveactions.discard(liveaction_db.id)
 
         return result
 

--- a/st2actions/tests/unit/test_worker.py
+++ b/st2actions/tests/unit/test_worker.py
@@ -98,7 +98,7 @@ class WorkerTestCase(DbTestCase):
         # over a separate thread, run the shutdown sequence on the main thread, and then let
         # the local runner to exit gracefully and allow _run_action to finish execution.
         with tempfile.NamedTemporaryFile() as fp:
-            params = {'cmd': 'while [ -e \'%s\' ]; do sleep 1; done' % fp.name}
+            params = {'cmd': 'while [ -e \'%s\' ]; do sleep 0.1; done' % fp.name}
             liveaction_db = self._get_liveaction_model(WorkerTestCase.local_action_db, params)
             liveaction_db = LiveAction.add_or_update(liveaction_db)
             executions.create_execution_object(liveaction_db)
@@ -106,7 +106,7 @@ class WorkerTestCase(DbTestCase):
 
             # Wait for the worker to add the liveaction to _running_liveactions.
             while len(action_worker._running_liveactions) <= 0:
-                eventlet.sleep(1)
+                eventlet.sleep(0.1)
 
             self.assertEqual(len(action_worker._running_liveactions), 1)
 

--- a/st2actions/tests/unit/test_worker.py
+++ b/st2actions/tests/unit/test_worker.py
@@ -14,8 +14,10 @@
 # limitations under the License.
 
 from bson.errors import InvalidStringData
+import eventlet
 import mock
 from oslo_config import cfg
+import tempfile
 
 import st2actions.worker as actions_worker
 from st2common.constants import action as action_constants
@@ -56,6 +58,17 @@ class WorkerTestCase(DbTestCase):
         WorkerTestCase.local_runnertype_db = models['runners']['run-local.yaml']
         WorkerTestCase.local_action_db = models['actions']['local.yaml']
 
+    def _get_liveaction_model(self, action_db, params):
+        status = action_constants.LIVEACTION_STATUS_REQUESTED
+        start_timestamp = date_utils.get_datetime_utc_now()
+        action_ref = ResourceReference(name=action_db.name, pack=action_db.pack).ref
+        parameters = params
+        context = {'user': cfg.CONF.system_user.user}
+        liveaction_db = LiveActionDB(status=status, start_timestamp=start_timestamp,
+                                     action=action_ref, parameters=parameters,
+                                     context=context)
+        return liveaction_db
+
     @mock.patch.object(LocalShellRunner, 'run', mock.MagicMock(
         return_value=(action_constants.LIVEACTION_STATUS_SUCCEEDED, NON_UTF8_RESULT, None)))
     def test_non_utf8_action_result_string(self):
@@ -71,19 +84,41 @@ class WorkerTestCase(DbTestCase):
             action_worker._run_action(liveaction_db)
         except InvalidStringData:
             liveaction_db = LiveAction.get_by_id(liveaction_db.id)
-            self.assertEqual(liveaction_db.status, "failed")
+            self.assertEqual(liveaction_db.status, action_constants.LIVEACTION_STATUS_FAILED)
             self.assertTrue('error' in liveaction_db.result)
             self.assertTrue('traceback' in liveaction_db.result)
             execution_db = ActionExecution.get_by_id(execution_db.id)
-            self.assertEqual(liveaction_db.status, "failed")
+            self.assertEqual(liveaction_db.status, action_constants.LIVEACTION_STATUS_FAILED)
 
-    def _get_liveaction_model(self, action_db, params):
-        status = action_constants.LIVEACTION_STATUS_REQUESTED
-        start_timestamp = date_utils.get_datetime_utc_now()
-        action_ref = ResourceReference(name=action_db.name, pack=action_db.pack).ref
-        parameters = params
-        context = {'user': cfg.CONF.system_user.user}
-        liveaction_db = LiveActionDB(status=status, start_timestamp=start_timestamp,
-                                     action=action_ref, parameters=parameters,
-                                     context=context)
-        return liveaction_db
+    def test_worker_shutdown(self):
+        action_worker = actions_worker.get_worker()
+
+        # Create a temporary file that is deleted when the file is closed and then set up an
+        # action to wait for this file to be deleted. This allows this test to run the action
+        # over a separate thread, run the shutdown sequence on the main thread, and then let
+        # the local runner to exit gracefully and allow _run_action to finish execution.
+        with tempfile.NamedTemporaryFile() as fp:
+            params = {'cmd': 'while [ -e \'%s\' ]; do sleep 1; done' % fp.name}
+            liveaction_db = self._get_liveaction_model(WorkerTestCase.local_action_db, params)
+            liveaction_db = LiveAction.add_or_update(liveaction_db)
+            executions.create_execution_object(liveaction_db)
+            runner_thread = eventlet.spawn(action_worker._run_action, liveaction_db)
+
+            # Wait for the worker to add the liveaction to _running_liveactions.
+            while len(action_worker._running_liveactions) <= 0:
+                eventlet.sleep(1)
+
+            self.assertEqual(len(action_worker._running_liveactions), 1)
+
+            # Shutdown the worker to trigger the abandon process.
+            action_worker.shutdown()
+            liveaction_db = LiveAction.get_by_id(liveaction_db.id)
+
+            # Verify that _running_liveactions is empty and the liveaction is abandoned.
+            self.assertEqual(len(action_worker._running_liveactions), 0)
+            self.assertEqual(liveaction_db.status, action_constants.LIVEACTION_STATUS_ABANDONED)
+
+        # Wait for the local runner to complete. This will activate the finally block in
+        # _run_action but will not result in KeyError because the discard method is used to
+        # to remove the liveaction from _running_liveactions.
+        runner_thread.wait()


### PR DESCRIPTION
On action runner shutdown, item in the _running_liveactions set is removed twice, once during the abandon process and a second time on completion of _run_action.