### PR TITLE
Add missing indexes

### DIFF
--- a/.circle/install-and-run-mongodb.sh
+++ b/.circle/install-and-run-mongodb.sh
@@ -19,8 +19,12 @@ wget -q ${DOWNLOAD_URL} -O /tmp/mongodb.tgz
 tar -xvf /tmp/mongodb.tgz -C ${MONGODB_DIR} --strip=1
 
 echo "Starting MongoDB v${MONGODB_VERSION}"
-v${MONGODB_DIR}/bin/mongod --nojournal --journalCommitInterval 500 --syncdelay 0 \
-    --wiredTigerStatisticsLogDelaySecs 0 --dbpath ${DATA_DIR} --bind_ip 127.0.0.1 &> /tmp/mongodb.log &
+# Note: We use --notablescan option to detected missing indexes early. When this
+# option is enabled, queries which result in table scan (which usually means a
+# missing index or a bad query) are not allowed and result in a failed test.
+${MONGODB_DIR}/bin/mongod --nojournal --journalCommitInterval 500 --syncdelay 0 \
+    --wiredTigerStatisticsLogDelaySecs 0 --notablescan \
+    --dbpath ${DATA_DIR} --bind_ip 127.0.0.1 &> /tmp/mongodb.log &
 MONGODB_PID=$!
 
 # Give process some time to start up

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -111,6 +111,8 @@ in development
 * The ``dest_server`` parameter has been removed from the ``linux.scp`` action. Going forward simply
   specify the server as part of the ``source`` and / or ``destination`` arguments. (improvement)
    #3335 #3463 [Nick Maludy]
+* Add missing database indexes which should speed up various queries on production deployments with
+  large datasets. (improvement)
 
 2.2.1 - April 3, 2017
 ---------------------

