### PR TITLE
Add pagination support for /api/v1/apikeys endpoints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ in development
   and didn't log anything which was confusing. (improvement) #3489
 
   Reported by Anthony Shaw.
+* Add missing pagination support to ``/v1/apikeys`` API endpoint. (improvement) #3486
 
 2.3.0 - June 19, 2017
 ---------------------

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -156,6 +156,8 @@ class ResourceController(object):
 
         # TODO: To protect us from DoS, we need to make max_limit mandatory
         offset = int(offset)
+        if offset >= 2**31:
+            raise ValueError('Offset "%s" specified is more than 32-bit int' % (offset))
 
         if limit and int(limit) > self.max_limit:
             # TODO: We should throw here, I don't like this.

--- a/st2api/st2api/controllers/v1/auth.py
+++ b/st2api/st2api/controllers/v1/auth.py
@@ -105,7 +105,7 @@ class ApiKeyController(BaseRestControllerMixin):
         resp.headers['X-Total-Count'] = str(api_key_dbs.count())
 
         if limit:
-             resp.headers['X-Limit'] = str(limit)
+            resp.headers['X-Limit'] = str(limit)
 
         return resp
 

--- a/st2api/st2api/controllers/v1/auth.py
+++ b/st2api/st2api/controllers/v1/auth.py
@@ -112,7 +112,7 @@ class ApiKeyController(BaseRestControllerMixin):
             api_keys = [ApiKeyAPI.from_model(api_key_db, mask_secrets=mask_secrets)
                         for api_key_db in api_key_dbs]
         except OverflowError:
-            msg = 'Offset "%s" specified is more than 8-byte ints' % (offset)
+            msg = 'Offset "%s" specified is more than 32 bit int' % (offset)
             raise ValueError(msg)
 
         resp = Response(json=api_keys)

--- a/st2api/tests/unit/controllers/v1/test_auth_api_keys.py
+++ b/st2api/tests/unit/controllers/v1/test_auth_api_keys.py
@@ -69,6 +69,8 @@ class TestApiKeyController(FunctionalTest):
     def test_get_all(self):
         resp = self.app.get('/v1/apikeys')
         self.assertEqual(resp.status_int, 200)
+        self.assertEqual(resp.headers['X-Total-Count'], "5")
+        self.assertEqual(resp.headers['X-Limit'], "50")
         self.assertEqual(len(resp.json), 5, '/v1/apikeys did not return all apikeys.')
 
         retrieved_ids = [apikey['id'] for apikey in resp.json]
@@ -80,6 +82,8 @@ class TestApiKeyController(FunctionalTest):
     def test_get_all_with_pagnination_with_offset_and_limit(self):
         resp = self.app.get('/v1/apikeys?offset=2&limit=1')
         self.assertEqual(resp.status_int, 200)
+        self.assertEqual(resp.headers['X-Total-Count'], "5")
+        self.assertEqual(resp.headers['X-Limit'], "1")
         self.assertEqual(len(resp.json), 1)
 
         retrieved_ids = [apikey['id'] for apikey in resp.json]
@@ -88,6 +92,8 @@ class TestApiKeyController(FunctionalTest):
     def test_get_all_with_pagnination_with_only_offset(self):
         resp = self.app.get('/v1/apikeys?offset=3')
         self.assertEqual(resp.status_int, 200)
+        self.assertEqual(resp.headers['X-Total-Count'], "5")
+        self.assertEqual(resp.headers['X-Limit'], "50")
         self.assertEqual(len(resp.json), 2)
 
         retrieved_ids = [apikey['id'] for apikey in resp.json]
@@ -96,6 +102,8 @@ class TestApiKeyController(FunctionalTest):
     def test_get_all_with_pagnination_with_only_limit(self):
         resp = self.app.get('/v1/apikeys?limit=2')
         self.assertEqual(resp.status_int, 200)
+        self.assertEqual(resp.headers['X-Total-Count'], "5")
+        self.assertEqual(resp.headers['X-Limit'], "2")
         self.assertEqual(len(resp.json), 2)
 
         retrieved_ids = [apikey['id'] for apikey in resp.json]

