### PR TITLE
Various fixes to make st2common package work standalone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,6 +258,11 @@ requirements: virtualenv .sdist-requirements
 			$(VIRTUALENV_DIR)/bin/pip install $(PIP_OPTIONS) -r $$req ; \
 	done
 
+	# Note: We install prance here and not as part of any component
+	# requirements.txt because it has a conflict with our dependency (requires
+	# new version of requests) which we cant resolve at this moment
+	$(VIRTUALENV_DIR)/bin/pip install "prance==0.6.1"
+
 .PHONY: virtualenv
 virtualenv: $(VIRTUALENV_DIR)/bin/activate
 $(VIRTUALENV_DIR)/bin/activate:

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -9,7 +9,7 @@ kombu==4.0.2
 # Note: amqp is used by kombu
 amqp==2.2.1
 oslo.config>=1.12.1,<1.13
-oslo.utils<3.1.0
+oslo.utils<=3.33.0,>=3.15.0
 six==1.10.0
 pyyaml>=3.12,<4.0
 requests[security]>=2.14.1,<2.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ mongoengine==0.12.0
 networkx==1.11
 nose
 oslo.config<1.13,>=1.12.1
-oslo.utils<3.1.0
+oslo.utils<=3.33.0,>=3.15.0
 paramiko==2.2.1
 passlib==1.7.1
 prance==0.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,6 @@ oslo.config<1.13,>=1.12.1
 oslo.utils<=3.33.0,>=3.15.0
 paramiko==2.2.1
 passlib==1.7.1
-prance==0.6.1
 prettytable
 prompt-toolkit==1.0.14
 psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
 gitpython==2.1.5
+greenlet==0.4.12
 gunicorn==19.7.1
 ipaddr
 jinja2

--- a/scripts/dist_utils.py
+++ b/scripts/dist_utils.py
@@ -16,14 +16,35 @@
 
 import os
 import re
+import sys
 
-from pip.req import parse_requirements
+from distutils.version import StrictVersion
+
+GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
+
+try:
+    import pip
+    from pip.req import parse_requirements
+except ImportError:
+    print('Download pip:\n', GET_PIP)
+    sys.exit(1)
 
 __all__ = [
+    'check_pip_version',
     'fetch_requirements',
     'apply_vagrant_workaround',
     'get_version_string',
 ]
+
+
+def check_pip_version():
+    """
+    Ensure that a minimum supported version of pip is installed.
+    """
+    if StrictVersion(pip.__version__) < StrictVersion('6.0.0'):
+        print("Upgrade pip, your version `{0}' "
+              "is outdated:\n{1}".format(pip.__version__, GET_PIP))
+        sys.exit(1)
 
 
 def fetch_requirements(requirements_file_path):

--- a/scripts/dist_utils.py
+++ b/scripts/dist_utils.py
@@ -86,5 +86,6 @@ def get_version_string(init_file):
 
         raise RuntimeError('Unable to find version string in %s.' % (init_file))
 
+
 # alias for get_version_string
 parse_version_string = get_version_string

--- a/scripts/dist_utils.py
+++ b/scripts/dist_utils.py
@@ -34,6 +34,7 @@ __all__ = [
     'fetch_requirements',
     'apply_vagrant_workaround',
     'get_version_string',
+    'parse_version_string'
 ]
 
 
@@ -84,3 +85,6 @@ def get_version_string(init_file):
             return version_match.group(1)
 
         raise RuntimeError('Unable to find version string in %s.' % (init_file))
+
+# alias for get_version_string
+parse_version_string = get_version_string

--- a/st2actions/dist_utils.py
+++ b/st2actions/dist_utils.py
@@ -16,14 +16,35 @@
 
 import os
 import re
+import sys
 
-from pip.req import parse_requirements
+from distutils.version import StrictVersion
+
+GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
+
+try:
+    import pip
+    from pip.req import parse_requirements
+except ImportError:
+    print('Download pip:\n', GET_PIP)
+    sys.exit(1)
 
 __all__ = [
+    'check_pip_version',
     'fetch_requirements',
     'apply_vagrant_workaround',
     'get_version_string',
 ]
+
+
+def check_pip_version():
+    """
+    Ensure that a minimum supported version of pip is installed.
+    """
+    if StrictVersion(pip.__version__) < StrictVersion('6.0.0'):
+        print("Upgrade pip, your version `{0}' "
+              "is outdated:\n{1}".format(pip.__version__, GET_PIP))
+        sys.exit(1)
 
 
 def fetch_requirements(requirements_file_path):

