### PR TITLE
Update Python runner to throw a more user-friendly exception on missing pack config item

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,7 +28,7 @@ Changed
   long retry delays are not recommended. For more information on this limitation please refer to
   the documentation - https://docs.stackstorm.com/reference/policies.html#retry. #3630
 * Update Python runner so it throws a more user-friendly exception in case Python script tries to
-  access a key in ``self.config`` dictionary which doesn't exist. (improvement)
+  access a key in ``self.config`` dictionary which doesn't exist. (improvement) #4014
 
 Fixed
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,7 @@ Changed
 * Increase maximum retry delay for ``action.retry`` policy from 5 seconds to 120 seconds. Because
   of the way retries are currently implemented (they are not st2notifier service restart safe),
   long retry delays are not recommended. For more information on this limitation please refer to
-  the documentation - https://docs.stackstorm.com/reference/policies.html#retry. #3630
+  the documentation - https://docs.stackstorm.com/reference/policies.html#retry. #3630 #3637
 * Update Python runner so it throws a more user-friendly exception in case Python script tries to
   access a key in ``self.config`` dictionary which doesn't exist. (improvement) #4014
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ Changed
   packages. Also add support for multiple runners (runner modules) inside a single Python package
   and consolidate Python packages from two to one for the following runners: local runners, remote
   runners, windows runners. (improvement) #3999
-* Upgrade eventlet library to the latest stable version (0.22.1) (improvement) #4007
+* Upgrade eventlet library to the latest stable version (0.22.1) (improvement) #4007 #3968
 * Increase maximum retry delay for ``action.retry`` policy from 5 seconds to 120 seconds. Because
   of the way retries are currently implemented (they are not st2notifier service restart safe),
   long retry delays are not recommended. For more information on this limitation please refer to

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,8 +26,9 @@ Changed
 * Increase maximum retry delay for ``action.retry`` policy from 5 seconds to 120 seconds. Because
   of the way retries are currently implemented (they are not st2notifier service restart safe),
   long retry delays are not recommended. For more information on this limitation please refer to
-  the documentation - https://docs.stackstorm.com/reference/policies.html#retry.
-  #3630
+  the documentation - https://docs.stackstorm.com/reference/policies.html#retry. #3630
+* Update Python runner so it throws a more user-friendly exception in case Python script tries to
+  access a key in ``self.config`` dictionary which doesn't exist. (improvement)
 
 Fixed
 ~~~~~

--- a/contrib/runners/python_runner/python_runner/python_action_wrapper.py
+++ b/contrib/runners/python_runner/python_runner/python_action_wrapper.py
@@ -42,7 +42,6 @@ from st2common.runners.base_action import Action
 from st2common.runners.utils import get_logger_for_python_runner_action
 from st2common.runners.utils import get_action_class_instance
 from st2common.util import loader as action_loader
-from st2common.content.utils import get_pack_base_path
 from st2common.constants.action import ACTION_OUTPUT_RESULT_DELIMITER
 from st2common.constants.keyvalue import SYSTEM_SCOPE
 from st2common.constants.runners import PYTHON_RUNNER_INVALID_ACTION_STATUS_EXIT_CODE
@@ -150,8 +149,11 @@ class PackConfigDict(dict):
         try:
             value = super(PackConfigDict, self).__getitem__(key)
         except KeyError:
-            pack_path = get_pack_base_path(pack_name=self._pack_name)
-            config_path = os.path.join(pack_path, 'configs/', self._pack_name + '.yaml')
+            # Note: We use late import to avoid performance overhead
+            from oslo_config import cfg
+
+            configs_path = os.path.join(cfg.CONF.system.base_path, 'configs/')
+            config_path = os.path.join(configs_path, self._pack_name + '.yaml')
             msg = CONFIG_MISSING_ITEM_ERROR % (self._pack_name, key, config_path)
             raise ValueError(msg)
 

