### PR TITLE
Quieted logrotate script

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,6 +56,11 @@ Fixed
 * Fix st2client API bug, a backward incompatible change in `query()` method, introduced in note
   implementation (#3514) in 2.3.1. The `query()` method is now backward compatible (pre 2.3) and
   `query_with_count()` method is used for results pagination and note. #3616
+* Fix logrotate script so that it no longer prints the `st2ctl` PID status to stdout
+  for each file that it rotates. Also, it will no longer print an error if
+  /var/log/st2/st2web.log is missing.
+  
+  Contributed by Nick Maludy. #3633
 
 2.3.1 - July 07, 2017
 ---------------------

--- a/conf/logrotate.conf
+++ b/conf/logrotate.conf
@@ -4,8 +4,15 @@ copytruncate
 notifempty
 
 ## Rules engine
-/var/log/st2/st2rulesengine.log
 /var/log/st2/st2rulesengine.audit.log {
+  rotate 5
+  size 10M
+  postrotate
+    st2ctl reopen-log-files st2rulesengine > /dev/null
+  endscript
+}
+
+/var/log/st2/st2rulesengine.log {
   size 100M
   rotate 5
   postrotate
@@ -14,7 +21,14 @@ notifempty
 }
 
 ## AUTH
-/var/log/st2/st2auth.log
+/var/log/st2/st2auth.log {
+  daily
+  rotate 5
+  postrotate
+    st2ctl reopen-log-files st2auth > /dev/null
+  endscript
+}
+
 /var/log/st2/st2auth.audit.log {
   daily
   rotate 5
@@ -24,7 +38,14 @@ notifempty
 }
 
 ## API
-/var/log/st2/st2api.log
+/var/log/st2/st2api.log {
+  daily
+  rotate 5
+  postrotate
+    st2ctl reopen-log-files st2api > /dev/null
+  endscript
+}
+
 /var/log/st2/st2api.audit.log {
   daily
   rotate 5
@@ -34,7 +55,14 @@ notifempty
 }
 
 ## Stream
-/var/log/st2/st2stream.log
+/var/log/st2/st2stream.log {
+  daily
+  rotate 5
+  postrotate
+    st2ctl reopen-log-files st2stream > /dev/null
+  endscript
+}
+
 /var/log/st2/st2stream.audit.log {
   daily
   rotate 5

--- a/conf/logrotate.conf
+++ b/conf/logrotate.conf
@@ -4,15 +4,8 @@ copytruncate
 notifempty
 
 ## Rules engine
+/var/log/st2/st2rulesengine.log
 /var/log/st2/st2rulesengine.audit.log {
-  rotate 5
-  size 10M
-  postrotate
-    st2ctl reopen-log-files st2rulesengine > /dev/null
-  endscript
-}
-
-/var/log/st2/st2rulesengine.log {
   size 100M
   rotate 5
   postrotate
@@ -21,14 +14,7 @@ notifempty
 }
 
 ## AUTH
-/var/log/st2/st2auth.log {
-  daily
-  rotate 5
-  postrotate
-    st2ctl reopen-log-files st2auth > /dev/null
-  endscript
-}
-
+/var/log/st2/st2auth.log
 /var/log/st2/st2auth.audit.log {
   daily
   rotate 5
@@ -38,14 +24,7 @@ notifempty
 }
 
 ## API
-/var/log/st2/st2api.log {
-  daily
-  rotate 5
-  postrotate
-    st2ctl reopen-log-files st2api > /dev/null
-  endscript
-}
-
+/var/log/st2/st2api.log
 /var/log/st2/st2api.audit.log {
   daily
   rotate 5
@@ -55,14 +34,7 @@ notifempty
 }
 
 ## Stream
-/var/log/st2/st2stream.log {
-  daily
-  rotate 5
-  postrotate
-    st2ctl reopen-log-files st2stream > /dev/null
-  endscript
-}
-
+/var/log/st2/st2stream.log
 /var/log/st2/st2stream.audit.log {
   daily
   rotate 5
@@ -116,15 +88,5 @@ notifempty
   rotate 5
   postrotate
     st2ctl reopen-log-files st2garbagecollector > /dev/null
-  endscript
-}
-
-## WebUI
-/var/log/st2/st2web.log {
-  daily
-  rotate 5
-  missingok
-  postrotate
-    st2ctl restart-component st2web > /dev/null
   endscript
 }

--- a/conf/logrotate.conf
+++ b/conf/logrotate.conf
@@ -8,7 +8,7 @@ notifempty
   rotate 5
   size 10M
   postrotate
-    st2ctl reopen-log-files st2rulesengine
+    st2ctl reopen-log-files st2rulesengine > /dev/null
   endscript
 }
 
@@ -16,7 +16,7 @@ notifempty
   size 100M
   rotate 5
   postrotate
-    st2ctl reopen-log-files st2rulesengine
+    st2ctl reopen-log-files st2rulesengine > /dev/null
   endscript
 }
 