--- a/st2common/st2common/models/db/action.py
+++ b/st2common/st2common/models/db/action.py
@@ -78,7 +78,9 @@ class ActionDB(stormbase.StormFoundationDB, stormbase.TagsMixin,
     notify = me.EmbeddedDocumentField(NotificationSchema)
 
     meta = {
-        'indexes': stormbase.TagsMixin.get_indices() + stormbase.UIDFieldMixin.get_indexes()
+        'indexes': [
+            {'fields': ['name']},
+        ] + stormbase.TagsMixin.get_indices() + stormbase.UIDFieldMixin.get_indexes()
     }
 
     def __init__(self, *args, **values):

--- a/st2common/st2common/models/db/action.py
+++ b/st2common/st2common/models/db/action.py
@@ -80,6 +80,8 @@ class ActionDB(stormbase.StormFoundationDB, stormbase.TagsMixin,
     meta = {
         'indexes': [
             {'fields': ['name']},
+            {'fields': ['pack']},
+            {'fields': ['ref']},
         ] + stormbase.TagsMixin.get_indices() + stormbase.UIDFieldMixin.get_indexes()
     }
 

--- a/st2common/st2common/models/db/actionalias.py
+++ b/st2common/st2common/models/db/actionalias.py
@@ -73,7 +73,9 @@ class ActionAliasDB(stormbase.StormFoundationDB, stormbase.ContentPackResourceMi
     )
 
     meta = {
-        'indexes': stormbase.UIDFieldMixin.get_indexes()
+        'indexes': [
+            {'fields': ['name']},
+        ] + stormbase.UIDFieldMixin.get_indexes()
     }
 
     def __init__(self, *args, **values):

--- a/st2common/st2common/models/db/execution.py
+++ b/st2common/st2common/models/db/execution.py
@@ -82,6 +82,7 @@ class ActionExecutionDB(stormbase.StormFoundationDB):
             {'fields': ['runner.name']},
             {'fields': ['trigger.name']},
             {'fields': ['trigger_type.name']},
+            {'fields': ['trigger_instance.id']},
             {'fields': ['context.user']},
             {'fields': ['-start_timestamp', 'action.ref', 'status']}
         ]

--- a/st2common/st2common/models/db/keyvalue.py
+++ b/st2common/st2common/models/db/keyvalue.py
@@ -43,6 +43,7 @@ class KeyValuePairDB(stormbase.StormBaseDB, stormbase.UIDFieldMixin):
 
     meta = {
         'indexes': [
+            {'fields': ['name']},
             {
                 'fields': ['expire_timestamp'],
                 'expireAfterSeconds': 0

--- a/st2common/st2common/models/db/liveaction.py
+++ b/st2common/st2common/models/db/liveaction.py
@@ -75,6 +75,8 @@ class LiveActionDB(stormbase.StormFoundationDB):
             {'fields': ['end_timestamp']},
             {'fields': ['action']},
             {'fields': ['status']},
+            {'fields': ['context']},
+            {'fields': ['context.trigger_instance.id']},
         ]
     }
 

--- a/st2common/st2common/models/db/policy.py
+++ b/st2common/st2common/models/db/policy.py
@@ -185,7 +185,6 @@ class PolicyDB(stormbase.StormFoundationDB, stormbase.ContentPackResourceMixin,
     meta = {
         'indexes': [
             {'fields': ['resource_ref']},
-            {'fields': ['resource_ref', 'enabled']}
         ]
     }
 

--- a/st2common/st2common/models/db/policy.py
+++ b/st2common/st2common/models/db/policy.py
@@ -184,6 +184,7 @@ class PolicyDB(stormbase.StormFoundationDB, stormbase.ContentPackResourceMixin,
 
     meta = {
         'indexes': [
+            {'fields': ['name']},
             {'fields': ['resource_ref']},
         ]
     }

--- a/st2common/st2common/models/db/policy.py
+++ b/st2common/st2common/models/db/policy.py
@@ -182,6 +182,13 @@ class PolicyDB(stormbase.StormFoundationDB, stormbase.ContentPackResourceMixin,
     parameters = me.DictField(
         help_text='The specification of input parameters for the policy.')
 
+    meta = {
+        'indexes': [
+            {'fields': ['resource_ref']},
+            {'fields': ['resource_ref', 'enabled']}
+        ]
+    }
+
     def __init__(self, *args, **kwargs):
         super(PolicyDB, self).__init__(*args, **kwargs)
         self.uid = self.get_uid()

--- a/st2common/st2common/models/db/rbac.py
+++ b/st2common/st2common/models/db/rbac.py
@@ -47,6 +47,13 @@ class RoleDB(stormbase.StormFoundationDB):
     system = me.BooleanField(default=False)
     permission_grants = me.ListField(field=me.StringField())
 
+    meta = {
+        'indexes': [
+            {'fields': ['name']},
+            {'fields': ['permission_grants']},
+        ]
+    }
+
 
 class UserRoleAssignmentDB(stormbase.StormFoundationDB):
     """
@@ -66,6 +73,13 @@ class UserRoleAssignmentDB(stormbase.StormFoundationDB):
     # st2-apply-rbac-auth-definitions tool.
     is_remote = me.BooleanField(default=False)
 
+    meta = {
+        'indexes': [
+            {'fields': ['user']},
+            {'fields': ['role']},
+        ]
+    }
+
 
 class PermissionGrantDB(stormbase.StormFoundationDB):
     """
@@ -80,6 +94,12 @@ class PermissionGrantDB(stormbase.StormFoundationDB):
     resource_uid = me.StringField(required=False)
     resource_type = me.StringField(required=False)
     permission_types = me.ListField(field=me.StringField())
+
+    meta = {
+        'indexes': [
+            {'fields': ['resource_uid']},
+        ]
+    }
 
 
 class GroupToRoleMappingDB(stormbase.StormFoundationDB):

--- a/st2common/st2common/models/db/rbac.py
+++ b/st2common/st2common/models/db/rbac.py
@@ -50,6 +50,7 @@ class RoleDB(stormbase.StormFoundationDB):
     meta = {
         'indexes': [
             {'fields': ['name']},
+            {'fields': ['system']},
             {'fields': ['permission_grants']},
         ]
     }
@@ -77,6 +78,7 @@ class UserRoleAssignmentDB(stormbase.StormFoundationDB):
         'indexes': [
             {'fields': ['user']},
             {'fields': ['role']},
+            {'fields': ['is_remote']},
         ]
     }
 

--- a/st2common/st2common/models/db/rule.py
+++ b/st2common/st2common/models/db/rule.py
@@ -88,6 +88,7 @@ class RuleDB(stormbase.StormFoundationDB, stormbase.TagsMixin,
 
     meta = {
         'indexes': [
+            {'fields': ['enabled']},
             {'fields': ['action.ref']},
             {'fields': ['trigger']}
         ] + stormbase.TagsMixin.get_indices() + stormbase.UIDFieldMixin.get_indexes()

--- a/st2common/st2common/models/db/rule_enforcement.py
+++ b/st2common/st2common/models/db/rule_enforcement.py
@@ -59,6 +59,7 @@ class RuleEnforcementDB(stormbase.StormFoundationDB, stormbase.TagsMixin):
             {'fields': ['rule.id']},
             {'fields': ['rule.ref']},
             {'fields': ['enforced_at']},
+            {'fields': ['-enforced_at']},
             {'fields': ['-enforced_at', 'rule.ref']},
         ] + stormbase.TagsMixin.get_indices()
     }

--- a/st2common/st2common/models/db/rule_enforcement.py
+++ b/st2common/st2common/models/db/rule_enforcement.py
@@ -41,8 +41,7 @@ class RuleReferenceSpecDB(me.EmbeddedDocument):
         return ''.join(result)
 
 
-class RuleEnforcementDB(stormbase.StormFoundationDB, stormbase.TagsMixin,
-                        stormbase.UIDFieldMixin):
+class RuleEnforcementDB(stormbase.StormFoundationDB, stormbase.TagsMixin):
     UID_FIELDS = ['id']
 
     trigger_instance_id = me.StringField(required=True)
@@ -61,8 +60,15 @@ class RuleEnforcementDB(stormbase.StormFoundationDB, stormbase.TagsMixin,
             {'fields': ['rule.ref']},
             {'fields': ['enforced_at']},
             {'fields': ['-enforced_at', 'rule.ref']},
-        ] + stormbase.TagsMixin.get_indices() + stormbase.UIDFieldMixin.get_indexes()
+        ] + stormbase.TagsMixin.get_indices()
     }
+
+    # NOTE: Note the following method is exposed so loggers in rbac resolvers can log objects
+    # with a consistent get_uid interface.
+    def get_uid(self):
+        # TODO Construct uid from non id field:
+        uid = [self.RESOURCE_TYPE, str(self.id)]
+        return ':'.join(uid)
 
 
 rule_enforcement_access = MongoDBAccess(RuleEnforcementDB)

--- a/st2common/st2common/models/db/rule_enforcement.py
+++ b/st2common/st2common/models/db/rule_enforcement.py
@@ -41,7 +41,10 @@ class RuleReferenceSpecDB(me.EmbeddedDocument):
         return ''.join(result)
 
 
-class RuleEnforcementDB(stormbase.StormFoundationDB, stormbase.TagsMixin):
+class RuleEnforcementDB(stormbase.StormFoundationDB, stormbase.TagsMixin,
+                        stormbase.UIDFieldMixin):
+    UID_FIELDS = ['id']
+
     trigger_instance_id = me.StringField(required=True)
     execution_id = me.StringField(required=False)
     failure_reason = me.StringField(required=False)
@@ -58,7 +61,7 @@ class RuleEnforcementDB(stormbase.StormFoundationDB, stormbase.TagsMixin):
             {'fields': ['rule.ref']},
             {'fields': ['enforced_at']},
             {'fields': ['-enforced_at', 'rule.ref']},
-        ] + stormbase.TagsMixin.get_indices()
+        ] + stormbase.TagsMixin.get_indices() + stormbase.UIDFieldMixin.get_indexes()
     }
 
 

