### PR TITLE
Update config loader to correctly handle default values which are falsey (None, False, {}, etc.)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,7 +44,10 @@ Fixed
   resolved. (bug-fix) #3487 #3496
 
   Reported by Chris Katzmann, Nick Maludy.
+* Update config loader so it correctly handles config schema default values which are falsey
+  (``False``, ``None``, ``0``, etc.) (bug-fix) #3504 #3531
 
+  Reported by Simas Čepaitis.
 
 2.3.0 - June 19, 2017
 ---------------------

--- a/st2common/st2common/util/config_loader.py
+++ b/st2common/st2common/util/config_loader.py
@@ -35,8 +35,6 @@ __all__ = [
 
 LOG = logging.getLogger(__name__)
 
-DEFAULT_VALUE_MAGIC_MARKER = '~~***---%%--%%--%--%%%***~~~+++'
-
 
 class ContentPackConfigLoader(object):
     """
@@ -155,13 +153,14 @@ class ContentPackConfigLoader(object):
         :rtype: ``dict``
         """
         for schema_item_key, schema_item in six.iteritems(schema):
-            default_value = schema_item.get('default', DEFAULT_VALUE_MAGIC_MARKER)
+            has_default_value = 'default' in schema_item
+            has_config_value = schema_item_key in config
+
+            default_value = schema_item.get('default', None)
             is_object = schema_item.get('type', None) == 'object'
             has_properties = schema_item.get('properties', None)
-            config_value = config.get(schema_item_key, DEFAULT_VALUE_MAGIC_MARKER)
 
-            if (default_value != DEFAULT_VALUE_MAGIC_MARKER and
-                    config_value == DEFAULT_VALUE_MAGIC_MARKER):
+            if has_default_value and not has_config_value:
                 # Config value is not provided, but default value is, use a default value
                 config[schema_item_key] = default_value
 

--- a/st2common/st2common/util/config_loader.py
+++ b/st2common/st2common/util/config_loader.py
@@ -35,6 +35,8 @@ __all__ = [
 
 LOG = logging.getLogger(__name__)
 
+DEFAULT_VALUE_MAGIC_MARKER = '~~***---%%--%%--%--%%%***~~~+++'
+
 
 class ContentPackConfigLoader(object):
     """
@@ -153,11 +155,14 @@ class ContentPackConfigLoader(object):
         :rtype: ``dict``
         """
         for schema_item_key, schema_item in six.iteritems(schema):
-            default_value = schema_item.get('default', None)
+            default_value = schema_item.get('default', DEFAULT_VALUE_MAGIC_MARKER)
             is_object = schema_item.get('type', None) == 'object'
             has_properties = schema_item.get('properties', None)
+            config_value = config.get(schema_item_key, DEFAULT_VALUE_MAGIC_MARKER)
 
-            if default_value and not config.get(schema_item_key, None):
+            if (default_value != DEFAULT_VALUE_MAGIC_MARKER and
+                    config_value == DEFAULT_VALUE_MAGIC_MARKER):
+                # Config value is not provided, but default value is, use a default value
                 config[schema_item_key] = default_value
 
             # Inspect nested object properties

--- a/st2common/tests/unit/test_config_loader.py
+++ b/st2common/tests/unit/test_config_loader.py
@@ -142,6 +142,8 @@ class ContentPackConfigLoaderTestCase(CleanDbTestCase):
         self.assertEqual(config['key_with_default_falsy_value_3'], {})
         self.assertEqual(config['key_with_default_falsy_value_4'], '')
         self.assertEqual(config['key_with_default_falsy_value_5'], 0)
+        self.assertEqual(config['key_with_default_falsy_value_6']['key_1'], False)
+        self.assertEqual(config['key_with_default_falsy_value_6']['key_2'], 0)
 
         # 2. Default values are overwrriten with config values which are also falsey
         values = {
@@ -150,6 +152,9 @@ class ContentPackConfigLoaderTestCase(CleanDbTestCase):
             'key_with_default_falsy_value_3': False,
             'key_with_default_falsy_value_4': None,
             'key_with_default_falsy_value_5': {},
+            'key_with_default_falsy_value_6': {
+                'key_2': False
+            }
         }
         config_db = ConfigDB(pack=pack_name, values=values)
         config_db = Config.add_or_update(config_db)
@@ -162,6 +167,8 @@ class ContentPackConfigLoaderTestCase(CleanDbTestCase):
         self.assertEqual(config['key_with_default_falsy_value_3'], False)
         self.assertEqual(config['key_with_default_falsy_value_4'], None)
         self.assertEqual(config['key_with_default_falsy_value_5'], {})
+        self.assertEqual(config['key_with_default_falsy_value_6']['key_1'], False)
+        self.assertEqual(config['key_with_default_falsy_value_6']['key_2'], False)
 
     def test_get_config_nested_schema_default_values_from_config_schema_are_used(self):
         # Special case for more complex config schemas with attributes ntesting.

--- a/st2common/tests/unit/test_config_loader.py
+++ b/st2common/tests/unit/test_config_loader.py
@@ -140,6 +140,8 @@ class ContentPackConfigLoaderTestCase(CleanDbTestCase):
         self.assertEqual(config['key_with_default_falsy_value_1'], False)
         self.assertEqual(config['key_with_default_falsy_value_2'], None)
         self.assertEqual(config['key_with_default_falsy_value_3'], {})
+        self.assertEqual(config['key_with_default_falsy_value_4'], '')
+        self.assertEqual(config['key_with_default_falsy_value_5'], 0)
 
     def test_get_config_nested_schema_default_values_from_config_schema_are_used(self):
         # Special case for more complex config schemas with attributes ntesting.

--- a/st2common/tests/unit/test_config_loader.py
+++ b/st2common/tests/unit/test_config_loader.py
@@ -130,7 +130,7 @@ class ContentPackConfigLoaderTestCase(CleanDbTestCase):
         config = loader.get_config()
         self.assertEqual(config['region'], 'default-region-value')
 
-    def test_default_values_are_used_when_default_values_are_falsy(self):
+    def test_default_values_are_used_when_default_values_are_falsey(self):
         pack_name = 'dummy_pack_17'
 
         loader = ContentPackConfigLoader(pack_name=pack_name)
@@ -142,6 +142,26 @@ class ContentPackConfigLoaderTestCase(CleanDbTestCase):
         self.assertEqual(config['key_with_default_falsy_value_3'], {})
         self.assertEqual(config['key_with_default_falsy_value_4'], '')
         self.assertEqual(config['key_with_default_falsy_value_5'], 0)
+
+        # 2. Default values are overwrriten with config values which are also falsey
+        values = {
+            'key_with_default_falsy_value_1': 0,
+            'key_with_default_falsy_value_2': '',
+            'key_with_default_falsy_value_3': False,
+            'key_with_default_falsy_value_4': None,
+            'key_with_default_falsy_value_5': {},
+        }
+        config_db = ConfigDB(pack=pack_name, values=values)
+        config_db = Config.add_or_update(config_db)
+
+        loader = ContentPackConfigLoader(pack_name=pack_name)
+        config = loader.get_config()
+
+        self.assertEqual(config['key_with_default_falsy_value_1'], 0)
+        self.assertEqual(config['key_with_default_falsy_value_2'], '')
+        self.assertEqual(config['key_with_default_falsy_value_3'], False)
+        self.assertEqual(config['key_with_default_falsy_value_4'], None)
+        self.assertEqual(config['key_with_default_falsy_value_5'], {})
 
     def test_get_config_nested_schema_default_values_from_config_schema_are_used(self):
         # Special case for more complex config schemas with attributes ntesting.

--- a/st2common/tests/unit/test_config_loader.py
+++ b/st2common/tests/unit/test_config_loader.py
@@ -130,6 +130,17 @@ class ContentPackConfigLoaderTestCase(CleanDbTestCase):
         config = loader.get_config()
         self.assertEqual(config['region'], 'default-region-value')
 
+    def test_default_values_are_used_when_default_values_are_falsy(self):
+        pack_name = 'dummy_pack_17'
+
+        loader = ContentPackConfigLoader(pack_name=pack_name)
+        config = loader.get_config()
+
+        # 1. Default values are used
+        self.assertEqual(config['key_with_default_falsy_value_1'], False)
+        self.assertEqual(config['key_with_default_falsy_value_2'], None)
+        self.assertEqual(config['key_with_default_falsy_value_3'], {})
+
     def test_get_config_nested_schema_default_values_from_config_schema_are_used(self):
         # Special case for more complex config schemas with attributes ntesting.
         # Validate that the default values are also used for one level nested object properties.

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_17/config.schema.yaml
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_17/config.schema.yaml
@@ -29,3 +29,11 @@
     type: "object"
     required: True
     default: {}
+  key_with_default_falsy_value_4:
+    type: "string"
+    required: True
+    default: ""
+  key_with_default_falsy_value_5:
+    type: "number"
+    required: True
+    default: 0

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_17/config.schema.yaml
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_17/config.schema.yaml
@@ -37,3 +37,15 @@
     type: "number"
     required: True
     default: 0
+  key_with_default_falsy_value_6:
+    type: "object"
+    required: True
+    properties:
+      key_1:
+        type: "boolean"
+        required: true
+        default: False
+      key_2:
+        type: "integer"
+        required: true
+        default: 0

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_17/config.schema.yaml
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_17/config.schema.yaml
@@ -1,0 +1,31 @@
+---
+  api_key:
+    type: "string"
+    required: true
+  api_secret:
+    type: "string"
+    secret: true
+    required: true
+  regions:
+    type: "array"
+    required: true
+    default: "us-east-1"
+  private_key_path:
+    type: "string"
+    required: false
+  region:
+    type: "string"
+    required: true
+    default: "default-region-value"
+  key_with_default_falsy_value_1:
+    type: "boolean"
+    required: True
+    default: False
+  key_with_default_falsy_value_2:
+    type: "boolean"
+    required: True
+    default: null
+  key_with_default_falsy_value_3:
+    type: "object"
+    required: True
+    default: {}

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_17/config.yaml
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_17/config.yaml
@@ -1,6 +1,0 @@
-api_key: ""
-api_secret: ""
-regions:
-  - "us-west-1"
-  - "us-east-1"
-private_key_path: null

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_17/config.yaml
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_17/config.yaml
@@ -1,0 +1,6 @@
+api_key: ""
+api_secret: ""
+regions:
+  - "us-west-1"
+  - "us-east-1"
+private_key_path: null

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_17/pack.yaml
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_17/pack.yaml
@@ -1,0 +1,6 @@
+---
+name : Dummy Pack 8 Invalid Name
+description : dummy pack
+version : 0.1.0
+author : st2-dev
+email : info@stackstorm.com

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_17/pack.yaml
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_17/pack.yaml
@@ -1,5 +1,5 @@
 ---
-name : Dummy Pack 8 Invalid Name
+name : Dummy Pack 17
 description : dummy pack
 version : 0.1.0
 author : st2-dev


### PR DESCRIPTION
This pull request works on top of #3504.

I decided to start with the test approach (failing test) and work from there to be sure we don't introduce any regressions.

Instead of using `setdefault` which caused a bunch of other issues with tests I decided to go with a "magic" value which is very unlikely to appear in the config as a default value or otherwise.