### PR TITLE
Additional contexts for rendering live params

### DIFF
--- a/st2common/st2common/util/param.py
+++ b/st2common/st2common/util/param.py
@@ -217,7 +217,7 @@ def _cast_params_from(params, context, schemas):
 
 
 def render_live_params(runner_parameters, action_parameters, params, action_context,
-        additional_contexts=None):
+        additional_contexts={}):
     '''
     Renders list of parameters. Ensures that there's no cyclic or missing dependencies. Returns a
     dict of plain rendered parameters.
@@ -226,9 +226,10 @@ def render_live_params(runner_parameters, action_parameters, params, action_cont
 
     G = _create_graph(action_context, config)
 
-    if additional_contexts:
-        for name, value in six.iteritems(additional_contexts):
-            G.add_node(name, value=value)
+    # Additional contexts are applied after all other contexts (see _create_graph), but before any
+    # of the dependencies have been resolved.
+    for name, value in six.iteritems(additional_contexts):
+        G.add_node(name, value=value)
 
     [_process(G, name, value) for name, value in six.iteritems(params)]
     _process_defaults(G, [action_parameters, runner_parameters])

--- a/st2common/st2common/util/param.py
+++ b/st2common/st2common/util/param.py
@@ -216,7 +216,8 @@ def _cast_params_from(params, context, schemas):
     return result
 
 
-def render_live_params(runner_parameters, action_parameters, params, action_context):
+def render_live_params(runner_parameters, action_parameters, params, action_context,
+        additional_contexts=None):
     '''
     Renders list of parameters. Ensures that there's no cyclic or missing dependencies. Returns a
     dict of plain rendered parameters.
@@ -224,6 +225,10 @@ def render_live_params(runner_parameters, action_parameters, params, action_cont
     config = get_config(action_context.get('pack'), action_context.get('user'))
 
     G = _create_graph(action_context, config)
+
+    if additional_contexts:
+        for name, value in six.iteritems(additional_contexts):
+            G.add_node(name, value=value)
 
     [_process(G, name, value) for name, value in six.iteritems(params)]
     _process_defaults(G, [action_parameters, runner_parameters])

--- a/st2common/tests/unit/test_param_utils.py
+++ b/st2common/tests/unit/test_param_utils.py
@@ -619,3 +619,34 @@ class ParamsUtilsTest(DbTestCase):
             )
 
         return liveaction_db
+
+    def test_get_live_params_with_additional_context(self):
+        runner_param_info = {
+            'r1': {
+                'default': 'some'
+            }
+        }
+        action_param_info = {
+            'r2': {
+                'default': '{{ r1 }}'
+            }
+        }
+        params = {
+            'r3': 'lolcathost',
+            'r1': '{{ additional.stuff }}'
+        }
+        action_context = {}
+        additional_contexts = {
+            'additional': {
+                'stuff': 'generic'
+            }
+        }
+
+        live_params = param_utils.render_live_params(
+            runner_param_info, action_param_info, params, action_context, additional_contexts)
+
+        expected_params = {
+            'r1': 'generic',
+            'r3': 'lolcathost'
+        }
+        self.assertEqual(live_params, expected_params)


### PR DESCRIPTION
The feature is required for serverless plugin, but might be useful to further extend the variety of contexts during rendering.