### PR TITLE
CI fix for permission issue when installing package_cloud

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -241,7 +241,7 @@ jobs:
           command: |
             set -x
             sudo apt-get -y install parallel jq
-            gem install package_cloud
+            sudo gem install package_cloud
             sudo wget -O /usr/local/bin/packagecloud.sh https://raw.githubusercontent.com/StackStorm/st2-packages/master/.circle/packagecloud.sh && sudo chmod +x /usr/local/bin/packagecloud.sh
       - run:
           name: Deploy deb/rpm packages to PackageCloud


### PR DESCRIPTION
Error in CI https://circleci.com/gh/StackStorm/st2/6203:  
```
+ gem install package_cloud
Fetching: thor-0.20.0.gem (100%)
ERROR:  While executing gem ... (Errno::EACCES)
    Permission denied @ rb_sysopen - /usr/local/bundle/cache/thor-0.20.0.gem
Exited with code 1
```
probably due to some upstream changes: `package_cloud` gem updated or CircleCI Docker image env updated.

Adding `sudo` worked well:
```
circleci@42640597e0bd:~$ sudo gem install package_cloud
Fetching: thor-0.20.0.gem (100%)
Successfully installed thor-0.20.0
Fetching: highline-1.6.20.gem (100%)
Successfully installed highline-1.6.20
Fetching: unf_ext-0.0.7.4.gem (100%)
Building native extensions. This could take a while...
Successfully installed unf_ext-0.0.7.4
Fetching: unf-0.1.4.gem (100%)
Successfully installed unf-0.1.4
Fetching: domain_name-0.5.20170404.gem (100%)
Successfully installed domain_name-0.5.20170404
Fetching: http-cookie-1.0.3.gem (100%)
Successfully installed http-cookie-1.0.3
Fetching: mime-types-data-3.2016.0521.gem (100%)
Successfully installed mime-types-data-3.2016.0521
Fetching: mime-types-3.1.gem (100%)
Successfully installed mime-types-3.1
Fetching: netrc-0.11.0.gem (100%)
Successfully installed netrc-0.11.0
Fetching: rest-client-2.0.2.gem (100%)
Successfully installed rest-client-2.0.2
Fetching: json_pure-1.8.1.gem (100%)
Successfully installed json_pure-1.8.1
Fetching: rainbow-2.2.2.gem (100%)
Building native extensions. This could take a while...
Successfully installed rainbow-2.2.2
Fetching: package_cloud-0.3.00.gem (100%)
Successfully installed package_cloud-0.3.00
13 gems installed
```

