### PR TITLE
Changelog for #3929, update st2client code and tests so it works under Python 3, run st2client Python 3 tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
     - TASK=ci-unit NODE_INDEX=0 NODE_TOTAL=2
     - TASK=ci-unit NODE_INDEX=1 NODE_TOTAL=2
     - TASK=ci-integration
+    - TASK=ci-py3-tests
     - TASK="ci-checks ci-packs-tests"
 
 addons:
@@ -49,7 +50,7 @@ cache:
     - .tox/
 
 install:
-  - make requirements
+  - if [ ${TASK} = 'ci-py3-tests' ]; then pip install tox; else make requirements; fi
   - if [ ${TASK} = 'ci-unit' ] || [ ${TASK} = 'ci-integration' ]; then pip install codecov; sudo .circle/add-itest-user.sh; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,16 @@ env:
     - CACHE_NAME=JOB1
   matrix:
     include:
-        - python: 2.7
-          env: TASK=ci-unit NODE_INDEX=0 NODE_TOTAL=2
-        - python: 2.7
-          env: TASK=ci-unit NODE_INDEX=1 NODE_TOTAL=2
-        - python: 2.7
-          env: TASK=ci-integration
-        - python: 3.6
-          env: TASK=ci-st2client-py3-tests
-        - python: 2.7
-          env: TASK="ci-checks ci-packs-tests"
+        - env: TASK=ci-unit NODE_INDEX=0 NODE_TOTAL=2
+          python: 2.7
+        - env: TASK=ci-unit NODE_INDEX=1 NODE_TOTAL=2
+          python: 2.7
+        - env: TASK=ci-integration
+          python: 2.7
+        - env: TASK="ci-checks ci-packs-tests"
+          python: 2.7
+        - env: TASK=ci-st2client-py3-tests
+          python: 3.6
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@
 sudo: required
 dist: precise
 language: python
+python:
+  - 2.7
 
 branches:
   only:
@@ -13,17 +15,16 @@ env:
   global:
     - CACHE_NAME=JOB1
   matrix:
-    include:
-        - env: TASK=ci-unit NODE_INDEX=0 NODE_TOTAL=2
-          python: 2.7
-        - env: TASK=ci-unit NODE_INDEX=1 NODE_TOTAL=2
-          python: 2.7
-        - env: TASK=ci-integration
-          python: 2.7
-        - env: TASK="ci-checks ci-packs-tests"
-          python: 2.7
-        - env: TASK=ci-st2client-py3-tests
-          python: 3.6
+    - env: TASK=ci-unit NODE_INDEX=0 NODE_TOTAL=2
+      python: 2.7
+    - env: TASK=ci-unit NODE_INDEX=1 NODE_TOTAL=2
+      python: 2.7
+    - env: TASK=ci-integration
+      python: 2.7
+    - env: TASK="ci-checks ci-packs-tests"
+      python: 2.7
+    - env: TASK=ci-st2client-py3-tests
+      python: 3.6
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,7 @@ cache:
     - virtualenv/
 
 install:
-  - if [ ${TASK} = 'ci-py3-tests' ]; then pip install tox; fi
-  - if [ ${TASK} != 'ci-py3-tests' ]; then make requirements; fi
+  - if [ ${TASK} = 'ci-py3-tests' ]; then pip install tox; else make requirements; fi
   - if [ ${TASK} = 'ci-unit' ] || [ ${TASK} = 'ci-integration' ]; then pip install codecov; sudo .circle/add-itest-user.sh; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@
 sudo: required
 dist: precise
 language: python
-python:
-  - 2.7
-  - 3.6
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
     - TASK=ci-unit NODE_INDEX=0 NODE_TOTAL=2
     - TASK=ci-unit NODE_INDEX=1 NODE_TOTAL=2
     - TASK=ci-integration
+    - TASK=ci-py3-tests
     - TASK="ci-checks ci-packs-tests"
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@
 sudo: required
 dist: precise
 language: python
-python:
-  - 2.7
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ branches:
 env:
   global:
     - CACHE_NAME=JOB1
-  matrix:
+matrix:
+  include:
     - env: TASK=ci-unit NODE_INDEX=0 NODE_TOTAL=2
       python: 2.7
     - env: TASK=ci-unit NODE_INDEX=1 NODE_TOTAL=2

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
     - TASK=ci-unit NODE_INDEX=0 NODE_TOTAL=2
     - TASK=ci-unit NODE_INDEX=1 NODE_TOTAL=2
     - TASK=ci-integration
-    - TASK=ci-py3-tests
+    - TASK=ci-st2client-py3-tests
     - TASK="ci-checks ci-packs-tests"
 
 addons:
@@ -50,7 +50,7 @@ cache:
     - .tox/
 
 install:
-  - if [ ${TASK} = 'ci-py3-tests' ]; then pip install tox; else make requirements; fi
+  - if [ ${TASK} = 'ci-st2client-py3-tests' ]; then pip install tox; else make requirements; fi
   - if [ ${TASK} = 'ci-unit' ] || [ ${TASK} = 'ci-integration' ]; then pip install codecov; sudo .circle/add-itest-user.sh; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ cache:
     - virtualenv/
 
 install:
-  - if [ ${TASK} = 'ci-py3-tests' ]; pip install tox; fi
+  - if [ ${TASK} = 'ci-py3-tests' ]; then pip install tox; fi
   - if [ ${TASK} != 'ci-py3-tests' ]; then make requirements; fi
   - if [ ${TASK} = 'ci-unit' ] || [ ${TASK} = 'ci-integration' ]; then pip install codecov; sudo .circle/add-itest-user.sh; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ cache:
     - virtualenv/
 
 install:
+  - if [ ${TASK} = 'ci-py3-tests' ]; pip install tox; fi
   - if [ ${TASK} != 'ci-py3-tests' ]; then make requirements; fi
   - if [ ${TASK} = 'ci-unit' ] || [ ${TASK} = 'ci-integration' ]; then pip install codecov; sudo .circle/add-itest-user.sh; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ cache:
     - virtualenv/
 
 install:
-  - make requirements
+  - if [ ${TASK} != 'ci-py3-tests' ]; then make requirements; fi
   - if [ ${TASK} = 'ci-unit' ] || [ ${TASK} = 'ci-integration' ]; then pip install codecov; sudo .circle/add-itest-user.sh; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,17 @@ env:
   global:
     - CACHE_NAME=JOB1
   matrix:
-    - TASK=ci-unit NODE_INDEX=0 NODE_TOTAL=2
-    - TASK=ci-unit NODE_INDEX=1 NODE_TOTAL=2
-    - TASK=ci-integration
-    - TASK=ci-st2client-py3-tests
-    - TASK="ci-checks ci-packs-tests"
-
+    include:
+        - python: 2.7
+          env: TASK=ci-unit NODE_INDEX=0 NODE_TOTAL=2
+        - python: 2.7
+          env: TASK=ci-unit NODE_INDEX=1 NODE_TOTAL=2
+        - python: 2.7
+          env: TASK=ci-integration
+        - python: 3.6
+          env: TASK=ci-st2client-py3-tests
+        - python: 2.7
+          env: TASK="ci-checks ci-packs-tests"
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ cache:
   pip: true
   directories:
     - virtualenv/
+    - .tox/
 
 install:
   - if [ ${TASK} = 'ci-py3-tests' ]; then pip install tox; else make requirements; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ dist: precise
 language: python
 python:
   - 2.7
+  - 3.6
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
     - TASK=ci-unit NODE_INDEX=0 NODE_TOTAL=2
     - TASK=ci-unit NODE_INDEX=1 NODE_TOTAL=2
     - TASK=ci-integration
-    - TASK=ci-py3-tests
     - TASK="ci-checks ci-packs-tests"
 
 addons:
@@ -50,7 +49,7 @@ cache:
     - .tox/
 
 install:
-  - if [ ${TASK} = 'ci-py3-tests' ]; then pip install tox; else make requirements; fi
+  - make requirements
   - if [ ${TASK} = 'ci-unit' ] || [ ${TASK} = 'ci-integration' ]; then pip install codecov; sudo .circle/add-itest-user.sh; fi
 
 script:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,7 +35,7 @@ Added
 
   Note: Python 2.7 is only officially supported and tested Python version. Using Python 3 is at
   your own risk - they are likely still many bugs related to Python 3 compatibility. You have been warned.
-  (new feature) #3929
+  (new feature) #3929 #3932
 
   Contributed by Anthony Shaw.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,13 +31,6 @@ Added
 * Added flag `--auto-dict` to `st2 run` and `st2 execution re-run` commands. This flag must now
   be specified in order to automatically convert list items to dicts based on presence of colon
   (`:`) in all of the list items (new feature) #3909
-* Update ``st2client`` package which is also utilized by the CLI so it also works under Python 3.
-
-  Note: Python 2.7 is only officially supported and tested Python version. Using Python 3 is at
-  your own risk - they are likely still many bugs related to Python 3 compatibility. You have been warned.
-  (new feature) #3929
-
-  Contributed by Anthony Shaw.
 
 Changed
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,10 @@ Added
 * Added flag `--auto-dict` to `st2 run` and `st2 execution re-run` commands. This flag must now
   be specified in order to automatically convert list items to dicts based on presence of colon
   (`:`) in all of the list items (new feature) #3909
+* Update ``st2client`` package which is also utilized by the CLI so it also works under Python 3.
+  (new feature) #3929
+
+  Contributed by Anthony Shaw.
 
 Changed
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,9 @@ Added
   be specified in order to automatically convert list items to dicts based on presence of colon
   (`:`) in all of the list items (new feature) #3909
 * Update ``st2client`` package which is also utilized by the CLI so it also works under Python 3.
+
+  Note: Python 2.7 is only officially supported and tested Python version. Using Python 3 is at
+  your own risk - they are likely still many bugs related to Python 3 compatibility. You have been warned.
   (new feature) #3929
 
   Contributed by Anthony Shaw.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,13 @@ Added
 * Added flag `--auto-dict` to `st2 run` and `st2 execution re-run` commands. This flag must now
   be specified in order to automatically convert list items to dicts based on presence of colon
   (`:`) in all of the list items (new feature) #3909
+* Update ``st2client`` package which is also utilized by the CLI so it also works under Python 3.
+
+  Note: Python 2.7 is only officially supported and tested Python version. Using Python 3 is at
+  your own risk - they are likely still many bugs related to Python 3 compatibility. You have been warned.
+  (new feature) #3929
+
+  Contributed by Anthony Shaw.
 
 Changed
 ~~~~~~~

--- a/Makefile
+++ b/Makefile
@@ -476,6 +476,13 @@ ci: ci-checks ci-unit ci-integration ci-mistral ci-packs-tests
 .PHONY: ci-checks
 ci-checks: compile .generated-files-check .pylint .flake8 .bandit .st2client-dependencies-check .st2common-circular-dependencies-check circle-lint-api-spec .rst-check
 
+.PHONY: ci-py3-tests
+ci-py3-tests:
+	@echo
+	@echo "==================== ci-py3-tests ===================="
+	@echo
+	tox -epy35
+
 .PHONY: .rst-check
 .rst-check:
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -481,6 +481,13 @@ ci-st2client-py3-tests:
 	@echo
 	@echo "==================== ci-st2client-py3-tests ===================="
 	@echo
+	tox -e py36 -v
+
+.PHONY: st2client-py3-tests
+st2client-py3-tests:
+	@echo
+	@echo "==================== ci-st2client-py3-tests ===================="
+	@echo
 	tox -e py36 -vv
 
 .PHONY: .rst-check

--- a/Makefile
+++ b/Makefile
@@ -476,10 +476,10 @@ ci: ci-checks ci-unit ci-integration ci-mistral ci-packs-tests
 .PHONY: ci-checks
 ci-checks: compile .generated-files-check .pylint .flake8 .bandit .st2client-dependencies-check .st2common-circular-dependencies-check circle-lint-api-spec .rst-check
 
-.PHONY: ci-py3-tests
-ci-py3-tests:
+.PHONY: ci-st2client-py3-tests
+ci-st2client-py3-tests:
 	@echo
-	@echo "==================== ci-py3-tests ===================="
+	@echo "==================== ci-st2client-py3-tests ===================="
 	@echo
 	tox -e py36 -vv
 

--- a/Makefile
+++ b/Makefile
@@ -481,7 +481,7 @@ ci-py3-tests:
 	@echo
 	@echo "==================== ci-py3-tests ===================="
 	@echo
