### PR TITLE
Refactor mistral runner to support callback

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,6 +39,10 @@ Changed
   access a key in ``self.config`` dictionary which doesn't exist. (improvement) #4014
 * Update various Python dependencies to the latest stable versions (apscheduler, gitpython,
   pymongo, stevedore, paramiko, tooz, flex, webob, prance).
+* Refactored mistral runner to support callback from mistral instead of relying on st2resultstracker.
+  This reduces the unnecessary traffic and CPU time by querying the mistral API. Included a command to
+  manually add a state entry for Mistral workflow execution to recover from any callback failures.
+  (improvement)
 
 Fixed
 ~~~~~

--- a/conf/st2.conf.sample
+++ b/conf/st2.conf.sample
@@ -191,6 +191,8 @@ jitter_interval = 0.1
 insecure = False
 # Username for authentication.
 keystone_username = None
+# Enable results tracking and disable callbacks.
+enable_polling = False
 # OpenStack project scope.
 keystone_project_name = None
 # Password for authentication.

--- a/contrib/examples/actions/workflows/mistral-branching.yaml
+++ b/contrib/examples/actions/workflows/mistral-branching.yaml
@@ -22,11 +22,17 @@ examples.mistral-branching:
             action: core.local
             input:
                 cmd: "echo 'Took path A.'"
+            publish:
+                stdout: <% task(a).result.stdout %> 
         b:
             action: core.local
             input:
                 cmd: "echo 'Took path B.'"
+            publish:
+                stdout: <% task(b).result.stdout %> 
         c:
             action: core.local
             input:
                 cmd: "echo 'Took path C.'"
+            publish:
+                stdout: <% task(c).result.stdout %> 

--- a/contrib/examples/actions/workflows/mistral-handle-error-task-default.yaml
+++ b/contrib/examples/actions/workflows/mistral-handle-error-task-default.yaml
@@ -8,11 +8,13 @@ examples.mistral-handle-error-task-default:
     type: direct
     input:
         - cmd
-    output:
-        stdout: <% $.stdout %>
+    vars:
+        error_handled: False
+
     task-defaults:
         on-error:
-            - notify_on_error
+            - handle_error
+
     tasks:
         task1:
             action: core.local cmd=<% $.cmd %>
@@ -20,9 +22,11 @@ examples.mistral-handle-error-task-default:
                 stdout: <% task(task1).result.stdout %>
 
         # Default exception handler
-        notify_on_error:
+        handle_error:
             action: core.local
             input:
                 cmd: "printf 'EPIC FAIL!'"
+            publish:
+                error_handled: True
             on-complete:
                 - fail

--- a/contrib/examples/actions/workflows/mistral-handle-error.yaml
+++ b/contrib/examples/actions/workflows/mistral-handle-error.yaml
@@ -8,18 +8,20 @@ examples.mistral-handle-error:
     type: direct
     input:
         - cmd
-    output:
-        stdout: <% $.stdout %>
+    vars:
+        error_handled: False
     tasks:
         task1:
             action: core.local cmd=<% $.cmd %>
             publish:
                 stdout: <% task(task1).result.stdout %>
             on-error:
-                - notify_on_error
-        notify_on_error:
+                - handle_error
+        handle_error:
             action: core.local
             input:
                 cmd: "printf '<% task(task1).result.stderr %>'"
+            publish:
+                error_handled: True
             on-complete:
                 - fail

--- a/contrib/examples/actions/workflows/tests/mistral-test-pause-resume.yaml
+++ b/contrib/examples/actions/workflows/tests/mistral-test-pause-resume.yaml
@@ -19,4 +19,4 @@ examples.mistral-test-pause-resume:
         task2:
             action: core.local
             input:
-                cmd: echo "<% $.var1 %>" 
+                cmd: 'sleep 10; echo "<% $.var1 %>"' 

--- a/contrib/examples/actions/workflows/tests/mistral-test-pause-resume.yaml
+++ b/contrib/examples/actions/workflows/tests/mistral-test-pause-resume.yaml
@@ -19,4 +19,4 @@ examples.mistral-test-pause-resume:
         task2:
             action: core.local
             input:
-                cmd: 'sleep 10; echo "<% $.var1 %>"' 
+                cmd: 'echo "<% $.var1 %>"' 

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2.py
@@ -147,6 +147,9 @@ WF2 = workflows.Workflow(None, {'name': WF2_NAME, 'definition': WF2_YAML})
 WF2_EXEC = copy.deepcopy(MISTRAL_EXECUTION)
 WF2_EXEC['workflow_name'] = WF2_NAME
 
+# Data for the notify param
+NOTIFY = [{'type': 'st2'}]
+
 
 @mock.patch.object(
     CUDPublisher,
@@ -270,7 +273,7 @@ class MistralRunnerTest(DbTestCase):
         }
 
         executions.ExecutionManager.create.assert_called_with(
-            WF1_NAME, workflow_input=workflow_input, env=env)
+            WF1_NAME, workflow_input=workflow_input, env=env, notify=NOTIFY)
 
     @mock.patch.object(
         workflows.WorkflowManager, 'list',
@@ -354,7 +357,7 @@ class MistralRunnerTest(DbTestCase):
         }
 
         executions.ExecutionManager.create.assert_called_with(
-            WF1_NAME, workflow_input=workflow_input, env=env)
+            WF1_NAME, workflow_input=workflow_input, env=env, notify=NOTIFY)
 
     @mock.patch.object(
         workflows.WorkflowManager, 'list',
@@ -429,7 +432,7 @@ class MistralRunnerTest(DbTestCase):
         }
 
         executions.ExecutionManager.create.assert_called_with(
-            WF1_NAME, workflow_input=workflow_input, env=env)
+            WF1_NAME, workflow_input=workflow_input, env=env, notify=NOTIFY)
 
     @mock.patch.object(
         workflows.WorkflowManager, 'list',
@@ -481,7 +484,7 @@ class MistralRunnerTest(DbTestCase):
         }
 
         executions.ExecutionManager.create.assert_called_with(
-            WF1_NAME, workflow_input=workflow_input, env=env)
+            WF1_NAME, workflow_input=workflow_input, env=env, notify=NOTIFY)
 
     @mock.patch.object(
         workflows.WorkflowManager, 'list',
@@ -535,7 +538,7 @@ class MistralRunnerTest(DbTestCase):
         }
 
         executions.ExecutionManager.create.assert_called_with(
-            WF1_NAME, workflow_input=workflow_input, env=env)
+            WF1_NAME, workflow_input=workflow_input, env=env, notify=NOTIFY)
 
     @mock.patch.object(
         workflows.WorkflowManager, 'list',
@@ -586,7 +589,7 @@ class MistralRunnerTest(DbTestCase):
         }
 
         executions.ExecutionManager.create.assert_called_with(
-            WF1_NAME, workflow_input=workflow_input, env=env)
+            WF1_NAME, workflow_input=workflow_input, env=env, notify=NOTIFY)
 
     @mock.patch.object(
         workflows.WorkflowManager, 'list',
@@ -638,7 +641,7 @@ class MistralRunnerTest(DbTestCase):
         }
 
         executions.ExecutionManager.create.assert_called_with(
-            WF1_NAME, workflow_input=workflow_input, env=env)
+            WF1_NAME, workflow_input=workflow_input, env=env, notify=NOTIFY)
 
     @mock.patch.object(
         workflows.WorkflowManager, 'list',

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_auth.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_auth.py
@@ -86,6 +86,9 @@ WF1_OLD = workflows.Workflow(None, {'name': WF1_NAME, 'definition': ''})
 WF1_EXEC = copy.deepcopy(MISTRAL_EXECUTION)
 WF1_EXEC['workflow_name'] = WF1_NAME
 
+# Data for the notify param
+NOTIFY = [{'type': 'st2'}]
+
 # Token for auth test cases
 TOKEN_API = TokenAPI(
     user=ACTION_CONTEXT['user'], token=uuid.uuid4().hex,
@@ -201,7 +204,7 @@ class MistralAuthTest(DbTestCase):
         }
 
         executions.ExecutionManager.create.assert_called_with(
-            WF1_NAME, workflow_input=workflow_input, env=env)
+            WF1_NAME, workflow_input=workflow_input, env=env, notify=NOTIFY)
 
     @mock.patch.object(
         keystone.KeystoneAuthHandler, 'authenticate',
@@ -270,4 +273,4 @@ class MistralAuthTest(DbTestCase):
         keystone.KeystoneAuthHandler.authenticate.assert_called_with(auth_req, session=None)
 
         executions.ExecutionManager.create.assert_called_with(
-            WF1_NAME, workflow_input=workflow_input, env=env)
+            WF1_NAME, workflow_input=workflow_input, env=env, notify=NOTIFY)

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_cancel.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_cancel.py
@@ -146,6 +146,9 @@ class MistralRunnerCancelTest(DbTestCase):
     @mock.patch.object(
         executions.ExecutionManager, 'update',
         mock.MagicMock(return_value=executions.Execution(None, WF1_EXEC_CANCELLED)))
+    @mock.patch.object(
+        action_service, 'is_children_active',
+        mock.MagicMock(return_value=True))
     def test_cancel(self):
         liveaction = LiveActionDB(action=WF1_NAME, parameters=ACTION_PARAMS)
         liveaction, execution = action_service.request(liveaction)
@@ -234,6 +237,9 @@ class MistralRunnerCancelTest(DbTestCase):
         executions.ExecutionManager, 'update',
         mock.MagicMock(side_effect=[requests.exceptions.ConnectionError(),
                                     executions.Execution(None, WF1_EXEC_CANCELLED)]))
+    @mock.patch.object(
+        action_service, 'is_children_active',
+        mock.MagicMock(return_value=True))
     def test_cancel_retry(self):
         liveaction = LiveActionDB(action=WF1_NAME, parameters=ACTION_PARAMS)
         liveaction, execution = action_service.request(liveaction)

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_pause_and_resume.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_pause_and_resume.py
@@ -143,6 +143,9 @@ class MistralRunnerPauseResumeTest(DbTestCase):
     @mock.patch.object(
         executions.ExecutionManager, 'update',
         mock.MagicMock(return_value=executions.Execution(None, WF1_EXEC_PAUSED)))
+    @mock.patch.object(
+        action_service, 'is_children_active',
+        mock.MagicMock(return_value=True))
     def test_pause(self):
         # Launch the workflow execution.
         liveaction = LiveActionDB(action=WF1_NAME, parameters=ACTION_PARAMS)
@@ -179,6 +182,9 @@ class MistralRunnerPauseResumeTest(DbTestCase):
         mock.MagicMock(side_effect=[
             executions.Execution(None, WF1_EXEC_PAUSED),
             executions.Execution(None, WF1_EXEC)]))
+    @mock.patch.object(
+        action_service, 'is_children_active',
+        mock.MagicMock(return_value=True))
     def test_resume(self):
         # Launch the workflow execution.
         liveaction = LiveActionDB(action=WF1_NAME, parameters=ACTION_PARAMS)
@@ -231,6 +237,9 @@ class MistralRunnerPauseResumeTest(DbTestCase):
             executions.Execution(None, WF1_EXEC_PAUSED),
             executions.Execution(None, WF2_EXEC),
             executions.Execution(None, WF1_EXEC)]))
+    @mock.patch.object(
+        action_service, 'is_children_active',
+        mock.MagicMock(return_value=True))
     def test_resume_subworkflow_action(self):
         requester = cfg.CONF.system_user.user
 
