### PR TITLE
Rewrite coverage handling in the root Makefile

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,4 +2,4 @@
 
 [run]
 include = st2*
-omit = *tests/*
+disable_warnings = include-ignored,module-not-imported

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,13 @@
 ; http://nedbatchelder.com/code/coverage/config.html
 
 [run]
-include = st2*
+branch = True
+concurrency = eventlet
+include = st2*,contrib/runners/*
 disable_warnings = include-ignored,module-not-imported
+omit = */*/wsgi.py
+       */*/util/wsgi.py  ; st2common/st2common/util/wsgi.py
+       */setup.py
+       contrib/runners/*/setup.py
+       */dist_utils.py
+       contrib/runners/*/dist_utils.py

--- a/Makefile
+++ b/Makefile
@@ -277,8 +277,8 @@ compilepy3:
 	@echo "Removing all coverage results directories"
 	@echo
 	rm -rf .coverage \
-	 .coverage-unit .coverage-unit-* \
-	 .coverage-integation .coverage-integration-* \
+	 .coverage-unit ".coverage-unit-*" \
+	 .coverage-integation ".coverage-integration-*" \
 	 .coverage-integration-mistal
 
 .PHONY: distclean

--- a/contrib/runners/action_chain_runner/tests/unit/test_actionchain_pause_resume.py
+++ b/contrib/runners/action_chain_runner/tests/unit/test_actionchain_pause_resume.py
@@ -125,6 +125,8 @@ class ActionChainRunnerPauseResumeTest(DbTestCase):
             if liveaction.status != status:
                 eventlet.sleep(interval)
                 continue
+            else:
+                break
 
         return liveaction
 


### PR DESCRIPTION
Adds tests directories to coverage results, and reworks the coverage handling in the root `Makefile` to (try to) avoid rerunning tests if they've already been run.

WIP because I may have broken everything since it's a subtantial rewrite of the make logic, but other than that I'm pretty happy with it.

When I ran everything manually and gathered coverage result I got about 80% coverage throughout the entire codebase (tests included), which (in my experience) is very good for a project this size.

Questions:
* Some covered files might be considered noise in coverage results (`wsgi.py`, `setup.py`, `dist_utils.py`) - do we want to ignore those in our reports? I kinda do.
* Do we care about coverage in `*/tests/`? Some projects like it ([pynacl](https://github.com/pyca/pynacl/pull/290)), some people don't ([rebar3](https://github.com/erlang/rebar3/issues/1635)).
* Should I print out headers for the combine/report/html coverage tasks?