### PR TITLE
Ensure parity between SensorType API spec and implementation

### DIFF
--- a/st2api/st2api/controllers/v1/sensors.py
+++ b/st2api/st2api/controllers/v1/sensors.py
@@ -36,7 +36,9 @@ class SensorTypeController(resource.ContentPackResourceController):
     access = SensorType
     supported_filters = {
         'name': 'name',
-        'pack': 'pack'
+        'pack': 'pack',
+        'enabled': 'enabled',
+        'trigger': 'trigger_types'
     }
 
     options = {

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -2983,10 +2983,6 @@ paths:
           in: query
           description: Entity pack name filter
           type: string
-        - name: action
-          in: query
-          description: Action ref filter
-          type: string
         - name: trigger
           in: query
           description: Trigger filter

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -2979,10 +2979,6 @@ paths:
           in: query
           description: Entity pack name filter
           type: string
-        - name: action
-          in: query
-          description: Action ref filter
-          type: string
         - name: trigger
           in: query
           description: Trigger filter


### PR DESCRIPTION
I'm currently working on Triggers app for st2web and I've noticed our /sensortypes endpoint doesn't confirm with its spec. The PR fixes that. It also allows us to filter sensortypes by triggers they produce, which in turn makes it easier to build trigger objects for the UI.