### PR TITLE
Travis CI build speed optimizations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,8 @@ install:
 
 before_script:
   # Note: We use ramdisk for better performance
-  - if [ ${TASK} = 'ci-unit' ] || [ ${TASK} = 'ci-integration' ] || [ ${TASK} = 'ci-packs-tests' ]; then sudo -E ./scripts/travis/create-and-mount-ramdisk.sh; fi
-  - if [ ${TASK} = 'ci-unit' ] || [ ${TASK} = 'ci-integration' ] || [ ${TASK} = 'ci-packs-tests' ]; then ./scripts/travis/install-and-run-mongodb.sh; fi
+  - if [ ${TASK} = 'ci-unit' ] || [ ${TASK} = 'ci-integration' ] || [ ${TASK} = 'ci-checks ci-packs-tests' ]; then sudo -E ./scripts/travis/create-and-mount-ramdisk.sh; fi
+  - if [ ${TASK} = 'ci-unit' ] || [ ${TASK} = 'ci-integration' ] || [ ${TASK} = 'ci-checks ci-packs-tests' ]; then ./scripts/travis/install-and-run-mongodb.sh; fi
 
 script:
   - make ${TASK}

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ env:
     - TASK=ci-unit NODE_INDEX=0 NODE_TOTAL=3
     - TASK=ci-unit NODE_INDEX=1 NODE_TOTAL=3
     - TASK=ci-unit NODE_INDEX=2 NODE_TOTAL=3
-    - TASK=ci-integration
+    - TASK=ci-integration NODE_INDEX=0 NODE_TOTAL=2
+    - TASK=ci-integration NODE_INDEX=1 NODE_TOTAL=2
     - TASK="ci-checks ci-packs-tests"
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,9 @@ addons:
 services:
   - rabbitmq
 
+git:
+  depth: 3
+
 cache:
   pip: true
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,8 @@ env:
   global:
     - CACHE_NAME=JOB1
   matrix:
-    - TASK=ci-unit NODE_INDEX=0 NODE_TOTAL=3
-    - TASK=ci-unit NODE_INDEX=1 NODE_TOTAL=3
-    - TASK=ci-unit NODE_INDEX=2 NODE_TOTAL=3
+    - TASK=ci-unit NODE_INDEX=0 NODE_TOTAL=2
+    - TASK=ci-unit NODE_INDEX=1 NODE_TOTAL=2
     - TASK=ci-integration NODE_INDEX=0 NODE_TOTAL=2
     - TASK=ci-integration NODE_INDEX=1 NODE_TOTAL=2
     - TASK="ci-checks ci-packs-tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ branches:
 env:
   global:
     - CACHE_NAME=JOB1
+    - MONGODB_VERSION=3.4.6
   matrix:
     - TASK=ci-unit NODE_INDEX=0 NODE_TOTAL=2
     - TASK=ci-unit NODE_INDEX=1 NODE_TOTAL=2
@@ -28,11 +29,9 @@ addons:
       - sourceline: 'deb [arch=amd64] http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.4 multiverse'
         key_url: 'https://www.mongodb.org/static/pgp/server-3.4.asc'
     packages:
-      - mongodb-org-server
       - mongodb-org-shell
 
 services:
-  - mongodb
   - rabbitmq
 
 cache:
@@ -41,6 +40,7 @@ cache:
     - virtualenv/
 
 install:
+  - .circle/install-and-run-mongodb.sh
   - make requirements
   - if [ ${TASK} = 'ci-unit' ] || [ ${TASK} = 'ci-integration' ]; then pip install codecov; sudo .circle/add-itest-user.sh; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@ env:
   global:
     - CACHE_NAME=JOB1
   matrix:
-    - TASK=ci-unit NODE_INDEX=0 NODE_TOTAL=2
-    - TASK=ci-unit NODE_INDEX=1 NODE_TOTAL=2
+    - TASK=ci-unit NODE_INDEX=0 NODE_TOTAL=3
+    - TASK=ci-unit NODE_INDEX=1 NODE_TOTAL=3
+    - TASK=ci-unit NODE_INDEX=2 NODE_TOTAL=3
     - TASK=ci-integration
     - TASK="ci-checks ci-packs-tests"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,13 @@ cache:
     - virtualenv/
 
 install:
-  - .circle/install-and-run-mongodb.sh
   - make requirements
   - if [ ${TASK} = 'ci-unit' ] || [ ${TASK} = 'ci-integration' ]; then pip install codecov; sudo .circle/add-itest-user.sh; fi
