### PR TITLE
Fix delays in st2resultstracker on querying workflow status

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,7 +45,10 @@ Fixed
 * Fix cancellation of subworkflow and subchain. Cancel of Mistral workflow or Action Chain is
   cascaded down to subworkflows appropriately. Cancel from tasks in the workflow or chain is
   cascaded up to the parent. (bug fix) 
-
+* Fix delays in st2resultstracker on querying workflow status from Mistral. Make sleep time for
+  empty queue and no workers configurable. Reduce the default sleep times to 1 second. StackStorm
+  instances that handle more workflows should consider increasing the query interval for better
+  CPU utilization.
 * Fix missing type for the parameters with enum in the core st2 packs.(bug fix) #3737
 
   Reported by Nick Maludy.

--- a/conf/st2.conf.sample
+++ b/conf/st2.conf.sample
@@ -180,7 +180,7 @@ api_url = None
 # Multiplier for the exponential backoff.
 retry_exp_msec = 1000
 # Jitter interval to smooth out HTTP requests to mistral tasks and executions API.
-jitter_interval = 1
+jitter_interval = 0
 # Allow insecure communication with Mistral.
 insecure = False
 # Username for authentication.
@@ -205,10 +205,14 @@ retry_exp_max_msec = 300000
 logging = conf/logging.notifier.conf
 
 [resultstracker]
-# Time interval between subsequent queries for a context to external workflow system.
-query_interval = 20
+# Time interval between queries to external workflow system.
+query_interval = 1
+# Sleep delay in between queries when query queue is empty.
+empty_q_sleep_time = 1
 # Location of the logging configuration file.
 logging = conf/logging.resultstracker.conf
+# Sleep delay for query when there is no more worker in pool.
+no_workers_sleep_time = 1
 # Number of threads to use to query external workflow systems.
 thread_pool_size = 10
 

--- a/conf/st2.conf.sample
+++ b/conf/st2.conf.sample
@@ -180,7 +180,7 @@ api_url = None
 # Multiplier for the exponential backoff.
 retry_exp_msec = 1000
 # Jitter interval to smooth out HTTP requests to mistral tasks and executions API.
-jitter_interval = 0
+jitter_interval = 0.1
 # Allow insecure communication with Mistral.
 insecure = False
 # Username for authentication.

--- a/st2actions/tests/integration/test_resultstracker.py
+++ b/st2actions/tests/integration/test_resultstracker.py
@@ -1,6 +1,8 @@
 import eventlet
 import mock
 
+from oslo_config import cfg
+
 import st2actions.resultstracker.resultstracker as results_tracker
 from st2common.constants import action as action_constants
 from st2common.exceptions.db import StackStormDBObjectNotFoundError
@@ -30,6 +32,18 @@ class ResultsTrackerTests(EventletTestCase, DbTestCase):
     states = None
     models = None
     liveactions = None
+
+    @classmethod
+    def setUpClass(cls):
+        super(ResultsTrackerTests, cls).setUpClass()
+        cfg.CONF.set_default('empty_q_sleep_time', 0.2, group='resultstracker')
+        cfg.CONF.set_default('no_workers_sleep_time', 0.1, group='resultstracker')
+
+    @classmethod
+    def tearDownClass(cls):
+        cfg.CONF.set_default('empty_q_sleep_time', 1, group='resultstracker')
+        cfg.CONF.set_default('no_workers_sleep_time', 1, group='resultstracker')
+        super(ResultsTrackerTests, cls).tearDownClass()
 
     def setUp(self):
         super(ResultsTrackerTests, self).setUp()
@@ -258,7 +272,7 @@ class ResultsTrackerTests(EventletTestCase, DbTestCase):
                 querier.__class__, 'query',
                 mock.MagicMock(return_value=(action_constants.LIVEACTION_STATUS_CANCELED, {}))):
             tracker._bootstrap()
