### PR TITLE
Throw a more user-friendly error on invalid file path when resolving path to a pack resource

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -62,6 +62,8 @@ Changed
   This reduces the unnecessary traffic and CPU time by querying the mistral API. Included a command to
   manually add a state entry for Mistral workflow execution to recover from any callback failures.
   (improvement)
+* Throw a more user-friendly error when writing pack data files to disk and when an invalid file
+  path is provided (e.g. path is outside the pack directory, etc.). (improvement) #4039 #4046
 
 Fixed
 ~~~~~

--- a/st2common/st2common/content/utils.py
+++ b/st2common/st2common/content/utils.py
@@ -271,7 +271,9 @@ def get_pack_file_abs_path(pack_ref, file_path):
     normalized_file_path = os.path.normpath('/' + file_path).lstrip('/')
 
     if normalized_file_path != file_path:
-        raise ValueError('Invalid file path: %s' % (file_path))
+        msg = ('Invalid file path: %s. File path needs to be relative to the pack directory (%s). '
+               'For example "actions/my_action.py" ' % (file_path, pack_base_path))
+        raise ValueError(msg)
 
     path_components.append(normalized_file_path)
     result = os.path.join(*path_components)
@@ -281,7 +283,9 @@ def get_pack_file_abs_path(pack_ref, file_path):
     # Final safety check for common prefix to avoid traversal attack
     common_prefix = os.path.commonprefix([pack_base_path, result])
     if common_prefix != pack_base_path:
-        raise ValueError('Invalid file_path: %s' % (file_path))
+        msg = ('Invalid file path: %s. File path needs to be relative to the pack directory (%s). '
+               'For example "actions/my_action.py" ' % (file_path, pack_base_path))
+        raise ValueError(msg)
 
     return result
 

--- a/st2common/st2common/content/utils.py
+++ b/st2common/st2common/content/utils.py
@@ -36,6 +36,11 @@ __all__ = [
     'check_pack_content_directory_exists'
 ]
 
+INVALID_FILE_PATH_ERROR = """
+Invalid file path: "%s". File path needs to be relative to the pack%sdirectory (%s).
+For example "my_%s.py".
+""".strip().replace('\n', ' ')
+
 
 def get_pack_group():
     """
@@ -246,7 +251,7 @@ def get_entry_point_abs_path(pack=None, entry_point=None):
     return entry_point_abs_path
 
 
-def get_pack_file_abs_path(pack_ref, file_path):
+def get_pack_file_abs_path(pack_ref, file_path, resource_type=None):
     """
     Retrieve full absolute path to the pack file.
 
@@ -260,9 +265,20 @@ def get_pack_file_abs_path(pack_ref, file_path):
                      actions/directory/my_file.py)
     :type file_path: ``str``
 
