### PR TITLE
Fix post to action execution with nonexistent action

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,6 +46,7 @@ Fixed
   #3572 #3573
 
   Reported by sibirajal.
+* Add a check to make sure action exists in the POST of the action execution API. (bug fix)
 
 2.3.1 - July 07, 2017
 ---------------------

--- a/st2api/tests/unit/controllers/v1/test_executions.py
+++ b/st2api/tests/unit/controllers/v1/test_executions.py
@@ -340,6 +340,14 @@ class ActionExecutionControllerTestCase(BaseActionExecutionControllerTestCase, F
         self.assertEqual(delete_resp.status_int, 200)
         self.assertEqual(delete_resp.json['status'], 'canceled')
 
+    def test_post_nonexistent_action(self):
+        live_action = copy.deepcopy(LIVE_ACTION_1)
+        live_action['action'] = 'mock.foobar'
+        post_resp = self._do_post(live_action, expect_errors=True)
+        self.assertEqual(post_resp.status_int, 400)
+        expected_error = 'Action "%s" cannot be found.' % live_action['action']
+        self.assertEqual(expected_error, post_resp.json['faultstring'])
+
     def test_post_parameter_validation_failed(self):
         execution = copy.deepcopy(LIVE_ACTION_1)
 


### PR DESCRIPTION
When liveaction reference an action that does not exists, the POST to action execution results in a 500 internal server error. The error should be 400 bad request. A check is added to check that the action_db is not type of NoneType before proceeding.