### PR TITLE
Add missing pip 10 fix to runners

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -480,7 +480,7 @@ debs:
 .PHONY: .sdist-requirements
 .sdist-requirements:
 	# Copy over shared dist utils module which is needed by setup.py
-	@for component in $(COMPONENTS); do\
+	@for component in $(COMPONENTS_WITH_RUNNERS); do\
 		cp -f ./scripts/dist_utils.py $$component/dist_utils.py;\
 	done
 


### PR DESCRIPTION
We've apparently missed updating dist_utils.py files in runners the same way we do it in components. This resulted in #4069 fix not propagating there and as a result, serverless plugin being broken in pip 10 environments. 