### PR TITLE
Fix a bug with duplicated log messages in Python runner action stderr output

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -94,8 +94,9 @@ Fixed
 * Fix a regression and a bug with no API validation being performed and API returning 500 instead
   of 400 status code if user didn't include any request payload (body) when hitting POST and PUT
   API endpoints where body is mandatory. (bug fix) #3864
-* Fix bugs with newlines in execution formatter (client)
-  (bug fix) #3872
+* Fix bugs with newlines in execution formatter (client) (bug fix) #3872
+* Fix a bug in Python runner which would cause action log messages to be duplicated in action
+  stderr output when utilizing action service / datastore service inside actions. (bug fix)
 
 2.5.0 - October 25, 2017
 ------------------------

--- a/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
+++ b/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
@@ -633,7 +633,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         self.assertTrue(expected_msg_5 in output['stderr'])
 
         # Verify messages are not duplicated
-        self.assertEqual(len(output['stderr'].split('\n')), 5 + 1)
+        self.assertEqual(len(output['stderr'].split('\n')), 6 + 1)
 
         # Only log messages with level info and above should be displayed
         runner = self._get_mock_runner_obj()

--- a/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
+++ b/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
@@ -611,9 +611,12 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         self.assertRaisesRegexp(Exception, expected_msg, wrapper._get_action_instance)
 
     def test_simple_action_log_messages_and_log_level_runner_param(self):
-        expected_msg_1 = 'st2.actions.python.PascalRowAction: INFO     test info log message'
-        expected_msg_2 = 'st2.actions.python.PascalRowAction: DEBUG    test debug log message'
-        expected_msg_3 = 'st2.actions.python.PascalRowAction: ERROR    test error log message'
+        expected_msg_1 = 'st2.actions.python.PascalRowAction: DEBUG    Creating new Client object.'
+        expected_msg_2 = 'Retrieving all the values from the datastore'
+
+        expected_msg_3 = 'st2.actions.python.PascalRowAction: INFO     test info log message'
+        expected_msg_4 = 'st2.actions.python.PascalRowAction: DEBUG    test debug log message'
+        expected_msg_5 = 'st2.actions.python.PascalRowAction: ERROR    test error log message'
 
         runner = self._get_mock_runner_obj()
         runner.entry_point = PASCAL_ROW_ACTION_PATH
@@ -626,6 +629,11 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         self.assertTrue(expected_msg_1 in output['stderr'])
         self.assertTrue(expected_msg_2 in output['stderr'])
         self.assertTrue(expected_msg_3 in output['stderr'])
+        self.assertTrue(expected_msg_4 in output['stderr'])
+        self.assertTrue(expected_msg_5 in output['stderr'])
+
+        # Verify messages are not duplicated
+        self.assertEqual(len(output['stderr'].split('\n')), 5 + 1)
 
         # Only log messages with level info and above should be displayed
         runner = self._get_mock_runner_obj()
@@ -639,9 +647,9 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         self.assertTrue(output is not None)
         self.assertEqual(output['result'], [1, 2])
 
-        self.assertTrue(expected_msg_1 in output['stderr'])
-        self.assertFalse(expected_msg_2 in output['stderr'])
         self.assertTrue(expected_msg_3 in output['stderr'])
+        self.assertFalse(expected_msg_4 in output['stderr'])
+        self.assertTrue(expected_msg_5 in output['stderr'])
 
         # Only log messages with level error and above should be displayed
         runner = self._get_mock_runner_obj()
@@ -655,9 +663,9 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         self.assertTrue(output is not None)
         self.assertEqual(output['result'], [1, 2])
 
-        self.assertFalse(expected_msg_1 in output['stderr'])
-        self.assertFalse(expected_msg_2 in output['stderr'])
-        self.assertTrue(expected_msg_3 in output['stderr'])
+        self.assertFalse(expected_msg_3 in output['stderr'])
+        self.assertFalse(expected_msg_4 in output['stderr'])
+        self.assertTrue(expected_msg_5 in output['stderr'])
 
     def _get_mock_runner_obj(self):
         runner = python_runner.get_runner()

