### PR TITLE
Fix performance regressions and overhead for Python runner actions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -112,6 +112,8 @@ Fixed
 
   Note: This is a breaking change so if your code utilizes this API endpoint you need to update
   to treat response as a dictionary and not as an array with a single item. #377
+* Partially fix performance overhead and regression for short and simple Python runner actions.
+  Full / complete fix will be included in v2.6.0. #3809
 
 Changed
 ~~~~~~~

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ argcomplete
 bcrypt
 eventlet==0.19.0
 flex==6.10.0
-git+https://github.com/Kami/entrypoints.git@dont_use_backports#egg=entrypoints
 git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file

--- a/st2actions/tests/integration/test_python_action_process_wrapper.py
+++ b/st2actions/tests/integration/test_python_action_process_wrapper.py
@@ -41,7 +41,8 @@ __all__ = [
 ]
 
 # Maximum limit for the process wrapper script execution time (in seconds)
-WRAPPER_PROCESS_RUN_TIME_UPPER_LIMIT = 0.20
+# TODO: Revert back to 0.20 once all performance fixes are back in
+WRAPPER_PROCESS_RUN_TIME_UPPER_LIMIT = 0.60
 
 ASSERTION_ERROR_MESSAGE = ("""
 Python wrapper process script took more than %s seconds to execute (%s). This most likely means

--- a/st2actions/tests/integration/test_python_action_process_wrapper.py
+++ b/st2actions/tests/integration/test_python_action_process_wrapper.py
@@ -62,13 +62,16 @@ TIME_BINARY_AVAILABLE = TIME_BINARY_PATH is not None
 @unittest2.skipIf(not TIME_BINARY_PATH, 'time binary not available')
 class PythonRunnerActionWrapperProcessTestCase(unittest2.TestCase):
     def test_process_wrapper_exits_in_reasonable_timeframe(self):
-        # 1. First run it without time to verify path is valid
+        # 1. Verify wrapper script path is correct and file exists
+        self.assertTrue(os.path.isfile(WRAPPER_SCRIPT_PATH))
+
+        # 2. First run it without time to verify path is valid
         command_string = 'python %s --is-subprocess' % (WRAPPER_SCRIPT_PATH)
         _, _, stderr = run_command(command_string, shell=True)
         self.assertTrue('usage: python_action_wrapper.py' in stderr)
         self.assertTrue('python_action_wrapper.py: error: argument' in stderr)
 
-        # 2. Now time it
+        # 3. Now time it
         command_string = '%s -f "%%e" python %s --is-subprocess' % (TIME_BINARY_PATH,
                                                                     WRAPPER_SCRIPT_PATH)
         _, _, stderr = run_command(command_string, shell=True)

--- a/st2actions/tests/integration/test_python_action_process_wrapper.py
+++ b/st2actions/tests/integration/test_python_action_process_wrapper.py
@@ -54,7 +54,8 @@ re-organize code if possible.
 """.strip())
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-WRAPPER_SCRIPT_PATH = os.path.join(BASE_DIR, '../../../st2common/st2common/runners/python_action_wrapper.py')
+WRAPPER_SCRIPT_PATH = os.path.join(BASE_DIR,
+                                   '../../../st2common/st2common/runners/python_action_wrapper.py')
 WRAPPER_SCRIPT_PATH = os.path.abspath(WRAPPER_SCRIPT_PATH)
 TIME_BINARY_PATH = find_executable('time')
 TIME_BINARY_AVAILABLE = TIME_BINARY_PATH is not None

