### PR TITLE
Disable bash history when sudo password is provided as a command line argument

### DIFF
--- a/st2common/st2common/models/system/action.py
+++ b/st2common/st2common/models/system/action.py
@@ -146,16 +146,16 @@ class ShellCommandAction(object):
         if self.env_vars:
             env_vars = copy.copy(self.env_vars)
 
-            # If sudo_passowrd is provided, explicitly disable bash history to make sure password
+            # If sudo_password is provided, explicitly disable bash history to make sure password
             # is not logged, because password is provided via command line
             if self.sudo and self.sudo_password:
                 env_vars['HISTFILE'] = '/dev/null'
                 env_vars['HISTSIZE'] = '0'
 
-            # Sort the dict to guarante consistent order
+            # Sort the dict to guarantee consistent order
             env_vars = collections.OrderedDict(sorted(env_vars.items()))
 
-            # Envrionment variables could contain spaces and open us to shell
+            # Environment variables could contain spaces and open us to shell
             # injection attacks. Always quote the key and the value.
             exports = ' '.join(
                 '%s=%s' % (quote_unix(k), quote_unix(v))

--- a/st2common/st2common/models/system/action.py
+++ b/st2common/st2common/models/system/action.py
@@ -143,11 +143,19 @@ class ShellCommandAction(object):
 
     def _get_env_vars_export_string(self):
         if self.env_vars:
+            env_vars = copy.copy(self.env_vars)
+
+            # If sudo_passowrd is provided, explicitly disable bash history to make sure password
+            # is not logged, because password is provided via command line
+            if self.sudo and self.sudo_password:
+                env_vars['HISTFILE'] = '/dev/null'
+                env_vars['HISTSIZE'] = '0'
+
             # Envrionment variables could contain spaces and open us to shell
             # injection attacks. Always quote the key and the value.
             exports = ' '.join(
                 '%s=%s' % (quote_unix(k), quote_unix(v))
-                for k, v in self.env_vars.iteritems()
+                for k, v in env_vars.iteritems()
             )
             shell_env_str = '%s %s' % (ShellCommandAction.EXPORT_CMD, exports)
         else:

--- a/st2common/st2common/models/system/action.py
+++ b/st2common/st2common/models/system/action.py
@@ -21,6 +21,7 @@ import six
 import sys
 import copy
 import traceback
+import collections
 
 from oslo_config import cfg
 
@@ -150,6 +151,9 @@ class ShellCommandAction(object):
             if self.sudo and self.sudo_password:
                 env_vars['HISTFILE'] = '/dev/null'
                 env_vars['HISTSIZE'] = '0'
+
+            # Sort the dict to guarante consistent order
+            env_vars = collections.OrderedDict(sorted(env_vars.items()))
 
             # Envrionment variables could contain spaces and open us to shell
             # injection attacks. Always quote the key and the value.

--- a/st2common/st2common/models/system/paramiko_command_action.py
+++ b/st2common/st2common/models/system/paramiko_command_action.py
@@ -47,7 +47,8 @@ class ParamikoRemoteCommandAction(RemoteAction):
             command = 'sudo %s -- bash -c %s' % (sudo_arguments, command)
 
             if self.sudo_password:
-                command = 'echo -e %s | %s' % (quote_unix('%s\n' % (self.sudo_password)), command)
+                command = ('set +o history ; echo -e %s | %s' %
+                          (quote_unix('%s\n' % (self.sudo_password)), command))
         else:
             if env_str:
                 command = '%s && cd %s && %s' % (env_str, cwd,

--- a/st2common/st2common/models/system/paramiko_script_action.py
+++ b/st2common/st2common/models/system/paramiko_script_action.py
@@ -54,7 +54,8 @@ class ParamikoRemoteScriptAction(RemoteScriptAction):
             command = 'sudo %s -- bash -c %s' % (sudo_arguments, command)
 
             if self.sudo_password:
-                command = 'echo -e %s | %s' % (quote_unix('%s\n' % (self.sudo_password)), command)
+                command = ('set +o history ; echo -e %s | %s' %
+                          (quote_unix('%s\n' % (self.sudo_password)), command))
         else:
             if script_arguments:
                 if env_str:

--- a/st2common/tests/unit/test_paramiko_command_action_model.py
+++ b/st2common/tests/unit/test_paramiko_command_action_model.py
@@ -47,15 +47,16 @@ class ParamikoRemoteCommandActionTestCase(unittest2.TestCase):
         cmd_action.sudo = True
         cmd_action.sudo_password = 'sudo pass'
 
-        ex = 'echo -e \'sudo pass\n\' | sudo -S -E -- bash -c \'cd /tmp && echo boo bah baz\''
+        ex = ('set +o history ; echo -e \'sudo pass\n\' | sudo -S -E -- '
+              'bash -c \'cd /tmp && echo boo bah baz\'')
         self.assertEqual(cmd_action.get_full_command_string(), ex)
 
     def test_get_command_string_with_env_vars(self):
         cmd_action = ParamikoRemoteCommandActionTestCase._get_test_command_action(
             'echo boo bah baz')
         cmd_action.env_vars = {'FOO': 'BAR', 'BAR': 'BEET CAFE'}
-        ex = 'export FOO=BAR ' + \
-             'BAR=\'BEET CAFE\'' + \
+        ex = 'export BAR=\'BEET CAFE\' ' + \
+             'FOO=BAR' + \
              ' && cd /tmp && echo boo bah baz'
         self.assertEqual(cmd_action.get_full_command_string(), ex)
 
@@ -66,14 +67,18 @@ class ParamikoRemoteCommandActionTestCase(unittest2.TestCase):
              '\'export FOO=BAR ' + \
              'BAR=\'"\'"\'BEET CAFE\'"\'"\'' + \
              ' && cd /tmp && echo boo bah baz\''
+        ex = 'sudo -E -- bash -c ' + \
+             '\'export BAR=\'"\'"\'BEET CAFE\'"\'"\' ' + \
+             'FOO=BAR' + \
+             ' && cd /tmp && echo boo bah baz\''
         self.assertEqual(cmd_action.get_full_command_string(), ex)
 
         # with sudo_password
         cmd_action.sudo = True
         cmd_action.sudo_password = 'sudo pass'
-        ex = 'echo -e \'sudo pass\n\' | sudo -S -E -- bash -c ' + \
-             '\'export FOO=BAR ' + \
-             'BAR=\'"\'"\'BEET CAFE\'"\'"\'' + \
+        ex = 'set +o history ; echo -e \'sudo pass\n\' | sudo -S -E -- bash -c ' + \
+             '\'export BAR=\'"\'"\'BEET CAFE\'"\'"\' ' + \
+             'FOO=BAR HISTFILE=/dev/null HISTSIZE=0' + \
              ' && cd /tmp && echo boo bah baz\''
         self.assertEqual(cmd_action.get_full_command_string(), ex)
 

--- a/st2common/tests/unit/test_paramiko_script_action_model.py
+++ b/st2common/tests/unit/test_paramiko_script_action_model.py
@@ -39,7 +39,7 @@ class ParamikoRemoteScriptActionTestCase(unittest2.TestCase):
         # with sudo password
         script_action.sudo = True
         script_action.sudo_password = 'sudo pass'
-        ex = 'echo -e \'sudo pass\n\' | sudo -S -E -- bash -c ' + \
+        ex = 'set +o history ; echo -e \'sudo pass\n\' | sudo -S -E -- bash -c ' + \
              '\'cd /tmp && ' + \
              '/tmp/remote_script.sh song=\'"\'"\'b s\'"\'"\' \'"\'"\'taylor swift\'"\'"\'\''
         self.assertEqual(script_action.get_full_command_string(), ex)
@@ -50,16 +50,16 @@ class ParamikoRemoteScriptActionTestCase(unittest2.TestCase):
             'ST2_ACTION_EXECUTION_ID': '55ce39d532ed3543aecbe71d',
             'FOO': 'BAR BAZ BOOZ'
         }
-        ex = 'export ST2_ACTION_EXECUTION_ID=55ce39d532ed3543aecbe71d ' + \
-             'FOO=\'BAR BAZ BOOZ\' && ' + \
+        ex = 'export FOO=\'BAR BAZ BOOZ\' ' + \
+             'ST2_ACTION_EXECUTION_ID=55ce39d532ed3543aecbe71d && ' + \
              'cd /tmp && /tmp/remote_script.sh song=\'b s\' \'taylor swift\''
         self.assertEqual(script_action.get_full_command_string(), ex)
 
         # Test with sudo
         script_action.sudo = True
         ex = 'sudo -E -- bash -c ' + \
-             '\'export ST2_ACTION_EXECUTION_ID=55ce39d532ed3543aecbe71d ' + \
-             'FOO=\'"\'"\'BAR BAZ BOOZ\'"\'"\' && ' + \
+             '\'export FOO=\'"\'"\'BAR BAZ BOOZ\'"\'"\' ' + \
+             'ST2_ACTION_EXECUTION_ID=55ce39d532ed3543aecbe71d && ' + \
              'cd /tmp && ' + \
              '/tmp/remote_script.sh song=\'"\'"\'b s\'"\'"\' \'"\'"\'taylor swift\'"\'"\'\''
         self.assertEqual(script_action.get_full_command_string(), ex)
@@ -68,9 +68,9 @@ class ParamikoRemoteScriptActionTestCase(unittest2.TestCase):
         script_action.sudo = True
         script_action.sudo_password = 'sudo pass'
 
-        ex = 'echo -e \'sudo pass\n\' | sudo -S -E -- bash -c ' + \
-             '\'export ST2_ACTION_EXECUTION_ID=55ce39d532ed3543aecbe71d ' + \
-             'FOO=\'"\'"\'BAR BAZ BOOZ\'"\'"\' && ' + \
+        ex = 'set +o history ; echo -e \'sudo pass\n\' | sudo -S -E -- bash -c ' + \
+             '\'export FOO=\'"\'"\'BAR BAZ BOOZ\'"\'"\' HISTFILE=/dev/null HISTSIZE=0 ' + \
+             'ST2_ACTION_EXECUTION_ID=55ce39d532ed3543aecbe71d && ' + \
              'cd /tmp && ' + \
              '/tmp/remote_script.sh song=\'"\'"\'b s\'"\'"\' \'"\'"\'taylor swift\'"\'"\'\''
         self.assertEqual(script_action.get_full_command_string(), ex)
@@ -96,16 +96,16 @@ class ParamikoRemoteScriptActionTestCase(unittest2.TestCase):
             'ST2_ACTION_EXECUTION_ID': '55ce39d532ed3543aecbe71d',
             'FOO': 'BAR BAZ BOOZ'
         }
