### PR TITLE
Add missing RBAC check to /v1/stream API endpoint

### DIFF
--- a/st2api/tests/base.py
+++ b/st2api/tests/base.py
@@ -13,119 +13,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
-from oslo_config import cfg
-
 try:
     import simplejson as json
 except ImportError:
     import json
 
 from st2api import app
-import st2common.bootstrap.runnersregistrar as runners_registrar
-from st2common.rbac.types import SystemRole
-from st2common.persistence.auth import User
-from st2common.persistence.rbac import UserRoleAssignment
-from st2common.models.db.auth import UserDB
-from st2common.models.db.rbac import UserRoleAssignmentDB
-from st2common.rbac.migrations import run_all as run_all_rbac_migrations
-from st2common.router import Router
-from st2tests.base import DbTestCase
-from st2tests.base import CleanDbTestCase
-from st2tests.api import TestApp
-import st2tests.config as tests_config
+from st2tests.api import BaseFunctionalTest
+from st2tests.api import BaseAPIControllerWithRBACTestCase
 
 
-class FunctionalTest(DbTestCase):
+class FunctionalTest(BaseFunctionalTest):
     """
     Base test case class for testing API controllers with auth and RBAC disabled.
     """
-    # By default auth is disabled
-    enable_auth = False
 
-    @classmethod
-    def setUpClass(cls):
-        super(FunctionalTest, cls).setUpClass()
-        cls._do_setUpClass()
-
-    @classmethod
-    def _do_setUpClass(cls):
-        tests_config.parse_args()
-
-        cfg.CONF.set_default('enable', cls.enable_auth, group='auth')
-
-        cfg.CONF.set_override(name='enable', override=False, group='rbac')
-
-        # TODO(manas) : register action types here for now. RunnerType registration can be moved
-        # to posting to /runnertypes but that implies implementing POST.
-        runners_registrar.register_runners()
-
-        cls.app = TestApp(app.setup_app())
+    app_module = app
 
 
-class APIControllerWithRBACTestCase(FunctionalTest, CleanDbTestCase):
+class APIControllerWithRBACTestCase(BaseAPIControllerWithRBACTestCase):
     """
     Base test case class for testing API controllers with RBAC enabled.
     """
 
-    enable_auth = True
-
-    @classmethod
-    def setUpClass(cls):
-        super(APIControllerWithRBACTestCase, cls).setUpClass()
-
-        # Make sure RBAC is enabeld
-        cfg.CONF.set_override(name='enable', override=True, group='rbac')
-
-    @classmethod
-    def tearDownClass(cls):
-        super(APIControllerWithRBACTestCase, cls).tearDownClass()
-
-    def setUp(self):
-        super(APIControllerWithRBACTestCase, self).setUp()
-
-        self.users = {}
-        self.roles = {}
-
-        # Run RBAC migrations
-        run_all_rbac_migrations()
-
-        # Insert mock users with default role assignments
-        role_names = [SystemRole.SYSTEM_ADMIN, SystemRole.ADMIN, SystemRole.OBSERVER]
-        for role_name in role_names:
-            user_db = UserDB(name=role_name)
-            user_db = User.add_or_update(user_db)
-            self.users[role_name] = user_db
-
-            role_assignment_db = UserRoleAssignmentDB(
-                user=user_db.name,
-                role=role_name)
-            UserRoleAssignment.add_or_update(role_assignment_db)
-
-        # Insert a user with no permissions and role assignments
-        user_1_db = UserDB(name='no_permissions')
-        user_1_db = User.add_or_update(user_1_db)
-        self.users['no_permissions'] = user_1_db
-
-    def tearDown(self):
-        super(APIControllerWithRBACTestCase, self).tearDown()
-
-        if getattr(self, 'request_context_mock', None):
-            self.request_context_mock.stop()
-            del(Router.mock_context)
-
-    def use_user(self, user_db):
-        """
-        Select a user which is to be used by the HTTP request following this call.
-        """
-        if not user_db:
-            raise ValueError('"user_db" is mandatory')
-
-        mock_context = {
-            'user': user_db
-        }
-        self.request_context_mock = mock.PropertyMock(return_value=mock_context)
-        Router.mock_context = self.request_context_mock
+    app_module = app
 
 
 class FakeResponse(object):

