### PR TITLE
update st2common with py3 statements

### DIFF
--- a/st2common/bin/migrations/v1.5/st2-migrate-datastore-to-include-scope-secret.py
+++ b/st2common/bin/migrations/v1.5/st2-migrate-datastore-to-include-scope-secret.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import sys
 import traceback as tb
 

--- a/st2common/bin/migrations/v2.1/st2-migrate-datastore-scopes.py
+++ b/st2common/bin/migrations/v2.1/st2-migrate-datastore-scopes.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import sys
 import traceback as tb
 

--- a/st2common/bin/paramiko_ssh_evenlets_tester.py
+++ b/st2common/bin/paramiko_ssh_evenlets_tester.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
 import argparse
 import os
 import pprint

--- a/st2common/dist_utils.py
+++ b/st2common/dist_utils.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import re
 import sys

--- a/st2common/setup.py
+++ b/st2common/setup.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os.path
 
 from setuptools import setup, find_packages

--- a/st2common/st2common/bootstrap/actionsregistrar.py
+++ b/st2common/st2common/bootstrap/actionsregistrar.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import re
 

--- a/st2common/st2common/bootstrap/aliasesregistrar.py
+++ b/st2common/st2common/bootstrap/aliasesregistrar.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import six
 

--- a/st2common/st2common/bootstrap/base.py
+++ b/st2common/st2common/bootstrap/base.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import glob
 
@@ -91,7 +92,7 @@ class ResourceRegistrar(object):
 
         :rype: ``list``
         """
-        return REGISTERED_PACKS_CACHE.keys()
+        return list(REGISTERED_PACKS_CACHE.keys())
 
     def register_packs(self, base_dirs):
         """

--- a/st2common/st2common/bootstrap/configsregistrar.py
+++ b/st2common/st2common/bootstrap/configsregistrar.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 
 from oslo_config import cfg
@@ -56,7 +57,7 @@ class ConfigsRegistrar(ResourceRegistrar):
 
         registered_count = 0
         packs = self._pack_loader.get_packs(base_dirs=base_dirs)
-        pack_names = packs.keys()
+        pack_names = list(packs.keys())
 
         for pack_name in pack_names:
             config_path = self._get_config_path_for_pack(pack_name=pack_name)

--- a/st2common/st2common/bootstrap/policiesregistrar.py
+++ b/st2common/st2common/bootstrap/policiesregistrar.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import glob
 import os
 import six

--- a/st2common/st2common/bootstrap/rulesregistrar.py
+++ b/st2common/st2common/bootstrap/rulesregistrar.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 
 import six

--- a/st2common/st2common/bootstrap/ruletypesregistrar.py
+++ b/st2common/st2common/bootstrap/ruletypesregistrar.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import copy
 
 from st2common import log as logging

--- a/st2common/st2common/bootstrap/runnersregistrar.py
+++ b/st2common/st2common/bootstrap/runnersregistrar.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 import os
 
 import st2common.content.utils as content_utils
@@ -22,6 +23,7 @@ from st2common.persistence.runner import RunnerType
 from st2common.content.loader import RunnersLoader, MetaLoader
 from st2common.constants.runners import MANIFEST_FILE_NAME
 from st2common.util.action_db import get_runnertype_by_name
