### PR TITLE
Make sure latest version of virtualenv is used on Travis and everywhere

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,16 @@ services:
   - mongodb
   - rabbitmq
 
+before_install:
+  - pip install --upgrade "pip>=9.0,<9.1"
+  - sudo pip install --upgrade "virtualenv==15.1.0"
+
 # Let's enable rabbitmqadmin
 # See https://github.com/messagebus/lapine/wiki/Testing-on-Travis.
 before_script:
   - git --version
+  - pip --version
+  - virtualenv --version
   - sudo rabbitmq-plugins enable rabbitmq_management
   - sudo wget http://guest:guest@localhost:15672/cli/rabbitmqadmin -O /usr/local/bin/rabbitmqadmin
   - sudo chmod +x /usr/local/bin/rabbitmqadmin

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,6 @@ services:
   - mongodb
   - rabbitmq
 
-before_install:
-  - pip install --upgrade "pip>=9.0,<9.1"
-  - sudo pip install --upgrade "virtualenv==15.1.0"
-
 # Let's enable rabbitmqadmin
 # See https://github.com/messagebus/lapine/wiki/Testing-on-Travis.
 before_script:
@@ -64,6 +60,8 @@ cache:
 before_install:
   # Work around for Travis timeout issues, see https://github.com/travis-ci/travis-ci/issues/9112
   - sudo apt-get update --option Acquire::Retries=100 --option Acquire::http::Timeout="60"
+  - pip install --upgrade "pip>=9.0,<9.1"
+  - sudo pip install --upgrade "virtualenv==15.1.0"
 
 install:
   - if [ "${TASK}" = 'compilepy3 ci-py3-unit' ]; then pip install tox; else make requirements; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,17 +40,6 @@ services:
   - mongodb
   - rabbitmq
 
-# Let's enable rabbitmqadmin
-# See https://github.com/messagebus/lapine/wiki/Testing-on-Travis.
-before_script:
-  - git --version
-  - pip --version
-  - virtualenv --version
-  - sudo rabbitmq-plugins enable rabbitmq_management
-  - sudo wget http://guest:guest@localhost:15672/cli/rabbitmqadmin -O /usr/local/bin/rabbitmqadmin
-  - sudo chmod +x /usr/local/bin/rabbitmqadmin
-  - sudo service rabbitmq-server restart
-
 cache:
   pip: true
   directories:
@@ -67,6 +56,17 @@ install:
   - if [ "${TASK}" = 'compilepy3 ci-py3-unit' ]; then pip install tox; else make requirements; fi
   - if [ "${TASK}" = 'ci-unit' ] || [ "${TASK}" = 'ci-integration' ]; then pip install codecov; fi
   - if [ "${TASK}" = 'ci-unit' ] || [ "${TASK}" = 'ci-integration' ] || [ "${TASK}" = 'compilepy3 ci-py3-unit' ]; then sudo .circle/add-itest-user.sh; fi
+
+# Let's enable rabbitmqadmin
+# See https://github.com/messagebus/lapine/wiki/Testing-on-Travis.
+before_script:
+  - git --version
+  - pip --version
+  - virtualenv --version
+  - sudo rabbitmq-plugins enable rabbitmq_management
+  - sudo wget http://guest:guest@localhost:15672/cli/rabbitmqadmin -O /usr/local/bin/rabbitmqadmin
+  - sudo chmod +x /usr/local/bin/rabbitmqadmin
+  - sudo service rabbitmq-server restart
 
 script:
   - make ${TASK}

--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ requirements: virtualenv .sdist-requirements
 	@echo
 	# Make sure we use latest version of pip which is < 10.0.0
 	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pip>=9.0,<9.1"
-	$(VIRTUALENV_DIR)/bin/pip install virtualenv  # Required for packs.install in dev envs.
+	$(VIRTUALENV_DIR)/bin/pip install --upgrade "virtualenv==15.1.0" # Required for packs.install in dev envs.
 
 	# Generate all requirements to support current CI pipeline.
 	$(VIRTUALENV_DIR)/bin/python scripts/fixate-requirements.py --skip=virtualenv -s st2*/in-requirements.txt -f fixed-requirements.txt -o requirements.txt


### PR DESCRIPTION
Merged some changes into master and master build failed even though all the branches / PR builds passed.

It's likely related to Travis dependencies cache and old version od virtualenv being used for master builds. I believe this change should fix it.