### PR TITLE
Update action-chain runner to display published variables by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,11 +15,13 @@ in development
   and didn't log anything which was confusing. (improvement) #3489
 
   Reported by Anthony Shaw.
-* Fix ``?name`` query param filter in ``/v1/actionalias`` API endpoint. (bug fix) #3503
+* Fix ``?name`` query parameter filter in ``/v1/actionalias`` API endpoint. (bug fix) #3503
 * Add missing pagination support to ``/v1/apikeys`` API endpoint. (improvement) #3486
-* Update action-chain runner so a default value of ``display_published`` runner parameter is
-  ``True``. This way it's consistent with Mistral runner behavior and variables published inside
-  action-chain workflow and stored and displayed by default. #3518
+* Update action-chain runner so a default value for ``display_published`` runner parameter is
+  ``True``. This way it's consistent with Mistral runner behavior and intermediate variables
+  published inside action-chain workflow are stored and displayed by default. #3518 #3519
+
+  Reported by Jacob Floyd.
 
 2.3.0 - June 19, 2017
 ---------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ in development
   Reported by Anthony Shaw.
 * Fix ``?name`` query param filter in ``/v1/actionalias`` API endpoint. (bug fix) #3503
 * Add missing pagination support to ``/v1/apikeys`` API endpoint. (improvement) #3486
+* Update action-chain runner so a default value of ``display_published`` runner parameter is
+  ``True``. This way it's consistent with Mistral runner behavior and variables published inside
+  action-chain workflow and stored and displayed by default. #3518
 
 2.3.0 - June 19, 2017
 ---------------------

--- a/contrib/runners/action_chain_runner/action_chain_runner.py
+++ b/contrib/runners/action_chain_runner/action_chain_runner.py
@@ -232,7 +232,7 @@ class ActionChainRunner(ActionRunner):
         self._meta_loader = MetaLoader()
         self._stopped = False
         self._skip_notify_tasks = []
-        self._display_published = False
+        self._display_published = True
         self._chain_notify = None
 
     def pre_run(self):
@@ -270,7 +270,7 @@ class ActionChainRunner(ActionRunner):
             self._chain_notify = getattr(self.liveaction, 'notify', None)
         if self.runner_parameters:
             self._skip_notify_tasks = self.runner_parameters.get('skip_notify', [])
-            self._display_published = self.runner_parameters.get('display_published', False)
+            self._display_published = self.runner_parameters.get('display_published', True)
 
         # Perform some pre-run chain validation
         try:

--- a/contrib/runners/action_chain_runner/runner.yaml
+++ b/contrib/runners/action_chain_runner/runner.yaml
@@ -5,7 +5,7 @@
   runner_module: action_chain_runner
   runner_parameters:
     display_published:
-      default: false
+      default: True
       description: Intermediate published variables will be stored and displayed.
       type: boolean
     skip_notify:

--- a/st2tests/st2tests/fixtures/generic/actionchains/chain_with_publish_2.yaml
+++ b/st2tests/st2tests/fixtures/generic/actionchains/chain_with_publish_2.yaml
@@ -1,0 +1,19 @@
+---
+chain:
+- name: t1
+  on-success: t2
+  publish:
+    t1_publish_param_1: 'foo1'
+    t1_publish_param_2: 'foo2'
+    t1_publish_param_3: 'foo3'
+    publish_last_wins: 'bar_first'
+  ref: wolfpack.a2
+- name: t2
+  ref: wolfpack.a2
+  publish:
+    t2_publish_param_1: 'foo4'
+    t2_publish_param_2: 'foo5'
+    t2_publish_param_3: 'foo6'
+    publish_last_wins: 'bar_last'
+
+default: t1


### PR DESCRIPTION
We added functionality to the action-chain runner to store and displayed intermediate published variables quite a while ago.

This functionality was controlled via `display_published` runner parameter which had a default value of `False`.

It looks like default Mistral runner behavior is to display published variables (#3518) so it makes sense to also make action-chain runner store and display it by default for consistency reasons.