### PR TITLE
Small improvements in the Python runner

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,15 +21,13 @@ Changed
 * Additional refactor which makes action runners fully standalone and re-distributable Python
   packages. Also add support for multiple runners (runner modules) inside a single Python package
   and consolidate Python packages from two to one for the following runners: local runners, remote
-  runners, windows runners. #3999
+  runners, windows runners. (improvement) #3999
 
 Fixed
 ~~~~~
-
-* Fix ``Argument list too long`` error when very large parameters are passed into the python
-  wrapper arguments. The fix utilizes ``stdin`` to pass parameters instead of cli argument
-  list.
-  (bug fix) #1598
+* Fix Python runner actions and ``Argument list too long`` error when very large parameters are
+  passed into the action. The fix utilizes ``stdin`` to pass parameters to the Python action wrapper
+  process instead of CLI argument list. (bug fix) #1598 #3976
 
 * Fix a regression in ``POST /v1/webhooks/<webhook name>`` API endpoint introduced in v2.4.0
   and add back support for arrays. In 2.4.0 support for arrays was inadvertently removed and

--- a/contrib/runners/python_runner/python_runner/python_runner.py
+++ b/contrib/runners/python_runner/python_runner/python_runner.py
@@ -47,6 +47,7 @@ from st2common.util.sandboxing import get_sandbox_path
 from st2common.util.sandboxing import get_sandbox_python_path
 from st2common.util.sandboxing import get_sandbox_python_binary_path
 from st2common.util.sandboxing import get_sandbox_virtualenv_path
+from st2common.util.shell import quote_unix
 from st2common.runners import python_action_wrapper
 from st2common.services.action import store_execution_output_data
 from st2common.runners.utils import make_read_and_store_stream_func
@@ -224,6 +225,9 @@ class PythonRunner(ActionRunner):
             action_db=self.action, store_data_func=store_execution_stderr_line)
 
         command_string = list2cmdline(args)
+        if stdin_params:
+            command_string = 'echo %s | %s' % (quote_unix(stdin_params), command_string)
+
         LOG.debug('Running command: PATH=%s PYTHONPATH=%s %s' % (env['PATH'], env['PYTHONPATH'],
                                                                  command_string))
         exit_code, stdout, stderr, timed_out = run_command(cmd=args,

--- a/st2actions/tests/integration/test_python_action_process_wrapper.py
+++ b/st2actions/tests/integration/test_python_action_process_wrapper.py
@@ -124,8 +124,11 @@ class PythonRunnerActionWrapperProcessTestCase(unittest2.TestCase):
                           '--stdin-parameters' %
                          (WRAPPER_SCRIPT_PATH, file_path, config))
         exit_code, stdout, stderr = run_command(command_string, shell=True)
+
+        expected_msg = ('ValueError: No input received and timed out while waiting for parameters '
+                        'from stdin')
         self.assertEqual(exit_code, 1)
-        self.assertTrue('ValueError: No input received and timed out while waiting for parameters from stdin' in stderr)
+        self.assertTrue(expected_msg in stderr)
 
     def test_stdin_params_invalid_format_friendly_error(self):
         config = {}

--- a/st2actions/tests/integration/test_python_action_process_wrapper.py
+++ b/st2actions/tests/integration/test_python_action_process_wrapper.py
@@ -115,3 +115,40 @@ class PythonRunnerActionWrapperProcessTestCase(unittest2.TestCase):
         exit_code, stdout, stderr = run_command(command_string, shell=True)
         self.assertEqual(exit_code, 0)
         self.assertTrue('"status"' in stdout)
+
+    def test_stdin_params_timeout_no_stdin_data_provided(self):
+        config = {}
+        file_path = os.path.join(BASE_DIR, '../../../contrib/examples/actions/noop.py')
+
+        command_string = ('python %s --pack=dummy --file-path=%s --config=\'%s\' '
+                          '--stdin-parameters' %
+                         (WRAPPER_SCRIPT_PATH, file_path, config))
+        exit_code, stdout, stderr = run_command(command_string, shell=True)
+        self.assertEqual(exit_code, 1)
+        self.assertTrue('ValueError: No input received and timed out while waiting for parameters from stdin' in stderr)
+
+    def test_stdin_params_invalid_format_friendly_error(self):
+        config = {}
+
+        file_path = os.path.join(BASE_DIR, '../../../contrib/examples/actions/noop.py')
+        # Not a valid JSON string
+        command_string = ('echo "invalid" | python %s --pack=dummy --file-path=%s --config=\'%s\' '
+                          '--stdin-parameters' %
+                         (WRAPPER_SCRIPT_PATH, file_path, config))
+        exit_code, stdout, stderr = run_command(command_string, shell=True)
+
+        expected_msg = ('ValueError: Failed to parse parameters from stdin. Expected a JSON '
+                        'object with "parameters" attribute: No JSON object could be decoded')
+        self.assertEqual(exit_code, 1)
+        self.assertTrue(expected_msg in stderr)
+
+        # JSON object missing "parameters" attribute/ key
+        command_string = ('echo \'{"foo": "bar"}\' | python %s --pack=dummy --file-path=%s --config=\'%s\' '
+                          '--stdin-parameters' %
+                         (WRAPPER_SCRIPT_PATH, file_path, config))
+        exit_code, stdout, stderr = run_command(command_string, shell=True)
+
+        expected_msg = ('ValueError: Failed to parse parameters from stdin. Expected a JSON '
+                        'object with "parameters" attribute: \'parameters\'')
+        self.assertEqual(exit_code, 1)
+        self.assertTrue(expected_msg in stderr)

