### PR TITLE
Match and multiple execute doc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,8 @@ generate-api-spec: requirements .generate-api-spec
 	@echo
 	echo "# NOTE: This file is auto-generated - DO NOT EDIT MANUALLY" > st2common/st2common/openapi.yaml
 	echo "# Edit st2common/st2common/openapi.yaml.j2 and then run" >> st2common/st2common/openapi.yaml
-	echo "# make .generate-api-spec make target to generate the final spec file" >> st2common/st2common/openapi.yaml
+	echo "# make .generate-api-spec" >> st2common/st2common/openapi.yaml
+	echo "# to generate the final spec file" >> st2common/st2common/openapi.yaml
 	. virtualenv/bin/activate; st2common/bin/st2-generate-api-spec >> st2common/st2common/openapi.yaml
 
 .PHONY: circle-lint-api-spec

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -1,6 +1,7 @@
 # NOTE: This file is auto-generated - DO NOT EDIT MANUALLY
 # Edit st2common/st2common/openapi.yaml.j2 and then run
-# make .generate-api-spec make target to generate the final spec file
+# make .generate-api-spec
+# to generate the final spec file
 swagger: '2.0'
 
 info:

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -793,7 +793,7 @@ paths:
     post:
       operationId: st2api.controllers.v1.aliasexecution:action_alias_execution_controller.match_and_execute
       description: |
-        Create an execution based on action alias match (if any).
+        Create executions based on action alias match (if any).
       parameters:
         - name: input_api
           in: body
@@ -811,9 +811,16 @@ paths:
           description: User performing the operation.
       responses:
         '201':
-          description: Action alias execution created
+          description: Action alias executions created
           schema:
-            $ref: '#/definitions/AliasExecution'
+            type: object
+            properties:
+              results:
+                description: List of all matched and executed actions
+                type: array
+                items:
+                  type: object
+                  $ref: '#/definitions/AliasExecution'
           examples:
             application/json:
               ref: 'core.local'
@@ -4119,9 +4126,114 @@ definitions:
   AliasExecution:
     x-api-model: st2common.models.api.action:AliasExecutionAPI
     type: object
+    properties:
+      actionalias:
+        type: object
+        description: Alias for an action
+        properties:
+          id:
+            type: string
+            description: Unique identifier for the action alias.
+          ref:
+            type: string
+            description: |
+              System computed user friendly reference for the alias. Provided
+              value will be overridden by computed value.
+          uid:
+            type: string
+          name:
+            type: string
+            description: Name of the action alias.
+          pack:
+            type: string
+            description: The content pack this actionalias belongs to.
+          description:
+            type: string
+            description: Description of the executed alias.
+            default: ""
+          enabled:
+            type: boolean
+            description: Flag indicating if action alias is enabled.
+            default: true
+          action_ref:
+            type: string
+            description: Reference to the aliased action
+          formats:
+            type: array
+            description: Possible parameter format.
+            items:
+              oneOf:
+              - type: string
+              - type: object
+                description: Matched alias formats
+                properties:
+                  representation:
+                    type: array
+                    description: Alias format representations
+                    items:
+                      type: string
+                  match_multiple:
+                    type: boolean
+                    optional: true
+                  display:
+                    type: string
+                    description: Display string of alias format
+          ack:
+            type: object
+            description: Acknowledgement message format.
+            properties:
+              enabled:
+                type: boolean
+              format:
+                type: string
+              extra:
+                type: object
+              append_url:
+                type: boolean
+          result:
+            type: object
+            description: Execution message format.
+            properties:
+              enabled:
+                type: boolean
+              format:
+                type: string
+              extra:
+                type: object
+          extra:
+            type: object
+            description: Extra parameters, usually adapter-specific
+      execution:
+        type: object
+        description: Execution result
+        properties:
+          $ref: '#/definitions/Execution'
+      message:
+        type: string
   AliasMatchAndExecuteInputAPI:
     x-api-model: st2common.models.api.action:AliasMatchAndExecuteInputAPI
     type: object
