### PR TITLE
Add support for sudo password to the local and remote runners

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -63,16 +63,16 @@ Changed
   ``AUDIT``. #3845
 * Mask values in an Inquiry response displayed to the user that were marked as "secret" in the
   inquiry's response schema. #3825
-* Added the ability of ``st2 key load`` to load keys from both JSON and YAML files.
-  Files can now contain a single KeyValuePair, or an array of KeyValuePairs.
-  Added the ability of ``st2 key load`` to load non-string values (hashes, arrays,
-  integers, booleans) and convert them to JSON before going into the datastore,
-  this conversion requires the user passing in the ``-c/--convert`` flag.
-  Updated ``st2 key load`` to load all properties of a key/value pair, now
-  secret values can be loaded. (improvement) #3815
+* Add the ability of ``st2 key load`` to load keys from both JSON and YAML files. Files can now
+  contain a single KeyValuePair, or an array of KeyValuePairs. (improvement) #3815
+* Add the ability of ``st2 key load`` to load non-string values (objects, arrays, integers,
+  booleans) and convert them to JSON before going into the datastore, this conversion requires the
+  user passing in the ``-c/--convert`` flag. (improvement) #3815
+* Updat ``st2 key load`` to load all properties of a key/value pair, now secret values can be
+  loaded. (improvement) #3815
 
   Contributed by Nick Maludy (Encore Technologies).
-  
+
 Fixed
 ~~~~~
 
@@ -212,7 +212,7 @@ Fixed
 Changed
 ~~~~~~~
 
-* Minor language and style tidy up of help strings and error messages #3782 
+* Minor language and style tidy up of help strings and error messages. #3782
 
 2.4.1 - September 12, 2017
 --------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -71,7 +71,7 @@ Changed
 * Add the ability of ``st2 key load`` to load non-string values (objects, arrays, integers,
   booleans) and convert them to JSON before going into the datastore, this conversion requires the
   user passing in the ``-c/--convert`` flag. (improvement) #3815
-* Updat ``st2 key load`` to load all properties of a key/value pair, now secret values can be
+* Update ``st2 key load`` to load all properties of a key/value pair, now secret values can be
   loaded. (improvement) #3815
 
   Contributed by Nick Maludy (Encore Technologies).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,8 @@ Added
   common code inside a ``lib`` directory inside a pack (with an ``__init__.py`` inside ``lib``
   directory to declare it a python package). You can then import the common code in sensors and
   actions. Please refer to documentation for samples and guidelines. #3490
+* Add support for password protected sudo to the local and remote runner. Password can be provided
+  via the new ``sudo_password`` runner parameter. (new feature) #3867
 
 Changed
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,9 @@ Added
   actions. Please refer to documentation for samples and guidelines. #3490
 * Add support for password protected sudo to the local and remote runner. Password can be provided
   via the new ``sudo_password`` runner parameter. (new feature) #3867
+* Add new ``--tail`` flag to the ``st2 run`` / ``st2 action execute`` and ``st2 execution re-run``
+  CLI command. When this flag is provided, new execution will automatically be followed and tailed
+  after it has been scheduled. (new feature) #3867
 
 Changed
 ~~~~~~~

--- a/contrib/runners/local_runner/local_runner/local_runner.py
+++ b/contrib/runners/local_runner/local_runner/local_runner.py
@@ -52,6 +52,7 @@ LOGGED_USER_USERNAME = pwd.getpwuid(os.getuid())[0]
 
 # constants to lookup in runner_parameters.
 RUNNER_SUDO = 'sudo'
+RUNNER_SUDO_PASSWORD = 'sudo_password'
 RUNNER_ON_BEHALF_USER = 'user'
 RUNNER_COMMAND = 'cmd'
 RUNNER_CWD = 'cwd'
@@ -84,6 +85,7 @@ class LocalShellRunner(ActionRunner, ShellRunnerMixin):
         super(LocalShellRunner, self).pre_run()
 
         self._sudo = self.runner_parameters.get(RUNNER_SUDO, False)
+        self._sudo_password = self.runner_parameters.get(RUNNER_SUDO_PASSWORD, None)
         self._on_behalf_user = self.context.get(RUNNER_ON_BEHALF_USER, LOGGED_USER_USERNAME)
         self._user = cfg.CONF.system_user.user
         self._cwd = self.runner_parameters.get(RUNNER_CWD, None)
@@ -105,7 +107,8 @@ class LocalShellRunner(ActionRunner, ShellRunnerMixin):
                                         user=self._user,
                                         env_vars=env_vars,
                                         sudo=self._sudo,
-                                        timeout=self._timeout)
+                                        timeout=self._timeout,
+                                        sudo_password=self._sudo_password)
         else:
             script_action = True
             script_local_path_abs = self.entry_point
@@ -121,7 +124,8 @@ class LocalShellRunner(ActionRunner, ShellRunnerMixin):
                                        env_vars=env_vars,
                                        sudo=self._sudo,
                                        timeout=self._timeout,
-                                       cwd=self._cwd)
+                                       cwd=self._cwd,
+                                       sudo_password=self._sudo_password)
 
         args = action.get_full_command_string()
         sanitized_args = action.get_sanitized_full_command_string()

--- a/contrib/runners/local_runner/local_runner/local_runner.py
+++ b/contrib/runners/local_runner/local_runner/local_runner.py
@@ -170,7 +170,17 @@ class LocalShellRunner(ActionRunner, ShellRunnerMixin):
         # Ideally os.killpg should have done the trick but for some reason that failed.
         # Note: pkill will set the returncode to 143 so we don't need to explicitly set
         # it to some non-zero value.
