### PR TITLE
Tidied author and description fields in packs

### DIFF
--- a/contrib/chatops/pack.yaml
+++ b/contrib/chatops/pack.yaml
@@ -2,7 +2,7 @@
 name: chatops
 description: ChatOps integration pack
 version: 1.0.0
-author: Stackstorm Inc
+author: StackStorm, Inc.
 contributors:
   - Anthony Shaw <anthonyshaw@apache.org>
 email: info@stackstorm.com

--- a/contrib/core/pack.yaml
+++ b/contrib/core/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name : core
-description : Pack containing basic actions.
+description : Basic core actions.
 version : 1.0.0
-author : Stackstorm Inc
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/contrib/default/pack.yaml
+++ b/contrib/default/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name: default
-description: Pack where all the resources which are created using the API and don't have a pack specified get saved.
+description: Default pack where all resources created using the API with no pack specified get saved.
 version: 1.0.0
-author : Stackstorm Inc
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/contrib/examples/pack.yaml
+++ b/contrib/examples/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name: examples
-description: Pack which contains various examples of sensors, triggers, actions and rules.
+description: Example sensors, triggers, actions and rules.
 version: 0.2.0
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/contrib/hello_st2/pack.yaml
+++ b/contrib/hello_st2/pack.yaml
@@ -1,10 +1,10 @@
 ---
 ref: hello_st2
 name: Hello StackStorm
-description: A simple pack containing examples of sensor, rule, and action.
+description: Simple pack containing examples of sensor, rule, and action.
 keywords:
     - example
     - test
 version: 0.1.0
-author: st2-dev
+author: StackStorm, Inc.
 email: info@stackstorm.com

--- a/contrib/linux/pack.yaml
+++ b/contrib/linux/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name : linux
-description : Generic linux actions
+description : Generic Linux actions
 keywords:
   - linux
   - nmap
@@ -17,5 +17,5 @@ keywords:
   - processes
   - ps
 version : 1.0.1
-author : Stackstorm Inc
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/contrib/packs/pack.yaml
+++ b/contrib/packs/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name : packs
-description : Pack containing pack management functionality.
+description : Pack management functionality.
 version : 1.0.0
-author : Stackstorm Inc
+author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
The `author:` field in our core packs was inconsistent with what we use in Exchange packs. This makes it `StackStorm, Inc.`.

Also cleaned up some pack descriptions. 

No changes to packs themselves, so not bothering to bump pack versions.

Related: https://github.com/StackStorm-Exchange/stackstorm-slack/pull/13