### PR TITLE
Support overlapping RBAC remote role assignments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -62,6 +62,9 @@ Fixed
 * Add missing ``-h`` / ``--help`` CLI flag to the following execution CLI commands: cancel, pause,
   resume. (bug fix) #3750
 * Fix execution cancel and pause CLI commands and make id a required argument. (bug fix) #3750
+* Fix ``st2 role-assignment list`` CLI command and allow ``--user``, ``--remote`` and ``--role``
+  arguments to be used together. Previously they were mutually exclusive so it wasn't possible to
+  use them together. (bug fix) #3763
 
 2.4.1 - September 12, 2017
 --------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,9 @@ Added
   set ``actionrunner.stream_output`` config option to ``True``.
 
   (new feature) #2175 #3657 #3729
+* Update ``st2 role-assignment list`` RBAC CLI command to include information about where a
+  particular assignment comes from (from which local assignment or mapping file). (improvement)
+  #3763
 
 Fixed
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,10 @@ Added
 * Update ``st2 role-assignment list`` RBAC CLI command to include information about where a
   particular assignment comes from (from which local assignment or mapping file). (improvement)
   #3763
+* Add support for overlapping RBAC role assignments for assignments via remote LDAP group to
+  StackStorm role mappings. This means that the same role can now be granted via multiple RBAC
+  mapping files.
+  #3763
 
 Fixed
 ~~~~~

--- a/st2api/st2api/controllers/v1/rbac.py
+++ b/st2api/st2api/controllers/v1/rbac.py
@@ -66,6 +66,7 @@ class RoleAssignmentsController(ResourceController):
     supported_filters = {
         'user': 'user',
         'role': 'role',
+        'source': 'source',
         'remote': 'is_remote'
     }
 

--- a/st2api/tests/unit/controllers/v1/test_action_views_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_action_views_rbac.py
@@ -86,7 +86,8 @@ class ActionViewsControllerRBACTestCase(APIControllerWithRBACTestCase):
         # Role assignments
         role_assignment_db = UserRoleAssignmentDB(
             user=self.users['action_view_a1'].name,
-            role=self.roles['action_view_a1'].name)
+            role=self.roles['action_view_a1'].name,
+            source='assignments/%s.yaml' % self.users['action_view_a1'].name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
     def test_get_entry_point_view_no_permission(self):

--- a/st2api/tests/unit/controllers/v1/test_actions_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_actions_rbac.py
@@ -93,7 +93,8 @@ class ActionControllerRBACTestCase(APIControllerWithRBACTestCase):
         user_db = self.users['action_create']
         role_assignment_db = UserRoleAssignmentDB(
             user=user_db.name,
-            role=self.roles['action_create'].name)
+            role=self.roles['action_create'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
     def test_create_action_no_action_create_permission(self):

--- a/st2api/tests/unit/controllers/v1/test_auth_api_keys_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_auth_api_keys_rbac.py
@@ -115,17 +115,20 @@ class ApiKeyControllerRBACTestCase(APIControllerWithRBACTestCase):
         # Role assignments
         role_assignment_db = UserRoleAssignmentDB(
             user=self.users['api_key_list'].name,
-            role=self.roles['api_key_list'].name)
+            role=self.roles['api_key_list'].name,
+            source='assignments/%s.yaml' % self.users['api_key_list'].name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         role_assignment_db = UserRoleAssignmentDB(
             user=self.users['api_key_view'].name,
-            role=self.roles['api_key_view'].name)
+            role=self.roles['api_key_view'].name,
+            source='assignments/%s.yaml' % self.users['api_key_view'].name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         role_assignment_db = UserRoleAssignmentDB(
             user=self.users['api_key_create'].name,
-            role=self.roles['api_key_create'].name)
+            role=self.roles['api_key_create'].name,
+            source='assignments/%s.yaml' % self.users['api_key_create'].name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
     def test_get_all_no_permissions(self):

--- a/st2api/tests/unit/controllers/v1/test_executions_filters_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_filters_rbac.py
@@ -63,7 +63,8 @@ class ExecutionViewsFiltersControllerRBACTestCase(APIControllerWithRBACTestCase)
         # Role assignments
         role_assignment_db = UserRoleAssignmentDB(
             user=self.users['execution_views_filters_list'].name,
-            role=self.roles['execution_views_filters_list'].name)
+            role=self.roles['execution_views_filters_list'].name,
+            source='assignments/%s.yaml' % self.users['execution_views_filters_list'].name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
     def test_get_view_filters_no_permissions(self):

--- a/st2api/tests/unit/controllers/v1/test_executions_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_rbac.py
@@ -66,13 +66,15 @@ class ActionExecutionRBACControllerTestCase(BaseActionExecutionControllerTestCas
         user_db = self.users['multiple_roles']
         role_assignment_db = UserRoleAssignmentDB(
             user=user_db.name,
-            role='admin')
+            role='admin',
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         for role in roles:
             role_assignment_db = UserRoleAssignmentDB(
                 user=user_db.name,
-                role=role)
+                role=role,
+                source='assignments/%s.yaml' % user_db.name)
             UserRoleAssignment.add_or_update(role_assignment_db)
 
     def test_post_rbac_info_in_context_success(self):

--- a/st2api/tests/unit/controllers/v1/test_policies_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_policies_rbac.py
@@ -107,12 +107,14 @@ class PolicyTypeControllerRBACTestCase(APIControllerWithRBACTestCase):
         # Role assignments
         role_assignment_db = UserRoleAssignmentDB(
             user=self.users['policy_type_list'].name,
-            role=self.roles['policy_type_list'].name)
+            role=self.roles['policy_type_list'].name,
+            source='assignments/%s.yaml' % self.users['policy_type_list'].name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         role_assignment_db = UserRoleAssignmentDB(
             user=self.users['policy_type_view'].name,
-            role=self.roles['policy_type_view'].name)
+            role=self.roles['policy_type_view'].name,
+            source='assignments/%s.yaml' % self.users['policy_type_view'].name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
     def test_get_all_no_permissions(self):
@@ -304,32 +306,38 @@ class PolicyControllerRBACTestCase(APIControllerWithRBACTestCase):
         # Role assignments
         role_assignment_db = UserRoleAssignmentDB(
             user=self.users['policy_list'].name,
-            role=self.roles['policy_list'].name)
+            role=self.roles['policy_list'].name,
+            source='assignments/%s.yaml' % self.users['policy_list'].name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         role_assignment_db = UserRoleAssignmentDB(
             user=self.users['policy_view_direct_policy1'].name,
-            role=self.roles['policy_view_direct_policy1'].name)
+            role=self.roles['policy_view_direct_policy1'].name,
+            source='assignments/%s.yaml' % self.users['policy_view_direct_policy1'].name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         role_assignment_db = UserRoleAssignmentDB(
             user=self.users['policy_view_policy8_parent_pack'].name,
-            role=self.roles['policy_view_policy8_parent_pack'].name)
+            role=self.roles['policy_view_policy8_parent_pack'].name,
+            source='assignments/%s.yaml' % self.users['policy_view_policy8_parent_pack'].name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         role_assignment_db = UserRoleAssignmentDB(
             user=self.users['policy_create_policy8_parent_pack'].name,
-            role=self.roles['policy_create_policy8_parent_pack'].name)
+            role=self.roles['policy_create_policy8_parent_pack'].name,
+            source='assignments/%s.yaml' % self.users['policy_create_policy8_parent_pack'].name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         role_assignment_db = UserRoleAssignmentDB(
             user=self.users['policy_update_direct_policy2'].name,
-            role=self.roles['policy_update_direct_policy2'].name)
+            role=self.roles['policy_update_direct_policy2'].name,
+            source='assignments/%s.yaml' % self.users['policy_update_direct_policy2'].name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         role_assignment_db = UserRoleAssignmentDB(
             user=self.users['policy_delete_policy8_parent_pack'].name,
-            role=self.roles['policy_delete_policy8_parent_pack'].name)
+            role=self.roles['policy_delete_policy8_parent_pack'].name,
+            source='assignments/%s.yaml' % self.users['policy_delete_policy8_parent_pack'].name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
     def test_get_all_no_permissions(self):

--- a/st2api/tests/unit/controllers/v1/test_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_rbac.py
@@ -58,12 +58,14 @@ class RBACControllerTestCase(APIControllerWithRBACTestCase):
             # Role assignments
             role_assignment_db = UserRoleAssignmentDB(
                 user=user_db.name,
-                role=role_db.name)
+                role=role_db.name,
+                source='assignments/%s.yaml' % user_db.name)
             UserRoleAssignment.add_or_update(role_assignment_db)
 
         role_assignment_db = UserRoleAssignmentDB(
             user='user_two',
             role='role_two',
+            source='assignments/user_two.yaml',
             is_remote=True)
         UserRoleAssignment.add_or_update(role_assignment_db)
 

--- a/st2api/tests/unit/controllers/v1/test_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_rbac.py
@@ -118,7 +118,7 @@ class RBACControllerTestCase(APIControllerWithRBACTestCase):
         self.assertEqual(resp.json[0]['user'], 'system_admin')
         self.assertEqual(resp.json[0]['is_remote'], False)
 
-    def test_role_assignments_get_all_with_user_role_and_remote_filter(self):
+    def test_role_assignments_get_all_with_user_rold_remote_and_source_filter(self):
         # ?user filter
         self.use_user(self.users['admin'])
 
@@ -150,6 +150,16 @@ class RBACControllerTestCase(APIControllerWithRBACTestCase):
 
         for role in resp.json:
             self.assertTrue(role['is_remote'])
