### PR TITLE
v2.5.1: Fix edge case for workflows stuck in running state

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,9 @@ Fixed
 * Fix a bug with datastore service used inside the Python runner actions not correctly scoping the
   auth token to the user who triggered the action. Token was incorrectly scoped to ``api_service``
   user without any permissions. (bug fix) #3823 #3535
+* Fix edge case for workflows stuck in running state. When Mistral receives a connection error from
+  the st2 API on requesting action execution, there's a duplicate action execution stuck in
+  requested state. This leads to the st2resultstracker assuming the workflow is still running.
 
 2.5.0 - October 25, 2017
 ------------------------


### PR DESCRIPTION
There is an edge case where mistral receives connection error from the st2 API when requesting action execution. When this happens, the action execution is requested twice. The first action execution is requested, the record is written into the MongoDB, but it is not published to the action runners. The second action execution is scheduled and the mistral workflow reach completion. The mistral querier for the st2resultstracker will see the first action execution in a non-completed state and assume the workflow is still running. This patch identifies this specific edge case and ignores the duplicate action execution.