### PR TITLE
id is a required argument for st2-track-result command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Fixed
 
   Note: This issue only affects users who utilize RBAC with remote LDAP groups to local RBAC
   roles synchronization feature enabled. (bug fix) #4103 #4105
+* Throw if ``id`` CLI argument is not passed to the ``st2-track-result`` script. (bug fix) #4115
 
 2.7.1 - April 20, 2018
 ----------------------

--- a/st2common/bin/st2-track-result
+++ b/st2common/bin/st2-track-result
@@ -33,7 +33,8 @@ LOG = logging.getLogger(__name__)
 
 def setup():
     cfg.CONF.register_cli_opt(
-        cfg.StrOpt('id', positional=True, help='ID of the action execution.')
+        cfg.StrOpt('id', positional=True, help='ID of the action execution.',
+                   required=True)
     )
 
     cfg.CONF.register_cli_opt(


### PR DESCRIPTION
We didn't declare `id` argument as required so script exited with a confusing error if id wasn't provided.

Before:

```bash
$ st2-track-result
2018-05-07 14:38:58,249 INFO [-] Connecting to database "st2" @ "127.0.0.1:27017" as user "None".
2018-05-07 14:38:58,336 INFO [-] Retrieving action execution record...
Traceback (most recent call last):
  File "/usr/bin/st2-track-result", line 113, in <module>
    add_result_tracker(cfg.CONF.id)
  File "/usr/bin/st2-track-result", line 48, in add_result_tracker
    exec_db = ActionExecution.get_by_id(exec_id)
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/persistence/base.py", line 87, in get_by_id
    return cls._get_impl().get_by_id(value)
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/models/db/__init__.py", line 295, in get_by_id
    return self.get(id=value, raise_exception=True)
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/models/db/__init__.py", line 325, in get
    instance = instances[0] if instances else None
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/mongoengine/queryset/base.py", line 215, in __nonzero__
    return self._has_data()
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/mongoengine/queryset/base.py", line 211, in _has_data
    return False if queryset.first() is None else True
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/mongoengine/queryset/base.py", line 300, in first
    result = queryset[0]
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/mongoengine/queryset/base.py", line 198, in __getitem__
    queryset._cursor[key],
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/mongoengine/queryset/base.py", line 1547, in _cursor
    self._cursor_obj = self._collection.find(self._query,
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/mongoengine/queryset/base.py", line 1590, in _query
    self._mongo_query = self._query_obj.to_query(self._document)
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/mongoengine/queryset/visitor.py", line 89, in to_query
    query = query.accept(QueryCompilerVisitor(document))
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/mongoengine/queryset/visitor.py", line 155, in accept
    return visitor.visit_query(self)
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/mongoengine/queryset/visitor.py", line 78, in visit_query
    return transform.query(self.document, **query.query)
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/mongoengine/queryset/transform.py", line 98, in query
    value = field.prepare_query_value(op, value)
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/mongoengine/base/fields.py", line 465, in prepare_query_value
    return self.to_mongo(value)
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/mongoengine/base/fields.py", line 461, in to_mongo
    self.error(six.text_type(e))
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/mongoengine/base/fields.py", line 159, in error
    raise ValidationError(message, errors=errors, field_name=field_name)
mongoengine.errors.ValidationError: u'None' is not a valid ObjectId, it must be a 12-byte input or a 24-character hex string
```

After:

```bash
$ st2-track-result
Traceback (most recent call last):
  File "st2common/bin/st2-track-result", line 111, in <module>
    setup()
  File "st2common/bin/st2-track-result", line 44, in setup
    script_setup.setup(config, register_mq_exchanges=False)
  File "/data/stanley/st2common/st2common/script_setup.py", line 73, in setup
    config.parse_args()
  File "/data/stanley/st2common/st2common/config.py", line 398, in parse_args
    default_config_files=[DEFAULT_CONFIG_FILE_PATH])
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/oslo_config/cfg.py", line 1884, in __call__
    self._check_required_opts()
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/oslo_config/cfg.py", line 2433, in _check_required_opts
    raise RequiredOptError(opt.name, group)
oslo_config.cfg.RequiredOptError: value required for option: id
```