### PR TITLE
Observer role should also grant "pack_search" view permission

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -103,6 +103,9 @@ Fixed
   expressions and default values. (bug fix) #4050 #4050
 
   Reported by @rakeshrm.
+* Make sure ``observer`` system role also grants ``pack_search`` permission. (bug fix) #4063 #4064
+
+  Reported by @SURAJTHEGREAT.
 
 2.6.0 - January 19, 2018
 ------------------------

--- a/st2api/tests/unit/controllers/v1/test_packs_rbac.py
+++ b/st2api/tests/unit/controllers/v1/test_packs_rbac.py
@@ -101,7 +101,10 @@ class PackControllerRBACTestCase(APIControllerWithRBACTestCase):
 
         data = {'query': 'test'}
         resp = self.app.post_json('/v1/packs/index/search', data, expect_errors=True)
+
+        expected_msg = 'User \"no_permissions\" doesn\'t have required permission \"pack_search\"'
         self.assertEqual(resp.status_code, http_client.FORBIDDEN)
+        self.assertEqual(resp.json['faultstring'], expected_msg)
 
         # Observer role also grants pack_search permission
         user_db = self.users['observer']

--- a/st2common/st2common/rbac/resolvers.py
+++ b/st2common/st2common/rbac/resolvers.py
@@ -60,7 +60,8 @@ __all__ = [
 # "Read" permission names which are granted to observer role by default
 READ_PERMISSION_NAMES = [
     'view',
-    'list'
+    'list',
+    'search'
 ]
 
 


### PR DESCRIPTION
"pack_search" permission is a read-only / view permission so observer role should also grant that permission.

This fixes an issue originally reported by a user in #4063.

Resolves #4063.