### PR TITLE
Fixed a very trivial problem with the processing to show a message

### DIFF
--- a/st2client/st2client/utils/interactive.py
+++ b/st2client/st2client/utils/interactive.py
@@ -389,7 +389,7 @@ class InteractiveForm(object):
                 try:
                     result[field] = self._read_field(field)
                 except ReaderNotImplemented as e:
-                    print('%s. Skipping...', str(e))
+                    print('%s. Skipping...' % str(e))
         except DialogInterrupted:
             if self.reraise:
                 raise


### PR DESCRIPTION
## Abstruct
I found a very trivial problem with the processing to show a message in the st2client, and fixed it.

## Background / Problem
I got following message which is (maybe) not intended format by the configuration command in some pack (e.g. `acos`).
```
$ st2 pack config acos
('%s. Skipping...', 'Interactive mode does not support arrays of object type yet')
```
## Solution
I fixed it to substitute variable. By this change, the above output message will be as follows.
```
$ st2 pack config acos
Interactive mode does not support arrays of object type yet. Skipping...
```