### PR TITLE
Fix call to keystone auth in mistral runner

### DIFF
--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_auth.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_auth.py
@@ -266,7 +266,7 @@ class MistralAuthTest(DbTestCase):
             'cacert': None
         }
 
-        keystone.KeystoneAuthHandler.authenticate.assert_called_with(auth_req)
+        keystone.KeystoneAuthHandler.authenticate.assert_called_with(auth_req, session=None)
 
         executions.ExecutionManager.create.assert_called_with(
             WF1_NAME, workflow_input=workflow_input, env=env)


### PR DESCRIPTION
The interface for the authenticate method has changed. Fix the unit tests associated with the interface change.