### PR TITLE
Implement pause and resume for Action Chain

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,8 +12,9 @@ Added
   #3183
 * Add limit/"-n" flag and pagination note(stderr) in the CLI for ``st2 key list``.
   Default limit is 50. #3641
-* Implement pause and resume for Mistral workflow. Pause and resume will cascade down to
-  subworkflows. Pause from a subworkflow will cascade to the parent workflow.
+* Implement pause and resume for Mistral workflow and Action Chain. Pause and resume will cascade
+  down to subworkflows and/or subchains. Pause from a subworkflow or subchain will cascade up to
+  the parent workflow. (new feature)
 * Add pack index endpoint. It will made a request for every index defined in st2.conf and return
   the combined list of available packs.
 * Added a new field ``timestamp_f`` to the GELF logging formatter that represents

--- a/contrib/examples/actions/chain-test-pause-resume-with-subchain.yaml
+++ b/contrib/examples/actions/chain-test-pause-resume-with-subchain.yaml
@@ -1,0 +1,13 @@
+---
+name: chain-test-pause-resume-with-subchain
+description: Simple action chain with a subchain to test pause and resume.
+runner_type: action-chain
+entry_point: chains/chain_test_pause_resume_with_subchain.yaml
+enabled: true
+parameters:
+    tempfile:
+        type: string
+        required: true
+    message:
+        type: string
+        required: true

--- a/contrib/examples/actions/chain-test-pause-resume-with-subworkflow.yaml
+++ b/contrib/examples/actions/chain-test-pause-resume-with-subworkflow.yaml
@@ -1,0 +1,13 @@
+---
+name: chain-test-pause-resume-with-subworkflow
+description: Simple action chain with a Mistral subworkflow to test pause and resume.
+runner_type: action-chain
+entry_point: chains/chain_test_pause_resume_with_subworkflow.yaml
+enabled: true
+parameters:
+    tempfile:
+        type: string
+        required: true
+    message:
+        type: string
+        required: true

--- a/contrib/examples/actions/chain-test-pause-resume.yaml
+++ b/contrib/examples/actions/chain-test-pause-resume.yaml
@@ -1,0 +1,13 @@
+---
+name: chain-test-pause-resume
+description: Simple action chain to test pause and resume.
+runner_type: action-chain
+entry_point: chains/chain_test_pause_resume.yaml
+enabled: true
+parameters:
+    tempfile:
+        type: string
+        required: true
+    message:
+        type: string
+        required: true

--- a/contrib/examples/actions/chains/chain_test_pause_resume.yaml
+++ b/contrib/examples/actions/chains/chain_test_pause_resume.yaml
@@ -1,0 +1,12 @@
+chain:
+    -
+        name: task1
+        ref: core.local
+        params:
+            cmd: "while [ -e '{{tempfile}}' ]; do sleep 0.1; done"
+        on-success: task2
+    -
+        name: task2
+        ref: core.local
+        params:
+            cmd: echo "{{message}}"

--- a/contrib/examples/actions/chains/chain_test_pause_resume_with_subchain.yaml
+++ b/contrib/examples/actions/chains/chain_test_pause_resume_with_subchain.yaml
@@ -1,0 +1,13 @@
+chain:
+    -
+        name: task1
+        ref: examples.chain-test-pause-resume
+        params:
+            tempfile: "{{tempfile}}"
+            message: "{{message}}"
+        on-success: task2
+    -
+        name: task2
+        ref: core.local
+        params:
+            cmd: echo foobar

--- a/contrib/examples/actions/chains/chain_test_pause_resume_with_subworkflow.yaml
+++ b/contrib/examples/actions/chains/chain_test_pause_resume_with_subworkflow.yaml
@@ -1,0 +1,13 @@
+chain:
+    -
+        name: task1
+        ref: examples.mistral-test-pause-resume
+        params:
+            tempfile: "{{tempfile}}"
+            message: "{{message}}"
+        on-success: task2
+    -
+        name: task2
+        ref: core.local
+        params:
+            cmd: echo foobar

--- a/contrib/examples/actions/mistral-test-pause-resume-subworkflow-chain.yaml
+++ b/contrib/examples/actions/mistral-test-pause-resume-subworkflow-chain.yaml
@@ -1,0 +1,14 @@
+---
+name: mistral-test-pause-resume-subworkflow-chain
+description: A sample workflow used to test the cascading pause and resume of subchain.
+pack: examples
+runner_type: mistral-v2
+entry_point: workflows/tests/mistral-test-pause-resume-subworkflow-chain.yaml
+enabled: true
+parameters:
+    tempfile:
+        type: string
+        required: true
+    message:
+        type: string
+        required: true

--- a/contrib/examples/actions/workflows/tests/mistral-test-pause-resume-subworkflow-chain.yaml
+++ b/contrib/examples/actions/workflows/tests/mistral-test-pause-resume-subworkflow-chain.yaml
@@ -1,0 +1,20 @@
+version: '2.0'
+
+examples.mistral-test-pause-resume-subworkflow-chain:
+    description: A sample workflow used to test the cascading pause and resume of subchain.
+    type: direct
+    input:
+        - tempfile
+        - message
+    tasks:
+        task1:
+            action: examples.chain-test-pause-resume
+            input:
+                tempfile: <% $.tempfile %>
+                message: <% $.message %>
+            on-success:
+                - task2
+        task2:
+            action: core.local
+            input:
+                cmd: echo "<% $.message %>"

--- a/contrib/runners/action_chain_runner/action_chain_runner.py
+++ b/contrib/runners/action_chain_runner/action_chain_runner.py
@@ -423,6 +423,10 @@ class ActionChainRunner(ActionRunner):
                     )
                 )
 
+        # If there are no action node to run next, then mark the chain successful.
+        if not action_node:
+            chain_status = action_constants.LIVEACTION_STATUS_SUCCEEDED
+
         # Setup parent context.
         parent_context = {
             'execution_id': self.execution_id

--- a/contrib/runners/action_chain_runner/action_chain_runner.py
+++ b/contrib/runners/action_chain_runner/action_chain_runner.py
@@ -329,8 +329,8 @@ class ActionChainRunner(ActionRunner):
         return self._run_chain(action_parameters, resuming=True)
 
     def _run_chain(self, action_parameters, resuming=False):
-        # Set chain status initially to success until chain cancels, fails, or times out below.
-        chain_status = action_constants.LIVEACTION_STATUS_SUCCEEDED
+        # Set chain status to fail unless explicitly set to succeed.
+        chain_status = action_constants.LIVEACTION_STATUS_FAILED
 
         # Result holds the final result that the chain store in the database.
         result = {'tasks': []}

--- a/contrib/runners/action_chain_runner/action_chain_runner.py
+++ b/contrib/runners/action_chain_runner/action_chain_runner.py
@@ -298,17 +298,21 @@ class ActionChainRunner(ActionRunner):
         )
 
     def resume(self):
