### PR TITLE
Fix for #4121 - Rendering nested lists in pack configs

### DIFF
--- a/st2common/tests/unit/test_config_loader.py
+++ b/st2common/tests/unit/test_config_loader.py
@@ -16,7 +16,9 @@
 from __future__ import absolute_import
 from st2common.persistence.pack import Config
 from st2common.models.db.pack import ConfigDB
+from st2common.models.db.keyvalue import KeyValuePairDB
 from st2common.exceptions.db import StackStormDBObjectNotFoundError
+from st2common.persistence.keyvalue import KeyValuePair
 from st2common.services.config import set_datastore_value_for_config_key
 from st2common.util.config_loader import ContentPackConfigLoader
 
@@ -330,4 +332,167 @@ class ContentPackConfigLoaderTestCase(CleanDbTestCase):
                         '"level0_object.level1_object.level2_key" with value "{{st2kvXX.invalid}}"'
                         ' for pack ".*?" config: \'st2kvXX\' is undefined')
         self.assertRaisesRegexp(Exception, expected_msg, loader.get_config)
+        config_db.delete()
+
+        # Renders fails on list item
+        values = {
+            'level0_object': [
+                'abc',
+                '{{st2kvXX.invalid}}'
+            ]
+        }
+        config_db = ConfigDB(pack=pack_name, values=values)
+        Config.add_or_update(config_db)
+
+        expected_msg = ('Failed to render dynamic configuration value for key '
+                        '"level0_object.1" with value "{{st2kvXX.invalid}}"'
+                        ' for pack ".*?" config: \'st2kvXX\' is undefined')
+        self.assertRaisesRegexp(Exception, expected_msg, loader.get_config)
+        config_db.delete()
+
+        # Renders fails on nested object in list item
+        values = {
+            'level0_object': [
+                {'level2_key': '{{st2kvXX.invalid}}'}
+            ]
+        }
+        config_db = ConfigDB(pack=pack_name, values=values)
+        Config.add_or_update(config_db)
+
+        expected_msg = ('Failed to render dynamic configuration value for key '
+                        '"level0_object.0.level2_key" with value "{{st2kvXX.invalid}}"'
+                        ' for pack ".*?" config: \'st2kvXX\' is undefined')
+        self.assertRaisesRegexp(Exception, expected_msg, loader.get_config)
+        config_db.delete()
+
+    def test_get_config_dynamic_config_item(self):
+        pack_name = 'dummy_pack_schema_with_nested_object_6'
+        loader = ContentPackConfigLoader(pack_name=pack_name)
+
+        ####################
+        # top level item
+        k1 = KeyValuePair.add_or_update(KeyValuePairDB(name='k1', value='v1'))
+        values = {
+            'level0_key': '{{st2kv.system.k1}}'
+        }
+        config_db = ConfigDB(pack=pack_name, values=values)
+        config_db = Config.add_or_update(config_db)
+
+        config_rendered = loader.get_config()
+
+        self.assertEquals(config_rendered, {'level0_key': 'v1'})
+
+        config_db.delete()
+
+    def test_get_config_dynamic_config_item_nested_dict(self):
+        pack_name = 'dummy_pack_schema_with_nested_object_7'
+        loader = ContentPackConfigLoader(pack_name=pack_name)
+
+        ####################
+        # top level item
+        k1 = KeyValuePair.add_or_update(KeyValuePairDB(name='k0', value='v0'))
+        k1 = KeyValuePair.add_or_update(KeyValuePairDB(name='k1', value='v1'))
+        k1 = KeyValuePair.add_or_update(KeyValuePairDB(name='k2', value='v2'))
+        values = {
+            'level0_key': '{{st2kv.system.k0}}',
+            'level0_object': {
+                'level1_key': '{{st2kv.system.k1}}',
+                'level1_object': {
+                    'level2_key': '{{st2kv.system.k2}}'
+                }
+            }
+        }
+        config_db = ConfigDB(pack=pack_name, values=values)
+        config_db = Config.add_or_update(config_db)
+
+        config_rendered = loader.get_config()
+
+        self.assertEquals(config_rendered,
+                          {
+                              'level0_key': 'v0',
+                              'level0_object': {
+                                  'level1_key': 'v1',
+                                  'level1_object': {
+                                      'level2_key': 'v2'
+                                  }
+                              }
+                          })
+
+        config_db.delete()
+
+    def test_get_config_dynamic_config_item_list(self):
+        pack_name = 'dummy_pack_schema_with_nested_object_7'
+        loader = ContentPackConfigLoader(pack_name=pack_name)
+
+        ####################
+        # top level item
+        k1 = KeyValuePair.add_or_update(KeyValuePairDB(name='k0', value='v0'))
+        k1 = KeyValuePair.add_or_update(KeyValuePairDB(name='k1', value='v1'))
+        values = {
+            'level0_key': [
+                'a',
+                '{{st2kv.system.k0}}',
+                'b',
+                '{{st2kv.system.k1}}',
+            ]
+        }
+        config_db = ConfigDB(pack=pack_name, values=values)
+        config_db = Config.add_or_update(config_db)
+
+        config_rendered = loader.get_config()
+
+        self.assertEquals(config_rendered,
+                          {
+                              'level0_key': [
+                                  'a',
+                                  'v0',
+                                  'b',
+                                  'v1'
+                              ]
+                          })
+
+        config_db.delete()
+
+    def test_get_config_dynamic_config_item_nested_list(self):
+        pack_name = 'dummy_pack_schema_with_nested_object_8'
+        loader = ContentPackConfigLoader(pack_name=pack_name)
+
+        ####################
+        # top level item
+        k1 = KeyValuePair.add_or_update(KeyValuePairDB(name='k0', value='v0'))
+        k1 = KeyValuePair.add_or_update(KeyValuePairDB(name='k1', value='v1'))
+        k1 = KeyValuePair.add_or_update(KeyValuePairDB(name='k2', value='v2'))
+        values = {
+            'level0_key': [
+                {
+                    'level1_key0': '{{st2kv.system.k0}}'
+                },
+                '{{st2kv.system.k1}}',
+                {
+                    'level1_key2':  [
+                        '{{st2kv.system.k2}}',
+                    ]
+                }
+            ]
+        }
+        config_db = ConfigDB(pack=pack_name, values=values)
+        config_db = Config.add_or_update(config_db)
+
+        config_rendered = loader.get_config()
+
+        self.assertEquals(config_rendered,
+                          {
+                              'level0_key': [
+                                  {
+                                      'level1_key0': 'v0'
+                                  },
+                                  'v1',
+                                  {
+                                      'level1_key2':  [
+                                          'v2',
+                                      ]
+                                  }
+                              ]
+                          })
+
         config_db.delete()


### PR DESCRIPTION
In the ConfigLoader when traversing the config object structure, `dicts` were taken into account and recursed properly, however `lists` were not considered.

This PR recognizes lists in the recursion and takes steps to render the values within them, potentially recursing further into each item if necessary.

Closes #4121 