--- a/st2actions/dist_utils.py
+++ b/st2actions/dist_utils.py
@@ -86,5 +86,6 @@ def get_version_string(init_file):
 
         raise RuntimeError('Unable to find version string in %s.' % (init_file))
 
+
 # alias for get_version_string
 parse_version_string = get_version_string

--- a/st2actions/dist_utils.py
+++ b/st2actions/dist_utils.py
@@ -34,6 +34,7 @@ __all__ = [
     'fetch_requirements',
     'apply_vagrant_workaround',
     'get_version_string',
+    'parse_version_string'
 ]
 
 
@@ -84,3 +85,6 @@ def get_version_string(init_file):
             return version_match.group(1)
 
         raise RuntimeError('Unable to find version string in %s.' % (init_file))
+
+# alias for get_version_string
+parse_version_string = get_version_string

--- a/st2api/dist_utils.py
+++ b/st2api/dist_utils.py
@@ -16,14 +16,35 @@
 
 import os
 import re
+import sys
 
-from pip.req import parse_requirements
+from distutils.version import StrictVersion
+
+GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
+
+try:
+    import pip
+    from pip.req import parse_requirements
+except ImportError:
+    print('Download pip:\n', GET_PIP)
+    sys.exit(1)
 
 __all__ = [
+    'check_pip_version',
     'fetch_requirements',
     'apply_vagrant_workaround',
     'get_version_string',
 ]
+
+
+def check_pip_version():
+    """
+    Ensure that a minimum supported version of pip is installed.
+    """
+    if StrictVersion(pip.__version__) < StrictVersion('6.0.0'):
+        print("Upgrade pip, your version `{0}' "
+              "is outdated:\n{1}".format(pip.__version__, GET_PIP))
+        sys.exit(1)
 
 
 def fetch_requirements(requirements_file_path):

--- a/st2api/dist_utils.py
+++ b/st2api/dist_utils.py
@@ -86,5 +86,6 @@ def get_version_string(init_file):
 
         raise RuntimeError('Unable to find version string in %s.' % (init_file))
 
+
 # alias for get_version_string
 parse_version_string = get_version_string

--- a/st2api/dist_utils.py
+++ b/st2api/dist_utils.py
@@ -34,6 +34,7 @@ __all__ = [
     'fetch_requirements',
     'apply_vagrant_workaround',
     'get_version_string',
+    'parse_version_string'
 ]
 
 
@@ -84,3 +85,6 @@ def get_version_string(init_file):
             return version_match.group(1)
 
         raise RuntimeError('Unable to find version string in %s.' % (init_file))
+
+# alias for get_version_string
+parse_version_string = get_version_string

--- a/st2auth/dist_utils.py
+++ b/st2auth/dist_utils.py
@@ -16,14 +16,35 @@
 
 import os
 import re
+import sys
 
-from pip.req import parse_requirements
+from distutils.version import StrictVersion
+
+GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
+
+try:
+    import pip
+    from pip.req import parse_requirements
+except ImportError:
+    print('Download pip:\n', GET_PIP)
+    sys.exit(1)
 
 __all__ = [
+    'check_pip_version',
     'fetch_requirements',
     'apply_vagrant_workaround',
     'get_version_string',
 ]
+
+
+def check_pip_version():
+    """
+    Ensure that a minimum supported version of pip is installed.
+    """
+    if StrictVersion(pip.__version__) < StrictVersion('6.0.0'):
+        print("Upgrade pip, your version `{0}' "
+              "is outdated:\n{1}".format(pip.__version__, GET_PIP))
+        sys.exit(1)
 
 
 def fetch_requirements(requirements_file_path):

--- a/st2auth/dist_utils.py
+++ b/st2auth/dist_utils.py
@@ -86,5 +86,6 @@ def get_version_string(init_file):
 
         raise RuntimeError('Unable to find version string in %s.' % (init_file))
 
+
 # alias for get_version_string
 parse_version_string = get_version_string

--- a/st2auth/dist_utils.py
+++ b/st2auth/dist_utils.py
@@ -34,6 +34,7 @@ __all__ = [
     'fetch_requirements',
     'apply_vagrant_workaround',
     'get_version_string',
+    'parse_version_string'
 ]
 
 
@@ -84,3 +85,6 @@ def get_version_string(init_file):
             return version_match.group(1)
 
         raise RuntimeError('Unable to find version string in %s.' % (init_file))
+
+# alias for get_version_string
+parse_version_string = get_version_string