-        ex = 'export ST2_ACTION_EXECUTION_ID=55ce39d532ed3543aecbe71d ' + \
-             'FOO=\'BAR BAZ BOOZ\' && ' + \
+        ex = 'export FOO=\'BAR BAZ BOOZ\' ' + \
+             'ST2_ACTION_EXECUTION_ID=55ce39d532ed3543aecbe71d && ' + \
              'cd /tmp && /tmp/remote_script.sh'
         self.assertEqual(script_action.get_full_command_string(), ex)
 
         # Test with sudo
         script_action.sudo = True
         ex = 'sudo -E -- bash -c ' + \
-             '\'export ST2_ACTION_EXECUTION_ID=55ce39d532ed3543aecbe71d ' + \
-             'FOO=\'"\'"\'BAR BAZ BOOZ\'"\'"\' && ' + \
+             '\'export FOO=\'"\'"\'BAR BAZ BOOZ\'"\'"\' ' + \
+             'ST2_ACTION_EXECUTION_ID=55ce39d532ed3543aecbe71d && ' + \
              'cd /tmp && ' + \
              '/tmp/remote_script.sh\''
         self.assertEqual(script_action.get_full_command_string(), ex)
@@ -129,7 +129,7 @@ class ParamikoRemoteScriptActionTestCase(unittest2.TestCase):
         script_action.sudo = True
         script_action.sudo_password = 'sudo pass'
 
