### PR TITLE
Add ability to pre-declare all the used message bus queues on service startup (allow users to use non RabbitMQ kombu transports)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,9 +14,16 @@ Changed
 ~~~~~~~
 
 * Install scripts and documentation has been updated to install MongoDB 3.4 by default (previously
-  3.2 was installed by default). If you want to upgrade an existing installation, please follow 
+  3.2 was installed by default). If you want to upgrade an existing installation, please follow
   official instructions at https://docs.mongodb.com/v3.4/release-notes/3.4-upgrade-standalone/.
   (improvement)
+* Add ability to pre-declare all used message bus queues (and as such, exchanges) on service setup
+  by setting new ``messaging.predeclare_queues`` config option to ``True``. This is required by
+  some non-default kombu backends such as the Redis one.
+
+  Keep in mind that the only officially supported and used messaging backend still is RabbitMQ.
+  We offer no support for other backends and you use them at your own discretion and risk.
+  (improvement) #3635 #3639
 
 Fixed
 ~~~~~

--- a/conf/st2.conf.sample
+++ b/conf/st2.conf.sample
@@ -163,7 +163,7 @@ mask_secrets = True
 url = amqp://guest:guest@127.0.0.1:5672//
 # How long should we wait between connection retries.
 connection_retry_wait = 10000
-# True to pre-declare all the queues on service setup. This is required with some non-standard kombu transports such as Redis one.
+# Set this to True to pre-declare all the AMQP queues on service startup. This is required with some non-standard kombu transports such as the Redis one.
 predeclare_queues = False
 # How many times should we retry connection before failing.
 connection_retries = 10

--- a/conf/st2.conf.sample
+++ b/conf/st2.conf.sample
@@ -163,6 +163,8 @@ mask_secrets = True
 url = amqp://guest:guest@127.0.0.1:5672//
 # How long should we wait between connection retries.
 connection_retry_wait = 10000
+# True to pre-declare all the queues on service setup. This is required with some non-standard kombu transports such as Redis one.
+predeclare_queues = False
 # How many times should we retry connection before failing.
 connection_retries = 10
 # URL of all the nodes in a messaging service cluster.

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -155,7 +155,11 @@ def register_opts(ignore_errors=False):
         cfg.IntOpt('connection_retries', default=10,
                    help='How many times should we retry connection before failing.'),
         cfg.IntOpt('connection_retry_wait', default=10000,
-                   help='How long should we wait between connection retries.')
+                   help='How long should we wait between connection retries.'),
+        cfg.BoolOpt('predeclare_queues', default=False,
+                   help=('True to pre-declare all the queues on service setup.'
+                         'This is required with some non-standard transports such as Redis one.'))
+
     ]
     do_register_opts(messaging_opts, 'messaging', ignore_errors)
 

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -157,8 +157,8 @@ def register_opts(ignore_errors=False):
         cfg.IntOpt('connection_retry_wait', default=10000,
                    help='How long should we wait between connection retries.'),
         cfg.BoolOpt('predeclare_queues', default=False,
-                   help=('True to pre-declare all the queues on service setup.'
-                         'This is required with some non-standard transports such as Redis one.'))
+                   help=('True to pre-declare all the queues on service setup. This is required '
+                         'with some non-standard kombu transports such as Redis one.'))
 
     ]
     do_register_opts(messaging_opts, 'messaging', ignore_errors)

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -157,9 +157,9 @@ def register_opts(ignore_errors=False):
         cfg.IntOpt('connection_retry_wait', default=10000,
                    help='How long should we wait between connection retries.'),
         cfg.BoolOpt('predeclare_queues', default=False,
-                   help=('True to pre-declare all the queues on service setup. This is required '
-                         'with some non-standard kombu transports such as Redis one.'))
-
+                   help=('Set this to True to pre-declare all the AMQP queues on service startup. '
+                         'This is required with some non-standard kombu transports such as the '
+                         'Redis one.'))
     ]
     do_register_opts(messaging_opts, 'messaging', ignore_errors)
 

--- a/st2common/st2common/transport/bootstrap_utils.py
+++ b/st2common/st2common/transport/bootstrap_utils.py
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import retrying
 import socket
+
+import retrying
 from oslo_config import cfg
 from kombu import Connection
+
 from st2common import log as logging
 from st2common.transport import utils as transport_utils
 from st2common.transport.actionexecutionstate import ACTIONEXECUTIONSTATE_XCHG
