### PR TITLE
Remove st2actions dependency from st2common

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ compile:
 .st2common-circular-dependencies-check:
 	@echo "Checking st2common for circular dependencies"
 	find ${ROOT_DIR}/st2common/st2common/ -name \*.py -type f -print0 | xargs -0 cat | grep st2reactor ; test $$? -eq 1
-	find ${ROOT_DIR}/st2common/st2common/ \( -name \*.py ! -name runnersregistrar\.py ! -name python_action_wrapper.py \) -type f -print0 | xargs -0 cat | grep st2actions ; test $$? -eq 1
+	find ${ROOT_DIR}/st2common/st2common/ \( -name \*.py ! -name runnersregistrar\.py \) -type f -print0 | xargs -0 cat | grep st2actions ; test $$? -eq 1
 	find ${ROOT_DIR}/st2common/st2common/ -name \*.py -type f -print0 | xargs -0 cat | grep st2api ; test $$? -eq 1
 	find ${ROOT_DIR}/st2common/st2common/ -name \*.py -type f -print0 | xargs -0 cat | grep st2auth ; test $$? -eq 1
 	find ${ROOT_DIR}/st2common/st2common/ -name \*.py -type f -print0 | xargs -0 cat | grep st2debug; test $$? -eq 1

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 **StackStorm** is a platform for integration and automation across services and tools, taking actions in response to events. Learn more at [www.stackstorm.com](http://www.stackstorm.com/product).
 
 [![Tests Build Status](https://travis-ci.org/StackStorm/st2.svg?branch=master)](https://travis-ci.org/StackStorm/st2) [![Packages Build Status](https://circleci.com/gh/StackStorm/st2/tree/master.svg?style=shield)](https://circleci.com/gh/StackStorm/st2) [![Codecov](https://codecov.io/github/StackStorm/st2/badge.svg?branch=master&service=github)](https://codecov.io/github/StackStorm/st2?branch=master) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/StackStorm/st2/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/StackStorm/st2/?branch=master) ![Python 2.7](https://img.shields.io/badge/python-2.7-blue.svg) [![Join our community Slack](https://stackstorm-community.herokuapp.com/badge.svg)](https://stackstorm.com/community-signup) [![IRC](https://img.shields.io/irc/%23stackstorm.png)](http://webchat.freenode.net/?channels=stackstorm)
+
 =======
 
 ## TL;DR

--- a/st2actions/st2actions/config.py
+++ b/st2actions/st2actions/config.py
@@ -31,60 +31,10 @@ def parse_args(args=None):
 
 def register_opts():
     _register_common_opts()
-    _register_action_runner_opts()
 
 
 def _register_common_opts():
     common_config.register_opts()
-
-
-def _register_action_runner_opts():
-    logging_opts = [
-        cfg.StrOpt('logging', default='conf/logging.conf',
-                   help='location of the logging.conf file'),
-    ]
-    CONF.register_opts(logging_opts, group='actionrunner')
-
-    dispatcher_pool_opts = [
-        cfg.IntOpt('workflows_pool_size', default=40,
-                   help='Internal pool size for dispatcher used by workflow actions.'),
-        cfg.IntOpt('actions_pool_size', default=60,
-                   help='Internal pool size for dispatcher used by regular actions.')
-    ]
-    CONF.register_opts(dispatcher_pool_opts, group='actionrunner')
-
-    db_opts = [
-        cfg.StrOpt('host', default='127.0.0.1', help='host of db server'),
-        cfg.IntOpt('port', default=27017, help='port of db server'),
-        cfg.StrOpt('db_name', default='st2', help='name of database')
-    ]
-    CONF.register_opts(db_opts, group='database')
-
-    ssh_runner_opts = [
-        cfg.StrOpt('remote_dir',
-                   default='/tmp',
-                   help='Location of the script on the remote filesystem.'),
-        cfg.BoolOpt('allow_partial_failure',
-                    default=False,
-                    help='How partial success of actions run on multiple nodes ' +
-                         'should be treated.'),
-        cfg.IntOpt('max_parallel_actions', default=50,
-                   help='Max number of parallel remote SSH actions that should be run.  ' +
-                        'Works only with Paramiko SSH runner.'),
-        cfg.BoolOpt('use_ssh_config', default=False,
-                    help='Use the .ssh/config file. Useful to override ports etc.'),
-        cfg.StrOpt('ssh_config_file_path',
-                   default='~/.ssh/config',
-                   help='Path to the ssh config file.')
-
-    ]
-    CONF.register_opts(ssh_runner_opts, group='ssh_runner')
-
-    cloudslang_opts = [
-        cfg.StrOpt('home_dir', default='/opt/cslang',
-                   help='CloudSlang home directory.'),
-    ]
-    CONF.register_opts(cloudslang_opts, group='cloudslang')
 
 
 def get_logging_config_path():

--- a/st2api/tests/unit/controllers/v1/test_executions.py
+++ b/st2api/tests/unit/controllers/v1/test_executions.py
@@ -1096,7 +1096,7 @@ class ActionExecutionOutputControllerTestCase(BaseActionExecutionControllerTestC
             action_execution_db = ActionExecution.add_or_update(action_execution_db)
 
         eventlet.spawn_after(0.2, insert_mock_data)
-        eventlet.spawn_after(1, publish_action_finished, action_execution_db)
+        eventlet.spawn_after(1.5, publish_action_finished, action_execution_db)
         resp = self.app.get('/v1/executions/%s/output' % (str(action_execution_db.id)),
                             expect_errors=False)
 

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -236,6 +236,40 @@ def register_opts(ignore_errors=False):
     ]
     do_register_opts(action_runner_opts, group='actionrunner')
 
+    dispatcher_pool_opts = [
+        cfg.IntOpt('workflows_pool_size', default=40,
+                   help='Internal pool size for dispatcher used by workflow actions.'),
+        cfg.IntOpt('actions_pool_size', default=60,
+                   help='Internal pool size for dispatcher used by regular actions.')
+    ]
+    do_register_opts(dispatcher_pool_opts, group='actionrunner')
+
+    ssh_runner_opts = [
+        cfg.StrOpt('remote_dir',
+                   default='/tmp',
+                   help='Location of the script on the remote filesystem.'),
+        cfg.BoolOpt('allow_partial_failure',
+                    default=False,
+                    help='How partial success of actions run on multiple nodes ' +
+                         'should be treated.'),
+        cfg.IntOpt('max_parallel_actions', default=50,
+                   help='Max number of parallel remote SSH actions that should be run.  ' +
+                        'Works only with Paramiko SSH runner.'),
+        cfg.BoolOpt('use_ssh_config', default=False,
+                    help='Use the .ssh/config file. Useful to override ports etc.'),
+        cfg.StrOpt('ssh_config_file_path',
+                   default='~/.ssh/config',
+                   help='Path to the ssh config file.')
+
+    ]
+    do_register_opts(ssh_runner_opts, group='ssh_runner')
+
+    cloudslang_opts = [
+        cfg.StrOpt('home_dir', default='/opt/cslang',
+                   help='CloudSlang home directory.'),
+    ]
+    do_register_opts(cloudslang_opts, group='cloudslang')
+
     # Common options (used by action runner and sensor container)
     action_sensor_opts = [
         cfg.BoolOpt('enable', default=True,

--- a/st2common/st2common/runners/python_action_wrapper.py
+++ b/st2common/st2common/runners/python_action_wrapper.py
@@ -35,7 +35,7 @@ import traceback
 from oslo_config import cfg
 
 from st2common import log as logging
-from st2actions import config
+from st2common import config
 from st2common.runners.base_action import Action
 from st2common.runners.utils import get_logger_for_python_runner_action
 from st2common.runners.utils import get_action_class_instance

--- a/st2common/st2common/services/triggers.py
+++ b/st2common/st2common/services/triggers.py
@@ -20,6 +20,7 @@ from st2common.constants.triggers import CRON_TIMER_TRIGGER_REF
 from st2common.exceptions.sensors import TriggerTypeRegistrationException
 from st2common.exceptions.triggers import TriggerDoesNotExistException
 from st2common.exceptions.db import StackStormDBObjectNotFoundError
+from st2common.exceptions.db import StackStormDBObjectConflictError
 from st2common.models.api.trigger import (TriggerAPI, TriggerTypeAPI)
 from st2common.models.system.common import ResourceReference
 from st2common.persistence.trigger import (Trigger, TriggerType)
@@ -359,7 +360,14 @@ def create_or_update_trigger_type_db(trigger_type):
     if is_update:
         trigger_type_api.id = existing_trigger_type_db.id
 
-    trigger_type_db = TriggerType.add_or_update(trigger_type_api)
+    try:
+        trigger_type_db = TriggerType.add_or_update(trigger_type_api)
+    except StackStormDBObjectConflictError:
+        # Operation is idempotent and trigger could have already been created by
+        # another process. Ignore object already exists because it simply means
+        # there was a race and object is already in the database.
+        trigger_type_db = get_trigger_type_db(ref)
+        is_update = True
 
     extra = {'trigger_type_db': trigger_type_db}
 


### PR DESCRIPTION
This removes circular dependency on st2actions inside st2common by moving common action runner options to `st2common.config`.

This means `st2common` is now fully standalone and we can re-use it inside `st2client`, our serverless stuff, etc.