### PR TITLE
Improved RabbitMQ failure message

### DIFF
--- a/st2common/st2common/transport/connection_retry_wrapper.py
+++ b/st2common/st2common/transport/connection_retry_wrapper.py
@@ -117,7 +117,7 @@ class ConnectionRetryWrapper(object):
                 wrapped_callback(connection=connection, channel=channel)
                 should_stop = True
             except connection.connection_errors + connection.channel_errors as e:
-                self._logger.exception('Connection or channel error identified: %s.' % (str(e)))
+                self._logger.exception('RabbitMQ connection or channel error: %s.' % (str(e)))
                 should_stop, wait = self._retry_context.test_should_stop()
                 # reset channel to None to avoid any channel closing errors. At this point
                 # in case of an exception there should be no channel but that is better to


### PR DESCRIPTION
Modified RabbitMQ connection error message to make it more obvious that it is RabbitMQ.

Fixes #3991 