### PR TITLE
Fix, tests for #4033

### DIFF
--- a/contrib/packs/tests/test_action_unload.py
+++ b/contrib/packs/tests/test_action_unload.py
@@ -88,8 +88,8 @@ class UnloadActionTestCase(BaseActionTestCase, CleanDbTestCase):
         self.assertEqual(len(action_dbs), 1)
         self.assertEqual(len(alias_dbs), 2)
         self.assertEqual(len(rule_dbs), 1)
-        self.assertEqual(len(sensor_dbs), 1)
-        self.assertEqual(len(trigger_type_dbs), 3)
+        self.assertEqual(len(sensor_dbs), 3)
+        self.assertEqual(len(trigger_type_dbs), 4)
         self.assertEqual(len(policy_dbs), 2)
 
         self.assertEqual(len(config_schema_dbs), 1)

--- a/st2api/st2api/controllers/v1/sensors.py
+++ b/st2api/st2api/controllers/v1/sensors.py
@@ -22,6 +22,7 @@ from st2common.models.api.sensor import SensorTypeAPI
 from st2common.exceptions.apivalidation import ValueValidationException
 from st2common.validators.api.misc import validate_not_part_of_system_pack
 from st2api.controllers import resource
+from st2api.controllers.controller_transforms import transform_to_bool
 from st2common.rbac.types import PermissionType
 from st2common.rbac import utils as rbac_utils
 from st2common.router import abort
@@ -39,6 +40,10 @@ class SensorTypeController(resource.ContentPackResourceController):
         'pack': 'pack',
         'enabled': 'enabled',
         'trigger': 'trigger_types'
+    }
+
+    filter_transform_functions = {
+        'enabled': transform_to_bool
     }
 
     options = {

--- a/st2api/tests/unit/controllers/v1/test_packs.py
+++ b/st2api/tests/unit/controllers/v1/test_packs.py
@@ -490,7 +490,7 @@ class PacksControllerTestCase(FunctionalTest):
                                                          'fail_on_failure': False})
 
         self.assertEqual(resp.status_int, 200)
