### PR TITLE
Experimental/circle 2.0 st2-packages (timing improvements) (executorType: Docker)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -45,7 +45,7 @@ jobs:
           name: Copy st2-packages files to build containers
           command: |
             # creating dummy container which will hold a volume with data files
-            docker create -v /root/st2-packages -v /root/build -v /var/log/st2 -v /var/log/mistral --name st2-packages-vol alpine:3.4 /bin/true
+            docker create -v /root/st2-packages -v /root/build -v /var/log/st2 -v /var/log/mistral -v /root/.cache/pip -v /tmp/wheelhouse --name st2-packages-vol alpine:3.4 /bin/true
             # copy st2-packages data files into this volume
             docker cp ~/st2-packages st2-packages-vol:/root
 
@@ -56,23 +56,20 @@ jobs:
 
       - run:
           name: Build the packages
-          command: docker-compose run trusty build
+          command: |
+            docker-compose run trusty build
+            # Once build container finishes we can copy packages directly from it
+            docker cp st2-packages-vol:/root/build /tmp/st2-packages
           working_directory: ~/st2-packages
 
       - run:
-          name: Copy produced artifacts back
-          command: |
-            # once application container finishes we can copy artifacts directly from it
-            mkdir -p /tmp/st2-packages
-            docker cp st2-packages-vol:/root/build /tmp/st2-packages
-            mkdir -p /tmp/st2-packages/log/st2
-            docker cp st2-packages-vol:/var/log/st2 /tmp/st2-packages/log/st2
-            mkdir -p /tmp/st2-packages/log/mistral
-            docker cp st2-packages-vol:/var/log/mistral /tmp/st2-packages/log/mistral
-
-      - run:
           name: Test the packages
-          command: docker-compose run trusty test
+          command: |
+            docker-compose run trusty test
+            # Once test container finishes we can copy logs directly from it
+            mkdir -p /tmp/st2-packages/log
+            docker cp st2-packages-vol:/var/log/st2 /tmp/st2-packages/log/st2
+            docker cp st2-packages-vol:/var/log/mistral /tmp/st2-packages/log/mistral
           working_directory: ~/st2-packages
 
       - store_artifacts:

--- a/circle.yml
+++ b/circle.yml
@@ -72,6 +72,7 @@ jobs:
       - run:
           name: Build the packages
           command: |
+            docker-compose run trusty build
             .circle/docker-compose.sh build ${DISTRO}
             # Once build container finishes we can copy packages directly from it
             docker cp st2-packages-vol:/root/build /tmp/st2-packages

--- a/circle.yml
+++ b/circle.yml
@@ -36,7 +36,7 @@ jobs:
           name: Download st2-packages repository
           command: |
             set -x
-            git clone --depth 1 ${ST2_PACKAGES_REPO} ~/st2-packages
+            git clone ${ST2_PACKAGES_REPO} ~/st2-packages
             cd ~/st2-packages
             git checkout ${CIRCLE_BRANCH} || true
 

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ jobs:
       - DOCKER_VERSION: 17.03.0-ce
       - DOCKER_COMPOSE_VERSION: 1.14.0
       - COMPOSE_FILE: docker-compose.circle2.yml:docker-compose.override.yml
-      - BASH_ENV: ~/.buildenv
+      - CIRCLE_ENV: ~/.buildenv
     steps:
       - checkout
       - setup_remote_docker:

--- a/circle.yml
+++ b/circle.yml
@@ -22,7 +22,6 @@ jobs:
           name: Install dependencies - should be done as a pre-packed Docker image later
           command: |
             set -x
-            apt-get update
             docker --version
             docker-compose --version
 #            apt-get install -y curl git bash

--- a/circle.yml
+++ b/circle.yml
@@ -40,6 +40,21 @@ jobs:
           working_directory: ~/st2-packages
 
       - run:
+          # Workaround for CircleCI docker-compose limtation where volumes don't work
+          # See detailed explanation: https://circleci.com/docs/2.0/building-docker-images/#mounting-folders
+          name: Copy st2-packages files to build containers
+          command: |
+            # creating dummy container which will hold a volume with data files
+            docker create -v /root/st2-packages --name st2-packages-vol alpine:3.4 /bin/true
+            # copy st2-packages data files into this volume
+            docker cp ~/st2-packages st2-packages-vol:/root
+
+      - run:
           name: Build the packages
           command: docker-compose run trusty build
+          working_directory: ~/st2-packages
+
+      - run:
+          name: Test the packages
+          command: docker-compose run trusty test
           working_directory: ~/st2-packages

--- a/circle.yml
+++ b/circle.yml
@@ -44,6 +44,8 @@ jobs:
           # See detailed explanation: https://circleci.com/docs/2.0/building-docker-images/#mounting-folders
           name: Copy st2-packages files to build containers
           command: |
+            # Remove st2-packages-vol container if exists in CircleCI cache
+            docker rm -f st2-packages-vol
             # creating dummy container which will hold a volume with data files
             docker create -v /root/st2-packages -v /root/build -v /var/log/st2 -v /var/log/mistral -v /root/.cache/pip -v /tmp/wheelhouse --name st2-packages-vol alpine:3.4 /bin/true
             # copy st2-packages data files into this volume

--- a/circle.yml
+++ b/circle.yml
@@ -18,21 +18,6 @@ jobs:
       - setup_remote_docker:
           reusable: true
       - run:
-          name: Initialize Build Environment
-          command: |
-            set -x
-            .circle/buildenv_st2.sh
-            .circle/buildenv_mistral.sh
-
-      - run:
-          name: Test env
-          command: export TEST_ENV=12345
-
-      - run:
-          name: Test env
-          command: echo $TEST_ENV
-
-      - run:
           name: Install dependencies - should be done as a pre-packed Docker image later
           command: |
             set -x
@@ -53,6 +38,22 @@ jobs:
             git clone ${ST2_PACKAGES_REPO} ~/st2-packages
             cd ~/st2-packages
             git checkout ${CIRCLE_BRANCH} || true