@@ -387,6 +396,9 @@ class MistralRunnerPauseResumeTest(DbTestCase):
             executions.Execution(None, WF1_EXEC_PAUSED),
             executions.Execution(None, WF2_EXEC),
             executions.Execution(None, WF1_EXEC)]))
+    @mock.patch.object(
+        action_service, 'is_children_active',
+        mock.MagicMock(return_value=True))
     def test_resume_missing_subworkflow_action(self):
         requester = cfg.CONF.system_user.user
 

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_rerun.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_rerun.py
@@ -396,17 +396,33 @@ class MistralRunnerTest(DbTestCase):
         executions.ExecutionManager, 'create',
         mock.MagicMock(return_value=executions.Execution(None, WB1_MAIN_EXEC)))
     @mock.patch.object(
+        executions.ExecutionManager, 'update',
+        mock.MagicMock(side_effect=[
+            executions.Execution(None, WB1_MAIN_EXEC),
+            executions.Execution(None, WB1_SUB1_EXEC)
+        ]))
+    @mock.patch.object(
         executions.ExecutionManager, 'get',
         mock.MagicMock(return_value=executions.Execution(None, WB1_MAIN_EXEC_ERRORED)))
     @mock.patch.object(
         executions.ExecutionManager, 'list',
-        mock.MagicMock(
-            return_value=[
+        mock.MagicMock(side_effect=[
+            [
                 executions.Execution(None, WB1_MAIN_EXEC_ERRORED),
-                executions.Execution(None, WB1_SUB1_EXEC_ERRORED)]))
+                executions.Execution(None, WB1_SUB1_EXEC_ERRORED)
+            ],
+            [
+                executions.Execution(None, WB1_SUB1_EXEC_ERRORED)
+            ]
+        ]))
     @mock.patch.object(
         tasks.TaskManager, 'list',
-        mock.MagicMock(side_effect=[WB1_MAIN_TASKS, WB1_SUB1_TASKS]))
+        mock.MagicMock(side_effect=[
+            WB1_MAIN_TASKS,     # First call of _get_tasks at mistral_v2 runner
+            WB1_SUB1_TASKS,     # Recursive call of the first _get_tasks
+            WB1_MAIN_TASKS,     # tasks.list in _update_workflow_env at mistral_v2 runner
+            []                  # Resursive call of _update_workflow_env
+        ]))
     @mock.patch.object(
         tasks.TaskManager, 'rerun',
         mock.MagicMock(return_value=None))
@@ -510,17 +526,33 @@ class MistralRunnerTest(DbTestCase):
         executions.ExecutionManager, 'create',
         mock.MagicMock(return_value=executions.Execution(None, WB1_MAIN_EXEC)))
     @mock.patch.object(
+        executions.ExecutionManager, 'update',
+        mock.MagicMock(side_effect=[
+            executions.Execution(None, WB1_MAIN_EXEC),
+            executions.Execution(None, WB1_SUB1_EXEC)
+        ]))
+    @mock.patch.object(
         executions.ExecutionManager, 'get',
         mock.MagicMock(return_value=executions.Execution(None, WB1_MAIN_EXEC_ERRORED)))
     @mock.patch.object(
         executions.ExecutionManager, 'list',
-        mock.MagicMock(
-            return_value=[
+        mock.MagicMock(side_effect=[
+            [
                 executions.Execution(None, WB1_MAIN_EXEC_ERRORED),
-                executions.Execution(None, WB1_SUB1_EXEC_ERRORED)]))
+                executions.Execution(None, WB1_SUB1_EXEC_ERRORED)
+            ],
+            [
+                executions.Execution(None, WB1_SUB1_EXEC_ERRORED)
+            ]
+        ]))
     @mock.patch.object(
         tasks.TaskManager, 'list',
-        mock.MagicMock(side_effect=[WB1_MAIN_TASKS, WB1_SUB1_TASKS]))
+        mock.MagicMock(side_effect=[
+            WB1_MAIN_TASKS,     # First call of _get_tasks at mistral_v2 runner
+            WB1_SUB1_TASKS,     # Recursive call of the first _get_tasks
+            WB1_MAIN_TASKS,     # tasks.list in _update_workflow_env at mistral_v2 runner
+            []                  # Resursive call of _update_workflow_env
+        ]))
     @mock.patch.object(
         tasks.TaskManager, 'rerun',
         mock.MagicMock(return_value=None))

--- a/st2actions/st2actions/container/base.py
+++ b/st2actions/st2actions/container/base.py
@@ -124,7 +124,8 @@ class RunnerContainer(object):
                 pass
 
             action_completed = status in action_constants.LIVEACTION_COMPLETED_STATES
-            if isinstance(runner, PollingAsyncActionRunner) and not action_completed:
+            if (isinstance(runner, PollingAsyncActionRunner) and
+                    runner.is_polling_enabled() and not action_completed):
                 queries.setup_query(liveaction_db.id, runnertype_db, context)
         except:
             LOG.exception('Failed to run action.')
@@ -215,7 +216,8 @@ class RunnerContainer(object):
 
             action_completed = status in action_constants.LIVEACTION_COMPLETED_STATES
 
-            if isinstance(runner, PollingAsyncActionRunner) and not action_completed:
+            if (isinstance(runner, PollingAsyncActionRunner) and
+                    runner.is_polling_enabled() and not action_completed):
                 queries.setup_query(liveaction_db.id, runnertype_db, context)
         except:
             _, ex, tb = sys.exc_info()

--- a/st2actions/tests/unit/test_polling_async_runner.py
+++ b/st2actions/tests/unit/test_polling_async_runner.py
@@ -1,0 +1,56 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+try:
+    import simplejson as json
+except:
+    import json
+
+from st2common.runners.base import PollingAsyncActionRunner
+from st2common.constants.action import (LIVEACTION_STATUS_RUNNING)
+
+RAISE_PROPERTY = 'raise'
+
+
+def get_runner():
+    return PollingAsyncTestRunner()
+
+
+class PollingAsyncTestRunner(PollingAsyncActionRunner):
+    def __init__(self):
+        super(PollingAsyncTestRunner, self).__init__(runner_id='1')
+        self.pre_run_called = False
+        self.run_called = False
+        self.post_run_called = False
+
+    def pre_run(self):
+        self.pre_run_called = True
+
+    def run(self, action_params):
+        self.run_called = True
+        result = {}
+        if self.runner_parameters.get(RAISE_PROPERTY, False):
+            raise Exception('Raise required.')
+        else:
+            result = {
+                'ran': True,
+                'action_params': action_params
+            }
+
+        return (LIVEACTION_STATUS_RUNNING, json.dumps(result), {'id': 'foo'})
+
+    def post_run(self, status, result):
+        self.post_run_called = True

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -644,7 +644,6 @@ class ActionExecutionsController(ActionExecutionsControllerMixin, ResourceContro
             LOG.exception('Failed updating liveaction %s. %s', liveaction_db.id, str(e))
             abort(http_client.BAD_REQUEST, 'Failed updating execution. %s' % str(e))
         except Exception as e:
-            print str(e)
             LOG.exception('Failed updating liveaction %s. %s', liveaction_db.id, str(e))
             abort(
                 http_client.INTERNAL_SERVER_ERROR,

--- a/st2common/bin/st2-track-result
+++ b/st2common/bin/st2-track-result
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mongoengine as me
+import sys
+
+from oslo_config import cfg
+
+from st2common import config
+from st2common.constants import action as action_constants
+from st2common.exceptions import db as db_exc
+from st2common import log as logging
+from st2common.persistence.execution import ActionExecution
+from st2common import script_setup
+from st2common.services import queries
+from st2common.util import action_db
+
+LOG = logging.getLogger(__name__)
+
+
+def setup():
+    cfg.CONF.register_cli_opt(
+        cfg.StrOpt('id', positional=True, help='ID of the action execution.')
+    )
+
+    cfg.CONF.register_cli_opt(
+        cfg.BoolOpt('delete', default=False, help='Delete the result tracker entry.')
+    )
+
+    script_setup.setup(config, register_mq_exchanges=False)
+
+
+def add_result_tracker(exec_id):
+    LOG.info('Retrieving action execution record...')
+    exec_db = ActionExecution.get_by_id(exec_id)
+    LOG.info('Found action execution record for "%s".', exec_id)
+
+    # Check runner type.
+    runner_type = exec_db.action.get('runner_type')
+
+    if runner_type != 'mistral-v2':
+        LOG.error('Result tracker is only supported for Mistral workflows.')
+        return
+
+    # Skip if action execution is completed.
+    if exec_db.status in action_constants.LIVEACTION_COMPLETED_STATES:
+        LOG.info('Action execution "%s" is already in a completed state.', exec_id)
+        LOG.info('Result tracker entry is not created.')
+        return
+
+    LOG.info('Retrieving runner type and liveaction records...')
+    runnertype_db = action_db.get_runnertype_by_name(exec_db.action.get('runner_type'))
+    liveaction_db = action_db.get_liveaction_by_id(exec_db.liveaction['id'])
+
+    # Skip if liveaction is completed.
+    if liveaction_db.status in action_constants.LIVEACTION_COMPLETED_STATES:
+        LOG.info('Liveaction "%s" is already in a completed state.', liveaction_db.id)
+        LOG.info('Result tracker entry is not created.')
+        return
+
+    # Add query into action execution state DB
+    try:
+        LOG.info('Inserting new request tracker entry...')
+        queries.setup_query(liveaction_db.id, runnertype_db, liveaction_db.context)
+        LOG.info('Successfully inserted the result tracker entry.')
+    except (db_exc.StackStormDBObjectConflictError, me.NotUniqueError):
+        LOG.error('Action execution "%s" already has a result tracker entry.', exec_id)
+    except Exception as e:
+        LOG.error('Unable to create result tracker entry for "%s". %s', exec_id, e.message)
+
+    # Add result tracker for children workflows.
+    for child_exec_id in exec_db.children:
+        child_exec = ActionExecution.get(id=child_exec_id, raise_exception=True)
+        if child_exec.runner['name'] == 'mistral-v2':
+            LOG.info('Adding result tracker for children "%s"...', child_exec_id)
+            add_result_tracker(child_exec_id)
+
+
+def del_result_tracker(exec_id):
+    LOG.info('Retrieving action execution record...')
+    exec_db = ActionExecution.get_by_id(exec_id)
+    LOG.info('Found action execution record for "%s".', exec_id)
+
+    LOG.info('Retrieving runner type and liveaction records...')
+    liveaction_db = action_db.get_liveaction_by_id(exec_db.liveaction['id'])
+
+    LOG.info('Removing result tracker entry...')
+    removed = queries.remove_query(liveaction_db.id)
+
+    if removed:
+        LOG.info('Successfully removed the result tracker entry.')
+    else:
+        LOG.info('There is no result tracker entry to remove.')
+
+
+if __name__ == '__main__':
+    setup()
+
+    if not cfg.CONF.delete:
+        add_result_tracker(cfg.CONF.id)
+    else:
+        del_result_tracker(cfg.CONF.id)

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -325,6 +325,9 @@ def register_opts(ignore_errors=False):
         cfg.StrOpt('keystone_auth_url', default=None, help='Auth endpoint for Keystone.'),
         cfg.StrOpt('cacert', default=None, help='Optional certificate to validate endpoint.'),
         cfg.BoolOpt('insecure', default=False, help='Allow insecure communication with Mistral.'),
+        cfg.BoolOpt(
+            'enable_polling', default=False,
+            help='Enable results tracking and disable callbacks.'),
         cfg.FloatOpt(
             'jitter_interval', default=0.1,
             help='Jitter interval to smooth out HTTP requests '

--- a/st2common/st2common/runners/base.py
+++ b/st2common/st2common/runners/base.py
@@ -33,6 +33,7 @@ from st2common.util.deprecation import deprecated
 __all__ = [
     'ActionRunner',
     'AsyncActionRunner',
+    'PollingAsyncActionRunner',
     'ShellRunnerMixin',
 
     'get_runner',
@@ -226,6 +227,11 @@ class ActionRunner(object):
 
 @six.add_metaclass(abc.ABCMeta)
 class AsyncActionRunner(ActionRunner):
+    pass
+
+
+@six.add_metaclass(abc.ABCMeta)
+class PollingAsyncActionRunner(AsyncActionRunner):
     pass
 
 

--- a/st2common/st2common/runners/base.py
+++ b/st2common/st2common/runners/base.py
@@ -232,7 +232,10 @@ class AsyncActionRunner(ActionRunner):
 
 @six.add_metaclass(abc.ABCMeta)
 class PollingAsyncActionRunner(AsyncActionRunner):
-    pass
+
+    @classmethod
+    def is_polling_enabled(cls):
+        return True
 
 
 class ShellRunnerMixin(object):

--- a/st2common/st2common/services/queries.py
+++ b/st2common/st2common/services/queries.py
@@ -1,0 +1,48 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import logging
+
+from st2common.models.db.executionstate import ActionExecutionStateDB
+from st2common.persistence.executionstate import ActionExecutionState
+
+
+LOG = logging.getLogger(__name__)
+
+
+def setup_query(liveaction_id, runnertype_db, query_context):
+    if not getattr(runnertype_db, 'query_module', None):
+        raise Exception('The runner "%s" does not have a query module.' % runnertype_db.name)
+
+    state_db = ActionExecutionStateDB(
+        execution_id=liveaction_id,
+        query_module=runnertype_db.query_module,
+        query_context=query_context
+    )
+
+    ActionExecutionState.add_or_update(state_db)
+
+
+def remove_query(liveaction_id):
+    state_db = ActionExecutionState.query(execution_id=liveaction_id)
+
+    if not state_db:
+        return False
+
+    ActionExecutionState.delete(state_db, publish=False, dispatch_trigger=False)
+
+    return True

--- a/st2common/tests/unit/services/test_action.py
+++ b/st2common/tests/unit/services/test_action.py
@@ -28,6 +28,7 @@ from st2common.models.system.common import ResourceReference
 from st2common.persistence.action import Action
 from st2common.persistence.liveaction import LiveAction
 from st2common.persistence.runner import RunnerType
+from st2common.runners import utils as runners_utils
 from st2common.services import action as action_service
 from st2common.services import executions
 from st2common.transport.publishers import PoolPublisher
@@ -173,6 +174,7 @@ ACTION_OVR_PARAM_BAD_ATTR_NOOP_REF = ResourceReference(
 USERNAME = 'stanley'
 
 
+@mock.patch.object(runners_utils, 'invoke_post_run', mock.MagicMock(return_value=None))
 @mock.patch.object(PoolPublisher, 'publish', mock.MagicMock())
 class TestActionExecutionService(DbTestCase):
 

--- a/st2tests/integration/mistral/test_errors.py
+++ b/st2tests/integration/mistral/test_errors.py
@@ -16,6 +16,8 @@
 from __future__ import absolute_import
 from integration.mistral import base
 
+from st2common.constants import action as action_constants
+
 
 class ExceptionHandlingTest(base.TestWorkflowExecution):
 
@@ -26,101 +28,89 @@ class ExceptionHandlingTest(base.TestWorkflowExecution):
         self.assertIn('Action "examples.mistral-foobar" cannot be found', t.exception.message)
 
     def test_bad_action(self):
-        execution = self._execute_workflow('examples.mistral-error-bad-action', {})
-        execution = self._wait_for_completion(execution)
-        self._assert_failure(execution)
-        self.assertIn('Failed to find action', execution.result['extra']['state_info'])
+        ex = self._execute_workflow('examples.mistral-error-bad-action', {})
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_FAILED)
+        self.assertIn('Failed to find action', ex.result['extra']['state_info'])
 
     def test_bad_wf_arg(self):
-        execution = self._execute_workflow('examples.mistral-error-bad-wf-arg', {})
-
-        execution = self._wait_for_completion(
-            execution,
-            expect_tasks=False,
-            expect_tasks_completed=False
-        )
-
-        self._assert_failure(execution, expect_tasks_failure=False)
-        self.assertIn('Invalid input', execution.result['extra']['state_info'])
+        ex = self._execute_workflow('examples.mistral-error-bad-wf-arg', {})
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_FAILED)
+        self.assertIn('Invalid input', ex.result['extra']['state_info'])
 
     def test_bad_task_transition(self):
-        execution = self._execute_workflow('examples.mistral-error-bad-task-transition', {})
-
-        execution = self._wait_for_completion(
-            execution,
-            expect_tasks=False,
-            expect_tasks_completed=False
-        )
-
-        self._assert_failure(execution, expect_tasks_failure=False)
-        self.assertIn("Task 'task3' not found", execution.result['error'])
+        ex = self._execute_workflow('examples.mistral-error-bad-task-transition', {})
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_FAILED)
+        self.assertIn("Task 'task3' not found", ex.result['error'])
 
     def test_bad_with_items(self):
-        execution = self._execute_workflow('examples.mistral-error-bad-with-items', {})
-        execution = self._wait_for_completion(execution, expect_tasks=False)
-        self._assert_failure(execution, expect_tasks_failure=False)
-        self.assertIn('Wrong input format', execution.result['extra']['state_info'])
+        ex = self._execute_workflow('examples.mistral-error-bad-with-items', {})
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_FAILED)
+        self.assertIn('Wrong input format', ex.result['extra']['state_info'])
 
     def test_bad_expr_yaql(self):
-        execution = self._execute_workflow('examples.mistral-test-yaql-bad-expr', {})
-        execution = self._wait_for_completion(execution)
-        self._assert_failure(execution, expect_tasks_failure=False)
-        self.assertIn('Can not evaluate YAQL expression', execution.result['extra']['state_info'])
+        ex = self._execute_workflow('examples.mistral-test-yaql-bad-expr', {})
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_FAILED)
+        self.assertIn('Can not evaluate YAQL expression', ex.result['extra']['state_info'])
 
     def test_bad_publish_yaql(self):
