### PR TITLE
Update "st2 execution tail" CLI command to just print raw action output by default

### DIFF
--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -1368,6 +1368,11 @@ class ActionExecutionTailCommand(resource.ResourceCommand):
         self.parser.add_argument('--type', dest='output_type', action='store',
                                  help=('Type of output to tail for. If not provided, '
                                       'defaults to all.'))
+        self.parser.add_argument('--include-metadata', dest='include_metadata',
+                                 action='store_true',
+                                 default=False,
+                                 help=('Include metadata (timestamp, output type) with the '
+                                       'output.'))
         self.parser.add_argument('-h', '--help',
                                  action='store_true', dest='help',
                                  help='Print usage for the given command.')
@@ -1379,6 +1384,7 @@ class ActionExecutionTailCommand(resource.ResourceCommand):
     def run_and_print(self, args, **kwargs):
         execution_id = args.id
         output_type = getattr(args, 'output_type', None)
+        include_metadata = args.include_metadata
 
         # Special case for id "last"
         if execution_id == 'last':
@@ -1408,6 +1414,7 @@ class ActionExecutionTailCommand(resource.ResourceCommand):
             if is_execution_event:
                 if status in LIVEACTION_COMPLETED_STATES:
                     # Execution has completed
+                    print('')
                     print('Execution %s has completed.' % (execution_id))
                     break
                 else:
@@ -1419,5 +1426,8 @@ class ActionExecutionTailCommand(resource.ResourceCommand):
             if output_type and event_output_type != output_type:
                 continue
 
-            sys.stdout.write('[%s][%s] %s' % (event['timestamp'], event['output_type'],
-                                              event['data']))
+            if include_metadata:
+                sys.stdout.write('[%s][%s] %s' % (event['timestamp'], event['output_type'],
+                                                  event['data']))
+            else:
+                sys.stdout.write(event['data'])


### PR DESCRIPTION
This pull request updates `st2 execution tail` command to just print raw output by default. This way it's consistent with the `/output` API endpoint.

User can also request metadata (timestamp, output type) to be printed by using `--include-metadata` flag.

Without the flag (default behavior):

```bash
st2 execution tail last
stderr -> Line: 1
stdout -> Line: 2
stderr -> Line: 3
stdout -> Line: 4
stderr -> Line: 5
stdout -> Line: 6
stderr -> Line: 7
stdout -> Line: 8
stderr -> Line: 9
stdout -> Line: 10

Execution 59ba7e5d0640fd4f73312076 has completed.
```

With the flag (previous default behavior):

```bash
st2 execution tail last --include-metadata
[2017-09-14T13:07:07.229150Z][stderr] stderr -> Line: 1
[2017-09-14T13:07:08.234801Z][stdout] stdout -> Line: 2
[2017-09-14T13:07:09.235263Z][stderr] stderr -> Line: 3
[2017-09-14T13:07:10.237950Z][stdout] stdout -> Line: 4
[2017-09-14T13:07:11.238072Z][stderr] stderr -> Line: 5
[2017-09-14T13:07:12.239523Z][stdout] stdout -> Line: 6
[2017-09-14T13:07:13.240308Z][stderr] stderr -> Line: 7
[2017-09-14T13:07:14.241287Z][stdout] stdout -> Line: 8
[2017-09-14T13:07:15.240921Z][stderr] stderr -> Line: 9
[2017-09-14T13:07:16.242700Z][stdout] stdout -> Line: 10

Execution 59ba7ef80640fd4f73312079 has completed.
```