--- a/st2common/st2common/runners/utils.py
+++ b/st2common/st2common/runners/utils.py
@@ -32,23 +32,34 @@ __all__ = [
 
 LOG = logging.getLogger(__name__)
 
+# Maps logger name to the actual logger instance
+# We re-use loggers for the same actions to make sure only a single instance exists for a
+# particular action. This way we avoid duplicate log messages, etc.
+LOGGERS = {}
+
 
 def get_logger_for_python_runner_action(action_name, log_level='debug'):
     """
     Set up a logger which logs all the messages with level DEBUG and above to stderr.
     """
-    level_name = log_level.upper()
-    log_level_constant = getattr(stdlib_logging, level_name, stdlib_logging.DEBUG)
     logger_name = 'actions.python.%s' % (action_name)
-    logger = logging.getLogger(logger_name)
 
-    console = stdlib_logging.StreamHandler()
-    console.setLevel(log_level_constant)
+    if logger_name not in LOGGERS:
+        level_name = log_level.upper()
+        log_level_constant = getattr(stdlib_logging, level_name, stdlib_logging.DEBUG)
+        logger = logging.getLogger(logger_name)
 
-    formatter = stdlib_logging.Formatter('%(name)-12s: %(levelname)-8s %(message)s')
-    console.setFormatter(formatter)
-    logger.addHandler(console)
-    logger.setLevel(log_level_constant)
+        console = stdlib_logging.StreamHandler()
+        console.setLevel(log_level_constant)
+
+        formatter = stdlib_logging.Formatter('%(name)-12s: %(levelname)-8s %(message)s')
+        console.setFormatter(formatter)
+        logger.addHandler(console)
+        logger.setLevel(log_level_constant)
+
+        LOGGERS[logger_name] = logger
+    else:
+        logger = LOGGERS[logger_name]
 
     return logger
 

--- a/st2common/st2common/services/datastore.py
+++ b/st2common/st2common/services/datastore.py
@@ -84,7 +84,7 @@ class BaseDatastoreService(object):
         :rtype: ``list`` of :class:`KeyValuePair`
         """
         client = self._get_api_client()
-        self._logger.debug('Retrieving all the value from the datastore')
+        self._logger.debug('Retrieving all the values from the datastore')
 
         key_prefix = self._get_full_key_prefix(local=local, prefix=prefix)
         kvps = client.keys.get_all(prefix=key_prefix)

--- a/st2common/st2common/services/datastore.py
+++ b/st2common/st2common/services/datastore.py
@@ -309,7 +309,7 @@ class ActionDatastoreService(BaseDatastoreService):
         Retrieve API client instance.
         """
         if not self._client:
-            self._logger.audit('Creating new Client object.')
+            self._logger.debug('Creating new Client object.')
 
             api_url = get_full_public_api_url()
             client = Client(api_url=api_url, token=self._auth_token)
@@ -343,7 +343,7 @@ class SensorDatastoreService(BaseDatastoreService):
         if not self._client or token_expire:
             # Note: Late import to avoid high import cost (time wise)
             from st2common.services.access import create_token
-            self._logger.audit('Creating new Client object.')
+            self._logger.debug('Creating new Client object.')
 
             ttl = cfg.CONF.auth.service_token_ttl
             api_url = get_full_public_api_url()

--- a/st2tests/st2tests/resources/packs/pythonactions/actions/pascal_row.py
+++ b/st2tests/st2tests/resources/packs/pythonactions/actions/pascal_row.py
@@ -6,6 +6,10 @@ from st2common.runners.base_action import Action
 
 class PascalRowAction(Action):
     def run(self, **kwargs):
+        # We call list values to verify that log messages are not duplicated when
+        # datastore service is used
+        self.action_service.list_values()
+
         self.logger.info('test info log message')
         self.logger.debug('test debug log message')
         self.logger.error('test error log message')

--- a/st2tests/st2tests/resources/packs/pythonactions/actions/pascal_row.py
+++ b/st2tests/st2tests/resources/packs/pythonactions/actions/pascal_row.py
@@ -8,7 +8,10 @@ class PascalRowAction(Action):
     def run(self, **kwargs):
         # We call list values to verify that log messages are not duplicated when
         # datastore service is used
-        self.action_service.list_values()
+        try:
+            self.action_service.list_values()
+        except Exception:
+            pass
 
         self.logger.info('test info log message')
         self.logger.debug('test debug log message')


### PR DESCRIPTION
There was a bug when all the log messages generated by a Python runner action would be duplicated when datastore service was used.

It looks like this issue was present for a very long time, but it only manifested itself when datastore service was also used inside an action (in that scenario two instances of the logger with the same name were created) so we didn't catch it earlier.

This PR fixes that by caching loggers by name and making sure there is always only a single instance of a logger with a particular name. Keep in mind that this function is called inside subprocess (python action wrapper) so there is no potential issue with this cache growing too large because cache is on per Python runner action process basis and not action runner basis.

Before:

```bash
actions.python.PrintConfigAction: DEBUG    test info
actions.python.PrintConfigAction: DEBUG    test info
actions.python.PrintConfigAction: INFO     test mesg
actions.python.PrintConfigAction: INFO     test mesg
actions.python.PrintConfigAction: DEBUG    Creating new Client object.
actions.python.PrintConfigAction: DEBUG    Creating new Client object.
actions.python.PrintConfigAction: DEBUG    Retrieving all the value from the datastore
actions.python.PrintConfigAction: DEBUG    Retrieving all the value from the datastore
actions.python.PrintConfigAction: DEBUG    test message
actions.python.PrintConfigAction: DEBUG    test message
actions.python.PrintConfigAction: INFO     test message
actions.python.PrintConfigAction: INFO     test message
```
After:

```bash
actions.python.PrintConfigAction: DEBUG    test info
actions.python.PrintConfigAction: INFO     test mesg
actions.python.PrintConfigAction: DEBUG    Creating new Client object.
actions.python.PrintConfigAction: DEBUG    Retrieving all the value from the datastore
actions.python.PrintConfigAction: DEBUG    test message
actions.python.PrintConfigAction: INFO     test message
```