### PR TITLE
Print more user-friendly exception on invalid log level

### DIFF
--- a/st2api/st2api/cmd/api.py
+++ b/st2api/st2api/cmd/api.py
@@ -74,8 +74,10 @@ def main():
         return _run_server()
     except SystemExit as exit_code:
         sys.exit(exit_code)
-    except Exception:
-        LOG.exception('(PID=%s) ST2 API quit due to exception.', os.getpid())
+    except Exception as e:
+        msg = getattr(e, 'message', str(e))
+        LOG.error('(PID=%s) ST2 API quit due to exception.', os.getpid())
+        LOG.error(msg)
         return 1
     finally:
         _teardown()

--- a/st2api/st2api/cmd/api.py
+++ b/st2api/st2api/cmd/api.py
@@ -76,8 +76,7 @@ def main():
         sys.exit(exit_code)
     except Exception as e:
         msg = getattr(e, 'message', str(e))
-        LOG.error('(PID=%s) ST2 API quit due to exception.', os.getpid())
-        LOG.error(msg)
+        LOG.exception('(PID=%s) ST2 API quit due to exception.', os.getpid())
         return 1
     finally:
         _teardown()

--- a/st2api/st2api/cmd/api.py
+++ b/st2api/st2api/cmd/api.py
@@ -74,8 +74,7 @@ def main():
         return _run_server()
     except SystemExit as exit_code:
         sys.exit(exit_code)
-    except Exception as e:
-        msg = getattr(e, 'message', str(e))
+    except Exception:
         LOG.exception('(PID=%s) ST2 API quit due to exception.', os.getpid())
         return 1
     finally:

--- a/st2common/st2common/log.py
+++ b/st2common/st2common/log.py
@@ -192,12 +192,13 @@ def setup(config_file, redirect_stderr=True, excludes=None, disable_existing_log
         exc_cls = type(exc)
         tb_msg = traceback.format_exc()
 
+        msg = str(exc)
+        msg += '\n\n' + tb_msg
+
         # revert stderr redirection since there is no logger in place.
         sys.stderr = sys.__stderr__
 
         # No logger yet therefore write to stderr
-        sys.stderr.write('ERROR: %s' % traceback.format_exc())
+        sys.stderr.write('ERROR: %s' % (msg))
 
-        msg = str(exc)
-        msg += '\n\n' + tb_msg
         raise exc_cls(six.text_type(msg))

--- a/st2common/st2common/log.py
+++ b/st2common/st2common/log.py
@@ -189,8 +189,15 @@ def setup(config_file, redirect_stderr=True, excludes=None, disable_existing_log
         if redirect_stderr:
             _redirect_stderr()
     except Exception as exc:
+        exc_cls = type(exc)
+        tb_msg = traceback.format_exc()
+
         # revert stderr redirection since there is no logger in place.
         sys.stderr = sys.__stderr__
+
         # No logger yet therefore write to stderr
         sys.stderr.write('ERROR: %s' % traceback.format_exc())
-        raise Exception(six.text_type(exc))
+
+        msg = str(exc)
+        msg += '\n\n' + tb_msg
+        raise exc_cls(six.text_type(msg))

--- a/st2common/st2common/service_setup.py
+++ b/st2common/st2common/service_setup.py
@@ -97,7 +97,7 @@ def setup(service, config, setup_db=True, register_mq_exchanges=True,
         tb_msg = traceback.format_exc()
         if 'log.setLevel' in tb_msg:
             msg = 'Invalid log level selected. Log level names need to be all uppercase.'
-            msg += '\n\n' + tb_msg
+            msg += '\n\n' + getattr(e, 'message', str(e))
             raise KeyError(msg)
         else:
             raise e

--- a/st2common/tests/unit/test_service_setup.py
+++ b/st2common/tests/unit/test_service_setup.py
@@ -52,8 +52,22 @@ datefmt=
 
 
 class ServiceSetupTestCase(CleanFilesTestCase):
-    def test_invalid_log_level_friendly_error_message(self):
+    def test_no_logging_config_found(self):
+        def mock_get_logging_config_path():
+            return ''
 
+        config.get_logging_config_path = mock_get_logging_config_path
+
+        expected_msg = "No section: .*"
+        self.assertRaisesRegexp(Exception, expected_msg,
+                                service_setup.setup, service='api',
+                                config=config,
+                                setup_db=False, register_mq_exchanges=False,
+                                register_signal_handlers=False,
+                                register_internal_trigger_types=False,
+                                run_migrations=False)
+
+    def test_invalid_log_level_friendly_error_message(self):
         _, mock_logging_config_path = tempfile.mkstemp()
         self.to_delete_files.append(mock_logging_config_path)
 
@@ -66,7 +80,8 @@ class ServiceSetupTestCase(CleanFilesTestCase):
         config.get_logging_config_path = mock_get_logging_config_path
 
         expected_msg = 'Invalid log level selected. Log level names need to be all uppercase'
-        self.assertRaisesRegexp(KeyError, expected_msg, service_setup.setup, service='api',
+        self.assertRaisesRegexp(KeyError, expected_msg,
+                                service_setup.setup, service='api',
                                 config=config,
                                 setup_db=False, register_mq_exchanges=False,
                                 register_signal_handlers=False,

--- a/st2common/tests/unit/test_service_setup.py
+++ b/st2common/tests/unit/test_service_setup.py
@@ -1,0 +1,74 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tempfile
+
+from st2common import service_setup
+
+from st2tests.base import CleanFilesTestCase
+from st2tests import config
+
+__all__ = [
+    'ServiceSetupTestCase'
+]
+
+MOCK_LOGGING_CONFIG_INVALID_LOG_LEVEL = """
+[loggers]
+keys=root
+
+[handlers]
+keys=consoleHandler
+
+[formatters]
+keys=simpleConsoleFormatter
+
+[logger_root]
+level=invalid_log_level
+handlers=consoleHandler
+
+[handler_consoleHandler]
+class=StreamHandler
+level=DEBUG
+formatter=simpleConsoleFormatter
+args=(sys.stdout,)
+
+[formatter_simpleConsoleFormatter]
+class=st2common.logging.formatters.ConsoleLogFormatter
+format=%(asctime)s %(levelname)s [-] %(message)s
+datefmt=
+""".strip()
+
+
+class ServiceSetupTestCase(CleanFilesTestCase):
+    def test_invalid_log_level_friendly_error_message(self):
+
+        _, mock_logging_config_path = tempfile.mkstemp()
+        self.to_delete_files.append(mock_logging_config_path)
+
+        with open(mock_logging_config_path, 'w') as fp:
+            fp.write(MOCK_LOGGING_CONFIG_INVALID_LOG_LEVEL)
+
+        def mock_get_logging_config_path():
+            return mock_logging_config_path
+
+        config.get_logging_config_path = mock_get_logging_config_path
+
+        expected_msg = 'Invalid log level selected. Log level names need to be all uppercase'
+        self.assertRaisesRegexp(KeyError, expected_msg, service_setup.setup, service='api',
+                                config=config,
+                                setup_db=False, register_mq_exchanges=False,
+                                register_signal_handlers=False,
+                                register_internal_trigger_types=False,
+                                run_migrations=False)


### PR DESCRIPTION
This pull request updates logging code to print a more user-friendly error message in case user selected an invalid log message.

In addition to that, I noticed existing code overwrote original exception class and always re-threw `Exception`. This pull request fixes that and preserves class of the original exception.

Resolves #3513.