### PR TITLE
Allow users to create rules which reference actions which don't exist in the system when RBAC is enabled

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,11 @@ Fixed
   (bug fix)
 
   Contributed by carbineneutral. #3534 #3544
+* Fix an API bug and allow users to create rules which reference actions which don't yet exist in
+  the system when RBAC is enabled and user doesn't have system admin permission. (bug fix)
+  #3572
+
+  Reported by sibirajal.
 
 2.3.1 - July 07, 2017
 ---------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,7 +33,7 @@ Fixed
   Contributed by carbineneutral. #3534 #3544
 * Fix an API bug and allow users to create rules which reference actions which don't yet exist in
   the system when RBAC is enabled and user doesn't have system admin permission. (bug fix)
-  #3572
+  #3572 #3573
 
   Reported by sibirajal.
 

--- a/st2api/tests/unit/controllers/v1/test_rules_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_rules_rbac.py
@@ -65,6 +65,11 @@ class RuleControllerRBACTestCase(APIControllerWithRBACTestCase):
             fixtures_pack=FIXTURES_PACK,
             fixtures_dict={'rules': [file_name]})['rules'][file_name]
 
+        file_name = 'rule_action_doesnt_exist.yaml'
+        RuleControllerRBACTestCase.RULE_3 = self.fixtures_loader.load_fixtures(
+            fixtures_pack=FIXTURES_PACK,
+            fixtures_dict={'rules': [file_name]})['rules'][file_name]
+
         # Insert mock users, roles and assignments
 
         # Users
@@ -153,6 +158,17 @@ class RuleControllerRBACTestCase(APIControllerWithRBACTestCase):
         resp = self.__do_post(RuleControllerRBACTestCase.RULE_1)
         expected_msg = ('User "rule_create" doesn\'t have required permission (webhook_create) '
                         'to use trigger core.st2.webhook')
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+        self.assertEqual(resp.json['faultstring'], expected_msg)
+
+    def test_post_user_has_no_permission_on_action_which_doesnt_exist_in_db(self):
+        # User has rule_create, but no action_execute on the action which doesn't exist in the db
+        user_db = self.users['rule_create_webhook_create']
+        self.use_user(user_db)
+
+        resp = self.__do_post(RuleControllerRBACTestCase.RULE_3)
+        expected_msg = ('User "rule_create_webhook_create" doesn\'t have required (action_execute)'
+                        ' permission to use action wolfpack.action-doesnt-exist-woo')
         self.assertEqual(resp.status_code, httplib.FORBIDDEN)
         self.assertEqual(resp.json['faultstring'], expected_msg)
 

--- a/st2common/st2common/rbac/resolvers.py
+++ b/st2common/st2common/rbac/resolvers.py
@@ -212,6 +212,7 @@ class ContentPackResourcePermissionsResolver(PermissionsResolver):
         self._log('Checking user resource permissions', extra=log_context)
 
         # First check the system role permissions
+        self._log('Checking grants via system role permissions', extra=log_context)
         has_system_role_permission = self._user_has_system_role_permission(
             user_db=user_db, permission_type=permission_type)
 
@@ -235,6 +236,7 @@ class ContentPackResourcePermissionsResolver(PermissionsResolver):
             permission_types = [permission_type]
 
         # Check direct grants on the specified resource
+        self._log('Checking direct grans on the specified resource', extra=log_context)
         resource_types = [self.resource_type]
         permission_grants = get_all_permission_grants_for_user(user_db=user_db,
                                                                resource_uid=resource_uid,
@@ -245,6 +247,7 @@ class ContentPackResourcePermissionsResolver(PermissionsResolver):
             return True
 
         # Check grants on the parent pack
+        self._log('Checking grants on the parent resource', extra=log_context)
         resource_types = [ResourceType.PACK]
         permission_grants = get_all_permission_grants_for_user(user_db=user_db,
                                                                resource_uid=pack_uid,

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -406,6 +406,8 @@ ALL_PERMISSION_TYPES = RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP.values()
 ALL_PERMISSION_TYPES = list(itertools.chain(*ALL_PERMISSION_TYPES))
 LIST_PERMISSION_TYPES = [permission_type for permission_type in ALL_PERMISSION_TYPES if
                          permission_type.endswith('_list')]
+CREATE_PERMISSION_TYPES = [permission_type for permission_type in ALL_PERMISSION_TYPES if
+                         permission_type.endswith('_create')]
 
 # List of global permissions (ones which don't apply to a specific resource)
 GLOBAL_PERMISSION_TYPES = [
@@ -430,7 +432,7 @@ GLOBAL_PERMISSION_TYPES = [
 
     # Execution
     PermissionType.EXECUTION_VIEWS_FILTERS_LIST
-] + LIST_PERMISSION_TYPES
+] + LIST_PERMISSION_TYPES + CREATE_PERMISSION_TYPES
 
 GLOBAL_PACK_PERMISSION_TYPES = [permission_type for permission_type in GLOBAL_PERMISSION_TYPES if
                                 permission_type.startswith('pack_')]

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -406,8 +406,6 @@ ALL_PERMISSION_TYPES = RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP.values()
 ALL_PERMISSION_TYPES = list(itertools.chain(*ALL_PERMISSION_TYPES))
 LIST_PERMISSION_TYPES = [permission_type for permission_type in ALL_PERMISSION_TYPES if
                          permission_type.endswith('_list')]
-CREATE_PERMISSION_TYPES = [permission_type for permission_type in ALL_PERMISSION_TYPES if
-                         permission_type.endswith('_create')]
 
 # List of global permissions (ones which don't apply to a specific resource)
 GLOBAL_PERMISSION_TYPES = [
@@ -432,7 +430,7 @@ GLOBAL_PERMISSION_TYPES = [
 
     # Execution
     PermissionType.EXECUTION_VIEWS_FILTERS_LIST
-] + LIST_PERMISSION_TYPES + CREATE_PERMISSION_TYPES
+] + LIST_PERMISSION_TYPES
 
 GLOBAL_PACK_PERMISSION_TYPES = [permission_type for permission_type in GLOBAL_PERMISSION_TYPES if
                                 permission_type.startswith('pack_')]

--- a/st2tests/st2tests/fixtures/generic/rules/rule_action_doesnt_exist.yaml
+++ b/st2tests/st2tests/fixtures/generic/rules/rule_action_doesnt_exist.yaml
@@ -1,0 +1,21 @@
+---
+action:
+  parameters:
+    ip1: '{{trigger.t1_p}}'
+    ip2: '{{trigger}}'
+  ref: wolfpack.action-doesnt-exist-woo
+criteria:
+  trigger.t1_p:
+    pattern: t1_p_v
+    type: equals
+description: ''
+enabled: true
+name: rule_action_doesnt_exist
+pack: examples
+tags:
+- name: tag1
+  value: dont-care
+- name: tag2
+  value: dont-care
+trigger:
+  type: wolfpack.triggertype-1


### PR DESCRIPTION
This pull request fixes a bug which didn't allow users to create rules via API which reference actions which don't exist in the system.

In theory, we didn't really have any hard defined rules around that (allowing user to create rules which reference actions which don't exist in the system), but since when RBAC is not enabled, we allow user to do that, we should also allow that when RBAC is enabled.

Either that, or we shouldn't allow rules which reference an action which doesn't exist in the system to be created in both scenarios.

Resolves #3572.