--- a/contrib/runners/python_runner/python_runner/python_action_wrapper.py
+++ b/contrib/runners/python_runner/python_runner/python_action_wrapper.py
@@ -64,14 +64,6 @@ either:
 For more information, please see: https://docs.stackstorm.com/upgrade_notes.html#st2-v1-6
 """.strip()
 
-CONFIG_MISSING_ITEM_ERROR = """
-Config for pack "%s" is missing key "%s".
-Make sure that the config file exists on disk (%s) and contains that key.
-
-Also make sure you run "st2ctl reload --register-configs" when you add a
-config and after every change you make to the config.
-"""
-
 # How many seconds to wait for stdin input when parameters are passed in via stdin before
 # timing out
 READ_STDIN_INPUT_TIMEOUT = 2
@@ -132,35 +124,6 @@ class ActionService(object):
 
     def delete_value(self, name, local=True, scope=SYSTEM_SCOPE):
         return self.datastore_service.delete_value(name, local)
-
-
-class PackConfigDict(dict):
-    """
-    Dictionary class wraper for pack config dictionaries.
-
-    This class throws a user-friendly exception in case user tries to access config item which
-    doesn't exist in the dict.
-    """
-    def __init__(self, pack_name, *args):
-        super(PackConfigDict, self).__init__(*args)
-        self._pack_name = pack_name
-
-    def __getitem__(self, key):
-        try:
-            value = super(PackConfigDict, self).__getitem__(key)
-        except KeyError:
-            # Note: We use late import to avoid performance overhead
-            from oslo_config import cfg
-
-            configs_path = os.path.join(cfg.CONF.system.base_path, 'configs/')
-            config_path = os.path.join(configs_path, self._pack_name + '.yaml')
-            msg = CONFIG_MISSING_ITEM_ERROR % (self._pack_name, key, config_path)
-            raise ValueError(msg)
-
-        return value
-
-    def __setitem__(self, key, value):
-        super(PackConfigDict, self).__setitem__(key, value)
 
 
 class PythonActionWrapper(object):
@@ -312,8 +275,6 @@ if __name__ == '__main__':
 
     if not isinstance(config, dict):
         raise ValueError('Pack config needs to be a dictionary')
-
-    config = PackConfigDict(args.pack, config)
 
     parameters = {}
 

--- a/contrib/runners/python_runner/python_runner/python_action_wrapper.py
+++ b/contrib/runners/python_runner/python_runner/python_action_wrapper.py
@@ -273,6 +273,9 @@ if __name__ == '__main__':
     parent_args = json.loads(args.parent_args) if args.parent_args else []
     log_level = args.log_level
 
+    if not isinstance(config, dict):
+        raise ValueError('Pack config needs to be a dictionary')
+
     parameters = {}
 
     if args.parameters:

--- a/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
+++ b/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
@@ -55,6 +55,9 @@ ACTION_2_PATH = os.path.join(tests_base.get_fixtures_path(),
                              'packs/dummy_pack_9/actions/invalid_syntax.py')
 NON_SIMPLE_TYPE_ACTION = os.path.join(tests_base.get_resources_path(), 'packs',
                                       'pythonactions/actions/non_simple_type.py')
+PRINT_CONFIG_ITEM_ACTION = os.path.join(tests_base.get_resources_path(), 'packs',
+                                      'pythonactions/actions/print_config_item_doesnt_exist.py')
+
 
 # Note: runner inherits parent args which doesn't work with tests since test pass additional
 # unrecognized args
@@ -719,6 +722,17 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         self.assertEqual(status, LIVEACTION_STATUS_SUCCEEDED)
         self.assertTrue(output is not None)
         self.assertEqual(output['result']['action_input'], large_value)
+
+    def test_missing_config_item_user_friendly_error(self):
+        runner = self._get_mock_runner_obj()
+        runner.entry_point = PRINT_CONFIG_ITEM_ACTION
+        runner.pre_run()
+        (status, output, _) = runner.run({})
+
+        self.assertEqual(status, LIVEACTION_STATUS_FAILED)
+        self.assertTrue(output is not None)
+        self.assertTrue('Config for pack "core" is missing key "key"' in output['stderr'])
+        self.assertTrue('make sure you run "st2ctl reload --register-configs"' in output['stderr'])
 
     def _get_mock_runner_obj(self):
         runner = python_runner.get_runner()

--- a/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
+++ b/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
@@ -731,6 +731,8 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
 
         self.assertEqual(status, LIVEACTION_STATUS_FAILED)
         self.assertTrue(output is not None)
+        self.assertTrue('{}' in output['stdout'])
+        self.assertTrue('default_value' in output['stdout'])
         self.assertTrue('Config for pack "core" is missing key "key"' in output['stderr'])
         self.assertTrue('make sure you run "st2ctl reload --register-configs"' in output['stderr'])
 

--- a/st2common/st2common/runners/base_action.py
+++ b/st2common/st2common/runners/base_action.py
@@ -19,6 +19,7 @@ import abc
 import six
 
 from st2common.runners.utils import get_logger_for_python_runner_action
+from st2common.runners.utils import PackConfigDict
 
 __all__ = [
     'Action'
@@ -46,9 +47,12 @@ class Action(object):
 
         if action_service and getattr(action_service, '_action_wrapper', None):
             log_level = getattr(action_service._action_wrapper, '_log_level', 'debug')
+            pack_name = getattr(action_service._action_wrapper, '_pack', 'unknown')
         else:
             log_level = 'debug'
+            pack_name = 'unknown'
 
+        self.config = PackConfigDict(pack_name, self.config)
         self.logger = get_logger_for_python_runner_action(action_name=self.__class__.__name__,
                                                           log_level=log_level)
 

--- a/st2common/st2common/runners/utils.py
+++ b/st2common/st2common/runners/utils.py
@@ -46,12 +46,11 @@ Make sure that the config file exists on disk (%s) and contains that key.
 
 Also make sure you run "st2ctl reload --register-configs" when you add a
 config and after every change you make to the config.
-"
+"""
+
 # Maps logger name to the actual logger instance
 # We re-use loggers for the same actions to make sure only a single instance exists for a
 # particular action. This way we avoid duplicate log messages, etc.
