### PR TITLE
Add step to skip immutable params to be overridden

### DIFF
--- a/st2common/st2common/util/param.py
+++ b/st2common/st2common/util/param.py
@@ -242,6 +242,10 @@ def _cast_params_from(params, context, schemas):
     for schema in schemas:
         for param_name, param_details in schema.items():
 
+            # Skip if the parameter have immutable set to true in schema
+            if param_details.get('immutable'):
+                continue
+
             # Skip if the parameter doesn't have a default, or if the
             # value in the context is identical to the default
             if 'default' not in param_details or \

--- a/st2common/tests/unit/test_param_utils.py
+++ b/st2common/tests/unit/test_param_utils.py
@@ -701,6 +701,22 @@ class ParamsUtilsTest(DbTestCase):
         """Test addition of template values in defaults to live params
         """
 
+        # Ensure parameter is skipped if the parameter has immutable set to true in schema
+        schemas = [
+            {
+                'templateparam': {
+                    'default': '{{ 3 | int }}',
+                    'type': 'integer',
+                    'immutable': True
+                }
+            }
+        ]
+        context = {
+            'templateparam': '3'
+        }
+        result = param_utils._cast_params_from({}, context, schemas)
+        self.assertEquals(result, {})
+
         # Test with no live params, and two parameters - one should make it through because
         # it was a template, and the other shouldn't because its default wasn't a template
         schemas = [


### PR DESCRIPTION
Regression from: https://github.com/StackStorm/st2/pull/3892

```bash
$ st2 run linux.lsof hosts=localhost
ERROR: 400 Client Error: Bad Request
MESSAGE: Override of immutable parameter(s) [u'cmd'] is unsupported. for url: http://127.0.0.1:9101/v1/executions
```