+
+      - run:
+          name: Initialize Build Environment
+          command: |
+            set -x
+            .circle/buildenv_st2.sh
+            .circle/buildenv_mistral.sh
+          working_directory: ~/st2-packages
+
+      - run:
+          name: Test env
+          command: export TEST_ENV=12345
+
+      - run:
+          name: Test env
+          command: echo $TEST_ENV
 
       - run:
           # Workaround for CircleCI docker-compose limtation where volumes don't work

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ jobs:
       - DEPLOY_PACKAGES: 0
       - DOCKER_VERSION: 17.03.0-ce
       - DOCKER_COMPOSE_VERSION: 1.14.0
-      - COMPOSE_FILE: docker-compose.circle2.yml
+      - COMPOSE_FILE: docker-compose.circle2.yml:docker-compose.override.yml
     steps:
       - checkout
       - setup_remote_docker:

--- a/circle.yml
+++ b/circle.yml
@@ -32,7 +32,7 @@ jobs:
             git checkout ${CIRCLE_BRANCH} || true
 
       - run:
-          name: Initialize Build Environment
+          name: Initialize packages Build Environment
           command: |
             set -x
             .circle/buildenv_st2.sh
@@ -50,12 +50,12 @@ jobs:
             docker cp ~/st2-packages st2-packages-vol:/root
 
       - run:
-          name: Pull the images
+          name: Pull dependent Docker Images
           command: .circle/docker-compose2.sh pull ${DISTRO}
           working_directory: ~/st2-packages
 
       - run:
-          name: Build the packages
+          name: Build the ${DISTRO} Packages
           command: |
             .circle/docker-compose2.sh build ${DISTRO}
             # Once build container finishes we can copy packages directly from it
@@ -70,7 +70,7 @@ jobs:
 #          working_directory: ~/st2-packages
 
       - run:
-          name: Test the packages
+          name: Test the Packages
           command: |
             .circle/docker-compose2.sh test ${DISTRO}
             # Once test container finishes we can copy logs directly from it
@@ -81,3 +81,9 @@ jobs:
 
       - store_artifacts:
           path: /tmp/st2-packages
+
+notify:
+  branches:
+    only:
+      - master
+      - /v[0-9]+\.[0-9]+/

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ jobs:
       - DOCKER_VERSION: 17.03.0-ce
       - DOCKER_COMPOSE_VERSION: 1.14.0
       - COMPOSE_FILE: docker-compose.circle2.yml:docker-compose.override.yml
-      - CIRCLE_ENV: ~/.buildenv
+      - BASH_ENV: ~/.buildenv
     steps:
       - checkout
       - setup_remote_docker:
@@ -66,13 +66,13 @@ jobs:
 
       - run:
           name: Pull the images
-          command: docker-compose run trusty /bin/true
+          command: .circle/docker-compose.sh pull ${DISTRO}
           working_directory: ~/st2-packages
 
       - run:
           name: Build the packages
           command: |
-            docker-compose run trusty build
+            .circle/docker-compose.sh build ${DISTRO}
             # Once build container finishes we can copy packages directly from it
             docker cp st2-packages-vol:/root/build /tmp/st2-packages
           working_directory: ~/st2-packages
@@ -87,7 +87,7 @@ jobs:
       - run:
           name: Test the packages
           command: |
-            docker-compose run trusty test
+            .circle/docker-compose.sh test ${DISTRO}
             # Once test container finishes we can copy logs directly from it
             mkdir -p /tmp/st2-packages/log
             docker cp st2-packages-vol:/var/log/st2 /tmp/st2-packages/log/st2

--- a/circle.yml
+++ b/circle.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
+        reusable: true
       - run:
           name: Install dependencies - should be done as a pre-packed Docker image later
           command: |

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ jobs:
     parallelism: 1
     docker:
       # The primary container is an instance of the first list image listed. Your build commands run in this container.
-      - image: docker/compose:1.14.0
+      - image: ubuntu:trusty
     working_directory: ~/st2
     environment:
       - DISTROS: "trusty xenial el6 el7"
@@ -14,9 +14,11 @@ jobs:
       - checkout
       - setup_remote_docker
       - run:
-          name: Install dependencies - this should be done as a pre-packed Docker image later
+          name: Install dependencies - should be done as a pre-packed Docker image later
           command: |
-            apt-get install -y sudo git
+            set -x
+            curl -L https://github.com/docker/compose/releases/download/1.14.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
+            chmod +x /usr/local/bin/docker-compose
 
       - run:
           name: Download st2-packages repository

--- a/circle.yml
+++ b/circle.yml
@@ -19,19 +19,11 @@ jobs:
       - setup_remote_docker:
           reusable: true
       - run:
-          name: Install dependencies - should be done as a pre-packed Docker image later
+          name: Docker version
           command: |
             set -x
             docker --version
             docker-compose --version
-#            apt-get install -y curl git bash
-#            # install docker client
-#            curl -L -o /tmp/docker-${DOCKER_VERSION}.tgz https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz
-#            tar -xz -C /tmp -f /tmp/docker-${DOCKER_VERSION}.tgz
-#            mv /tmp/docker/* /usr/bin
-#            # install docker compose
-#            curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
-#            chmod +x /usr/local/bin/docker-compose
 
       - run:
           name: Download st2-packages repository
@@ -51,11 +43,15 @@ jobs:
 
       - run:
           name: Test env
-          command: export TEST_ENV=12345
+          command: |
+            export TEST_ENV=12345
+            echo $TEST_ENV
 
       - run:
           name: Test env
-          command: echo $TEST_ENV
+          command: |
+            echo $TEST_ENV
+            echo $DISTRO
 
       - run:
           # Workaround for CircleCI docker-compose limtation where volumes don't work

--- a/circle.yml
+++ b/circle.yml
@@ -32,5 +32,5 @@ jobs:
 
       - run:
           name: Pull the dependent build & test Docker images
-          command: docker-compose run ${DISTRO} /bin/true
+          command: docker-compose run trusty /bin/true
           working_directory: ~/st2-packages