@@ -26,7 +28,6 @@ from st2common.transport.execution import EXECUTION_XCHG
 from st2common.transport.liveaction import LIVEACTION_XCHG, LIVEACTION_STATUS_MGMT_XCHG
 from st2common.transport.reactor import SENSOR_CUD_XCHG
 from st2common.transport.reactor import TRIGGER_CUD_XCHG, TRIGGER_INSTANCE_XCHG
-
 from st2common.transport import actionexecutionstate
 from st2common.transport import announcement
 from st2common.transport import execution
@@ -40,9 +41,16 @@ __all__ = [
 ]
 
 # List of exchanges which are pre-declared on service set up.
-EXCHANGES = [ACTIONEXECUTIONSTATE_XCHG, ANNOUNCEMENT_XCHG, EXECUTION_XCHG, LIVEACTION_XCHG,
-             LIVEACTION_STATUS_MGMT_XCHG, TRIGGER_CUD_XCHG, TRIGGER_INSTANCE_XCHG,
-             SENSOR_CUD_XCHG]
+EXCHANGES = [
+    ACTIONEXECUTIONSTATE_XCHG,
+    ANNOUNCEMENT_XCHG,
+    EXECUTION_XCHG,
+    LIVEACTION_XCHG,
+    LIVEACTION_STATUS_MGMT_XCHG,
+    TRIGGER_CUD_XCHG,
+    TRIGGER_INSTANCE_XCHG,
+    SENSOR_CUD_XCHG
+]
 
 # List of queues which are pre-declared on service set up.
 # Because of the worker model used, this is required with some non-standard transports such as

--- a/st2common/st2common/transport/bootstrap_utils.py
+++ b/st2common/st2common/transport/bootstrap_utils.py
@@ -37,7 +37,10 @@ from st2common.transport import reactor
 LOG = logging.getLogger('st2common.transport.bootstrap')
 
 __all__ = [
-    'register_exchanges'
+    'register_exchanges',
+
+    'EXCHANGES',
+    'QUEUES'
 ]
 
 # List of exchanges which are pre-declared on service set up.
@@ -92,12 +95,16 @@ def _do_register_exchange(exchange, connection, channel, retry_wrapper):
 def _do_predeclare_queue(channel, queue):
     LOG.debug('Predeclaring queue for exchange "%s"' % (queue.exchange.name))
 
+    bound_queue = None
+
     try:
         bound_queue = queue(channel)
         bound_queue.declare(nowait=False)
         LOG.debug('Predeclared queue for exchange "%s"' % (queue.exchange.name))
     except Exception:
         LOG.exception('Failed to predeclare queue for exchange "%s"' % (queue.exchange.name))
+
+    return bound_queue
 
 
 def register_exchanges():

