### PR TITLE
Fix bugs with newlines and unicode in execution formatter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -74,6 +74,8 @@ Fixed
   executions in the database. (bug fix) #3760 #3802
 * Fix 'NameError: name 'cmd' is not defined' error when using ``linux.service`` with CentOS systems.
   #3843. Contributed by @shkadov
+* Fix bugs with newlines in execution formatter (client)
+  (bug fix) #3872
 
 2.5.0 - October 25, 2017
 ------------------------

--- a/st2client/st2client/formatters/execution.py
+++ b/st2client/st2client/formatters/execution.py
@@ -60,6 +60,7 @@ class ExecutionResult(formatters.Formatter):
                                                      width=sys.maxint,
                                                      indent=2)[len(attr) + 2:-1]
                     value = ('\n' if isinstance(value, dict) else '') + formatted_value
+                    value = strutil.dedupe_newlines(value)
 
                 # transform the value of our attribute so things like 'status'
                 # and 'timestamp' are formatted nicely
@@ -69,4 +70,4 @@ class ExecutionResult(formatters.Formatter):
 
                 output += ('\n' if output else '') + '%s: %s' % \
                     (DisplayColors.colorize(attr, DisplayColors.BLUE), value)
-        return output
+        return strutil.unescape(output)

--- a/st2client/st2client/formatters/execution.py
+++ b/st2client/st2client/formatters/execution.py
@@ -70,4 +70,5 @@ class ExecutionResult(formatters.Formatter):
 
                 output += ('\n' if output else '') + '%s: %s' % \
                     (DisplayColors.colorize(attr, DisplayColors.BLUE), value)
-        return strutil.unescape(output)
+
+        return strutil.unescape(output).decode('unicode_escape').encode('utf-8')

--- a/st2client/st2client/utils/strutil.py
+++ b/st2client/st2client/utils/strutil.py
@@ -27,6 +27,19 @@ def unescape(s):
     return s
 
 
+def dedupe_newlines(s):
+    """yaml.safe_dump converts single newlines to double.
+
+    Since we're printing this output and not loading it, we should
+    deduplicate them.
+    """
+
+    if isinstance(s, basestring):
+        s = s.replace('\n\n', '\n')
+
+    return s
+
+
 def strip_carriage_returns(s):
     if isinstance(s, basestring):
         s = s.replace('\\r', '')

--- a/st2client/tests/fixtures/execution_get_default.txt
+++ b/st2client/tests/fixtures/execution_get_default.txt
@@ -8,17 +8,11 @@ result:
     return_code: 0
     stderr: ''
     stdout: 'PING 127.0.0.1 (127.0.0.1) 56(84) bytes of data.
-
       64 bytes from 127.0.0.1: icmp_seq=1 ttl=64 time=0.015 ms
-
       64 bytes from 127.0.0.1: icmp_seq=2 ttl=64 time=0.024 ms
-
       64 bytes from 127.0.0.1: icmp_seq=3 ttl=64 time=0.030 ms
 
-
       --- 127.0.0.1 ping statistics ---
-
       3 packets transmitted, 3 received, 0% packet loss, time 1998ms
-
       rtt min/avg/max/mdev = 0.015/0.023/0.030/0.006 ms'
     succeeded: true

--- a/st2client/tests/fixtures/execution_unescape_newline.txt
+++ b/st2client/tests/fixtures/execution_unescape_newline.txt
@@ -1,0 +1,13 @@
+id: 547e19561e2e2417d3dde123
+status: succeeded (1s elapsed)
+parameters: None
+result: 
+  localhost:
+    failed: false
+    return_code: 0
+    stderr: "FOOBAR1
+Traceback (most recent call last):
+ "
+    stdout: 'FOOBAR2
+      '
+    succeeded: true

--- a/st2client/tests/fixtures/execution_unicode.json
+++ b/st2client/tests/fixtures/execution_unicode.json
@@ -1,0 +1,27 @@
+{
+    "id": "547e19561e2e2417d3dde321",
+    "parameters": {
+        "cmd": "echo '‡'"
+    },
+    "callback": {},
+    "context": {
+        "user": "stanley"
+    },
+    "result": {
+        "failed": false,
+        "stderr": "",
+        "return_code": 0,
+        "succeeded": true,
+        "stdout": "‡"
+    },
+    "status": "succeeded",
+    "start_timestamp": "2014-12-02T19:56:06.900000Z",
+    "end_timestamp": "2014-12-02T19:56:07.000000Z",
+    "action": {
+        "ref": "core.local"
+    },
+    "liveaction": {
+        "callback": {},
+        "id": "1"
+    }
+}