-        exit_code, stdout, stderr, timed_out = shell.run_command(cmd=args, stdin=None,
+
+        if self._sudo_password:
+            LOG.debug('Supplying sudo password via stdin')
+            echo_process = subprocess.Popen(['echo', self._sudo_password + '\n'],
+                                            stdout=subprocess.PIPE)
+            stdin = echo_process.stdout
+        else:
+            stdin = None
+
+        exit_code, stdout, stderr, timed_out = shell.run_command(cmd=args,
+                                                                 stdin=stdin,
                                                                  stdout=subprocess.PIPE,
                                                                  stderr=subprocess.PIPE,
                                                                  shell=True,

--- a/contrib/runners/local_runner/local_runner/local_runner.py
+++ b/contrib/runners/local_runner/local_runner/local_runner.py
@@ -124,10 +124,12 @@ class LocalShellRunner(ActionRunner, ShellRunnerMixin):
                                        cwd=self._cwd)
 
         args = action.get_full_command_string()
+        sanitized_args = action.get_sanitized_full_command_string()
 
         # For consistency with the old Fabric based runner, make sure the file is executable
         if script_action:
             args = 'chmod +x %s ; %s' % (script_local_path_abs, args)
+            sanitized_args = 'chmod +x %s ; %s' % (script_local_path_abs, sanitized_args)
 
         env = os.environ.copy()
 
@@ -140,7 +142,7 @@ class LocalShellRunner(ActionRunner, ShellRunnerMixin):
 
         LOG.info('Executing action via LocalRunner: %s', self.runner_id)
         LOG.info('[Action info] name: %s, Id: %s, command: %s, user: %s, sudo: %s' %
-                 (action.name, action.action_exec_id, args, action.user, action.sudo))
+                 (action.name, action.action_exec_id, sanitized_args, action.user, action.sudo))
 
         stdout = StringIO()
         stderr = StringIO()

--- a/contrib/runners/local_runner/local_runner/runner.yaml
+++ b/contrib/runners/local_runner/local_runner/runner.yaml
@@ -27,6 +27,7 @@
       default: null
       description: Sudo password. To be used when paswordless sudo is not allowed.
       type: string
+      secret: true
       required: false
     timeout:
       default: 60
@@ -60,6 +61,7 @@
       description: Sudo password. To be used when paswordless sudo is not allowed.
       type: string
       required: false
+      secret: true
     timeout:
       default: 60
       description: Action timeout in seconds. Action will get killed if it doesn't

--- a/contrib/runners/local_runner/local_runner/runner.yaml
+++ b/contrib/runners/local_runner/local_runner/runner.yaml
@@ -23,6 +23,11 @@
       default: false
       description: The command will be executed with sudo.
       type: boolean
+    sudo_password:
+      default: null
+      description: Sudo password. To be used when paswordless sudo is not allowed.
+      type: string
+      required: false
     timeout:
       default: 60
       description: Action timeout in seconds. Action will get killed if it doesn't
@@ -50,6 +55,11 @@
       default: false
       description: The command will be executed with sudo.
       type: boolean
+    sudo_password:
+      default: null
+      description: Sudo password. To be used when paswordless sudo is not allowed.
+      type: string
+      required: false
     timeout:
       default: 60
       description: Action timeout in seconds. Action will get killed if it doesn't

--- a/contrib/runners/local_runner/tests/integration/test_localrunner.py
+++ b/contrib/runners/local_runner/tests/integration/test_localrunner.py
@@ -326,10 +326,25 @@ class LocalShellCommandRunnerTestCase(RunnerTestCase, CleanDbTestCase):
             '$sudo p@ss 2'
         ]
 
+        cmd = ('{ read sudopass; echo $sudopass; }')
+
+        # without sudo
         for sudo_password in sudo_passwords:
-            cmd = ('{ read sudopass; echo $sudopass; }')
             runner = self._get_runner(action_db, cmd=cmd)
             runner.pre_run()
+            runner._sudo_password = sudo_password
+            status, result, _ = runner.run({})
+            runner.post_run(status, result)
+
+            self.assertEquals(status,
+                    action_constants.LIVEACTION_STATUS_SUCCEEDED)
+            self.assertEquals(result['stdout'], sudo_password)
+
+        # with sudo
+        for sudo_password in sudo_passwords:
+            runner = self._get_runner(action_db, cmd=cmd)
+            runner.pre_run()
+            runner._sudo = True
             runner._sudo_password = sudo_password
             status, result, _ = runner.run({})
             runner.post_run(status, result)

--- a/contrib/runners/remote_command_runner/remote_command_runner/remote_command_runner.py
+++ b/contrib/runners/remote_command_runner/remote_command_runner/remote_command_runner.py
@@ -70,6 +70,7 @@ class ParamikoRemoteCommandRunner(BaseParallelSSHRunner):
                                            hosts=self._hosts,
                                            parallel=self._parallel,
                                            sudo=self._sudo,
+                                           sudo_password=self._sudo_password,
                                            timeout=self._timeout,
                                            cwd=self._cwd)
 

--- a/contrib/runners/remote_command_runner/remote_command_runner/runner.yaml
+++ b/contrib/runners/remote_command_runner/remote_command_runner/runner.yaml
@@ -68,6 +68,12 @@
       default: false
       description: The remote command will be executed with sudo.
       type: boolean
+    sudo_password:
+      default: null
+      description: Sudo password. To be used when paswordless sudo is not allowed.
+      type: string
+      required: false
+      secret: true
     timeout:
       default: 60
       description: Action timeout in seconds. Action will get killed if it doesn't

--- a/contrib/runners/remote_script_runner/remote_script_runner/remote_script_runner.py
+++ b/contrib/runners/remote_script_runner/remote_script_runner/remote_script_runner.py
@@ -144,6 +144,7 @@ class ParamikoRemoteScriptRunner(BaseParallelSSHRunner):
                                           hosts=self._hosts,
                                           parallel=self._parallel,
                                           sudo=self._sudo,
