### PR TITLE
Refactor the callback module for post run to be more generic

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,7 @@ Added
 Changed
 ~~~~~~~
 
+* Refactor the callback module for the post run in runner to be more generic. (improvement)
 * Update various Python dependencies to the latest stable versions (gunicorn, gitpython,
   python-gnupg, tooz, flex). #4110
 * Update all the service and script entry points to use ``/etc/st2/st2.conf`` as a default value
@@ -200,7 +201,6 @@ Changed
   two new attributes added - ``succeeded`` and ``failed``.
 
   For more information, please refer to the upgrade notes. #4044 #4047
-* Refactor the callback module for the post run in runner to be more generic. (improvement)
 
 Fixed
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -200,6 +200,7 @@ Changed
   two new attributes added - ``succeeded`` and ``failed``.
 
   For more information, please refer to the upgrade notes. #4044 #4047
+* Refactor the callback module for the post run in runner to be more generic. (improvement)
 
 Fixed
 ~~~~~

--- a/contrib/runners/action_chain_runner/action_chain_runner/action_chain_runner.py
+++ b/contrib/runners/action_chain_runner/action_chain_runner/action_chain_runner.py
@@ -331,7 +331,7 @@ class ActionChainRunner(ActionRunner):
     def resume(self):
         # Restore runner and action parameters since they are not provided on resume.
         runner_parameters, action_parameters = param_utils.render_final_params(
-            self.runner_type_db.runner_parameters,
+            self.runner_type.runner_parameters,
             self.action.parameters,
             self.liveaction.parameters,
             self.liveaction.context

--- a/contrib/runners/mistral_v2/callback/mistral_v2.py
+++ b/contrib/runners/mistral_v2/callback/mistral_v2.py
@@ -113,7 +113,14 @@ class MistralCallbackHandler(callback.AsyncActionExecutionCallbackHandler):
             return value
 
     @classmethod
-    def callback(cls, url, context, status, result):
+    def callback(cls, liveaction):
+        assert isinstance(liveaction.callback, dict)
+        assert 'url' in liveaction.callback
+
+        url = liveaction.callback['url']
+        status = liveaction.status
+        result = liveaction.result
+
         if status not in MISTRAL_ACCEPTED_STATES:
             LOG.warning('Unable to callback %s because status "%s" is not supported.', url, status)
             return

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_callback.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_callback.py
@@ -105,6 +105,27 @@ class MistralRunnerCallbackTest(DbTestCase):
     def get_runner_class(cls, package_name, module_name):
         return runners.get_runner(package_name, module_name).__class__
 
+    def get_liveaction_instance(self, status=None, result=None):
+        callback = {
+            'source': MISTRAL_RUNNER_NAME,
+            'url': 'http://127.0.0.1:8989/v2/action_executions/12345'
+        }
+
+        liveaction = LiveActionDB(
+            action='core.local',
+            parameters={'cmd': 'uname -a'},
+            callback=callback,
+            context=dict()
+        )
+
+        if status:
+            liveaction.status = status
+
+        if result:
+            liveaction.result = result
+
+        return liveaction
+
     def test_callback_handler_status_map(self):
         # Ensure all StackStorm status are mapped otherwise leads to zombie workflow.
         self.assertListEqual(sorted(self.status_map.keys()),
@@ -114,9 +135,10 @@ class MistralRunnerCallbackTest(DbTestCase):
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(return_value=None))
     def test_callback_handler_with_result_as_text(self):
-        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
-                                     action_constants.LIVEACTION_STATUS_SUCCEEDED,
-                                     '<html></html>')
+        status = action_constants.LIVEACTION_STATUS_SUCCEEDED
+        result = '<html></html>'
+        liveaction = self.get_liveaction_instance(status, result)
+        self.callback_class.callback(liveaction)
 
         action_executions.ActionExecutionManager.update.assert_called_with(
             '12345',
@@ -128,8 +150,10 @@ class MistralRunnerCallbackTest(DbTestCase):
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(return_value=None))
     def test_callback_handler_with_result_as_dict(self):