--- a/st2client/dist_utils.py
+++ b/st2client/dist_utils.py
@@ -16,14 +16,35 @@
 
 import os
 import re
+import sys
 
-from pip.req import parse_requirements
+from distutils.version import StrictVersion
+
+GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
+
+try:
+    import pip
+    from pip.req import parse_requirements
+except ImportError:
+    print('Download pip:\n', GET_PIP)
+    sys.exit(1)
 
 __all__ = [
+    'check_pip_version',
     'fetch_requirements',
     'apply_vagrant_workaround',
     'get_version_string',
 ]
+
+
+def check_pip_version():
+    """
+    Ensure that a minimum supported version of pip is installed.
+    """
+    if StrictVersion(pip.__version__) < StrictVersion('6.0.0'):
+        print("Upgrade pip, your version `{0}' "
+              "is outdated:\n{1}".format(pip.__version__, GET_PIP))
+        sys.exit(1)
 
 
 def fetch_requirements(requirements_file_path):

--- a/st2client/dist_utils.py
+++ b/st2client/dist_utils.py
@@ -86,5 +86,6 @@ def get_version_string(init_file):
 
         raise RuntimeError('Unable to find version string in %s.' % (init_file))
 
+
 # alias for get_version_string
 parse_version_string = get_version_string

--- a/st2client/dist_utils.py
+++ b/st2client/dist_utils.py
@@ -34,6 +34,7 @@ __all__ = [
     'fetch_requirements',
     'apply_vagrant_workaround',
     'get_version_string',
+    'parse_version_string'
 ]
 
 
@@ -84,3 +85,6 @@ def get_version_string(init_file):
             return version_match.group(1)
 
         raise RuntimeError('Unable to find version string in %s.' % (init_file))
+
+# alias for get_version_string
+parse_version_string = get_version_string

--- a/st2common/dist_utils.py
+++ b/st2common/dist_utils.py
@@ -16,14 +16,35 @@
 
 import os
 import re
+import sys
 
-from pip.req import parse_requirements
+from distutils.version import StrictVersion
+
+GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
+
+try:
+    import pip
+    from pip.req import parse_requirements
+except ImportError:
+    print('Download pip:\n', GET_PIP)
+    sys.exit(1)
 
 __all__ = [
+    'check_pip_version',
     'fetch_requirements',
     'apply_vagrant_workaround',
     'get_version_string',
 ]
+
+
+def check_pip_version():
+    """
+    Ensure that a minimum supported version of pip is installed.
+    """
+    if StrictVersion(pip.__version__) < StrictVersion('6.0.0'):
+        print("Upgrade pip, your version `{0}' "
+              "is outdated:\n{1}".format(pip.__version__, GET_PIP))
+        sys.exit(1)
 
 
 def fetch_requirements(requirements_file_path):

--- a/st2common/dist_utils.py
+++ b/st2common/dist_utils.py
@@ -86,5 +86,6 @@ def get_version_string(init_file):
 
         raise RuntimeError('Unable to find version string in %s.' % (init_file))
 
+
 # alias for get_version_string
 parse_version_string = get_version_string

--- a/st2common/dist_utils.py
+++ b/st2common/dist_utils.py
@@ -34,6 +34,7 @@ __all__ = [
     'fetch_requirements',
     'apply_vagrant_workaround',
     'get_version_string',
+    'parse_version_string'
 ]
 
 
@@ -84,3 +85,6 @@ def get_version_string(init_file):
             return version_match.group(1)
 
         raise RuntimeError('Unable to find version string in %s.' % (init_file))
+
+# alias for get_version_string
+parse_version_string = get_version_string

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -28,5 +28,4 @@ git+https://github.com/Kami/entrypoints.git@dont_use_backports#egg=entrypoints
 routes
 flex
 webob
-prance
 jsonpath-rw

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -2,6 +2,8 @@
 apscheduler
 python-dateutil
 eventlet
+# used by eventlet
+greenlet
 jinja2
 jsonschema
 kombu

--- a/st2debug/dist_utils.py
+++ b/st2debug/dist_utils.py
@@ -16,14 +16,35 @@
 
 import os
 import re
+import sys
 
-from pip.req import parse_requirements
+from distutils.version import StrictVersion
+
+GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
+
+try:
+    import pip
+    from pip.req import parse_requirements
+except ImportError:
+    print('Download pip:\n', GET_PIP)
+    sys.exit(1)
 
 __all__ = [
+    'check_pip_version',
     'fetch_requirements',
     'apply_vagrant_workaround',
     'get_version_string',
 ]
