### PR TITLE
Added capability to transform_array function to escape colons

### DIFF
--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -23,6 +23,7 @@ import calendar
 import time
 import six
 import sys
+import re
 
 from os.path import join as pjoin
 
@@ -573,11 +574,14 @@ class ActionRunCommandMixin(object):
             except ValueError:
                 result = [v.strip() for v in value.split(',')]
 
+            # Negative lookbehind regex to ensure that the colon isn't escaped
+            escape_exp = re.compile('(?<!\\\):')
+
             # When each values in this array represent dict type, this converts
             # the 'result' to the dict type value.
-            if all([isinstance(x, str) and ':' in x for x in result]):
+            if all([isinstance(x, str) and escape_exp.search(x) for x in result]):
                 result_dict = {}
-                for (k, v) in [x.split(':') for x in result]:
+                for (k, v) in [escape_exp.split(x) for x in result]:
                     # To parse values using the 'transformer' according to the type which is
                     # specified in the action metadata, calling 'normalize' method recursively.
                     if 'properties' in action_params and k in action_params['properties']:

--- a/st2client/tests/unit/test_command_actionrun.py
+++ b/st2client/tests/unit/test_command_actionrun.py
@@ -151,3 +151,27 @@ class ActionRunCommandTest(unittest2.TestCase):
             {'foo': '1', 'bar': '2'},
             {'hoge': 'A', 'fuga': 'B'}
         ])
+
+    def test_escape_colon(self):
+        runner = RunnerType()
+        runner.runner_parameters = {}
+
+        action = Action()
+        action.ref = 'test.action'
+        action.parameters = {
+            'param_array': {'type': 'array'},
+        }
+
+        subparser = mock.Mock()
+        command = ActionRunCommand(action, self, subparser, name='test')
+
+        mockarg = mock.Mock()
+        mockarg.inherit_env = False
+        mockarg.parameters = [
+            'param_array=foo\:bar,foo2:bar2',
+        ]
+
+        param = command._get_action_parameters_from_args(action=action, runner=runner, args=mockarg)
+
+        self.assertEqual(param['param_array'], ['foo\\:bar', 'foo2:bar2'])
+


### PR DESCRIPTION
https://github.com/StackStorm/st2/pull/3670 introduced a cool new capability to split strings in an array parameter on a colon `:` character in order to specify a dictionary more easily.

However, this breaks use cases where the user wants to provide an array of strings that all contain `:` and doesn't want them split. For instance, some network interfaces have a colon in their name and it shouldn't be split up.

This PR builds on the work in #3670 and uses a negative lookbehind regular expression to ensure that the colon in question isn't preceded by a backslash: `\`. So, the user can place this behind the colon, and this conversion will be skipped.