### PR TITLE
Match and multiple execute

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,14 +20,19 @@ Added
   All runners are now also fully fledged Python packages (previously they were single module
   Python packages which caused various install and distribution related issues when installing
   them via pip) (new feature)
-* Add new ``search`` rule criteria comparison operator. For the usage, please refer to the
-  documentation. (new feature) #3833
+* Add new ``search`` rule criteria comparison operator. Please refer to the documentation for
+  usage. (new feature) #3833
 
   Contributed by @ahubl-mz.
 * Add new ``/api/v1/user`` API endpoint. This API endpoint is only available to the authenticated
   users and returns various metadata on the authenticated user (which method did the user use to
   authenticate, under which username the user is authenticated, which RBAC roles are assignment to
   this user in case RBAC is enabled, etc.) (new feature) #3831
+* The ``/api/v1/match_and_execute`` API endpoint matches a single alias and executes multiple times
+  if the alias format has a ``match_multiple`` key set to ``true``. Please refer to the
+  documentation for usage. #3884
+
+  Contributed by @ahubl-mz.
 * Add new ``get_user_info`` method to action and sensor service. With this method, user can
   retrieve information about the user account which is used to perform datastore operations inside
   the action and sensor service. (new feature) #3831

--- a/contrib/runners/local_runner/tests/integration/test_localrunner.py
+++ b/contrib/runners/local_runner/tests/integration/test_localrunner.py
@@ -435,7 +435,7 @@ class LocalShellScriptRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         # False is a default behavior so end result should be the same
         cfg.CONF.set_override(name='stream_output', group='actionrunner', override=False)
 
-    def test_script_with_paramters_parameter_serialization(self):
+    def test_script_with_parameters_parameter_serialization(self):
         models = self.fixtures_loader.load_models(
             fixtures_pack='generic', fixtures_dict={'actions': ['local_script_with_params.yaml']})
         action_db = models['actions']['local_script_with_params.yaml']

--- a/st2api/st2api/controllers/v1/actionalias.py
+++ b/st2api/st2api/controllers/v1/actionalias.py
@@ -78,16 +78,18 @@ class ActionAliasController(resource.ContentPackResourceController):
         command = action_alias_match_api.command
 
         try:
-            match = get_matching_alias(command=command)
+            format_ = get_matching_alias(command=command)
         except ActionAliasAmbiguityException as e:
             LOG.exception('Command "%s" matched (%s) patterns.', e.command, len(e.matches))
             return abort(http_client.BAD_REQUEST, str(e))
 
         # Convert ActionAliasDB to API
-        action_alias_api = ActionAliasAPI.from_model(match[0])
-        match = [action_alias_api, match[1], match[2]]
-        result = self._match_tuple_to_dict(match=match)
-        return result
+        action_alias_api = ActionAliasAPI.from_model(format_['alias'])
+        return {
+            'actionalias': action_alias_api,
+            'display': format_['display'],
+            'representation': format_['representation'],
+        }
 
     def help(self, filter, pack, limit, offset, **kwargs):
         """
@@ -200,13 +202,6 @@ class ActionAliasController(resource.ContentPackResourceController):
         LOG.audit('Action alias deleted. ActionAlias.id=%s.' % (action_alias_db.id), extra=extra)
 
         return Response(status=http_client.NO_CONTENT)
-
-    def _match_tuple_to_dict(self, match):
-        return {
-            'actionalias': match[0],
-            'display': match[1],
-            'representation': match[2]
-        }
 
 
 action_alias_controller = ActionAliasController()

--- a/st2api/st2api/controllers/v1/aliasexecution.py
+++ b/st2api/st2api/controllers/v1/aliasexecution.py
@@ -88,11 +88,12 @@ class ActionAliasExecutionController(BaseRestControllerMixin):
             params['notification_route'] = input_api.notification_route
 
         alias_execution_api = AliasMatchAndExecuteInputAPI(**params)
-        result = self.post(payload=alias_execution_api, requester_user=requester_user,
-                           show_secrets=show_secrets)
-        return result
+        result = self._post(payload=alias_execution_api, requester_user=requester_user,
+                            show_secrets=show_secrets)
 
-    def post(self, payload, requester_user, show_secrets=False):
+        return Response(json=result, status=http_client.CREATED)
+
+    def _post(self, payload, requester_user, show_secrets=False, match_multiple=False):
         action_alias_name = payload.name if payload else None
 
         if not action_alias_name:
@@ -166,6 +167,10 @@ class ActionAliasExecutionController(BaseRestControllerMixin):
                     'extra': 'Cannot render "extra" in field "ack" for alias. ' + e.message
                 })
 
+        return result
+
+    def post(self, payload, requester_user, show_secrets=False):
+        result = self._post(payload, requester_user, show_secrets)
         return Response(json=result, status=http_client.CREATED)
 
     def _tokenize_alias_execution(self, alias_execution):

--- a/st2api/st2api/controllers/v1/aliasexecution.py
+++ b/st2api/st2api/controllers/v1/aliasexecution.py
@@ -64,13 +64,13 @@ class ActionAliasExecutionController(BaseRestControllerMixin):
         command = input_api.command
 
         try:
-            match = get_matching_alias(command=command)
+            format_ = get_matching_alias(command=command)
         except ActionAliasAmbiguityException as e:
             LOG.exception('Command "%s" matched (%s) patterns.', e.command, len(e.matches))
             return abort(http_client.BAD_REQUEST, str(e))
 
-        action_alias_db = match[0]
-        representation = match[2]
+        action_alias_db = format_['alias']
+        representation = format_['representation']
 
         params = {
             'name': action_alias_db.name,

--- a/st2common/st2common/models/utils/action_alias_utils.py
+++ b/st2common/st2common/models/utils/action_alias_utils.py
@@ -176,6 +176,22 @@ class ActionAliasFormatParser(object):
 
         return self.match_params_in_stream(matched_stream)
 
+    def get_multiple_extracted_param_value(self):
+        """
+        Match command against the format string and extract paramters from the command string.
+
+        :rtype: ``list of dicts``
+        """
+        result = {}
+
+        # 4. Matching the command against our regex to get the param values
+        matched_streams = self._regex.finditer(self._param_stream)
+
+        results = []
+        for matched_stream in matched_streams:
+            results.append(self.match_params_in_stream(matched_stream))
+        return results
+
 
 def extract_parameters_for_action_alias_db(action_alias_db, format_str, param_stream):
     """

