### PR TITLE
Update release date (v2.3)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,11 +1,7 @@
 Changelog
 =========
 
-in development
---------------
-
-
-2.3.0 - June 14, 2017
+2.3.0 - June 19, 2017
 ---------------------
 
 * Refactor the action execution asynchronous callback functionality into the runner plugin


### PR DESCRIPTION
Same as https://github.com/StackStorm/st2/pull/3483, but for v2.3 branch.