### PR TITLE
Fix for #4025 - st2ctl environment variables

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,7 @@ Added
   (new feature) #4016 #3922
 * Added the ability of ``st2ctl`` to utilize environment variables from ``/etc/default/st2ctl``
   (for Ubuntu/Debian) and ``/etc/sysconfig/st2ctl`` (RHEL/CentOS). This allows
-  deployments to override ``COMPONENTS`` and ``ST2_CONFIG`` in a global location
+  deployments to override ``COMPONENTS`` and ``ST2_CONF`` in a global location
   so ``st2ctl`` can start/stop/restart selected components and utilize a non-default
   location for ``st2.conf``.
   (new feature) #4027

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,14 @@ Added
   Note: For this feature to work, Python 3 needs to be installed on the system and ``virtualenv``
   package installed on the system needs to support Python 3 (it needs to be a recent version).
   (new feature) #4016 #3922
+* Added the ability of ``st2ctl`` to utilize environment variables from ``/etc/default/st2ctl``
+  (for Ubuntu/Debian) and ``/etc/sysconfig/st2ctl`` (RHEL/CentOS). This allows
+  deployments to override ``COMPONENTS`` and ``ST2_CONFIG`` in a global location
+  so ``st2ctl`` can start/stop/restart selected components and utilize a non-default
+  location for ``st2.conf``.
+  (new feature) #4027
+
+  Contributed by Nick Maludy (Encore Technologies).
 
 Changed
 ~~~~~~~

--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -14,13 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-LOGFILE="/dev/null"
 COMPONENTS="st2actionrunner st2api st2stream st2auth st2garbagecollector st2notifier st2resultstracker st2rulesengine st2sensorcontainer st2chatops mistral"
-STANCONF="/etc/st2/st2.conf"
+ST2_CONFIG="/etc/st2/st2.conf"
 
 # Ensure global environment is sourced if exists
 # Does not happen consistently with all OSes we support.
 [ -r /etc/environment ] && . /etc/environment
+
+# load in environment to allow override of COMPONENTS and ST2_CONFIG above
+# Ubuntu/Debian
+[ -r /etc/default/st2ctl ] && . /etc/default/st2ctl
+# RHEL/CentOS
+[ -r /etc/sysconfig/st2ctl ] && . /etc/sysconfig/st2ctl
 
 
 function print_usage() {
@@ -162,13 +167,13 @@ function register_content() {
     REGISTER_FLAGS=${flags}
   fi
 
-  echo "Registering content...[flags = --config-file ${STANCONF} ${REGISTER_FLAGS}]"
-  st2-register-content --config-file ${STANCONF} ${REGISTER_FLAGS}
+  echo "Registering content...[flags = --config-file ${ST2_CONFIG} ${REGISTER_FLAGS}]"
+  st2-register-content --config-file ${ST2_CONFIG} ${REGISTER_FLAGS}
 }
 
 function clean_db() {
   echo "Dropping st2 Database..."
-  /opt/stackstorm/st2/bin/st2-cleanup-db --config-file ${STANCONF}
+  /opt/stackstorm/st2/bin/st2-cleanup-db --config-file ${ST2_CONFIG}
 }
 
 function clean_logs() {

--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -15,17 +15,17 @@
 # limitations under the License.
 
 COMPONENTS="st2actionrunner st2api st2stream st2auth st2garbagecollector st2notifier st2resultstracker st2rulesengine st2sensorcontainer st2chatops mistral"
-ST2_CONFIG="/etc/st2/st2.conf"
+ST2_CONF="/etc/st2/st2.conf"
 
 # Ensure global environment is sourced if exists
 # Does not happen consistently with all OSes we support.
-[ -r /etc/environment ] && . /etc/environment
+[ -r /etc/environment ] && source /etc/environment
 
-# load in environment to allow override of COMPONENTS and ST2_CONFIG above
+# load in environment to allow override of COMPONENTS and ST2_CONF above
 # Ubuntu/Debian
-[ -r /etc/default/st2ctl ] && . /etc/default/st2ctl
+[ -r /etc/default/st2ctl ] && source /etc/default/st2ctl
 # RHEL/CentOS
-[ -r /etc/sysconfig/st2ctl ] && . /etc/sysconfig/st2ctl
+[ -r /etc/sysconfig/st2ctl ] && source /etc/sysconfig/st2ctl
 
 
 function print_usage() {
@@ -167,13 +167,13 @@ function register_content() {
     REGISTER_FLAGS=${flags}
   fi
 
-  echo "Registering content...[flags = --config-file ${ST2_CONFIG} ${REGISTER_FLAGS}]"
-  st2-register-content --config-file ${ST2_CONFIG} ${REGISTER_FLAGS}
+  echo "Registering content...[flags = --config-file ${ST2_CONF} ${REGISTER_FLAGS}]"
+  st2-register-content --config-file ${ST2_CONF} ${REGISTER_FLAGS}
 }
 
 function clean_db() {
   echo "Dropping st2 Database..."
-  /opt/stackstorm/st2/bin/st2-cleanup-db --config-file ${ST2_CONFIG}
+  /opt/stackstorm/st2/bin/st2-cleanup-db --config-file ${ST2_CONF}
 }
 
 function clean_logs() {


### PR DESCRIPTION
This is a fix for #4025 .

It adds the ability for `st2ctl` to load in environment variables from an `/etc/default/st2ctl` (ubuntu) or `/etc/sysconfig/st2ctl` file. This allows deployments to utilize selective component lists and non-default st2.conf  locations.