--- a/st2api/tests/base.py
+++ b/st2api/tests/base.py
@@ -24,18 +24,10 @@ from st2tests.api import BaseAPIControllerWithRBACTestCase
 
 
 class FunctionalTest(BaseFunctionalTest):
-    """
-    Base test case class for testing API controllers with auth and RBAC disabled.
-    """
-
     app_module = app
 
 
 class APIControllerWithRBACTestCase(BaseAPIControllerWithRBACTestCase):
-    """
-    Base test case class for testing API controllers with RBAC enabled.
-    """
-
     app_module = app
 
 

--- a/st2common/st2common/constants/types.py
+++ b/st2common/st2common/constants/types.py
@@ -53,4 +53,7 @@ class ResourceType(Enum):
     TRACE = 'trace'
     TIMER = 'timer'
 
+    # Special resource type for stream related stuff
+    STREAM = 'stream'
+
     UNKNOWN = 'unknown'

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -3753,8 +3753,14 @@ paths:
   /stream/v1/stream:
     get:
       operationId: st2stream.controllers.v1.stream:stream_controller.get_all
+      x-permissions: stream_view
       description: |
         Event stream endpoint.
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: EventSource compatible stream of events
@@ -3936,7 +3942,7 @@ definitions:
       status:
         description: The current status of the action execution.
         type: string
-        enum: ['requested', 'scheduled', 'delayed', 'running', 'succeeded', 'failed', 'timeout', 'abandoned', 'canceling', 'canceled']
+        enum: ['requested', 'scheduled', 'delayed', 'running', 'succeeded', 'failed', 'timeout', 'abandoned', 'canceling', 'canceled', 'pausing', 'paused', 'resuming']
       start_timestamp:
         description: The start time when the action is executed.
         type: string
@@ -3995,7 +4001,7 @@ definitions:
               pattern: ^\d{4}\-\d{2}\-\d{2}(\s|T)\d{2}:\d{2}:\d{2}(\.\d{3,6})?(Z|\+00|\+0000|\+00:00)$
             status:
               type: string
-              enum: ['requested', 'scheduled', 'delayed', 'running', 'succeeded', 'failed', 'timeout', 'abandoned', 'canceling', 'canceled']
+              enum: ['requested', 'scheduled', 'delayed', 'running', 'succeeded', 'failed', 'timeout', 'abandoned', 'canceling', 'canceled', 'pausing', 'paused', 'resuming']
     required:
       - id
     additionalProperties: False
@@ -4015,7 +4021,7 @@ definitions:
       status:
         description: The current status of the action execution.
         type: string
-        enum: ['requested', 'scheduled', 'delayed', 'running', 'succeeded', 'failed', 'timeout', 'abandoned', 'canceling', 'canceled']
+        enum: ['requested', 'scheduled', 'delayed', 'running', 'succeeded', 'failed', 'timeout', 'abandoned', 'canceling', 'canceled', 'pausing', 'paused', 'resuming']
       result:
         type: object
     additionalProperties: False
@@ -4243,7 +4249,7 @@ definitions:
       status:
         description: The current status of the action execution.
         type: string
-        enum: ['requested', 'scheduled', 'delayed', 'running', 'succeeded', 'failed', 'timeout', 'abandoned', 'canceling', 'canceled']
+        enum: ['requested', 'scheduled', 'delayed', 'running', 'succeeded', 'failed', 'timeout', 'abandoned', 'canceling', 'canceled', 'pausing', 'paused', 'resuming']
       start_timestamp:
         description: The start time when the action is executed.
         type: string

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -3750,8 +3750,14 @@ paths:
   /stream/v1/stream:
     get:
       operationId: st2stream.controllers.v1.stream:stream_controller.get_all