--- a/st2api/tests/unit/controllers/v1/test_auth_api_keys.py
+++ b/st2api/tests/unit/controllers/v1/test_auth_api_keys.py
@@ -119,7 +119,7 @@ class TestApiKeyController(FunctionalTest):
         resp = self.app.get('/v1/apikeys?offset=2147483648&limit=1', expect_errors=True)
         self.assertEqual(resp.status_int, 400)
         self.assertEqual(resp.json['faultstring'],
-                         'Offset "2147483648" specified is more than 8-byte ints')
+                         'Offset "2147483648" specified is more than 32 bit int')
 
     def test_get_one_by_id(self):
         resp = self.app.get('/v1/apikeys/%s' % self.apikey1.id)

--- a/st2api/tests/unit/controllers/v1/test_auth_api_keys.py
+++ b/st2api/tests/unit/controllers/v1/test_auth_api_keys.py
@@ -72,11 +72,46 @@ class TestApiKeyController(FunctionalTest):
         self.assertEqual(len(resp.json), 5, '/v1/apikeys did not return all apikeys.')
 
         retrieved_ids = [apikey['id'] for apikey in resp.json]
-
         self.assertEqual(retrieved_ids,
                          [str(self.apikey1.id), str(self.apikey2.id), str(self.apikey3.id),
                           str(self.apikey4.id), str(self.apikey5.id)],
                          'Incorrect api keys retrieved.')
+
+    def test_get_all_with_pagnination_with_offset_and_limit(self):
+        resp = self.app.get('/v1/apikeys?offset=2&limit=1')
+        self.assertEqual(resp.status_int, 200)
+        self.assertEqual(len(resp.json), 1)
+
+        retrieved_ids = [apikey['id'] for apikey in resp.json]
+        self.assertEqual(retrieved_ids, [str(self.apikey3.id)])
+
+    def test_get_all_with_pagnination_with_only_offset(self):
+        resp = self.app.get('/v1/apikeys?offset=3')
+        self.assertEqual(resp.status_int, 200)
+        self.assertEqual(len(resp.json), 2)
+
+        retrieved_ids = [apikey['id'] for apikey in resp.json]
+        self.assertEqual(retrieved_ids, [str(self.apikey4.id), str(self.apikey5.id)])
+
+    def test_get_all_with_pagnination_with_only_limit(self):
+        resp = self.app.get('/v1/apikeys?limit=2')
+        self.assertEqual(resp.status_int, 200)
+        self.assertEqual(len(resp.json), 2)
+
+        retrieved_ids = [apikey['id'] for apikey in resp.json]
+        self.assertEqual(retrieved_ids, [str(self.apikey1.id), str(self.apikey2.id)])
+
+    def test_get_all_invalid_limit_too_large(self):
+        resp = self.app.get('/v1/apikeys?offset=2&limit=1000', expect_errors=True)
+        self.assertEqual(resp.status_int, 400)
+        self.assertEqual(resp.json['faultstring'],
+                         'Limit "1000" specified, maximum value is "100"')
+
+    def test_get_all_invalid_offset_too_large(self):
+        resp = self.app.get('/v1/apikeys?offset=2147483648&limit=1', expect_errors=True)
+        self.assertEqual(resp.status_int, 400)
+        self.assertEqual(resp.json['faultstring'],
+                         'Offset "2147483648" specified is more than 8-byte ints')
 
     def test_get_one_by_id(self):
         resp = self.app.get('/v1/apikeys/%s' % self.apikey1.id)

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -235,6 +235,11 @@ paths:
           in: query
           description: Number of actions to get
           type: integer
+        - name: offset
+          in: query
+          description: Number of actions offset
+          type: integer
+          default: 0
         - name: id
           in: query
           description: Action id filter
@@ -424,6 +429,11 @@ paths:
           in: query
           description: Number of actions to get
           type: integer
+        - name: offset
+          in: query
+          description: Number of actions offset
+          type: integer
+          default: 0
         - name: id
           in: query
           description: Action id filter
@@ -698,12 +708,12 @@ paths:
           type: string
         - name: limit
           in: query