-        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
-                                     action_constants.LIVEACTION_STATUS_SUCCEEDED, {'a': 1})
+        status = action_constants.LIVEACTION_STATUS_SUCCEEDED
+        result = {'a': 1}
+        liveaction = self.get_liveaction_instance(status, result)
+        self.callback_class.callback(liveaction)
 
         action_executions.ActionExecutionManager.update.assert_called_with(
             '12345',
@@ -141,8 +165,10 @@ class MistralRunnerCallbackTest(DbTestCase):
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(return_value=None))
     def test_callback_handler_with_result_as_json_str(self):
-        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
-                                     action_constants.LIVEACTION_STATUS_SUCCEEDED, '{"a": 1}')
+        status = action_constants.LIVEACTION_STATUS_SUCCEEDED
+        result = '{"a": 1}'
+        liveaction = self.get_liveaction_instance(status, result)
+        self.callback_class.callback(liveaction)
 
         action_executions.ActionExecutionManager.update.assert_called_with(
             '12345',
@@ -150,8 +176,10 @@ class MistralRunnerCallbackTest(DbTestCase):
             output='{"a": 1}'
         )
 
-        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
-                                     action_constants.LIVEACTION_STATUS_SUCCEEDED, "{'a': 1}")
+        status = action_constants.LIVEACTION_STATUS_SUCCEEDED
+        result = "{'a': 1}"
+        liveaction = self.get_liveaction_instance(status, result)
+        self.callback_class.callback(liveaction)
 
         action_executions.ActionExecutionManager.update.assert_called_with(
             '12345',
@@ -159,8 +187,10 @@ class MistralRunnerCallbackTest(DbTestCase):
             output='{"a": 1}'
         )
 
-        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
-                                     action_constants.LIVEACTION_STATUS_SUCCEEDED, u"{'a': 1}")
+        status = action_constants.LIVEACTION_STATUS_SUCCEEDED
+        result = u"{'a': 1}"
+        liveaction = self.get_liveaction_instance(status, result)
+        self.callback_class.callback(liveaction)
 
         action_executions.ActionExecutionManager.update.assert_called_with(
             '12345',
@@ -168,8 +198,10 @@ class MistralRunnerCallbackTest(DbTestCase):
             output='{"a": 1}'
         )
 
-        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
-                                     action_constants.LIVEACTION_STATUS_SUCCEEDED, "{u'a': u'xyz'}")
+        status = action_constants.LIVEACTION_STATUS_SUCCEEDED
+        result = "{u'a': u'xyz'}"
+        liveaction = self.get_liveaction_instance(status, result)
+        self.callback_class.callback(liveaction)
 
         action_executions.ActionExecutionManager.update.assert_called_with(
             '12345',
@@ -181,9 +213,10 @@ class MistralRunnerCallbackTest(DbTestCase):
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(return_value=None))
     def test_callback_handler_with_result_as_list(self):
-        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
-                                     action_constants.LIVEACTION_STATUS_SUCCEEDED,
-                                     ["a", "b", "c"])
+        status = action_constants.LIVEACTION_STATUS_SUCCEEDED
+        result = ["a", "b", "c"]
+        liveaction = self.get_liveaction_instance(status, result)
+        self.callback_class.callback(liveaction)
 
         action_executions.ActionExecutionManager.update.assert_called_with(
             '12345',
@@ -195,9 +228,10 @@ class MistralRunnerCallbackTest(DbTestCase):
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(return_value=None))
     def test_callback_handler_with_result_as_list_str(self):
-        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
-                                     action_constants.LIVEACTION_STATUS_SUCCEEDED,
-                                     '["a", "b", "c"]')
+        status = action_constants.LIVEACTION_STATUS_SUCCEEDED
+        result = '["a", "b", "c"]'
+        liveaction = self.get_liveaction_instance(status, result)
+        self.callback_class.callback(liveaction)
 
         action_executions.ActionExecutionManager.update.assert_called_with(
             '12345',
@@ -205,9 +239,10 @@ class MistralRunnerCallbackTest(DbTestCase):
             output='["a", "b", "c"]'
         )
 
