### PR TITLE
Added [resultstracker] query_interval to st2.conf.sample

### DIFF
--- a/conf/st2.conf.sample
+++ b/conf/st2.conf.sample
@@ -195,6 +195,8 @@ logging = conf/logging.notifier.conf
 [resultstracker]
 # Location of the logging configuration file.
 logging = conf/logging.resultstracker.conf
+# The time, in seconds, for polling 3rd party workflow systems (such as mistral)
+query_interval = 20
 
 [rulesengine]
 # Location of the logging configuration file.


### PR DESCRIPTION
The `[resultstracker] query_interval` option was added st2. It was documented in the changelog but was not added to `st2.conf.sample`. This adds it to `st2.conf.sample`
