### PR TITLE
[st2client] Implemented ArrayObjectReader to set configuration interactively from the schema of array which has elements of object type.

### DIFF
--- a/st2client/st2client/utils/interactive.py
+++ b/st2client/st2client/utils/interactive.py
@@ -317,16 +317,18 @@ class ArrayObjectReader(StringReader):
 
     def read(self):
         results = []
-        prefix = u'{}.'.format(self.name)
         properties = self.spec.get('items', {}).get('properties', {})
-        message = 'Would you like to continue to set other settings of "%s"?' % self.name
+        message = '~~~ Would you like to add another item to  "%s" array / list?' % self.name
 
         is_continue = True
+        index = 0
         while is_continue:
+            prefix = u'{name}[{index}].'.format(name=self.name, index=index)
             results.append(InteractiveForm(properties,
                                            prefix=prefix,
                                            reraise=True).initiate_dialog())
 
+            index += 1
             if Question(message, {'default': 'y'}).read() != 'y':
                 is_continue = False
 

--- a/st2client/st2client/utils/interactive.py
+++ b/st2client/st2client/utils/interactive.py
@@ -310,6 +310,29 @@ class ArrayReader(StringReader):
         return [item.strip() for item in response.split(',')]
 
 
+class ArrayObjectReader(StringReader):
+    @staticmethod
+    def condition(spec):
+        return spec.get('type', None) == 'array' and spec.get('items', {}).get('type') == 'object'
+
+    def read(self):
+        results = []
+        prefix = u'{}.'.format(self.name)
+        properties = self.spec.get('items', {}).get('properties', {})
+        message = 'Would you like to continue to set other settings of "%s"?' % self.name
+
+        is_continue = True
+        while is_continue:
+            results.append(InteractiveForm(properties,
+                                           prefix=prefix,
+                                           reraise=True).initiate_dialog())
+
+            if Question(message, {'default': 'y'}).read() != 'y':
+                is_continue = False
+
+        return results
+
+
 class ArrayEnumReader(EnumReader):
     def __init__(self, name, spec, prefix=None):
         self.items = spec.get('items', {})
@@ -371,6 +394,7 @@ class InteractiveForm(object):
         IntegerReader,
         ObjectReader,
         ArrayEnumReader,
+        ArrayObjectReader,
         ArrayReader,
         SecretStringReader,
         StringReader

--- a/st2client/tests/unit/test_interactive.py
+++ b/st2client/tests/unit/test_interactive.py
@@ -366,7 +366,7 @@ class TestInteractive(unittest2.TestCase):
         self.is_continued = False
 
         def side_effect(msg, **kwargs):
-            if re.match(r'^Would you like to continue to set other settings.*', msg):
+            if re.match(r'^~~~ Would you like to add another item to.*', msg):
                 # prompt requires the input to judge continuing setting, or not
                 if not self.is_continued:
                     # continuing the configuration only once

--- a/st2client/tests/unit/test_interactive.py
+++ b/st2client/tests/unit/test_interactive.py
@@ -16,6 +16,7 @@
 import logging
 import mock
 from StringIO import StringIO
+import re
 import unittest2
 
 import prompt_toolkit
@@ -340,3 +341,47 @@ class TestInteractive(unittest2.TestCase):
         self.assertPromptMessage(prompt_mock, message)
         self.assertPromptDescription(prompt_mock, 'some description')
         self.assertPromptValidate(prompt_mock, '0,2,4,')
+
+    @mock.patch.object(interactive, 'prompt')
+    def test_arrayobjectreader(self, prompt_mock):
+        spec = {
+            'items': {
+                'type': 'object',
+                'properties': {
+                    'foo': {
+                        'type': 'string',
+                        'description': 'some description',
+                    },
+                    'bar': {
+                        'type': 'string',
+                        'description': 'some description',
+                    }
+                }
+            },
+            'description': 'some description',
+        }
+        Reader = interactive.ArrayObjectReader('some', spec)
+
+        # To emulate continuing setting, this flag variable is needed
+        self.is_continued = False
+
+        def side_effect(msg, **kwargs):
+            if re.match(r'^Would you like to continue to set other settings.*', msg):
+                # prompt requires the input to judge continuing setting, or not
+                if not self.is_continued:
+                    # continuing the configuration only once
+                    self.is_continued = True
+                    return ''
+                else:
+                    # finishing to configuration
+                    return 'n'
+            else:
+                # prompt requires the input of property value in the object
+                return 'value'
+
+        prompt_mock.side_effect = side_effect
+        results = Reader.read()
+
+        self.assertEqual(len(results), 2)
+        self.assertTrue(all([len(x.keys()) == 2 for x in results]))
+        self.assertTrue(all(['foo' in x and 'bar' in x for x in results]))


### PR DESCRIPTION
## Abstract
I implemented a ArrayObjectReader for InteractiveForm in the st2client to set configuration from the schema of array which has elements of dicts interactively.

## Background / Problem
As [enykeev said](https://github.com/StackStorm/st2/pull/2964#issuecomment-254734078), the InteractiveForm of st2client has a restriction that couldn't set configuration from the `array of objects` type.
By this restriction, some pack (e.g. [git](https://github.com/StackStorm-Exchange/stackstorm-git), [napalm](https://github.com/StackStorm-Exchange/stackstorm-napalm) and [acos](https://github.com/StackStorm-Exchange/stackstorm-acos)) couldn't interactively set complete configuration by `st2 pack config` command.

## Solution
I implemented another Reader that dedicate to set configuration sets continuously from the schema of `array of objects` type.
