### PR TITLE
Fix cancellation of delayed action execution

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Fixed
 
   Reported by theuiz.
 * Fix mistral callback failure when result contains unicode. (bug fix)
+* Fix cancellation of delayed action execution for tasks in workflow. (bug fix)
 
 Changed
 ~~~~~~~

--- a/st2actions/tests/unit/test_execution_cancellation.py
+++ b/st2actions/tests/unit/test_execution_cancellation.py
@@ -13,9 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
-
 import mock
+import six
 
 from oslo_config import cfg
 
@@ -23,51 +22,82 @@ from oslo_config import cfg
 import st2tests.config as tests_config
 tests_config.parse_args()
 
-import st2common.bootstrap.runnersregistrar as runners_registrar
-from st2common.runners.base import ActionRunner
-import local_runner
 from st2common.constants import action as action_constants
+from st2common.models.api.action import ActionAPI, RunnerTypeAPI
 from st2common.models.db.liveaction import LiveActionDB
-from st2common.models.api.action import ActionAPI
-from st2common.persistence.action import Action
-from st2common.persistence.liveaction import LiveAction
+from st2common.persistence.action import Action, LiveAction
+from st2common.persistence.runner import RunnerType
+from st2common.runners import base as runners
 from st2common.services import action as action_service
 from st2common.transport.liveaction import LiveActionPublisher
 from st2common.transport.publishers import CUDPublisher
-from st2tests.fixtures.packs import executions as fixture
+from st2common.util import loader
 from st2tests import DbTestCase
+from st2tests.fixturesloader import FixturesLoader
+from st2tests.mocks.execution import MockExecutionPublisher
 from st2tests.mocks.liveaction import MockLiveActionPublisher
 
 
-MOCK_RESULT = {
-    'message': 'Action canceled by user.',
-    'user': cfg.CONF.system_user.user
+TEST_FIXTURES = {
+    'runners': [
+        'testrunner1.yaml'
+    ],
+    'actions': [
+        'action1.yaml'
+    ]
 }
 
+PACK = 'generic'
+LOADER = FixturesLoader()
+FIXTURES = LOADER.load_fixtures(fixtures_pack=PACK, fixtures_dict=TEST_FIXTURES)
 
-@mock.patch.object(local_runner.LocalShellRunner, 'run',
-                   mock.MagicMock(return_value=(action_constants.LIVEACTION_STATUS_RUNNING,
-                                                'Non-empty', None)))
-@mock.patch('st2common.runners.base.register_runner',
-            mock.MagicMock(return_value=local_runner))
+
 class ExecutionCancellationTest(DbTestCase):
 
     @classmethod
     def setUpClass(cls):
         super(ExecutionCancellationTest, cls).setUpClass()
-        runners_registrar.register_runners()
-        action_local = ActionAPI(**copy.deepcopy(fixture.ARTIFACTS['actions']['local']))
-        Action.add_or_update(ActionAPI.to_model(action_local))
+
+        for _, fixture in six.iteritems(FIXTURES['runners']):
+            instance = RunnerTypeAPI(**fixture)
+            RunnerType.add_or_update(RunnerTypeAPI.to_model(instance))
+
+        for _, fixture in six.iteritems(FIXTURES['actions']):
+            instance = ActionAPI(**fixture)
+            Action.add_or_update(ActionAPI.to_model(instance))
+
+    @classmethod
+    def tearDownClass(cls):
+        # Unset the cache for the runner modules
+        loader.RUNNER_MODULES_CACHE = {}
+
+        super(ExecutionCancellationTest, cls).tearDownClass()
 
     def tearDown(self):
-        super(ExecutionCancellationTest, self).tearDown()
+        # Ensure all liveactions are canceled at end of each test.
+        for liveaction in LiveAction.get_all():
+            action_service.update_status(
+                liveaction, action_constants.LIVEACTION_STATUS_CANCELED)
 
-    @mock.patch.object(CUDPublisher, 'publish_create',
-                       mock.MagicMock(side_effect=MockLiveActionPublisher.publish_create))
-    @mock.patch.object(LiveActionPublisher, 'publish_state',
-                       mock.MagicMock(side_effect=MockLiveActionPublisher.publish_state))
+    @classmethod
+    def get_runner_class(cls, runner_name):
+        return runners.get_runner(runner_name).__class__
+
+    @mock.patch.object(
+        CUDPublisher, 'publish_create',
+        mock.MagicMock(side_effect=MockLiveActionPublisher.publish_create))
+    @mock.patch.object(
+        CUDPublisher, 'publish_update',
+        mock.MagicMock(side_effect=MockExecutionPublisher.publish_update))
+    @mock.patch.object(
+        LiveActionPublisher, 'publish_state',
+        mock.MagicMock(side_effect=MockLiveActionPublisher.publish_state))
     def test_basic_cancel(self):
-        liveaction = LiveActionDB(action='executions.local', parameters={'cmd': 'uname -a'})
+        runner_cls = self.get_runner_class('runner')
+        runner_run_result = (action_constants.LIVEACTION_STATUS_RUNNING, 'foobar', None)
+        runner_cls.run = mock.Mock(return_value=runner_run_result)
+
+        liveaction = LiveActionDB(action='wolfpack.action-1', parameters={'actionstr': 'foo'})
         liveaction, _ = action_service.request(liveaction)
         liveaction = LiveAction.get_by_id(str(liveaction.id))
         self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_RUNNING)
@@ -76,16 +106,25 @@ class ExecutionCancellationTest(DbTestCase):
         action_service.request_cancellation(liveaction, cfg.CONF.system_user.user)
         liveaction = LiveAction.get_by_id(str(liveaction.id))
         self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_CANCELED)
