### PR TITLE
Fix dist_utils.py so it works with pip >= 10.0

### DIFF
--- a/scripts/dist_utils.py
+++ b/scripts/dist_utils.py
@@ -25,10 +25,22 @@ GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
 try:
     import pip
-    from pip.req import parse_requirements
-except ImportError:
+except ImportError as e:
+    print('Failed to import pip: %s' % (str(e)))
     print('Download pip:\n', GET_PIP)
     sys.exit(1)
+
+try:
+    # pip < 10.0
+    from pip.req import parse_requirements
+except ImportError:
+    # pip >= 10.0
+
+    try:
+        from pip._internal.req.req_file import parse_requirements
+    except ImportError:
+        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        sys.exit(1)
 
 __all__ = [
     'check_pip_version',

--- a/scripts/dist_utils.py
+++ b/scripts/dist_utils.py
@@ -25,9 +25,11 @@ GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
 try:
     import pip
+    from pip import __version__ as pip_version
 except ImportError as e:
     print('Failed to import pip: %s' % (str(e)))
-    print('Download pip:\n', GET_PIP)
+    print('')
+    print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
 
 try:
@@ -38,8 +40,9 @@ except ImportError:
 
     try:
         from pip._internal.req.req_file import parse_requirements
-    except ImportError:
+    except ImportError as e:
         print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 
 __all__ = [

--- a/st2actions/dist_utils.py
+++ b/st2actions/dist_utils.py
@@ -25,10 +25,25 @@ GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
 try:
     import pip
+    from pip import __version__ as pip_version
+except ImportError as e:
+    print('Failed to import pip: %s' % (str(e)))
+    print('')
+    print('Download pip:\n%s' % (GET_PIP))
+    sys.exit(1)
+
+try:
+    # pip < 10.0
     from pip.req import parse_requirements
 except ImportError:
-    print('Download pip:\n', GET_PIP)
-    sys.exit(1)
+    # pip >= 10.0
+
+    try:
+        from pip._internal.req.req_file import parse_requirements
+    except ImportError as e:
+        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Using pip: %s' % (str(pip_version)))
+        sys.exit(1)
 
 __all__ = [
     'check_pip_version',

--- a/st2api/dist_utils.py
+++ b/st2api/dist_utils.py
@@ -25,10 +25,25 @@ GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
 try:
     import pip
+    from pip import __version__ as pip_version
+except ImportError as e:
+    print('Failed to import pip: %s' % (str(e)))
+    print('')
+    print('Download pip:\n%s' % (GET_PIP))
+    sys.exit(1)
+
+try:
+    # pip < 10.0
     from pip.req import parse_requirements
 except ImportError:
-    print('Download pip:\n', GET_PIP)
-    sys.exit(1)
+    # pip >= 10.0
+
+    try:
+        from pip._internal.req.req_file import parse_requirements
+    except ImportError as e:
+        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Using pip: %s' % (str(pip_version)))
+        sys.exit(1)
 
 __all__ = [
     'check_pip_version',

--- a/st2auth/dist_utils.py
+++ b/st2auth/dist_utils.py
@@ -25,10 +25,25 @@ GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
 try:
     import pip
+    from pip import __version__ as pip_version
+except ImportError as e:
+    print('Failed to import pip: %s' % (str(e)))
+    print('')
+    print('Download pip:\n%s' % (GET_PIP))
+    sys.exit(1)
+
+try:
+    # pip < 10.0
     from pip.req import parse_requirements
 except ImportError:
-    print('Download pip:\n', GET_PIP)
-    sys.exit(1)
+    # pip >= 10.0
+
+    try:
+        from pip._internal.req.req_file import parse_requirements
+    except ImportError as e:
+        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Using pip: %s' % (str(pip_version)))
+        sys.exit(1)
 
 __all__ = [
     'check_pip_version',

--- a/st2client/dist_utils.py
+++ b/st2client/dist_utils.py
@@ -25,10 +25,25 @@ GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
 try:
     import pip
+    from pip import __version__ as pip_version
+except ImportError as e:
+    print('Failed to import pip: %s' % (str(e)))
+    print('')
+    print('Download pip:\n%s' % (GET_PIP))
+    sys.exit(1)
+
+try:
+    # pip < 10.0
     from pip.req import parse_requirements
 except ImportError:
-    print('Download pip:\n', GET_PIP)
-    sys.exit(1)
+    # pip >= 10.0
+
+    try:
+        from pip._internal.req.req_file import parse_requirements
+    except ImportError as e:
+        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Using pip: %s' % (str(pip_version)))
+        sys.exit(1)
 
 __all__ = [
     'check_pip_version',

--- a/st2common/dist_utils.py
+++ b/st2common/dist_utils.py
@@ -25,10 +25,25 @@ GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
 try:
     import pip
+    from pip import __version__ as pip_version
+except ImportError as e:
+    print('Failed to import pip: %s' % (str(e)))
+    print('')
+    print('Download pip:\n%s' % (GET_PIP))
+    sys.exit(1)
+
+try:
+    # pip < 10.0
     from pip.req import parse_requirements
 except ImportError:
-    print('Download pip:\n', GET_PIP)
-    sys.exit(1)
+    # pip >= 10.0
+
+    try:
+        from pip._internal.req.req_file import parse_requirements
+    except ImportError as e:
+        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Using pip: %s' % (str(pip_version)))
+        sys.exit(1)
 
 __all__ = [
     'check_pip_version',

--- a/st2debug/dist_utils.py
+++ b/st2debug/dist_utils.py
@@ -25,10 +25,25 @@ GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
 try:
     import pip
+    from pip import __version__ as pip_version
+except ImportError as e:
+    print('Failed to import pip: %s' % (str(e)))
+    print('')
+    print('Download pip:\n%s' % (GET_PIP))
+    sys.exit(1)
+
+try:
+    # pip < 10.0
     from pip.req import parse_requirements
 except ImportError:
-    print('Download pip:\n', GET_PIP)
-    sys.exit(1)
+    # pip >= 10.0
+
+    try:
+        from pip._internal.req.req_file import parse_requirements
+    except ImportError as e:
+        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Using pip: %s' % (str(pip_version)))
+        sys.exit(1)
 
 __all__ = [
     'check_pip_version',

--- a/st2exporter/dist_utils.py
+++ b/st2exporter/dist_utils.py
@@ -25,10 +25,25 @@ GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
 try:
     import pip
+    from pip import __version__ as pip_version
+except ImportError as e:
+    print('Failed to import pip: %s' % (str(e)))
+    print('')
+    print('Download pip:\n%s' % (GET_PIP))
+    sys.exit(1)
+
+try:
+    # pip < 10.0
     from pip.req import parse_requirements
 except ImportError:
-    print('Download pip:\n', GET_PIP)
-    sys.exit(1)
+    # pip >= 10.0
+
+    try:
+        from pip._internal.req.req_file import parse_requirements
+    except ImportError as e:
+        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Using pip: %s' % (str(pip_version)))
+        sys.exit(1)
 
 __all__ = [
     'check_pip_version',

--- a/st2reactor/dist_utils.py
+++ b/st2reactor/dist_utils.py
@@ -25,10 +25,25 @@ GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
 try:
     import pip
+    from pip import __version__ as pip_version
+except ImportError as e:
+    print('Failed to import pip: %s' % (str(e)))
+    print('')
+    print('Download pip:\n%s' % (GET_PIP))
+    sys.exit(1)
+
+try:
+    # pip < 10.0
     from pip.req import parse_requirements
 except ImportError:
-    print('Download pip:\n', GET_PIP)
-    sys.exit(1)
+    # pip >= 10.0
+
+    try:
+        from pip._internal.req.req_file import parse_requirements
+    except ImportError as e:
+        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Using pip: %s' % (str(pip_version)))
+        sys.exit(1)
 
 __all__ = [
     'check_pip_version',

--- a/st2stream/dist_utils.py
+++ b/st2stream/dist_utils.py
@@ -25,10 +25,25 @@ GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
 try:
     import pip
+    from pip import __version__ as pip_version
+except ImportError as e:
+    print('Failed to import pip: %s' % (str(e)))
+    print('')
+    print('Download pip:\n%s' % (GET_PIP))
+    sys.exit(1)
+
+try:
+    # pip < 10.0
     from pip.req import parse_requirements
 except ImportError:
-    print('Download pip:\n', GET_PIP)
-    sys.exit(1)
+    # pip >= 10.0
+
+    try:
+        from pip._internal.req.req_file import parse_requirements
+    except ImportError as e:
+        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Using pip: %s' % (str(pip_version)))
+        sys.exit(1)
 
 __all__ = [
     'check_pip_version',

--- a/st2tests/dist_utils.py
+++ b/st2tests/dist_utils.py
@@ -25,10 +25,25 @@ GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
 try:
     import pip
+    from pip import __version__ as pip_version
+except ImportError as e:
+    print('Failed to import pip: %s' % (str(e)))
+    print('')
+    print('Download pip:\n%s' % (GET_PIP))
+    sys.exit(1)
+
+try:
+    # pip < 10.0
     from pip.req import parse_requirements
 except ImportError:
-    print('Download pip:\n', GET_PIP)
-    sys.exit(1)
+    # pip >= 10.0
+
+    try:
+        from pip._internal.req.req_file import parse_requirements
+    except ImportError as e:
+        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Using pip: %s' % (str(pip_version)))
+        sys.exit(1)
 
 __all__ = [
     'check_pip_version',


### PR DESCRIPTION
pip removed "public" `parse_requirements` method in the latest version and this breaks our build in places where we don't pin pip to version `<9.1`.

This pull request fixes that. Eventually we should move away from `parse_requirements` since it not documented / part of the public API anymore (they actually argue it was never part of a public API, but a lot of projects depend on it so I would argue otherwise).

Note: This PR can be merged post v2.7.0 because this repo is fine, builds are only failing in some other repos where we don't pin pip.

## TODO

- [x] Re-generate generated files once approved (to avoid diff confusion)