-        ex = 'echo -e \'sudo pass\n\' | sudo -S -E -- bash -c ' + \
+        ex = 'set +o history ; echo -e \'sudo pass\n\' | sudo -S -E -- bash -c ' + \
              '\'cd /tmp && \'"\'"\'/tmp/remote script.sh\'"\'"\'\''
         self.assertEqual(script_action.get_full_command_string(), ex)
 
@@ -154,8 +154,8 @@ class ParamikoRemoteScriptActionTestCase(unittest2.TestCase):
         script_action.sudo = True
         script_action.sudo_password = 'sudo pass'
 
-        ex = 'echo -e \'sudo pass\n\' | sudo -S -E -- bash -c ' + \
-             '\'export FOO=BAR && ' + \
+        ex = 'set +o history ; echo -e \'sudo pass\n\' | sudo -S -E -- bash -c ' + \
+             '\'export FOO=BAR HISTFILE=/dev/null HISTSIZE=0 && ' + \
              'cd /tmp && \'"\'"\'/tmp/remote script.sh\'"\'"\'\''
         self.assertEqual(script_action.get_full_command_string(), ex)
 


### PR DESCRIPTION
This pull request updates remote command and script runner to explicitly disable bash history when user provides `sudo_password` parameter which is passed to `sudo` binary as a command line (stdin) argument.

As mentioned here (https://github.com/StackStorm/st2/pull/3867#issuecomment-349273078), the way paramiko executes shell commands bash history is not enabled, but it's still better to be on the safe side and also try to explicitly disable it ourselves.

Disabling is done by setting `HISTFILE` (I set it to `/dev/null`, if this would become problematic in some installations where user doesn't have write access to `/dev/null` we can change that approach to try unseting this variable instead) and `HISTSIZE` environment variable and by explicitly calling `set +o history` command before any other commands which are executed as part of a paramiko session.

Even though we disable bash history, there are other ways in which user with the access to the box could intercept this password so that's just additional layer and actual limitation / potential security implications of supplying `sudo_password` parameter are documented in the docs.