-	tox -epy35
+	tox -e py35 -vv
 
 .PHONY: .rst-check
 .rst-check:

--- a/Makefile
+++ b/Makefile
@@ -481,7 +481,7 @@ ci-py3-tests:
 	@echo
 	@echo "==================== ci-py3-tests ===================="
 	@echo
-	tox -e py35 -vv
+	tox -e py36 -vv
 
 .PHONY: .rst-check
 .rst-check:

--- a/st2client/st2client/base.py
+++ b/st2client/st2client/base.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import pwd
 import json

--- a/st2client/st2client/client.py
+++ b/st2client/st2client/client.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import logging
 

--- a/st2client/st2client/commands/__init__.py
+++ b/st2client/st2client/commands/__init__.py
@@ -15,6 +15,7 @@
 
 from __future__ import print_function
 from __future__ import absolute_import
+
 import abc
 import six
 import logging

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import ast
 import copy
@@ -27,6 +28,8 @@ import sys
 
 from os.path import join as pjoin
 
+from six.moves import range
+
 from st2client import models
 from st2client.commands import resource
 from st2client.commands.resource import ResourceNotFoundError
@@ -37,7 +40,6 @@ from st2client.utils import jsutil
 from st2client.utils.date import format_isodate_for_user_timezone
 from st2client.utils.date import parse as parse_isotime
 from st2client.utils.color import format_status
-from six.moves import range
 
 LOG = logging.getLogger(__name__)
 

--- a/st2client/st2client/commands/action_alias.py
+++ b/st2client/st2client/commands/action_alias.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 from st2client.models import core
 from st2client.models.action_alias import ActionAlias
 from st2client.models.action_alias import ActionAliasMatch

--- a/st2client/st2client/commands/auth.py
+++ b/st2client/st2client/commands/auth.py
@@ -14,10 +14,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import getpass
 import json
 import logging
-import six.moves.http_client
 
 import requests
 from six.moves.configparser import ConfigParser
@@ -191,7 +191,7 @@ class WhoamiCommand(resource.ResourceCommand):
         except Exception as e:
             response = getattr(e, 'response', None)
             status_code = getattr(response, 'status_code', None)
-            is_unathorized_error = (status_code == six.moves.http_client.UNAUTHORIZED)
+            is_unathorized_error = (status_code == http_client.UNAUTHORIZED)
 
             if response and is_unathorized_error:
                 print('Not authenticated')

--- a/st2client/st2client/commands/inquiry.py
+++ b/st2client/st2client/commands/inquiry.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import json
 import logging
 

--- a/st2client/st2client/commands/keyvalue.py
+++ b/st2client/st2client/commands/keyvalue.py
@@ -14,17 +14,20 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import json
 import logging
+
 from os.path import join as pjoin
+
+import six
 
 from st2client.commands import resource
 from st2client.commands.noop import NoopCommand
 from st2client.formatters import table
 from st2client.models.keyvalue import KeyValuePair
 from st2client.utils.date import format_isodate_for_user_timezone
-import six
 
 LOG = logging.getLogger(__name__)
 

--- a/st2client/st2client/commands/policy.py
+++ b/st2client/st2client/commands/policy.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import logging
 
 from st2client import models

--- a/st2client/st2client/commands/rbac.py
+++ b/st2client/st2client/commands/rbac.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 from st2client.formatters import table
 from st2client.commands import resource
 from st2client.models.rbac import Role

--- a/st2client/st2client/commands/resource.py
+++ b/st2client/st2client/commands/resource.py
@@ -14,16 +14,18 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import abc
 import six
 import json
 import logging
-import six.moves.http_client
-from functools import wraps
 import traceback
 
+from functools import wraps
+
 import yaml
+from six.moves import http_client
 
 from st2client import commands
 from st2client.exceptions.operations import OperationFailureException
@@ -166,7 +168,7 @@ class ResourceCommand(commands.Command):
             # Hack for "Unauthorized" exceptions, we do want to propagate those
             response = getattr(e, 'response', None)
             status_code = getattr(response, 'status_code', None)
-            if status_code and status_code == six.moves.http_client.UNAUTHORIZED:
+            if status_code and status_code == http_client.UNAUTHORIZED:
                 raise e
 
             instance = None

--- a/st2client/st2client/commands/rule.py
+++ b/st2client/st2client/commands/rule.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 from st2client import models
 from st2client.commands import resource
 from st2client.formatters import table

--- a/st2client/st2client/commands/rule_enforcement.py
+++ b/st2client/st2client/commands/rule_enforcement.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 from st2client import models
 from st2client.commands import resource
 from st2client.formatters import table

--- a/st2client/st2client/commands/sensor.py
+++ b/st2client/st2client/commands/sensor.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 from st2client.models import Sensor
 from st2client.commands import resource
 

--- a/st2client/st2client/commands/timer.py
+++ b/st2client/st2client/commands/timer.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 from st2client.models import Timer
 from st2client.commands import resource
 

--- a/st2client/st2client/commands/trace.py
+++ b/st2client/st2client/commands/trace.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 from st2client.models import Resource, Trace, TriggerInstance, Rule, LiveAction
 from st2client.exceptions.operations import OperationFailureException
 from st2client.formatters import table

--- a/st2client/st2client/commands/trigger.py
+++ b/st2client/st2client/commands/trigger.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 from st2client.commands import resource
 from st2client.models import TriggerType
 from st2client.formatters import table

--- a/st2client/st2client/commands/triggerinstance.py
+++ b/st2client/st2client/commands/triggerinstance.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 from st2client.commands import resource
 from st2client.formatters import table
 from st2client.models import TriggerInstance

--- a/st2client/st2client/commands/webhook.py
+++ b/st2client/st2client/commands/webhook.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 from st2client.models import Webhook
 from st2client.commands import resource
 

