### PR TITLE
Fix Travis caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,12 @@ install:
 script:
   - make ${TASK}
 
+# Don't store cache for target PR branch (typically `master`), because it will be re-used for opened PRs
+# See: https://docs.travis-ci.com/user/caching/#Pull-request-builds-and-caches
+# Alternative: use strict pip pinning, including git-based pip packages
+before_cache:
+  - if [ ${TRAVIS_EVENT_TYPE} != 'pull_request' ]; rm -rf virtualenv/ fi
+
 after_success:
   - if [ ${TASK} = 'ci-unit' ] || [ ${TASK} = 'ci-integration' ]; then codecov; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ cache:
     - virtualenv/
 
 install:
+  - env
   - make requirements
   - if [ ${TASK} = 'ci-unit' ] || [ ${TASK} = 'ci-integration' ]; then pip install codecov; sudo .circle/add-itest-user.sh; fi
 


### PR DESCRIPTION
This should fix cases when travis caches pip installs from https://github.com/StackStorm/st2/blob/master/requirements.txt#L9 when the target `master` branch code was actually updated (happened in https://github.com/StackStorm/st2/pull/3721).

Pull Request caches rely first on `master` branch: https://docs.travis-ci.com/user/caching/#Pull-request-builds-and-caches  So we won't cache `master` branch anymore. It means first build for every PR comes with no cache.

There is also no way to invalidate the cache at the moment once the content is changed in remote git, except of pip upgrade or version change in pip package. See reports in pip:
- https://github.com/pypa/pip/issues/2837
- https://github.com/pypa/pip/issues/2835

Using --editable pip requirements will fix the issue, but it's not supported by `dh-virtualenv`: https://github.com/spotify/dh-virtualenv/issues/134

---

I won't know if the fix actually worked or not before merging this into `master` and testing https://github.com/StackStorm/st2/pull/3727 afterwards.