+
+
+def check_pip_version():
+    """
+    Ensure that a minimum supported version of pip is installed.
+    """
+    if StrictVersion(pip.__version__) < StrictVersion('6.0.0'):
+        print("Upgrade pip, your version `{0}' "
+              "is outdated:\n{1}".format(pip.__version__, GET_PIP))
+        sys.exit(1)
 
 
 def fetch_requirements(requirements_file_path):

--- a/st2debug/dist_utils.py
+++ b/st2debug/dist_utils.py
@@ -86,5 +86,6 @@ def get_version_string(init_file):
 
         raise RuntimeError('Unable to find version string in %s.' % (init_file))
 
+
 # alias for get_version_string
 parse_version_string = get_version_string

--- a/st2debug/dist_utils.py
+++ b/st2debug/dist_utils.py
@@ -34,6 +34,7 @@ __all__ = [
     'fetch_requirements',
     'apply_vagrant_workaround',
     'get_version_string',
+    'parse_version_string'
 ]
 
 
@@ -84,3 +85,6 @@ def get_version_string(init_file):
             return version_match.group(1)
 
         raise RuntimeError('Unable to find version string in %s.' % (init_file))
+
+# alias for get_version_string
+parse_version_string = get_version_string

--- a/st2exporter/dist_utils.py
+++ b/st2exporter/dist_utils.py
@@ -16,14 +16,35 @@
 
 import os
 import re
+import sys
 
-from pip.req import parse_requirements
+from distutils.version import StrictVersion
+
+GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
+
+try:
+    import pip
+    from pip.req import parse_requirements
+except ImportError:
+    print('Download pip:\n', GET_PIP)
+    sys.exit(1)
 
 __all__ = [
+    'check_pip_version',
     'fetch_requirements',
     'apply_vagrant_workaround',
     'get_version_string',
 ]
+
+
+def check_pip_version():
+    """
+    Ensure that a minimum supported version of pip is installed.
+    """
+    if StrictVersion(pip.__version__) < StrictVersion('6.0.0'):
+        print("Upgrade pip, your version `{0}' "
+              "is outdated:\n{1}".format(pip.__version__, GET_PIP))
+        sys.exit(1)
 
 
 def fetch_requirements(requirements_file_path):

--- a/st2exporter/dist_utils.py
+++ b/st2exporter/dist_utils.py
@@ -86,5 +86,6 @@ def get_version_string(init_file):
 
         raise RuntimeError('Unable to find version string in %s.' % (init_file))
 
+
 # alias for get_version_string
 parse_version_string = get_version_string

--- a/st2exporter/dist_utils.py
+++ b/st2exporter/dist_utils.py
@@ -34,6 +34,7 @@ __all__ = [
     'fetch_requirements',
     'apply_vagrant_workaround',
     'get_version_string',
+    'parse_version_string'
 ]
 
 
@@ -84,3 +85,6 @@ def get_version_string(init_file):
             return version_match.group(1)
 
         raise RuntimeError('Unable to find version string in %s.' % (init_file))
+
+# alias for get_version_string
+parse_version_string = get_version_string

--- a/st2reactor/dist_utils.py
+++ b/st2reactor/dist_utils.py
@@ -16,14 +16,35 @@
 
 import os
 import re
+import sys
 
-from pip.req import parse_requirements
+from distutils.version import StrictVersion
+
+GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
+
+try:
+    import pip
+    from pip.req import parse_requirements
+except ImportError:
+    print('Download pip:\n', GET_PIP)
+    sys.exit(1)
 
 __all__ = [
+    'check_pip_version',
     'fetch_requirements',
     'apply_vagrant_workaround',
     'get_version_string',
 ]
+
+
+def check_pip_version():
+    """
+    Ensure that a minimum supported version of pip is installed.
+    """
+    if StrictVersion(pip.__version__) < StrictVersion('6.0.0'):
+        print("Upgrade pip, your version `{0}' "
+              "is outdated:\n{1}".format(pip.__version__, GET_PIP))
+        sys.exit(1)
 
 
 def fetch_requirements(requirements_file_path):

--- a/st2reactor/dist_utils.py
+++ b/st2reactor/dist_utils.py
@@ -86,5 +86,6 @@ def get_version_string(init_file):
 
         raise RuntimeError('Unable to find version string in %s.' % (init_file))
 
+
 # alias for get_version_string
 parse_version_string = get_version_string