+
+before_script:
+  # Note: We use ramdisk for better performance
+  - if [ ${TASK} = 'ci-unit' ] || [ ${TASK} = 'ci-integration' ] || [ ${TASK} = 'ci-packs-tests' ]; then sudo -E ./scripts/travis/create-and-mount-ramdisk.sh; fi
+  - if [ ${TASK} = 'ci-unit' ] || [ ${TASK} = 'ci-integration' ] || [ ${TASK} = 'ci-packs-tests' ]; then ./scripts/travis/install-and-run-mongodb.sh; fi
 
 script:
   - make ${TASK}

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,10 @@ PYTHON_TARGET := 2.7
 REQUIREMENTS := test-requirements.txt requirements.txt
 PIP_OPTIONS := $(ST2_PIP_OPTIONS)
 
+NODE_INDEX ?= 0
+NODE_TOTAL ?= 1
+TEST_DB_NAME := st2-test-$(NODE_INDEX)
+
 NOSE_OPTS := --rednose --immediate --with-parallel
 NOSE_TIME := $(NOSE_TIME)
 
@@ -51,6 +55,7 @@ play:
 	@echo COMPONENTS_TEST=$(COMPONENTS_TEST)
 	@echo COMPONENTS_TEST_COMMA=$(COMPONENTS_TEST_COMMA)
 	@echo COMPONENT_PYTHONPATH=$(COMPONENT_PYTHONPATH)
+	@echo TEST_DB_NAME=$(TEST_DB_NAME)
 
 
 .PHONY: check
@@ -353,13 +358,13 @@ itests: requirements .itests
 	@echo
 	@echo "================ integration tests with coverage (HTML reports) ================"
 	@echo
-	@echo "----- Dropping st2-test db -----"
-	@mongo st2-test --eval "db.dropDatabase();"
+	@echo "----- Dropping $(TEST_DB_NAME) db -----"
+	@mongo $(TEST_DB_NAME) --eval "db.dropDatabase();"
 	@for component in $(COMPONENTS_TEST); do\
 		echo "==========================================================="; \
 		echo "Running tests in" $$component; \
 		echo "==========================================================="; \
-		. $(VIRTUALENV_DIR)/bin/activate; nosetests $(NOSE_OPTS) -s -v --with-coverage \
+		. $(VIRTUALENV_DIR)/bin/activate; TEST_DB_NAME=$(TEST_DB_NAME) nosetests $(NOSE_OPTS) -s -v --with-coverage \
 			--cover-inclusive --cover-html \
 			--cover-package=$(COMPONENTS_TEST_COMMA) $$component/tests/integration || exit 1; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,12 @@ PIP_OPTIONS := $(ST2_PIP_OPTIONS)
 
 NODE_INDEX ?= 0
 NODE_TOTAL ?= 1
-TEST_DB_NAME := st2-test-$(NODE_INDEX)
+
+ifeq ($(shell test $(NODE_TOTAL) -gt 1; echo $$?),0)
+  TEST_DB_NAME := st2-test-$(NODE_INDEX)
+else
+  TEST_DB_NAME := st2-test
+endif
 
 NOSE_OPTS := --rednose --immediate --with-parallel
 NOSE_TIME := $(NOSE_TIME)

--- a/Makefile
+++ b/Makefile
@@ -316,8 +316,8 @@ unit-tests: requirements .unit-tests
 	@echo
 	@echo "==================== tests ===================="
 	@echo
-	@echo "----- Dropping st2-test db -----"
-	@mongo st2-test --eval "db.dropDatabase();"
+	@echo "----- Dropping $(TEST_DB_NAME) db -----"
+	@mongo $(TEST_DB_NAME) --eval "db.dropDatabase();"
 	@for component in $(COMPONENTS_TEST); do\
 		echo "==========================================================="; \
 		echo "Running tests in" $$component; \
@@ -330,8 +330,8 @@ unit-tests: requirements .unit-tests
 	@echo
 	@echo "==================== unit tests with coverage (HTML reports) ===================="
 	@echo
-	@echo "----- Dropping st2-test db -----"
-	@mongo st2-test --eval "db.dropDatabase();"
+	@echo "----- Dropping $(TEST_DB_NAME) db -----"
+	@mongo $(TEST_DB_NAME) --eval "db.dropDatabase();"
 	@for component in $(COMPONENTS_TEST); do\
 		echo "==========================================================="; \
 		echo "Running tests in" $$component; \
