### PR TITLE
[RBAC] Only allow limit=-1 to be used by admins, allow admins to override max_page_size

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,9 +40,13 @@ Added
   (new feature) #3929 #3932
 
   Contributed by Anthony Shaw.
-* Add ``limit=-1`` support for the API to fetch full result set (CLI equivalent flag
+* Add ``?limit=-1`` support for the API to fetch full result set (CLI equivalent flag
   ``--last/-n``). Post error message for ``limit=0`` and fix corner case where negative values for
   limit query param were not handled correctly. #3761 #3708 #3735
+* Only allow RBAC admins to retrieve all the results at once using ``?limit=-1`` query param, upate
+  the code so ``api.max_page_size`` config option only applies to non-admin users, meaning users
+  with admin permission can specify arbitrary value for ``?limit`` query param which can also be
+  larger than ``api.max_page_size``. (improvement) #3939
 
 Changed
 ~~~~~~~

--- a/st2api/st2api/controllers/exp/inquiries.py
+++ b/st2api/st2api/controllers/exp/inquiries.py
@@ -70,7 +70,8 @@ class InquiriesController(ResourceController):
             raw_filters={
                 'status': action_constants.LIVEACTION_STATUS_PENDING,
                 'runner': INQUIRY_RUNNER
-            }
+            },
+            requester_user=requester_user
         )
 
         # Since "model" is set to InquiryAPI (for good reasons), _get_all returns a list of

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -27,6 +27,7 @@ from st2common import log as logging
 from st2common.models.system.common import ResourceReference
 from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2common.rbac import utils as rbac_utils
+from st2common.exceptions.rbac import AccessDeniedError
 from st2common.util import schema as util_schema
 from st2common.router import abort
 from st2common.router import Response
@@ -439,7 +440,10 @@ def validate_limit_query_param(limit, requester_user=None):
         if int(limit) == -1:
             if not user_is_admin:
                 # Only admins can specify limit -1
-                pass
+                message = ('Administrator access required to be able to specify limit=-1 and '
+                           'retrieve all the records')
+                raise AccessDeniedError(message=message,
+                                        user_db=requester_user)
 
             return 0
         elif int(limit) <= -2:

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -449,14 +449,12 @@ def validate_limit_query_param(limit, requester_user=None):
         elif int(limit) <= -2:
             msg = 'Limit, "%s" specified, must be a positive number.' % (limit)
             raise ValueError(msg)
-        elif int(limit) > cfg.CONF.api.max_page_size:
+        elif int(limit) > cfg.CONF.api.max_page_size and not user_is_admin:
             msg = ('Limit "%s" specified, maximum value is "%s"' % (limit,
                                                                     cfg.CONF.api.max_page_size))
 
-            if not user_is_admin:
-                raise AccessDeniedError(message=msg,
-                                        user_db=requester_user)
-
+            raise AccessDeniedError(message=msg,
+                                    user_db=requester_user)
             raise ValueError(msg)
     # Disable n = 0
     elif limit == 0:

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -455,11 +455,10 @@ def validate_limit_query_param(limit, requester_user=None):
 
             raise AccessDeniedError(message=msg,
                                     user_db=requester_user)
-            raise ValueError(msg)
     # Disable n = 0
     elif limit == 0:
-        msg = 'Limit, "%s" specified, must be a positive number or -1 for full result set.'\
-            % (limit)
+        msg = ('Limit, "%s" specified, must be a positive number or -1 for full result set.' %
+               (limit))
         raise ValueError(msg)
 
     return limit

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -449,9 +449,14 @@ def validate_limit_query_param(limit, requester_user=None):
         elif int(limit) <= -2:
             msg = 'Limit, "%s" specified, must be a positive number.' % (limit)
             raise ValueError(msg)
-        elif int(limit) > cfg.CONF.api.max_page_size and not user_is_admin:
-            msg = 'Limit "%s" specified, maximum value is "%s"' \
-                % (limit, cfg.CONF.api.max_page_size)
+        elif int(limit) > cfg.CONF.api.max_page_size:
+            msg = ('Limit "%s" specified, maximum value is "%s"' % (limit,
+                                                                    cfg.CONF.api.max_page_size))
+
+            if not user_is_admin:
+                raise AccessDeniedError(message=msg,
+                                        user_db=requester_user)
+
             raise ValueError(msg)
     # Disable n = 0
     elif limit == 0:

--- a/st2api/st2api/controllers/v1/actionalias.py
+++ b/st2api/st2api/controllers/v1/actionalias.py
@@ -56,11 +56,12 @@ class ActionAliasController(resource.ContentPackResourceController):
         'help': ['POST']
     }
 
-    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
+    def get_all(self, sort=None, offset=0, limit=None, requester_user=None, **raw_filters):
         return super(ActionAliasController, self)._get_all(sort=sort,
                                                            offset=offset,
                                                            limit=limit,
-                                                           raw_filters=raw_filters)
+                                                           raw_filters=raw_filters,
+                                                           requester_user=requester_user)
 
     def get_one(self, ref_or_id, requester_user):
         permission_type = PermissionType.ACTION_ALIAS_VIEW

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -711,7 +711,8 @@ class ActionExecutionsController(ActionExecutionsControllerMixin, ResourceContro
                                              mask_secrets=from_model_kwargs['mask_secrets'])
 
     def _get_action_executions(self, exclude_fields=None, sort=None, offset=0, limit=None,
-                               query_options=None, raw_filters=None, from_model_kwargs=None):
+                               query_options=None, raw_filters=None, from_model_kwargs=None,
+                               requester_user=None):
         """
         :param exclude_fields: A list of object fields to exclude.
         :type exclude_fields: ``list``
@@ -729,7 +730,8 @@ class ActionExecutionsController(ActionExecutionsControllerMixin, ResourceContro
                                                                 offset=offset,
                                                                 limit=limit,
                                                                 query_options=query_options,
-                                                                raw_filters=raw_filters)
+                                                                raw_filters=raw_filters,
+                                                                requester_user=requester_user)
 
 
 action_executions_controller = ActionExecutionsController()

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -540,7 +540,8 @@ class ActionExecutionsController(ActionExecutionsControllerMixin, ResourceContro
                                            offset=offset,
                                            limit=limit,
                                            query_options=query_options,
-                                           raw_filters=raw_filters)
+                                           raw_filters=raw_filters,
+                                           requester_user=requester_user)
 
     def get_one(self, id, requester_user, exclude_attributes=None, show_secrets=False):
         """