--- a/st2common/st2common/models/utils/action_alias_utils.py
+++ b/st2common/st2common/models/utils/action_alias_utils.py
@@ -178,7 +178,7 @@ class ActionAliasFormatParser(object):
 
     def get_multiple_extracted_param_value(self):
         """
-        Match command against the format string and extract paramters from the command string.
+        Match command against the format string and extract parameters from the command string.
 
         :rtype: ``list of dicts``
         """
@@ -193,7 +193,7 @@ class ActionAliasFormatParser(object):
         return results
 
 
-def extract_parameters_for_action_alias_db(action_alias_db, format_str, param_stream):
+def extract_parameters_for_action_alias_db(action_alias_db, format_str, param_stream, match_multiple=False):
     """
     Extract parameters from the user input based on the provided format string.
 
@@ -207,13 +207,19 @@ def extract_parameters_for_action_alias_db(action_alias_db, format_str, param_st
         raise ValueError('Format string "%s" is not available on the alias "%s"' %
                          (format_str, action_alias_db.name))
 
-    result = extract_parameters(format_str=format_str, param_stream=param_stream)
+    result = extract_parameters(
+        format_str=format_str,
+        param_stream=param_stream,
+        match_multiple=match_multiple)
     return result
 
 
-def extract_parameters(format_str, param_stream):
+def extract_parameters(format_str, param_stream, match_multiple=False):
     parser = ActionAliasFormatParser(alias_format=format_str, param_stream=param_stream)
-    return parser.get_extracted_param_value()
+    if match_multiple:
+        return parser.get_multiple_extracted_param_value()
+    else:
+        return parser.get_extracted_param_value()
 
 
 def search_regex_tokens(needle_tokens, haystack_tokens, backwards=False):

--- a/st2common/st2common/models/utils/action_alias_utils.py
+++ b/st2common/st2common/models/utils/action_alias_utils.py
@@ -45,21 +45,25 @@ class ActionAliasFormatParser(object):
 
     def __init__(self, alias_format=None, param_stream=None):
         self._format = alias_format or ''
-        self._param_stream = param_stream or ''
-
-    def get_extracted_param_value(self):
-        """
-        Match command against the format string and extract paramters from the command string.
-
-        :rtype: ``dict``
-        """
-        result = {}
-
-        param_stream = self._param_stream
+        self._original_param_stream = param_stream or ''
+        self._param_stream = self._original_param_stream
+        self._snippets = self.generate_snippets()
 
         # As there's a lot of questions about using regular expressions,
         # I'll try to be thorough when documenting this code.
 
+        # 1. Matching the arbitrary key-value pairs at the end of the command
+        # to support extra parameters (not specified in the format string),
+        # and cutting them from the command string afterwards.
+        self._kv_pairs, self._param_stream = self.match_kv_pairs_at_end()
+
+        # 2. Matching optional parameters (with default values).
+        self._optional = self.generate_optional_params_regex()
+
+        # 3. Convert the mangled format string into a regex object
+        self._regex = self.transform_format_string_into_regex()
+
+    def generate_snippets(self):
         # I'll split the whole convoluted regex into snippets to make it
         # a bit more readable (hopefully).
         snippets = dict()
@@ -87,25 +91,37 @@ class ActionAliasFormatParser(object):
         # Required parameter (no default value):
         snippets['required'] = '{{' + snippets['key'] + '}}'
 
+        return snippets
+
+    def match_kv_pairs_at_end(self):
+        param_stream = self._param_stream
+
         # 1. Matching the arbitrary key-value pairs at the end of the command
         # to support extra parameters (not specified in the format string),
         # and cutting them from the command string afterwards.
-        ending_pairs = re.match(snippets['ending'], param_stream, re.DOTALL)
+        ending_pairs = re.match(self._snippets['ending'], param_stream, re.DOTALL)
         has_ending_pairs = ending_pairs and ending_pairs.group(1)
         if has_ending_pairs:
-            kv_pairs = re.findall(snippets['pairs'], ending_pairs.group(1), re.DOTALL)
+            kv_pairs = re.findall(self._snippets['pairs'], ending_pairs.group(1), re.DOTALL)
             param_stream = param_stream.replace(ending_pairs.group(1), '')
+        else:
+            kv_pairs = []
         param_stream = " %s " % (param_stream)
 
-        # 2. Matching optional parameters (with default values).
-        optional = re.findall(snippets['optional'], self._format, re.DOTALL)
+        return (kv_pairs, param_stream)
 
+    def generate_optional_params_regex(self):
+        # 2. Matching optional parameters (with default values).
+        return re.findall(self._snippets['optional'], self._format, re.DOTALL)
+
+    def transform_format_string_into_regex(self):
+        # 3. Convert the mangled format string into a regex object
         # Transforming our format string into a regular expression,
         # substituting {{ ... }} with regex named groups, so that param_stream
         # matched against this expression yields a dict of params with values.
         param_match = r'\1["\']?(?P<\2>(?:(?<=\').+?(?=\')|(?<=").+?(?=")|{.+?}|.+?))["\']?'
-        reg = re.sub(r'(\s*)' + snippets['optional'], r'(?:' + param_match + r')?', self._format)
-        reg = re.sub(r'(\s*)' + snippets['required'], param_match, reg)
+        reg = re.sub(r'(\s*)' + self._snippets['optional'], r'(?:' + param_match + r')?', self._format)
+        reg = re.sub(r'(\s*)' + self._snippets['required'], param_match, reg)
 
         reg_tokens = parse(reg, flags=re.DOTALL)
 
@@ -117,33 +133,48 @@ class ActionAliasFormatParser(object):
         if not search_regex_tokens(((AT, AT_END), (AT, AT_END_STRING)), reg_tokens, backwards=True):
             reg = reg + r'\s*$'
 
-        # 3. Matching the command against our regex to get the param values
-        matched_stream = re.match(reg, param_stream, re.DOTALL)
+        return re.compile(reg, re.DOTALL)
 
+    def match_params_in_stream(self, matched_stream):
+        # 5. Pull out a dictionary of matched groups, apply default parameters and extra parameters
         if not matched_stream:
             # If no match is found we throw since this indicates provided user string (command)
             # didn't match the provided format string
             raise ParseException('Command "%s" doesn\'t match format string "%s"' %
-                                 (self._param_stream, self._format))
+                                 (self._original_param_stream, self._format))
 
         # Compiling results from the steps 1-3.
         if matched_stream:
             result = matched_stream.groupdict()
 
-        for param in optional:
+        # Apply optional parameters/add the default parameters
+        for param in self._optional:
             matched_value = result[param[0]] if matched_stream else None
             matched_result = matched_value or ''.join(param[1:])
             if matched_result is not None:
                 result[param[0]] = matched_result
 
-        if has_ending_pairs:
-            for pair in kv_pairs:
-                result[pair[0]] = ''.join(pair[2:])
+        # Apply given parameters
+        for pair in self._kv_pairs:
+            result[pair[0]] = ''.join(pair[2:])
 
         if self._format and not (self._param_stream.strip() or any(result.values())):
             raise ParseException('No value supplied and no default value found.')
 
         return result
+
+    def get_extracted_param_value(self):
+        """
+        Match command against the format string and extract parameters from the command string.
+
+        :rtype: ``dict``
+        """
+        result = {}
+
+        # 4. Matching the command against our regex to get the param values
+        matched_stream = self._regex.search(self._param_stream)
+
+        return self.match_params_in_stream(matched_stream)
 
 
 def extract_parameters_for_action_alias_db(action_alias_db, format_str, param_stream):

--- a/st2common/st2common/persistence/execution.py
+++ b/st2common/st2common/persistence/execution.py
@@ -42,8 +42,8 @@ class ActionExecution(Access):
         return cls.publisher
 
     @classmethod
-    def delete_by_query(cls, **query):
-        return cls._get_impl().delete_by_query(**query)
+    def delete_by_query(cls, *args, **query):
+        return cls._get_impl().delete_by_query(*args, **query)
 
 
 class ActionExecutionOutput(Access):
@@ -61,5 +61,5 @@ class ActionExecutionOutput(Access):
         return cls.publisher
 
     @classmethod
-    def delete_by_query(cls, **query):
-        return cls._get_impl().delete_by_query(**query)
+    def delete_by_query(cls, *args, **query):
+        return cls._get_impl().delete_by_query(*args, **query)

--- a/st2common/st2common/persistence/liveaction.py
+++ b/st2common/st2common/persistence/liveaction.py
@@ -35,5 +35,5 @@ class LiveAction(persistence.StatusBasedResource):
         return cls.publisher
 
     @classmethod
-    def delete_by_query(cls, **query):
-        return cls._get_impl().delete_by_query(**query)
+    def delete_by_query(cls, *args, **query):
+        return cls._get_impl().delete_by_query(*args, **query)

--- a/st2common/st2common/persistence/trigger.py
+++ b/st2common/st2common/persistence/trigger.py
@@ -87,5 +87,5 @@ class TriggerInstance(Access):
         return cls.impl
 
     @classmethod
-    def delete_by_query(cls, **query):
-        return cls._get_impl().delete_by_query(**query)
+    def delete_by_query(cls, *args, **query):
+        return cls._get_impl().delete_by_query(*args, **query)

--- a/st2common/st2common/util/actionalias_helpstring.py
+++ b/st2common/st2common/util/actionalias_helpstring.py
@@ -52,7 +52,7 @@ def generate_helpstring_result(aliases, filter=None, pack=None, limit=0, offset=
         if pack and pack != alias.pack:
             continue
         for format_ in alias.formats:
-            display, _ = normalise_alias_format_string(format_)
+            display, _, _ = normalise_alias_format_string(format_)
             if display:
                 # Skip help strings not containing keyword.
                 if not re.search(filter or '', display, flags=re.IGNORECASE):

--- a/st2common/st2common/util/actionalias_matching.py
+++ b/st2common/st2common/util/actionalias_matching.py
@@ -43,9 +43,22 @@ def list_format_strings_from_aliases(aliases):
         for format_ in alias.formats:
             display, representations = normalise_alias_format_string(format_)
             if display and len(representations) == 0:
-                patterns.extend([(display, [])])
+                patterns.append({
+                    'alias': alias,
+                    'format': format_,
+                    'display': display,
+                    'representation': [],
+                })
             else:
-                patterns.extend([(display, representation) for representation in representations])
+                patterns.extend([
+                    {
+                        'alias': alias,
+                        'format': format_,
+                        'display': display,
+                        'representation': representation,
+                    }
+                    for representation in representations
+                ])
     return patterns
 
 
@@ -88,15 +101,15 @@ def match_command_to_alias(command, aliases):
     results = []
 
     for alias in aliases:
-        format_strings = list_format_strings_from_aliases([alias])
-        for format_string in format_strings:
+        formats = list_format_strings_from_aliases([alias])
+        for format_ in formats:
             try:
-                extract_parameters(format_str=format_string[1],
+                extract_parameters(format_str=format_['representation'],
                                    param_stream=command)
             except ParseException:
                 continue
 
-            results.append((alias, format_string[0], format_string[1]))
+            results.append(format_)
     return results
 
 

--- a/st2common/st2common/util/actionalias_matching.py
+++ b/st2common/st2common/util/actionalias_matching.py
@@ -47,7 +47,7 @@ def list_format_strings_from_aliases(aliases):
                     'alias': alias,
                     'format': format_,
                     'display': display,
-                    'representation': [],
+                    'representation': '',
                 })
             else:
                 patterns.extend([

--- a/st2common/st2common/util/actionalias_matching.py
+++ b/st2common/st2common/util/actionalias_matching.py
@@ -15,6 +15,7 @@
 
 import six
 
+from mongoengine.queryset.visitor import Q
 
 from st2common.exceptions.content import ParseException
 from st2common.exceptions.actionalias import ActionAliasAmbiguityException
@@ -24,11 +25,12 @@ from st2common.models.utils.action_alias_utils import extract_parameters
 __all__ = [
     'list_format_strings_from_aliases',
     'normalise_alias_format_string',
-    'match_command_to_alias'
+    'match_command_to_alias',
+    'get_matching_alias',
 ]
 
 
-def list_format_strings_from_aliases(aliases):
+def list_format_strings_from_aliases(aliases, match_multiple=False):
     '''
     List patterns from a collection of alias objects
 
@@ -41,7 +43,7 @@ def list_format_strings_from_aliases(aliases):
     patterns = []
     for alias in aliases:
         for format_ in alias.formats:
-            display, representations = normalise_alias_format_string(format_)
+            display, representations, _match_multiple = normalise_alias_format_string(format_)
             if display and len(representations) == 0:
                 patterns.append({
                     'alias': alias,
@@ -56,6 +58,7 @@ def list_format_strings_from_aliases(aliases):
                         'format': format_,
                         'display': display,
                         'representation': representation,
+                        'match_multiple': _match_multiple,
                     }
                     for representation in representations
                 ])
@@ -79,6 +82,7 @@ def normalise_alias_format_string(alias_format):
     '''
     display = None
     representation = []
+    match_multiple = False
 
     if isinstance(alias_format, six.string_types):
         display = alias_format
@@ -88,20 +92,21 @@ def normalise_alias_format_string(alias_format):
         representation = alias_format.get('representation') or []
         if isinstance(representation, six.string_types):
             representation = [representation]
+        match_multiple = alias_format.get('match_multiple', match_multiple)
     else:
         raise TypeError("alias_format '%s' is neither a dictionary or string type."
                         % repr(alias_format))
-    return (display, representation)
+    return (display, representation, match_multiple)
 
 
-def match_command_to_alias(command, aliases):
+def match_command_to_alias(command, aliases, match_multiple=False):
     """
     Match the text against an action and return the action reference.
     """
     results = []
 
     for alias in aliases:
-        formats = list_format_strings_from_aliases([alias])
+        formats = list_format_strings_from_aliases([alias], match_multiple)
         for format_ in formats:
             try:
                 extract_parameters(format_str=format_['representation'],
@@ -118,7 +123,9 @@ def get_matching_alias(command):
     Find a matching ActionAliasDB object (if any) for the provided command.
     """
     # 1. Get aliases
