### PR TITLE
Run tests on PyPy on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ dist: precise
 language: python
 python:
   - 2.7
+  - pypy
 
 branches:
   only:
@@ -19,6 +20,12 @@ env:
     - TASK=ci-unit NODE_INDEX=1 NODE_TOTAL=2
     - TASK=ci-integration
     - TASK="ci-checks ci-packs-tests"
+
+matrix:
+  fast_finish: true
+    allow_failures:
+      - env:
+        python: pypy
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ env:
 
 matrix:
   fast_finish: true
-    allow_failures:
-      - env:
-        python: pypy
+  allow_failures:
+    - env:
+      python: pypy
 
 addons:
   apt:

--- a/st2api/tests/unit/controllers/v1/test_executions.py
+++ b/st2api/tests/unit/controllers/v1/test_executions.py
@@ -1096,7 +1096,7 @@ class ActionExecutionOutputControllerTestCase(BaseActionExecutionControllerTestC
             action_execution_db = ActionExecution.add_or_update(action_execution_db)
 
         eventlet.spawn_after(0.2, insert_mock_data)
-        eventlet.spawn_after(1, publish_action_finished, action_execution_db)
+        eventlet.spawn_after(1.5, publish_action_finished, action_execution_db)
         resp = self.app.get('/v1/executions/%s/output' % (str(action_execution_db.id)),
                             expect_errors=False)
 


### PR DESCRIPTION
This pull request updates Travis config so we now also run tests under PyPy there.

I've set `matrix.fast_finish` and `matrix.allow_failures` property for PyPy tests so they don't block the whole build - whole build is considered as finish as soon as other, non PyPy tests finish (https://docs.travis-ci.com/user/customizing-the-build/#Fast-Finishing).

I've done this to speed things up, because also waiting on PyPy builds would slow the whole build down for another 8-10 minutes which is unacceptable right now.

Down the road, we do need to finish a way to speed it up (perhaps buy more parallel contains) and make it part of the build.