### PR TITLE
Fix invocation of Mistral workflow from Action Chain

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -48,6 +48,7 @@ Fixed
   Reported by sibirajal.
 * Add a check to make sure action exists in the POST of the action execution API. (bug fix)
 * Fix api key generation, to use system user, when auth is disabled. (bug fix) #3578 #3593
+* Fix invocation of Mistral workflow from Action Chain with jinja in params. (bug fix) #3440
 
 2.3.1 - July 07, 2017
 ---------------------

--- a/contrib/examples/actions/chains/invoke_mistral_with_jinja.yaml
+++ b/contrib/examples/actions/chains/invoke_mistral_with_jinja.yaml
@@ -1,0 +1,6 @@
+chain:
+    -
+        name: task1
+        ref: examples.mistral-basic
+        params:
+            cmd: "{{cmd}}"

--- a/contrib/examples/actions/invoke_mistral_with_jinja.yaml
+++ b/contrib/examples/actions/invoke_mistral_with_jinja.yaml
@@ -1,0 +1,10 @@
+---
+name: invoke-mistral-with-jinja
+description: Example to invoke a Mistral workflow from an Action Chain
+runner_type: action-chain
+entry_point: chains/invoke_mistral_with_jinja.yaml
+enabled: true
+parameters:
+    cmd:
+        type: string
+        required: true

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2.py
@@ -283,6 +283,81 @@ class MistralRunnerTest(DbTestCase):
     @mock.patch.object(
         executions.ExecutionManager, 'create',
         mock.MagicMock(return_value=executions.Execution(None, WF1_EXEC)))
+    def test_launch_workflow_under_parent_chain_with_jinja_params(self):
+        ac_ctx = {
+            'chain': {
+                'params': {
+                    'var1': 'foobar',
+                    'var2': '{{foobar}}',
+                    'var3': ['{{foo}}', '{{bar}}'],
+                    'var4': {
+                        'foobar': '{{foobar}}'
+                    },
+                }
+            }
+        }
+
+        liveaction = LiveActionDB(action=WF1_NAME, parameters=ACTION_PARAMS, context=ac_ctx)
+        liveaction, execution = action_service.request(liveaction)
+        liveaction = LiveAction.get_by_id(str(liveaction.id))
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_RUNNING)
+
+        mistral_context = liveaction.context.get('mistral', None)
+        self.assertIsNotNone(mistral_context)
+        self.assertEqual(mistral_context['execution_id'], WF1_EXEC.get('id'))
+        self.assertEqual(mistral_context['workflow_name'], WF1_EXEC.get('workflow_name'))
+
+        workflow_input = copy.deepcopy(ACTION_PARAMS)
+        workflow_input.update({'count': '3'})
+
+        env = {
+            'st2_execution_id': str(execution.id),
+            'st2_liveaction_id': str(liveaction.id),
+            'st2_action_api_url': 'http://0.0.0.0:9101/v1',
+            '__actions': {
+                'st2.action': {
+                    'st2_context': {
+                        'api_url': 'http://0.0.0.0:9101/v1',
+                        'endpoint': 'http://0.0.0.0:9101/v1/actionexecutions',
+                        'parent': {
+                            'pack': 'mistral_tests',
+                            'execution_id': str(execution.id),
+                            'chain': {
+                                'params': {
+                                    'var1': 'foobar',
+                                    'var2': '{% raw %}{{foobar}}{% endraw %}',
+                                    'var3': [
+                                        '{% raw %}{{foo}}{% endraw %}',
+                                        '{% raw %}{{bar}}{% endraw %}'
+                                    ],
+                                    'var4': {
+                                        'foobar': '{% raw %}{{foobar}}{% endraw %}'
+                                    }
+                                }
+                            }
+                        },
+                        'notify': {},
+                        'skip_notify_tasks': []
+                    }
+                }
+            }
+        }
+
+        executions.ExecutionManager.create.assert_called_with(
+            WF1_NAME, workflow_input=workflow_input, env=env)
+
+    @mock.patch.object(
+        workflows.WorkflowManager, 'list',
+        mock.MagicMock(return_value=[]))
+    @mock.patch.object(
+        workflows.WorkflowManager, 'get',
+        mock.MagicMock(return_value=WF1))
+    @mock.patch.object(
+        workflows.WorkflowManager, 'create',
+        mock.MagicMock(return_value=[WF1]))
+    @mock.patch.object(
+        executions.ExecutionManager, 'create',
+        mock.MagicMock(return_value=executions.Execution(None, WF1_EXEC)))
     def test_launch_workflow_with_st2_https(self):
         cfg.CONF.set_override('api_url', 'https://0.0.0.0:9101', group='auth')
 

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2.py
@@ -293,6 +293,9 @@ class MistralRunnerTest(DbTestCase):
                     'var4': {
                         'foobar': '{{foobar}}'
                     },
