### PR TITLE
Fix git URL mangling StackStorm/st2#3534

### DIFF
--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -293,7 +293,7 @@ class DownloadGitRepoAction(Action):
                 url = 'https://github.com/{}'.format(repo_url)
             else:
                 url = repo_url
-            return url if url.endswith('.git') else '{}.git'.format(url)
+            return url
 
     @staticmethod
     def _get_pack_metadata(pack_dir):


### PR DESCRIPTION
Fixes StackStorm/st2#3534.

Remove the automatic suffixing of ".git" to any pack download git repo URL that doesn't already have it.
