### PR TITLE
Increase 'pack register content' timeout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -61,6 +61,7 @@ Fixed
   parameters and by passing --sort=asc|desc parameter to the st2 trace list CLI command.
   Descending order by default.(bug fix) #3237 #3665
 * Fix pack index health endpoint. It now points to the right controller. #3672
+* Fix 'pack register content' failures appearing on some slower systems by lifting action timeout #3685
 
 2.3.2 - July 28, 2017
 ---------------------

--- a/contrib/packs/actions/load.yaml
+++ b/contrib/packs/actions/load.yaml
@@ -16,5 +16,5 @@
         type: "string"
     timeout:
       type: "integer"
-      default: 180
+      default: 300
       description: "Make sure that all pack content is loaded within specified timeout"


### PR DESCRIPTION
Our [AWS pack](https://github.com/stackstorm-exchange/stackstorm-aws) ballooned into `3581` actions which sometimes results in `st2 pack install aws` failures on slower systems (reported in #community).

For now "temporary" increasing pack register timeout.

The proper fix is to investigate the performance and research the pack content registration optimizations 
StackStorm by design should handle big packs https://github.com/StackStorm/st2/issues/3686.

Also there is a related cosmetic enhancement https://github.com/StackStorm/st2/issues/3586 which helps to additionally signalize if there is a *huge* amount of content in a pack.