### PR TITLE
Support unicode with line feed in CLI print 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Added
   returning the result. (improvement)
 
   Contributed by mierdin. #3482
+* Fix st2client to display unicode characters in pack content description. (bug-fix)
 
 Changed
 ~~~~~~~

--- a/st2client/st2client/formatters/execution.py
+++ b/st2client/st2client/formatters/execution.py
@@ -41,7 +41,7 @@ class ExecutionResult(formatters.Formatter):
             entry = vars(entry)
             output = ''
             for attr in attrs:
-                value = jsutil.get_value(entry, attr)
+                value = strutil.unescape(jsutil.get_value(entry, attr))
                 if (isinstance(value, basestring) and len(value) > 0 and
                         value[0] in ['{', '['] and value[len(value) - 1] in ['}', ']']):
                     new_value = ast.literal_eval(value)
@@ -60,4 +60,4 @@ class ExecutionResult(formatters.Formatter):
                     value = ('\n' if isinstance(value, dict) else '') + formatted_value
                 output += ('\n' if output else '') + '%s: %s' % \
                     (DisplayColors.colorize(attr, DisplayColors.BLUE), value)
-        return strutil.unescape(output)
+        return output

--- a/st2client/st2client/formatters/execution.py
+++ b/st2client/st2client/formatters/execution.py
@@ -41,7 +41,8 @@ class ExecutionResult(formatters.Formatter):
             entry = vars(entry)
             output = ''
             for attr in attrs:
-                value = strutil.unescape(jsutil.get_value(entry, attr))
+                value = jsutil.get_value(entry, attr)
+                value = strutil.strip_carriage_returns(strutil.unescape(value))
                 if (isinstance(value, basestring) and len(value) > 0 and
                         value[0] in ['{', '['] and value[len(value) - 1] in ['}', ']']):
                     new_value = ast.literal_eval(value)

--- a/st2client/st2client/formatters/table.py
+++ b/st2client/st2client/formatters/table.py
@@ -141,14 +141,14 @@ class MultiColumnTable(formatters.Formatter):
                         value = cls._get_field_value(value, name)
                         if type(value) is str:
                             break
-                    value = strutil.unescape(value)
+                    value = strutil.strip_carriage_returns(strutil.unescape(value))
                     values.append(value)
                 else:
                     value = cls._get_simple_field_value(entry, field_name)
                     transform_function = attribute_transform_functions.get(field_name,
                                                                            lambda value: value)
                     value = transform_function(value=value)
-                    value = strutil.unescape(value)
+                    value = strutil.strip_carriage_returns(strutil.unescape(value))
                     values.append(value)
             table.add_row(values)
 
@@ -244,7 +244,7 @@ class PropertyValueTable(formatters.Formatter):
             if type(value) is dict or type(value) is list:
                 value = json.dumps(value, indent=4)
 
-            value = strutil.unescape(value)
+            value = strutil.strip_carriage_returns(strutil.unescape(value))
             table.add_row([attribute, value])
         return table
 

--- a/st2client/st2client/utils/strutil.py
+++ b/st2client/st2client/utils/strutil.py
@@ -15,5 +15,5 @@
 
 
 def unescape(s):