+      x-permissions: {{ PERMISSION_TYPE.STREAM_VIEW }}
       description: |
         Event stream endpoint.
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: EventSource compatible stream of events

--- a/st2common/st2common/rbac/resolvers.py
+++ b/st2common/st2common/rbac/resolvers.py
@@ -48,6 +48,7 @@ __all__ = [
     'WebhookPermissionsResolver',
     'TracePermissionsResolver',
     'TriggerPermissionsResolver',
+    'StreamPermissionsResolver',
 
     'get_resolver_for_resource_type',
     'get_resolver_for_permission_type'
@@ -1037,6 +1038,15 @@ class PolicyPermissionsResolver(ContentPackResourcePermissionsResolver):
                                                   permission_type=permission_type)
 
 
+class StreamPermissionsResolver(PermissionsResolver):
+    resource_type = ResourceType.STREAM
+    view_grant_permission_types = []
+
+    def user_has_permission(self, user_db, permission_type):
+        assert permission_type in [PermissionType.STREAM_VIEW]
+        return self._user_has_global_permission(user_db=user_db, permission_type=permission_type)
+
+
 def get_resolver_for_resource_type(resource_type):
     """
     Return resolver instance for the provided resource type.
@@ -1075,6 +1085,8 @@ def get_resolver_for_resource_type(resource_type):
         resolver_cls = PolicyTypePermissionsResolver
     elif resource_type == ResourceType.POLICY:
         resolver_cls = PolicyPermissionsResolver
+    elif resource_type == ResourceType.STREAM:
+        resolver_cls = StreamPermissionsResolver
     else:
         raise ValueError('Unsupported resource: %s' % (resource_type))
 

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -150,6 +150,8 @@ class PermissionType(Enum):
     POLICY_DELETE = 'policy_delete'
     POLICY_ALL = 'policy_all'
 
+    STREAM_VIEW = 'stream_view'
+
     @classmethod
     def get_valid_permissions_for_resource_type(cls, resource_type):
         """
@@ -250,6 +252,7 @@ class ResourceType(Enum):
     API_KEY = SystemResourceType.API_KEY
     TRACE = SystemResourceType.TRACE
     TRIGGER = SystemResourceType.TRIGGER
+    STREAM = SystemResourceType.STREAM
 
 
 class SystemRole(Enum):
@@ -429,7 +432,10 @@ GLOBAL_PERMISSION_TYPES = [
     PermissionType.POLICY_CREATE,
 
     # Execution
-    PermissionType.EXECUTION_VIEWS_FILTERS_LIST
+    PermissionType.EXECUTION_VIEWS_FILTERS_LIST,
+
+    # Stream
+    PermissionType.STREAM_VIEW
 ] + LIST_PERMISSION_TYPES
 
 GLOBAL_PACK_PERMISSION_TYPES = [permission_type for permission_type in GLOBAL_PERMISSION_TYPES if
@@ -558,7 +564,10 @@ PERMISION_TYPE_TO_DESCRIPTION_MAP = {
     PermissionType.POLICY_MODIFY: ('Ability to modify an existing policy.'),
     PermissionType.POLICY_DELETE: ('Ability to delete an existing policy.'),
     PermissionType.POLICY_ALL: ('Ability to perform all the supported operations on a particular '
-                                'policy.')
+                                'policy.'),
+
+    PermissionType.STREAM_VIEW: ('Ability to view / listen to the events on the stream API '
+                                 'endpoint.')
 }
 
 

--- a/st2stream/st2stream/controllers/v1/stream.py
+++ b/st2stream/st2stream/controllers/v1/stream.py
@@ -37,7 +37,7 @@ def format(gen):
 
 
 class StreamController(object):
