### PR TITLE
Log API responses under DEBUG log level instead of INFO

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,8 +32,8 @@ Changed
   published inside action-chain workflow are stored and displayed by default. #3518 #3519
 
   Reported by Jacob Floyd.
-* To reduce API service log clutter, log whole API responses (API controller response body)
-  under ``DEBUG`` log level instead of under ``INFO``. (improvement) #3539
+* Reduce API service (``st2api``) log clutter and log whole API response (API controller method
+  return value / response body) under ``DEBUG`` log level instead of ``INFO``. (improvement) #3539
 
   Reported by Sibiraja L.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,10 @@ Changed
   published inside action-chain workflow are stored and displayed by default. #3518 #3519
 
   Reported by Jacob Floyd.
+* To reduce API service log clutter, log whole API responses (API controller response body)
+  under ``DEBUG`` log level instead of under ``INFO``. (improvement) #3539
+
+  Reported by Sibiraja L.
 
 Fixed
 ~~~~~

--- a/st2common/st2common/middleware/logging.py
+++ b/st2common/st2common/middleware/logging.py
@@ -96,7 +96,9 @@ class LoggingMiddleware(object):
         LOG.info(log_msg, extra=values)
 
         if log_result:
-            controller_result = retval[0]
-            LOG.debug(controller_result, extra=values)
+            values['result'] = retval[0]
+            log_msg = ('%(request_id)s - %(status)s %(content_length)s %(runtime)sms\n%(result)s' %
+                      (values))
+            LOG.debug(log_msg, extra=values)
 
         return retval

--- a/st2common/st2common/middleware/logging.py
+++ b/st2common/st2common/middleware/logging.py
@@ -73,11 +73,13 @@ class LoggingMiddleware(object):
         except NotFoundException:
             endpoint = {}
 
+        log_result = endpoint.get('x-log-result', True)
+
         if isinstance(retval, types.GeneratorType):
+            # Note: We don't log the result when return value is a generator, because this would
+            # result in calling str() on the generator and as such, exhausting it
             content_length = [float('inf')]
             log_result = False
-        else:
-            log_result = True
 
         # Log the response
         values = {
@@ -90,13 +92,11 @@ class LoggingMiddleware(object):
             'request_id': request.headers.get(REQUEST_ID_HEADER, None)
         }
 
-        controller_result = retval[0]
-
         log_msg = '%(request_id)s - %(status)s %(content_length)s %(runtime)sms' % (values)
-
         LOG.info(log_msg, extra=values)
 
         if log_result:
+            controller_result = retval[0]
             LOG.debug(controller_result, extra=values)
 
         return retval

--- a/st2common/st2common/middleware/logging.py
+++ b/st2common/st2common/middleware/logging.py
@@ -73,13 +73,13 @@ class LoggingMiddleware(object):
         except NotFoundException:
             endpoint = {}
 
-        log_result = endpoint.get('x-log-result', True)
-
         if isinstance(retval, types.GeneratorType):
             content_length = [float('inf')]
             log_result = False
+        else:
+            log_result = True
 
-        # Log the incoming request
+        # Log the response
         values = {
             'method': request.method,
             'path': request.path,
@@ -90,13 +90,13 @@ class LoggingMiddleware(object):
             'request_id': request.headers.get(REQUEST_ID_HEADER, None)
         }
 
-        if log_result:
-            values['result'] = retval[0]
-            log_msg = '%(request_id)s - %(status)s %(content_length)s %(runtime)sms\n%(result)s'\
-                      % values
-        else:
-            log_msg = '%(request_id)s - %(status)s %(content_length)s %(runtime)sms' % values
+        controller_result = retval[0]
+
+        log_msg = '%(request_id)s - %(status)s %(content_length)s %(runtime)sms' % (values)
 
         LOG.info(log_msg, extra=values)
+
+        if log_result:
+            LOG.debug(controller_result, extra=values)
 
         return retval


### PR DESCRIPTION
When moving to API v2.0 we changed the code to always log whole API responses (raw data returned by the controller method) if API endpoint doesn't explicitly declare `x-log-result: True` attribute (we did this for API endpoints which return a lot of data).

I think better way to handle that is to log responses under `DEBUG` level. That's what we did in the past and logging it under `INFO` causes too much log clutter and makes it easier to miss more important messages.