--- a/circle.yml
+++ b/circle.yml
@@ -17,6 +17,7 @@ jobs:
           name: Install dependencies - should be done as a pre-packed Docker image later
           command: |
             set -x
+            sudo apt install -y curl
             curl -L https://github.com/docker/compose/releases/download/1.14.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
             chmod +x /usr/local/bin/docker-compose
 

--- a/circle.yml
+++ b/circle.yml
@@ -18,6 +18,21 @@ jobs:
       - setup_remote_docker:
           reusable: true
       - run:
+          name: Initialize Build Environment
+          command: |
+            set -x
+            .circle/buildenv_st2.sh
+            .circle/buildenv_mistral.sh
+
+      - run:
+          name: Test env
+          command: export TEST_ENV=12345
+
+      - run:
+          name: Test env
+          command: echo $TEST_ENV
+
+      - run:
           name: Install dependencies - should be done as a pre-packed Docker image later
           command: |
             set -x
@@ -62,11 +77,12 @@ jobs:
             docker cp st2-packages-vol:/root/build /tmp/st2-packages
           working_directory: ~/st2-packages
 
-      - run:
-          name: Build the packages 2nd time (compare timing)
-          command: |
-            docker-compose run trusty build
-          working_directory: ~/st2-packages
+#      - run:
+#          # TODO: It works! Enable cache for pip and wheelhouse
+#          name: Build the packages 2nd time (compare timing)
+#          command: |
+#            docker-compose run trusty build
+#          working_directory: ~/st2-packages
 
       - run:
           name: Test the packages

--- a/circle.yml
+++ b/circle.yml
@@ -17,8 +17,8 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-        reusable: true    # default - false
-        exclusive: true   # default - true
+          reusable: true    # default - false
+          exclusive: true   # default - true
       - run:
           name: Docker version
           command: |

--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,6 @@ jobs:
       - checkout
       - setup_remote_docker:
           reusable: true
-          exclusive: false
       - run:
           name: Install dependencies - should be done as a pre-packed Docker image later
           command: |
@@ -52,12 +51,12 @@ jobs:
 
       - run:
           name: Pull the dependent build & test Docker images
-          command: docker-compose run xenial /bin/true
+          command: docker-compose run trusty /bin/true
           working_directory: ~/st2-packages
 
       - run:
           name: Build the packages
-          command: docker-compose run xenial build
+          command: docker-compose run trusty build
           working_directory: ~/st2-packages
 
       - run:
@@ -73,7 +72,7 @@ jobs:
 
       - run:
           name: Test the packages
-          command: docker-compose run xenial test
+          command: docker-compose run trusty test
           working_directory: ~/st2-packages
 
       - store_artifacts:

--- a/circle.yml
+++ b/circle.yml
@@ -29,3 +29,8 @@ jobs:
             git clone --depth 1 ${ST2_PACKAGES_REPO} ~/st2-packages
             cd ~/st2-packages
             git checkout ${CIRCLE_BRANCH} || true
+
+      - run:
+          name: Pull the dependent build & test Docker images
+          command: docker-compose run ${DISTRO} /bin/true
+          working_directory: ~/st2-packages

--- a/circle.yml
+++ b/circle.yml
@@ -34,3 +34,8 @@ jobs:
           name: Pull the dependent build & test Docker images
           command: docker-compose run trusty /bin/true
           working_directory: ~/st2-packages
+
+      - run:
+          name: Build the packages
+          command: docker-compose build trusty
+          working_directory: ~/st2-packages

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,8 @@ jobs:
       - DISTROS: "trusty xenial el6 el7"
       - ST2_PACKAGES_REPO: https://github.com/StackStorm/st2-packages
       - DEPLOY_PACKAGES: 0
+      #- DOCKER_COMPOSE_VERSION: 1.14.0
+      - DOCKER_COMPOSE_VERSION: 1.9.0
     steps:
       - checkout
       - setup_remote_docker:
@@ -21,7 +23,7 @@ jobs:
             set -x
             apt-get update
             apt-get install -y curl git bash
-            curl -L https://github.com/docker/compose/releases/download/1.14.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
+            curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
             chmod +x /usr/local/bin/docker-compose
 
       - run:

--- a/circle.yml
+++ b/circle.yml
@@ -42,20 +42,20 @@ jobs:
             git checkout ${CIRCLE_BRANCH} || true
 
       - run:
+          # Workaround for CircleCI docker-compose limtation where volumes don't work
+          # See detailed explanation: https://circleci.com/docs/2.0/building-docker-images/#mounting-folders
+          name: Copy st2-packages files to build containers
+          command: |
+            # creating dummy container which will hold a volume with data files
+            docker create -v /root/st2-packages -v /root/build -v /var/log/st2 -v /var/log/mistral --name st2-packages-vol alpine:3.4 /bin/true
+            # copy st2-packages data files into this volume
+            docker cp ~/st2-packages st2-packages-vol:/root
+
+      - run:
           name: Pull the dependent build & test Docker images
           command: docker-compose run trusty /bin/true
           working_directory: ~/st2-packages
 
-#      - run:
-#          # Workaround for CircleCI docker-compose limtation where volumes don't work
-#          # See detailed explanation: https://circleci.com/docs/2.0/building-docker-images/#mounting-folders
-#          name: Copy st2-packages files to build containers
-#          command: |
-#            # creating dummy container which will hold a volume with data files
-#            docker create -v /root/st2-packages -v /root/build -v /var/log/st2 -v /var/log/mistral --name st2-packages-vol alpine:3.4 /bin/true
-#            # copy st2-packages data files into this volume
-#            docker cp ~/st2-packages st2-packages-vol:/root
-#
 #      - run:
 #          name: Build the packages
 #          command: docker-compose run trusty build

--- a/circle.yml
+++ b/circle.yml
@@ -14,6 +14,7 @@ jobs:
       - checkout
       - setup_remote_docker
         reusable: true
