### PR TITLE
Register internal trigger types in the init / setup phase of st2-register-content script

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,6 +54,8 @@ Fixed
   (``False``, ``None``, ``0``, etc.) (bug-fix) #3504 #3531
 
   Reported by Simas Čepaitis.
+* Fix ``st2ctl register`` failure to register rules in some race conditions.
+  ``st2-register-content`` will now register internal trigger types by default. (bug-fix) #3542
 
 2.3.0 - June 19, 2017
 ---------------------

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -375,7 +375,8 @@ def register_content():
 
 
 def setup(argv):
-    common_setup(config=config, setup_db=True, register_mq_exchanges=True)
+    common_setup(config=config, setup_db=True, register_mq_exchanges=True,
+                 register_internal_trigger_types=True)
 
 
 def teardown():

--- a/st2common/st2common/script_setup.py
+++ b/st2common/st2common/script_setup.py
@@ -62,6 +62,7 @@ def setup(config, setup_db=True, register_mq_exchanges=True,
     2. Establishes DB connection
     3. Suppress DEBUG log level if --verbose flag is not used
     4. Registers RabbitMQ exchanges
+    5. Registers internal trigger types (optional, disabled by default)
 
     :param config: Config object to use to parse args.
     """

--- a/st2common/st2common/script_setup.py
+++ b/st2common/st2common/script_setup.py
@@ -29,6 +29,7 @@ from oslo_config import cfg
 from st2common import log as logging
 from st2common.database_setup import db_setup
 from st2common.database_setup import db_teardown
+from st2common import triggers
 from st2common.logging.filters import LogLevelFilter
 from st2common.transport.bootstrap_utils import register_exchanges_with_retry
 
@@ -50,7 +51,8 @@ def register_common_cli_options():
     cfg.CONF.register_cli_opt(cfg.BoolOpt('verbose', short='v', default=False))
 
 
-def setup(config, setup_db=True, register_mq_exchanges=True):
+def setup(config, setup_db=True, register_mq_exchanges=True,
+          register_internal_trigger_types=False):
     """
     Common setup function.
 
@@ -90,6 +92,9 @@ def setup(config, setup_db=True, register_mq_exchanges=True):
 
     if register_mq_exchanges:
         register_exchanges_with_retry()
+
+    if register_internal_trigger_types:
+        triggers.register_internal_trigger_types()
 
 
 def teardown():

--- a/st2common/st2common/triggers.py
+++ b/st2common/st2common/triggers.py
@@ -47,7 +47,7 @@ def _register_internal_trigger_type(trigger_definition):
 
     # trigger types with parameters do no require a shadow trigger.
     if trigger_type_db and not trigger_type_db.parameters_schema:
-        LOG.info('Registered trigger: %s.', trigger_definition['name'])
+        LOG.debug('Registered trigger: %s.', trigger_definition['name'])
         try:
             trigger_db = create_shadow_trigger(trigger_type_db)
 

--- a/st2common/st2common/triggers.py
+++ b/st2common/st2common/triggers.py
@@ -23,6 +23,8 @@ from st2common import log as logging
 from st2common.constants.triggers import (INTERNAL_TRIGGER_TYPES, ACTION_SENSOR_TRIGGER)
 from st2common.exceptions.db import StackStormDBObjectConflictError
 from st2common.services.triggers import create_trigger_type_db, create_shadow_trigger
+from st2common.services.triggers import get_trigger_type_db
+from st2common.models.system.common import ResourceReference
 
 __all__ = [
     'register_internal_trigger_types'
@@ -35,13 +37,16 @@ def _register_internal_trigger_type(trigger_definition):
     try:
         trigger_type_db = create_trigger_type_db(trigger_type=trigger_definition)
     except (NotUniqueError, StackStormDBObjectConflictError):
-        # We ignore conflict error since this operation is idempodent and race is not an
-        # issue
-        LOG.debug('Trigger type "%s" already exists, ignoring...' %
-                  (trigger_definition['name']), exc_info=True)
+        # We ignore conflict error since this operation is idempotent and race is not an issue
+        LOG.debug('Trigger type "%s" already exists, ignoring...' % (trigger_definition['name']),
+                  exc_info=True)
+
+        ref = ResourceReference.to_string_reference(name=trigger_definition['name'],
+                                                    pack=trigger_definition['pack'])
+        trigger_type_db = get_trigger_type_db(ref)
 
     # trigger types with parameters do no require a shadow trigger.
-    if not trigger_type_db.parameters_schema:
+    if trigger_type_db and not trigger_type_db.parameters_schema:
         LOG.info('Registered trigger: %s.', trigger_definition['name'])
         try:
             trigger_db = create_shadow_trigger(trigger_type_db)

--- a/st2common/st2common/triggers.py
+++ b/st2common/st2common/triggers.py
@@ -38,21 +38,23 @@ def _register_internal_trigger_type(trigger_definition):
         trigger_type_db = create_trigger_type_db(trigger_type=trigger_definition)
     except (NotUniqueError, StackStormDBObjectConflictError):
         # We ignore conflict error since this operation is idempotent and race is not an issue
-        LOG.debug('Trigger type "%s" already exists, ignoring...' % (trigger_definition['name']),
-                  exc_info=True)
+        LOG.debug('Internal trigger type "%s" already exists, ignoring...' %
+                  (trigger_definition['name']), exc_info=True)
 
         ref = ResourceReference.to_string_reference(name=trigger_definition['name'],
                                                     pack=trigger_definition['pack'])
         trigger_type_db = get_trigger_type_db(ref)
 
+    if trigger_type_db:
+        LOG.debug('Registered internal trigger: %s.', trigger_definition['name'])
+
     # trigger types with parameters do no require a shadow trigger.
     if trigger_type_db and not trigger_type_db.parameters_schema:
-        LOG.debug('Registered trigger: %s.', trigger_definition['name'])
         try:
             trigger_db = create_shadow_trigger(trigger_type_db)
 
             extra = {'trigger_db': trigger_db}
-            LOG.audit('Trigger created for parameter-less TriggerType. Trigger.id=%s' %
+            LOG.audit('Trigger created for parameter-less internal TriggerType. Trigger.id=%s' %
                       (trigger_db.id), extra=extra)
         except StackStormDBObjectConflictError:
             LOG.debug('Shadow trigger "%s" already exists. Ignoring.',


### PR DESCRIPTION
The should fix the race issue described in https://github.com/StackStorm/st2-packages/issues/445.

Previously we didn't register internal trigger types inside this script so if user ran this script before any of the service which register them was started (e.g. st2api, st2stream, etc.) and rules were to be registered, the script would fail with "Failed to create trigger" error.

More context and explanation in https://github.com/StackStorm/st2-packages/issues/445 and https://github.com/StackStorm/st2/pull/3538#discussion_r125071929.