-    def get_all(self):
+    def get_all(self, requester_user):
         def make_response():
             res = Response(content_type='text/event-stream',
                            app_iter=format(get_listener().generator()))

--- a/st2stream/st2stream/controllers/v1/stream.py
+++ b/st2stream/st2stream/controllers/v1/stream.py
@@ -37,7 +37,7 @@ def format(gen):
 
 
 class StreamController(object):
-    def get_all(self, requester_user):
+    def get_all(self, requester_user=None):
         def make_response():
             res = Response(content_type='text/event-stream',
                            app_iter=format(get_listener().generator()))

--- a/st2stream/tests/unit/controllers/v1/base.py
+++ b/st2stream/tests/unit/controllers/v1/base.py
@@ -13,21 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from webtest import TestApp
-
-from st2tests import DbTestCase
 from st2stream import app
-import st2tests.config as tests_config
+from st2tests.api import BaseFunctionalTest
+from st2tests.api import BaseAPIControllerWithRBACTestCase
+
+__all__ = [
+    'FunctionalTest',
+    'APIControllerWithRBACTestCase'
+]
 
 
-class FunctionalTest(DbTestCase):
+class FunctionalTest(BaseFunctionalTest):
+    app_module = app
+    register_runners = False
 
-    @classmethod
-    def setUpClass(cls):
-        super(FunctionalTest, cls).setUpClass()
-        tests_config.parse_args()
-        cls.app = TestApp(app.setup_app())
 
-    @classmethod
-    def tearDownClass(cls):
-        super(FunctionalTest, cls).tearDownClass()
+class APIControllerWithRBACTestCase(BaseAPIControllerWithRBACTestCase):
+    app_module = app

--- a/st2stream/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
+++ b/st2stream/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
@@ -1,0 +1,74 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import httplib
+
+import six
+
+from st2common.persistence.rbac import UserRoleAssignment
+from st2common.models.db.rbac import UserRoleAssignmentDB
+
+from base import APIControllerWithRBACTestCase
+
+http_client = six.moves.http_client
+
+__all__ = [
+    'APIControllersRBACTestCase'
+]
+
+
+class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
+    """
+    Test class which hits all the API endpoints which are behind the RBAC wall with a user which
+    has no permissions and makes sure API returns access denied.
+    """
+
+    def setUp(self):
+        super(APIControllersRBACTestCase, self).setUp()
+
+        self.role_assignment_db_model = UserRoleAssignmentDB(user='user', role='role')
+        UserRoleAssignment.add_or_update(self.role_assignment_db_model)
+
+    def test_api_endpoints_behind_rbac_wall(self):
+
+        supported_endpoints = [
+            # Stream
+            {
+                'path': '/v1/stream',
+                'method': 'GET'
+            }
+        ]
+
+        self.use_user(self.users['no_permissions'])
+        for endpoint in supported_endpoints:
+            response = self._perform_request_for_endpoint(endpoint=endpoint)
+            msg = '%s "%s" didn\'t return 403 status code (body=%s)' % (endpoint['method'],
+                                                                        endpoint['path'],
+                                                                        response.body)
+            self.assertEqual(response.status_code, httplib.FORBIDDEN, msg)
+
+    def _perform_request_for_endpoint(self, endpoint):
+        if endpoint['method'] == 'GET':
+            response = self.app.get(endpoint['path'], expect_errors=True)
+        elif endpoint['method'] == 'POST':
+            return self.app.post_json(endpoint['path'], endpoint['payload'], expect_errors=True)
+        elif endpoint['method'] == 'PUT':
+            return self.app.put_json(endpoint['path'], endpoint['payload'], expect_errors=True)
+        elif endpoint['method'] == 'DELETE':
+            return self.app.delete(endpoint['path'], expect_errors=True)
+        else:
+            raise ValueError('Unsupported method: %s' % (endpoint['method']))
+
+        return response

--- a/st2stream/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
+++ b/st2stream/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
@@ -19,6 +19,7 @@ import six
 
 from st2common.persistence.rbac import UserRoleAssignment
 from st2common.models.db.rbac import UserRoleAssignmentDB
