### PR TITLE
Add missing "ref" field to SensorTypeDB model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     - env: TASK="ci-checks ci-packs-tests"
       python: 2.7
     - env: TASK="compilepy3 ci-py3-unit" CACHE_NAME=py3
-      python: 3.6.4
+      python: 3.6
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     - env: TASK="ci-checks ci-packs-tests"
       python: 2.7
     - env: TASK="compilepy3 ci-py3-unit" CACHE_NAME=py3
-      python: 3.6
+      python: 3.6.4
 addons:
   apt:
     sources:

--- a/st2api/tests/unit/controllers/v1/test_sensortypes.py
+++ b/st2api/tests/unit/controllers/v1/test_sensortypes.py
@@ -63,6 +63,7 @@ class SensorTypeControllerTestCase(FunctionalTest):
         resp = self.app.get('/v1/sensortypes?name=SampleSensor2')
         self.assertEqual(len(resp.json), 1)
         self.assertEqual(resp.json[0]['name'], 'SampleSensor2')
+        self.assertEqual(resp.json[0]['ref'], 'dummy_pack_1.SampleSensor2')
 
         resp = self.app.get('/v1/sensortypes?name=SampleSensor3')
         self.assertEqual(len(resp.json), 1)
@@ -99,6 +100,7 @@ class SensorTypeControllerTestCase(FunctionalTest):
         resp = self.app.get('/v1/sensortypes/dummy_pack_1.SampleSensor')
         self.assertEqual(resp.status_int, http_client.OK)
         self.assertEqual(resp.json['name'], 'SampleSensor')
+        self.assertEqual(resp.json['ref'], 'dummy_pack_1.SampleSensor')
 
     def test_get_one_doesnt_exist(self):
         resp = self.app.get('/v1/sensortypes/1', expect_errors=True)
@@ -117,6 +119,7 @@ class SensorTypeControllerTestCase(FunctionalTest):
         data['enabled'] = False
         put_resp = self.app.put_json('/v1/sensortypes/dummy_pack_1.SampleSensor', data)
         self.assertEqual(put_resp.status_int, http_client.OK)
+        self.assertEqual(put_resp.json['ref'], 'dummy_pack_1.SampleSensor')
         self.assertFalse(put_resp.json['enabled'])
 
         # Verify sensor has been disabled

--- a/st2common/st2common/models/db/sensor.py
+++ b/st2common/st2common/models/db/sensor.py
@@ -43,6 +43,7 @@ class SensorTypeDB(stormbase.StormBaseDB, stormbase.ContentPackResourceMixin,
     UID_FIELDS = ['pack', 'name']
 
     name = me.StringField(required=True)
+    ref = me.StringField(required=True)
     pack = me.StringField(required=True, unique_with='name')
     artifact_uri = me.StringField()
     entry_point = me.StringField()

--- a/st2common/st2common/util/monkey_patch.py
+++ b/st2common/st2common/util/monkey_patch.py
@@ -55,6 +55,7 @@ def use_select_poll_workaround():
     import eventlet
 
     # Work around to get tests to pass with eventlet >= 0.20.0
+    print(sys.modules.keys())
     if 'nose' in sys.modules.keys():
         sys.modules['select'] = eventlet.patcher.original('select')
         subprocess.select = eventlet.patcher.original('select')

--- a/st2common/st2common/util/monkey_patch.py
+++ b/st2common/st2common/util/monkey_patch.py
@@ -55,7 +55,6 @@ def use_select_poll_workaround():
     import eventlet
 
     # Work around to get tests to pass with eventlet >= 0.20.0
-    print(sys.modules.keys())
     if 'nose' in sys.modules.keys():
         sys.modules['select'] = eventlet.patcher.original('select')
         subprocess.select = eventlet.patcher.original('select')

--- a/st2common/st2common/util/monkey_patch.py
+++ b/st2common/st2common/util/monkey_patch.py
@@ -59,6 +59,13 @@ def use_select_poll_workaround():
         sys.modules['select'] = eventlet.patcher.original('select')
         subprocess.select = eventlet.patcher.original('select')
 
+        if sys.version_info >= (3, 6, 5):
+            # If we also don't patch selectors.select, it will fail with Python >= 3.6.5
+            import selectors
+
+            sys.modules['selectors'] = selectors
+            selectors.select = sys.modules['select']
+
 
 def is_use_debugger_flag_provided():
     # 1. Check sys.argv directly


### PR DESCRIPTION
Small issue caught by @enykeev.

I assume this was simply an oversight because all the tests still pass and register-content-script still works as expected.