### PR TITLE
pylint ignore mistralclient.api.v2.executions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,7 @@ Fixed
   ``http_proxy`` or ``https_proxy`` environment variables for ``st2api`` and ``st2actionrunner``
   processes and pack commands will work with proxy. Refer to documentation for details on
   proxy configuration. (bug-fix) #3137
+* Fix no-member linting error on U16 by ignoring mistralclient.api.v2.executions module.
 
 
 2.3.1 - July 07, 2017

--- a/lint-configs/python/.pylintrc
+++ b/lint-configs/python/.pylintrc
@@ -23,7 +23,7 @@ disable=C0103,C0111,I0011,I0012,W0704,W0142,W0212,W0232,W0613,W0702,R0201,W0614,
 [TYPECHECK]
 # Note: This modules are manipulated during the runtime so we can't detect all the properties during
 # static analysis
-ignored-modules=distutils,eventlet.green.subprocess,six,six.moves
+ignored-modules=distutils,eventlet.green.subprocess,six,six.moves,mistralclient.api.v2.executions
 
 [FORMAT]
 max-line-length=100


### PR DESCRIPTION
Ignore `mistralclient.api.v2.executions` module to prevent `no-member` error on later versions of python (as used in u16)