### PR TITLE
Transport util fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,10 @@ Changed
 Fixed
 ~~~~~
 
+* Fix retrying in message bus exchange registration. (bug fix) #3635 #3638
+
+  Reported by John Arnold.
+
 2.3.2 - July 28, 2017
 ---------------------
 

--- a/st2common/st2common/transport/bootstrap_utils.py
+++ b/st2common/st2common/transport/bootstrap_utils.py
@@ -75,8 +75,11 @@ def register_exchanges():
 
 
 def register_exchanges_with_retry():
+    def retry_if_io_error(exception):
+        return isinstance(exception, socket.error)
+
     retrying_obj = retrying.Retrying(
-        retry_on_exception=socket.error,
+        retry_on_exception=retry_if_io_error,
         wait_fixed=cfg.CONF.messaging.connection_retry_wait,
         stop_max_attempt_number=cfg.CONF.messaging.connection_retries
     )

--- a/st2common/st2common/transport/bootstrap_utils.py
+++ b/st2common/st2common/transport/bootstrap_utils.py
@@ -47,16 +47,16 @@ def _do_register_exchange(exchange, connection, channel, retry_wrapper):
             'auto_delete': exchange.auto_delete,
             'arguments': exchange.arguments,
             'nowait': False,
-            'passive': None
+            'passive': False
         }
         # Use the retry wrapper to increase resiliency in recoverable errors.
         retry_wrapper.ensured(connection=connection,
                               obj=channel,
                               to_ensure_func=channel.exchange_declare,
                               **kwargs)
-        LOG.debug('registered exchange %s.', exchange.name)
+        LOG.debug('Registered exchange %s (%s).' % (exchange.name, str(kwargs)))
     except Exception:
-        LOG.exception('Failed to register exchange : %s.', exchange.name)
+        LOG.exception('Failed to register exchange: %s.', exchange.name)
 
 
 def register_exchanges():


### PR DESCRIPTION
Various transport util fixes:

1. Fix usage of `retrying` library inside `register_exchanges_with_retry` function. We incorrectly passed in an exception for `retry_on_exception` argument which actually expects a callable.

Part of #3635.