### PR TITLE
Remove MongoDB database dependency from Python runner

### DIFF
--- a/st2common/st2common/util/pack.py
+++ b/st2common/st2common/util/pack.py
@@ -22,10 +22,14 @@ from st2common.util import schema as util_schema
 from st2common.constants.pack import MANIFEST_FILE_NAME
 from st2common.constants.pack import PACK_REF_WHITELIST_REGEX
 from st2common.content.loader import MetaLoader
+from st2common.persistence.pack import Pack
 
 __all__ = [
     'get_pack_ref_from_metadata',
     'get_pack_metadata',
+
+    'get_pack_common_libs_path_for_pack_ref',
+    'get_pack_common_libs_path_for_pack_db',
 
     'validate_config_against_schema',
 
@@ -112,7 +116,13 @@ def validate_config_against_schema(config_schema, config_object, config_path,
     return cleaned
 
 
-def get_pack_common_libs_path(pack_db):
+def get_pack_common_libs_path_for_pack_ref(pack_ref):
+    pack_db = Pack.get_by_ref(pack_ref)
+    pack_common_libs_path = get_pack_common_libs_path_for_pack_db(pack_db=pack_db)
+    return pack_common_libs_path
+
+
+def get_pack_common_libs_path_for_pack_db(pack_db):
     """
     Return the pack's common lib path. This is the path where common code for sensors
     and actions are placed.

--- a/st2common/tests/unit/test_util_pack.py
+++ b/st2common/tests/unit/test_util_pack.py
@@ -16,12 +16,12 @@
 import unittest2
 
 from st2common.models.db.pack import PackDB
-from st2common.util.pack import get_pack_common_libs_path
+from st2common.util.pack import get_pack_common_libs_path_for_pack_db
 
 
 class PackUtilsTestCase(unittest2.TestCase):
 
-    def test_get_pack_common_libs_path(self):
+    def test_get_pack_common_libs_path_for_pack_db(self):
         pack_model_args = {
             'name': 'Yolo CI',
             'ref': 'yolo_ci',
@@ -31,10 +31,10 @@ class PackUtilsTestCase(unittest2.TestCase):
             'path': '/opt/stackstorm/packs/yolo_ci/'
         }
         pack_db = PackDB(**pack_model_args)
-        lib_path = get_pack_common_libs_path(pack_db)
+        lib_path = get_pack_common_libs_path_for_pack_db(pack_db)
         self.assertEqual('/opt/stackstorm/packs/yolo_ci/lib', lib_path)
 
-    def test_get_pack_common_libs_path_no_path_in_pack_db(self):
+    def test_get_pack_common_libs_path_for_pack_db_no_path_in_pack_db(self):
         pack_model_args = {
             'name': 'Yolo CI',
             'ref': 'yolo_ci',
@@ -43,5 +43,5 @@ class PackUtilsTestCase(unittest2.TestCase):
             'author': 'Volkswagen'
         }
         pack_db = PackDB(**pack_model_args)
-        lib_path = get_pack_common_libs_path(pack_db)
+        lib_path = get_pack_common_libs_path_for_pack_db(pack_db)
         self.assertEqual(None, lib_path)

--- a/st2reactor/st2reactor/container/process_container.py
+++ b/st2reactor/st2reactor/container/process_container.py
@@ -33,11 +33,10 @@ from st2common.constants.triggers import (SENSOR_SPAWN_TRIGGER, SENSOR_EXIT_TRIG
 from st2common.constants.exit_codes import SUCCESS_EXIT_CODE
 from st2common.constants.exit_codes import FAILURE_EXIT_CODE
 from st2common.models.system.common import ResourceReference
-from st2common.persistence.pack import Pack
 from st2common.services.access import create_token
 from st2common.transport.reactor import TriggerDispatcher
 from st2common.util.api import get_full_public_api_url
-from st2common.util.pack import get_pack_common_libs_path
+from st2common.util.pack import get_pack_common_libs_path_for_pack_ref
 from st2common.util.shell import on_parent_exit
 from st2common.util.sandboxing import get_sandbox_python_path
 from st2common.util.sandboxing import get_sandbox_python_binary_path
@@ -265,7 +264,6 @@ class ProcessSensorContainer(object):
         """
         sensor_id = self._get_sensor_id(sensor=sensor)
         pack_ref = sensor['pack']
-        pack_db = Pack.get_by_ref(pack_ref)
 
         virtualenv_path = get_sandbox_virtualenv_path(pack=pack_ref)
         python_path = get_sandbox_python_binary_path(pack=pack_ref)
@@ -295,7 +293,11 @@ class ProcessSensorContainer(object):
 
         sandbox_python_path = get_sandbox_python_path(inherit_from_parent=True,
                                                       inherit_parent_virtualenv=True)
-        pack_common_libs_path = get_pack_common_libs_path(pack_db=pack_db)
+
+        if self._enable_common_pack_libs:
+            pack_common_libs_path = get_pack_common_libs_path_for_pack_ref(pack_ref=pack_ref)
+        else:
+            pack_common_libs_path = None
 
         env = os.environ.copy()
 


### PR DESCRIPTION
Not so long ago, we refactored a bunch of runners and runner container code to make runners fully standalone (they don't depend on MongoDB and RabbitMQ anymore).

We follow "dependency injection" approach and the required parameters are passed to runners by the action container service instead of being retrieved the the runner itself (that's a better abstraction anyway).

It turns out, https://github.com/StackStorm/st2/pull/3658 inadvertently added MongoDB dependency back to the Python runner.

This pull request updates the code to remove this dependency (common libs path is only retrieved if that feature is enabled in the config (off by default) and MongoDB related connection errors are ignored) so the Python runner works on AWS Lambda again.

Slightly better and long term solution is update the code so this pack_db object is retrieved inside the runner and pack_path passed to the runners by the action container service.

Or maybe even better, we don't store pack_path on the PackDB object and dynamically retrieve the path in the code by iterating over file system paths - we already do this in other places (I already originally had some concerns about that in the past - https://github.com/StackStorm/st2/pull/3658#discussion_r132112782).

In any case, we also need some tests which very that all the runners (starting with Python one) are fully standalone and we can be sure they work on lambda. If we had those tests, this issue would be caught faster and automatically.

And this is also a good example why we should aim to merge PRs faster, #3658 was lingering in limbo for a while before it was merged.