+                    'var5': {
+                        'foobar': '{% for item in items %}foobar{% end for %}'
+                    }
                 }
             }
         }
@@ -332,6 +335,12 @@ class MistralRunnerTest(DbTestCase):
                                     ],
                                     'var4': {
                                         'foobar': '{% raw %}{{foobar}}{% endraw %}'
+                                    },
+                                    'var5': {
+                                        'foobar': (
+                                            '{% raw %}{% for item in items %}'
+                                            'foobar{% end for %}{% endraw %}'
+                                        )
                                     }
                                 }
                             }

--- a/st2common/st2common/util/jinja.py
+++ b/st2common/st2common/util/jinja.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import json
+import re
 import six
 
 from st2common import log as logging
@@ -33,6 +34,12 @@ JINJA_EXPRESSIONS_START_MARKERS = [
     '{{',
     '{%'
 ]
+
+JINJA_REGEX = '({{(.*)}})'
+JINJA_REGEX_PTRN = re.compile(JINJA_REGEX)
+JINJA_BLOCK_REGEX = '({%(.*)%})'
+JINJA_BLOCK_REGEX_PTRN = re.compile(JINJA_BLOCK_REGEX)
+
 
 LOG = logging.getLogger(__name__)
 
@@ -180,3 +187,17 @@ def is_jinja_expression(value):
             return True
 
     return False
+
+
+def convert_jinja_to_raw_block(value):
+    if isinstance(value, dict):
+        return {k: convert_jinja_to_raw_block(v) for k, v in six.iteritems(value)}
+
+    if isinstance(value, list):
+        return [convert_jinja_to_raw_block(v) for v in value]
+
+    if isinstance(value, six.string_types):
+        if JINJA_REGEX_PTRN.findall(value) or JINJA_BLOCK_REGEX_PTRN.findall(value):
+            return '{% raw %}' + value + '{% endraw %}'
+
+    return value

--- a/st2common/st2common/util/workflow/mistral.py
+++ b/st2common/st2common/util/workflow/mistral.py
@@ -61,10 +61,10 @@ SPEC_TYPES = {
     }
 }
 
-JINJA_WITH_ST2KV = '{{st2kv\..*?|.*?\sst2kv\..*?}}'
-JINJA_WITH_ST2KV_PTRN = re.compile(JINJA_WITH_ST2KV)
-JINJA_WITH_LOCAL_CTX = '{{.*?_\..*?}}'
-JINJA_WITH_LOCAL_CTX_PTRN = re.compile(JINJA_WITH_LOCAL_CTX)
+JINJA_REGEX_WITH_ST2KV = '{{st2kv\..*?|.*?\sst2kv\..*?}}'
+JINJA_REGEX_WITH_ST2KV_PTRN = re.compile(JINJA_REGEX_WITH_ST2KV)
+JINJA_REGEX_WITH_LOCAL_CTX = '{{.*?_\..*?}}'
+JINJA_REGEX_WITH_LOCAL_CTX_PTRN = re.compile(JINJA_REGEX_WITH_LOCAL_CTX)
 
 
 def _parse_cmd_and_input(cmd_str):
@@ -147,8 +147,8 @@ def _transform_action_param(action_ref, param_name, param_value):
         }
 
     if isinstance(param_value, six.string_types):