--- a/st2common/st2common/transport/bootstrap_utils.py
+++ b/st2common/st2common/transport/bootstrap_utils.py
@@ -57,14 +57,14 @@ EXCHANGES = [
 # Redis one. Even though kombu requires queues to be pre-declared upfront in such scenarios,
 # RabbitMQ transport doesn't require that.
 QUEUES = [
-    actionexecutionstate.get_queue(name='init', routing_key='init'),
-    announcement.get_queue(name='init', routing_key='init'),
-    execution.get_queue(name='init', routing_key='init'),
-    liveaction.get_queue(name='init', routing_key='init'),
-    liveaction.get_status_management_queue(name='init', routing_key='init'),
-    reactor.get_trigger_cud_queue(name='init', routing_key='init'),
-    reactor.get_trigger_instances_queue(name='init', routing_key='init'),
-    reactor.get_sensor_cud_queue(name='init', routing_key='init'),
+    actionexecutionstate.get_queue(name='st2.preinit', routing_key='init'),
+    announcement.get_queue(name='st2.preinit', routing_key='init'),
+    execution.get_queue(name='st2.preinit', routing_key='init'),
+    liveaction.get_queue(name='st2.preinit', routing_key='init'),
+    liveaction.get_status_management_queue(name='st2.preinit', routing_key='init'),
+    reactor.get_trigger_cud_queue(name='st2.preinit', routing_key='init'),
+    reactor.get_trigger_instances_queue(name='st2.preinit', routing_key='init'),
+    reactor.get_sensor_cud_queue(name='st2.preinit', routing_key='init'),
 ]
 
 

--- a/st2common/st2common/transport/bootstrap_utils.py
+++ b/st2common/st2common/transport/bootstrap_utils.py
@@ -94,7 +94,7 @@ def _do_predeclare_queue(channel, queue):
 
     try:
         bound_queue = queue(channel)
-        bound_queue.declare()
+        bound_queue.declare(nowait=False)
         LOG.debug('Predeclared queue for exchange "%s"' % (queue.exchange.name))
     except Exception:
         LOG.exception('Failed to predeclare queue for exchange "%s"' % (queue.exchange.name))


### PR DESCRIPTION
This pull request adds ability to predeclare all the used message bus queues (and as such, exchanges) on service startup and allows users to use other non-RabbitMQ kombu transports which are not officially supported.

## Background

#3635 inspired me to dig in a little to try to find out what is going on. After spending whole morning digging in and tracking what is going on, I managed to track down the root cause on why Redis kombu transport doesn't work.

#3638 fixed a small issue which was just related to retrying and error propagation, but the fix for the actual root cause of things not working is included in this PR.

When trying to use Redis kombu transport instead of RabbitMQ one, you got an error like this on each service start up:

```bash
2017-08-02 10:35:44,107 ERROR [-] Rabbitmq connection error: 
Cannot route message for exchange 'st2.liveaction': Table empty or key no longer exists.
Probably the key (u'_kombu.binding.st2.liveaction') has been removed from the Redis database.
```

If you inspect Redis keys you actually find out that none of the exchanges were pre-declared and that's why the issue arises and publishing a message to message bus exchange fails.

```bash
127.0.0.1:6379> keys *
 1) "_kombu.binding.st2.liveaction.status"
 2) "st2.trigger.watch.TimersController-5ad3e912b6"
 3) "st2.trigger.watch.WebhooksController-4e7cd714fd"
 4) "st2.trigger.watch.TimersController-efc54cba86"
 6) "st2.trigger.watch.TimersController-f76e523afb"
 7) "st2.trigger.watch.WebhooksController-d1ae5a0ee9"
 8) "st2.trigger.watch.WebhooksController-24c40d85d4"
```

It turned out that only exchanges for queues which already exist were pre-declared (aka exchanges for which we already have consumers online). That's problematic and obviously won't work in distributed HA workers model.

In this model, producer can be online before the consumer (e.g. API is online before action runner and other services which actually bind a queue to a particular exchange). Another example of late binding is the stream service - we actually only bind to the exchange once first request hits `/v1/stream` endpoint aka stream service.

In fact this happens very often in such setups and it's one of the benefits and reasons of using a worker model - you want messages to still be queued even if the consumer is not online yet and delivered / processed when consumer comes online (normal scenario for such model).

In our example this could mean action runner and other services not being online yet / being restarted / similar, but API service is online and user queues action execution. We obviously want to allow user to perform this operation and queue execution to be run which will be picked up and processed when the action runner service is online.

kombu documentation specifically clarifies this needs to be done in such scenarios (http://docs.celeryproject.org/projects/kombu/en/latest/userguide/producers.html), but because of the implementation details this is not actually required with RabbitMQ transport (nasty!) and our code works just fine with RabbitMQ transport (I guess we were just lucky).

> The declare argument lets you pass a list of entities that must be declared before sending the message. This is especially important when using the retry flag, since the broker may actually restart during a retry in which case non-durable entities are removed.

> Say you are writing a task queue, and the workers may have not started yet so the queues aren’t declared. In this case you need to define both the exchange, and the declare the queue so that the message is delivered to the queue while the workers are offline

## Proposed solution

The solution which fixes this problem is to pre-declare all the queues which causes exchanges to be pre-declared in Redis.

After this change, Redis keyspace looks like this after service set up is ran.

```bash
127.0.0.1:6379> keys *
1) "_kombu.binding.st2.liveaction"
2) "_kombu.binding.st2.liveaction.status"
3) "_kombu.binding.st2.execution"
4) "_kombu.binding.st2.actionexecutionstate"
5) "_kombu.binding.st2.trigger_instances_dispatch"
6) "_kombu.binding.st2.announcement"
7) "_kombu.binding.st2.sensor"
8) "_kombu.binding.st2.trigger"
```

After this change I tested basic functionality (run an action, etc.) and it seems to work fine, but who knows how many different edge case related issues could still be hiding underneath. 

Having said that - **RabbitMQ is still only officially supported and recommended backend by us and using any other backend is at user's own risk. You have been warned - if you use a non-officially supported backend we don't provide support for it and we can't guarantee everything will work. If you are fine with that, go ahead, but don't complain to us if things don't work.**

Even though running this pre-declare code shouldn't in any negative way affect other existing stuff, I still decided to put it behind a feature flag (`messaging.predeclare_queues` config option).

This whole pre-init / pre-declare phase is also nothing special and follows exactly the same pre-initialization approach which is required in a distributed system and we do for other things.

Resolves #3635.