### PR TITLE
Fix name query param filter for /v1/actionalias API endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ in development
   and didn't log anything which was confusing. (improvement) #3489
 
   Reported by Anthony Shaw.
+* Fix ``?name`` query param filter in ``/v1/actionalias`` API endpoint. (bug fix) #3503
 
 2.3.0 - June 19, 2017
 ---------------------

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -523,6 +523,10 @@ paths:
       description: |
           Get list of action-aliases.
       parameters:
+        - name: name
+          in: query
+          description: Entity name filter
+          type: string
         - name: pack
           in: query
           description: Only return resources belonging to the provided pack

--- a/st2tests/st2tests/fixtures/generic/aliases/alias7.yaml
+++ b/st2tests/st2tests/fixtures/generic/aliases/alias7.yaml
@@ -1,0 +1,8 @@
+---
+    name: "alias7"
+    pack: "generic"
+    description: "DON'T CARE"
+    action_ref: "core.remote"
+    formats:
+        - "format1"
+        - "format2"


### PR DESCRIPTION
The title says it all.

While working on that, I also noticed a bunch of other OpenAPI definitions for query parameter filters are wrong. They declare param type as array, but it should actually be a string (it's probably due to copy and paste because in one place we support an array, but in others we don't).

It works out of pure luck because we don't do strict query param validation in all the places.  This needs to be fixed in a separate PR.

For example:

```yaml
        - name: name
          in: query
          description: Entity name filter
          type: array
          items:
            type: string
```

Reported by @LindsayHill.