### PR TITLE
Update st2tests with python 3 syntax

### DIFF
--- a/st2tests/dist_utils.py
+++ b/st2tests/dist_utils.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import re
 import sys

--- a/st2tests/integration/mistral/base.py
+++ b/st2tests/integration/mistral/base.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import retrying
 import unittest2
 

--- a/st2tests/integration/mistral/test_errors.py
+++ b/st2tests/integration/mistral/test_errors.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from integration.mistral import base
 
 

--- a/st2tests/integration/mistral/test_examples.py
+++ b/st2tests/integration/mistral/test_examples.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import six
 
 from integration.mistral import base

--- a/st2tests/integration/mistral/test_filters.py
+++ b/st2tests/integration/mistral/test_filters.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import json
 import yaml
 

--- a/st2tests/integration/mistral/test_st2kv.py
+++ b/st2tests/integration/mistral/test_st2kv.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from integration.mistral import base
 
 from st2client import models

--- a/st2tests/integration/mistral/test_wiring.py
+++ b/st2tests/integration/mistral/test_wiring.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import shutil
 import tempfile
@@ -20,6 +21,7 @@ import tempfile
 import eventlet
 
 from integration.mistral import base
+from six.moves import range
 
 
 class WiringTest(base.TestWorkflowExecution):
@@ -31,7 +33,7 @@ class WiringTest(base.TestWorkflowExecution):
 
         # Create temporary directory used by the tests
         _, self.temp_dir_path = tempfile.mkstemp()
-        os.chmod(self.temp_dir_path, 0755)   # nosec
+        os.chmod(self.temp_dir_path, 0o755)   # nosec
 
     def tearDown(self):
         if self.temp_dir_path and os.path.exists(self.temp_dir_path):

--- a/st2tests/integration/mistral/test_wiring_cancel.py
+++ b/st2tests/integration/mistral/test_wiring_cancel.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import shutil
 import tempfile
@@ -29,7 +30,7 @@ class CancellationWiringTest(base.TestWorkflowExecution):
 
         # Create temporary directory used by the tests
         _, self.temp_dir_path = tempfile.mkstemp()
-        os.chmod(self.temp_dir_path, 0755)   # nosec
+        os.chmod(self.temp_dir_path, 0o755)   # nosec
 
     def tearDown(self):
         if self.temp_dir_path and os.path.exists(self.temp_dir_path):

--- a/st2tests/integration/mistral/test_wiring_pause_resume.py
+++ b/st2tests/integration/mistral/test_wiring_pause_resume.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import shutil
 import tempfile
@@ -29,7 +30,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution):
 
         # Create temporary directory used by the tests
         _, self.temp_dir_path = tempfile.mkstemp()
-        os.chmod(self.temp_dir_path, 0755)   # nosec
+        os.chmod(self.temp_dir_path, 0o755)   # nosec
 
     def tearDown(self):
         if self.temp_dir_path and os.path.exists(self.temp_dir_path):

--- a/st2tests/integration/mistral/test_wiring_rerun.py
+++ b/st2tests/integration/mistral/test_wiring_rerun.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import shutil
 import tempfile
@@ -29,7 +30,7 @@ class RerunWiringTest(base.TestWorkflowExecution):
 
         # Create temporary directory used by the tests
         _, self.temp_dir_path = tempfile.mkstemp()
-        os.chmod(self.temp_dir_path, 0755)   # nosec
+        os.chmod(self.temp_dir_path, 0o755)   # nosec
 
     def tearDown(self):
         if self.temp_dir_path and os.path.exists(self.temp_dir_path):

--- a/st2tests/setup.py
+++ b/st2tests/setup.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os.path
 
 from setuptools import setup, find_packages

--- a/st2tests/st2tests/__init__.py
+++ b/st2tests/st2tests/__init__.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2tests.base import EventletTestCase
 from st2tests.base import DbTestCase
 from st2tests.base import DbModelTestCase

--- a/st2tests/st2tests/action_aliases.py
+++ b/st2tests/st2tests/action_aliases.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 
 from st2common.content.loader import ContentPackLoader

--- a/st2tests/st2tests/actions.py
+++ b/st2tests/st2tests/actions.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.runners.utils import get_action_class_instance
 from st2tests.mocks.action import MockActionWrapper
 from st2tests.mocks.action import MockActionService