-        execution = self._execute_workflow('examples.mistral-test-yaql-bad-publish', {})
-        execution = self._wait_for_completion(execution)
-        self._assert_failure(execution, expect_tasks_failure=False)
-        self.assertIn('Can not evaluate YAQL expression', execution.result['extra']['state_info'])
+        ex = self._execute_workflow('examples.mistral-test-yaql-bad-publish', {})
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_FAILED)
+        self.assertIn('Can not evaluate YAQL expression', ex.result['extra']['state_info'])
 
     def test_bad_subworkflow_input_yaql(self):
-        execution = self._execute_workflow('examples.mistral-test-yaql-bad-subworkflow-input', {})
-        execution = self._wait_for_completion(execution)
-        self._assert_failure(execution, expect_tasks_failure=False)
-        self.assertIn('Can not evaluate YAQL expression', execution.result['extra']['state_info'])
+        ex = self._execute_workflow('examples.mistral-test-yaql-bad-subworkflow-input', {})
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_FAILED)
+        self.assertIn('Can not evaluate YAQL expression', ex.result['extra']['state_info'])
 
     def test_bad_task_transition_yaql(self):
-        execution = self._execute_workflow('examples.mistral-test-yaql-bad-task-transition', {})
-        execution = self._wait_for_completion(execution)
-        self._assert_failure(execution, expect_tasks_failure=False)
-        self.assertIn('Can not evaluate YAQL expression', execution.result['extra']['state_info'])
+        ex = self._execute_workflow('examples.mistral-test-yaql-bad-task-transition', {})
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_FAILED)
+        self.assertIn('Can not evaluate YAQL expression', ex.result['extra']['state_info'])
 
     def test_bad_with_items_yaql(self):
-        execution = self._execute_workflow('examples.mistral-test-yaql-bad-with-items', {})
-        execution = self._wait_for_completion(execution, expect_tasks=False)
-        self._assert_failure(execution, expect_tasks_failure=False)
-        self.assertIn('Can not evaluate YAQL expression', execution.result['extra']['state_info'])
+        ex = self._execute_workflow('examples.mistral-test-yaql-bad-with-items', {})
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_FAILED)
+        self.assertIn('Can not evaluate YAQL expression', ex.result['extra']['state_info'])
 
     def test_bad_expr_jinja(self):
-        execution = self._execute_workflow('examples.mistral-test-jinja-bad-expr', {})
-        execution = self._wait_for_completion(execution, expect_tasks=False)
-        self._assert_failure(execution, expect_tasks_failure=False)
+        ex = self._execute_workflow('examples.mistral-test-jinja-bad-expr', {})
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_FAILED)
 
         # TODO: Currently, Mistral returns "UndefinedError ContextView object has no attribute".
         # Need to fix Mistral to return "Cannot evaulate Jinja expression."
         # self.assertIn('Can not evaluate Jinja expression',
-        # execution.result['extra']['state_info'])
+        # ex.result['extra']['state_info'])
 
     def test_bad_publish_jinja(self):
-        execution = self._execute_workflow('examples.mistral-test-jinja-bad-publish', {})
-        execution = self._wait_for_completion(execution)
-        self._assert_failure(execution, expect_tasks_failure=False)
-        self.assertIn('Can not evaluate Jinja expression', execution.result['extra']['state_info'])
+        ex = self._execute_workflow('examples.mistral-test-jinja-bad-publish', {})
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_FAILED)
+        self.assertIn('Can not evaluate Jinja expression', ex.result['extra']['state_info'])
 
     def test_bad_subworkflow_input_jinja(self):
-        execution = self._execute_workflow('examples.mistral-test-jinja-bad-subworkflow-input', {})
-        execution = self._wait_for_completion(execution)
-        self._assert_failure(execution, expect_tasks_failure=False)
-        self.assertIn('Can not evaluate Jinja expression', execution.result['extra']['state_info'])
+        ex = self._execute_workflow('examples.mistral-test-jinja-bad-subworkflow-input', {})
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_FAILED)
+        self.assertIn('Can not evaluate Jinja expression', ex.result['extra']['state_info'])
 
     def test_bad_task_transition_jinja(self):
-        execution = self._execute_workflow('examples.mistral-test-jinja-bad-task-transition', {})
-        execution = self._wait_for_completion(execution)
-        self._assert_failure(execution, expect_tasks_failure=False)
-        self.assertIn('Can not evaluate Jinja expression', execution.result['extra']['state_info'])
+        ex = self._execute_workflow('examples.mistral-test-jinja-bad-task-transition', {})
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_FAILED)
+        self.assertIn('Can not evaluate Jinja expression', ex.result['extra']['state_info'])
 
     def test_bad_with_items_jinja(self):
-        execution = self._execute_workflow('examples.mistral-test-jinja-bad-with-items', {})
-        execution = self._wait_for_completion(execution, expect_tasks=False)
-        self._assert_failure(execution, expect_tasks_failure=False)
-        self.assertIn('Can not evaluate Jinja expression', execution.result['extra']['state_info'])
+        ex = self._execute_workflow('examples.mistral-test-jinja-bad-with-items', {})
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_FAILED)
+        self.assertIn('Can not evaluate Jinja expression', ex.result['extra']['state_info'])

--- a/st2tests/integration/mistral/test_examples.py
+++ b/st2tests/integration/mistral/test_examples.py
@@ -14,113 +14,94 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import six
 
 from integration.mistral import base