--- a/st2common/st2common/models/db/rule_enforcement.py
+++ b/st2common/st2common/models/db/rule_enforcement.py
@@ -55,6 +55,8 @@ class RuleEnforcementDB(stormbase.StormFoundationDB, stormbase.TagsMixin):
     meta = {
         'indexes': [
             {'fields': ['rule.ref']},
+            {'fields': ['-enforced_at']},
+            {'fields': ['+enforced_at']},
         ]
     }
 

--- a/st2common/st2common/models/db/rule_enforcement.py
+++ b/st2common/st2common/models/db/rule_enforcement.py
@@ -42,8 +42,6 @@ class RuleReferenceSpecDB(me.EmbeddedDocument):
 
 
 class RuleEnforcementDB(stormbase.StormFoundationDB, stormbase.TagsMixin):
-    UID_FIELDS = ['id']
-
     trigger_instance_id = me.StringField(required=True)
     execution_id = me.StringField(required=False)
     failure_reason = me.StringField(required=False)
@@ -54,18 +52,14 @@ class RuleEnforcementDB(stormbase.StormFoundationDB, stormbase.TagsMixin):
 
     meta = {
         'indexes': [
+            {'fields': ['trigger_instance_id']},
+            {'fields': ['execution_id']},
+            {'fields': ['rule.id']},
             {'fields': ['rule.ref']},
-            {'fields': ['-enforced_at']},
-            {'fields': ['+enforced_at']},
-        ]
+            {'fields': ['enforced_at']},
+            {'fields': ['-enforced_at', 'rule.ref']},
+        ] + stormbase.TagsMixin.get_indices()
     }
