### PR TITLE
[st2client] Corrected the implementation of transformer of array to parse the values in object as the type which is specified in the action metadata

### DIFF
--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -523,7 +523,7 @@ class ActionRunCommandMixin(object):
                     result[key] = value
             return result
 
-        def transform_array(value, action_params={}):
+        def transform_array(value, action_params=None):
             # Sometimes an array parameter only has a single element:
             #
             #     i.e. "st2 run foopack.fooaction arrayparam=51"
@@ -554,6 +554,9 @@ class ActionRunCommandMixin(object):
             # When each values in this array represent dict type, this converts
             # the 'result' to the dict type value.
             if all([isinstance(x, str) and ':' in x for x in result]):
+                if not action_params:
+                    action_params = {}
+
                 result_dict = {}
                 for (k, v) in [x.split(':') for x in result]:
                     # To parse values using the 'transformer' according to the type which is

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -575,7 +575,10 @@ class ActionRunCommandMixin(object):
             'string': str
         }
 
-        def get_param_type(key, action_params=action.parameters):
+        def get_param_type(key, action_params=None):
+            if not action_params:
+                action_params = action.parameters
+
             param = None
             if key in runner.runner_parameters:
                 param = runner.runner_parameters[key]
@@ -587,10 +590,19 @@ class ActionRunCommandMixin(object):
 
             return None
 
-        def normalize(name, value, action_params=action.parameters):
+        def normalize(name, value, action_params=None):
             """ The desired type is contained in the action meta-data, so we can look that up
                 and call the desired "caster" function listed in the "transformer" dict
             """
+
+            # By default, this method uses a parameter which is defined in the action metadata.
+            # This method assume to be called recursively for parsing values in an array of objects
+            # type value according to the nested action metadata definition.
+            #
+            # This is a best practice to pass a list value as default argument to prevent
+            # unforeseen consequence by being created a persistent object.
+            if not action_params:
+                action_params = action.parameters
 
             # Users can also specify type for each array parameter inside an action metadata
             # (items: type: int for example) and this information is available here so we could

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -523,7 +523,7 @@ class ActionRunCommandMixin(object):
                     result[key] = value
             return result
 
-        def transform_array(value, action_params = {}):
+        def transform_array(value, action_params={}):
             # Sometimes an array parameter only has a single element:
             #
             #     i.e. "st2 run foopack.fooaction arrayparam=51"

--- a/st2client/tests/unit/test_command_actionrun.py
+++ b/st2client/tests/unit/test_command_actionrun.py
@@ -70,7 +70,13 @@ class ActionRunCommandTest(unittest2.TestCase):
             'param_object': {'type': 'object'},
             'param_boolean': {'type': 'boolean'},
             'param_array': {'type': 'array'},
-            'param_array_of_dicts': {'type': 'array'},
+            'param_array_of_dicts': {'type': 'array', 'properties': {
+                'foo': {'type': 'string'},
+                'bar': {'type': 'integer'},
+                'baz': {'type': 'number'},
+                'qux': {'type': 'object'},
+                'quux': {'type': 'boolean'}}
+            },
         }
 
         subparser = mock.Mock()
@@ -85,7 +91,8 @@ class ActionRunCommandTest(unittest2.TestCase):
             'param_object=hoge=1,fuga=2',
             'param_boolean=False',
             'param_array=foo,bar,baz',
-            'param_array_of_dicts=foo:1,bar:2'
+            'param_array_of_dicts=foo:HOGE,bar:1,baz:1.23,qux:foo=bar,quux:True',
+            'param_array_of_dicts=foo:FUGA,bar:2,baz:2.34,qux:bar=baz,quux:False'
         ]
 
         param = command._get_action_parameters_from_args(action=action, runner=runner, args=mockarg)
@@ -97,7 +104,17 @@ class ActionRunCommandTest(unittest2.TestCase):
         self.assertEqual(param['param_object'], {'hoge': '1', 'fuga': '2'})
         self.assertFalse(param['param_boolean'])
         self.assertEqual(param['param_array'], ['foo', 'bar', 'baz'])
-        self.assertEqual(param['param_array_of_dicts'], [{'foo': '1', 'bar': '2'}])
+
+        # checking the result of parsing for array of objects
+        self.assertTrue(isinstance(param['param_array_of_dicts'], list))
+        self.assertEqual(len(param['param_array_of_dicts']), 2)
+        for param in param['param_array_of_dicts']:
+            self.assertTrue(isinstance(param, dict))
+            self.assertTrue(isinstance(param['foo'], str))
+            self.assertTrue(isinstance(param['bar'], int))
+            self.assertTrue(isinstance(param['baz'], float))
+            self.assertTrue(isinstance(param['qux'], dict))
+            self.assertTrue(isinstance(param['quux'], bool))
 
     def test_get_params_from_args_with_multiple_declarations(self):
         runner = RunnerType()


### PR DESCRIPTION
This is the correction based on [the suggestion from Kami](https://github.com/StackStorm/st2/pull/3670/files#r134171370).

This patch corrects the `_get_action_parameters_from_args` method, which parses `array of dicts` value from the command-line arguments, to parse each values in the object as the type which is specified in the action metadata.
