### PR TITLE
Upgrade various Python deps to the latest stable versions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,8 @@ Changed
   output of ``st2 execution list`` command). (improvement) #3810
 
   Contributed by Nick Maludy.
+* Update various Python dependencies to the latest stable versions (kombu, amqp, apscheduler,
+  gitpython, pymongo, stevedore, paramiko, prompt-toolkit, flex). #3830
 
 Fixed
 ~~~~~

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -5,29 +5,29 @@ greenlet==0.4.12
 # depend on rely
 eventlet==0.19.0
 gunicorn==19.7.1
-kombu==4.0.2
+kombu==4.1.0
 # Note: amqp is used by kombu
-amqp==2.2.1
+amqp==2.2.2
 oslo.config>=1.12.1,<1.13
 oslo.utils<=3.33.0,>=3.15.0
 six==1.10.0
 pyyaml>=3.12,<4.0
 requests[security]>=2.14.1,<2.15
-apscheduler==3.3.1
-gitpython==2.1.5
+apscheduler==3.4.0
+gitpython==2.1.7
 jsonschema==2.6.0
 # Note: mongoengine v0.13.0 introduces memory usage regression so we can't
 # upgrade - https://github.com/StackStorm/st2/pull/3597
 mongoengine==0.12.0
-pymongo==3.4.0
+pymongo==3.5.1
 passlib==1.7.1
 lockfile==0.12.2
 python-gnupg==0.4.1
 jsonpath-rw==1.4.0
 pyinotify==0.9.6
 semver==2.7.7
-stevedore==1.22.0
-paramiko==2.2.1
+stevedore==1.27.1
+paramiko==2.3.1
 networkx==1.11
 python-keyczar==0.716
 retrying==1.3.3
@@ -35,10 +35,10 @@ retrying==1.3.3
 virtualenv==15.1.0
 sseclient==0.0.18
 python-editor==1.0.3
-prompt-toolkit==1.0.14
+prompt-toolkit==1.0.15
 tooz==1.57.4
 zake==0.2.2
 routes==2.4.1
-flex==6.10.0
+flex==6.11.1
 webob==1.7.3
 prance==0.6.1


### PR DESCRIPTION
This pull request updates various Python libraries we use to latest stable versions which mostly include bug-fixes.

(Sadly we are still blocked on upgrading eventlet, mongoengine and requests due to some breaking API changes and performance issues)