### PR TITLE
Don't log MongoDB password if password is included in the hostname as part of the URI string

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -89,6 +89,11 @@ Fixed
   #3748 #3786
 
   Reported by Christopher Baklid.
+* Don't log MongoDB database password if user specifies URI for ``database.db_host`` parameter and
+  that URI also includes a password. Default and a common scenario is specifying password as a
+  separate ``database.password`` parameter. #3797
+
+  Reported by Igor Cherkaev.
 
 Changed
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -89,9 +89,9 @@ Fixed
   #3748 #3786
 
   Reported by Christopher Baklid.
-* Don't log MongoDB database password if user specifies URI for ``database.db_host`` parameter and
-  that URI also includes a password. Default and a common scenario is specifying password as a
-  separate ``database.password`` parameter. #3797
+* Don't log MongoDB database password if user specifies URI for ``database.db_host`` config
+  parameter and that URI also includes a password. Default and a common scenario is specifying
+  password as a separate ``database.password`` config parameter. #3797
 
   Reported by Igor Cherkaev.
 

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -82,6 +82,12 @@ def db_setup(db_name, db_host, db_port, username=None, password=None, ensure_ind
         # Hostname is provided as a URI string. Make sure we don't log the password in case one is
         # included as part of the URI string.
         uri_dict = uri_parser.parse_uri(db_host)
+        username_string = uri_dict.get('username', username) or username
+
+        if uri_dict.get('username', None) and username:
+            # Username argument has precedence over connection string username
+            username_string = username
+
         hostnames = get_host_names_for_uri_dict(uri_dict=uri_dict)
 
         if len(uri_dict['nodelist']) > 1:
@@ -90,9 +96,10 @@ def db_setup(db_name, db_host, db_port, username=None, password=None, ensure_ind
             host_string = hostnames
     else:
         host_string = '%s:%s' % (db_host, db_port)
+        username_string = username
 
-    LOG.info('Connecting to database "%s" @ "%s" as user "%s".', db_name, host_string,
-             str(username))
+    LOG.info('Connecting to database "%s" @ "%s" as user "%s".' % (db_name, host_string,
+                                                                   str(username_string)))
 
     ssl_kwargs = _get_ssl_kwargs(ssl=ssl, ssl_keyfile=ssl_keyfile, ssl_certfile=ssl_certfile,
                                  ssl_cert_reqs=ssl_cert_reqs, ssl_ca_certs=ssl_ca_certs,

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -79,8 +79,8 @@ def db_setup(db_name, db_host, db_port, username=None, password=None, ensure_ind
              ssl_cert_reqs=None, ssl_ca_certs=None, ssl_match_hostname=True):
 
     if '://' in db_host:
-        # Connecting to replica set, exclude password from the connection uri which is included
-        # in the log message
+        # Hostname is provided as a URI string. Make sure we don't log the password in case one is
+        # included as part of the URI string.
         uri_dict = uri_parser.parse_uri(db_host)
         hostnames = get_host_names_for_uri_dict(uri_dict=uri_dict)
 

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -20,6 +20,7 @@ import ssl as ssl_lib
 
 import six
 import mongoengine
+from pymongo import uri_parser
 from pymongo.errors import OperationFailure
 
 from st2common import log as logging
@@ -76,8 +77,22 @@ def get_model_classes():
 def db_setup(db_name, db_host, db_port, username=None, password=None, ensure_indexes=True,
              ssl=False, ssl_keyfile=None, ssl_certfile=None,
              ssl_cert_reqs=None, ssl_ca_certs=None, ssl_match_hostname=True):
-    LOG.info('Connecting to database "%s" @ "%s:%s" as user "%s".',
-             db_name, db_host, db_port, str(username))
+
+    if '://' in db_host:
+        # Connecting to replica set, exclude password from the connection uri which is included
+        # in the log message
+        uri_dict = uri_parser.parse_uri(db_host)
+        hostnames = get_host_names_for_uri_dict(uri_dict=uri_dict)
+
+        if len(uri_dict['nodelist']) > 1:
+            host_string = '%s (replica set)' % (hostnames)
+        else:
+            host_string = hostnames
+    else:
+        host_string = '%s:%s' % (db_host, db_port)
+
+    LOG.info('Connecting to database "%s" @ "%s" as user "%s".', db_name, host_string,
+             str(username))
 
     ssl_kwargs = _get_ssl_kwargs(ssl=ssl, ssl_keyfile=ssl_keyfile, ssl_certfile=ssl_certfile,
                                  ssl_cert_reqs=ssl_cert_reqs, ssl_ca_certs=ssl_ca_certs,
@@ -378,3 +393,13 @@ class MongoDBAccess(object):
                 order_by_list = [sort_key] + order_by_list
 
         return filters, order_by_list
+
+
+def get_host_names_for_uri_dict(uri_dict):
+    hosts = []
+
+    for host, port in uri_dict['nodelist']:
+        hosts.append('%s:%s' % (host, port))
+
+    hosts = ','.join(hosts)
+    return hosts

--- a/st2common/tests/unit/test_db.py
+++ b/st2common/tests/unit/test_db.py
@@ -23,6 +23,7 @@ from st2common.models.system.common import ResourceReference
 from st2common.transport.publishers import PoolPublisher
 from st2common.util import schema as util_schema
 from st2common.util import reference
+from st2common.models.db import db_setup
 from st2common.util import date as date_utils
 from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2common.models.db.trigger import TriggerTypeDB, TriggerDB, TriggerInstanceDB
@@ -46,6 +47,72 @@ class DbConnectionTest(DbTestCase):
 
         expected_str = "host=['%s:%s']" % (cfg.CONF.database.host, cfg.CONF.database.port)
         self.assertTrue(expected_str in str(client), 'Not connected to desired host.')
+
+    @mock.patch('st2common.models.db.mongoengine', mock.Mock())
+    @mock.patch('st2common.models.db.LOG')
+    def test_db_setup_connecting_info_logging(self, mock_log):
+        # Verify that password is not included in the log message
+        db_name = 'st2'
+        db_port = '27017'
+        username = 'user_st2'
+        password = 'pass_st2'
+
+        # 1. Password provided as separate argument
+        db_host = 'localhost'
+        username = 'user_st2'
+        password = 'pass_st2'
+        db_setup(db_name=db_name, db_host=db_host, db_port=db_port, username=username,
+                 password=password)
+
+        expected_message = 'Connecting to database "st2" @ "localhost:27017" as user "user_st2".'
+        actual_message = mock_log.info.call_args_list[0][0][0]
+        self.assertEqual(expected_message, actual_message)
+
+        # 2. Password provided as part of uri string (single host)
+        db_host = 'mongodb://user_st22:pass_st22@127.0.0.2:5555'
+        username = None
+        password = None
+        db_setup(db_name=db_name, db_host=db_host, db_port=db_port, username=username,
+                 password=password)
+
+        expected_message = 'Connecting to database "st2" @ "127.0.0.2:5555" as user "user_st22".'
+        actual_message = mock_log.info.call_args_list[1][0][0]
+        self.assertEqual(expected_message, actual_message)
+
+        # 3. Password provided as part of uri string (single host) - username
+        # provided as argument has precedence
+        db_host = 'mongodb://user_st210:pass_st23@127.0.0.2:5555'
+        username = 'user_st23'
+        password = None
+        db_setup(db_name=db_name, db_host=db_host, db_port=db_port, username=username,
+                 password=password)
+
+        expected_message = 'Connecting to database "st2" @ "127.0.0.2:5555" as user "user_st23".'
+        actual_message = mock_log.info.call_args_list[2][0][0]
+        self.assertEqual(expected_message, actual_message)
+
+        # 4. Just host provided in the url string
+        db_host = 'mongodb://127.0.0.2:5555'
+        username = 'user_st24'
+        password = 'foobar'
+        db_setup(db_name=db_name, db_host=db_host, db_port=db_port, username=username,
+                 password=password)
+
+        expected_message = 'Connecting to database "st2" @ "127.0.0.2:5555" as user "user_st24".'
+        actual_message = mock_log.info.call_args_list[3][0][0]
+        self.assertEqual(expected_message, actual_message)
+
+        # 5. Multiple hosts specified as part of connection uri
+        db_host = 'mongodb://user6:pass6@host1,host2,host3'
+        username = None
+        password = 'foobar'
+        db_setup(db_name=db_name, db_host=db_host, db_port=db_port, username=username,
+                 password=password)
+
+        expected_message = ('Connecting to database "st2" @ "host1:27017,host2:27017,host3:27017 '
+                            '(replica set)" as user "user6".')
+        actual_message = mock_log.info.call_args_list[4][0][0]
+        self.assertEqual(expected_message, actual_message)
 
 
 @mock.patch.object(PoolPublisher, 'publish', mock.MagicMock())


### PR DESCRIPTION
Updates the code to not log the MongoDB password in case password is specified as part of the connection host URI string (e.g. ``database.host = mongodb://username:passwordfoo@host1,127.0.0.2:5555``).

Default scenarios is specifying password as a separate ``database.password`` config option. This is still the recommended approach going forward.

Thanks to @emptywee for reporting this.

Resolves #3797.