-        # Restore chain holder if it is not initialized.
-        if not self.chain_holder:
-            self.pre_run()
-
-        # Restore action parameters if it is not provided.
-        _, action_parameters = param_utils.render_final_params(
+        # Restore runner and action parameters since they are not provided on resume.
+        runner_parameters, action_parameters = param_utils.render_final_params(
             self.runner_type_db.runner_parameters,
             self.action.parameters,
             self.liveaction.parameters,
             self.liveaction.context
         )
+
+        # Assign runner parameters needed for pre-run.
+        if runner_parameters:
+            self.runner_parameters = runner_parameters
+
+        # Restore chain holder if it is not initialized.
+        if not self.chain_holder:
+            self.pre_run()
 
         # Change the status of the liveaction from resuming to running.
         self.liveaction = action_service.update_status(

--- a/contrib/runners/action_chain_runner/action_chain_runner.py
+++ b/contrib/runners/action_chain_runner/action_chain_runner.py
@@ -372,7 +372,7 @@ class ActionChainRunner(ActionRunner):
                 context_result[task['name']] = task['result']
 
             # Restore or initialize the top_level_error
-            # thata stores a reference to a top level error.
+            # that stores a reference to a top level error.
             if 'error' in result or 'traceback' in result:
                 top_level_error = {
                     'error': result.get('error'),

--- a/contrib/runners/action_chain_runner/tests/unit/test_actionchain.py
+++ b/contrib/runners/action_chain_runner/tests/unit/test_actionchain.py
@@ -115,8 +115,18 @@ CHAIN_NOTIFY_API = {'notify': {'on-complete': {'message': 'foo happened.'}}}
 CHAIN_NOTIFY_DB = NotificationsHelper.to_model(CHAIN_NOTIFY_API)
 
 
-@mock.patch.object(action_db_util, 'get_runnertype_by_name',
-                   mock.MagicMock(return_value=RUNNER))
+@mock.patch.object(
+    action_db_util,
+    'get_runnertype_by_name',
+    mock.MagicMock(return_value=RUNNER))
+@mock.patch.object(
+    action_service,
+    'is_action_canceled_or_canceling',
+    mock.MagicMock(return_value=False))
+@mock.patch.object(
+    action_service,
+    'is_action_paused_or_pausing',
+    mock.MagicMock(return_value=False))
 class TestActionChainRunner(DbTestCase):
 
     def test_runner_creation(self):
@@ -142,8 +152,7 @@ class TestActionChainRunner(DbTestCase):
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_1_PATH
         chain_runner.action = ACTION_1
-        action_ref = ResourceReference.to_string_reference(name=ACTION_1.name,
-                                                           pack=ACTION_1.pack)
+        action_ref = ResourceReference.to_string_reference(name=ACTION_1.name, pack=ACTION_1.pack)
         chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.liveaction.notify = CHAIN_NOTIFY_DB
         chain_runner.container_service = RunnerContainerService()
@@ -173,9 +182,7 @@ class TestActionChainRunner(DbTestCase):
             return liveaction
 
         chain_runner._run_action = mock_run_action
-
-        action_ref = ResourceReference.to_string_reference(name=ACTION_1.name,
-                                                           pack=ACTION_1.pack)
+        action_ref = ResourceReference.to_string_reference(name=ACTION_1.name, pack=ACTION_1.pack)
         chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
@@ -209,9 +216,7 @@ class TestActionChainRunner(DbTestCase):
             return liveaction
 
         chain_runner._run_action = mock_run_action
-
-        action_ref = ResourceReference.to_string_reference(name=ACTION_1.name,
-                                                           pack=ACTION_1.pack)
+        action_ref = ResourceReference.to_string_reference(name=ACTION_1.name, pack=ACTION_1.pack)
         chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
@@ -232,8 +237,7 @@ class TestActionChainRunner(DbTestCase):
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_ACTION_CALL_NO_PARAMS_PATH
         chain_runner.action = ACTION_1
-        action_ref = ResourceReference.to_string_reference(name=ACTION_1.name,
-                                                           pack=ACTION_1.pack)
+        action_ref = ResourceReference.to_string_reference(name=ACTION_1.name, pack=ACTION_1.pack)
         chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.liveaction.notify = CHAIN_NOTIFY_DB
         chain_runner.container_service = RunnerContainerService()
@@ -250,6 +254,8 @@ class TestActionChainRunner(DbTestCase):
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_NO_DEFAULT
         chain_runner.action = ACTION_1
+        action_ref = ResourceReference.to_string_reference(name=ACTION_1.name, pack=ACTION_1.pack)
+        chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
         chain_runner.run({})
@@ -271,6 +277,8 @@ class TestActionChainRunner(DbTestCase):
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_NO_DEFAULT_2
         chain_runner.action = ACTION_1
+        action_ref = ResourceReference.to_string_reference(name=ACTION_1.name, pack=ACTION_1.pack)
+        chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
         chain_runner.run({})
@@ -305,6 +313,8 @@ class TestActionChainRunner(DbTestCase):
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_1_PATH
         chain_runner.action = ACTION_1
+        action_ref = ResourceReference.to_string_reference(name=ACTION_1.name, pack=ACTION_1.pack)
+        chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
         chain_runner.run({})
@@ -320,6 +330,8 @@ class TestActionChainRunner(DbTestCase):
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_1_PATH
         chain_runner.action = ACTION_1
+        action_ref = ResourceReference.to_string_reference(name=ACTION_1.name, pack=ACTION_1.pack)
+        chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
         status, _, _ = chain_runner.run({})
@@ -365,6 +377,8 @@ class TestActionChainRunner(DbTestCase):
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_1_PATH
         chain_runner.action = ACTION_1
+        action_ref = ResourceReference.to_string_reference(name=ACTION_1.name, pack=ACTION_1.pack)
+        chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
         status, results, _ = chain_runner.run({})
@@ -388,6 +402,8 @@ class TestActionChainRunner(DbTestCase):
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_FIRST_TASK_RENDER_FAIL_PATH
         chain_runner.action = ACTION_1
+        action_ref = ResourceReference.to_string_reference(name=ACTION_1.name, pack=ACTION_1.pack)
+        chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
         chain_runner.run({'s1': 1, 's2': 2, 's3': 3, 's4': 4})
@@ -402,6 +418,8 @@ class TestActionChainRunner(DbTestCase):
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_LIST_TEMP_PATH
         chain_runner.action = ACTION_1
+        action_ref = ResourceReference.to_string_reference(name=ACTION_1.name, pack=ACTION_1.pack)
+        chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
         chain_runner.run({'s1': 1, 's2': 2, 's3': 3, 's4': 4})
@@ -416,6 +434,8 @@ class TestActionChainRunner(DbTestCase):
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_DICT_TEMP_PATH
         chain_runner.action = ACTION_1
+        action_ref = ResourceReference.to_string_reference(name=ACTION_1.name, pack=ACTION_1.pack)
+        chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
         chain_runner.run({'s1': 1, 's2': 2, 's3': 3, 's4': 4})
@@ -432,6 +452,8 @@ class TestActionChainRunner(DbTestCase):
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_DEP_INPUT
         chain_runner.action = ACTION_1
+        action_ref = ResourceReference.to_string_reference(name=ACTION_1.name, pack=ACTION_1.pack)
+        chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
         chain_runner.run({'s1': 1, 's2': 2, 's3': 3, 's4': 4})
@@ -453,6 +475,8 @@ class TestActionChainRunner(DbTestCase):
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_DEP_RESULTS_INPUT
         chain_runner.action = ACTION_1
+        action_ref = ResourceReference.to_string_reference(name=ACTION_1.name, pack=ACTION_1.pack)
+        chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
         chain_runner.run({'s1': 1})
@@ -511,6 +535,8 @@ class TestActionChainRunner(DbTestCase):
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_SECOND_TASK_RENDER_FAIL_PATH
         chain_runner.action = ACTION_1
+        action_ref = ResourceReference.to_string_reference(name=ACTION_1.name, pack=ACTION_1.pack)
+        chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
         status, result, _ = chain_runner.run({})
@@ -536,6 +562,8 @@ class TestActionChainRunner(DbTestCase):
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_TYPED_PARAMS
         chain_runner.action = ACTION_2
+        action_ref = ResourceReference.to_string_reference(name=ACTION_2.name, pack=ACTION_2.pack)
+        chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
         chain_runner.run({'s1': 1, 's2': 'two', 's3': 3.14})
@@ -554,6 +582,7 @@ class TestActionChainRunner(DbTestCase):
                        mock.MagicMock(return_value=ACTION_2))
     @mock.patch.object(action_service, 'request', return_value=(DummyActionExecution(), None))
     def test_chain_runner_typed_system_params(self, request):
+        action_ref = ResourceReference.to_string_reference(name=ACTION_2.name, pack=ACTION_2.pack)
         kvps = []
         try:
             kvps.append(KeyValuePair.add_or_update(KeyValuePairDB(name='a', value='1')))
@@ -561,6 +590,7 @@ class TestActionChainRunner(DbTestCase):
             chain_runner = acr.get_runner()
             chain_runner.entry_point = CHAIN_SYSTEM_PARAMS
             chain_runner.action = ACTION_2
+            chain_runner.liveaction = LiveActionDB(action=action_ref)
             chain_runner.container_service = RunnerContainerService()
             chain_runner.pre_run()
             chain_runner.run({})
@@ -577,12 +607,14 @@ class TestActionChainRunner(DbTestCase):
                        mock.MagicMock(return_value=ACTION_2))
     @mock.patch.object(action_service, 'request', return_value=(DummyActionExecution(), None))
     def test_chain_runner_vars_system_params(self, request):
+        action_ref = ResourceReference.to_string_reference(name=ACTION_2.name, pack=ACTION_2.pack)
         kvps = []
         try:
             kvps.append(KeyValuePair.add_or_update(KeyValuePairDB(name='a', value='two')))
             chain_runner = acr.get_runner()
             chain_runner.entry_point = CHAIN_WITH_SYSTEM_VARS
             chain_runner.action = ACTION_2
+            chain_runner.liveaction = LiveActionDB(action=action_ref)
             chain_runner.container_service = RunnerContainerService()
             chain_runner.pre_run()
             chain_runner.run({})
@@ -603,6 +635,8 @@ class TestActionChainRunner(DbTestCase):
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_WITH_ACTIONPARAM_VARS
         chain_runner.action = ACTION_2
+        action_ref = ResourceReference.to_string_reference(name=ACTION_2.name, pack=ACTION_2.pack)
+        chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
         chain_runner.run({'input_a': 'two'})
@@ -621,6 +655,8 @@ class TestActionChainRunner(DbTestCase):
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_WITH_PUBLISH
         chain_runner.action = ACTION_2
+        action_ref = ResourceReference.to_string_reference(name=ACTION_2.name, pack=ACTION_2.pack)
+        chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.container_service = RunnerContainerService()
         chain_runner.runner_parameters = {'display_published': True}
         chain_runner.pre_run()
@@ -650,6 +686,8 @@ class TestActionChainRunner(DbTestCase):
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_WITH_PUBLISH_PARAM_RENDERING_FAILURE
         chain_runner.action = ACTION_1
+        action_ref = ResourceReference.to_string_reference(name=ACTION_1.name, pack=ACTION_1.pack)
+        chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
 
@@ -715,13 +753,16 @@ class TestActionChainRunner(DbTestCase):
                                 chain_runner.pre_run)
 
     @mock.patch.object(action_db_util, 'get_action_by_ref',
-                       mock.MagicMock(return_value=ACTION_1))
+                       mock.MagicMock(return_value=ACTION_2))
     @mock.patch.object(action_service, 'request', return_value=(DummyActionExecution(), None))
     def test_params_and_parameters_attributes_both_work(self, _):
