### PR TITLE
Also delete compressed stale actionrunner logs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Fixed
 * Fix retrying in message bus exchange registration. (bug fix) #3635 #3638
 
   Reported by John Arnold.
+* Fix logrotate configuration to delete stale compressed st2actionrunner logs #3647
 
 2.3.2 - July 28, 2017
 ---------------------

--- a/conf/logrotate.conf
+++ b/conf/logrotate.conf
@@ -105,7 +105,7 @@ notifempty
   postrotate
     # Delete all files that haven't been modified in over 30 days
     # Clean up stale PID logs
-    find /var/log/st2/ -type f -name "st2actionrunner*.log" -mtime +30 -exec rm -f {} \;
+    find /var/log/st2/ -type f -name "st2actionrunner*.log*" -mtime +30 -exec rm -f {} \;
     st2ctl reopen-log-files st2actionrunner > /dev/null
   endscript
 }


### PR DESCRIPTION
In #2898 we modified the logrotate configuration to be more specific about the stale st2actionrunner log files we were deleting. This was good, because it fixed the problem with mysteriously disappearing st2actionrunner-related files.

However we are now too specific. 

This line:
```sh
find /var/log/st2/ -type f -name "st2actionrunner*.log" -mtime +30 -exec rm -f {} \;
```
will delete stale st2actionrunner.<pid>.log files that might have been left behind after an ST2 restart.

However if there are older compressed files that logrotate had previously created, such st2actionrunner.<oldpid>.log.gz, then they will not be matched by the `find` statement. Any <newpid> files will be maintained by logrotate, rotated daily, with files older than 5 days deleted. But if ST2 is restarted, we get orphaned st2actionrunner.<oldpid>.log.gz files.

This change will match both <oldpid>.log files and <oldpid>.log.[1-5].gz files.