### PR TITLE
Python runner should throw / log an error when failing to de-serialize action result

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,13 +6,13 @@ in development
 
 * Update ``st2 run`` / ``st2 execution run`` command to display result of workflow actions when
   they finish. In the workflow case, result of the last task (action) of the workflow is used.
-  (improvement)
+  (improvement) #3481
 * Update Python runner so it mimics behavior from StackStorm pre 1.6 and returns action result as
   is (serialized as string) in case we are unable to serialize action result because it contains
   non-simple types (e.g. class instances) which can't be serialized.
 
   In v1.6 we introduced a change when in such instances, we simply returned ``None`` as result
-  and didn't log anything which was confusing. (improvement)
+  and didn't log anything which was confusing. (improvement) #3489
 
   Reported by Anthony Shaw.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Changelog
 in development
 --------------
 
+* Update Python runner so it mimics behavior from StackStorm pre 1.6 and returns action result as
+  is (serialized as string) in case we are unable to serialize action result because it contains
+  non-simple types (e.g. class instances) which can't be serialized.
+
+  In v1.6 we introduced a change when in such instances, we simply returned ``None`` as result
+  and didn't log anything which was confusing. (improvement)
+
+  Reported by Anthony Shaw.
 
 2.3.0 - June 19, 2017
 ---------------------

--- a/contrib/runners/python_runner/python_runner.py
+++ b/contrib/runners/python_runner/python_runner.py
@@ -178,8 +178,10 @@ class PythonRunner(ActionRunner):
         # Parse the serialized action result object
         try:
             action_result = json.loads(action_result)
-        except:
-            pass
+        except Exception as e:
+            # Failed to de-serialize the result, probably it contains non-simple type or similar
+            # TODO: Should we throw instead?
+            LOG.warning('Failed to de-serialize result "%s": %s' % (str(action_result), str(e)))
 
         if action_result and isinstance(action_result, dict):
             result = action_result.get('result', None)

--- a/contrib/runners/python_runner/python_runner.py
+++ b/contrib/runners/python_runner/python_runner.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import os
+import re
 import sys
 import json
 import uuid
@@ -180,14 +181,20 @@ class PythonRunner(ActionRunner):
             action_result = json.loads(action_result)
         except Exception as e:
             # Failed to de-serialize the result, probably it contains non-simple type or similar
-            # TODO: Should we throw instead?
             LOG.warning('Failed to de-serialize result "%s": %s' % (str(action_result), str(e)))
+            pass
 
         if action_result and isinstance(action_result, dict):
             result = action_result.get('result', None)
             status = action_result.get('status', None)
         else:
-            result = 'None'
+            # Failed to de-serialize return result as is aka as a string
+            match = re.search("'result': (.*?)$", action_result).groups()
+
+            if match:
+                action_result = match[0]
+
+            result = action_result
             status = None
 
         output = {

--- a/contrib/runners/python_runner/python_runner.py
+++ b/contrib/runners/python_runner/python_runner.py
@@ -189,10 +189,10 @@ class PythonRunner(ActionRunner):
                 status = action_result.get('status', None)
             else:
                 # Failed to de-serialize action result aka result is a string
-                match = re.search("'result': (.*?)$", action_result or '').groups()
+                match = re.search("'result': (.*?)$", action_result or '')
 
                 if match:
-                    action_result = match[0]
+                    action_result = match.groups()[0]
 
                 result = action_result
                 status = None

--- a/contrib/runners/python_runner/python_runner.py
+++ b/contrib/runners/python_runner/python_runner.py
@@ -182,19 +182,22 @@ class PythonRunner(ActionRunner):
         except Exception as e:
             # Failed to de-serialize the result, probably it contains non-simple type or similar
             LOG.warning('Failed to de-serialize result "%s": %s' % (str(action_result), str(e)))
-            pass
 
-        if action_result and isinstance(action_result, dict):
-            result = action_result.get('result', None)
-            status = action_result.get('status', None)
+        if action_result:
+            if isinstance(action_result, dict):
+                result = action_result.get('result', None)
+                status = action_result.get('status', None)
+            else:
+                # Failed to de-serialize action result aka result is a string
+                match = re.search("'result': (.*?)$", action_result or '').groups()
+
+                if match:
+                    action_result = match[0]
+
+                result = action_result
+                status = None
         else:
-            # Failed to de-serialize return result as is aka as a string
-            match = re.search("'result': (.*?)$", action_result).groups()
-
-            if match:
-                action_result = match[0]
-
-            result = action_result
+            result = 'None'
             status = None
 
         output = {

--- a/st2tests/st2tests/resources/packs/pythonactions/actions/non_simple_type.py
+++ b/st2tests/st2tests/resources/packs/pythonactions/actions/non_simple_type.py
@@ -1,0 +1,15 @@
+from st2common.runners.base_action import Action
+
+
+class Test(object):
+    foo = 'bar'
+
+
+class NonSimpleTypeAction(Action):
+    def run(self):
+        result = [
+            {'a': '1'},
+            {'c': 2, 'h': 3},
+            {'e': Test()}
+        ]
+        return result


### PR DESCRIPTION
@tonybaloney reported this issue (user unfriendly behavior) on Slack.

Right now, if Python runner actions returns a result which can't be serialized (e.g. non complex type such as class instance, datetime object or similar), Python runner will "silently" swallow this issue and simply return `None` as the result.

This is obviously very unfriendly and confusing.

The code change I included just logs a message and still returns `None`, but I think a better and more user-friendly approach is to simply throw a very explicit and user-friendly error message - something along the lines of "Failed to de-serialize action result, it most likely contains a non-simple type or similar, see docs at YYY on info on Python runner action results".

The thing is if we can't serialize and de-serialize the result user can't do anything with it anyway so throw makes sense because user / developer interaction is required (updating the action code so it only returns simple types).

@tonybaloney asked if we recently made a change which affects that, but AFAIK this behavior has been there since the beginning - I checked the code and we did the same thing in v1.6 as well (https://github.com/StackStorm/st2/blob/v1.6/st2actions/st2actions/runners/pythonrunner.py#L190).

Example action which reproduces this issue - https://gist.github.com/Kami/7e654186f95eda654589a171c9f90d12