### PR TITLE
Fix git url mangling in packs.download action

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,11 @@ Changed
 Fixed
 ~~~~~
 
+* Don't automatically append ``.git`` suffix to repo URIs passed to ``packs.download`` action.
+  This fixes a bug and now action also works with repo urls which don't contain ``.git`` suffix.
+  (bug fix)
+
+  Contributed by carbineneutral. #3534 #3544
 
 2.3.1 - July 07, 2017
 ---------------------

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -293,7 +293,7 @@ class DownloadGitRepoAction(Action):
                 url = 'https://github.com/{}'.format(repo_url)
             else:
                 url = repo_url
-            return url if url.endswith('.git') else '{}.git'.format(url)
+            return url
 
     @staticmethod
     def _get_pack_metadata(pack_dir):

--- a/contrib/packs/tests/test_action_download.py
+++ b/contrib/packs/tests/test_action_download.py
@@ -269,17 +269,17 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
     def test_resolve_urls(self):
         url = DownloadGitRepoAction._eval_repo_url(
             "https://github.com/StackStorm-Exchange/stackstorm-test")
-        self.assertEqual(url, "https://github.com/StackStorm-Exchange/stackstorm-test.git")
+        self.assertEqual(url, "https://github.com/StackStorm-Exchange/stackstorm-test")
 
         url = DownloadGitRepoAction._eval_repo_url(
             "https://github.com/StackStorm-Exchange/stackstorm-test.git")
         self.assertEqual(url, "https://github.com/StackStorm-Exchange/stackstorm-test.git")
 
         url = DownloadGitRepoAction._eval_repo_url("StackStorm-Exchange/stackstorm-test")
-        self.assertEqual(url, "https://github.com/StackStorm-Exchange/stackstorm-test.git")
+        self.assertEqual(url, "https://github.com/StackStorm-Exchange/stackstorm-test")
 
         url = DownloadGitRepoAction._eval_repo_url("git://StackStorm-Exchange/stackstorm-test")
-        self.assertEqual(url, "git://StackStorm-Exchange/stackstorm-test.git")
+        self.assertEqual(url, "git://StackStorm-Exchange/stackstorm-test")
 
         url = DownloadGitRepoAction._eval_repo_url("git://StackStorm-Exchange/stackstorm-test.git")
         self.assertEqual(url, "git://StackStorm-Exchange/stackstorm-test.git")

--- a/contrib/packs/tests/test_action_download.py
+++ b/contrib/packs/tests/test_action_download.py
@@ -290,6 +290,12 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
         url = DownloadGitRepoAction._eval_repo_url("file:///home/vagrant/stackstorm-test")
         self.assertEqual(url, "file:///home/vagrant/stackstorm-test")
 
+        url = DownloadGitRepoAction._eval_repo_url('ssh://<user@host>/AutomationStackStorm')
+        self.assertEqual(url, 'ssh://<user@host>/AutomationStackStorm')
+
+        url = DownloadGitRepoAction._eval_repo_url('ssh://joe@local/AutomationStackStorm')
+        self.assertEqual(url, 'ssh://joe@local/AutomationStackStorm')
+
     def test_run_pack_download_edge_cases(self):
         """
         Edge cases to test:

--- a/st2common/tests/unit/test_pack_management.py
+++ b/st2common/tests/unit/test_pack_management.py
@@ -31,7 +31,7 @@ class InstallPackTestCase(unittest2.TestCase):
 
     def test_eval_repo(self):
         result = DownloadGitRepoAction._eval_repo_url('stackstorm/st2contrib')
-        self.assertEqual(result, 'https://github.com/stackstorm/st2contrib.git')
+        self.assertEqual(result, 'https://github.com/stackstorm/st2contrib')
 
         result = DownloadGitRepoAction._eval_repo_url('git@github.com:StackStorm/st2contrib.git')
         self.assertEqual(result, 'git@github.com:StackStorm/st2contrib.git')


### PR DESCRIPTION
Fixes https://github.com/StackStorm/st2/issues/3534
Closes https://github.com/StackStorm/st2/pull/3544

This pull request works on top oif #3544 and adds a changelog entry and updates affected tests so the change will be ready in time for v2.3.2 release.