-    action_alias_dbs = ActionAlias.query(enabled=True)
+    action_alias_dbs = ActionAlias.query(
+        Q(formats__match_multiple=None) | Q(formats__match_multiple=False),
+        enabled=True)
 
     # 2. Match alias(es) to command
     matches = match_command_to_alias(command=command, aliases=action_alias_dbs)
@@ -129,9 +136,23 @@ def get_matching_alias(command):
                                             matches=matches,
                                             command=command)
     elif len(matches) == 0:
-        raise ActionAliasAmbiguityException("Command '%s' matched no patterns" %
-                                            command,
-                                            matches=[],
-                                            command=command)
+        match_multiple_action_alias_dbs = ActionAlias.query(
+            formats__match_multiple=True,
+            enabled=True)
+
+        matches = match_command_to_alias(command=command, aliases=match_multiple_action_alias_dbs,
+                                         match_multiple=True)
+
+        if len(matches) > 1:
+            raise ActionAliasAmbiguityException("Command '%s' matched more than 1 (multi) pattern" %
+                                                command,
+                                                matches=matches,
+                                                command=command)
+
+        if len(matches) == 0:
+            raise ActionAliasAmbiguityException("Command '%s' matched no patterns" %
+                                                command,
+                                                matches=[],
+                                                command=command)
 
     return matches[0]

