### PR TITLE
Runner container temporary auth token scoping test case

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Added
 * Add stevedore related metadata to Python package setup.py files for runner packages. This way
   runners can be installed using pip and dynamically enumerated and loaded using stevedore and
   corresponding helper functions. (new feature)
+* Add new ``search`` rule criteria comparison operator. For the usage, please refer to the
+  documentation. (new feature) #3833
+
+  Contributed by @ahubl-mz.
 
 Changed
 ~~~~~~~


### PR DESCRIPTION
Just a small test case for bug described in https://github.com/StackStorm/st2/issues/3823#issuecomment-342756557.

We should also look into adding a proper "end to end" st2tests test for this, but it will be quite a bit more involved.