### PR TITLE
Server side event filtering for /v1/stream API endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Added
   system). This allows adjacent logging events to be distinguished more accurately
   by the time they occurred.
   Contributed by Nick Maludy (Encore Technologies) #3362
+* Require new ``STREAM_VIEW`` RBAC permission type to be able to view ``/v1/stream`` stream API
+  endpoint. (improvement) #3676
 * Add new ``?events``, ``?action_refs`` and ``?execution_ids`` query params to ``/v1/stream/``
   API endpoint. Those query parameters allow user to filter out which events to receive based
   on the event type, action ref and execution id. By default, when no filters are provided, all

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Added
   system). This allows adjacent logging events to be distinguished more accurately
   by the time they occurred.
   Contributed by Nick Maludy (Encore Technologies) #3362
+* Add new ``?events``, ``?action_refs`` and ``?execution_ids`` query params to ``/v1/stream/``
+  API endpoint. Those query parameters allow user to filter out which events to receive based
+  on the event type, action ref and execution id. By default, when no filters are provided, all
+  events are returned. (new feature)
 
 Changed
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ Added
 * Add new ``?events``, ``?action_refs`` and ``?execution_ids`` query params to ``/v1/stream/``
   API endpoint. Those query parameters allow user to filter out which events to receive based
   on the event type, action ref and execution id. By default, when no filters are provided, all
-  events are returned. (new feature)
+  events are returned. (new feature) #3677
 
 Changed
 ~~~~~~~

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -518,7 +518,7 @@ class StreamManager(object):
             query_params['st2-api-key'] = kwargs.get('api_key')
 
         if events:
-            query_params = ','.join(events)
+            query_params['events'] = ','.join(events)
 
         query_string = '?' + urllib.parse.urlencode(query_params)
         url = url + query_string

--- a/st2stream/st2stream/controllers/v1/stream.py
+++ b/st2stream/st2stream/controllers/v1/stream.py
@@ -41,7 +41,7 @@ def format(gen):
 
 
 class StreamController(object):
-    def get_all(self, events=None, action_refs=None, execution_ids=None, requster_user=None):
+    def get_all(self, events=None, action_refs=None, execution_ids=None, requester_user=None):
         events = events.split(',') if events else None
         action_refs = action_refs.split(',') if action_refs else None
         execution_ids = execution_ids.split(',') if execution_ids else None

--- a/st2stream/st2stream/controllers/v1/stream.py
+++ b/st2stream/st2stream/controllers/v1/stream.py
@@ -20,6 +20,10 @@ from st2common.router import Response
 from st2common.util.jsonify import json_encode
 from st2stream.listener import get_listener
 
+__all__ = [
+    'StreamController'
+]
+
 LOG = logging.getLogger(__name__)
 
 
@@ -37,10 +41,16 @@ def format(gen):
 
 
 class StreamController(object):
-    def get_all(self, requester_user=None):
+    def get_all(self, events=None, action_refs=None, execution_ids=None, requster_user=None):
+        events = events.split(',') if events else None
+        action_refs = action_refs.split(',') if action_refs else None
+        execution_ids = execution_ids.split(',') if execution_ids else None
+
         def make_response():
-            res = Response(content_type='text/event-stream',
-                           app_iter=format(get_listener().generator()))
+            listener = get_listener()
+            app_iter = format(listener.generator(events=events, action_refs=action_refs,
+                                                 execution_ids=execution_ids))
+            res = Response(content_type='text/event-stream', app_iter=app_iter)
             return res
 
         stream = make_response()

--- a/st2stream/st2stream/listener.py
+++ b/st2stream/st2stream/listener.py
@@ -79,14 +79,44 @@ class Listener(ConsumerMixin):
         for queue in self.queues:
             queue.put(pack)
 
-    def generator(self):
+    def generator(self, events=None, action_refs=None, execution_ids=None):
         queue = eventlet.Queue()
         queue.put('')
         self.queues.append(queue)
+
         try:
             while not self._stopped:
                 try:
-                    yield queue.get(timeout=cfg.CONF.stream.heartbeat)
+                    # TODO: Move to common option
+                    message = queue.get(timeout=cfg.CONF.stream.heartbeat)
+
+                    if not message:
+                        yield message
+                        continue
+
+                    event_name, body = message
+                    # TODO: We now do late filtering, but this could also be performed on the
+                    # message bus level if we modified our exchange layout and utilize routing keys
+                    # Filter on event name
+                    if events and event_name not in events:
+                        LOG.debug('Skipping event "%s"' % (event_name))
+                        continue
+
+                    # Filter on action ref
+                    action_ref = self._get_action_ref_for_body(body=body)
+                    if action_refs and action_ref not in action_refs:
+                        LOG.debug('Skipping event "%s" with action_ref "%s"' % (event_name,
+                                                                                action_ref))
+                        continue
+
+                    # Filter on execution id
+                    execution_id = self._get_execution_id_for_body(body=body)
+                    if execution_ids and execution_id not in execution_ids:
+                        LOG.debug('Skipping event "%s" with execution_id "%s"' % (event_name,
+                                                                                  execution_id))
+                        continue
+
+                    yield message
                 except eventlet.queue.Empty:
                     yield
         finally:
