### PR TITLE
Add database model to support coordinated write

### DIFF
--- a/st2common/st2common/exceptions/db.py
+++ b/st2common/st2common/exceptions/db.py
@@ -33,3 +33,10 @@ class StackStormDBObjectConflictError(StackStormBaseException):
         super(StackStormDBObjectConflictError, self).__init__(message)
         self.conflict_id = conflict_id
         self.model_object = model_object
+
+
+class StackStormDBObjectWriteConflictError(StackStormBaseException):
+
+    def __init__(self, instance):
+        msg = 'Conflict saving DB object with id "%s" and rev "%s".' % (instance.id, instance.rev)
+        super(StackStormDBObjectWriteConflictError, self).__init__(msg)

--- a/st2common/st2common/models/db/stormbase.py
+++ b/st2common/st2common/models/db/stormbase.py
@@ -272,3 +272,17 @@ class ContentPackResourceMixin(object):
             ref = ResourceReference(pack=self.pack, name=self.name)
 
         return ref
+
+
+class ChangeRevisionFieldMixin(object):
+
+    rev = me.IntField(required=True, default=1)
+
+    @classmethod
+    def get_indexes(cls):
+        return [
+            {
+                'fields': ['id', 'rev'],
+                'unique': True
+            }
+        ]

--- a/st2common/tests/unit/base.py
+++ b/st2common/tests/unit/base.py
@@ -27,7 +27,10 @@ __all__ = [
     'BaseDBModelCRUDTestCase',
 
     'FakeModel',
-    'FakeModelDB'
+    'FakeModelDB',
+
+    'ChangeRevFakeModel',
+    'ChangeRevFakeModelDB'
 ]
 
 
@@ -87,6 +90,26 @@ class FakeModelDB(stormbase.StormBaseDB):
 
 class FakeModel(Access):
     impl = db.MongoDBAccess(FakeModelDB)
+
+    @classmethod
+    def _get_impl(cls):
+        return cls.impl
+
+    @classmethod
+    def _get_by_object(cls, object):
+        return None
+
+    @classmethod
+    def _get_publisher(cls):
+        return None
+
+
+class ChangeRevFakeModelDB(stormbase.StormBaseDB, stormbase.ChangeRevisionFieldMixin):
+    context = stormbase.EscapedDictField()
+
+
+class ChangeRevFakeModel(Access):
+    impl = db.ChangeRevisionMongoDBAccess(ChangeRevFakeModelDB)
 
     @classmethod
     def _get_impl(cls):

--- a/st2common/tests/unit/test_persistence_change_revision.py
+++ b/st2common/tests/unit/test_persistence_change_revision.py
@@ -1,0 +1,98 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import uuid
+
+from st2common.exceptions import db as db_exc
+from st2tests import DbTestCase
+
+from tests.unit.base import ChangeRevFakeModel, ChangeRevFakeModelDB
+
+
+class TestChangeRevision(DbTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestChangeRevision, cls).setUpClass()
+        cls.access = ChangeRevFakeModel()
+
+    def tearDown(self):
+        ChangeRevFakeModelDB.drop_collection()
+        super(TestChangeRevision, self).tearDown()
+
+    def test_crud(self):
+        initial = ChangeRevFakeModelDB(name=uuid.uuid4().hex, context={'a': 1})
+
+        # Test create
+        created = self.access.add_or_update(initial)
+        self.assertEqual(initial.rev, 1)
+        doc_id = created.id
+
+        # Test read
+        retrieved = self.access.get_by_id(doc_id)
+        self.assertDictEqual(created.context, retrieved.context)
+
+        # Test update
+        retrieved = self.access.update(retrieved, context={'a': 2})
+        updated = self.access.get_by_id(doc_id)
+        self.assertNotEqual(created.rev, updated.rev)
+        self.assertEqual(retrieved.rev, updated.rev)
+        self.assertDictEqual(retrieved.context, updated.context)
+
+        # Test add or update
+        retrieved.context = {'a': 1, 'b': 2}
+        retrieved = self.access.add_or_update(retrieved)
+        updated = self.access.get_by_id(doc_id)
+        self.assertNotEqual(created.rev, updated.rev)
+        self.assertEqual(retrieved.rev, updated.rev)
+        self.assertDictEqual(retrieved.context, updated.context)
+
+        # Test delete
+        created.delete()
+
+        self.assertRaises(
+            db_exc.StackStormDBObjectNotFoundError,
+            self.access.get_by_id,
+            doc_id
+        )
+
+    def test_write_conflict(self):
+        initial = ChangeRevFakeModelDB(name=uuid.uuid4().hex, context={'a': 1})
+
+        # Prep record
+        created = self.access.add_or_update(initial)
+        self.assertEqual(initial.rev, 1)
+        doc_id = created.id
+
+        # Get two separate instances of the document.
+        retrieved1 = self.access.get_by_id(doc_id)
+        retrieved2 = self.access.get_by_id(doc_id)
+
+        # Test update on instance 1, expect success
+        retrieved1 = self.access.update(retrieved1, context={'a': 2})
+        updated = self.access.get_by_id(doc_id)
+        self.assertNotEqual(created.rev, updated.rev)
+        self.assertEqual(retrieved1.rev, updated.rev)
+        self.assertDictEqual(retrieved1.context, updated.context)
+
+        # Test update on instance 2, expect race error
+        self.assertRaises(
+            db_exc.StackStormDBObjectWriteConflictError,
+            self.access.update,
+            retrieved2,
+            context={'a': 1, 'b': 2}
+        )


### PR DESCRIPTION
Add a base model with a change revision field that is used as save condition in MongoDB for coordinated writes between multiple threads or processes. This is required to support coordinated update of workflow execution by parallel tasks running at multiple processes.