### PR TITLE
Fix for #3783 - TTL parameter for PUT /api/v1/keys/{name}

### DIFF
--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -4244,6 +4244,9 @@ definitions:
       scope:
         description: "Scope the item is under. Example: 'user'."
         type: string
+      ttl:
+        description: TTL (in seconds) for this value.
+        type: integer
       user:
         description: User for user scoped items (admin only).
         type: string

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -4241,6 +4241,9 @@ definitions:
       scope:
         description: "Scope the item is under. Example: 'user'."
         type: string
+      ttl:
+        description: TTL (in seconds) for this value.
+        type: integer
       user:
         description: User for user scoped items (admin only).
         type: string


### PR DESCRIPTION
This is a fix for #3783 where the TTL parameter for PUT /api/v1/keys/{name} was missing.

I added the parameter to `st2common/st2common/openapi.yaml.j2` and updated the main definition using `make .generate-api-spec`.

Is there a way, in the future, to auto-generate `st2common/st2common/openapi.yaml.j2` or does this need to be updated manually?