@@ -349,8 +349,8 @@ itests: requirements .itests
 	@echo
 	@echo "==================== integration tests ===================="
 	@echo
-	@echo "----- Dropping st2-test db -----"
-	@mongo st2-test --eval "db.dropDatabase();"
+	@echo "----- Dropping $(TEST_DB_NAME) db -----"
+	@mongo $(TEST_DB_NAME) --eval "db.dropDatabase();"
 	@for component in $(COMPONENTS_TEST); do\
 		echo "==========================================================="; \
 		echo "Running tests in" $$component; \

--- a/contrib/runners/local_runner/tests/integration/test_localrunner.py
+++ b/contrib/runners/local_runner/tests/integration/test_localrunner.py
@@ -90,7 +90,7 @@ class LocalShellCommandRunnerTestCase(TestCase):
             'localrunner_pack', 'actions', 'text_gen.py')
         runner = self._get_runner(action_db, entry_point=entry_point)
         runner.pre_run()
-        char_count = 10 ** 6  # Note 10^7 succeeds but ends up being slow.
+        char_count = 10 ** 5  # Note 10^7 succeeds but ends up being slow.
         status, result, _ = runner.run({'chars': char_count})
         runner.post_run(status, result)
         self.assertEquals(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)

--- a/scripts/travis/install-and-run-mongodb.sh
+++ b/scripts/travis/install-and-run-mongodb.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 
 # Script which installs versions of MongoDB specified using an environment variable
-
-if [ ! "${MONGODB}" ]; then
-    echo "MONGODB environment variable not set"
+if [ ! "${MONGODB_VERSION}" ]; then
+    echo "MONGODB_VERSION environment variable not set."
     exit 2
 fi
+
+MONGODB_DIR=/tmp/mongodb
 
 # Note: MongoDB 2.4 and 2.6 don't work with ramdisk since they don't work with
 # small files and require at least 3 GB of space
@@ -15,19 +16,36 @@ else
     DATA_DIR=/mnt/ramdisk/mongodb
 fi
 
-wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB}.tgz -O /tmp/mongodb.tgz
-tar -xvf /tmp/mongodb.tgz
+
 mkdir -p ${DATA_DIR}
