### PR TITLE
Trigger e2e tests for PRs

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -107,7 +107,7 @@ jobs:
 
   # Dummy rule for testing CircleCI Webhooks
   dummy_packages:
-    parallelism: 4
+    parallelism: 1
     # 4CPUs & 8GB RAM CircleCI machine
     # sadly, it doesn't work with 'setup_remote_docker'
     resource_class: large
@@ -257,7 +257,7 @@ workflows:
       - dummy_packages
       - deploy:
           requires:
-            - packages
+            - dummy_packages
           filters:
             branches:
               only:

--- a/circle.yml
+++ b/circle.yml
@@ -105,26 +105,6 @@ jobs:
             - ~/.cache/pip/
             - virtualenv/
 
-  # Dummy rule for testing CircleCI Webhooks
-  dummy_packages:
-    parallelism: 1
-    # 4CPUs & 8GB RAM CircleCI machine
-    # sadly, it doesn't work with 'setup_remote_docker'
-    resource_class: large
-    docker:
-      # The primary container is an instance of the first list image listed. Your build commands run in this container.
-      - image: circleci/python:2.7
-    working_directory: ~/st2
-    environment:
-      - DISTROS: "trusty xenial el6 el7"
-      - ST2_PACKAGES_REPO: https://github.com/StackStorm/st2-packages
-      - ST2_PACKAGES: "st2"
-      - ST2_CHECKOUT: 0
-      - ST2_GITDIR: /tmp/st2
-      - BASH_ENV: ~/.buildenv
-    steps:
-      - checkout
-
   # Build & Test st2 packages
   packages:
     parallelism: 4

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,6 @@
+# Setup in CircleCI account the following ENV variables:
+# PACKAGECLOUD_ORGANIZATION (default: stackstorm)
+# PACKAGECLOUD_TOKEN
 version: 2
 jobs:
   # Run st2 Unit Tests
@@ -248,3 +251,7 @@ experimental:
       only:
         - master
         - /v[0-9]+\.[0-9]+/
+
+notify:
+  webhooks:
+    - url: https://ci-webhooks.stackstorm.net/webhooks/build/events

--- a/circle.yml
+++ b/circle.yml
@@ -105,6 +105,26 @@ jobs:
             - ~/.cache/pip/
             - virtualenv/
 
+  # Dummy rule for testing CircleCI Webhooks
+  dummy_packages:
+    parallelism: 4
+    # 4CPUs & 8GB RAM CircleCI machine
+    # sadly, it doesn't work with 'setup_remote_docker'
+    resource_class: large
+    docker:
+      # The primary container is an instance of the first list image listed. Your build commands run in this container.
+      - image: circleci/python:2.7
+    working_directory: ~/st2
+    environment:
+      - DISTROS: "trusty xenial el6 el7"
+      - ST2_PACKAGES_REPO: https://github.com/StackStorm/st2-packages
+      - ST2_PACKAGES: "st2"
+      - ST2_CHECKOUT: 0
+      - ST2_GITDIR: /tmp/st2
+      - BASH_ENV: ~/.buildenv
+    steps:
+      - checkout
+
   # Build & Test st2 packages
   packages:
     parallelism: 4
@@ -234,7 +254,7 @@ workflows:
   version: 2
   package-test-and-deploy:
     jobs:
-      - packages
+      - dummy_packages
       - deploy:
           requires:
             - packages

--- a/circle.yml
+++ b/circle.yml
@@ -200,20 +200,6 @@ jobs:
           paths:
             - .
 
-  # Trigger st2 webhook to run end2end tests
-  trigger_e2etests:
-    docker:
-      # The primary container is an instance of the first list image listed. Your build commands run in this container.
-      - image: circleci/python:2.7
-    working_directory: ~/st2
-    steps:
-      - run:
-          name: Docker version
-          command: |
-            set -x
-            docker --version
-            docker-compose --version
-
   # Deploy produced deb/rpm packages to PackageCloud staging
   deploy:
     docker:
@@ -239,6 +225,7 @@ jobs:
           name: Deploy deb/rpm packages to PackageCloud
           command: "parallel -v -j0 --line-buffer packagecloud.sh deploy {} {}/build ::: ${DISTROS}"
 
+# TODO: Return to workflows when "Auto-cancel redundant builds” feature is implemented for Workflows: https://discuss.circleci.com/t/auto-cancel-redundant-builds-not-working-for-workflow/13852
 # Putting everything together
 workflows:
   version: 2

--- a/circle.yml
+++ b/circle.yml
@@ -244,18 +244,9 @@ workflows:
   version: 2
   package-test-and-deploy:
     jobs:
-      - unit
-      - integration
-      - lint
       - packages
-      - trigger_e2etests:
-          requires:
-            - packages
       - deploy:
           requires:
-            - unit
-            - integration
-            - lint
             - packages
           filters:
             branches:
@@ -263,7 +254,6 @@ workflows:
                 - master
                 - /v[0-9]+\.[0-9]+/
                 - feature/circleci
-                #- experimental/circle-2.0-workflows
 
 experimental:
   notify:

--- a/circle.yml
+++ b/circle.yml
@@ -194,7 +194,7 @@ jobs:
             .circle/docker-compose2.sh build ${DISTRO}
             # Once build container finishes we can copy packages directly from it
             mkdir -p ~/st2/packages/${DISTRO}/log/
-            docker cp st2-packages-vol:/root/build ~/st2/packages/${DISTRO}
+            docker cp st2-packages-vol:/root/build/. ~/st2/packages/${DISTRO}
           working_directory: ~/st2-packages
 #      # TODO: It works! (~0.5-1min speed-up) Enable CircleCI2.0 cache for pip and wheelhouse later
 #      - run:
@@ -246,7 +246,7 @@ jobs:
             sudo wget -O /usr/local/bin/packagecloud.sh https://raw.githubusercontent.com/StackStorm/st2-packages/master/.circle/packagecloud.sh && sudo chmod +x /usr/local/bin/packagecloud.sh
       - run:
           name: Deploy deb/rpm packages to PackageCloud
-          command: "parallel -v -j0 --line-buffer packagecloud.sh deploy {} {}/build ::: ${DISTROS}"
+          command: "parallel -v -j0 --line-buffer packagecloud.sh deploy {} {} ::: ${DISTROS}"
 
 # TODO: Return to workflows when "Auto-cancel redundant builds” feature is implemented for Workflows: https://discuss.circleci.com/t/auto-cancel-redundant-builds-not-working-for-workflow/13852
 # Putting everything together
@@ -254,10 +254,10 @@ workflows:
   version: 2
   package-test-and-deploy:
     jobs:
-      - dummy_packages
+      - packages
       - deploy:
           requires:
-            - dummy_packages
+            - packages
           filters:
             branches:
               only:


### PR DESCRIPTION
Fixes https://github.com/StackStorm/st2ci/issues/94

Related changes:
- [x] https://github.com/StackStorm/st2-packages/pull/476
- [x] https://github.com/StackStorm/st2ci/pull/103
- [x] https://github.com/StackStorm/st2cd/pull/295

Remove Unit + Integration tests from CircleCI, - after experiment we decided to go with Travis due to timing reasons for such tests.
Check what's needed from https://github.com/stackstorm/st2ci to trigger `e2e` stackstorm tests once the packages are ready.