+
+from st2common.constants import action as action_constants
 
 
 class ExamplesTest(base.TestWorkflowExecution):
 
     def test_environment(self):
-        execution = self._execute_workflow('examples.mistral-env-var')
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
-        tasks = {t['name']: t for t in execution.result['tasks']}
-        expected_output = 'http://127.0.0.1:9101/executions/' + execution.id
-        self.assertEqual(tasks['task1']['result']['stdout'], expected_output)
+        ex = self._execute_workflow('examples.mistral-env-var')
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        expected_output = 'http://127.0.0.1:9101/executions/' + ex.id
+        self.assertEqual(ex.result['url'], expected_output)
 
     def test_branching(self):
         # Execute with path a.
-        inputs = {'which': 'a'}
-        execution = self._execute_workflow('examples.mistral-branching', parameters=inputs)
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=2)
-        tasks = {t['name']: t for t in execution.result['tasks']}
-        self.assertEqual(tasks['a']['state'], 'SUCCESS')
-        self.assertEqual(tasks['a']['result']['stdout'], 'Took path A.')
+        params = {'which': 'a'}
+        ex = self._execute_workflow('examples.mistral-branching', params)
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(ex.result['stdout'], 'Took path A.')
 
         # Execute with path b.
-        inputs = {'which': 'b'}
-        execution = self._execute_workflow('examples.mistral-branching', parameters=inputs)
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=2)
-        tasks = {t['name']: t for t in execution.result['tasks']}
-        self.assertEqual(tasks['b']['state'], 'SUCCESS')
-        self.assertEqual(tasks['b']['result']['stdout'], 'Took path B.')
+        params = {'which': 'b'}
+        ex = self._execute_workflow('examples.mistral-branching', params)
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(ex.result['stdout'], 'Took path B.')
 
         # Execute with path c.
-        inputs = {'which': 'c'}
-        execution = self._execute_workflow('examples.mistral-branching', parameters=inputs)
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=2)
-        tasks = {t['name']: t for t in execution.result['tasks']}
-        self.assertEqual(tasks['c']['state'], 'SUCCESS')
-        self.assertEqual(tasks['c']['result']['stdout'], 'Took path C.')
+        params = {'which': 'c'}
+        ex = self._execute_workflow('examples.mistral-branching', params)
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(ex.result['stdout'], 'Took path C.')
 
     def test_join(self):
-        execution = self._execute_workflow('examples.mistral-join')
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=5)
-        tasks = {t['name']: t for t in execution.result['tasks']}
-        for task_name, task_result in six.iteritems(tasks):
-            self.assertEqual(task_result['result']['stdout'], task_name)
+        ex = self._execute_workflow('examples.mistral-join')
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
 
     def test_handle_error(self):
-        execution = self._execute_workflow('examples.mistral-handle-error')
-        execution = self._wait_for_completion(execution, expect_tasks_completed=False)
-        self.assertEqual(execution.status, 'failed')
-        self.assertIn('tasks', execution.result)
-        self.assertEqual(2, len(execution.result['tasks']))
-        tasks = {t['name']: t for t in execution.result['tasks']}
-        self.assertEqual(tasks['task1']['state'], 'ERROR')
-        self.assertIn(tasks['notify_on_error']['state'], ['RUNNING', 'SUCCESS'])
+        ex = self._execute_workflow('examples.mistral-handle-error')
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_FAILED)
+        self.assertTrue(ex.result['error_handled'])
 
     def test_handle_error_task_default(self):
-        execution = self._execute_workflow('examples.mistral-handle-error-task-default')
-        execution = self._wait_for_completion(execution, expect_tasks_completed=False)
-        self.assertEqual(execution.status, 'failed')
-        self.assertIn('tasks', execution.result)
-        self.assertEqual(2, len(execution.result['tasks']))
-        tasks = {t['name']: t for t in execution.result['tasks']}
-        self.assertEqual(tasks['task1']['state'], 'ERROR')
-        self.assertIn(tasks['notify_on_error']['state'], ['RUNNING', 'SUCCESS'])
+        ex = self._execute_workflow('examples.mistral-handle-error-task-default')
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_FAILED)
+        self.assertTrue(ex.result['error_handled'])
 
     def test_handle_retry(self):
-        execution = self._execute_workflow('examples.mistral-handle-retry')
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=4)
+        ex = self._execute_workflow('examples.mistral-handle-retry')
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
 
     def test_repeat(self):
-        inputs = {'cmd': 'echo "Yo!"', 'count': 3}
-        execution = self._execute_workflow('examples.mistral-repeat', parameters=inputs)
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
-        self.assertEqual(len(execution.result['result']), inputs['count'])
-        self.assertListEqual(execution.result['result'], ['Yo!'] * inputs['count'])
+        params = {'cmd': 'echo "Yo!"', 'count': 3}
+        ex = self._execute_workflow('examples.mistral-repeat', params)
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(len(ex.result['result']), params['count'])
+        self.assertListEqual(ex.result['result'], ['Yo!'] * params['count'])
 
     def test_repeat_with_items(self):
-        inputs = {'cmds': ['echo "a"', 'echo "b"', 'echo "c"']}
-        execution = self._execute_workflow('examples.mistral-repeat-with-items', parameters=inputs)
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
-        self.assertEqual(len(execution.result['result']), len(inputs['cmds']))
-        self.assertListEqual(sorted(execution.result['result']), ['a', 'b', 'c'])
+        params = {'cmds': ['echo "a"', 'echo "b"', 'echo "c"']}
+        ex = self._execute_workflow('examples.mistral-repeat-with-items', params)
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(len(ex.result['result']), len(params['cmds']))
+        self.assertListEqual(sorted(ex.result['result']), ['a', 'b', 'c'])
 
     def test_with_items_batch_processing(self):
-        inputs = {'cmd': 'date +%s', 'count': 4}
-        execution = self._execute_workflow('examples.mistral-with-items-concurrency',
-                                           parameters=inputs)
+        params = {'cmd': 'date +%s', 'count': 4}
+        ex = self._execute_workflow('examples.mistral-with-items-concurrency', params)
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(len(ex.result['result']), params['count'])
 
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
-        self.assertEqual(len(execution.result['result']), inputs['count'])
-
-        timestamps = [int(dt) for dt in execution.result['result']]
+        timestamps = [int(dt) for dt in ex.result['result']]
         self.assertTrue(timestamps[1] - timestamps[0] < 3)
         self.assertTrue(timestamps[3] - timestamps[2] < 3)
         self.assertTrue(timestamps[2] - timestamps[1] >= 3)
 
     def test_workbook_multiple_subflows(self):
-        execution = self._execute_workflow('examples.mistral-workbook-multiple-subflows')
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=4)
+        ex = self._execute_workflow('examples.mistral-workbook-multiple-subflows')
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)

--- a/st2tests/integration/mistral/test_filters.py
+++ b/st2tests/integration/mistral/test_filters.py
@@ -19,27 +19,32 @@ import yaml
 
 from integration.mistral import base
 
+from st2common.constants import action as action_constants
+
+
 REGEX_SEARCH_STRINGS = [
     "Your address is 567 Elsewhere Dr. My address is 123 Somewhere Ave.",
     "567 Elsewhere Dr is your address. My address is 123 Somewhere Ave.",
     "No address to be found here! Well, maybe 127.0.0.1"
 ]
 
+REGEX_PATTERN = '([0-9]{3} \\w+ (?:Ave|St|Dr))'
+
 
 class FromJsonStringFiltersTest(base.TestWorkflowExecution):
 
     def test_from_json_string(self):
