### PR TITLE
Add missing meta files for mistral itest workflows

### DIFF
--- a/contrib/examples/actions/mistral-test-func-from-json-string.yaml
+++ b/contrib/examples/actions/mistral-test-func-from-json-string.yaml
@@ -1,0 +1,11 @@
+---
+name: mistral-test-func-from-json-string
+description: Example for using the custom filter "from_json_string"
+enabled: true
+entry_point: workflows/tests/mistral-test-func-from-json-string.yaml
+pack: examples
+runner_type: mistral-v2
+parameters:
+  input_str:
+    required: true
+    type: string

--- a/contrib/examples/actions/mistral-test-func-from-yaml-string.yaml
+++ b/contrib/examples/actions/mistral-test-func-from-yaml-string.yaml
@@ -1,0 +1,11 @@
+---
+name: mistral-test-func-from-yaml-string
+description: Example for using the custom filter "from_yaml_string"
+enabled: true
+entry_point: workflows/tests/mistral-test-func-from-yaml-string.yaml
+pack: examples
+runner_type: mistral-v2
+parameters:
+  input_str:
+    required: true
+    type: string

--- a/contrib/examples/actions/mistral-test-func-jsonpath-query.yaml
+++ b/contrib/examples/actions/mistral-test-func-jsonpath-query.yaml
@@ -1,0 +1,14 @@
+---
+name: mistral-test-func-jsonpath-query
+description: Test jsonpath_query custom filter in mistral
+enabled: true
+entry_point: workflows/tests/mistral-test-func-jsonpath-query.yaml
+pack: examples
+runner_type: mistral-v2
+parameters:
+  input_obj:
+    type: object
+    required: true
+  input_query:
+    type: string
+    required: true


### PR DESCRIPTION
Some of the workflows for testing custom filters in the mistral integration test are missing meta files.