-        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
-                                     action_constants.LIVEACTION_STATUS_SUCCEEDED,
-                                     u'["a", "b", "c"]')
+        status = action_constants.LIVEACTION_STATUS_SUCCEEDED
+        result = u'["a", "b", "c"]'
+        liveaction = self.get_liveaction_instance(status, result)
+        self.callback_class.callback(liveaction)
 
         action_executions.ActionExecutionManager.update.assert_called_with(
             '12345',
@@ -215,9 +250,10 @@ class MistralRunnerCallbackTest(DbTestCase):
             output='["a", "b", "c"]'
         )
 
-        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
-                                     action_constants.LIVEACTION_STATUS_SUCCEEDED,
-                                     '[u"a", "b", "c"]')
+        status = action_constants.LIVEACTION_STATUS_SUCCEEDED
+        result = '[u"a", "b", "c"]'
+        liveaction = self.get_liveaction_instance(status, result)
+        self.callback_class.callback(liveaction)
 
         action_executions.ActionExecutionManager.update.assert_called_with(
             '12345',
@@ -229,8 +265,10 @@ class MistralRunnerCallbackTest(DbTestCase):
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(return_value=None))
     def test_callback_handler_with_result_unicode_str(self):
-        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
-                                     action_constants.LIVEACTION_STATUS_SUCCEEDED, '什麼')
+        status = action_constants.LIVEACTION_STATUS_SUCCEEDED
+        result = '什麼'
+        liveaction = self.get_liveaction_instance(status, result)
+        self.callback_class.callback(liveaction)
 
         if six.PY2:
             expected_output = '\\u4ec0\\u9ebc'
@@ -247,8 +285,10 @@ class MistralRunnerCallbackTest(DbTestCase):
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(return_value=None))
     def test_callback_handler_with_result_unicode_encoded_as_ascii_str(self):
-        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
-                                     action_constants.LIVEACTION_STATUS_SUCCEEDED, '\u4ec0\u9ebc')
+        status = action_constants.LIVEACTION_STATUS_SUCCEEDED
+        result = '\u4ec0\u9ebc'
+        liveaction = self.get_liveaction_instance(status, result)
+        self.callback_class.callback(liveaction)
 
         if six.PY2:
             expected_output = '\\\\u4ec0\\\\u9ebc'
@@ -265,8 +305,10 @@ class MistralRunnerCallbackTest(DbTestCase):
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(return_value=None))
     def test_callback_handler_with_result_unicode_encoded_as_type(self):
-        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
-                                     action_constants.LIVEACTION_STATUS_SUCCEEDED, u'\u4ec0\u9ebc')
+        status = action_constants.LIVEACTION_STATUS_SUCCEEDED
+        result = u'\u4ec0\u9ebc'
+        liveaction = self.get_liveaction_instance(status, result)
+        self.callback_class.callback(liveaction)
 
         if six.PY2:
             expected_output = '\\u4ec0\\u9ebc'
@@ -283,9 +325,10 @@ class MistralRunnerCallbackTest(DbTestCase):
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(return_value=None))
     def test_callback_handler_with_result_as_list_with_unicode_str(self):
-        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
-                                     action_constants.LIVEACTION_STATUS_SUCCEEDED,
-                                     ['\u4ec0\u9ebc'])
+        status = action_constants.LIVEACTION_STATUS_SUCCEEDED
+        result = ['\u4ec0\u9ebc']
+        liveaction = self.get_liveaction_instance(status, result)
+        self.callback_class.callback(liveaction)
 
         if six.PY2:
             expected_output = '["\\\\u4ec0\\\\u9ebc"]'
@@ -302,9 +345,10 @@ class MistralRunnerCallbackTest(DbTestCase):
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(return_value=None))
     def test_callback_handler_with_result_as_list_with_unicode_type(self):