-        self.assertEqual(resp.json, {'sensors': 1})
+        self.assertEqual(resp.json, {'sensors': 3})
 
         # Verify that plural name form also works
         resp = self.app.post_json('/v1/packs/register', {'types': ['sensors'],

--- a/st2api/tests/unit/controllers/v1/test_sensortypes.py
+++ b/st2api/tests/unit/controllers/v1/test_sensortypes.py
@@ -37,12 +37,12 @@ class SensorTypeControllerTestCase(FunctionalTest):
     def test_get_all_and_minus_one(self):
         resp = self.app.get('/v1/sensortypes')
         self.assertEqual(resp.status_int, http_client.OK)
-        self.assertEqual(len(resp.json), 1)
+        self.assertEqual(len(resp.json), 3)
         self.assertEqual(resp.json[0]['name'], 'SampleSensor')
 
         resp = self.app.get('/v1/sensortypes/?limit=-1')
         self.assertEqual(resp.status_int, http_client.OK)
-        self.assertEqual(len(resp.json), 1)
+        self.assertEqual(len(resp.json), 3)
         self.assertEqual(resp.json[0]['name'], 'SampleSensor')
 
     def test_get_all_negative_limit(self):
@@ -50,6 +50,31 @@ class SensorTypeControllerTestCase(FunctionalTest):
         self.assertEqual(resp.status_int, 400)
         self.assertEqual(resp.json['faultstring'],
                          u'Limit, "-22" specified, must be a positive number.')
+
+    def test_get_all_filters(self):
+        resp = self.app.get('/v1/sensortypes')
+        self.assertEqual(resp.status_int, http_client.OK)
+        self.assertEqual(len(resp.json), 3)
+
+        # ?enabled filter
+        resp = self.app.get('/v1/sensortypes?enabled=False')
+        self.assertEqual(len(resp.json), 1)
+        self.assertEqual(resp.json[0]['enabled'], False)
+
+        resp = self.app.get('/v1/sensortypes?enabled=True')
+        self.assertEqual(len(resp.json), 2)
+        self.assertEqual(resp.json[0]['enabled'], True)
+        self.assertEqual(resp.json[1]['enabled'], True)
+
+        # ?trigger filter
+        resp = self.app.get('/v1/sensortypes?trigger=dummy_pack_1.event3')
+        self.assertEqual(len(resp.json), 1)
+        self.assertEqual(resp.json[0]['trigger_types'], ['dummy_pack_1.event3'])
+
+        resp = self.app.get('/v1/sensortypes?trigger=dummy_pack_1.event')
+        self.assertEqual(len(resp.json), 2)
+        self.assertEqual(resp.json[0]['trigger_types'], ['dummy_pack_1.event'])
+        self.assertEqual(resp.json[1]['trigger_types'], ['dummy_pack_1.event'])
 
     def test_get_one_success(self):
         resp = self.app.get('/v1/sensortypes/dummy_pack_1.SampleSensor')

--- a/st2api/tests/unit/controllers/v1/test_sensortypes.py
+++ b/st2api/tests/unit/controllers/v1/test_sensortypes.py
@@ -56,6 +56,25 @@ class SensorTypeControllerTestCase(FunctionalTest):
         self.assertEqual(resp.status_int, http_client.OK)
         self.assertEqual(len(resp.json), 3)
 
+        # ?name filter
+        resp = self.app.get('/v1/sensortypes?name=foobar')
+        self.assertEqual(len(resp.json), 0)
+
+        resp = self.app.get('/v1/sensortypes?name=SampleSensor2')
+        self.assertEqual(len(resp.json), 1)
+        self.assertEqual(resp.json[0]['name'], 'SampleSensor2')
+
+        resp = self.app.get('/v1/sensortypes?name=SampleSensor3')
+        self.assertEqual(len(resp.json), 1)
+        self.assertEqual(resp.json[0]['name'], 'SampleSensor3')
+
+        # ?pack filter
+        resp = self.app.get('/v1/sensortypes?pack=foobar')
+        self.assertEqual(len(resp.json), 0)
+
+        resp = self.app.get('/v1/sensortypes?pack=dummy_pack_1')
+        self.assertEqual(len(resp.json), 3)
+
         # ?enabled filter
         resp = self.app.get('/v1/sensortypes?enabled=False')
         self.assertEqual(len(resp.json), 1)

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_1/sensors/my_sensor_2.yaml
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_1/sensors/my_sensor_2.yaml
@@ -1,0 +1,15 @@
+---
+  class_name: "SampleSensor2"
+  entry_point: "my_sensor.py"
+  description: "Sample sensor that emits triggers."
+  trigger_types:
+    -
+      name: "event"
+      description: "An example trigger."
+      payload_schema:
+        type: "object"
+        properties:
+          executed_at:
+            type: "string"
+            format: "date-time"
+            default: "2014-07-30 05:04:24.578325"

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_1/sensors/my_sensor_3.yaml
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_1/sensors/my_sensor_3.yaml
@@ -1,0 +1,16 @@
+---
+  class_name: "SampleSensor3"
+  entry_point: "my_sensor.py"
+  enabled: false
+  description: "Sample sensor that emits triggers."
+  trigger_types:
+    -
+      name: "event3"
+      description: "An example trigger."
+      payload_schema:
+        type: "object"
+        properties:
+          executed_at:
+            type: "string"
+            format: "date-time"
+            default: "2014-07-30 05:04:24.578325"


### PR DESCRIPTION
This pull request fixes `?enabled` query parameter filter added in #4033. 

It was missing a transformation so it didn't actually work. In addition to that, it also adds tests for those filters.

A couple of things (most of them we already talked about in the past):
* Such changes are not much help without the corresponding test cases
* We should utilize correct types for query param filters and not just abuse `type: string` for everything. It's wrong and incorrect (e.g. enabled should have `type: boolean`). I already voiced my opinion about that in the past (especially for arrays), but we should do something about it.
* We should auto-generate tests for all the query param filters using openapi definition file. Previous point is a pre-requisite for this.