--- a/st2client/tests/fixtures/execution_unicode.txt
+++ b/st2client/tests/fixtures/execution_unicode.txt
@@ -1,0 +1,10 @@
+id: 547e19561e2e2417d3dde321
+status: succeeded (1s elapsed)
+parameters: 
+  cmd: "echo '‡'"
+result: 
+  failed: false
+  return_code: 0
+  stderr: ''
+  stdout: "‡"
+  succeeded: true

--- a/st2client/tests/fixtures/execution_with_stack_trace.json
+++ b/st2client/tests/fixtures/execution_with_stack_trace.json
@@ -1,0 +1,26 @@
+{
+    "id": "547e19561e2e2417d3dde123",
+    "callback": {},
+    "context": {
+        "user": "stanley"
+    },
+    "result": {
+        "localhost": {
+            "failed": false,
+            "return_code": 0,
+            "succeeded": true,
+            "stdout": "FOOBAR2\n",
+            "stderr": "FOOBAR1\nTraceback (most recent call last):\n "
+        }
+    },
+    "status": "succeeded",
+    "start_timestamp": "2014-12-02T19:56:06.900000Z",
+    "end_timestamp": "2014-12-02T19:56:07.000000Z",
+    "action": {
+        "ref": "core.stacktrace"
+    },
+    "liveaction": {
+        "callback": {},
+        "id": "1"
+    }
+}

--- a/st2client/tests/unit/test_formatters.py
+++ b/st2client/tests/unit/test_formatters.py
@@ -38,6 +38,7 @@ LOG = logging.getLogger(__name__)
 FIXTURES_MANIFEST = {
     'executions': ['execution.json',
                    'execution_result_has_carriage_return.json',
+                   'execution_unicode.json',
                    'execution_with_stack_trace.json'],
     'results': ['execution_get_default.txt',
                 'execution_get_detail.txt',
@@ -46,11 +47,13 @@ FIXTURES_MANIFEST = {
                 'execution_get_attributes.txt',
                 'execution_list_attr_start_timestamp.txt',
                 'execution_list_empty_response_start_timestamp_attr.txt',
-                'execution_unescape_newline.txt']
+                'execution_unescape_newline.txt',
+                'execution_unicode.txt']
 }
 
 FIXTURES = loader.load_fixtures(fixtures_dict=FIXTURES_MANIFEST)
 EXECUTION = FIXTURES['executions']['execution.json']
+UNICODE = FIXTURES['executions']['execution_unicode.json']
 NEWLINE = FIXTURES['executions']['execution_with_stack_trace.json']
 HAS_CARRIAGE_RETURN = FIXTURES['executions']['execution_result_has_carriage_return.json']
 
@@ -113,6 +116,9 @@ class TestExecutionResultFormatter(unittest2.TestCase):
         httpclient.HTTPClient, 'get',
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(NEWLINE), 200, 'OK', {})))
     def test_execution_unescape_newline(self):
+        """Ensure client renders newline characters
+        """
+
         argv = ['execution', 'get', NEWLINE['id']]
         self.assertEqual(self.shell.run(argv), 0)
         self._undo_console_redirect()
@@ -120,6 +126,21 @@ class TestExecutionResultFormatter(unittest2.TestCase):
             content = fd.read()
 
         self.assertEqual(content, FIXTURES['results']['execution_unescape_newline.txt'])
+
+    @mock.patch.object(
+        httpclient.HTTPClient, 'get',
+        mock.MagicMock(return_value=base.FakeResponse(json.dumps(UNICODE), 200, 'OK', {})))
+    def test_execution_unicode(self):
+        """Ensure client renders unicode escape sequences
+        """
+
+        argv = ['execution', 'get', UNICODE['id']]
+        self.assertEqual(self.shell.run(argv), 0)
+        self._undo_console_redirect()
+        with open(self.path, 'r') as fd:
+            content = fd.read()
+
+        self.assertEqual(content, FIXTURES['results']['execution_unicode.txt'])
 
     def test_execution_get_detail_in_json(self):
         argv = ['execution', 'get', EXECUTION['id'], '-d', '-j']

--- a/st2client/tests/unit/test_formatters.py
+++ b/st2client/tests/unit/test_formatters.py
@@ -37,18 +37,21 @@ LOG = logging.getLogger(__name__)
 
 FIXTURES_MANIFEST = {
     'executions': ['execution.json',
-                   'execution_result_has_carriage_return.json'],
+                   'execution_result_has_carriage_return.json',
+                   'execution_with_stack_trace.json'],
     'results': ['execution_get_default.txt',
                 'execution_get_detail.txt',
                 'execution_get_result_by_key.txt',
                 'execution_result_has_carriage_return.txt',
                 'execution_get_attributes.txt',
                 'execution_list_attr_start_timestamp.txt',
-                'execution_list_empty_response_start_timestamp_attr.txt']
+                'execution_list_empty_response_start_timestamp_attr.txt',
+                'execution_unescape_newline.txt']
 }
 
 FIXTURES = loader.load_fixtures(fixtures_dict=FIXTURES_MANIFEST)
 EXECUTION = FIXTURES['executions']['execution.json']