-          description: Number of actions to get
+          description: Number of action alias to get
           type: integer
           default: 100
         - name: offset
           in: query
-          description: Number of actions offset
+          description: Number of action alias offset
           type: integer
           default: 0
       responses:
@@ -768,12 +778,12 @@ paths:
           required: false
         - name: limit
           in: query
-          description: Number of actions to get
+          description: Number of executions to get
           type: integer
           default: 100
         - name: offset
           in: query
-          description: Number of actions offset
+          description: Number of executions offset
           type: integer
           default: 0
         - name: sort
@@ -1198,12 +1208,12 @@ paths:
           type: string
         - name: limit
           in: query
-          description: Number of actions to get
+          description: Number of keys to get from datastore
           type: integer
           default: 100
         - name: offset
           in: query
-          description: Number of actions offset
+          description: Number of keys offset
           type: integer
           default: 0
         - name: sort
@@ -1349,12 +1359,12 @@ paths:
       parameters:
         - name: limit
           in: query
-          description: Number of actions to get
+          description: Number of packs to get
           type: integer
           default: 100
         - name: offset
           in: query
-          description: Number of actions offset
+          description: Number of packs offset
           type: integer
           default: 0
         - name: sort
@@ -1620,12 +1630,12 @@ paths:
       parameters:
         - name: limit
           in: query
-          description: Number of actions to get
+          description: Number of configs to get
           type: integer
           default: 100
         - name: offset
           in: query
-          description: Number of actions offset
+          description: Number of configs offset
           type: integer
           default: 0
         - name: sort
@@ -1742,12 +1752,12 @@ paths:
       parameters:
         - name: limit
           in: query
-          description: Number of actions to get
+          description: Number of config_schemas to get
           type: integer
           default: 100
         - name: offset
           in: query
-          description: Number of actions offset
+          description: Number of config_schemas offset
           type: integer
           default: 0
         - name: sort
@@ -1819,12 +1829,12 @@ paths:
           type: string
         - name: limit
           in: query
-          description: Number of actions to get
+          description: Number of policytypes to get
           type: integer
           default: 100
         - name: offset
           in: query
-          description: Number of actions offset
+          description: Number of policytypes offset
           type: integer
           default: 0
         - name: sort
@@ -2212,6 +2222,11 @@ paths:
           in: query
           description: Number of entities to get
           type: integer
+        - name: offset
+          in: query
+          description: Number of policytypes offset
+          type: integer
+          default: 0
         - name: id
           in: query
           description: Entity id filter
@@ -2385,6 +2400,11 @@ paths:
           in: query
           description: Number of entities to get
           type: integer
+        - name: offset
+          in: query
+          description: Number of policytypes offset
+          type: integer
+          default: 0
         - name: id
           in: query
           description: Entity id filter
@@ -2512,12 +2532,12 @@ paths:
           required: false
         - name: limit
           in: query
-          description: Number of actions to get
+          description: Number of runnertypes to get
           type: integer
           default: 100
         - name: offset
           in: query
-          description: Number of actions offset
+          description: Number of runnertypes offset
           type: integer
           default: 0
         - name: sort
@@ -2630,6 +2650,11 @@ paths:
           in: query
           description: Number of entities to get
           type: integer
+        - name: offset
+          in: query
+          description: Number of policytypes offset
+          type: integer
+          default: 0
         - name: id
           in: query
           description: Entity id filter
@@ -2902,7 +2927,7 @@ paths:
           default: 50
         - name: offset
           in: query
-          description: Number of actions offset
+          description: Number of ruleenforcements offset
           type: integer
           default: 0
         - name: sort
@@ -3053,12 +3078,12 @@ paths:
       parameters:
         - name: limit
           in: query
-          description: Number of actions to get
+          description: Number of traces to get
           type: integer
           default: 100
         - name: offset
           in: query
-          description: Number of actions offset
+          description: Number of traces offset
           type: integer
           default: 0
         - name: sort
@@ -3153,12 +3178,12 @@ paths:
       parameters:
         - name: limit
           in: query
-          description: Number of actions to get
+          description: Number of triggertypes to get
           type: integer
           default: 100
         - name: offset
           in: query