--- a/st2client/st2client/config_parser.py
+++ b/st2client/st2client/config_parser.py
@@ -18,6 +18,7 @@ Module for parsing CLI config file.
 """
 
 from __future__ import absolute_import
+
 import os
 
 from collections import defaultdict

--- a/st2client/st2client/exceptions/operations.py
+++ b/st2client/st2client/exceptions/operations.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 from st2client.exceptions.base import StackStormCLIBaseException
 
 

--- a/st2client/st2client/formatters/__init__.py
+++ b/st2client/st2client/formatters/__init__.py
@@ -14,8 +14,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import abc
 import logging
+
 import six
 
 

--- a/st2client/st2client/formatters/doc.py
+++ b/st2client/st2client/formatters/doc.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import json
 import logging
 

--- a/st2client/st2client/formatters/execution.py
+++ b/st2client/st2client/formatters/execution.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import ast
 import logging
 import sys

--- a/st2client/st2client/formatters/execution.py
+++ b/st2client/st2client/formatters/execution.py
@@ -75,7 +75,7 @@ class ExecutionResult(formatters.Formatter):
                     (DisplayColors.colorize(attr, DisplayColors.BLUE), value)
 
         if six.PY3:
-            return strutil.unescape(output)
+            return strutil.unescape(str(output))
         else:
             # Assume Python 2
-            return strutil.unescape(output).decode('unicode_escape').encode('utf-8')
+            return strutil.unescape(str(output)).decode('unicode_escape').encode('utf-8')

--- a/st2client/st2client/formatters/execution.py
+++ b/st2client/st2client/formatters/execution.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 import ast
 import logging
 import sys
+import struct
 
 import yaml
 
@@ -29,6 +30,8 @@ import six
 
 
 LOG = logging.getLogger(__name__)
+
+PLATFORM_MAXINT = 2 ** (struct.Struct('i').size * 8 - 1) - 1
 
 
 class ExecutionResult(formatters.Formatter):
@@ -60,7 +63,7 @@ class ExecutionResult(formatters.Formatter):
                     #    and likely we will see other issues like storage :P.
                     formatted_value = yaml.safe_dump({attr: value},
                                                      default_flow_style=False,
-                                                     width=sys.maxint,
+                                                     width=PLATFORM_MAXINT,
                                                      indent=2)[len(attr) + 2:-1]
                     value = ('\n' if isinstance(value, dict) else '') + formatted_value
                     value = strutil.dedupe_newlines(value)

--- a/st2client/st2client/formatters/execution.py
+++ b/st2client/st2client/formatters/execution.py
@@ -17,7 +17,6 @@ from __future__ import absolute_import
 
 import ast
 import logging
-import sys
 import struct
 
 import yaml

--- a/st2client/st2client/formatters/execution.py
+++ b/st2client/st2client/formatters/execution.py
@@ -74,4 +74,8 @@ class ExecutionResult(formatters.Formatter):
                 output += ('\n' if output else '') + '%s: %s' % \
                     (DisplayColors.colorize(attr, DisplayColors.BLUE), value)
 
-        return strutil.unescape(output).decode('unicode_escape').encode('utf-8')
+            if six.PY3:
+                return strutil.unescape(output)
+            else:
+                # Assume Python 2
+                return strutil.unescape(output).decode('unicode_escape').encode('utf-8')

--- a/st2client/st2client/formatters/execution.py
+++ b/st2client/st2client/formatters/execution.py
@@ -74,8 +74,8 @@ class ExecutionResult(formatters.Formatter):
                 output += ('\n' if output else '') + '%s: %s' % \
                     (DisplayColors.colorize(attr, DisplayColors.BLUE), value)
 
-            if six.PY3:
-                return strutil.unescape(output)
-            else:
-                # Assume Python 2
-                return strutil.unescape(output).decode('unicode_escape').encode('utf-8')
+        if six.PY3:
+            return strutil.unescape(output)
+        else:
+            # Assume Python 2
+            return strutil.unescape(output).decode('unicode_escape').encode('utf-8')

--- a/st2client/st2client/formatters/table.py
+++ b/st2client/st2client/formatters/table.py
@@ -14,19 +14,20 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import json
 import math
 import logging
 import sys
 
+import six
 from prettytable import PrettyTable
 from six.moves import zip
+from six.moves import range
 
 from st2client import formatters
 from st2client.utils import strutil
 from st2client.utils.terminal import get_terminal_size
-import six
-from six.moves import range
 
 
 LOG = logging.getLogger(__name__)

--- a/st2client/st2client/formatters/table.py
+++ b/st2client/st2client/formatters/table.py
@@ -292,4 +292,5 @@ class SingleRowTable(object):
             note = PrettyTable([""])
         note.header = False
         note.add_row([message])
-        return sys.stderr.write(str(note) + "\n")
+        sys.stderr.write((str(note) + '\n'))
+        return

--- a/st2client/st2client/models/__init__.py
+++ b/st2client/st2client/models/__init__.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 from st2client.models.core import *         # noqa
 from st2client.models.auth import *       # noqa
 from st2client.models.action import *       # noqa

--- a/st2client/st2client/models/action.py
+++ b/st2client/st2client/models/action.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import logging
 
 from st2client.models import core

--- a/st2client/st2client/models/action_alias.py
+++ b/st2client/st2client/models/action_alias.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 from st2client.models import core
 
 __all__ = [

--- a/st2client/st2client/models/aliasexecution.py
+++ b/st2client/st2client/models/aliasexecution.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 from st2client.models import core
 
 __all__ = [

--- a/st2client/st2client/models/auth.py
+++ b/st2client/st2client/models/auth.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import logging
 
 from st2client.models import core

--- a/st2client/st2client/models/config.py
+++ b/st2client/st2client/models/config.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 from st2client.models import core
 
 

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -17,11 +17,11 @@ from __future__ import absolute_import
 import os
 import json
 import logging
-import six.moves.http_client
 from functools import wraps
 
 import six
 from six.moves import urllib
+from six.moves import http_client
 
 from st2client.utils import httpclient
 
@@ -190,7 +190,7 @@ class ResourceManager(object):
             params['user'] = user
 
         response = self.client.get(url=url, params=params, **kwargs)
-        if response.status_code != six.moves.http_client.OK:
+        if response.status_code != http_client.OK:
             self.handle_error(response)
         return [self.resource.deserialize(item)
                 for item in response.json()]
@@ -199,9 +199,9 @@ class ResourceManager(object):
     def get_by_id(self, id, **kwargs):
         url = '/%s/%s' % (self.resource.get_url_path_name(), id)
         response = self.client.get(url, **kwargs)
-        if response.status_code == six.moves.http_client.NOT_FOUND:
+        if response.status_code == http_client.NOT_FOUND:
             return None
-        if response.status_code != six.moves.http_client.OK:
+        if response.status_code != http_client.OK:
             self.handle_error(response)
         return self.resource.deserialize(response.json())
 
@@ -229,9 +229,9 @@ class ResourceManager(object):
         else:
             response = self.client.get(url)
 
-        if response.status_code == six.moves.http_client.NOT_FOUND:
+        if response.status_code == http_client.NOT_FOUND:
             return None
-        if response.status_code != six.moves.http_client.OK:
+        if response.status_code != http_client.OK:
             self.handle_error(response)
 
         if self_deserialize:
@@ -268,10 +268,10 @@ class ResourceManager(object):
         else:
             response = self.client.get(url)
 
-        if response.status_code == six.moves.http_client.NOT_FOUND:
+        if response.status_code == http_client.NOT_FOUND:
             # for query and query_with_count
             return [], None
-        if response.status_code != six.moves.http_client.OK:
+        if response.status_code != http_client.OK:
             self.handle_error(response)
         items = response.json()
         instances = [self.resource.deserialize(item) for item in items]
@@ -305,7 +305,7 @@ class ResourceManager(object):
     def create(self, instance, **kwargs):
         url = '/%s' % self.resource.get_url_path_name()
         response = self.client.post(url, instance.serialize(), **kwargs)
-        if response.status_code != six.moves.http_client.OK:
+        if response.status_code != http_client.OK:
             self.handle_error(response)
         instance = self.resource.deserialize(response.json())
         return instance
@@ -314,7 +314,7 @@ class ResourceManager(object):
     def update(self, instance, **kwargs):
         url = '/%s/%s' % (self.resource.get_url_path_name(), instance.id)
         response = self.client.put(url, instance.serialize(), **kwargs)
-        if response.status_code != six.moves.http_client.OK:
+        if response.status_code != http_client.OK:
             self.handle_error(response)
         instance = self.resource.deserialize(response.json())
         return instance
@@ -324,9 +324,9 @@ class ResourceManager(object):
         url = '/%s/%s' % (self.resource.get_url_path_name(), instance.id)
         response = self.client.delete(url, **kwargs)
 
-        if response.status_code not in [six.moves.http_client.OK,
-                                        six.moves.http_client.NO_CONTENT,
-                                        six.moves.http_client.NOT_FOUND]:
+        if response.status_code not in [http_client.OK,
+                                        http_client.NO_CONTENT,
+                                        http_client.NOT_FOUND]:
             self.handle_error(response)
             return False
 
@@ -336,9 +336,9 @@ class ResourceManager(object):
     def delete_by_id(self, instance_id, **kwargs):
         url = '/%s/%s' % (self.resource.get_url_path_name(), instance_id)
         response = self.client.delete(url, **kwargs)
-        if response.status_code not in [six.moves.http_client.OK,
-                                        six.moves.http_client.NO_CONTENT,
-                                        six.moves.http_client.NOT_FOUND]:
+        if response.status_code not in [http_client.OK,
+                                        http_client.NO_CONTENT,
+                                        http_client.NOT_FOUND]:
             self.handle_error(response)
             return False
         try:
@@ -360,7 +360,7 @@ class ActionAliasResourceManager(ResourceManager):
     def match(self, instance, **kwargs):
         url = '/%s/match' % self.resource.get_url_path_name()
         response = self.client.post(url, instance.serialize(), **kwargs)
-        if response.status_code != six.moves.http_client.OK:
+        if response.status_code != http_client.OK:
             self.handle_error(response)
         match = response.json()
         return (self.resource.deserialize(match['actionalias']), match['representation'])
@@ -372,7 +372,7 @@ class ActionAliasExecutionManager(ResourceManager):
         url = '/%s/match_and_execute' % self.resource.get_url_path_name()
         response = self.client.post(url, instance.serialize(), **kwargs)
 
-        if response.status_code != six.moves.http_client.OK:
+        if response.status_code != http_client.OK:
             self.handle_error(response)
         instance = self.resource.deserialize(response.json())
         return instance
@@ -396,7 +396,7 @@ class LiveActionResourceManager(ResourceManager):
         }
 
         response = self.client.post(url, data, **kwargs)
-        if response.status_code != six.moves.http_client.OK:
+        if response.status_code != http_client.OK:
             self.handle_error(response)
 
         instance = self.resource.deserialize(response.json())
@@ -410,7 +410,7 @@ class LiveActionResourceManager(ResourceManager):
             url += '?' + urllib.parse.urlencode({'output_type': output_type})
 
         response = self.client.get(url, **kwargs)
-        if response.status_code != six.moves.http_client.OK:
+        if response.status_code != http_client.OK:
             self.handle_error(response)
 
         return response.text
@@ -422,7 +422,7 @@ class LiveActionResourceManager(ResourceManager):
 
         response = self.client.put(url, data, **kwargs)
 
-        if response.status_code != six.moves.http_client.OK:
+        if response.status_code != http_client.OK:
             self.handle_error(response)
 
         return self.resource.deserialize(response.json())
@@ -434,7 +434,7 @@ class LiveActionResourceManager(ResourceManager):
 
         response = self.client.put(url, data, **kwargs)
 
-        if response.status_code != six.moves.http_client.OK:
+        if response.status_code != http_client.OK:
             self.handle_error(response)
 
         return self.resource.deserialize(response.json())
@@ -457,7 +457,7 @@ class InquiryResourceManager(ResourceManager):
 
         response = self.client.put(url, payload, **kwargs)
 
-        if response.status_code != six.moves.http_client.OK:
+        if response.status_code != http_client.OK:
             self.handle_error(response)
 
         return self.resource.deserialize(response.json())
@@ -468,7 +468,7 @@ class TriggerInstanceResourceManager(ResourceManager):
     def re_emit(self, trigger_instance_id, **kwargs):
         url = '/%s/%s/re_emit' % (self.resource.get_url_path_name(), trigger_instance_id)
         response = self.client.post(url, None, **kwargs)
-        if response.status_code != six.moves.http_client.OK:
+        if response.status_code != http_client.OK:
             self.handle_error(response)
         return response.json()
 
@@ -486,7 +486,7 @@ class PackResourceManager(ResourceManager):
             'force': force
         }
         response = self.client.post(url, payload, **kwargs)
-        if response.status_code != six.moves.http_client.OK:
+        if response.status_code != http_client.OK:
             self.handle_error(response)
         instance = AsyncRequest.deserialize(response.json())
         return instance
@@ -495,7 +495,7 @@ class PackResourceManager(ResourceManager):
     def remove(self, packs, **kwargs):
         url = '/%s/uninstall' % (self.resource.get_url_path_name())
         response = self.client.post(url, {'packs': packs}, **kwargs)
-        if response.status_code != six.moves.http_client.OK:
+        if response.status_code != http_client.OK:
             self.handle_error(response)
         instance = AsyncRequest.deserialize(response.json())
         return instance
@@ -508,7 +508,7 @@ class PackResourceManager(ResourceManager):
         else:
             payload = {'pack': args.pack}
         response = self.client.post(url, payload, **kwargs)
-        if response.status_code != six.moves.http_client.OK:
+        if response.status_code != http_client.OK:
             self.handle_error(response)
         data = response.json()
         if isinstance(data, list):
@@ -525,7 +525,7 @@ class PackResourceManager(ResourceManager):
         if packs:
             payload['packs'] = packs
         response = self.client.post(url, payload, **kwargs)
-        if response.status_code != six.moves.http_client.OK:
+        if response.status_code != http_client.OK:
             self.handle_error(response)
         instance = self.resource.deserialize(response.json())
         return instance
@@ -536,7 +536,7 @@ class ConfigManager(ResourceManager):
     def update(self, instance, **kwargs):
         url = '/%s/%s' % (self.resource.get_url_path_name(), instance.pack)
         response = self.client.put(url, instance.values, **kwargs)
-        if response.status_code != six.moves.http_client.OK:
+        if response.status_code != http_client.OK:
             self.handle_error(response)
         instance = self.resource.deserialize(response.json())
         return instance

--- a/st2client/st2client/models/inquiry.py
+++ b/st2client/st2client/models/inquiry.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import logging
 
 from st2client.models import core

--- a/st2client/st2client/models/keyvalue.py
+++ b/st2client/st2client/models/keyvalue.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import logging
 
 from st2client.models import core

--- a/st2client/st2client/models/pack.py
+++ b/st2client/st2client/models/pack.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 from st2client.models import core
 
 

--- a/st2client/st2client/models/policy.py
+++ b/st2client/st2client/models/policy.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import logging
 
 from st2client.models import core

--- a/st2client/st2client/models/rbac.py
+++ b/st2client/st2client/models/rbac.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 from st2client.models import core
 
 __all__ = [

--- a/st2client/st2client/models/reactor.py
+++ b/st2client/st2client/models/reactor.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import logging
 
 from st2client.models import core

--- a/st2client/st2client/models/timer.py
+++ b/st2client/st2client/models/timer.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import logging
 
 from st2client.models import core

--- a/st2client/st2client/models/trace.py
+++ b/st2client/st2client/models/trace.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from __future__ import absolute_import
+
 from st2client.models import core
 
 

--- a/st2client/st2client/models/webhook.py
+++ b/st2client/st2client/models/webhook.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import logging
 
 from st2client.models import core

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -184,7 +184,8 @@ class Shell(BaseCLIApp):
         )
 
         # Set up list of commands and subcommands.
-        self.subparsers = self.parser.add_subparsers()
+        self.subparsers = self.parser.add_subparsers(dest='parser')
+        self.subparsers.required = True
         self.commands = {}
 
         self.commands['run'] = action.ActionRunCommand(
@@ -327,8 +328,16 @@ class Shell(BaseCLIApp):
             # Set up client.
             self.client = self.get_client(args=args, debug=debug)
 
+            # TODO: This is not so nice work-around for Python 3 because of a breaking change in
+            # Python 3 - https://bugs.python.org/issue16308
+            try:
+                func = getattr(args, 'func')
+            except AttributeError:
+                parser.print_help()
+                sys.exit(2)
+
             # Execute command.
-            args.func(args)
+            func(args)
 
             return 0
         except OperationFailureException as e:

--- a/st2client/tests/fixtures/execution_result_has_carriage_return_py3.txt
+++ b/st2client/tests/fixtures/execution_result_has_carriage_return_py3.txt
@@ -1,0 +1,71 @@
++-----------------+--------------------------------------------------------------+
+| Property        | Value                                                        |
++-----------------+--------------------------------------------------------------+
+| id              | 548235439c993840e690d710                                     |
+| action.ref      | packs.uninstall                                              |
+| context.user    | stanley                                                      |
+| parameters      | {                                                            |
+|                 |     "packs": [                                               |
+|                 |         "sensu"                                              |
+|                 |     ]                                                        |
+|                 | }                                                            |
+| status          | succeeded                                                    |
+| start_timestamp | Fri, 05 Dec 2014 22:44:19 UTC                                |
+| end_timestamp   |                                                              |
+| result          | {                                                            |
+|                 |     "unregister": {                                          |
+|                 |         "exit_code": 0,                                      |
+|                 |         "result": null,                                      |
+|                 |         "stderr": "st2.actions.python.UnregisterPackAction:  |
+|                 | DEBUG    Removing pack sensu.                                |
+|                 | st2.actions.python.UnregisterPackAction: INFO     Removed    |
+|                 | pack sensu.                                                  |
+|                 | ",                                                           |
+|                 |         "stdout": ""                                         |
+|                 |     },                                                       |
+|                 |     "restart-sensor-container": {                            |
+|                 |         "localhost": {                                       |
+|                 |             "failed": false,                                 |
+|                 |             "stderr": "",                                    |
+|                 |             "return_code": 0,                                |
+|                 |             "succeeded": true,                               |
+|                 |             "stdout": "restarting service sensor_containesr  |
+|                 | with 1 process(es).                                          |
+|                 | sensor_containesr is not running                             |
+|                 | actionrunner PID: 16604                                      |
+|                 | actionrunner PID: 16605                                      |
+|                 | actionrunner PID: 16606                                      |
+|                 | actionrunner PID: 16607                                      |
+|                 | actionrunner PID: 16608                                      |
+|                 | actionrunner PID: 16609                                      |
+|                 | actionrunner PID: 16610                                      |
+|                 | actionrunner PID: 16611                                      |
+|                 | actionrunner PID: 16612                                      |
+|                 | actionrunner PID: 16613                                      |
+|                 | actionrunner PID: 19916                                      |
+|                 | st2api PID: 16614                                            |
+|                 | sensor_container is not running                              |
+|                 | history PID: 16616                                           |
+|                 | rules_engine PID: 16617                                      |
+|                 | mistral PID: 16624                                           |
+|                 | mistral PID: 16625"                                          |
+|                 |         }                                                    |
+|                 |     },                                                       |
+|                 |     "delete": {                                              |
+|                 |         "exit_code": 0,                                      |
+|                 |         "result": null,                                      |
+|                 |         "stderr": "st2.actions.python.UninstallPackAction:   |
+|                 | DEBUG    Deleting pack directory                             |
+|                 | "/opt/stackstorm/packs/sensu"                                |
+|                 | st2.actions.python.UninstallPackAction: DEBUG    Deleting    |
+|                 | virtualenv "/opt/stackstorm/virtualenvs/sensu" for pack      |
+|                 | "sensu"                                                      |
+|                 | ",                                                           |
+|                 |         "stdout": ""                                         |
+|                 |     }                                                        |
+|                 | }                                                            |
+| liveaction      | {                                                            |
+|                 |     "callback": {},                                          |
+|                 |     "id": "1"                                                |
+|                 | }                                                            |
++-----------------+--------------------------------------------------------------+

--- a/st2client/tests/fixtures/execution_unicode_py3.txt
+++ b/st2client/tests/fixtures/execution_unicode_py3.txt
@@ -1,0 +1,10 @@
+id: 547e19561e2e2417d3dde321
+status: succeeded (1s elapsed)
+parameters: 
+  cmd: "echo '\u2021'"
+result: 
+  failed: false
+  return_code: 0
+  stderr: ''
+  stdout: "\u2021"
+  succeeded: true

--- a/st2client/tests/unit/test_auth.py
+++ b/st2client/tests/unit/test_auth.py
@@ -23,6 +23,8 @@ import requests
 import argparse
 import logging
 
+import six
+
 from tests import base
 from st2client import shell
 from st2client.models.core import add_auth_token_to_kwargs_from_env
@@ -32,12 +34,20 @@ from st2client.utils.httpclient import add_auth_token_to_headers, add_json_conte
 
 LOG = logging.getLogger(__name__)
 
-RULE = {
-    'id': uuid.uuid4().hex,
-    'description': 'i am THE rule.',
-    'name': 'drule',
-    'pack': 'cli',
-}
+if six.PY3:
+    RULE = {
+        'name': 'drule',
+        'description': 'i am THE rule.',
+        'pack': 'cli',
+        'id': uuid.uuid4().hex
+    }
+else:
+    RULE = {
+        'id': uuid.uuid4().hex,
+        'description': 'i am THE rule.',
+        'name': 'drule',
+        'pack': 'cli',
+    }
 
 
 class TestLoginBase(base.BaseCLITestCase):
@@ -48,8 +58,6 @@ class TestLoginBase(base.BaseCLITestCase):
     since the tests create actual files on the filesystem - as well as to cut down
     on duplicate code in each test class
     """