-
-        execution = self._execute_workflow(
+        ex = self._execute_workflow(
             'examples.mistral-test-func-from-json-string',
             parameters={
                 "input_str": '{"a": "b"}'
             }
         )
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
-        jinja_dict = execution.result['result_jinja']
-        yaql_dict = execution.result['result_yaql']
+
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        jinja_dict = ex.result['result_jinja']
+        yaql_dict = ex.result['result_yaql']
         self.assertTrue(isinstance(jinja_dict, dict))
         self.assertEqual(jinja_dict["a"], "b")
         self.assertTrue(isinstance(yaql_dict, dict))
@@ -49,17 +54,17 @@ class FromJsonStringFiltersTest(base.TestWorkflowExecution):
 class FromYamlStringFiltersTest(base.TestWorkflowExecution):
 
     def test_from_yaml_string(self):
-
-        execution = self._execute_workflow(
+        ex = self._execute_workflow(
             'examples.mistral-test-func-from-yaml-string',
             parameters={
                 "input_str": 'a: b'
             }
         )
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
-        jinja_dict = execution.result['result_jinja']
-        yaql_dict = execution.result['result_yaql']
+
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        jinja_dict = ex.result['result_jinja']
+        yaql_dict = ex.result['result_yaql']
         self.assertTrue(isinstance(jinja_dict, dict))
         self.assertEqual(jinja_dict["a"], "b")
         self.assertTrue(isinstance(yaql_dict, dict))
@@ -69,27 +74,24 @@ class FromYamlStringFiltersTest(base.TestWorkflowExecution):
 class JsonEscapeFiltersTest(base.TestWorkflowExecution):
 
     def test_json_escape(self):
-
         breaking_str = 'This text """ breaks JSON'
-        inputs = {'input_str': breaking_str}
-        execution = self._execute_workflow(
-            'examples.mistral-test-func-json-escape', parameters=inputs
-        )
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
-        jinja_dict = json.loads(execution.result['result_jinja'])[0]
-        yaql_dict = json.loads(execution.result['result_yaql'])[0]
+        params = {'input_str': breaking_str}
+        ex = self._execute_workflow('examples.mistral-test-func-json-escape', params)
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        jinja_dict = json.loads(ex.result['result_jinja'])[0]
+        yaql_dict = json.loads(ex.result['result_yaql'])[0]
         self.assertTrue(isinstance(jinja_dict, dict))
-        self.assertEqual(jinja_dict["title"], breaking_str)
+        self.assertEqual(jinja_dict['title'], breaking_str)
         self.assertTrue(isinstance(yaql_dict, dict))
-        self.assertEqual(yaql_dict["title"], breaking_str)
+        self.assertEqual(yaql_dict['title'], breaking_str)
 
 
 class JsonpathQueryFiltersTest(base.TestWorkflowExecution):
 
     def test_jsonpath_query(self):
 
-        execution = self._execute_workflow(
+        ex = self._execute_workflow(
             'examples.mistral-test-func-jsonpath-query',
             parameters={
                 "input_obj": {'people': [{'first': 'James', 'last': 'Smith'},
@@ -101,10 +103,10 @@ class JsonpathQueryFiltersTest(base.TestWorkflowExecution):
         )
         expected_result = ['Smith', 'Alberts', 'Davis']
 
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
-        jinja_result = execution.result['result_jinja']
-        yaql_result = execution.result['result_yaql']
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        jinja_result = ex.result['result_jinja']
+        yaql_result = ex.result['result_yaql']
         self.assertTrue(isinstance(jinja_result, list))
         self.assertEqual(jinja_result, expected_result)
         self.assertTrue(isinstance(yaql_result, list))
@@ -114,291 +116,220 @@ class JsonpathQueryFiltersTest(base.TestWorkflowExecution):
 class RegexMatchFiltersTest(base.TestWorkflowExecution):
 
     def test_regex_match(self):
-
-        execution = self._execute_workflow(
-            'examples.mistral-test-func-regex-match',
-            parameters={
-                "input_str": REGEX_SEARCH_STRINGS[1],
-                "regex_pattern": "([0-9]{3} \\w+ (?:Ave|St|Dr))"
-            }
-        )
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
-        self.assertTrue(execution.result['result_jinja'])
-        self.assertTrue(execution.result['result_yaql'])
+        params = {'input_str': REGEX_SEARCH_STRINGS[1], 'regex_pattern': REGEX_PATTERN}
+        ex = self._execute_workflow('examples.mistral-test-func-regex-match', params)
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertTrue(ex.result['result_jinja'])
+        self.assertTrue(ex.result['result_yaql'])
 
     def test_regex_nomatch(self):
-
-        execution = self._execute_workflow(
-            'examples.mistral-test-func-regex-match',
-            parameters={
-                "input_str": REGEX_SEARCH_STRINGS[0],
-                "regex_pattern": "([0-9]{3} \\w+ (?:Ave|St|Dr))"
-            }
-        )
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
-        self.assertFalse(execution.result['result_jinja'])
-        self.assertFalse(execution.result['result_yaql'])
+        params = {'input_str': REGEX_SEARCH_STRINGS[0], 'regex_pattern': REGEX_PATTERN}
+        ex = self._execute_workflow('examples.mistral-test-func-regex-match', params)
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertFalse(ex.result['result_jinja'])
+        self.assertFalse(ex.result['result_yaql'])
 
 
 class RegexReplaceFiltersTest(base.TestWorkflowExecution):
 
     def test_regex_replace(self):
+        params = {
+            'input_str': REGEX_SEARCH_STRINGS[1],
+            'regex_pattern': REGEX_PATTERN,
+            'replacement_str': 'foo'
+        }
 
-        execution = self._execute_workflow(
-            'examples.mistral-test-func-regex-replace',
-            parameters={
-                "input_str": REGEX_SEARCH_STRINGS[1],
-                "regex_pattern": "([0-9]{3} \\w+ (?:Ave|St|Dr))",
-                "replacement_str": "foo"
-            }
-        )
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
-        self.assertEqual(
-            execution.result['result_jinja'],
-            "foo is your address. My address is foo."
-        )
-        self.assertEqual(execution.result['result_yaql'], "foo is your address. My address is foo.")
+        ex = self._execute_workflow('examples.mistral-test-func-regex-replace', params)
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        expected_result = 'foo is your address. My address is foo.'
+        self.assertEqual(ex.result['result_jinja'], expected_result)
+        self.assertEqual(ex.result['result_yaql'], expected_result)
 
 
 class RegexSearchFiltersTest(base.TestWorkflowExecution):
 
     def test_regex_search(self):
-
-        execution = self._execute_workflow(
-            'examples.mistral-test-func-regex-search',
-            parameters={
-                "input_str": REGEX_SEARCH_STRINGS[0],
-                "regex_pattern": "([0-9]{3} \\w+ (?:Ave|St|Dr))"
-            }
-        )
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
-        self.assertTrue(execution.result['result_jinja'])
-        self.assertTrue(execution.result['result_yaql'])
+        params = {'input_str': REGEX_SEARCH_STRINGS[0], 'regex_pattern': REGEX_PATTERN}
+        ex = self._execute_workflow('examples.mistral-test-func-regex-search', params)
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertTrue(ex.result['result_jinja'])
+        self.assertTrue(ex.result['result_yaql'])
 
     def test_regex_nosearch(self):
-
-        execution = self._execute_workflow(
-            'examples.mistral-test-func-regex-search',
-            parameters={
-                "input_str": REGEX_SEARCH_STRINGS[2],
-                "regex_pattern": "([0-9]{3} \\w+ (?:Ave|St|Dr))"
-            }
-        )
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
-        self.assertFalse(execution.result['result_jinja'])
-        self.assertFalse(execution.result['result_yaql'])
+        params = {'input_str': REGEX_SEARCH_STRINGS[2], 'regex_pattern': REGEX_PATTERN}
+        ex = self._execute_workflow('examples.mistral-test-func-regex-search', params)
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertFalse(ex.result['result_jinja'])
+        self.assertFalse(ex.result['result_yaql'])
 
 
 class RegexSubstringFiltersTest(base.TestWorkflowExecution):
 
     def test_regex_substring(self):
-
-        execution = self._execute_workflow(
-            'examples.mistral-test-func-regex-substring',
-            parameters={
-                "input_str": REGEX_SEARCH_STRINGS[0],
-                "regex_pattern": "([0-9]{3} \\w+ (?:Ave|St|Dr))"
-            }
-        )
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
-        self.assertEqual(execution.result['result_jinja'], '567 Elsewhere Dr')
-        self.assertEqual(execution.result['result_yaql'], '567 Elsewhere Dr')
-        self.assertEqual(execution.result['result_jinja_index_1'], '123 Somewhere Ave')
-        self.assertEqual(execution.result['result_yaql_index_1'], '123 Somewhere Ave')
+        params = {'input_str': REGEX_SEARCH_STRINGS[0], 'regex_pattern': REGEX_PATTERN}
+        ex = self._execute_workflow('examples.mistral-test-func-regex-substring', params)
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(ex.result['result_jinja'], '567 Elsewhere Dr')
+        self.assertEqual(ex.result['result_yaql'], '567 Elsewhere Dr')
+        self.assertEqual(ex.result['result_jinja_index_1'], '123 Somewhere Ave')
+        self.assertEqual(ex.result['result_yaql_index_1'], '123 Somewhere Ave')
 
 
 class ToHumanTimeFromSecondsFiltersTest(base.TestWorkflowExecution):
 
     def test_to_human_time_from_seconds(self):
-
-        execution = self._execute_workflow(
-            'examples.mistral-test-func-to-human-time-from-seconds',
-            parameters={"seconds": 4587}
-        )
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
-        self.assertEqual(execution.result['result_jinja'], '1h16m27s')
-        self.assertEqual(execution.result['result_yaql'], '1h16m27s')
+        action_ref = 'examples.mistral-test-func-to-human-time-from-seconds'
+        params = {'seconds': 4587}
+        ex = self._execute_workflow(action_ref, params)
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(ex.result['result_jinja'], '1h16m27s')
+        self.assertEqual(ex.result['result_yaql'], '1h16m27s')
 
 
 class UseNoneFiltersTest(base.TestWorkflowExecution):
 
     def test_use_none(self):
-
-        inputs = {'input_str': 'foo'}
-        execution = self._execute_workflow(
-            'examples.mistral-test-func-use-none', parameters=inputs
-        )
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=2)
-        self.assertEqual(execution.result['none_result_jinja'], '%*****__%NONE%__*****%')
-        self.assertEqual(execution.result['none_result_yaql'], '%*****__%NONE%__*****%')
-        self.assertEqual(execution.result['str_result_jinja'], 'foo')
-        self.assertEqual(execution.result['str_result_yaql'], 'foo')
+        params = {'input_str': 'foo'}
+        ex = self._execute_workflow('examples.mistral-test-func-use-none', params)
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(ex.result['none_result_jinja'], '%*****__%NONE%__*****%')
+        self.assertEqual(ex.result['none_result_yaql'], '%*****__%NONE%__*****%')
+        self.assertEqual(ex.result['str_result_jinja'], 'foo')
+        self.assertEqual(ex.result['str_result_yaql'], 'foo')
 
 
 class ToComplexFiltersTest(base.TestWorkflowExecution):
 
     def test_to_complex(self):
-
-        execution = self._execute_workflow(
-            'examples.mistral-test-func-to-complex',
-            parameters={
-                "input_obj": {"a": "b"}
-            }
-        )
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
-        jinja_dict = json.loads(execution.result['result_jinja'])
-        yaql_dict = json.loads(execution.result['result_yaql'])
+        params = {'input_obj': {'a': 'b'}}
+        ex = self._execute_workflow('examples.mistral-test-func-to-complex', params)
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        jinja_dict = json.loads(ex.result['result_jinja'])
+        yaql_dict = json.loads(ex.result['result_yaql'])
         self.assertTrue(isinstance(jinja_dict, dict))
-        self.assertEqual(jinja_dict["a"], "b")
+        self.assertEqual(jinja_dict['a'], 'b')
         self.assertTrue(isinstance(yaql_dict, dict))
-        self.assertEqual(yaql_dict["a"], "b")
+        self.assertEqual(yaql_dict['a'], 'b')
 
 
 class ToJsonStringFiltersTest(base.TestWorkflowExecution):
 
     def test_to_json_string(self):
-
-        execution = self._execute_workflow(
-            'examples.mistral-test-func-to-json-string',
-            parameters={
-                "input_obj": {"a": "b"}
-            }
-        )
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
-        jinja_dict = json.loads(execution.result['result_jinja'])
-        yaql_dict = json.loads(execution.result['result_yaql'])
+        params = {'input_obj': {'a': 'b'}}
+        ex = self._execute_workflow('examples.mistral-test-func-to-json-string', params)
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        jinja_dict = json.loads(ex.result['result_jinja'])
+        yaql_dict = json.loads(ex.result['result_yaql'])
         self.assertTrue(isinstance(jinja_dict, dict))
-        self.assertEqual(jinja_dict["a"], "b")
+        self.assertEqual(jinja_dict['a'], 'b')
         self.assertTrue(isinstance(yaql_dict, dict))
-        self.assertEqual(yaql_dict["a"], "b")
+        self.assertEqual(yaql_dict['a'], 'b')
 
 
 class ToYamlStringFiltersTest(base.TestWorkflowExecution):
 
     def test_to_yaml_string(self):
-
-        execution = self._execute_workflow(
-            'examples.mistral-test-func-to-yaml-string',
-            parameters={
-                "input_obj": {"a": "b"}
-            }
-        )
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
-        jinja_dict = yaml.load(execution.result['result_jinja'])
-        yaql_dict = yaml.load(execution.result['result_yaql'])
+        params = {'input_obj': {'a': 'b'}}
+        ex = self._execute_workflow('examples.mistral-test-func-to-yaml-string', params)
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        jinja_dict = yaml.load(ex.result['result_jinja'])
+        yaql_dict = yaml.load(ex.result['result_yaql'])
         self.assertTrue(isinstance(jinja_dict, dict))
-        self.assertEqual(jinja_dict["a"], "b")
+        self.assertEqual(jinja_dict['a'], 'b')
         self.assertTrue(isinstance(yaql_dict, dict))
-        self.assertEqual(yaql_dict["a"], "b")
+        self.assertEqual(yaql_dict['a'], 'b')
 
 
 class VersionCompareFiltersTest(base.TestWorkflowExecution):
 
     def test_version_compare(self):
-
         versions = {
             '0.9.3': 1,
             '0.10.1': 0,
             '0.10.2': -1
         }
+
         for compare_version, expected_result in versions.items():
-            execution = self._execute_workflow(
-                'examples.mistral-test-func-version-compare',
-                parameters={
-                    "version_a": '0.10.1',
-                    "version_b": compare_version
-                }
-            )
-            execution = self._wait_for_completion(execution)
-            self._assert_success(execution, num_tasks=1)
-            self.assertEqual(execution.result['result_jinja'], expected_result)
-            self.assertEqual(execution.result['result_yaql'], expected_result)
+            action_ref = 'examples.mistral-test-func-version-compare'
+            params = {'version_a': '0.10.1', 'version_b': compare_version}
+            ex = self._execute_workflow(action_ref, params)
+            ex = self._wait_for_completion(ex)
+            self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+            self.assertEqual(ex.result['result_jinja'], expected_result)
+            self.assertEqual(ex.result['result_yaql'], expected_result)
 
 
 class VersionMoreThanFiltersTest(base.TestWorkflowExecution):
 
     def test_version_more_than(self):
-
         versions = {
             '0.9.3': True,
             '0.10.1': False,
             '0.10.2': False
         }
+
         for compare_version, expected_result in versions.items():
-            execution = self._execute_workflow(
-                'examples.mistral-test-func-version-more-than',
-                parameters={
-                    "version_a": '0.10.1',
-                    "version_b": compare_version
-                }
-            )
-            execution = self._wait_for_completion(execution)
-            self._assert_success(execution, num_tasks=1)
-            self.assertEqual(execution.result['result_jinja'], expected_result)
-            self.assertEqual(execution.result['result_yaql'], expected_result)
+            action_ref = 'examples.mistral-test-func-version-more-than'
+            params = {'version_a': '0.10.1', 'version_b': compare_version}
+            ex = self._execute_workflow(action_ref, params)
+            ex = self._wait_for_completion(ex)
+            self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+            self.assertEqual(ex.result['result_jinja'], expected_result)
+            self.assertEqual(ex.result['result_yaql'], expected_result)
 
 
 class VersionLessThanFiltersTest(base.TestWorkflowExecution):
 
     def test_version_less_than(self):
-
         versions = {
             '0.9.3': False,
             '0.10.1': False,
             '0.10.2': True
         }
+
         for compare_version, expected_result in versions.items():
-            execution = self._execute_workflow(
-                'examples.mistral-test-func-version-less-than',
-                parameters={
-                    "version_a": '0.10.1',
-                    "version_b": compare_version
-                }
-            )
-            execution = self._wait_for_completion(execution)
-            self._assert_success(execution, num_tasks=1)
-            self.assertEqual(execution.result['result_jinja'], expected_result)
-            self.assertEqual(execution.result['result_yaql'], expected_result)
+            action_ref = 'examples.mistral-test-func-version-less-than'
+            params = {'version_a': '0.10.1', 'version_b': compare_version}
+            ex = self._execute_workflow(action_ref, params)
+            ex = self._wait_for_completion(ex)
+            self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+            self.assertEqual(ex.result['result_jinja'], expected_result)
+            self.assertEqual(ex.result['result_yaql'], expected_result)
 
 
 class VersionEqualFiltersTest(base.TestWorkflowExecution):
 
     def test_version_equal(self):
-
         versions = {
             '0.9.3': False,
             '0.10.1': True,
             '0.10.2': False
         }
+
         for compare_version, expected_result in versions.items():
-            execution = self._execute_workflow(
-                'examples.mistral-test-func-version-equal',
-                parameters={
-                    "version_a": '0.10.1',
-                    "version_b": compare_version
-                }
-            )
-            execution = self._wait_for_completion(execution)
-            self._assert_success(execution, num_tasks=1)
-            self.assertEqual(execution.result['result_jinja'], expected_result)
-            self.assertEqual(execution.result['result_yaql'], expected_result)
+            action_ref = 'examples.mistral-test-func-version-equal'
+            params = {'version_a': '0.10.1', 'version_b': compare_version}
+            ex = self._execute_workflow(action_ref, params)
+            ex = self._wait_for_completion(ex)
+            self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+            self.assertEqual(ex.result['result_jinja'], expected_result)
+            self.assertEqual(ex.result['result_yaql'], expected_result)
 
 
 class VersionMatchFiltersTest(base.TestWorkflowExecution):
 
     def test_version_match(self):
-
         versions = {
             '>=0.9.3': True,
             '>0.11.3': False,
@@ -406,79 +337,56 @@ class VersionMatchFiltersTest(base.TestWorkflowExecution):
             '<=0.10.1': True,
             '<0.10.2': True
         }
+
         for compare_version, expected_result in versions.items():
-            execution = self._execute_workflow(
-                'examples.mistral-test-func-version-match',
-                parameters={
-                    "version_a": '0.10.1',
-                    "version_b": compare_version
-                }
-            )
-            execution = self._wait_for_completion(execution)
-            self._assert_success(execution, num_tasks=1)
-            self.assertEqual(execution.result['result_jinja'], expected_result)
-            self.assertEqual(execution.result['result_yaql'], expected_result)
+            action_ref = 'examples.mistral-test-func-version-match'
+            params = {'version_a': '0.10.1', 'version_b': compare_version}
+            ex = self._execute_workflow(action_ref, params)
+            ex = self._wait_for_completion(ex)
+            self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+            self.assertEqual(ex.result['result_jinja'], expected_result)
+            self.assertEqual(ex.result['result_yaql'], expected_result)
 
 
 class VersionBumpMajorFiltersTest(base.TestWorkflowExecution):
 
     def test_version_bump_major(self):
-
-        execution = self._execute_workflow(
-            'examples.mistral-test-func-version-bump-major',
-            parameters={
-                "version": '0.10.1'
-            }
-        )
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
-        self.assertEqual(execution.result['result_jinja'], '1.0.0')
-        self.assertEqual(execution.result['result_yaql'], '1.0.0')
+        params = {'version': '0.10.1'}
+        ex = self._execute_workflow('examples.mistral-test-func-version-bump-major', params)
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(ex.result['result_jinja'], '1.0.0')
+        self.assertEqual(ex.result['result_yaql'], '1.0.0')
 
 
 class VersionBumpMinorFiltersTest(base.TestWorkflowExecution):
 
     def test_version_bump_minor(self):
-
-        execution = self._execute_workflow(
-            'examples.mistral-test-func-version-bump-minor',
-            parameters={
-                "version": '0.10.1'
-            }
-        )
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
-        self.assertEqual(execution.result['result_jinja'], '0.11.0')
-        self.assertEqual(execution.result['result_yaql'], '0.11.0')
+        params = {'version': '0.10.1'}
+        ex = self._execute_workflow('examples.mistral-test-func-version-bump-minor', params)
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(ex.result['result_jinja'], '0.11.0')
+        self.assertEqual(ex.result['result_yaql'], '0.11.0')
 
 
 class VersionBumpPatchFiltersTest(base.TestWorkflowExecution):
 
     def test_version_bump_patch(self):
-
-        execution = self._execute_workflow(
-            'examples.mistral-test-func-version-bump-patch',
-            parameters={
-                "version": '0.10.1'
-            }
-        )
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
-        self.assertEqual(execution.result['result_jinja'], '0.10.2')
-        self.assertEqual(execution.result['result_yaql'], '0.10.2')
+        params = {'version': '0.10.1'}
+        ex = self._execute_workflow('examples.mistral-test-func-version-bump-patch', params)
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(ex.result['result_jinja'], '0.10.2')
+        self.assertEqual(ex.result['result_yaql'], '0.10.2')
 
 
 class VersionStripPatchFiltersTest(base.TestWorkflowExecution):
 
     def test_version_strip_patch(self):
-
-        execution = self._execute_workflow(
-            'examples.mistral-test-func-version-strip-patch',
-            parameters={
-                "version": '0.10.1'
-            }
-        )
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
-        self.assertEqual(execution.result['result_jinja'], '0.10')
-        self.assertEqual(execution.result['result_yaql'], '0.10')
+        params = {'version': '0.10.1'}
+        ex = self._execute_workflow('examples.mistral-test-func-version-strip-patch', params)
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(ex.result['result_jinja'], '0.10')
+        self.assertEqual(ex.result['result_yaql'], '0.10')

--- a/st2tests/integration/mistral/test_st2kv.py
+++ b/st2tests/integration/mistral/test_st2kv.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 from integration.mistral import base
 
 from st2client import models
+from st2common.constants import action as action_constants
 
 
 class CustomKeyValuePairTest(base.TestWorkflowExecution):
@@ -61,19 +62,19 @@ class UnencryptedKeyValuePairTest(CustomKeyValuePairTest):
     secret = False
 
     def test_yaql_system_kvp(self):
-        execution = self._execute_workflow('examples.mistral-yaql-st2kv-system-scope')
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
+        ex = self._execute_workflow('examples.mistral-yaql-st2kv-system-scope')
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
 
     def test_yaql_user_kvp(self):
-        execution = self._execute_workflow('examples.mistral-yaql-st2kv-user-scope')
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
+        ex = self._execute_workflow('examples.mistral-yaql-st2kv-user-scope')
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
 
     def test_jinja_system_kvp(self):
-        execution = self._execute_workflow('examples.mistral-jinja-st2kv-system-scope')
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
+        ex = self._execute_workflow('examples.mistral-jinja-st2kv-system-scope')
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
 
     def test_jinja_user_kvp(self):
         # Pending completion of jinja rendering of user scoped variable.
@@ -85,19 +86,19 @@ class EncryptedKeyValuePairTest(CustomKeyValuePairTest):
     secret = True
 
     def test_yaql_system_kvp(self):
-        execution = self._execute_workflow('examples.mistral-yaql-st2kv-system-scope')
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
+        ex = self._execute_workflow('examples.mistral-yaql-st2kv-system-scope')
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
 
     def test_yaql_user_kvp(self):
-        execution = self._execute_workflow('examples.mistral-yaql-st2kv-user-scope')
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
+        ex = self._execute_workflow('examples.mistral-yaql-st2kv-user-scope')
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
 
     def test_jinja_system_kvp(self):
-        execution = self._execute_workflow('examples.mistral-jinja-st2kv-system-scope-encrypted')
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
+        ex = self._execute_workflow('examples.mistral-jinja-st2kv-system-scope-encrypted')
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
 
     def test_jinja_user_kvp(self):
         # Per https://docs.stackstorm.com/datastore.html#storing-secrets,

--- a/st2tests/integration/mistral/test_wiring.py
+++ b/st2tests/integration/mistral/test_wiring.py
@@ -23,6 +23,8 @@ import eventlet
 from integration.mistral import base
 from six.moves import range
 
+from st2common.constants import action as action_constants
+
 
 class WiringTest(base.TestWorkflowExecution):
 
@@ -43,63 +45,71 @@ class WiringTest(base.TestWorkflowExecution):
                 os.remove(self.temp_dir_path)
 
     def test_basic_workflow(self):
-        execution = self._execute_workflow('examples.mistral-basic', {'cmd': 'date'})
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
-        self.assertIn('stdout', execution.result)
+        ex = self._execute_workflow('examples.mistral-basic', {'cmd': 'date'})
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertIn('stdout', ex.result)
+        self.assertEqual(len(ex.result.get('tasks', [])), 1)
 
     def test_basic_workbook(self):
-        execution = self._execute_workflow('examples.mistral-workbook-basic', {'cmd': 'date'})
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
-        self.assertIn('stdout', execution.result)
+        ex = self._execute_workflow('examples.mistral-workbook-basic', {'cmd': 'date'})
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertIn('stdout', ex.result)
+        self.assertEqual(len(ex.result.get('tasks', [])), 1)
 
     def test_complex_workbook_with_yaql(self):
-        execution = self._execute_workflow(
-            'examples.mistral-workbook-complex', {'vm_name': 'demo1'})
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=8)
-        self.assertIn('vm_id', execution.result)
+        params = {'vm_name': 'demo1'}
+        ex = self._execute_workflow('examples.mistral-workbook-complex', params)
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertIn('vm_id', ex.result)
+        self.assertEqual(len(ex.result.get('tasks', [])), 8)
 
     def test_complex_workbook_with_jinja(self):
-        execution = self._execute_workflow(
-            'examples.mistral-jinja-workbook-complex', {'vm_name': 'demo2'})
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=8)
-        self.assertIn('vm_id', execution.result)
+        params = {'vm_name': 'demo2'}
+        ex = self._execute_workflow('examples.mistral-jinja-workbook-complex', params)
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertIn('vm_id', ex.result)
+        self.assertEqual(len(ex.result.get('tasks', [])), 8)
 
     def test_complex_workbook_subflow_actions(self):
-        execution = self._execute_workflow(
-            'examples.mistral-workbook-subflows', {'subject': 'st2', 'adjective': 'cool'})
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=2)
-        self.assertIn('tagline', execution.result)
-        self.assertEqual(execution.result['tagline'], 'st2 is cool!')
+        params = {'subject': 'st2', 'adjective': 'cool'}
+        ex = self._execute_workflow('examples.mistral-workbook-subflows', params)
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertIn('tagline', ex.result)
+        self.assertEqual(ex.result['tagline'], 'st2 is cool!')
+        self.assertEqual(len(ex.result.get('tasks', [])), 2)
 
     def test_with_items(self):
         params = {'cmd': 'date', 'count': 8}
-        execution = self._execute_workflow('examples.mistral-repeat', params)
-        execution = self._wait_for_completion(execution)
-        self._assert_success(execution, num_tasks=1)
-        self.assertEqual(len(execution.result['result']), params['count'])
+        ex = self._execute_workflow('examples.mistral-repeat', params)
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(len(ex.result['result']), params['count'])
+        self.assertEqual(len(ex.result.get('tasks', [])), 1)
 
     def test_concurrent_load(self):
         wf_name = 'examples.mistral-workbook-complex'
         wf_params = {'vm_name': 'demo1'}
-        executions = [self._execute_workflow(wf_name, wf_params) for i in range(3)]
+        exs = [self._execute_workflow(wf_name, wf_params) for i in range(3)]
 
-        eventlet.sleep(30)
+        eventlet.sleep(20)
 
-        for execution in executions:
-            e = self._wait_for_completion(execution)
-            self._assert_success(e, num_tasks=8)
+        for ex in exs:
+            e = self._wait_for_completion(ex)
+            self.assertEqual(e.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
             self.assertIn('vm_id', e.result)
+            self.assertEqual(len(e.result.get('tasks', [])), 8)
 
     def test_execution_failure(self):
-        execution = self._execute_workflow('examples.mistral-basic', {'cmd': 'foo'})
-        execution = self._wait_for_completion(execution)
-        self._assert_failure(execution)
+        ex = self._execute_workflow('examples.mistral-basic', {'cmd': 'foo'})
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_FAILED)
 
     def test_invoke_from_action_chain(self):
-        execution = self._execute_workflow('examples.invoke-mistral-with-jinja', {'cmd': 'date'})
-        execution = self._wait_for_state(execution, ['succeeded'])
+        ex = self._execute_workflow('examples.invoke-mistral-with-jinja', {'cmd': 'date'})
+        ex = self._wait_for_completion(ex)
+        self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)

--- a/st2tests/integration/mistral/test_wiring_cancel.py
+++ b/st2tests/integration/mistral/test_wiring_cancel.py
@@ -20,6 +20,8 @@ import tempfile
 
 from integration.mistral import base
 
+from st2common.constants import action as action_constants
+
 
 class CancellationWiringTest(base.TestWorkflowExecution):
 
@@ -46,26 +48,28 @@ class CancellationWiringTest(base.TestWorkflowExecution):
 
         # Launch the workflow. The workflow will wait for the temp file to be deleted.
         params = {'tempfile': path, 'message': 'foobar'}
-        execution = self._execute_workflow('examples.mistral-test-cancel', params)
-        execution = self._wait_for_task(execution, 'task1', 'RUNNING')
+        ex = self._execute_workflow('examples.mistral-test-cancel', params)
+        self._wait_for_task(ex, 'task1', action_constants.LIVEACTION_STATUS_RUNNING)
 
         # Cancel the workflow before the temp file is created. The workflow will be paused
         # but task1 will still be running to allow for graceful exit.
-        self.st2client.liveactions.delete(execution)
+        self.st2client.liveactions.delete(ex)
 
-        # Expecting the execution to be canceling, waiting for task1 to be completed.
-        execution = self._wait_for_state(execution, ['canceling'])
+        # Expecting the ex to be canceling, waiting for task1 to be completed.
+        ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_CANCELING)
 
         # Delete the temporary file.
         os.remove(path)
         self.assertFalse(os.path.exists(path))
 
