### PR TITLE
Fix: Sort order for trace API endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,9 @@ Fixed
 
   This also fixes an issue with Redis kombu backend not working. (bug fix) #3635 #3639 #3648
 * Fix logrotate configuration to delete stale compressed st2actionrunner logs #3647
+* Fix trace list API endpoint sorting by `start_timestamp`, using ?sort_desc=True|False query
+  parameters and by passing --sort=asc|desc parameter to the st2 trace list CLI command.
+  Descending order by default.(bug fix) #3237 #3665
 
 2.3.2 - July 28, 2017
 ---------------------
@@ -90,7 +93,7 @@ Fixed
 * Fix logrotate script so that it no longer prints the `st2ctl` PID status to stdout
   for each file that it rotates. Also, it will no longer print an error if
   /var/log/st2/st2web.log is missing.
-  
+
   Contributed by Nick Maludy. #3633
 
 2.3.1 - July 07, 2017

--- a/st2api/st2api/controllers/v1/traces.py
+++ b/st2api/st2api/controllers/v1/traces.py
@@ -41,11 +41,10 @@ class TracesController(ResourceController):
         # Use a custom sort order when filtering on a timestamp so we return a correct result as
         # expected by the user
         query_options = None
-        if 'sort_desc' in raw_filters:
-            query_options = {'sort': ['-start_timestamp', 'action.ref']}
-        elif 'sort_asc' in raw_filters:
-            query_options = {'sort': ['+start_timestamp', 'action.ref']}
-
+        if 'sort_desc' in raw_filters and raw_filters['sort_desc'] == 'True':
+            query_options = {'sort': ['-start_timestamp', 'trace_tag']}
+        elif 'sort_asc' in raw_filters and raw_filters['sort_asc'] == 'True':
+            query_options = {'sort': ['+start_timestamp', 'trace_tag']}
         return self._get_all(sort=sort,
                              offset=offset,
                              limit=limit,

--- a/st2api/tests/unit/controllers/v1/test_traces.py
+++ b/st2api/tests/unit/controllers/v1/test_traces.py
@@ -50,10 +50,37 @@ class TestTraces(FunctionalTest):
 
         # Note: traces are returned sorted by start_timestamp in descending order by default
         retrieved_trace_tags = [trace['trace_tag'] for trace in resp.json]
-
         self.assertEqual(retrieved_trace_tags,
                          [self.trace3.trace_tag, self.trace2.trace_tag, self.trace1.trace_tag],
                          'Incorrect traces retrieved.')
+
+    def test_get_all_ascending_and_descending(self):
+        resp = self.app.get('/v1/traces?sort_asc=True')
+        self.assertEqual(resp.status_int, 200)
+        self.assertEqual(len(resp.json), 3, '/v1/traces did not return all traces.')
+
+        retrieved_trace_tags = [trace['trace_tag'] for trace in resp.json]
+        self.assertEqual(retrieved_trace_tags,
+                         [self.trace1.trace_tag, self.trace2.trace_tag, self.trace3.trace_tag],
+                         'Incorrect traces retrieved.')
+
+        resp = self.app.get('/v1/traces?sort_desc=True')
+        self.assertEqual(resp.status_int, 200)
+        self.assertEqual(len(resp.json), 3, '/v1/traces did not return all traces.')
+
+        retrieved_trace_tags = [trace['trace_tag'] for trace in resp.json]
+        self.assertEqual(retrieved_trace_tags,
+                         [self.trace3.trace_tag, self.trace2.trace_tag, self.trace1.trace_tag],
+                         'Incorrect traces retrieved.')
+
+    def test_get_all_limit(self):
+        resp = self.app.get('/v1/traces?limit=1')
+        self.assertEqual(resp.status_int, 200)
+        self.assertEqual(len(resp.json), 1, '/v1/traces did not return all traces.')
+
+        retrieved_trace_tags = [trace['trace_tag'] for trace in resp.json]
+        self.assertEqual(retrieved_trace_tags,
+                         [self.trace3.trace_tag], 'Incorrect traces retrieved.')
 
     def test_get_by_id(self):
         resp = self.app.get('/v1/traces/%s' % self.trace1.id)

--- a/st2client/st2client/commands/trace.py
+++ b/st2client/st2client/commands/trace.py
@@ -180,12 +180,12 @@ class TraceListCommand(resource.ResourceCommand, SingleTraceDisplayMixin):
                         table.SingleRowTable.note_box(self.resource_name, 1)
         else:
             if args.json or args.yaml:
-                self.print_output(reversed(instances), table.MultiColumnTable,
+                self.print_output(instances, table.MultiColumnTable,
                                   attributes=args.attr, widths=args.width,
                                   json=args.json, yaml=args.yaml,
                                   attribute_transform_functions=self.attribute_transform_functions)
             else:
-                self.print_output(reversed(instances), table.MultiColumnTable,
+                self.print_output(instances, table.MultiColumnTable,
                                   attributes=args.attr, widths=args.width,
                                   attribute_transform_functions=self.attribute_transform_functions)
 


### PR DESCRIPTION
Fixes https://github.com/StackStorm/st2/issues/3237


Before:
```
$ st2 trace list -n 8 -s desc
+--------------------------+-------------------------------------+-------------------------------------+-------------------------------+
| id                       | uid                                 | trace_tag                           | start_timestamp               |
+--------------------------+-------------------------------------+-------------------------------------+-------------------------------+
| 598de263909a50671f647460 | trace:ce4402928eaaf5d73b726c9e6f93c | trigger_instance-                   | Fri, 11 Aug 2017 16:59:15 UTC |
|                          | fcf                                 | 598de263909a50671f64745f            |                               |
| 598de263909a50671f647462 | trace:5ae516a7cb1a30a35e45647d8163d | trigger_instance-                   | Fri, 11 Aug 2017 16:59:15 UTC |
|                          | a73                                 | 598de263909a50671f647461            |                               |
| 598de263909a50671f647464 | trace:a4121e540baf28889d9dd5165bf7b | trigger_instance-                   | Fri, 11 Aug 2017 16:59:15 UTC |
|                          | bd9                                 | 598de263909a50671f647463            |                               |
| 598de266909a50671f647466 | trace:c5f41f63465ee90c91af44d6c1038 | st2.IntervalTimer-3fc4fbad-         | Fri, 11 Aug 2017 16:59:18 UTC |
|                          | 443                                 | 8cb7-4af1-8a99-bda01e85977f         |                               |
| 598de26b909a50671f647468 | trace:d9923809a6f997c0bbff0d75f7640 | st2.IntervalTimer-3fc4fbad-         | Fri, 11 Aug 2017 16:59:23 UTC |
|                          | ee6                                 | 8cb7-4af1-8a99-bda01e85977f         |                               |
| 598de270909a50671f64746a | trace:a7259feb9e9187af09ccd250926cc | st2.IntervalTimer-3fc4fbad-         | Fri, 11 Aug 2017 16:59:28 UTC |
|                          | 0d9                                 | 8cb7-4af1-8a99-bda01e85977f         |                               |
| 598de275909a50671f64746c | trace:588501d2efd76d00327af1008405a | st2.IntervalTimer-3fc4fbad-         | Fri, 11 Aug 2017 16:59:33 UTC |
|                          | 6f5                                 | 8cb7-4af1-8a99-bda01e85977f         |                               |
| 598de27a909a50671f64746e | trace:36f9675404a4f09cf46c6e70fc549 | st2.IntervalTimer-3fc4fbad-         | Fri, 11 Aug 2017 16:59:38 UTC |
|                          | 283                                 | 8cb7-4af1-8a99-bda01e85977f         |                               |
+--------------------------+-------------------------------------+-------------------------------------+-------------------------------+
+--------------------------------------------------------------------------------------------------------------------------------------+
| Note: Only first 8 traces are displayed. Use -n/--last flag for more results.                                                        |
+--------------------------------------------------------------------------------------------------------------------------------------+


$ st2 trace list -n 8 -s asc
+--------------------------+-------------------------------------+-------------------------------------+-------------------------------+
| id                       | uid                                 | trace_tag                           | start_timestamp               |
+--------------------------+-------------------------------------+-------------------------------------+-------------------------------+
| 598de263909a50671f647462 | trace:5ae516a7cb1a30a35e45647d8163d | trigger_instance-                   | Fri, 11 Aug 2017 16:59:15 UTC |
|                          | a73                                 | 598de263909a50671f647461            |                               |
| 598de263909a50671f647464 | trace:a4121e540baf28889d9dd5165bf7b | trigger_instance-                   | Fri, 11 Aug 2017 16:59:15 UTC |
|                          | bd9                                 | 598de263909a50671f647463            |                               |
| 598de266909a50671f647466 | trace:c5f41f63465ee90c91af44d6c1038 | st2.IntervalTimer-3fc4fbad-         | Fri, 11 Aug 2017 16:59:18 UTC |
|                          | 443                                 | 8cb7-4af1-8a99-bda01e85977f         |                               |
| 598de26b909a50671f647468 | trace:d9923809a6f997c0bbff0d75f7640 | st2.IntervalTimer-3fc4fbad-         | Fri, 11 Aug 2017 16:59:23 UTC |
|                          | ee6                                 | 8cb7-4af1-8a99-bda01e85977f         |                               |
| 598de270909a50671f64746a | trace:a7259feb9e9187af09ccd250926cc | st2.IntervalTimer-3fc4fbad-         | Fri, 11 Aug 2017 16:59:28 UTC |
|                          | 0d9                                 | 8cb7-4af1-8a99-bda01e85977f         |                               |
| 598de275909a50671f64746c | trace:588501d2efd76d00327af1008405a | st2.IntervalTimer-3fc4fbad-         | Fri, 11 Aug 2017 16:59:33 UTC |
|                          | 6f5                                 | 8cb7-4af1-8a99-bda01e85977f         |                               |
| 598de27a909a50671f64746e | trace:36f9675404a4f09cf46c6e70fc549 | st2.IntervalTimer-3fc4fbad-         | Fri, 11 Aug 2017 16:59:38 UTC |
|                          | 283                                 | 8cb7-4af1-8a99-bda01e85977f         |                               |
| 598de27f909a50671f647470 | trace:d114de2fc040b7bba32281774cde4 | st2.IntervalTimer-3fc4fbad-         | Fri, 11 Aug 2017 16:59:43 UTC |
|                          | 3f8                                 | 8cb7-4af1-8a99-bda01e85977f         |                               |
+--------------------------+-------------------------------------+-------------------------------------+-------------------------------+
+--------------------------------------------------------------------------------------------------------------------------------------+
| Note: Only first 8 traces are displayed. Use -n/--last flag for more results.                                                        |
+--------------------------------------------------------------------------------------------------------------------------------------+

```

After:
```
$ st2 trace list -n 8 -s desc
+--------------------------+-------------------------------------+-------------------------------------+-------------------------------+
| id                       | uid                                 | trace_tag                           | start_timestamp               |
+--------------------------+-------------------------------------+-------------------------------------+-------------------------------+
| 598de391909a506a86dc6675 | trace:91993bcf784e7cc42057d9ad8c654 | st2.IntervalTimer-3fc4fbad-         | Fri, 11 Aug 2017 17:04:17 UTC |
|                          | cc0                                 | 8cb7-4af1-8a99-bda01e85977f         |                               |
| 598de38c909a506a86dc6673 | trace:4ae74f64d16703410d3464256404c | st2.IntervalTimer-3fc4fbad-         | Fri, 11 Aug 2017 17:04:12 UTC |
|                          | 3db                                 | 8cb7-4af1-8a99-bda01e85977f         |                               |
| 598de387909a506a86dc6671 | trace:1852d2356b51840997fec0248dd91 | st2.IntervalTimer-3fc4fbad-         | Fri, 11 Aug 2017 17:04:07 UTC |
|                          | a07                                 | 8cb7-4af1-8a99-bda01e85977f         |                               |
| 598de382909a506a86dc666f | trace:68179761e452f4af5cbb7e2e61583 | st2.IntervalTimer-3fc4fbad-         | Fri, 11 Aug 2017 17:04:02 UTC |
|                          | b87                                 | 8cb7-4af1-8a99-bda01e85977f         |                               |
| 598de37d909a506a86dc666d | trace:a986c59d168c14a7a4f8150e5ffb3 | st2.IntervalTimer-3fc4fbad-         | Fri, 11 Aug 2017 17:03:57 UTC |
|                          | 609                                 | 8cb7-4af1-8a99-bda01e85977f         |                               |
| 598de378909a506a86dc666b | trace:5127f2672c1c44cde0ab21e04b260 | st2.IntervalTimer-3fc4fbad-         | Fri, 11 Aug 2017 17:03:52 UTC |
|                          | 530                                 | 8cb7-4af1-8a99-bda01e85977f         |                               |
| 598de373909a506a86dc6669 | trace:968862bd4524a88520c40a7a9a69b | st2.IntervalTimer-3fc4fbad-         | Fri, 11 Aug 2017 17:03:47 UTC |
|                          | f7a                                 | 8cb7-4af1-8a99-bda01e85977f         |                               |
| 598de36f909a506a86dc6667 | trace:24370c437a442ba4104b6ef0e7f66 | st2.IntervalTimer-3fc4fbad-         | Fri, 11 Aug 2017 17:03:42 UTC |
|                          | 2c2                                 | 8cb7-4af1-8a99-bda01e85977f         |                               |
+--------------------------+-------------------------------------+-------------------------------------+-------------------------------+
+--------------------------------------------------------------------------------------------------------------------------------------+
| Note: Only first 8 traces are displayed. Use -n/--last flag for more results.                                                        |
+--------------------------------------------------------------------------------------------------------------------------------------+


$ st2 trace list -n 8 -s asc
+--------------------------+-------------------------------------+-------------------------------------+-------------------------------+
| id                       | uid                                 | trace_tag                           | start_timestamp               |
+--------------------------+-------------------------------------+-------------------------------------+-------------------------------+
| 598ce700909a50191df1cc78 | trace:70c05e6dbb28fbd161e398a138c9a | trigger_instance-                   | Thu, 10 Aug 2017 23:06:40 UTC |
|                          | c18                                 | 598ce700909a50191df1cc77            |                               |
| 598ce700909a50191df1cc7a | trace:b4b6f1ed72c4cb21cbd45caf40249 | trigger_instance-                   | Thu, 10 Aug 2017 23:06:40 UTC |
|                          | 262                                 | 598ce700909a50191df1cc79            |                               |
| 598ce700909a50191df1cc7c | trace:5926ecdd8725d3f3692339ef4b052 | trigger_instance-                   | Thu, 10 Aug 2017 23:06:40 UTC |
|                          | 9f7                                 | 598ce700909a50191df1cc7b            |                               |
| 598ce701909a50191df1cc7e | trace:289229b14c0ee91824ecf82f133db | trigger_instance-                   | Thu, 10 Aug 2017 23:06:41 UTC |
|                          | fd9                                 | 598ce701909a50191df1cc7d            |                               |
| 598ce701909a50191df1cc80 | trace:1fdd665b8893f504da95ca3bf2d62 | trigger_instance-                   | Thu, 10 Aug 2017 23:06:41 UTC |
|                          | a54                                 | 598ce701909a50191df1cc7f            |                               |
| 598ce701909a50191df1cc82 | trace:f86dfa16cfb3e921c2be452018464 | trigger_instance-                   | Thu, 10 Aug 2017 23:06:41 UTC |
|                          | f3a                                 | 598ce701909a50191df1cc81            |                               |
| 598ce701909a50191df1cc84 | trace:a171894e9ea0ead5f6f391a03f923 | trigger_instance-                   | Thu, 10 Aug 2017 23:06:41 UTC |
|                          | 778                                 | 598ce701909a50191df1cc83            |                               |
| 598ce708909a50191df1cc86 | trace:782b345101c4ceec52c486ebc52a1 | trigger_instance-                   | Thu, 10 Aug 2017 23:06:48 UTC |
|                          | 306                                 | 598ce708909a50191df1cc85            |                               |
+--------------------------+-------------------------------------+-------------------------------------+-------------------------------+
+--------------------------------------------------------------------------------------------------------------------------------------+
| Note: Only first 8 traces are displayed. Use -n/--last flag for more results.                                                        |
+--------------------------------------------------------------------------------------------------------------------------------------+
```
