### PR TITLE
Make windows runners output object be consistent with other runner output objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,8 @@ Added
   Note: To be able to utilize this functionality, git version >= 2.5.0 must be installed on the
   system.
   (new feature) #3997
+* Update windows runner to correctly handle and use ``timeout`` action execution status.
+  (improvement) #4047
 
 Changed
 ~~~~~~~
@@ -64,6 +66,14 @@ Changed
   (improvement)
 * Throw a more user-friendly error when writing pack data files to disk and when an invalid file
   path is provided (e.g. path is outside the pack directory, etc.). (improvement) #4039 #4046
+* Change the output object returned by Windows runners so it matches the format from the local and
+  remote runner.
+
+  Note: This change is backward incompatible - ``result`` attribute has been removed (same
+  information is available in ``stdout`` attribute), ``exit_code`` renamed to ``return_code`` and
+  two new attributes added - ``succeeded`` and ``failed``.
+
+  For more information, please refer to the upgrade notes. #4044 #4047
 
 Fixed
 ~~~~~

--- a/contrib/runners/windows_runner/tests/unit/test_windows_runners.py
+++ b/contrib/runners/windows_runner/tests/unit/test_windows_runners.py
@@ -247,9 +247,27 @@ class WindowsRunnerTestCase(TestCase):
         self.assertEqual(status, LIVEACTION_STATUS_FAILED)
         self.assertDictEqual(output, expected_output)
 
+        # failure with winexe error
+        exit_code, stdout, stderr, timed_out = 1, 'stdout fail 2', 'stderr fail 2', False
+        runner._run_script = mock.Mock(return_value=(exit_code, stdout, stderr, timed_out))
+        runner._parse_winexe_error = mock.Mock(return_value='winexe error 2')
+
+        runner.runner_parameters = {}
+        (status, output, _) = runner.run({})
+
+        expected_output = {
+            'stdout': 'stdout fail 2',
+            'stderr': 'stderr fail 2',
+            'return_code': 1,
+            'succeeded': False,
+            'failed': True,
+            'error': 'winexe error 2'
+        }
+
         # timeout with non zero exit code
         exit_code, stdout, stderr, timed_out = 200, 'stdout timeout', 'stderr timeout', True
         runner._run_script = mock.Mock(return_value=(exit_code, stdout, stderr, timed_out))
+        runner._parse_winexe_error = mock.Mock(return_value=None)
         runner._timeout = 5
 
         runner.runner_parameters = {}

--- a/contrib/runners/windows_runner/tests/unit/test_windows_runners.py
+++ b/contrib/runners/windows_runner/tests/unit/test_windows_runners.py
@@ -209,6 +209,7 @@ class WindowsRunnerTestCase(TestCase):
         runner._delete_directory = mock.Mock()
         runner._get_share_absolute_path = mock.Mock(return_value='/tmp')
         runner._parse_winexe_error = mock.Mock(return_value='')
+        runner._verify_winexe_exists = mock.Mock()
 
         # success
         exit_code, stdout, stderr, timed_out = 0, 'stdout foo', 'stderr bar', False

--- a/contrib/runners/windows_runner/tests/unit/test_windows_runners.py
+++ b/contrib/runners/windows_runner/tests/unit/test_windows_runners.py
@@ -158,13 +158,13 @@ class WindowsRunnerTestCase(TestCase):
             'a b c -arg1 value1 -arg2 -arg3:$false -arg4 foo,bar,baz'
         ]
 
-        runner = self._get_script_runner()
+        runner = self._get_mock_script_runner()
         for arguments, expected_value in zip(arguments, expected_values):
             actual_value = runner._get_script_arguments(**arguments)
             self.assertEqual(actual_value, expected_value)
 
     def test_parse_share_information(self):
-        runner = self._get_script_runner()
+        runner = self._get_mock_script_runner()
 
         fixture_path = os.path.join(FIXTURES_DIR, 'net_share_C_stdout.txt')
         with open(fixture_path, 'r') as fp:
@@ -183,7 +183,7 @@ class WindowsRunnerTestCase(TestCase):
 
     @mock.patch('windows_runner.windows_script_runner.run_command')
     def test_get_share_absolute_path(self, mock_run_command):
-        runner = self._get_script_runner()
+        runner = self._get_mock_script_runner()
 
         fixture_path = os.path.join(FIXTURES_DIR, 'net_share_C_stdout.txt')
         with open(fixture_path, 'r') as fp:
@@ -202,8 +202,8 @@ class WindowsRunnerTestCase(TestCase):
         share_path = runner._get_share_absolute_path(share='C$')
         self.assertEqual(share_path, 'C:\\')
 
