### PR TITLE
Include git revision of StackStorm release in the st2 --version output when running a dev release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 in development
 --------------
 
+Added
+~~~~~
+
+* When running a dev (unstable) release include git revision hash in the output when using
+  ``st2 --version`` CLI command. (new feature) #4117
+
 Changed
 ~~~~~~~
 

--- a/st2client/tests/unit/test_shell.py
+++ b/st2client/tests/unit/test_shell.py
@@ -60,6 +60,15 @@ class ShellTestCase(base.BaseCLITestCase):
         super(ShellTestCase, self).__init__(*args, **kwargs)
         self.shell = Shell()
 
+    def setUp(self):
+        super(ShellTestCase, self).setUp()
+
+        if six.PY3:
+            # In python --version outputs to stdout and in 2.x to stderr
+            self.version_output = self.stdout
+        else:
+            self.version_output = self.stderr
+
     def test_commands_usage_and_help_strings(self):
         # No command, should print out user friendly usage / help string
         self.assertEqual(self.shell.run([]), 2)
@@ -371,8 +380,8 @@ class ShellTestCase(base.BaseCLITestCase):
         shell = Shell()
         shell.parser.parse_args(args=['--version'])
 
-        self.stderr.seek(0)
-        stderr = self.stderr.read()
+        self.version_output.seek(0)
+        stderr = self.version_output.read()
         self.assertTrue('v2.8.0, on Python' in stderr)
 
     @mock.patch('sys.exit', mock.Mock())
@@ -383,10 +392,10 @@ class ShellTestCase(base.BaseCLITestCase):
         st2client.shell.PACKAGE_METADATA_FILE_PATH = package_metadata_path
 
         shell = Shell()
-        shell.parser.parse_args(args=['--version'])
+        shell.run(argv=['--version'])
 
-        self.stderr.seek(0)
-        stderr = self.stderr.read()
+        self.version_output.seek(0)
+        stderr = self.version_output.read()
         self.assertTrue('v2.8.0, on Python' in stderr)
 
     @mock.patch('sys.exit', mock.Mock())
@@ -398,8 +407,8 @@ class ShellTestCase(base.BaseCLITestCase):
         shell = Shell()
         shell.parser.parse_args(args=['--version'])
 
-        self.stderr.seek(0)
-        stderr = self.stderr.read()
+        self.version_output.seek(0)
+        stderr = self.version_output.read()
         self.assertTrue('v2.9dev, on Python' in stderr)
 
     @mock.patch('sys.exit', mock.Mock())
@@ -413,8 +422,8 @@ class ShellTestCase(base.BaseCLITestCase):
         shell = Shell()
         shell.parser.parse_args(args=['--version'])
 
-        self.stderr.seek(0)
-        stderr = self.stderr.read()
+        self.version_output.seek(0)
+        stderr = self.version_output.read()
         self.assertTrue('v2.9dev (abcdefg), on Python' in stderr)
 
     def _write_mock_package_metadata_file(self):

--- a/st2client/tests/unit/test_shell.py
+++ b/st2client/tests/unit/test_shell.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import time
 import datetime
@@ -25,6 +26,7 @@ import six
 import mock
 import unittest2
 
+import st2client
 from st2client.shell import Shell
 from st2client.client import Client
 from st2client.utils import httpclient