-        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
-                                     action_constants.LIVEACTION_STATUS_SUCCEEDED,
-                                     [u'\u4ec0\u9ebc'])
+        status = action_constants.LIVEACTION_STATUS_SUCCEEDED
+        result = [u'\u4ec0\u9ebc']
+        liveaction = self.get_liveaction_instance(status, result)
+        self.callback_class.callback(liveaction)
 
         if six.PY2:
             expected_output = '["\\\\u4ec0\\\\u9ebc"]'
@@ -321,9 +365,10 @@ class MistralRunnerCallbackTest(DbTestCase):
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(return_value=None))
     def test_callback_handler_with_result_as_dict_with_unicode_str(self):
-        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
-                                     action_constants.LIVEACTION_STATUS_SUCCEEDED,
-                                     {'a': '\u4ec0\u9ebc'})
+        status = action_constants.LIVEACTION_STATUS_SUCCEEDED
+        result = {'a': '\u4ec0\u9ebc'}
+        liveaction = self.get_liveaction_instance(status, result)
+        self.callback_class.callback(liveaction)
 
         if six.PY2:
             expected_output = '{"a": "\\\\u4ec0\\\\u9ebc"}'
@@ -340,9 +385,10 @@ class MistralRunnerCallbackTest(DbTestCase):
         action_executions.ActionExecutionManager, 'update',
         mock.MagicMock(return_value=None))
     def test_callback_handler_with_result_as_dict_with_unicode_type(self):
-        self.callback_class.callback('http://127.0.0.1:8989/v2/action_executions/12345', {},
-                                     action_constants.LIVEACTION_STATUS_SUCCEEDED,
-                                     {'a': u'\u4ec0\u9ebc'})
+        status = action_constants.LIVEACTION_STATUS_SUCCEEDED
+        result = {'a': u'\u4ec0\u9ebc'}
+        liveaction = self.get_liveaction_instance(status, result)
+        self.callback_class.callback(liveaction)
 
         if six.PY2:
             expected_output = '{"a": "\\\\u4ec0\\\\u9ebc"}'
@@ -363,15 +409,7 @@ class MistralRunnerCallbackTest(DbTestCase):
         local_run_result = (action_constants.LIVEACTION_STATUS_SUCCEEDED, NON_EMPTY_RESULT, None)
         local_runner_cls.run = mock.Mock(return_value=local_run_result)
         expected_mistral_status = self.status_map[local_run_result[0]]
-
-        liveaction = LiveActionDB(
-            action='core.local', parameters={'cmd': 'uname -a'},
-            callback={
-                'source': MISTRAL_RUNNER_NAME,
-                'url': 'http://127.0.0.1:8989/v2/action_executions/12345'
-            }
-        )
-
+        liveaction = self.get_liveaction_instance()
         liveaction, execution = action_service.request(liveaction)
         liveaction = LiveAction.get_by_id(str(liveaction.id))
 
@@ -387,15 +425,7 @@ class MistralRunnerCallbackTest(DbTestCase):
         local_runner_cls = self.get_runner_class('local_runner', 'local_shell_command_runner')
         local_run_result = (action_constants.LIVEACTION_STATUS_RUNNING, NON_EMPTY_RESULT, None)
         local_runner_cls.run = mock.Mock(return_value=local_run_result)
-
-        liveaction = LiveActionDB(
-            action='core.local', parameters={'cmd': 'uname -a'},
-            callback={
-                'source': MISTRAL_RUNNER_NAME,
-                'url': 'http://127.0.0.1:8989/v2/action_executions/12345'
-            }
-        )
-
+        liveaction = self.get_liveaction_instance()
         liveaction, execution = action_service.request(liveaction)
         liveaction = LiveAction.get_by_id(str(liveaction.id))
 
@@ -411,15 +441,7 @@ class MistralRunnerCallbackTest(DbTestCase):
         local_runner_cls.run = mock.Mock(return_value=local_run_result)
         local_cancel_result = (action_constants.LIVEACTION_STATUS_CANCELING, NON_EMPTY_RESULT, None)
         local_runner_cls.cancel = mock.Mock(return_value=local_cancel_result)
