### PR TITLE
Update sample rule to flush cached data to disk

### DIFF
--- a/contrib/examples/rules/sample_rule_with_webhook.yaml
+++ b/contrib/examples/rules/sample_rule_with_webhook.yaml
@@ -17,4 +17,4 @@
     action:
         ref: "core.local"
         parameters:
-            cmd: "echo \"{{trigger.body}}\" >> ~/st2.webhook_sample.out"
+            cmd: "echo \"{{trigger.body}}\" >> ~/st2.webhook_sample.out ; sync"


### PR DESCRIPTION
`test_quickstart_rules` has been failing intermediately for many months now and we simply can't figure out where the failure / race is coming from..

The main problem with this issue is that it's hard / impossible to replicate locally so fixing it is also hard.

We tried many things already and with this PR I'm going to try another thing.