### PR TITLE
Added option to print test coverage and timings to st2-run-pack-tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,11 +7,6 @@ in development
 Added
 ~~~~~
 
-* Added test coverage and test timing capabilities to ``st2-run-pack-tests``.
-  The ``-c`` option enables test coverage and the ``-t`` option enables test timings.
-  These capabilities have also been enabled in the ci pipeline for packs in the exchange.
-  (Nick Maludy)
-
 * Add support for ``passphrase`` parameter to ``remote-shell-script`` runner and as such, support
   for password protected SSH key files. (improvement)
 
@@ -29,6 +24,13 @@ Added
   the result (improvement)
 
   Contributed by mierdin. #3482
+
+  
+* Added test coverage and test timing capabilities to ``st2-run-pack-tests``.
+  The ``-c`` option enables test coverage and the ``-t`` option enables test timings.
+  These capabilities have also been enabled in the ci pipeline for packs in the exchange.
+
+  Contributed by Nick Maludy. #3508
 
 Changed
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 in development
 --------------
 
+* Added test coverage and test timing capabilities to ``st2-run-pack-tests``.
+  The ``-c`` option enables test coverage and the ``-t`` option enables test timings.
+  These capabilities have also been enabled in the ci pipeline for packs in the exchange.
+  (Nick Maludy)
 * Update ``st2 run`` / ``st2 execution run`` command to display result of workflow actions when
   they finish. In the workflow case, result of the last task (action) of the workflow is used.
   (improvement) #3481
@@ -93,7 +97,7 @@ in development
   support non-ascii (unicode) characters. (bug fix)
 * When RBAC is enabled and action is scheduled (ran) through the API, include ``rbac`` dictionary
   with ``user`` and ``roles`` ``action_context`` attribute. (improvement)
-* Fix a bug in query base module when outstanding queries to mistral or other workflow engines 
+* Fix a bug in query base module when outstanding queries to mistral or other workflow engines
   could cause a tight loop without cooperative yield leading to 100% CPU usage by st2resultstracker
   process. (bug-fix)
 * Make the query interval to third party workflow systems (including mistral) a configurable

--- a/Makefile
+++ b/Makefile
@@ -392,7 +392,7 @@ packs-tests: requirements .packs-tests
 	@echo
 	@echo "==================== packs-tests ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate; find ${ROOT_DIR}/contrib/* -maxdepth 0 -type d -print0 | xargs -0 -I FILENAME ./st2common/bin/st2-run-pack-tests -c -t -x -v -p FILENAME
