### PR TITLE
Add a search operator to rules engine

### DIFF
--- a/st2common/st2common/operators.py
+++ b/st2common/st2common/operators.py
@@ -14,13 +14,18 @@
 # limitations under the License.
 
 import re
+import six
 import fnmatch
 
 from st2common.util import date as date_utils
+from st2common.constants.rules import TRIGGER_ITEM_PAYLOAD_PREFIX
+from st2common.util.payload import PayloadLookup
 
 __all__ = [
+    'SEARCH',
     'get_operator',
-    'get_allowed_operators'
+    'get_allowed_operators',
+    'UnrecognizedConditionError',
 ]
 
 
@@ -35,7 +40,101 @@ def get_operator(op):
     else:
         raise Exception('Invalid operator: ' + op)
 
+
+class UnrecognizedConditionError(Exception):
+    pass
+
+
 # Operation implementations
+
+
+def search(value, criteria_pattern, criteria_condition, check_function):
+    """
+    Search a list of values that match all child criteria. If condition is 'any', return a
+    successful match if any items match all child criteria. If condition is 'all', return a
+    successful match if ALL items match all child criteria.
+
+    value: the payload list to search
+    condition: one of:
+      * any - return true if any items of the list match and false if none of them match
+      * all - return true if all items of the list match and false if any of them do not match
+    pattern: a dictionary of criteria to apply to each item of the list
+
+    This operator has O(n) algorithmic complexity in terms of number of child patterns.
+    This operator has O(n) algorithmic complexity in terms of number of payload fields.
+
+    However, it has O(n_patterns * n_payloads) algorithmic complexity, where:
+      n_patterns = number of child patterns
+      n_payloads = number of fields in payload
+    It is therefore very easy to write a slow rule when using this operator.
+
+    This operator should ONLY be used when trying to match a small number of child patterns and/or
+    a small number of payload list elements.
+
+    Other conditions (such as 'count', 'count_gt', 'count_gte', etc.) can be added as needed.
+
+    Data from the trigger:
+
+    {
+        "fields": [
+            {
+                "field_name": "Status",
+                "to_value": "Approved"
+            }
+        ]
+    }
+
+    And an example usage in criteria:
+
+    ---
+    criteria:
+      trigger.fields:
+        type: search
+        # Controls whether this criteria has to match any or all items of the list
+        condition: any  # or all
+        pattern:
+          # Here our context is each item of the list
+          # All of these patterns have to match the item for the item to match
+          # These are simply other operators applied to each item in the list
+          item.field_name:
+            type: "equals"
+            pattern: "Status"
+
+          item.to_value:
+            type: "equals"
+            pattern: "Approved"
+    """
+    if criteria_condition == 'any':
+        # Any item of the list can match all patterns
+        rtn = any([
+            # Any payload item can match
+            all([
+                # Match all patterns
+                check_function(
+                    child_criterion_k, child_criterion_v,
+                    PayloadLookup(child_payload, prefix=TRIGGER_ITEM_PAYLOAD_PREFIX))
+                for child_criterion_k, child_criterion_v in six.iteritems(criteria_pattern)
+            ])
+            for child_payload in value
+        ])
+    elif criteria_condition == 'all':
+        # Every item of the list must match all patterns
+        rtn = all([
+            # All payload items must match
+            all([
+                # Match all patterns
+                check_function(
+                    child_criterion_k, child_criterion_v,
+                    PayloadLookup(child_payload, prefix=TRIGGER_ITEM_PAYLOAD_PREFIX))
+                for child_criterion_k, child_criterion_v in six.iteritems(criteria_pattern)
+            ])
+            for child_payload in value
+        ])
+    else:
+        raise UnrecognizedConditionError("The '%s' search condition is not recognized, only 'any' "
+                                         "and 'all' are allowed" % criteria_condition)
+
+    return rtn
 
 
 def equals(value, criteria_pattern):
@@ -231,6 +330,7 @@ INSIDE_LONG = 'inside'
 INSIDE_SHORT = 'in'
 NINSIDE_LONG = 'ninside'
 NINSIDE_SHORT = 'nin'