-        self.assertDictEqual(liveaction.result, MOCK_RESULT)
 
-    @mock.patch.object(CUDPublisher, 'publish_create',
-                       mock.MagicMock(side_effect=MockLiveActionPublisher.publish_create))
-    @mock.patch.object(LiveActionPublisher, 'publish_state',
-                       mock.MagicMock(side_effect=MockLiveActionPublisher.publish_state))
-    @mock.patch.object(ActionRunner, 'cancel',
-                       mock.MagicMock(side_effect=Exception('Mock cancellation failure.')))
+    @mock.patch.object(
+        CUDPublisher, 'publish_create',
+        mock.MagicMock(side_effect=MockLiveActionPublisher.publish_create))
+    @mock.patch.object(
+        CUDPublisher, 'publish_update',
+        mock.MagicMock(side_effect=MockExecutionPublisher.publish_update))
+    @mock.patch.object(
+        LiveActionPublisher, 'publish_state',
+        mock.MagicMock(side_effect=MockLiveActionPublisher.publish_state))
+    @mock.patch.object(
+        runners.ActionRunner, 'cancel',
+        mock.MagicMock(side_effect=Exception('Mock cancellation failure.')))
     def test_failed_cancel(self):
-        liveaction = LiveActionDB(action='executions.local', parameters={'cmd': 'uname -a'})
+        runner_cls = self.get_runner_class('runner')
+        runner_run_result = (action_constants.LIVEACTION_STATUS_RUNNING, 'foobar', None)
+        runner_cls.run = mock.Mock(return_value=runner_run_result)
+
+        liveaction = LiveActionDB(action='wolfpack.action-1', parameters={'actionstr': 'foo'})
         liveaction, _ = action_service.request(liveaction)
         liveaction = LiveAction.get_by_id(str(liveaction.id))
         self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_RUNNING)
@@ -94,15 +133,21 @@ class ExecutionCancellationTest(DbTestCase):
         action_service.request_cancellation(liveaction, cfg.CONF.system_user.user)
 
         # Cancellation failed and execution state remains "canceling".
-        ActionRunner.cancel.assert_called_once_with()
+        runners.ActionRunner.cancel.assert_called_once_with()
         liveaction = LiveAction.get_by_id(str(liveaction.id))
         self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_CANCELING)
 
-    @mock.patch.object(CUDPublisher, 'publish_create', mock.MagicMock(return_value=None))
-    @mock.patch.object(LiveActionPublisher, 'publish_state', mock.MagicMock(return_value=None))
-    @mock.patch.object(ActionRunner, 'cancel', mock.MagicMock(return_value=None))
+    @mock.patch.object(
+        CUDPublisher, 'publish_create',
+        mock.MagicMock(return_value=None))
+    @mock.patch.object(
+        LiveActionPublisher, 'publish_state',
+        mock.MagicMock(return_value=None))
+    @mock.patch.object(
+        runners.ActionRunner, 'cancel',
+        mock.MagicMock(return_value=None))
     def test_noop_cancel(self):
-        liveaction = LiveActionDB(action='executions.local', parameters={'cmd': 'uname -a'})
+        liveaction = LiveActionDB(action='wolfpack.action-1', parameters={'actionstr': 'foo'})
         liveaction, _ = action_service.request(liveaction)
         liveaction = LiveAction.get_by_id(str(liveaction.id))
         self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_REQUESTED)
@@ -112,6 +157,6 @@ class ExecutionCancellationTest(DbTestCase):
 
         # Cancel is only called when liveaction is still in running state.
         # Otherwise, the cancellation is only a state change.
-        self.assertFalse(ActionRunner.cancel.called)
+        self.assertFalse(runners.ActionRunner.cancel.called)
         liveaction = LiveAction.get_by_id(str(liveaction.id))
         self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_CANCELED)

--- a/st2actions/tests/unit/test_execution_cancellation.py
+++ b/st2actions/tests/unit/test_execution_cancellation.py
@@ -24,9 +24,11 @@ import st2tests.config as tests_config
 tests_config.parse_args()
 
 from st2common.constants import action as action_constants
-from st2common.models.api.action import ActionAPI, RunnerTypeAPI
+from st2common.models.api.action import ActionAPI
+from st2common.models.api.action import RunnerTypeAPI
 from st2common.models.db.liveaction import LiveActionDB
-from st2common.persistence.action import Action, LiveAction
+from st2common.persistence.action import Action
+from st2common.persistence.action import LiveAction
 from st2common.persistence.runner import RunnerType
 from st2common.runners import base as runners
 from st2common.services import action as action_service

--- a/st2common/st2common/services/action.py
+++ b/st2common/st2common/services/action.py
@@ -214,10 +214,13 @@ def request_cancellation(liveaction, requester):
         'user': requester
     }
 
-    # There is real work only when liveaction is still running.
-    status = (action_constants.LIVEACTION_STATUS_CANCELING
-              if liveaction.status == action_constants.LIVEACTION_STATUS_RUNNING
-              else action_constants.LIVEACTION_STATUS_CANCELED)
+    # Run cancelation sequence for liveaction that is in running state or
+    # if the liveaction is operating under a workflow.
+    if ('parent' in liveaction.context or
+            liveaction.status in action_constants.LIVEACTION_STATUS_RUNNING):
+        status = action_constants.LIVEACTION_STATUS_CANCELING
+    else:
+        status = action_constants.LIVEACTION_STATUS_CANCELED
 
     liveaction = update_status(liveaction, status, result=result)
 


### PR DESCRIPTION
On cancellation request, if the liveaction has a parent, set the status to canceling to trigger post_run for the liveaction. Currently, the action execution is set to canceled and callback to Mistral is not performed, thus leading to workflows stuck in running state.