+	. $(VIRTUALENV_DIR)/bin/activate; find ${ROOT_DIR}/contrib/* -maxdepth 0 -type d -print0 | xargs -0 -I FILENAME ./st2common/bin/st2-run-pack-tests -c -t -x -p FILENAME
 
 .PHONY: cli
 cli:

--- a/Makefile
+++ b/Makefile
@@ -362,7 +362,7 @@ packs-tests: requirements .packs-tests
 	@echo
 	@echo "==================== packs-tests ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate; find ${ROOT_DIR}/contrib/* -maxdepth 0 -type d -print0 | xargs -0 -I FILENAME ./st2common/bin/st2-run-pack-tests -x -p FILENAME
+	. $(VIRTUALENV_DIR)/bin/activate; find ${ROOT_DIR}/contrib/* -maxdepth 0 -type d -print0 | xargs -0 -I FILENAME ./st2common/bin/st2-run-pack-tests -c -t -x -p FILENAME
 
 .PHONY: cli
 cli:

--- a/Makefile
+++ b/Makefile
@@ -362,7 +362,7 @@ packs-tests: requirements .packs-tests
 	@echo
 	@echo "==================== packs-tests ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate; find ${ROOT_DIR}/contrib/* -maxdepth 0 -type d -print0 | xargs -0 -I FILENAME ./st2common/bin/st2-run-pack-tests -c -t -x -p FILENAME
+	. $(VIRTUALENV_DIR)/bin/activate; find ${ROOT_DIR}/contrib/* -maxdepth 0 -type d -print0 | xargs -0 -I FILENAME ./st2common/bin/st2-run-pack-tests -c -t -x -v -p FILENAME
 
 .PHONY: cli
 cli:

--- a/st2common/bin/st2-run-pack-tests
+++ b/st2common/bin/st2-run-pack-tests
@@ -306,10 +306,10 @@ if [ "${ENABLE_COVERAGE}" = true ]; then
   # the options: --cover-package=/absolte/path OR --cover-package=./relative/path
 
   # For each of the sub-directory in the pack, excluding the "tests" directory
-  PACK_SUB_DIRS=$(find $PACK_DIR -mindepth 1 -maxdepth 1 -type d -and -not -name "tests")
+  PACK_SUB_DIRS=$(find $PACK_PATH -mindepth 1 -maxdepth 1 -type d -and -not -name "tests")
   for pack_sub_dir in $PACK_SUB_DIRS; do
     verbose_log "Enabling nosetests coverage for directory: $pack_sub_dir"
-    NOSE_OPTS+=(--cover-package=./$pack_sub_dir)
+    NOSE_OPTS+=(--cover-package=$pack_sub_dir)
   done # end for each $PACK_PYTHON_DIR
 fi # end enable test coverage
 

--- a/st2common/bin/st2-run-pack-tests
+++ b/st2common/bin/st2-run-pack-tests
@@ -37,11 +37,13 @@ PACK_TEST_PYTHON_DEPENDENCIES_NAMES=(
     'mock'
     'unittest2'
     'nose'
+    'coverage'
 )
 PACK_TEST_PYTHON_DEPENDENCIES_VERSIONS=(
     '>=2.0,<2.1'
     '>=1.1.0,<2.0'
     '>=1.3.7'
+    ''
 )
 
 VIRTUALENVS_DIR="/tmp/st2-pack-tests-virtualenvs"
@@ -54,6 +56,8 @@ ST2_PIP_OPTIONS=${ST2_PIP_OPTIONS:-"-q"}
 CREATE_VIRTUALENV=true
 JUST_TESTS=false
 VERBOSE=false
+ENABLE_COVERAGE=false
+ENABLE_TIMING=false
 
 VIRTUALENV_ACTIVATED=false
 
@@ -65,14 +69,16 @@ STACKSTORM_VIRTUALENV_PYTHON_BINARY="${STACKSTORM_VIRTUALENV_BIN}/python"
 ####################
 
 function usage() {
-    echo "Usage: $0 [-x] [-j] [-v] -p <path to pack>" >&2
-    echo "  -x : Do not create virtualenv for test for tests, e.g. when running in existing one." >&2
-    echo "  -j : Just run tests (use previously installed dependencies" >&2
+    echo "Usage: $0  [-c] [-j] [-t] [-v] [-x] -p <path to pack>" >&2
+    echo "  -c : Run tests with code coverage reporting enabled" >&2
+    echo "  -j : Just run tests. Use previously installed dependencies" >&2
     echo "       and virtualenv if any. For subsequent test runs." >&2
+    echo "  -t : Run tests with timing enabled" >&2
     echo "  -v : Verbose mode (log debug messages to stdout)." >&2
+    echo "  -x : Do not create virtualenv for test for tests, e.g. when running in existing one." >&2
 }
 
-while getopts ":p:xjv" o; do
+while getopts ":p:xjvct" o; do
     case "${o}" in
         p)
             PACK_PATH=${OPTARG}
@@ -85,6 +91,13 @@ while getopts ":p:xjv" o; do
             ;;
         v)
             VERBOSE=true
+            ;;
+        c)
+            echo "ENABLED COVERAGE"
+            ENABLE_COVERAGE=true
+            ;;
+        t)
+            ENABLE_TIMING=true
             ;;
         \?)
             echo "Invalid option: -$OPTARG" >&2
@@ -273,7 +286,66 @@ fi
 echo "Running tests..."
 # Note: We run nosetests with "--exe" option so it also runs test files which are executable
 # (pack install command automatically makes all the files, including test files executable)
-nosetests -s -v --exe ${PACK_TESTS_PATH}
+NOSE_OPTS=(-s -v --exe --rednose --immediate)
+
+# Should we pass in arguments to enable test coverage
+if [ "${ENABLE_COVERAGE}" = true ]; then
+  verbose_log "Enabling nosetests coverage"
+
+  # base options to enable test coverage printouts
+  NOSE_OPTS+=(--with-coverage --cover-html)
+
+  # Now, by default nosetests prints out test coverage for every module found
+  # in the $PYTHONPATH... as you can imagine this is not ideal and may contain
+  # a LOT of files. To only print out the modules that we care about we need to
+  # specify them on the cdmline using --cover-package=package.name
+
+  # There are two directories that way contain python files
+  PACK_PYTHON_DIRS=("${PACK_PATH}/actions/" "${PACK_PATH}/sensors/")
+
+  # There are two scenarios for python files in the PACK_PYTHON_DIRS
+  # 1) there are xxx.py files in the root of the directory (ex: actions/example.py)
+  # 2) there are sub directories that contain __init__.py files that signify
+  #    to python that they're a module (ex: actions/lib/__init.py). All files
+  #    within this sub directory will be checked for coverage if we
+  #    specify the option for the base module (ex: --cover-package=lib)
+
+  # for each of the directories in the pack that may contain python files
+  for pack_python_dir in ${PACK_PYTHON_DIRS}; do
+
+    # find all *.py files in the root of the $pack_python_dir
+    for py_absolute in $(find $pack_python_dir  -mindepth 1 -maxdepth 1 -name "*.py"); do
+      # remove the $pack_python_dir directory from the beginning of $py_absolute
+      py_relative=${py_absolute#$pack_python_dir}
+      # convert '/'s to '.'s and remove the '.py' at the end
+      py_package=$(echo "$py_relative" | sed 's/\//./g' | sed 's/\.py//g')
+      # append the name of this package to the nose options
+      verbose_log "Enabling nosetests coverage for python package: $py_package"
+      NOSE_OPTS+=(--cover-package=$py_package)
+    done
+
+    # find all __init__.py files in sub directories of $pack_python_dir
+    for init_absolute in $(find $pack_python_dir  -mindepth 2 -name "__init__.py"); do
+      # remove the $pack_python_dir directory from the beginning of $py_absolute
+      init_relative=${init_absolute#$pack_python_dir}
+      # remove the filename from $init_relative so we're just left with the
+      # directory path (this is the name of the package :) ) and then
+      # convert '/'s to '.'s
+      init_package=$(dirname $init_relative | sed 's/\//./g')
+      # append the name of this package to the nose options
+      verbose_log "Enabling nosetests coverage for python package: $init_package"
+      NOSE_OPTS+=(--cover-package=$init_package)
+    done
+  done # end for each $PACK_PYTHON_DIR
+fi # end enable test coverage
+
+# Should we pass in arguments to enable test timing
+if [ "${ENABLE_TIMING}" = true ]; then
+  verbose_log "Enabling nosetests timings"
+  NOSE_OPTS+=(--with-timer)
+fi
+
+nosetests ${NOSE_OPTS[@]} ${PACK_TESTS_PATH}
 TESTS_EXIT_CODE=$?
 
 # Clean up and unset the variables

--- a/st2common/bin/st2-run-pack-tests
+++ b/st2common/bin/st2-run-pack-tests
@@ -93,7 +93,6 @@ while getopts ":p:xjvct" o; do
             VERBOSE=true
             ;;
         c)
-            echo "ENABLED COVERAGE"
             ENABLE_COVERAGE=true
             ;;
         t)

--- a/st2common/bin/st2-run-pack-tests
+++ b/st2common/bin/st2-run-pack-tests
@@ -37,13 +37,15 @@ PACK_TEST_PYTHON_DEPENDENCIES_NAMES=(
     'mock'
     'unittest2'
     'nose'
+    'nose-timer'
     'coverage'
 )
 PACK_TEST_PYTHON_DEPENDENCIES_VERSIONS=(
     '>=2.0,<2.1'
     '>=1.1.0,<2.0'
     '>=1.3.7'
-    ''
+    '>=0.7.0'
+    '>=4.4.1'
 )
 
 VIRTUALENVS_DIR="/tmp/st2-pack-tests-virtualenvs"
@@ -72,7 +74,7 @@ function usage() {
     echo "Usage: $0  [-c] [-j] [-t] [-v] [-x] -p <path to pack>" >&2
     echo "  -c : Run tests with code coverage reporting enabled" >&2
     echo "  -j : Just run tests. Use previously installed dependencies" >&2
-    echo "       and virtualenv if any. For subsequent test runs." >&2
+    echo "       and virtualenv, if any, for subsequent test runs." >&2
     echo "  -t : Run tests with timing enabled" >&2
     echo "  -v : Verbose mode (log debug messages to stdout)." >&2
     echo "  -x : Do not create virtualenv for test for tests, e.g. when running in existing one." >&2
@@ -287,54 +289,27 @@ echo "Running tests..."
 # (pack install command automatically makes all the files, including test files executable)
 NOSE_OPTS=(-s -v --exe --rednose --immediate)
 
-# Should we pass in arguments to enable test coverage
+# Is test coverage reporting enabled?
 if [ "${ENABLE_COVERAGE}" = true ]; then
   verbose_log "Enabling nosetests coverage"
 
-  # base options to enable test coverage printouts
-  NOSE_OPTS+=(--with-coverage)
+  # Base options to enable test coverage reporting
+  # --with-coverage : enables coverage reporting
+  # --cover-erase : removes old coverage reports before starting 
+  NOSE_OPTS+=(--with-coverage --cover-erase)
 
-  # Now, by default nosetests prints out test coverage for every module found
+  # Now, by default nosetests reports test coverage for every module found
   # in the $PYTHONPATH... as you can imagine this is not ideal and may contain
-  # a LOT of files. To only print out the modules that we care about we need to
-  # specify them on the cdmline using --cover-package=package.name
+  # a LOT of files.
+  # We can restrict nosetest to only report on python files from certain
+  # directories by specifying those directories (absolute or relative) using
+  # the options: --cover-package=/absolte/path OR --cover-package=./relative/path
 
-  # There are two directories that way contain python files
-  PACK_PYTHON_DIRS=("${PACK_PATH}/actions/" "${PACK_PATH}/sensors/")
-
-  # There are two scenarios for python files in the PACK_PYTHON_DIRS
-  # 1) there are xxx.py files in the root of the directory (ex: actions/example.py)
-  # 2) there are sub directories that contain __init__.py files that signify
-  #    to python that they're a module (ex: actions/lib/__init.py). All files
-  #    within this sub directory will be checked for coverage if we
-  #    specify the option for the base module (ex: --cover-package=lib)
-
-  # for each of the directories in the pack that may contain python files
-  for pack_python_dir in ${PACK_PYTHON_DIRS}; do
-
-    # find all *.py files in the root of the $pack_python_dir
-    for py_absolute in $(find $pack_python_dir  -mindepth 1 -maxdepth 1 -name "*.py"); do
-      # remove the $pack_python_dir directory from the beginning of $py_absolute
-      py_relative=${py_absolute#$pack_python_dir}
-      # convert '/'s to '.'s and remove the '.py' at the end
-      py_package=$(echo "$py_relative" | sed 's/\//./g' | sed 's/\.py//g')
-      # append the name of this package to the nose options
-      verbose_log "Enabling nosetests coverage for python package: $py_package"
-      NOSE_OPTS+=(--cover-package=$py_package)
-    done
-
-    # find all __init__.py files in sub directories of $pack_python_dir
-    for init_absolute in $(find $pack_python_dir  -mindepth 2 -name "__init__.py"); do
-      # remove the $pack_python_dir directory from the beginning of $py_absolute
-      init_relative=${init_absolute#$pack_python_dir}
-      # remove the filename from $init_relative so we're just left with the
-      # directory path (this is the name of the package :) ) and then
-      # convert '/'s to '.'s
-      init_package=$(dirname $init_relative | sed 's/\//./g')
-      # append the name of this package to the nose options
-      verbose_log "Enabling nosetests coverage for python package: $init_package"
-      NOSE_OPTS+=(--cover-package=$init_package)
-    done
+  # For each of the sub-directory in the pack, excluding the "tests" directory
+  PACK_SUB_DIRS=$(find $PACK_DIR -mindepth 1 -maxdepth 1 -type d -and -not -name "tests")
+  for pack_sub_dir in $PACK_SUB_DIRS; do
+    verbose_log "Enabling nosetests coverage for directory: $pack_sub_dir"
+    NOSE_OPTS+=(--cover-package=./$pack_sub_dir)
   done # end for each $PACK_PYTHON_DIR
 fi # end enable test coverage
 
@@ -344,8 +319,14 @@ if [ "${ENABLE_TIMING}" = true ]; then
   NOSE_OPTS+=(--with-timer)
 fi
 
+# Change to the pack's directory (required for test coverage reporting)
+pushd ${PACK_PATH}
+
+# Execute the tests
 nosetests ${NOSE_OPTS[@]} ${PACK_TESTS_PATH}
 TESTS_EXIT_CODE=$?
+
+popd # ${PACK_PATH
 
 # Clean up and unset the variables
 if [ ${VIRTUALENV_ACTIVATED} = true ]; then

--- a/st2common/bin/st2-run-pack-tests
+++ b/st2common/bin/st2-run-pack-tests
@@ -292,7 +292,7 @@ if [ "${ENABLE_COVERAGE}" = true ]; then
   verbose_log "Enabling nosetests coverage"
 
   # base options to enable test coverage printouts
-  NOSE_OPTS+=(--with-coverage --cover-html)
+  NOSE_OPTS+=(--with-coverage)
 
   # Now, by default nosetests prints out test coverage for every module found
   # in the $PYTHONPATH... as you can imagine this is not ideal and may contain


### PR DESCRIPTION
This adds the ability to print test coverage and test timings to st2-run-pack-tests

Two new cmdline flags were added to support these features:

```
# -c : Run tests with code coverage reporting enabled
st2-run-pack-tests -c -p path/to/pack
```

```
# -t : Run tests with timing enabled
st2-run-pack-tests -t -p path/to/pack
```

Example output:
```
stackstorm-activedirectory/ci/virtualenv/bin/activate; \
/tmp/st2/st2common/bin/st2-run-pack-tests -c -t -x -p stackstorm-activedirectory/ci/../ || exit 1;
ENABLED COVERAGE
Running tests for pack: stackstorm-activedirectory
Installing dependencies from st2 repository...
DEPRECATION: The default format will switch to columns in the future. You can use --format=(legacy|columns) (or define a format=(legacy|columns) in your pip.conf under the [list] section) to disable this warning.                        
Installing global pack test dependencies...
Installing pack-specific dependencies...
Installing pack-specific test dependencies...
Running tests...
test_create_creds_spec (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_init (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_resolve_creds_from_cmdline (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_resolve_creds_from_cmdline_override_config (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_resolve_creds_from_config (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_resolve_creds_spec_config_creds_missing (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_resolve_creds_spec_config_creds_missing_password (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_resolve_creds_spec_config_creds_missing_username (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_resolve_creds_spec_from_cmdline (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_resolve_creds_spec_from_cmdline_override_config (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_resolve_creds_spec_from_config (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_resolve_output_ps_config (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_resolve_output_ps_config_invalid (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_resolve_output_ps_config_missing (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_resolve_output_ps_json (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_resolve_transport_cmdline (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_resolve_transport_config_base (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_resolve_transport_config_creds (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_resolve_transport_default (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_resolve_transport_kwargs_none (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_run_ad_cmdlet (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_run_ad_cmdlet_cmdlet_credentials (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_run_ad_cmdlet_cmdlet_credentials_json (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_run_ad_cmdlet_fail (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_run_ad_cmdlet_json (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_run_ad_cmdlet_json_parse_empty (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_run_ad_cmdlet_json_stderr_parse_fail (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_run_ad_cmdlet_json_stdout_parse_fail (test_action_lib_baseaction.TestActionLibBaseAction) ... passed
test_init (test_winrm_connection.TestWinRmConnection) ... passed





TEST RESULT OUTPUT:

Name                      Stmts   Miss  Cover
---------------------------------------------
lib/__init__.py               0      0   100%
lib/action.py               120     10    92%
lib/winrm_connection.py       8      2    75%
run_cmdlet.py                 6      3    50%
---------------------------------------------
TOTAL                       134     15    89%
[success] 4.29% test_action_lib_baseaction.TestActionLibBaseAction.test_run_ad_cmdlet_json_stderr_parse_fail: 0.0093s
[success] 3.96% test_action_lib_baseaction.TestActionLibBaseAction.test_run_ad_cmdlet_json_parse_empty: 0.0085s
[success] 3.94% test_action_lib_baseaction.TestActionLibBaseAction.test_run_ad_cmdlet_json: 0.0085s
[success] 3.93% test_action_lib_baseaction.TestActionLibBaseAction.test_run_ad_cmdlet_json_stdout_parse_fail: 0.0085s
[success] 3.91% test_action_lib_baseaction.TestActionLibBaseAction.test_run_ad_cmdlet_cmdlet_credentials_json: 0.0085s
[success] 3.87% test_action_lib_baseaction.TestActionLibBaseAction.test_run_ad_cmdlet_cmdlet_credentials: 0.0084s
[success] 3.84% test_action_lib_baseaction.TestActionLibBaseAction.test_run_ad_cmdlet_fail: 0.0083s
[success] 3.84% test_action_lib_baseaction.TestActionLibBaseAction.test_run_ad_cmdlet: 0.0083s
[success] 3.53% test_action_lib_baseaction.TestActionLibBaseAction.test_resolve_creds_from_config: 0.0076s
[success] 3.52% test_action_lib_baseaction.TestActionLibBaseAction.test_resolve_creds_from_cmdline: 0.0076s
[success] 3.50% test_action_lib_baseaction.TestActionLibBaseAction.test_resolve_creds_spec_from_cmdline: 0.0076s
[success] 3.49% test_action_lib_baseaction.TestActionLibBaseAction.test_create_creds_spec: 0.0075s
[success] 3.48% test_action_lib_baseaction.TestActionLibBaseAction.test_resolve_creds_spec_config_creds_missing_username: 0.0075s
[success] 3.44% test_action_lib_baseaction.TestActionLibBaseAction.test_resolve_creds_spec_config_creds_missing_password: 0.0074s
[success] 3.39% test_action_lib_baseaction.TestActionLibBaseAction.test_resolve_output_ps_config: 0.0073s
[success] 3.37% test_action_lib_baseaction.TestActionLibBaseAction.test_resolve_creds_spec_config_creds_missing: 0.0073s
[success] 3.37% test_action_lib_baseaction.TestActionLibBaseAction.test_resolve_creds_from_cmdline_override_config: 0.0073s
[success] 3.37% test_action_lib_baseaction.TestActionLibBaseAction.test_resolve_creds_spec_from_cmdline_override_config: 0.0073s
[success] 3.36% test_action_lib_baseaction.TestActionLibBaseAction.test_resolve_output_ps_config_missing: 0.0073s
[success] 3.35% test_action_lib_baseaction.TestActionLibBaseAction.test_resolve_creds_spec_from_config: 0.0072s
[success] 3.34% test_action_lib_baseaction.TestActionLibBaseAction.test_resolve_output_ps_json: 0.0072s
[success] 3.34% test_action_lib_baseaction.TestActionLibBaseAction.test_resolve_output_ps_config_invalid: 0.0072s
[success] 3.33% test_action_lib_baseaction.TestActionLibBaseAction.test_resolve_transport_config_creds: 0.0072s
[success] 3.33% test_action_lib_baseaction.TestActionLibBaseAction.test_resolve_transport_default: 0.0072s
[success] 3.32% test_action_lib_baseaction.TestActionLibBaseAction.test_resolve_transport_cmdline: 0.0072s
[success] 3.32% test_action_lib_baseaction.TestActionLibBaseAction.test_resolve_transport_config_base: 0.0072s
[success] 3.30% test_action_lib_baseaction.TestActionLibBaseAction.test_resolve_transport_kwargs_none: 0.0071s
[success] 3.28% test_action_lib_baseaction.TestActionLibBaseAction.test_init: 0.0071s
[success] 0.67% test_winrm_connection.TestWinRmConnection.test_init: 0.0014s
-----------------------------------------------------------------------------
29 tests run in 0.821 seconds (29 tests passed)
```