### PR TITLE
Display result for workflow actions on completion when using st2 run command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 in development
 --------------
 
+* Update ``st2 run`` / ``st2 execution run`` command to display result of workflow actions when
+  they finish. In the workflow case, result of the last task (action) of the workflow is used.
+  (improvement)
 
 2.3.0 - June 14, 2017
 ---------------------

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -395,7 +395,9 @@ class ActionRunCommandMixin(object):
             task_result = self._get_task_result(task=tasks[-1])
 
             if task_result:
-                options['attributes'].insert(status_index + 1, 'result')
+                instance.result_task = tasks[-1].get('name', 'unknown')
+                options['attributes'].insert(status_index + 1, 'result_task')
+                options['attributes'].insert(status_index + 2, 'result')
                 instance.result = task_result
 
         # print root task

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -356,14 +356,15 @@ class ActionRunCommandMixin(object):
             # No child error, there might be a global error, include result in the output
             options['attributes'].append('result')
 
+        status_index = options['attributes'].index('status')
+
+        if isinstance(instance.result, dict):
+            tasks = instance.result.get('tasks', [])
+        else:
+            tasks = []
+
         # On failure we also want to include error message and traceback at the top level
         if instance.status == 'failed':
-            status_index = options['attributes'].index('status')
-            if isinstance(instance.result, dict):
-                tasks = instance.result.get('tasks', [])
-            else:
-                tasks = []
-
             top_level_error, top_level_traceback = self._get_top_level_error(live_action=instance)
 
             if len(tasks) >= 1:
@@ -387,6 +388,15 @@ class ActionRunCommandMixin(object):
                 options['attributes'].insert(status_index + 1, 'error')
                 options['attributes'].insert(status_index + 2, 'traceback')
                 options['attributes'].insert(status_index + 3, 'failed_on')
+
+        # Include result on the top-level object so user doesn't need to issue another command to
+        # see the result
+        if len(tasks) >= 1:
+            task_result = self._get_task_result(task=tasks[-1])
+
+            if task_result:
+                options['attributes'].insert(status_index + 1, 'result')
+                instance.result = task_result
 
         # print root task
         self.print_output(instance, formatter, **options)
@@ -459,6 +469,12 @@ class ActionRunCommandMixin(object):
             traceback = None
 
         return error, traceback
+
+    def _get_task_result(self, task):
+        if not task:
+            return None
+
+        return task['result']
 
     def _get_action_parameters_from_args(self, action, runner, args):
         """


### PR DESCRIPTION
This pull request updates `st2 run` / `st2 execution run` CLI command to display a result of workflow actions when execution finishes.

In this case result refers to the result of the last task (action) inside the workflow.

This saves some typing because before that you need to do something like that to retrieve result of a workflow:

```bash
st2 run examples.workflow
.... wait
st2 execution get <execution id of last task in the workflow>
```

Before:

![screenshot from 2017-06-15 11-29-58](https://user-images.githubusercontent.com/125088/27174952-0b86fad4-51be-11e7-8e5b-4790359e094f.png)

After:

![screenshot from 2017-06-15 11-32-35](https://user-images.githubusercontent.com/125088/27175074-5ad5e370-51be-11e7-8281-581952d1fff0.png)

Resolves #3476