--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -78,7 +78,8 @@ class ActionsController(resource.ContentPackResourceController):
         super(ActionsController, self).__init__(*args, **kwargs)
         self._trigger_dispatcher = TriggerDispatcher(LOG)
 
-    def get_all(self, exclude_attributes=None, sort=None, offset=0, limit=None, **raw_filters):
+    def get_all(self, exclude_attributes=None, sort=None, offset=0, limit=None,
+                requester_user=None, **raw_filters):
         if exclude_attributes:
             exclude_fields = exclude_attributes.split(',')
         else:
@@ -89,7 +90,8 @@ class ActionsController(resource.ContentPackResourceController):
                                                        sort=sort,
                                                        offset=offset,
                                                        limit=limit,
-                                                       raw_filters=raw_filters)
+                                                       raw_filters=raw_filters,
+                                                       requester_user=requester_user)
 
     def get_one(self, ref_or_id, requester_user):
         return super(ActionsController, self)._get_one(ref_or_id, requester_user=requester_user,

--- a/st2api/st2api/controllers/v1/auth.py
+++ b/st2api/st2api/controllers/v1/auth.py
@@ -103,7 +103,7 @@ class ApiKeyController(BaseRestControllerMixin):
         mask_secrets = self._get_mask_secrets(show_secrets=show_secrets,
                                               requester_user=requester_user)
 
-        limit = resource.limit_query_validation(limit)
+        limit = resource.validate_limit_query_param(limit, requester_user=requester_user)
 
         api_key_dbs = ApiKey.get_all(limit=limit, offset=offset)
 

--- a/st2api/st2api/controllers/v1/keyvalue.py
+++ b/st2api/st2api/controllers/v1/keyvalue.py
@@ -159,7 +159,8 @@ class KeyValuePairController(ResourceController):
                                                                 sort=sort,
                                                                 offset=offset,
                                                                 limit=limit,
-                                                                raw_filters=raw_filters)
+                                                                raw_filters=raw_filters,
+                                                                requester_user=requester_user)
         return kvp_apis
 
     def put(self, kvp, name, requester_user, scope=FULL_SYSTEM_SCOPE):

--- a/st2api/st2api/controllers/v1/pack_config_schemas.py
+++ b/st2api/st2api/controllers/v1/pack_config_schemas.py
@@ -40,7 +40,7 @@ class PackConfigSchemasController(ResourceController):
         # this case, RBAC is checked on the parent PackDB object
         self.get_one_db_method = packs_service.get_pack_by_ref
 
-    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
+    def get_all(self, sort=None, offset=0, limit=None, requester_user=None, **raw_filters):
         """
         Retrieve config schema for all the packs.
 
@@ -51,7 +51,8 @@ class PackConfigSchemasController(ResourceController):
         return super(PackConfigSchemasController, self)._get_all(sort=sort,
                                                                  offset=offset,
                                                                  limit=limit,
-                                                                 raw_filters=raw_filters)
+                                                                 raw_filters=raw_filters,
+                                                                 requester_user=requester_user)
 
     def get_one(self, pack_ref, requester_user):
         """

--- a/st2api/st2api/controllers/v1/pack_configs.py
+++ b/st2api/st2api/controllers/v1/pack_configs.py
@@ -69,7 +69,8 @@ class PackConfigsController(ResourceController, BaseRestControllerMixin):
                                                            offset=offset,
                                                            limit=limit,
                                                            from_model_kwargs=from_model_kwargs,
