### PR TITLE
Fix a bug with API user not being honored in /v1/packs/install and /v1/packs/uninstall API endpoints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -71,7 +71,8 @@ Fixed
 * Fix 'pack register content' failures appearing on some slower systems by lifting action timeout.
   #3685
 * Fix a bug with ``/v1/packs/install`` and ``/v1/packs/uninstall`` API endpoints incorrectly using
-  system user for executed actions instead of the user which performed the API operation. #3693
+  system user for scheduled pack install and pack uninstall executions instead of the user which
+  performed the API operation.(bug fix) #3693 #3696
 
   Reported by theuiz.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -68,7 +68,12 @@ Fixed
   parameters and by passing --sort=asc|desc parameter to the st2 trace list CLI command.
   Descending order by default.(bug fix) #3237 #3665
 * Fix pack index health endpoint. It now points to the right controller. #3672
-* Fix 'pack register content' failures appearing on some slower systems by lifting action timeout #3685
+* Fix 'pack register content' failures appearing on some slower systems by lifting action timeout.
+  #3685
+* Fix a bug with ``/v1/packs/install`` and ``/v1/packs/uninstall`` API endpoints incorrectly using
+  system user for executed actions instead of the user which performed the API operation. #3693
+
+  Reported by theuiz.
 
 2.3.2 - July 28, 2017
 ---------------------

--- a/st2api/tests/unit/controllers/v1/test_packs_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_packs_rbac.py
@@ -1,0 +1,79 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+import six
+
+from st2common.router import Response
+from st2api.controllers.v1.actionexecutions import ActionExecutionsControllerMixin
+from tests.base import APIControllerWithRBACTestCase
+
+http_client = six.moves.http_client
+
+__all__ = [
+    'PackControllerRBACTestCase'
+]
+
+
+class PackControllerRBACTestCase(APIControllerWithRBACTestCase):
+    @mock.patch.object(ActionExecutionsControllerMixin, '_handle_schedule_execution')
+    def test_install(self, _handle_schedule_execution):
+        user_db = self.users['system_admin']
+        self.use_user(user_db)
+
+        _handle_schedule_execution.return_value = Response(json={'id': '123'})
+        payload = {'packs': ['some']}
+
+        resp = self.app.post_json('/v1/packs/install', payload)
+
+        self.assertEqual(resp.status_int, 202)
+        self.assertEqual(resp.json, {'execution_id': '123'})
+
+        # Verify created execution correctly used the user which performed the API operation
+        call_kwargs = _handle_schedule_execution.call_args[1]
+        self.assertEqual(call_kwargs['requester_user'], user_db)
+        self.assertEqual(call_kwargs['liveaction_api'].user, user_db.name)
+
+        # Try with a different user
+        user_db = self.users['admin']
+        self.use_user(user_db)
+
+        resp = self.app.post_json('/v1/packs/install', payload)
+
+        self.assertEqual(resp.status_int, 202)
+        self.assertEqual(resp.json, {'execution_id': '123'})
+
+        # Verify created execution correctly used the user which performed the API operation
+        call_kwargs = _handle_schedule_execution.call_args[1]
+        self.assertEqual(call_kwargs['requester_user'], user_db)
+        self.assertEqual(call_kwargs['liveaction_api'].user, user_db.name)
+
+    @mock.patch.object(ActionExecutionsControllerMixin, '_handle_schedule_execution')
+    def test_uninstall(self, _handle_schedule_execution):
+        user_db = self.users['system_admin']
+        self.use_user(user_db)
+
+        _handle_schedule_execution.return_value = Response(json={'id': '123'})
+        payload = {'packs': ['some']}
+
+        resp = self.app.post_json('/v1/packs/uninstall', payload)
+
+        self.assertEqual(resp.status_int, 202)
+        self.assertEqual(resp.json, {'execution_id': '123'})
+
+        # Verify created execution correctly used the user which performed the API operation
+        call_kwargs = _handle_schedule_execution.call_args[1]
+        self.assertEqual(call_kwargs['requester_user'], user_db)
+        self.assertEqual(call_kwargs['liveaction_api'].user, user_db.name)

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -1447,6 +1447,11 @@ paths:
           description: Packs to be installed
           schema:
             $ref: '#/definitions/PacksInstall'
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '202':
           description: Pack installation request has been accepted
@@ -1472,6 +1477,11 @@ paths:
           description: Packs to be uninstalled
           schema:
             $ref: '#/definitions/PacksUninstall'
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '202':
           description: Pack uninstallation request has been accepted

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -1444,6 +1444,11 @@ paths:
           description: Packs to be installed
           schema:
             $ref: '#/definitions/PacksInstall'
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '202':
           description: Pack installation request has been accepted
@@ -1469,6 +1474,11 @@ paths:
           description: Packs to be uninstalled
           schema:
             $ref: '#/definitions/PacksUninstall'
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '202':
           description: Pack uninstallation request has been accepted


### PR DESCRIPTION
This pull request fixes a bug with not honoring the user which performed the API operation when scheduling an execution for pack install and pack uninstall in those two corresponding API endpoints.

This means that instead of the user which performed API operation, system user (stanley) was used for those scheduled executions.

This is a regression which was introduced when we moved from scheduling executions directly for pack install and uninstall to the new API.

Thanks to @theuiz for catching and reporting this.

Resolves #3693.