### PR TITLE
Fix a regression with API endpoint not returning 400 and performing no validation in some scenarios

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -72,7 +72,7 @@ Fixed
   #3843. Contributed by @shkadov
 * Fix a regression and a bug with no API validation being performed and API returning 500 instead
   of 400 status code if user didn't include any request payload (body) when hitting POST and PUT
-  API endpoints where body is mandatory. (bug fix)
+  API endpoints where body is mandatory. (bug fix) #3864
 
 2.5.0 - October 25, 2017
 ------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -70,6 +70,9 @@ Fixed
   executions in the database. (bug fix) #3760 #3802
 * Fix 'NameError: name 'cmd' is not defined' error when using ``linux.service`` with CentOS systems.
   #3843. Contributed by @shkadov
+* Fix a regression and a bug with no API validation being performed and API returning 500 instead
+  of 400 status code if user didn't include any request payload (body) when hitting POST and PUT
+  API endpoints where body is mandatory. (bug fix)
 
 2.5.0 - October 25, 2017
 ------------------------

--- a/st2api/st2api/controllers/v1/rules.py
+++ b/st2api/st2api/controllers/v1/rules.py
@@ -138,13 +138,16 @@ class RuleController(resource.ContentPackResourceController):
         LOG.debug('PUT /rules/ lookup with id=%s found object: %s', rule_ref_or_id, rule_db)
 
         try:
-            rule_id = getattr(rule, 'id', None)
-
-            if rule_id is not None and rule_id is not '' and rule_id != rule_ref_or_id:
+            if rule.id is not None and rule.id is not '' and rule.id != rule_ref_or_id:
                 LOG.warning('Discarding mismatched id=%s found in payload and using uri_id=%s.',
                             rule.id, rule_ref_or_id)
             old_rule_db = rule_db
-            rule_db = RuleAPI.to_model(rule)
+
+            try:
+                rule_db = RuleAPI.to_model(rule)
+            except TriggerDoesNotExistException as e:
+                abort(http_client.BAD_REQUEST, str(e))
+                return
 
             # Check referenced trigger and action permissions
             # Note: This needs to happen after "to_model" call since to_model performs some

--- a/st2api/st2api/controllers/v1/rules.py
+++ b/st2api/st2api/controllers/v1/rules.py
@@ -138,7 +138,9 @@ class RuleController(resource.ContentPackResourceController):
         LOG.debug('PUT /rules/ lookup with id=%s found object: %s', rule_ref_or_id, rule_db)
 
         try:
-            if rule.id is not None and rule.id is not '' and rule.id != rule_ref_or_id:
+            rule_id = getattr(rule, 'id', None)
+
+            if rule_id is not None and rule_id is not '' and rule_id != rule_ref_or_id:
                 LOG.warning('Discarding mismatched id=%s found in payload and using uri_id=%s.',
                             rule.id, rule_ref_or_id)
             old_rule_db = rule_db

--- a/st2api/tests/unit/controllers/v1/test_policies_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_policies_rbac.py
@@ -427,11 +427,9 @@ class PolicyControllerRBACTestCase(APIControllerWithRBACTestCase):
         user_db = self.users['no_permissions']
         self.use_user(user_db)
 
-        policy_uid = self.models['policies']['policy_1.yaml'].get_uid()
         data = self.POLICY_1
         resp = self.app.post_json('/v1/policies', data, expect_errors=True)
-        expected_msg = ('User "no_permissions" doesn\'t have required permission "policy_create" '
-                        'on resource "%s"' % (policy_uid))
+        expected_msg = ('User "no_permissions" doesn\'t have required permission "policy_create"')
         self.assertEqual(resp.status_code, httplib.FORBIDDEN)
         self.assertEqual(resp.json['faultstring'], expected_msg)
 

--- a/st2api/tests/unit/controllers/v1/test_rules.py
+++ b/st2api/tests/unit/controllers/v1/test_rules.py
@@ -364,6 +364,29 @@ class TestRuleController(FunctionalTest):
                          'rule_type should be backstop')
         self.__do_delete(rule_id)
 
