### PR TITLE
Update "st2 execution tail" command to support two levels nested workflows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 in development
 --------------
 
+Added
+~~~~~
+
+* Update ``st2 execution tail`` command so it supports double nested workflows (workflow ->
+  workflow -> execution). Previously, only top-level executions and single nested workflows
+  (workflow -> execution) were supported. (improvement) #3962 #3960
 
 2.6.0 - January 19, 2018
 ------------------------

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -1450,6 +1450,7 @@ class ActionExecutionTailCommand(resource.ResourceCommand):
     def tail_execution(cls, execution_manager, stream_manager, execution, output_type=None,
                        include_metadata=False, **kwargs):
         execution_id = str(execution.id)
+
         # Note: For non-workflow actions child_execution_id always matches parent_execution_id so
         # we don't need to do any other checks to determine if executions represents a workflow
         # action

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -1495,7 +1495,11 @@ class ActionExecutionTailCommand(resource.ResourceCommand):
                         # We don't care about other child events so we simply skip then
                         continue
                 else:
-                    if status in LIVEACTION_COMPLETED_STATES:
+                    if status == LIVEACTION_STATUS_RUNNING:
+                        print('Execution %s has started.' % (execution_id))
+                        print('')
+                        continue
+                    elif status in LIVEACTION_COMPLETED_STATES:
                         # Bail out once parent execution has finished
                         print('')
                         print('Execution %s has completed (status=%s).' % (execution_id, status))

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -1453,7 +1453,7 @@ class ActionExecutionTailCommand(resource.ResourceCommand):
         # Note: For non-workflow actions child_execution_id always matches parent_execution_id so
         # we don't need to do any other checks to determine if executions represents a workflow
         # action
-        parent_execution_id = execution_id
+        parent_execution_id = execution_id  # noqa
 
         # Execution has already finished
         if execution.status in LIVEACTION_COMPLETED_STATES:
@@ -1475,7 +1475,9 @@ class ActionExecutionTailCommand(resource.ResourceCommand):
                 task_execution_id = context['execution_id']
                 task_name = context['task_name']
                 task_parent_execution_id = context['parent_execution_id']
-                is_child_execution = (task_parent_execution_id == parent_execution_id)
+
+                # An execution is considered a child execution if it has parent execution id
+                is_child_execution = bool(task_parent_execution_id)
 
                 if is_child_execution:
                     if status == LIVEACTION_STATUS_RUNNING:

--- a/st2client/tests/unit/test_execution_tail_command.py
+++ b/st2client/tests/unit/test_execution_tail_command.py
@@ -150,6 +150,19 @@ MOCK_LIVEACTION_4_CHILD_1_RUNNING = {
     'status': LIVEACTION_STATUS_RUNNING
 }
 