-            eventlet.sleep(1)
+            eventlet.sleep(2)
 
             exec_id = str(ResultsTrackerTests.states['state1.yaml'].execution_id)
             exec_db = LiveAction.get_by_id(exec_id)

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -263,7 +263,7 @@ def register_opts(ignore_errors=False):
         cfg.StrOpt('cacert', default=None, help='Optional certificate to validate endpoint.'),
         cfg.BoolOpt('insecure', default=False, help='Allow insecure communication with Mistral.'),
         cfg.FloatOpt(
-            'jitter_interval', default=0,
+            'jitter_interval', default=0.1,
             help='Jitter interval to smooth out HTTP requests '
                  'to mistral tasks and executions API.'),
         cfg.StrOpt(

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -262,26 +262,37 @@ def register_opts(ignore_errors=False):
         cfg.StrOpt('keystone_auth_url', default=None, help='Auth endpoint for Keystone.'),
         cfg.StrOpt('cacert', default=None, help='Optional certificate to validate endpoint.'),
         cfg.BoolOpt('insecure', default=False, help='Allow insecure communication with Mistral.'),
-        cfg.FloatOpt('jitter_interval', default=1,
-                   help='Jitter interval to smooth out HTTP requests ' +
-                        'to mistral tasks and executions API.'),
-
-        cfg.StrOpt('api_url', default=None, help=('URL Mistral uses to talk back to the API.'
-            'If not provided it defaults to public API URL. Note: This needs to be a base '
-            'URL without API version (e.g. http://127.0.0.1:9101)'))
+        cfg.FloatOpt(
+            'jitter_interval', default=0,
+            help='Jitter interval to smooth out HTTP requests '
+                 'to mistral tasks and executions API.'),
+        cfg.StrOpt(
+            'api_url', default=None,
+            help='URL Mistral uses to talk back to the API.'
+                 'If not provided it defaults to public API URL. '
+                 'Note: This needs to be a base URL without API '
+                 'version (e.g. http://127.0.0.1:9101)')
     ]
     do_register_opts(mistral_opts, group='mistral', ignore_errors=ignore_errors)
 
     # Results Tracker query module options
     # Note that these are currently used only by mistral query module.
     query_opts = [
-        cfg.IntOpt('thread_pool_size', default=10,
-                   help='Number of threads to use to query external workflow systems.'),
-        cfg.FloatOpt('query_interval', default=20,
-                     help='Time interval between subsequent queries for a context ' +
-                          'to external workflow system.')
+        cfg.IntOpt(
+            'thread_pool_size', default=10,
+            help='Number of threads to use to query external workflow systems.'),
+        cfg.FloatOpt(
+            'query_interval', default=1,
+            help='Time interval between queries to external workflow system.'),
+        cfg.FloatOpt(
+            'empty_q_sleep_time', default=1,
+            help='Sleep delay in between queries when query queue is empty.'),
+        cfg.FloatOpt(
+            'no_workers_sleep_time', default=1,
+            help='Sleep delay for query when there is no more worker in pool.')
     ]
     do_register_opts(query_opts, group='resultstracker', ignore_errors=ignore_errors)
+
     # XXX: This is required for us to support deprecated config group results_tracker
     query_opts = [
         cfg.IntOpt('thread_pool_size',

--- a/st2tests/st2tests/fixtures/packs/runners/test_querymodule/query/test_querymodule.py
+++ b/st2tests/st2tests/fixtures/packs/runners/test_querymodule/query/test_querymodule.py
@@ -11,5 +11,4 @@ class TestQuerier(Querier):
 
 
 def get_instance():
-    return TestQuerier(empty_q_sleep_time=0.2,
-                       no_workers_sleep_time=0.1)
+    return TestQuerier()


### PR DESCRIPTION
Fix delays in st2resultstracker on querying workflow status from Mistral. Make sleep time for empty queue and no workers configurable. Reduce the default sleep times to 1 second. StackStorm instances that handle more workflows should consider increasing the query interval and jitter interval for better CPU utilization. For reference, `make mistral-itest` is reduced from 800+s to 500+s to complete.