### PR TITLE
Add timeout and print extra info to unit tests for action chain pause and resume

### DIFF
--- a/contrib/runners/action_chain_runner/tests/unit/test_actionchain_pause_resume.py
+++ b/contrib/runners/action_chain_runner/tests/unit/test_actionchain_pause_resume.py
@@ -160,7 +160,8 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
 
         # Wait until the liveaction is pausing.
         liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSING)
-        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING)
+        extra_info = str(liveaction)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING, extra_info)
 
         # Delete the temporary file that the action chain is waiting on.
         os.remove(path)
@@ -168,7 +169,8 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
 
         # Wait until the liveaction is paused.
         liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSED)
-        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED)
+        extra_info = str(liveaction)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED, extra_info)
 
         # Wait for non-blocking threads to complete. Ensure runner is not running.
         MockLiveActionPublisherNonBlocking.wait_all()
@@ -209,7 +211,8 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
 
         # Wait until the liveaction is pausing.
         liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSING)
-        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING)
+        extra_info = str(liveaction)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING, extra_info)
 
         # Delete the temporary file that the action chain is waiting on.
         os.remove(path)
@@ -217,7 +220,8 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
 
         # Wait until the liveaction is paused.
         liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSED)
-        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED)
+        extra_info = str(liveaction)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED, extra_info)
 
         # Wait for non-blocking threads to complete. Ensure runner is not running.
         MockLiveActionPublisherNonBlocking.wait_all()
@@ -260,7 +264,8 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
 
         # Wait until the liveaction is pausing.
         liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSING)
-        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING)
+        extra_info = str(liveaction)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING, extra_info)
 
         # Delete the temporary file that the action chain is waiting on.
         os.remove(path)
@@ -268,7 +273,8 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
 
         # Wait until the liveaction is paused.
         liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSED)
-        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED)
+        extra_info = str(liveaction)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED, extra_info)
 
         # Wait for non-blocking threads to complete. Ensure runner is not running.
         MockLiveActionPublisherNonBlocking.wait_all()
@@ -310,7 +316,8 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
 
         # Wait until the liveaction is pausing.
         liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSING)
-        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING)
+        extra_info = str(liveaction)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING, extra_info)
 
         # Delete the temporary file that the action chain is waiting on.
         os.remove(path)
@@ -318,7 +325,8 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
 
         # Wait until the liveaction is paused.
         liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSED)
-        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED)
+        extra_info = str(liveaction)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED, extra_info)
 
         # Wait for non-blocking threads to complete. Ensure runner is not running.
         MockLiveActionPublisherNonBlocking.wait_all()
@@ -373,14 +381,16 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
 
         # Wait until the liveaction is pausing.
         liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSING)
-        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING)
+        extra_info = str(liveaction)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING, extra_info)
         self.assertEqual(len(execution.children), 1)
 
         # Wait until the subworkflow is pausing.
         task1_exec = ActionExecution.get_by_id(execution.children[0])
         task1_live = LiveAction.get_by_id(task1_exec.liveaction['id'])
         task1_live = self._wait_for_status(task1_live, action_constants.LIVEACTION_STATUS_PAUSING)
-        self.assertEqual(task1_live.status, action_constants.LIVEACTION_STATUS_PAUSING)
+        extra_info = str(task1_live)
+        self.assertEqual(task1_live.status, action_constants.LIVEACTION_STATUS_PAUSING, extra_info)
 
         # Delete the temporary file that the action chain is waiting on.
         os.remove(path)
@@ -388,14 +398,16 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
 
         # Wait until the liveaction is paused.
         liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSED)
-        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED)
+        extra_info = str(liveaction)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED, extra_info)
         self.assertEqual(len(execution.children), 1)
 
         # Wait until the subworkflow is paused.
         task1_exec = ActionExecution.get_by_id(execution.children[0])
         task1_live = LiveAction.get_by_id(task1_exec.liveaction['id'])
         task1_live = self._wait_for_status(task1_live, action_constants.LIVEACTION_STATUS_PAUSED)
-        self.assertEqual(task1_live.status, action_constants.LIVEACTION_STATUS_PAUSED)
+        extra_info = str(task1_live)
+        self.assertEqual(task1_live.status, action_constants.LIVEACTION_STATUS_PAUSED, extra_info)
 
         # Wait for non-blocking threads to complete. Ensure runner is not running.
         MockLiveActionPublisherNonBlocking.wait_all()
@@ -460,7 +472,8 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
         task1_exec = ActionExecution.get_by_id(execution.children[0])
         task1_live = LiveAction.get_by_id(task1_exec.liveaction['id'])
         task1_live = self._wait_for_status(task1_live, action_constants.LIVEACTION_STATUS_PAUSING)
-        self.assertEqual(task1_live.status, action_constants.LIVEACTION_STATUS_PAUSING)
+        extra_info = str(task1_live)
+        self.assertEqual(task1_live.status, action_constants.LIVEACTION_STATUS_PAUSING, extra_info)
 
         # Delete the temporary file that the action chain is waiting on.
         os.remove(path)
@@ -470,11 +483,13 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
         task1_exec = ActionExecution.get_by_id(execution.children[0])
         task1_live = LiveAction.get_by_id(task1_exec.liveaction['id'])
         task1_live = self._wait_for_status(task1_live, action_constants.LIVEACTION_STATUS_PAUSED)
-        self.assertEqual(task1_live.status, action_constants.LIVEACTION_STATUS_PAUSED)
+        extra_info = str(task1_live)
+        self.assertEqual(task1_live.status, action_constants.LIVEACTION_STATUS_PAUSED, extra_info)
 
         # Wait until the parent liveaction is paused.
         liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSED)
