### PR TITLE
[v2.5] Correctly scope token generated by DatastoreService to the user which ran the action

### DIFF
--- a/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
+++ b/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
@@ -568,6 +568,24 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
                        'No module named invalid')
         self.assertRaisesRegexp(Exception, expected_msg, wrapper._get_action_instance)
 
+    def test_action_service_datastore_service_uses_correct_api_username(self):
+        # Verify the fix for regression described at
+        # https://github.com/StackStorm/st2/issues/3823#issuecomment-342756557
+
+        # Verify correct
+        wrapper = PythonActionWrapper(pack='dummy_pack_5', file_path=PASCAL_ROW_ACTION_PATH,
+                                      user='joe1')
+        action_instance = wrapper._get_action_instance()
+        self.assertEqual(action_instance.action_service.datastore_service._api_username, 'joe1')
+
+        wrapper = PythonActionWrapper(pack='dummy_pack_5', file_path=PASCAL_ROW_ACTION_PATH,
+                                      user='joe2')
+        action_instance = wrapper._get_action_instance()
+
+        wrapper = PythonActionWrapper(pack='dummy_pack_5', file_path=PASCAL_ROW_ACTION_PATH,
+                                      user='joe3')
+        action_instance = wrapper._get_action_instance()
+
     def _get_mock_runner_obj(self):
         runner = python_runner.get_runner()
         runner.execution = MOCK_EXECUTION

--- a/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
+++ b/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
@@ -581,10 +581,12 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         wrapper = PythonActionWrapper(pack='dummy_pack_5', file_path=PASCAL_ROW_ACTION_PATH,
                                       user='joe2')
         action_instance = wrapper._get_action_instance()
+        self.assertEqual(action_instance.action_service.datastore_service._api_username, 'joe2')
 
         wrapper = PythonActionWrapper(pack='dummy_pack_5', file_path=PASCAL_ROW_ACTION_PATH,
                                       user='joe3')
         action_instance = wrapper._get_action_instance()
+        self.assertEqual(action_instance.action_service.datastore_service._api_username, 'joe3')
 
     def _get_mock_runner_obj(self):
         runner = python_runner.get_runner()

--- a/st2common/st2common/runners/python_action_wrapper.py
+++ b/st2common/st2common/runners/python_action_wrapper.py
@@ -83,10 +83,11 @@ class ActionService(object):
         if not self._datastore_service:
             action_name = self._action_wrapper._class_name
             logger = get_logger_for_python_runner_action(action_name=action_name)
+            api_username = self._action_wrapper._user
             self._datastore_service = DatastoreService(logger=logger,
                                                        pack_name=self._action_wrapper._pack,
                                                        class_name=self._action_wrapper._class_name,
-                                                       api_username='action_service')
+                                                       api_username=api_username)
         return self._datastore_service
 
     ##################################


### PR DESCRIPTION
This pull request fixes a bug reported in #3823.

The code incorrectly scoped the auth token which is available inside action service to Python runner actions to `action_service` user instead of to the user which ran the action.

This regression has been there for a quite a while since datastore service was refactored so it can also be used by sensors.

This change is only meant for v2.5.1 in case we decide to release it. It has been supersede by https://github.com/StackStorm/st2/pull/3803 for master / 2.6.0.

#3803 has a proper fix which is to use a temporary auth token which is generated by the action runner container for the duration of the action life-time and is correctly scoped to the user who ran the action (or stanley for actions kicked by the rules, etc.). That is in fact what we already did in the past at some point, but it got overwritten with some other changes in the past.

The temporary auth token has been designed especially for that purpose and has many benefits. One of the benefits is that this token is only active / valid for the duration of the action life-time. The token which is / was generated inside DatastoreService is valid until it expires (by default TTL is 24 hours) which is obviously not great.

## TODO

- [ ] Changelog entry