+
+        # ?source filter
+        resp = self.app.get('/v1/rbac/role_assignments?source=doesnt_exist')
+        self.assertEqual(resp.status_int, 200)
+        self.assertEqual(len(resp.json), 0)
+
+        resp = self.app.get('/v1/rbac/role_assignments?source=assignments/user_two.yaml')
+        self.assertEqual(resp.status_int, 200)
+        self.assertEqual(len(resp.json), 1)
+        self.assertEqual(resp.json[0]['source'], 'assignments/user_two.yaml')
 
     def test_role_assignment_get_one(self):
         self.use_user(self.users['admin'])

--- a/st2api/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
+++ b/st2api/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
@@ -122,7 +122,8 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
         self.models = self.fixtures_loader.save_fixtures_to_db(fixtures_pack=FIXTURES_PACK,
                                                                fixtures_dict=TEST_FIXTURES)
 
-        self.role_assignment_db_model = UserRoleAssignmentDB(user='user', role='role')
+        self.role_assignment_db_model = UserRoleAssignmentDB(
+            user='user', role='role', source='assignments/user.yaml')
         UserRoleAssignment.add_or_update(self.role_assignment_db_model)
 
     @mock.patch.object(HooksHolder, 'get_triggers_for_hook', mock.MagicMock(

--- a/st2api/tests/unit/controllers/v1/test_rbac_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_rbac_rbac.py
@@ -86,13 +86,15 @@ class RBACRoleAssignmentsControllerRBACTestCase(APIControllerWithRBACTestCase):
         # Role assignments
         role_assignment_db = UserRoleAssignmentDB(
             user=self.users['user_foo'].name,
-            role=self.roles['user_foo'].name)
+            role=self.roles['user_foo'].name,
+            source='assignments/%s.yaml' % self.users['user_foo'].name)
         UserRoleAssignment.add_or_update(role_assignment_db)
         self.role_assignments['assignment_one'] = role_assignment_db
 
         role_assignment_db = UserRoleAssignmentDB(
             user='user_bar',
-            role=self.roles['user_foo'].name)
+            role=self.roles['user_foo'].name,
+            source='assignments/user_bar.yaml')
         UserRoleAssignment.add_or_update(role_assignment_db)
         self.role_assignments['assignment_two'] = role_assignment_db
 

--- a/st2api/tests/unit/controllers/v1/test_rules_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_rules_rbac.py
@@ -134,19 +134,22 @@ class RuleControllerRBACTestCase(APIControllerWithRBACTestCase):
         user_db = self.users['rule_create']
         role_assignment_db = UserRoleAssignmentDB(
             user=user_db.name,
-            role=self.roles['rule_create'].name)
+            role=self.roles['rule_create'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['rule_create_webhook_create']
         role_assignment_db = UserRoleAssignmentDB(
             user=user_db.name,
-            role=self.roles['rule_create_webhook_create'].name)
+            role=self.roles['rule_create_webhook_create'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['rule_create_webhook_create_core_local_execute']
         role_assignment_db = UserRoleAssignmentDB(
             user=user_db.name,
-            role=self.roles['rule_create_webhook_create_core_local_execute'].name)
+            role=self.roles['rule_create_webhook_create_core_local_execute'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
     def test_post_webhook_trigger_no_trigger_and_action_permission(self):

--- a/st2api/tests/unit/controllers/v1/test_timers_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_timers_rbac.py
@@ -103,12 +103,14 @@ class TimerControllerRBACTestCase(APIControllerWithRBACTestCase):
         # Role assignments
         role_assignment_db = UserRoleAssignmentDB(
             user=self.users['timer_list'].name,
-            role=self.roles['timer_list'].name)
+            role=self.roles['timer_list'].name,
+            source='assignments/%s.yaml' % self.users['timer_list'].name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         role_assignment_db = UserRoleAssignmentDB(
             user=self.users['timer_view'].name,
-            role=self.roles['timer_view'].name)
+            role=self.roles['timer_view'].name,
+            source='assignments/%s.yaml' % self.users['timer_view'].name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
     def test_get_all_no_permissions(self):

--- a/st2api/tests/unit/controllers/v1/test_traces_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_traces_rbac.py
@@ -102,12 +102,14 @@ class TraceControllerRBACTestCase(APIControllerWithRBACTestCase):
         # Role assignments
         role_assignment_db = UserRoleAssignmentDB(
             user=self.users['trace_list'].name,
-            role=self.roles['trace_list'].name)
+            role=self.roles['trace_list'].name,
+            source='assignments/%s.yaml' % self.users['trace_list'].name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         role_assignment_db = UserRoleAssignmentDB(
             user=self.users['trace_view'].name,
-            role=self.roles['trace_view'].name)
+            role=self.roles['trace_view'].name,
+            source='assignments/%s.yaml' % self.users['trace_view'].name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
     def test_get_all_no_permissions(self):

--- a/st2api/tests/unit/controllers/v1/test_webhooks_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_webhooks_rbac.py
@@ -89,12 +89,14 @@ class WebhookControllerRBACTestCase(APIControllerWithRBACTestCase):
         # Role assignments
         role_assignment_db = UserRoleAssignmentDB(
             user=self.users['webhook_list'].name,
-            role=self.roles['webhook_list'].name)
+            role=self.roles['webhook_list'].name,
+            source='assignments/%s.yaml' % self.users['webhook_list'].name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         role_assignment_db = UserRoleAssignmentDB(
             user=self.users['webhook_view'].name,
-            role=self.roles['webhook_view'].name)
+            role=self.roles['webhook_view'].name,
+            source='assignments/%s.yaml' % self.users['webhook_view'].name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
     def test_get_all_no_permissions(self):

--- a/st2auth/st2auth/handlers.py
+++ b/st2auth/st2auth/handlers.py
@@ -180,7 +180,7 @@ class StandaloneAuthHandler(AuthHandlerBase):
                           extra=extra)
                 try:
                     user_groups = self._auth_backend.get_user_groups(username=username)
-                except NotImplementedError:
+                except (NotImplementedError, AttributeError):
                     LOG.debug('Configured auth backend doesn\'t expose user group membership '
                               'information, skipping sync...')
                     return token
@@ -205,7 +205,7 @@ class StandaloneAuthHandler(AuthHandlerBase):
                     LOG.exception('Failed to synchronize remote groups for user "%s"' % (username),
                                   extra=extra)
                 else:
-                    LOG.debug('Successfuly synchronized groups for user "%s"' % (username),
+                    LOG.debug('Successfully synchronized groups for user "%s"' % (username),
                               extra=extra)
 
                 return token

--- a/st2auth/tests/unit/test_handlers.py
+++ b/st2auth/tests/unit/test_handlers.py
@@ -82,16 +82,18 @@ class HandlerTestCase(CleanDbTestCase):
         # Insert mock local role assignments
         role_db = create_role(name='mock_local_role_1')
         user_db = self.users['user_1']
-        role_assignment_db_1 = assign_role_to_user(role_db=role_db, user_db=user_db,
-                                                   is_remote=False)
+        source = 'assignments/%s.yaml' % user_db.name
+        role_assignment_db_1 = assign_role_to_user(
+            role_db=role_db, user_db=user_db, source=source, is_remote=False)
 
         self.roles['mock_local_role_1'] = role_db
         self.role_assignments['assignment_1'] = role_assignment_db_1
 
         role_db = create_role(name='mock_local_role_2')
         user_db = self.users['user_1']
-        role_assignment_db_2 = assign_role_to_user(role_db=role_db, user_db=user_db,
-                                                   is_remote=False)
+        source = 'assignments/%s.yaml' % user_db.name
+        role_assignment_db_2 = assign_role_to_user(
+            role_db=role_db, user_db=user_db, source=source, is_remote=False)
 
         self.roles['mock_local_role_2'] = role_db
         self.role_assignments['assignment_2'] = role_assignment_db_2
@@ -313,7 +315,8 @@ class HandlerTestCase(CleanDbTestCase):
 
         # Single mapping, new remote assignment should be created
         create_group_to_role_map(group='CN=stormers,OU=groups,DC=stackstorm,DC=net',
-                                 roles=['mock_role_3', 'mock_role_4'])
+                                 roles=['mock_role_3', 'mock_role_4'],
+                                 source='mappings/stormers.yaml')
 
         # Verify initial state
         role_dbs = get_roles_for_user(user_db=user_db, include_remote=True)
@@ -331,6 +334,7 @@ class HandlerTestCase(CleanDbTestCase):
 
         # Verify a new role assignments based on the group mapping has been created
         role_dbs = get_roles_for_user(user_db=user_db, include_remote=True)
+
         self.assertEqual(len(role_dbs), 4)
         self.assertEqual(role_dbs[0], self.roles['mock_local_role_1'])
         self.assertEqual(role_dbs[1], self.roles['mock_local_role_2'])

--- a/st2client/st2client/commands/rbac.py
+++ b/st2client/st2client/commands/rbac.py
@@ -104,7 +104,7 @@ class RoleAssignmentBranch(resource.ResourceBranch):
 
 
 class RoleAssignmentListCommand(resource.ResourceCommand):
-    display_attributes = ['id', 'role', 'user', 'is_remote', 'description', 'source']
+    display_attributes = ['id', 'role', 'user', 'is_remote', 'source', 'description']
     attribute_display_order = ROLE_ASSIGNMENT_ATTRIBUTE_DISPLAY_ORDER
 
     def __init__(self, resource, *args, **kwargs):

--- a/st2client/st2client/commands/rbac.py
+++ b/st2client/st2client/commands/rbac.py
@@ -104,7 +104,7 @@ class RoleAssignmentBranch(resource.ResourceBranch):
 
 
 class RoleAssignmentListCommand(resource.ResourceCommand):
-    display_attributes = ['id', 'role', 'user', 'is_remote', 'description']
+    display_attributes = ['id', 'role', 'user', 'is_remote', 'description', 'metadata.source']
     attribute_display_order = ROLE_ASSIGNMENT_ATTRIBUTE_DISPLAY_ORDER
 
     def __init__(self, resource, *args, **kwargs):

--- a/st2client/st2client/commands/rbac.py
+++ b/st2client/st2client/commands/rbac.py
@@ -104,7 +104,7 @@ class RoleAssignmentBranch(resource.ResourceBranch):
 
 
 class RoleAssignmentListCommand(resource.ResourceCommand):
-    display_attributes = ['id', 'role', 'user', 'is_remote', 'description', 'metadata.source']
+    display_attributes = ['id', 'role', 'user', 'is_remote', 'description', 'source']
     attribute_display_order = ROLE_ASSIGNMENT_ATTRIBUTE_DISPLAY_ORDER
 
     def __init__(self, resource, *args, **kwargs):

--- a/st2client/st2client/commands/rbac.py
+++ b/st2client/st2client/commands/rbac.py
@@ -116,6 +116,7 @@ class RoleAssignmentListCommand(resource.ResourceCommand):
         # Filter options
         self.parser.add_argument('-r', '--role', help='Role to filter on.')
         self.parser.add_argument('-u', '--user', help='User to filter on.')
+        self.parser.add_argument('-s', '--source', help='Source to filter on.')
         self.parser.add_argument('--remote', action='store_true',
                                 help='Only display remote role assignments.')
 
@@ -136,11 +137,12 @@ class RoleAssignmentListCommand(resource.ResourceCommand):
             kwargs['role'] = args.role
         if args.user:
             kwargs['user'] = args.user
-
+        if args.source:
+            kwargs['source'] = args.source
         if args.remote:
             kwargs['remote'] = args.remote
 
-        if args.role or args.user or args.remote:
+        if args.role or args.user or args.remote or args.source:
             result = self.manager.query(**kwargs)
         else:
             result = self.manager.get_all(**kwargs)

--- a/st2client/st2client/commands/rbac.py
+++ b/st2client/st2client/commands/rbac.py
@@ -113,12 +113,10 @@ class RoleAssignmentListCommand(resource.ResourceCommand):
             resource.get_plural_display_name().lower(),
             *args, **kwargs)
 
-        self.group = self.parser.add_mutually_exclusive_group()
-
         # Filter options
-        self.group.add_argument('-r', '--role', help='Role to filter on.')
-        self.group.add_argument('-u', '--user', help='User to filter on.')
-        self.group.add_argument('--remote', action='store_true',
+        self.parser.add_argument('-r', '--role', help='Role to filter on.')
+        self.parser.add_argument('-u', '--user', help='User to filter on.')
+        self.parser.add_argument('--remote', action='store_true',
                                 help='Only display remote role assignments.')
 
         # Display options

--- a/st2common/st2common/models/api/rbac.py
+++ b/st2common/st2common/models/api/rbac.py
@@ -111,8 +111,8 @@ class UserRoleAssignmentAPI(BaseAPI):
             'is_remote': {
                 'type': 'boolean'
             },
-            'metadata': {
-                'type': 'object'
+            'source': {
+                'type': 'string'
             }
         },
         'additionalProperties': False

--- a/st2common/st2common/models/api/rbac.py
+++ b/st2common/st2common/models/api/rbac.py
@@ -110,6 +110,9 @@ class UserRoleAssignmentAPI(BaseAPI):
             },
             'is_remote': {
                 'type': 'boolean'
+            },
+            'metadata': {
+                'type': 'object'
             }
         },
         'additionalProperties': False