+    def test_update_rule_no_data(self):
+        post_resp = self.__do_post(self.RULE_1)
+        rule_1_id = self.__get_rule_id(post_resp)
+
+        put_resp = self.__do_put(rule_1_id, {})
+        expected_msg = "'name' is a required property"
+        self.assertEqual(put_resp.status_code, http_client.BAD_REQUEST)
+        self.assertEqual(put_resp.json['faultstring'], expected_msg)
+
+        self.__do_delete(rule_1_id)
+
+    def test_update_rule_missing_id_in_body(self):
+        post_resp = self.__do_post(self.RULE_1)
+        rule_1_id = self.__get_rule_id(post_resp)
+
+        rule_without_id = copy.deepcopy(self.RULE_1)
+        rule_without_id.pop('id', None)
+        put_resp = self.__do_put(rule_1_id, rule_without_id)
+        self.assertEqual(put_resp.status_int, http_client.OK)
+        self.assertEqual(put_resp.json['id'], rule_1_id)
+
+        self.__do_delete(rule_1_id)
+
     @staticmethod
     def __get_rule_id(resp):
         return resp.json['id']

--- a/st2common/st2common/exceptions/rbac.py
+++ b/st2common/st2common/exceptions/rbac.py
@@ -53,13 +53,13 @@ class ResourceAccessDeniedError(AccessDeniedError):
     Class representing an error where user doesn't have a required permission on a resource.
     """
 
-    def __init__(self, user_db, resource_db, permission_type):
-        self.resource_db = resource_db
+    def __init__(self, user_db, resource_api_or_db, permission_type):
+        self.resource_api_db = resource_api_or_db
         self.permission_type = permission_type
 
-        resource_uid = resource_db.get_uid() if resource_db else 'unknown'
+        resource_uid = resource_api_or_db.get_uid() if resource_api_or_db else 'unknown'
 
-        if resource_db and permission_type not in GLOBAL_PERMISSION_TYPES:
+        if resource_api_or_db and permission_type not in GLOBAL_PERMISSION_TYPES:
             message = ('User "%s" doesn\'t have required permission "%s" on resource "%s"' %
                        (user_db.name, permission_type, resource_uid))
         else:

--- a/st2common/st2common/exceptions/rbac.py
+++ b/st2common/st2common/exceptions/rbac.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from st2common.exceptions import StackStormBaseException
+from st2common.rbac.types import GLOBAL_PERMISSION_TYPES
 
 __all__ = [
     'AccessDeniedError',
@@ -58,7 +59,7 @@ class ResourceAccessDeniedError(AccessDeniedError):
 
         resource_uid = resource_db.get_uid() if resource_db else 'unknown'
 
-        if resource_db:
+        if resource_db and permission_type not in GLOBAL_PERMISSION_TYPES:
             message = ('User "%s" doesn\'t have required permission "%s" on resource "%s"' %
                        (user_db.name, permission_type, resource_uid))
         else:

--- a/st2common/st2common/models/api/base.py
+++ b/st2common/st2common/models/api/base.py
@@ -131,6 +131,11 @@ class APIUIDMixin(object):
         pack_uid = resource_db.get_pack_uid()
         return pack_uid
 
+    def is_valid_uid(self):
+        resource_db = self.to_model(self)
+        resource_uid = resource_db.get_uid()
+        return resource_db.is_valid_uid()
+
 
 def cast_argument_value(value_type, value):
     if value_type == bool:

--- a/st2common/st2common/models/api/base.py
+++ b/st2common/st2common/models/api/base.py
@@ -131,10 +131,9 @@ class APIUIDMixin(object):
         pack_uid = resource_db.get_pack_uid()
         return pack_uid
 
-    def is_valid_uid(self):
+    def has_valid_uid(self):
         resource_db = self.to_model(self)
-        resource_uid = resource_db.get_uid()
-        return resource_db.is_valid_uid()
+        return resource_db.has_valid_uid()
 
 
 def cast_argument_value(value_type, value):

--- a/st2common/st2common/models/db/stormbase.py
+++ b/st2common/st2common/models/db/stormbase.py
@@ -219,10 +219,14 @@ class UIDFieldMixin(object):
         uid = self.UID_SEPARATOR.join(parts)
         return uid
 
-    def is_valid_uid(self):
+    def get_uid_parts(self):
         parts = self.uid.split(self.UID_SEPARATOR)
         parts = [part for part in parts if part.strip()]
-        return len(parts) > 1
+        return parts
+
+    def has_valid_uid(self):
+        parts = self.get_uid_parts()
+        return len(parts) == len(self.UID_FIELDS) + 1
 
 
 class ContentPackResourceMixin(object):

--- a/st2common/st2common/models/db/stormbase.py
+++ b/st2common/st2common/models/db/stormbase.py
@@ -209,6 +209,11 @@ class UIDFieldMixin(object):
         return indexes
 
     def get_uid(self):
+        """
+        Return an object UID constructed from the object properties / fields.
+
+        :rtype: ``str``
+        """
         parts = []
         parts.append(self.RESOURCE_TYPE)
 
@@ -220,11 +225,21 @@ class UIDFieldMixin(object):
         return uid
 
     def get_uid_parts(self):
+        """
+        Return values for fields which make up the UID.
+
+        :rtype: ``list``
+        """
         parts = self.uid.split(self.UID_SEPARATOR)
         parts = [part for part in parts if part.strip()]
         return parts
 
     def has_valid_uid(self):
+        """
+        Return True if object contains a valid id (aka all parts contain a valid value).
+
+        :rtype: ``bool``
+        """
         parts = self.get_uid_parts()
         return len(parts) == len(self.UID_FIELDS) + 1
 

--- a/st2common/st2common/models/db/stormbase.py
+++ b/st2common/st2common/models/db/stormbase.py
@@ -230,7 +230,7 @@ class UIDFieldMixin(object):
 
         :rtype: ``list``
         """