-        # Wait for the execution to be canceled.
-        execution = self._wait_for_state(execution, ['canceled'])
+        # Wait for the ex to be canceled.
+        ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_CANCELED)
 
         # Task is completed successfully for graceful exit.
-        self.assertEqual(len(execution.result.get('tasks', [])), 1)
-        self.assertEqual(execution.result['tasks'][0]['state'], 'SUCCESS')
+        self._wait_for_task(ex, 'task1', action_constants.LIVEACTION_STATUS_SUCCEEDED)
+
+        # Get the updated execution with task result.
+        ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_CANCELED)
 
     def test_task_cancellation(self):
         # A temp file is created during test setup. Ensure the temp file exists.
@@ -74,21 +78,17 @@ class CancellationWiringTest(base.TestWorkflowExecution):
 
         # Launch the workflow. The workflow will wait for the temp file to be deleted.
         params = {'tempfile': path, 'message': 'foobar'}
-        execution = self._execute_workflow('examples.mistral-test-cancel', params)
-        execution = self._wait_for_task(execution, 'task1', 'RUNNING')
+        ex = self._execute_workflow('examples.mistral-test-cancel', params)
+        task_exs = self._wait_for_task(ex, 'task1', action_constants.LIVEACTION_STATUS_RUNNING)
 
-        # Identify and cancel the task execution.
-        task_executions = [e for e in self.st2client.liveactions.get_all()
-                           if e.context.get('parent', {}).get('execution_id') == execution.id]
+        # Cancel the task execution.
+        self.st2client.liveactions.delete(task_exs[0])
 
