### PR TITLE
Use 'precise' distro for Travis, which runs x2 faster to Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # Used old infrastructure, needed for integration tests:
 # http://docs.travis-ci.com/user/workers/standard-infrastructure/
 sudo: required
+dist: precise
 language: python
 python:
   - 2.7


### PR DESCRIPTION
A few days ago Travis moved from `precise` to `trusty` as a base distro OS for environment we use.
After a quick look Unit tests were running x2 slower in new distro.

NEW `trusty` (slower, `12-15mins`):
https://travis-ci.org/StackStorm/st2/jobs/254995061

OLD `precise` (faster, `6-7mins`):
https://travis-ci.org/StackStorm/st2/jobs/254770338

Switching back to `precise`.

----

On related note, this could be a reason why CircleCI was slower for Unit tests, - because of base distro.
I'll need to try CircleCI Unit tests in Precise env to see if that improves the timing.