### PR TITLE
Perform API input data validation using API model definitions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,8 @@ Fixed
   (bug fix)
 
   Contributed by carbineneutral. #3534 #3544
+* Fix API validation regression so all input data sent to some POST and PUT API endpoints is
+  correctly validated. (bug fix)
 
 2.3.1 - July 07, 2017
 ---------------------

--- a/st2api/tests/unit/controllers/v1/test_policies_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_policies_rbac.py
@@ -42,7 +42,8 @@ FIXTURES_PACK = 'generic'
 TEST_FIXTURES = {
     'policytypes': [
         'fake_policy_type_1.yaml',
-        'fake_policy_type_2.yaml'
+        'fake_policy_type_2.yaml',
+        'fake_policy_type_3.yaml'
     ],
     'policies': [
         'policy_1.yaml',
@@ -143,7 +144,7 @@ class PolicyTypeControllerRBACTestCase(APIControllerWithRBACTestCase):
         # policy_type_list permission, but no policy_type_view permission
         resp = self.app.get('/v1/policytypes')
         self.assertEqual(resp.status_code, httplib.OK)
-        self.assertEqual(len(resp.json), 2)
+        self.assertEqual(len(resp.json), 3)
 
         policy_type_id = self.models['policytypes']['fake_policy_type_1.yaml'].id
         policy_type_uid = self.models['policytypes']['fake_policy_type_1.yaml'].get_uid()

--- a/st2api/tests/unit/controllers/v1/test_rules.py
+++ b/st2api/tests/unit/controllers/v1/test_rules.py
@@ -210,6 +210,12 @@ class TestRuleController(FunctionalTest):
         self.assertEqual(post_resp_2.json['conflict-id'], org_id)
         self.__do_delete(org_id)
 
+    def test_post_invalid_rule_data(self):
+        post_resp = self.__do_post({'name': 'rule'})
+        self.assertEqual(post_resp.status_int, http_client.BAD_REQUEST)
+        expected_msg = "'trigger' is a required property"
+        self.assertEqual(post_resp.json['faultstring'], expected_msg)
+
     def test_post_trigger_parameter_schema_validation_fails(self):
         post_resp = self.__do_post(TestRuleController.RULE_2)
         self.assertEqual(post_resp.status_int, http_client.BAD_REQUEST)

--- a/st2common/st2common/router.py
+++ b/st2common/st2common/router.py
@@ -365,7 +365,7 @@ class Router(object):
                             # Call validate on the API model - note we should eventually move all
                             # those model schema definitions into openapi.yaml
                             try:
-                                instance.validate()
+                                instance = instance.validate()
                             except (jsonschema.ValidationError, ValueError) as e:
                                 raise exc.HTTPBadRequest(detail=e.message,
                                                          comment=traceback.format_exc())

--- a/st2common/st2common/router.py
+++ b/st2common/st2common/router.py
@@ -370,6 +370,8 @@ class Router(object):
                                 raise exc.HTTPBadRequest(detail=e.message,
                                                          comment=traceback.format_exc())
                         else:
+                            LOG.debug('Missing x-api-model definition for %s, using generic Body '
+                                      'model.' % (endpoint['operationId']))
                             model = Body
                             instance = model(**data)
 

--- a/st2common/st2common/router.py
+++ b/st2common/st2common/router.py
@@ -360,10 +360,20 @@ class Router(object):
 
                         if 'x-api-model' in schema:
                             Model = op_resolver(schema['x-api-model'])
-                        else:
-                            Model = Body
+                            instance = Model(**data)
 
-                        kw[argument_name] = Model(**data)
+                            # Call validate on the API model - note we should eventually move all
+                            # those model schema definitions into openapi.yaml
+                            try:
+                                instance.validate()
+                            except (jsonschema.ValidationError, ValueError) as e:
+                                raise exc.HTTPBadRequest(detail=e.message,
+                                                         comment=traceback.format_exc())
+                        else:
+                            model = Body
+                            instance = model(**data)
+
+                        kw[argument_name] = instance
                 else:
                     kw[argument_name] = None
 

--- a/st2tests/st2tests/fixtures/generic/policytypes/fake_policy_type_3.yaml
+++ b/st2tests/st2tests/fixtures/generic/policytypes/fake_policy_type_3.yaml
@@ -1,0 +1,25 @@
+---
+name: concurrency.attr
+description: Limits the concurrent executions for the action by attribute(s).
+enabled: true
+resource_type: action
+module: st2actions.policies.concurrency_by_attr
+parameters:
+    threshold:
+        description: Concurrency threshold.
+        type: integer
+        required: true
+    action:
+        description: Which action to perform on the execution once the concurrency threshold has been reached.
+        type: string
+        default: delay
+        enum:
+            - delay
+            - cancel
+    attributes:
+        description: List of attributes by which to limit the concurrency.
+        type: array
+        uniqueItems: true
+        items:
+            type: string
+            minLength: 1


### PR DESCRIPTION
This is a stop gap for regression described in #3575 until we implement a long term solution described in that issue (making sure each openapi entity definition contains corresponding JSON schema which is generated and copied over from API model schema attribute).

It should fix the regression (we didn't perform any API validation for endpoints which didn't have entity json schema defined in openapi.yaml).

The code basically does what we did before move to API v2, but we still need to be careful it doesn't break something.

While working on that, I thought we should actually still call `model.validate()` inside the router when performing API input data validation, even when we automatically generate and move all JSON schema definitions to openapi.yaml.

The reason for that is that `model.validate()` doesn't just validate values, but it also returns a cleaned object with default values assigned (we rely on this functionality in some places). That way, definition in `openapi.yaml` would only be used for documentation and auto-generation purposes.