+        exclusive: false
       - run:
           name: Install dependencies - should be done as a pre-packed Docker image later
           command: |

--- a/circle.yml
+++ b/circle.yml
@@ -14,6 +14,7 @@ jobs:
       - DOCKER_VERSION: 17.03.0-ce
       - DOCKER_COMPOSE_VERSION: 1.14.0
       - COMPOSE_FILE: docker-compose.circle2.yml:docker-compose.override.yml
+      - BASH_ENV: ~/.buildenv
     steps:
       - checkout
       - setup_remote_docker:

--- a/circle.yml
+++ b/circle.yml
@@ -7,10 +7,16 @@ jobs:
       - image: docker/compose:1.14.0
     working_directory: ~/st2
     environment:
-      - FOO: "bar"
+      - DISTROS: "trusty xenial el6 el7"
+      - ST2_PACKAGES_REPO: https://github.com/StackStorm/st2-packages
+      - DEPLOY_PACKAGES: 0
     steps:
       - checkout
       - setup_remote_docker
       - run:
-          name: YOLO
-          command: echo 'YOLO'
+          name: Download st2-packages repository
+          command: |
+            set -x
+            git clone --depth 1 ${ST2_PACKAGES_REPO} ~/st2-packages
+            cd ~/st2-packages
+            git checkout ${CIRCLE_BRANCH} || true

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,7 @@ jobs:
       - DOCKER_VERSION: 17.03.0-ce
       - DOCKER_COMPOSE_VERSION: 1.14.0
 #      - COMPOSE_FILE: docker-compose.circle2.yml
-#      - COMPOSE_FILE: docker-compose.override.yml:docker-compose.circle2.yml
+      - COMPOSE_FILE: docker-compose.override.yml:docker-compose.circle2.yml
     steps:
       - checkout
       - setup_remote_docker:

--- a/circle.yml
+++ b/circle.yml
@@ -10,8 +10,9 @@ jobs:
       - DISTROS: "trusty xenial el6 el7"
       - ST2_PACKAGES_REPO: https://github.com/StackStorm/st2-packages
       - DEPLOY_PACKAGES: 0
-      #- DOCKER_COMPOSE_VERSION: 1.14.0
-      - DOCKER_COMPOSE_VERSION: 1.9.0
+      - DOCKER_VERSION: 17.03.0-ce
+      - DOCKER_COMPOSE_VERSION: 1.14.0
+      - COMPOSE_FILE: docker-compose.circle2.yml
     steps:
       - checkout
       - setup_remote_docker:
@@ -23,6 +24,11 @@ jobs:
             set -x
             apt-get update
             apt-get install -y curl git bash