+SEARCH = 'search'
 
 # operator lookups
 operators = {
@@ -265,5 +365,6 @@ operators = {
     INSIDE_LONG: inside,
     INSIDE_SHORT: inside,
     NINSIDE_LONG: ninside,
-    NINSIDE_SHORT: ninside
+    NINSIDE_SHORT: ninside,
+    SEARCH: search,
 }

--- a/st2common/tests/unit/test_operators.py
+++ b/st2common/tests/unit/test_operators.py
@@ -546,7 +546,7 @@ class OperatorTest(unittest2.TestCase):
         op = operators.get_operator('matchwildcard')
         self.assertTrue(op('v1', 'v1'), 'Failed matchwildcard.')
 
-        self.assertFalse(op('test foo test', 'foo'), 'Failed matchwildcard.')
+        self.assertFalse(op('test foo test', 'foo'), 'Passed matchwildcard.')
         self.assertTrue(op('test foo test', '*foo*'), 'Failed matchwildcard.')
         self.assertTrue(op('bar', 'b*r'), 'Failed matchwildcard.')
         self.assertTrue(op('bar', 'b?r'), 'Failed matchwildcard.')
@@ -596,7 +596,7 @@ class OperatorTest(unittest2.TestCase):
         self.assertTrue(op(string, '(ponies|unicorns)'), 'Failed regex.')
 
         string = 'apple unicorns oranges'
-        self.assertFalse(op(string, '(pikachu|snorlax|charmander)'), 'Failed regex.')
+        self.assertFalse(op(string, '(pikachu|snorlax|charmander)'), 'Passed regex.')
 
     def test_regex_fail(self):
         op = operators.get_operator('regex')
@@ -651,7 +651,7 @@ class OperatorTest(unittest2.TestCase):
 
     def test_iequals_fail(self):
         op = operators.get_operator('iequals')
-        self.assertFalse(op('ABC', 'BCA'), 'Failed iequals.')
+        self.assertFalse(op('ABC', 'BCA'), 'Passed iequals.')
         self.assertFalse(op('1', None), 'Passed iequals with None as criteria_pattern.')
 
     def test_contains(self):

--- a/st2common/tests/unit/test_operators.py
+++ b/st2common/tests/unit/test_operators.py
@@ -811,3 +811,24 @@ class OperatorTest(unittest2.TestCase):
         self.assertFalse(op('a', None), 'Should return False')
         self.assertFalse(op('a', 'abc'), 'Should return False')
         self.assertTrue(op('a', 'bcd'), 'Should return True')
+
+
+class GetOperatorsTest(unittest2.TestCase):
+    def test_get_operator(self):
+        self.assertTrue(bool(operators.get_operator('equals')))
+        self.assertTrue(bool(operators.get_operator('EQUALS')))
+
+    def test_get_operator_returns_same_operator_with_different_cases(self):
+        equals = operators.get_operator('equals')
+        EQUALS = operators.get_operator('EQUALS')
+        Equals = operators.get_operator('Equals')
+        self.assertEqual(equals, EQUALS)
+        self.assertEqual(equals, Equals)
+
+    def test_get_operator_with_nonexistent_operator(self):
+        with self.assertRaises(Exception):
+            operators.get_operator('weird')
+
+    def test_get_allowed_operators(self):
+        # This test will need to change as operators are deprecated
+        self.assertGreater(len(operators.get_allowed_operators()), 0)

--- a/st2common/tests/unit/test_operators.py
+++ b/st2common/tests/unit/test_operators.py
@@ -551,6 +551,8 @@ class OperatorTest(unittest2.TestCase):
         self.assertTrue(op('bar', 'b*r'), 'Failed matchwildcard.')
         self.assertTrue(op('bar', 'b?r'), 'Failed matchwildcard.')
 
+        self.assertFalse(op('1', None), 'Passed matchwildcard with None as criteria_pattern.')
+
     def test_matchregex(self):
         op = operators.get_operator('matchregex')
         self.assertTrue(op('v1', 'v1$'), 'Failed matchregex.')
@@ -577,6 +579,7 @@ class OperatorTest(unittest2.TestCase):
     def test_iregex_fail(self):
         op = operators.get_operator('iregex')
         self.assertFalse(op('V1_foo', 'v1$'), 'Passed iregex.')
+        self.assertFalse(op('1', None), 'Passed iregex with None as criteria_pattern.')
 
     def test_regex(self):
         op = operators.get_operator('regex')
@@ -602,6 +605,8 @@ class OperatorTest(unittest2.TestCase):
         string = 'fooPONIESbarfooooo'
         self.assertFalse(op(string, 'ponies'), 'Passed regex.')
 
+        self.assertFalse(op('1', None), 'Passed regex with None as criteria_pattern.')
+
     def test_matchregex_case_variants(self):
         op = operators.get_operator('MATCHREGEX')
         self.assertTrue(op('v1', 'v1$'), 'Failed matchregex.')
@@ -611,6 +616,7 @@ class OperatorTest(unittest2.TestCase):
     def test_matchregex_fail(self):
         op = operators.get_operator('matchregex')
         self.assertFalse(op('v1_foo', 'v1$'), 'Passed matchregex.')
+        self.assertFalse(op('1', None), 'Passed matchregex with None as criteria_pattern.')
 
     def test_equals_numeric(self):
         op = operators.get_operator('equals')
@@ -624,6 +630,7 @@ class OperatorTest(unittest2.TestCase):
     def test_equals_fail(self):
         op = operators.get_operator('equals')
         self.assertFalse(op('1', '2'), 'Passed equals.')
+        self.assertFalse(op('1', None), 'Passed equals with None as criteria_pattern.')
 
     def test_nequals(self):
         op = operators.get_operator('nequals')
@@ -645,6 +652,7 @@ class OperatorTest(unittest2.TestCase):
     def test_iequals_fail(self):
         op = operators.get_operator('iequals')
         self.assertFalse(op('ABC', 'BCA'), 'Failed iequals.')
+        self.assertFalse(op('1', None), 'Passed iequals with None as criteria_pattern.')
 
     def test_contains(self):
         op = operators.get_operator('contains')
@@ -659,6 +667,7 @@ class OperatorTest(unittest2.TestCase):
         op = operators.get_operator('contains')
         self.assertFalse(op('hasystack needl haystack', 'needle'))
         self.assertFalse(op('needla', 'needle'))
+        self.assertFalse(op('1', None), 'Passed contains with None as criteria_pattern.')
 
     def test_icontains(self):
         op = operators.get_operator('icontains')
@@ -673,6 +682,7 @@ class OperatorTest(unittest2.TestCase):
         op = operators.get_operator('icontains')
         self.assertFalse(op('hasystack needl haystack', 'needle'))
         self.assertFalse(op('needla', 'needle'))
+        self.assertFalse(op('1', None), 'Passed icontains with None as criteria_pattern.')
 
     def test_ncontains(self):
         op = operators.get_operator('ncontains')
@@ -687,6 +697,7 @@ class OperatorTest(unittest2.TestCase):
         op = operators.get_operator('ncontains')
         self.assertFalse(op('hasystack needle haystack', 'needle'))
         self.assertFalse(op('needla', 'needla'))
+        self.assertFalse(op('1', None), 'Passed ncontains with None as criteria_pattern.')
 
     def test_incontains(self):
         op = operators.get_operator('incontains')
@@ -701,6 +712,7 @@ class OperatorTest(unittest2.TestCase):
         op = operators.get_operator('incontains')
         self.assertFalse(op('hasystack needle haystack', 'nEeDle'))
         self.assertFalse(op('needlA', 'needlA'))
+        self.assertFalse(op('1', None), 'Passed incontains with None as criteria_pattern.')
 
     def test_startswith(self):
         op = operators.get_operator('startswith')
@@ -711,6 +723,7 @@ class OperatorTest(unittest2.TestCase):
         op = operators.get_operator('startswith')
         self.assertFalse(op('hasystack needle haystack', 'needle'))
         self.assertFalse(op('a hasystack needle haystack', 'haystack'))
+        self.assertFalse(op('1', None), 'Passed startswith with None as criteria_pattern.')
 
     def test_istartswith(self):
         op = operators.get_operator('istartswith')
@@ -721,6 +734,7 @@ class OperatorTest(unittest2.TestCase):
         op = operators.get_operator('istartswith')
         self.assertFalse(op('hasystack needle haystack', 'NEEDLE'))
         self.assertFalse(op('a hasystack needle haystack', 'haystack'))
+        self.assertFalse(op('1', None), 'Passed istartswith with None as criteria_pattern.')
 
     def test_endswith(self):
         op = operators.get_operator('endswith')
@@ -731,6 +745,7 @@ class OperatorTest(unittest2.TestCase):
         op = operators.get_operator('endswith')
         self.assertFalse(op('hasystack needle haystackend', 'haystack'))
         self.assertFalse(op('a hasystack needle haystack', 'a'))
+        self.assertFalse(op('1', None), 'Passed endswith with None as criteria_pattern.')
 
     def test_iendswith(self):
         op = operators.get_operator('iendswith')
@@ -741,6 +756,7 @@ class OperatorTest(unittest2.TestCase):
         op = operators.get_operator('iendswith')
         self.assertFalse(op('hasystack needle haystack', 'NEEDLE'))
         self.assertFalse(op('a hasystack needle haystack', 'a '))
+        self.assertFalse(op('1', None), 'Passed iendswith with None as criteria_pattern.')
 
     def test_lt(self):
         op = operators.get_operator('lessthan')
@@ -753,6 +769,7 @@ class OperatorTest(unittest2.TestCase):
     def test_lt_fail(self):
         op = operators.get_operator('lessthan')
         self.assertFalse(op(1, 1), 'Passed lessthan.')
+        self.assertFalse(op('1', None), 'Passed lessthan with None as criteria_pattern.')
 
     def test_gt(self):
         op = operators.get_operator('greaterthan')
@@ -765,6 +782,7 @@ class OperatorTest(unittest2.TestCase):
     def test_gt_fail(self):
         op = operators.get_operator('greaterthan')
         self.assertFalse(op(2, 3), 'Passed greaterthan.')
+        self.assertFalse(op('1', None), 'Passed greaterthan with None as criteria_pattern.')
 
     def test_timediff_lt(self):
         op = operators.get_operator('timediff_lt')
@@ -775,6 +793,8 @@ class OperatorTest(unittest2.TestCase):
         op = operators.get_operator('timediff_lt')
         self.assertFalse(op('2014-07-01T00:01:01.000000', 10),
                          'Passed test_timediff_lt.')
+        self.assertFalse(op('2014-07-01T00:01:01.000000', None),
+                         'Passed test_timediff_lt with None as criteria_pattern.')
 
     def test_timediff_gt(self):
         op = operators.get_operator('timediff_gt')
@@ -785,6 +805,8 @@ class OperatorTest(unittest2.TestCase):
         op = operators.get_operator('timediff_gt')
         self.assertFalse(op(date_utils.get_datetime_utc_now().isoformat(), 10),
                          'Passed test_timediff_gt.')
+        self.assertFalse(op('2014-07-01T00:01:01.000000', None),
+                         'Passed test_timediff_gt with None as criteria_pattern.')
 
     def test_exists(self):
         op = operators.get_operator('exists')

--- a/st2common/tests/unit/test_util_payload.py
+++ b/st2common/tests/unit/test_util_payload.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest2
+
+from st2common.util.payload import PayloadLookup
+
+__all__ = [
+    'PayloadLookupTestCase'
+]
+
+
+class PayloadLookupTestCase(unittest2.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.payload = PayloadLookup({
+            'pikachu': "Has no ears",
+            'charmander': "Plays with fire",
+        })
+        super(PayloadLookupTestCase, cls).setUpClass()
+
+    def test_get_key(self):
+        self.assertEqual(self.payload.get_value('trigger.pikachu'), ["Has no ears"])
+        self.assertEqual(self.payload.get_value('trigger.charmander'), ["Plays with fire"])
+
+    def test_explicitly_get_multiple_keys(self):
+        self.assertEqual(self.payload.get_value('trigger.pikachu[*]'), ["Has no ears"])
+        self.assertEqual(self.payload.get_value('trigger.charmander[*]'), ["Plays with fire"])
+
+    def test_get_nonexistent_key(self):
+        self.assertIsNone(self.payload.get_value('trigger.squirtle'))

--- a/st2reactor/st2reactor/rules/filter.py
+++ b/st2reactor/st2reactor/rules/filter.py
@@ -16,13 +16,12 @@
 import six
 import json
 import re
-from jsonpath_rw import parse
 
 from st2common import log as logging
 import st2common.operators as criteria_operators
-from st2common.constants.rules import TRIGGER_PAYLOAD_PREFIX, RULE_TYPE_BACKSTOP, MATCH_CRITERIA
-from st2common.constants.keyvalue import SYSTEM_SCOPES
-from st2common.services.keyvalues import KeyValueLookup
+from st2common.constants.rules import RULE_TYPE_BACKSTOP, MATCH_CRITERIA
+
+from st2common.util.payload import PayloadLookup
 from st2common.util.templating import render_template_with_system_context
 
 
@@ -78,8 +77,7 @@ class RuleFilter(object):
         LOG.debug('Trigger payload: %s', self.trigger_instance.payload,
                   extra=self._base_logger_context)
 
-        for criterion_k in criteria.keys():
-            criterion_v = criteria[criterion_k]
+        for (criterion_k, criterion_v) in six.iteritems(criteria):
             is_rule_applicable, payload_value, criterion_pattern = self._check_criterion(
                 criterion_k,
                 criterion_v,
@@ -110,6 +108,7 @@ class RuleFilter(object):
             return (False, None, None)
 
         criteria_operator = criterion_v['type']
+        criteria_condition = criterion_v.get('condition', None)
         criteria_pattern = criterion_v.get('pattern', None)
 
         # Render the pattern (it can contain a jinja expressions)
@@ -138,13 +137,23 @@ class RuleFilter(object):
         op_func = criteria_operators.get_operator(criteria_operator)
 
         try:
-            result = op_func(value=payload_value, criteria_pattern=criteria_pattern)
+            if criteria_operator == criteria_operators.SEARCH:
+                result = op_func(value=payload_value, criteria_pattern=criteria_pattern,
+                                 criteria_condition=criteria_condition,
+                                 check_function=self._bool_criterion)
+            else:
+                result = op_func(value=payload_value, criteria_pattern=criteria_pattern)
         except:
             LOG.exception('There might be a problem with the criteria in rule %s.', self.rule,
                           extra=self._base_logger_context)
             return (False, None, None)
 
         return result, payload_value, criteria_pattern
+
+    def _bool_criterion(self, criterion_k, criterion_v, payload_lookup):
+        # Pass through to _check_criterion, but pull off and return only the
+        # final result
+        return self._check_criterion(criterion_k, criterion_v, payload_lookup)[0]
 
     def _render_criteria_pattern(self, criteria_pattern, criteria_context):
         # Note: Here we want to use strict comparison to None to make sure that
@@ -228,21 +237,3 @@ class SecondPassRuleFilter(RuleFilter):
 
     def _is_backstop_rule(self):
         return self.rule.type['ref'] == RULE_TYPE_BACKSTOP
-
-
-class PayloadLookup(object):
-
-    def __init__(self, payload):
-        self.context = {
-            TRIGGER_PAYLOAD_PREFIX: payload
-        }
-
-        for system_scope in SYSTEM_SCOPES:
-            self.context[system_scope] = KeyValueLookup(scope=system_scope)
-
-    def get_value(self, lookup_key):
-        expr = parse(lookup_key)
-        matches = [match.value for match in expr.find(self.context)]
-        if not matches:
-            return None
-        return matches

--- a/st2reactor/tests/unit/test_filter.py
+++ b/st2reactor/tests/unit/test_filter.py
@@ -37,7 +37,16 @@ MOCK_TRIGGER_INSTANCE = TriggerInstanceDB(
         'bool': True,
         'int': 1,
         'float': 0.8,
-        'list': ['v1', True, 1]
+        'list': ['v1', True, 1],
+        'recursive_list': [
+            {
+                'field_name': "Status",
+                'to_value': "Approved",
+            }, {
+                'field_name': "Signed off by",
+                'to_value': "Stanley",
+            }
+        ],
     }
 )
 
@@ -76,6 +85,86 @@ class FilterTest(DbTestCase):
         trigger_instance.payload = None
         f = RuleFilter(trigger_instance, MOCK_TRIGGER, rule)
         self.assertTrue(f.filter(), 'equals check should have failed.')
+
+    def test_search_operator_pass_any_criteria(self):
+        rule = MOCK_RULE_1
+        rule.criteria = {
+            'trigger.recursive_list': {
+                'type': 'search',
+                'condition': 'any',
+                'pattern': {
+                    'item.field_name': {
+                        'type': 'equals',
+                        'pattern': 'Status',
+                    },
+                    'item.to_value': {
+                        'type': 'equals',
+                        'pattern': 'Approved'
+                    }
+                }
+            }
+        }
+        f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
+        self.assertTrue(f.filter(), 'Failed evaluation')
+
+    def test_search_operator_fail_any_criteria(self):
+        rule = MOCK_RULE_1
+        rule.criteria = {
+            'trigger.recursive_list': {
+                'type': 'search',
+                'condition': 'any',
+                'pattern': {
+                    'item.field_name': {
+                        'type': 'equals',
+                        'pattern': 'Status',
+                    },
+                    'item.to_value': {
+                        'type': 'equals',
+                        'pattern': 'Denied',
+                    }
+                }
+            }
+        }
+        f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
+        self.assertFalse(f.filter(), 'Passed evaluation')
+
+    def test_search_operator_pass_all_criteria(self):
+        rule = MOCK_RULE_1
+        rule.criteria = {
+            'trigger.recursive_list': {
+                'type': 'search',
+                'condition': 'all',
+                'pattern': {
+                    'item.field_name': {
+                        'type': 'startswith',
+                        'pattern': 'S',
+                    }
+                }
+            }
+        }
+        f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
+        self.assertTrue(f.filter(), 'Failed evaluation')
+
+    def test_search_operator_fail_all_criteria(self):
+        rule = MOCK_RULE_1
+        rule.criteria = {
+            'trigger.recursive_list': {
+                'type': 'search',
+                'condition': 'all',
+                'pattern': {
+                    'item.field_name': {
+                        'type': 'equals',
+                        'pattern': 'Status',
+                    },
+                    'item.to_value': {
+                        'type': 'equals',
+                        'pattern': 'Denied',
+                    }
+                }
+            }
+        }
+        f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
+        self.assertFalse(f.filter(), 'Passed evaluation')
 
     def test_matchregex_operator_pass_criteria(self):
         rule = MOCK_RULE_1


### PR DESCRIPTION
# Overview #

This PR adds a `search` operator to StackStorm's rules engine that searches through arrays and compares each element of the array to the child patterns of this operator. It takes a non-optional `condition` parameter that controls how individual items affect the overall match.

# Examples #

Many things are best explained via examples, so here's a few example usages for you:

## Example Rule 1 ##
#### At least one field should be a "Status" field with a new "Approved" status ####

```yaml
---
criteria:
  trigger.fields:
    type: search
    # Controls whether this criteria has to match any or all items of the list
    condition: any  # or all
    pattern:
      # Here our context is each item of the list
      # All of these patterns have to patch the item for the item to match
      # These are simply other operators applied to each item in the list
      item.field_name:
        type: "equals"
        pattern: "Status"
      item.to_value:
        type: "equals"
        pattern: "Approved"
```

This example criteria would search through a trigger's `fields` array for a dictionary:

```json
{
  "field_name": "Status",
  "to_value": "Approved"
}
```

Because the `search` condition was specified as `any`, the following payload would match:

```json
{
  "fields": [
    {
      "field_type": "Built-in",
      "field_name": "Status",
      "to_value": "Approved"
    }, {
      "field_type": "Custom",
      "field_name": "Signed off by",
      "to_value": "Stanley"
    }
  ]
}
```

If the `search` condition was specified as `all`, the above payload would not match.

## Example Rule 2 ##

#### All fields should be custom fields ####

```yaml
---
criteria:
  trigger.fields:
    type: search
    condition: all
    pattern:
      item.field_type:
        type: "equals"
        pattern: "Custom"
```

This example criteria would search through a trigger's `fields` array for a dictionary:

```json
{
  "field_type:" "Custom"
}
```

Because the `search` condition was specified as `all`, the following payload would match:

```json
{
  "fields": [
    {
      "field_type": "Custom",
      "field_name": "Status",
      "to_value": "Approved"
    }, {
      "field_type": "Custom",
      "field_name": "Signed off by",
      "to_value": "Stanley"
    }
  ]
}
```

But the original payload would not match:

```json
{
  "fields": [
    {
      "field_type": "Custom",
      "field_name": "Status",
      "to_value": "Approved"
    }, {
      "field_type": "Built-in",  // <-- must be Custom for search operator to match
      "field_name": "Signed off by",
      "to_value": "Stanley"
    }
  ]
}
```

# Extensibility #

The `search` condition is extensible if users need more conditions in the future:

* `count_gt` - Count of matched fields should be greater than...
* `count_gte` - Count of matched fields should be greater than or equal to...
* `count_lt` - Count of matched fields should be less than...
* `count_lte` - Count of matched fields should be less than or equal to...

However, we only need the `any` condition at this point, so we only implemented (and documented) the `any` and `all` conditions.

# Additional Considerations #

I needed to use the `PayloadLookup` class from `st2common.operators`, so I broke that out into its own module in `st2common.utils.payload` and imported it in `st2reactor.rules.filter` to keep reverse compatibility.

Note that this makes the rules engine a little bit more complex (it actually turns the rules engine into a recursive descent parser), and naive users could certainly create a rule that takes awhile to process. However, this negligible overhead (an additional `if` statement) to the rules engine unless it is used, and we think this potential complexity is worth "powering up" the rules engine.

# Tests #

Unit tests for the search operator itself, and for the additional logic in the `RuleFilter.filter` function are included - 100% coverage of all new code. I will need some guidance if you would like additional testing.

5dcd25c6c43e247f9a7bbdc1143091e705a73117 I have added unit tests for the `PayloadLookup` class as well since I broke it out into its own module.

The setup for the tests for the `search` operator are quite long and are separated into their own test case. I considered breaking them out into their own module, but I figured it was best to keep all of the operator tests in the same module.

#### Coverage ####

I tried to boost test coverage (including branch conditions) for any modules I modified. Here's an excerpt from my test coverage report:

```
Name                                              Stmts   Miss Branch BrPart  Cover
-----------------------------------------------------------------------------------
...
st2common/operators.py                              150      0     46      0   100%
...
st2common/util/payload.py                            15      0      4      0   100%
...
st2reactor/rules/filter.py                           98     18     30      3    80%
```

As you can see, I hit 100% for two of the three modules, and according to the detailed report, it seems that all of my additional code was tested.

Please note that this is only coverage from three different tests:

* `st2common/tests/unit/test_operators.py`
* `st2common/tests/unit/test_util_payload.py`
* `st2reactor/tests/unit/test_filter.py`

#### Additionally ####

* 37045ab12defe981f020c603637c9380eecb01f0 I sprinkled in a few small corrections to test failure messages
* 10035dd0af397895a9d13774e7864dfe24e6ab59 I added tests for the `get_operator` and `get_allowed_operators` functions from `st2common.operators`
* cb39323c8e1d50a1759c9f8ae16e7749e1dcd005 I added tests for all applicable operators where `criteria_pattern` is `None`

# Documentation #

The search operator function itself has an extensive docstring, complete with example usage.

I have not yet had time to write any patches for the StackStorm documentation, but I absolutely will do so once this PR is merged.

# Motivation #

We have a single webhook from an internal system that is more difficult to scale (we can have it dispatch multiple webhooks but it has to do a **lot** of filtering to decide which webhooks to dispatch). This new operator will allow us to search through a changelog in the webhook data for changed fields and do the filtering on the StackStorm side of things.

We could implement this via a workflow, but then we would need the workflow to dispatch an additional webhook back to our StackStorm instance, and there's a possibility that a poorly coded workflow could create an endless dispatch loop, or create a great deal of load on our StackStorm system. Implementing searching an array with arbitrary patterns is the cleanest approach to this problem.

This allows us to use the rules engine to filter the webhook data, which is a lot more lightweight than running an entire workflow. By reducing the number of webhooks from our internal system down to one and implementing this operator in StackStorm's rules engine, we are able to minimize the load on either system.

Finally, while StackStorm already has operators that work on arrays (the `contains` and `ncontains` operators), they are not flexible or extensible enough for our use case. StackStorm neatly sidesteps needing to iterate through dictionaries with the JSON-path notation, but without this operator, it simply does not support arrays to the level that we require.

# Final Notes #

I am hoping that this PR will be merged before the next point release (either 2.5.1 or 2.6), hopefully in the next few weeks. I am more than happy to work with you towards that goal. Please let me know if there's anything you need from me.