### PR TITLE
Fix boolean config value race condition

### DIFF
--- a/st2common/st2common/util/config_loader.py
+++ b/st2common/st2common/util/config_loader.py
@@ -156,8 +156,9 @@ class ContentPackConfigLoader(object):
             default_value = schema_item.get('default', None)
             is_object = schema_item.get('type', None) == 'object'
             has_properties = schema_item.get('properties', None)
+            config_value = config.get(schema_item_key, None)
 
-            if default_value and not config.get(schema_item_key, None):
+            if default_value and config_value is None:
                 config[schema_item_key] = default_value
 
             # Inspect nested object properties

--- a/st2common/st2common/util/config_loader.py
+++ b/st2common/st2common/util/config_loader.py
@@ -156,15 +156,12 @@ class ContentPackConfigLoader(object):
             default_value = schema_item.get('default', None)
             is_object = schema_item.get('type', None) == 'object'
             has_properties = schema_item.get('properties', None)
-            config_value = config.get(schema_item_key, None)
 
-            if default_value and config_value is None:
-                config[schema_item_key] = default_value
+            config.setdefault(schema_item_key, default_value)
 
             # Inspect nested object properties
             if is_object and has_properties:
-                if not config.get(schema_item_key, None):
-                    config[schema_item_key] = {}
+                config.setdefault(schema_item_key, {})
 
                 self._assign_default_values(schema=schema_item['properties'],
                                             config=config[schema_item_key])


### PR DESCRIPTION
This PR fixes race condition for boolean config values. When pack schema had

```
type: boolean
default: true
```
Overriding it in pack's config with `value: false`, would still give `value: true`.

I apologize for not including tests in this PR, but I could not quickly find a way how I could pass boolean value to `set_datastore_value_for_config_key` in `st2common/tests/unit/test_config_loader.py` . If someone could point me the right direction, I would be glad to add unit test for that.