-
-    capture_output = True
 
     DOTST2_PATH = os.path.expanduser('~/.st2/')
     CONFIG_FILE = tempfile.mkstemp(suffix='st2.conf')
@@ -269,6 +277,8 @@ class TestLoginUncaughtException(TestLoginBase):
 
 class TestAuthToken(base.BaseCLITestCase):
 
+    capture_output = False
+
     def __init__(self, *args, **kwargs):
         super(TestAuthToken, self).__init__(*args, **kwargs)
         self.parser = argparse.ArgumentParser()
@@ -466,6 +476,7 @@ class TestAuthToken(base.BaseCLITestCase):
             kwargs = {'headers': {'X-Auth-Token': token}}
             requests.get.assert_called_with(get_url, **kwargs)
             kwargs = {'headers': {'content-type': 'application/json', 'X-Auth-Token': token}}
+
             requests.put.assert_called_with(put_url, json.dumps(RULE), **kwargs)
 
             # Test with token from env.
@@ -474,6 +485,9 @@ class TestAuthToken(base.BaseCLITestCase):
             self.shell.run(['rule', 'update', rule_ref, path])
             kwargs = {'headers': {'X-Auth-Token': token}}
             requests.get.assert_called_with(get_url, **kwargs)
+
+            # Note: We parse the payload because data might not be in the same
+            # order as the fixture
             kwargs = {'headers': {'content-type': 'application/json', 'X-Auth-Token': token}}
             requests.put.assert_called_with(put_url, json.dumps(RULE), **kwargs)
         finally:

--- a/st2client/tests/unit/test_formatters.py
+++ b/st2client/tests/unit/test_formatters.py
@@ -47,11 +47,13 @@ FIXTURES_MANIFEST = {
                 'execution_get_detail.txt',
                 'execution_get_result_by_key.txt',
                 'execution_result_has_carriage_return.txt',
+                'execution_result_has_carriage_return_py3.txt',
                 'execution_get_attributes.txt',
                 'execution_list_attr_start_timestamp.txt',
                 'execution_list_empty_response_start_timestamp_attr.txt',
                 'execution_unescape_newline.txt',
-                'execution_unicode.txt']
+                'execution_unicode.txt',
+                'execution_unicode_py3.txt']
 }
 
 FIXTURES = loader.load_fixtures(fixtures_dict=FIXTURES_MANIFEST)
@@ -144,7 +146,10 @@ class TestExecutionResultFormatter(unittest2.TestCase):
         with open(self.path, 'r') as fd:
             content = fd.read()
 
-        self.assertEqual(content, FIXTURES['results']['execution_unicode.txt'])
+        if six.PY2:
+            self.assertEqual(content, FIXTURES['results']['execution_unicode.txt'])
+        else:
+            self.assertEqual(content, FIXTURES['results']['execution_unicode_py3.txt'])
 
     def test_execution_get_detail_in_json(self):
         argv = ['execution', 'get', EXECUTION['id'], '-d', '-j']