-
-    # XXX: Note the following method is exposed so loggers in rbac resolvers can log objects
-    # with a consistent get_uid interface.
-    def get_uid(self):
-        # TODO Construct uid from non id field:
-        uid = [self.RESOURCE_TYPE, str(self.id)]
-        return ':'.join(uid)
 
 
 rule_enforcement_access = MongoDBAccess(RuleEnforcementDB)

--- a/st2common/st2common/models/db/sensor.py
+++ b/st2common/st2common/models/db/sensor.py
@@ -51,7 +51,9 @@ class SensorTypeDB(stormbase.StormBaseDB, stormbase.ContentPackResourceMixin,
                               help_text=u'Flag indicating whether the sensor is enabled.')
 
     meta = {
-        'indexes': stormbase.UIDFieldMixin.get_indexes()
+        'indexes': [
+            {'fields': ['enabled']},
+        ] + stormbase.UIDFieldMixin.get_indexes()
     }
 
     def __init__(self, *args, **values):

--- a/st2common/st2common/models/db/trigger.py
+++ b/st2common/st2common/models/db/trigger.py
@@ -83,6 +83,13 @@ class TriggerDB(stormbase.StormBaseDB, stormbase.ContentPackResourceMixin,
     parameters = me.DictField()
     ref_count = me.IntField(default=0)
 
+    meta = {
+        'indexes': [
+            {'fields': ['type']},
+            {'fields': ['parameters']},
+        ] + stormbase.UIDFieldMixin.get_indexes()
+    }
+
     def __init__(self, *args, **values):
         super(TriggerDB, self).__init__(*args, **values)
         self.ref = self.get_reference().ref

--- a/st2common/st2common/models/db/trigger.py
+++ b/st2common/st2common/models/db/trigger.py
@@ -85,6 +85,7 @@ class TriggerDB(stormbase.StormBaseDB, stormbase.ContentPackResourceMixin,
 
     meta = {
         'indexes': [
+            {'fields': ['name']},
             {'fields': ['type']},
             {'fields': ['parameters']},
         ] + stormbase.UIDFieldMixin.get_indexes()

--- a/st2common/tests/unit/base.py
+++ b/st2common/tests/unit/base.py
@@ -74,6 +74,15 @@ class FakeModelDB(stormbase.StormBaseDB):
     category = mongoengine.StringField()
     timestamp = mongoengine.DateTimeField()
 
+    meta = {
+        'indexes': [
+            {'fields': ['index']},
+            {'fields': ['category']},
+            {'fields': ['timestamp']},
+            {'fields': ['context.user']},
+        ]
+    }
+
 
 class FakeModel(Access):
     impl = db.MongoDBAccess(FakeModelDB)


### PR DESCRIPTION
I was looking into speeding up tests and decided to run mongodb with `--notablescan` option to find out if we have any queries which result in table scans (aka index not being used).

It turns out we do indeed have such offenders.

This pull request adds missing indexes which should speed up some queries in production installations with a lot of data.

Going forward, I would propose running MongoDB on Circle CI with `--notablescan` option. This will immediately let us know if we are missing an index since a query which would result in a table scan and as such the test case itself will fail.

Based on top off #3465 (once that PR is approved and merged the diff will look much saner).