### PR TITLE
Add missing passpharse argument to the remote script runner

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,10 @@ in development
   published inside action-chain workflow are stored and displayed by default. #3518 #3519
 
   Reported by Jacob Floyd.
+* Add suppor for ``passphrase`` parameter to ``remote-shell-script`` runner and as such, support
+  for password protected SSH key files. (improvement)
+
+  Reported by Sibiraja L, Nick Maludy.
 
 2.3.0 - June 19, 2017
 ---------------------

--- a/contrib/runners/remote_script_runner/runner.yaml
+++ b/contrib/runners/remote_script_runner/runner.yaml
@@ -38,6 +38,11 @@
       description: Default to parallel execution.
       immutable: true
       type: boolean
+    passphrase:
+      description: Passphrase for the private key, if needed.
+      required: false
+      secret: true
+      type: string
     password:
       description: Password used to log in. If not provided, private key from the
         config file is used.

--- a/st2actions/tests/unit/test_paramiko_ssh_runner.py
+++ b/st2actions/tests/unit/test_paramiko_ssh_runner.py
@@ -143,7 +143,7 @@ class ParamikoSSHRunnerTestCase(unittest2.TestCase):
         }
         mock_client.assert_called_with(**expected_kwargs)
 
-        # Private key provided as path to the private key file + passpharse
+        # Private key provided as path to the private key file + passphrase
         runner = Runner('id')
         runner.context = {}
         runner_parameters = {


### PR DESCRIPTION
It looks like remote shell script runner was missing `passphrase` parameter and as such, password / passphrase supported private SSH key files were not supported (remote command runner supports it just fine).