--- a/st2actions/tests/integration/test_python_action_process_wrapper.py
+++ b/st2actions/tests/integration/test_python_action_process_wrapper.py
@@ -53,7 +53,8 @@ re-organize code if possible.
 """.strip())
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-WRAPPER_SCRIPT_PATH = os.path.join(BASE_DIR, '../../st2common/runners/python_action_wrapper.py')
+WRAPPER_SCRIPT_PATH = os.path.join(BASE_DIR, '../../../st2common/st2common/runners/python_action_wrapper.py')
+WRAPPER_SCRIPT_PATH = os.path.abspath(WRAPPER_SCRIPT_PATH)
 TIME_BINARY_PATH = find_executable('time')
 TIME_BINARY_AVAILABLE = TIME_BINARY_PATH is not None
 
@@ -61,8 +62,16 @@ TIME_BINARY_AVAILABLE = TIME_BINARY_PATH is not None
 @unittest2.skipIf(not TIME_BINARY_PATH, 'time binary not available')
 class PythonRunnerActionWrapperProcessTestCase(unittest2.TestCase):
     def test_process_wrapper_exits_in_reasonable_timeframe(self):
-        _, _, stderr = run_command('%s -f "%%e" python %s --is-subprocess' %
-                                   (TIME_BINARY_PATH, WRAPPER_SCRIPT_PATH), shell=True)
+        # 1. First run it without time to verify path is valid
+        command_string = 'python %s --is-subprocess' % (WRAPPER_SCRIPT_PATH)
+        _, _, stderr = run_command(command_string, shell=True)
+        self.assertTrue('usage: python_action_wrapper.py' in stderr)
+        self.assertTrue('python_action_wrapper.py: error: argument' in stderr)
+
+        # 2. Now time it
+        command_string = '%s -f "%%e" python %s --is-subprocess' % (TIME_BINARY_PATH,
+                                                                    WRAPPER_SCRIPT_PATH)
+        _, _, stderr = run_command(command_string, shell=True)
 
         stderr = stderr.strip().split('\n')[-1]
 

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -23,8 +23,6 @@ tooz
 # to be installed manually
 zake
 ipaddr
-# Note: our fork of entrypoints contains a fix for backports mess
-git+https://github.com/Kami/entrypoints.git@dont_use_backports#egg=entrypoints
 routes
 flex
 webob

--- a/st2common/st2common/runners/base_action.py
+++ b/st2common/st2common/runners/base_action.py
@@ -19,6 +19,10 @@ import six
 
 from st2common.runners.utils import get_logger_for_python_runner_action
 
+__all__ = [
+    'Action'
+]
+
 
 @six.add_metaclass(abc.ABCMeta)
 class Action(object):

--- a/st2common/st2common/runners/utils.py
+++ b/st2common/st2common/runners/utils.py
@@ -13,17 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import eventlet
-
 import logging as stdlib_logging
 
 from oslo_config import cfg
 
 from st2common.constants.action import ACTION_OUTPUT_RESULT_DELIMITER
 from st2common import log as logging
-from st2common.runners import base as runners
-from st2common.util import action_db as action_db_utils
-from st2common.content import utils as content_utils
 
 
 __all__ = [
@@ -99,6 +94,10 @@ def make_read_and_store_stream_func(execution_db, action_db, store_data_func):
 
     This function writes read data into a buffer and stores it in a database.
     """
+    # NOTE: This import has intentionally been moved here to avoid massive performance overhead
+    # (1+ second) for other functions inside this module which don't need to use those imports.
+    import eventlet
+
     def read_and_store_stream(stream, buff):
         try:
             while not stream.closed:
@@ -125,6 +124,12 @@ def make_read_and_store_stream_func(execution_db, action_db, store_data_func):
 
 
 def invoke_post_run(liveaction_db, action_db=None):
+    # NOTE: This import has intentionally been moved here to avoid massive performance overhead
+    # (1+ second) for other functions inside this module which don't need to use those imports.
+    from st2common.runners import base as runners
+    from st2common.util import action_db as action_db_utils
+    from st2common.content import utils as content_utils
+
     LOG.info('Invoking post run for action execution %s.', liveaction_db.id)
 
     # Identify action and runner.

--- a/st2common/st2common/util/monkey_patch.py
+++ b/st2common/st2common/util/monkey_patch.py
@@ -23,7 +23,7 @@ import sys
 
 __all__ = [
     'monkey_patch',
-    'monkey_patch_pkg_resources'
+    'is_use_debugger_flag_provided'
 ]
 
 USE_DEBUGGER_FLAG = '--use-debugger'
@@ -42,15 +42,6 @@ def monkey_patch():
 
     patch_thread = not is_use_debugger_flag_provided()
     eventlet.monkey_patch(os=True, select=True, socket=True, thread=patch_thread, time=True)
