### PR TITLE
Make sure temporary stream output queues get deleted, make all queues used by the stream service auto deletable

### DIFF
--- a/st2common/st2common/transport/announcement.py
+++ b/st2common/st2common/transport/announcement.py
@@ -70,5 +70,6 @@ class AnnouncementDispatcher(object):
         self._publisher.publish(payload=payload, routing_key=routing_key)
 
 
-def get_queue(name=None, routing_key='#', exclusive=False):
-    return Queue(name, ANNOUNCEMENT_XCHG, routing_key=routing_key, exclusive=exclusive)
+def get_queue(name=None, routing_key='#', exclusive=False, auto_delete=False):
+    return Queue(name, ANNOUNCEMENT_XCHG, routing_key=routing_key, exclusive=exclusive,
+                 auto_delete=auto_delete)

--- a/st2common/st2common/transport/execution.py
+++ b/st2common/st2common/transport/execution.py
@@ -40,9 +40,11 @@ class ActionExecutionOutputPublisher(publishers.CUDPublisher):
         super(ActionExecutionOutputPublisher, self).__init__(urls, EXECUTION_OUTPUT_XCHG)
 
 
-def get_queue(name=None, routing_key=None, exclusive=False):
-    return Queue(name, EXECUTION_XCHG, routing_key=routing_key, exclusive=exclusive)
+def get_queue(name=None, routing_key=None, exclusive=False, auto_delete=False):
+    return Queue(name, EXECUTION_XCHG, routing_key=routing_key, exclusive=exclusive,
+                 auto_delete=auto_delete)
 
 
-def get_output_queue(name=None, routing_key=None, exclusive=False):
-    return Queue(name, EXECUTION_OUTPUT_XCHG, routing_key=routing_key, exclusive=exclusive)
+def get_output_queue(name=None, routing_key=None, exclusive=False, auto_delete=False):
+    return Queue(name, EXECUTION_OUTPUT_XCHG, routing_key=routing_key, exclusive=exclusive,
+                 auto_delete=auto_delete)

--- a/st2common/st2common/transport/queues.py
+++ b/st2common/st2common/transport/queues.py
@@ -84,17 +84,21 @@ RULESENGINE_WORK_QUEUE = reactor.get_trigger_instances_queue(
 
 # Used by the stream service
 STREAM_ANNOUNCEMENT_WORK_QUEUE = announcement.get_queue(routing_key=publishers.ANY_RK,
-                                                        exclusive=True)
+                                                        exclusive=True,
+                                                        auto_delete=True)
 STREAM_EXECUTION_ALL_WORK_QUEUE = execution.get_queue(routing_key=publishers.ANY_RK,
-                                                      exclusive=True)
+                                                      exclusive=True,
+                                                      auto_delete=True)
 STREAM_EXECUTION_UPDATE_WORK_QUEUE = execution.get_queue(routing_key=publishers.UPDATE_RK,
-                                                         exclusive=True)
+                                                         exclusive=True,
+                                                         auto_delete=True)
 STREAM_LIVEACTION_WORK_QUEUE = Queue(None, liveaction.LIVEACTION_XCHG,
-                                     routing_key=publishers.ANY_RK, exclusive=True)
+                                     routing_key=publishers.ANY_RK,
+                                     exclusive=True, auto_delete=True)
 
 # TODO: Perhaps we should use pack.action name as routing key so we can do more efficient filtering
 # later, if needed
 STREAM_EXECUTION_OUTPUT_QUEUE = execution.get_output_queue(name=None,
-                                                           routing_key=publishers.CREATE_RKm
-                                                           exclusive=True
+                                                           routing_key=publishers.CREATE_RK,
+                                                           exclusive=True,
                                                            auto_delete=True)

--- a/st2common/st2common/transport/queues.py
+++ b/st2common/st2common/transport/queues.py
@@ -95,4 +95,6 @@ STREAM_LIVEACTION_WORK_QUEUE = Queue(None, liveaction.LIVEACTION_XCHG,
 # TODO: Perhaps we should use pack.action name as routing key so we can do more efficient filtering
 # later, if needed
 STREAM_EXECUTION_OUTPUT_QUEUE = execution.get_output_queue(name=None,
-                                                           routing_key=publishers.CREATE_RK)
+                                                           routing_key=publishers.CREATE_RKm
+                                                           exclusive=True
+                                                           auto_delete=True)


### PR DESCRIPTION
The issue with execution output queues used by stream service never getting deleted was caught by deploying v2.5dev on CI server and by @armab, @enykeev.

The issue was that the queue wasn't exclusive.

This pull request fixes that and on top of that, it also makes all queues used by the stream service auto deletable.

We use random queue names for queues used by the stream service, but we don't have `auto_delete=True`. This means that when stream service restart, existing queue will persist, but we will create a new queue on start which will be used by the consumers. This means old queue will be left around, but nothing will ever consume from it again.

Also, as far as I know, we basically want (almost) always use `exclusive=True` and `auto_delete=True` for queues with random names. If we don't do that, we will have zombie queues laying around.

Somewhat related to #3640 - I also recommended using auto_delete=True there.

This also brings up an issue with testing for things like that - we need to test for CPU usage, memory usage, number of queues, etc. over time. This means we should invest some time into a framework so we can better test for issues like that.