@@ -25,7 +25,7 @@ notifempty
   daily
   rotate 5
   postrotate
-    st2ctl reopen-log-files st2auth
+    st2ctl reopen-log-files st2auth > /dev/null
   endscript
 }
 
@@ -33,7 +33,7 @@ notifempty
   daily
   rotate 5
   postrotate
-    st2ctl reopen-log-files st2auth
+    st2ctl reopen-log-files st2auth > /dev/null
   endscript
 }
 
@@ -42,7 +42,7 @@ notifempty
   daily
   rotate 5
   postrotate
-    st2ctl reopen-log-files st2api
+    st2ctl reopen-log-files st2api > /dev/null
   endscript
 }
 
@@ -50,7 +50,7 @@ notifempty
   daily
   rotate 5
   postrotate
-    st2ctl reopen-log-files st2api
+    st2ctl reopen-log-files st2api > /dev/null
   endscript
 }
 
@@ -59,7 +59,7 @@ notifempty
   daily
   rotate 5
   postrotate
-    st2ctl reopen-log-files st2stream
+    st2ctl reopen-log-files st2stream > /dev/null
   endscript
 }
 
@@ -67,7 +67,7 @@ notifempty
   daily
   rotate 5
   postrotate
-    st2ctl reopen-log-files st2stream
+    st2ctl reopen-log-files st2stream > /dev/null
   endscript
 }
 
@@ -76,7 +76,7 @@ notifempty
   daily
   rotate 5
   postrotate
-    st2ctl reopen-log-files st2resultstracker
+    st2ctl reopen-log-files st2resultstracker > /dev/null
   endscript
 }
 
@@ -85,7 +85,7 @@ notifempty
   daily
   rotate 5
   postrotate
-    st2ctl reopen-log-files st2notifier
+    st2ctl reopen-log-files st2notifier > /dev/null
   endscript
 }
 
@@ -94,7 +94,7 @@ notifempty
   daily
   rotate 5
   postrotate
-    st2ctl reopen-log-files st2sensorcontainer
+    st2ctl reopen-log-files st2sensorcontainer > /dev/null
   endscript
 }
 
@@ -106,7 +106,7 @@ notifempty
     # Delete all files that haven't been modified in over 30 days
     # Clean up stale PID logs
     find /var/log/st2/ -type f -name "st2actionrunner*.log" -mtime +30 -exec rm -f {} \;
-    st2ctl reopen-log-files st2actionrunner
+    st2ctl reopen-log-files st2actionrunner > /dev/null
   endscript
 }
 
@@ -115,7 +115,7 @@ notifempty
   daily
   rotate 5
   postrotate
-    st2ctl reopen-log-files st2garbagecollector
+    st2ctl reopen-log-files st2garbagecollector > /dev/null
   endscript
 }
 
@@ -123,7 +123,8 @@ notifempty
 /var/log/st2/st2web.log {
   daily
   rotate 5
+  missingok
   postrotate
-    st2ctl restart-component st2web
+    st2ctl restart-component st2web > /dev/null
   endscript
 }


### PR DESCRIPTION
This is a fix for https://github.com/StackStorm/st2/issues/3633

The following updates have been made:

1. Redirect `stdout` to `/dev/null` for every `st2ctl reopen-log-files` command
2. Added `missingok` to `/var/log/st2/st2web.log` because this file does not seem to be created (at least on my Red Hat test box)

