### PR TITLE
Throw more user-friendly error on if a cycle is found inside action parameters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,8 @@ Added
 * Add new ``--tail`` flag to the ``st2 run`` / ``st2 action execute`` and ``st2 execution re-run``
   CLI command. When this flag is provided, new execution will automatically be followed and tailed
   after it has been scheduled. (new feature) #3867
+* Now a more user-friendly error message is thrown if a cycle is found inside the Jinja template
+  string (e.g. when parameter / variable references itself). (improvement) #3908
 
 Changed
 ~~~~~~~

--- a/st2api/tests/unit/controllers/v1/test_executions.py
+++ b/st2api/tests/unit/controllers/v1/test_executions.py
@@ -459,7 +459,7 @@ class ActionExecutionControllerTestCase(BaseActionExecutionControllerTestCase, F
         post_resp = self._do_post(execution, expect_errors=True)
         self.assertEqual(post_resp.status_int, 400)
         self.assertEqual(post_resp.json['faultstring'],
-                         'Dependecy unsatisfied in ABSENT')
+                         'Dependecy unsatisfied in variable "ABSENT"')
 
     def test_post_parameter_validation_explicit_none(self):
         execution = copy.deepcopy(LIVE_ACTION_1)

--- a/st2api/tests/unit/controllers/v1/test_executions.py
+++ b/st2api/tests/unit/controllers/v1/test_executions.py
@@ -459,7 +459,7 @@ class ActionExecutionControllerTestCase(BaseActionExecutionControllerTestCase, F
         post_resp = self._do_post(execution, expect_errors=True)
         self.assertEqual(post_resp.status_int, 400)
         self.assertEqual(post_resp.json['faultstring'],
-                         'Dependecy unsatisfied in variable "ABSENT"')
+                         'Dependency unsatisfied in variable "ABSENT"')
 
     def test_post_parameter_validation_explicit_none(self):
         execution = copy.deepcopy(LIVE_ACTION_1)

--- a/st2common/st2common/util/param.py
+++ b/st2common/st2common/util/param.py
@@ -141,7 +141,7 @@ def _validate(G):
     '''
     for name in G.nodes():
         if 'value' not in G.node[name] and 'template' not in G.node[name]:
-            msg = 'Dependecy unsatisfied in variable "%s"' % name
+            msg = 'Dependency unsatisfied in variable "%s"' % name
             raise ParamException(msg)
 
     if not nx.is_directed_acyclic_graph(G):
@@ -157,7 +157,7 @@ def _validate(G):
             variable_names.append(variable_name)
 
         variable_names = ', '.join(variable_names)
-        msg = ('Cyclic dependecy found in the following variables: %s. Likely the variable is '
+        msg = ('Cyclic dependency found in the following variables: %s. Likely the variable is '
                'referencing itself' % (variable_names))
         raise ParamException(msg)
 
@@ -172,7 +172,7 @@ def _render(node, render_context):
         if isinstance(node['template'], list) or isinstance(node['template'], dict):
             node['template'] = json.dumps(node['template'])
 
-            # Finds occourances of "{{variable}}" and adds `to_complex` filter
+            # Finds occurrences of "{{variable}}" and adds `to_complex` filter
             # so types are honored. If it doesn't follow that syntax then it's
             # rendered as a string.
             node['template'] = re.sub(

--- a/st2common/st2common/util/param.py
+++ b/st2common/st2common/util/param.py
@@ -141,7 +141,7 @@ def _validate(G):
     '''
     for name in G.nodes():
         if 'value' not in G.node[name] and 'template' not in G.node[name]:
-            msg = 'Dependecy unsatisfied in %s' % name
+            msg = 'Dependecy unsatisfied in variable "%s"' % name
             raise ParamException(msg)
 
     if not nx.is_directed_acyclic_graph(G):

--- a/st2common/st2common/util/param.py
+++ b/st2common/st2common/util/param.py
@@ -145,7 +145,20 @@ def _validate(G):
             raise ParamException(msg)
 
     if not nx.is_directed_acyclic_graph(G):
-        msg = 'Cyclic dependecy found'
+        graph_cycles = nx.simple_cycles(G)
+
+        variable_names = []
+        for cycle in graph_cycles:
+            try:
+                variable_name = cycle[0]
+            except IndexError:
+                continue
+
+            variable_names.append(variable_name)
+
+        variable_names = ', '.join(variable_names)
+        msg = ('Cyclic dependecy found in the following variables: %s. Likely the variable is '
+               'referencing itself' % (variable_names))
         raise ParamException(msg)
 
 