-        parts = self.uid.split(self.UID_SEPARATOR)
+        parts = self.uid.split(self.UID_SEPARATOR)  # pylint: disable=no-member
         parts = [part for part in parts if part.strip()]
         return parts
 

--- a/st2common/st2common/models/db/stormbase.py
+++ b/st2common/st2common/models/db/stormbase.py
@@ -213,11 +213,16 @@ class UIDFieldMixin(object):
         parts.append(self.RESOURCE_TYPE)
 
         for field in self.UID_FIELDS:
-            value = getattr(self, field, None)
+            value = getattr(self, field, None) or ''
             parts.append(value)
 
         uid = self.UID_SEPARATOR.join(parts)
         return uid
+
+    def is_valid_uid(self):
+        parts = self.uid.split(self.UID_SEPARATOR)
+        parts = [part for part in parts if part.strip()]
+        return len(parts) > 1
 
 
 class ContentPackResourceMixin(object):

--- a/st2common/st2common/models/db/trigger.py
+++ b/st2common/st2common/models/db/trigger.py
@@ -110,6 +110,11 @@ class TriggerDB(stormbase.StormBaseDB, stormbase.ContentPackResourceMixin,
         uid = uid + self.UID_SEPARATOR + parameters
         return uid
 
+    def has_valid_uid(self):
+        parts = self.get_uid_parts()
+        # Note: We add 1 for parameters field which is not part of self.UID_FIELDS
+        return len(parts) == len(self.UID_FIELDS) + 1 + 1
+
 
 class TriggerInstanceDB(stormbase.StormFoundationDB):
     """An instance or occurrence of a type of Trigger.

--- a/st2common/st2common/rbac/utils.py
+++ b/st2common/st2common/rbac/utils.py
@@ -123,7 +123,7 @@ def assert_user_has_resource_api_permission(user_db, resource_api, permission_ty
 
     if not has_permission:
         # TODO: Refactor exception
-        raise ResourceAccessDeniedError(user_db=user_db, resource_db=resource_api,
+        raise ResourceAccessDeniedError(user_db=user_db, resource_api_or_db=resource_api,
                                         permission_type=permission_type)
 
 
@@ -138,7 +138,7 @@ def assert_user_has_resource_db_permission(user_db, resource_db, permission_type
                                                      permission_type=permission_type)
 
     if not has_permission:
-        raise ResourceAccessDeniedError(user_db=user_db, resource_db=resource_db,
+        raise ResourceAccessDeniedError(user_db=user_db, resource_api_or_db=resource_db,
                                         permission_type=permission_type)
 
 

--- a/st2common/st2common/router.py
+++ b/st2common/st2common/router.py
@@ -387,10 +387,7 @@ class Router(object):
 
                     if 'x-api-model' in schema:
                         Model = op_resolver(schema['x-api-model'])
-                        print 'xxx'
-                        print data
                         instance = Model(**data)
-                        print instance
 
                         # Call validate on the API model - note we should eventually move all
                         # those model schema definitions into openapi.yaml
@@ -406,8 +403,6 @@ class Router(object):
                         instance = model(**data)
 
                     kw[argument_name] = instance
-                #else:
-                #    kw[argument_name] = None
 
             # Making sure all required params are present
             required = param.get('required', False)

--- a/st2common/st2common/router.py
+++ b/st2common/st2common/router.py
@@ -343,63 +343,71 @@ class Router(object):
             elif source == 'request':
                 kw[argument_name] = getattr(req, name)
             elif source == 'body':
-                if req.body:
-                    content_type = req.headers.get('Content-Type', 'application/json')
-                    content_type = parse_content_type_header(content_type=content_type)[0]
-                    schema = param['schema']
+                # Note: We also want to perform validation if no body is explicitly provided - in a
+                # lot of POST, PUT scenarios, body is mandatory
+                if not req.body:
+                    req.body = '{}'
 
-                    try:
-                        if content_type == 'application/json':
-                            data = req.json
-                        elif content_type == 'text/plain':
-                            data = req.body
-                        elif content_type in ['application/x-www-form-urlencoded',
-                                              'multipart/form-data']:
-                            data = urlparse.parse_qs(req.body)
-                        else:
-                            raise ValueError('Unsupported Content-Type: "%s"' % (content_type))
-                    except Exception as e:
-                        detail = 'Failed to parse request body: %s' % str(e)
-                        raise exc.HTTPBadRequest(detail=detail)
+                content_type = req.headers.get('Content-Type', 'application/json')
+                content_type = parse_content_type_header(content_type=content_type)[0]
+                schema = param['schema']
+                print content_type
 
-                    try:
-                        CustomValidator(schema, resolver=self.spec_resolver).validate(data)
-                    except (jsonschema.ValidationError, ValueError) as e:
-                        raise exc.HTTPBadRequest(detail=e.message,
-                                                 comment=traceback.format_exc())
-
-                    if content_type == 'text/plain':
-                        kw[argument_name] = data
+                try:
+                    if content_type == 'application/json':
+                        data = req.json
+                    elif content_type == 'text/plain':
+                        data = req.body
+                    elif content_type in ['application/x-www-form-urlencoded',
+                                          'multipart/form-data']:
+                        data = urlparse.parse_qs(req.body)
                     else:
-                        class Body(object):
-                            def __init__(self, **entries):
-                                self.__dict__.update(entries)
+                        raise ValueError('Unsupported Content-Type: "%s"' % (content_type))
+                except Exception as e:
+                    detail = 'Failed to parse request body: %s' % str(e)
+                    raise exc.HTTPBadRequest(detail=detail)
 
-                        ref = schema.get('$ref', None)
-                        if ref:
-                            with self.spec_resolver.resolving(ref) as resolved:
-                                schema = resolved
+                try:
+                    CustomValidator(schema, resolver=self.spec_resolver).validate(data)
+                except (jsonschema.ValidationError, ValueError) as e:
+                    raise exc.HTTPBadRequest(detail=e.message,
+                                             comment=traceback.format_exc())
 
-                        if 'x-api-model' in schema:
-                            Model = op_resolver(schema['x-api-model'])
-                            instance = Model(**data)
-
-                            # Call validate on the API model - note we should eventually move all
-                            # those model schema definitions into openapi.yaml
-                            try:
-                                instance = instance.validate()
-                            except (jsonschema.ValidationError, ValueError) as e:
-                                raise exc.HTTPBadRequest(detail=e.message,
-                                                         comment=traceback.format_exc())
-                        else:
-                            LOG.debug('Missing x-api-model definition for %s, using generic Body '
-                                      'model.' % (endpoint['operationId']))
-                            model = Body
-                            instance = model(**data)
-
-                        kw[argument_name] = instance
+                if content_type == 'text/plain':
+                    kw[argument_name] = data
                 else:
-                    kw[argument_name] = None
+                    class Body(object):
+                        def __init__(self, **entries):
+                            self.__dict__.update(entries)
+
+                    ref = schema.get('$ref', None)
+                    if ref:
+                        with self.spec_resolver.resolving(ref) as resolved:
+                            schema = resolved
+
+                    if 'x-api-model' in schema:
+                        Model = op_resolver(schema['x-api-model'])
+                        print 'xxx'
+                        print data
+                        instance = Model(**data)
+                        print instance
+
+                        # Call validate on the API model - note we should eventually move all
+                        # those model schema definitions into openapi.yaml
+                        try:
+                            instance = instance.validate()
+                        except (jsonschema.ValidationError, ValueError) as e:
+                            raise exc.HTTPBadRequest(detail=e.message,
+                                                     comment=traceback.format_exc())
+                    else:
+                        LOG.debug('Missing x-api-model definition for %s, using generic Body '
+                                  'model.' % (endpoint['operationId']))
+                        model = Body
+                        instance = model(**data)
+
+                    kw[argument_name] = instance
+                #else:
+                #    kw[argument_name] = None
 
             # Making sure all required params are present
             required = param.get('required', False)

--- a/st2common/st2common/router.py
+++ b/st2common/st2common/router.py
@@ -351,7 +351,6 @@ class Router(object):
                 content_type = req.headers.get('Content-Type', 'application/json')
                 content_type = parse_content_type_header(content_type=content_type)[0]
                 schema = param['schema']
-                print content_type
 
                 try:
                     if content_type == 'application/json':

--- a/st2common/tests/unit/test_db_model_uids.py
+++ b/st2common/tests/unit/test_db_model_uids.py
@@ -26,6 +26,7 @@ from st2common.models.db.trigger import TriggerTypeDB
 from st2common.models.db.trigger import TriggerDB
 from st2common.models.db.policy import PolicyTypeDB
 from st2common.models.db.policy import PolicyDB
+from st2common.models.db.auth import ApiKeyDB
 
 __all__ = [
     'DBModelUIDFieldTestCase'
@@ -36,18 +37,23 @@ class DBModelUIDFieldTestCase(unittest2.TestCase):
     def test_get_uid(self):
         pack_db = PackDB(ref='ma_pack')
         self.assertEqual(pack_db.get_uid(), 'pack:ma_pack')
+        self.assertTrue(pack_db.has_valid_uid())
 
         sensor_type_db = SensorTypeDB(name='sname', pack='spack')
         self.assertEqual(sensor_type_db.get_uid(), 'sensor_type:spack:sname')
+        self.assertTrue(sensor_type_db.has_valid_uid())
 
         action_db = ActionDB(name='aname', pack='apack', runner_type={})
         self.assertEqual(action_db.get_uid(), 'action:apack:aname')
+        self.assertTrue(action_db.has_valid_uid())
 
         rule_db = RuleDB(name='rname', pack='rpack')
         self.assertEqual(rule_db.get_uid(), 'rule:rpack:rname')
+        self.assertTrue(rule_db.has_valid_uid())
 
         trigger_type_db = TriggerTypeDB(name='ttname', pack='ttpack')
         self.assertEqual(trigger_type_db.get_uid(), 'trigger_type:ttpack:ttname')
+        self.assertTrue(trigger_type_db.has_valid_uid())
 
         trigger_db = TriggerDB(name='tname', pack='tpack')
         self.assertTrue(trigger_db.get_uid().startswith('trigger:tpack:tname:'))
@@ -60,21 +66,34 @@ class DBModelUIDFieldTestCase(unittest2.TestCase):
         parameters = {'a': 1, 'b': 'unicode', 'c': [1, 2, 3], 'd': {'g': 1, 'h': 2}}
         trigger_db = TriggerDB(name='tname', pack='tpack', parameters=parameters)
         self.assertEqual(trigger_db.get_uid(), 'trigger:tpack:tname:%s' % (paramers_hash))
+        self.assertTrue(trigger_db.has_valid_uid())
 
         parameters = {'c': [1, 2, 3], 'b': u'unicode', 'd': {'h': 2, 'g': 1}, 'a': 1}
         trigger_db = TriggerDB(name='tname', pack='tpack', parameters=parameters)
         self.assertEqual(trigger_db.get_uid(), 'trigger:tpack:tname:%s' % (paramers_hash))
+        self.assertTrue(trigger_db.has_valid_uid())
 
         parameters = {'b': u'unicode', 'c': [1, 2, 3], 'd': {'h': 2, 'g': 1}, 'a': 1}
         trigger_db = TriggerDB(name='tname', pack='tpack', parameters=parameters)
         self.assertEqual(trigger_db.get_uid(), 'trigger:tpack:tname:%s' % (paramers_hash))
+        self.assertTrue(trigger_db.has_valid_uid())
 
         parameters = OrderedDict({'c': [1, 2, 3], 'b': u'unicode', 'd': {'h': 2, 'g': 1}, 'a': 1})
         trigger_db = TriggerDB(name='tname', pack='tpack', parameters=parameters)
         self.assertEqual(trigger_db.get_uid(), 'trigger:tpack:tname:%s' % (paramers_hash))
+        self.assertTrue(trigger_db.has_valid_uid())
 
         policy_type_db = PolicyTypeDB(resource_type='action', name='concurrency')
         self.assertEqual(policy_type_db.get_uid(), 'policy_type:action:concurrency')
+        self.assertTrue(policy_type_db.has_valid_uid())
 
         policy_db = PolicyDB(pack='dummy', name='policy1')
         self.assertEqual(policy_db.get_uid(), 'policy:dummy:policy1')
+
+        api_key_db = ApiKeyDB(key_hash='valid')
+        self.assertEqual(api_key_db.get_uid(), 'api_key:valid')
+        self.assertTrue(api_key_db.has_valid_uid())
+
+        api_key_db = ApiKeyDB()
+        self.assertEqual(api_key_db.get_uid(), 'api_key:')
+        self.assertFalse(api_key_db.has_valid_uid())


### PR DESCRIPTION
This pull request fixes a regression introduced when we were moving to new Swagger based API.

In some scenarios, no API validation was perform and internal server error 500 was incorrectly returned to the user instead of correct and more-user friendly 400 bad request with the actual message which describes what is wrong.

Those scenarios include:

- 500 internal error would be returned in case user provided no request body when request body is mandatory (POST, PUT)
- API validation hasn't been performed which means API model hasn't been instantiated and default model values set which resulted in issues like this #3863. This worked fine in the past and ID is already provided in the URL so no need to provide it again in the body.

## TODO

- [x] Tests

Fixes #3863.