-        st2kv_matches = JINJA_WITH_ST2KV_PTRN.findall(param_value)
-        local_ctx_matches = JINJA_WITH_LOCAL_CTX_PTRN.findall(param_value)
+        st2kv_matches = JINJA_REGEX_WITH_ST2KV_PTRN.findall(param_value)
+        local_ctx_matches = JINJA_REGEX_WITH_LOCAL_CTX_PTRN.findall(param_value)
 
         if st2kv_matches and local_ctx_matches:
             raise WorkflowDefinitionException('Parameter "%s" for action "%s" containing '

--- a/st2common/tests/unit/test_util_jinja.py
+++ b/st2common/tests/unit/test_util_jinja.py
@@ -65,13 +65,27 @@ class JinjaUtilsRenderTestCase(unittest2.TestCase):
         expected_raw_block = '{% raw %}{{foobar}}{% endraw %}'
         self.assertEqual(expected_raw_block, jinja_utils.convert_jinja_to_raw_block(jinja_expr))
 
+        jinja_block_expr = '{% for item in items %}foobar{% end for %}'
+        expected_raw_block = '{% raw %}{% for item in items %}foobar{% end for %}{% endraw %}'
+        self.assertEqual(
+            expected_raw_block,
+            jinja_utils.convert_jinja_to_raw_block(jinja_block_expr)
+        )
+
     def test_convert_list_to_raw(self):
-        jinja_expr = ['foobar', '{{foo}}', '{{bar}}', {'foobar': '{{foobar}}'}]
+        jinja_expr = [
+            'foobar',
+            '{{foo}}',
+            '{{bar}}',
+            '{% for item in items %}foobar{% end for %}',
+            {'foobar': '{{foobar}}'}
+        ]
 
         expected_raw_block = [
             'foobar',
             '{% raw %}{{foo}}{% endraw %}',
             '{% raw %}{{bar}}{% endraw %}',
+            '{% raw %}{% for item in items %}foobar{% end for %}{% endraw %}',
             {'foobar': '{% raw %}{{foobar}}{% endraw %}'}
         ]
 
@@ -81,7 +95,8 @@ class JinjaUtilsRenderTestCase(unittest2.TestCase):
         jinja_expr = {
             'var1': 'foobar',
             'var2': ['{{foo}}', '{{bar}}'],
-            'var3': {'foobar': '{{foobar}}'}
+            'var3': {'foobar': '{{foobar}}'},
+            'var4': {'foobar': '{% for item in items %}foobar{% end for %}'}
         }
 
         expected_raw_block = {
@@ -92,6 +107,9 @@ class JinjaUtilsRenderTestCase(unittest2.TestCase):
             ],
             'var3': {
                 'foobar': '{% raw %}{{foobar}}{% endraw %}'
+            },
+            'var4': {
+                'foobar': '{% raw %}{% for item in items %}foobar{% end for %}{% endraw %}'
             }
         }
 

--- a/st2common/tests/unit/test_util_jinja.py
+++ b/st2common/tests/unit/test_util_jinja.py
@@ -59,3 +59,40 @@ class JinjaUtilsRenderTestCase(unittest2.TestCase):
             allow_undefined=True)
 
         self.assertEqual(actual, expected)
+
+    def test_convert_str_to_raw(self):
+        jinja_expr = '{{foobar}}'
+        expected_raw_block = '{% raw %}{{foobar}}{% endraw %}'
+        self.assertEqual(expected_raw_block, jinja_utils.convert_jinja_to_raw_block(jinja_expr))
+
+    def test_convert_list_to_raw(self):
+        jinja_expr = ['foobar', '{{foo}}', '{{bar}}', {'foobar': '{{foobar}}'}]
+
+        expected_raw_block = [
+            'foobar',
+            '{% raw %}{{foo}}{% endraw %}',
+            '{% raw %}{{bar}}{% endraw %}',
+            {'foobar': '{% raw %}{{foobar}}{% endraw %}'}
+        ]
+
+        self.assertListEqual(expected_raw_block, jinja_utils.convert_jinja_to_raw_block(jinja_expr))
+
+    def test_convert_dict_to_raw(self):
+        jinja_expr = {
+            'var1': 'foobar',
+            'var2': ['{{foo}}', '{{bar}}'],
+            'var3': {'foobar': '{{foobar}}'}
+        }
+
+        expected_raw_block = {
+            'var1': 'foobar',
+            'var2': [
+                '{% raw %}{{foo}}{% endraw %}',
+                '{% raw %}{{bar}}{% endraw %}'
+            ],
+            'var3': {
+                'foobar': '{% raw %}{{foobar}}{% endraw %}'
+            }
+        }
+
+        self.assertDictEqual(expected_raw_block, jinja_utils.convert_jinja_to_raw_block(jinja_expr))

--- a/st2tests/integration/mistral/test_wiring.py
+++ b/st2tests/integration/mistral/test_wiring.py
@@ -347,3 +347,7 @@ class WiringTest(base.TestWorkflowExecution):
 
         children = self.st2client.liveactions.get_property(execution.id, 'children')
         self.assertEqual(len(children), 2)
+
+    def test_invoke_from_action_chain(self):
+        execution = self._execute_workflow('examples.invoke-mistral-with-jinja', {'cmd': 'date'})
+        execution = self._wait_for_state(execution, ['succeeded'])


### PR DESCRIPTION
If the parent action chain contains jinja expression in the execution parameters, the jinja expression will be included in the context begin passed into the Mistral subworkflow. Mistral will try to evaluate the expression when it is evaulating input args and if the expression contains references to local data context, the evaulation fails because the data context is already out of scope. This patch converts the jinja expression into raw jinja blocks when passing thru the context.