### PR TITLE
[RBAC] Fix an issue (race) with remote to local group sync during concurrent authentication

### DIFF
--- a/st2common/st2common/rbac/syncer.py
+++ b/st2common/st2common/rbac/syncer.py
@@ -456,7 +456,8 @@ class RBACRemoteGroupToRoleSyncer(object):
                 assignment_db = rbac_services.assign_role_to_user(role_db=role_db, user_db=user_db,
                                                                   description=description,
                                                                   is_remote=True,
-                                                                  source=mapping_db.source)
+                                                                  source=mapping_db.source,
+                                                                  ignore_already_exists_error=True)
                 assert assignment_db.is_remote is True
                 created_assignments_dbs.append(assignment_db)
 

--- a/st2common/st2common/services/rbac.py
+++ b/st2common/st2common/services/rbac.py
@@ -223,7 +223,8 @@ def assign_role_to_user(role_db, user_db, description=None, is_remote=False, sou
             raise e
 
         role_assignment_db = UserRoleAssignment.query(user=user_db.name, role=role_db.name,
-                                                      source=source, description=description)
+                                                      source=source,
+                                                      description=description).first()
 
     return role_assignment_db
 

--- a/st2common/st2common/services/rbac.py
+++ b/st2common/st2common/services/rbac.py
@@ -14,7 +14,9 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 from mongoengine.queryset.visitor import Q
+from mongoengine import NotUniqueError
 
 from st2common.rbac.types import PermissionType
 from st2common.rbac.types import ResourceType
@@ -27,6 +29,7 @@ from st2common.models.db.rbac import RoleDB
 from st2common.models.db.rbac import UserRoleAssignmentDB
 from st2common.models.db.rbac import PermissionGrantDB
 from st2common.models.db.rbac import GroupToRoleMappingDB
+from st2common.exceptions.db import StackStormDBObjectConflictError
 
 
 __all__ = [
@@ -186,7 +189,8 @@ def delete_role(name):
     return result
 
 
-def assign_role_to_user(role_db, user_db, description=None, is_remote=False, source=None):
+def assign_role_to_user(role_db, user_db, description=None, is_remote=False, source=None,
+                        ignore_already_exists_error=False):
     """
     Assign role to a user.
 
@@ -205,11 +209,21 @@ def assign_role_to_user(role_db, user_db, description=None, is_remote=False, sou
     :param source: Source from where this assignment comes from. For example, path of a file if
                    it's a local assignment or mapping or "API".
     :type source: ``str``
+
+    :param: ignore_already_exists_error: True to ignore error if an assignment already exists.
+    :type ignore_already_exists_error: ``bool``
     """
     role_assignment_db = UserRoleAssignmentDB(user=user_db.name, role=role_db.name, source=source,
                                               description=description, is_remote=is_remote)
 
-    role_assignment_db = UserRoleAssignment.add_or_update(role_assignment_db)
+    try:
+        role_assignment_db = UserRoleAssignment.add_or_update(role_assignment_db)
+    except (NotUniqueError, StackStormDBObjectConflictError) as e:
+        if not ignore_already_exists_error:
+            raise e
+
+        role_assignment_db = UserRoleAssignment.query(user=user_db.name, role=role_db.name,
+                                                      source=source, description=description)
 
     return role_assignment_db
 

--- a/st2common/tests/unit/services/test_rbac.py
+++ b/st2common/tests/unit/services/test_rbac.py
@@ -269,6 +269,9 @@ class RBACServicesTestCase(CleanDbTestCase):
             ignore_already_exists_error=True)
 
         self.assertEqual(role_assignment_db_1, role_assignment_db_2)
+        self.assertEqual(role_assignment_db_1.id, role_assignment_db_2.id)
+        self.assertEqual(role_assignment_db_1.user, role_assignment_db_2.user)
+        self.assertEqual(role_assignment_db_1.role, role_assignment_db_2.role)
 
     def test_get_all_permission_grants_for_user(self):
         user_db = self.users['1_custom_role']


### PR DESCRIPTION
This pull request fixes issue described in #4103.

If a user tried to authenticate with the same token concurrently in a short time frame, there was a race condition which would cause an exception to be thrown and potentially not all the remote group mappings for that user to be synchronized.

Keep in mind that this issue only affects users who use RBAC with remote LDAP groups to local RBAC roles synchronization feature enabled.

In addition to that, the error is not fatal (authentication would succeed, as designed), but it could potentially result in not all the mappings for a user to be synchronized (depending on when the race occurred and number of mappings defined on disk).

Since the RBAC functionality follows "whitelist" approach that behavior is fail safe - the worst case (race occurring) would mean not all the mappings are synchronized and user has access to less / not all the resources that are defined in the mappings.

Resolves #4103.