--- a/st2common/tests/unit/test_resource_registrar.py
+++ b/st2common/tests/unit/test_resource_registrar.py
@@ -162,7 +162,7 @@ class ResourceRegistrarTestCase(CleanDbTestCase):
         self.assertEqual(pack_db.stackstorm_version, '>=1.6.0, <2.2.0')
         self.assertEqual(pack_db.system, {'centos': {'foo': '>= 1.0'}})
 
-        # Note: We only store paramters which are defined in the schema, all other custom user
+        # Note: We only store parameters which are defined in the schema, all other custom user
         # defined attributes are ignored
         self.assertTrue(not hasattr(pack_db, 'future'))
         self.assertTrue(not hasattr(pack_db, 'this'))

--- a/st2common/tests/unit/test_util_actionalias_matching.py
+++ b/st2common/tests/unit/test_util_actionalias_matching.py
@@ -100,6 +100,16 @@ class ActionAliasTestCase(unittest2.TestCase):
         self.assertEqual([result[0]], result[1])
         self.assertEqual(result[0], "Quite an experience to live in fear, isn't it?")
 
+    def test_normalise_alias_format_string_error(self, mock):
+        alias_list = ["Quite an experience to live in fear, isn't it?"]
+        expected_msg = ("alias_format '%s' is neither a dictionary or string type."
+            % repr(alias_list))
+
+        with self.assertRaises(TypeError) as cm:
+            matching.normalise_alias_format_string(alias_list)
+
+        self.assertEqual(cm.exception.message, expected_msg)
+
     def test_matching(self, mock):
         ALIASES = [
             MemoryActionAliasDB(name="spengler", ref="ghostbusters.1",

--- a/st2common/tests/unit/test_util_actionalias_matching.py
+++ b/st2common/tests/unit/test_util_actionalias_matching.py
@@ -75,9 +75,9 @@ class ActionAliasTestCase(unittest2.TestCase):
         result = matching.list_format_strings_from_aliases(ALIASES)
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0]['display'], 'Watch this.')
-        self.assertEqual(result[0]['representation'], [])
+        self.assertEqual(result[0]['representation'], '')
         self.assertEqual(result[1]['display'], "He's just like his {{relation}}.")