+import six
 
 __all__ = [
     'register_runner_types',
@@ -43,7 +45,7 @@ def register_runners(runner_dirs=None, experimental=False, fail_on_failure=True)
 
     runners = runner_loader.get_runners(runner_dirs)
 
-    for runner, path in runners.iteritems():
+    for runner, path in six.iteritems(runners):
         LOG.debug('Runner "%s"' % (runner))
         runner_manifest = os.path.join(path, MANIFEST_FILE_NAME)
         meta_loader = MetaLoader()

--- a/st2common/st2common/bootstrap/sensorsregistrar.py
+++ b/st2common/st2common/bootstrap/sensorsregistrar.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 
 import six

--- a/st2common/st2common/bootstrap/triggersregistrar.py
+++ b/st2common/st2common/bootstrap/triggersregistrar.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 
 import six

--- a/st2common/st2common/callback/base.py
+++ b/st2common/st2common/callback/base.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import abc
 import six
 

--- a/st2common/st2common/cmd/apply_rbac_definitions.py
+++ b/st2common/st2common/cmd/apply_rbac_definitions.py
@@ -17,6 +17,7 @@
 A script which applies RBAC definitions and role assignments stored on disk.
 """
 
+from __future__ import absolute_import
 from st2common import config
 from st2common.script_setup import setup as common_setup
 from st2common.script_setup import teardown as common_teardown
@@ -40,9 +41,9 @@ def apply_definitions():
     loader = RBACDefinitionsLoader()
     result = loader.load()
 
-    role_definition_apis = result['roles'].values()
-    role_assignment_apis = result['role_assignments'].values()
-    group_to_role_map_apis = result['group_to_role_maps'].values()
+    role_definition_apis = list(result['roles'].values())
+    role_assignment_apis = list(result['role_assignments'].values())
+    group_to_role_map_apis = list(result['group_to_role_maps'].values())
 
     syncer = RBACDefinitionsDBSyncer()
     result = syncer.sync(role_definition_apis=role_definition_apis,

--- a/st2common/st2common/cmd/generate_api_spec.py
+++ b/st2common/st2common/cmd/generate_api_spec.py
@@ -18,6 +18,7 @@ A script generates final openapi.yaml file based on openapi.yaml.j2 Jinja
 template file.
 """
 
+from __future__ import absolute_import
 from st2common import config
 from st2common import log as logging
 from st2common.util import spec_loader

--- a/st2common/st2common/cmd/purge_executions.py
+++ b/st2common/st2common/cmd/purge_executions.py
@@ -21,6 +21,7 @@ timestamp.
 *** RISK RISK RISK. You will lose data. Run at your own risk. ***
 """
 
+from __future__ import absolute_import
 from datetime import datetime
 import pytz
 

--- a/st2common/st2common/cmd/purge_trigger_instances.py
+++ b/st2common/st2common/cmd/purge_trigger_instances.py
@@ -21,6 +21,7 @@ timestamp.
 *** RISK RISK RISK. You will lose data. Run at your own risk. ***
 """
 
+from __future__ import absolute_import
 from datetime import datetime
 import pytz
 

--- a/st2common/st2common/cmd/validate_api_spec.py
+++ b/st2common/st2common/cmd/validate_api_spec.py
@@ -19,6 +19,7 @@ A script that validates each entry defined in OpenAPI-Spec for st2 APIs
 in st2common/models/api/.
 """
 
+from __future__ import absolute_import
 import os
 
 from oslo_config import cfg
@@ -29,6 +30,7 @@ from st2common import log as logging
 from st2common.util import spec_loader
 from st2common.script_setup import setup as common_setup
 from st2common.script_setup import teardown as common_teardown
+import six
 
 
 __all__ = [
@@ -58,7 +60,7 @@ def _validate_definitions(spec):
     error = False
     verbose = cfg.CONF.verbose
 
-    for (model, definition) in defs.iteritems():
+    for (model, definition) in six.iteritems(defs):
         api_model = definition.get('x-api-model', None)
 
         if not api_model:

--- a/st2common/st2common/cmd/validate_config.py
+++ b/st2common/st2common/cmd/validate_config.py
@@ -17,6 +17,7 @@
 Script for validating a config file against a a particular config schema.
 """
 
+from __future__ import absolute_import
 import os
 import yaml
 

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import socket
 import sys

--- a/st2common/st2common/constants/logging.py
+++ b/st2common/st2common/constants/logging.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 
 __all__ = [

--- a/st2common/st2common/constants/meta.py
+++ b/st2common/st2common/constants/meta.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import yaml
 
 __all__ = [

--- a/st2common/st2common/constants/runners.py
+++ b/st2common/st2common/constants/runners.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from oslo_config import cfg
 
 __all__ = [

--- a/st2common/st2common/constants/system.py
+++ b/st2common/st2common/constants/system.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common import __version__
 
 __all__ = [

--- a/st2common/st2common/constants/triggers.py
+++ b/st2common/st2common/constants/triggers.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.constants.pack import SYSTEM_PACK_NAME
 from st2common.models.system.common import ResourceReference
 
@@ -246,7 +247,7 @@ WEBHOOK_TRIGGER_TYPES = {
         'payload_schema': WEBHOOKS_PAYLOAD_SCHEMA
     }
 }
-WEBHOOK_TRIGGER_TYPE = WEBHOOK_TRIGGER_TYPES.keys()[0]
+WEBHOOK_TRIGGER_TYPE = list(WEBHOOK_TRIGGER_TYPES.keys())[0]
 
 # Timer specs
 
@@ -405,7 +406,7 @@ TIMER_TRIGGER_TYPES = {
     }
 }
 
-SYSTEM_TRIGGER_TYPES = dict(WEBHOOK_TRIGGER_TYPES.items() + TIMER_TRIGGER_TYPES.items())
+SYSTEM_TRIGGER_TYPES = dict(list(WEBHOOK_TRIGGER_TYPES.items()) + list(TIMER_TRIGGER_TYPES.items()))
 
 # various status to record lifecycle of a TriggerInstance
 TRIGGER_INSTANCE_PENDING = 'pending'

--- a/st2common/st2common/constants/types.py
+++ b/st2common/st2common/constants/types.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.util.enum import Enum
 
 __all__ = [

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import sys
 import logging

--- a/st2common/st2common/content/loader.py
+++ b/st2common/st2common/content/loader.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import re
 

--- a/st2common/st2common/content/utils.py
+++ b/st2common/st2common/content/utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import os.path
 

--- a/st2common/st2common/content/validators.py
+++ b/st2common/st2common/content/validators.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 from pkg_resources import get_distribution
 

--- a/st2common/st2common/database_setup.py
+++ b/st2common/st2common/database_setup.py
@@ -17,6 +17,7 @@
 Module contain database set up and teardown related functionality.
 """
 
+from __future__ import absolute_import
 from oslo_config import cfg
 
 from st2common.models import db

--- a/st2common/st2common/exceptions/action.py
+++ b/st2common/st2common/exceptions/action.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.exceptions import StackStormBaseException
 
 __all__ = [

--- a/st2common/st2common/exceptions/actionalias.py
+++ b/st2common/st2common/exceptions/actionalias.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.exceptions import StackStormBaseException
 
 __all__ = [

--- a/st2common/st2common/exceptions/actionrunner.py
+++ b/st2common/st2common/exceptions/actionrunner.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.exceptions import StackStormPluginException
 
 

--- a/st2common/st2common/exceptions/api.py
+++ b/st2common/st2common/exceptions/api.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.exceptions import StackStormBaseException
 
 __all__ = [

--- a/st2common/st2common/exceptions/apivalidation.py
+++ b/st2common/st2common/exceptions/apivalidation.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.exceptions import StackStormBaseException
 
 

--- a/st2common/st2common/exceptions/auth.py
+++ b/st2common/st2common/exceptions/auth.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.exceptions import StackStormBaseException
 from st2common.exceptions.db import StackStormDBObjectNotFoundError
 

--- a/st2common/st2common/exceptions/content.py
+++ b/st2common/st2common/exceptions/content.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.exceptions import StackStormBaseException
 
 

--- a/st2common/st2common/exceptions/db.py
+++ b/st2common/st2common/exceptions/db.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.exceptions import StackStormBaseException
 
 

--- a/st2common/st2common/exceptions/keyvalue.py
+++ b/st2common/st2common/exceptions/keyvalue.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.exceptions import StackStormBaseException
 
 __all__ = [

--- a/st2common/st2common/exceptions/param.py
+++ b/st2common/st2common/exceptions/param.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.exceptions import StackStormBaseException
 
 

--- a/st2common/st2common/exceptions/plugins.py
+++ b/st2common/st2common/exceptions/plugins.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.exceptions import StackStormPluginException
 
 

--- a/st2common/st2common/exceptions/rbac.py
+++ b/st2common/st2common/exceptions/rbac.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.exceptions import StackStormBaseException
 from st2common.rbac.types import GLOBAL_PERMISSION_TYPES
 

--- a/st2common/st2common/exceptions/resultstracker.py
+++ b/st2common/st2common/exceptions/resultstracker.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.exceptions import StackStormBaseException
 
 

--- a/st2common/st2common/exceptions/sensors.py
+++ b/st2common/st2common/exceptions/sensors.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.exceptions import StackStormBaseException
 from st2common.exceptions import StackStormPluginException
 

--- a/st2common/st2common/exceptions/trace.py
+++ b/st2common/st2common/exceptions/trace.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.exceptions import StackStormBaseException
 from st2common.exceptions.db import StackStormDBObjectNotFoundError
 

--- a/st2common/st2common/exceptions/triggers.py
+++ b/st2common/st2common/exceptions/triggers.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.exceptions import StackStormBaseException
 
 

--- a/st2common/st2common/exceptions/workflow.py
+++ b/st2common/st2common/exceptions/workflow.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.exceptions import StackStormBaseException
 
 

--- a/st2common/st2common/fields.py
+++ b/st2common/st2common/fields.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import datetime
 import calendar
 

--- a/st2common/st2common/garbage_collection/executions.py
+++ b/st2common/st2common/garbage_collection/executions.py
@@ -18,6 +18,7 @@ Module with utility functions for purging old action executions and
 corresponding live action objects.
 """
 
+from __future__ import absolute_import
 import copy
 
 from mongoengine.errors import InvalidQueryError

--- a/st2common/st2common/garbage_collection/inquiries.py
+++ b/st2common/st2common/garbage_collection/inquiries.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from oslo_config import cfg
 
 from st2common.constants import action as action_constants

--- a/st2common/st2common/garbage_collection/trigger_instances.py
+++ b/st2common/st2common/garbage_collection/trigger_instances.py
@@ -17,6 +17,7 @@
 Module with utility functions for purging old trigger instance objects.
 """
 
+from __future__ import absolute_import
 from mongoengine.errors import InvalidQueryError
 
 from st2common.persistence.trigger import TriggerInstance

--- a/st2common/st2common/jinja/filters/complex_type.py
+++ b/st2common/st2common/jinja/filters/complex_type.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import json
 
 __all__ = [

--- a/st2common/st2common/jinja/filters/crypto.py
+++ b/st2common/st2common/jinja/filters/crypto.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from oslo_config import cfg
 
 from st2common.services.keyvalues import KeyValueLookup

--- a/st2common/st2common/jinja/filters/data.py
+++ b/st2common/st2common/jinja/filters/data.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import json
 import yaml
 

--- a/st2common/st2common/jinja/filters/json_escape.py
+++ b/st2common/st2common/jinja/filters/json_escape.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import json
 
 __all__ = [

--- a/st2common/st2common/jinja/filters/jsonpath_query.py
+++ b/st2common/st2common/jinja/filters/jsonpath_query.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import jsonpath_rw
 
 __all__ = [

--- a/st2common/st2common/jinja/filters/regex.py
+++ b/st2common/st2common/jinja/filters/regex.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import re
 import six
 

--- a/st2common/st2common/jinja/filters/time.py
+++ b/st2common/st2common/jinja/filters/time.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import datetime
 
 __all__ = [
@@ -30,7 +31,7 @@ def to_human_time_from_seconds(seconds):
 
     :rtype: ``str``
     """
-    assert (isinstance(seconds, int) or isinstance(seconds, long) or
+    assert (isinstance(seconds, int) or isinstance(seconds, int) or
             isinstance(seconds, float))
 
     return _get_human_time(seconds)
@@ -56,7 +57,7 @@ def _get_human_time(seconds):
         return '%s\u03BCs' % seconds  # Microseconds
 
     if isinstance(seconds, float):
-        seconds = long(round(seconds))  # Let's lose microseconds.
+        seconds = int(round(seconds))  # Let's lose microseconds.
 
     timedelta = datetime.timedelta(seconds=seconds)
     offset_date = datetime.datetime(1, 1, 1) + timedelta

--- a/st2common/st2common/jinja/filters/version.py
+++ b/st2common/st2common/jinja/filters/version.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import semver
 
 __all__ = [

--- a/st2common/st2common/logging/filters.py
+++ b/st2common/st2common/logging/filters.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import logging
 
 __all__ = [

--- a/st2common/st2common/logging/handlers.py
+++ b/st2common/st2common/logging/handlers.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import socket
 import time

--- a/st2common/st2common/logging/misc.py
+++ b/st2common/st2common/logging/misc.py
@@ -92,7 +92,7 @@ def set_log_level_for_all_loggers(level=logging.DEBUG):
     Set a log level for all the loggers and handlers to the provided level.
     """
     root_logger = logging.getLogger()
-    loggers = logging.Logger.manager.loggerDict.values()
+    loggers = list(logging.Logger.manager.loggerDict.values())
     loggers += [root_logger]
 
     for logger in loggers:

--- a/st2common/st2common/middleware/cors.py
+++ b/st2common/st2common/middleware/cors.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from oslo_config import cfg
 from webob.headers import ResponseHeaders
 

--- a/st2common/st2common/middleware/error_handling.py
+++ b/st2common/st2common/middleware/error_handling.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import traceback
 
 from mongoengine import ValidationError

--- a/st2common/st2common/middleware/logging.py
+++ b/st2common/st2common/middleware/logging.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import time
 import types
 import itertools

--- a/st2common/st2common/middleware/request_id.py
+++ b/st2common/st2common/middleware/request_id.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import uuid
 
 from webob.headers import ResponseHeaders

--- a/st2common/st2common/middleware/streaming.py
+++ b/st2common/st2common/middleware/streaming.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import fnmatch
 
 __all__ = [

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import copy
 
 from st2common.util import isotime

--- a/st2common/st2common/models/api/actionrunner.py
+++ b/st2common/st2common/models/api/actionrunner.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common import log as logging
 from st2common.models.api.base import BaseAPI
 

--- a/st2common/st2common/models/api/auth.py
+++ b/st2common/st2common/models/api/auth.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import six
 
 from oslo_config import cfg

--- a/st2common/st2common/models/api/base.py
+++ b/st2common/st2common/models/api/base.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import abc
 
 import six

--- a/st2common/st2common/models/api/execution.py
+++ b/st2common/st2common/models/api/execution.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import copy
 
 import six

--- a/st2common/st2common/models/api/inquiry.py
+++ b/st2common/st2common/models/api/inquiry.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import copy
 import six
 

--- a/st2common/st2common/models/api/keyvalue.py
+++ b/st2common/st2common/models/api/keyvalue.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import copy
 import datetime

--- a/st2common/st2common/models/api/notification.py
+++ b/st2common/st2common/models/api/notification.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.models.db.notification import NotificationSchema, NotificationSubSchema
 
 NotificationSubSchemaAPI = {

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 
 import jsonschema

--- a/st2common/st2common/models/api/policy.py
+++ b/st2common/st2common/models/api/policy.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.persistence.policy import PolicyType
 from st2common.models.api.base import BaseAPI
 from st2common.models.api.base import APIUIDMixin

--- a/st2common/st2common/models/api/rbac.py
+++ b/st2common/st2common/models/api/rbac.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.models.api.base import BaseAPI
 from st2common.models.db.rbac import RoleDB
 from st2common.models.db.rbac import UserRoleAssignmentDB

--- a/st2common/st2common/models/api/rule.py
+++ b/st2common/st2common/models/api/rule.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import copy
 
 import six

--- a/st2common/st2common/models/api/rule_enforcement.py
+++ b/st2common/st2common/models/api/rule_enforcement.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import six
 
 from st2common.models.api.base import BaseAPI

--- a/st2common/st2common/models/api/sensor.py
+++ b/st2common/st2common/models/api/sensor.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.models.api.base import BaseAPI
 from st2common.models.db.sensor import SensorTypeDB
 from st2common.models.utils import sensor_type_utils

--- a/st2common/st2common/models/api/tag.py
+++ b/st2common/st2common/models/api/tag.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.models.db.stormbase import TagField
 
 __all__ = [

--- a/st2common/st2common/models/api/trace.py
+++ b/st2common/st2common/models/api/trace.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.util import isotime
 from st2common.models.api.base import BaseAPI
 from st2common.models.api.base import APIUIDMixin

--- a/st2common/st2common/models/api/trigger.py
+++ b/st2common/st2common/models/api/trigger.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import uuid
 
 from st2common.constants.triggers import TRIGGER_INSTANCE_STATUSES

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import copy
 import importlib
 import traceback
@@ -217,7 +218,7 @@ def drop_obsolete_types_indexes(model_class):
     collection.update({}, {'$unset': {'_types': 1}}, multi=True)
 
     info = collection.index_information()
-    indexes_to_drop = [key for key, value in info.iteritems()
+    indexes_to_drop = [key for key, value in six.iteritems(info)
                        if '_types' in dict(value['key']) or 'types' in value]
 
     LOG.debug('Will drop obsolete types indexes for model "%s": %s' % (class_name,
@@ -405,7 +406,7 @@ class MongoDBAccess(object):
         return count
 
     def _undo_dict_field_escape(self, instance):
-        for attr, field in instance._fields.iteritems():
+        for attr, field in six.iteritems(instance._fields):
             if isinstance(field, stormbase.EscapedDictField):
                 value = getattr(instance, attr)
                 setattr(instance, attr, field.to_python(value))
@@ -444,7 +445,7 @@ class MongoDBAccess(object):
         result = copy.deepcopy(filters)
 
         null_filters = {k: v for k, v in six.iteritems(filters)
-                        if v is None or (type(v) in [str, unicode] and str(v.lower()) == 'null')}
+                        if v is None or (type(v) in [str, six.text_type] and str(v.lower()) == 'null')}
 
         for key in null_filters.keys():
             result['%s__exists' % (key)] = False
@@ -453,11 +454,11 @@ class MongoDBAccess(object):
         return result
 
     def _process_datetime_range_filters(self, filters, order_by=None):
-        ranges = {k: v for k, v in filters.iteritems()
-                  if type(v) in [str, unicode] and '..' in v}
+        ranges = {k: v for k, v in six.iteritems(filters)
+                  if type(v) in [str, six.text_type] and '..' in v}
 
         order_by_list = copy.deepcopy(order_by) if order_by else []
-        for k, v in ranges.iteritems():
+        for k, v in six.iteritems(ranges):
             values = v.split('..')
             dt1 = isotime.parse(values[0])
             dt2 = isotime.parse(values[1])

--- a/st2common/st2common/models/db/action.py
+++ b/st2common/st2common/models/db/action.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import mongoengine as me
 
 from st2common import log as logging

--- a/st2common/st2common/models/db/actionalias.py
+++ b/st2common/st2common/models/db/actionalias.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import mongoengine as me
 
 from st2common import log as logging

--- a/st2common/st2common/models/db/auth.py
+++ b/st2common/st2common/models/db/auth.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import copy
 import mongoengine as me
 

--- a/st2common/st2common/models/db/execution.py
+++ b/st2common/st2common/models/db/execution.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import copy
 
 import mongoengine as me

--- a/st2common/st2common/models/db/executionstate.py
+++ b/st2common/st2common/models/db/executionstate.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import mongoengine as me
 
 from st2common import log as logging

--- a/st2common/st2common/models/db/keyvalue.py
+++ b/st2common/st2common/models/db/keyvalue.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import mongoengine as me
 
 from st2common.constants.keyvalue import FULL_SYSTEM_SCOPE

--- a/st2common/st2common/models/db/liveaction.py
+++ b/st2common/st2common/models/db/liveaction.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import copy
 
 import mongoengine as me

--- a/st2common/st2common/models/db/marker.py
+++ b/st2common/st2common/models/db/marker.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import mongoengine as me
 
 from st2common.fields import ComplexDateTimeField

--- a/st2common/st2common/models/db/notification.py
+++ b/st2common/st2common/models/db/notification.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import mongoengine as me
 
 from st2common.models.db import stormbase

--- a/st2common/st2common/models/db/pack.py
+++ b/st2common/st2common/models/db/pack.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import copy
 import mongoengine as me
 

--- a/st2common/st2common/models/db/policy.py
+++ b/st2common/st2common/models/db/policy.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import mongoengine as me
 
 from st2common import log as logging

--- a/st2common/st2common/models/db/rbac.py
+++ b/st2common/st2common/models/db/rbac.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import mongoengine as me
 
 from st2common.models.db import MongoDBAccess

--- a/st2common/st2common/models/db/reactor.py
+++ b/st2common/st2common/models/db/reactor.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.models.db.rule import (ActionExecutionSpecDB, RuleDB)
 from st2common.models.db.sensor import SensorTypeDB
 from st2common.models.db.trigger import (TriggerDB, TriggerTypeDB, TriggerInstanceDB)

--- a/st2common/st2common/models/db/rule.py
+++ b/st2common/st2common/models/db/rule.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import mongoengine as me
 
 from st2common.models.db import MongoDBAccess

--- a/st2common/st2common/models/db/rule_enforcement.py
+++ b/st2common/st2common/models/db/rule_enforcement.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import mongoengine as me
 
 from st2common.fields import ComplexDateTimeField

--- a/st2common/st2common/models/db/runner.py
+++ b/st2common/st2common/models/db/runner.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import mongoengine as me
 
 from st2common import log as logging

--- a/st2common/st2common/models/db/sensor.py
+++ b/st2common/st2common/models/db/sensor.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import mongoengine as me
 
 from st2common.models.db import MongoDBAccess

--- a/st2common/st2common/models/db/stormbase.py
+++ b/st2common/st2common/models/db/stormbase.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import abc
 import datetime
 
@@ -68,7 +69,7 @@ class StormFoundationDB(me.Document, DictSerializableClassMixin):
         attrs = list()
         for k in sorted(self._fields.keys()):
             v = getattr(self, k)
-            v = '"%s"' % str(v) if type(v) in [str, unicode, datetime.datetime] else str(v)
+            v = '"%s"' % str(v) if type(v) in [str, six.text_type, datetime.datetime] else str(v)
             attrs.append('%s=%s' % (k, v))
         return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
 

--- a/st2common/st2common/models/db/timer.py
+++ b/st2common/st2common/models/db/timer.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import mongoengine as me
 
 from st2common.models.db import stormbase

--- a/st2common/st2common/models/db/trace.py
+++ b/st2common/st2common/models/db/trace.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import hashlib
 
 import mongoengine as me

--- a/st2common/st2common/models/db/trigger.py
+++ b/st2common/st2common/models/db/trigger.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import json
 import hashlib
 

--- a/st2common/st2common/models/db/webhook.py
+++ b/st2common/st2common/models/db/webhook.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import mongoengine as me
 
 from st2common.models.db import stormbase

--- a/st2common/st2common/models/system/action.py
+++ b/st2common/st2common/models/system/action.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 # pylint: disable=not-context-manager
 
+from __future__ import absolute_import
 import os
 import pwd
 import six
@@ -159,7 +160,7 @@ class ShellCommandAction(object):
             # injection attacks. Always quote the key and the value.
             exports = ' '.join(
                 '%s=%s' % (quote_unix(k), quote_unix(v))
-                for k, v in env_vars.iteritems()
+                for k, v in six.iteritems(env_vars)
             )
             shell_env_str = '%s %s' % (ShellCommandAction.EXPORT_CMD, exports)
         else:
@@ -269,7 +270,7 @@ class ShellScriptAction(ShellCommandAction):
         # add all named_args in the format <kwarg_op>name=value (e.g. --name=value)
         if named_args is not None:
             for (arg, value) in six.iteritems(named_args):
-                if value is None or (isinstance(value, (str, unicode)) and len(value) < 1):
+                if value is None or (isinstance(value, (str, six.text_type)) and len(value) < 1):
                     LOG.debug('Ignoring arg %s as its value is %s.', arg, value)
                     continue
 

--- a/st2common/st2common/models/system/actionchain.py
+++ b/st2common/st2common/models/system/actionchain.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import six
 import string
 

--- a/st2common/st2common/models/system/keyvalue.py
+++ b/st2common/st2common/models/system/keyvalue.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.constants.keyvalue import USER_SEPARATOR
 
 __all__ = [

--- a/st2common/st2common/models/system/paramiko_command_action.py
+++ b/st2common/st2common/models/system/paramiko_command_action.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import pwd
 

--- a/st2common/st2common/models/system/paramiko_script_action.py
+++ b/st2common/st2common/models/system/paramiko_script_action.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common import log as logging
 from st2common.models.system.action import RemoteScriptAction
 from st2common.models.system.action import SUDO_COMMON_OPTIONS

--- a/st2common/st2common/models/utils/action_alias_utils.py
+++ b/st2common/st2common/models/utils/action_alias_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import re
 import sys
 from sre_parse import (

--- a/st2common/st2common/models/utils/action_param_utils.py
+++ b/st2common/st2common/models/utils/action_param_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import copy
 import six
 
@@ -24,8 +25,8 @@ LOG = logging.getLogger(__name__)
 
 
 def _merge_param_meta_values(action_meta=None, runner_meta=None):
-    runner_meta_keys = runner_meta.keys() if runner_meta else []
-    action_meta_keys = action_meta.keys() if action_meta else []
+    runner_meta_keys = list(runner_meta.keys()) if runner_meta else []
+    action_meta_keys = list(action_meta.keys()) if action_meta else []
     all_keys = set(runner_meta_keys).union(set(action_meta_keys))
 
     merged_meta = {}

--- a/st2common/st2common/models/utils/profiling.py
+++ b/st2common/st2common/models/utils/profiling.py
@@ -17,6 +17,7 @@
 Module containing MongoDB profiling related functionality.
 """
 
+from __future__ import absolute_import
 from mongoengine.queryset import QuerySet
 
 from st2common import log as logging

--- a/st2common/st2common/models/utils/sensor_type_utils.py
+++ b/st2common/st2common/models/utils/sensor_type_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 
 from st2common.constants.pack import SYSTEM_PACK_NAME

--- a/st2common/st2common/operators.py
+++ b/st2common/st2common/operators.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import re
 import six
 import fnmatch

--- a/st2common/st2common/persistence/action.py
+++ b/st2common/st2common/persistence/action.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.models.db.action import action_access
 from st2common.persistence import base as persistence
 from st2common.persistence.actionalias import ActionAlias

--- a/st2common/st2common/persistence/actionalias.py
+++ b/st2common/st2common/persistence/actionalias.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.models.db.actionalias import actionalias_access
 from st2common.persistence import base as persistence
 

--- a/st2common/st2common/persistence/auth.py
+++ b/st2common/st2common/persistence/auth.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.exceptions.auth import (TokenNotFoundError, ApiKeyNotFoundError,
                                        UserNotFoundError, AmbiguousUserError,
                                        NoNicknameOriginProvidedError)

--- a/st2common/st2common/persistence/base.py
+++ b/st2common/st2common/persistence/base.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import abc
 
 import six

--- a/st2common/st2common/persistence/cleanup.py
+++ b/st2common/st2common/persistence/cleanup.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import sys
 
 from st2common import config

--- a/st2common/st2common/persistence/db_init.py
+++ b/st2common/st2common/persistence/db_init.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import mongoengine
 
 from oslo_config import cfg

--- a/st2common/st2common/persistence/execution.py
+++ b/st2common/st2common/persistence/execution.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common import transport
 from st2common.models.db import MongoDBAccess
 from st2common.models.db.execution import ActionExecutionDB

--- a/st2common/st2common/persistence/executionstate.py
+++ b/st2common/st2common/persistence/executionstate.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common import transport
 from st2common.models.db.executionstate import actionexecstate_access
 from st2common.persistence import base as persistence

--- a/st2common/st2common/persistence/keyvalue.py
+++ b/st2common/st2common/persistence/keyvalue.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common import log as logging
 from st2common.constants.triggers import KEY_VALUE_PAIR_CREATE_TRIGGER
 from st2common.constants.triggers import KEY_VALUE_PAIR_UPDATE_TRIGGER

--- a/st2common/st2common/persistence/liveaction.py
+++ b/st2common/st2common/persistence/liveaction.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common import transport
 from st2common.models.db.liveaction import liveaction_access
 from st2common.persistence import base as persistence

--- a/st2common/st2common/persistence/marker.py
+++ b/st2common/st2common/persistence/marker.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.models.db import MongoDBAccess
 from st2common.models.db.marker import MarkerDB
 from st2common.models.db.marker import DumperMarkerDB

--- a/st2common/st2common/persistence/pack.py
+++ b/st2common/st2common/persistence/pack.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.persistence import base
 from st2common.models.db.pack import pack_access
 from st2common.models.db.pack import config_schema_access

--- a/st2common/st2common/persistence/policy.py
+++ b/st2common/st2common/persistence/policy.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.models.db import MongoDBAccess
 from st2common.models.db.policy import PolicyTypeReference, PolicyTypeDB, PolicyDB
 from st2common.persistence.base import Access, ContentPackResource

--- a/st2common/st2common/persistence/rbac.py
+++ b/st2common/st2common/persistence/rbac.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.persistence import base
 from st2common.models.db.rbac import role_access
 from st2common.models.db.rbac import user_role_assignment_access

--- a/st2common/st2common/persistence/reactor.py
+++ b/st2common/st2common/persistence/reactor.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.persistence.rule import Rule
 from st2common.persistence.sensor import SensorType
 from st2common.persistence.trigger import (Trigger, TriggerInstance, TriggerType)

--- a/st2common/st2common/persistence/rule.py
+++ b/st2common/st2common/persistence/rule.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.models.db.rule import rule_access, rule_type_access
 from st2common.persistence.base import Access, ContentPackResource
 

--- a/st2common/st2common/persistence/rule_enforcement.py
+++ b/st2common/st2common/persistence/rule_enforcement.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.models.db.rule_enforcement import rule_enforcement_access
 from st2common.persistence.base import Access
 

--- a/st2common/st2common/persistence/runner.py
+++ b/st2common/st2common/persistence/runner.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.persistence import base as persistence
 from st2common.models.db.runner import runnertype_access
 

--- a/st2common/st2common/persistence/sensor.py
+++ b/st2common/st2common/persistence/sensor.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common import transport
 from st2common.models.db.sensor import sensor_type_access
 from st2common.persistence.base import ContentPackResource

--- a/st2common/st2common/persistence/trace.py
+++ b/st2common/st2common/persistence/trace.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.models.db.trace import trace_access
 from st2common.persistence.base import Access
 

--- a/st2common/st2common/persistence/trigger.py
+++ b/st2common/st2common/persistence/trigger.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common import log as logging
 from st2common import transport
 from st2common.exceptions.db import StackStormDBObjectNotFoundError

--- a/st2common/st2common/policies/__init__.py
+++ b/st2common/st2common/policies/__init__.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.policies.base import get_driver
 from st2common.policies.base import ResourcePolicyApplicator
 

--- a/st2common/st2common/policies/base.py
+++ b/st2common/st2common/policies/base.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import abc
 import importlib
 import inspect

--- a/st2common/st2common/policies/concurrency.py
+++ b/st2common/st2common/policies/concurrency.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.constants import action as action_constants
 from st2common.policies import base
 from st2common.services import coordination

--- a/st2common/st2common/query/base.py
+++ b/st2common/st2common/query/base.py
@@ -13,9 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import abc
 import eventlet
-import Queue
+import six.moves.queue
 import six
 import time
 
@@ -59,7 +60,7 @@ class Querier(object):
         self._no_workers_sleep_time = self._get_config_value('no_workers_sleep_time')
         self._query_interval = self._get_config_value('query_interval')
         self._query_thread_pool_size = self._get_config_value('thread_pool_size')
-        self._query_contexts = Queue.Queue()
+        self._query_contexts = six.moves.queue.Queue()
         self._thread_pool = eventlet.GreenPool(self._query_thread_pool_size)
         self._started = False
 

--- a/st2common/st2common/rbac/loader.py
+++ b/st2common/st2common/rbac/loader.py
@@ -17,6 +17,7 @@
 Module for loading RBAC role definitions and grants from the filesystem.
 """
 
+from __future__ import absolute_import
 import os
 import glob
 

--- a/st2common/st2common/rbac/migrations.py
+++ b/st2common/st2common/rbac/migrations.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from mongoengine import NotUniqueError
 
 from st2common.rbac.types import SystemRole

--- a/st2common/st2common/rbac/resolvers.py
+++ b/st2common/st2common/rbac/resolvers.py
@@ -18,6 +18,7 @@ Module containing resolver classes which contain permission resolving logic for 
 types.
 """
 
+from __future__ import absolute_import
 import sys
 import logging as stdlib_logging
 

--- a/st2common/st2common/rbac/syncer.py
+++ b/st2common/st2common/rbac/syncer.py
@@ -16,6 +16,7 @@
 """
 Module for syncing RBAC definitions in the database with the ones from the filesystem.
 """
+from __future__ import absolute_import
 import itertools
 
 from collections import defaultdict
@@ -214,9 +215,9 @@ class RBACDefinitionsDBSyncer(object):
         # and ones which are in the database). We want to make sure assignments are correctly
         # deleted from the database for users which existing in the database, but have no
         # assignment file on disk and for assignments for users which don't exist in the database.
-        all_usernames = (username_to_user_db_map.keys() +
-                         username_to_role_assignment_apis_map.keys() +
-                         username_to_role_assignment_dbs_map.keys())
+        all_usernames = (list(username_to_user_db_map.keys()) +
+                         list(username_to_role_assignment_apis_map.keys()) +
+                         list(username_to_role_assignment_dbs_map.keys()))
         all_usernames = list(set(all_usernames))
 
         results = {}
@@ -290,7 +291,7 @@ class RBACDefinitionsDBSyncer(object):
         db_roles = set([(entry.role, entry.source) for entry in role_assignment_dbs])
 
         api_roles = [
-            list(itertools.izip_longest(entry.roles, [], fillvalue=entry.file_path))
+            list(itertools.zip_longest(entry.roles, [], fillvalue=entry.file_path))
             for entry in role_assignment_apis
         ]
 

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import six
 import itertools
 
@@ -417,7 +418,7 @@ RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP = {
     ]
 }
 
-ALL_PERMISSION_TYPES = RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP.values()
+ALL_PERMISSION_TYPES = list(RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP.values())
 ALL_PERMISSION_TYPES = list(itertools.chain(*ALL_PERMISSION_TYPES))
 LIST_PERMISSION_TYPES = [permission_type for permission_type in ALL_PERMISSION_TYPES if
                          permission_type.endswith('_list')]

--- a/st2common/st2common/rbac/utils.py
+++ b/st2common/st2common/rbac/utils.py
@@ -17,6 +17,7 @@
 RBAC related utility functions.
 """
 
+from __future__ import absolute_import
 import six
 
 from oslo_config import cfg

--- a/st2common/st2common/router.py
+++ b/st2common/st2common/router.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import copy
 import functools
 import re

--- a/st2common/st2common/runners/__init__.py
+++ b/st2common/st2common/runners/__init__.py
@@ -15,6 +15,7 @@
 
 # Note: Imports are in-line to avoid large import time overhead
 
+from __future__ import absolute_import
 __all__ = [
     'BACKENDS_NAMESPACE',
 

--- a/st2common/st2common/runners/base.py
+++ b/st2common/st2common/runners/base.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import abc
 
 import six

--- a/st2common/st2common/runners/base_action.py
+++ b/st2common/st2common/runners/base_action.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import abc
 
 import six

--- a/st2common/st2common/runners/parallel_ssh.py
+++ b/st2common/st2common/runners/parallel_ssh.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import json
 import re
 import os

--- a/st2common/st2common/runners/paramiko_ssh.py
+++ b/st2common/st2common/runners/paramiko_ssh.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import posixpath
 from StringIO import StringIO
@@ -32,6 +33,7 @@ from st2common.log import logging
 from st2common.util.misc import strip_shell_chars
 from st2common.util.shell import quote_unix
 from st2common.constants.runners import DEFAULT_SSH_PORT, REMOTE_RUNNER_PRIVATE_KEY_HEADER
+import six
 
 __all__ = [
     'ParamikoSSHClient',
@@ -182,13 +184,13 @@ class ParamikoSSHClient(object):
                 local_mode = os.stat(local_path).st_mode
 
             # Cast to octal integer in case of string
-            if isinstance(local_mode, basestring):
+            if isinstance(local_mode, six.string_types):
                 local_mode = int(local_mode, 8)
-            local_mode = local_mode & 07777
+            local_mode = local_mode & 0o7777
             remote_mode = rattrs.st_mode
             # Only bitshift if we actually got an remote_mode
             if remote_mode is not None:
-                remote_mode = (remote_mode & 07777)
+                remote_mode = (remote_mode & 0o7777)
             if local_mode != remote_mode:
                 self.sftp.chmod(remote_path, local_mode)
 

--- a/st2common/st2common/runners/paramiko_ssh_runner.py
+++ b/st2common/st2common/runners/paramiko_ssh_runner.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from oslo_config import cfg
 import six
 

--- a/st2common/st2common/runners/python_action_wrapper.py
+++ b/st2common/st2common/runners/python_action_wrapper.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import sys
 

--- a/st2common/st2common/runners/utils.py
+++ b/st2common/st2common/runners/utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import logging as stdlib_logging
 
 from oslo_config import cfg

--- a/st2common/st2common/runners/windows_runner.py
+++ b/st2common/st2common/runners/windows_runner.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import abc
 from distutils.spawn import find_executable
 

--- a/st2common/st2common/services/access.py
+++ b/st2common/st2common/services/access.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import uuid
 import datetime
 

--- a/st2common/st2common/services/action.py
+++ b/st2common/st2common/services/action.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import six
 
 from st2common import log as logging

--- a/st2common/st2common/services/config.py
+++ b/st2common/st2common/services/config.py
@@ -17,6 +17,7 @@
 Service functions for managing pack configuration inside the datastore.
 """
 
+from __future__ import absolute_import
 from st2common import log as logging
 from st2common.services.keyvalues import get_key_reference
 from st2common.constants.keyvalue import FULL_USER_SCOPE

--- a/st2common/st2common/services/coordination.py
+++ b/st2common/st2common/services/coordination.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from oslo_config import cfg
 from tooz import coordination
 from tooz import locking

--- a/st2common/st2common/services/datastore.py
+++ b/st2common/st2common/services/datastore.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from datetime import timedelta
 
 from oslo_config import cfg

--- a/st2common/st2common/services/executions.py
+++ b/st2common/st2common/services/executions.py
@@ -28,6 +28,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from oslo_config import cfg
 import six
 
@@ -45,6 +46,7 @@ from st2common.models.api.rule import RuleAPI
 from st2common.models.api.trigger import TriggerTypeAPI, TriggerAPI, TriggerInstanceAPI
 from st2common.models.db.execution import ActionExecutionDB
 from st2common.runners import utils as runners_utils
+from six.moves import range
 
 
 __all__ = [

--- a/st2common/st2common/services/keyvalues.py
+++ b/st2common/st2common/services/keyvalues.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common import log as logging
 
 from st2common.constants.keyvalue import SYSTEM_SCOPE, FULL_SYSTEM_SCOPE

--- a/st2common/st2common/services/packs.py
+++ b/st2common/st2common/services/packs.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import itertools
 import json
 
@@ -23,6 +24,7 @@ from oslo_config import cfg
 from st2common import log as logging
 from st2common.persistence.pack import Pack
 from st2common.util.misc import lowercase_value
+from six.moves import range
 
 __all__ = [
     'get_pack_by_ref',

--- a/st2common/st2common/services/rbac.py
+++ b/st2common/st2common/services/rbac.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from mongoengine.queryset.visitor import Q
 
 from st2common.rbac.types import PermissionType

--- a/st2common/st2common/services/rules.py
+++ b/st2common/st2common/services/rules.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import six
 
 from st2common import log as logging

--- a/st2common/st2common/services/sensor_watcher.py
+++ b/st2common/st2common/services/sensor_watcher.py
@@ -17,6 +17,7 @@
 # XXX: This file has a lot of duplication with TriggerWatcher.
 # XXX: Refactor.
 
+from __future__ import absolute_import
 import eventlet
 from kombu.mixins import ConsumerMixin
 from kombu import Connection

--- a/st2common/st2common/services/trace.py
+++ b/st2common/st2common/services/trace.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 from mongoengine import ValidationError
 
 from st2common import log as logging
@@ -375,7 +375,7 @@ def _to_trace_component_db(component):
     :rtype: ``TraceComponentDB``
     """
     if not isinstance(component, (six.string_types, dict)):
-        print type(component)
+        print(type(component))
         raise ValueError('Expected component to be str or dict')
 
     object_id = component if isinstance(component, six.string_types) else component['id']

--- a/st2common/st2common/services/trace.py
+++ b/st2common/st2common/services/trace.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from mongoengine import ValidationError
 
 from st2common import log as logging
@@ -26,6 +27,7 @@ from st2common.models.system.common import ResourceReference
 from st2common.persistence.execution import ActionExecution
 from st2common.persistence.trace import Trace
 from st2common.services import executions
+import six
 
 LOG = logging.getLogger(__name__)
 
@@ -372,11 +374,11 @@ def _to_trace_component_db(component):
 
     :rtype: ``TraceComponentDB``
     """
-    if not isinstance(component, (basestring, dict)):
+    if not isinstance(component, (six.string_types, dict)):
         print type(component)
         raise ValueError('Expected component to be str or dict')
 
-    object_id = component if isinstance(component, basestring) else component['id']
+    object_id = component if isinstance(component, six.string_types) else component['id']
     ref = component.get('ref', '') if isinstance(component, dict) else ''
     caused_by = component.get('caused_by', {}) if isinstance(component, dict) else {}
 

--- a/st2common/st2common/services/triggers.py
+++ b/st2common/st2common/services/triggers.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import six
 
 from st2common import log as logging

--- a/st2common/st2common/services/triggerwatcher.py
+++ b/st2common/st2common/services/triggerwatcher.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 # pylint: disable=assignment-from-none
 
+from __future__ import absolute_import
 import eventlet
 from kombu.mixins import ConsumerMixin
 from kombu import Connection

--- a/st2common/st2common/stream/listener.py
+++ b/st2common/st2common/stream/listener.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import fnmatch
 
 import eventlet

--- a/st2common/st2common/transport/__init__.py
+++ b/st2common/st2common/transport/__init__.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.transport import liveaction, actionexecutionstate, execution, publishers, reactor
 from st2common.transport import utils, connection_retry_wrapper
 

--- a/st2common/st2common/transport/actionexecutionstate.py
+++ b/st2common/st2common/transport/actionexecutionstate.py
@@ -15,6 +15,7 @@
 
 # All Exchanges and Queues related to liveaction.
 
+from __future__ import absolute_import
 from kombu import Exchange, Queue
 from st2common.transport import publishers
 

--- a/st2common/st2common/transport/announcement.py
+++ b/st2common/st2common/transport/announcement.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from kombu import Exchange, Queue
 
 from st2common import log as logging

--- a/st2common/st2common/transport/bootstrap.py
+++ b/st2common/st2common/transport/bootstrap.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import logging
 import st2common.config as config
 

--- a/st2common/st2common/transport/bootstrap_utils.py
+++ b/st2common/st2common/transport/bootstrap_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import socket
 
 import retrying

--- a/st2common/st2common/transport/connection_retry_wrapper.py
+++ b/st2common/st2common/transport/connection_retry_wrapper.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import eventlet
 
 __all__ = ['ConnectionRetryWrapper', 'ClusterRetryContext']

--- a/st2common/st2common/transport/consumers.py
+++ b/st2common/st2common/transport/consumers.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import abc
 import eventlet
 import six

--- a/st2common/st2common/transport/execution.py
+++ b/st2common/st2common/transport/execution.py
@@ -15,6 +15,7 @@
 
 # All Exchanges and Queues related to liveaction.
 
+from __future__ import absolute_import
 from kombu import Exchange, Queue
 from st2common.transport import publishers
 

--- a/st2common/st2common/transport/liveaction.py
+++ b/st2common/st2common/transport/liveaction.py
@@ -15,6 +15,7 @@
 
 # All Exchanges and Queues related to liveaction.
 
+from __future__ import absolute_import
 from kombu import Exchange, Queue
 from st2common.transport import publishers
 

--- a/st2common/st2common/transport/publishers.py
+++ b/st2common/st2common/transport/publishers.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import copy
 
 from kombu import Connection

--- a/st2common/st2common/transport/queues.py
+++ b/st2common/st2common/transport/queues.py
@@ -20,6 +20,7 @@ They are located inside this module so they can be referenced inside multiple pl
 encountering cylic import issues.
 """
 
+from __future__ import absolute_import
 from kombu import Queue
 
 from st2common.constants import action as action_constants

--- a/st2common/st2common/transport/reactor.py
+++ b/st2common/st2common/transport/reactor.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from kombu import Exchange, Queue
 
 from st2common import log as logging

--- a/st2common/st2common/transport/utils.py
+++ b/st2common/st2common/transport/utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from oslo_config import cfg
 
 __all__ = [

--- a/st2common/st2common/triggers.py
+++ b/st2common/st2common/triggers.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import six
 
 from mongoengine import ValidationError

--- a/st2common/st2common/util/action_db.py
+++ b/st2common/st2common/util/action_db.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 try:
     import simplejson as json
 except ImportError:

--- a/st2common/st2common/util/actionalias_helpstring.py
+++ b/st2common/st2common/util/actionalias_helpstring.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import re
 from st2common.util.actionalias_matching import normalise_alias_format_string
 

--- a/st2common/st2common/util/actionalias_matching.py
+++ b/st2common/st2common/util/actionalias_matching.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import six
 
 from mongoengine.queryset.visitor import Q

--- a/st2common/st2common/util/api.py
+++ b/st2common/st2common/util/api.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from oslo_config import cfg
 
 from st2common import log as logging

--- a/st2common/st2common/util/argument_parser.py
+++ b/st2common/st2common/util/argument_parser.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import argparse
 
 __all__ = [

--- a/st2common/st2common/util/auth.py
+++ b/st2common/st2common/util/auth.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import base64
 import hashlib
 import os

--- a/st2common/st2common/util/casts.py
+++ b/st2common/st2common/util/casts.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import ast
 import json
 

--- a/st2common/st2common/util/compat.py
+++ b/st2common/st2common/util/compat.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import six
 
 

--- a/st2common/st2common/util/config_loader.py
+++ b/st2common/st2common/util/config_loader.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import copy
 
 import six

--- a/st2common/st2common/util/config_parser.py
+++ b/st2common/st2common/util/config_parser.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 
 import yaml

--- a/st2common/st2common/util/crypto.py
+++ b/st2common/st2common/util/crypto.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import binascii
 
 __all__ = [

--- a/st2common/st2common/util/date.py
+++ b/st2common/st2common/util/date.py
@@ -17,6 +17,7 @@
 Date related utility functions.
 """
 
+from __future__ import absolute_import
 import datetime
 
 import dateutil.tz

--- a/st2common/st2common/util/debugging.py
+++ b/st2common/st2common/util/debugging.py
@@ -17,6 +17,7 @@
 Module containing various debugging functionality.
 """
 
+from __future__ import absolute_import
 import paramiko
 from kombu.utils.debug import setup_logging
 

--- a/st2common/st2common/util/deprecation.py
+++ b/st2common/st2common/util/deprecation.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import warnings
 
 

--- a/st2common/st2common/util/enum.py
+++ b/st2common/st2common/util/enum.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import inspect
 
 __all__ = [
@@ -23,7 +24,7 @@ __all__ = [
 class Enum(object):
     @classmethod
     def get_valid_values(cls):
-        keys = cls.__dict__.keys()
+        keys = list(cls.__dict__.keys())
         values = [getattr(cls, key) for key in keys if (not key.startswith('_') and
                   not inspect.ismethod(getattr(cls, key)))]
         return values

--- a/st2common/st2common/util/file_system.py
+++ b/st2common/st2common/util/file_system.py
@@ -17,6 +17,7 @@
 File system related utility functions.
 """
 
+from __future__ import absolute_import
 import os
 import os.path
 import fnmatch

--- a/st2common/st2common/util/green/shell.py
+++ b/st2common/st2common/util/green/shell.py
@@ -17,6 +17,7 @@
 Shell utility functions which use non-blocking and eventlet friendly code.
 """
 
+from __future__ import absolute_import
 import os
 
 import six

--- a/st2common/st2common/util/greenpooldispatch.py
+++ b/st2common/st2common/util/greenpooldispatch.py
@@ -13,10 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import time
 
 import eventlet
-import Queue
+import six.moves.queue
 
 from st2common import log as logging
 
@@ -47,7 +48,7 @@ class BufferedDispatcher(object):
         self._monitor_thread_no_workers_sleep_time = monitor_thread_no_workers_sleep_time
         self._name = name
 
-        self._work_buffer = Queue.Queue()
+        self._work_buffer = six.moves.queue.Queue()
 
         # Internal attributes we use to track how long the pool is busy without any free workers
         self._pool_last_free_ts = time.time()

--- a/st2common/st2common/util/gunicorn_workers.py
+++ b/st2common/st2common/util/gunicorn_workers.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import sys
 
 from gunicorn.workers.sync import SyncWorker

--- a/st2common/st2common/util/hash.py
+++ b/st2common/st2common/util/hash.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import hashlib
 
 

--- a/st2common/st2common/util/http.py
+++ b/st2common/st2common/util/http.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import six
 
 http_client = six.moves.http_client

--- a/st2common/st2common/util/ip_utils.py
+++ b/st2common/st2common/util/ip_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import re
 
 import ipaddr

--- a/st2common/st2common/util/isotime.py
+++ b/st2common/st2common/util/isotime.py
@@ -17,10 +17,12 @@
 ISO8601 date related utility functions.
 """
 
+from __future__ import absolute_import
 import re
 import datetime
 
 from st2common.util import date as date_utils
+import six
 
 __all__ = [
     'format',
@@ -42,7 +44,7 @@ def format(dt, usec=True, offset=True):
     :type dt: ``datetime.datetime``
     """
     # pylint: disable=no-member
-    if isinstance(dt, basestring):
+    if isinstance(dt, six.string_types):
         dt = parse(dt)
     fmt = ISO8601_FORMAT_MICROSECOND if usec else ISO8601_FORMAT
     if offset:
@@ -56,7 +58,7 @@ def format(dt, usec=True, offset=True):
 
 def validate(value, raise_exception=True):
     if (isinstance(value, datetime.datetime) or
-            (type(value) in [str, unicode] and re.match(ISO8601_UTC_REGEX, value))):
+            (type(value) in [str, six.text_type] and re.match(ISO8601_UTC_REGEX, value))):
         return True
     if raise_exception:
         raise ValueError('Datetime value does not match expected format.')

--- a/st2common/st2common/util/jinja.py
+++ b/st2common/st2common/util/jinja.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import json
 import re
 import six

--- a/st2common/st2common/util/jsonify.py
+++ b/st2common/st2common/util/jsonify.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 try:
     import simplejson as json
     from simplejson import JSONEncoder
@@ -64,7 +65,7 @@ def json_loads(obj, keys=None):
         return None
 
     if not keys:
-        keys = obj.keys()
+        keys = list(obj.keys())
 
     for key in keys:
         try:

--- a/st2common/st2common/util/keyvalue.py
+++ b/st2common/st2common/util/keyvalue.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
 from st2common.constants.keyvalue import ALL_SCOPE, DATASTORE_PARENT_SCOPE
 from st2common.constants.keyvalue import DATASTORE_SCOPE_SEPARATOR
 

--- a/st2common/st2common/util/loader.py
+++ b/st2common/st2common/util/loader.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import imp
 import inspect
 import json

--- a/st2common/st2common/util/misc.py
+++ b/st2common/st2common/util/misc.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import sys
 import collections
@@ -102,7 +103,7 @@ def deep_update(d, u):
     Perform deep merge / update of the target dict.
     """
 
-    for k, v in u.iteritems():
+    for k, v in six.iteritems(u):
         if isinstance(v, collections.Mapping):
             r = deep_update(d.get(k, {}), v)
             d[k] = r

--- a/st2common/st2common/util/mongoescape.py
+++ b/st2common/st2common/util/mongoescape.py
@@ -13,22 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import copy
 import six
+from six.moves import zip
 
 # http://docs.mongodb.org/manual/faq/developers/#faq-dollar-sign-escaping
 UNESCAPED = ['.', '$']
 ESCAPED = [u'\uFF0E', u'\uFF04']
-ESCAPE_TRANSLATION = dict(zip(UNESCAPED, ESCAPED))
-UNESCAPE_TRANSLATION = dict(zip(ESCAPED, UNESCAPED))
+ESCAPE_TRANSLATION = dict(list(zip(UNESCAPED, ESCAPED)))
+UNESCAPE_TRANSLATION = dict(list(zip(ESCAPED, UNESCAPED)))
 
 # Note: Because of old rule escaping code, two different characters can be translated back to dot
 RULE_CRITERIA_UNESCAPED = ['.']
 RULE_CRITERIA_ESCAPED = [u'\u2024']
-RULE_CRITERIA_ESCAPE_TRANSLATION = dict(zip(RULE_CRITERIA_UNESCAPED,
-                                            RULE_CRITERIA_ESCAPED))
-RULE_CRITERIA_UNESCAPE_TRANSLATION = dict(zip(RULE_CRITERIA_ESCAPED,
-                                              RULE_CRITERIA_UNESCAPED))
+RULE_CRITERIA_ESCAPE_TRANSLATION = dict(list(zip(RULE_CRITERIA_UNESCAPED,
+                                            RULE_CRITERIA_ESCAPED)))
+RULE_CRITERIA_UNESCAPE_TRANSLATION = dict(list(zip(RULE_CRITERIA_ESCAPED,
+                                              RULE_CRITERIA_UNESCAPED)))
 
 
 def _prep_work_items(d):

--- a/st2common/st2common/util/pack.py
+++ b/st2common/st2common/util/pack.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import re
 

--- a/st2common/st2common/util/param.py
+++ b/st2common/st2common/util/param.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import json
 import re
 import six

--- a/st2common/st2common/util/payload.py
+++ b/st2common/st2common/util/payload.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from jsonpath_rw import parse
 
 from st2common.constants.keyvalue import SYSTEM_SCOPES

--- a/st2common/st2common/util/queues.py
+++ b/st2common/st2common/util/queues.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import uuid
 
 

--- a/st2common/st2common/util/reference.py
+++ b/st2common/st2common/util/reference.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.exceptions import db
 from st2common.models.system.common import ResourceReference
 

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -18,6 +18,7 @@ Utility functions for our sandboxing model which is implemented on top of
 separate processes and virtualenv.
 """
 
+from __future__ import absolute_import
 import os
 import sys
 from distutils.sysconfig import get_python_lib

--- a/st2common/st2common/util/schema/__init__.py
+++ b/st2common/st2common/util/schema/__init__.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import copy
 
@@ -124,8 +125,8 @@ CustomValidator = create(
 
 def is_property_type_single(property_schema):
     return (isinstance(property_schema, dict) and
-            'anyOf' not in property_schema.keys() and
-            'oneOf' not in property_schema.keys() and
+            'anyOf' not in list(property_schema.keys()) and
+            'oneOf' not in list(property_schema.keys()) and
             not isinstance(property_schema.get('type', 'string'), list))
 
 
@@ -135,11 +136,11 @@ def is_property_type_list(property_schema):
 
 
 def is_property_type_anyof(property_schema):
-    return isinstance(property_schema, dict) and 'anyOf' in property_schema.keys()
+    return isinstance(property_schema, dict) and 'anyOf' in list(property_schema.keys())
 
 
 def is_property_type_oneof(property_schema):
-    return isinstance(property_schema, dict) and 'oneOf' in property_schema.keys()
+    return isinstance(property_schema, dict) and 'oneOf' in list(property_schema.keys())
 
 
 def is_property_nullable(property_type_schema):
@@ -338,7 +339,7 @@ def get_schema_for_action_parameters(action_db):
 
     # Perform validation, make sure user is not providing parameters which can't
     # be overriden
-    runner_parameter_names = runner_type.runner_parameters.keys()
+    runner_parameter_names = list(runner_type.runner_parameters.keys())
 
     for name, schema in six.iteritems(action_db.parameters):
         if name not in runner_parameter_names:

--- a/st2common/st2common/util/secrets.py
+++ b/st2common/st2common/util/secrets.py
@@ -17,6 +17,7 @@
 Utility functions related to masking secrets in the logs.
 """
 
+from __future__ import absolute_import
 import copy
 
 import six

--- a/st2common/st2common/util/shell.py
+++ b/st2common/st2common/util/shell.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import shlex
 import signal

--- a/st2common/st2common/util/spec_loader.py
+++ b/st2common/st2common/util/spec_loader.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import pkg_resources
 
 import jinja2

--- a/st2common/st2common/util/system_info.py
+++ b/st2common/st2common/util/system_info.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import socket
 

--- a/st2common/st2common/util/templating.py
+++ b/st2common/st2common/util/templating.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import six
 
 from st2common.util.jinja import get_jinja_environment

--- a/st2common/st2common/util/types.py
+++ b/st2common/st2common/util/types.py
@@ -17,6 +17,7 @@
 Based on http://code.activestate.com/recipes/576694/ (MIT license)
 """
 
+from __future__ import absolute_import
 import collections
 
 __all__ = [

--- a/st2common/st2common/util/uid.py
+++ b/st2common/st2common/util/uid.py
@@ -17,6 +17,7 @@
 Module containing model UID related utility functions.
 """
 
+from __future__ import absolute_import
 from st2common.models.db.stormbase import UIDFieldMixin
 
 __all__ = [

--- a/st2common/st2common/util/versioning.py
+++ b/st2common/st2common/util/versioning.py
@@ -17,6 +17,7 @@
 Module containing various versioning utils.
 """
 
+from __future__ import absolute_import
 import semver
 
 from st2common import __version__ as stackstorm_version

--- a/st2common/st2common/util/virtualenvs.py
+++ b/st2common/st2common/util/virtualenvs.py
@@ -17,6 +17,7 @@
 Pack virtual environment related utility functions.
 """
 
+from __future__ import absolute_import
 import os
 import re
 import shutil

--- a/st2common/st2common/util/workflow/mistral.py
+++ b/st2common/st2common/util/workflow/mistral.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import copy
 import json
 import re
@@ -99,7 +100,7 @@ def _merge_dicts(left, right):
     if right is None:
         return left
 
-    for k, v in right.iteritems():
+    for k, v in six.iteritems(right):
         if k not in left:
             left[k] = v
         else:

--- a/st2common/st2common/util/wsgi.py
+++ b/st2common/st2common/util/wsgi.py
@@ -17,6 +17,7 @@
 Eventlet WSGI server related utility functions.
 """
 
+from __future__ import absolute_import
 import eventlet
 
 from st2common import log as logging

--- a/st2common/st2common/validators/api/action.py
+++ b/st2common/st2common/validators/api/action.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import six
 
 from st2common.exceptions.apivalidation import ValueValidationException
@@ -23,6 +24,7 @@ from st2common.util import schema as util_schema
 from st2common.content.utils import get_packs_base_paths
 from st2common.content.utils import check_pack_content_directory_exists
 from st2common.models.system.common import ResourceReference
+from six.moves import range
 
 
 LOG = logging.getLogger(__name__)
@@ -103,7 +105,7 @@ def _validate_position_values_contiguous(position_params):
         return True
 
     positions = sorted(position_params.keys())
-    contiguous = (positions == range(min(positions), max(positions) + 1))
+    contiguous = (positions == list(range(min(positions), max(positions) + 1)))
 
     if not contiguous:
         msg = 'Positions supplied %s for parameters are not contiguous.' % positions

--- a/st2common/st2common/validators/api/misc.py
+++ b/st2common/st2common/validators/api/misc.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.constants.pack import SYSTEM_PACK_NAME
 from st2common.exceptions.apivalidation import ValueValidationException
 

--- a/st2common/st2common/validators/api/reactor.py
+++ b/st2common/st2common/validators/api/reactor.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import six
 
 from oslo_config import cfg
@@ -50,7 +51,7 @@ def validate_criteria(criteria):
         if operator not in allowed_operators:
             raise ValueValidationException('For field: ' + key + ', operator ' + operator +
                                            ' not in list of allowed operators: ' +
-                                           str(allowed_operators.keys()))
+                                           str(list(allowed_operators.keys())))
         pattern = value.get('pattern', None)
         if pattern is None:
             raise ValueValidationException('For field: ' + key + ', no pattern specified ' +

--- a/st2common/st2common/validators/workflow/base.py
+++ b/st2common/st2common/validators/workflow/base.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import abc
 import six
 

--- a/st2common/st2common/validators/workflow/mistral/v2.py
+++ b/st2common/st2common/validators/workflow/mistral/v2.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import re
 
 import six

--- a/st2common/tests/fixtures/mock_runner/callback/mock_runner.py
+++ b/st2common/tests/fixtures/mock_runner/callback/mock_runner.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common import log as logging
 from st2common.callback import base as callback
 

--- a/st2common/tests/fixtures/mock_runner/mock_runner.py
+++ b/st2common/tests/fixtures/mock_runner/mock_runner.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import uuid
 
 from st2common import log as logging

--- a/st2common/tests/fixtures/mock_runner/query/mock_runner.py
+++ b/st2common/tests/fixtures/mock_runner/query/mock_runner.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import uuid
 
 from st2common.constants import action as action_constants

--- a/st2common/tests/integration/test_register_content_script.py
+++ b/st2common/tests/integration/test_register_content_script.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import glob
 

--- a/st2common/tests/resources/loadableplugin/plugin/sampleplugin.py
+++ b/st2common/tests/resources/loadableplugin/plugin/sampleplugin.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import plugin.util.randomutil
 
 

--- a/st2common/tests/resources/loadableplugin/plugin/sampleplugin2.py
+++ b/st2common/tests/resources/loadableplugin/plugin/sampleplugin2.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import plugin.util.randomutil
 
 

--- a/st2common/tests/resources/loadableplugin/plugin/util/randomutil.py
+++ b/st2common/tests/resources/loadableplugin/plugin/util/randomutil.py
@@ -1,4 +1,6 @@
+from __future__ import absolute_import
 import random
+from six.moves import range
 
 
 def get_random_numbers(count):

--- a/st2common/tests/unit/base.py
+++ b/st2common/tests/unit/base.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import time
 
 import mongoengine

--- a/st2common/tests/unit/services/test_access.py
+++ b/st2common/tests/unit/services/test_access.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import datetime
 import uuid
 

--- a/st2common/tests/unit/services/test_action.py
+++ b/st2common/tests/unit/services/test_action.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import jsonschema
 import mock
 import six
@@ -33,6 +34,7 @@ from st2common.transport.publishers import PoolPublisher
 from st2common.util import isotime
 from st2common.util import action_db
 from st2tests import DbTestCase
+from six.moves import range
 
 
 RUNNER = {

--- a/st2common/tests/unit/services/test_keyvalue.py
+++ b/st2common/tests/unit/services/test_keyvalue.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common.constants.keyvalue import SYSTEM_SCOPE, USER_SCOPE

--- a/st2common/tests/unit/services/test_rbac.py
+++ b/st2common/tests/unit/services/test_rbac.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from pymongo import MongoClient
 
 from st2tests.base import CleanDbTestCase

--- a/st2common/tests/unit/services/test_synchronization.py
+++ b/st2common/tests/unit/services/test_synchronization.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 import uuid
 

--- a/st2common/tests/unit/services/test_trace.py
+++ b/st2common/tests/unit/services/test_trace.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import bson
 import copy
 

--- a/st2common/tests/unit/services/test_trace_injection_action_services.py
+++ b/st2common/tests/unit/services/test_trace_injection_action_services.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.exceptions.trace import TraceNotFoundException
 from st2common.persistence.liveaction import LiveAction
 from st2common.persistence.trace import Trace

--- a/st2common/tests/unit/test_action_alias_utils.py
+++ b/st2common/tests/unit/test_action_alias_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from sre_parse import (parse, AT, AT_BEGINNING, AT_BEGINNING_STRING, AT_END, AT_END_STRING)
 from unittest2 import TestCase
 from st2common.exceptions.content import ParseException

--- a/st2common/tests/unit/test_action_api_validator.py
+++ b/st2common/tests/unit/test_action_api_validator.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 try:
     import simplejson as json
 except ImportError:

--- a/st2common/tests/unit/test_action_db_utils.py
+++ b/st2common/tests/unit/test_action_db_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import copy
 import uuid
 
@@ -225,7 +226,7 @@ class ActionDBUtilsTestCase(DbTestCase):
 
         self.assertEqual(origliveaction_db.id, newliveaction_db.id)
         self.assertEqual(newliveaction_db.status, status)
-        self.assertIn('a.b.c', result.keys())
+        self.assertIn('a.b.c', list(result.keys()))
         self.assertDictEqual(newliveaction_db.result, result)
         self.assertDictEqual(newliveaction_db.context, context)
         self.assertEqual(newliveaction_db.end_timestamp, now)

--- a/st2common/tests/unit/test_action_param_utils.py
+++ b/st2common/tests/unit/test_action_param_utils.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import copy
 import six
 

--- a/st2common/tests/unit/test_action_system_models.py
+++ b/st2common/tests/unit/test_action_system_models.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common.models.system.action import RemoteAction

--- a/st2common/tests/unit/test_actionchain_schema.py
+++ b/st2common/tests/unit/test_actionchain_schema.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from jsonschema.exceptions import ValidationError

--- a/st2common/tests/unit/test_aliasesregistrar.py
+++ b/st2common/tests/unit/test_aliasesregistrar.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 
 from st2common.bootstrap import aliasesregistrar

--- a/st2common/tests/unit/test_api_model_validation.py
+++ b/st2common/tests/unit/test_api_model_validation.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common.models.api.base import BaseAPI

--- a/st2common/tests/unit/test_casts.py
+++ b/st2common/tests/unit/test_casts.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import json
 
 import unittest2

--- a/st2common/tests/unit/test_config_loader.py
+++ b/st2common/tests/unit/test_config_loader.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.persistence.pack import Config
 from st2common.models.db.pack import ConfigDB
 from st2common.exceptions.db import StackStormDBObjectNotFoundError

--- a/st2common/tests/unit/test_config_parser.py
+++ b/st2common/tests/unit/test_config_parser.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from unittest2 import TestCase
 
 from st2common.util.config_parser import ContentPackConfigParser

--- a/st2common/tests/unit/test_configs_registrar.py
+++ b/st2common/tests/unit/test_configs_registrar.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 
 import mock

--- a/st2common/tests/unit/test_connection_retry_wrapper.py
+++ b/st2common/tests/unit/test_connection_retry_wrapper.py
@@ -13,9 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest
 
 from st2common.transport.connection_retry_wrapper import ClusterRetryContext
+from six.moves import range
 
 
 class TestClusterRetryContext(unittest.TestCase):

--- a/st2common/tests/unit/test_content_loader.py
+++ b/st2common/tests/unit/test_content_loader.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 
 import unittest2

--- a/st2common/tests/unit/test_content_utils.py
+++ b/st2common/tests/unit/test_content_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import os.path
 

--- a/st2common/tests/unit/test_crypto_utils.py
+++ b/st2common/tests/unit/test_crypto_utils.py
@@ -13,11 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from keyczar.keys import AesKey
 from unittest2 import TestCase
 
 
 import st2common.util.crypto as crypto_utils
+from six.moves import range
 
 
 class CryptoUtilsTestCase(TestCase):
@@ -37,7 +39,7 @@ class CryptoUtilsTestCase(TestCase):
         original = 'Kami is a little boy.'
         cryptos = set()
 
-        for _ in xrange(0, 10000):
+        for _ in range(0, 10000):
             crypto = crypto_utils.symmetric_encrypt(CryptoUtilsTestCase.test_crypto_key,
                                                     original)
             self.assertTrue(crypto not in cryptos)

--- a/st2common/tests/unit/test_datastore.py
+++ b/st2common/tests/unit/test_datastore.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 from datetime import timedelta
 from st2common.util.date import get_datetime_utc_now

--- a/st2common/tests/unit/test_date_utils.py
+++ b/st2common/tests/unit/test_date_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import datetime
 
 import pytz

--- a/st2common/tests/unit/test_db.py
+++ b/st2common/tests/unit/test_db.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import jsonschema
 import mock
 import mongoengine.connection

--- a/st2common/tests/unit/test_db_action_state.py
+++ b/st2common/tests/unit/test_db_action_state.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import bson
 
 from st2common.models.db.executionstate import ActionExecutionStateDB

--- a/st2common/tests/unit/test_db_auth.py
+++ b/st2common/tests/unit/test_db_auth.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.models.db.auth import UserDB
 from st2common.models.db.auth import TokenDB
 from st2common.models.db.auth import ApiKeyDB

--- a/st2common/tests/unit/test_db_base.py
+++ b/st2common/tests/unit/test_db_base.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import mongoengine
 
 from st2common.models.db import stormbase

--- a/st2common/tests/unit/test_db_execution.py
+++ b/st2common/tests/unit/test_db_execution.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import mock
 
 from st2common.constants.secrets import MASKED_ATTRIBUTE_VALUE

--- a/st2common/tests/unit/test_db_fields.py
+++ b/st2common/tests/unit/test_db_fields.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import datetime
 import calendar
 

--- a/st2common/tests/unit/test_db_liveaction.py
+++ b/st2common/tests/unit/test_db_liveaction.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import mock
 
 from st2common.models.db.liveaction import LiveActionDB

--- a/st2common/tests/unit/test_db_marker.py
+++ b/st2common/tests/unit/test_db_marker.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.models.db.marker import DumperMarkerDB
 from st2common.persistence.marker import DumperMarker
 from st2common.exceptions.db import StackStormDBObjectNotFoundError

--- a/st2common/tests/unit/test_db_model_uids.py
+++ b/st2common/tests/unit/test_db_model_uids.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import json
 import hashlib
 from collections import OrderedDict

--- a/st2common/tests/unit/test_db_pack.py
+++ b/st2common/tests/unit/test_db_pack.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.models.db.pack import PackDB
 from st2common.persistence.pack import Pack
 

--- a/st2common/tests/unit/test_db_policy.py
+++ b/st2common/tests/unit/test_db_policy.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common.constants import pack as pack_constants

--- a/st2common/tests/unit/test_db_rbac.py
+++ b/st2common/tests/unit/test_db_rbac.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.models.db.rbac import RoleDB
 from st2common.models.db.rbac import UserRoleAssignmentDB
 from st2common.models.db.rbac import PermissionGrantDB

--- a/st2common/tests/unit/test_db_rule_enforcement.py
+++ b/st2common/tests/unit/test_db_rule_enforcement.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import bson
 import mock
 

--- a/st2common/tests/unit/test_db_trace.py
+++ b/st2common/tests/unit/test_db_trace.py
@@ -13,12 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import bson
 
 from st2common.models.db.trace import TraceDB, TraceComponentDB
 from st2common.persistence.trace import Trace
 
 from st2tests.base import CleanDbTestCase
+from six.moves import range
 
 
 class TraceDBTest(CleanDbTestCase):

--- a/st2common/tests/unit/test_db_uid_mixin.py
+++ b/st2common/tests/unit/test_db_uid_mixin.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2tests.base import CleanDbTestCase
 from st2common.models.db.pack import PackDB
 from st2common.models.db.action import ActionDB

--- a/st2common/tests/unit/test_executions.py
+++ b/st2common/tests/unit/test_executions.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import copy
 import bson
 import datetime
@@ -24,6 +25,7 @@ from st2common.util import date as date_utils
 from st2common.persistence.execution import ActionExecution
 from st2common.models.api.execution import ActionExecutionAPI
 from st2common.exceptions.db import StackStormDBObjectNotFoundError
+from six.moves import range
 
 
 class TestActionExecutionHistoryModel(DbTestCase):

--- a/st2common/tests/unit/test_executions_util.py
+++ b/st2common/tests/unit/test_executions_util.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import mock
 import six
 
@@ -33,6 +34,7 @@ from st2tests.base import CleanDbTestCase
 from st2tests.fixturesloader import FixturesLoader
 
 import st2tests.config as tests_config
+from six.moves import range
 tests_config.parse_args()
 
 FIXTURES_PACK = 'generic'

--- a/st2common/tests/unit/test_greenpooldispatch.py
+++ b/st2common/tests/unit/test_greenpooldispatch.py
@@ -13,11 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import eventlet
 import mock
 
 from st2common.util.greenpooldispatch import BufferedDispatcher
 from unittest2 import TestCase
+from six.moves import range
 
 
 class TestGreenPoolDispatch(TestCase):

--- a/st2common/tests/unit/test_hash.py
+++ b/st2common/tests/unit/test_hash.py
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common.util import hash as hash_utils
 from st2common.util import auth as auth_utils
+from six.moves import range
 
 
 class TestHashWithApiKeys(unittest2.TestCase):

--- a/st2common/tests/unit/test_ip_utils.py
+++ b/st2common/tests/unit/test_ip_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common.util.ip_utils import split_host_port

--- a/st2common/tests/unit/test_isotime_utils.py
+++ b/st2common/tests/unit/test_isotime_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import datetime
 
 import unittest

--- a/st2common/tests/unit/test_jinja_render_crypto_filters.py
+++ b/st2common/tests/unit/test_jinja_render_crypto_filters.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from oslo_config import cfg
 
 from st2tests.base import CleanDbTestCase

--- a/st2common/tests/unit/test_jinja_render_data_filters.py
+++ b/st2common/tests/unit/test_jinja_render_data_filters.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import json
 import unittest2
 import yaml

--- a/st2common/tests/unit/test_jinja_render_json_escape_filters.py
+++ b/st2common/tests/unit/test_jinja_render_json_escape_filters.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common.util import jinja as jinja_utils

--- a/st2common/tests/unit/test_jinja_render_jsonpath_query_filters.py
+++ b/st2common/tests/unit/test_jinja_render_jsonpath_query_filters.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common.util import jinja as jinja_utils

--- a/st2common/tests/unit/test_jinja_render_regex_filters.py
+++ b/st2common/tests/unit/test_jinja_render_regex_filters.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common.util import jinja as jinja_utils

--- a/st2common/tests/unit/test_jinja_render_time_filters.py
+++ b/st2common/tests/unit/test_jinja_render_time_filters.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common.util import jinja as jinja_utils

--- a/st2common/tests/unit/test_jinja_render_version_filters.py
+++ b/st2common/tests/unit/test_jinja_render_version_filters.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common.util import jinja as jinja_utils

--- a/st2common/tests/unit/test_json_schema.py
+++ b/st2common/tests/unit/test_json_schema.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from unittest2 import TestCase
 from jsonschema.exceptions import ValidationError
 

--- a/st2common/tests/unit/test_jsonify.py
+++ b/st2common/tests/unit/test_jsonify.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import unittest2
 
 import st2common.util.jsonify as jsonify

--- a/st2common/tests/unit/test_keyvalue_lookup.py
+++ b/st2common/tests/unit/test_keyvalue_lookup.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2tests.base import CleanDbTestCase
 from st2common.constants.keyvalue import FULL_SYSTEM_SCOPE, FULL_USER_SCOPE
 from st2common.constants.keyvalue import SYSTEM_SCOPE, USER_SCOPE

--- a/st2common/tests/unit/test_keyvalue_system_model.py
+++ b/st2common/tests/unit/test_keyvalue_system_model.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common.models.system.keyvalue import InvalidUserKeyReferenceError

--- a/st2common/tests/unit/test_logger.py
+++ b/st2common/tests/unit/test_logger.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest
 import os
 import sys

--- a/st2common/tests/unit/test_logging.py
+++ b/st2common/tests/unit/test_logging.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common.logging.misc import get_logger_name_for_module

--- a/st2common/tests/unit/test_misc_utils.py
+++ b/st2common/tests/unit/test_misc_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common.util.misc import rstrip_last_char

--- a/st2common/tests/unit/test_model_utils_profiling.py
+++ b/st2common/tests/unit/test_model_utils_profiling.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import mock
 
 from st2tests import DbTestCase

--- a/st2common/tests/unit/test_mongoescape.py
+++ b/st2common/tests/unit/test_mongoescape.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest
 
 from st2common.util import mongoescape
@@ -62,12 +63,12 @@ class TestMongoEscape(unittest.TestCase):
         field = {'k1.k2.k3': 'v1'}
 
         escaped = mongoescape.escape_chars(field)
-        self.assertIn('k1.k2.k3', field.keys())
-        self.assertIn(u'k1\uff0ek2\uff0ek3', escaped.keys())
+        self.assertIn('k1.k2.k3', list(field.keys()))
+        self.assertIn(u'k1\uff0ek2\uff0ek3', list(escaped.keys()))
 
         unescaped = mongoescape.unescape_chars(escaped)
-        self.assertIn('k1.k2.k3', unescaped.keys())
-        self.assertIn(u'k1\uff0ek2\uff0ek3', escaped.keys())
+        self.assertIn('k1.k2.k3', list(unescaped.keys()))
+        self.assertIn(u'k1\uff0ek2\uff0ek3', list(escaped.keys()))
 
     def test_complex(self):
         field = {

--- a/st2common/tests/unit/test_notification_helper.py
+++ b/st2common/tests/unit/test_notification_helper.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common.models.api.notification import NotificationsHelper

--- a/st2common/tests/unit/test_operators.py
+++ b/st2common/tests/unit/test_operators.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common import operators

--- a/st2common/tests/unit/test_pack_action_alias_unit_testing_utils.py
+++ b/st2common/tests/unit/test_pack_action_alias_unit_testing_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 
 import mock

--- a/st2common/tests/unit/test_pack_management.py
+++ b/st2common/tests/unit/test_pack_management.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import sys
 

--- a/st2common/tests/unit/test_param_utils.py
+++ b/st2common/tests/unit/test_param_utils.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import mock
 
 from st2common.exceptions.param import ParamException

--- a/st2common/tests/unit/test_paramiko_command_action_model.py
+++ b/st2common/tests/unit/test_paramiko_command_action_model.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common.models.system.paramiko_command_action import ParamikoRemoteCommandAction

--- a/st2common/tests/unit/test_paramiko_script_action_model.py
+++ b/st2common/tests/unit/test_paramiko_script_action_model.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common.models.system.paramiko_script_action import ParamikoRemoteScriptAction

--- a/st2common/tests/unit/test_persistence.py
+++ b/st2common/tests/unit/test_persistence.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import uuid
 import datetime
 
@@ -22,6 +23,7 @@ from st2tests import DbTestCase
 from st2common.util import date as date_utils
 from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from tests.unit.base import FakeModel, FakeModelDB
+from six.moves import range
 
 
 class TestPersistence(DbTestCase):
@@ -188,8 +190,8 @@ class TestPersistence(DbTestCase):
         obj2 = self.access.add_or_update(obj1)
 
         # Check that the original dict has not been altered.
-        self.assertIn('a.b.c', context.keys())
-        self.assertNotIn('a\uff0eb\uff0ec', context.keys())
+        self.assertIn('a.b.c', list(context.keys()))
+        self.assertNotIn('a\uff0eb\uff0ec', list(context.keys()))
 
         # Check to_python has run and context is not left escaped.
         self.assertDictEqual(obj2.context, context)

--- a/st2common/tests/unit/test_plugin_loader.py
+++ b/st2common/tests/unit/test_plugin_loader.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import abc
 import copy
 import os

--- a/st2common/tests/unit/test_policies.py
+++ b/st2common/tests/unit/test_policies.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.persistence.policy import PolicyType, Policy
 from st2common.policies import ResourcePolicyApplicator, get_driver
 from st2tests import DbTestCase

--- a/st2common/tests/unit/test_policies_registrar.py
+++ b/st2common/tests/unit/test_policies_registrar.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 
 import jsonschema

--- a/st2common/tests/unit/test_purge_executions.py
+++ b/st2common/tests/unit/test_purge_executions.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import copy
 from datetime import timedelta
 
@@ -29,6 +30,7 @@ from st2common.persistence.liveaction import LiveAction
 from st2common.util import date as date_utils
 from st2tests.base import CleanDbTestCase
 from st2tests.fixturesloader import FixturesLoader
+from six.moves import range
 
 LOG = logging.getLogger(__name__)
 

--- a/st2common/tests/unit/test_purge_trigger_instances.py
+++ b/st2common/tests/unit/test_purge_trigger_instances.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from datetime import timedelta
 
 from st2common import log as logging

--- a/st2common/tests/unit/test_query_base.py
+++ b/st2common/tests/unit/test_query_base.py
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import Queue
+from __future__ import absolute_import
+import six.moves.queue
 import time
 
 from unittest2 import TestCase
@@ -70,7 +71,7 @@ class QueryBaseTests(TestCase):
 
         now = time.time()
 
-        query_contexts = Queue.Queue()
+        query_contexts = six.moves.queue.Queue()
         query_contexts.put((now + 100000, mock_query_state_1)),
         query_contexts.put((now + 100001, mock_query_state_2)),
         query_contexts.put((now - 200000, mock_query_state_3)),

--- a/st2common/tests/unit/test_queue_consumer.py
+++ b/st2common/tests/unit/test_queue_consumer.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import mock
 from kombu import Exchange, Queue
 

--- a/st2common/tests/unit/test_queue_utils.py
+++ b/st2common/tests/unit/test_queue_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import re
 
 from unittest2 import TestCase

--- a/st2common/tests/unit/test_rbac.py
+++ b/st2common/tests/unit/test_rbac.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from oslo_config import cfg
 
 from st2tests import config

--- a/st2common/tests/unit/test_rbac_loader.py
+++ b/st2common/tests/unit/test_rbac_loader.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 
 import unittest2

--- a/st2common/tests/unit/test_rbac_resolvers.py
+++ b/st2common/tests/unit/test_rbac_resolvers.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import six
 import unittest2
 from oslo_config import cfg

--- a/st2common/tests/unit/test_rbac_resolvers_action.py
+++ b/st2common/tests/unit/test_rbac_resolvers_action.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
 from st2common.rbac.types import PermissionType
 from st2common.rbac.types import ResourceType
 from st2common.persistence.auth import User

--- a/st2common/tests/unit/test_rbac_resolvers_action_alias.py
+++ b/st2common/tests/unit/test_rbac_resolvers_action_alias.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
 from st2common.rbac.types import PermissionType
 from st2common.rbac.types import ResourceType
 from st2common.persistence.auth import User

--- a/st2common/tests/unit/test_rbac_resolvers_execution.py
+++ b/st2common/tests/unit/test_rbac_resolvers_execution.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.constants import action as action_constants
 from st2common.rbac.types import PermissionType
 from st2common.rbac.types import ResourceType

--- a/st2common/tests/unit/test_rbac_resolvers_inquiry.py
+++ b/st2common/tests/unit/test_rbac_resolvers_inquiry.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.constants import action as action_constants
 from st2common.rbac.types import PermissionType
 from st2common.rbac.types import ResourceType

--- a/st2common/tests/unit/test_rbac_resolvers_key_value_pair.py
+++ b/st2common/tests/unit/test_rbac_resolvers_key_value_pair.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.rbac.types import PermissionType
 from st2common.rbac.types import ResourceType
 from st2common.persistence.keyvalue import KeyValuePair

--- a/st2common/tests/unit/test_rbac_resolvers_rule.py
+++ b/st2common/tests/unit/test_rbac_resolvers_rule.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.triggers import register_internal_trigger_types
 from st2common.rbac.types import PermissionType
 from st2common.rbac.types import ResourceType

--- a/st2common/tests/unit/test_rbac_resolvers_rule_enforcement.py
+++ b/st2common/tests/unit/test_rbac_resolvers_rule_enforcement.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 __all__ = [
     'RuleEnforcementPermissionsResolverTestCase'
 ]

--- a/st2common/tests/unit/test_rbac_resolvers_runner.py
+++ b/st2common/tests/unit/test_rbac_resolvers_runner.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.rbac.types import PermissionType
 from st2common.rbac.types import ResourceType
 from st2common.persistence.auth import User

--- a/st2common/tests/unit/test_rbac_resolvers_sensor.py
+++ b/st2common/tests/unit/test_rbac_resolvers_sensor.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.rbac.types import PermissionType
 from st2common.rbac.types import ResourceType
 from st2common.persistence.auth import User

--- a/st2common/tests/unit/test_rbac_resolvers_webhook.py
+++ b/st2common/tests/unit/test_rbac_resolvers_webhook.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.rbac.types import PermissionType
 from st2common.rbac.types import ResourceType
 from st2common.persistence.auth import User

--- a/st2common/tests/unit/test_rbac_syncer.py
+++ b/st2common/tests/unit/test_rbac_syncer.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from pymongo import MongoClient
 
 from st2tests.base import CleanDbTestCase

--- a/st2common/tests/unit/test_rbac_types.py
+++ b/st2common/tests/unit/test_rbac_types.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from unittest2 import TestCase
 
 from st2common.constants.types import ResourceType as SystemType

--- a/st2common/tests/unit/test_rbac_utils.py
+++ b/st2common/tests/unit/test_rbac_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from oslo_config import cfg
 
 from st2tests.base import DbTestCase

--- a/st2common/tests/unit/test_reference.py
+++ b/st2common/tests/unit/test_reference.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import copy
 import mock
 import mongoengine

--- a/st2common/tests/unit/test_register_internal_trigger.py
+++ b/st2common/tests/unit/test_register_internal_trigger.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.persistence.trigger import Trigger
 from st2common.triggers import register_internal_trigger_types
 from st2tests.base import DbTestCase

--- a/st2common/tests/unit/test_resource_reference.py
+++ b/st2common/tests/unit/test_resource_reference.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common.models.system.common import ResourceReference

--- a/st2common/tests/unit/test_resource_registrar.py
+++ b/st2common/tests/unit/test_resource_registrar.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 
 import mock

--- a/st2common/tests/unit/test_runners_utils.py
+++ b/st2common/tests/unit/test_runners_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import mock
 
 from st2common.runners import utils

--- a/st2common/tests/unit/test_sensor_type_utils.py
+++ b/st2common/tests/unit/test_sensor_type_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import mock
 import unittest2
 

--- a/st2common/tests/unit/test_sensor_watcher.py
+++ b/st2common/tests/unit/test_sensor_watcher.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from kombu.message import Message
 import mock
 import unittest2

--- a/st2common/tests/unit/test_service_setup.py
+++ b/st2common/tests/unit/test_service_setup.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import tempfile
 
 import mock

--- a/st2common/tests/unit/test_shell_action_system_model.py
+++ b/st2common/tests/unit/test_shell_action_system_model.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import pwd
 import os
 import copy

--- a/st2common/tests/unit/test_state_publisher.py
+++ b/st2common/tests/unit/test_state_publisher.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import kombu
 import mock
 import mongoengine as me

--- a/st2common/tests/unit/test_system_info.py
+++ b/st2common/tests/unit/test_system_info.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
 import os
 import socket
 import unittest

--- a/st2common/tests/unit/test_tags.py
+++ b/st2common/tests/unit/test_tags.py
@@ -13,12 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import random
 import string
 
 from mongoengine import ValidationError
 from st2common.models.db import stormbase
 from st2tests import DbTestCase
+from six.moves import range
 
 
 class TaggedModel(stormbase.StormFoundationDB, stormbase.TagsMixin):

--- a/st2common/tests/unit/test_time_jinja_filters.py
+++ b/st2common/tests/unit/test_time_jinja_filters.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from unittest2 import TestCase
 
 from st2common.jinja.filters import time

--- a/st2common/tests/unit/test_trigger_services.py
+++ b/st2common/tests/unit/test_trigger_services.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2common.exceptions.triggers import TriggerDoesNotExistException
 from st2common.models.api.rule import RuleAPI
 from st2common.models.system.common import ResourceReference

--- a/st2common/tests/unit/test_triggers_registrar.py
+++ b/st2common/tests/unit/test_triggers_registrar.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 
 import st2common.bootstrap.triggersregistrar as triggers_registrar

--- a/st2common/tests/unit/test_unit_testing_mocks.py
+++ b/st2common/tests/unit/test_unit_testing_mocks.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from st2tests.base import BaseSensorTestCase

--- a/st2common/tests/unit/test_util_actionalias_helpstrings.py
+++ b/st2common/tests/unit/test_util_actionalias_helpstrings.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 import mock
 
@@ -81,7 +82,7 @@ class ActionAliasTestCase(unittest2.TestCase):
     Test scenarios must consist of 80s movie quotes.
     '''
     def check_data_structure(self, result):
-        tmp = result.keys()
+        tmp = list(result.keys())
         tmp.sort()
         self.assertEqual(tmp, ["available", "helpstrings"])
 

--- a/st2common/tests/unit/test_util_actionalias_matching.py
+++ b/st2common/tests/unit/test_util_actionalias_matching.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 import mock
 

--- a/st2common/tests/unit/test_util_api.py
+++ b/st2common/tests/unit/test_util_api.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from oslo_config import cfg
@@ -22,6 +23,7 @@ from st2common.util.api import get_base_public_api_url
 from st2common.util.api import get_full_public_api_url
 from st2common.util.api import get_mistral_api_url
 from st2tests.config import parse_args
+from six.moves import zip
 parse_args()
 
 

--- a/st2common/tests/unit/test_util_compact.py
+++ b/st2common/tests/unit/test_util_compact.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common.util.compat import to_ascii

--- a/st2common/tests/unit/test_util_file_system.py
+++ b/st2common/tests/unit/test_util_file_system.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import os.path
 

--- a/st2common/tests/unit/test_util_http.py
+++ b/st2common/tests/unit/test_util_http.py
@@ -7,9 +7,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common.util.http import parse_content_type_header
+from six.moves import zip
 
 __all__ = [
     'HTTPUtilTestCase'

--- a/st2common/tests/unit/test_util_jinja.py
+++ b/st2common/tests/unit/test_util_jinja.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common.util import jinja as jinja_utils

--- a/st2common/tests/unit/test_util_loader.py
+++ b/st2common/tests/unit/test_util_loader.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import imp
 import os
 import mock

--- a/st2common/tests/unit/test_util_mistral_dsl_transform.py
+++ b/st2common/tests/unit/test_util_mistral_dsl_transform.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import copy
 import six
 import yaml

--- a/st2common/tests/unit/test_util_pack.py
+++ b/st2common/tests/unit/test_util_pack.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common.models.db.pack import PackDB

--- a/st2common/tests/unit/test_util_payload.py
+++ b/st2common/tests/unit/test_util_payload.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common.util.payload import PayloadLookup

--- a/st2common/tests/unit/test_util_sandboxing.py
+++ b/st2common/tests/unit/test_util_sandboxing.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 import sys
 import unittest

--- a/st2common/tests/unit/test_util_shell.py
+++ b/st2common/tests/unit/test_util_shell.py
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common.util.shell import quote_unix
 from st2common.util.shell import quote_windows
+from six.moves import zip
 
 
 class ShellUtilsTestCase(unittest2.TestCase):

--- a/st2common/tests/unit/test_util_templating.py
+++ b/st2common/tests/unit/test_util_templating.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from st2tests.base import CleanDbTestCase
 from st2common.constants.keyvalue import FULL_USER_SCOPE
 from st2common.models.db.keyvalue import KeyValuePairDB

--- a/st2common/tests/unit/test_util_url.py
+++ b/st2common/tests/unit/test_util_url.py
@@ -13,9 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common.util.url import get_url_without_trailing_slash
+from six.moves import zip
 
 
 class URLUtilsTestCase(unittest2.TestCase):

--- a/st2common/tests/unit/test_validator_mistral.py
+++ b/st2common/tests/unit/test_validator_mistral.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import mock
 import six
 import yaml

--- a/st2common/tests/unit/test_versioning_utils.py
+++ b/st2common/tests/unit/test_versioning_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import unittest2
 
 from st2common.util.versioning import complex_semver_match

--- a/st2common/tests/unit/test_virtualenvs.py
+++ b/st2common/tests/unit/test_virtualenvs.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import tempfile
 


### PR DESCRIPTION
* Use absolute import
* Use ``six.iteritems()`` for items iterators. 
* Cast `keys()` and `items()` views to lists to safeguard existing Python2 behaviour.