### PR TITLE
Fix cleanup db in launchdev

### DIFF
--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -59,6 +59,11 @@ function init(){
         ST2_REPO=${CURRENT_DIR}/${COMMAND_PATH}/..
     fi
 
+    VENV=${ST2_REPO}/virtualenv
+    PY=${VENV}/bin/python
+    echo "Using virtualenv: ${VENV}"
+    echo "Using python: ${PY}"
+
     if [ -z "$ST2_CONF" ]; then
         ST2_CONF=${ST2_REPO}/conf/st2.dev.conf
     fi
@@ -399,10 +404,10 @@ function st2stop(){
 
 function st2clean(){
     # clean mongo
-    ./virtualenv/bin/python \
-        ./st2common/bin/st2-cleanup-db \
-        --config-file $ST2_CONF
-    
+    . ${VENV}/bin/activate
+    python ${ST2_REPO}/st2common/bin/st2-cleanup-db --config-file $ST2_CONF
+    deactivate
+
     # start with clean logs
     LOGDIR=$(dirname $0)/../logs
     if [ -d ${LOGDIR} ]; then


### PR DESCRIPTION
Fix relative virtualenv, python, and db cleanup file paths. Activate the virtualenv to execute the cleanup DB script otherwise the script will complain about non-existent module st2common.persistence.cleanup.