### PR TITLE
Update CLI to print more user-friendly help string if no argument is provided

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,12 @@ Fixed
 
   Reported by theuiz.
 
+Changed
+~~~~~~~
+
+* Update ``st2`` CLI command to print a more user-friendly usage / help string if no arguments are
+    passed to the CLI. (improvement) #3710
+
 2.4.0 - August 23, 2017
 -----------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@ Changed
 ~~~~~~~
 
 * Update ``st2`` CLI command to print a more user-friendly usage / help string if no arguments are
-    passed to the CLI. (improvement) #3710
+  passed to the CLI. (improvement) #3710
 
 2.4.0 - August 23, 2017
 -----------------------

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -62,7 +62,7 @@ __all__ = [
 
 LOGGER = logging.getLogger(__name__)
 
-CLI_DESCRIPTION = 'CLI for StackStorm event-driven automation platform - https://stackstorm.com'
+CLI_DESCRIPTION = 'CLI for StackStorm event-driven automation platform. https://stackstorm.com'
 USAGE_STRING = """
 Usage: %(prog)s [options] <command> <sub command> [options]
 

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -292,8 +292,8 @@ class Shell(BaseCLIApp):
             # to the main ArgumentParser class above, this would also set a custom usage string for
             # sub-parsers which we don't want.
             parser.usage = USAGE_STRING
-            print(parser.format_help())
-            return 0
+            sys.stderr.write(parser.format_help())
+            return 2
 
         # Provide autocomplete for shell
         argcomplete.autocomplete(self.parser)

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -62,7 +62,7 @@ __all__ = [
 
 LOGGER = logging.getLogger(__name__)
 
-CLI_DESCRIPTION = 'CLI for StackStorm event-driven automation platform. https://stackstorm.com'
+CLI_DESCRIPTION = 'CLI for StackStorm event-driven automation platform - https://stackstorm.com'
 USAGE_STRING = """
 Usage: %(prog)s [options] <command> <sub command> [options]
 

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -88,7 +88,7 @@ class Shell(BaseCLIApp):
         self.client = None
 
         # Set up the main parser.
-        self.parser = argparse.ArgumentParser(description=CLI_DESCRIPTION, usage=USAGE_STRING)
+        self.parser = argparse.ArgumentParser(description=CLI_DESCRIPTION)
 
         # Set up general program options.
         self.parser.add_argument(
@@ -288,6 +288,10 @@ class Shell(BaseCLIApp):
 
         if len(argv) == 0:
             # Print a more user-friendly help string if no arguments are provided
+            # Note: We only set usage variable for the main parser. If we passed "usage" argument
+            # to the main ArgumentParser class above, this would also set a custom usage string for
+            # sub-parsers which we don't want.
+            parser.usage = USAGE_STRING
             print(parser.format_help())
             return 0
 

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -63,6 +63,15 @@ __all__ = [
 LOGGER = logging.getLogger(__name__)
 
 CLI_DESCRIPTION = 'CLI for StackStorm event-driven automation platform. https://stackstorm.com'
+USAGE_STRING = """
+Usage: %(prog)s [options] <command> <sub command> [options]
+
+For example:
+
+    %(prog)s action list --pack=st2
+    %(prog)s run core.local cmd=date
+    %(prog)s --debug run core.local cmd=date
+""".strip()
 
 
 class Shell(BaseCLIApp):
@@ -79,7 +88,7 @@ class Shell(BaseCLIApp):
         self.client = None
 
         # Set up the main parser.
-        self.parser = argparse.ArgumentParser(description=CLI_DESCRIPTION)
+        self.parser = argparse.ArgumentParser(description=CLI_DESCRIPTION, usage=USAGE_STRING)
 
         # Set up general program options.
         self.parser.add_argument(
@@ -177,7 +186,7 @@ class Shell(BaseCLIApp):
 
         # Set up list of commands and subcommands.
         self.subparsers = self.parser.add_subparsers()
-        self.commands = dict()
+        self.commands = {}
 
         self.commands['action'] = action.ActionBranch(
             'An activity that happens as a response to the external event.',
@@ -274,6 +283,13 @@ class Shell(BaseCLIApp):
 
     def run(self, argv):
         debug = False
+
+        parser = self.parser
+
+        if len(argv) == 0:
+            # Print a more user-friendly help string if no arguments are provided
+            print(parser.format_help())
+            return 0
 
         # Provide autocomplete for shell
         argcomplete.autocomplete(self.parser)

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -188,6 +188,9 @@ class Shell(BaseCLIApp):
         self.subparsers = self.parser.add_subparsers()
         self.commands = {}
 
+        self.commands['run'] = action.ActionRunCommand(
+            models.Action, self, self.subparsers, name='run', add_help=False)
+
         self.commands['action'] = action.ActionBranch(
             'An activity that happens as a response to the external event.',
             self, self.subparsers)
@@ -198,6 +201,12 @@ class Shell(BaseCLIApp):
 
         self.commands['auth'] = auth.TokenCreateCommand(
             models.Token, self, self.subparsers, name='auth')
+
+        self.commands['login'] = auth.LoginCommand(
+            models.Token, self, self.subparsers, name='login')
+
+        self.commands['whoami'] = auth.WhoamiCommand(
+            models.Token, self, self.subparsers, name='whoami')
 
         self.commands['api-key'] = auth.ApiKeyBranch(
             'API Keys.',
@@ -211,9 +220,6 @@ class Shell(BaseCLIApp):
             'Key value pair is used to store commonly used configuration '
             'for reuse in sensors, actions, and rules.',
             self, self.subparsers)
-
-        self.commands['login'] = auth.LoginCommand(
-            models.Token, self, self.subparsers, name='login')
 
         self.commands['pack'] = pack.PackBranch(
             'A group of related integration resources: '
@@ -233,8 +239,13 @@ class Shell(BaseCLIApp):
             'based on some criteria.',
             self, self.subparsers)
 
-        self.commands['run'] = action.ActionRunCommand(
-            models.Action, self, self.subparsers, name='run', add_help=False)
+        self.commands['webhook'] = webhook.WebhookBranch(
+            'Webhooks.',
+            self, self.subparsers)
+
+        self.commands['timer'] = timer.TimerBranch(
+            'Timers.',
+            self, self.subparsers)
 
         self.commands['runner'] = resource.ResourceBranch(
             models.RunnerType,
@@ -256,17 +267,6 @@ class Shell(BaseCLIApp):
 
         self.commands['trigger-instance'] = triggerinstance.TriggerInstanceBranch(
             'Actual instances of triggers received by st2.',
-            self, self.subparsers)
-
-        self.commands['webhook'] = webhook.WebhookBranch(
-            'Webhooks.',
-            self, self.subparsers)
-
-        self.commands['whoami'] = auth.WhoamiCommand(
-            models.Token, self, self.subparsers, name='whoami')
-
-        self.commands['timer'] = timer.TimerBranch(
-            'Timers.',
             self, self.subparsers)
 
         self.commands['rule-enforcement'] = rule_enforcement.RuleEnforcementBranch(

--- a/st2client/tests/unit/test_shell.py
+++ b/st2client/tests/unit/test_shell.py
@@ -49,6 +49,49 @@ class TestShell(base.BaseCLITestCase):
         super(TestShell, self).__init__(*args, **kwargs)
         self.shell = Shell()
 
+    def test_commands_usage_and_help_strings(self):
+        # No command, should print out user friendly usage / help string
+        self.assertEqual(self.shell.run([]), 0)
+
+        self.stdout.seek(0)
+        stdout = self.stdout.read()
+        self.assertTrue('Usage: ' in stdout)
+        self.assertTrue('For example:' in stdout)
+        self.assertTrue('CLI for StackStorm' in stdout)
+        self.assertTrue('positional arguments:' in stdout)
+
+        self.stdout.truncate()
+        self.stderr.truncate()
+
+        # --help should result in the same output
+        try:
+            self.assertEqual(self.shell.run(['--help']), 0)
+        except SystemExit as e:
+            self.assertEqual(e.code, 0)
+
+        self.stdout.seek(0)
+        stdout = self.stdout.read()
+        self.assertTrue('Usage: ' in stdout)
+        self.assertTrue('For example:' in stdout)
+        self.assertTrue('CLI for StackStorm' in stdout)
+        self.assertTrue('positional arguments:' in stdout)
+
+        self.stdout.truncate()
+        self.stderr.truncate()
+
+        # Sub command with no args
+        try:
+            self.assertEqual(self.shell.run(['action']), 2)
+        except SystemExit as e:
+            self.assertEqual(e.code, 2)
+
+        self.stderr.seek(0)
+        stderr = self.stderr.read()
+
+        self.assertTrue('usage' in stderr)
+        self.assertTrue('{list,get,create,update' in stderr)
+        self.assertTrue('error: too few arguments' in stderr)
+
     def test_endpoints_default(self):
         base_url = 'http://127.0.0.1'
         auth_url = 'http://127.0.0.1:9100'

--- a/st2client/tests/unit/test_shell.py
+++ b/st2client/tests/unit/test_shell.py
@@ -51,14 +51,14 @@ class TestShell(base.BaseCLITestCase):
 
     def test_commands_usage_and_help_strings(self):
         # No command, should print out user friendly usage / help string
-        self.assertEqual(self.shell.run([]), 0)
+        self.assertEqual(self.shell.run([]), 2)
 
-        self.stdout.seek(0)
-        stdout = self.stdout.read()
-        self.assertTrue('Usage: ' in stdout)
-        self.assertTrue('For example:' in stdout)
-        self.assertTrue('CLI for StackStorm' in stdout)
-        self.assertTrue('positional arguments:' in stdout)
+        self.stderr.seek(0)
+        stderr = self.stderr.read()
+        self.assertTrue('Usage: ' in stderr)
+        self.assertTrue('For example:' in stderr)
+        self.assertTrue('CLI for StackStorm' in stderr)
+        self.assertTrue('positional arguments:' in stderr)
 
         self.stdout.truncate()
         self.stderr.truncate()


### PR DESCRIPTION
Before:

```bash
st2
usage: shell.py [-h] [--version] [--url BASE_URL] [--auth-url AUTH_URL]
                [--api-url API_URL] [--stream-url STREAM_URL]
                [--api-version API_VERSION] [--cacert CACERT]
                [--config-file CONFIG_FILE] [--print-config] [--skip-config]
                [--debug]
                {action,action-alias,auth,apikey,execution,key,login,pack,policy,policy-type,rule,run,runner,sensor,trace,trigger,trigger-instance,webhook,whoami,timer,rule-enforcement,role,role-assignment}
                ...
shell.py: error: too few arguments
```

After:

```bash
st2
usage: Usage: st2 [options] {command} [options]

For example:

    st2 action list --pack=st2
    st2 run core.local cmd=date
    st2 --debug run core.local cmd=date

CLI for StackStorm event-driven automation platform. https://stackstorm.com

positional arguments:
  {run,action,action-alias,auth,login,whoami,apikey,execution,key,pack,policy,policy-type,rule,webhook,timer,runner,sensor,trace,trigger,trigger-instance,rule-enforcement,role,role-assignment}
    run                 A command to invoke an action manually.
    action              An activity that happens as a response to the external
                        event.
    action-alias        Action aliases.
    auth                Authenticate user and acquire access token.
    login               Authenticate user, acquire access token, and update
                        CLI config directory
    whoami              Display the currently authenticated/configured user
    apikey              API Keys.
    execution           An invocation of an action.
    key                 Key value pair is used to store commonly used
                        configuration for reuse in sensors, actions, and
                        rules.
    pack                A group of related integration resources: actions,
                        rules, and sensors.
    policy              Policy that is enforced on a resource.
    policy-type         Type of policy that can be applied to resources.
    rule                A specification to invoke an "action" on a "trigger"
                        selectively based on some criteria.
    webhook             Webhooks.
    timer               Timers.
    runner              Runner is a type of handler for a specific class of
                        actions.
    sensor              An adapter which allows you to integrate StackStorm
                        with external system.
    trace               A group of executions, rules and triggerinstances that
                        are related.
    trigger             An external event that is mapped to a st2 input. It is
                        the st2 invocation point.
    trigger-instance    Actual instances of triggers received by st2.
    rule-enforcement    Models that represent enforcement of rules.
    role                RBAC roles.
    role-assignment     RBAC role assignments.

optional arguments:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  --url BASE_URL        Base URL for the API servers. Assumes all servers use
                        the same base URL and default ports are used. Get
                        ST2_BASE_URL from the environment variables by
                        default.
  --auth-url AUTH_URL   URL for the authentication service. Get ST2_AUTH_URL
                        from the environment variables by default.
  --api-url API_URL     URL for the API server. Get ST2_API_URL from the
                        environment variables by default.
  --stream-url STREAM_URL
                        URL for the stream endpoint. Get ST2_STREAM_URLfrom
                        the environment variables by default.
  --api-version API_VERSION
                        API version to use. Get ST2_API_VERSION from the
                        environment variables by default.
  --cacert CACERT       Path to the CA cert bundle for the SSL endpoints. Get
                        ST2_CACERT from the environment variables by default.
                        If this is not provided, then SSL cert will not be
                        verified.
  --config-file CONFIG_FILE
                        Path to the CLI config file
  --print-config        Parse the config file and print the values
  --skip-config         Don't parse and use the CLI config file
  --debug               Enable debug mode
```

Resolves #3709.