-          description: Number of actions offset
+          description: Number of triggertypes offset
           type: integer
           default: 0
         - name: sort
@@ -3406,12 +3431,12 @@ paths:
       parameters:
         - name: limit
           in: query
-          description: Number of actions to get
+          description: Number of triggerinstances to get
           type: integer
           default: 100
         - name: offset
           in: query
-          description: Number of actions offset
+          description: Number of triggerinstances offset
           type: integer
           default: 0
         - name: sort

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -7,12 +7,12 @@ info:
     {% raw %}
     ## Welcome
 
-    Welcome to the StackStorm API Reference documentation! You can use the StackStorm API to integrate StackStorm with 3rd-party systems and custom applications. Example integrations include writing your own self-service user portal, or integrating with other orchestration systems. 
+    Welcome to the StackStorm API Reference documentation! You can use the StackStorm API to integrate StackStorm with 3rd-party systems and custom applications. Example integrations include writing your own self-service user portal, or integrating with other orchestration systems.
 
     This document provides an overview of how to use the API. Use the menu on the left to look up details of specific API endpoints. For more information about how StackStorm works, and how to use it, check out the main [StackStorm documentation](https://docs.stackstorm.com).
 
     > ### A Quick Note
-    > This API is intended for software developers, and those are who are comfortable working with RESTful APIs, and writing some code. You do not need to use this API to work with StackStorm, or to use and write integration packs for StackStorm. 
+    > This API is intended for software developers, and those are who are comfortable working with RESTful APIs, and writing some code. You do not need to use this API to work with StackStorm, or to use and write integration packs for StackStorm.
 
     ## Accessing the API
 
@@ -22,7 +22,7 @@ info:
 
     To authenticate against the StackStorm API, either an authentication token or an API key (but not both) should be provided in the HTTP request headers. The headers are named `X-Auth-Token` and `St2-Api-Key` respectively. In situation when it is impossble to provide a header to the response, query parameters `x-auth-token` and `st2-api-key` could be used instead, but would require you to weight in on security implications.
 
-    An authentication token is a time-limited access token, granted once a user authenticates, typically using a username and password. This is suitable for short-term, interactive sessions. [API Keys](https://docs.stackstorm.com/authentication.html#api-keys) do not expire, and are therefore better suited for use with integrating other applications. 
+    An authentication token is a time-limited access token, granted once a user authenticates, typically using a username and password. This is suitable for short-term, interactive sessions. [API Keys](https://docs.stackstorm.com/authentication.html#api-keys) do not expire, and are therefore better suited for use with integrating other applications.
 
     ### Authentication Tokens
 
@@ -69,13 +69,13 @@ info:
     The StackStorm API supports these HTTP methods:
 
     * **GET:** Use to retrieve data, e.g. current status of an execution. GET requests will not update or change data.
-    * **POST:** Use to create new resources. For example, make a POST request to create a new rule, or execute an action. 
+    * **POST:** Use to create new resources. For example, make a POST request to create a new rule, or execute an action.
     * **PUT:** Use to create or update a resource, e.g. to update an existing Key-Value pair.
     * **DELETE:** Remove a resource, e.g. delete an API key.
 
     There is also an implicit support of **OPTIONS** method that will return a set of CORS-related headers.
 
-    Methods **HEAD** and **PATCH** are not supported in API v1, but might be considered in future iterations. 
+    Methods **HEAD** and **PATCH** are not supported in API v1, but might be considered in future iterations.
 
     ## SSL
 
@@ -186,7 +186,7 @@ info:
     }
     ```
 
-    `4xx` codes indicate a bad request, whereas `5xx` errors indicate a server-side problem with StackStorm. 
+    `4xx` codes indicate a bad request, whereas `5xx` errors indicate a server-side problem with StackStorm.
 
     ## Support
 
@@ -2710,6 +2710,16 @@ paths:
           in: query
           description: Show secrets in plain text
           type: boolean
+        - name: limit
+          in: query
+          description: List N most recent apikeys.
+          type: integer
+          default: 50
+        - name: offset
+          in: query
+          description: Number of apikeys offset
+          type: integer
+          default: 0
       x-parameters:
         - name: user
           in: context

--- a/st2common/st2common/persistence/auth.py
+++ b/st2common/st2common/persistence/auth.py
@@ -99,28 +99,15 @@ class ApiKey(Access):
         return cls.impl
 
     @classmethod
-    def get(cls, value, limit=None, offset=0):
+    def get(cls, value):
         # DB does not contain key but the key_hash.
         value_hash = hash_utils.hash(value)
+        result = cls.query(key_hash=value_hash).first()
 
-        # TODO: To protect us from DoS, we need to make max_limit mandatory
-        offset = int(offset)
-
-        if limit and int(limit) > cls.max_limit:
-            # TODO: We should throw here, I don't like this.
-            msg = 'Limit "%s" specified, maximum value is "%s"' % (limit, cls.max_limit)
-            raise ValueError(msg)
-
-        instances = cls.query(key_hash=value_hash).first()
-
-        if not instances:
+        if not result:
             raise ApiKeyNotFoundError('ApiKey with key_hash=%s not found.' % value_hash)
 
-        if limit == 1:
-            # Perform the filtering on the DB side
-            instances = instances.limit(limit)
-
-        return instances
+        return result
 
     @classmethod
     def get_by_key_or_id(cls, value):

--- a/st2common/st2common/persistence/auth.py
+++ b/st2common/st2common/persistence/auth.py
@@ -20,8 +20,6 @@ from st2common.models.db import MongoDBAccess
 from st2common.models.db.auth import UserDB, TokenDB, ApiKeyDB
 from st2common.persistence.base import Access
 from st2common.util import hash as hash_utils
-from oslo_config import cfg
-# from st2common.router import Response
 
 
 class User(Access):
@@ -85,14 +83,6 @@ class Token(Access):
 
 class ApiKey(Access):
     impl = MongoDBAccess(ApiKeyDB)
-
-    # Maximum value of limit which can be specified by user
-    @property
-    def max_limit(self):
-        return cfg.CONF.api.max_page_size
-
-    # Default number of items returned per page if no limit is explicitly provided
-    default_limit = 100
 
     @classmethod
     def _get_impl(cls):


### PR DESCRIPTION
Addresses: https://github.com/StackStorm/st2/issues/3369
```
$  curl -v -X GET -H  'Connection: keep-alive' -H  'Accept-Encoding: gzip, deflate' -H  'Accept: */*' -H  'User-Agent: python-requests/2.14.2' -H  'X-Auth-Token: <token>' 'http://127.0.0.1:9101/v1/apikeys/?limit=1'

*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 9101 (#0)
> GET /v1/apikeys/?limit=1 HTTP/1.1
> Host: 127.0.0.1:9101
> Connection: keep-alive
> Accept-Encoding: gzip, deflate
> Accept: */*
> User-Agent: python-requests/2.14.2
> X-Auth-Token: <token>
>
< HTTP/1.1 200 OK
< Server: gunicorn/19.6.0
< Date: Fri, 16 Jun 2017 16:15:07 GMT
< Connection: keep-alive
< Content-Type: application/json
< Content-Length: 245
< X-Total-Count: 2
< X-Limit: 1
< Access-Control-Allow-Origin: http://127.0.0.1:3000
< Access-Control-Allow-Methods: GET,POST,PUT,DELETE,OPTIONS
< Access-Control-Allow-Headers: Content-Type,Authorization,X-Auth-Token,St2-Api-Key,X-Request-ID
< Access-Control-Expose-Headers: Content-Type,X-Limit,X-Total-Count,X-Request-ID
< X-Request-ID: 658ab5e1-b874-4acb-b0af-d47ece4ff7a1
<
[
    {
        "uid": "********",
        "key_hash": "********",
        "created_at": "2017-06-14T19:44:47.496745Z",
        "enabled": true,
        "user": "st2admin",
        "id": "5941922fde59a4212d147155",
        "metadata": {}
    }
* Connection #0 to host 127.0.0.1 left intact
```
To do:
- [x]  Fix corner cases of invalid limit and offset count
- [x]   Add Unit tests