+                                          sudo_password=self._sudo_password,
                                           timeout=self._timeout,
                                           cwd=self._cwd)
 

--- a/contrib/runners/remote_script_runner/remote_script_runner/runner.yaml
+++ b/contrib/runners/remote_script_runner/remote_script_runner/runner.yaml
@@ -64,6 +64,12 @@
       default: false
       description: The remote command will be executed with sudo.
       type: boolean
+    sudo_password:
+      default: null
+      description: Sudo password. To be used when paswordless sudo is not allowed.
+      type: string
+      required: false
+      secret: true
     timeout:
       default: 60
       description: Action timeout in seconds. Action will get killed if it doesn't

--- a/lint-configs/python/.flake8
+++ b/lint-configs/python/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 100
-ignore = E128,E402
+ignore = E128,E402,E722
 exclude=*.egg/*

--- a/st2actions/tests/unit/test_parallel_ssh.py
+++ b/st2actions/tests/unit/test_parallel_ssh.py
@@ -25,6 +25,13 @@ from st2common.runners.paramiko_ssh import SSHCommandTimeoutError
 import st2tests.config as tests_config
 tests_config.parse_args()
 
+MOCK_STDERR_SUDO_PASSWORD_ERROR = """
+[sudo] password for bar: Sorry, try again.\n
+[sudo] password for bar:' Sorry, try again.\n
+[sudo] password for bar: \n
+sudo: 2 incorrect password attempts
+"""
+
 
 class ParallelSSHTests(unittest2.TestCase):
 
@@ -250,3 +257,29 @@ class ParallelSSHTests(unittest2.TestCase):
         results = client.run('stuff', timeout=60)
         self.assertTrue('127.0.0.1' in results)
         self.assertDictEqual(results['127.0.0.1']['stdout'], {'foo': 'bar'})
+
+    @patch('paramiko.SSHClient', Mock)
+    @patch.object(ParamikoSSHClient, 'run', MagicMock(
+        return_value=('', MOCK_STDERR_SUDO_PASSWORD_ERROR, 0))
+    )
+    @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
+                  MagicMock(return_value=False))
+    def test_run_sudo_password_user_friendly_error(self):
+        hosts = ['127.0.0.1']
+        client = ParallelSSHClient(hosts=hosts,
+                                   user='ubuntu',
+                                   pkey_file='~/.ssh/id_rsa',
+                                   connect=True,
+                                   sudo_password=True)
+        results = client.run('stuff', timeout=60)
+
+        print results
+
+        expected_error = ('Failed executing command "stuff" on host "127.0.0.1" '
+                          'Invalid sudo password provided or sudo is not configured for '
+                          'this user (bar)')
+
+        self.assertTrue('127.0.0.1' in results)
+        self.assertEqual(results['127.0.0.1']['succeeded'], False)
+        self.assertEqual(results['127.0.0.1']['failed'], True)
+        self.assertTrue(expected_error in results['127.0.0.1']['error'])

--- a/st2actions/tests/unit/test_parallel_ssh.py
+++ b/st2actions/tests/unit/test_parallel_ssh.py
@@ -273,8 +273,6 @@ class ParallelSSHTests(unittest2.TestCase):
                                    sudo_password=True)
         results = client.run('stuff', timeout=60)
 
-        print results
-
         expected_error = ('Failed executing command "stuff" on host "127.0.0.1" '
                           'Invalid sudo password provided or sudo is not configured for '
                           'this user (bar)')

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -313,7 +313,7 @@ class ActionExecutionOutputController(ActionExecutionsControllerMixin, ResourceC
         execution_id = str(execution_db.id)
 
         query_filters = {}
-        if output_type:
+        if output_type and output_type != 'all':
             query_filters['output_type'] = output_type
 
         def existing_output_iter():

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -258,6 +258,8 @@ class ActionRunCommandMixin(object):
         if args.async:
             self.print_output('To get the results, execute:\n st2 execution get %s' %
                               (execution.id), six.text_type)
+            self.print_output('\nTo view output in real-time, execute:\n st2 execution '
+                              'tail %s' % (execution.id), six.text_type)
         else:
             self._print_execution_details(execution=execution, args=args, **kwargs)
 

--- a/st2client/tests/unit/test_execution_tail_command.py
+++ b/st2client/tests/unit/test_execution_tail_command.py
@@ -31,6 +31,11 @@ __all__ = [
 ]
 
 # Mock objects
+MOCK_LIVEACTION_1_RUNNING = {
+    'id': 'idfoo1',
+    'status': LIVEACTION_STATUS_RUNNING
+}
+
 MOCK_LIVEACTION_1_SUCCEEDED = {
     'id': 'idfoo1',
     'status': LIVEACTION_STATUS_SUCCEEDED
@@ -260,7 +265,7 @@ class ActionExecutionTailCommandTestCase(BaseCLITestCase):
 
     @mock.patch.object(
         httpclient.HTTPClient, 'get',
-        mock.MagicMock(return_value=base.FakeResponse(json.dumps(MOCK_LIVEACTION_3_RUNNING),
+        mock.MagicMock(return_value=base.FakeResponse(json.dumps(MOCK_LIVEACTION_1_RUNNING),
                                                       200, 'OK')))
     @mock.patch('st2client.client.StreamManager', autospec=True)
     def test_tail_simple_execution_running_no_data_produced(self, mock_stream_manager):

--- a/st2common/st2common/models/system/action.py
+++ b/st2common/st2common/models/system/action.py
@@ -30,7 +30,7 @@ from st2common.util.shell import quote_unix
 from st2common.constants.action import LIBS_DIR as ACTION_LIBS_DIR
 from st2common.util.secrets import get_secret_parameters
 from st2common.util.secrets import mask_secret_parameters
-from st2common.logging.formatters import MASKED_ATTRIBUTE_VALUE
+from st2common.constants.secrets import MASKED_ATTRIBUTE_VALUE
 
 __all__ = [
     'ShellCommandAction',

--- a/st2common/st2common/models/system/action.py
+++ b/st2common/st2common/models/system/action.py
@@ -95,6 +95,22 @@ class ShellCommandAction(object):
 
         return command
 
+    def get_sanitized_full_command_string(self):
+        """
+        Get a command string which can be used inside the log messages (if provided, sudo password
+        is masked).
+
+        :rtype: ``password``
+        """
+        command_string = self.get_full_command_string()
+
+        if self.sudo_password:
+            # Mask sudo password
+            split = command_string.split('|', 1)
+            command_string = 'echo -e \'**********\n\' | %s' % (split[1])
+
+        return command_string
+
     def get_timeout(self):
         return self.timeout
 

--- a/st2common/st2common/models/system/action.py
+++ b/st2common/st2common/models/system/action.py
@@ -30,6 +30,7 @@ from st2common.util.shell import quote_unix
 from st2common.constants.action import LIBS_DIR as ACTION_LIBS_DIR
 from st2common.util.secrets import get_secret_parameters
 from st2common.util.secrets import mask_secret_parameters
+from st2common.logging.formatters import MASKED_ATTRIBUTE_VALUE
 
 __all__ = [
     'ShellCommandAction',
@@ -106,8 +107,8 @@ class ShellCommandAction(object):
 
         if self.sudo_password:
             # Mask sudo password
-            split = command_string.split('|', 1)
-            command_string = 'echo -e \'**********\n\' | %s' % (split[1])
+            split = command_string.split(' | ', 1)
+            command_string = 'echo -e \'%s\n\' | %s' % (MASKED_ATTRIBUTE_VALUE, split[1])
 
         return command_string
 

--- a/st2common/st2common/models/system/action.py
+++ b/st2common/st2common/models/system/action.py
@@ -129,7 +129,7 @@ class ShellCommandAction(object):
         if self.sudo_password:
             flags.append('-S')
 
-        flags = flags + copy.copy(SUDO_COMMON_OPTIONS)
+        flags = flags + SUDO_COMMON_OPTIONS
 
         return flags
 
@@ -141,7 +141,7 @@ class ShellCommandAction(object):
         :rtype: ``list``
         """
         flags = self._get_common_sudo_arguments()
-        flags += copy.copy(SUDO_DIFFERENT_USER_OPTIONS)
+        flags += SUDO_DIFFERENT_USER_OPTIONS
         flags += ['-u', user]
 
         return flags

--- a/st2common/st2common/models/system/paramiko_command_action.py
+++ b/st2common/st2common/models/system/paramiko_command_action.py
@@ -15,7 +15,6 @@
 
 import os
 import pwd
-import copy
 
 from st2common import log as logging
 from st2common.models.system.action import RemoteAction
@@ -70,6 +69,6 @@ class ParamikoRemoteCommandAction(RemoteAction):
         if self.sudo_password:
             flags.append('-S')
 
-        flags = flags + copy(SUDO_COMMON_OPTIONS)
+        flags = flags + SUDO_COMMON_OPTIONS
 
         return flags

--- a/st2common/st2common/models/system/paramiko_command_action.py
+++ b/st2common/st2common/models/system/paramiko_command_action.py
@@ -32,8 +32,7 @@ LOGGED_USER_USERNAME = pwd.getpwuid(os.getuid())[0]
 class ParamikoRemoteCommandAction(RemoteAction):
 
     def get_full_command_string(self):
-        # Note: We pass -E to sudo because we want to preserve user provided
-        # environment variables
+        # Note: We pass -E to sudo because we want to preserve user provided environment variables
         env_str = self._get_env_vars_export_string()
         cwd = self.get_cwd()
 

--- a/st2common/st2common/models/system/paramiko_script_action.py
+++ b/st2common/st2common/models/system/paramiko_script_action.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
-
 from st2common import log as logging
 from st2common.models.system.action import RemoteScriptAction
 from st2common.models.system.action import SUDO_COMMON_OPTIONS

--- a/st2common/st2common/models/system/paramiko_script_action.py
+++ b/st2common/st2common/models/system/paramiko_script_action.py
@@ -83,6 +83,6 @@ class ParamikoRemoteScriptAction(RemoteScriptAction):
         if self.sudo_password:
             flags.append('-S')
 
-        flags = flags + copy(SUDO_COMMON_OPTIONS)
+        flags = flags + SUDO_COMMON_OPTIONS
 
         return flags

--- a/st2common/st2common/runners/parallel_ssh.py
+++ b/st2common/st2common/runners/parallel_ssh.py
@@ -38,7 +38,8 @@ class ParallelSSHClient(object):
 
     def __init__(self, hosts, user=None, password=None, pkey_file=None, pkey_material=None, port=22,
                  bastion_host=None, concurrency=10, raise_on_any_error=False, connect=True,
-                 passphrase=None, handle_stdout_line_func=None, handle_stderr_line_func=None):
+                 passphrase=None, handle_stdout_line_func=None, handle_stderr_line_func=None,
+                 sudo_password=False):
         """
         :param handle_stdout_line_func: Callback function which is called dynamically each time a
                                         new stdout line is received.
@@ -61,6 +62,7 @@ class ParallelSSHClient(object):
         self._passphrase = passphrase
         self._handle_stdout_line_func = handle_stdout_line_func
         self._handle_stderr_line_func = handle_stderr_line_func
+        self._sudo_password = sudo_password
 
         if not hosts:
             raise Exception('Need an non-empty list of hosts to talk to.')
@@ -282,10 +284,9 @@ class ParallelSSHClient(object):
             client = self._hosts_client[host]
             (stdout, stderr, exit_code) = client.run(cmd, timeout=timeout,
                                                      call_line_handler_func=True)
-            is_succeeded = (exit_code == 0)
-            result_dict = {'stdout': stdout, 'stderr': stderr, 'return_code': exit_code,
-                           'succeeded': is_succeeded, 'failed': not is_succeeded}
-            results[host] = jsonify.json_loads(result_dict, ParallelSSHClient.KEYS_TO_TRANSFORM)
+
+            result = self._handle_command_result(stdout=stdout, stderr=stderr, exit_code=exit_code)
+            results[host] = result
         except Exception as ex:
             cmd = self._sanitize_command_string(cmd=cmd)
             error = 'Failed executing command "%s" on host "%s"' % (cmd, host)
@@ -342,6 +343,27 @@ class ParallelSSHClient(object):
             port = self._ssh_port
 
         return (hostname, port)
+
+    def _handle_command_result(self, stdout, stderr, exit_code):
+        # Detect if user provided an invalid sudo password or sudo is not configured for that user
+        if self._sudo_password:
+            if re.search('sudo: \d+ incorrect password attempts', stderr):
+                match = re.search('\[sudo\] password for (.+?)\:', stderr)
+
+                if match:
+                    username = match.groups()[0]
+                else:
+                    username = 'unknown'
+
+                error = ('Invalid sudo password provided or sudo is not configured for this user '
+                        '(%s)' % (username))
+                raise ValueError(error)
+        is_succeeded = (exit_code == 0)
+        result_dict = {'stdout': stdout, 'stderr': stderr, 'return_code': exit_code,
+                       'succeeded': is_succeeded, 'failed': not is_succeeded}
+
+        result = jsonify.json_loads(result_dict, ParallelSSHClient.KEYS_TO_TRANSFORM)
+        return result
 
     @staticmethod
     def _sanitize_command_string(cmd):

--- a/st2common/st2common/runners/paramiko_ssh_runner.py
+++ b/st2common/st2common/runners/paramiko_ssh_runner.py
@@ -41,6 +41,7 @@ RUNNER_PASSWORD = 'password'
 RUNNER_PRIVATE_KEY = 'private_key'
 RUNNER_PARALLEL = 'parallel'
 RUNNER_SUDO = 'sudo'
+RUNNER_SUDO_PASSWORD = 'sudo_password'
 RUNNER_ON_BEHALF_USER = 'user'
 RUNNER_REMOTE_DIR = 'dir'
 RUNNER_COMMAND = 'cmd'
@@ -60,6 +61,7 @@ class BaseParallelSSHRunner(ActionRunner, ShellRunnerMixin):
         self._hosts = None
         self._parallel = True
         self._sudo = False
+        self._sudo_password = None
         self._on_behalf_user = None
         self._username = None
         self._password = None
@@ -97,8 +99,11 @@ class BaseParallelSSHRunner(ActionRunner, ShellRunnerMixin):
         self._parallel = self.runner_parameters.get(RUNNER_PARALLEL, True)
         self._sudo = self.runner_parameters.get(RUNNER_SUDO, False)
         self._sudo = self._sudo if self._sudo else False
+        self._sudo_password = self.runner_parameters.get(RUNNER_SUDO_PASSWORD, None)
+
         if self.context:
             self._on_behalf_user = self.context.get(RUNNER_ON_BEHALF_USER, self._on_behalf_user)
+
         self._cwd = self.runner_parameters.get(RUNNER_CWD, None)
         self._env = self.runner_parameters.get(RUNNER_ENV, {})
         self._kwarg_op = self.runner_parameters.get(RUNNER_KWARG_OP, '--')

--- a/st2common/st2common/runners/paramiko_ssh_runner.py
+++ b/st2common/st2common/runners/paramiko_ssh_runner.py
@@ -176,6 +176,9 @@ class BaseParallelSSHRunner(ActionRunner, ShellRunnerMixin):
             # Default to stanley key file specified in the config
             client_kwargs['pkey_file'] = self._ssh_key_file
 
+        if self._sudo_password:
+            client_kwargs['sudo_password'] = True
+
         self._parallel_ssh_client = ParallelSSHClient(**client_kwargs)
 
     def post_run(self, status, result):

--- a/st2common/st2common/util/param.py
+++ b/st2common/st2common/util/param.py
@@ -217,11 +217,12 @@ def _cast_params_from(params, context, schemas):
 
 
 def render_live_params(runner_parameters, action_parameters, params, action_context,
-        additional_contexts={}):
+                       additional_contexts=None):
     '''
     Renders list of parameters. Ensures that there's no cyclic or missing dependencies. Returns a
     dict of plain rendered parameters.
     '''
+    additional_contexts = additional_contexts or {}
     config = get_config(action_context.get('pack'), action_context.get('user'))
 
     G = _create_graph(action_context, config)

--- a/st2common/tests/unit/test_logger.py
+++ b/st2common/tests/unit/test_logger.py
@@ -28,7 +28,7 @@ from oslo_config import cfg
 from st2common import log as logging
 from st2common.logging.formatters import ConsoleLogFormatter
 from st2common.logging.formatters import GelfLogFormatter
-from st2common.logging.formatters import MASKED_ATTRIBUTE_VALUE
+from st2common.constants.secrets import MASKED_ATTRIBUTE_VALUE
 from st2common.models.db.action import ActionDB
 from st2common.models.db.execution import ActionExecutionDB
 import st2tests.config as tests_config

--- a/st2common/tests/unit/test_paramiko_command_action_model.py
+++ b/st2common/tests/unit/test_paramiko_command_action_model.py
@@ -17,11 +17,16 @@ import unittest2
 
 from st2common.models.system.paramiko_command_action import ParamikoRemoteCommandAction
 
+__all__ = [
+    'ParamikoRemoteCommandActionTestCase'
+]
 
-class ParamikoRemoteComamndActionTests(unittest2.TestCase):
+
+class ParamikoRemoteCommandActionTestCase(unittest2.TestCase):
 
     def test_get_command_string_no_env_vars(self):
-        cmd_action = ParamikoRemoteComamndActionTests._get_test_command_action('echo boo bah baz')
+        cmd_action = ParamikoRemoteCommandActionTestCase._get_test_command_action(
+            'echo boo bah baz')
         ex = 'cd /tmp && echo boo bah baz'
         self.assertEqual(cmd_action.get_full_command_string(), ex)
         # With sudo
@@ -31,13 +36,23 @@ class ParamikoRemoteComamndActionTests(unittest2.TestCase):
 
         # Executing a path command requires user to provide an escaped input.
         # E.g. st2 run core.remote hosts=localhost cmd='"/tmp/space stuff.sh"'
-        cmd_action = ParamikoRemoteComamndActionTests._get_test_command_action(
+        cmd_action = ParamikoRemoteCommandActionTestCase._get_test_command_action(
             '"/t/space stuff.sh"')
         ex = 'cd /tmp && "/t/space stuff.sh"'
         self.assertEqual(cmd_action.get_full_command_string(), ex)
 
+        # sudo_password provided
+        cmd_action = ParamikoRemoteCommandActionTestCase._get_test_command_action(
+            'echo boo bah baz')
+        cmd_action.sudo = True
+        cmd_action.sudo_password = 'sudo pass'
+
+        ex = 'echo -e \'sudo pass\n\' | sudo -S -E -- bash -c \'cd /tmp && echo boo bah baz\''
+        self.assertEqual(cmd_action.get_full_command_string(), ex)
+
     def test_get_command_string_with_env_vars(self):
-        cmd_action = ParamikoRemoteComamndActionTests._get_test_command_action('echo boo bah baz')
+        cmd_action = ParamikoRemoteCommandActionTestCase._get_test_command_action(
+            'echo boo bah baz')
         cmd_action.env_vars = {'FOO': 'BAR', 'BAR': 'BEET CAFE'}
         ex = 'export FOO=BAR ' + \
              'BAR=\'BEET CAFE\'' + \
@@ -46,27 +61,39 @@ class ParamikoRemoteComamndActionTests(unittest2.TestCase):
 
         # With sudo
         cmd_action.sudo = True
+
         ex = 'sudo -E -- bash -c ' + \
              '\'export FOO=BAR ' + \
              'BAR=\'"\'"\'BEET CAFE\'"\'"\'' + \
              ' && cd /tmp && echo boo bah baz\''
         self.assertEqual(cmd_action.get_full_command_string(), ex)
 
+        # with sudo_password
+        cmd_action.sudo = True
+        cmd_action.sudo_password = 'sudo pass'
+        ex = 'echo -e \'sudo pass\n\' | sudo -S -E -- bash -c ' + \
+             '\'export FOO=BAR ' + \
+             'BAR=\'"\'"\'BEET CAFE\'"\'"\'' + \
+             ' && cd /tmp && echo boo bah baz\''
+        self.assertEqual(cmd_action.get_full_command_string(), ex)
+
     def test_get_command_string_no_user(self):
-        cmd_action = ParamikoRemoteComamndActionTests._get_test_command_action('echo boo bah baz')
+        cmd_action = ParamikoRemoteCommandActionTestCase._get_test_command_action(
+            'echo boo bah baz')
         cmd_action.user = None
         ex = 'cd /tmp && echo boo bah baz'
         self.assertEqual(cmd_action.get_full_command_string(), ex)
 
         # Executing a path command requires user to provide an escaped input.
         cmd = 'bash "/tmp/stuff space.sh"'
-        cmd_action = ParamikoRemoteComamndActionTests._get_test_command_action(cmd)
+        cmd_action = ParamikoRemoteCommandActionTestCase._get_test_command_action(cmd)
         cmd_action.user = None
         ex = 'cd /tmp && bash "/tmp/stuff space.sh"'
         self.assertEqual(cmd_action.get_full_command_string(), ex)
 
     def test_get_command_string_no_user_env_vars(self):
-        cmd_action = ParamikoRemoteComamndActionTests._get_test_command_action('echo boo bah baz')
+        cmd_action = ParamikoRemoteCommandActionTestCase._get_test_command_action(
+            'echo boo bah baz')
         cmd_action.user = None
         cmd_action.env_vars = {'FOO': 'BAR'}
         ex = 'export FOO=BAR && cd /tmp && echo boo bah baz'

--- a/st2common/tests/unit/test_paramiko_script_action_model.py
+++ b/st2common/tests/unit/test_paramiko_script_action_model.py
@@ -17,11 +17,15 @@ import unittest2
 
 from st2common.models.system.paramiko_script_action import ParamikoRemoteScriptAction
 
+__all__ = [
+    'ParamikoRemoteScriptActionTestCase'
+]
 
-class ParamikoRemoteScriptActionTests(unittest2.TestCase):
+
+class ParamikoRemoteScriptActionTestCase(unittest2.TestCase):
 
     def test_get_command_string_no_env_vars(self):
-        script_action = ParamikoRemoteScriptActionTests._get_test_script_action()
+        script_action = ParamikoRemoteScriptActionTestCase._get_test_script_action()
         ex = 'cd /tmp && /tmp/remote_script.sh song=\'b s\' \'taylor swift\''
         self.assertEqual(script_action.get_full_command_string(), ex)
 
@@ -32,8 +36,16 @@ class ParamikoRemoteScriptActionTests(unittest2.TestCase):
              '/tmp/remote_script.sh song=\'"\'"\'b s\'"\'"\' \'"\'"\'taylor swift\'"\'"\'\''
         self.assertEqual(script_action.get_full_command_string(), ex)
 
+        # with sudo password
+        script_action.sudo = True
+        script_action.sudo_password = 'sudo pass'
+        ex = 'echo -e \'sudo pass\n\' | sudo -S -E -- bash -c ' + \
+             '\'cd /tmp && ' + \
+             '/tmp/remote_script.sh song=\'"\'"\'b s\'"\'"\' \'"\'"\'taylor swift\'"\'"\'\''
+        self.assertEqual(script_action.get_full_command_string(), ex)
+
     def test_get_command_string_with_env_vars(self):
-        script_action = ParamikoRemoteScriptActionTests._get_test_script_action()
+        script_action = ParamikoRemoteScriptActionTestCase._get_test_script_action()
         script_action.env_vars = {
             'ST2_ACTION_EXECUTION_ID': '55ce39d532ed3543aecbe71d',
             'FOO': 'BAR BAZ BOOZ'
@@ -52,8 +64,19 @@ class ParamikoRemoteScriptActionTests(unittest2.TestCase):
              '/tmp/remote_script.sh song=\'"\'"\'b s\'"\'"\' \'"\'"\'taylor swift\'"\'"\'\''
         self.assertEqual(script_action.get_full_command_string(), ex)
 
+        # with sudo password
+        script_action.sudo = True
+        script_action.sudo_password = 'sudo pass'
+
+        ex = 'echo -e \'sudo pass\n\' | sudo -S -E -- bash -c ' + \
+             '\'export ST2_ACTION_EXECUTION_ID=55ce39d532ed3543aecbe71d ' + \
+             'FOO=\'"\'"\'BAR BAZ BOOZ\'"\'"\' && ' + \
+             'cd /tmp && ' + \
+             '/tmp/remote_script.sh song=\'"\'"\'b s\'"\'"\' \'"\'"\'taylor swift\'"\'"\'\''
+        self.assertEqual(script_action.get_full_command_string(), ex)
+
     def test_get_command_string_no_script_args_no_env_args(self):
-        script_action = ParamikoRemoteScriptActionTests._get_test_script_action()
+        script_action = ParamikoRemoteScriptActionTestCase._get_test_script_action()
         script_action.named_args = {}
         script_action.positional_args = []
         ex = 'cd /tmp && /tmp/remote_script.sh'
@@ -66,7 +89,7 @@ class ParamikoRemoteScriptActionTests(unittest2.TestCase):
         self.assertEqual(script_action.get_full_command_string(), ex)
 
     def test_get_command_string_no_script_args_with_env_args(self):
-        script_action = ParamikoRemoteScriptActionTests._get_test_script_action()
+        script_action = ParamikoRemoteScriptActionTestCase._get_test_script_action()
         script_action.named_args = {}
         script_action.positional_args = []
         script_action.env_vars = {
@@ -88,7 +111,7 @@ class ParamikoRemoteScriptActionTests(unittest2.TestCase):
         self.assertEqual(script_action.get_full_command_string(), ex)
 
     def test_script_path_shell_injection_safe(self):
-        script_action = ParamikoRemoteScriptActionTests._get_test_script_action()
+        script_action = ParamikoRemoteScriptActionTestCase._get_test_script_action()
         test_path = '/tmp/remote script.sh'
         script_action.remote_script = test_path
         script_action.named_args = {}
@@ -102,8 +125,16 @@ class ParamikoRemoteScriptActionTests(unittest2.TestCase):
              '\'cd /tmp && \'"\'"\'/tmp/remote script.sh\'"\'"\'\''
         self.assertEqual(script_action.get_full_command_string(), ex)
 
+        # With sudo_password
+        script_action.sudo = True
+        script_action.sudo_password = 'sudo pass'
+
+        ex = 'echo -e \'sudo pass\n\' | sudo -S -E -- bash -c ' + \
+             '\'cd /tmp && \'"\'"\'/tmp/remote script.sh\'"\'"\'\''
+        self.assertEqual(script_action.get_full_command_string(), ex)
+
     def test_script_path_shell_injection_safe_with_env_vars(self):
-        script_action = ParamikoRemoteScriptActionTests._get_test_script_action()
+        script_action = ParamikoRemoteScriptActionTestCase._get_test_script_action()
         test_path = '/tmp/remote script.sh'
         script_action.remote_script = test_path
         script_action.named_args = {}
@@ -115,6 +146,15 @@ class ParamikoRemoteScriptActionTests(unittest2.TestCase):
         # Test with sudo
         script_action.sudo = True
         ex = 'sudo -E -- bash -c ' + \
+             '\'export FOO=BAR && ' + \
+             'cd /tmp && \'"\'"\'/tmp/remote script.sh\'"\'"\'\''
+        self.assertEqual(script_action.get_full_command_string(), ex)
+
+        # With sudo_password
+        script_action.sudo = True
+        script_action.sudo_password = 'sudo pass'
+
+        ex = 'echo -e \'sudo pass\n\' | sudo -S -E -- bash -c ' + \
              '\'export FOO=BAR && ' + \
              'cd /tmp && \'"\'"\'/tmp/remote script.sh\'"\'"\'\''
         self.assertEqual(script_action.get_full_command_string(), ex)

--- a/st2common/tests/unit/test_shell_action_system_model.py
+++ b/st2common/tests/unit/test_shell_action_system_model.py
@@ -68,7 +68,7 @@ class ShellCommandActionTestCase(unittest2.TestCase):
         action = ShellCommandAction(**kwargs)
         command = action.get_full_command_string()
 
-        expected_command = 'echo -e \'sudopass\n\' | sudo -S -E -H -u mauser -- bash -c \'ls -la\''
+        expected_command = 'sudo -S -E -H -u mauser -- bash -c \'ls -la\''
         self.assertEqual(command, expected_command)
 
         # sudo is used, it doesn't matter what user is specified since the
@@ -88,7 +88,7 @@ class ShellCommandActionTestCase(unittest2.TestCase):
         action = ShellCommandAction(**kwargs)
         command = action.get_full_command_string()
 
-        expected_command = 'echo -e \'sudopass\n\' | sudo -S -E -- bash -c \'ls -la\''
+        expected_command = 'sudo -S -E -- bash -c \'ls -la\''
         self.assertEqual(command, expected_command)
 
 
@@ -137,7 +137,7 @@ class ShellScriptActionTestCase(unittest2.TestCase):
         action = ShellScriptAction(**kwargs)
         command = action.get_full_command_string()
 
-        expected_command = 'echo -e \'sudopass\n\' | sudo -S -E -H -u mauser -- bash -c /tmp/foo.sh'
+        expected_command = 'sudo -S -E -H -u mauser -- bash -c /tmp/foo.sh'
         self.assertEqual(command, expected_command)
 
         # complex sudo password which needs escaping
@@ -148,7 +148,7 @@ class ShellScriptActionTestCase(unittest2.TestCase):
         action = ShellScriptAction(**kwargs)
         command = action.get_full_command_string()
 
-        expected_command = ('echo -e \'$udo p\'"\'"\'as"sss\n\' | sudo -S -E -H '
+        expected_command = ('sudo -S -E -H '
                             '-u mauser -- bash -c /tmp/foo.sh')
         self.assertEqual(command, expected_command)
 
@@ -166,7 +166,7 @@ class ShellScriptActionTestCase(unittest2.TestCase):
         action = ShellScriptAction(**kwargs)
         command = action.get_full_command_string()
 
-        expected_command = 'echo -e \'sudopass\n\' | sudo -S -E -- bash -c /tmp/foo.sh'
+        expected_command = 'sudo -S -E -- bash -c /tmp/foo.sh'
         self.assertEqual(command, expected_command)
 
     def test_command_construction_with_parameters(self):
@@ -190,7 +190,7 @@ class ShellScriptActionTestCase(unittest2.TestCase):
         action = ShellScriptAction(**kwargs)
         command = action.get_full_command_string()
 
-        expected = ('echo -e \'sudopass\n\' | sudo -S -E -- bash -c '
+        expected = ('sudo -S -E -- bash -c '
                     '\'/tmp/foo.sh key2=value2 key1=value1\'')
         self.assertEqual(command, expected)
 
@@ -215,7 +215,7 @@ class ShellScriptActionTestCase(unittest2.TestCase):
         action = ShellScriptAction(**kwargs)
 
         command = action.get_full_command_string()
-        expected = ('echo -e \'sudopass\n\' | sudo -S -E -H -u mauser -- bash -c '
+        expected = ('sudo -S -E -H -u mauser -- bash -c '
                     '\'/tmp/foo.sh key2=value2 key1=value1\'')
         self.assertEqual(command, expected)
 

--- a/st2common/tests/unit/test_shell_action_system_model.py
+++ b/st2common/tests/unit/test_shell_action_system_model.py
@@ -21,7 +21,7 @@ import unittest2
 
 from st2common.models.system.action import ShellCommandAction
 from st2common.models.system.action import ShellScriptAction
-
+from st2common.logging.formatters import MASKED_ATTRIBUTE_VALUE
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 FIXTURES_DIR = os.path.abspath(os.path.join(CURRENT_DIR, '../fixtures'))
@@ -150,6 +150,11 @@ class ShellScriptActionTestCase(unittest2.TestCase):
 
         expected_command = ('echo -e \'$udo p\'"\'"\'as"sss\n\' | sudo -S -E -H '
                             '-u mauser -- bash -c /tmp/foo.sh')
+        self.assertEqual(command, expected_command)
+
+        command = action.get_sanitized_full_command_string()
+        expected_command = ('echo -e \'%s\n\' | sudo -S -E -H '
+                            '-u mauser -- bash -c /tmp/foo.sh' % (MASKED_ATTRIBUTE_VALUE))
         self.assertEqual(command, expected_command)
 
         # sudo is used, it doesn't matter what user is specified since the

--- a/tools/log_watcher.py
+++ b/tools/log_watcher.py
@@ -129,9 +129,9 @@ def _detect_log_lines(fil, matchers):
 
         ln = 0
         for line in lines:
-            l = line.strip()
+            line = line.strip()
             ln += 1
-            matched, level, line = _match(l, matchers)
+            matched, level, line = _match(line, matchers)
             if matched:
                 # print('File: %s, Level: %s, Line: %d:%s' % (fil, level, ln, line.strip()))
                 FILE_LOG_COUNT[fil][level] += 1


### PR DESCRIPTION
This pull request adds support for sudo password.

As an additional change, I added new ``--tail`` flag to ``st2 run`` and ``st2 execution re-run`` commands. When this flag is provided, new execution is automatically tailed once it's scheduled (it saves typing one command - previously you first need to do run then tail).

## TODO

- [x] More tests
- [x] Remote runner testing and implementation
- [x] Correctly intercept and handle "invalid sudo password" errors and throw a user-friendly exception
  - [x] Local runner
  - [x] Remote runner
- [x] Documentation