### PR TITLE
Fix timeout listening for events with client side async execution

### DIFF
--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -524,4 +524,10 @@ class StreamManager(object):
         url = url + query_string
 
         for message in SSEClient(url):
+
+            # If the execution on the API server takes too long, the message
+            # can be empty. In this case, rerun the query.
+            if not message.data:
+                continue
+
             yield json.loads(message.data)


### PR DESCRIPTION
On pack install, the command listens for event from the API server. If the execution takes too long, the SSEClient which listens for events on the client side returns an empty string which leads to JSON load error.