@@ -282,7 +285,14 @@ class UserRoleAssignmentFileFormatAPI(BaseAPI):
                     'type': 'string'
                 },
                 'required': True
+            },
+            'file_path': {
+                'type': 'string',
+                'description': 'Path of the file of where this assignment comes from.',
+                'default': None,
+                'required': False
             }
+
         },
         'additionalProperties': False
     }
@@ -324,7 +334,12 @@ class AuthGroupToRoleMapAssignmentFileFormatAPI(BaseAPI):
                 },
                 'required': True
             },
-
+            'file_path': {
+                'type': 'string',
+                'description': 'Path of the file of where this assignment comes from.',
+                'default': None,
+                'required': False
+            }
         },
         'additionalProperties': False
     }

--- a/st2common/st2common/models/db/rbac.py
+++ b/st2common/st2common/models/db/rbac.py
@@ -118,7 +118,6 @@ class GroupToRoleMappingDB(stormbase.StormFoundationDB):
         source: Source where this assignment comes from. Path to a file for local assignments
                 and "API" for API assignments.
         description: Optional description for this mapping.
-        metata: Optional metadata for this mapping.
     """
     group = me.StringField(required=True, unique=True)
     roles = me.ListField(field=me.StringField())

--- a/st2common/st2common/models/db/rbac.py
+++ b/st2common/st2common/models/db/rbac.py
@@ -62,24 +62,26 @@ class UserRoleAssignmentDB(stormbase.StormFoundationDB):
     Attribute:
         user: A reference to the user name to which the role is assigned.
         role: A reference to the role name which is assigned to the user.
+        source: Path to the metadata for this user role assignment.
         description: Optional assigment description.
-        metata: Optional metadata for this assignment.
     """
     user = me.StringField(required=True)
-    role = me.StringField(required=True, unique_with='user')
+    role = me.StringField(required=True, unique_with=['user', 'source'])
+    source = me.StringField(required=True, unique_with=['user', 'role'])
     description = me.StringField()
     # True if this is assigned created on authentication based on the remote groups provided by
     # the auth backends.
     # Remote assignments are special in a way that they are not manipulated with when running
     # st2-apply-rbac-auth-definitions tool.
     is_remote = me.BooleanField(default=False)
-    metadata = me.DictField(default={})
 
     meta = {
         'indexes': [
             {'fields': ['user']},
             {'fields': ['role']},
+            {'fields': ['source']},
             {'fields': ['is_remote']},
+            {'fields': ['user', 'role']},
         ]
     }
 
@@ -112,15 +114,16 @@ class GroupToRoleMappingDB(stormbase.StormFoundationDB):
     Attribute:
         group: Name of the remote auth backend group.
         roles: A reference to the local RBAC role names.
+        source: Path to the metadata for this group to role mapping.
         description: Optional description for this mapping.
         metata: Optional metadata for this mapping.
     """
     group = me.StringField(required=True, unique=True)
     roles = me.ListField(field=me.StringField())
+    source = me.StringField()
     description = me.StringField()
     enabled = me.BooleanField(required=True, default=True,
                               help_text='A flag indicating whether the mapping is enabled.')
-    metadata = me.DictField(default={})
 
 
 # Specialized access objects

--- a/st2common/st2common/models/db/rbac.py
+++ b/st2common/st2common/models/db/rbac.py
@@ -63,6 +63,7 @@ class UserRoleAssignmentDB(stormbase.StormFoundationDB):
         user: A reference to the user name to which the role is assigned.
         role: A reference to the role name which is assigned to the user.
         description: Optional assigment description.
+        metata: Optional metadata for this assignment.
     """
     user = me.StringField(required=True)
     role = me.StringField(required=True, unique_with='user')
@@ -72,6 +73,7 @@ class UserRoleAssignmentDB(stormbase.StormFoundationDB):
     # Remote assignments are special in a way that they are not manipulated with when running
     # st2-apply-rbac-auth-definitions tool.
     is_remote = me.BooleanField(default=False)
