### PR TITLE
Datastore Service - Get Token TTL from configured max

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -66,6 +66,11 @@ Fixed
   Reported by Simas Čepaitis.
 * Fix ``st2ctl register`` failure to register rules in some race conditions.
   ``st2-register-content`` will now register internal trigger types by default. (bug-fix) #3542
+* Correctly use service token TTL when generating temporary token for datastore service. This
+  fixes a bug and allows user to set TTL value for non service tokens to less than 24 hours.
+  (bug fix) #3523 #3524
+
+  Reported by theuiz.
 
 2.3.0 - June 19, 2017
 ---------------------

--- a/st2actions/st2actions/container/base.py
+++ b/st2actions/st2actions/container/base.py
@@ -17,6 +17,8 @@ import json
 import sys
 import traceback
 
+from oslo_config import cfg
+
 from st2common import log as logging
 from st2common.util import date as date_utils
 from st2common.constants import action as action_constants
@@ -277,7 +279,9 @@ class RunnerContainer(object):
             'live_action_id': str(liveaction_db.id)
 
         }
-        token_db = access.create_token(username=user, metadata=metadata, service=True)
+
+        ttl = cfg.CONF.auth.service_token_ttl
+        token_db = access.create_token(username=user, ttl=ttl, metadata=metadata, service=True)
         return token_db
 
     def _delete_auth_token(self, auth_token):

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -210,8 +210,10 @@ def register_opts(ignore_errors=False):
         cfg.StrOpt('api_url', default=None,
                    help='Base URL to the API endpoint excluding the version'),
         cfg.BoolOpt('enable', default=True, help='Enable authentication middleware.'),
-        cfg.IntOpt('token_ttl', default=86400, help='Access token ttl in seconds.'),
-        cfg.IntOpt('service_token_ttl', default=86400, help='Service token ttl in seconds.')
+        cfg.IntOpt('token_ttl', default=(24 * 60 * 60), help='Access token ttl in seconds.'),
+        # This TTL is used for tokens which belong to StackStorm services
+        cfg.IntOpt('service_token_ttl', default=(24 * 60 * 60),
+                   help='Service token ttl in seconds.')
     ]
     do_register_opts(auth_opts, 'auth', ignore_errors)
 

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -210,7 +210,8 @@ def register_opts(ignore_errors=False):
         cfg.StrOpt('api_url', default=None,
                    help='Base URL to the API endpoint excluding the version'),
         cfg.BoolOpt('enable', default=True, help='Enable authentication middleware.'),
-        cfg.IntOpt('token_ttl', default=86400, help='Access token ttl in seconds.')
+        cfg.IntOpt('token_ttl', default=86400, help='Access token ttl in seconds.'),
+        cfg.IntOpt('service_token_ttl', default=86400, help='Service token ttl in seconds.')
     ]
     do_register_opts(auth_opts, 'auth', ignore_errors)
 

--- a/st2common/st2common/services/datastore.py
+++ b/st2common/st2common/services/datastore.py
@@ -214,9 +214,9 @@ class DatastoreService(object):
 
         if not self._client or token_expire:
             self._logger.audit('Creating new Client object.')
-            ttl = cfg.CONF.auth.token_ttl
+            ttl = cfg.CONF.auth.service_token_ttl
             self._token_expire = get_datetime_utc_now() + timedelta(seconds=ttl)
-            temporary_token = create_token(username=self._api_username, ttl=ttl)
+            temporary_token = create_token(username=self._api_username, ttl=ttl, service=True)
             api_url = get_full_public_api_url()
             self._client = Client(api_url=api_url, token=temporary_token.token)
 

--- a/st2common/st2common/services/datastore.py
+++ b/st2common/st2common/services/datastore.py
@@ -14,6 +14,9 @@
 # limitations under the License.
 
 from datetime import timedelta
+
+from oslo_config import cfg
+
 from st2client.client import Client
 from st2client.models import KeyValuePair
 from st2common.services.access import create_token
@@ -211,7 +214,7 @@ class DatastoreService(object):
 
         if not self._client or token_expire:
             self._logger.audit('Creating new Client object.')
-            ttl = (24 * 60 * 60)
+            ttl = cfg.CONF.auth.token_ttl
             self._token_expire = get_datetime_utc_now() + timedelta(seconds=ttl)
             temporary_token = create_token(username=self._api_username, ttl=ttl)
             api_url = get_full_public_api_url()

--- a/st2reactor/st2reactor/container/process_container.py
+++ b/st2reactor/st2reactor/container/process_container.py
@@ -23,6 +23,7 @@ from collections import defaultdict
 
 import eventlet
 from eventlet.support import greenlets as greenlet
+from oslo_config import cfg
 
 from st2common import log as logging
 from st2common.constants.error_messages import PACK_VIRTUALENV_DOESNT_EXIST
@@ -290,7 +291,7 @@ class ProcessSensorContainer(object):
                                                     inherit_parent_virtualenv=True)
 
         # Include full api URL and API token specific to that sensor
-        ttl = (24 * 60 * 60)
+        ttl = cfg.CONF.auth.service_token_ttl
         metadata = {
             'service': 'sensors_container',
             'sensor_path': sensor['file_path'],


### PR DESCRIPTION
Fixes #3523 

Datastore should get its TTL from the configured max instead of hard-coded value. Without this change if `token_ttl` is set to a value `<` the default any python action that access the data service will throw an error.