### PR TITLE
Fix Error definition being too lax

### DIFF
--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -288,7 +288,7 @@ paths:
           x-as: requester_user
           description: User performing the operation.
       responses:
-        '200':
+        '201':
           description: Single action being created
           schema:
             $ref: '#/definitions/Action'
@@ -686,7 +686,7 @@ paths:
           schema:
             $ref: '#/definitions/ActionAliasMatchRequest'
       responses:
-        '200':
+        '201':
           description: Action alias match pattern
           schema:
             $ref: '#/definitions/ActionAliasMatch'
@@ -919,7 +919,7 @@ paths:
           x-as: requester_user
           description: User performing the operation.
       responses:
-        '200':
+        '201':
           description: Execution being created
           schema:
             $ref: '#/definitions/Execution'
@@ -1024,7 +1024,7 @@ paths:
           x-as: requester_user
           description: User performing the operation.
       responses:
-        '204':
+        '200':
           description: Execution cancelled
         default:
           description: Unexpected error
@@ -1070,7 +1070,7 @@ paths:
           x-as: requester_user
           description: User performing the operation.
       responses:
-        '200':
+        '201':
           description: Single action being created
           schema:
             $ref: '#/definitions/Execution'
@@ -1446,10 +1446,10 @@ paths:
           schema:
             $ref: '#/definitions/PacksInstall'
       responses:
-        '200':
-          description: Packs Installed.
+        '202':
+          description: Pack installation request has been accepted
           schema:
-            $ref: '#/definitions/PacksList'
+            $ref: '#/definitions/AsyncRequest'
           examples:
             application/json:
               ref: 'core.webhook'
@@ -1471,10 +1471,10 @@ paths:
           schema:
             $ref: '#/definitions/PacksUninstall'
       responses:
-        '200':
-          description: Packs Uninstalled.
+        '202':
+          description: Pack uninstallation request has been accepted
           schema:
-            $ref: '#/definitions/PacksList'
+            $ref: '#/definitions/AsyncRequest'
           examples:
             application/json:
               ref: 'core.webhook'
@@ -1960,7 +1960,7 @@ paths:
           x-as: requester_user
           description: User performing the operation.
       responses:
-        '200':
+        '201':
           description: Policy created successfully.
           schema:
             $ref: '#/definitions/PolicyList'
@@ -2296,7 +2296,7 @@ paths:
           x-as: requester_user
           description: User performing the operation.
       responses:
-        '200':
+        '201':
           description: Single action being created
           schema:
             $ref: '#/definitions/Rule'
@@ -2816,7 +2816,7 @@ paths:
           x-as: requester_user
           description: User performing the operation.
       responses:
-        '200':
+        '201':
           description: Single action being created
           schema:
             $ref: '#/definitions/ApiKey'
@@ -3234,7 +3234,7 @@ paths:
           schema:
             $ref: '#/definitions/TriggerTypeRequest'
       responses:
-        '200':
+        '201':
           description: Single trigger type being created
           schema:
             $ref: '#/definitions/TriggerType'
@@ -3345,7 +3345,7 @@ paths:
           schema:
             $ref: '#/definitions/TriggerRequest'
       responses:
-        '200':
+        '201':
           description: Single trigger being created
           schema:
             $ref: '#/definitions/Trigger'
@@ -3523,7 +3523,7 @@ paths:
           required: true
       responses:
         '200':
-          description: Single trigger being created
+          description: Trigger instance being re-emitted
           schema:
             $ref: '#/definitions/TriggerInstance'
           examples:
@@ -3581,7 +3581,7 @@ paths:
           x-as: requester_user
           description: User performing the operation.
       responses:
-        '201':
+        '202':
           description: Single action being created
           schema:
             $ref: '#/definitions/WebhookBody'
@@ -4291,6 +4291,14 @@ definitions:
     # additionalProperties: False
     x-additional-check: st2api.controllers.resource:parameter_validation
     default: {}
+  AsyncRequest:
+    type: object
+    properties:
+      execution_id:
+        type: string
+    required:
+      - execution_id
+    additionalProperties: false
   DataFilesSubSchema:
     type: object
     properties:
@@ -4401,6 +4409,8 @@ definitions:
     properties:
       faultstring:
         type: string