+    param: resource_type: Optional resource type. If provided, more user-friendly exception
+                          is thrown on error.
+    :type resource_type: ``str``
+
     :rtype: ``str``
     """
     pack_base_path = get_pack_base_path(pack_name=pack_ref)
+
+    if resource_type:
+        resource_type_plural = ' %ss ' % (resource_type)
+        resource_base_path = os.path.join(pack_base_path, '%ss/' % (resource_type))
+    else:
+        resource_type_plural = ' '
+        resource_base_path = pack_base_path
 
     path_components = []
     path_components.append(pack_base_path)
@@ -271,8 +287,8 @@ def get_pack_file_abs_path(pack_ref, file_path):
     normalized_file_path = os.path.normpath('/' + file_path).lstrip('/')
 
     if normalized_file_path != file_path:
-        msg = ('Invalid file path: "%s". File path needs to be relative to the pack directory '
-               '(%s). For example "actions/my_action.py".' % (file_path, pack_base_path))
+        msg = INVALID_FILE_PATH_ERROR % (file_path, resource_type_plural, resource_base_path,
+                                         resource_type or 'action')
         raise ValueError(msg)
 
     path_components.append(normalized_file_path)
@@ -283,8 +299,8 @@ def get_pack_file_abs_path(pack_ref, file_path):
     # Final safety check for common prefix to avoid traversal attack
     common_prefix = os.path.commonprefix([pack_base_path, result])
     if common_prefix != pack_base_path:
-        msg = ('Invalid file path: "%s". File path needs to be relative to the pack directory '
-               '(%s). For example "actions/my_action.py".' % (file_path, pack_base_path))
+        msg = INVALID_FILE_PATH_ERROR % (file_path, resource_type_plural, resource_base_path,
+                                         resource_type or 'action')
         raise ValueError(msg)
 
     return result
@@ -321,7 +337,8 @@ def get_pack_resource_file_abs_path(pack_ref, resource_type, file_path):
 
     path_components.append(file_path)
     file_path = os.path.join(*path_components)
-    result = get_pack_file_abs_path(pack_ref=pack_ref, file_path=file_path)
+    result = get_pack_file_abs_path(pack_ref=pack_ref, file_path=file_path,
+                                    resource_type=resource_type)
     return result
 
 

--- a/st2common/st2common/content/utils.py
+++ b/st2common/st2common/content/utils.py
@@ -271,8 +271,8 @@ def get_pack_file_abs_path(pack_ref, file_path):
     normalized_file_path = os.path.normpath('/' + file_path).lstrip('/')
 
     if normalized_file_path != file_path:
-        msg = ('Invalid file path: %s. File path needs to be relative to the pack directory (%s). '
-               'For example "actions/my_action.py" ' % (file_path, pack_base_path))
+        msg = ('Invalid file path: "%s". File path needs to be relative to the pack directory '
+               '(%s). For example "actions/my_action.py".' % (file_path, pack_base_path))
         raise ValueError(msg)
 
     path_components.append(normalized_file_path)
@@ -283,8 +283,8 @@ def get_pack_file_abs_path(pack_ref, file_path):
     # Final safety check for common prefix to avoid traversal attack
     common_prefix = os.path.commonprefix([pack_base_path, result])
     if common_prefix != pack_base_path:
-        msg = ('Invalid file path: %s. File path needs to be relative to the pack directory (%s). '
-               'For example "actions/my_action.py" ' % (file_path, pack_base_path))
+        msg = ('Invalid file path: "%s". File path needs to be relative to the pack directory '
+               '(%s). For example "actions/my_action.py".' % (file_path, pack_base_path))
         raise ValueError(msg)
 
     return result

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -286,10 +286,13 @@ class ActionCreateAPI(ActionAPI, APIUIDMixin):
             'properties': {
                 'file_path': {
                     'type': 'string',
+                    'description': ('Path to the file relative to the pack actions directory '
+                                    '(e.g. my_action.py)'),
                     'required': True
                 },
                 'content': {
                     'type': 'string',
+                    'description': 'Raw file content.',
                     'required': True
                 },
             },

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -4837,8 +4837,10 @@ definitions:
           properties:
             file_path:
               type: string
+              description: Path to the file relative to the pack actions directory (e.g. my_action.py).
             content:
               type: string
+              description: Raw file content.
           additionalProperties: False
         default: []
     # additionalProperties: false

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -4833,8 +4833,10 @@ definitions:
           properties:
             file_path:
               type: string
+              description: Path to the file relative to the pack actions directory (e.g. my_action.py).
             content:
               type: string
+              description: Raw file content.
           additionalProperties: False
         default: []
     # additionalProperties: false

--- a/st2common/tests/unit/test_content_utils.py
+++ b/st2common/tests/unit/test_content_utils.py
@@ -25,6 +25,7 @@ from st2common.content.utils import get_pack_base_path
 from st2common.content.utils import get_packs_base_paths
 from st2common.content.utils import get_aliases_base_paths
 from st2common.content.utils import get_pack_resource_file_abs_path
+from st2common.content.utils import get_pack_file_abs_path
 from st2common.content.utils import get_entry_point_abs_path
 from st2common.content.utils import get_action_libs_abs_path
 from st2tests import config as tests_config
@@ -117,11 +118,30 @@ class ContentUtilsTestCase(unittest2.TestCase):
                      '/opt/stackstorm/packs/invalid_pack/actions/my_action.py',
                      '../../foo.py']
         for file_path in file_paths:
+            # action resource_type
             expected_msg = ('Invalid file path: ".*%s"\. File path needs to be relative to the '
-                            'pack directory (.*). For example ".*"\.' % (file_path))
+                            'pack actions directory (.*). For example "my_action.py"\.' %
+                            (file_path))
             self.assertRaisesRegexp(ValueError, expected_msg, get_pack_resource_file_abs_path,
                                     pack_ref='dummy_pack_1',
                                     resource_type='action',
+                                    file_path=file_path)
+
+            # sensor resource_type
+            expected_msg = ('Invalid file path: ".*%s"\. File path needs to be relative to the '
+                            'pack sensors directory (.*). For example "my_sensor.py"\.' %
+                            (file_path))
+            self.assertRaisesRegexp(ValueError, expected_msg, get_pack_resource_file_abs_path,
+                                    pack_ref='dummy_pack_1',
+                                    resource_type='sensor',
+                                    file_path=file_path)
+
+            # no resource type
+            expected_msg = ('Invalid file path: ".*%s"\. File path needs to be relative to the '
+                            'pack directory (.*). For example "my_action.py"\.' %
+                            (file_path))
+            self.assertRaisesRegexp(ValueError, expected_msg, get_pack_file_abs_path,
+                                    pack_ref='dummy_pack_1',
                                     file_path=file_path)
 
         # Valid paths

--- a/st2common/tests/unit/test_content_utils.py
+++ b/st2common/tests/unit/test_content_utils.py
@@ -117,8 +117,8 @@ class ContentUtilsTestCase(unittest2.TestCase):
                      '/opt/stackstorm/packs/invalid_pack/actions/my_action.py',
                      '../../foo.py']
         for file_path in file_paths:
-            expected_msg = ('Invalid file path: .*%s\. File path needs to be relative to the pack '
-                            'directory' % (file_path))
+            expected_msg = ('Invalid file path: ".*%s"\. File path needs to be relative to the '
+                            'pack directory (.*). For example ".*"\.' % (file_path))
             self.assertRaisesRegexp(ValueError, expected_msg, get_pack_resource_file_abs_path,
                                     pack_ref='dummy_pack_1',
                                     resource_type='action',

--- a/st2common/tests/unit/test_content_utils.py
+++ b/st2common/tests/unit/test_content_utils.py
@@ -113,9 +113,12 @@ class ContentUtilsTestCase(unittest2.TestCase):
                                 file_path='test.py')
 
         # Invalid paths (directory traversal and absolute paths)
-        file_paths = ['/tmp/foo.py', '../foo.py', '/etc/passwd', '../../foo.py']
+        file_paths = ['/tmp/foo.py', '../foo.py', '/etc/passwd', '../../foo.py',
+                     '/opt/stackstorm/packs/invalid_pack/actions/my_action.py',
+                     '../../foo.py']
         for file_path in file_paths:
-            expected_msg = 'Invalid file path: .*%s' % (file_path)
+            expected_msg = ('Invalid file path: .*%s\. File path needs to be relative to the pack '
+                            'directory' % (file_path))
             self.assertRaisesRegexp(ValueError, expected_msg, get_pack_resource_file_abs_path,
                                     pack_ref='dummy_pack_1',
                                     resource_type='action',


### PR DESCRIPTION
For security reasons (to avoid directory traversal attacks, writing outside of the pack directory, etc.), we only allow users to write pack data files inside the pack directory.

The error we threw before was a bit ambiguous and not user-friendly so this PR fixes that.

Before:

```bash
Invalid file path: /opt/stackstorm/packs/dummy_pack_2/bar.py
```

After:

```
Invalid file path: /opt/stackstorm/packs/dummy_pack_2/bar.py. File path needs to be relative to the pack actions directory (opt/stackstorm/packs/test/actions). For example "my_action.py".
```

Related issue #4039.