+NEWLINE = FIXTURES['executions']['execution_with_stack_trace.json']
 HAS_CARRIAGE_RETURN = FIXTURES['executions']['execution_result_has_carriage_return.json']
 
 
@@ -105,6 +108,18 @@ class TestExecutionResultFormatter(unittest2.TestCase):
         argv = ['execution', 'get', EXECUTION['id'], '-d']
         content = self._get_execution(argv)
         self.assertEqual(content, FIXTURES['results']['execution_get_detail.txt'])
+
+    @mock.patch.object(
+        httpclient.HTTPClient, 'get',
+        mock.MagicMock(return_value=base.FakeResponse(json.dumps(NEWLINE), 200, 'OK', {})))
+    def test_execution_unescape_newline(self):
+        argv = ['execution', 'get', NEWLINE['id']]
+        self.assertEqual(self.shell.run(argv), 0)
+        self._undo_console_redirect()
+        with open(self.path, 'r') as fd:
+            content = fd.read()
+
+        self.assertEqual(content, FIXTURES['results']['execution_unescape_newline.txt'])
 
     def test_execution_get_detail_in_json(self):
         argv = ['execution', 'get', EXECUTION['id'], '-d', '-j']


### PR DESCRIPTION
The execution formatter had some bugs that caused some problems with properly representing newline characters. This PR addresses two problems:

- Extra escape characters are added to the output of `yaml.safe_dump`. This means that newline characters `\n` are escaped, and are, as a result, not honored in the final client output. This means that complicated output like stack traces are output as a single line, which makes it wholly unreadable.
- `yaml.safe_dump` also adds a second `\n` to existing instances of `\n`, resulting in `\n\n`. Since we're printing this resulting value, this results in a lot of whitespace in output

# Explanation of Changes

As documented in #3855, the client has exhibited some strange behavior showing certain executions - in particular, Python stack traces:

```
~$ st2 run testpack.newline_test_error outcome="exception"
.
id: 5a1359b132ed3504e7a69b4f
status: failed
parameters:
  outcome: exception
result:
  exit_code: 1
  result: None
  stderr: "FOOBAR1\nTraceback (most recent call last):\n  File \"/home/vagrant/st2/st2common/st2common/runners/python_action_wrapper.py\", line 276, in <module>\n    obj.run()\n  File \"/home/vagrant/st2/st2common/st2common/runners/python_action_wrapper.py\", line 169, in run\n    output = action.run(**self._parameters)\n  File \"/opt/stackstorm/packs/testpack/actions/newline_test_error.py\", line 24, in run\n    raise Exception(\"This is an exception\")\nException: This is an exception\n"
  stdout: 'FOOBAR2

    '
```

The above example shows the entire stack trace on a single line, since the newline characters are escaped behind the scenes. This makes reading this stack trace incredibly hard to read. This is actually a VERY simple example - I've run into way worse examples during support for our own CI, such as when this comes up for tabular output, making tables 100% unreadable.

Please see [this comment](https://github.com/StackStorm/st2/issues/3855#issuecomment-345835804) for a detailed explanation of why this is happening.

The fix was to pass the resulting value for each attribute through `strutils.unescape()` once more. This stripped away the extra escape slashes, and newline characters are now rendered properly on output:

```
~$ st2 run testpack.newline_test_error outcome="exception"
.
id: 5a13599b32ed3504e7a69b4c
status: failed
parameters:
  outcome: exception
result:
  exit_code: 1
  result: None
  stderr: "FOOBAR1
Traceback (most recent call last):
  File "/home/vagrant/st2/st2common/st2common/runners/python_action_wrapper.py", line 276, in <module>
    obj.run()
  File "/home/vagrant/st2/st2common/st2common/runners/python_action_wrapper.py", line 169, in run
    output = action.run(**self._parameters)
  File "/opt/stackstorm/packs/testpack/actions/newline_test_error.py", line 24, in run
    raise Exception("This is an exception")
Exception: This is an exception
"
  stdout: 'FOOBAR2
    '
```

In addition, I added a new function for removing duplicate newlines introduced by `yaml.safe_dump`. This addresses the concerns brought up in #3602 - note that in the first output above, `stdout` contained a line of whitespace at the end, and in the second output, this whitespace is gone.

Closes https://github.com/StackStorm/st2/issues/3855
Closes https://github.com/StackStorm/st2/issues/3602