### PR TITLE
"st2 pack install" command shouldn't need access to pack index

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -65,10 +65,10 @@ Changed
 
 Fixed
 ~~~~~
+
 * Fix Python runner actions and ``Argument list too long`` error when very large parameters are
   passed into the action. The fix utilizes ``stdin`` to pass parameters to the Python action wrapper
   process instead of CLI argument list. (bug fix) #1598 #3976
-
 * Fix a regression in ``POST /v1/webhooks/<webhook name>`` API endpoint introduced in v2.4.0
   and add back support for arrays. In 2.4.0 support for arrays was inadvertently removed and
   only objects were supported. Keep in mind that this only applies to custom user-defined
@@ -78,10 +78,11 @@ Fixed
   to not work. (bugfix) #4001
 
   Contributed by Nick Maludy (Encore Technologies).
-  
 * Fixed missing "paused" status option from "st2 execution list" help output. (bugfix) #4037
 
   Contributed by Ben Hohnke (NTT Communications ICT Solutions)
+* Fix "st2 pack install" command so it doesn't require access to pack index (index.stackstorm.org)
+  when installing a local pack (pack name starting with "file://"). (bug fix) #3771 #3772
 
 2.6.0 - January 19, 2018
 ------------------------

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -209,7 +209,7 @@ class PackInstallCommand(PackAsyncCommand):
             if args.pack.startswith('file://'):
                 return
 
-            pack_info = self.manager.search(args, **kwargs)
+            pack_info = self.manager.search(args, ignore_errors=True, **kwargs)
             content = getattr(pack_info, 'content', {})
 
             if content:
@@ -229,7 +229,7 @@ class PackInstallCommand(PackAsyncCommand):
                 if args.pack.startswith('file://'):
                     return
 
-                pack_info = self.manager.search(args, **kwargs)
+                pack_info = self.manager.search(args, ignore_errors=True, **kwargs)
                 content = getattr(pack_info, 'content', {})
 
                 if content:

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -200,10 +200,15 @@ class PackInstallCommand(PackAsyncCommand):
 
     def _get_content_counts_for_pack(self, args, **kwargs):
         # Global content list, excluding "tests"
+        # Note: We skip this step for local packs
         pack_content = {'actions': 0, 'rules': 0, 'sensors': 0, 'aliases': 0, 'triggers': 0}
 
         if len(args.packs) == 1:
             args.pack = args.packs[0]
+
+            if args.pack.startswith('file://'):
+                return
+
             pack_info = self.manager.search(args, **kwargs)
             content = getattr(pack_info, 'content', {})
 
@@ -220,6 +225,10 @@ class PackInstallCommand(PackAsyncCommand):
             for pack in args.packs:
                 # args.pack required for search
                 args.pack = pack
+
+                if args.pack.startswith('file://'):
+                    return
+
                 pack_info = self.manager.search(args, **kwargs)
                 content = getattr(pack_info, 'content', {})
 

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -499,14 +499,19 @@ class PackResourceManager(ResourceManager):
         return instance
 
     @add_auth_token_to_kwargs_from_env
-    def search(self, args, **kwargs):
+    def search(self, args, ignore_errors=False, **kwargs):
         url = '/%s/index/search' % (self.resource.get_url_path_name())
         if 'query' in vars(args):
             payload = {'query': args.query}
         else:
             payload = {'pack': args.pack}
-        response = self.client.post(url, payload, **kwargs)
+
+            response = self.client.post(url, payload, **kwargs)
+
         if response.status_code != http_client.OK:
+            if ignore_errors:
+                return None
+
             self.handle_error(response)
         data = response.json()
         if isinstance(data, list):


### PR DESCRIPTION
A while ago we added a change which displays number of artifacts which are to be registered when running "st2 pack install" command (#3675).

That change inadvertently introduced a regression and dependency of "st2 pack install" command on access to index.stackstorm.org pack index.

This pull request includes two changes / fixes:

* Don't try to access pack index when installing a local pack (pack path starts with "file://")
* Ignore errors related to index access in "st2 pack install" command. This CLI command could run from any host and that host doesn't necessary need access to pack index - only the actual StackStorm instance where action runner runs needs access to index to be able to install a pack.

Now when installing a local pack or remote pack and server where "st2 pack install" is running can't access index, user experience is slightly degraded (graceful degradation) and no "resource counts" are displayed, but installation still works.

Resolves #3771 #3772.