### PR TITLE
Various debug mode logging improvements

### DIFF
--- a/st2common/st2common/log.py
+++ b/st2common/st2common/log.py
@@ -25,7 +25,7 @@ from functools import wraps
 
 import six
 
-from st2common.logging.filters import ExclusionFilter
+from st2common.logging.filters import LoggerNameExclusionFilter
 
 # Those are here for backward compatibility reasons
 from st2common.logging.handlers import FormatNamedFileHandler
@@ -168,7 +168,7 @@ logging.Logger.audit = _audit
 def _add_exclusion_filters(handlers, excludes=None):
     if excludes:
         for h in handlers:
-            h.addFilter(ExclusionFilter(excludes))
+            h.addFilter(LoggerNameExclusionFilter(excludes))
 
 
 def _redirect_stderr():

--- a/st2common/st2common/logging/filters.py
+++ b/st2common/st2common/logging/filters.py
@@ -16,12 +16,17 @@
 import logging
 
 __all__ = [
-    'ExclusionFilter',
+    'LoggerNameExclusionFilter',
+    'LoggerFunctionNameExclusionFilter',
     'LogLevelFilter',
 ]
 
 
-class ExclusionFilter(object):
+class LoggerNameExclusionFilter(object):
+    """
+    Filter which excludes log messages whose first component of the logger name matches one of the
+    entries in the exclusions list.
+    """
 
     def __init__(self, exclusions):
         self._exclusions = set(exclusions)
@@ -29,9 +34,30 @@ class ExclusionFilter(object):
     def filter(self, record):
         if len(self._exclusions) < 1:
             return True
+
         module_decomposition = record.name.split('.')
         exclude = len(module_decomposition) > 0 and module_decomposition[0] in self._exclusions
         return not exclude
+
+
+class LoggerFunctionNameExclusionFilter(object):
+    """
+    Filter which excludes log messages whose function name matches one of the names in the
+    exclusions list.
+    """
+
+    def __init__(self, exclusions):
+        self._exclusions = set(exclusions)
+
+    def filter(self, record):
+        if len(self._exclusions) < 1:
+            return True
+
+        function_name = getattr(record, 'funcName', None)
+        if function_name in self._exclusions:
+            return False
+
+        return True
 
 
 class LogLevelFilter(logging.Filter):

--- a/st2common/st2common/util/debugging.py
+++ b/st2common/st2common/util/debugging.py
@@ -52,6 +52,12 @@ def enable_debugging():
 def disable_debugging():
     global ENABLE_DEBUGGING
     ENABLE_DEBUGGING = False
+
+    set_log_level_for_all_loggers(level=stdlib_logging.INFO)
+
+    setup_logging(loglevel=stdlib_logging.INFO)
+    paramiko.common.logging.basicConfig(level=paramiko.common.INFO)
+
     return ENABLE_DEBUGGING
 
 

--- a/st2common/st2common/util/debugging.py
+++ b/st2common/st2common/util/debugging.py
@@ -17,6 +17,9 @@
 Module containing various debugging functionality.
 """
 
+import paramiko
+from kombu.utils.debug import setup_logging
+
 import logging as stdlib_logging
 
 from st2common.logging.misc import set_log_level_for_all_loggers
@@ -34,7 +37,14 @@ def enable_debugging():
     global ENABLE_DEBUGGING
     ENABLE_DEBUGGING = True
 
+    # Set debug level for all StackStorm loggers
     set_log_level_for_all_loggers(level=stdlib_logging.DEBUG)
+
+    # Set debug log level for kombu
+    setup_logging(loglevel=stdlib_logging.DEBUG)
+
+    # Set debug log level for paramiko
+    paramiko.common.logging.basicConfig(level=paramiko.common.DEBUG)
 
     return ENABLE_DEBUGGING
 


### PR DESCRIPTION
This pull request improves various debug mode related logging:

1. When debug mode is enabled, also set paramiko and kombu logger level to `DEBUG`
2. When `disable_logging` function is called, actually reset logger levels back to `INFO`
3. When debug mode is enabled, don't filter out all log messages using level `DEBUG` generated by `pyamqp`, but only the ones generated by `heartbit_tick` function which is called every 2 seconds. Disabling all the DEBUG messages means we lose some valuable debugging information.