--- a/st2tests/st2tests/api.py
+++ b/st2tests/st2tests/api.py
@@ -17,6 +17,7 @@
 Various base classes and test utility functions for API related tests.
 """
 
+from __future__ import absolute_import
 import webtest
 import mock
 from oslo_config import cfg

--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 try:
     import simplejson as json
 except ImportError:

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from oslo_config import cfg, types
 
 from st2common import log as logging

--- a/st2tests/st2tests/fixtures/history_views/__init__.py
+++ b/st2tests/st2tests/fixtures/history_views/__init__.py
@@ -1,6 +1,8 @@
+from __future__ import absolute_import
 import os
 import yaml
 import glob
+import six
 
 
 PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)))
@@ -10,6 +12,6 @@ ARTIFACTS = {}
 
 for f in FILES:
     f_name = os.path.split(f)[1]
-    name = unicode(os.path.splitext(f_name)[0])
+    name = six.text_type(os.path.splitext(f_name)[0])
     with open(f, 'r') as fd:
         ARTIFACTS[name] = yaml.safe_load(fd)

--- a/st2tests/st2tests/fixtures/localrunner_pack/actions/text_gen.py
+++ b/st2tests/st2tests/fixtures/localrunner_pack/actions/text_gen.py
@@ -1,8 +1,10 @@
 #! /usr/bin/python
 
+from __future__ import absolute_import
 import argparse
 import string
 import random
+from six.moves import range
 
 
 def print_random_chars(chars=1000, selection=string.letters + string.digits):

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_1/actions/my_action.py
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_1/actions/my_action.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from st2common.runners.base_action import Action
 
 

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_2/actions/my_action.py
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_2/actions/my_action.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from st2common.runners.base_action import Action
 
 

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_3/actions/my_action.py
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_3/actions/my_action.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from st2common.runners.base_action import Action
 
 

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_9/actions/invalid_syntax.py
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_9/actions/invalid_syntax.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from invalid import Invalid   # noqa
 
 

--- a/st2tests/st2tests/fixtures/packs/executions/__init__.py
+++ b/st2tests/st2tests/fixtures/packs/executions/__init__.py
@@ -1,7 +1,9 @@
+from __future__ import absolute_import
 import os
 import bson
 import glob
 import yaml
+import six
 
 
 PATH = os.path.dirname(os.path.realpath(__file__))
@@ -11,11 +13,11 @@ ARTIFACTS = {}
 
 for f in FILES:
     f_name = os.path.split(f)[1]
-    name = unicode(os.path.splitext(f_name)[0])
+    name = six.text_type(os.path.splitext(f_name)[0])
     with open(f, 'r') as fd:
         ARTIFACTS[name] = yaml.safe_load(fd)
     if isinstance(ARTIFACTS[name], dict):
-        ARTIFACTS[name][u'id'] = unicode(bson.ObjectId())
+        ARTIFACTS[name][u'id'] = six.text_type(bson.ObjectId())
     elif isinstance(ARTIFACTS[name], list):
         for item in ARTIFACTS[name]:
-            item[u'id'] = unicode(bson.ObjectId())
+            item[u'id'] = six.text_type(bson.ObjectId())

--- a/st2tests/st2tests/fixtures/packs/runners/test_querymodule/query/test_querymodule.py
+++ b/st2tests/st2tests/fixtures/packs/runners/test_querymodule/query/test_querymodule.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from st2common.query.base import Querier
 from st2common.constants.action import LIVEACTION_STATUS_SUCCEEDED
 

--- a/st2tests/st2tests/fixturesloader.py
+++ b/st2tests/st2tests/fixturesloader.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import copy
 import os
 
@@ -351,7 +352,7 @@ class FixturesLoader(object):
         return fixtures_pack_path
 
     def _validate_fixture_dict(self, fixtures_dict, allowed=ALLOWED_FIXTURES):
-        fixture_types = fixtures_dict.keys()
+        fixture_types = list(fixtures_dict.keys())
         for fixture_type in fixture_types:
             if fixture_type not in allowed:
                 raise Exception('Disallowed fixture type: %s' % fixture_type)

--- a/st2tests/st2tests/http.py
+++ b/st2tests/st2tests/http.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import json
 
 

--- a/st2tests/st2tests/mocks/action.py
+++ b/st2tests/st2tests/mocks/action.py
@@ -17,6 +17,7 @@
 Mock classes for use in pack testing.
 """
 
+from __future__ import absolute_import
 from logging import RootLogger
 
 from mock import Mock

