### PR TITLE
Throw a more user-friendly exception on invalid API endpoint input type

### DIFF
--- a/st2api/tests/unit/controllers/v1/test_webhooks.py
+++ b/st2api/tests/unit/controllers/v1/test_webhooks.py
@@ -181,6 +181,11 @@ class TestWebhooksController(FunctionalTest):
         self.assertTrue('Failed to parse request body' in post_resp)
         self.assertTrue('Unsupported Content-Type' in post_resp)
 
+    def test_custom_webhook_invalid_input_type(self):
+        post_resp = self.__do_post('sample', [{'foo': 'bar'}], expect_errors=True)
+        self.assertTrue('Input body needs to be an object, got: ' in post_resp)
+        self.assertEqual(post_resp.status_int, http_client.BAD_REQUEST)
+
     def test_leading_trailing_slashes(self):
         # Ideally the test should setup fixtures in DB. However, the triggerwatcher
         # that is supposed to load the models from DB does not real start given

--- a/st2api/tests/unit/controllers/v1/test_webhooks.py
+++ b/st2api/tests/unit/controllers/v1/test_webhooks.py
@@ -183,7 +183,7 @@ class TestWebhooksController(FunctionalTest):
 
     def test_custom_webhook_invalid_input_type(self):
         post_resp = self.__do_post('sample', [{'foo': 'bar'}], expect_errors=True)
-        self.assertTrue('Input body needs to be an object, got: ' in post_resp)
+        self.assertTrue('Input body needs to be an object, got: array' in post_resp)
         self.assertEqual(post_resp.status_int, http_client.BAD_REQUEST)
 
     def test_leading_trailing_slashes(self):

--- a/st2common/st2common/router.py
+++ b/st2common/st2common/router.py
@@ -37,6 +37,7 @@ from st2common.persistence.auth import User
 from st2common.rbac import resolvers
 from st2common.util import date as date_utils
 from st2common.util.jsonify import json_encode
+from st2common.util.jsonify import get_json_type_for_python_value
 from st2common.util.http import parse_content_type_header
 
 
@@ -506,7 +507,8 @@ class Router(object):
         except TypeError as e:
             # Throw a more user-friendly exception when input data is not an object
             if 'type object argument after ** must be a mapping, not' in str(e):
-                msg = ('Input body needs to be an object, got: %s' % (type(data)))
+                type_string = get_json_type_for_python_value(data)
+                msg = ('Input body needs to be an object, got: %s' % (type_string))
                 raise ValueError(msg)
 
             raise e

--- a/st2common/st2common/router.py
+++ b/st2common/st2common/router.py
@@ -387,7 +387,7 @@ class Router(object):
 
                     if 'x-api-model' in schema:
                         Model = op_resolver(schema['x-api-model'])
-                        instance = Model(**data)
+                        instance = self._get_model_instance(model_cls=Model, data=data)
 
                         # Call validate on the API model - note we should eventually move all
                         # those model schema definitions into openapi.yaml
@@ -400,7 +400,7 @@ class Router(object):
                         LOG.debug('Missing x-api-model definition for %s, using generic Body '
                                   'model.' % (endpoint['operationId']))
                         model = Body
-                        instance = model(**data)
+                        instance = self._get_model_instance(model_cls=model, data=data)
 
                     kw[argument_name] = instance
 
@@ -499,3 +499,16 @@ class Router(object):
         req = Request(environ)
         resp = self(req)
         return resp(environ, start_response)
+
+    def _get_model_instance(self, model_cls, data):
+        try:
+            instance = model_cls(**data)
+        except TypeError as e:
+            # Throw a more user-friendly exception when input data is not an object
+            if 'type object argument after ** must be a mapping, not' in str(e):
+                msg = ('Input body needs to be an object, got: %s' % (type(data)))
+                raise ValueError(msg)
+
+            raise e
+
+        return instance

--- a/st2common/st2common/util/jsonify.py
+++ b/st2common/st2common/util/jsonify.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 try:
     import simplejson as json
     from simplejson import JSONEncoder
@@ -27,7 +28,9 @@ import six
 __all__ = [
     'json_encode',
     'json_loads',
-    'try_loads'
+    'try_loads',
+
+    'get_json_type_for_python_value'
 ]
 
 
@@ -80,3 +83,25 @@ def try_loads(s):
         return json.loads(s) if s and isinstance(s, six.string_types) else s
     except:
         return s
+
+
+def get_json_type_for_python_value(value):
+    """
+    Return JSON type string for the provided Python value.
+
+    :rtype: ``str``
+    """
+    if isinstance(value, six.text_type):
+        return 'string'
+    elif isinstance(value, (int, float)):
+        return 'number'
+    elif isinstance(value, dict):
+        return 'object'
+    elif isinstance(value, (list, tuple)):
+        return 'array'
+    elif isinstance(value, bool):
+        return 'boolean'
+    elif value is None:
+        return 'null'
+    else:
+        return 'unknown'


### PR DESCRIPTION
This pull request updates router code to throw a more user-friendly exception when invalid type is specified for the API endpoint input data. This only applies to API endpoints which don't explicitly define model schema such as `POST /v1/webhooks`.

Previously internal server error without any context was returned.

This pull request should be merged in any case, even if decide not to go with the approach implemented in #3956.

Before:

```bash
{
    "faultstring": "Internal Server Error"
}
````

After:

```bash
{
    "faultstring": "Input body needs to be an object, got: array"
}
```

Related #3955 #3956