### PR TITLE
Fix syntax in changelog.rst, validate changelog rst file syntax on CI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -912,21 +912,6 @@ in development
   easier since user simply needs to start sensor container with ``--debug`` flag and all the sensor
   logs with level debug or higher will be routed to the container log. (improvement)
 
-0.13.2 - September 09, 2015
----------------------------
-
-* ``private_key`` supplied for remote_actions is now used to auth correctly.
-  ``private_key`` argument should be the contents of private key file (of user specified in username argument). (bug-fix)
-* Last newline character ('\n') is now stripped from ``stdout`` and ``stderr`` fields in
-  local and remote command/shell runners. (improvement)
-* Fix sensor container service so the ``config`` argument is correctly passed to the sensor
-  instances in the system packs. Previously, this argument didn't get passed correctly to
-  the FileWatchSensor from the system linux pack. (bug-fix)
-* Make sure sensor processes correctly pick up parent ``--debug`` flag. This makes
-  debugging a lot easier since user simply needs to start sensor container with ``--debug``
-  flag and all the sensor logs with level debug or higher will be routed to the container
-  log. (improvement)
-
 0.13.1 - August 28, 2015
 ------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -110,7 +110,7 @@ in development
   instead of ``None`` when the pack was not found in the index. (bug fix)
 * The ``dest_server`` parameter has been removed from the ``linux.scp`` action. Going forward simply
   specify the server as part of the ``source`` and / or ``destination`` arguments. (improvement)
-   #3335 #3463 [Nick Maludy]
+  #3335 #3463 [Nick Maludy]
 * Add missing database indexes which should speed up various queries on production deployments with
   large datasets. (improvement)
 * Use a default value for a config item from config schema even if that config item is not required

--- a/Makefile
+++ b/Makefile
@@ -421,6 +421,9 @@ ci-checks: compile pylint flake8 bandit .st2client-dependencies-check .st2common
 
 .PHONY: .rst-check
 .rst-check:
+	@echo
+	@echo "==================== rst-check ===================="
+	@echo
 	. $(VIRTUALENV_DIR)/bin/activate; rstcheck CHANGELOG.rst
 
 .PHONY: ci-unit

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ bandit: requirements .bandit
 lint: requirements .lint
 
 .PHONY: .lint
-.lint: .flake8 .pylint .bandit .st2client-dependencies-check .st2common-circular-dependencies-check
+.lint: .flake8 .pylint .bandit .st2client-dependencies-check .st2common-circular-dependencies-check .rst-check
 
 .PHONY: clean
 clean: .cleanpycs
@@ -413,13 +413,15 @@ debs:
 	#done
 
 
-
-
 .PHONY: ci
 ci: ci-checks ci-unit ci-integration ci-mistral ci-packs-tests
 
 .PHONY: ci-checks
-ci-checks: compile pylint flake8 bandit .st2client-dependencies-check .st2common-circular-dependencies-check
+ci-checks: compile pylint flake8 bandit .st2client-dependencies-check .st2common-circular-dependencies-check .rst-check
+
+.PHONY: .rst-check
+.rst-check:
+	. $(VIRTUALENV_DIR)/bin/activate; rstcheck CHANGELOG.rst
 
 .PHONY: ci-unit
 ci-unit: compile .unit-tests-coverage-html

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -21,3 +21,4 @@ RandomWords
 gunicorn>=19.3.0,<19.4
 psutil
 webtest==2.0.25
+rstcheck>=3.1.0,<3.2


### PR DESCRIPTION
I also added rstcheck Make target which runs on Circle CI on every build.

This will prevent such issues from happening in the future - https://github.com/StackStorm/st2docs/pull/521#issuecomment-308170615.