### PR TITLE
Update openapi.yaml definition file - user is required property for match and execute API endpoint

### DIFF
--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -4216,6 +4216,7 @@ definitions:
     required:
       - command
       - source_channel
+      - user
     properties:
       command:
         type: string

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -4212,6 +4212,7 @@ definitions:
     required:
       - command
       - source_channel
+      - user
     properties:
       command:
         type: string


### PR DESCRIPTION
"user" is a required property for match and execute API endpoint, but API schema doesn't define that so if this property is not included in the request body API will fail with internal server error instead of with user-friendly "bad requests".

```bash
2017-12-08 10:23:53,360 ERROR [-] Failed to call controller function "match_and_execute" for operation "st2api.controllers.v1.aliasexecution:action_alias_execution_controller.match_and_execute": 'AliasMatchAndExecuteInputAPI' object has no attribute 'user'
Traceback (most recent call last):
  File "/data/stanley/st2common/st2common/router.py", line 450, in __call__
    resp = func(**kw)
  File "/data/stanley/st2api/st2api/controllers/v1/aliasexecution.py", line 79, in match_and_execute
    'user': input_api.user,
AttributeError: 'AliasMatchAndExecuteInputAPI' object has no attribute 'user'
2017-12-08 10:23:53,363 ERROR [-] API call failed: 'AliasMatchAndExecuteInputAPI' object has no attribute 'user'
Traceback (most recent call last):
  File "/data/stanley/st2common/st2common/middleware/error_handling.py", line 46, in __call__
    return self.app(environ, start_response)
  File "/data/stanley/st2common/st2common/middleware/streaming.py", line 47, in __call__
    return self.app(environ, start_response)
  File "/data/stanley/st2common/st2common/router.py", line 499, in as_wsgi
    resp = self(req)
  File "/data/stanley/st2common/st2common/router.py", line 454, in __call__
    raise e
AttributeError: 'AliasMatchAndExecuteInputAPI' object has no attribute 'user' (_exception_data={},_exception_class='AttributeError',_exception_message="'AliasMatchAndExecuteInputAPI' object has no attribute 'user'")
```