### PR TITLE
Friendlier error message if git submodules are not checked out, check out submodules as part of make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,6 +275,9 @@ requirements: virtualenv .sdist-requirements
 	# new version of requests) which we cant resolve at this moment
 	$(VIRTUALENV_DIR)/bin/pip install "prance==0.6.1"
 
+	# Some of the tests rely on submodule so we need to make sure submodules are check out
+	git submodule update --init --recursive
+
 .PHONY: virtualenv
 	# Note: We always want to update virtualenv/bin/activate file to make sure
 	# PYTHONPATH is up to date and to avoid caching issues on Travis

--- a/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
+++ b/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
@@ -40,6 +40,7 @@ from st2tests.base import RunnerTestCase
 from st2tests.base import CleanDbTestCase
 from st2tests.base import blocking_eventlet_spawn
 from st2tests.base import make_mock_stream_readline
+from st2tests.fixturesloader import assert_submodules_are_checked_out
 import st2tests.base as tests_base
 
 
@@ -80,6 +81,11 @@ MOCK_EXECUTION.id = '598dbf0c0640fd54bffc688b'
 class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
     register_packs = True
     register_pack_configs = True
+
+    @classmethod
+    def setUpClass(cls):
+        super(PythonRunnerTestCase, cls).setUpClass()
+        assert_submodules_are_checked_out()
 
     def test_runner_creation(self):
         runner = python_runner.get_runner()

--- a/st2tests/st2tests/fixturesloader.py
+++ b/st2tests/st2tests/fixturesloader.py
@@ -128,6 +128,12 @@ FIXTURE_PERSISTENCE_MODEL = {
     'users': User
 }
 
+GIT_SUBMODULES_NOT_CHECKED_OUT_ERROR = """
+Git submodule "%s" is not checked out. Make sure to run "git submodule update --init
+ --recursive" in the repository root directory to check out all the
+submodules.
+""".replace('\n', '').strip()
+
 
 def get_fixtures_base_path():
     return os.path.join(os.path.dirname(__file__), 'fixtures')
@@ -368,3 +374,18 @@ class FixturesLoader(object):
 
     def get_fixture_file_path_abs(self, fixtures_pack, fixtures_type, fixture_name):
         return os.path.join(get_fixtures_base_path(), fixtures_pack, fixtures_type, fixture_name)
+
+
+def assert_submodules_are_checked_out():
+    """
+    Function which verifies that user has ran "git submodule update --init --recursive" in the
+    root of the directory and that the "st2tests/st2tests/fixtures/packs/test" git repo submodule
+    used by the tests is checked out.
+    """
+    test_pack_path = os.path.abspath(os.path.join(get_fixtures_packs_base_path(), 'test/'))
+    submodule_git_dir_path = os.path.join(test_pack_path, '.git')
+
+    if not os.path.isdir(submodule_git_dir_path):
+        raise ValueError(GIT_SUBMODULES_NOT_CHECKED_OUT_ERROR % (test_pack_path))
+
+    return True

--- a/st2tests/st2tests/fixturesloader.py
+++ b/st2tests/st2tests/fixturesloader.py
@@ -385,7 +385,8 @@ def assert_submodules_are_checked_out():
     test_pack_path = os.path.abspath(os.path.join(get_fixtures_packs_base_path(), 'test/'))
     submodule_git_dir_path = os.path.join(test_pack_path, '.git')
 
-    if not os.path.isdir(submodule_git_dir_path):
+    # NOTE: In newer versions of git, that .git is a file and not a directory
+    if not os.path.exists(submodule_git_dir_path):
         raise ValueError(GIT_SUBMODULES_NOT_CHECKED_OUT_ERROR % (test_pack_path))
 
     return True


### PR DESCRIPTION
Some of our unit tests now rely on git submodules being checked out.

This pull request includes two changes to make that more user (developer) friendly:

* Check out submodules as part of `requirements` make target. This way submodules will always be checked out for the tests which rely on `requirements` target. This change is not explicitly needed for CI systems because CI systems check out submodules by default, but that's not the case with older git versions when user (developer) checks out the git repo manually.

* Throw a more user-friendly exception is user tries to run a test which relies on git submodules, but submodules are not checked out.

Related docs PR https://github.com/StackStorm/st2docs/pull/720.