### PR TITLE
Update "st2 apikey load" to update an existing entry if one already exists

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -79,6 +79,12 @@ Fixed
   Reported by Carlos.
 * Fix action-alias execute response to show execution id and matching action-alias #3231 (bug fix)
   Reported by Carlos.
+* Fix ``st2 apikey load`` command to update an existing entry if items in input file contain ``id``
+  attribute and item already exists on the server. This way the behavior is consistent with
+  ``st2 key load`` command and the command is idempotent if each item contains ``id`` attribute.
+  #3748 #3786
+
+  Reported by Christopher Baklid.
 
 2.4.1 - September 12, 2017
 --------------------------


### PR DESCRIPTION
This pull request fixes a bug / non-consistent behavior reported in #3748.

It updates ``st2 apikey load`` command so it doesn't throw an updates an existing entry if input file contains `id` attribute for an item and item already exists on the server.

This way behavior is also consistent with ``st2 key load`` command.

See https://gist.github.com/Kami/bc7567c6b2b8a62f7680f64921cbf7fc for example output.

Resolves #3748