### PR TITLE
Update st2 CLI to print a warning if a locale with non utf-8 encoding is used

### DIFF
--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -132,7 +132,6 @@ class Shell(BaseCLIApp):
         self.client = None
 
         # Set up the main parser.
-        self._check_locale_and_print_warning()
         self.parser = argparse.ArgumentParser(description=CLI_DESCRIPTION)
 
         # Set up general program options.
@@ -368,6 +367,8 @@ class Shell(BaseCLIApp):
         # Parse config and store it in the config module
         config = self._parse_config_file(args=args)
         set_config(config=config)
+
+        self._check_locale_and_print_warning()
 
         # Setup client and run the command
         try:

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -422,7 +422,8 @@ class Shell(BaseCLIApp):
             preferred_encoding = locale.getpreferredencoding()
         except ValueError:
             # Ignore unknown locale errors for now
-            return
+            default_locale = 'unknown'
+            preferred_encoding = 'unknown'
 
         if preferred_encoding and preferred_encoding.lower() != 'utf-8':
             msg = NON_UTF8_LOCALE % (default_locale or 'unknown', preferred_encoding)

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -78,7 +78,7 @@ For example:
 
 NON_UTF8_LOCALE = """
 Locale %s with encoding %s which is not UTF-8 is used. This means that some functionality which
-relies on outputing unicode characters won't work.
+relies on outputting unicode characters won't work.
 
 You are encouraged to use UTF-8 locale by setting LC_ALL environment variable to en_US.UTF-8 or
 similar.


### PR DESCRIPTION
This pull request updates st2 CLI to print a warning and notify the user if a locale with non-utf8 encoding is used.

Using non utf-8 locale could cause issues and confusion in case use has actions which produce unicode data so it makes sense to warn user in such scenario.

Related issue #4120.

### Example output

1. C locale

```bash
LC_ALL=C python st2 run core.local cmd="printf '\xE2\x98\xA0'" --tail
2018-05-11 14:50:40,379  WARNING - Locale unknown with encoding ANSI_X3.4-1968 which is not UTF-8 is used. This means that some functionality which
relies on outputting unicode characters won't work.

You are encouraged to use UTF-8 locale by setting LC_ALL environment variable to en_US.UTF-8 or
similar.
2018-05-11 14:50:40,423  WARNING - Auth API server is not available, skipping authentication.
Tailing execution "5af5adc00640fd35b085f819"
Execution 5af5adc00640fd35b085f819 has started.

ERROR: 'ascii' codec can't encode character u'\u2620' in position 0: ordinal not in range(128)
```

2. en_US locale with non utf-8 encoding

```bash
LC_ALL=en_US st2 run core.local cmd="printf '\xE2\x98\xA0'" --tail
2018-05-11 14:50:55,646  WARNING - Locale en_US with encoding ISO-8859-1 which is not UTF-8 is used. This means that some functionality which
relies on outputting unicode characters won't work.

You are encouraged to use UTF-8 locale by setting LC_ALL environment variable to en_US.UTF-8 or
similar.
2018-05-11 14:50:55,722  WARNING - Auth API server is not available, skipping authentication.
Tailing execution "5af5adcf0640fd35b085f81c"
Execution 5af5adcf0640fd35b085f81c has started.

ERROR: 'latin-1' codec can't encode character u'\u2620' in position 0: ordinal not in range(256)
```

3. Invalid locale (which falls back to C)

```bash
$ LC_ALL=foo st2 run core.local cmd="printf '\xE2\x98\xA0'" --tail
2018-05-11 14:59:30,503  WARNING - Locale unknown with encoding unknown which is not UTF-8 is used. This means that some functionality which
relies on outputting unicode characters won't work.

You are encouraged to use UTF-8 locale by setting LC_ALL environment variable to en_US.UTF-8 or
similar.
2018-05-11 14:51:24,702  WARNING - Auth API server is not available, skipping authentication.
Tailing execution "5af5adec0640fd35b085f81f"
Execution 5af5adec0640fd35b085f81f has started.

ERROR: 'ascii' codec can't encode character u'\u2620' in position 0: ordinal not in range(128)
```

4. Locale with utf-8 encoding (implicit, system default)

```bash
$ locale
LANG=en_US.UTF-8
LANGUAGE=
LC_CTYPE="en_US.UTF-8"
LC_NUMERIC="en_US.UTF-8"
LC_TIME="en_US.UTF-8"
LC_COLLATE="en_US.UTF-8"
LC_MONETARY="en_US.UTF-8"
LC_MESSAGES="en_US.UTF-8"
LC_PAPER="en_US.UTF-8"
LC_NAME="en_US.UTF-8"
LC_ADDRESS="en_US.UTF-8"
LC_TELEPHONE="en_US.UTF-8"
LC_MEASUREMENT="en_US.UTF-8"
LC_IDENTIFICATION="en_US.UTF-8"
LC_ALL=

$ st2 run core.local cmd="printf '\xE2\x98\xA0'" --tail
2018-05-11 14:55:38,699  WARNING - Auth API server is not available, skipping authentication.
Tailing execution "5af5aeea0640fd35b085f825"
Execution 5af5aeea0640fd35b085f825 has started.

☠
Execution 5af5aeea0640fd35b085f825 has completed (status=succeeded).

id: 5af5aeea0640fd35b085f825
status: succeeded
parameters: 
  cmd: printf 'â '
result: 
  failed: false
  return_code: 0
  stderr: ''
  stdout: "☠"
  succeeded: true
```

4. Locale with utf-8 encoding (explicit)

```bash
$ LC_ALL=en_US.UTF-8 python st2client/st2client/shell.py run core.local cmd="printf '\xE2\x98\xA0'" --tail
2018-05-11 14:56:19,332  WARNING - Auth API server is not available, skipping authentication.
Tailing execution "5af5af130640fd35b085f82b"
Execution 5af5af130640fd35b085f82b has started.

☠
Execution 5af5af130640fd35b085f82b has completed (status=succeeded).

id: 5af5af130640fd35b085f82b
status: succeeded
parameters: 
  cmd: printf 'â '
result: 
  failed: false
  return_code: 0
  stderr: ''
  stdout: "☠"
  succeeded: true
```

## TODO

- [ ] Tests
- [ ] Config option which allows user to skip that check