--- a/st2reactor/dist_utils.py
+++ b/st2reactor/dist_utils.py
@@ -34,6 +34,7 @@ __all__ = [
     'fetch_requirements',
     'apply_vagrant_workaround',
     'get_version_string',
+    'parse_version_string'
 ]
 
 
@@ -84,3 +85,6 @@ def get_version_string(init_file):
             return version_match.group(1)
 
         raise RuntimeError('Unable to find version string in %s.' % (init_file))
+
+# alias for get_version_string
+parse_version_string = get_version_string

--- a/st2stream/dist_utils.py
+++ b/st2stream/dist_utils.py
@@ -16,14 +16,35 @@
 
 import os
 import re
+import sys
 
-from pip.req import parse_requirements
+from distutils.version import StrictVersion
+
+GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
+
+try:
+    import pip
+    from pip.req import parse_requirements
+except ImportError:
+    print('Download pip:\n', GET_PIP)
+    sys.exit(1)
 
 __all__ = [
+    'check_pip_version',
     'fetch_requirements',
     'apply_vagrant_workaround',
     'get_version_string',
 ]
+
+
+def check_pip_version():
+    """
+    Ensure that a minimum supported version of pip is installed.
+    """
+    if StrictVersion(pip.__version__) < StrictVersion('6.0.0'):
+        print("Upgrade pip, your version `{0}' "
+              "is outdated:\n{1}".format(pip.__version__, GET_PIP))
+        sys.exit(1)
 
 
 def fetch_requirements(requirements_file_path):

--- a/st2stream/dist_utils.py
+++ b/st2stream/dist_utils.py
@@ -86,5 +86,6 @@ def get_version_string(init_file):
 
         raise RuntimeError('Unable to find version string in %s.' % (init_file))
 
+
 # alias for get_version_string
 parse_version_string = get_version_string

--- a/st2stream/dist_utils.py
+++ b/st2stream/dist_utils.py
@@ -34,6 +34,7 @@ __all__ = [
     'fetch_requirements',
     'apply_vagrant_workaround',
     'get_version_string',
+    'parse_version_string'
 ]
 
 
@@ -84,3 +85,6 @@ def get_version_string(init_file):
             return version_match.group(1)
 
         raise RuntimeError('Unable to find version string in %s.' % (init_file))
+
+# alias for get_version_string
+parse_version_string = get_version_string

--- a/st2tests/dist_utils.py
+++ b/st2tests/dist_utils.py
@@ -16,14 +16,35 @@
 
 import os
 import re
+import sys
 
-from pip.req import parse_requirements
+from distutils.version import StrictVersion
+
+GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
+
+try:
+    import pip
+    from pip.req import parse_requirements
+except ImportError:
+    print('Download pip:\n', GET_PIP)
+    sys.exit(1)
 
 __all__ = [
+    'check_pip_version',
     'fetch_requirements',
     'apply_vagrant_workaround',
     'get_version_string',
 ]
+
+
+def check_pip_version():
+    """
+    Ensure that a minimum supported version of pip is installed.
+    """
+    if StrictVersion(pip.__version__) < StrictVersion('6.0.0'):
+        print("Upgrade pip, your version `{0}' "
+              "is outdated:\n{1}".format(pip.__version__, GET_PIP))
+        sys.exit(1)
 
 
 def fetch_requirements(requirements_file_path):

--- a/st2tests/dist_utils.py
+++ b/st2tests/dist_utils.py
@@ -86,5 +86,6 @@ def get_version_string(init_file):
 
         raise RuntimeError('Unable to find version string in %s.' % (init_file))
 
+
 # alias for get_version_string
 parse_version_string = get_version_string

--- a/st2tests/dist_utils.py
+++ b/st2tests/dist_utils.py
@@ -34,6 +34,7 @@ __all__ = [
     'fetch_requirements',
     'apply_vagrant_workaround',
     'get_version_string',
+    'parse_version_string'
 ]
 
 
@@ -84,3 +85,6 @@ def get_version_string(init_file):
             return version_match.group(1)
 
         raise RuntimeError('Unable to find version string in %s.' % (init_file))
+
+# alias for get_version_string
+parse_version_string = get_version_string


### PR DESCRIPTION
* tooz requires newer version of `oslo.utils` so we need to update the version
* Add missing greenlet dependency
* Remove `prance` from component `in-requirements.txt` because it depends on a new version of requests (something we can't fulfill atm) Related to https://github.com/StackStorm/st2/issues/3603 https://github.com/StackStorm/st2/issues/3596
* Update dist_utils to include missing functions