+from st2common.rbac.types import PermissionType
 
 from base import APIControllerWithRBACTestCase
 
@@ -54,10 +55,14 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
         self.use_user(self.users['no_permissions'])
         for endpoint in supported_endpoints:
             response = self._perform_request_for_endpoint(endpoint=endpoint)
+            expected_msg = ('User "%s" doesn\'t have required permission "%s"' %
+                            (self.users['no_permissions'].name, PermissionType.STREAM_VIEW))
+
             msg = '%s "%s" didn\'t return 403 status code (body=%s)' % (endpoint['method'],
                                                                         endpoint['path'],
                                                                         response.body)
             self.assertEqual(response.status_code, httplib.FORBIDDEN, msg)
+            self.assertRegexpMatches(response.json['faultstring'], expected_msg)
 
     def _perform_request_for_endpoint(self, endpoint):
         if endpoint['method'] == 'GET':

--- a/st2stream/tests/unit/controllers/v1/test_stream.py
+++ b/st2stream/tests/unit/controllers/v1/test_stream.py
@@ -22,8 +22,7 @@ from st2common.persistence.action import Action, RunnerType
 from st2stream.controllers.v1 import stream
 import st2stream.listener
 from st2tests.api import SUPER_SECRET_PARAMETER
-from st2api.tests.base import FunctionalTest
-#from base import FunctionalTest
+from base import FunctionalTest
 
 
 RUNNER_TYPE_1 = {

--- a/st2stream/tests/unit/controllers/v1/test_stream.py
+++ b/st2stream/tests/unit/controllers/v1/test_stream.py
@@ -22,7 +22,8 @@ from st2common.persistence.action import Action, RunnerType
 from st2stream.controllers.v1 import stream
 import st2stream.listener
 from st2tests.api import SUPER_SECRET_PARAMETER
-from base import FunctionalTest
+from st2api.tests.base import FunctionalTest
+#from base import FunctionalTest
 
 
 RUNNER_TYPE_1 = {

--- a/st2tests/st2tests/api.py
+++ b/st2tests/st2tests/api.py
@@ -89,6 +89,8 @@ class BaseFunctionalTest(DbTestCase):
     # By default auth is disabled
     enable_auth = False
 
+    register_runners = True
+
     @classmethod
     def setUpClass(cls):
         super(BaseFunctionalTest, cls).setUpClass()
@@ -104,7 +106,8 @@ class BaseFunctionalTest(DbTestCase):
 
         # TODO(manas) : register action types here for now. RunnerType registration can be moved
         # to posting to /runnertypes but that implies implementing POST.
-        runners_registrar.register_runners()
+        if cls.register_runners:
+            runners_registrar.register_runners()
 
         cls.app = TestApp(cls.app_module.setup_app())
 

--- a/st2tests/st2tests/api.py
+++ b/st2tests/st2tests/api.py
@@ -13,7 +13,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Various base classes and test utility functions for API related tests.
+"""
+
 import webtest
+import mock
+from oslo_config import cfg
+
+from st2common.router import Router
+from st2common.rbac.types import SystemRole
+from st2common.persistence.auth import User
+from st2common.persistence.rbac import UserRoleAssignment
+from st2common.models.db.auth import UserDB
+from st2common.models.db.rbac import UserRoleAssignmentDB
+from st2common.rbac.migrations import run_all as run_all_rbac_migrations
+from st2common.bootstrap import runnersregistrar as runners_registrar
+from st2tests.base import DbTestCase
+from st2tests.base import CleanDbTestCase
+from st2tests import config as tests_config
+
+__all__ = [
+    'BaseFunctionalTest',
+    'BaseAPIControllerWithRBACTestCase',
+
+    'TestApp'
+]
 
 
 SUPER_SECRET_PARAMETER = 'SUPER_SECRET_PARAMETER_THAT_SHOULD_NEVER_APPEAR_IN_RESPONSES_OR_LOGS'
@@ -51,3 +76,99 @@ class TestApp(webtest.TestApp):
             raise ResponseValidationError('Response missing a required CORS header')
 
         return res
+
+
+class BaseFunctionalTest(DbTestCase):
+    """
+    Base test case class for testing API controllers with auth and RBAC disabled.
+    """
+
+    # App used by the tests
+    app_module = None
+
+    # By default auth is disabled
+    enable_auth = False
+
+    @classmethod
+    def setUpClass(cls):
+        super(BaseFunctionalTest, cls).setUpClass()
+        cls._do_setUpClass()
+
+    @classmethod
+    def _do_setUpClass(cls):
+        tests_config.parse_args()
+
+        cfg.CONF.set_default('enable', cls.enable_auth, group='auth')
+
+        cfg.CONF.set_override(name='enable', override=False, group='rbac')
+
+        # TODO(manas) : register action types here for now. RunnerType registration can be moved
+        # to posting to /runnertypes but that implies implementing POST.
+        runners_registrar.register_runners()
+
+        cls.app = TestApp(cls.app_module.setup_app())
+
+
+class BaseAPIControllerWithRBACTestCase(BaseFunctionalTest, CleanDbTestCase):
+    """
+    Base test case class for testing API controllers with RBAC enabled.
+    """
+
+    enable_auth = True
+
+    @classmethod
+    def setUpClass(cls):
+        super(BaseAPIControllerWithRBACTestCase, cls).setUpClass()
+
+        # Make sure RBAC is enabeld
+        cfg.CONF.set_override(name='enable', override=True, group='rbac')
+
+    @classmethod
+    def tearDownClass(cls):
+        super(BaseAPIControllerWithRBACTestCase, cls).tearDownClass()
+
+    def setUp(self):
+        super(BaseAPIControllerWithRBACTestCase, self).setUp()
+
+        self.users = {}
+        self.roles = {}
+
+        # Run RBAC migrations
+        run_all_rbac_migrations()
+
+        # Insert mock users with default role assignments
+        role_names = [SystemRole.SYSTEM_ADMIN, SystemRole.ADMIN, SystemRole.OBSERVER]
+        for role_name in role_names:
+            user_db = UserDB(name=role_name)
+            user_db = User.add_or_update(user_db)
+            self.users[role_name] = user_db
+
+            role_assignment_db = UserRoleAssignmentDB(
+                user=user_db.name,
+                role=role_name)
+            UserRoleAssignment.add_or_update(role_assignment_db)
+
+        # Insert a user with no permissions and role assignments
+        user_1_db = UserDB(name='no_permissions')
+        user_1_db = User.add_or_update(user_1_db)
+        self.users['no_permissions'] = user_1_db
+
+    def tearDown(self):
+        super(BaseAPIControllerWithRBACTestCase, self).tearDown()
+
+        if getattr(self, 'request_context_mock', None):
+            self.request_context_mock.stop()
+            del(Router.mock_context)
+
+    def use_user(self, user_db):
+        """
+        Select a user which is to be used by the HTTP request following this call.
+        """
+        if not user_db:
+            raise ValueError('"user_db" is mandatory')
+
+        mock_context = {
+            'user': user_db
+        }
+        self.request_context_mock = mock.PropertyMock(return_value=mock_context)
+        Router.mock_context = self.request_context_mock


### PR DESCRIPTION
I decided to pick some fixes and improvements from #3657, base them on top of master and include them as separate PRs.

This will make #3657 a bit small and easier to review. This way I can also ensure some of those changes make it in v2.4.0 in case #3657 won't be merged in time for v2.4.0.

## Description

This pull request fixes a bug and adds missing RBAC check to `/v1/stream` API endpoint. In addition to that, it also includes some tests refactoring to reduce code duplication and make some base test classes possible to re-use between different packages.