### PR TITLE
Fix context field index

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 in development
 --------------
 
+
+2.3.0 - June 14, 2017
+---------------------
+
 * Refactor the action execution asynchronous callback functionality into the runner plugin
   architecture. (improvement)
 * Introduce new ``CAPABILITIES`` constant on auth backend classes. With this constant, auth

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ eventlet<0.19,>=0.18.4
 flex==6.5.0
 git+https://github.com/Kami/entrypoints.git@dont_use_backports#egg=entrypoints
 git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper
-git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
+git+https://github.com/StackStorm/python-mistralclient.git@st2-2.3.0#egg=python-mistralclient
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
 gitpython==2.1.3
 gunicorn==19.6.0

--- a/st2actions/in-requirements.txt
+++ b/st2actions/in-requirements.txt
@@ -4,7 +4,7 @@ python-dateutil
 eventlet
 jinja2
 kombu
-git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
+git+https://github.com/StackStorm/python-mistralclient.git@st2-2.3.0#egg=python-mistralclient
 oslo.config
 oslo.utils
 requests

--- a/st2client/st2client/__init__.py
+++ b/st2client/st2client/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '2.3dev'
+__version__ = '2.3.0'

--- a/st2common/st2common/__init__.py
+++ b/st2common/st2common/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '2.3dev'
+__version__ = '2.3.0'

--- a/st2common/st2common/models/db/liveaction.py
+++ b/st2common/st2common/models/db/liveaction.py
@@ -75,7 +75,7 @@ class LiveActionDB(stormbase.StormFoundationDB):
             {'fields': ['end_timestamp']},
             {'fields': ['action']},
             {'fields': ['status']},
-            {'fields': ['context']},
+            {'fields': ['#context']},
             {'fields': ['context.trigger_instance.id']},
         ]
     }


### PR DESCRIPTION
This field can contain more than 1024 bytes of data so regular index won't work - we need to use a hashed one.