### PR TITLE
Retrieve live params first, include template-driven defaults

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,6 +50,9 @@ Added
 * Added flag `--auto-dict` to `st2 run` and `st2 execution re-run` commands. This flag must now
   be specified in order to automatically convert list items to dicts based on presence of colon
   (`:`) in all of the list items (new feature) #3909 
+* Jinja templates in default parameter values now render as live parameters, if no "real" live
+  parameter was provided. This allows the template to render pre-schema validation, resulting
+  in the intended value type. (improvement) #3892
 
 Changed
 ~~~~~~~

--- a/st2common/st2common/util/param.py
+++ b/st2common/st2common/util/param.py
@@ -21,6 +21,7 @@ import networkx as nx
 from jinja2 import meta
 from st2common import log as logging
 from st2common.util.config_loader import get_config
+from st2common.util.jinja import is_jinja_expression
 from st2common.constants.action import ACTION_CONTEXT_KV_PREFIX
 from st2common.constants.pack import PACK_CONFIG_CONTEXT_KV_PREFIX
 from st2common.constants.keyvalue import DATASTORE_PARENT_SCOPE, SYSTEM_SCOPE, FULL_SYSTEM_SCOPE
@@ -207,12 +208,43 @@ def _cast_params_from(params, context, schemas):
     Pick a list of parameters from context and cast each of them according to the schemas provided
     '''
     result = {}
+
+    # First, cast only explicitly provided live parameters
     for name in params:
         param_schema = {}
         for schema in schemas:
             if name in schema:
                 param_schema = schema[name]
         result[name] = _cast(context[name], param_schema)
+
+    # Now, iterate over all parameters, and add any to the live set that satisfy ALL of the
+    # following criteria:
+    #
+    # - Have a default value that is a Jinja template
+    # - Are using the default value (i.e. not being overwritten by an actual live param)
+    #
+    # We do this because the execution API controller first determines live params before
+    # validating params against the schema. So, we want to make sure that if the default
+    # value is a template, it is rendered and added to the live params before this validation.
+    for schema in schemas:
+        for param_name, param_details in schema.items():
+
+            # Skip if the parameter doesn't have a default, or if the
+            # value in the context is identical to the default
+            if 'default' not in param_details or \
+                    param_details.get('default') == context[param_name]:
+                continue
+
+            # Skip if the default value isn't a Jinja expression
+            if not is_jinja_expression(param_details.get('default')):
+                continue
+
+            # Skip if the parameter is being overridden
+            if param_name in params:
+                continue
+
+            result[param_name] = _cast(context[param_name], param_details)
+
     return result
 
 

--- a/st2common/tests/unit/test_param_utils.py
+++ b/st2common/tests/unit/test_param_utils.py
@@ -696,3 +696,82 @@ class ParamsUtilsTest(DbTestCase):
         expected_msg = 'Dependency unsatisfied in variable "variable_not_defined"'
         self.assertRaisesRegexp(ParamException, expected_msg, param_utils.render_live_params,
                                 runner_param_info, action_param_info, params, action_context)
+
+    def test_add_default_templates_to_live_params(self):
+        """Test addition of template values in defaults to live params
+        """
+
+        # Test with no live params, and two parameters - one should make it through because
+        # it was a template, and the other shouldn't because its default wasn't a template
+        schemas = [
+            {
+                'templateparam': {
+                    'default': '{{ 3 | int }}',
+                    'type': 'integer'
+                }
+            }
+        ]
+        context = {
+            'templateparam': '3'
+        }
+        result = param_utils._cast_params_from({}, context, schemas)
+        self.assertEquals(result, {'templateparam': 3})
+
+        # Ensure parameter is skipped if the value in context is identical to default
+        schemas = [
+            {
+                'nottemplateparam': {
+                    'default': '4',
+                    'type': 'integer'
+                }
+            }
+        ]
+        context = {
+            'nottemplateparam': '4',
+        }
+        result = param_utils._cast_params_from({}, context, schemas)
+        self.assertEquals(result, {})
+
+        # Ensure parameter is skipped if the parameter doesn't have a default
+        schemas = [
+            {
+                'nottemplateparam': {
+                    'type': 'integer'
+                }
+            }
+        ]
+        context = {
+            'nottemplateparam': '4',
+        }
+        result = param_utils._cast_params_from({}, context, schemas)
+        self.assertEquals(result, {})
+
+        # Skip if the default value isn't a Jinja expression
+        schemas = [
+            {
+                'nottemplateparam': {
+                    'default': '5',
+                    'type': 'integer'
+                }
+            }
+        ]
+        context = {
+            'nottemplateparam': '4',
+        }
+        result = param_utils._cast_params_from({}, context, schemas)
+        self.assertEquals(result, {})
+
+        # Ensure parameter is skipped if the parameter is being overridden
+        schemas = [
+            {
+                'templateparam': {
+                    'default': '{{ 3 | int }}',
+                    'type': 'integer'
+                }
+            }
+        ]
+        context = {
+            'templateparam': '4',
+        }
+        result = param_utils._cast_params_from({'templateparam': '4'}, context, schemas)
+        self.assertEquals(result, {'templateparam': 4})

--- a/st2common/tests/unit/test_param_utils.py
+++ b/st2common/tests/unit/test_param_utils.py
@@ -647,6 +647,7 @@ class ParamsUtilsTest(DbTestCase):
 
         expected_params = {
             'r1': 'generic',
+            'r2': 'generic',
             'r3': 'lolcathost'
         }
         self.assertEqual(live_params, expected_params)


### PR DESCRIPTION
# Problem

#3820 reported an issue that parameter defaults that use Jinja templates that return something other than string, simply don't work.

This is caused by two things:

- The code in the API controller that handles execution scheduling currently makes a call to `action_service.create_request` before the live parameters are retrieved, which is where any templates are rendered into a result value. So if a parameter is an `integer` but the default value is still a template (string) - even if that template is expected to return an int, naturally this will cause problems because it hasn't even rendered yet.
- The call to `param_utils.render_live_params` and the function calls within will render the templates, but will not actually use the resulting value, as the default values for parameters are not seen as "live". So even though there's a rendered value available to use, it's not placed in the params list because it wasn't passed in explicitly by the user, and the same problem occurs, as the unrendered template value is used (string).

# Proposed Solution

To fix the behavior observed in #3820, I propose the following changes:

- A simple re-order will address the first problem. Wait to call `action_service.request` until the live params are retrieved.
- After the existing behavior around live parameters, I suggest that we detect if a parameter's default is a template, and the resulting value of that template is actually being used (i.e. isn't being overridden by the user). In effect, we treat the resulting value as a live parameter (we're literally adding it to the same dict). If a default value is rendered and used, it shows up as if the user had passed that value in.

I think treating rendered default values as "live" parameters makes sense. Inherently, since we're using a template, it could easily be user-provided, even if the user provides it via `st2kv`. It's a bit of a paradigm change but I think it makes sense, personally.

One potential consequence to note is that the parameter schema will now have to validate against what the template's value **will be**, but IMO this should already be happening anyways. I would expect that if I'm getting a value from a template, that the datatype should be predictable, and if it's different for any reason, I would expect a validation error at runtime. We've already inherently moved this problem to runtime by using templates in params like this anyways - this just makes the resulting behavior more intuitive.

# Demo

I threw together a quick action to demonstrate the new logic:

```yaml
---
description: Run a local linux command
enabled: true
runner_type: local-shell-cmd
name: nmaludy-test
pack: testpack
parameters:
  kv_test:
    type: integer
    default: "{{ st2kv.system.nick_test | int }}"
```

I'll create the referenced key in the datastore and execute my action:

```
~$ st2 key set -s system nick_test 31415
+------------------+-----------+
| Property         | Value     |
+------------------+-----------+
| name             | nick_test |
| value            | 31415     |
| expire_timestamp |           |
+------------------+-----------+
~$ st2 run testpack.nmaludy-test cmd=date
.
id: 5a2667e632ed353390a8bc7a
status: succeeded
parameters:
  cmd: date
  kv_test: 31415
result:
  failed: false
  return_code: 0
  stderr: ''
  stdout: Tue Dec  5 09:33:27 UTC 2017
  succeeded: true
```

Note that `kv_test` appears in the resulting live parameters as if I had passed it in explicitly. While it's true, I didn't do this at the CLI, I believe the intention is the same - the default value is based on dynamic retrieval from the datastore via the template.

Note also that I can still override this with my own value - a "true" live param:

```
~$ st2 run testpack.nmaludy-test cmd=date kv_test=12345
.
id: 5a2667f832ed353390a8bc7d
status: succeeded
parameters:
  cmd: date
  kv_test: 12345
result:
  failed: false
  return_code: 0
  stderr: ''
  stdout: Tue Dec  5 09:33:44 UTC 2017
  succeeded: true
```

Closes #3820 
