### PR TITLE
Check for NoneType when converting Jinja to raw blocks in Mistral runner

### DIFF
--- a/contrib/runners/mistral_v2/mistral_v2.py
+++ b/contrib/runners/mistral_v2/mistral_v2.py
@@ -170,7 +170,10 @@ class MistralRunner(AsyncActionRunner):
         # into raw block. If there is any jinja expressions, Mistral will try to evaulate
         # the expression. If there is a local context reference, the evaluation will fail
         # because the local context reference is out of scope.
-        for k, v in six.iteritems(parent_context.get('chain', {}).get('params', {})):
+        chain_ctx = parent_context.get('chain') or {}
+        chain_params_ctx = chain_ctx.get('params') or {}
+
+        for k, v in six.iteritems(chain_params_ctx):
             parent_context['chain']['params'][k] = jinja.convert_jinja_to_raw_block(v)
 
         st2_execution_context = {

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2.py
@@ -367,6 +367,112 @@ class MistralRunnerTest(DbTestCase):
     @mock.patch.object(
         executions.ExecutionManager, 'create',
         mock.MagicMock(return_value=executions.Execution(None, WF1_EXEC)))
+    def test_launch_workflow_under_parent_chain_with_nonetype_in_chain_context(self):
+        ac_ctx = {'chain': None}
+
+        liveaction = LiveActionDB(action=WF1_NAME, parameters=ACTION_PARAMS, context=ac_ctx)
+        liveaction, execution = action_service.request(liveaction)
+        liveaction = LiveAction.get_by_id(str(liveaction.id))
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_RUNNING)
+
+        mistral_context = liveaction.context.get('mistral', None)
+        self.assertIsNotNone(mistral_context)
+        self.assertEqual(mistral_context['execution_id'], WF1_EXEC.get('id'))
+        self.assertEqual(mistral_context['workflow_name'], WF1_EXEC.get('workflow_name'))
+
+        workflow_input = copy.deepcopy(ACTION_PARAMS)
+        workflow_input.update({'count': '3'})
+
+        env = {
+            'st2_execution_id': str(execution.id),
+            'st2_liveaction_id': str(liveaction.id),
+            'st2_action_api_url': 'http://0.0.0.0:9101/v1',
+            '__actions': {
+                'st2.action': {
+                    'st2_context': {
+                        'api_url': 'http://0.0.0.0:9101/v1',
+                        'endpoint': 'http://0.0.0.0:9101/v1/actionexecutions',
+                        'parent': {
+                            'pack': 'mistral_tests',
+                            'execution_id': str(execution.id),
+                            'chain': None
+                        },
+                        'notify': {},
+                        'skip_notify_tasks': []
+                    }
+                }
+            }
+        }
+
+        executions.ExecutionManager.create.assert_called_with(
+            WF1_NAME, workflow_input=workflow_input, env=env)
+
+    @mock.patch.object(
+        workflows.WorkflowManager, 'list',
+        mock.MagicMock(return_value=[]))
+    @mock.patch.object(
+        workflows.WorkflowManager, 'get',
+        mock.MagicMock(return_value=WF1))
+    @mock.patch.object(
+        workflows.WorkflowManager, 'create',
+        mock.MagicMock(return_value=[WF1]))
+    @mock.patch.object(
+        executions.ExecutionManager, 'create',
+        mock.MagicMock(return_value=executions.Execution(None, WF1_EXEC)))
+    def test_launch_workflow_under_parent_chain_with_nonetype_in_params_context(self):
+        ac_ctx = {'chain': {'params': None}}
+
+        liveaction = LiveActionDB(action=WF1_NAME, parameters=ACTION_PARAMS, context=ac_ctx)
+        liveaction, execution = action_service.request(liveaction)
+        liveaction = LiveAction.get_by_id(str(liveaction.id))
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_RUNNING)
+
+        mistral_context = liveaction.context.get('mistral', None)
+        self.assertIsNotNone(mistral_context)
+        self.assertEqual(mistral_context['execution_id'], WF1_EXEC.get('id'))
+        self.assertEqual(mistral_context['workflow_name'], WF1_EXEC.get('workflow_name'))
+
+        workflow_input = copy.deepcopy(ACTION_PARAMS)
+        workflow_input.update({'count': '3'})
+
+        env = {
+            'st2_execution_id': str(execution.id),
+            'st2_liveaction_id': str(liveaction.id),
+            'st2_action_api_url': 'http://0.0.0.0:9101/v1',
+            '__actions': {
+                'st2.action': {
+                    'st2_context': {
+                        'api_url': 'http://0.0.0.0:9101/v1',
+                        'endpoint': 'http://0.0.0.0:9101/v1/actionexecutions',
+                        'parent': {
+                            'pack': 'mistral_tests',
+                            'execution_id': str(execution.id),
+                            'chain': {
+                                'params': None
+                            }
+                        },
+                        'notify': {},
+                        'skip_notify_tasks': []
+                    }
+                }
+            }
+        }
+
+        executions.ExecutionManager.create.assert_called_with(
+            WF1_NAME, workflow_input=workflow_input, env=env)
+
+    @mock.patch.object(
+        workflows.WorkflowManager, 'list',
+        mock.MagicMock(return_value=[]))
+    @mock.patch.object(
+        workflows.WorkflowManager, 'get',
+        mock.MagicMock(return_value=WF1))
+    @mock.patch.object(
+        workflows.WorkflowManager, 'create',
+        mock.MagicMock(return_value=[WF1]))
+    @mock.patch.object(
+        executions.ExecutionManager, 'create',
+        mock.MagicMock(return_value=executions.Execution(None, WF1_EXEC)))
     def test_launch_workflow_with_st2_https(self):
         cfg.CONF.set_override('api_url', 'https://0.0.0.0:9101', group='auth')
 


### PR DESCRIPTION
When converting the jinja expression in the raw blocks in Mistral runner for a parent Action Chain, check for NoneType in the context dictionary.