### PR TITLE
Fix for a regression which broke sensors which rely on select.poll() functionality

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,11 @@ Fixed
 
   Note: This issue only affects users who utilize RBAC with remote LDAP groups to local RBAC
   roles synchronization feature enabled. (bug fix) #4103 #4105
+* Fix an issue with some sensors which rely on ``select.poll()`` (FileWatch, GithubSensor, etc.)
+  stopped working with StackStorm >= 2.7.0.
+
+  StackStorm v2.7.0 inadvertently introduced a change which broke a small set of
+  sensors which rely on ``select.poll()`` functionality. (bug fix)
 
 2.7.1 - April 20, 2018
 ----------------------

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -3,7 +3,7 @@
 greenlet==0.4.13
 # Note: 0.20.0 removed select.poll() on which some of our code and libraries we
 # depend on rely
-eventlet==0.22.1
+eventlet==0.23.0
 gunicorn==19.8.1
 kombu==4.1.0
 # Note: amqp is used by kombu

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 apscheduler==3.5.1
 argcomplete
 bcrypt
-eventlet==0.22.1
+eventlet==0.23.0
 flex==6.13.1
 git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -37,8 +37,9 @@ from st2reactor.sensor.base import Sensor
 from st2reactor.sensor.base import PollingSensor
 from st2reactor.sensor import config
 from st2common.services.datastore import SensorDatastoreService
-from st2common.util.monkey_patch import monkey_patch
 from st2common.validators.api.reactor import validate_trigger_payload
+from st2common.util.monkey_patch import monkey_patch
+from st2common.util.monkey_patch import use_select_poll_workaround
 
 __all__ = [
     'SensorWrapper',
@@ -46,6 +47,7 @@ __all__ = [
 ]
 
 monkey_patch()
+use_select_poll_workaround(nose_only=False)
 
 
 class SensorService(object):

--- a/st2reactor/tests/unit/test_sensor_wrapper.py
+++ b/st2reactor/tests/unit/test_sensor_wrapper.py
@@ -136,3 +136,11 @@ class SensorWrapperTestCase(unittest2.TestCase):
             self.assertTrue('line 5, in <module>' in str(e))
         else:
             self.fail('NameError not thrown')
+
+    def test_sensor_wrapper_poll_method_still_works(self):
+        # Verify that sensor wrapper correctly applied select.poll() eventlet workaround so code
+        # which relies on select.poll() such as subprocess.poll() still works
+        # Note: If workaround is not applied "AttributeError: 'module' object has no attribute
+        # 'poll'" will be thrown
+        import select
+        self.assertTrue(select.poll())

--- a/st2reactor/tests/unit/test_sensor_wrapper.py
+++ b/st2reactor/tests/unit/test_sensor_wrapper.py
@@ -3,6 +3,10 @@ import os
 import unittest2
 
 import mock
+import eventlet
+
+from st2common.util.monkey_patch import monkey_patch
+monkey_patch()
 
 import st2tests.config as tests_config
 from st2tests.base import TESTS_CONFIG_PATH
@@ -143,4 +147,7 @@ class SensorWrapperTestCase(unittest2.TestCase):
         # Note: If workaround is not applied "AttributeError: 'module' object has no attribute
         # 'poll'" will be thrown
         import select
+
+        self.assertTrue(eventlet.patcher.is_monkey_patched(select))
+        self.assertTrue(select != eventlet.patcher.original('select'))
         self.assertTrue(select.poll())


### PR DESCRIPTION
## Background

In v2.7.0 we upgraded eventlet to the latest stable version. That stable version removed `select.poll()` which was available in previous releases (but it was blocking) to make it harder for users to "accidentally" use blocking code.

That change broke some sensors which rely on `select.poll()` functionality.

Users would see an error similar to one below:

```bash
2018-05-09 07:57:29,425 ERROR [-] AttributeError
2018-05-09 07:57:29,425 ERROR [-] : 
2018-05-09 07:57:29,425 ERROR [-] 'module' object has no attribute 'poll'
2018-05-09 07:57:29,425 ERROR [-] 
```

## Proposed solution

This PR adds `select` module which includes blocking version of `poll()` back to `sys.modules` so it can be used by the sensors which need it.

The behavior will now be the same as in releases prior to v2.7.0. Blocking code is not great and ideally we could avoid it where we can, but sadly we have no control over 3rd party libraries and integrations which use that blocking code construct.

Keep in mind, that each sensor is running in a separate and dedicated process so blocking inside that process it not that big of deal (compared to blocking in a main service process which would be a no go).

Related issues #3968 #4007 #4094 

Resolves #4094