-
-        liveaction = LiveActionDB(
-            action='core.local', parameters={'cmd': 'uname -a'},
-            callback={
-                'source': MISTRAL_RUNNER_NAME,
-                'url': 'http://127.0.0.1:8989/v2/action_executions/12345'
-            }
-        )
-
+        liveaction = self.get_liveaction_instance()
         liveaction, execution = action_service.request(liveaction)
         liveaction = LiveAction.get_by_id(str(liveaction.id))
 
@@ -435,15 +457,7 @@ class MistralRunnerCallbackTest(DbTestCase):
         local_run_result = (action_constants.LIVEACTION_STATUS_CANCELED, NON_EMPTY_RESULT, None)
         local_runner_cls.run = mock.Mock(return_value=local_run_result)
         expected_mistral_status = self.status_map[local_run_result[0]]
-
-        liveaction = LiveActionDB(
-            action='core.local', parameters={'cmd': 'uname -a'},
-            callback={
-                'source': MISTRAL_RUNNER_NAME,
-                'url': 'http://127.0.0.1:8989/v2/action_executions/12345'
-            }
-        )
-
+        liveaction = self.get_liveaction_instance()
         liveaction, execution = action_service.request(liveaction)
         liveaction = LiveAction.get_by_id(str(liveaction.id))
 
@@ -461,15 +475,7 @@ class MistralRunnerCallbackTest(DbTestCase):
         local_runner_cls.run = mock.Mock(return_value=local_run_result)
         local_pause_result = (action_constants.LIVEACTION_STATUS_PAUSING, NON_EMPTY_RESULT, None)
         local_runner_cls.pause = mock.Mock(return_value=local_pause_result)
-
-        liveaction = LiveActionDB(
-            action='core.local', parameters={'cmd': 'uname -a'},
-            callback={
-                'source': MISTRAL_RUNNER_NAME,
-                'url': 'http://127.0.0.1:8989/v2/action_executions/12345'
-            }
-        )
-
+        liveaction = self.get_liveaction_instance()
         liveaction, execution = action_service.request(liveaction)
         liveaction = LiveAction.get_by_id(str(liveaction.id))
 
@@ -485,15 +491,7 @@ class MistralRunnerCallbackTest(DbTestCase):
         local_run_result = (action_constants.LIVEACTION_STATUS_PAUSED, NON_EMPTY_RESULT, None)
         local_runner_cls.run = mock.Mock(return_value=local_run_result)
         expected_mistral_status = self.status_map[local_run_result[0]]
-
-        liveaction = LiveActionDB(
-            action='core.local', parameters={'cmd': 'uname -a'},
-            callback={
-                'source': MISTRAL_RUNNER_NAME,
-                'url': 'http://127.0.0.1:8989/v2/action_executions/12345'
-            }
-        )
-
+        liveaction = self.get_liveaction_instance()
         liveaction, execution = action_service.request(liveaction)
         liveaction = LiveAction.get_by_id(str(liveaction.id))
 
@@ -511,15 +509,7 @@ class MistralRunnerCallbackTest(DbTestCase):
         local_runner_cls.run = mock.Mock(return_value=local_run_result)
         local_resume_result = (action_constants.LIVEACTION_STATUS_RUNNING, NON_EMPTY_RESULT, None)
         local_runner_cls.resume = mock.Mock(return_value=local_resume_result)
-
-        liveaction = LiveActionDB(
-            action='core.local', parameters={'cmd': 'uname -a'},
-            callback={
-                'source': MISTRAL_RUNNER_NAME,
-                'url': 'http://127.0.0.1:8989/v2/action_executions/12345'
-            }
-        )
-
+        liveaction = self.get_liveaction_instance()
         liveaction, execution = action_service.request(liveaction)
         liveaction = LiveAction.get_by_id(str(liveaction.id))
 
@@ -535,15 +525,7 @@ class MistralRunnerCallbackTest(DbTestCase):
         local_runner_cls = self.get_runner_class('local_runner', 'local_shell_command_runner')
         local_run_result = (action_constants.LIVEACTION_STATUS_SUCCEEDED, NON_EMPTY_RESULT, None)
         local_runner_cls.run = mock.Mock(return_value=local_run_result)
