### PR TITLE
Remove changelog entry for --python3 "st2 pack install" CLI flag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,14 +17,6 @@ Added
 * Add support for utf-8 / unicode characters in the pack config files. (improvement) #3980 #3989
 
   Contributed by @sumkire.
-* Add new ``--python3`` flag to ``st2 pack install`` CLI command and ``python3`` parameter to
-  ``packs.{install,setup_virtualenv}`` actions. When the value of this parameter is True, it
-  uses ``python3`` binary when creating virtual environment for that pack (based on the value of
-  ``actionrunner.python3_binary`` config option).
-
-  Note: For this feature to work, Python 3 needs to be installed on the system and ``virtualenv``
-  package installed on the system needs to support Python 3 (it needs to be a recent version).
-  (new feature) #4016 #3922
 * Added the ability of ``st2ctl`` to utilize environment variables from ``/etc/default/st2ctl``
   (for Ubuntu/Debian) and ``/etc/sysconfig/st2ctl`` (RHEL/CentOS). This allows
   deployments to override ``COMPONENTS`` and ``ST2_CONF`` in a global location


### PR DESCRIPTION
During the release testing, we encountered some issues with this feature (thanks to @warrenvw and @m4dcoder, I also confirmed some of that issues on Ubuntu 16.06 which ships with Python 3 by default).

There are still some scenarios related to StackStorm and 3rd party library imports which don't work and cause exceptions so that feature doesn't work as expected.

For now the best thing to do is to simple remove any mention of this feature.

Sadly I didn't have time to dig in and we need to get the release out. Hopefully we will have time to dig in and get it fixed and fully working in time for v2.8.0.

/cc @tonybaloney ^Just a heads up