+        action_ref = ResourceReference.to_string_reference(name=ACTION_2.name, pack=ACTION_2.pack)
+
         # "params" attribute used
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_ACTION_PARAMS_ATTRIBUTE
         chain_runner.action = ACTION_2
+        chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
 
@@ -744,6 +785,7 @@ class TestActionChainRunner(DbTestCase):
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_ACTION_PARAMETERS_ATTRIBUTE
         chain_runner.action = ACTION_2
+        chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
 
@@ -765,6 +807,8 @@ class TestActionChainRunner(DbTestCase):
     @mock.patch.object(action_service, 'request',
                        return_value=(DummyActionExecution(result={'raw_out': 'published'}), None))
     def test_display_published_is_true_by_default(self, _):
+        action_ref = ResourceReference.to_string_reference(name=ACTION_2.name, pack=ACTION_2.pack)
+
         expected_published_values = {
             't1_publish_param_1': 'foo1',
             't1_publish_param_2': 'foo2',
@@ -779,6 +823,7 @@ class TestActionChainRunner(DbTestCase):
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_WITH_PUBLISH_2
         chain_runner.action = ACTION_2
+        chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.container_service = RunnerContainerService()
         chain_runner.runner_parameters = {}
         chain_runner.pre_run()
@@ -793,6 +838,7 @@ class TestActionChainRunner(DbTestCase):
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_WITH_PUBLISH_2
         chain_runner.action = ACTION_2
+        chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.container_service = RunnerContainerService()
         chain_runner.runner_parameters = {'display_published': True}
         chain_runner.pre_run()
@@ -807,6 +853,7 @@ class TestActionChainRunner(DbTestCase):
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_WITH_PUBLISH_2
         chain_runner.action = ACTION_2
+        chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.container_service = RunnerContainerService()
         chain_runner.runner_parameters = {'display_published': False}
         chain_runner.pre_run()

--- a/contrib/runners/action_chain_runner/tests/unit/test_actionchain.py
+++ b/contrib/runners/action_chain_runner/tests/unit/test_actionchain.py
@@ -500,6 +500,8 @@ class TestActionChainRunner(DbTestCase):
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_FIRST_TASK_RENDER_FAIL_PATH
         chain_runner.action = ACTION_1
+        action_ref = ResourceReference.to_string_reference(name=ACTION_1.name, pack=ACTION_1.pack)
+        chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
         chain_runner.run({})
@@ -514,6 +516,8 @@ class TestActionChainRunner(DbTestCase):
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_FIRST_TASK_RENDER_FAIL_PATH
         chain_runner.action = ACTION_1
+        action_ref = ResourceReference.to_string_reference(name=ACTION_1.name, pack=ACTION_1.pack)
+        chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
         status, result, _ = chain_runner.run({})
@@ -729,6 +733,8 @@ class TestActionChainRunner(DbTestCase):
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_WITH_INVALID_ACTION
         chain_runner.action = ACTION_2
+        action_ref = ResourceReference.to_string_reference(name=ACTION_2.name, pack=ACTION_2.pack)
+        chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
 

--- a/contrib/runners/action_chain_runner/tests/unit/test_actionchain_notifications.py
+++ b/contrib/runners/action_chain_runner/tests/unit/test_actionchain_notifications.py
@@ -17,6 +17,8 @@ import mock
 
 from st2actions.container.service import RunnerContainerService
 from st2common.constants.action import LIVEACTION_STATUS_SUCCEEDED
+from st2common.models.db.liveaction import LiveActionDB
+from st2common.models.system.common import ResourceReference
 from st2common.services import action as action_service
 from st2common.util import action_db as action_db_util
 from st2tests import DbTestCase
@@ -48,8 +50,18 @@ CHAIN_1_PATH = FixturesLoader().get_fixture_file_path_abs(
     FIXTURES_PACK, 'actionchains', 'chain_with_notifications.yaml')
 
 
-@mock.patch.object(action_db_util, 'get_runnertype_by_name',
-                   mock.MagicMock(return_value=RUNNER))
+@mock.patch.object(
+    action_db_util,
+    'get_runnertype_by_name',
+    mock.MagicMock(return_value=RUNNER))
+@mock.patch.object(
+    action_service,
+    'is_action_canceled_or_canceling',
+    mock.MagicMock(return_value=False))
+@mock.patch.object(
+    action_service,
+    'is_action_paused_or_pausing',
+    mock.MagicMock(return_value=False))
 class TestActionChainNotifications(DbTestCase):
 
     @mock.patch.object(action_db_util, 'get_action_by_ref',
@@ -59,6 +71,8 @@ class TestActionChainNotifications(DbTestCase):
         chain_runner = acr.get_runner()
         chain_runner.entry_point = CHAIN_1_PATH
         chain_runner.action = ACTION_1
+        action_ref = ResourceReference.to_string_reference(name=ACTION_1.name, pack=ACTION_1.pack)
+        chain_runner.liveaction = LiveActionDB(action=action_ref)
         chain_runner.container_service = RunnerContainerService()
         chain_runner.pre_run()
         chain_runner.run({})

--- a/contrib/runners/action_chain_runner/tests/unit/test_actionchain_pause_resume.py
+++ b/contrib/runners/action_chain_runner/tests/unit/test_actionchain_pause_resume.py
@@ -41,7 +41,8 @@ TEST_FIXTURES = {
         'test_pause_resume_with_error.yaml',
         'test_pause_resume_with_subworkflow.yaml',
         'test_pause_resume_with_context_access.yaml',
-        'test_pause_resume_with_init_vars.yaml'
+        'test_pause_resume_with_init_vars.yaml',
+        'test_pause_resume_with_no_more_task.yaml'
     ],
     'actions': [
         'test_pause_resume.yaml',
@@ -49,7 +50,8 @@ TEST_FIXTURES = {
         'test_pause_resume_with_error.yaml',
         'test_pause_resume_with_subworkflow.yaml',
         'test_pause_resume_with_context_access.yaml',
-        'test_pause_resume_with_init_vars.yaml'
+        'test_pause_resume_with_init_vars.yaml',
+        'test_pause_resume_with_no_more_task.yaml'
     ]
 }
 
@@ -621,3 +623,52 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
         self.assertIn('tasks', liveaction.result)
         self.assertEqual(len(liveaction.result['tasks']), 2)
         self.assertEqual(liveaction.result['tasks'][1]['result']['stdout'], 'FOOBAR')
+
+    def test_chain_pause_resume_with_no_more_task(self):
+        # A temp file is created during test setup. Ensure the temp file exists.
+        # The test action chain will stall until this file is deleted. This gives
+        # the unit test a moment to run any test related logic.
+        path = self.temp_file_path
+        self.assertTrue(os.path.exists(path))
+
+        action = TEST_PACK + '.' + 'test_pause_resume_with_no_more_task'
+        params = {'tempfile': path, 'message': 'foobar'}
+        liveaction = LiveActionDB(action=action, parameters=params)
+        liveaction, execution = action_service.request(liveaction)
+        liveaction = LiveAction.get_by_id(str(liveaction.id))
+
+        # Wait until the liveaction is running.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_RUNNING)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_RUNNING)
+
+        # Request action chain to pause.
+        liveaction, execution = action_service.request_pause(liveaction, USERNAME)
+
+        # Wait until the liveaction is pausing.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSING)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING)
+
+        # Delete the temporary file that the action chain is waiting on.
+        os.remove(path)
+        self.assertFalse(os.path.exists(path))
+
+        # Wait until the liveaction is paused.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSED)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED)
+
+        # Wait for non-blocking threads to complete. Ensure runner is not running.
+        MockLiveActionPublisherNonBlocking.wait_all()
+
+        # Request action chain to resume.
+        liveaction, execution = action_service.request_resume(liveaction, USERNAME)
+
+        # Wait until the liveaction is completed.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+
+        # Wait for non-blocking threads to complete.
+        MockLiveActionPublisherNonBlocking.wait_all()
+
+        # Check liveaction result.
+        self.assertIn('tasks', liveaction.result)
+        self.assertEqual(len(liveaction.result['tasks']), 1)

--- a/contrib/runners/action_chain_runner/tests/unit/test_actionchain_pause_resume.py
+++ b/contrib/runners/action_chain_runner/tests/unit/test_actionchain_pause_resume.py
@@ -620,4 +620,4 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
         # Check liveaction result.
         self.assertIn('tasks', liveaction.result)
         self.assertEqual(len(liveaction.result['tasks']), 2)
-        self.assertEqual(liveaction.result['tasks'][1]['result']['stdout'], 'foobar')
+        self.assertEqual(liveaction.result['tasks'][1]['result']['stdout'], 'FOOBAR')

--- a/contrib/runners/action_chain_runner/tests/unit/test_actionchain_pause_resume.py
+++ b/contrib/runners/action_chain_runner/tests/unit/test_actionchain_pause_resume.py
@@ -40,14 +40,16 @@ TEST_FIXTURES = {
         'test_pause_resume_with_published_vars.yaml',
         'test_pause_resume_with_error.yaml',
         'test_pause_resume_with_subworkflow.yaml',
-        'test_pause_resume_with_context_access.yaml'
+        'test_pause_resume_with_context_access.yaml',
+        'test_pause_resume_with_init_vars.yaml'
     ],
     'actions': [
         'test_pause_resume.yaml',
         'test_pause_resume_with_published_vars.yaml',
         'test_pause_resume_with_error.yaml',
         'test_pause_resume_with_subworkflow.yaml',
-        'test_pause_resume_with_context_access.yaml'
+        'test_pause_resume_with_context_access.yaml',
+        'test_pause_resume_with_init_vars.yaml'
     ]
 }
 
@@ -569,3 +571,53 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
         self.assertIn('tasks', liveaction.result)
         self.assertEqual(len(liveaction.result['tasks']), 3)
         self.assertEqual(liveaction.result['tasks'][2]['result']['stdout'], 'foobar')
+
+    def test_chain_pause_resume_with_init_vars(self):
+        # A temp file is created during test setup. Ensure the temp file exists.
+        # The test action chain will stall until this file is deleted. This gives
+        # the unit test a moment to run any test related logic.
+        path = self.temp_file_path
+        self.assertTrue(os.path.exists(path))
+
+        action = TEST_PACK + '.' + 'test_pause_resume_with_init_vars'
+        params = {'tempfile': path, 'message': 'foobar'}
+        liveaction = LiveActionDB(action=action, parameters=params)
+        liveaction, execution = action_service.request(liveaction)
+        liveaction = LiveAction.get_by_id(str(liveaction.id))
+
+        # Wait until the liveaction is running.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_RUNNING)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_RUNNING)
+
+        # Request action chain to pause.
+        liveaction, execution = action_service.request_pause(liveaction, USERNAME)
+
+        # Wait until the liveaction is pausing.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSING)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING)
+
+        # Delete the temporary file that the action chain is waiting on.
+        os.remove(path)
+        self.assertFalse(os.path.exists(path))
+
+        # Wait until the liveaction is paused.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSED)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED)
+
+        # Wait for non-blocking threads to complete. Ensure runner is not running.
+        MockLiveActionPublisherNonBlocking.wait_all()
+
+        # Request action chain to resume.
+        liveaction, execution = action_service.request_resume(liveaction, USERNAME)
+
+        # Wait until the liveaction is completed.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+
+        # Wait for non-blocking threads to complete.
+        MockLiveActionPublisherNonBlocking.wait_all()
+
+        # Check liveaction result.
+        self.assertIn('tasks', liveaction.result)
+        self.assertEqual(len(liveaction.result['tasks']), 2)
+        self.assertEqual(liveaction.result['tasks'][1]['result']['stdout'], 'foobar')

--- a/contrib/runners/action_chain_runner/tests/unit/test_actionchain_pause_resume.py
+++ b/contrib/runners/action_chain_runner/tests/unit/test_actionchain_pause_resume.py
@@ -1,0 +1,469 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import eventlet
+import mock
+import os
+import tempfile
+
+from st2common.bootstrap import actionsregistrar
+from st2common.bootstrap import runnersregistrar
+
+from st2common.constants import action as action_constants
+from st2common.models.db.liveaction import LiveActionDB
+from st2common.persistence.execution import ActionExecution
+from st2common.persistence.liveaction import LiveAction
+from st2common.services import action as action_service
+from st2common.transport.liveaction import LiveActionPublisher
+from st2common.transport.publishers import CUDPublisher
+
+from st2tests import DbTestCase
+from st2tests import fixturesloader
+from st2tests.mocks.liveaction import MockLiveActionPublisherNonBlocking
+
+
+TEST_FIXTURES = {
+    'chains': [
+        'test_pause_resume.yaml',
+        'test_pause_resume_with_published_vars.yaml',
+        'test_pause_resume_with_error.yaml',
+        'test_pause_resume_with_subworkflow.yaml'
+    ],
+    'actions': [
+        'test_pause_resume.yaml',
+        'test_pause_resume_with_published_vars.yaml',
+        'test_pause_resume_with_error.yaml',
+        'test_pause_resume_with_subworkflow.yaml'
+    ]
+}
+
+TEST_PACK = 'action_chain_tests'
+TEST_PACK_PATH = fixturesloader.get_fixtures_packs_base_path() + '/' + TEST_PACK
+
+PACKS = [
+    TEST_PACK_PATH,
+    fixturesloader.get_fixtures_packs_base_path() + '/core'
+]
+
+USERNAME = 'stanley'
+
+
+@mock.patch.object(
+    CUDPublisher,
+    'publish_update',
+    mock.MagicMock(return_value=None))
+@mock.patch.object(
+    CUDPublisher,
+    'publish_create',
+    mock.MagicMock(return_value=None))
+@mock.patch.object(
+    LiveActionPublisher,
+    'publish_state',
+    mock.MagicMock(side_effect=MockLiveActionPublisherNonBlocking.publish_state))
+class ActionChainRunnerPauseResumeTest(DbTestCase):
+
+    temp_file_path = None
+
+    @classmethod
+    def setUpClass(cls):
+        super(ActionChainRunnerPauseResumeTest, cls).setUpClass()
+
+        # Register runners.
+        runnersregistrar.register_runners()
+
+        # Register test pack(s).
+        actions_registrar = actionsregistrar.ActionsRegistrar(
+            use_pack_cache=False,
+            fail_on_failure=True
+        )
+
+        for pack in PACKS:
+            actions_registrar.register_from_pack(pack)
+
+    def setUp(self):
+        super(ActionChainRunnerPauseResumeTest, self).setUp()
+
+        # Create temporary directory used by the tests
+        _, self.temp_file_path = tempfile.mkstemp()
+        os.chmod(self.temp_file_path, 0755)   # nosec
+
+    def tearDown(self):
+        if self.temp_file_path and os.path.exists(self.temp_file_path):
+            os.remove(self.temp_file_path)
+
+        super(ActionChainRunnerPauseResumeTest, self).tearDown()
+
+    def _wait_for_status(self, liveaction, status, interval=0.1, retries=100):
+        # Wait until the liveaction reaches status.
+        for i in range(0, retries):
+            liveaction = LiveAction.get_by_id(str(liveaction.id))
+            if liveaction.status != status:
+                eventlet.sleep(interval)
+                continue
+
+        return liveaction
+
+    def _wait_for_children(self, execution, interval=0.1, retries=100):
+        # Wait until the execution has children.
+        for i in range(0, retries):
+            execution = ActionExecution.get_by_id(str(execution.id))
+            if len(getattr(execution, 'children', [])) <= 0:
+                eventlet.sleep(interval)
+                continue
+
+        return execution
+
+    def test_chain_pause_resume(self):
+        # A temp file is created during test setup. Ensure the temp file exists.
+        # The test action chain will stall until this file is deleted. This gives
+        # the unit test a moment to run any test related logic.
+        path = self.temp_file_path
+        self.assertTrue(os.path.exists(path))
+
+        action = TEST_PACK + '.' + 'test_pause_resume'
+        params = {'tempfile': path, 'message': 'foobar'}
+        liveaction = LiveActionDB(action=action, parameters=params)
+        liveaction, execution = action_service.request(liveaction)
+        liveaction = LiveAction.get_by_id(str(liveaction.id))
+
+        # Wait until the liveaction is running.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_RUNNING)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_RUNNING)
+
+        # Request action chain to pause.
+        liveaction, execution = action_service.request_pause(liveaction, USERNAME)
+
+        # Wait until the liveaction is pausing.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSING)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING)
+
+        # Delete the temporary file that the action chain is waiting on.
+        os.remove(path)
+        self.assertFalse(os.path.exists(path))
+
+        # Wait until the liveaction is paused.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSED)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED)
+
+        # Wait for non-blocking threads to complete. Ensure runner is not running.
+        MockLiveActionPublisherNonBlocking.wait_all()
+
+        # Request action chain to resume.
+        liveaction, execution = action_service.request_resume(liveaction, USERNAME)
+
+        # Wait until the liveaction is completed.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+
+        # Wait for non-blocking threads to complete.
+        MockLiveActionPublisherNonBlocking.wait_all()
+
+        # Check liveaction result.
+        self.assertIn('tasks', liveaction.result)
+        self.assertEqual(len(liveaction.result['tasks']), 2)
+
+    def test_chain_pause_resume_with_published_vars(self):
+        # A temp file is created during test setup. Ensure the temp file exists.
+        # The test action chain will stall until this file is deleted. This gives
+        # the unit test a moment to run any test related logic.
+        path = self.temp_file_path
+        self.assertTrue(os.path.exists(path))
+
+        action = TEST_PACK + '.' + 'test_pause_resume_with_published_vars'
+        params = {'tempfile': path, 'message': 'foobar'}
+        liveaction = LiveActionDB(action=action, parameters=params)
+        liveaction, execution = action_service.request(liveaction)
+        liveaction = LiveAction.get_by_id(str(liveaction.id))
+
+        # Wait until the liveaction is running.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_RUNNING)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_RUNNING)
+
+        # Request action chain to pause.
+        liveaction, execution = action_service.request_pause(liveaction, USERNAME)
+
+        # Wait until the liveaction is pausing.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSING)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING)
+
+        # Delete the temporary file that the action chain is waiting on.
+        os.remove(path)
+        self.assertFalse(os.path.exists(path))
+
+        # Wait until the liveaction is paused.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSED)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED)
+
+        # Wait for non-blocking threads to complete. Ensure runner is not running.
+        MockLiveActionPublisherNonBlocking.wait_all()
+
+        # Request action chain to resume.
+        liveaction, execution = action_service.request_resume(liveaction, USERNAME)
+
+        # Wait until the liveaction is completed.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+
+        # Wait for non-blocking threads to complete.
+        MockLiveActionPublisherNonBlocking.wait_all()
+
+        # Check liveaction result.
+        self.assertIn('tasks', liveaction.result)
+        self.assertEqual(len(liveaction.result['tasks']), 2)
+        self.assertIn('published', liveaction.result)
+        self.assertDictEqual({'var1': 'foobar', 'var2': 'fubar'}, liveaction.result['published'])
+
+    def test_chain_pause_resume_with_error(self):
+        # A temp file is created during test setup. Ensure the temp file exists.
+        # The test action chain will stall until this file is deleted. This gives
+        # the unit test a moment to run any test related logic.
+        path = self.temp_file_path
+        self.assertTrue(os.path.exists(path))
+
+        action = TEST_PACK + '.' + 'test_pause_resume_with_error'
+        params = {'tempfile': path, 'message': 'foobar'}
+        liveaction = LiveActionDB(action=action, parameters=params)
+        liveaction, execution = action_service.request(liveaction)
+        liveaction = LiveAction.get_by_id(str(liveaction.id))
+
+        # Wait until the liveaction is running.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_RUNNING)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_RUNNING)
+
+        # Request action chain to pause.
+        liveaction, execution = action_service.request_pause(liveaction, USERNAME)
+
+        # Wait until the liveaction is pausing.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSING)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING)
+
+        # Delete the temporary file that the action chain is waiting on.
+        os.remove(path)
+        self.assertFalse(os.path.exists(path))
+
+        # Wait until the liveaction is paused.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSED)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED)
+
+        # Wait for non-blocking threads to complete. Ensure runner is not running.
+        MockLiveActionPublisherNonBlocking.wait_all()
+
+        # Request action chain to resume.
+        liveaction, execution = action_service.request_resume(liveaction, USERNAME)
+
+        # Wait until the liveaction is completed.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+
+        # Wait for non-blocking threads to complete.
+        MockLiveActionPublisherNonBlocking.wait_all()
+
+        # Check liveaction result.
+        self.assertIn('tasks', liveaction.result)
+        self.assertEqual(len(liveaction.result['tasks']), 2)
+        self.assertTrue(liveaction.result['tasks'][0]['result']['failed'])
+        self.assertEqual(1, liveaction.result['tasks'][0]['result']['return_code'])
+        self.assertTrue(liveaction.result['tasks'][1]['result']['succeeded'])
+        self.assertEqual(0, liveaction.result['tasks'][1]['result']['return_code'])
+
+    def test_chain_pause_resume_cascade_to_subworkflow(self):
+        # A temp file is created during test setup. Ensure the temp file exists.
+        # The test action chain will stall until this file is deleted. This gives
+        # the unit test a moment to run any test related logic.
+        path = self.temp_file_path
+        self.assertTrue(os.path.exists(path))
+
+        action = TEST_PACK + '.' + 'test_pause_resume_with_subworkflow'
+        params = {'tempfile': path, 'message': 'foobar'}
+        liveaction = LiveActionDB(action=action, parameters=params)
+        liveaction, execution = action_service.request(liveaction)
+        liveaction = LiveAction.get_by_id(str(liveaction.id))
+
+        # Wait until the liveaction is running.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_RUNNING)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_RUNNING)
+
+        # Wait for subworkflow to register.
+        execution = self._wait_for_children(execution)
+        self.assertEqual(len(execution.children), 1)
+
+        # Wait until the subworkflow is running.
+        task1_exec = ActionExecution.get_by_id(execution.children[0])
+        task1_live = LiveAction.get_by_id(task1_exec.liveaction['id'])
+        task1_live = self._wait_for_status(task1_live, action_constants.LIVEACTION_STATUS_RUNNING)
+        self.assertEqual(task1_live.status, action_constants.LIVEACTION_STATUS_RUNNING)
+
+        # Request action chain to pause.
+        liveaction, execution = action_service.request_pause(liveaction, USERNAME)
+
+        # Wait until the liveaction is pausing.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSING)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING)
+        self.assertEqual(len(execution.children), 1)
+
+        # Wait until the subworkflow is pausing.
+        task1_exec = ActionExecution.get_by_id(execution.children[0])
+        task1_live = LiveAction.get_by_id(task1_exec.liveaction['id'])
+        task1_live = self._wait_for_status(task1_live, action_constants.LIVEACTION_STATUS_PAUSING)
+        self.assertEqual(task1_live.status, action_constants.LIVEACTION_STATUS_PAUSING)
+
+        # Delete the temporary file that the action chain is waiting on.
+        os.remove(path)
+        self.assertFalse(os.path.exists(path))
+
+        # Wait until the liveaction is paused.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSED)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED)
+        self.assertEqual(len(execution.children), 1)
+
+        # Wait until the subworkflow is paused.
+        task1_exec = ActionExecution.get_by_id(execution.children[0])
+        task1_live = LiveAction.get_by_id(task1_exec.liveaction['id'])
+        task1_live = self._wait_for_status(task1_live, action_constants.LIVEACTION_STATUS_PAUSED)
+        self.assertEqual(task1_live.status, action_constants.LIVEACTION_STATUS_PAUSED)
+
+        # Wait for non-blocking threads to complete. Ensure runner is not running.
+        MockLiveActionPublisherNonBlocking.wait_all()
+
+        # Check liveaction result.
+        self.assertIn('tasks', liveaction.result)
+        self.assertEqual(len(liveaction.result['tasks']), 1)
+
+        subworkflow = liveaction.result['tasks'][0]
+        self.assertEqual(len(subworkflow['result']['tasks']), 1)
+        self.assertEqual(subworkflow['state'], action_constants.LIVEACTION_STATUS_PAUSED)
+
+        # Request action chain to resume.
+        liveaction, execution = action_service.request_resume(liveaction, USERNAME)
+
+        # Wait until the liveaction is completed.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+
+        # Wait for non-blocking threads to complete.
+        MockLiveActionPublisherNonBlocking.wait_all()
+
+        # Check liveaction result.
+        self.assertIn('tasks', liveaction.result)
+        self.assertEqual(len(liveaction.result['tasks']), 2)
+
+        subworkflow = liveaction.result['tasks'][0]
+        self.assertEqual(len(subworkflow['result']['tasks']), 2)
+        self.assertEqual(subworkflow['state'], action_constants.LIVEACTION_STATUS_SUCCEEDED)
+
+    def test_chain_pause_resume_cascade_to_parent_workflow(self):
+        # A temp file is created during test setup. Ensure the temp file exists.
+        # The test action chain will stall until this file is deleted. This gives
+        # the unit test a moment to run any test related logic.
+        path = self.temp_file_path
+        self.assertTrue(os.path.exists(path))
+
+        action = TEST_PACK + '.' + 'test_pause_resume_with_subworkflow'
+        params = {'tempfile': path, 'message': 'foobar'}
+        liveaction = LiveActionDB(action=action, parameters=params)
+        liveaction, execution = action_service.request(liveaction)
+        liveaction = LiveAction.get_by_id(str(liveaction.id))
+
+        # Wait until the liveaction is running.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_RUNNING)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_RUNNING)
+
+        # Wait for subworkflow to register.
+        execution = self._wait_for_children(execution)
+        self.assertEqual(len(execution.children), 1)
+
+        # Wait until the subworkflow is running.
+        task1_exec = ActionExecution.get_by_id(execution.children[0])
+        task1_live = LiveAction.get_by_id(task1_exec.liveaction['id'])
+        task1_live = self._wait_for_status(task1_live, action_constants.LIVEACTION_STATUS_RUNNING)
+        self.assertEqual(task1_live.status, action_constants.LIVEACTION_STATUS_RUNNING)
+
+        # Request subworkflow to pause.
+        task1_live, task1_exec = action_service.request_pause(task1_live, USERNAME)
+
+        # Wait until the subworkflow is pausing.
+        task1_exec = ActionExecution.get_by_id(execution.children[0])
+        task1_live = LiveAction.get_by_id(task1_exec.liveaction['id'])
+        task1_live = self._wait_for_status(task1_live, action_constants.LIVEACTION_STATUS_PAUSING)
+        self.assertEqual(task1_live.status, action_constants.LIVEACTION_STATUS_PAUSING)
+
+        # Delete the temporary file that the action chain is waiting on.
+        os.remove(path)
+        self.assertFalse(os.path.exists(path))
+
+        # Wait until the subworkflow is paused.
+        task1_exec = ActionExecution.get_by_id(execution.children[0])
+        task1_live = LiveAction.get_by_id(task1_exec.liveaction['id'])
+        task1_live = self._wait_for_status(task1_live, action_constants.LIVEACTION_STATUS_PAUSED)
+        self.assertEqual(task1_live.status, action_constants.LIVEACTION_STATUS_PAUSED)
+
+        # Wait until the parent liveaction is paused.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSED)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED)
+        self.assertEqual(len(execution.children), 1)
+
+        # Wait for non-blocking threads to complete. Ensure runner is not running.
+        MockLiveActionPublisherNonBlocking.wait_all()
+
+        # Check liveaction result.
+        self.assertIn('tasks', liveaction.result)
+        self.assertEqual(len(liveaction.result['tasks']), 1)
+
+        subworkflow = liveaction.result['tasks'][0]
+        self.assertEqual(len(subworkflow['result']['tasks']), 1)
+        self.assertEqual(subworkflow['state'], action_constants.LIVEACTION_STATUS_PAUSED)
+
+        # Request subworkflow to resume.
+        task1_live, task1_exec = action_service.request_resume(task1_live, USERNAME)
+
+        # Wait until the subworkflow is paused.
+        task1_exec = ActionExecution.get_by_id(execution.children[0])
+        task1_live = LiveAction.get_by_id(task1_exec.liveaction['id'])
+        task1_live = self._wait_for_status(task1_live, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(task1_live.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+
+        # The parent workflow will stay paused.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSED)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED)
+
+        # Wait for non-blocking threads to complete.
+        MockLiveActionPublisherNonBlocking.wait_all()
+
+        # Check liveaction result of the parent, which should stay the same
+        # because only the subworkflow was resumed.
+        self.assertIn('tasks', liveaction.result)
+        self.assertEqual(len(liveaction.result['tasks']), 1)
+
+        subworkflow = liveaction.result['tasks'][0]
+        self.assertEqual(len(subworkflow['result']['tasks']), 1)
+        self.assertEqual(subworkflow['state'], action_constants.LIVEACTION_STATUS_PAUSED)
+
+        # Request parent workflow to resume.
+        liveaction, execution = action_service.request_resume(liveaction, USERNAME)
+
+        # Wait until the liveaction is completed.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+
+        # Wait for non-blocking threads to complete.
+        MockLiveActionPublisherNonBlocking.wait_all()
+
+        # Check liveaction result.
+        self.assertIn('tasks', liveaction.result)
+        self.assertEqual(len(liveaction.result['tasks']), 2)
+
+        subworkflow = liveaction.result['tasks'][0]
+        self.assertEqual(len(subworkflow['result']['tasks']), 2)
+        self.assertEqual(subworkflow['state'], action_constants.LIVEACTION_STATUS_SUCCEEDED)

--- a/contrib/runners/action_chain_runner/tests/unit/test_actionchain_pause_resume.py
+++ b/contrib/runners/action_chain_runner/tests/unit/test_actionchain_pause_resume.py
@@ -39,13 +39,15 @@ TEST_FIXTURES = {
         'test_pause_resume.yaml',
         'test_pause_resume_with_published_vars.yaml',
         'test_pause_resume_with_error.yaml',
-        'test_pause_resume_with_subworkflow.yaml'
+        'test_pause_resume_with_subworkflow.yaml',
+        'test_pause_resume_with_context_access.yaml'
     ],
     'actions': [
         'test_pause_resume.yaml',
         'test_pause_resume_with_published_vars.yaml',
         'test_pause_resume_with_error.yaml',
-        'test_pause_resume_with_subworkflow.yaml'
+        'test_pause_resume_with_subworkflow.yaml',
+        'test_pause_resume_with_context_access.yaml'
     ]
 }
 
@@ -517,3 +519,53 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
         subworkflow = liveaction.result['tasks'][0]
         self.assertEqual(len(subworkflow['result']['tasks']), 2)
         self.assertEqual(subworkflow['state'], action_constants.LIVEACTION_STATUS_SUCCEEDED)
+
+    def test_chain_pause_resume_with_context_access(self):
+        # A temp file is created during test setup. Ensure the temp file exists.
+        # The test action chain will stall until this file is deleted. This gives
+        # the unit test a moment to run any test related logic.
+        path = self.temp_file_path
+        self.assertTrue(os.path.exists(path))
+
+        action = TEST_PACK + '.' + 'test_pause_resume_with_context_access'
+        params = {'tempfile': path, 'message': 'foobar'}
+        liveaction = LiveActionDB(action=action, parameters=params)
+        liveaction, execution = action_service.request(liveaction)
+        liveaction = LiveAction.get_by_id(str(liveaction.id))
+
+        # Wait until the liveaction is running.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_RUNNING)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_RUNNING)
+
+        # Request action chain to pause.
+        liveaction, execution = action_service.request_pause(liveaction, USERNAME)
+
+        # Wait until the liveaction is pausing.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSING)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING)
+
+        # Delete the temporary file that the action chain is waiting on.
+        os.remove(path)
+        self.assertFalse(os.path.exists(path))
+
+        # Wait until the liveaction is paused.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSED)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED)
+
+        # Wait for non-blocking threads to complete. Ensure runner is not running.
+        MockLiveActionPublisherNonBlocking.wait_all()
+
+        # Request action chain to resume.
+        liveaction, execution = action_service.request_resume(liveaction, USERNAME)
+
+        # Wait until the liveaction is completed.
+        liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+
+        # Wait for non-blocking threads to complete.
+        MockLiveActionPublisherNonBlocking.wait_all()
+
+        # Check liveaction result.
+        self.assertIn('tasks', liveaction.result)
+        self.assertEqual(len(liveaction.result['tasks']), 3)
+        self.assertEqual(liveaction.result['tasks'][2]['result']['stdout'], 'foobar')

--- a/contrib/runners/mistral_v2/mistral_v2.py
+++ b/contrib/runners/mistral_v2/mistral_v2.py
@@ -387,7 +387,7 @@ class MistralRunner(AsyncActionRunner):
 
         # If workflow is executed under another parent workflow, pause the corresponding
         # action execution for the task in the parent workflow.
-        if 'parent' in getattr(self, 'context', {}):
+        if 'parent' in getattr(self, 'context', {}) and mistral_ctx.get('action_execution_id'):
             mistral_action_ex_id = mistral_ctx.get('action_execution_id')
             self._client.action_executions.update(mistral_action_ex_id, 'PAUSED')
 
@@ -420,7 +420,7 @@ class MistralRunner(AsyncActionRunner):
 
         # If workflow is executed under another parent workflow, resume the corresponding
         # action execution for the task in the parent workflow.
-        if 'parent' in getattr(self, 'context', {}):
+        if 'parent' in getattr(self, 'context', {}) and mistral_ctx.get('action_execution_id'):
             mistral_action_ex_id = mistral_ctx.get('action_execution_id')
             self._client.action_executions.update(mistral_action_ex_id, 'RUNNING')
 

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -360,7 +360,7 @@ class ActionRunCommandMixin(object):
 
         status_index = options['attributes'].index('status')
 
-        if isinstance(instance.result, dict):
+        if hasattr(instance, 'result') and isinstance(instance.result, dict):
             tasks = instance.result.get('tasks', [])
         else:
             tasks = []

--- a/st2common/st2common/services/action.py
+++ b/st2common/st2common/services/action.py
@@ -187,6 +187,12 @@ def is_action_canceled_or_canceling(liveaction_id):
                                     action_constants.LIVEACTION_STATUS_CANCELING]
 
 
+def is_action_paused_or_pausing(liveaction_id):
+    liveaction_db = action_utils.get_liveaction_by_id(liveaction_id)
+    return liveaction_db.status in [action_constants.LIVEACTION_STATUS_PAUSED,
+                                    action_constants.LIVEACTION_STATUS_PAUSING]
+
+
 def request_cancellation(liveaction, requester):
     """
     Request cancellation of an action execution.
@@ -213,7 +219,7 @@ def request_cancellation(liveaction, requester):
               if liveaction.status == action_constants.LIVEACTION_STATUS_RUNNING
               else action_constants.LIVEACTION_STATUS_CANCELED)
 
-    update_status(liveaction, status, result=result)
+    liveaction = update_status(liveaction, status, result=result)
 
     execution = ActionExecution.get(liveaction__id=str(liveaction.id))
 
@@ -253,7 +259,7 @@ def request_pause(liveaction, requester):
             % liveaction.id
         )
 
-    update_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSING)
+    liveaction = update_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSING)
 
     execution = ActionExecution.get(liveaction__id=str(liveaction.id))
 
@@ -292,7 +298,7 @@ def request_resume(liveaction, requester):
             % liveaction.id
         )
 
-    update_status(liveaction, action_constants.LIVEACTION_STATUS_RESUMING)
+    liveaction = update_status(liveaction, action_constants.LIVEACTION_STATUS_RESUMING)
 
     execution = ActionExecution.get(liveaction__id=str(liveaction.id))
 

--- a/st2tests/integration/mistral/base.py
+++ b/st2tests/integration/mistral/base.py
@@ -64,9 +64,13 @@ class TestWorkflowExecution(unittest2.TestCase):
             self.assertIn('tasks', execution.result)
             self.assertGreater(len(execution.result['tasks']), 0)
 
+        mistral_completed_states = ['SUCCESS', 'ERROR', 'CANCELLED']
+        chain_completed_states = ['succeeded', 'failed', 'abandoned', 'canceled']
+        completed_states = mistral_completed_states + chain_completed_states
+
         if expect_tasks and expect_tasks_completed:
             tasks = execution.result['tasks']
-            self.assertTrue(all([t['state'] in ['SUCCESS', 'ERROR', 'CANCELLED'] for t in tasks]))
+            self.assertTrue(all([t['state'] in completed_states for t in tasks]))
 
         return execution
 
@@ -74,7 +78,7 @@ class TestWorkflowExecution(unittest2.TestCase):
         self.assertEqual(execution.status, 'succeeded')
         tasks = execution.result.get('tasks', [])
         self.assertEqual(num_tasks, len(tasks))
-        self.assertTrue(all([task['state'] == 'SUCCESS' for task in tasks]))
+        self.assertTrue(all([task['state'] in ['SUCCESS', 'succeeded'] for task in tasks]))
 
     def _assert_failure(self, execution, expect_tasks_failure=True):
         self.assertEqual(execution.status, 'failed')

--- a/st2tests/integration/mistral/test_wiring.py
+++ b/st2tests/integration/mistral/test_wiring.py
@@ -510,3 +510,91 @@ class WiringTest(base.TestWorkflowExecution):
         # Wait for completion.
         execution = self._wait_for_completion(execution)
         self._assert_success(execution, num_tasks=2)
+
+    def test_pause_resume_cascade_to_subchain(self):
+        # A temp file is created during test setup. Ensure the temp file exists.
+        path = self.temp_dir_path
+        self.assertTrue(os.path.exists(path))
+
+        # Launch the workflow. The workflow will wait for the temp file to be deleted.
+        params = {'tempfile': path, 'message': 'foobar'}
+        action_ref = 'examples.mistral-test-pause-resume-subworkflow-chain'
+        execution = self._execute_workflow(action_ref, params)
+        execution = self._wait_for_task(execution, 'task1', 'RUNNING')
+
+        # Pause the workflow before the temp file is created. The workflow will be paused
+        # but task1 will still be running to allow for graceful exit.
+        execution = self.st2client.liveactions.pause(execution.id)
+
+        # Expecting the execution to be pausing, waiting for task1 to be completed.
+        execution = self._wait_for_state(execution, ['pausing'])
+
+        # Get the subworkflow execution.
+        task_executions = [e for e in self.st2client.liveactions.get_all()
+                           if e.context.get('parent', {}).get('execution_id') == execution.id]
+
+        subworkflow_execution = self.st2client.liveactions.get_by_id(task_executions[0].id)
+        subworkflow_execution = self._wait_for_state(subworkflow_execution, ['pausing'])
+
+        # Delete the temporary file.
+        os.remove(path)
+        self.assertFalse(os.path.exists(path))
+
+        # Wait for the executions to be paused.
+        subworkflow_execution = self._wait_for_state(subworkflow_execution, ['paused'])
+        execution = self._wait_for_state(execution, ['paused'])
+
+        # Resume the parent execution.
+        execution = self.st2client.liveactions.resume(execution.id)
+
+        # Wait for completion.
+        subworkflow_execution = self._wait_for_completion(subworkflow_execution)
+        self._assert_success(subworkflow_execution, num_tasks=2)
+
+        execution = self._wait_for_completion(execution)
+        self._assert_success(execution, num_tasks=2)
+
+    def test_pause_resume_cascade_subworkflow_from_chain(self):
+        # A temp file is created during test setup. Ensure the temp file exists.
+        path = self.temp_dir_path
+        self.assertTrue(os.path.exists(path))
+
+        # Launch the workflow. The workflow will wait for the temp file to be deleted.
+        params = {'tempfile': path, 'message': 'foobar'}
+        action_ref = 'examples.chain-test-pause-resume-with-subworkflow'
+        execution = self._execute_workflow(action_ref, params)
+
+        # Expecting the execution to be running.
+        execution = self._wait_for_state(execution, ['running'])
+
+        # Pause the workflow before the temp file is created. The workflow will be paused
+        # but task1 will still be running to allow for graceful exit.
+        execution = self.st2client.liveactions.pause(execution.id)
+
+        # Expecting the execution to be pausing, waiting for task1 to be completed.
+        execution = self._wait_for_state(execution, ['pausing'])
+
+        # Get the subworkflow execution.
+        task_executions = [e for e in self.st2client.liveactions.get_all()
+                           if e.context.get('parent', {}).get('execution_id') == execution.id]
+
+        subworkflow_execution = self.st2client.liveactions.get_by_id(task_executions[0].id)
+        subworkflow_execution = self._wait_for_state(subworkflow_execution, ['pausing'])
+
+        # Delete the temporary file.
+        os.remove(path)
+        self.assertFalse(os.path.exists(path))
+
+        # Wait for the executions to be paused.
+        subworkflow_execution = self._wait_for_state(subworkflow_execution, ['paused'])
+        execution = self._wait_for_state(execution, ['paused'])
+
+        # Resume the parent execution.
+        execution = self.st2client.liveactions.resume(execution.id)
+
+        # Wait for completion.
+        subworkflow_execution = self._wait_for_completion(subworkflow_execution)
+        self._assert_success(subworkflow_execution, num_tasks=2)
+
+        execution = self._wait_for_completion(execution)
+        self._assert_success(execution, num_tasks=2)

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume.yaml
@@ -1,0 +1,12 @@
+chain:
+    -
+        name: task1
+        ref: core.local
+        params:
+            cmd: "while [ -e '{{tempfile}}' ]; do sleep 0.1; done"
+        on-success: task2
+    -
+        name: task2
+        ref: core.local
+        params:
+            cmd: echo "{{message}}"

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_last_task_failed_with_no_next_task.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_last_task_failed_with_no_next_task.yaml
@@ -1,0 +1,6 @@
+chain:
+    -
+        name: task1
+        ref: core.local
+        params:
+            cmd: "while [ -e '{{tempfile}}' ]; do sleep 0.1; done; exit 1"

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_with_context_access.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_with_context_access.yaml
@@ -1,0 +1,18 @@
+chain:
+    -
+        name: task1
+        ref: core.local
+        params:
+            cmd: echo "{{message}}"
+        on-success: task2
+    -
+        name: task2
+        ref: core.local
+        params:
+            cmd: "while [ -e '{{tempfile}}' ]; do sleep 0.1; done"
+        on-success: task3
+    -
+        name: task3
+        ref: core.local
+        params:
+            cmd: echo "{{task1.stdout}}"

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_with_error.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_with_error.yaml
@@ -1,0 +1,12 @@
+chain:
+    -
+        name: task1
+        ref: core.local
+        params:
+            cmd: "while [ -e '{{tempfile}}' ]; do sleep 0.1; exit 1"
+        on-failure: task2
+    -
+        name: task2
+        ref: core.local
+        params:
+            cmd: echo "{{message}}"

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_with_init_vars.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_with_init_vars.yaml
@@ -1,0 +1,14 @@
+vars:
+    var1: "{{message}}"
+chain:
+    -
+        name: task1
+        ref: core.local
+        params:
+            cmd: "while [ -e '{{tempfile}}' ]; do sleep 0.1; done"
+        on-success: task2
+    -
+        name: task2
+        ref: core.local
+        params:
+            cmd: echo "{{var1}}"

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_with_init_vars.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_with_init_vars.yaml
@@ -6,6 +6,8 @@ chain:
         ref: core.local
         params:
             cmd: "while [ -e '{{tempfile}}' ]; do sleep 0.1; done"
+        publish:
+            var1: "{{var1|upper}}"            
         on-success: task2
     -
         name: task2

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_with_no_more_task.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_with_no_more_task.yaml
@@ -1,0 +1,6 @@
+chain:
+    -
+        name: task1
+        ref: core.local
+        params:
+            cmd: "while [ -e '{{tempfile}}' ]; do sleep 0.1; done"

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_with_published_vars.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_with_published_vars.yaml
@@ -1,0 +1,16 @@
+chain:
+    -
+        name: task1
+        ref: core.local
+        params:
+            cmd: "while [ -e '{{tempfile}}' ]; do sleep 0.1; done"
+        publish:
+            var1: foobar
+        on-success: task2
+    -
+        name: task2
+        ref: core.local
+        params:
+            cmd: echo "{{message}}"
+        publish:
+            var2: fubar

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_with_subworkflow.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_with_subworkflow.yaml
@@ -1,0 +1,13 @@
+chain:
+    -
+        name: task1
+        ref: action_chain_tests.test_pause_resume
+        params:
+            tempfile: "{{tempfile}}"
+            message: "{{message}}"
+        on-success: task2
+    -
+        name: task2
+        ref: core.local
+        params:
+            cmd: echo foobar

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/test_pause_resume.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/test_pause_resume.yaml
@@ -1,0 +1,14 @@
+---
+name: test_pause_resume
+pack: action_chain_tests
+description: Simple action chain to test pause and resume.
+runner_type: action-chain
+entry_point: chains/test_pause_resume.yaml
+enabled: true
+parameters:
+    tempfile:
+        type: string
+        required: true
+    message:
+        type: string
+        required: true

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/test_pause_resume_last_task_failed_with_no_next_task.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/test_pause_resume_last_task_failed_with_no_next_task.yaml
@@ -1,0 +1,14 @@
+---
+name: test_pause_resume_last_task_failed_with_no_next_task
+pack: action_chain_tests
+description: Simple action chain to test pause and resume.
+runner_type: action-chain
+entry_point: chains/test_pause_resume_last_task_failed_with_no_next_task.yaml
+enabled: true
+parameters:
+    tempfile:
+        type: string
+        required: true
+    message:
+        type: string
+        required: true

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/test_pause_resume_with_context_access.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/test_pause_resume_with_context_access.yaml
@@ -1,0 +1,14 @@
+---
+name: test_pause_resume_with_context_access
+pack: action_chain_tests
+description: Simple action chain to test context is preserved during pause and resume.
+runner_type: action-chain
+entry_point: chains/test_pause_resume_with_context_access.yaml
+enabled: true
+parameters:
+    tempfile:
+        type: string
+        required: true
+    message:
+        type: string
+        required: true

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/test_pause_resume_with_error.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/test_pause_resume_with_error.yaml
@@ -1,0 +1,14 @@
+---
+name: test_pause_resume_with_error
+pack: action_chain_tests
+description: Simple action chain to test error handling during pause and resume.
+runner_type: action-chain
+entry_point: chains/test_pause_resume_with_error.yaml
+enabled: true
+parameters:
+    tempfile:
+        type: string
+        required: true
+    message:
+        type: string
+        required: true

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/test_pause_resume_with_init_vars.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/test_pause_resume_with_init_vars.yaml
@@ -1,0 +1,14 @@
+---
+name: test_pause_resume_with_init_vars
+pack: action_chain_tests
+description: Simple action chain to test init vars are preserved during pause and resume.
+runner_type: action-chain
+entry_point: chains/test_pause_resume_with_init_vars.yaml
+enabled: true
+parameters:
+    tempfile:
+        type: string
+        required: true
+    message:
+        type: string
+        required: true

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/test_pause_resume_with_no_more_task.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/test_pause_resume_with_no_more_task.yaml
@@ -1,0 +1,14 @@
+---
+name: test_pause_resume_with_no_more_task
+pack: action_chain_tests
+description: Simple action chain to test pause and resume.
+runner_type: action-chain
+entry_point: chains/test_pause_resume_with_no_more_task.yaml
+enabled: true
+parameters:
+    tempfile:
+        type: string
+        required: true
+    message:
+        type: string
+        required: true

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/test_pause_resume_with_published_vars.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/test_pause_resume_with_published_vars.yaml
@@ -1,0 +1,14 @@
+---
+name: test_pause_resume_with_published_vars
+pack: action_chain_tests
+description: Simple action chain to test published vars are preserved during pause and resume.
+runner_type: action-chain
+entry_point: chains/test_pause_resume_with_published_vars.yaml
+enabled: true
+parameters:
+    tempfile:
+        type: string
+        required: true
+    message:
+        type: string
+        required: true

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/test_pause_resume_with_subworkflow.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/test_pause_resume_with_subworkflow.yaml
@@ -1,0 +1,14 @@
+---
+name: test_pause_resume_with_subworkflow
+pack: action_chain_tests
+description: Simple action chain with subworkflow to test pause and resume.
+runner_type: action-chain
+entry_point: chains/test_pause_resume_with_subworkflow.yaml
+enabled: true
+parameters:
+    tempfile:
+        type: string
+        required: true
+    message:
+        type: string
+        required: true

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/pack.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/pack.yaml
@@ -1,0 +1,6 @@
+---
+name : action_chain_tests
+description : Content pack for action chain tests
+version : 0.1.0
+author : st2-dev
+email : info@stackstorm.com


### PR DESCRIPTION
Allows Action Chain to be paused and then resumed. Pause and resume will cascade down to sub-chain or sub-workflow. Pausing a sub-chain or sub-workflow will cascade the pause up to the parent Action Chain. Resuming a sub-chain or sub-workflow on the other hand will not cascade up up to the parent Action Chain to allow troubleshooting/debugging purposes.