### PR TITLE
Incorporate unit + integration test experiments (timing improvement)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     - TASK=ci-unit NODE_INDEX=0 NODE_TOTAL=2
     - TASK=ci-unit NODE_INDEX=1 NODE_TOTAL=2
     - TASK=ci-integration
-    - TASK=ci-checks ci-packs-tests
+    - TASK="ci-checks ci-packs-tests"
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ env:
     - TASK=ci-unit NODE_INDEX=0 NODE_TOTAL=2
     - TASK=ci-unit NODE_INDEX=1 NODE_TOTAL=2
     - TASK=ci-integration
-    - TASK=ci-checks
-    - TASK=ci-packs-tests
+    - TASK=ci-checks ci-packs-tests
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,8 @@ after_success:
   - if [ ${TASK} = 'ci-unit' ] || [ ${TASK} = 'ci-integration' ]; then codecov; fi
 
 # https://docs.travis-ci.com/user/notifications/#Webhooks-Delivery-Format
-notifications:
-  webhooks:
-    #- https://ci-webhooks.stackstorm.net/webhooks/build/events
-    # See: webhook.site/#/06fde88c-1610-4c85-ba4e-d9bcacfefe4c
-    - http://webhook.site/06fde88c-1610-4c85-ba4e-d9bcacfefe4c
+#notifications:
+#  webhooks:
+#    #- https://ci-webhooks.stackstorm.net/webhooks/build/events
+#    # See: webhook.site/#/06fde88c-1610-4c85-ba4e-d9bcacfefe4c
+#    - http://webhook.site/06fde88c-1610-4c85-ba4e-d9bcacfefe4c

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
 branches:
   only:
     - master
+    - /^v[0-9]+\.[0-9]+$/
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,56 @@
+# Used old infrastructure, needed for integration tests:
+# http://docs.travis-ci.com/user/workers/standard-infrastructure/
+sudo: required
+language: python
+python:
+  - 2.7
+
+branches:
+  only:
+    - master
+
+env:
+  global:
+    - CACHE_NAME=JOB1
+  matrix:
+    - TASK=ci-unit NODE_INDEX=0 NODE_TOTAL=2
+    - TASK=ci-unit NODE_INDEX=1 NODE_TOTAL=2
+    - TASK=ci-integration
+    - TASK=ci-checks
+    - TASK=ci-packs-tests
+
+addons:
+  apt:
+    sources:
+      - mongodb-upstart
+      - sourceline: 'deb [arch=amd64] http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.4 multiverse'
+        key_url: 'https://www.mongodb.org/static/pgp/server-3.4.asc'
+    packages:
+      - mongodb-org-server
+      - mongodb-org-shell
+
+services:
+  - mongodb
+  - rabbitmq
+
+cache:
+  pip: true
+  directories:
+    - virtualenv/
+
+install:
+  - make requirements
+  - if [ ${TASK} = 'ci-unit' ] || [ ${TASK} = 'ci-integration' ]; then pip install codecov; sudo .circle/add-itest-user.sh; fi
+
+script:
+  - make ${TASK}
+
+after_success:
+  - if [ ${TASK} = 'ci-unit' ] || [ ${TASK} = 'ci-integration' ]; then codecov; fi
+
+# https://docs.travis-ci.com/user/notifications/#Webhooks-Delivery-Format
+notifications:
+  webhooks:
+    #- https://ci-webhooks.stackstorm.net/webhooks/build/events
+    # See: webhook.site/#/06fde88c-1610-4c85-ba4e-d9bcacfefe4c
+    - http://webhook.site/06fde88c-1610-4c85-ba4e-d9bcacfefe4c

--- a/Makefile
+++ b/Makefile
@@ -30,15 +30,15 @@ PYTHON_TARGET := 2.7
 REQUIREMENTS := test-requirements.txt requirements.txt
 PIP_OPTIONS := $(ST2_PIP_OPTIONS)
 
-NOSE_OPTS := --rednose --immediate
+NOSE_OPTS := --rednose --immediate --with-parallel
 NOSE_TIME := $(NOSE_TIME)
 
 ifdef NOSE_TIME
-	NOSE_OPTS := --rednose --immediate --with-timer
+	NOSE_OPTS := --rednose --immediate --with-parallel --with-timer
 endif
 
 ifndef PIP_OPTIONS
