### PR TITLE
Fix the encryption key path for the key value config in st2tests

### DIFF
--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -14,6 +14,9 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
+import os
+
 from oslo_config import cfg, types
 
 from st2common import log as logging
@@ -91,9 +94,12 @@ def _override_api_opts():
 
 
 def _override_keyvalue_opts():
-    CONF.set_override(name='encryption_key_path',
-                      override='st2tests/conf/st2_kvstore_tests.crypto.key.json',
-                      group='keyvalue')
+    current_file_path = os.path.dirname(__file__)
+    rel_st2_base_path = os.path.join(current_file_path, '../..')
+    abs_st2_base_path = os.path.abspath(rel_st2_base_path)
+    rel_enc_key_path = 'st2tests/conf/st2_kvstore_tests.crypto.key.json'
+    ovr_enc_key_path = os.path.join(abs_st2_base_path, rel_enc_key_path)
+    CONF.set_override(name='encryption_key_path', override=ovr_enc_key_path, group='keyvalue')
 
 
 def _register_common_opts():


### PR DESCRIPTION
The encryption key path that is overriding config in st2tests is relative. In certain unit tests, the path is not recognizable. This patch provides an absolute path of the key file instead.