### PR TITLE
Remove local pack config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,11 @@ Changed
   official instructions at https://docs.mongodb.com/v3.4/release-notes/3.4-upgrade-standalone/.
   (improvement)
 
+Removed
+~~~~~~~
+
+* The feature to use local config.yaml in packs is removed.
+
 Fixed
 ~~~~~
 

--- a/st2common/st2common/bootstrap/base.py
+++ b/st2common/st2common/bootstrap/base.py
@@ -143,15 +143,13 @@ class ResourceRegistrar(object):
         # will be fully removed in v2.4.0.
         config_path = os.path.join(pack_dir, 'config.yaml')
         if os.path.isfile(config_path):
-            LOG.warning('Pack "%s" contains a deprecated config.yaml file (%s). '
-                        'Support for "config.yaml" files has been deprecated in StackStorm v1.6.0 '
-                        'in favor of config.schema.yaml config schema files and config files in '
-                        '/opt/stackstorm/configs/ directory.'
-                        'Support for config.yaml files will be removed in next major release '
-                        ' (v2.4.0) so you are strongly encouraged to migrate. '
-                        'For more information please refer to %s ' %
-                        (pack_db.name, config_path,
-                         'https://docs.stackstorm.com/reference/pack_configs.html'))
+            LOG.error('Pack "%s" contains a deprecated config.yaml file (%s). '
+                      'Support for "config.yaml" files has been deprecated in StackStorm v1.6.0 '
+                      'in favor of config.schema.yaml config schema files and config files in '
+                      '/opt/stackstorm/configs/ directory. Support for config.yaml files has '
+                      'been removed in the release (v2.4.0) so please migrate. For more '
+                      'information please refer to %s ' % (pack_db.name, config_path,
+                      'https://docs.stackstorm.com/reference/pack_configs.html'))
 
         # 2. Register corresponding pack config schema
         config_schema_db = self._register_pack_config_schema_db(pack_name=pack_name,

--- a/st2common/st2common/util/config_loader.py
+++ b/st2common/st2common/util/config_loader.py
@@ -60,13 +60,6 @@ class ContentPackConfigLoader(object):
     def get_config(self):
         result = {}
 
-        # 1. Retrieve values from pack local config.yaml file
-        config = self._config_parser.get_config()
-
-        if config:
-            config = config.config or {}
-            result.update(config)
-
         # Retrieve corresponding ConfigDB and ConfigSchemaDB object
         # Note: ConfigSchemaDB is optional right now. If it doesn't exist, we assume every value
         # is of a type string

--- a/st2common/tests/unit/test_config_loader.py
+++ b/st2common/tests/unit/test_config_loader.py
@@ -30,20 +30,15 @@ class ContentPackConfigLoaderTestCase(CleanDbTestCase):
     register_packs = True
     register_pack_configs = True
 
-    def test_get_config_all_values_are_loaded_from_local_config(self):
-        # Test a scenario where all the values are loaded from pack local config and pack global
-        # config (pack name.yaml) doesn't exist
+    def test_ensure_local_pack_config_feature_removed(self):
+        # Test a scenario where all the values are loaded from pack local
+        # config and pack global config (pack name.yaml) doesn't exist.
         # Test a scenario where no values are overridden in the datastore
         loader = ContentPackConfigLoader(pack_name='dummy_pack_4')
         config = loader.get_config()
+        expected_config = {}
 
-        expected_config = {
-            'api_key': '',
-            'api_secret': '',
-            'regions': ['us-west-1', 'us-east-1'],
-            'private_key_path': None
-        }
-        self.assertEqual(config, expected_config)
+        self.assertDictEqual(config, expected_config)
 
     def test_get_config_some_values_overriden_in_datastore(self):
         # Test a scenario where some values are overriden in datastore via pack


### PR DESCRIPTION
The feature to use the local config.yaml in packs is removed. The config.yaml is deprecated and replaced by the config schema in earlier version.

On content loading in bootstrap, the warning message is replaced with the following error message.

2017-08-17 19:48:50,326 ERROR [-] Pack "demo" contains a deprecated config.yaml file (/opt/stackstorm/packs/demo/config.yaml). Support for "config.yaml" files has been deprecated in StackStorm v1.6.0 in favor of config.schema.yaml config schema files and config files in /opt/stackstorm/configs/ directory. Support for config.yaml files has been removed in the release (v2.4.0) so please migrate. For more information please refer to https://docs.stackstorm.com/reference/pack_configs.html