@@ -178,8 +183,14 @@ class TestExecutionResultFormatter(unittest2.TestCase):
         self._undo_console_redirect()
         with open(self.path, 'r') as fd:
             content = fd.read()
-        self.assertEqual(
-            content, FIXTURES['results']['execution_result_has_carriage_return.txt'])
+
+        if six.PY2:
+            self.assertEqual(
+                content, FIXTURES['results']['execution_result_has_carriage_return.txt'])
+        else:
+            self.assertEqual(
+                content,
+                FIXTURES['results']['execution_result_has_carriage_return_py3.txt'])
 
     @mock.patch.object(
         httpclient.HTTPClient, 'get',

--- a/st2client/tests/unit/test_formatters.py
+++ b/st2client/tests/unit/test_formatters.py
@@ -221,15 +221,13 @@ class TestExecutionResultFormatter(unittest2.TestCase):
         with mock.patch('sys.stderr', new=BytesIO()) as fackety_fake:
             expected = "Note: Only one action execution is displayed. Use -n/--last flag for " \
                 "more results."
-            print self.table.note_box("action executions", 1)
+            print(self.table.note_box("action executions", 1))
             content = (fackety_fake.getvalue().split("|")[1].strip())
             self.assertEquals(content, expected)
 
     def test_SinlgeRowTable_notebox_zero(self):
         with mock.patch('sys.stderr', new=BytesIO()) as fackety_fake:
-            print self.table.note_box("action executions", 0)
             contents = (fackety_fake.getvalue())
-            print "sdf", contents
             self.assertEquals(contents, "")
 
     def test_SinlgeRowTable_notebox_default(self):

--- a/st2client/tests/unit/test_formatters.py
+++ b/st2client/tests/unit/test_formatters.py
@@ -24,6 +24,8 @@ import tempfile
 import unittest2
 
 from io import BytesIO
+from six.moves import StringIO
+
 from tests import base
 from tests.fixtures import loader
 
@@ -70,6 +72,7 @@ class TestExecutionResultFormatter(unittest2.TestCase):
     def setUp(self):
         self.fd, self.path = tempfile.mkstemp()
         self._redirect_console(self.path)
+        self.maxDiff = None
 
     def tearDown(self):
         self._undo_console_redirect()
@@ -218,7 +221,7 @@ class TestExecutionResultFormatter(unittest2.TestCase):
         return content
 
     def test_SinlgeRowTable_notebox_one(self):
-        with mock.patch('sys.stderr', new=BytesIO()) as fackety_fake:
+        with mock.patch('sys.stderr', new=StringIO()) as fackety_fake:
             expected = "Note: Only one action execution is displayed. Use -n/--last flag for " \
                 "more results."
             print(self.table.note_box("action executions", 1))
@@ -228,16 +231,16 @@ class TestExecutionResultFormatter(unittest2.TestCase):
     def test_SinlgeRowTable_notebox_zero(self):
         with mock.patch('sys.stderr', new=BytesIO()) as fackety_fake:
             contents = (fackety_fake.getvalue())
-            self.assertEquals(contents, "")
+            self.assertEquals(contents, b'')
 
     def test_SinlgeRowTable_notebox_default(self):
-        with mock.patch('sys.stderr', new=BytesIO()) as fackety_fake:
+        with mock.patch('sys.stderr', new=StringIO()) as fackety_fake:
             expected = "Note: Only first 50 action executions are displayed. Use -n/--last flag " \
                 "for more results."
             print(self.table.note_box("action executions", 50))
             content = (fackety_fake.getvalue().split("|")[1].strip())
             self.assertEquals(content, expected)
-        with mock.patch('sys.stderr', new=BytesIO()) as fackety_fake:
+        with mock.patch('sys.stderr', new=StringIO()) as fackety_fake:
             expected = "Note: Only first 15 action executions are displayed. Use -n/--last flag " \
                 "for more results."
             print(self.table.note_box("action executions", 15))

--- a/st2client/tests/unit/test_interactive.py
+++ b/st2client/tests/unit/test_interactive.py
@@ -16,12 +16,12 @@
 from __future__ import absolute_import
 import logging
 import mock
-from StringIO import StringIO
 import re
 import unittest2
 
 import prompt_toolkit
 from prompt_toolkit.document import Document
+from six.moves import StringIO
 
 from st2client.utils import interactive
 import six

--- a/st2client/tests/unit/test_keyvalue.py
+++ b/st2client/tests/unit/test_keyvalue.py
@@ -273,7 +273,6 @@ class TestKeyValueLoad(TestKeyValueBase):
         try:
             array = [KEYVALUE, KEYVALUE_ALL]
             json_str = json.dumps(array, indent=4)
-            print json_str
             LOG.info(json_str)
             with open(path, 'a') as f:
                 f.write(json_str)

--- a/st2client/tests/unit/test_shell.py
+++ b/st2client/tests/unit/test_shell.py
@@ -21,6 +21,7 @@ import json
 import logging
 import tempfile
 
+import six
 import mock
 import unittest2
 
@@ -90,8 +91,10 @@ class TestShell(base.BaseCLITestCase):
         stderr = self.stderr.read()
 
         self.assertTrue('usage' in stderr)
-        self.assertTrue('{list,get,create,update' in stderr)
-        self.assertTrue('error: too few arguments' in stderr)
+
+        if six.PY2:
+            self.assertTrue('{list,get,create,update' in stderr)
+            self.assertTrue('error: too few arguments' in stderr)
 
     def test_endpoints_default(self):
         base_url = 'http://127.0.0.1'

--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,8 @@ commands =
     nosetests -sv st2reactor/tests/unit
     nosetests -sv st2tests/tests/unit
 
-[testenv:py35]
-basepython = python3.5
+[testenv:py36]
+basepython = python3.6
 setenv = PYTHONPATH = {toxinidir}/external:{toxinidir}/st2common
          VIRTUALENV_DIR = {envdir}
 install_command = pip install -U --force-reinstall {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,6 @@ setenv = PYTHONPATH = {toxinidir}/external
          VIRTUALENV_DIR = {envdir}
 install_command = pip install -U --force-reinstall {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
-       -r{toxinidir}/test-requirements.txt
        -e{toxinidir}/st2client
 commands =
     nosetests -sv st2client/tests/unit

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ commands =
 
 [testenv:py35]
 basepython = python3.5
-setenv = PYTHONPATH = {toxinidir}/external
+setenv = PYTHONPATH = {toxinidir}/external:{toxinidir}/st2common
          VIRTUALENV_DIR = {envdir}
 install_command = pip install -U --force-reinstall {opts} {packages}
 deps = -r{toxinidir}/requirements.txt


### PR DESCRIPTION
This pull request adds changelog item for #3929.

In addition to that, it also includes some other changes:

* Import reorganization so it follows the existing systle
* Run st2client tests under Python 3 on Travis - if we don't have tests continuously running, it's the same as if we haven't done those changes