### PR TITLE
[WIP] Make elapsed time based off of "running" start timestamp

### DIFF
--- a/st2actions/st2actions/worker.py
+++ b/st2actions/st2actions/worker.py
@@ -30,6 +30,7 @@ from st2common.transport.consumers import MessageHandler
 from st2common.transport.consumers import ActionsQueueConsumer
 from st2common.transport import utils as transport_utils
 from st2common.util import action_db as action_utils
+from st2common.util import date as date_utils
 from st2common.util import system_info
 from st2common.transport import queues
 
@@ -139,6 +140,7 @@ class ActionExecutionDispatcher(MessageHandler):
         # Update liveaction status to "running"
         liveaction_db = action_utils.update_liveaction_status(
             status=action_constants.LIVEACTION_STATUS_RUNNING,
+            running_start_timestamp=date_utils.get_datetime_utc_now,
             runner_info=runner_info,
             liveaction_id=liveaction_db.id)
 

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -155,9 +155,15 @@ def format_execution_status(instance):
     """
     start_timestamp = getattr(instance, 'start_timestamp', None)
     end_timestamp = getattr(instance, 'end_timestamp', None)
+    running_start_timestamp = getattr(instance, 'running_start_timestamp', None)
 
     if instance.status == LIVEACTION_STATUS_RUNNING and start_timestamp:
         start_timestamp = instance.start_timestamp
+
+        # Override with running start timestamp if available
+        if running_start_timestamp:
+            start_timestamp = running_start_timestamp
+
         start_timestamp = parse_isotime(start_timestamp)
         start_timestamp = calendar.timegm(start_timestamp.timetuple())
         now = int(time.time())

--- a/st2common/st2common/models/db/execution.py
+++ b/st2common/st2common/models/db/execution.py
@@ -53,6 +53,9 @@ class ActionExecutionDB(stormbase.StormFoundationDB):
     start_timestamp = ComplexDateTimeField(
         default=date_utils.get_datetime_utc_now,
         help_text='The timestamp when the liveaction was created.')
+    running_start_timestamp = ComplexDateTimeField(
+        default=date_utils.get_datetime_utc_now,
+        help_text='The timestamp when the liveaction entered "running" state.')
     end_timestamp = ComplexDateTimeField(
         help_text='The timestamp when the liveaction has finished.')
     parameters = stormbase.EscapedDynamicField(


### PR DESCRIPTION
Executions that are delayed for any reason, such as by policy, have an unintuitive elapsed time counter, since the start_timestamp is based off of the initial scheduled time, not when the execution actually started running. So if I simultaneously run 4 identical executions, and because of policy, they run in sequence, each elapsed time will seemingly build off of the previous one.

I'm playing around with different options here, to try to make this a little better.