### PR TITLE
Better regex anchors for upstream

### DIFF
--- a/st2common/st2common/models/utils/action_alias_utils.py
+++ b/st2common/st2common/models/utils/action_alias_utils.py
@@ -90,7 +90,7 @@ class ActionAliasFormatParser(object):
         param_match = r'\1["\']?(?P<\2>(?:(?<=\').+?(?=\')|(?<=").+?(?=")|{.+?}|.+?))["\']?'
         reg = re.sub(r'(\s*)' + snippets['optional'], r'(?:' + param_match + r')?', self._format)
         reg = re.sub(r'(\s*)' + snippets['required'], param_match, reg)
-        reg = '^\s*' + reg + r'\s*$'
+        reg = r'^\s*' + reg + r'\s*$'
 
         # 3. Matching the command against our regex to get the param values
         matched_stream = re.match(reg, param_stream, re.DOTALL)

--- a/st2common/tests/unit/test_action_alias_utils.py
+++ b/st2common/tests/unit/test_action_alias_utils.py
@@ -234,6 +234,63 @@ class TestActionAliasParser(TestCase):
         extracted_values = parser.get_extracted_param_value()
         self.assertEqual(extracted_values, {'pony1': 'foo', 'pony2': 'bar'})
 
+    def test_regex_beginning_anchors(self):
+        alias_format = r'^\s*foo (?P<issue_key>[A-Z][A-Z0-9]+-[0-9]+)'
+        param_stream = 'foo ASDF-1234'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'issue_key': 'ASDF-1234'})
+
+    def test_regex_beginning_anchors_dont_match(self):
+        alias_format = r'^\s*foo (?P<issue_key>[A-Z][A-Z0-9]+-[0-9]+)'
+        param_stream = 'bar foo ASDF-1234'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+
+        expected_msg = r'''Command "bar foo ASDF-1234" doesn't match format string '''\
+                       r'''"^\s*foo (?P<issue_key>[A-Z][A-Z0-9]+-[0-9]+)"'''
+        with self.assertRaises(ParseException) as e:
+            parser.get_extracted_param_value()
+
+            self.assertEqual(e.msg, expected_msg)
+
+    def test_regex_ending_anchors(self):
+        alias_format = r'foo (?P<issue_key>[A-Z][A-Z0-9]+-[0-9]+)\s*$'
+        param_stream = 'foo ASDF-1234'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'issue_key': 'ASDF-1234'})
+
+    def test_regex_ending_anchors_dont_match(self):
+        alias_format = r'foo (?P<issue_key>[A-Z][A-Z0-9]+-[0-9]+)\s*$'
+        param_stream = 'foo ASDF-1234 bar'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+
+        expected_msg = r'''Command "foo ASDF-1234 bar" doesn't match format string '''\
+                       r'''"foo (?P<issue_key>[A-Z][A-Z0-9]+-[0-9]+)\s*$"'''
+        with self.assertRaises(ParseException) as e:
+            parser.get_extracted_param_value()
+
+            self.assertEqual(e.msg, expected_msg)
+
+    def test_regex_beginning_and_ending_anchors(self):
+        alias_format = r'^\s*foo (?P<issue_key>[A-Z][A-Z0-9]+-[0-9]+) bar\s*$'
+        param_stream = 'foo ASDF-1234 bar'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+        extracted_values = parser.get_extracted_param_value()
+        self.assertEqual(extracted_values, {'issue_key': 'ASDF-1234'})
+
+    def test_regex_beginning_and_ending_anchors_dont_match(self):
+        alias_format = r'^\s*foo (?P<issue_key>[A-Z][A-Z0-9]+-[0-9]+)\s*$'
+        param_stream = 'bar ASDF-1234'
+        parser = ActionAliasFormatParser(alias_format, param_stream)
+
+        expected_msg = r'''Command "bar ASDF-1234" doesn't match format string '''\
+                       r'''"^\s*foo (?P<issue_key>[A-Z][A-Z0-9]+-[0-9]+)\s*$"'''
+        with self.assertRaises(ParseException) as e:
+            parser.get_extracted_param_value()
+
+            self.assertEqual(e.msg, expected_msg)
+
 
 class TestSearchRegexTokens(TestCase):
     beginning_tokens = ((AT, AT_BEGINNING), (AT, AT_BEGINNING_STRING))
@@ -245,6 +302,11 @@ class TestSearchRegexTokens(TestCase):
 
     def test_no_ending_tokens(self):
         tokens = parse("^asdf")
+        self.assertFalse(search_regex_tokens(self.end_tokens, tokens))
+
+    def test_no_beginning_or_ending_tokens(self):
+        tokens = parse("asdf")
+        self.assertFalse(search_regex_tokens(self.beginning_tokens, tokens))
         self.assertFalse(search_regex_tokens(self.end_tokens, tokens))
 
     def test_backwards(self):

--- a/st2common/tests/unit/test_action_alias_utils.py
+++ b/st2common/tests/unit/test_action_alias_utils.py
@@ -13,9 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from sre_parse import (parse, AT, AT_BEGINNING, AT_BEGINNING_STRING, AT_END, AT_END_STRING)
 from unittest2 import TestCase
 from st2common.exceptions.content import ParseException
-from st2common.models.utils.action_alias_utils import ActionAliasFormatParser
+from st2common.models.utils.action_alias_utils import (
+    ActionAliasFormatParser, search_regex_tokens,
+)
 
 
 class TestActionAliasParser(TestCase):
@@ -230,3 +233,28 @@ class TestActionAliasParser(TestCase):
         parser = ActionAliasFormatParser(alias_format, param_stream)
         extracted_values = parser.get_extracted_param_value()
         self.assertEqual(extracted_values, {'pony1': 'foo', 'pony2': 'bar'})
+
+
+class TestSearchRegexTokens(TestCase):
+    beginning_tokens = ((AT, AT_BEGINNING), (AT, AT_BEGINNING_STRING))
+    end_tokens = ((AT, AT_END), (AT, AT_END_STRING))
+
+    def test_beginning_tokens(self):
+        tokens = parse("^asdf")
+        self.assertTrue(search_regex_tokens(self.beginning_tokens, tokens))
+
+    def test_no_ending_tokens(self):
+        tokens = parse("^asdf")
+        self.assertFalse(search_regex_tokens(self.end_tokens, tokens))
+
+    def test_backwards(self):
+        tokens = parse("^asdf$")
+        self.assertTrue(search_regex_tokens(self.end_tokens, tokens, backwards=True))
+
+    def test_branches(self):
+        tokens = parse("^asdf|fdsa$")
+        self.assertTrue(search_regex_tokens(self.end_tokens, tokens))
+
+    def test_subpatterns(self):
+        tokens = parse("^(?:asdf|fdsa$)")
+        self.assertTrue(search_regex_tokens(self.end_tokens, tokens))


### PR DESCRIPTION
The first commit is a tiny fix for regex mangling - it simply changes a non-raw string into a raw string.

The second commit enables more expressive regular expressions in the action alias parser/mangler.

Instead of blindly adding anchors to action alias format regexes, it now searches the existing regex for anchors and does *not* add anchors if it already contains them.

This allows users to create regexes that already contain anchors

```python
re.compile(r"^jira issue {{ issue_key }}$")
```

or regexes that can match multiple times per string, like when you want to find multiple Jira issues in a Slack message:

```python
re.compile(r"(?:^|\b)(?P<issue_key>[A-Z][A-Z0-9]+-\d+)(?:\b|$")
```

I have included tests for the new parse tree searching function.

I will be working to upstream our changes to the Stackstorm Jira pack once this gets merged.