--- a/st2common/tests/unit/test_param_utils.py
+++ b/st2common/tests/unit/test_param_utils.py
@@ -674,3 +674,24 @@ class ParamsUtilsTest(DbTestCase):
         expected_msg = 'Cyclic dependecy found in the following variables: cyclic, morecyclic'
         self.assertRaisesRegexp(ParamException, expected_msg, param_utils.render_live_params,
                                 runner_param_info, action_param_info, params, action_context)
+
+    def test_unsatisfied_dependency_friendly_error_message(self):
+        runner_param_info = {
+            'r1': {
+                'default': 'some',
+            }
+        }
+        action_param_info = {
+            'r2': {
+                'default': '{{ r1 }}'
+            }
+        }
+        params = {
+            'r3': 'lolcathost',
+            'r4': '{{ variable_not_defined }}',
+        }
+        action_context = {}
+
+        expected_msg = 'Dependecy unsatisfied in variable "variable_not_defined"'
+        self.assertRaisesRegexp(ParamException, expected_msg, param_utils.render_live_params,
+                                runner_param_info, action_param_info, params, action_context)

--- a/st2common/tests/unit/test_param_utils.py
+++ b/st2common/tests/unit/test_param_utils.py
@@ -650,3 +650,27 @@ class ParamsUtilsTest(DbTestCase):
             'r3': 'lolcathost'
         }
         self.assertEqual(live_params, expected_params)
+
+    def test_cyclic_dependency_friendly_error_message(self):
+        runner_param_info = {
+            'r1': {
+                'default': 'some',
+                'cyclic': 'cyclic value',
+                'morecyclic': 'cyclic value'
+            }
+        }
+        action_param_info = {
+            'r2': {
+                'default': '{{ r1 }}'
+            }
+        }
+        params = {
+            'r3': 'lolcathost',
+            'cyclic': '{{ cyclic }}',
+            'morecyclic': '{{ morecyclic }}'
+        }
+        action_context = {}
+
+        expected_msg = 'Cyclic dependecy found in the following variables: cyclic, morecyclic'
+        self.assertRaisesRegexp(ParamException, expected_msg, param_utils.render_live_params,
+                                runner_param_info, action_param_info, params, action_context)

--- a/st2common/tests/unit/test_param_utils.py
+++ b/st2common/tests/unit/test_param_utils.py
@@ -473,7 +473,7 @@ class ParamsUtilsTest(DbTestCase):
             param_utils.get_finalized_params(runner_param_info, action_param_info, params, {})
             test_pass = False
         except ParamException as e:
-            test_pass = e.message.find('Dependecy') == 0
+            test_pass = e.message.find('Dependency') == 0
         self.assertTrue(test_pass)
 
         params = {}
@@ -484,7 +484,7 @@ class ParamsUtilsTest(DbTestCase):
             param_utils.get_finalized_params(runner_param_info, action_param_info, params, {})
             test_pass = False
         except ParamException as e:
-            test_pass = e.message.find('Dependecy') == 0
+            test_pass = e.message.find('Dependency') == 0
         self.assertTrue(test_pass)
 
     def test_get_finalized_params_no_double_rendering(self):
@@ -671,7 +671,7 @@ class ParamsUtilsTest(DbTestCase):
         }
         action_context = {}
 
-        expected_msg = 'Cyclic dependecy found in the following variables: cyclic, morecyclic'
+        expected_msg = 'Cyclic dependency found in the following variables: cyclic, morecyclic'
         self.assertRaisesRegexp(ParamException, expected_msg, param_utils.render_live_params,
                                 runner_param_info, action_param_info, params, action_context)
 
@@ -692,6 +692,6 @@ class ParamsUtilsTest(DbTestCase):
         }
         action_context = {}
 
-        expected_msg = 'Dependecy unsatisfied in variable "variable_not_defined"'
+        expected_msg = 'Dependency unsatisfied in variable "variable_not_defined"'
         self.assertRaisesRegexp(ParamException, expected_msg, param_utils.render_live_params,
                                 runner_param_info, action_param_info, params, action_context)


### PR DESCRIPTION
Previously only "Cyclic dependency found" error was thrown if a cycle was found (e.g. parameter is referencing itself or similar) which made it quite unfriendly and harder / slower to troubleshoot the issue.

With this change we now reference the actual variable where cycle is found to make the error more obvious and troubleshooting easier.

Before:

```
Cyclic dependency found
```

After:

```
Cyclic dependency found in the following variables: cyclic, morecyclic
```