-        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED)
+        extra_info = str(liveaction)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED, extra_info)
         self.assertEqual(len(execution.children), 1)
 
         # Wait for non-blocking threads to complete. Ensure runner is not running.
@@ -553,7 +568,8 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
 
         # Wait until the liveaction is pausing.
         liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSING)
-        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING)
+        extra_info = str(liveaction)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING, extra_info)
 
         # Delete the temporary file that the action chain is waiting on.
         os.remove(path)
@@ -561,7 +577,8 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
 
         # Wait until the liveaction is paused.
         liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSED)
-        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED)
+        extra_info = str(liveaction)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED, extra_info)
 
         # Wait for non-blocking threads to complete. Ensure runner is not running.
         MockLiveActionPublisherNonBlocking.wait_all()
@@ -603,7 +620,8 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
 
         # Wait until the liveaction is pausing.
         liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSING)
-        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING)
+        extra_info = str(liveaction)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING, extra_info)
 
         # Delete the temporary file that the action chain is waiting on.
         os.remove(path)
@@ -611,7 +629,8 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
 
         # Wait until the liveaction is paused.
         liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSED)
-        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED)
+        extra_info = str(liveaction)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED, extra_info)
 
         # Wait for non-blocking threads to complete. Ensure runner is not running.
         MockLiveActionPublisherNonBlocking.wait_all()
@@ -653,7 +672,8 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
 
         # Wait until the liveaction is pausing.
         liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSING)
-        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING)
+        extra_info = str(liveaction)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING, extra_info)
 
         # Delete the temporary file that the action chain is waiting on.
         os.remove(path)
@@ -661,7 +681,8 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
 
         # Wait until the liveaction is paused.
         liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSED)
-        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED)
+        extra_info = str(liveaction)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED, extra_info)
 
         # Wait for non-blocking threads to complete. Ensure runner is not running.
         MockLiveActionPublisherNonBlocking.wait_all()
@@ -702,7 +723,8 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
 
         # Wait until the liveaction is pausing.
         liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSING)
-        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING)
+        extra_info = str(liveaction)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING, extra_info)
 
         # Delete the temporary file that the action chain is waiting on.
         os.remove(path)
@@ -710,7 +732,8 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
 
         # Wait until the liveaction is paused.
         liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSED)
-        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED)
+        extra_info = str(liveaction)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED, extra_info)
 
         # Wait for non-blocking threads to complete. Ensure runner is not running.
         MockLiveActionPublisherNonBlocking.wait_all()
@@ -753,7 +776,8 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
         # This workflow runs 'core.ask' so will pause on its own. We just need to
         # wait until the liveaction is pausing.
         liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSING)
-        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING)
+        extra_info = str(liveaction)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSING, extra_info)
 
         # Delete the temporary file that the action chain is waiting on.
         os.remove(path)
@@ -761,7 +785,8 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
 
         # Wait until the liveaction is paused.
         liveaction = self._wait_for_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSED)
-        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED)
+        extra_info = str(liveaction)
+        self.assertEqual(liveaction.status, action_constants.LIVEACTION_STATUS_PAUSED, extra_info)
 
         # Wait for non-blocking threads to complete. Ensure runner is not running.
         MockLiveActionPublisherNonBlocking.wait_all()

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_cancel.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_cancel.yaml
@@ -4,6 +4,7 @@ chain:
         ref: core.local
         params:
             cmd: "while [ -e '{{tempfile}}' ]; do sleep 0.1; done"
+            timeout: 180
         on-success: task2
     -
         name: task2

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume.yaml
@@ -4,6 +4,7 @@ chain:
         ref: core.local
         params:
             cmd: "while [ -e '{{tempfile}}' ]; do sleep 0.1; done"
+            timeout: 180
         on-success: task2
     -
         name: task2

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_last_task_failed_with_no_next_task.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_last_task_failed_with_no_next_task.yaml
@@ -4,3 +4,4 @@ chain:
         ref: core.local
         params:
             cmd: "while [ -e '{{tempfile}}' ]; do sleep 0.1; done; exit 1"
+            timeout: 180

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_with_context_access.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_with_context_access.yaml
@@ -10,6 +10,7 @@ chain:
         ref: core.local
         params:
             cmd: "while [ -e '{{tempfile}}' ]; do sleep 0.1; done"
+            timeout: 180
         on-success: task3
     -
         name: task3

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_with_error.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_with_error.yaml
@@ -4,6 +4,7 @@ chain:
         ref: core.local
         params:
             cmd: "while [ -e '{{tempfile}}' ]; do sleep 0.1; exit 1"
+            timeout: 180
         on-failure: task2
     -
         name: task2

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_with_init_vars.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_with_init_vars.yaml
@@ -6,6 +6,7 @@ chain:
         ref: core.local
         params:
             cmd: "while [ -e '{{tempfile}}' ]; do sleep 0.1; done"
+            timeout: 180
         publish:
             var1: "{{var1|upper}}"            
         on-success: task2

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_with_no_more_task.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_with_no_more_task.yaml
@@ -4,3 +4,4 @@ chain:
         ref: core.local
         params:
             cmd: "while [ -e '{{tempfile}}' ]; do sleep 0.1; done"
+            timeout: 180

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_with_published_vars.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume_with_published_vars.yaml
@@ -4,6 +4,7 @@ chain:
         ref: core.local
         params:
             cmd: "while [ -e '{{tempfile}}' ]; do sleep 0.1; done"
+            timeout: 180
         publish:
             var1: foobar
         on-success: task2


### PR DESCRIPTION
Unable to reproduce unit test error in the action chain pause and resume. Increase the timeout for the core.local action in the unit tests and also print extra data during assert for troubleshooting.