### PR TITLE
s/results_tracker/resultstracker in config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,9 @@ Fixed
   resolved. (bug-fix) #3487 #3496
 
   Reported by Chris Katzmann, Nick Maludy.
+* Deprecate ``results_tracker`` config group and move configuration variables to ``resultstracker``
+  group instead. If you have ``results_tracker`` config group in the config, it is recommended
+  to switch to ``resultstracker`` instead. (bug-fix) #3500
 
 
 2.3.0 - June 19, 2017

--- a/conf/st2.dev.conf
+++ b/conf/st2.dev.conf
@@ -92,6 +92,7 @@ remote_dir = /tmp
 
 [resultstracker]
 logging = st2actions/conf/logging.resultstracker.conf
+query_interval = 0.1
 
 [notifier]
 logging = st2actions/conf/logging.notifier.conf
@@ -101,9 +102,6 @@ logging = st2exporter/conf/logging.exporter.conf
 
 [content]
 pack_group = stanley
-
-[results_tracker]
-query_interval = 0.1
 
 [mistral]
 jitter_interval = 0

--- a/conf/st2.tests.conf
+++ b/conf/st2.tests.conf
@@ -80,15 +80,13 @@ remote_dir = /tmp
 
 [resultstracker]
 logging = st2actions/conf/logging.resultstracker.conf
+query_interval = 0.1
 
 [notifier]
 logging = st2actions/conf/logging.notifier.conf
 
 [exporter]
 logging = st2exporter/conf/logging.exporter.conf
-
-[results_tracker]
-query_interval = 0.1
 
 [mistral]
 jitter_interval = 0

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -276,7 +276,7 @@ def register_opts(ignore_errors=False):
                    help='Time interval between subsequent queries for a context ' +
                         'to external workflow system.')
     ]
-    do_register_opts(query_opts, group='results_tracker', ignore_errors=ignore_errors)
+    do_register_opts(query_opts, group='resultstracker', ignore_errors=ignore_errors)
 
     # Common CLI options
     debug = cfg.BoolOpt('debug', default=False,

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -277,6 +277,8 @@ def register_opts(ignore_errors=False):
                         'to external workflow system.')
     ]
     do_register_opts(query_opts, group='resultstracker', ignore_errors=ignore_errors)
+    # XXX: This is required for us to support deprecated config group results_tracker
+    do_register_opts(query_opts, group='results_tracker', ignore_errors=ignore_errors)
 
     # Common CLI options
     debug = cfg.BoolOpt('debug', default=False,

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -273,11 +273,18 @@ def register_opts(ignore_errors=False):
         cfg.IntOpt('thread_pool_size', default=10,
                    help='Number of threads to use to query external workflow systems.'),
         cfg.FloatOpt('query_interval', default=20,
-                   help='Time interval between subsequent queries for a context ' +
-                        'to external workflow system.')
+                     help='Time interval between subsequent queries for a context ' +
+                          'to external workflow system.')
     ]
     do_register_opts(query_opts, group='resultstracker', ignore_errors=ignore_errors)
     # XXX: This is required for us to support deprecated config group results_tracker
+    query_opts = [
+        cfg.IntOpt('thread_pool_size',
+                   help='Number of threads to use to query external workflow systems.'),
+        cfg.FloatOpt('query_interval',
+                     help='Time interval between subsequent queries for a context ' +
+                          'to external workflow system.')
+    ]
     do_register_opts(query_opts, group='results_tracker', ignore_errors=ignore_errors)
 
     # Common CLI options

--- a/st2common/st2common/query/base.py
+++ b/st2common/st2common/query/base.py
@@ -45,17 +45,25 @@ class Querier(object):
     def __init__(self, empty_q_sleep_time=5,
                  no_workers_sleep_time=1, container_service=None):
 
-        query_interval = cfg.CONF.resultstracker.query_interval
-        thread_pool_size = cfg.CONF.resultstracker.thread_pool_size
-
         # Let's check to see if deprecated config group ``results_tracker`` is being used.
         try:
             query_interval = cfg.CONF.results_tracker.query_interval
+            LOG.warning('You are using deprecated config group ``results_tracker``.' +
+                        '\nPlease use ``resultstracker`` group instead.')
+        except:
+            pass
+
+        try:
             thread_pool_size = cfg.CONF.results_tracker.thread_pool_size
             LOG.warning('You are using deprecated config group ``results_tracker``.' +
                         '\nPlease use ``resultstracker`` group instead.')
         except:
             pass
+
+        if not query_interval:
+            query_interval = cfg.CONF.resultstracker.query_interval
+        if not thread_pool_size:
+            thread_pool_size = cfg.CONF.resultstracker.thread_pool_size
 
         self._query_thread_pool_size = thread_pool_size
         self._query_interval = query_interval

--- a/st2common/st2common/query/base.py
+++ b/st2common/st2common/query/base.py
@@ -44,8 +44,21 @@ class Querier(object):
 
     def __init__(self, empty_q_sleep_time=5,
                  no_workers_sleep_time=1, container_service=None):
-        self._query_thread_pool_size = cfg.CONF.results_tracker.thread_pool_size
-        self._query_interval = cfg.CONF.results_tracker.query_interval
+
+        query_interval = cfg.CONF.resultstracker.query_interval
+        thread_pool_size = cfg.CONF.resultstracker.thread_pool_size
+
+        # Let's check to see if deprecated config group ``results_tracker`` is being used.
+        try:
+            query_interval = cfg.CONF.results_tracker.query_interval
+            thread_pool_size = cfg.CONF.results_tracker.thread_pool_size
+            LOG.warning('You are using deprecated config group ``results_tracker``.' +
+                        '\nPlease use ``resultstracker`` group instead.')
+        except:
+            pass
+
+        self._query_thread_pool_size = thread_pool_size
+        self._query_interval = query_interval
         self._query_contexts = Queue.Queue()
         self._thread_pool = eventlet.GreenPool(self._query_thread_pool_size)
         self._empty_q_sleep_time = empty_q_sleep_time

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -80,7 +80,7 @@ def _override_common_opts():
     CONF.set_override(name='url', override='zake://', group='coordination')
     CONF.set_override(name='lock_timeout', override=1, group='coordination')
     CONF.set_override(name='jitter_interval', override=0, group='mistral')
-    CONF.set_override(name='query_interval', override=0.1, group='results_tracker')
+    CONF.set_override(name='query_interval', override=0.1, group='resultstracker')
 
 
 def _override_api_opts():


### PR DESCRIPTION
Fixes: https://github.com/StackStorm/st2/issues/3500

Context: 

There was already a ``resultstracker`` config group but I accidentally shipped the new configs in ``results_tracker`` config section. With this PR, I am adding a deprecation warning for ``results_tracker`` section but we will still parse it. Going forward, 

The config will stay 

```
[resultstracker]
query_interval = 0.1
```

Since we introduced ``results_tracker`` as a config group, we'll support it for this version and then deprecate the config. So we'll pick up 

```
[results_tracker]
query_interval = 0.1
```

This will however spit out a warning to remind people. 