-        self.assertGreater(len(task_executions), 0)
+        # Wait for the task and parent workflow to be canceled.
+        self._wait_for_task(ex, 'task1', action_constants.LIVEACTION_STATUS_CANCELED)
 
-        self.st2client.liveactions.delete(task_executions[0])
-
-        # Wait for the execution and task to be canceled.
-        execution = self._wait_for_state(execution, ['canceled'])
-        self.assertEqual(len(execution.result.get('tasks', [])), 1)
-        self.assertEqual(execution.result['tasks'][0]['state'], 'CANCELLED')
+        # Get the updated execution with task result.
+        ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_CANCELED)
 
     def test_cancellation_cascade_to_subworkflow_action(self):
         # A temp file is created during test setup. Ensure the temp file exists.
@@ -98,34 +98,27 @@ class CancellationWiringTest(base.TestWorkflowExecution):
         # Launch the workflow. The workflow will wait for the temp file to be deleted.
         params = {'tempfile': path, 'message': 'foobar'}
         action_ref = 'examples.mistral-test-cancel-subworkflow-action'
-        execution = self._execute_workflow(action_ref, params)
-        execution = self._wait_for_task(execution, 'task1', 'RUNNING')
+        ex = self._execute_workflow(action_ref, params)
+        task_exs = self._wait_for_task(ex, 'task1', action_constants.LIVEACTION_STATUS_RUNNING)
+        subwf_ex = task_exs[0]
 
         # Cancel the workflow before the temp file is created. The workflow will be canceled
         # but task1 will still be running to allow for graceful exit.
-        self.st2client.liveactions.delete(execution)
+        self.st2client.liveactions.delete(ex)
 
-        # Expecting the execution to be canceling, waiting for task1 to be completed.
-        execution = self._wait_for_state(execution, ['canceling'])
-
-        # Get the subworkflow execution.
-        task_executions = [e for e in self.st2client.liveactions.get_all()
-                           if e.context.get('parent', {}).get('execution_id') == execution.id]
-
-        subworkflow_execution = self.st2client.liveactions.get_by_id(task_executions[0].id)
-        subworkflow_execution = self._wait_for_state(subworkflow_execution, ['canceling'])
+        # Expecting the ex to be canceling, waiting for task1 to be completed.
+        ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_CANCELING)
+        subwf_ex = self._wait_for_state(subwf_ex, action_constants.LIVEACTION_STATUS_CANCELING)
 
         # Delete the temporary file.
         os.remove(path)
         self.assertFalse(os.path.exists(path))
 
-        # Wait for the executions to be canceled.
-        subworkflow_execution = self._wait_for_state(subworkflow_execution, ['canceled'])
-        execution = self._wait_for_state(execution, ['canceled'])
+        # Wait for the exs to be canceled.
+        subwf_ex = self._wait_for_state(subwf_ex, action_constants.LIVEACTION_STATUS_CANCELED)
 
-        # Task is canceled in the execution result.
-        self.assertEqual(len(execution.result.get('tasks', [])), 1)
-        self.assertEqual(execution.result['tasks'][0]['state'], 'CANCELLED')
+        # Get the updated execution with task result.
+        ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_CANCELED)
 
     def test_cancellation_cascade_to_subchain(self):
         # A temp file is created during test setup. Ensure the temp file exists.
@@ -135,34 +128,27 @@ class CancellationWiringTest(base.TestWorkflowExecution):
         # Launch the workflow. The workflow will wait for the temp file to be deleted.
         params = {'tempfile': path, 'message': 'foobar'}
         action_ref = 'examples.mistral-test-cancel-subworkflow-chain'
-        execution = self._execute_workflow(action_ref, params)
-        execution = self._wait_for_task(execution, 'task1', 'RUNNING')
+        ex = self._execute_workflow(action_ref, params)
+        task_exs = self._wait_for_task(ex, 'task1', action_constants.LIVEACTION_STATUS_RUNNING)
+        subwf_ex = task_exs[0]
 
         # Cancel the workflow before the temp file is created. The workflow will be canceled
         # but task1 will still be running to allow for graceful exit.
-        self.st2client.liveactions.delete(execution)
+        self.st2client.liveactions.delete(ex)
 
-        # Expecting the execution to be canceling, waiting for task1 to be completed.
-        execution = self._wait_for_state(execution, ['canceling'])
-
-        # Get the subworkflow execution.
-        task_executions = [e for e in self.st2client.liveactions.get_all()
-                           if e.context.get('parent', {}).get('execution_id') == execution.id]
-
-        subworkflow_execution = self.st2client.liveactions.get_by_id(task_executions[0].id)
-        subworkflow_execution = self._wait_for_state(subworkflow_execution, ['canceling'])
+        # Expecting the ex to be canceling, waiting for task1 to be completed.
+        ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_CANCELING)
+        subwf_ex = self._wait_for_state(subwf_ex, action_constants.LIVEACTION_STATUS_CANCELING)
 
         # Delete the temporary file.
         os.remove(path)
         self.assertFalse(os.path.exists(path))
 
-        # Wait for the executions to be canceled.
-        subworkflow_execution = self._wait_for_state(subworkflow_execution, ['canceled'])
-        execution = self._wait_for_state(execution, ['canceled'])
+        # Wait for the exs to be canceled.
+        subwf_ex = self._wait_for_state(subwf_ex, action_constants.LIVEACTION_STATUS_CANCELED)
 
-        # Task is canceled in the execution result.
-        self.assertEqual(len(execution.result.get('tasks', [])), 1)
-        self.assertEqual(execution.result['tasks'][0]['state'], 'CANCELLED')
+        # Get the updated execution with task result.
+        ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_CANCELED)
 
     def test_cancellation_cascade_from_subworkflow_action(self):
         # A temp file is created during test setup. Ensure the temp file exists.