@@ -94,6 +124,39 @@ class Listener(ConsumerMixin):
 
     def shutdown(self):
         self._stopped = True
+
+    def _get_action_ref_for_body(self, body):
+        """
+        Retrieve action_ref for the provided message body.
+        """
+        if not body:
+            return None
+
+        action_ref = None
+
+        if isinstance(body, ActionExecutionAPI):
+            action_ref = body.action.get('ref', None) if body.action else None
+        elif isinstance(body, LiveActionAPI):
+            action_ref = body.action
+        elif isinstance(body, (ActionExecutionStdoutAPI, ActionExecutionStderrAPI)):
+            action_ref = body.action_ref
+
+        return action_ref
+
+    def _get_execution_id_for_body(self, body):
+        if not body:
+            return None
+
+        execution_id = None
+
+        if isinstance(body, ActionExecutionAPI):
+            execution_id = str(body.id)
+        elif isinstance(body, LiveActionAPI):
+            execution_id = None
+        elif isinstance(body, (ActionExecutionStdoutAPI, ActionExecutionStderrAPI)):
+            execution_id = body.execution_id
+
+        return execution_id
 
 
 def listen(listener):

--- a/st2stream/st2stream/listener.py
+++ b/st2stream/st2stream/listener.py
@@ -138,8 +138,6 @@ class Listener(ConsumerMixin):
             action_ref = body.action.get('ref', None) if body.action else None
         elif isinstance(body, LiveActionAPI):
             action_ref = body.action
-        elif isinstance(body, (ActionExecutionStdoutAPI, ActionExecutionStderrAPI)):
-            action_ref = body.action_ref
 
         return action_ref
 
@@ -153,8 +151,6 @@ class Listener(ConsumerMixin):
             execution_id = str(body.id)
         elif isinstance(body, LiveActionAPI):
             execution_id = None
-        elif isinstance(body, (ActionExecutionStdoutAPI, ActionExecutionStderrAPI)):
-            execution_id = body.execution_id
 
         return execution_id
 

--- a/st2stream/tests/unit/controllers/v1/test_stream.py
+++ b/st2stream/tests/unit/controllers/v1/test_stream.py
@@ -15,12 +15,17 @@
 
 import mock
 
-from st2common.models.api.action import ActionAPI, RunnerTypeAPI
+from oslo_config import cfg
+
+from st2common.models.api.action import ActionAPI
+from st2common.models.api.action import RunnerTypeAPI
+from st2common.models.api.execution import ActionExecutionAPI
 from st2common.models.api.execution import LiveActionAPI
 from st2common.models.db.liveaction import LiveActionDB
+from st2common.models.db.execution import ActionExecutionDB
 from st2common.persistence.action import Action, RunnerType
-from st2stream.controllers.v1 import stream
 import st2stream.listener
+from st2stream.controllers.v1 import stream
 from st2tests.api import SUPER_SECRET_PARAMETER
 from base import FunctionalTest
 
@@ -70,12 +75,25 @@ LIVE_ACTION_1 = {
     }
 }
 
+EXECUTION_1 = {
+    'id': '598dbf0c0640fd54bffc688b',
+    'action': {
+        'ref': 'sixpack.st2.dummy.action1'
+    },
+    'parameters': {
+        'hosts': 'localhost',
+        'cmd': 'uname -a',
+        'd': SUPER_SECRET_PARAMETER
+    }
+}
+
 
 class META(object):
-    delivery_info = {
-        'exchange': 'some',
-        'routing_key': 'thing'
-    }
+    delivery_info = {}
+
+    def __init__(self, exchange='some', routing_key='thing'):
+        self.delivery_info['exchange'] = exchange
+        self.delivery_info['routing_key'] = routing_key
 
     def ack(self):
         pass
@@ -112,3 +130,107 @@ class TestStreamController(FunctionalTest):
         self.assertIn('event: some__thing', message)
         self.assertIn('data: {"', message)
         self.assertNotIn(SUPER_SECRET_PARAMETER, message)
