### PR TITLE
Fix context field index

### DIFF
--- a/st2common/st2common/models/db/liveaction.py
+++ b/st2common/st2common/models/db/liveaction.py
@@ -75,7 +75,7 @@ class LiveActionDB(stormbase.StormFoundationDB):
             {'fields': ['end_timestamp']},
             {'fields': ['action']},
             {'fields': ['status']},
-            {'fields': ['context']},
+            {'fields': ['#context']},
             {'fields': ['context.trigger_instance.id']},
         ]
     }

--- a/st2common/st2common/models/db/liveaction.py
+++ b/st2common/st2common/models/db/liveaction.py
@@ -75,7 +75,6 @@ class LiveActionDB(stormbase.StormFoundationDB):
             {'fields': ['end_timestamp']},
             {'fields': ['action']},
             {'fields': ['status']},
-            {'fields': ['#context']},
             {'fields': ['context.trigger_instance.id']},
         ]
     }

--- a/st2common/st2common/models/db/rbac.py
+++ b/st2common/st2common/models/db/rbac.py
@@ -51,7 +51,6 @@ class RoleDB(stormbase.StormFoundationDB):
         'indexes': [
             {'fields': ['name']},
             {'fields': ['system']},
-            {'fields': ['permission_grants']},
         ]
     }
 


### PR DESCRIPTION
This field can contain more than 1024 bytes of data so regular index won't work - we need to use a hashed one.