@@ -172,33 +158,26 @@ class CancellationWiringTest(base.TestWorkflowExecution):
         # Launch the workflow. The workflow will wait for the temp file to be deleted.
         params = {'tempfile': path, 'message': 'foobar'}
         action_ref = 'examples.mistral-test-cancel-subworkflow-action'
-        execution = self._execute_workflow(action_ref, params)
-        execution = self._wait_for_task(execution, 'task1', 'RUNNING')
+        ex = self._execute_workflow(action_ref, params)
+        task_exs = self._wait_for_task(ex, 'task1', action_constants.LIVEACTION_STATUS_RUNNING)
+        subwf_ex = task_exs[0]
 
-        # Identify and cancel the task execution.
-        task_executions = [e for e in self.st2client.liveactions.get_all()
-                           if e.context.get('parent', {}).get('execution_id') == execution.id]
+        # Cancel the subworkflow action.
+        self.st2client.liveactions.delete(subwf_ex)
 
-        self.assertGreater(len(task_executions), 0)
-
-        self.st2client.liveactions.delete(task_executions[0])
-        subworkflow_execution = self.st2client.liveactions.get_by_id(task_executions[0].id)
-
-        # Expecting task1 and main workflow execution to be canceling.
-        subworkflow_execution = self._wait_for_state(subworkflow_execution, ['canceling'])
-        execution = self._wait_for_state(execution, ['canceling'])
+        # Expecting task1 and main workflow ex to be canceling.
+        subwf_ex = self._wait_for_state(subwf_ex, action_constants.LIVEACTION_STATUS_CANCELING)
+        ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_CANCELING)
 
         # Delete the temporary file.
         os.remove(path)
         self.assertFalse(os.path.exists(path))
 
-        # Wait for the executions to be canceled.
-        subworkflow_execution = self._wait_for_state(subworkflow_execution, ['canceled'])
-        execution = self._wait_for_state(execution, ['canceled'])
+        # Wait for the exs to be canceled.
+        subwf_ex = self._wait_for_state(subwf_ex, action_constants.LIVEACTION_STATUS_CANCELED)
 
-        # Task is canceled in the execution result.
-        self.assertEqual(len(execution.result.get('tasks', [])), 1)
-        self.assertEqual(execution.result['tasks'][0]['state'], 'CANCELLED')
+        # Get the updated execution with task result.
+        ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_CANCELED)
 
     def test_cancellation_cascade_from_subchain(self):
         # A temp file is created during test setup. Ensure the temp file exists.
@@ -208,33 +187,26 @@ class CancellationWiringTest(base.TestWorkflowExecution):
         # Launch the workflow. The workflow will wait for the temp file to be deleted.
         params = {'tempfile': path, 'message': 'foobar'}
         action_ref = 'examples.mistral-test-cancel-subworkflow-chain'
-        execution = self._execute_workflow(action_ref, params)
-        execution = self._wait_for_task(execution, 'task1', 'RUNNING')
+        ex = self._execute_workflow(action_ref, params)
+        task_exs = self._wait_for_task(ex, 'task1', action_constants.LIVEACTION_STATUS_RUNNING)
+        subwf_ex = task_exs[0]
 
-        # Identify and cancel the task execution.
-        task_executions = [e for e in self.st2client.liveactions.get_all()
-                           if e.context.get('parent', {}).get('execution_id') == execution.id]
+        # Cancel the subworkflow action.
+        self.st2client.liveactions.delete(subwf_ex)
 
-        self.assertGreater(len(task_executions), 0)
-
-        self.st2client.liveactions.delete(task_executions[0])
-        subworkflow_execution = self.st2client.liveactions.get_by_id(task_executions[0].id)
-
-        # Expecting task1 to be canceling. Main workflow execution is still running.
-        subworkflow_execution = self._wait_for_state(subworkflow_execution, ['canceling'])
-        execution = self._wait_for_state(execution, ['running'])
+        # Expecting task1 and main workflow ex to be canceling.
+        subwf_ex = self._wait_for_state(subwf_ex, action_constants.LIVEACTION_STATUS_CANCELING)
+        ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_RUNNING)
 
         # Delete the temporary file.
         os.remove(path)
         self.assertFalse(os.path.exists(path))
 
-        # Wait for the executions to be canceled.
-        subworkflow_execution = self._wait_for_state(subworkflow_execution, ['canceled'])
-        execution = self._wait_for_state(execution, ['canceled'])
+        # Wait for the exs to be canceled.
+        subwf_ex = self._wait_for_state(subwf_ex, action_constants.LIVEACTION_STATUS_CANCELED)
 
-        # Task is canceled in the execution result.
-        self.assertEqual(len(execution.result.get('tasks', [])), 1)
-        self.assertEqual(execution.result['tasks'][0]['state'], 'CANCELLED')
+        # Get the updated execution with task result.
+        ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_CANCELED)
 
     def test_cancellation_chain_cascade_to_subworkflow(self):
         # A temp file is created during test setup. Ensure the temp file exists.
@@ -244,32 +216,32 @@ class CancellationWiringTest(base.TestWorkflowExecution):
         # Launch the workflow. The workflow will wait for the temp file to be deleted.
         params = {'tempfile': path, 'message': 'foobar'}
         action_ref = 'examples.chain-test-cancel-with-subworkflow'
-        execution = self._execute_workflow(action_ref, params)
-
-        # Expecting the execution to be running.
-        execution = self._wait_for_state(execution, ['running'])
+        ex = self._execute_workflow(action_ref, params)
+        ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_RUNNING)
 
         # Cancel the workflow before the temp file is created. The workflow will be canceled
         # but task1 will still be running to allow for graceful exit.
-        self.st2client.liveactions.delete(execution)
+        self.st2client.liveactions.delete(ex)
 
-        # Expecting the execution to be cancelinging, waiting for task1 to be completed.
-        execution = self._wait_for_state(execution, ['canceling'])
+        # Expecting the ex to be cancelinging, waiting for task1 to be completed.
+        ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_CANCELING)
 
-        # Get the subworkflow execution.
-        task_executions = [e for e in self.st2client.liveactions.get_all()
-                           if e.context.get('parent', {}).get('execution_id') == execution.id]
-
-        subworkflow_execution = self.st2client.liveactions.get_by_id(task_executions[0].id)
-        subworkflow_execution = self._wait_for_state(subworkflow_execution, ['canceling'])
+        # Get the subworkflow ex. Since this is from an Action Chain, the task
+        # context is not available like task of Mistral workflows. Therefore, query
+        # for the children liveactions of the chain to get the task execution.
+        task_exs = self._get_children(ex)
+        self.assertEqual(len(task_exs), 1)
+        subwf_ex = self._wait_for_state(task_exs[0], action_constants.LIVEACTION_STATUS_CANCELING)
 
         # Delete the temporary file.
         os.remove(path)
         self.assertFalse(os.path.exists(path))
 
-        # Wait for the executions to be paused.
-        subworkflow_execution = self._wait_for_state(subworkflow_execution, ['canceled'])
-        execution = self._wait_for_state(execution, ['canceled'])
+        # Wait for the exs to be canceled.
+        subwf_ex = self._wait_for_state(subwf_ex, action_constants.LIVEACTION_STATUS_CANCELED)
+
+        # Get the updated execution with task result.
+        ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_CANCELED)
 
     def test_cancellation_chain_cascade_from_subworkflow(self):
         # A temp file is created during test setup. Ensure the temp file exists.
@@ -279,28 +251,28 @@ class CancellationWiringTest(base.TestWorkflowExecution):
         # Launch the workflow. The workflow will wait for the temp file to be deleted.
         params = {'tempfile': path, 'message': 'foobar'}
         action_ref = 'examples.chain-test-cancel-with-subworkflow'
-        execution = self._execute_workflow(action_ref, params)
+        ex = self._execute_workflow(action_ref, params)
+        ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_RUNNING)
 
-        # Expecting the execution to be running.
-        execution = self._wait_for_state(execution, ['running'])
+        # Identify and cancel the task ex.
+        # Get the subworkflow ex. Since this is from an Action Chain, the task
+        # context is not available like task of Mistral workflows. Therefore, query
+        # for the children liveactions of the chain to get the task execution.
+        task_exs = self._get_children(ex)
+        self.assertEqual(len(task_exs), 1)
+        subwf_ex = self._wait_for_state(task_exs[0], action_constants.LIVEACTION_STATUS_RUNNING)
+        self.st2client.liveactions.delete(subwf_ex)
 
-        # Identify and cancel the task execution.
-        task_executions = [e for e in self.st2client.liveactions.get_all()
-                           if e.context.get('parent', {}).get('execution_id') == execution.id]
-
-        self.assertGreater(len(task_executions), 0)
-
-        self.st2client.liveactions.delete(task_executions[0])
-        subworkflow_execution = self.st2client.liveactions.get_by_id(task_executions[0].id)
-
-        # Expecting task1 and main workflow execution to be canceling.
-        subworkflow_execution = self._wait_for_state(subworkflow_execution, ['canceling'])
-        execution = self._wait_for_state(execution, ['running'])
+        # Expecting task1 and main workflow ex to be canceling.
+        subwf_ex = self._wait_for_state(subwf_ex, action_constants.LIVEACTION_STATUS_CANCELING)
+        ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_RUNNING)
 
         # Delete the temporary file.
         os.remove(path)
         self.assertFalse(os.path.exists(path))
 
-        # Wait for the executions to be paused.
-        subworkflow_execution = self._wait_for_state(subworkflow_execution, ['canceled'])
-        execution = self._wait_for_state(execution, ['canceled'])
+        # Wait for the exs to be canceled.
+        subwf_ex = self._wait_for_state(subwf_ex, action_constants.LIVEACTION_STATUS_CANCELED)
+
+        # Get the updated execution with task result.
+        ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_CANCELED)

--- a/st2tests/st2tests/fixtures/generic/actions/async_action2.yaml
+++ b/st2tests/st2tests/fixtures/generic/actions/async_action2.yaml
@@ -1,0 +1,22 @@
+---
+description: Awesome action-2
+enabled: true
+entry_point: ''
+name: async-action-2
+pack: wolfpack
+parameters:
+  actionimmutable:
+    default: actionimmutable
+    immutable: true
+    type: string
+  actionint:
+    default: 10
+    type: number
+  actionstr:
+    required: true
+    type: string
+  runnerdummy:
+    default: actiondummy
+  runnerimmutable:
+    default: failed_override
+runner_type: test-async-runner-2

--- a/st2tests/st2tests/fixtures/generic/runners/testasyncrunner2.yaml
+++ b/st2tests/st2tests/fixtures/generic/runners/testasyncrunner2.yaml
@@ -1,8 +1,9 @@
 ---
-description: A test async runner.
+description: A test polling async runner.
 enabled: true
-name: test-async-runner-1
-runner_module: test_async_runner
+name: test-async-runner-2
+query_module: test_querier
+runner_module: test_polling_async_runner
 runner_parameters:
   runnerdummy:
     default: runnerdummy

--- a/st2tests/st2tests/fixtures/packs/runners/test_polling_async_runner/test_polling_async_runner.py
+++ b/st2tests/st2tests/fixtures/packs/runners/test_polling_async_runner/test_polling_async_runner.py
@@ -1,0 +1,1 @@
+../../../../../../st2actions/tests/unit/test_polling_async_runner.py


### PR DESCRIPTION
Refactor mistral runner to support callback from mistral instead of relying on st2resultstracker. This reduces the unnecessary traffic and CPU time by querying the mistral API. Add a new PollingAsyncActionRunner for runner that need to add results tracking automatically. Mistral runner will not create a state entry anymore by default. Add a command to manually add a state entry for Mistral workflow execution to recover from any callback failures. Unit and integration tests are refactored accordingly.