### PR TITLE
Add flag to opt-in to dict conversion when colons are detected

### DIFF
--- a/st2client/tests/unit/test_action.py
+++ b/st2client/tests/unit/test_action.py
@@ -386,6 +386,60 @@ class ActionCommandTestCase(base.BaseCLITestCase):
     @mock.patch.object(
         httpclient.HTTPClient, 'post',
         mock.MagicMock(return_value=base.FakeResponse(json.dumps(LIVE_ACTION), 200, 'OK')))
+    def test_param_dict_conversion_flag(self):
+        """Ensure that the automatic conversion to dict based on colons only occurs with the flag
+        """
+
+        self.shell.run(
+            [
+                'run',
+                'mockety.mock2',
+                'list=key1:value1,key2:value2',
+                '--auto-dict'
+            ]
+        )
+        expected = {
+            'action': 'mockety.mock2',
+            'user': None,
+            'parameters': {
+                'list': [
+                    {
+                        'key1': 'value1',
+                        'key2': 'value2'
+                    }
+                ]
+            }
+        }
+        httpclient.HTTPClient.post.assert_called_with('/executions', expected)
+
+        self.shell.run(
+            [
+                'run',
+                'mockety.mock2',
+                'list=key1:value1,key2:value2'
+            ]
+        )
+        expected = {
+            'action': 'mockety.mock2',
+            'user': None,
+            'parameters': {
+                'list': [
+                    'key1:value1',
+                    'key2:value2'
+                ]
+            }
+        }
+        httpclient.HTTPClient.post.assert_called_with('/executions', expected)
+
+    @mock.patch.object(
+        models.ResourceManager, 'get_by_ref_or_id',
+        mock.MagicMock(side_effect=get_by_ref))
+    @mock.patch.object(
+        models.ResourceManager, 'get_by_name',
+        mock.MagicMock(side_effect=get_by_name))
+    @mock.patch.object(
+        httpclient.HTTPClient, 'post',
+        mock.MagicMock(return_value=base.FakeResponse(json.dumps(LIVE_ACTION), 200, 'OK')))
     def test_param_value_with_equal_sign(self):
         self.shell.run(['run', 'mockety.mock2', 'key=foo=bar&ponies=unicorns'])
         expected = {'action': 'mockety.mock2', 'user': None,


### PR DESCRIPTION
https://github.com/StackStorm/st2/pull/3670 introduced a cool new capability to split strings in an array parameter on a colon `:` character in order to specify a dictionary more easily.

However, this breaks a few corner cases, such as those where the user wants to provide an array of strings that all contain `:` and doesn't want them split. For instance, some network interfaces have a colon in their name and it shouldn't be split up.

This kicked off a long discussion internally, and we've decided to go for a more robust, exhaustive method of dealing with more complicated data types, likely to be implemented in the 2.6 release timeframe, perhaps 2.7.

Until that time, we need to take a stopgap measure to retain the functionality for those that need it, while getting things working again for some of the corner cases that don't want it. To that end, this PR implements a new flag `--auto-dict`, which you **MUST** specify to get the functionality introduced by #3670. The default functionality for `st2 run` will be to **NOT** interpret colons, but revert back to the way this was handled prior to #3670.

Note again that **this flag is temporary** and should not be relied upon long-term. Eventually, it will be replaced with more permanent, exhaustive handling of complex datatypes for action parameters.

# Usage

I put together a simple action that just returns its input values so we can see how the parameters have or haven't been affected by the use of this new flag. Note that without the flag, the default is to behave as it was before - it will not split the list items into dicts, but rather leave them as strings:

```
$ st2 run testpack.pythontest testparam=key1:value1,key2:value2
.
id: 5a30328a32ed350bde0a7ea5
status: succeeded
parameters:
  testparam:
  - key1:value1
  - key2:value2
result:
  exit_code: 0
  result:
  - key1:value1
  - key2:value2
  stderr: ''
  stdout: ''
```

However, this functionality can be opted into by using the `--auto-dict` flag:

```
$ st2 run testpack.pythontest testparam=key1:value1,key2:value2 --auto-dict
.
id: 5a30329232ed350bde0a7ea8
status: succeeded
parameters:
  testparam:
  - key1: value1
    key2: value2
result:
  exit_code: 0
  result:
  - key1: value1
    key2: value2
  stderr: ''
  stdout: ''
```