-
-
-def monkey_patch_pkg_resources():
-    # Note: This is a work-around for a very slow "pkg_resources" import.
-    # pkg_resources is used by cryptography which is used by eventlet and importing pkg_resources
-    # adds ~500-600ms to the import time of any script which uses that code :/
-    # See https://github.com/pypa/setuptools/issues/510 for details
-    import entrypoints
-    sys.modules['pkg_resources'] = entrypoints
 
 
 def is_use_debugger_flag_provided():


### PR DESCRIPTION
In the past I spent quite a lot of time working on optimizing the run time of simple and short Python runner actions (there was a lot of overhead added by start up time, mostly by some very slow imports).

I managed to get it down to 0.2 seconds or so, but we recently moved some modules around and added some function definitions to some modules which introduced big performance overheads (run time is now back at ~2 seconds).

The reason for that was a broken test - the test which should ensure that we don't introduce performance regressions didn't work correctly because it didn't actually check that the script it tries to run exists (it broke when we moved wrapper script from `st2actions` to `st2common`).

As a first step, I of course fixed this test so things like that won't happen again - 69a63f55fca9c9636365b26016e83da5b119f7af.

I also managed to track down performance regressions we introduced and get run time down to around 0.5s - 9f7febad96a343cd032b9c651f78ff82d3e1630b. This is still not where we were originally, but with changes here and changes in #3803 (merged in time for v2.6), run time is down back to 0.2-0.3 seconds again.

Before:

```bash
(virtualenv)vagrant@vagrant-ubuntu-trusty-64:/data/stanley$ python /data/stanley/st2common/st2common/runners/python_action_wrapper.py --is-subprocess
usage: python_action_wrapper.py [-h] --pack PACK --file-path FILE_PATH
                                [--config CONFIG] [--parameters PARAMETERS]
                                [--user USER] [--parent-args PARENT_ARGS]
python_action_wrapper.py: error: argument --pack is required
(virtualenv)vagrant@vagrant-ubuntu-trusty-64:/data/stanley$ time python /data/stanley/st2common/st2common/runners/python_action_wrapper.py --is-subprocess
usage: python_action_wrapper.py [-h] --pack PACK --file-path FILE_PATH
                                [--config CONFIG] [--parameters PARAMETERS]
                                [--user USER] [--parent-args PARENT_ARGS]
python_action_wrapper.py: error: argument --pack is required

real	0m1.779s
user	0m0.371s
sys	0m0.691s
(virtualenv)vagrant@vagrant-ubuntu-trusty-64:/data/stanley$ python /data/stanley/st2common/st2common/runners/python_action_wrapper.py --is-subprocess
usage: python_action_wrapper.py [-h] --pack PACK --file-path FILE_PATH
                                [--config CONFIG] [--parameters PARAMETERS]
                                [--user USER] [--parent-args PARENT_ARGS]
python_action_wrapper.py: error: argument --pack is required
(virtualenv)vagrant@vagrant-ubuntu-trusty-64:/data/stanley$ time python /data/stanley/st2common/st2common/runners/python_action_wrapper.py --is-subprocess
usage: python_action_wrapper.py [-h] --pack PACK --file-path FILE_PATH
                                [--config CONFIG] [--parameters PARAMETERS]
                                [--user USER] [--parent-args PARENT_ARGS]
python_action_wrapper.py: error: argument --pack is required

real	0m1.779s
user	0m0.371s
sys	0m0.691s
```

After:

```bash
(virtualenv)vagrant@vagrant-ubuntu-trusty-64:/data/stanley$ time python /data/stanley/st2common/st2common/runners/python_action_wrapper.py --is-subprocess
usage: python_action_wrapper.py [-h] --pack PACK --file-path FILE_PATH
                                [--parameters PARAMETERS] [--user USER]
                                [--parent-args PARENT_ARGS]
python_action_wrapper.py: error: argument --pack is required

real	0m0.517s
user	0m0.070s
sys	0m0.225s
```

/cc @bigmstone @m4dcoder - just a heads up - some imports like eventlet, etc. can add a lot of overhead and that's why the imports were organized as they were before to avoid this overhead in python runner wrapper script