### PR TITLE
Add type to vmstat action

### DIFF
--- a/contrib/linux/actions/vmstat.yaml
+++ b/contrib/linux/actions/vmstat.yaml
@@ -10,4 +10,5 @@
       default: "vmstat {{args}}"
     args:
       description: "Command line arguments"
+      type: string
       default: " "


### PR DESCRIPTION
The linux.vmstat action fails due to the type missing. It expects arguments to be passed as a string. 

Without this fix running linux.vmstat fails with an error:
```
$ st2 run linux.vmstat hosts='localhost' args="3 2"
ERROR: 'type'
```

After the fix the command completes successfully:
```
$ st2 run linux.vmstat hosts='localhost' args="3 2"
..
id: 5a2948d4a44fdf731ec3f18e
status: succeeded
parameters: 
  args: 3 2
  hosts: localhost
result: 
  localhost:
    failed: false
    return_code: 0
    stderr: ''
    stdout: "procs -----------memory---------- ---swap-- -----io---- -system-- ------cpu-----\n r  b   swpd   free   buff  cache   si   so    bi    bo   in   cs us sy id wa st\n 0  0      0 137056 190248 2092336    0    0     3    47   76  114  1  0 99  0  0\n 0  0      0 136980 190248 2092452    0    0     0     4  545  790  3  0 97  0  0"
```