+
+    @mock.patch.object(st2stream.listener, 'listen', mock.Mock())
+    def test_get_all_with_filters(self):
+        cfg.CONF.set_override(name='heartbeat', group='stream', override=0.1)
+
+        listener = st2stream.listener.get_listener()
+        process_execution = listener.processor(ActionExecutionAPI)
+        process_liveaction = listener.processor(LiveActionAPI)
+
+        execution_api = ActionExecutionDB(**EXECUTION_1)
+        liveaction_api = LiveActionDB(**LIVE_ACTION_1)
+        liveaction_api_2 = LiveActionDB(**LIVE_ACTION_1)
+        liveaction_api_2.action = 'dummy.action1'
+
+        def dispatch_and_handle_mock_data(resp):
+            received_messages_data = ''
+            for index, message in enumerate(resp._app_iter):
+                if message.strip():
+                    received_messages_data += message
+
+                # Dispatch some mock events
+                if index == 0:
+                    meta = META('st2.execution', 'create')
+                    process_execution(execution_api, meta)
+                elif index == 1:
+                    meta = META('st2.execution', 'update')
+                    process_execution(execution_api, meta)
+                elif index == 2:
+                    meta = META('st2.execution', 'delete')
+                    process_execution(execution_api, meta)
+                elif index == 3:
+                    meta = META('st2.liveaction', 'create')
+                    process_liveaction(liveaction_api, meta)
+                elif index == 4:
+                    meta = META('st2.liveaction', 'create')
+                    process_liveaction(liveaction_api, meta)
+                elif index == 5:
+                    meta = META('st2.liveaction', 'delete')
+                    process_liveaction(liveaction_api_2, meta)
+                else:
+                    break
+
+            received_messages = received_messages_data.split('\n\n')
+            received_messages = [message for message in received_messages if message]
+            return received_messages
+
+        # 1. Default filter
+        resp = stream.StreamController().get_all()
+
+        received_messages = dispatch_and_handle_mock_data(resp)
+        self.assertEqual(len(received_messages), 6)
+
+        # 1. ?events= filter
+        # No filter provided - all messages should be received
+        resp = stream.StreamController().get_all()
+
+        received_messages = dispatch_and_handle_mock_data(resp)
+        self.assertEqual(len(received_messages), 6)
+
+        # Filter provided, only two messages should be received
+        events = ['st2.execution__create', 'st2.liveaction__delete']
+        events = ','.join(events)
+        resp = stream.StreamController().get_all(events=events)
+
+        received_messages = dispatch_and_handle_mock_data(resp)
+        self.assertEqual(len(received_messages), 2)
+
+        # Filter provided, invalid , no message should be received
+        events = ['invalid1', 'invalid2']
+        events = ','.join(events)
+        resp = stream.StreamController().get_all(events=events)
+
+        received_messages = dispatch_and_handle_mock_data(resp)
+        self.assertEqual(len(received_messages), 0)
+
+        # 2. ?action_refs= filter
+        action_refs = ['invalid1', 'invalid2']
+        action_refs = ','.join(action_refs)
+        resp = stream.StreamController().get_all(action_refs=action_refs)
+
+        received_messages = dispatch_and_handle_mock_data(resp)
+        self.assertEqual(len(received_messages), 0)
+
+        action_refs = ['dummy.action1']
+        action_refs = ','.join(action_refs)
+        resp = stream.StreamController().get_all(action_refs=action_refs)
+
+        received_messages = dispatch_and_handle_mock_data(resp)
+        self.assertEqual(len(received_messages), 1)
+
+        # 3. ?execution_ids= filter
+        execution_ids = ['invalid1', 'invalid2']
+        execution_ids = ','.join(execution_ids)
+        resp = stream.StreamController().get_all(execution_ids=execution_ids)
+
+        received_messages = dispatch_and_handle_mock_data(resp)
+        self.assertEqual(len(received_messages), 0)
+
+        execution_ids = [EXECUTION_1['id']]
+        execution_ids = ','.join(execution_ids)
+        resp = stream.StreamController().get_all(execution_ids=execution_ids)
+
+        received_messages = dispatch_and_handle_mock_data(resp)
+        self.assertEqual(len(received_messages), 3)


### PR DESCRIPTION
I decided to pick some fixes and improvements from #3657, base them on top of master and include them as separate PRs.

This will make #3657 a bit small and easier to review. This way I can also ensure some of those changes make it in v2.4.0 in case #3657 won't be merged in time for v2.4.0.

## Description

This pull request adds server side filtering based on the event name, action ref and execution id to the ``/v1/stream`` endpoint. In addition to that, it updates st2client to use server-side filtering instead of doing client side based filtering.

As mentioned above, this change was originally added because it was needed in #3657, but it's something which is generally useful outside of #3657 and this way it's also easier to review it.

As mentioned and discussed on Slack - more efficient way to do server side filtering would be to filter it on the message bus level instead of inside the stream listener, but this would require substantial changes to the code and how we handle routing keys and exchanges and it's an over kill for now.