### PR TITLE
Use default value from config schema even if config item is not required

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -111,6 +111,10 @@ in development
 * The ``dest_server`` parameter has been removed from the ``linux.scp`` action. Going forward simply
   specify the server as part of the ``source`` and / or ``destination`` arguments. (improvement)
    #3335 #3463 [Nick Maludy]
+* Use a default value for a config item from config schema even if that config item is not required
+  (``required: false``). (improvement)
+
+  Reported by nmlaudy. #3468 #3469
 
 2.2.1 - April 3, 2017
 ---------------------

--- a/st2common/st2common/util/config_loader.py
+++ b/st2common/st2common/util/config_loader.py
@@ -154,11 +154,10 @@ class ContentPackConfigLoader(object):
         """
         for schema_item_key, schema_item in six.iteritems(schema):
             default_value = schema_item.get('default', None)
-            is_required = schema_item.get('required', False)
             is_object = schema_item.get('type', None) == 'object'
             has_properties = schema_item.get('properties', None)
 
-            if is_required and default_value and not config.get(schema_item_key, None):
+            if default_value and not config.get(schema_item_key, None):
                 config[schema_item_key] = default_value
 
             # Inspect nested object properties

--- a/st2common/tests/unit/test_config_loader.py
+++ b/st2common/tests/unit/test_config_loader.py
@@ -94,8 +94,8 @@ class ContentPackConfigLoaderTestCase(CleanDbTestCase):
         config = loader.get_config()
         self.assertEqual(config['region'], 'us-west-1')
 
-        # Value is provided in the config
-        # Attribute has required: false
+        # Config item attribute has required: false
+        # Value is provided in the config - it should be used as provided
         pack_name = 'dummy_pack_5'
 
         loader = ContentPackConfigLoader(pack_name=pack_name)
@@ -106,12 +106,11 @@ class ContentPackConfigLoaderTestCase(CleanDbTestCase):
         del config_db['values']['non_required_with_default_value']
         Config.add_or_update(config_db)
 
-        # When config doesn't contain a value for that item default value should still be use and
-        # set
+        # No value in the config - default value should be used
         config_db = Config.get_by_pack(pack_name)
         config_db.delete()
 
-        # When there is no config, default value should still be used and set
+        # No config exists for that pack - default value should be used
         loader = ContentPackConfigLoader(pack_name=pack_name)
         config = loader.get_config()
         self.assertEqual(config['non_required_with_default_value'], 'some default value')

--- a/st2tests/st2tests/fixtures/packs/configs/dummy_pack_5.yaml
+++ b/st2tests/st2tests/fixtures/packs/configs/dummy_pack_5.yaml
@@ -4,3 +4,4 @@
   regions:
     - "us-west-1"
   private_key_path: "{{st2kv.system.private_key_path}}"  # global pack datastore value
+  non_required_with_default_value: "config value"

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_5/config.schema.yaml
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_5/config.schema.yaml
@@ -17,3 +17,7 @@
     type: "string"
     required: true
     default: "default-region-value"
+  non_required_with_default_value:
+    type: "string"
+    required: false
+    default: "some default value"


### PR DESCRIPTION
This pull request updates config loader to use a default value from config schema for a particular config item is used and set even if that item is not required (``required: false``).

For more details and context, see #3468.

I believe this should have no negative / breaking impact. 

Resolves #3468.