+            # install docker client
+            curl -L -o /tmp/docker-${DOCKER_VERSION}.tgz https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz
+            tar -xz -C /tmp -f /tmp/docker-${DOCKER_VERSION}.tgz
+            mv /tmp/docker/* /usr/bin
+            # install docker compose
             curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
             chmod +x /usr/local/bin/docker-compose
 
@@ -45,7 +51,7 @@ jobs:
           name: Copy st2-packages files to build containers
           command: |
             # creating dummy container which will hold a volume with data files
-            docker create -v /root/st2-packages --name st2-packages-vol alpine:3.4 /bin/true
+            docker create -v /root/st2-packages -v /root/build -v /var/log/st2 -v /var/log/mistral --name st2-packages-vol alpine:3.4 /bin/true
             # copy st2-packages data files into this volume
             docker cp ~/st2-packages st2-packages-vol:/root
 
@@ -53,6 +59,15 @@ jobs:
           name: Build the packages
           command: docker-compose run trusty build
           working_directory: ~/st2-packages
+
+      - run:
+          name: Copy produced artifacts back
+          command: |
+          # once application container finishes we can copy artifacts directly from it
+          docker cp st2packages_trusty_run_2:/root/build /tmp/st2-packages
+          docker cp st2-packages-vol:/root/build /tmp/st2-packages
+          docker cp st2-packages-vol:/var/log/st2 /tmp/st2-packages/log/st2
+          docker cp st2-packages-vol:/var/log/mistral /tmp/st2-packages/log/mistral
 
       - run:
           name: Test the packages

--- a/circle.yml
+++ b/circle.yml
@@ -12,8 +12,7 @@ jobs:
       - DEPLOY_PACKAGES: 0
       - DOCKER_VERSION: 17.03.0-ce
       - DOCKER_COMPOSE_VERSION: 1.14.0
-#      - COMPOSE_FILE: docker-compose.circle2.yml
-      - COMPOSE_FILE: docker-compose.override.yml:docker-compose.circle2.yml
+      - COMPOSE_FILE: docker-compose.circle2.yml
     steps:
       - checkout
       - setup_remote_docker:

--- a/circle.yml
+++ b/circle.yml
@@ -19,6 +19,11 @@ jobs:
       - setup_remote_docker:
           reusable: true
       - run:
+          name: Debug
+          command: |
+            echo $CIRCLE_ENV
+            ls -la $CIRCLE_ENV
+      - run:
           name: Docker version
           command: |
             set -x

--- a/circle.yml
+++ b/circle.yml
@@ -56,11 +56,11 @@ jobs:
           command: docker-compose run trusty /bin/true
           working_directory: ~/st2-packages
 
-#      - run:
-#          name: Build the packages
-#          command: docker-compose run trusty build
-#          working_directory: ~/st2-packages
-#
+      - run:
+          name: Build the packages
+          command: docker-compose run trusty build
+          working_directory: ~/st2-packages
+
 #      - run:
 #          name: Copy produced artifacts back
 #          command: |

--- a/circle.yml
+++ b/circle.yml
@@ -34,10 +34,10 @@ jobs:
 
       - run:
           name: Pull the dependent build & test Docker images
-          command: docker-compose run xenial /bin/true
+          command: docker-compose run trusty /bin/true
           working_directory: ~/st2-packages
 
       - run:
           name: Build the packages
-          command: docker-compose build xenial
+          command: docker-compose run trusty build
           working_directory: ~/st2-packages

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ jobs:
       - DEPLOY_PACKAGES: 0
       - DOCKER_VERSION: 17.03.0-ce
       - DOCKER_COMPOSE_VERSION: 1.14.0
-      - COMPOSE_FILE: docker-compose.circle2.yml
+      - COMPOSE_FILE: ~/st2-packages/docker-compose.circle2.yml
     steps:
       - checkout
       - setup_remote_docker:

--- a/circle.yml
+++ b/circle.yml
@@ -19,11 +19,6 @@ jobs:
       - setup_remote_docker:
           reusable: true
       - run:
-          name: Debug
-          command: |
-            echo $CIRCLE_ENV
-            sudo ls -la $CIRCLE_ENV
-      - run:
           name: Docker version
           command: |
             set -x

--- a/circle.yml
+++ b/circle.yml
@@ -10,10 +10,8 @@ jobs:
     environment:
       - DISTROS: "trusty xenial el6 el7"
       - ST2_PACKAGES_REPO: https://github.com/StackStorm/st2-packages
+      - ST2_PACKAGES: "st2"
       - DEPLOY_PACKAGES: 0
-      - DOCKER_VERSION: 17.03.0-ce
-      - DOCKER_COMPOSE_VERSION: 1.14.0
-      - COMPOSE_FILE: docker-compose.circle2.yml:docker-compose.override.yml
       - BASH_ENV: ~/.buildenv
     steps:
       - checkout

--- a/circle.yml
+++ b/circle.yml
@@ -16,7 +16,7 @@ jobs:
       - run:
           name: Install dependencies - this should be done as a pre-packed Docker image later
           command: |
-            sudo apt-get install -y git
+            apt-get install -y sudo git
 
       - run:
           name: Download st2-packages repository

--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,7 @@ version: 2
 jobs:
   build:
     parallelism: 4
+    # 4CPUs & 8GB RAM CircleCI machine
     resource_class: large
     docker:
       # The primary container is an instance of the first list image listed. Your build commands run in this container.
@@ -16,7 +17,8 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          reusable: true
+        reusable: true    # default - false
+        exclusive: true   # default - true
       - run:
           name: Docker version
           command: |
@@ -54,7 +56,11 @@ jobs:
 
       - run:
           name: Pull dependent Docker Images
-          command: .circle/docker-compose2.sh pull ${DISTRO}
+          command: |
+            # Clean-up running containers from the previous build
+            .circle/docker-compose2.sh clean
+            # Pull Docker images
+            .circle/docker-compose2.sh pull ${DISTRO}
           working_directory: ~/st2-packages
 
       - run:
@@ -80,6 +86,8 @@ jobs:
             mkdir -p /tmp/st2-packages/log
             docker cp st2-packages-vol:/var/log/st2 /tmp/st2-packages/log/st2
             docker cp st2-packages-vol:/var/log/mistral /tmp/st2-packages/log/mistral
+            # Clean-up running containers
+            .circle/docker-compose2.sh clean
           working_directory: ~/st2-packages
 
       - store_artifacts:

--- a/circle.yml
+++ b/circle.yml
@@ -1,48 +1,13 @@
-notify:
-  webhooks:
-    - url: https://ci-webhooks.stackstorm.net/webhooks/build/events
-
-machine:
-  services:
-    - postgresql
-    - rabbitmq-server
-  environment:
-    # We add /tmp/mongodb/bin/ directory to PATH so the correct and latest version of mongo shell
-    # binary is used.
-    PATH: /tmp/mongodb/bin/:${PATH}
-    # Enable nose timing info so per test case test timing is printed at the end
-    NOSE_TIME: "1"
-
-dependencies:
-  cache_directories:
-    - ~/.cache/pip
-  pre:
-    - sudo .circle/configure-services.sh
-    - sudo .circle/add-itest-user.sh
-    # We install and test with all the supported MongoDB versions
-    - case $CIRCLE_NODE_INDEX in [1,2]) sudo service mongodb stop ; MONGODB_VERSION=3.2.13 sudo -E .circle/install-and-run-mongodb.sh > /tmp/mongodb-install.log 2>&1 ;; [3,4]) sudo service mongodb stop ; MONGODB_VERSION=3.4.4 sudo -E .circle/install-and-run-mongodb.sh > /tmp/mongodb-install.log 2>&1 ;; esac:
-        background: true
-    # We sleep a bit to wait for the background process to start and script to
-    # finish
-    - case $CIRCLE_NODE_INDEX in [1,2]) sleep 10 ;; esac
-    # Tail the logs so it's easier to see what is going on. Sadly when using "background: true"
-    # whole output is ignored.
-    - case $CIRCLE_NODE_INDEX in [1,2]) tail -50 /tmp/mongodb-install.log ;; [3,4]) tail -50 /tmp/mongodb-install.log ;; esac
-    - sudo pip install codecov
-  override:
-    - make compile requirements
-
-test:
-  override:
-    - case $CIRCLE_NODE_INDEX in 0) make ci-checks ci-packs-tests ;; 1) make ci-unit ;; 2) make ci-integration ;; 3) make ci-unit ;; 4) make ci-integration ;; esac:
-        parallel: true
-  post:
-    - case $CIRCLE_NODE_INDEX in 0) . virtualenv/bin/activate; st2common/bin/st2-generate-api-spec > $CIRCLE_ARTIFACTS/openapi.yaml ;; [1,2]) codecov ;; esac:
-        parallel: true
-
-experimental:
-  notify:
-    branches:
-      only:
-        - master
-        - /v[0-9]+\.[0-9]+/
+version: 2
+jobs:
+  build:
+    #working_directory: ~/st2
+    docker:
+      # The primary container is an instance of the first list image listed. Your build commands run in this container.
+      - image: docker/compose:1.14.0
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: YOLO
+          command: echo 'YOLO'

--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,9 @@
 version: 2
 jobs:
   build:
-    parallelism: 1
+    parallelism: 4
     docker:
       # The primary container is an instance of the first list image listed. Your build commands run in this container.
-      #- image: ubuntu:trusty
       - image: circleci/python:2.7
     working_directory: ~/st2
     environment:

--- a/circle.yml
+++ b/circle.yml
@@ -71,14 +71,14 @@ jobs:
             docker cp st2-packages-vol:/root/build /tmp/st2-packages
           working_directory: ~/st2-packages
 
-      # TODO: It works! Enable cache for pip and wheelhouse
-      - run:
-          name: Build the ${DISTRO} Packages 2nd time (compare with pip/wheelhouse cached)
-          command: |
-            .circle/docker-compose2.sh build ${DISTRO}
-            # Once build container finishes we can copy packages directly from it
-            docker cp st2-packages-vol:/root/build /tmp/st2-packages
-          working_directory: ~/st2-packages
+#      # TODO: It works! (~0.5-1min speed-up) Enable CircleCI2.0 cache for pip and wheelhouse later
+#      - run:
+#          name: Build the ${DISTRO} Packages 2nd time (compare with pip/wheelhouse cached)
+#          command: |
+#            .circle/docker-compose2.sh build ${DISTRO}
+#            # Once build container finishes we can copy packages directly from it
+#            docker cp st2-packages-vol:/root/build /tmp/st2-packages
+#          working_directory: ~/st2-packages
 
       - run:
           name: Test the Packages

--- a/circle.yml
+++ b/circle.yml
@@ -60,16 +60,15 @@ jobs:
           command: docker-compose run trusty build
           working_directory: ~/st2-packages
 
-#      - run:
-#          name: Copy produced artifacts back
-#          command: |
-#            # once application container finishes we can copy artifacts directly from it
-#            docker cp st2packages_trusty_run_2:/root/build /tmp/st2-packages
-#            docker cp st2-packages-vol:/root/build /tmp/st2-packages
-#            docker cp st2-packages-vol:/var/log/st2 /tmp/st2-packages/log/st2
-#            docker cp st2-packages-vol:/var/log/mistral /tmp/st2-packages/log/mistral
-#
-#      - run:
-#          name: Test the packages
-#          command: docker-compose run trusty test
-#          working_directory: ~/st2-packages
+      - run:
+          name: Copy produced artifacts back
+          command: |
+            # once application container finishes we can copy artifacts directly from it
+            docker cp st2-packages-vol:/root/build /tmp/st2-packages
+            docker cp st2-packages-vol:/var/log/st2 /tmp/st2-packages/log/st2
+            docker cp st2-packages-vol:/var/log/mistral /tmp/st2-packages/log/mistral
+
+      - run:
+          name: Test the packages
+          command: docker-compose run trusty test
+          working_directory: ~/st2-packages

--- a/circle.yml
+++ b/circle.yml
@@ -43,18 +43,6 @@ jobs:
           working_directory: ~/st2-packages
 
       - run:
-          name: Test env
-          command: |
-            export TEST_ENV=12345
-            echo $TEST_ENV
-
-      - run:
-          name: Test env
-          command: |
-            echo $TEST_ENV
-            echo $DISTRO
-
-      - run:
           # Workaround for CircleCI docker-compose limtation where volumes don't work
           # See detailed explanation: https://circleci.com/docs/2.0/building-docker-images/#mounting-folders
           name: Copy st2-packages files to build containers
@@ -66,14 +54,13 @@ jobs:
 
       - run:
           name: Pull the images
-          command: .circle/docker-compose.sh pull ${DISTRO}
+          command: .circle/docker-compose2.sh pull ${DISTRO}
           working_directory: ~/st2-packages
 
       - run:
           name: Build the packages
           command: |
-            docker-compose run trusty build
-            .circle/docker-compose.sh build ${DISTRO}
+            .circle/docker-compose2.sh build ${DISTRO}
             # Once build container finishes we can copy packages directly from it
             docker cp st2-packages-vol:/root/build /tmp/st2-packages
           working_directory: ~/st2-packages
@@ -88,7 +75,7 @@ jobs:
       - run:
           name: Test the packages
           command: |
-            .circle/docker-compose.sh test ${DISTRO}
+            .circle/docker-compose2.sh test ${DISTRO}
             # Once test container finishes we can copy logs directly from it
             mkdir -p /tmp/st2-packages/log
             docker cp st2-packages-vol:/var/log/st2 /tmp/st2-packages/log/st2

--- a/circle.yml
+++ b/circle.yml
@@ -50,7 +50,7 @@ jobs:
             docker cp ~/st2-packages st2-packages-vol:/root
 
       - run:
-          name: Pull the dependent build & test Docker images
+          name: Pull the images
           command: docker-compose run trusty /bin/true
           working_directory: ~/st2-packages
 
@@ -60,6 +60,12 @@ jobs:
             docker-compose run trusty build
             # Once build container finishes we can copy packages directly from it
             docker cp st2-packages-vol:/root/build /tmp/st2-packages
+          working_directory: ~/st2-packages
+
+      - run:
+          name: Build the packages 2nd time (compare timing)
+          command: |
+            docker-compose run trusty build
           working_directory: ~/st2-packages
 
       - run:

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ jobs:
       - DEPLOY_PACKAGES: 0
       - DOCKER_VERSION: 17.03.0-ce
       - DOCKER_COMPOSE_VERSION: 1.14.0
-      - COMPOSE_FILE: st2-packages/docker-compose.circle2.yml
+      - COMPOSE_FILE: docker-compose.circle2.yml
     steps:
       - checkout
       - setup_remote_docker:

--- a/circle.yml
+++ b/circle.yml
@@ -22,7 +22,7 @@ jobs:
           name: Debug
           command: |
             echo $CIRCLE_ENV
-            ls -la $CIRCLE_ENV
+            sudo ls -la $CIRCLE_ENV
       - run:
           name: Docker version
           command: |

--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,8 @@ jobs:
           name: Install dependencies - should be done as a pre-packed Docker image later
           command: |
             set -x
-            sudo apt install -y curl
+            apt-get update
+            apt-get install -y curl
             curl -L https://github.com/docker/compose/releases/download/1.14.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
             chmod +x /usr/local/bin/docker-compose
 

--- a/circle.yml
+++ b/circle.yml
@@ -63,11 +63,11 @@ jobs:
       - run:
           name: Copy produced artifacts back
           command: |
-          # once application container finishes we can copy artifacts directly from it
-          docker cp st2packages_trusty_run_2:/root/build /tmp/st2-packages
-          docker cp st2-packages-vol:/root/build /tmp/st2-packages
-          docker cp st2-packages-vol:/var/log/st2 /tmp/st2-packages/log/st2
-          docker cp st2-packages-vol:/var/log/mistral /tmp/st2-packages/log/mistral
+            # once application container finishes we can copy artifacts directly from it
+            docker cp st2packages_trusty_run_2:/root/build /tmp/st2-packages
+            docker cp st2-packages-vol:/root/build /tmp/st2-packages
+            docker cp st2-packages-vol:/var/log/st2 /tmp/st2-packages/log/st2
+            docker cp st2-packages-vol:/var/log/mistral /tmp/st2-packages/log/mistral
 
       - run:
           name: Test the packages

--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,7 @@ version: 2
 jobs:
   build:
     parallelism: 4
+    resource_class: large
     docker:
       # The primary container is an instance of the first list image listed. Your build commands run in this container.
       - image: circleci/python:2.7

--- a/circle.yml
+++ b/circle.yml
@@ -14,6 +14,11 @@ jobs:
       - checkout
       - setup_remote_docker
       - run:
+          name: Install dependencies - this should be done as a pre-packed Docker image later
+          command: |
+            sudo apt-get install -y git
+
+      - run:
           name: Download st2-packages repository
           command: |
             set -x

--- a/circle.yml
+++ b/circle.yml
@@ -34,10 +34,10 @@ jobs:
 
       - run:
           name: Pull the dependent build & test Docker images
-          command: docker-compose run trusty /bin/true
+          command: docker-compose run xenial /bin/true
           working_directory: ~/st2-packages
 
       - run:
           name: Build the packages
-          command: docker-compose build trusty
+          command: docker-compose build xenial
           working_directory: ~/st2-packages

--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ jobs:
           command: |
             set -x
             apt-get update
-            apt-get install -y curl
+            apt-get install -y curl git bash
             curl -L https://github.com/docker/compose/releases/download/1.14.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
             chmod +x /usr/local/bin/docker-compose
 

--- a/circle.yml
+++ b/circle.yml
@@ -71,12 +71,14 @@ jobs:
             docker cp st2-packages-vol:/root/build /tmp/st2-packages
           working_directory: ~/st2-packages
 
-#      - run:
-#          # TODO: It works! Enable cache for pip and wheelhouse
-#          name: Build the packages 2nd time (compare timing)
-#          command: |
-#            docker-compose run trusty build
-#          working_directory: ~/st2-packages
+      # TODO: It works! Enable cache for pip and wheelhouse
+      - run:
+          name: Build the ${DISTRO} Packages 2nd time (compare with pip/wheelhouse cached)
+          command: |
+            .circle/docker-compose2.sh build ${DISTRO}
+            # Once build container finishes we can copy packages directly from it
+            docker cp st2-packages-vol:/root/build /tmp/st2-packages
+          working_directory: ~/st2-packages
 
       - run:
           name: Test the Packages

--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,13 @@
 version: 2
 jobs:
   build:
-    #working_directory: ~/st2
+    parallelism: 1
     docker:
       # The primary container is an instance of the first list image listed. Your build commands run in this container.
       - image: docker/compose:1.14.0
+    working_directory: ~/st2
+    environment:
+      - FOO: "bar"
     steps:
       - checkout
       - setup_remote_docker

--- a/circle.yml
+++ b/circle.yml
@@ -12,9 +12,9 @@ jobs:
       - DEPLOY_PACKAGES: 0
     steps:
       - checkout
-      - setup_remote_docker
-        reusable: true
-        exclusive: false
+      - setup_remote_docker:
+          reusable: true
+          exclusive: false
       - run:
           name: Install dependencies - should be done as a pre-packed Docker image later
           command: |

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,8 @@ jobs:
     parallelism: 1
     docker:
       # The primary container is an instance of the first list image listed. Your build commands run in this container.
-      - image: ubuntu:trusty
+      #- image: ubuntu:trusty
+      - image: circleci/python:2.7
     working_directory: ~/st2
     environment:
       - DISTROS: "trusty xenial el6 el7"
@@ -22,14 +23,16 @@ jobs:
           command: |
             set -x
             apt-get update
-            apt-get install -y curl git bash
-            # install docker client
-            curl -L -o /tmp/docker-${DOCKER_VERSION}.tgz https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz
-            tar -xz -C /tmp -f /tmp/docker-${DOCKER_VERSION}.tgz
-            mv /tmp/docker/* /usr/bin
-            # install docker compose
-            curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
-            chmod +x /usr/local/bin/docker-compose
+            docker --version
+            docker-compose --version
+#            apt-get install -y curl git bash
+#            # install docker client
+#            curl -L -o /tmp/docker-${DOCKER_VERSION}.tgz https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz
+#            tar -xz -C /tmp -f /tmp/docker-${DOCKER_VERSION}.tgz
+#            mv /tmp/docker/* /usr/bin
+#            # install docker compose
+#            curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
+#            chmod +x /usr/local/bin/docker-compose
 
       - run:
           name: Download st2-packages repository

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ jobs:
       - DEPLOY_PACKAGES: 0
       - DOCKER_VERSION: 17.03.0-ce
       - DOCKER_COMPOSE_VERSION: 1.14.0
-      - COMPOSE_FILE: ~/st2-packages/docker-compose.circle2.yml
+      - COMPOSE_FILE: st2-packages/docker-compose.circle2.yml
     steps:
       - checkout
       - setup_remote_docker:

--- a/circle.yml
+++ b/circle.yml
@@ -48,7 +48,7 @@ jobs:
           name: Copy st2-packages files to build containers
           command: |
             # Remove st2-packages-vol container if exists in CircleCI cache
-            docker rm -f st2-packages-vol
+            docker rm -f st2-packages-vol || true
             # creating dummy container which will hold a volume with data files
             docker create -v /root/st2-packages -v /root/build -v /var/log/st2 -v /var/log/mistral -v /root/.cache/pip -v /tmp/wheelhouse --name st2-packages-vol alpine:3.4 /bin/true
             # copy st2-packages data files into this volume

--- a/circle.yml
+++ b/circle.yml
@@ -52,23 +52,29 @@ jobs:
 
       - run:
           name: Pull the dependent build & test Docker images
-          command: docker-compose run trusty /bin/true
+          command: docker-compose run xenial /bin/true
           working_directory: ~/st2-packages
 
       - run:
           name: Build the packages
-          command: docker-compose run trusty build
+          command: docker-compose run xenial build
           working_directory: ~/st2-packages
 
       - run:
           name: Copy produced artifacts back
           command: |
             # once application container finishes we can copy artifacts directly from it
+            mkdir -p /tmp/st2-packages
             docker cp st2-packages-vol:/root/build /tmp/st2-packages
+            mkdir -p /tmp/st2-packages/log/st2
             docker cp st2-packages-vol:/var/log/st2 /tmp/st2-packages/log/st2
+            mkdir -p /tmp/st2-packages/log/mistral
             docker cp st2-packages-vol:/var/log/mistral /tmp/st2-packages/log/mistral
 
       - run:
           name: Test the packages
-          command: docker-compose run trusty test
+          command: docker-compose run xenial test
           working_directory: ~/st2-packages
+
+      - store_artifacts:
+          path: /tmp/st2-packages

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,8 @@ jobs:
       - DEPLOY_PACKAGES: 0
       - DOCKER_VERSION: 17.03.0-ce
       - DOCKER_COMPOSE_VERSION: 1.14.0
-      - COMPOSE_FILE: docker-compose.circle2.yml
+#      - COMPOSE_FILE: docker-compose.circle2.yml
+#      - COMPOSE_FILE: docker-compose.override.yml:docker-compose.circle2.yml
     steps:
       - checkout
       - setup_remote_docker:
@@ -45,31 +46,31 @@ jobs:
           command: docker-compose run trusty /bin/true
           working_directory: ~/st2-packages
 
-      - run:
-          # Workaround for CircleCI docker-compose limtation where volumes don't work
-          # See detailed explanation: https://circleci.com/docs/2.0/building-docker-images/#mounting-folders
-          name: Copy st2-packages files to build containers
-          command: |
-            # creating dummy container which will hold a volume with data files
-            docker create -v /root/st2-packages -v /root/build -v /var/log/st2 -v /var/log/mistral --name st2-packages-vol alpine:3.4 /bin/true
-            # copy st2-packages data files into this volume
-            docker cp ~/st2-packages st2-packages-vol:/root
-
-      - run:
-          name: Build the packages
-          command: docker-compose run trusty build
-          working_directory: ~/st2-packages
-
-      - run:
-          name: Copy produced artifacts back
-          command: |
-            # once application container finishes we can copy artifacts directly from it
-            docker cp st2packages_trusty_run_2:/root/build /tmp/st2-packages
-            docker cp st2-packages-vol:/root/build /tmp/st2-packages
-            docker cp st2-packages-vol:/var/log/st2 /tmp/st2-packages/log/st2
-            docker cp st2-packages-vol:/var/log/mistral /tmp/st2-packages/log/mistral
-
-      - run:
-          name: Test the packages
-          command: docker-compose run trusty test
-          working_directory: ~/st2-packages
+#      - run:
+#          # Workaround for CircleCI docker-compose limtation where volumes don't work
+#          # See detailed explanation: https://circleci.com/docs/2.0/building-docker-images/#mounting-folders
+#          name: Copy st2-packages files to build containers
+#          command: |
+#            # creating dummy container which will hold a volume with data files
+#            docker create -v /root/st2-packages -v /root/build -v /var/log/st2 -v /var/log/mistral --name st2-packages-vol alpine:3.4 /bin/true
+#            # copy st2-packages data files into this volume
+#            docker cp ~/st2-packages st2-packages-vol:/root
+#
+#      - run:
+#          name: Build the packages
+#          command: docker-compose run trusty build
+#          working_directory: ~/st2-packages
+#
+#      - run:
+#          name: Copy produced artifacts back
+#          command: |
+#            # once application container finishes we can copy artifacts directly from it
+#            docker cp st2packages_trusty_run_2:/root/build /tmp/st2-packages
+#            docker cp st2-packages-vol:/root/build /tmp/st2-packages
+#            docker cp st2-packages-vol:/var/log/st2 /tmp/st2-packages/log/st2
+#            docker cp st2-packages-vol:/var/log/mistral /tmp/st2-packages/log/mistral
+#
+#      - run:
+#          name: Test the packages
+#          command: docker-compose run trusty test
+#          working_directory: ~/st2-packages


### PR DESCRIPTION
Experimenting with CircleCI2.0.

With the other timing experiments https://github.com/StackStorm/st2/pull/3545, we're trying to understand if Circle2.0 would work somehow faster/easier.

With 2.0 hope to get: 
- [x] Native docker (latest docker can be used, instead of outdated/pinned in CircleCI1.0)
- [x] Test `CentOS7` & `Xenial` packages (see https://github.com/StackStorm/st2-packages/issues/31 CircleCI 1.0 limitation for systemd)
- [x] Custom jobs resources (CPU). Our build was designed to beneift from the multi-processing (to check)
- [x] Docker layer caching (to check https://circleci.com/docs/2.0/docker-layer-caching/)
- [x] Workflows (if needed) see https://github.com/StackStorm/st2/issues/3561 experiments

Respective `docker-compose` workarounds: https://github.com/StackStorm/st2-packages/pull/467 to make 2.0 working.