### PR TITLE
Fix race condition in execution output test case

### DIFF
--- a/st2api/tests/unit/controllers/v1/test_executions.py
+++ b/st2api/tests/unit/controllers/v1/test_executions.py
@@ -39,6 +39,7 @@ from st2common.transport.publishers import PoolPublisher
 from st2common.util import action_db as action_db_util
 from st2common.util import isotime
 from st2common.util import date as date_utils
+from st2common.stream.listener import get_listener
 import st2common.validators.api.action as action_validator
 from tests.base import BaseActionExecutionControllerTestCase
 from st2tests.api import SUPER_SECRET_PARAMETER
@@ -1195,6 +1196,10 @@ class ActionExecutionControllerTestCase(BaseActionExecutionControllerTestCase, F
 class ActionExecutionOutputControllerTestCase(BaseActionExecutionControllerTestCase,
                                               FunctionalTest):
     def test_get_output_running_execution(self):
+        # Retrieve lister instance to avoid race with listener connection not
+        # being established early enough for tests to pass
+        listener = get_listener(name='execution_output')  # NOQA
+
         # Test the execution output API endpoint for execution which is running (blocking)
         status = action_constants.LIVEACTION_STATUS_RUNNING
         timestamp = date_utils.get_datetime_utc_now()

--- a/st2api/tests/unit/controllers/v1/test_executions.py
+++ b/st2api/tests/unit/controllers/v1/test_executions.py
@@ -1199,7 +1199,7 @@ class ActionExecutionOutputControllerTestCase(BaseActionExecutionControllerTestC
         # Retrieve lister instance to avoid race with listener connection not being established
         # early enough for tests to pass.
         # NOTE: This only affects tests where listeners are not pre-initialized.
-        listener = get_listener(name='execution_output')  # NOQA
+        listener = get_listener(name='execution_output')
         eventlet.sleep(1.0)
 
         # Test the execution output API endpoint for execution which is running (blocking)

--- a/st2api/tests/unit/controllers/v1/test_executions.py
+++ b/st2api/tests/unit/controllers/v1/test_executions.py
@@ -1199,6 +1199,7 @@ class ActionExecutionOutputControllerTestCase(BaseActionExecutionControllerTestC
         # Retrieve lister instance to avoid race with listener connection not
         # being established early enough for tests to pass
         listener = get_listener(name='execution_output')  # NOQA
+        eventlet.sleep(0.5)
 
         # Test the execution output API endpoint for execution which is running (blocking)
         status = action_constants.LIVEACTION_STATUS_RUNNING


### PR DESCRIPTION
This pull request should fixes intermediate failures like the one here - https://travis-ci.org/StackStorm/st2/jobs/316638594.

The problem only manifests itself in the tests, because `get_listener` is a non-blocking method, so it's possible that `listener.listen` won't yet be called when we hit API endpoint and as such, we will miss out some messages.

This can't happen outside the tests, because listeners are pre-intialized.