### PR TITLE
[WIP] Add MY_EXECUTION_VIEW Permission Type

### DIFF
--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -181,7 +181,8 @@ class PermissionType(Enum):
         # * EXECUTION_VIEWS_FILTERS_LIST
         if permission_type == PermissionType.PACK_VIEWS_INDEX_HEALTH:
             return ResourceType.PACK
-        elif permission_type == PermissionType.EXECUTION_VIEWS_FILTERS_LIST or permission_type == PermissionType.MY_EXECUTION_VIEW:
+        elif permission_type == PermissionType.EXECUTION_VIEWS_FILTERS_LIST \
+                or permission_type == PermissionType.MY_EXECUTION_VIEW:
             return ResourceType.EXECUTION
 
         split = permission_type.split('_')

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -96,6 +96,8 @@ class PermissionType(Enum):
     EXECUTION_ALL = 'execution_all'
     EXECUTION_VIEWS_FILTERS_LIST = 'execution_views_filters_list'
 
+    MY_EXECUTION_VIEW = 'my_execution_view'
+
     RULE_LIST = 'rule_list'
     RULE_VIEW = 'rule_view'
     RULE_CREATE = 'rule_create'
@@ -179,7 +181,7 @@ class PermissionType(Enum):
         # * EXECUTION_VIEWS_FILTERS_LIST
         if permission_type == PermissionType.PACK_VIEWS_INDEX_HEALTH:
             return ResourceType.PACK
-        elif permission_type == PermissionType.EXECUTION_VIEWS_FILTERS_LIST:
+        elif permission_type == PermissionType.EXECUTION_VIEWS_FILTERS_LIST or permission_type == PermissionType.MY_EXECUTION_VIEW:
             return ResourceType.EXECUTION
 
         split = permission_type.split('_')
@@ -303,6 +305,8 @@ RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP = {
         PermissionType.ACTION_EXECUTE,
         PermissionType.ACTION_ALL,
 
+        PermissionType.MY_EXECUTION_VIEW,
+
         PermissionType.ACTION_ALIAS_VIEW,
         PermissionType.ACTION_ALIAS_CREATE,
         PermissionType.ACTION_ALIAS_MODIFY,
@@ -328,7 +332,9 @@ RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP = {
         PermissionType.ACTION_MODIFY,
         PermissionType.ACTION_DELETE,
         PermissionType.ACTION_EXECUTE,
-        PermissionType.ACTION_ALL
+        PermissionType.ACTION_ALL,
+
+        PermissionType.MY_EXECUTION_VIEW
     ],
     ResourceType.ACTION_ALIAS: [
         PermissionType.ACTION_ALIAS_LIST,
@@ -359,6 +365,8 @@ RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP = {
         PermissionType.EXECUTION_STOP,
         PermissionType.EXECUTION_ALL,
         PermissionType.EXECUTION_VIEWS_FILTERS_LIST,
+
+        PermissionType.MY_EXECUTION_VIEW,
     ],
     ResourceType.KEY_VALUE_PAIR: [
         PermissionType.KEY_VALUE_VIEW,
@@ -445,6 +453,7 @@ GLOBAL_PERMISSION_TYPES = [
 
     # Execution
     PermissionType.EXECUTION_VIEWS_FILTERS_LIST,
+    PermissionType.MY_EXECUTION_VIEW,
 
     # Stream
     PermissionType.STREAM_VIEW,
@@ -517,6 +526,9 @@ PERMISION_TYPE_TO_DESCRIPTION_MAP = {
                                    'particular execution.'),
     PermissionType.EXECUTION_VIEWS_FILTERS_LIST: ('Ability view all the distinct execution '
                                                   'filters.'),
+
+    PermissionType.MY_EXECUTION_VIEW: ('Ability to view an execution if it was started by the '
+                                       'requesting user.'),
 
     PermissionType.RULE_LIST: 'Ability to list (view all) rules.',
     PermissionType.RULE_VIEW: 'Ability to view a rule.',


### PR DESCRIPTION
MY_EXECUTION_VIEW is a limited form of EXECUTION_VIEW.
It allows a user to only view executions that they started.

This is important because, though ACTION_EXECUTE implies ACTION_VIEW,
it does not imply EXECUTION_VIEW. If a user had a role that gave them
ACTION_VIEW on a particular action, then they would get the implicit
EXECUTION_VIEW permission on all executions for that action even if they
did not start the action. The implicit permission from ACTION_EXECUTE
to ACTION_VIEW and from ACTION_VIEW to EXECUTION_VIEW make sense, but
adding an additional implicit permission from ACTION_EXECUTE to
EXECUTION_VIEW would, perhaps, open up more data than intended. This
resolves that by introducing a concept of execution ownership.

MY_EXECUTION_VIEW can be a global permission, or it can apply to a pack
or a particular action in a pack. As a global permission, a user can
view any execution that they started. As a pack-level permission, a user
can view any action executions when the associated action is part of a
particular pack and the execution was started by that same user. As an
action-level permission, the user is allowed to see the executions for a
particular action if they started that execution.

Example roles:
```yaml
---
name: "view_my_executions"
description: "Allow a user to view any of their own executions"
permission_grants:
  -
    permission_types:
      - "my_execution_view"
```
```yaml
---
name: "my_linux_actions"
description: "Allow a user to execute linux actions and view only the linux actions they started"
permission_grants:
  -
    resource_uid: "pack:linux"
    permission_types:
      - "action_execute"
      - "my_execution_view"
```
```yaml
---
name: "my_check_loadavg"
description: "Allow a user to execute check_loadavg actions and view only the executions they started"
permission_grants:
  -
    resource_uid: "action:linux:check_loadavg"
    permission_types:
      - "action_execute"
      - "my_execution_view"
```

NOTE: This only adds the MY_EXECUTION_VIEW permission. It does not make
it an implicit permission of any other permissions. It might make sense
to make ACTION_EXECUTE imply MY_EXECUTION_VIEW, but this commit does not
do that, leaving it as an opportunity for future development.

TODO:
- [ ] test it :)
- [ ] write unit tests