### PR TITLE
Add version string to st2api module

### DIFF
--- a/st2api/setup.py
+++ b/st2api/setup.py
@@ -20,18 +20,19 @@ from setuptools import setup, find_packages
 
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
-from st2api import __version__
+from dist_utils import get_version_string
 
 ST2_COMPONENT = 'st2api'
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
+INIT_FILE = os.path.join(BASE_DIR, 'st2api/__init__.py')
 
 install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 
 apply_vagrant_workaround()
 setup(
     name=ST2_COMPONENT,
-    version=__version__,
+    version=get_version_string(INIT_FILE),
     description='{} StackStorm event-driven automation platform component'.format(ST2_COMPONENT),
     author='StackStorm',
     author_email='info@stackstorm.com',

--- a/st2api/st2api/__init__.py
+++ b/st2api/st2api/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = '2.6dev'


### PR DESCRIPTION
It occurred when installing:
```
Obtaining file:///opt/stack/github/st2/st2api
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/opt/stack/github/st2/st2api/setup.py", line 23, in <module>
        from st2api import __version__
    ImportError: cannot import name __version__
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /opt/stack/github/st2/st2api/
```