@@ -43,12 +45,19 @@ username = foo
 password = bar
 """
 
+MOCK_PACKAGE_METADATA = """
+[server]
+version = 2.8dev
+git_sha = abcdefg
+circle_build_url = https://circleci.com/gh/StackStorm/st2/7213
+"""
 
-class TestShell(base.BaseCLITestCase):
+
+class ShellTestCase(base.BaseCLITestCase):
     capture_output = True
 
     def __init__(self, *args, **kwargs):
-        super(TestShell, self).__init__(*args, **kwargs)
+        super(ShellTestCase, self).__init__(*args, **kwargs)
         self.shell = Shell()
 
     def test_commands_usage_and_help_strings(self):
@@ -353,6 +362,68 @@ class TestShell(base.BaseCLITestCase):
             ['trigger', 'delete', 'abc']
         ]
         self._validate_parser(args_list)
+
+    @mock.patch('sys.exit', mock.Mock())
+    @mock.patch('st2client.shell.__version__', 'v2.8.0')
+    def test_get_version_no_package_metadata_file_stable_version(self):
+        # stable version, package metadata file doesn't exist on disk - no git revision should be
+        # included
+        shell = Shell()
+        shell.parser.parse_args(args=['--version'])
+
+        self.stderr.seek(0)
+        stderr = self.stderr.read()
+        self.assertTrue('v2.8.0, on Python' in stderr)
+
+    @mock.patch('sys.exit', mock.Mock())
+    @mock.patch('st2client.shell.__version__', 'v2.8.0')
+    def test_get_version_package_metadata_file_exists_stable_version(self):
+        # stable version, package metadata file exists on disk - no git revision should be included
+        package_metadata_path = self._write_mock_package_metadata_file()
+        st2client.shell.PACKAGE_METADATA_FILE_PATH = package_metadata_path
+
+        shell = Shell()
+        shell.parser.parse_args(args=['--version'])
+
+        self.stderr.seek(0)
+        stderr = self.stderr.read()
+        self.assertTrue('v2.8.0, on Python' in stderr)
+
+    @mock.patch('sys.exit', mock.Mock())
+    @mock.patch('st2client.shell.__version__', 'v2.9dev')
+    @mock.patch('st2client.shell.PACKAGE_METADATA_FILE_PATH', '/tmp/doesnt/exist.1')
+    def test_get_version_no_package_metadata_file_dev_version(self):
+        # dev version, package metadata file doesn't exist on disk - no git revision should be
+        # included since package metadata file doesn't exist on disk
+        shell = Shell()
+        shell.parser.parse_args(args=['--version'])
+
+        self.stderr.seek(0)
+        stderr = self.stderr.read()
+        self.assertTrue('v2.9dev, on Python' in stderr)
+
+    @mock.patch('sys.exit', mock.Mock())
+    @mock.patch('st2client.shell.__version__', 'v2.9dev')
+    def test_get_version_package_metadata_file_exists_dev_version(self):
+        # dev version, package metadata file exists on disk - git revision should be included
+        # since package metadata file exists on disk and contains server.git_sha attribute
+        package_metadata_path = self._write_mock_package_metadata_file()
+        st2client.shell.PACKAGE_METADATA_FILE_PATH = package_metadata_path
+
+        shell = Shell()
+        shell.parser.parse_args(args=['--version'])
+
+        self.stderr.seek(0)
+        stderr = self.stderr.read()
+        self.assertTrue('v2.9dev (abcdefg), on Python' in stderr)
+
+    def _write_mock_package_metadata_file(self):
+        _, package_metadata_path = tempfile.mkstemp()
+
+        with open(package_metadata_path, 'w') as fp:
+            fp.write(MOCK_PACKAGE_METADATA)
+
+        return package_metadata_path
 
 
 class CLITokenCachingTestCase(unittest2.TestCase):


### PR DESCRIPTION
This pull request updates ``st2 --version`` CLI command to also include git revision of the release when running a dev release and when file with package metadata is available.

Before:

```bash
$ st2 --version
st2 2.8dev, on Python 2.7
```

After:

```bash
$ st2 --version
st2 2.8dev (5f89c1f), on Python 2.7.6
```

This saves some typing since you don't need to manually check the package metadata file (`/opt/stackstorm/st2/package.meta`).

If others think it makes sense, we could also include git revision when running a stable (non dev) release, but I personally think that's not needed and it would just make it confusing (we have a corresponding git tag for each final release which is not the case for dev releases).

## TODO

- [x] Tests