### PR TITLE
Add support for glob based event type filtering, fix whitelist for /v1/stream API endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -69,7 +69,7 @@ Fixed
   ``st2.announcement__errbot`` and other event names starting with ``st2.announcement__*`` prefix
   are not filtered out. #3769 (bug fix)
 
-  Reported by Nick Maludy.
+  Reported by Carlos.
 
 2.4.1 - September 12, 2017
 --------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -65,6 +65,11 @@ Fixed
 * Fix ``st2 role-assignment list`` CLI command and allow ``--user``, ``--remote`` and ``--role``
   arguments to be used together. Previously they were mutually exclusive so it wasn't possible to
   use them together. (bug fix) #3763
+* Update default event name whitelist for ``/v1/stream`` API endpoint and make sure
+  ``st2.announcement__errbot`` and other event names starting with ``st2.announcement__*`` prefix
+  are not filtered out. #3769 (bug fix)
+
+  Reported by Nick Maludy.
 
 2.4.1 - September 12, 2017
 --------------------------

--- a/st2stream/st2stream/controllers/v1/stream.py
+++ b/st2stream/st2stream/controllers/v1/stream.py
@@ -27,7 +27,7 @@ __all__ = [
 LOG = logging.getLogger(__name__)
 
 DEFAULT_EVENTS_WHITELIST = [
-    'st2.announcement__chatops',
+    'st2.announcement__*',
 
     'st2.execution__create',
     'st2.execution__update',

--- a/st2stream/tests/unit/controllers/v1/test_stream.py
+++ b/st2stream/tests/unit/controllers/v1/test_stream.py
@@ -214,10 +214,11 @@ class TestStreamController(FunctionalTest):
         resp = stream.StreamController().get_all()
 
         received_messages = dispatch_and_handle_mock_data(resp)
-        self.assertEqual(len(received_messages), 8)
+        self.assertEqual(len(received_messages), 9)
         self.assertTrue('st2.execution__create' in received_messages[0])
         self.assertTrue('st2.liveaction__delete' in received_messages[5])
         self.assertTrue('st2.announcement__chatops' in received_messages[7])
+        self.assertTrue('st2.announcement__errbot' in received_messages[8])
 
         # 1. ?events= filter
         # No filter provided - all messages should be received

--- a/st2stream/tests/unit/controllers/v1/test_stream.py
+++ b/st2stream/tests/unit/controllers/v1/test_stream.py
@@ -198,6 +198,10 @@ class TestStreamController(FunctionalTest):
                 elif index == 9:
                     meta = META('st2.execution.output', 'create')
                     process_output(output_api_stderr, meta)
+                elif index == 10:
+                    meta = META('st2.announcement', 'errbot')
+                    process_no_api_model({}, meta)
+
                 else:
                     break
 
@@ -221,11 +225,12 @@ class TestStreamController(FunctionalTest):
         resp = stream.StreamController().get_all()
 
         received_messages = dispatch_and_handle_mock_data(resp)
-        self.assertEqual(len(received_messages), 10)
+        self.assertEqual(len(received_messages), 11)
         self.assertTrue('st2.execution__create' in received_messages[0])
         self.assertTrue('st2.announcement__chatops' in received_messages[7])
         self.assertTrue('st2.execution.output__create' in received_messages[8])
         self.assertTrue('st2.execution.output__create' in received_messages[9])
+        self.assertTrue('st2.announcement__errbot' in received_messages[10])
 
         # Filter provided, only three messages should be received
         events = ['st2.execution__create', 'st2.liveaction__delete']
@@ -249,6 +254,16 @@ class TestStreamController(FunctionalTest):
         self.assertTrue('st2.liveaction__create' in received_messages[1])
         self.assertTrue('st2.liveaction__delete' in received_messages[2])
         self.assertTrue('st2.liveaction__delete' in received_messages[3])
+
+        # Glob filter
+        events = ['st2.announcement__*']
+        events = ','.join(events)
+        resp = stream.StreamController().get_all(events=events)
+
+        received_messages = dispatch_and_handle_mock_data(resp)
+        self.assertEqual(len(received_messages), 2)
+        self.assertTrue('st2.announcement__chatops' in received_messages[0])
+        self.assertTrue('st2.announcement__errbot' in received_messages[1])
 
         # Filter provided
         events = ['st2.execution.output__create']


### PR DESCRIPTION
This pull request adds support for glob based event type / name filtering to the `/v1/stream` API endpoint.

In addition to that, it fixes a bug caught by @nzlosh - changes I added for streaming support accidentally filtered out `st2.announcement__errbot` events.

If we decide to officially support and maintain errbot we also need to add automated tests for it which will catch issues like that.

Note: This iteration over a list and glob based filtering might not be the most performant - if this indeed turn out to be a bottleneck at some point in the future, we can always optimize it.

Thanks to @nzlosh for catching and reporting this.