+    metadata = me.DictField(default={})
 
     meta = {
         'indexes': [
@@ -111,12 +113,14 @@ class GroupToRoleMappingDB(stormbase.StormFoundationDB):
         group: Name of the remote auth backend group.
         roles: A reference to the local RBAC role names.
         description: Optional description for this mapping.
+        metata: Optional metadata for this mapping.
     """
     group = me.StringField(required=True, unique=True)
     roles = me.ListField(field=me.StringField())
     description = me.StringField()
     enabled = me.BooleanField(required=True, default=True,
                               help_text='A flag indicating whether the mapping is enabled.')
+    metadata = me.DictField(default={})
 
 
 # Specialized access objects

--- a/st2common/st2common/models/db/rbac.py
+++ b/st2common/st2common/models/db/rbac.py
@@ -62,7 +62,8 @@ class UserRoleAssignmentDB(stormbase.StormFoundationDB):
     Attribute:
         user: A reference to the user name to which the role is assigned.
         role: A reference to the role name which is assigned to the user.
-        source: Path to the metadata for this user role assignment.
+        source: Source where this assignment comes from. Path to a file for local assignments
+                and "API" for API assignments.
         description: Optional assigment description.
     """
     user = me.StringField(required=True)
@@ -114,7 +115,8 @@ class GroupToRoleMappingDB(stormbase.StormFoundationDB):
     Attribute:
         group: Name of the remote auth backend group.
         roles: A reference to the local RBAC role names.
-        source: Path to the metadata for this group to role mapping.
+        source: Source where this assignment comes from. Path to a file for local assignments
+                and "API" for API assignments.
         description: Optional description for this mapping.
         metata: Optional metadata for this mapping.
     """

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -2234,6 +2234,10 @@ paths:
           in: query
           description: Role to filter on.
           type: string
+        - name: source
+          in: query
+          description: Source to filter on.
+          type: string
         - name: remote
           in: query
           description: Only include remote role assignments.

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -2231,6 +2231,10 @@ paths:
           in: query
           description: Role to filter on.
           type: string
+        - name: source
+          in: query
+          description: Source to filter on.
+          type: string
         - name: remote
           in: query
           description: Only include remote role assignments.

--- a/st2common/st2common/rbac/loader.py
+++ b/st2common/st2common/rbac/loader.py
@@ -44,11 +44,11 @@ class RBACDefinitionsLoader(object):
 
     def __init__(self):
         base_path = cfg.CONF.system.base_path
-        rbac_definitions_path = os.path.join(base_path, 'rbac/')
 
-        self._role_definitions_path = os.path.join(rbac_definitions_path, 'roles/')
-        self._role_assignments_path = os.path.join(rbac_definitions_path, 'assignments/')
-        self._role_maps_path = os.path.join(rbac_definitions_path, 'mappings/')
+        self._rbac_definitions_path = os.path.join(base_path, 'rbac/')
+        self._role_definitions_path = os.path.join(self._rbac_definitions_path, 'roles/')
+        self._role_assignments_path = os.path.join(self._rbac_definitions_path, 'assignments/')
+        self._role_maps_path = os.path.join(self._rbac_definitions_path, 'mappings/')
         self._meta_loader = MetaLoader()
 
     def load(self):
@@ -113,6 +113,7 @@ class RBACDefinitionsLoader(object):
                 LOG.debug('Skipping disabled role assignment for user "%s"' % (username))
                 continue
 
+            role_assignment_api.file_path = file_path.replace(self._rbac_definitions_path, '')
             result[username] = role_assignment_api
 
         return result
@@ -133,6 +134,7 @@ class RBACDefinitionsLoader(object):
                 file_path=file_path)
 
             group_name = group_to_role_map_api.group
+            group_to_role_map_api.file_path = file_path.replace(self._rbac_definitions_path, '')
             result[group_name] = group_to_role_map_api
 
         return result
@@ -187,6 +189,7 @@ class RBACDefinitionsLoader(object):
             raise ValueError(msg)
 
         group_to_role_map_api = AuthGroupToRoleMapAssignmentFileFormatAPI(**content)
+        group_to_role_map_api.file_path = file_path.replace(self._rbac_definitions_path, '')
         group_to_role_map_api = group_to_role_map_api.validate()
 
         return group_to_role_map_api

--- a/st2common/st2common/rbac/loader.py
+++ b/st2common/st2common/rbac/loader.py
@@ -175,7 +175,7 @@ class RBACDefinitionsLoader(object):
             raise ValueError(msg)
 
         user_role_assignment_api = UserRoleAssignmentFileFormatAPI(**content)
-        user_role_assignment_api.file_path = file_path.replace(self._rbac_definitions_path, '')
+        user_role_assignment_api.file_path = file_path[file_path.rfind('assignments/'):]
         user_role_assignment_api = user_role_assignment_api.validate()
 
         return user_role_assignment_api
@@ -188,7 +188,7 @@ class RBACDefinitionsLoader(object):
             raise ValueError(msg)
 
         group_to_role_map_api = AuthGroupToRoleMapAssignmentFileFormatAPI(**content)
-        group_to_role_map_api.file_path = file_path.replace(self._rbac_definitions_path, '')
+        group_to_role_map_api.file_path = file_path[file_path.rfind('mappings/'):]
         group_to_role_map_api = group_to_role_map_api.validate()
 
         return group_to_role_map_api

--- a/st2common/st2common/rbac/loader.py
+++ b/st2common/st2common/rbac/loader.py
@@ -113,7 +113,6 @@ class RBACDefinitionsLoader(object):
                 LOG.debug('Skipping disabled role assignment for user "%s"' % (username))
                 continue
 
-            role_assignment_api.file_path = file_path.replace(self._rbac_definitions_path, '')
             result[username] = role_assignment_api
 
         return result
@@ -134,7 +133,6 @@ class RBACDefinitionsLoader(object):
                 file_path=file_path)
 
             group_name = group_to_role_map_api.group
-            group_to_role_map_api.file_path = file_path.replace(self._rbac_definitions_path, '')
             result[group_name] = group_to_role_map_api
 
         return result
@@ -177,6 +175,7 @@ class RBACDefinitionsLoader(object):
             raise ValueError(msg)
 
         user_role_assignment_api = UserRoleAssignmentFileFormatAPI(**content)
+        user_role_assignment_api.file_path = file_path.replace(self._rbac_definitions_path, '')
         user_role_assignment_api = user_role_assignment_api.validate()
 
         return user_role_assignment_api

--- a/st2common/st2common/rbac/syncer.py
+++ b/st2common/st2common/rbac/syncer.py
@@ -16,6 +16,7 @@
 """
 Module for syncing RBAC definitions in the database with the ones from the filesystem.
 """
+import itertools
 
 from collections import defaultdict
 
@@ -198,9 +199,12 @@ class RBACDefinitionsDBSyncer(object):
         user_dbs = User.get_all()
 
         username_to_user_db_map = dict([(user_db.name, user_db) for user_db in user_dbs])
-        username_to_role_assignment_api_map = dict([(role_assignment_api.username,
-            role_assignment_api) for role_assignment_api in role_assignment_apis])
+        username_to_role_assignment_apis_map = defaultdict(list)
         username_to_role_assignment_dbs_map = defaultdict(list)
+
+        for role_assignment_api in role_assignment_apis:
+            username = role_assignment_api.username
+            username_to_role_assignment_apis_map[username].append(role_assignment_api)
 
         for role_assignment_db in role_assignment_dbs:
             username = role_assignment_db.user
@@ -211,13 +215,12 @@ class RBACDefinitionsDBSyncer(object):
         # deleted from the database for users which existing in the database, but have no
         # assignment file on disk and for assignments for users which don't exist in the database.
         all_usernames = (username_to_user_db_map.keys() +
-                         username_to_role_assignment_api_map.keys() +
+                         username_to_role_assignment_apis_map.keys() +
                          username_to_role_assignment_dbs_map.keys())
         all_usernames = list(set(all_usernames))
 
         results = {}
         for username in all_usernames:
-            role_assignment_api = username_to_role_assignment_api_map.get(username, None)
             user_db = username_to_user_db_map.get(username, None)
 
             if not user_db:
@@ -228,6 +231,7 @@ class RBACDefinitionsDBSyncer(object):
                 LOG.debug(('User "%s" doesn\'t exist in the DB, creating assignment anyway' %
                           (username)))
 
+            role_assignment_apis = username_to_role_assignment_apis_map.get(username, [])
             role_assignment_dbs = username_to_role_assignment_dbs_map.get(username, [])
 
             # Additional safety assert to ensure we don't accidentally manipulate remote
@@ -235,9 +239,9 @@ class RBACDefinitionsDBSyncer(object):
             for role_assignment_db in role_assignment_dbs:
                 assert role_assignment_db.is_remote is False
 
-            result = self._sync_user_role_assignments(user_db=user_db,
-                                                      role_assignment_dbs=role_assignment_dbs,
-                                                      role_assignment_api=role_assignment_api)
+            result = self._sync_user_role_assignments(
+                user_db=user_db, role_assignment_dbs=role_assignment_dbs,
+                role_assignment_apis=role_assignment_apis)
 
             results[username] = result
 
@@ -268,7 +272,7 @@ class RBACDefinitionsDBSyncer(object):
 
         LOG.info('Group to role map definitions synchronized.')
 
-    def _sync_user_role_assignments(self, user_db, role_assignment_dbs, role_assignment_api):
+    def _sync_user_role_assignments(self, user_db, role_assignment_dbs, role_assignment_apis):
         """
         Synchronize role assignments for a particular user.
 
@@ -278,61 +282,71 @@ class RBACDefinitionsDBSyncer(object):
         :param role_assignment_dbs: Existing user role assignments.
         :type role_assignment_dbs: ``list`` of :class:`UserRoleAssignmentDB`
 
-        :param role_assignment_api: Role assignment API for a particular user.
-        :param role_assignment_api: :class:`UserRoleAssignmentFileFormatAPI`
+        :param role_assignment_apis: List of user role assignments to apply.
+        :param role_assignment_apis: ``list`` of :class:`UserRoleAssignmentFileFormatAPI`
 
         :rtype: ``tuple``
         """
-        db_role_names = [role_assignment_db.role for role_assignment_db in role_assignment_dbs]
-        db_role_names = set(db_role_names)
-        api_role_names = role_assignment_api.roles if role_assignment_api else []
-        api_role_names = set(api_role_names)
+        db_roles = set([(entry.role, entry.source) for entry in role_assignment_dbs])
+
+        api_roles = [
+            list(itertools.izip_longest(entry.roles, [], fillvalue=entry.file_path))
+            for entry in role_assignment_apis
+        ]
+
+        api_roles = set(list(itertools.chain.from_iterable(api_roles)))
 
         # A list of new assignments which should be added to the database
-        new_role_names = api_role_names.difference(db_role_names)
+        new_roles = api_roles.difference(db_roles)
 
         # A list of assignments which need to be updated in the database
-        updated_role_names = db_role_names.intersection(api_role_names)
+        updated_roles = db_roles.intersection(api_roles)
 
         # A list of assignments which should be removed from the database
-        removed_role_names = (db_role_names - api_role_names)
+        removed_roles = (db_roles - api_roles)
 
-        LOG.debug('New assignments for user "%s": %r' % (user_db.name, new_role_names))
-        LOG.debug('Updated assignments for user "%s": %r' % (user_db.name, updated_role_names))
-        LOG.debug('Removed assignments for user "%s": %r' % (user_db.name, removed_role_names))
+        LOG.debug('New assignments for user "%s": %r' % (user_db.name, new_roles))
+        LOG.debug('Updated assignments for user "%s": %r' % (user_db.name, updated_roles))
+        LOG.debug('Removed assignments for user "%s": %r' % (user_db.name, removed_roles))
 
         # Build a list of role assignments to delete
-        role_names_to_delete = updated_role_names.union(removed_role_names)
-        role_assignment_dbs_to_delete = [role_assignment_db for role_assignment_db
-                                         in role_assignment_dbs
-                                         if role_assignment_db.role in role_names_to_delete]
+        roles_to_delete = updated_roles.union(removed_roles)
 
-        queryset_filter = (Q(user=user_db.name) & Q(role__in=role_names_to_delete) &
-                           (Q(is_remote=False) | Q(is_remote__exists=False)))
-        UserRoleAssignmentDB.objects(queryset_filter).delete()
-        LOG.debug('Removed %s assignments for user "%s"' %
-                (len(role_assignment_dbs_to_delete), user_db.name))
+        role_assignment_dbs_to_delete = [
+            role_assignment_db for role_assignment_db in role_assignment_dbs
+            if (role_assignment_db.role, role_assignment_db.source) in roles_to_delete
+        ]
+
+        for role_to_delete in roles_to_delete:
+            queryset_filter = (
+                Q(user=user_db.name) &
+                Q(role=role_to_delete[0]) &
+                Q(source=role_to_delete[1]) &
+                (Q(is_remote=False) | Q(is_remote__exists=False))
+            )
+
+            UserRoleAssignmentDB.objects(queryset_filter).delete()
+
+            LOG.debug('Removed role "%s" from "%s" for user "%s".' %
+                (role_to_delete[0], role_to_delete[1], user_db.name))
 
         # Build a list of roles assignments to create
-        role_names_to_create = new_role_names.union(updated_role_names)
-        role_dbs_to_assign = Role.query(name__in=role_names_to_create)
-
+        roles_to_create = new_roles.union(updated_roles)
         created_role_assignment_dbs = []
-        for role_db in role_dbs_to_assign:
-            if role_db.name in role_assignment_api.roles:
-                description = getattr(role_assignment_api, 'description', None)
-                source = getattr(role_assignment_api, 'file_path', None)
-            else:
-                description = None
-                source = None
 
-            assignment_db = rbac_services.assign_role_to_user(role_db=role_db, user_db=user_db,
-                                                              description=description,
-                                                              source=source)
+        for role in roles_to_create:
+            role_db = list(Role.query(name=role[0]))[0]
+            role_assignment_api = [r for r in role_assignment_apis if r.file_path == role[1]][0]
+            description = getattr(role_assignment_api, 'description', None)
+            source = role[1]
+
+            assignment_db = rbac_services.assign_role_to_user(
+                role_db=role_db, user_db=user_db, source=source, description=description)
+
             created_role_assignment_dbs.append(assignment_db)
 
-        LOG.debug('Created %s new assignments for user "%s"' % (len(role_dbs_to_assign),
-                                                                user_db.name))
+            LOG.debug('Assigned role "%s" from "%s" for user "%s".' %
+                (role[0], role[1], user_db.name))
 
         return (created_role_assignment_dbs, role_assignment_dbs_to_delete)
 

--- a/st2common/st2common/rbac/syncer.py
+++ b/st2common/st2common/rbac/syncer.py
@@ -259,10 +259,12 @@ class RBACDefinitionsDBSyncer(object):
 
         # 2. Insert all mappings read from disk
         for group_to_role_map_api in group_to_role_map_apis:
+            source = getattr(group_to_role_map_api, 'file_path', None)
             rbac_services.create_group_to_role_map(group=group_to_role_map_api.group,
                                                    roles=group_to_role_map_api.roles,
                                                    description=group_to_role_map_api.description,
-                                                   enabled=group_to_role_map_api.enabled)
+                                                   enabled=group_to_role_map_api.enabled,
+                                                   source=source)
 
         LOG.info('Group to role map definitions synchronized.')
 
@@ -319,10 +321,14 @@ class RBACDefinitionsDBSyncer(object):
         for role_db in role_dbs_to_assign:
             if role_db.name in role_assignment_api.roles:
                 description = getattr(role_assignment_api, 'description', None)
+                source = getattr(role_assignment_api, 'file_path', None)
             else:
                 description = None
+                source = None
+
             assignment_db = rbac_services.assign_role_to_user(role_db=role_db, user_db=user_db,
-                                                              description=description)
+                                                              description=description,
+                                                              source=source)
             created_role_assignment_dbs.append(assignment_db)
 
         LOG.debug('Created %s new assignments for user "%s"' % (len(role_dbs_to_assign),
@@ -418,9 +424,11 @@ class RBACRemoteGroupToRoleSyncer(object):
 
                 description = ('Automatic role assignment based on the remote user membership in '
                                'group "%s"' % (mapping_db.group))
+                source = mapping_db.metadata.get('source', None)
                 assignment_db = rbac_services.assign_role_to_user(role_db=role_db, user_db=user_db,
                                                                   description=description,
-                                                                  is_remote=True)
+                                                                  is_remote=True,
+                                                                  source=source)
                 assert assignment_db.is_remote is True
                 created_assignments_dbs.append(assignment_db)
 

--- a/st2common/st2common/rbac/syncer.py
+++ b/st2common/st2common/rbac/syncer.py
@@ -424,11 +424,10 @@ class RBACRemoteGroupToRoleSyncer(object):
 
                 description = ('Automatic role assignment based on the remote user membership in '
                                'group "%s"' % (mapping_db.group))
-                source = mapping_db.metadata.get('source', None)
                 assignment_db = rbac_services.assign_role_to_user(role_db=role_db, user_db=user_db,
                                                                   description=description,
                                                                   is_remote=True,
-                                                                  source=source)
+                                                                  source=mapping_db.source)
                 assert assignment_db.is_remote is True
                 created_assignments_dbs.append(assignment_db)
 

--- a/st2common/st2common/services/rbac.py
+++ b/st2common/st2common/services/rbac.py
@@ -205,15 +205,11 @@ def assign_role_to_user(role_db, user_db, description=None, is_remote=False, sou
                    it's a local assignment or mapping or "API".
     :type source: ``str``
     """
-    metadata = {
-        'source': source
-    }
+    role_assignment_db = UserRoleAssignmentDB(user=user_db.name, role=role_db.name, source=source,
+                                              description=description, is_remote=is_remote)
 
-    role_assignment_db = UserRoleAssignmentDB(user=user_db.name, role=role_db.name,
-                                              description=description,
-                                              is_remote=is_remote,
-                                              metadata=metadata)
     role_assignment_db = UserRoleAssignment.add_or_update(role_assignment_db)
+
     return role_assignment_db
 
 
@@ -337,17 +333,14 @@ def get_all_group_to_role_maps():
 
 
 def create_group_to_role_map(group, roles, description=None, enabled=True, source=None):
-    metadata = {
-        'source': source
-    }
-
     group_to_role_map_db = GroupToRoleMappingDB(group=group,
                                                 roles=roles,
+                                                source=source,
                                                 description=description,
-                                                enabled=enabled,
-                                                metadata=metadata)
+                                                enabled=enabled)
 
     group_to_role_map_db = GroupToRoleMapping.add_or_update(group_to_role_map_db)
+
     return group_to_role_map_db
 
 

--- a/st2common/st2common/services/rbac.py
+++ b/st2common/st2common/services/rbac.py
@@ -223,9 +223,10 @@ def revoke_role_from_user(role_db, user_db):
     :param user_db: User to revoke the role from.
     :type user_db: :class:`UserDB`
     """
-    role_assignment_db = UserRoleAssignment.get(user=user_db.name, role=role_db.name)
-    result = UserRoleAssignment.delete(role_assignment_db)
-    return result
+    role_assignment_dbs = UserRoleAssignment.query(user=user_db.name, role=role_db.name)
+
+    for role_assignment_db in role_assignment_dbs:
+        UserRoleAssignment.delete(role_assignment_db)
 
 
 def get_all_permission_grants_for_user(user_db, resource_uid=None, resource_types=None,

--- a/st2common/st2common/services/rbac.py
+++ b/st2common/st2common/services/rbac.py
@@ -185,7 +185,7 @@ def delete_role(name):
     return result
 
 
-def assign_role_to_user(role_db, user_db, description=None, is_remote=False):
+def assign_role_to_user(role_db, user_db, description=None, is_remote=False, source=None):
     """
     Assign role to a user.
 
@@ -200,10 +200,19 @@ def assign_role_to_user(role_db, user_db, description=None, is_remote=False):
 
     :param include_remote: True if this a remote assignment.
     :type include_remote: ``bool``
+
+    :param source: Source from where this assignment comes from. For example, path of a file if
+                   it's a local assignment or mapping or "API".
+    :type source: ``str``
     """
+    metadata = {
+        'source': source
+    }
+
     role_assignment_db = UserRoleAssignmentDB(user=user_db.name, role=role_db.name,
                                               description=description,
-                                              is_remote=is_remote)
+                                              is_remote=is_remote,
+                                              metadata=metadata)
     role_assignment_db = UserRoleAssignment.add_or_update(role_assignment_db)
     return role_assignment_db
 
@@ -327,11 +336,16 @@ def get_all_group_to_role_maps():
     return result
 
 
-def create_group_to_role_map(group, roles, description=None, enabled=True):
+def create_group_to_role_map(group, roles, description=None, enabled=True, source=None):
+    metadata = {
+        'source': source
+    }
+
     group_to_role_map_db = GroupToRoleMappingDB(group=group,
                                                 roles=roles,
                                                 description=description,
-                                                enabled=enabled)
+                                                enabled=enabled,
+                                                metadata=metadata)
 
     group_to_role_map_db = GroupToRoleMapping.add_or_update(group_to_role_map_db)
     return group_to_role_map_db

--- a/st2common/tests/unit/services/test_rbac.py
+++ b/st2common/tests/unit/services/test_rbac.py
@@ -72,8 +72,9 @@ class RBACServicesTestCase(CleanDbTestCase):
         rbac_services.create_role(name='role_4')
 
         # Create some mock role assignments
-        role_assignment_1 = UserRoleAssignmentDB(user=self.users['1_custom_role'].name,
-                                                 role=self.roles['custom_role_1'].name)
+        role_assignment_1 = UserRoleAssignmentDB(
+            user=self.users['1_custom_role'].name, role=self.roles['custom_role_1'].name,
+            source='assignments/%s.yaml' % self.users['1_custom_role'].name)
         role_assignment_1 = UserRoleAssignment.add_or_update(role_assignment_1)
 
         # Note: User use pymongo to insert mock data because we want to insert a
@@ -185,8 +186,9 @@ class RBACServicesTestCase(CleanDbTestCase):
         self.assertItemsEqual(role_dbs, [])
 
         # Assign a role, should have one role assigned
-        rbac_services.assign_role_to_user(role_db=self.roles['custom_role_1'],
-                                          user_db=user_db)
+        rbac_services.assign_role_to_user(
+            role_db=self.roles['custom_role_1'], user_db=user_db,
+            source='assignments/%s.yaml' % user_db.name)
 
         role_dbs = rbac_services.get_roles_for_user(user_db=user_db)
         self.assertItemsEqual(role_dbs, [self.roles['custom_role_1']])
@@ -215,7 +217,9 @@ class RBACServicesTestCase(CleanDbTestCase):
         self.assertItemsEqual(role_dbs, [])
 
         # Assign a role, should have one role assigned
-        rbac_services.assign_role_to_user(role_db=self.roles['custom_role_1'], user_db=user_db)
+        rbac_services.assign_role_to_user(
+            role_db=self.roles['custom_role_1'], user_db=user_db,
+            source='assignments/%s_1.yaml' % user_db.name)
 
         role_dbs = rbac_services.get_roles_for_user(user_db=user_db)
         self.assertItemsEqual(role_dbs, [self.roles['custom_role_1']])
@@ -224,7 +228,9 @@ class RBACServicesTestCase(CleanDbTestCase):
         self.assertItemsEqual(role_dbs, [self.roles['custom_role_1']])
 
         # Assign the same role again.
-        rbac_services.assign_role_to_user(role_db=self.roles['custom_role_1'], user_db=user_db)
+        rbac_services.assign_role_to_user(
+            role_db=self.roles['custom_role_1'], user_db=user_db,
+            source='assignments/%s_2.yaml' % user_db.name)
 
         role_dbs_2 = rbac_services.get_roles_for_user(user_db=user_db)
         self.assertItemsEqual(role_dbs_2, [self.roles['custom_role_1']])

--- a/st2common/tests/unit/services/test_rbac.py
+++ b/st2common/tests/unit/services/test_rbac.py
@@ -203,6 +203,43 @@ class RBACServicesTestCase(CleanDbTestCase):
         role_dbs = user_db.get_roles()
         self.assertItemsEqual(role_dbs, [])
 
+    def test_grant_duplicate_role(self):
+        user_db = UserDB(name='test-user-1')
+        user_db = User.add_or_update(user_db)
+
+        # Initial state, no roles
+        role_dbs = rbac_services.get_roles_for_user(user_db=user_db)
+        self.assertItemsEqual(role_dbs, [])
+
+        role_dbs = user_db.get_roles()
+        self.assertItemsEqual(role_dbs, [])
+
+        # Assign a role, should have one role assigned
+        rbac_services.assign_role_to_user(role_db=self.roles['custom_role_1'], user_db=user_db)
+
+        role_dbs = rbac_services.get_roles_for_user(user_db=user_db)
+        self.assertItemsEqual(role_dbs, [self.roles['custom_role_1']])
+
+        role_dbs = user_db.get_roles()
+        self.assertItemsEqual(role_dbs, [self.roles['custom_role_1']])
+
+        # Assign the same role again.
+        rbac_services.assign_role_to_user(role_db=self.roles['custom_role_1'], user_db=user_db)
+
+        role_dbs_2 = rbac_services.get_roles_for_user(user_db=user_db)
+        self.assertItemsEqual(role_dbs_2, [self.roles['custom_role_1']])
+
+        role_dbs = user_db.get_roles()
+        self.assertItemsEqual(role_dbs_2, [self.roles['custom_role_1']])
+
+        # Revoke previously assigned role, should have no roles again
+        rbac_services.revoke_role_from_user(role_db=self.roles['custom_role_1'], user_db=user_db)
+
+        role_dbs = rbac_services.get_roles_for_user(user_db=user_db)
+        self.assertItemsEqual(role_dbs, [])
+        role_dbs = user_db.get_roles()
+        self.assertItemsEqual(role_dbs, [])
+
     def test_get_all_permission_grants_for_user(self):
         user_db = self.users['1_custom_role']
         role_db = self.roles['custom_role_1']

--- a/st2common/tests/unit/test_db_rbac.py
+++ b/st2common/tests/unit/test_db_rbac.py
@@ -52,6 +52,7 @@ class UserRoleAssignmentDBModelCRUDTestCase(BaseDBModelCRUDTestCase, DbTestCase)
     model_class_kwargs = {
         'user': 'user_one',
         'role': 'role_one',
+        'source': 'source_one',
         'is_remote': True
     }
     update_attribute_name = 'role'

--- a/st2common/tests/unit/test_rbac_loader.py
+++ b/st2common/tests/unit/test_rbac_loader.py
@@ -93,7 +93,7 @@ class RBACDefinitionsLoaderTestCase(unittest2.TestCase):
         self.assertEqual(user_role_assignment_api.username, 'user3')
         self.assertEqual(user_role_assignment_api.description, 'Observer assignments')
         self.assertEqual(user_role_assignment_api.roles, ['observer'])
-        self.assertTrue(user_role_assignment_api.file_path.endswith('assignments/user3.yaml'))
+        self.assertEqual(user_role_assignment_api.file_path, 'assignments/user3.yaml')
 
     def test_load_role_definitions_duplicate_role_definition(self):
         loader = RBACDefinitionsLoader()
@@ -199,7 +199,7 @@ class RBACDefinitionsLoaderTestCase(unittest2.TestCase):
         assignment_api = loader.load_user_role_assignments_from_file(file_path=file_path)
         self.assertEqual(assignment_api.username, 'stackstorm_user')
         self.assertFalse(assignment_api.enabled)
-        self.assertTrue(assignment_api.file_path.endswith('assignments/user_sample.yaml'))
+        self.assertEqual(assignment_api.file_path, 'assignments/user_sample.yaml')
 
     def test_load_group_to_role_mappings_empty_file(self):
         loader = RBACDefinitionsLoader()
@@ -251,4 +251,4 @@ class RBACDefinitionsLoaderTestCase(unittest2.TestCase):
         self.assertEqual(role_mapping_api.roles, ['role_one', 'role_two', 'role_three'])
         self.assertEqual(role_mapping_api.description, 'Grant 3 roles to stormers group members')
         self.assertFalse(role_mapping_api.enabled)
-        self.assertTrue(role_mapping_api.file_path.endswith('mappings/mapping_two.yaml'))
+        self.assertEqual(role_mapping_api.file_path, 'mappings/mapping_two.yaml')

--- a/st2common/tests/unit/test_rbac_loader.py
+++ b/st2common/tests/unit/test_rbac_loader.py
@@ -93,6 +93,7 @@ class RBACDefinitionsLoaderTestCase(unittest2.TestCase):
         self.assertEqual(user_role_assignment_api.username, 'user3')
         self.assertEqual(user_role_assignment_api.description, 'Observer assignments')
         self.assertEqual(user_role_assignment_api.roles, ['observer'])
+        self.assertTrue(user_role_assignment_api.file_path.endswith('assignments/user3.yaml'))
 
     def test_load_role_definitions_duplicate_role_definition(self):
         loader = RBACDefinitionsLoader()
@@ -198,6 +199,7 @@ class RBACDefinitionsLoaderTestCase(unittest2.TestCase):
         assignment_api = loader.load_user_role_assignments_from_file(file_path=file_path)
         self.assertEqual(assignment_api.username, 'stackstorm_user')
         self.assertFalse(assignment_api.enabled)
+        self.assertTrue(assignment_api.file_path.endswith('assignments/user_sample.yaml'))
 
     def test_load_group_to_role_mappings_empty_file(self):
         loader = RBACDefinitionsLoader()
@@ -240,6 +242,7 @@ class RBACDefinitionsLoaderTestCase(unittest2.TestCase):
         self.assertEqual(role_mapping_api.roles, ['pack_admin'])
         self.assertEqual(role_mapping_api.description, None)
         self.assertTrue(role_mapping_api.enabled)
+        self.assertTrue(role_mapping_api.file_path.endswith('mappings/mapping_one.yaml'))
 
         file_path = os.path.join(get_fixtures_base_path(), 'rbac/mappings/mapping_two.yaml')
         role_mapping_api = loader.load_group_to_role_map_assignment_from_file(file_path=file_path)
@@ -248,3 +251,4 @@ class RBACDefinitionsLoaderTestCase(unittest2.TestCase):
         self.assertEqual(role_mapping_api.roles, ['role_one', 'role_two', 'role_three'])
         self.assertEqual(role_mapping_api.description, 'Grant 3 roles to stormers group members')
         self.assertFalse(role_mapping_api.enabled)
+        self.assertTrue(role_mapping_api.file_path.endswith('mappings/mapping_two.yaml'))

--- a/st2common/tests/unit/test_rbac_resolvers.py
+++ b/st2common/tests/unit/test_rbac_resolvers.py
@@ -248,21 +248,30 @@ class BasePermissionsResolverTestCase(CleanDbTestCase):
 
     def _insert_common_mock_role_assignments(self):
         # Insert common mock role assignments
-        role_assignment_admin = UserRoleAssignmentDB(user=self.users['admin'].name,
-                                                     role=self.roles['admin_role'].name)
+        role_assignment_admin = UserRoleAssignmentDB(
+            user=self.users['admin'].name, role=self.roles['admin_role'].name,
+            source='assignments/admin.yaml')
+
         role_assignment_admin = UserRoleAssignment.add_or_update(role_assignment_admin)
-        role_assignment_observer = UserRoleAssignmentDB(user=self.users['observer'].name,
-                                                        role=self.roles['observer_role'].name)
+
+        role_assignment_observer = UserRoleAssignmentDB(
+            user=self.users['observer'].name, role=self.roles['observer_role'].name,
+            source='assignments/observer.yaml')
+
         role_assignment_observer = UserRoleAssignment.add_or_update(role_assignment_observer)
 
         user_db = self.users['1_custom_role_no_permissions']
-        role_assignment_db = UserRoleAssignmentDB(user=user_db.name,
-                                                  role=self.roles['custom_role_1'].name)
+        role_assignment_db = UserRoleAssignmentDB(
+            user=user_db.name, role=self.roles['custom_role_1'].name,
+            source='assignments/%s.yaml' % user_db.name)
+
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_pack_grant']
-        role_assignment_db = UserRoleAssignmentDB(user=user_db.name,
-                                                  role=self.roles['custom_role_pack_grant'].name)
+        role_assignment_db = UserRoleAssignmentDB(
+            user=user_db.name, role=self.roles['custom_role_pack_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
+
         UserRoleAssignment.add_or_update(role_assignment_db)
 
 

--- a/st2common/tests/unit/test_rbac_resolvers_action.py
+++ b/st2common/tests/unit/test_rbac_resolvers_action.py
@@ -210,61 +210,62 @@ class ActionPermissionsResolverTestCase(BasePermissionsResolverTestCase):
         # Create some mock role assignments
         user_db = self.users['custom_role_action_pack_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_action_pack_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_action_pack_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_action_grant']
-        role_assignment_db = UserRoleAssignmentDB(user=user_db.name,
-                                                  role=self.roles['custom_role_action_grant'].name)
+        role_assignment_db = UserRoleAssignmentDB(
+            user=user_db.name, role=self.roles['custom_role_action_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_pack_action_all_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_pack_action_all_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_pack_action_all_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_action_all_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_action_all_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_action_all_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_action_execute_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_action_execute_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_action_execute_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['action_pack_action_create_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['action_pack_action_create_grant'].name)
+            user=user_db.name, role=self.roles['action_pack_action_create_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['action_pack_action_all_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['action_pack_action_all_grant'].name)
+            user=user_db.name, role=self.roles['action_pack_action_all_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['action_action_create_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['action_action_create_grant'].name)
+            user=user_db.name, role=self.roles['action_action_create_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['action_action_all_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['action_action_all_grant'].name)
+            user=user_db.name, role=self.roles['action_action_all_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_action_list_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_action_list_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_action_list_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
     def test_user_has_permission(self):

--- a/st2common/tests/unit/test_rbac_resolvers_action_alias.py
+++ b/st2common/tests/unit/test_rbac_resolvers_action_alias.py
@@ -190,55 +190,56 @@ class ActionAliasPermissionsResolverTestCase(BasePermissionsResolverTestCase):
         # Create some mock role assignments
         user_db = self.users['alias_pack_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['alias_pack_grant'].name)
+            user=user_db.name, role=self.roles['alias_pack_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['alias_grant']
-        role_assignment_db = UserRoleAssignmentDB(user=user_db.name,
-                                                  role=self.roles['alias_grant'].name)
+        role_assignment_db = UserRoleAssignmentDB(
+            user=user_db.name, role=self.roles['alias_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['pack_alias_all_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['pack_alias_all_grant'].name)
+            user=user_db.name, role=self.roles['pack_alias_all_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['alias_all_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['alias_all_grant'].name)
+            user=user_db.name, role=self.roles['alias_all_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['alias_modify_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['alias_modify_grant'].name)
+            user=user_db.name, role=self.roles['alias_modify_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['alias_pack_alias_create_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['alias_pack_alias_create_grant'].name)
+            user=user_db.name, role=self.roles['alias_pack_alias_create_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['alias_pack_alias_all_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['alias_pack_alias_all_grant'].name)
+            user=user_db.name, role=self.roles['alias_pack_alias_all_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['alias_alias_create_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['alias_alias_create_grant'].name)
+            user=user_db.name, role=self.roles['alias_alias_create_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['alias_list_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['alias_list_grant'].name)
+            user=user_db.name, role=self.roles['alias_list_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
     def test_user_has_permission(self):

--- a/st2common/tests/unit/test_rbac_resolvers_execution.py
+++ b/st2common/tests/unit/test_rbac_resolvers_execution.py
@@ -198,56 +198,57 @@ class ExecutionPermissionsResolverTestCase(BasePermissionsResolverTestCase):
         # Create some mock role assignments
         user_db = self.users['custom_role_unrelated_pack_action_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_unrelated_pack_action_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_unrelated_pack_action_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_pack_action_grant_unrelated_permission']
         role_assignment_db = UserRoleAssignmentDB(
             user=user_db.name,
-            role=self.roles['custom_role_pack_action_grant_unrelated_permission'].name)
+            role=self.roles['custom_role_pack_action_grant_unrelated_permission'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_pack_action_view_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_pack_action_view_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_pack_action_view_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_action_view_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_action_view_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_action_view_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_pack_action_execute_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_pack_action_execute_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_pack_action_execute_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_action_execute_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_action_execute_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_action_execute_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_pack_action_all_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_pack_action_all_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_pack_action_all_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_action_all_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_action_all_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_action_all_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_execution_list_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_execution_list_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_execution_list_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
     def test_user_has_permission(self):

--- a/st2common/tests/unit/test_rbac_resolvers_rule.py
+++ b/st2common/tests/unit/test_rbac_resolvers_rule.py
@@ -212,61 +212,62 @@ class RulePermissionsResolverTestCase(BasePermissionsResolverTestCase):
         # Create some mock role assignments
         user_db = self.users['custom_role_rule_pack_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_rule_pack_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_rule_pack_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_rule_grant']
-        role_assignment_db = UserRoleAssignmentDB(user=user_db.name,
-                                                  role=self.roles['custom_role_rule_grant'].name)
+        role_assignment_db = UserRoleAssignmentDB(
+            user=user_db.name, role=self.roles['custom_role_rule_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_pack_rule_all_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_pack_rule_all_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_pack_rule_all_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_rule_all_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_rule_all_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_rule_all_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_rule_modify_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_rule_modify_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_rule_modify_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['rule_pack_rule_create_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['rule_pack_rule_create_grant'].name)
+            user=user_db.name, role=self.roles['rule_pack_rule_create_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['rule_pack_rule_all_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['rule_pack_rule_all_grant'].name)
+            user=user_db.name, role=self.roles['rule_pack_rule_all_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['rule_rule_create_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['rule_rule_create_grant'].name)
+            user=user_db.name, role=self.roles['rule_rule_create_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['rule_rule_all_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['rule_rule_all_grant'].name)
+            user=user_db.name, role=self.roles['rule_rule_all_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_rule_list_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_rule_list_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_rule_list_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
     def test_user_has_permission(self):

--- a/st2common/tests/unit/test_rbac_resolvers_rule_enforcement.py
+++ b/st2common/tests/unit/test_rbac_resolvers_rule_enforcement.py
@@ -237,61 +237,62 @@ class RuleEnforcementPermissionsResolverTestCase(BasePermissionsResolverTestCase
         # Create some mock role assignments
         user_db = self.users['custom_role_rule_pack_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_rule_pack_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_rule_pack_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_rule_grant']
-        role_assignment_db = UserRoleAssignmentDB(user=user_db.name,
-                                                  role=self.roles['custom_role_rule_grant'].name)
+        role_assignment_db = UserRoleAssignmentDB(
+            user=user_db.name, role=self.roles['custom_role_rule_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_pack_rule_all_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_pack_rule_all_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_pack_rule_all_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_rule_all_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_rule_all_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_rule_all_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_rule_modify_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_rule_modify_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_rule_modify_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['rule_pack_rule_create_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['rule_pack_rule_create_grant'].name)
+            user=user_db.name, role=self.roles['rule_pack_rule_create_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['rule_pack_rule_all_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['rule_pack_rule_all_grant'].name)
+            user=user_db.name, role=self.roles['rule_pack_rule_all_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['rule_rule_create_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['rule_rule_create_grant'].name)
+            user=user_db.name, role=self.roles['rule_rule_create_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['rule_rule_all_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['rule_rule_all_grant'].name)
+            user=user_db.name, role=self.roles['rule_rule_all_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_rule_list_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_rule_list_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_rule_list_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
     def test_user_has_permission(self):

--- a/st2common/tests/unit/test_rbac_resolvers_runner.py
+++ b/st2common/tests/unit/test_rbac_resolvers_runner.py
@@ -78,14 +78,14 @@ class RunnerPermissionsResolverTestCase(BasePermissionsResolverTestCase):
         # Create some mock role assignments
         user_db = self.users['custom_role_runner_view_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_runner_view_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_runner_view_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_runner_modify_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_runner_modify_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_runner_modify_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
     def test_user_has_resource_db_permission(self):

--- a/st2common/tests/unit/test_rbac_resolvers_sensor.py
+++ b/st2common/tests/unit/test_rbac_resolvers_sensor.py
@@ -131,31 +131,32 @@ class SensorPermissionsResolverTestCase(BasePermissionsResolverTestCase):
         # Create some mock role assignments
         user_db = self.users['custom_role_sensor_pack_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_sensor_pack_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_sensor_pack_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_sensor_grant']
-        role_assignment_db = UserRoleAssignmentDB(user=user_db.name,
-                                                  role=self.roles['custom_role_sensor_grant'].name)
+        role_assignment_db = UserRoleAssignmentDB(
+            user=user_db.name, role=self.roles['custom_role_sensor_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_pack_sensor_all_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_pack_sensor_all_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_pack_sensor_all_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_sensor_all_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_sensor_all_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_sensor_all_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
         user_db = self.users['custom_role_sensor_list_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_sensor_list_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_sensor_list_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
     def test_user_has_permission(self):

--- a/st2common/tests/unit/test_rbac_resolvers_webhook.py
+++ b/st2common/tests/unit/test_rbac_resolvers_webhook.py
@@ -60,8 +60,8 @@ class WebhookPermissionsResolverTestCase(BasePermissionsResolverTestCase):
         # Create some mock role assignments
         user_db = self.users['custom_role_webhook_grant']
         role_assignment_db = UserRoleAssignmentDB(
-            user=user_db.name,
-            role=self.roles['custom_role_webhook_grant'].name)
+            user=user_db.name, role=self.roles['custom_role_webhook_grant'].name,
+            source='assignments/%s.yaml' % user_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
 
     def test_user_has_resource_db_permission(self):

--- a/st2common/tests/unit/test_rbac_syncer.py
+++ b/st2common/tests/unit/test_rbac_syncer.py
@@ -247,6 +247,24 @@ class RBACDefinitionsDBSyncerTestCase(BaseRBACDefinitionsDBSyncerTestCase):
         self.assertEqual(role_assignment_dbs[0].source, 'assignments/user2.yaml')
         self.assertEqual(role_assignment_dbs[1].source, 'assignments/user2.yaml')
 
+    def test_sync_user_assignments_role_doesnt_exist_in_db(self):
+        syncer = RBACDefinitionsDBSyncer()
+
+        self._insert_mock_roles()
+
+        # Initial state, no roles
+        role_dbs = get_roles_for_user(user_db=self.users['user_2'])
+        self.assertItemsEqual(role_dbs, [])
+
+        # Do the sync with role defined in separate files
+        assignment1 = UserRoleAssignmentFileFormatAPI(
+            username='user_2', roles=['doesnt_exist'], file_path='assignments/user2.yaml')
+
+        expected_msg = ('Role "doesnt_exist" referenced in assignment file '
+                        '"assignments/user2.yaml" doesn\'t exist')
+        self.assertRaisesRegexp(ValueError, expected_msg, syncer.sync_users_role_assignments,
+                                role_assignment_apis=[assignment1])
+
     def test_sync_user_assignments_multiple_sources_same_role_assignment(self):
         syncer = RBACDefinitionsDBSyncer()
 

--- a/st2common/tests/unit/test_rbac_syncer.py
+++ b/st2common/tests/unit/test_rbac_syncer.py
@@ -630,6 +630,7 @@ class RBACRemoteGroupToRoleSyncerTestCase(BaseRBACDefinitionsDBSyncerTestCase):
         self.assertEqual(role_dbs[2], self.roles['mock_remote_role_3'])
         self.assertEqual(role_dbs[3], self.roles['mock_remote_role_4'])
 
+        role_assignment_dbs = get_role_assignments_for_user(user_db=self.users['user_1'])
         self.assertEqual(len(role_assignment_dbs), 4)
         self.assertEqual(role_assignment_dbs[2].source, 'mappings/stormers.yaml')
         self.assertEqual(role_assignment_dbs[3].source, 'mappings/stormers.yaml')

--- a/st2common/tests/unit/test_rbac_syncer.py
+++ b/st2common/tests/unit/test_rbac_syncer.py
@@ -271,8 +271,10 @@ class RBACDefinitionsDBSyncerTestCase(BaseRBACDefinitionsDBSyncerTestCase):
 
         role_assignment_dbs = get_role_assignments_for_user(user_db=self.users['user_2'])
         self.assertEqual(len(role_assignment_dbs), 2)
-        self.assertEqual(role_assignment_dbs[0].source, 'assignments/user2a.yaml')
-        self.assertEqual(role_assignment_dbs[1].source, 'assignments/user2b.yaml')
+
+        sources = [r.source for r in role_assignment_dbs]
+        self.assertIn('assignments/user2a.yaml', sources)
+        self.assertIn('assignments/user2b.yaml', sources)
 
     def test_sync_user_assignments_locally_removed_assignments_are_removed_from_db(self):
         syncer = RBACDefinitionsDBSyncer()
@@ -360,6 +362,7 @@ class RBACDefinitionsDBSyncerTestCase(BaseRBACDefinitionsDBSyncerTestCase):
         syncer.sync_users_role_assignments(role_assignment_apis=[])
 
         role_dbs = get_roles_for_user(user_db=user_db)
+
         self.assertEqual(len(role_dbs), 0)
 
         username = 'doesntexistwhaha_2'

--- a/st2common/tests/unit/test_rbac_utils.py
+++ b/st2common/tests/unit/test_rbac_utils.py
@@ -50,13 +50,15 @@ class RBACUtilsTestCase(DbTestCase):
         cls.regular_user.save()
 
         # Add system admin role assignment
-        role_assignment_1 = UserRoleAssignmentDB(user=cls.system_admin_user.name,
-                                                 role=SystemRole.SYSTEM_ADMIN)
+        role_assignment_1 = UserRoleAssignmentDB(
+            user=cls.system_admin_user.name, role=SystemRole.SYSTEM_ADMIN,
+            source='assignments/%s.yaml' % cls.system_admin_user.name)
         role_assignment_1.save()
 
         # Add admin role assignment
-        role_assignment_2 = UserRoleAssignmentDB(user=cls.admin_user.name,
-                                                 role=SystemRole.ADMIN)
+        role_assignment_2 = UserRoleAssignmentDB(
+            user=cls.admin_user.name, role=SystemRole.ADMIN,
+            source='assignments/%s.yaml' % cls.admin_user.name)
         role_assignment_2.save()
 
     def setUp(self):

--- a/st2stream/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
+++ b/st2stream/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
@@ -39,7 +39,8 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
     def setUp(self):
         super(APIControllersRBACTestCase, self).setUp()
 
-        self.role_assignment_db_model = UserRoleAssignmentDB(user='user', role='role')
+        self.role_assignment_db_model = UserRoleAssignmentDB(
+            user='user', role='role', source='assignments/user.yaml')
         UserRoleAssignment.add_or_update(self.role_assignment_db_model)
 
     def test_api_endpoints_behind_rbac_wall(self):

--- a/st2tests/st2tests/api.py
+++ b/st2tests/st2tests/api.py
@@ -147,8 +147,8 @@ class BaseAPIControllerWithRBACTestCase(BaseFunctionalTest, CleanDbTestCase):
             self.users[role_name] = user_db
 
             role_assignment_db = UserRoleAssignmentDB(
-                user=user_db.name,
-                role=role_name)
+                user=user_db.name, role=role_name,
+                source='assignments/%s.yaml' % user_db.name)
             UserRoleAssignment.add_or_update(role_assignment_db)
 
         # Insert a user with no permissions and role assignments


### PR DESCRIPTION
Right now we don't support overlapping role assignments (each role can only be granted by one assignment / mapping file) so it's always clear where a particular role assignment comes from.

It looks like our users have a valid use case for overlapping role assignments (single role being granted by multiple assignment or mapping files - #3755) so we will add support for that.

Once we will add support for that, it will be less obvious and potentially more confusing where a particular role assignment comes from.

Because of that, I modified existing code to store and include information on where a particular assignment come. This should hopefully make it obvious and help with "I removed the role assignment file, but assignment is still there" and related issues.

Before (once we add support for overlapping assignments):

```bash
+--------------------------+-------------+-------+-----------+-------------+
| id                       | role        | user  | is_remote | description |
+--------------------------+-------------+-------+-----------+-------------+
| 59c8ce8d0640fd1d06bac3d0 | observer    | tomaz | False     |             |
| 59c8ce8d0640fd1d06bac3d1 | admin       | testu | False     |             |
| 59c8ce8d0640fd1d06bac3d1 | admin       | testu | False     |             |
| 59c8ce8d0640fd1d06bac3d2 | rule_create | testu | False     |             |
| 59c8ce8d0640fd1d06bac3d2 | rule_delete | testu | False     |             |
| 59c8ce8d0640fd1d06bac3d2 | rule_delete | testu | True      |             |
+--------------------------+-------------+-------+-----------+-------------+
```

After:

```
+--------------------------+-------------+-------+-----------+-------------+------------------------+
| id                       | role        | user  | is_remote | description | metadata.source        |
+--------------------------+-------------+-------+-----------+-------------+------------------------+
| 59c8ce8d0640fd1d06bac3d0 | observer    | tomaz | False     |             | assignments/tomaz.yaml |
| 59c8ce8d0640fd1d06bac3d1 | admin       | testu | False     |             | assignments/testu.yaml |
| 59c8ce8d0640fd1d06bac3d1 | admin       | testu | False     |             | assignments/admin.yaml |
| 59c8ce8d0640fd1d06bac3d2 | rule_create | testu | False     |             | assignments/testu.yaml |
| 59c8ce8d0640fd1d06bac3d2 | rule_delete | testu | False     |             | assignments/testu.yaml |
| 59c8ce8d0640fd1d06bac3d2 | rule_delete | testu | True      |             | mappings/mapping1.yaml |
+--------------------------+-------------+-------+-----------+-------------+------------------------+
```

Part of #3755.