-"""
-
 LOGGERS = {}
 
 

--- a/st2common/st2common/runners/utils.py
+++ b/st2common/st2common/runners/utils.py
@@ -15,6 +15,8 @@
 
 from __future__ import absolute_import
 
+import os
+
 import logging as stdlib_logging
 
 import six
@@ -25,6 +27,8 @@ from st2common import log as logging
 
 
 __all__ = [
+    'PackConfigDict',
+
     'get_logger_for_python_runner_action',
     'get_action_class_instance',
 
@@ -35,10 +39,49 @@ __all__ = [
 
 LOG = logging.getLogger(__name__)
 
+# Error which is thrown when Python action tries to access self.config key which doesn't exist
+CONFIG_MISSING_ITEM_ERROR = """
+Config for pack "%s" is missing key "%s".
+Make sure that the config file exists on disk (%s) and contains that key.
+
+Also make sure you run "st2ctl reload --register-configs" when you add a
+config and after every change you make to the config.
+"
 # Maps logger name to the actual logger instance
 # We re-use loggers for the same actions to make sure only a single instance exists for a
 # particular action. This way we avoid duplicate log messages, etc.
+"""
+
 LOGGERS = {}
+
+
+class PackConfigDict(dict):
+    """
+    Dictionary class wraper for pack config dictionaries.
+
+    This class throws a user-friendly exception in case user tries to access config item which
+    doesn't exist in the dict.
+    """
+    def __init__(self, pack_name, *args):
+        super(PackConfigDict, self).__init__(*args)
+        self._pack_name = pack_name
+
+    def __getitem__(self, key):
+        try:
+            value = super(PackConfigDict, self).__getitem__(key)
+        except KeyError:
+            # Note: We use late import to avoid performance overhead
+            from oslo_config import cfg
+
+            configs_path = os.path.join(cfg.CONF.system.base_path, 'configs/')
+            config_path = os.path.join(configs_path, self._pack_name + '.yaml')
+            msg = CONFIG_MISSING_ITEM_ERROR % (self._pack_name, key, config_path)
+            raise ValueError(msg)
+
+        return value
+
+    def __setitem__(self, key, value):
+        super(PackConfigDict, self).__setitem__(key, value)
 
 
 def get_logger_for_python_runner_action(action_name, log_level='debug'):

--- a/st2tests/st2tests/resources/packs/pythonactions/actions/print_config_item_doesnt_exist.py
+++ b/st2tests/st2tests/resources/packs/pythonactions/actions/print_config_item_doesnt_exist.py
@@ -21,4 +21,6 @@ from st2common.runners.base_action import Action
 class PrintConfigItemAction(Action):
     def run(self):
         print(self.config)
+        # Verify .get() still works
+        print(self.config.get('item1', 'default_value'))
         print(self.config['key'])

--- a/st2tests/st2tests/resources/packs/pythonactions/actions/print_config_item_doesnt_exist.py
+++ b/st2tests/st2tests/resources/packs/pythonactions/actions/print_config_item_doesnt_exist.py
@@ -1,0 +1,24 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+from st2common.runners.base_action import Action
+
+
+class PrintConfigItemAction(Action):
+    def run(self):
+        print(self.config)
+        print(self.config['key'])


### PR DESCRIPTION
This pull request updates Python runner so it throws a more user-friendly exception when a script tries to access a key in ``self.config`` dictionary which doesn't exist.

@LindsayHill did a good job of adding a note to most pack README.md files which says user need to run ``st2ctl reload --register-configs`` after adding / modifying configs, but it's still easy to miss / forget that step so we should throw as user-friendly exception as possible.

Before:

```bash
python ./st2client/st2client/shell.py run examples.print_config
id: 5a9540d60640fd0bc9dbf6b4
status: failed
parameters: None
result: 
  exit_code: 1
  result: None
  stderr: "Traceback (most recent call last):
  File "/data/stanley/contrib/runners/python_runner/python_runner/python_action_wrapper.py", line 356, in <module>
    obj.run()
  File "/data/stanley/contrib/runners/python_runner/python_runner/python_action_wrapper.py", line 213, in run
    output = action.run(**self._parameters)
  File "/opt/stackstorm/packs/examples/actions/print_config.py", line 9, in run
    api_user = self.config['api_user']
KeyError: 'api_user'
"
  stdout: '=========
    '
```

After:

```bash
python ./st2client/st2client/shell.py run examples.print_config
id: 5a9540a90640fd0bc9dbf6b1
status: failed
parameters: None
result: 
  exit_code: 1
  result: None
  stderr: "Traceback (most recent call last):
  File "/data/stanley/contrib/runners/python_runner/python_runner/python_action_wrapper.py", line 356, in <module>
    obj.run()
  File "/data/stanley/contrib/runners/python_runner/python_runner/python_action_wrapper.py", line 213, in run
    output = action.run(**self._parameters)
  File "/opt/stackstorm/packs/examples/actions/print_config.py", line 9, in run
    api_user = self.config['api_user']
  File "/data/stanley/contrib/runners/python_runner/python_runner/python_action_wrapper.py", line 156, in __getitem__
    raise ValueError(msg)
ValueError: 
Config for pack "examples" is missing key "api_user".
Make sure that the config file exists on disk (/opt/stackstorm/configs/examples.yaml) and contains that key.

Also make sure you run "st2ctl reload --register-configs" when you add a
config and after every change you make to the config.

"
  stdout: '=========
    '
```

## TODO

- [x] Tests