-	PIP_OPTIONS := -U -q
+	PIP_OPTIONS :=
 endif
 
 .PHONY: all
@@ -262,7 +262,7 @@ $(VIRTUALENV_DIR)/bin/activate:
 	@echo
 	@echo "==================== virtualenv ===================="
 	@echo
-	test -d $(VIRTUALENV_DIR) || virtualenv --no-site-packages $(VIRTUALENV_DIR)
+	test -f $(VIRTUALENV_DIR)/bin/activate || virtualenv --no-site-packages $(VIRTUALENV_DIR)
 
 	# Setup PYTHONPATH in bash activate script...
 	echo '' >> $(VIRTUALENV_DIR)/bin/activate
@@ -447,7 +447,7 @@ debs:
 ci: ci-checks ci-unit ci-integration ci-mistral ci-packs-tests
 
 .PHONY: ci-checks
-ci-checks: compile pylint flake8 bandit .st2client-dependencies-check .st2common-circular-dependencies-check circle-lint-api-spec .rst-check
+ci-checks: compile .pylint .flake8 .bandit .st2client-dependencies-check .st2common-circular-dependencies-check circle-lint-api-spec .rst-check
 
 .PHONY: .rst-check
 .rst-check:
@@ -457,7 +457,7 @@ ci-checks: compile pylint flake8 bandit .st2client-dependencies-check .st2common
 	. $(VIRTUALENV_DIR)/bin/activate; rstcheck --report warning CHANGELOG.rst
 
 .PHONY: ci-unit
-ci-unit: compile .unit-tests-coverage-html
+ci-unit: .unit-tests-coverage-html
 
 .PHONY: .ci-prepare-integration
 .ci-prepare-integration:

--- a/circle.yml
+++ b/circle.yml
@@ -34,7 +34,7 @@ dependencies:
 
 test:
   override:
-    - case $CIRCLE_NODE_INDEX in 0) make ci-checks ci-packs-tests ;; 1) make ci-unit ;; 2) make ci-integration ;; 3) make ci-unit ;; 4) make ci-integration ;; esac:
+    - case $CIRCLE_NODE_INDEX in 0) unset CIRCLE_NODE_TOTAL; unset CIRCLE_NODE_INDEX; make ci-checks ci-packs-tests ;; 1) unset CIRCLE_NODE_TOTAL; unset CIRCLE_NODE_INDEX; make ci-unit ;; 2) unset CIRCLE_NODE_TOTAL; unset CIRCLE_NODE_INDEX; make ci-integration ;; 3) unset CIRCLE_NODE_TOTAL; unset CIRCLE_NODE_INDEX; make ci-unit ;; 4) unset CIRCLE_NODE_TOTAL; unset CIRCLE_NODE_INDEX; make ci-integration ;; esac:
         parallel: true
   post:
     - case $CIRCLE_NODE_INDEX in 0) . virtualenv/bin/activate; st2common/bin/st2-generate-api-spec > $CIRCLE_ARTIFACTS/openapi.yaml ;; [1,2]) codecov ;; esac:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -15,10 +15,12 @@ sphinx-autobuild
 # nosetests enhancements
 rednose
 nose-timer
+# splitting tests run on a separate CI machines
+nose-parallel
 # Required by st2client tests
-pyyaml
+pyyaml<4.0,>=3.12
 RandomWords
-gunicorn>=19.3.0,<19.4
+gunicorn==19.6.0
 psutil
 webtest==2.0.25
 rstcheck>=3.1.0,<3.2


### PR DESCRIPTION
> Related to https://github.com/StackStorm/st2ci/issues/94

Resulting config from the https://github.com/armab/st2/pull/3 prev. week experiments to improve the unit+integration test timing.
![](https://i.imgur.com/ZdpWdq1.png)
The build timing is now `7-10mins` for unit + integration + lint checks, comparing to old `25-30mins`.

As suggested 1yr. ago https://github.com/StackStorm/discussions/issues/143#issuecomment-184856516  avoid putting all eggs in Circle which was there only for packaging because of really advanced and unique features. But we don't need all that + cryptic UI for unit + integration tests. Also we'll suffer from the queue.

---

This change is the part of the bigger game/plan, but for now it's experimental and I'm not changing any workflows yet. Just seeing how it behaves under the load. We'll see just another :white_check_mark: in GitHub status which is OK to ignore. I may experiment with more checks later.