--- a/st2actions/tests/integration/test_python_action_process_wrapper.py
+++ b/st2actions/tests/integration/test_python_action_process_wrapper.py
@@ -141,14 +141,3 @@ class PythonRunnerActionWrapperProcessTestCase(unittest2.TestCase):
                         'object with "parameters" attribute: No JSON object could be decoded')
         self.assertEqual(exit_code, 1)
         self.assertTrue(expected_msg in stderr)
-
-        # JSON object missing "parameters" attribute/ key
-        command_string = ('echo \'{"foo": "bar"}\' | python %s --pack=dummy --file-path=%s --config=\'%s\' '
-                          '--stdin-parameters' %
-                         (WRAPPER_SCRIPT_PATH, file_path, config))
-        exit_code, stdout, stderr = run_command(command_string, shell=True)
-
-        expected_msg = ('ValueError: Failed to parse parameters from stdin. Expected a JSON '
-                        'object with "parameters" attribute: \'parameters\'')
-        self.assertEqual(exit_code, 1)
-        self.assertTrue(expected_msg in stderr)

--- a/st2common/st2common/runners/python_action_wrapper.py
+++ b/st2common/st2common/runners/python_action_wrapper.py
@@ -294,7 +294,7 @@ if __name__ == '__main__':
 
         try:
             stdin_parameters = json.loads(stdin_data)
-            stdin_parameters = stdin_parameters['parameters']
+            stdin_parameters = stdin_parameters.get('parameters', {})
         except Exception as e:
             msg = ('Failed to parse parameters from stdin. Expected a JSON object with '
                    '"parameters" attribute: %s' % (str(e)))

--- a/st2common/st2common/runners/python_action_wrapper.py
+++ b/st2common/st2common/runners/python_action_wrapper.py
@@ -294,7 +294,7 @@ if __name__ == '__main__':
 
         try:
             stdin_parameters = json.loads(stdin_data)
-            stdin_parameters = stdin_parameters.get('parameters', {})
+            stdin_parameters = stdin_parameters['parameters']
         except Exception as e:
             msg = ('Failed to parse parameters from stdin. Expected a JSON object with '
                    '"parameters" attribute: %s' % (str(e)))

--- a/st2common/st2common/runners/python_action_wrapper.py
+++ b/st2common/st2common/runners/python_action_wrapper.py
@@ -14,9 +14,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import sys
-from six.moves import input
+import select
 
 # Note: This work-around is required to fix the issue with other Python modules which live
 # inside this directory polluting and masking sys.path for Python runner actions.
@@ -62,6 +63,10 @@ either:
 
 For more information, please see: https://docs.stackstorm.com/upgrade_notes.html#st2-v1-6
 """.strip()
+
+# How many seconds to wait for stdin input when parameters are passed in via stdin before
+# timing out
+READ_STDIN_INPUT_TIMEOUT = 2
 
 
 class ActionService(object):
@@ -278,7 +283,14 @@ if __name__ == '__main__':
 
     if args.stdin_parameters:
         LOG.debug('Getting parameters from stdin')
-        stdin_parameters = json.loads(input())
+
+        i, _, _ = select.select([sys.stdin], [], [], READ_STDIN_INPUT_TIMEOUT)
+
+        if not i:
+            raise ValueError(('No input received and timed out while waiting for '
+                              'parameters from stdin'))
+
+        stdin_parameters = json.loads(sys.stdin.readline().strip())
         stdin_parameters = stdin_parameters.get('parameters', {})
         parameters.update(stdin_parameters)
 

--- a/st2common/st2common/runners/python_action_wrapper.py
+++ b/st2common/st2common/runners/python_action_wrapper.py
@@ -290,8 +290,16 @@ if __name__ == '__main__':
             raise ValueError(('No input received and timed out while waiting for '
                               'parameters from stdin'))
 
-        stdin_parameters = json.loads(sys.stdin.readline().strip())
-        stdin_parameters = stdin_parameters.get('parameters', {})
+        stdin_data = sys.stdin.readline().strip()
+
+        try:
+            stdin_parameters = json.loads(stdin_data)
+            stdin_parameters = stdin_parameters.get('parameters', {})
+        except Exception as e:
+            msg = ('Failed to parse parameters from stdin. Expected a JSON object with '
+                   '"parameters" attribute: %s' % (str(e)))
+            raise ValueError(msg)
+
         parameters.update(stdin_parameters)
 
     LOG.debug('Received parameters: %s', parameters)


### PR DESCRIPTION
This pull request implements small improvements in the Python runner mentioned in #3976:

1. When parameters are passed to the action wrapper process via stdin, time out and throw an exception if no input is received within 2 seconds.

Without that change, we would wait for the input indefinitely when running the wrapper script directly (e.g. for debugging purposes) and up to `timeout` runner parameter seconds when running action under action runner.

2. Update runner to print full command string which can be used to run python wrapper process when using stdin parameters

Before:

```bash
/opt/stackstorm/virtualenvs/examples/bin/python -u /data/stanley/st2common/st2common/runners/python_action_wrapper.py --pack=examples --file-path=/opt/stackstorm/packs/examples/actions/print_to_stdout_and_stderr.py --user=stanley "--parent-args=[\"--config-file\", \"conf/st2.dev.conf\"]" --stdin-parameters "--config={\"region\": \"us-east-1\"}"
```

After:

```bash
echo '{"parameters": {"count": 3, "sleep_delay": 0.5}}' | /opt/stackstorm/virtualenvs/examples/bin/python -u /data/stanley/st2common/st2common/runners/python_action_wrapper.py --pack=examples --file-path=/opt/stackstorm/packs/examples/actions/print_to_stdout_and_stderr.py --user=stanley "--parent-args=[\"--config-file\", \"conf/st2.dev.conf\"]" --stdin-parameters "--config={\"region\": \"us-east-1\"}"
```

## TODO

 - [x] Tests