-echo "Starting MongoDB v${MONGODB}"
-${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --nojournal --journalCommitInterval 500 \
-    --syncdelay 0 --dbpath ${DATA_DIR} --bind_ip 127.0.0.1 &> /tmp/mongodb.log &
-EXIT_CODE=$?
+mkdir -p ${MONGODB_DIR}
+
+DOWNLOAD_URL="http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB_VERSION}.tgz"
+
+echo "Downloading MongoDB ${MONGODB_VERSION} from ${DOWNLOAD_URL}"
+wget -q ${DOWNLOAD_URL} -O /tmp/mongodb.tgz
+tar -xvf /tmp/mongodb.tgz -C ${MONGODB_DIR} --strip=1
+
+echo "Starting MongoDB v${MONGODB_VERSION}"
+# Note: We use --notablescan option to detected missing indexes early. When this
+# option is enabled, queries which result in table scan (which usually means a
+# missing index or a bad query) are not allowed and result in a failed test.
+${MONGODB_DIR}/bin/mongod --nojournal --journalCommitInterval 500 --syncdelay 0 \
+    --wiredTigerStatisticsLogDelaySecs 0 --noIndexBuildRetry --noscripting --notablescan \
+    --dbpath ${DATA_DIR} --bind_ip 127.0.0.1 &> /tmp/mongodb.log &
+MONGODB_PID=$!
+
+# Give process some time to start up
 sleep 5
 
-if [ ${EXIT_CODE} -ne 0 ]; then
+if ps -p ${MONGODB_PID} > /dev/null; then
+    echo "MongoDB successfuly started"
+    tail -30 /tmp/mongodb.log
+    exit 9
+else
     echo "Failed to start MongoDB"
     tail -30 /tmp/mongodb.log
     exit 1
 fi
 
-tail -30 /tmp/mongodb.log
+exit 0

--- a/scripts/travis/install-and-run-mongodb.sh
+++ b/scripts/travis/install-and-run-mongodb.sh
@@ -41,11 +41,9 @@ sleep 5
 if ps -p ${MONGODB_PID} > /dev/null; then
     echo "MongoDB successfuly started"
     tail -30 /tmp/mongodb.log
-    exit 9
+    exit 0
 else
     echo "Failed to start MongoDB"
     tail -30 /tmp/mongodb.log
     exit 1
 fi
-
-exit 0

--- a/st2actions/tests/integration/test_notifier.py
+++ b/st2actions/tests/integration/test_notifier.py
@@ -21,6 +21,7 @@ from eventlet.green import subprocess
 from st2common.constants.scheduler import SCHEDULER_ENABLED_LOG_LINE, SCHEDULER_DISABLED_LOG_LINE
 from st2tests.base import IntegrationTestCase
 from st2tests.base import CleanDbTestCase
+from st2tests.base import get_temporary_tests_config_path
 
 __all__ = [
     'SchedulerEnableDisableTestCase'
@@ -28,8 +29,7 @@ __all__ = [
 
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-ST2_CONFIG_PATH = os.path.join(BASE_DIR, '../../../conf/st2.tests.conf')
-ST2_CONFIG_PATH = os.path.abspath(ST2_CONFIG_PATH)
+ST2_CONFIG_PATH = get_temporary_tests_config_path()
 BINARY = os.path.join(BASE_DIR, '../../../st2actions/bin/st2notifier')
 BINARY = os.path.abspath(BINARY)
 CMD = [BINARY, '--config-file']

--- a/st2api/tests/integration/test_gunicorn_configs.py
+++ b/st2api/tests/integration/test_gunicorn_configs.py
@@ -25,10 +25,14 @@ from eventlet.green import subprocess
 from st2common.models.utils import profiling
 from st2common.util.shell import kill_process
 from st2tests.base import IntegrationTestCase
+from st2tests.base import get_temporary_tests_config_path
+
+__all__ = [
+    'GunicornWSGIEntryPointTestCase'
+]
 
 
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-ST2_CONFIG_PATH = os.path.join(BASE_DIR, '../../../conf/st2.tests.conf')
+ST2_CONFIG_PATH = get_temporary_tests_config_path()
 
 
 class GunicornWSGIEntryPointTestCase(IntegrationTestCase):

--- a/st2api/tests/unit/controllers/v1/test_executions.py
+++ b/st2api/tests/unit/controllers/v1/test_executions.py
@@ -293,7 +293,7 @@ class ActionExecutionControllerTestCase(BaseActionExecutionControllerTestCase, F
 
         resp = self.app.get('/v1/executions?offset=%s&limit=1' % total_count)
         self.assertEqual(resp.status_int, 200)
-        self.assertTrue(len(resp.json), 0)
+        self.assertEqual(len(resp.json), 1)
 
     def test_get_one_fail(self):
         resp = self.app.get('/v1/executions/100', expect_errors=True)

--- a/st2common/tests/integration/test_register_content_script.py
+++ b/st2common/tests/integration/test_register_content_script.py
@@ -20,13 +20,15 @@ from st2tests.base import IntegrationTestCase
 from st2common.util.shell import run_command
 from st2tests import config as test_config
 from st2tests.fixturesloader import get_fixtures_packs_base_path
+from st2tests.base import get_temporary_tests_config_path
 
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 SCRIPT_PATH = os.path.join(BASE_DIR, '../../bin/st2-register-content')
 SCRIPT_PATH = os.path.abspath(SCRIPT_PATH)
 
-BASE_CMD_ARGS = [SCRIPT_PATH, '--config-file=conf/st2.tests.conf', '-v']
+ST2_CONFIG_PATH = get_temporary_tests_config_path()
+BASE_CMD_ARGS = [SCRIPT_PATH, '--config-file=%s' % (ST2_CONFIG_PATH), '-v']
 BASE_REGISTER_ACTIONS_CMD_ARGS = BASE_CMD_ARGS + ['--register-actions']
 
 PACKS_PATH = get_fixtures_packs_base_path()

--- a/st2reactor/tests/integration/test_garbage_collector.py
+++ b/st2reactor/tests/integration/test_garbage_collector.py
@@ -25,6 +25,7 @@ from st2common.models.db.execution import ActionExecutionDB
 from st2common.persistence.execution import ActionExecution
 from st2tests.base import IntegrationTestCase
 from st2tests.base import CleanDbTestCase
+from st2tests.base import get_temporary_tests_config_path
 
 __all__ = [
     'GarbageCollectorServiceTestCase'
@@ -32,8 +33,7 @@ __all__ = [
 
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-ST2_CONFIG_PATH = os.path.join(BASE_DIR, '../../../conf/st2.tests.conf')
-ST2_CONFIG_PATH = os.path.abspath(ST2_CONFIG_PATH)
+ST2_CONFIG_PATH = get_temporary_tests_config_path()
 BINARY = os.path.join(BASE_DIR, '../../../st2reactor/bin/st2garbagecollector')
 BINARY = os.path.abspath(BINARY)
 CMD = [BINARY, '--config-file', ST2_CONFIG_PATH]

--- a/st2reactor/tests/integration/test_rules_engine.py
+++ b/st2reactor/tests/integration/test_rules_engine.py
@@ -21,6 +21,7 @@ from eventlet.green import subprocess
 from st2common.constants.timer import TIMER_ENABLED_LOG_LINE, TIMER_DISABLED_LOG_LINE
 from st2tests.base import IntegrationTestCase
 from st2tests.base import CleanDbTestCase
+from st2tests.base import get_temporary_tests_config_path
 
 __all__ = [
     'TimerEnableDisableTestCase'
@@ -28,8 +29,7 @@ __all__ = [
 
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-ST2_CONFIG_PATH = os.path.join(BASE_DIR, '../../../conf/st2.tests.conf')
-ST2_CONFIG_PATH = os.path.abspath(ST2_CONFIG_PATH)
+ST2_CONFIG_PATH = get_temporary_tests_config_path()
 BINARY = os.path.join(BASE_DIR, '../../../st2reactor/bin/st2rulesengine')
 BINARY = os.path.abspath(BINARY)
 CMD = [BINARY, '--config-file']

--- a/st2reactor/tests/integration/test_sensor_container.py
+++ b/st2reactor/tests/integration/test_sensor_container.py
@@ -27,14 +27,14 @@ from st2reactor.container.process_container import PROCESS_EXIT_TIMEOUT
 from st2common.util.green.shell import run_command
 from st2common.bootstrap.sensorsregistrar import register_sensors
 from st2tests.base import IntegrationTestCase
+from st2tests.base import get_temporary_tests_config_path
 
 __all__ = [
     'SensorContainerTestCase'
 ]
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-ST2_CONFIG_PATH = os.path.join(BASE_DIR, '../../../conf/st2.tests.conf')
-ST2_CONFIG_PATH = os.path.abspath(ST2_CONFIG_PATH)
+ST2_CONFIG_PATH = get_temporary_tests_config_path()
 BINARY = os.path.join(BASE_DIR, '../../../st2reactor/bin/st2sensorcontainer')
 BINARY = os.path.abspath(BINARY)
 CMD = [BINARY, '--config-file', ST2_CONFIG_PATH, '--sensor-ref=examples.SamplePollingSensor']

--- a/st2reactor/tests/unit/test_sensor_wrapper.py
+++ b/st2reactor/tests/unit/test_sensor_wrapper.py
@@ -4,13 +4,15 @@ import unittest2
 import mock
 
 import st2tests.config as tests_config
-from st2tests.base import TESTS_CONFIG_PATH
 from st2common.models.db.trigger import TriggerDB
 from st2reactor.container.sensor_wrapper import SensorWrapper
 from st2reactor.sensor.base import Sensor, PollingSensor
+from st2tests.base import get_temporary_tests_config_path
 
 CURRENT_DIR = os.path.abspath(os.path.dirname(__file__))
 RESOURCES_DIR = os.path.abspath(os.path.join(CURRENT_DIR, '../resources'))
+
+TESTS_CONFIG_PATH = get_temporary_tests_config_path()
 
 __all__ = [
     'SensorWrapperTestCase'

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 from oslo_config import cfg, types
 
 from st2common import log as logging
@@ -63,7 +65,8 @@ def _register_config_opts():
 
 
 def _override_db_opts():
-    CONF.set_override(name='db_name', override='st2-test', group='database')
+    db_name = os.environ.get('TEST_DB_NAME', 'st2-test')
+    CONF.set_override(name='db_name', override=db_name, group='database')
     CONF.set_override(name='host', override='127.0.0.1', group='database')
 
 


### PR DESCRIPTION
Just experimenting a bit if we can also split integration Tests into multiple chunks to speed up the run time.

In addition to that, I also added back some "performance optimizations" I added to Travis long time ago but were lost once we moved to Circle CI (disable journaling for mongodb, etc.).