### PR TITLE
Add a test case which verifies tracebacks in Python runner actions are not duplicated in stderr

### DIFF
--- a/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
+++ b/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
@@ -699,6 +699,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         self.assertTrue(expected_msg_4 not in output['stderr'])
         self.assertTrue(expected_msg_5 in output['stderr'])
 
+    def test_traceback_messages_are_not_duplicated_in_stderr(self):
         # Verify tracebacks are not duplicated
         runner = self._get_mock_runner_obj()
         runner.entry_point = PASCAL_ROW_ACTION_PATH

--- a/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
+++ b/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
@@ -699,6 +699,23 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         self.assertTrue(expected_msg_4 not in output['stderr'])
         self.assertTrue(expected_msg_5 in output['stderr'])
 
+        # Verify tracebacks are not duplicated
+        runner = self._get_mock_runner_obj()
+        runner.entry_point = PASCAL_ROW_ACTION_PATH
+        runner.pre_run()
+        (status, output, _) = runner.run({'row_index': 'f'})
+        self.assertEqual(status, LIVEACTION_STATUS_FAILED)
+        self.assertTrue(output is not None)
+
+        expected_msg_1 = 'Traceback (most recent'
+        expected_msg_2 = 'ValueError: Duplicate traceback test'
+
+        self.assertTrue(expected_msg_1 in output['stderr'])
+        self.assertTrue(expected_msg_2 in output['stderr'])
+
+        self.assertEqual(output.count(expected_msg_1, 1))
+        self.assertEqual(output.count(expected_msg_2, 1))
+
     def test_execution_with_very_large_parameter(self):
         runner = self._get_mock_runner_obj()
         runner.entry_point = ECHOER_ACTION_PATH

--- a/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
+++ b/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
@@ -713,8 +713,8 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         self.assertTrue(expected_msg_1 in output['stderr'])
         self.assertTrue(expected_msg_2 in output['stderr'])
 
-        self.assertEqual(output.count(expected_msg_1, 1))
-        self.assertEqual(output.count(expected_msg_2, 1))
+        self.assertEqual(output['stderr'].count(expected_msg_1), 1)
+        self.assertEqual(output['stderr'].count(expected_msg_2), 1)
 
     def test_execution_with_very_large_parameter(self):
         runner = self._get_mock_runner_obj()

--- a/st2tests/st2tests/resources/packs/pythonactions/actions/pascal_row.py
+++ b/st2tests/st2tests/resources/packs/pythonactions/actions/pascal_row.py
@@ -39,6 +39,8 @@ class PascalRowAction(Action):
             return [math.factorial(row_index) /
                     (math.factorial(i) * math.factorial(row_index - i))
                     for i in range(row_index + 1)]
+        elif row_index == 'f':
+            raise ValueError('Duplicate traceback test')
         else:
             return True, [math.factorial(row_index) /
                           (math.factorial(i) * math.factorial(row_index - i))


### PR DESCRIPTION
This pull request adds a test case which verifies Traceback messages are not duplicated in Python runner action stderr output.

A user reported an issue which says Tracebacks are duplicated in action stderr. I was unable to replicate the issue in {v2.5.0,v2.6.0,master} and I noticed we don't have a test case for it yet, so I added one.

The test case passes, because the issue doesn't seem to exist or it's related to some edge case or a specific action.

(We do have a test case for duplicated logger messages, it was added as part of https://github.com/StackStorm/st2/pull/3893).