### PR TITLE
Change log level for datastore messages from audit to debug (master)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,8 @@ Changed
   Contributed by Nick Maludy.
 * Update various Python dependencies to the latest stable versions (kombu, amqp, apscheduler,
   gitpython, pymongo, stevedore, paramiko, prompt-toolkit, flex). #3830
+* Update log messages in the datastore service to correctly use ``DEBUG`` log level instead of
+  ``AUDIT``. #3845
 
 Fixed
 ~~~~~

--- a/st2common/st2common/services/datastore.py
+++ b/st2common/st2common/services/datastore.py
@@ -66,7 +66,7 @@ class BaseDatastoreService(object):
         :rtype: ``list`` of :class:`KeyValuePair`
         """
         client = self._get_api_client()
-        self._logger.audit('Retrieving all the value from the datastore')
+        self._logger.debug('Retrieving all the value from the datastore')
 
         key_prefix = self._get_full_key_prefix(local=local, prefix=prefix)
         kvps = client.keys.get_all(prefix=key_prefix)
@@ -99,7 +99,7 @@ class BaseDatastoreService(object):
         name = self._get_full_key_name(name=name, local=local)
 
         client = self._get_api_client()
-        self._logger.audit('Retrieving value from the datastore (name=%s)', name)
+        self._logger.debug('Retrieving value from the datastore (name=%s)', name)
 
         try:
             params = {'decrypt': str(decrypt).lower(), 'scope': scope}
@@ -153,7 +153,7 @@ class BaseDatastoreService(object):
         value = str(value)
         client = self._get_api_client()
 
-        self._logger.audit('Setting value in the datastore (name=%s)', name)
+        self._logger.debug('Setting value in the datastore (name=%s)', name)
 
         instance = KeyValuePair()
         instance.id = name
@@ -199,7 +199,7 @@ class BaseDatastoreService(object):
         instance.id = name
         instance.name = name
 
-        self._logger.audit('Deleting value from the datastore (name=%s)', name)
+        self._logger.debug('Deleting value from the datastore (name=%s)', name)
 
         try:
             params = {'scope': scope}


### PR DESCRIPTION
Change from #3845 for master (2.6dev).