+    required:
+      - faultstring
 
 securityDefinitions:
   X-Auth-Token:

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -285,7 +285,7 @@ paths:
           x-as: requester_user
           description: User performing the operation.
       responses:
-        '200':
+        '201':
           description: Single action being created
           schema:
             $ref: '#/definitions/Action'
@@ -683,7 +683,7 @@ paths:
           schema:
             $ref: '#/definitions/ActionAliasMatchRequest'
       responses:
-        '200':
+        '201':
           description: Action alias match pattern
           schema:
             $ref: '#/definitions/ActionAliasMatch'
@@ -916,7 +916,7 @@ paths:
           x-as: requester_user
           description: User performing the operation.
       responses:
-        '200':
+        '201':
           description: Execution being created
           schema:
             $ref: '#/definitions/Execution'
@@ -1021,7 +1021,7 @@ paths:
           x-as: requester_user
           description: User performing the operation.
       responses:
-        '204':
+        '200':
           description: Execution cancelled
         default:
           description: Unexpected error
@@ -1067,7 +1067,7 @@ paths:
           x-as: requester_user
           description: User performing the operation.
       responses:
-        '200':
+        '201':
           description: Single action being created
           schema:
             $ref: '#/definitions/Execution'
@@ -1443,10 +1443,10 @@ paths:
           schema:
             $ref: '#/definitions/PacksInstall'
       responses:
-        '200':
-          description: Packs Installed.
+        '202':
+          description: Pack installation request has been accepted
           schema:
-            $ref: '#/definitions/PacksList'
+            $ref: '#/definitions/AsyncRequest'
           examples:
             application/json:
               ref: 'core.webhook'
@@ -1468,10 +1468,10 @@ paths:
           schema:
             $ref: '#/definitions/PacksUninstall'
       responses:
-        '200':
-          description: Packs Uninstalled.
+        '202':
+          description: Pack uninstallation request has been accepted
           schema:
-            $ref: '#/definitions/PacksList'
+            $ref: '#/definitions/AsyncRequest'
           examples:
             application/json:
               ref: 'core.webhook'
@@ -1957,7 +1957,7 @@ paths:
           x-as: requester_user
           description: User performing the operation.
       responses:
-        '200':
+        '201':
           description: Policy created successfully.
           schema:
             $ref: '#/definitions/PolicyList'
@@ -2293,7 +2293,7 @@ paths:
           x-as: requester_user
           description: User performing the operation.
       responses:
-        '200':
+        '201':
           description: Single action being created
           schema:
             $ref: '#/definitions/Rule'
@@ -2813,7 +2813,7 @@ paths:
           x-as: requester_user
           description: User performing the operation.
       responses:
-        '200':
+        '201':
           description: Single action being created
           schema:
             $ref: '#/definitions/ApiKey'
@@ -3231,7 +3231,7 @@ paths:
           schema:
             $ref: '#/definitions/TriggerTypeRequest'
       responses:
-        '200':
+        '201':
           description: Single trigger type being created
           schema:
             $ref: '#/definitions/TriggerType'
@@ -3342,7 +3342,7 @@ paths:
           schema:
             $ref: '#/definitions/TriggerRequest'
       responses:
-        '200':
+        '201':
           description: Single trigger being created
           schema:
             $ref: '#/definitions/Trigger'
@@ -3520,7 +3520,7 @@ paths:
           required: true
       responses:
         '200':
-          description: Single trigger being created
+          description: Trigger instance being re-emitted
           schema:
             $ref: '#/definitions/TriggerInstance'
           examples:
@@ -3578,7 +3578,7 @@ paths:
           x-as: requester_user
           description: User performing the operation.
       responses:
-        '201':
+        '202':
           description: Single action being created
           schema:
             $ref: '#/definitions/WebhookBody'
@@ -4288,6 +4288,14 @@ definitions:
     # additionalProperties: False
     x-additional-check: st2api.controllers.resource:parameter_validation
     default: {}
+  AsyncRequest:
+    type: object
+    properties:
+      execution_id:
+        type: string
+    required:
+      - execution_id
+    additionalProperties: false
   DataFilesSubSchema:
     type: object
     properties:
@@ -4398,6 +4406,8 @@ definitions:
     properties:
       faultstring:
         type: string
+    required:
+      - faultstring
 
 securityDefinitions:
   X-Auth-Token:


### PR DESCRIPTION
This resulted in unit tests not catching a number of obvious validation errors.