### PR TITLE
Add changelog entry for the fix to Mistral shutdown issue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Fixed
   Reported by theuiz.
 * Fix mistral callback failure when result contains unicode. (bug fix)
 * Fix cancellation of delayed action execution for tasks in workflow. (bug fix)
+* Fix timeout of mistral shutdown in systemd service. The fix is done upstream.
+  https://review.openstack.org/#/c/499853/ (bug fix)
 
 Changed
 ~~~~~~~


### PR DESCRIPTION
Add a changelog entry for the upstream fix on the Mistral slow shutdown issue with systemd service.