-
-        liveaction = LiveActionDB(
-            action='core.local', parameters={'cmd': 'uname -a'},
-            callback={
-                'source': MISTRAL_RUNNER_NAME,
-                'url': 'http://127.0.0.1:8989/v2/action_executions/12345'
-            }
-        )
-
+        liveaction = self.get_liveaction_instance()
         liveaction, execution = action_service.request(liveaction)
         liveaction = LiveAction.get_by_id(str(liveaction.id))
         self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
@@ -563,15 +545,7 @@ class MistralRunnerCallbackTest(DbTestCase):
         local_runner_cls = self.get_runner_class('local_runner', 'local_shell_command_runner')
         local_run_result = (action_constants.LIVEACTION_STATUS_SUCCEEDED, NON_EMPTY_RESULT, None)
         local_runner_cls.run = mock.Mock(return_value=local_run_result)
-
-        liveaction = LiveActionDB(
-            action='core.local', parameters={'cmd': 'uname -a'},
-            callback={
-                'source': MISTRAL_RUNNER_NAME,
-                'url': 'http://127.0.0.1:8989/v2/action_executions/12345'
-            }
-        )
-
+        liveaction = self.get_liveaction_instance()
         liveaction, execution = action_service.request(liveaction)
         liveaction = LiveAction.get_by_id(str(liveaction.id))
         self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)

--- a/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
+++ b/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
@@ -937,7 +937,7 @@ fatal: invalid reference: vinvalid
         liveaction_db = mock.Mock()
         liveaction_db.id = '123'
         liveaction_db.context = {'user': user}
-        runner = container._get_runner(runnertype_db=runnertype_db, action_db=action_db,
+        runner = container._get_runner(runner_type_db=runnertype_db, action_db=action_db,
                                        liveaction_db=liveaction_db)
         runner.execution = MOCK_EXECUTION
         runner.action = action_db

--- a/st2actions/tests/unit/test_runner_container.py
+++ b/st2actions/tests/unit/test_runner_container.py
@@ -109,8 +109,8 @@ class RunnerContainerTest(DbTestCase):
         runnertype_db = RunnerContainerTest.runnertype_db
         runner = get_runner(runnertype_db.runner_module, runnertype_db.runner_module)
 
-        runner.runner_type_db = runnertype_db
-        runner.runner_type_db.enabled = False
+        runner.runner_type = runnertype_db
+        runner.runner_type.enabled = False
 
         expected_msg = 'Runner "test-runner-1" has been disabled by the administrator'
         self.assertRaisesRegexp(ValueError, expected_msg, runner.pre_run)

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -96,6 +96,7 @@ ENV_VARS_BLACKLIST = [
 WORKFLOW_RUNNER_TYPES = [
     'action-chain',
     'mistral-v2',
+    'orchestra'
 ]
 
 
@@ -860,6 +861,8 @@ class ActionRunCommandMixin(object):
             task_name_key = 'context.chain.name'
         elif context and 'mistral' in context:
             task_name_key = 'context.mistral.task_name'
+        elif context and 'orchestra' in context:
+            task_name_key = 'context.orchestra.task.name'
         # Use LiveAction as the object so that the formatter lookup does not change.
         # AKA HACK!
         return models.action.LiveAction(**{

--- a/st2common/st2common/callback/base.py
+++ b/st2common/st2common/callback/base.py
@@ -33,5 +33,5 @@ class AsyncActionExecutionCallbackHandler(object):
 
     @staticmethod
     @abc.abstractmethod
-    def callback(url, context, status, result):
+    def callback(liveaction):
         raise NotImplementedError()


### PR DESCRIPTION
Refactor the callback module for runner post run to be more generic. Currently, the callback takes a REST endpoint as input argument. The callback module is abstracted to take other input arguments. In this patch, the entire liveaction database object is passed to avoid overcrowding the method signature. Unfortunately, the liveaction object that the runner reference to is out dated by the time the runner makes the post run and there are more than one references of the object in the runner container. The runner container and runner is refactored to ensure references objects are used and updated.