-        self.assertEqual(result[1]['representation'], [])
+        self.assertEqual(result[1]['representation'], '')
 
     def test_list_format_strings_from_aliases_with_representation_only(self, mock):
         ALIASES = [

--- a/st2common/tests/unit/test_util_actionalias_matching.py
+++ b/st2common/tests/unit/test_util_actionalias_matching.py
@@ -40,8 +40,8 @@ class ActionAliasTestCase(unittest2.TestCase):
 
         self.assertEqual(len(result), 2)
 
-        self.assertEqual(result[0][0], "Come with me if you want to live")
-        self.assertEqual(result[1][0],
+        self.assertEqual(result[0]['display'], "Come with me if you want to live")
+        self.assertEqual(result[1]['display'],
                          "I need your {{item}}, your {{item2}} and"
                          " your {{vehicle}}")
 
@@ -58,12 +58,12 @@ class ActionAliasTestCase(unittest2.TestCase):
 
         self.assertEqual(len(result), 3)
 
-        self.assertEqual(result[0][0], "Number 5 is {{status}}")
-        self.assertEqual(result[0][1], "Number 5 is {{status=alive}}")
-        self.assertEqual(result[1][0], "Hey, laser lips, your mama was a snow blower.")
-        self.assertEqual(result[1][1], "Hey, laser lips, your mama was a snow blower.")
-        self.assertEqual(result[2][0], "How do I feel? I feel... {{status}}!")
-        self.assertEqual(result[2][1], "How do I feel? I feel... {{status}}!")
+        self.assertEqual(result[0]['display'],        "Number 5 is {{status}}")
+        self.assertEqual(result[0]['representation'], "Number 5 is {{status=alive}}")
+        self.assertEqual(result[1]['display'],        "Hey, laser lips, your mama was a snow blower.")
+        self.assertEqual(result[1]['representation'], "Hey, laser lips, your mama was a snow blower.")
+        self.assertEqual(result[2]['display'],        "How do I feel? I feel... {{status}}!")
+        self.assertEqual(result[2]['representation'], "How do I feel? I feel... {{status}}!")
 
     def test_list_format_strings_from_aliases_with_display_only(self, mock):
         ALIASES = [
@@ -74,10 +74,10 @@ class ActionAliasTestCase(unittest2.TestCase):
         ]
         result = matching.list_format_strings_from_aliases(ALIASES)
         self.assertEqual(len(result), 2)
-        self.assertEqual(result[0][0], 'Watch this.')
-        self.assertEqual(result[0][1], [])
-        self.assertEqual(result[1][0], "He's just like his {{relation}}.")
-        self.assertEqual(result[1][1], [])
+        self.assertEqual(result[0]['display'], 'Watch this.')
+        self.assertEqual(result[0]['representation'], [])
+        self.assertEqual(result[1]['display'], "He's just like his {{relation}}.")
+        self.assertEqual(result[1]['representation'], [])
 
     def test_list_format_strings_from_aliases_with_representation_only(self, mock):
         ALIASES = [
@@ -88,10 +88,10 @@ class ActionAliasTestCase(unittest2.TestCase):
         ]
         result = matching.list_format_strings_from_aliases(ALIASES)
         self.assertEqual(len(result), 2)
-        self.assertEqual(result[0][0], None)
-        self.assertEqual(result[0][1], "That's okay daddy. You can't hug a {{object}}.")
-        self.assertEqual(result[1][0], None)
-        self.assertEqual(result[1][1], 'You are my greatest invention.')
+        self.assertEqual(result[0]['display'], None)
+        self.assertEqual(result[0]['representation'], "That's okay daddy. You can't hug a {{object}}.")
+        self.assertEqual(result[1]['display'], None)
+        self.assertEqual(result[1]['representation'], 'You are my greatest invention.')
 
     def test_normalise_alias_format_string(self, mock):
         result = matching.normalise_alias_format_string(
@@ -108,7 +108,7 @@ class ActionAliasTestCase(unittest2.TestCase):
         COMMAND = "Don't cross the streams"
         match = matching.match_command_to_alias(COMMAND, ALIASES)
         self.assertEqual(len(match), 1)
-        self.assertEqual(match[0][0].ref, "ghostbusters.1")
-        self.assertEqual(match[0][2], "{{choice}} cross the {{target}}")
+        self.assertEqual(match[0]['alias'].ref, "ghostbusters.1")
+        self.assertEqual(match[0]['representation'], "{{choice}} cross the {{target}}")
 
     # we need some more complex scenarios in here.

--- a/st2tests/st2tests/fixtures/aliases/actions/action2.yaml
+++ b/st2tests/st2tests/fixtures/aliases/actions/action2.yaml
@@ -1,0 +1,10 @@
+---
+    name: "action2"
+    description: ""
+    runner_type: "test-runner"
+    pack: "wolfpack"
+    entry_point: "/tmp/test/action2.sh"
+    enabled: true
+    parameters:
+        issue_key:
+            type: "string"

--- a/st2tests/st2tests/fixtures/aliases/aliases/alias_fixes1.yaml
+++ b/st2tests/st2tests/fixtures/aliases/aliases/alias_fixes1.yaml
@@ -1,0 +1,10 @@
+---
+    name: "alias_match_multiple_fixes1"
+    pack: "aliases"
+    description: "DON'T CARE"
+    action_ref: "wolfpack.action2"
+    formats:
+        - display: "fixes <issue_key>"
+          representation:
+              - "(?:\\b|^)fixes (?P<issue_key>[A-Z][A-Z0-9]+-[0-9]+)(?:\\b|$)"
+          match_multiple: true

--- a/st2tests/st2tests/fixtures/aliases/aliases/alias_fixes2.yaml
+++ b/st2tests/st2tests/fixtures/aliases/aliases/alias_fixes2.yaml
@@ -1,0 +1,10 @@
+---
+    name: "alias_match_multiple_fixes2"
+    pack: "aliases"
+    description: "DON'T CARE"
+    action_ref: "wolfpack.action2"
+    formats:
+        - display: "fixes <issue_key>"
+          representation:
+              - "(?:\\b|^)fixes (?P<issue_key>[A-Z][A-Z0-9]+-[0-9]+)(?:\\b|$)"
+          match_multiple: true

--- a/st2tests/st2tests/fixtures/aliases/aliases/alias_match_multiple.yaml
+++ b/st2tests/st2tests/fixtures/aliases/aliases/alias_match_multiple.yaml
@@ -1,0 +1,10 @@
+---
+    name: "alias_match_multiple"
+    pack: "aliases"
+    description: "DON'T CARE"
+    action_ref: "wolfpack.action2"
+    formats:
+        - display: "duplicate of <issue_key>"
+          representation:
+              - "(?:\\b|^)duplicate of (?P<issue_key>[A-Z][A-Z0-9]+-[0-9]+)(?:\\b|$)"
+          match_multiple: true


### PR DESCRIPTION
# Overview #

This is the server-side implementation of [hubot-stackstorm PR #148](https://github.com/StackStorm/hubot-stackstorm/pull/148) with a few tweaks.

This PR refactors and re-implements the `match_and_execute` API endpoint to match a command to a single alias and execute the associated action multiple times.

That prose is kind of difficult to parse and grok, so here's some [pseudocode](https://stackoverflow.com/a/12076662):

```python
match = [command.match(alias) for alias in action_aliases if not alias.multiple_match]
if match:
    return {'results': [match[0].execute()]}
else:
    matches = [command.match(alias) for alias in action_aliases if alias.multiple_match]
    if matches:
        return {'results': [match.execute() for match in matches]}
```

This implementation will only ever match a *single* alias per command. Once it has matched that single alias, it will execute the alias action multiple times with each distinct captured group.

# Example #

#### An action alias that can match multiple times in a message ####

```yaml
---
name: "jira_get_issue"
pack: "jira"
action_ref: "jira.get_issue"
description: "Get a blurb from a Jira issue."
formats:
  # This display format can only match a command once
  - display: "jira issue <issue key>"
    representation:
      - "jira i(?:ssue)? (?P<issue_key>[A-Z][A-Z0-9]+-[0-9]+)"
  # This display format can match a command multiple times
  - display: "<issue key>"
    representation:
      - (?:^|\b)(?P<issue_key>[A-Z][A-Z0-9]+-[0-9]+)(?:\b|$)
    match_multiple: true
```

This action alias allows StackStorm to match a Jira issue key multiple times in one message, so the following Slack message would execute the associated action multiple times:

> Hey, I started working on SERVICEDESK-1234, but I got blocked by INFRASTRUCTURE-4321. I'm switching over to working on SERVICEDESK-1235 instead.

Specifically, with this change, the action would be dispatched three different times:

1. Once for the issue key `SERVICEDESK-1234`
2. Once for the issue key `INFRASTRUCTURE-4321`
3. Once for the issue key `SERVICEDESK-1235`

# Extensibility #

Our current actions simply respond with a blob of the the issue description in Slack, saving our users a round trip to Jira (which could itself include a login) to read the issue. However, the exact action is not limited to this.

# Reviewing Notes #

I needed to refactor quite a bit of code to support this. I tried to break up each refactor into its own commit, but some of them were a little noisy. I recommend GitHub's "split" mode for viewing the diffs, and look at the commits in the following order:

1. [`f5946e3`](https://github.com/StackStorm/st2/pull/3884/commits/f5946e34c9c023c81e8733e06c69ed872f832989#diff-8c5ac792de74fa5c41c1601685adde17R126) - You'll review the full commit later, but this link will take you to exactly what you need to look at now. Take a look at how I implemented single and multiple matching. This will give you context for the rest of the refactors.
2. [`7d6187f `](https://github.com/StackStorm/st2/pull/3884/commits/7d6187fef141b164b4a01a8b73e71a1c77ec4c57?diff=split) - Refactor `ActionAliasFormatParser` into multiple functions that mutate the object's state, to break out the regex matching into its own function ([`get_extracted_parameter_value`](https://github.com/StackStorm/st2/pull/3884/commits/7d6187fef141b164b4a01a8b73e71a1c77ec4c57#diff-ef06cf3802f64c52e0fab1e5b7cb8310R166)), and use `re.search()` instead of `re.match()` (explained below).
3. 1a70f14 - Add a function to `ActionAliasFormatParser` to match multiple times (using `re.finditer()`).
4. ae64b03 - Use a common `_post` function in `ActionAliasExecutionController` to do the heavy lifting, and use it in both `post()` and `match_and_execute()`.
5. 2f848d8 - Instead of returning a tuple and utilizing a decoding function, simply return a dictionary and use it directly (this makes the next commits easier to read).
6. 9fdbfbd - Make `list_format_strings_from_aliases` more consistent when an alias format doesn't have a representation.
7. 89f9f74 - There is a lot of noise in this commit, but the main change is the `query` function. I tweaked it to use keyword-only arguments for `offset`, `limit`, `order_by`, and `exclude_fields` (there were no uses of this function with positional arguments), and added support for using `Q` objects from `mongoengine`. I saw that `**filters` were cleaned up a bit, so I added a `_process_arg_filters` companion function to recursively process each filter in the tree of Q objects. Enabling Q objects in ORM queries allows me to query alias formats that don't have `match_multiple` keys OR where the value of the `match_multiple` key is `False`, as I do in the next commit.
8. f5946e3 - Now that you have the context for this seminal commit, check out the whole diff.
9. ac826be - A bonus test for the `normalise_alias_format_string`.
10. ea24f24 - Changelog update (and reword previous entry for clarity)

# Additional Considerations #

#### Zero reverse compatibility ####

As noted in [hubot-stackstorm PR #148](https://github.com/StackStorm/hubot-stackstorm/pull/148), this re-implementation is not reverse-compatible with previous uses. However, there are no official clients using this endpoint yet.

#### Keyword-only arguments in Python 2 ####

I ran into some issues with keyword-only arguments in some functions [[here](https://github.com/StackStorm/st2/pull/3884/commits/89f9f740c4caf802b4ccd36b8aca60ce840a142e#diff-734ce69988d4bfce994e3e76105db6c6R275) and commented on [here](https://github.com/StackStorm/st2/pull/3884/commits/89f9f740c4caf802b4ccd36b8aca60ce840a142e#diff-734ce69988d4bfce994e3e76105db6c6R308)], so I forced them to be keyword-only arguments by unpacking them from `**filters`. PEP-3102 enables explicit keyword-only parameters, so those function definitions can be tweaked once StackStorm supports Python 3+ (and stops supporting Python 2). 🤞 

#### `re.match` vs `re.search` ####

Note that in 7d6187f I switched the regex matching function from `re.match` [[here](https://github.com/StackStorm/st2/pull/3884/commits/7d6187fef141b164b4a01a8b73e71a1c77ec4c57#diff-ef06cf3802f64c52e0fab1e5b7cb8310L121)] to `re.search` [[here](https://github.com/StackStorm/st2/pull/3884/commits/7d6187fef141b164b4a01a8b73e71a1c77ec4c57#diff-ef06cf3802f64c52e0fab1e5b7cb8310R175)]. The `re.match` function only matches at the beginning of the string, whereas the `re.search` function matches anywhere in the string.

#### `QCombination` objects from `mongoengine` ####

The test for `QCombination` objects is a little wonky since the `QCombination` class is not "exported" in that module. The `QCombination` objects themselves might be a (fairly stable) implementation detail in `mongoengine`. I can remove [the check](https://github.com/StackStorm/st2/pull/3884/commits/89f9f740c4caf802b4ccd36b8aca60ce840a142e#diff-734ce69988d4bfce994e3e76105db6c6R394) altogether if necessary so instead of this:

```python
if isinstance(arg, visitor.Q):
    # ...
elif isinstance(arg, visitor.QCombination):
    # ...
else:
   raise TypeError(...)
```

we can just do this:

```python
if isinstance(arg, visitor.Q):
    # ...
else:
    # Assume some sort of object with `children` and `operation` attributes
    # here, and blow up if our implicit expectations are not met
    # ...
```

Since `.query` is an internal API anyway I can't imagine any users passing in anything other than Q objects, but I added the check in there to give a more useful error message.

# Tests #

I have added tests for almost all additional code. I did *not* add tests for:

* Non-`Q` objects in ORM queries
* `*args` to `query` besides my usage (which causes a surprisingly large amount of coverage in `_process_arg_filters`

I can add those tests in if you would like, but frankly I think they are of marginal utility.

#### Coverage ####

I am not able to run all of the unit tests on my local machine, but of the tests that I was able to run, I was able to exercise almost every line of changed or additional code. Here are the raw results for the relevant files:

```
Name                                                Stmts   Miss Branch BrPart  Cover
-------------------------------------------------------------------------------------
st2api/controllers/v1/actionalias.py                   96     16      4      2    82%
st2api/controllers/v1/aliasexecution.py               130     26     32      8    77%
st2common/models/db/__init__.py                       243     99     76     14    56%
st2common/models/utils/action_alias_utils.py          108      2     40      4    96%
st2common/util/actionalias_helpstring.py               30      2     20      1    94%
st2common/util/actionalias_matching.py                 55      0     24      0   100%
```

The "bonus" test for `normalise_alias_format_string` in `st2common/st2common/util/actionalias_matching.py`, along with the tests for my additional code, bumps the test coverage for that file up to 💯 %!

# Documentation #

I have not yet had the time to write documentation for this additional functionality, but I absolutely will do so once this PR is merged.

# Motivation #

This PR sets the stage for some of our changes to the [StackStorm Jira pack](https://github.com/StackStorm-Exchange/stackstorm-jira) <sup>1</sup>.

Our ultimate goal with this is to have a "JiraBot" listen in on Slack channels and when anybody mentions a Jira issue, the JiraBot pulls the issue summary from Jira and dumps it into the channel (with pretty formatting of course). Since a since Slack message can contain multiple issue keys, we want to be able to dump the summary for each one into Slack.

# Final Notes #

We are running hubot-stackstorm with my changes in [hubot-stackstorm PR #148](https://github.com/StackStorm/hubot-stackstorm/pull/148) to implement multiple dispatch until this is merged and released.

This is not a reverse compatible change, so it may not be appropriate to include in a point release (even though the endpoint has no official users yet).

However, if you are willing to include it in a point release, I'm hoping to get it into the next one (2.6, as of this writing). I am more than happy to work with you towards that goal. Please let me know if you need anything from me.

Thanks!

----------------

<sup>1</sup> This is upcoming - we're waiting on the release of StackStorm 2.5.1 to develop it since the webhook from Jira will require the `search` operator from my PR #3833.