--- a/st2tests/st2tests/mocks/datastore.py
+++ b/st2tests/st2tests/mocks/datastore.py
@@ -17,6 +17,7 @@
 Mock classes for use in pack testing.
 """
 
+from __future__ import absolute_import
 from st2common.constants.keyvalue import SYSTEM_SCOPE
 from st2common.services.datastore import BaseDatastoreService
 from st2client.models.keyvalue import KeyValuePair
@@ -79,7 +80,7 @@ class MockDatastoreService(BaseDatastoreService):
         key_prefix = self._get_full_key_prefix(local=local, prefix=prefix)
 
         if not key_prefix:
-            return self._datastore_items.values()
+            return list(self._datastore_items.values())
 
         result = []
         for name, kvp in self._datastore_items.items():

--- a/st2tests/st2tests/mocks/execution.py
+++ b/st2tests/st2tests/mocks/execution.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import eventlet
 import traceback
 

--- a/st2tests/st2tests/mocks/liveaction.py
+++ b/st2tests/st2tests/mocks/liveaction.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import eventlet
 import traceback
 

--- a/st2tests/st2tests/mocks/liveaction.py
+++ b/st2tests/st2tests/mocks/liveaction.py
@@ -84,6 +84,6 @@ class MockLiveActionPublisherNonBlocking(object):
             try:
                 thread.wait()
             except Exception as e:
-                print str(e)
+                print(str(e))
             finally:
                 cls.threads.remove(thread)

--- a/st2tests/st2tests/mocks/runner.py
+++ b/st2tests/st2tests/mocks/runner.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import json
 
 from st2common.runners.base import ActionRunner

--- a/st2tests/st2tests/mocks/sensor.py
+++ b/st2tests/st2tests/mocks/sensor.py
@@ -17,6 +17,7 @@
 Mock classes for use in pack testing.
 """
 
+from __future__ import absolute_import
 from logging import RootLogger
 
 from mock import Mock

--- a/st2tests/st2tests/pack_resource.py
+++ b/st2tests/st2tests/pack_resource.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import inspect
 

--- a/st2tests/st2tests/policies/concurrency.py
+++ b/st2tests/st2tests/policies/concurrency.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.constants import action as action_constants
 from st2common.util import action_db as action_utils
 from st2actions.policies.concurrency import BaseConcurrencyApplicator

--- a/st2tests/st2tests/policies/mock_exception.py
+++ b/st2tests/st2tests/policies/mock_exception.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.policies import base
 
 

--- a/st2tests/st2tests/resources/packs/pythonactions/actions/non_simple_type.py
+++ b/st2tests/st2tests/resources/packs/pythonactions/actions/non_simple_type.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from st2common.runners.base_action import Action
 
 

--- a/st2tests/st2tests/resources/packs/pythonactions/actions/pascal_row.py
+++ b/st2tests/st2tests/resources/packs/pythonactions/actions/pascal_row.py
@@ -1,7 +1,9 @@
+from __future__ import absolute_import
 import math
 
 
 from st2common.runners.base_action import Action
+from six.moves import range
 
 
 class PascalRowAction(Action):

--- a/st2tests/st2tests/resources/packs/pythonactions/actions/python_paths.py
+++ b/st2tests/st2tests/resources/packs/pythonactions/actions/python_paths.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import sys
 

--- a/st2tests/st2tests/resources/packs/pythonactions/actions/test.py
+++ b/st2tests/st2tests/resources/packs/pythonactions/actions/test.py
@@ -1,6 +1,7 @@
 # Python action which uses the same module name as built-in Python module
 # (test)
 
+from __future__ import absolute_import
 from st2common.runners.base_action import Action
 
 

--- a/st2tests/st2tests/sensors.py
+++ b/st2tests/st2tests/sensors.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2tests.mocks.sensor import MockSensorWrapper
 from st2tests.mocks.sensor import MockSensorService
 from st2tests.pack_resource import BasePackResourceTestCase

--- a/st2tests/testpacks/checks/actions/checks/check_loadavg.py
+++ b/st2tests/testpacks/checks/actions/checks/check_loadavg.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from __future__ import absolute_import
 import sys
 
 


### PR DESCRIPTION
Updates

* Absolute import
* Octal literals
* Use `six.text_type` instead of unicode initializer (redirects to str in 3)
* Changes instances of `keys()` and `values()` to lists just incase