+MOCK_LIVEACTION_4_CHILD_1_1_RUNNING = {
+    'id': 'idmistralchild1_1',
+    'context': {
+        'mistral': {
+            'task_name': 'task_1'
+        },
+        'parent': {
+            'execution_id': 'idmistralchild1'
+        }
+    },
+    'status': LIVEACTION_STATUS_RUNNING
+}
+
 MOCK_LIVEACTION_4_CHILD_1_SUCCEEDED = {
     'id': 'idmistralchild1',
     'context': {
@@ -158,6 +171,19 @@ MOCK_LIVEACTION_4_CHILD_1_SUCCEEDED = {
         },
         'parent': {
             'execution_id': 'idfoo4'
+        }
+    },
+    'status': LIVEACTION_STATUS_SUCCEEDED
+}
+
+MOCK_LIVEACTION_4_CHILD_1_1_SUCCEEDED = {
+    'id': 'idmistralchild1_1',
+    'context': {
+        'mistral': {
+            'task_name': 'task_1',
+        },
+        'parent': {
+            'execution_id': 'idmistralchild1'
         }
     },
     'status': LIVEACTION_STATUS_SUCCEEDED
@@ -172,6 +198,20 @@ MOCK_LIVEACTION_4_CHILD_1_OUTPUT_1 = {
 
 MOCK_LIVEACTION_4_CHILD_1_OUTPUT_2 = {
     'execution_id': 'mistral',
+    'timestamp': '1505732598',
+    'output_type': 'stderr',
+    'data': 'line mistral 5\n'
+}
+
+MOCK_LIVEACTION_4_CHILD_1_1_OUTPUT_1 = {
+    'execution_id': 'idmistralchild1_1',
+    'timestamp': '1505732598',
+    'output_type': 'stdout',
+    'data': 'line mistral 4\n'
+}
+
+MOCK_LIVEACTION_4_CHILD_1_1_OUTPUT_2 = {
+    'execution_id': 'idmistralchild1_1',
     'timestamp': '1505732598',
     'output_type': 'stderr',
     'data': 'line mistral 5\n'
@@ -451,6 +491,83 @@ Child execution (task=task_1) idmistralchild1 has started.
 
 line mistral 4
 line mistral 5
+
+Child execution (task=task_1) idmistralchild1 has finished (status=succeeded).
+Child execution (task=task_2) idmistralchild2 has started.
+
+line mistral 100
+
+Child execution (task=task_2) idmistralchild2 has finished (status=timeout).
+
+Execution idfoo4 has completed (status=succeeded).
+""".lstrip()
+        self.assertEqual(stdout, expected_result)
+        self.assertEqual(stderr, '')
+
+    @mock.patch.object(
+        httpclient.HTTPClient, 'get',
+        mock.MagicMock(return_value=base.FakeResponse(json.dumps(MOCK_LIVEACTION_4_RUNNING),
+                                                     200, 'OK')))
+    @mock.patch('st2client.client.StreamManager', autospec=True)
+    def test_tail_double_nested_mistral_workflow_execution(self, mock_stream_manager):
+        argv = ['execution', 'tail', 'idfoo4']
+
+        MOCK_EVENTS = [
+            # Workflow started running
+            MOCK_LIVEACTION_4_RUNNING,
+
+            # Child task 1 started running (sub workflow)
+            MOCK_LIVEACTION_4_CHILD_1_RUNNING,
+
+            # Child task 1 started running
+            MOCK_LIVEACTION_4_CHILD_1_1_RUNNING,
+
+            # Output produced by the child task
+            MOCK_LIVEACTION_4_CHILD_1_1_OUTPUT_1,
+            MOCK_LIVEACTION_4_CHILD_1_1_OUTPUT_2,
+
+            # Child task 1 has finished
+            MOCK_LIVEACTION_4_CHILD_1_1_SUCCEEDED,
+
+            # Child task 1 finished (sub workflow)
+            MOCK_LIVEACTION_4_CHILD_1_SUCCEEDED,
+
+            # Child task 2 started running
+            MOCK_LIVEACTION_4_CHILD_2_RUNNING,
+
+            # Output produced by child task
+            MOCK_LIVEACTION_4_CHILD_2_OUTPUT_1,
+
+            # Child task 2 finished
+            MOCK_LIVEACTION_4_CHILD_2_TIMED_OUT,
+
+            # Parent workflow task finished
+            MOCK_LIVEACTION_4_SUCCEDED
+        ]
+
+        mock_cls = mock.Mock()
+        mock_cls.listen = mock.Mock()
+        mock_listen_generator = mock.Mock()
+        mock_listen_generator.return_value = MOCK_EVENTS
+        mock_cls.listen.side_effect = mock_listen_generator
+        mock_stream_manager.return_value = mock_cls
+
+        self.assertEqual(self.shell.run(argv), 0)
+        self.assertEqual(mock_listen_generator.call_count, 1)
+
+        stdout = self.stdout.getvalue()
+        stderr = self.stderr.getvalue()
+
+        expected_result = """
+
+Child execution (task=task_1) idmistralchild1 has started.
+
+Child execution (task=task_1) idmistralchild1_1 has started.
+
+line mistral 4
+line mistral 5
+
+Child execution (task=task_1) idmistralchild1_1 has finished (status=succeeded).
 
 Child execution (task=task_1) idmistralchild1 has finished (status=succeeded).
 Child execution (task=task_2) idmistralchild2 has started.

--- a/st2client/tests/unit/test_execution_tail_command.py
+++ b/st2client/tests/unit/test_execution_tail_command.py
@@ -364,6 +364,8 @@ Execution idfoo1 has completed (status=succeeded).
         stderr = self.stderr.getvalue()
 
         expected_result = """
+Execution idfoo3 has started.
+
 line 1
 line 2
 
@@ -421,6 +423,8 @@ Execution idfoo3 has completed (status=succeeded).
         stderr = self.stderr.getvalue()
 
         expected_result = """
+Execution idfoo3 has started.
+
 Child execution (task=task_1) idchild1 has started.
 
 line ac 4
@@ -487,6 +491,8 @@ Execution idfoo3 has completed (status=succeeded).
         stderr = self.stderr.getvalue()
 
         expected_result = """
+Execution idfoo4 has started.
+
 Child execution (task=task_1) idmistralchild1 has started.
 
 line mistral 4
@@ -559,6 +565,7 @@ Execution idfoo4 has completed (status=succeeded).
         stderr = self.stderr.getvalue()
 
         expected_result = """
+Execution idfoo4 has started.
 
 Child execution (task=task_1) idmistralchild1 has started.
 


### PR DESCRIPTION
This pull request updates "st2 execution tail" command to support two level deeply nested workflow (e.g. workflow -> workflow -> execution).

Previously only top-level executions and workflows were supported (e.g. execution, workflow -> execution).

Before:

```bash
st2 run --tail examples.mistral-workbook-subflows
Tailing execution "5a688d74e693a751cdf53852"
Child execution (task=print_subject) 5a688d74e693a751cdf53855 has started.

Child execution (task=print_subject) 5a688d74e693a751cdf53855 has started.

StackStorm
Execution 5a688d74e693a751cdf53852 has completed (status=succeeded).

id: 5a688d74e693a751cdf53852
action.ref: examples.mistral-workbook-subflows
parameters: None
status: running
start_timestamp: Wed, 24 Jan 2018 13:43:16 UTC
end_timestamp: 
+-----------------------------+------------------------+---------------+------------------------+-------------------------------+
| id                          | status                 | task          | action                 | start_timestamp               |
+-----------------------------+------------------------+---------------+------------------------+-------------------------------+
| + 5a688d74e693a751cdf53855  | running (1s elapsed)   | print_subject | examples.mistral-basic | Wed, 24 Jan 2018 13:43:16 UTC |
|    5a688d75e693a751cdf53857 | succeeded (0s elapsed) | task1         | core.local             | Wed, 24 Jan 2018 13:43:17 UTC |
+-----------------------------+------------------------+---------------+------------------------+-------------------------------+
```

After:

```bash
st2 run --tail examples.mistral-workbook-subflows
Tailing execution "5a688ce3e693a751cdf53847"

Execution idfoo4 has started.

Child execution (task=print_subject) 5a688ce3e693a751cdf5384a has started.

Child execution (task=print_subject) 5a688ce3e693a751cdf5384a has started.

Child execution (task=task1) 5a688ce3e693a751cdf5384c has started.

StackStorm
Child execution (task=task1) 5a688ce3e693a751cdf5384c has finished (status=succeeded).

Child execution (task=print_subject) 5a688ce3e693a751cdf5384a has finished (status=succeeded).
Child execution (task=print_adjective) 5a688ceee693a751cdf5384e has started.

Child execution (task=print_adjective) 5a688ceee693a751cdf5384e has started.

Child execution (task=task1) 5a688ceee693a751cdf53850 has started.

awesome
Child execution (task=task1) 5a688ceee693a751cdf53850 has finished (status=succeeded).

Child execution (task=print_adjective) 5a688ceee693a751cdf5384e has finished (status=succeeded).

Execution 5a688ce3e693a751cdf53847 has completed (status=succeeded).

id: 5a688ce3e693a751cdf53847
action.ref: examples.mistral-workbook-subflows
parameters: None
status: succeeded
result_task: print_adjective
result: 
  extra:
    state: SUCCESS
    state_info: null
  stdout: awesome
  tasks:
  - created_at: '2018-01-24 13:41:02'
    id: 46e9957f-629f-4adf-ac0a-7e96d305bdab
    input: null
    name: task1
    published:
      stderr: ''
      stdout: awesome
    result:
      failed: false
      return_code: 0
      stderr: ''
      stdout: awesome
      succeeded: true
    state: SUCCESS
    state_info: null
    updated_at: '2018-01-24 13:41:02'
    workflow_execution_id: 7227396e-7e3a-42a1-88e1-42868a697428
    workflow_name: examples.mistral-basic
start_timestamp: Wed, 24 Jan 2018 13:40:51 UTC
end_timestamp: Wed, 24 Jan 2018 13:41:17 UTC
+-----------------------------+-------------------------+-----------------+------------------------+-------------------------------+
| id                          | status                  | task            | action                 | start_timestamp               |
+-----------------------------+-------------------------+-----------------+------------------------+-------------------------------+
| + 5a688ce3e693a751cdf5384a  | succeeded (10s elapsed) | print_subject   | examples.mistral-basic | Wed, 24 Jan 2018 13:40:51 UTC |
|    5a688ce3e693a751cdf5384c | succeeded (1s elapsed)  | task1           | core.local             | Wed, 24 Jan 2018 13:40:51 UTC |
| + 5a688ceee693a751cdf5384e  | succeeded (9s elapsed)  | print_adjective | examples.mistral-basic | Wed, 24 Jan 2018 13:41:02 UTC |
|    5a688ceee693a751cdf53850 | succeeded (0s elapsed)  | task1           | core.local             | Wed, 24 Jan 2018 13:41:02 UTC |
+-----------------------------+-------------------------+-----------------+------------------------+-------------------------------+
```

Resolves #3960.