### PR TITLE
Enable real-time action output streaming by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,6 +50,10 @@ Changed
   gitpython, pymongo, stevedore, paramiko, prompt-toolkit, flex). #3830
 * Mask values in an Inquiry response displayed to the user that were marked as "secret" in the
   inquiry's response schema. #3825
+* Real-time action output streaming is now enabled by default. For more information on this
+  feature, please refer to the documentation - https://docs.stackstorm.com/latest/reference/action_output_streaming.html.
+  You can disable this functionality by setting ``actionrunner.stream_output`` config option in
+  ``st2.conf`` to ``False`` and restart the services (``sudo st2ctl restart``).
 
 Fixed
 ~~~~~

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -231,8 +231,8 @@ def register_opts(ignore_errors=False):
         cfg.ListOpt('virtualenv_opts', default=['--system-site-packages'],
                     help='List of virtualenv options to be passsed to "virtualenv" command that ' +
                          'creates pack virtualenv.'),
-        cfg.BoolOpt('stream_output', default=False, help='True to store and stream action output '
-                                                         '(stdout and stderr) in real-time.')
+        cfg.BoolOpt('stream_output', default=True, help='True to store and stream action output '
+                                                        '(stdout and stderr) in real-time.')
     ]
     do_register_opts(action_runner_opts, group='actionrunner')
 

--- a/st2common/st2common/runners/paramiko_ssh_runner.py
+++ b/st2common/st2common/runners/paramiko_ssh_runner.py
@@ -156,6 +156,9 @@ class BaseParallelSSHRunner(ActionRunner, ShellRunnerMixin):
             # streaming for multiple hosts by running one execution per host.
             client_kwargs['handle_stdout_line_func'] = handle_stdout_line_func
             client_kwargs['handle_stderr_line_func'] = handle_stderr_line_func
+        else:
+            LOG.debug('Real-time action output streaming is disabled, because action is running '
+                      'on more than one host')
 
         if self._password:
             client_kwargs['password'] = self._password


### PR DESCRIPTION
As discussed in the past.

If needed or wanted, users can still disable it by updating st2.conf.

## TODO

- [ ] Update docs