-    def test_run_output_object(self):
-        runner = self._get_script_runner()
+    def test_run_output_object_and_status(self):
+        runner = self._get_mock_script_runner()
 
         runner._upload_file = mock.Mock(return_value=('/tmp/a', '/tmp/b'))
         runner._delete_directory = mock.Mock()
@@ -301,7 +301,7 @@ class WindowsRunnerTestCase(TestCase):
         runner = Runner('id')
         return runner
 
-    def _get_script_runner(self, action_parameters=None):
+    def _get_mock_script_runner(self, action_parameters=None):
         runner = WindowsScriptRunner('id')
         runner._host = None
         runner._username = None

--- a/contrib/runners/windows_runner/tests/unit/test_windows_runners.py
+++ b/contrib/runners/windows_runner/tests/unit/test_windows_runners.py
@@ -210,6 +210,7 @@ class WindowsRunnerTestCase(TestCase):
         runner._get_share_absolute_path = mock.Mock(return_value='/tmp')
         runner._parse_winexe_error = mock.Mock(return_value='')
         runner._verify_winexe_exists = mock.Mock()
+        runner._verify_smbclient_exists = mock.Mock()
 
         # success
         exit_code, stdout, stderr, timed_out = 0, 'stdout foo', 'stderr bar', False

--- a/contrib/runners/windows_runner/windows_runner/windows_command_runner.py
+++ b/contrib/runners/windows_runner/windows_runner/windows_command_runner.py
@@ -93,13 +93,12 @@ class WindowsCommandRunner(BaseWindowsRunner):
         if exit_code != 0:
             error = self._parse_winexe_error(stdout=stdout, stderr=stderr)
 
-        result = stdout
-
         output = {
             'stdout': stdout,
             'stderr': stderr,
-            'exit_code': exit_code,
-            'result': result
+            'return_code': exit_code,
+            'succeeded': (exit_code == 0),
+            'failed': (exit_code != 0)
         }
 
         if error:

--- a/contrib/runners/windows_runner/windows_runner/windows_command_runner.py
+++ b/contrib/runners/windows_runner/windows_runner/windows_command_runner.py
@@ -90,15 +90,17 @@ class WindowsCommandRunner(BaseWindowsRunner):
         else:
             error = None
 
-        if exit_code != 0:
+        succeeded = (exit_code == 0)
+
+        if not succeeded:
             error = self._parse_winexe_error(stdout=stdout, stderr=stderr)
 
         output = {
             'stdout': stdout,
             'stderr': stderr,
             'return_code': exit_code,
-            'succeeded': (exit_code == 0),
-            'failed': (exit_code != 0)
+            'succeeded': succeeded,
+            'failed': not succeeded
         }
 
         if error:

--- a/contrib/runners/windows_runner/windows_runner/windows_script_runner.py
+++ b/contrib/runners/windows_runner/windows_runner/windows_script_runner.py
@@ -118,15 +118,17 @@ class WindowsScriptRunner(BaseWindowsRunner, ShellRunnerMixin):
         else:
             error = None
 
-        if exit_code != 0:
+        succeeded = (exit_code == 0)
+
+        if not succeeded:
             error = self._parse_winexe_error(stdout=stdout, stderr=stderr)
 
         output = {
             'stdout': stdout,
             'stderr': stderr,
             'return_code': exit_code,
-            'succeeded': (exit_code == 0),
-            'failed': (exit_code != 0)
+            'succeeded': succeeded,
+            'failed': not succeeded
         }
 
         if error:

--- a/contrib/runners/windows_runner/windows_runner/windows_script_runner.py
+++ b/contrib/runners/windows_runner/windows_runner/windows_script_runner.py
@@ -121,13 +121,12 @@ class WindowsScriptRunner(BaseWindowsRunner, ShellRunnerMixin):
         if exit_code != 0:
             error = self._parse_winexe_error(stdout=stdout, stderr=stderr)
 
-        result = stdout
-
         output = {
             'stdout': stdout,
             'stderr': stderr,
-            'exit_code': exit_code,
-            'result': result
+            'return_code': exit_code,
+            'succeeded': (exit_code == 0),
+            'failed': (exit_code != 0)
         }
 
         if error:


### PR DESCRIPTION
This pull request updates a result / output dictionary returned by the Windows runners to match local and remote runner output object.

The change is breaking / partially backward incompatible so it needs to be included in minor / major release (2.7.0) and we need to document that change in changelog and upgrade notes document.

## TODO

- [x] Update affected tests
- [x] New tests
- [x] Changelog entry
- [x] Upgrade notes entry - https://github.com/StackStorm/st2docs/pull/707

Related issue #4044.