-    return (s.replace('\\r\\n', '\\n').encode('utf-8').decode('string_escape').decode('utf-8')
+    return (s.replace('\r\n', '\n')
             if isinstance(s, basestring) else s)

--- a/st2client/st2client/utils/strutil.py
+++ b/st2client/st2client/utils/strutil.py
@@ -15,5 +15,5 @@
 
 
 def unescape(s):
-    return (s.replace('\\r\\n', '\\n').decode('unicode_escape').encode('utf-8')
+    return (s.replace('\\r\\n', '\\n').encode('utf-8').decode('string_escape').decode('utf-8')
             if isinstance(s, basestring) else s)

--- a/st2client/st2client/utils/strutil.py
+++ b/st2client/st2client/utils/strutil.py
@@ -15,5 +15,10 @@
 
 
 def unescape(s):
-    return (s.replace('\r\n', '\n')
-            if isinstance(s, basestring) else s)
+    if isinstance(s, basestring):
+        s = s.replace('\\n', '\n')
+        s = s.replace('\\r', '')
+        s = s.replace('\\"', '\"')
+        s = s.replace('\r', '')
+
+    return s

--- a/st2client/st2client/utils/strutil.py
+++ b/st2client/st2client/utils/strutil.py
@@ -15,10 +15,21 @@
 
 
 def unescape(s):
+    """
+    Action execution escapes escaped chars in result (i.e. \n is stored as \\n).
+    This function unescapes those chars.
+    """
     if isinstance(s, basestring):
         s = s.replace('\\n', '\n')
-        s = s.replace('\\r', '')
+        s = s.replace('\\r', '\r')
         s = s.replace('\\"', '\"')
+
+    return s
+
+
+def strip_carriage_returns(s):
+    if isinstance(s, basestring):
+        s = s.replace('\\r', '')
         s = s.replace('\r', '')
 
     return s

--- a/st2client/tests/unit/test_util_strutil.py
+++ b/st2client/tests/unit/test_util_strutil.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest2
+
+from st2client.utils.strutil import unescape
+
+
+class StrUtilTestCase(unittest2.TestCase):
+# See https://mail.python.org/pipermail/python-list/2006-January/411909.html
+
+    def test_unicode_string(self):
+        in_str = '\u8c03\u7528CMS\u63a5\u53e3\u5220\u9664\u865a\u62df\u76ee\u5f55'
+        out_str = unescape(in_str)
+        self.assertEqual(out_str, in_str)
+
+    def test_carriage_return_in_string(self):
+        in_str = 'Windows editors introduce\\r\\nlike a noob in 2017.'
+        out_str = unescape(in_str)
+        exp_str = 'Windows editors introduce\nlike a noob in 2017.'
+        self.assertEqual(out_str, exp_str)
+
+    def test_unicode_with_line_feed_like_chars(self):
+        in_str = u'€\\n€'
+        out_str = unescape(in_str)
+        exp_str = u'€\n€'
+        self.assertEqual(out_str, exp_str)

--- a/st2client/tests/unit/test_util_strutil.py
+++ b/st2client/tests/unit/test_util_strutil.py
@@ -29,13 +29,13 @@ class StrUtilTestCase(unittest2.TestCase):
         self.assertEqual(out_str, in_str)
 
     def test_carriage_return_in_string(self):
-        in_str = 'Windows editors introduce\\r\\nlike a noob in 2017.'
+        in_str = 'Windows editors introduce\r\nlike a noob in 2017.'
         out_str = unescape(in_str)
         exp_str = 'Windows editors introduce\nlike a noob in 2017.'
         self.assertEqual(out_str, exp_str)
 
     def test_unicode_with_line_feed_like_chars(self):
         in_str = u'€\\n€'
-        out_str = unescape(in_str)
+        out_str = unescape(in_str).encode('utf-8').decode('string_escape').decode('utf-8')
         exp_str = u'€\n€'
         self.assertEqual(out_str, exp_str)

--- a/st2client/tests/unit/test_util_strutil.py
+++ b/st2client/tests/unit/test_util_strutil.py
@@ -21,7 +21,7 @@ from st2client.utils.strutil import unescape
 
 
 class StrUtilTestCase(unittest2.TestCase):
-# See https://mail.python.org/pipermail/python-list/2006-January/411909.html
+    # See https://mail.python.org/pipermail/python-list/2006-January/411909.html
 
     def test_unicode_string(self):
         in_str = '\u8c03\u7528CMS\u63a5\u53e3\u5220\u9664\u865a\u62df\u76ee\u5f55'

--- a/st2client/tests/unit/test_util_strutil.py
+++ b/st2client/tests/unit/test_util_strutil.py
@@ -17,25 +17,31 @@
 
 import unittest2
 
-from st2client.utils.strutil import unescape
+from st2client.utils import strutil
 
 
 class StrUtilTestCase(unittest2.TestCase):
     # See https://mail.python.org/pipermail/python-list/2006-January/411909.html
 
+    def test_unescape(self):
+        in_str = 'Action execution result double escape \\"stuffs\\".\\r\\n'
+        expected = 'Action execution result double escape \"stuffs\".\r\n'
+        out_str = strutil.unescape(in_str)
+        self.assertEqual(out_str, expected)
+
     def test_unicode_string(self):
         in_str = '\u8c03\u7528CMS\u63a5\u53e3\u5220\u9664\u865a\u62df\u76ee\u5f55'
-        out_str = unescape(in_str)
+        out_str = strutil.unescape(in_str)
         self.assertEqual(out_str, in_str)
 
-    def test_carriage_return_in_string(self):
+    def test_strip_carriage_returns(self):
         in_str = 'Windows editors introduce\r\nlike a noob in 2017.'
-        out_str = unescape(in_str)
+        out_str = strutil.strip_carriage_returns(in_str)
         exp_str = 'Windows editors introduce\nlike a noob in 2017.'
         self.assertEqual(out_str, exp_str)
 
     def test_unicode_with_line_feed_like_chars(self):
         in_str = u'€\\n€'
-        out_str = unescape(in_str).encode('utf-8').decode('string_escape').decode('utf-8')
+        out_str = strutil.unescape(in_str).encode('utf-8').decode('string_escape').decode('utf-8')
         exp_str = u'€\n€'
         self.assertEqual(out_str, exp_str)

--- a/st2client/tests/unit/test_util_strutil.py
+++ b/st2client/tests/unit/test_util_strutil.py
@@ -39,9 +39,3 @@ class StrUtilTestCase(unittest2.TestCase):
         out_str = strutil.strip_carriage_returns(in_str)
         exp_str = 'Windows editors introduce\nlike a noob in 2017.'
         self.assertEqual(out_str, exp_str)
-
-    def test_unicode_with_line_feed_like_chars(self):
-        in_str = u'€\\n€'
-        out_str = strutil.unescape(in_str).encode('utf-8').decode('string_escape').decode('utf-8')
-        exp_str = u'€\n€'
-        self.assertEqual(out_str, exp_str)


### PR DESCRIPTION
Fixes: https://github.com/StackStorm/st2/issues/3510

See https://mail.python.org/pipermail/python-list/2006-January/411909.html. 

TODO

- [x] Validate other prints (rule, sensor etc etc) actually use this util. 

Test cases without any code change:

```
======================================================================
ERROR: test_unicode_with_line_feed_like_chars (tests.unit.test_util_strutil.StrUtilTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/mnt/src/storm/st2/st2client/tests/unit/test_util_strutil.py", line 38, in test_unicode_with_line_feed_like_chars
    out_str = unescape(in_str)
  File "/mnt/src/storm/st2/st2client/st2client/utils/strutil.py", line 20, in unescape
    if isinstance(s, basestring) else s)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u20ac' in position 0: ordinal not in range(128)
```

After the fix: 

```
test_unicode_with_line_feed_like_chars (tests.unit.test_util_strutil.StrUtilTestCase) ... ok
```

With the fix:

```
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯ st2 action list --pack=cms                            issues/3510/unicode_support_action_list ✭ ✱
+------------------------+------+------------------------------+
| ref                    | pack | description                  |
+------------------------+------+------------------------------+
| cms.get_group_info     | cms  | 根据group_id查询group信息    |
| cms.get_pool_info      | cms  | 根据pool_id查询pool信息      |
| cms.get_server_info    | cms  | 根据pool_id查询server信息    |
| cms.get_site_info      | cms  | 根据group_id查询站点信息     |
| cms.get_vd_info        | cms  | 根据group_id查询虚拟目录信息 |
| cms.group_deletion     | cms  | 调用CMS接口删除Group         |
| cms.pool_deletion      | cms  | 调用CMS接口删除Group         |
| cms.site_deletion      | cms  | 调用CMS接口删除站点          |
| cms.ticket_association | cms  | 关联单子                     |
| cms.vd_deletion        | cms  | 调用CMS接口删除虚拟目录      |
+------------------------+------+------------------------------+
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯
```