-                                                           raw_filters=raw_filters)
+                                                           raw_filters=raw_filters,
+                                                           requester_user=requester_user)
 
     def get_one(self, pack_ref, requester_user, show_secrets=False):
         """

--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -337,11 +337,12 @@ class PacksController(BasePacksController):
         super(PacksController, self).__init__()
         self.get_one_db_method = self._get_by_ref_or_id
 
-    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
+    def get_all(self, sort=None, offset=0, limit=None, requester_user=None, **raw_filters):
         return super(PacksController, self)._get_all(sort=sort,
                                                      offset=offset,
                                                      limit=limit,
-                                                     raw_filters=raw_filters)
+                                                     raw_filters=raw_filters,
+                                                     requester_user=requester_user)
 
     def get_one(self, ref_or_id, requester_user):
         return self._get_one_by_ref_or_id(ref_or_id=ref_or_id, requester_user=requester_user)

--- a/st2api/st2api/controllers/v1/policies.py
+++ b/st2api/st2api/controllers/v1/policies.py
@@ -139,11 +139,12 @@ class PolicyController(resource.ContentPackResourceController):
         'sort': ['pack', 'name']
     }
 
-    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
+    def get_all(self, sort=None, offset=0, limit=None, requester_user=None, **raw_filters):
         return self._get_all(sort=sort,
                              offset=offset,
                              limit=limit,
-                             raw_filters=raw_filters)
+                             raw_filters=raw_filters,
+                             requester_user=requester_user)
 
     def get_one(self, ref_or_id, requester_user):
         permission_type = PermissionType.POLICY_VIEW

--- a/st2api/st2api/controllers/v1/policies.py
+++ b/st2api/st2api/controllers/v1/policies.py
@@ -49,11 +49,12 @@ class PolicyTypeController(resource.ResourceController):
     def get_one(self, ref_or_id, requester_user):
         return self._get_one(ref_or_id, requester_user=requester_user)
 
-    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
+    def get_all(self, sort=None, offset=0, limit=None, requester_user=None, **raw_filters):
         return self._get_all(sort=sort,
                              offset=offset,
                              limit=limit,
-                             raw_filters=raw_filters)
+                             raw_filters=raw_filters,
+                             requester_user=requester_user)
 
     def _get_one(self, ref_or_id, requester_user):
         instance = self._get_by_ref_or_id(ref_or_id=ref_or_id)
@@ -73,7 +74,7 @@ class PolicyTypeController(resource.ResourceController):
         return result
 
     def _get_all(self, exclude_fields=None, sort=None, offset=0, limit=None, query_options=None,
-                 from_model_kwargs=None, raw_filters=None):
+                 from_model_kwargs=None, raw_filters=None, requester_user=None):
 
         resp = super(PolicyTypeController, self)._get_all(exclude_fields=exclude_fields,
                                                           sort=sort,
@@ -81,7 +82,8 @@ class PolicyTypeController(resource.ResourceController):
                                                           limit=limit,
                                                           query_options=query_options,
                                                           from_model_kwargs=from_model_kwargs,
-                                                          raw_filters=raw_filters)
+                                                          raw_filters=raw_filters,
+                                                          requester_user=requester_user)
 
         if self.include_reference:
             result = resp.json

--- a/st2api/st2api/controllers/v1/rbac.py
+++ b/st2api/st2api/controllers/v1/rbac.py
@@ -54,7 +54,8 @@ class RolesController(ResourceController):
         return self._get_all(sort=sort,
                              offset=offset,
                              limit=limit,
-                             raw_filters=raw_filters)
+                             raw_filters=raw_filters,
+                             requester_user=requester_user)
 
 
 class RoleAssignmentsController(ResourceController):
@@ -78,7 +79,8 @@ class RoleAssignmentsController(ResourceController):
         return self._get_all(sort=sort,
                              offset=offset,
                              limit=limit,
-                             raw_filters=raw_filters)
+                             raw_filters=raw_filters,
+                             requester_user=requester_user)
 
     def get_one(self, id, requester_user):
         result = self._get_one_by_id(id,

--- a/st2api/st2api/controllers/v1/rule_enforcements.py
+++ b/st2api/st2api/controllers/v1/rule_enforcements.py
@@ -57,11 +57,12 @@ class RuleEnforcementController(resource.ResourceController):
         'enforced_at_lt': lambda value: isotime.parse(value=value)
     }
 
-    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
+    def get_all(self, sort=None, offset=0, limit=None, requester_user=None, **raw_filters):
         return super(RuleEnforcementController, self)._get_all(sort=sort,
                                                                offset=offset,
                                                                limit=limit,
-                                                               raw_filters=raw_filters)
+                                                               raw_filters=raw_filters,
+                                                               requester_user=requester_user)
 
     def get_one(self, id, requester_user):
         return super(RuleEnforcementController,

--- a/st2api/st2api/controllers/v1/rules.py
+++ b/st2api/st2api/controllers/v1/rules.py
@@ -65,13 +65,14 @@ class RuleController(resource.ContentPackResourceController):
 
     include_reference = True
 
-    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
+    def get_all(self, sort=None, offset=0, limit=None, requester_user=None, **raw_filters):
         from_model_kwargs = {'ignore_missing_trigger': True}
         return super(RuleController, self)._get_all(from_model_kwargs=from_model_kwargs,
                                                     sort=sort,
                                                     offset=offset,
                                                     limit=limit,
-                                                    raw_filters=raw_filters)
+                                                    raw_filters=raw_filters,
+                                                    requester_user=requester_user)
 
     def get_one(self, ref_or_id, requester_user):
         from_model_kwargs = {'ignore_missing_trigger': True}

--- a/st2api/st2api/controllers/v1/ruleviews.py
+++ b/st2api/st2api/controllers/v1/ruleviews.py
@@ -84,11 +84,12 @@ class RuleViewController(resource.ContentPackResourceController):
 
     include_reference = True
 
-    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
+    def get_all(self, sort=None, offset=0, limit=None, requester_user=None, **raw_filters):
         rules = self._get_all(sort=sort,
                               offset=offset,
                               limit=limit,
-                              raw_filters=raw_filters)
+                              raw_filters=raw_filters,
+                              requester_user=requester_user)
         result = self._append_view_properties(rules.json)
         rules.json = result
         return rules

--- a/st2api/st2api/controllers/v1/runnertypes.py
+++ b/st2api/st2api/controllers/v1/runnertypes.py
@@ -45,11 +45,12 @@ class RunnerTypesController(ResourceController):
         'sort': ['name']
     }
 
-    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
+    def get_all(self, sort=None, offset=0, limit=None, requester_user=None, **raw_filters):
         return super(RunnerTypesController, self)._get_all(sort=sort,
                                                            offset=offset,
                                                            limit=limit,
-                                                           raw_filters=raw_filters)
+                                                           raw_filters=raw_filters,
+                                                           requester_user=requester_user)
 
     def get_one(self, name_or_id, requester_user):
         return self._get_one_by_name_or_id(name_or_id,

--- a/st2api/st2api/controllers/v1/sensors.py
+++ b/st2api/st2api/controllers/v1/sensors.py
@@ -45,11 +45,12 @@ class SensorTypeController(resource.ContentPackResourceController):
 
     include_reference = True
 
-    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
+    def get_all(self, sort=None, offset=0, limit=None, requester_user=None, **raw_filters):
         return super(SensorTypeController, self)._get_all(sort=sort,
                                                           offset=offset,
                                                           limit=limit,
-                                                          raw_filters=raw_filters)
+                                                          raw_filters=raw_filters,
+                                                          requester_user=requester_user)
 
     def get_one(self, ref_or_id, requester_user):
         permission_type = PermissionType.SENSOR_VIEW

--- a/st2api/st2api/controllers/v1/traces.py
+++ b/st2api/st2api/controllers/v1/traces.py
@@ -37,7 +37,7 @@ class TracesController(ResourceController):
         'sort': ['-start_timestamp', 'trace_tag']
     }
 
-    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
+    def get_all(self, sort=None, offset=0, limit=None, requester_user=None, **raw_filters):
         # Use a custom sort order when filtering on a timestamp so we return a correct result as
         # expected by the user
         query_options = None
@@ -49,7 +49,8 @@ class TracesController(ResourceController):
                              offset=offset,
                              limit=limit,
                              query_options=query_options,
-                             raw_filters=raw_filters)
+                             raw_filters=raw_filters,
+                             requester_user=requester_user)
 
     def get_one(self, id, requester_user):
         return self._get_one_by_id(id,

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -55,11 +55,12 @@ class TriggerTypeController(resource.ContentPackResourceController):
 
     include_reference = True
 
-    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
+    def get_all(self, sort=None, offset=0, limit=None, requester_user=None, **raw_filters):
         return self._get_all(sort=sort,
                              offset=offset,
                              limit=limit,
-                             raw_filters=raw_filters)
+                             raw_filters=raw_filters,
+                             requester_user=requester_user)
 
     def get_one(self, triggertype_ref_or_id):
         return self._get_one(triggertype_ref_or_id, permission_type=None, requester_user=None)
@@ -210,7 +211,7 @@ class TriggerController(object):
         trigger_api = TriggerAPI.from_model(trigger_db)
         return trigger_api
 
-    def get_all(self):
+    def get_all(self, requester_user=None):
         """
             List all triggers.
 

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -385,7 +385,7 @@ class TriggerInstanceController(TriggerInstanceControllerMixin, resource.Resourc
         """
         return self._get_one_by_id(instance_id, permission_type=None, requester_user=None)
 
-    def get_all(self, sort=None, offset=0, limit=None, **raw_filters):
+    def get_all(self, sort=None, offset=0, limit=None, requester_user=None, **raw_filters):
         """
             List all triggerinstances.
 
@@ -395,7 +395,8 @@ class TriggerInstanceController(TriggerInstanceControllerMixin, resource.Resourc
         trigger_instances = self._get_trigger_instances(sort=sort,
                                                         offset=offset,
                                                         limit=limit,
-                                                        raw_filters=raw_filters)
+                                                        raw_filters=raw_filters,
+                                                        requester_user=requester_user)
         return trigger_instances
 
     def _get_trigger_instances(self, sort=None, offset=0, limit=None, raw_filters=None):

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -399,7 +399,8 @@ class TriggerInstanceController(TriggerInstanceControllerMixin, resource.Resourc
                                                         requester_user=requester_user)
         return trigger_instances
 
-    def _get_trigger_instances(self, sort=None, offset=0, limit=None, raw_filters=None):
+    def _get_trigger_instances(self, sort=None, offset=0, limit=None, raw_filters=None,
+                               requester_user=None):
         if limit is None:
             limit = self.default_limit
 
@@ -409,7 +410,8 @@ class TriggerInstanceController(TriggerInstanceControllerMixin, resource.Resourc
         return super(TriggerInstanceController, self)._get_all(sort=sort,
                                                                offset=offset,
                                                                limit=limit,
-                                                               raw_filters=raw_filters)
+                                                               raw_filters=raw_filters,
+                                                               requester_user=requester_user)
 
 
 triggertype_controller = TriggerTypeController()

--- a/st2api/tests/unit/controllers/v1/test_actions.py
+++ b/st2api/tests/unit/controllers/v1/test_actions.py
@@ -332,7 +332,9 @@ class TestActionController(FunctionalTest, CleanFilesTestCase):
         self.__do_delete(action_1_id)
         self.__do_delete(action_2_id)
 
-    def test_get_all_invalid_limit_too_large(self):
+    @mock.patch('st2common.rbac.utils.user_is_admin', mock.Mock(return_value=False))
+    def test_get_all_invalid_limit_too_large_none_admin(self):
+        # limit > max_page_size, but user is not admin
         resp = self.app.get('/v1/actions?limit=1000', expect_errors=True)
         self.assertEqual(resp.status_int, 400)
         self.assertEqual(resp.json['faultstring'], 'Limit "1000" specified, maximum value is'

--- a/st2api/tests/unit/controllers/v1/test_actions.py
+++ b/st2api/tests/unit/controllers/v1/test_actions.py
@@ -16,6 +16,7 @@
 import os
 import os.path
 import copy
+import httplib
 
 try:
     import simplejson as json
@@ -336,7 +337,7 @@ class TestActionController(FunctionalTest, CleanFilesTestCase):
     def test_get_all_invalid_limit_too_large_none_admin(self):
         # limit > max_page_size, but user is not admin
         resp = self.app.get('/v1/actions?limit=1000', expect_errors=True)
-        self.assertEqual(resp.status_int, 400)
+        self.assertEqual(resp.status_int, httplib.FORBIDDEN)
         self.assertEqual(resp.json['faultstring'], 'Limit "1000" specified, maximum value is'
                          ' "100"')
 

--- a/st2api/tests/unit/controllers/v1/test_auth_api_keys.py
+++ b/st2api/tests/unit/controllers/v1/test_auth_api_keys.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import httplib
+
 import mock
 from oslo_config import cfg
 
@@ -107,7 +109,7 @@ class TestApiKeyController(FunctionalTest):
     def test_get_all_invalid_limit_too_large_none_admin(self):
         # limit > max_page_size, but user is not admin
         resp = self.app.get('/v1/apikeys?offset=2&limit=1000', expect_errors=True)
-        self.assertEqual(resp.status_int, 400)
+        self.assertEqual(resp.status_int, httplib.FORBIDDEN)
         self.assertEqual(resp.json['faultstring'],
                          'Limit "1000" specified, maximum value is "100"')
 

--- a/st2api/tests/unit/controllers/v1/test_auth_api_keys.py
+++ b/st2api/tests/unit/controllers/v1/test_auth_api_keys.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import mock
 from oslo_config import cfg
 
 from st2common.constants.secrets import MASKED_ATTRIBUTE_VALUE
@@ -102,7 +103,9 @@ class TestApiKeyController(FunctionalTest):
         retrieved_ids = [apikey['id'] for apikey in resp.json]
         self.assertEqual(retrieved_ids, [str(self.apikey1.id), str(self.apikey2.id)])
 
-    def test_get_all_invalid_limit_too_large(self):
+    @mock.patch('st2common.rbac.utils.user_is_admin', mock.Mock(return_value=False))
+    def test_get_all_invalid_limit_too_large_none_admin(self):
+        # limit > max_page_size, but user is not admin
         resp = self.app.get('/v1/apikeys?offset=2&limit=1000', expect_errors=True)
         self.assertEqual(resp.status_int, 400)
         self.assertEqual(resp.json['faultstring'],

--- a/st2api/tests/unit/controllers/v1/test_auth_api_keys_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_auth_api_keys_rbac.py
@@ -205,3 +205,16 @@ class ApiKeyControllerRBACTestCase(APIControllerWithRBACTestCase):
         # User not provide
         resp = self.app.post_json('/v1/apikeys', {'user': 'joe22'})
         self.assertEqual(resp.status_code, httplib.CREATED)
+
+    def test_get_all_limit_minus_one(self):
+        user_db = self.users['observer']
+        self.use_user(user_db)
+
+        resp = self.app.get('/v1/apikeys?limit=-1', expect_errors=True)
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+
+        user_db = self.users['admin']
+        self.use_user(user_db)
+
+        resp = self.app.get('/v1/apikeys?limit=-1')
+        self.assertEqual(resp.status_code, httplib.OK)

--- a/st2api/tests/unit/controllers/v1/test_executions_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_rbac.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import httplib
+
 import mock
 
 import st2common.validators.api.action as action_validator
@@ -121,3 +123,16 @@ class ActionExecutionRBACControllerTestCase(BaseActionExecutionControllerTestCas
         }
 
         self.assertEqual(resp.json['context'], expected_context)
+
+    def test_get_all_limit_minus(self):
+        user_db = self.users['observer']
+        self.use_user(user_db)
+
+        resp = self.app.get('/v1/actionexecutions?limit=-1', expect_errors=True)
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+
+        user_db = self.users['admin']
+        self.use_user(user_db)
+
+        resp = self.app.get('/v1/actionexecutions?limit=-1')
+        self.assertEqual(resp.status_code, httplib.OK)

--- a/st2api/tests/unit/controllers/v1/test_executions_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_rbac.py
@@ -124,7 +124,7 @@ class ActionExecutionRBACControllerTestCase(BaseActionExecutionControllerTestCas
 
         self.assertEqual(resp.json['context'], expected_context)
 
-    def test_get_all_limit_minus(self):
+    def test_get_all_limit_minus_one(self):
         user_db = self.users['observer']
         self.use_user(user_db)
 

--- a/st2api/tests/unit/controllers/v1/test_kvps_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_kvps_rbac.py
@@ -106,6 +106,14 @@ class KeyValuesControllerRBACTestCase(APIControllerWithRBACTestCase):
         self.assertTrue(resp.json[1]['secret'])
         self.assertTrue(len(resp.json[1]['value']) > 50)
 
+        resp = self.app.get('/v1/keys')
+        self.assertEqual(resp.status_int, 200)
+        self.assertEqual(len(resp.json), self.system_scoped_items_count)
+        for item in resp.json:
+            self.assertEqual(item['scope'], FULL_SYSTEM_SCOPE)
+
+        # limit=-1 admin user
+        self.use_user(self.users['admin'])
         resp = self.app.get('/v1/keys/?limit=-1')
         self.assertEqual(resp.status_int, 200)
         self.assertEqual(len(resp.json), self.system_scoped_items_count)
@@ -131,7 +139,7 @@ class KeyValuesControllerRBACTestCase(APIControllerWithRBACTestCase):
         self.assertTrue(resp.json[1]['secret'])
         self.assertTrue(len(resp.json[1]['value']) > 50)
 
-        resp = self.app.get('/v1/keys?scope=st2kv.user&limit=-1')
+        resp = self.app.get('/v1/keys?scope=st2kv.user')
         self.assertEqual(resp.status_int, 200)
         self.assertEqual(len(resp.json), self.user_scoped_items_per_user_count['user1'])
         for item in resp.json:

--- a/st2api/tests/unit/controllers/v1/test_kvps_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_kvps_rbac.py
@@ -386,3 +386,16 @@ class KeyValuesControllerRBACTestCase(APIControllerWithRBACTestCase):
         self.assertEqual(resp.status_code, httplib.FORBIDDEN)
         self.assertTrue('"user" attribute can only be provided by admins' in
                         resp.json['faultstring'])
+
+    def test_get_all_limit_minus_one(self):
+        user_db = self.users['observer']
+        self.use_user(user_db)
+
+        resp = self.app.get('/v1/keys?limit=-1', expect_errors=True)
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+
+        user_db = self.users['admin']
+        self.use_user(user_db)
+
+        resp = self.app.get('/v1/keys?limit=-1')
+        self.assertEqual(resp.status_code, httplib.OK)

--- a/st2api/tests/unit/controllers/v1/test_packs_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_packs_rbac.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import httplib
+
 import mock
 import six
 
@@ -77,3 +79,16 @@ class PackControllerRBACTestCase(APIControllerWithRBACTestCase):
         call_kwargs = _handle_schedule_execution.call_args[1]
         self.assertEqual(call_kwargs['requester_user'], user_db)
         self.assertEqual(call_kwargs['liveaction_api'].user, user_db.name)
+
+    def test_get_all_limit_minus_one(self):
+        user_db = self.users['observer']
+        self.use_user(user_db)
+
+        resp = self.app.get('/v1/packs?limit=-1', expect_errors=True)
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+
+        user_db = self.users['admin']
+        self.use_user(user_db)
+
+        resp = self.app.get('/v1/packs?limit=-1')
+        self.assertEqual(resp.status_code, httplib.OK)

--- a/st2api/tests/unit/controllers/v1/test_policies_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_policies_rbac.py
@@ -183,6 +183,19 @@ class PolicyTypeControllerRBACTestCase(APIControllerWithRBACTestCase):
         self.assertEqual(resp.status_code, httplib.FORBIDDEN)
         self.assertEqual(resp.json['faultstring'], expected_msg)
 
+    def test_get_all_limit_minus_one(self):
+        user_db = self.users['observer']
+        self.use_user(user_db)
+
+        resp = self.app.get('/v1/policytypes?limit=-1', expect_errors=True)
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+
+        user_db = self.users['admin']
+        self.use_user(user_db)
+
+        resp = self.app.get('/v1/policytypes?limit=-1')
+        self.assertEqual(resp.status_code, httplib.OK)
+
 
 class PolicyControllerRBACTestCase(APIControllerWithRBACTestCase):
     fixtures_loader = FixturesLoader()
@@ -487,3 +500,16 @@ class PolicyControllerRBACTestCase(APIControllerWithRBACTestCase):
                         ' on resource "%s"' % (policy_uid))
         self.assertEqual(resp.status_code, httplib.FORBIDDEN)
         self.assertEqual(resp.json['faultstring'], expected_msg)
+
+    def test_get_all_limit_minus_one(self):
+        user_db = self.users['observer']
+        self.use_user(user_db)
+
+        resp = self.app.get('/v1/policies?limit=-1', expect_errors=True)
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+
+        user_db = self.users['admin']
+        self.use_user(user_db)
+
+        resp = self.app.get('/v1/policies?limit=-1')
+        self.assertEqual(resp.status_code, httplib.OK)

--- a/st2api/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
+++ b/st2api/tests/unit/controllers/v1/test_rbac_for_supported_endpoints.py
@@ -141,7 +141,8 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
             # Runners
             {
                 'path': '/v1/runnertypes',
-                'method': 'GET'
+                'method': 'GET',
+                'is_getall': True
             },
             {
                 'path': '/v1/runnertypes/test-runner-1',
@@ -155,7 +156,8 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
             # Packs
             {
                 'path': '/v1/packs',
-                'method': 'GET'
+                'method': 'GET',
+                'is_getall': True
             },
             {
                 'path': '/v1/packs/dummy_pack_1',
@@ -194,7 +196,8 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
             # Pack config schemas
             {
                 'path': '/v1/config_schemas',
-                'method': 'GET'
+                'method': 'GET',
+                'is_getall': True
             },
             {
                 'path': '/v1/config_schemas/dummy_pack_1',
@@ -206,8 +209,9 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
             },
             # Pack configs
             {
-                'path': '/v1/configs/',
-                'method': 'GET'
+                'path': '/v1/configs',
+                'method': 'GET',
+                'is_getall': True
             },
             {
                 'path': '/v1/configs/dummy_pack_1',
@@ -223,7 +227,8 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
             # Sensors
             {
                 'path': '/v1/sensortypes',
-                'method': 'GET'
+                'method': 'GET',
+                'is_getall': True
             },
             {
                 'path': '/v1/sensortypes/%s' % (sensor_model.ref),
@@ -237,7 +242,8 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
             # Actions
             {
                 'path': '/v1/actions',
-                'method': 'GET'
+                'method': 'GET',
+                'is_getall': True
             },
             {
                 'path': '/v1/actions/wolfpack.action-1',
@@ -260,7 +266,8 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
             # Action aliases
             {
                 'path': '/v1/actionalias',
-                'method': 'GET'
+                'method': 'GET',
+                'is_getall': True
             },
             {
                 'path': '/v1/actionalias/aliases.alias1',
@@ -288,7 +295,8 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
             # Rules
             {
                 'path': '/v1/rules',
-                'method': 'GET'
+                'method': 'GET',
+                'is_getall': True
             },
             {
                 'path': '/v1/rules/%s' % (rule_model.ref),
@@ -311,7 +319,8 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
             # Rule enforcements
             {
                 'path': '/v1/ruleenforcements',
-                'method': 'GET'
+                'method': 'GET',
+                'is_getall': True
             },
             {
                 'path': '/v1/ruleenforcements/%s' % (enforcement_model.id),
@@ -320,7 +329,8 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
             # Action Executions
             {
                 'path': '/v1/executions',
-                'method': 'GET'
+                'method': 'GET',
+                'is_getall': True
             },
             {
                 'path': '/v1/executions/%s' % (execution_model.id),
@@ -375,7 +385,8 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
             # Traces
             {
                 'path': '/v1/traces',
-                'method': 'GET'
+                'method': 'GET',
+                'is_getall': True
             },
             {
                 'path': '/v1/traces/%s' % (trace_model.id),
@@ -402,7 +413,8 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
             # RBAC - roles
             {
                 'path': '/v1/rbac/roles',
-                'method': 'GET'
+                'method': 'GET',
+                'is_getall': True
             },
             {
                 'path': '/v1/rbac/roles/admin',
@@ -411,7 +423,8 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
             # RBAC - user role assignments
             {
                 'path': '/v1/rbac/role_assignments',
-                'method': 'GET'
+                'method': 'GET',
+                'is_getall': True
             },
             {
                 'path': '/v1/rbac/role_assignments/%s' % (self.role_assignment_db_model['id']),
@@ -420,7 +433,8 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
             # RBAC - permission types
             {
                 'path': '/v1/rbac/permission_types',
-                'method': 'GET'
+                'method': 'GET',
+                'is_getall': True
             },
             {
                 'path': '/v1/rbac/permission_types/action',
@@ -435,6 +449,29 @@ class APIControllersRBACTestCase(APIControllerWithRBACTestCase):
                                                                         endpoint['path'],
                                                                         response.body)
             self.assertEqual(response.status_code, httplib.FORBIDDEN, msg)
+
+        # Also test ?limit=-1 - non-admin user
+        self.use_user(self.users['observer'])
+
+        for endpoint in supported_endpoints:
+            if not endpoint.get('is_getall', False):
+                continue
+
+            response = self.app.get(endpoint['path'] + '?limit=-1', expect_errors=True)
+            msg = '%s "%s" didn\'t return 403 status code (body=%s)' % (endpoint['method'],
+                                                                        endpoint['path'],
+                                                                        response.body)
+            self.assertEqual(response.status_code, httplib.FORBIDDEN, msg)
+
+        # Also test ?limit=-1 - admin user
+        self.use_user(self.users['admin'])
+
+        for endpoint in supported_endpoints:
+            if not endpoint.get('is_getall', False):
+                continue
+
+            response = self.app.get(endpoint['path'] + '?limit=-1')
+            self.assertEqual(response.status_code, httplib.OK)
 
     def test_icon_png_file_is_whitelisted(self):
         self.use_user(self.users['no_permissions'])

--- a/st2api/tests/unit/controllers/v1/test_rules_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_rules_rbac.py
@@ -207,6 +207,19 @@ class RuleControllerRBACTestCase(APIControllerWithRBACTestCase):
         resp = self.__do_post(RuleControllerRBACTestCase.RULE_1)
         self.assertEqual(resp.status_code, httplib.CREATED)
 
+    def test_get_all_limit_minus_one(self):
+        user_db = self.users['observer']
+        self.use_user(user_db)
+
+        resp = self.app.get('/v1/rules?limit=-1', expect_errors=True)
+        self.assertEqual(resp.status_code, httplib.FORBIDDEN)
+
+        user_db = self.users['admin']
+        self.use_user(user_db)
+
+        resp = self.app.get('/v1/rules?limit=-1')
+        self.assertEqual(resp.status_code, httplib.OK)
+
     @mock.patch.object(PoolPublisher, 'publish', mock.MagicMock())
     def __do_post(self, rule):
         return self.app.post_json('/v1/rules', rule, expect_errors=True)

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -197,12 +197,18 @@ info:
     Join our [Slack Community](https://stackstorm.com/community-signup) to get help from the engineering team and fellow users. You can also create issues against the main [StackStorm GitHub repo](https://github.com/StackStorm/st2/issues), or the [st2apidocs repo](https://github.com/StackStorm/st2apidocs) for documentation-specific issues.
 
     We also recommend reviewing the main [StackStorm documentation](https://docs.stackstorm.com/).
+    
 
 paths:
   /api/v1/:
     get:
       operationId: st2api.controllers.root:root_controller.index
       description: General API info.
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: General API info.
@@ -1275,11 +1281,6 @@ paths:
           type: array
           items:
             type: string
-      x-parameters:
-        - name: user
-          in: context
-          x-as: requester_user
-          description: User performing the operation.
       responses:
         '200':
           description: A number of distinct values for the requested filters
@@ -2466,6 +2467,7 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+
   /api/v1/rules:
     get:
       operationId: st2api.controllers.v1.rules:rule_controller.get_all
@@ -2740,11 +2742,6 @@ paths:
     get:
       operationId: st2api.controllers.v1.ruletypes:rule_types_controller.get_all
       description: Returns a list of all rule types.
-      x-parameters:
-        - name: user
-          in: context
-          x-as: requester_user
-          description: User performing the operation.
       responses:
         '200':
           description: List of rules
@@ -3603,6 +3600,11 @@ paths:
     get:
       operationId: st2api.controllers.v1.triggers:trigger_controller.get_all
       description: Returns a list of all triggers.
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of triggers

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -204,11 +204,6 @@ paths:
     get:
       operationId: st2api.controllers.root:root_controller.index
       description: General API info.
-      x-parameters:
-        - name: user
-          in: context
-          x-as: requester_user
-          description: User performing the operation.
       responses:
         '200':
           description: General API info.

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -573,6 +573,20 @@ paths:
           in: query
           description: Only return resources belonging to the provided pack
           type: string
+        - name: limit
+          in: query
+          description: Number of keys to get
+          type: integer
+          default: 100
+        - name: offset
+          in: query
+          description: Number of keys to offset
+          type: integer
+          default: 0
+        - name: sort
+          in: query
+          description: Comma-separated list of fields to sort by
+          type: string
       x-parameters:
         - name: user
           in: context

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -197,7 +197,6 @@ info:
     Join our [Slack Community](https://stackstorm.com/community-signup) to get help from the engineering team and fellow users. You can also create issues against the main [StackStorm GitHub repo](https://github.com/StackStorm/st2/issues), or the [st2apidocs repo](https://github.com/StackStorm/st2apidocs) for documentation-specific issues.
 
     We also recommend reviewing the main [StackStorm documentation](https://docs.stackstorm.com/).
-    
 
 paths:
   /api/v1/:
@@ -281,6 +280,11 @@ paths:
           in: query
           description: Action pack name filter
           type: string
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of actions
@@ -568,6 +572,11 @@ paths:
           in: query
           description: Only return resources belonging to the provided pack
           type: string
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of action aliases.
@@ -1266,6 +1275,11 @@ paths:
           type: array
           items:
             type: string
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: A number of distinct values for the requested filters
@@ -1570,6 +1584,11 @@ paths:
           in: query
           description: Entity ref filter
           type: string
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of installed packs.
@@ -1990,6 +2009,11 @@ paths:
           type: array
           items:
             type: string
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: Get packs config schema.
@@ -2067,6 +2091,11 @@ paths:
           type: array
           items:
             type: string
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of policy types
@@ -2135,6 +2164,11 @@ paths:
           description: Number of policies to offset
           type: integer
           default: 0
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: Policy created successfully.
@@ -2432,7 +2466,6 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-
   /api/v1/rules:
     get:
       operationId: st2api.controllers.v1.rules:rule_controller.get_all
@@ -2476,6 +2509,11 @@ paths:
           in: query
           description: Enabled filter
           type: string
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of rules
@@ -2649,6 +2687,11 @@ paths:
           in: query
           description: Enabled filter
           type: string
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of rules
@@ -2697,6 +2740,11 @@ paths:
     get:
       operationId: st2api.controllers.v1.ruletypes:rule_types_controller.get_all
       description: Returns a list of all rule types.
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of rules
@@ -2774,6 +2822,11 @@ paths:
           type: array
           items:
             type: string
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of rules
@@ -2894,6 +2947,11 @@ paths:
           in: query
           description: Enabled filter
           type: string
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of rules
@@ -3187,6 +3245,11 @@ paths:
               Only return enforcements with enforced_at lower than the one provided. Use time in the format.
           type: string
           pattern: ^\d{4}\-\d{2}\-\d{2}(\s|T)\d{2}:\d{2}:\d{2}(\.\d{3,6})?(Z|\+00|\+0000|\+00:00)$
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of rule enforcements
@@ -3341,6 +3404,11 @@ paths:
           description: |
               Sort in descending order by start timestamp, desc/descending (latest first)
           type: string
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of traces
@@ -3419,6 +3487,11 @@ paths:
           in: query
           description: Pack name filter
           type: string
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of trigger types
@@ -3682,6 +3755,11 @@ paths:
           description: Start timestamp greater than filter
           type: string
           pattern: ^\d{4}\-\d{2}\-\d{2}(\s|T)\d{2}:\d{2}:\d{2}(\.\d{3,6})?(Z|\+00|\+0000|\+00:00)$
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of trigger instances

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -569,6 +569,20 @@ paths:
           in: query
           description: Only return resources belonging to the provided pack
           type: string
+        - name: limit
+          in: query
+          description: Number of keys to get
+          type: integer
+          default: 100
+        - name: offset
+          in: query
+          description: Number of keys to offset
+          type: integer
+          default: 0
+        - name: sort
+          in: query
+          description: Comma-separated list of fields to sort by
+          type: string
       x-parameters:
         - name: user
           in: context

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -200,6 +200,11 @@ paths:
     get:
       operationId: st2api.controllers.root:root_controller.index
       description: General API info.
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: General API info.
@@ -277,6 +282,11 @@ paths:
           in: query
           description: Action pack name filter
           type: string
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of actions
@@ -564,6 +574,11 @@ paths:
           in: query
           description: Only return resources belonging to the provided pack
           type: string
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of action aliases.
@@ -1566,6 +1581,11 @@ paths:
           in: query
           description: Entity ref filter
           type: string
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of installed packs.
@@ -1986,6 +2006,11 @@ paths:
           type: array
           items:
             type: string
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: Get packs config schema.
@@ -2063,6 +2088,11 @@ paths:
           type: array
           items:
             type: string
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of policy types
@@ -2131,6 +2161,11 @@ paths:
           description: Number of policies to offset
           type: integer
           default: 0
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: Policy created successfully.
@@ -2472,6 +2507,11 @@ paths:
           in: query
           description: Enabled filter
           type: string
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of rules
@@ -2645,6 +2685,11 @@ paths:
           in: query
           description: Enabled filter
           type: string
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of rules
@@ -2770,6 +2815,11 @@ paths:
           type: array
           items:
             type: string
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of rules
@@ -2890,6 +2940,11 @@ paths:
           in: query
           description: Enabled filter
           type: string
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of rules
@@ -3183,6 +3238,11 @@ paths:
               Only return enforcements with enforced_at lower than the one provided. Use time in the format.
           type: string
           pattern: {{ ISO8601_UTC_REGEX }}
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of rule enforcements
@@ -3337,6 +3397,11 @@ paths:
           description: |
               Sort in descending order by start timestamp, desc/descending (latest first)
           type: string
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of traces
@@ -3415,6 +3480,11 @@ paths:
           in: query
           description: Pack name filter
           type: string
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of trigger types
@@ -3526,6 +3596,11 @@ paths:
     get:
       operationId: st2api.controllers.v1.triggers:trigger_controller.get_all
       description: Returns a list of all triggers.
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of triggers
@@ -3678,6 +3753,11 @@ paths:
           description: Start timestamp greater than filter
           type: string
           pattern: {{ ISO8601_UTC_REGEX }}
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
       responses:
         '200':
           description: List of trigger instances

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -200,11 +200,6 @@ paths:
     get:
       operationId: st2api.controllers.root:root_controller.index
       description: General API info.
-      x-parameters:
-        - name: user
-          in: context
-          x-as: requester_user
-          description: User performing the operation.
       responses:
         '200':
           description: General API info.


### PR DESCRIPTION
This pull request adds some RBAC changes on top off #3761 we have agreed upon.

1. Only allow `limit=-1` (aka retrieve all the results at once) be used by RBAC admins
2. Allow RBAC admins to specify arbitrary large value for `?limit` parameter even if it's larger than `max_page_size` config option (in short, `max_page_size` limit only applies to non-admin users)