+    required:
+      - command
+      - source_channel
+    properties:
+      command:
+        type: string
+        description: "Command string to parse (eg: message from chat)"
+      user:
+        type: string
+        description: User that requested the execution (or messaged in chat)
+      source_channel:
+        type: string
+        description: Channel the message is from (different than the notification channel)
+      notification_channel:
+        type: string
+        description: StackStorm notification channel to use to respond
+        default: ""
+      notification_route:
+        type: string
+        description: StackStorm notification route to use to respond
+        default: ""
   Execution:
     title: ActionExecution
     description: Record of the execution of an action.

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -789,7 +789,7 @@ paths:
     post:
       operationId: st2api.controllers.v1.aliasexecution:action_alias_execution_controller.match_and_execute
       description: |
-        Create an execution based on action alias match (if any).
+        Create executions based on action alias match (if any).
       parameters:
         - name: input_api
           in: body
@@ -807,9 +807,16 @@ paths:
           description: User performing the operation.
       responses:
         '201':
-          description: Action alias execution created
+          description: Action alias executions created
           schema:
-            $ref: '#/definitions/AliasExecution'
+            type: object
+            properties:
+              results:
+                description: List of all matched and executed actions
+                type: array
+                items:
+                  type: object
+                  $ref: '#/definitions/AliasExecution'
           examples:
             application/json:
               ref: 'core.local'
@@ -4115,9 +4122,114 @@ definitions:
   AliasExecution:
     x-api-model: st2common.models.api.action:AliasExecutionAPI
     type: object
+    properties:
+      actionalias:
+        type: object
+        description: Alias for an action
+        properties:
+          id:
+            type: string
+            description: Unique identifier for the action alias.
+          ref:
+            type: string
+            description: |
+              System computed user friendly reference for the alias. Provided
+              value will be overridden by computed value.
+          uid:
+            type: string
+          name:
+            type: string
+            description: Name of the action alias.
+          pack:
+            type: string
+            description: The content pack this actionalias belongs to.
+          description:
+            type: string
+            description: Description of the executed alias.
+            default: ""
+          enabled:
+            type: boolean
+            description: Flag indicating if action alias is enabled.
+            default: true
+          action_ref:
+            type: string
+            description: Reference to the aliased action
+          formats:
+            type: array
+            description: Possible parameter format.
+            items:
+              oneOf:
+              - type: string
+              - type: object
+                description: Matched alias formats
+                properties:
+                  representation:
+                    type: array
+                    description: Alias format representations
+                    items:
+                      type: string
+                  match_multiple:
+                    type: boolean
+                    optional: true
+                  display:
+                    type: string
+                    description: Display string of alias format
+          ack:
+            type: object
+            description: Acknowledgement message format.
+            properties:
+              enabled:
+                type: boolean
+              format:
+                type: string
+              extra:
+                type: object
+              append_url:
+                type: boolean
+          result:
+            type: object
+            description: Execution message format.
+            properties:
+              enabled:
+                type: boolean
+              format:
+                type: string
+              extra:
+                type: object
+          extra:
+            type: object
+            description: Extra parameters, usually adapter-specific
+      execution:
+        type: object
+        description: Execution result
+        properties:
+          $ref: '#/definitions/Execution'
+      message:
+        type: string
   AliasMatchAndExecuteInputAPI:
     x-api-model: st2common.models.api.action:AliasMatchAndExecuteInputAPI
     type: object
+    required:
+      - command
+      - source_channel
+    properties:
+      command:
+        type: string
+        description: "Command string to parse (eg: message from chat)"
+      user:
+        type: string
+        description: User that requested the execution (or messaged in chat)
+      source_channel:
+        type: string
+        description: Channel the message is from (different than the notification channel)
+      notification_channel:
+        type: string
+        description: StackStorm notification channel to use to respond
+        default: ""
+      notification_route:
+        type: string
+        description: StackStorm notification route to use to respond
+        default: ""
   Execution:
     title: ActionExecution
     description: Record of the execution of an action.


### PR DESCRIPTION
This PR is the companion API documentation for #3884.

I'm not super familiar with how Swagger all works, so please make sure everything looks fine, particularly my use `oneOf` to define a heterogeneous array. My intent here is that items of the `formats` array are either plain strings or objects that match the subschema.

The first commit is tweaking the injected header to make it clear what the actual command is. I tried to run `make .generate-api-spec make target`, which was incorrect.

The second commit is filling out the expected input and output JSON schemas.