### PR TITLE
Metrics Fixup

### DIFF
--- a/st2actions/st2actions/container/base.py
+++ b/st2actions/st2actions/container/base.py
@@ -81,16 +81,16 @@ class RunnerContainer(object):
                 'in an unsupported status of "%s".' % liveaction_db.status
             )
 
-        liveaction_db = funcs[liveaction_db.status](
-            runner=runner,
-            runnertype_db=runnertype_db,
-            action_db=action_db,
-            liveaction_db=liveaction_db
-        )
+        with CounterWithTimer(key="st2.action.executions"):
+            liveaction_db = funcs[liveaction_db.status](
+                runner=runner,
+                runnertype_db=runnertype_db,
+                action_db=action_db,
+                liveaction_db=liveaction_db
+            )
 
         return liveaction_db.result
 
-    @CounterWithTimer(key="st2.action.executions")
     def _do_run(self, runner, runnertype_db, action_db, liveaction_db):
         # Create a temporary auth token which will be available
         # for the duration of the action execution.

--- a/st2common/st2common/metrics/base.py
+++ b/st2common/st2common/metrics/base.py
@@ -40,7 +40,7 @@ def _strip_pack(action, pack):
     formatted_pack = "%s." % (pack)
 
     if formatted_pack in action:
-        return action.strip(formatted_pack)
+        return action.replace(formatted_pack, '')
 
     return action
 

--- a/st2common/st2common/metrics/base.py
+++ b/st2common/st2common/metrics/base.py
@@ -36,16 +36,25 @@ PLUGIN_NAMESPACE = 'st2common.metrics.driver'
 METRICS = None
 
 
+def _strip_pack(action, pack):
+    formatted_pack = "%s." % (pack)
+
+    if formatted_pack in action:
+        return action.strip(formatted_pack)
+
+    return action
+
+
 def _format_metrics_key_for_action_db(action_db):
-    action_name = action_db.name
     action_pack = action_db.pack
-    return '.%s.%s' % (action_pack, action_name)
+    action_name = _strip_pack(action_db.name, action_pack)
+    return [action_pack, action_name]
 
 
 def _format_metrics_key_for_liveaction_db(liveaction_db):
-    action_name = liveaction_db.action
     action_pack = liveaction_db.context.get('pack', 'unknown')
-    return '.%s.%s' % (action_pack, action_name)
+    action_name = _strip_pack(liveaction_db.action, action_pack)
+    return [action_pack, action_name]
 
 
 def format_metrics_key(action_db=None, liveaction_db=None, key=None):
@@ -56,15 +65,15 @@ def format_metrics_key(action_db=None, liveaction_db=None, key=None):
     metrics_key_items = ['st2']
 
     if action_db:
-        metrics_key_items.append(_format_metrics_key_for_action_db(action_db))
+        metrics_key_items.extend(_format_metrics_key_for_action_db(action_db))
 
     if liveaction_db:
-        metrics_key_items.append(
+        metrics_key_items.extend(
             _format_metrics_key_for_liveaction_db(liveaction_db)
         )
 
     if key:
-        metrics_key_items.append('.%s' % key)
+        metrics_key_items.append('%s' % key)
 
     metrics_key = '.'.join(metrics_key_items)
 

--- a/st2common/st2common/metrics/base.py
+++ b/st2common/st2common/metrics/base.py
@@ -46,7 +46,7 @@ def _strip_pack(action, pack):
 
 
 def _format_metrics_key_for_action_db(action_db):
-    action_pack = action_db.pack
+    action_pack = action_db.pack if action_db.pack else 'unknown'
     action_name = _strip_pack(action_db.name, action_pack)
     return [action_pack, action_name]
 

--- a/st2common/st2common/metrics/drivers/statsd_driver.py
+++ b/st2common/st2common/metrics/drivers/statsd_driver.py
@@ -25,15 +25,14 @@ class StatsdDriver(BaseMetricsDriver):
     def __init__(self):
         statsd.Connection.set_defaults(host=cfg.CONF.metrics.host, port=cfg.CONF.metrics.port)
         self._counters = {}
-        self._timers = {}
+        self._timer = statsd.Timer('')
 
     def time(self, key, time):
         """ Timer metric
         """
         check_key(key)
         assert isinstance(time, Number)
-        self._timers[key] = self._timers.get(key, statsd.Timer(''))
-        self._timers[key].send(key, time)
+        self._timer.send(key, time)
 
     def inc_counter(self, key, amount=1):
         """ Increment counter

--- a/st2common/tests/unit/test_metrics.py
+++ b/st2common/tests/unit/test_metrics.py
@@ -367,6 +367,18 @@ class TestFormatMetrics(unittest2.TestCase):
 
         self.assertEquals(key, "st2.%s.%s.%s" % (pack, action, test_key))
 
+    def test_format_metrics_liveaction_db_without_pack(self):
+        action = 'lakface'
+        pack = 'unknown'
+
+        liveaction_db = MagicMock()
+        liveaction_db.context = {}
+        liveaction_db.action = "%s.%s" % (pack, action)
+
+        key = base.format_metrics_key(liveaction_db=liveaction_db)
+
+        self.assertEquals(key, "st2.%s.%s" % (pack, action))
+
     def test_format_metrics_action_db_without_key(self):
         pack = 'test'
         action = 'lakface'
@@ -391,3 +403,15 @@ class TestFormatMetrics(unittest2.TestCase):
         key = base.format_metrics_key(action_db=action_db, key=test_key)
 
         self.assertEquals(key, "st2.%s.%s.%s" % (pack, action, test_key))
+
+    def test_format_metrics_action_db_without_pack(self):
+        action = 'lakface'
+        pack = 'unknown'
+
+        action_db = MagicMock()
+        action_db.pack = None
+        action_db.name = action
+
+        key = base.format_metrics_key(action_db=action_db)
+
+        self.assertEquals(key, "st2.%s.%s" % (pack, action))


### PR DESCRIPTION
Original metrics PR had some missing pieces. Chiefly incorrect naming generated by the metrics formatter. Wrote some tests to cover that from happening again. Also had to move decorator to the context manager for `_do_run` because we're accessing it by placing it into a dictionary and apparently that has some interesting side effects on decorators that I'll be interested to explore when I have some more time.