### PR TITLE
Include Python patch version and which Python executable is used when using st2 --version

### DIFF
--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -93,10 +93,13 @@ class Shell(BaseCLIApp):
         self.parser.add_argument(
             '--version',
             action='version',
-            version='%(prog)s {version}, on Python {python_major}.{python_minor}'.format(
+            version=('%(prog)s {version}, on Python {python_major}.{python_minor}.{python_micro}'
+                    ' ({python_executable})').format(
                 version=__version__,
                 python_major=sys.version_info.major,
-                python_minor=sys.version_info.minor))
+                python_minor=sys.version_info.minor,
+                python_micro=sys.version_info.micro,
+                python_executable=sys.executable))
 
         self.parser.add_argument(
             '--url',


### PR DESCRIPTION
Small change to make the output a bit less confusing.

Before:

```bash
st2 2.8dev, on Python 2.7
```

After:

```bash
st2 2.8dev, on Python 2.7.6 (/data/stanley/virtualenv/bin/python)
```