### PR TITLE
Experimental and opt-in Python 3 support for Python runner actions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,16 @@ Added
   values - ``succeeded`` (trigger instance matched a rule and action execution was triggered
   successfully), ``failed`` (trigger instance matched a rule, but it didn't result in an action
   execution due to Jinja rendering failure or other exception). (improvement) #4134
+* Add new ``--python3`` flag to ``st2 pack install`` CLI command and ``python3`` parameter to
+  ``packs.{install,setup_virtualenv}`` actions. When the value of this parameter is True, it
+  uses ``python3`` binary when creating virtual environment for that pack (based on the value of
+  ``actionrunner.python3_binary`` config option).
+
+  Note 1: For this feature to work, Python 3 needs to be installed on the system, ``virtualenv``
+  package installed on the system needs to support Python 3 (it needs to be a recent version) and
+  pack in question needs to support Python 3.
+
+  Note 2: This feature is experimental and opt-in. (new feature) #4016 #3922 #4149
 
 Changed
 ~~~~~~~

--- a/contrib/examples/actions/python_runner_print_python_version.yaml
+++ b/contrib/examples/actions/python_runner_print_python_version.yaml
@@ -1,0 +1,7 @@
+---
+name: python_runner_print_python_version
+runner_type: run-python
+description: Action which prints version if Python executable which is used.
+enabled: true
+entry_point: pythonactions/print_python_version.py
+parameters: {}

--- a/contrib/examples/actions/pythonactions/print_python_version.py
+++ b/contrib/examples/actions/pythonactions/print_python_version.py
@@ -1,0 +1,10 @@
+import sys
+
+from st2common.runners.base_action import Action
+
+
+class PrintPythonVersionAction(Action):
+
+    def run(self):
+        print('Using Python executable: %s' % (sys.executable))
+        print('Using Python version: %s' % (sys.version))

--- a/contrib/runners/python_runner/python_runner/python_runner.py
+++ b/contrib/runners/python_runner/python_runner/python_runner.py
@@ -201,7 +201,6 @@ class PythonRunner(GitWorktreeActionRunner):
                 pack_common_libs_path = self._get_pack_common_libs_path(pack_ref=pack)
             except Exception as e:
                 LOG.debug('Failed to retrieve pack common lib path: %s' % (str(e)))
-                print(e)
                 # There is no MongoDB connection available in Lambda and pack common lib
                 # functionality is not also mandatory for Lambda so we simply ignore those errors.
                 # Note: We should eventually refactor this code to make runner standalone and not

--- a/contrib/runners/python_runner/python_runner/python_runner.py
+++ b/contrib/runners/python_runner/python_runner/python_runner.py
@@ -218,23 +218,26 @@ class PythonRunner(GitWorktreeActionRunner):
         # If python3.? directory exists in pack virtualenv lib/ path it means Python 3 is used by
         # that virtual environment and we take that in to account when constructing PYTHONPATH
         pack_base_path = get_pack_base_path(pack_name=pack)
-        pack_actions_lib_paths = os.path.join(pack_base_path, 'actions/lib/')
-        pack_virtualenv_lib_path = os.path.join(virtualenv_path, 'lib')
 
-        virtualenv_directories = os.listdir(pack_virtualenv_lib_path)
-        virtualenv_directories = [dir_name for dir_name in virtualenv_directories if
-                                  fnmatch.fnmatch(dir_name, 'python3*')]
-        uses_python3 = bool(virtualenv_directories)
+        if virtualenv_path and os.path.isdir(virtualenv_path):
+            pack_actions_lib_paths = os.path.join(pack_base_path, 'actions/lib/')
+            pack_virtualenv_lib_path = os.path.join(virtualenv_path, 'lib')
 
-        if uses_python3:
-            # Add Python 3 lib/site-packages directory infrot of the system site packages
-            # This is important because we want Python 3 compatible libraries to be used from the
-            # pack virtual environment and not system ones
-            python3_site_packages_directory = os.path.join(pack_virtualenv_lib_path,
-                                                           virtualenv_directories[0],
-                                                           'site-packages')
-            sandbox_python_path = (python3_site_packages_directory + ':' + pack_actions_lib_paths +
-                                   ':' + sandbox_python_path)
+            virtualenv_directories = os.listdir(pack_virtualenv_lib_path)
+            virtualenv_directories = [dir_name for dir_name in virtualenv_directories if
+                                      fnmatch.fnmatch(dir_name, 'python3*')]
+            uses_python3 = bool(virtualenv_directories)
+
+            if uses_python3:
+                # Add Python 3 lib/site-packages directory infrot of the system site packages
+                # This is important because we want Python 3 compatible libraries to be used from
+                # the pack virtual environment and not system ones
+                python3_site_packages_directory = os.path.join(pack_virtualenv_lib_path,
+                                                               virtualenv_directories[0],
+                                                               'site-packages')
+                sandbox_python_path = (python3_site_packages_directory + ':' +
+                                       pack_actions_lib_paths +
+                                       ':' + sandbox_python_path)
 
         if self._enable_common_pack_libs and pack_common_libs_path:
             env['PYTHONPATH'] = pack_common_libs_path + ':' + sandbox_python_path

--- a/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
+++ b/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
@@ -662,6 +662,9 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         self.assertTrue(expected_msg_5 in output['stderr'])
 
         # Verify messages are not duplicated
+        print('===')
+        print(output['stderr'])
+        print('===')
         self.assertEqual(len(output['stderr'].strip().split('\n')), 5)
 
         # Only log messages with level info and above should be displayed

--- a/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
+++ b/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
@@ -661,16 +661,22 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         self.assertTrue(expected_msg_4 in output['stderr'])
         self.assertTrue(expected_msg_5 in output['stderr'])
 
-        # Verify messages are not duplicated
-        if 'No handlers could be found for logger' in output['stderr']:
-            # Tests on some CI services don't use correct logging config
-            expected_count = 6
-        else:
-            expected_count = 5
-
         stderr = output['stderr'].strip().split('\n')
-        msg = ('Expected %s line, got %s - "%s"' % (expected_count, stderr, len(stderr)))
-        self.assertEqual(len(stderr), expected_count, msg)
+        expected_count = 5
+
+        # Remove lines we don't care about
+        lines = []
+        for line in stderr:
+            if 'configuration option is not configured' in line:
+                continue
+
+            if 'No handlers could be found for logger' in line:
+                continue
+
+            lines.append(line)
+
+        msg = ('Expected %s lines, got %s - "%s"' % (expected_count, len(lines), str(lines)))
+        self.assertEqual(len(lines), expected_count, msg)
 
         # Only log messages with level info and above should be displayed
         runner = self._get_mock_runner_obj()

--- a/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
+++ b/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
@@ -668,7 +668,9 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         else:
             expected_count = 5
 
-        self.assertEqual(len(output['stderr'].strip().split('\n')), expected_count)
+        stderr = output['stderr'].strip().split('\n')
+        msg = ('Expected %s line, got %s - "%s"' % (expected_count, stderr, len(stderr)))
+        self.assertEqual(len(stderr), expected_count, msg)
 
         # Only log messages with level info and above should be displayed
         runner = self._get_mock_runner_obj()

--- a/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
+++ b/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
@@ -662,7 +662,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         self.assertTrue(expected_msg_5 in output['stderr'])
 
         # Verify messages are not duplicated
-        self.assertEqual(len(output['stderr'].split('\n')), 6 + 1)
+        self.assertEqual(len(output['stderr'].strip().split('\n')), 5)
 
         # Only log messages with level info and above should be displayed
         runner = self._get_mock_runner_obj()

--- a/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
+++ b/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
@@ -662,10 +662,13 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         self.assertTrue(expected_msg_5 in output['stderr'])
 
         # Verify messages are not duplicated
-        print('===')
-        print(output['stderr'])
-        print('===')
-        self.assertEqual(len(output['stderr'].strip().split('\n')), 5)
+        if 'No handlers could be found for logger' in output['stderr']:
+            # Tests on some CI services don't use correct logging config
+            expected_count = 6
+        else:
+            expected_count = 5
+
+        self.assertEqual(len(output['stderr'].strip().split('\n')), expected_count)
 
         # Only log messages with level info and above should be displayed
         runner = self._get_mock_runner_obj()

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -185,6 +185,10 @@ class PackInstallCommand(PackAsyncCommand):
                                  metavar='pack',
                                  help='Name of the %s in Exchange, or a git repo URL.' %
                                  resource.get_plural_display_name().lower())
+        self.parser.add_argument('--python3',
+                                 action='store_true',
+                                 default=False,
+                                 help='Use Python 3 binary for pack virtual environment.')
         self.parser.add_argument('--force',
                                  action='store_true',
                                  default=False,
@@ -192,7 +196,7 @@ class PackInstallCommand(PackAsyncCommand):
 
     def run(self, args, **kwargs):
         self._get_content_counts_for_pack(args, **kwargs)
-        return self.manager.install(args.packs, force=args.force, **kwargs)
+        return self.manager.install(args.packs, python3=args.python3, force=args.force, **kwargs)
 
     def _get_content_counts_for_pack(self, args, **kwargs):
         # Global content list, excluding "tests"

--- a/st2common/st2common/constants/pack.py
+++ b/st2common/st2common/constants/pack.py
@@ -87,6 +87,12 @@ BASE_PACK_REQUIREMENTS = [
     'six>=1.9.0,<2.0'
 ]
 
+# Python requirements which are common to all the packs and need to be installed
+# for Python 3 pack virtual environments to work
+BASE_PACK_PYTHON3_REQUIREMENTS = [
+    'pyyaml>=3.12,<4.0'
+]
+
 # Name of the pack manifest file
 MANIFEST_FILE_NAME = 'pack.yaml'
 

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -19,17 +19,21 @@ separate processes and virtualenv.
 """
 
 from __future__ import absolute_import
+
 import os
 import sys
+import fnmatch
 from distutils.sysconfig import get_python_lib
 
 from oslo_config import cfg
 
 from st2common.constants.pack import SYSTEM_PACK_NAMES
+from st2common.content.utils import get_pack_base_path
 
 __all__ = [
     'get_sandbox_python_binary_path',
     'get_sandbox_python_path',
+    'get_sandbox_python_path_for_python_action',
     'get_sandbox_path',
     'get_sandbox_virtualenv_path'
 ]
@@ -116,6 +120,46 @@ def get_sandbox_python_path(inherit_from_parent=True, inherit_parent_virtualenv=
 
     sandbox_python_path = ':'.join(sandbox_python_path)
     sandbox_python_path = ':' + sandbox_python_path
+    return sandbox_python_path
+
+
+def get_sandbox_python_path_for_python_action(pack, inherit_from_parent=True,
+                                              inherit_parent_virtualenv=True):
+
+    """
+    Same as get_sandbox_python_path function, but it's intended to be used for Python runner actions
+    and also takes into account if a pack virtual environment uses Python 3.
+    """
+    sandbox_python_path = get_sandbox_python_path(
+        inherit_from_parent=inherit_from_parent,
+        inherit_parent_virtualenv=inherit_parent_virtualenv)
+
+    # If python3.? directory exists in pack virtualenv lib/ path it means Python 3 is used by
+    # that virtual environment and we take that in to account when constructing PYTHONPATH
+    pack_base_path = get_pack_base_path(pack_name=pack)
+    virtualenv_path = get_sandbox_virtualenv_path(pack=pack)
+
+    if virtualenv_path and os.path.isdir(virtualenv_path):
+        pack_actions_lib_paths = os.path.join(pack_base_path, 'actions/lib/')
+        pack_virtualenv_lib_path = os.path.join(virtualenv_path, 'lib')
+
+        virtualenv_directories = os.listdir(pack_virtualenv_lib_path)
+        virtualenv_directories = [dir_name for dir_name in virtualenv_directories if
+                                  fnmatch.fnmatch(dir_name, 'python3*')]
+        uses_python3 = bool(virtualenv_directories)
+    else:
+        uses_python3 = False
+
+    if uses_python3:
+        # Add Python 3 lib/site-packages directory infrot of the system site packages
+        # This is important because we want Python 3 compatible libraries to be used from
+        # the pack virtual environment and not system ones
+        python3_site_packages_directory = os.path.join(pack_virtualenv_lib_path,
+                                                       virtualenv_directories[0],
+                                                       'site-packages')
+        sandbox_python_path = (python3_site_packages_directory + ':' + pack_actions_lib_paths +
+                               ':' + sandbox_python_path)
+
     return sandbox_python_path
 
 

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -151,7 +151,7 @@ def get_sandbox_python_path_for_python_action(pack, inherit_from_parent=True,
         uses_python3 = False
 
     if uses_python3:
-        # Add Python 3 lib/site-packages directory infrot of the system site packages
+        # Add Python 3 lib/site-packages directory infront of the system site packages
         # This is important because we want Python 3 compatible libraries to be used from
         # the pack virtual environment and not system ones
         python3_site_packages_directory = os.path.join(pack_virtualenv_lib_path,

--- a/st2common/st2common/util/virtualenvs.py
+++ b/st2common/st2common/util/virtualenvs.py
@@ -102,7 +102,7 @@ def setup_pack_virtualenv(pack_name, update=False, logger=None, include_pip=True
 
     # 3. Install base Python 3 requirements which are common to all the packs
     if use_python3:
-        logger.debug('Installing base Python 3requirements')
+        logger.debug('Installing base Python 3 requirements')
         for requirement in BASE_PACK_PYTHON3_REQUIREMENTS:
             install_requirement(virtualenv_path=virtualenv_path, requirement=requirement,
                                 proxy_config=proxy_config, logger=logger)

--- a/st2common/st2common/util/virtualenvs.py
+++ b/st2common/st2common/util/virtualenvs.py
@@ -27,6 +27,7 @@ from oslo_config import cfg
 from st2common import log as logging
 from st2common.constants.pack import PACK_REF_WHITELIST_REGEX
 from st2common.constants.pack import BASE_PACK_REQUIREMENTS
+from st2common.constants.pack import BASE_PACK_PYTHON3_REQUIREMENTS
 from st2common.util.shell import run_command
 from st2common.util.shell import quote_unix
 from st2common.util.compat import to_ascii
@@ -99,7 +100,14 @@ def setup_pack_virtualenv(pack_name, update=False, logger=None, include_pip=True
         install_requirement(virtualenv_path=virtualenv_path, requirement=requirement,
                             proxy_config=proxy_config, logger=logger)
 
-    # 3. Install pack-specific requirements
+    # 3. Install base Python 3 requirements which are common to all the packs
+    if use_python3:
+        logger.debug('Installing base Python 3requirements')
+        for requirement in BASE_PACK_PYTHON3_REQUIREMENTS:
+            install_requirement(virtualenv_path=virtualenv_path, requirement=requirement,
+                                proxy_config=proxy_config, logger=logger)
+
+    # 4. Install pack-specific requirements
     requirements_file_path = os.path.join(pack_path, 'requirements.txt')
     has_requirements = os.path.isfile(requirements_file_path)
 

--- a/st2common/tests/unit/test_util_sandboxing.py
+++ b/st2common/tests/unit/test_util_sandboxing.py
@@ -37,6 +37,12 @@ class SandboxingUtilsTestCase(unittest.TestCase):
         cls.old_python_path = os.environ.get('PYTHONPATH', '')
         cls.old_real_prefix = sys.real_prefix
 
+    @classmethod
+    def tearDownClass(cls):
+        os.environ['PATH'] = cls.old_path
+        os.environ['PYTHONPATH'] = cls.old_python_path
+        sys.real_prefix = cls.old_real_prefix
+
     def test_get_sandbox_python_binary_path(self):
         # Non-system content pack, should use pack specific virtualenv binary
         result = get_sandbox_python_binary_path(pack='mapack')

--- a/st2common/tests/unit/test_util_sandboxing.py
+++ b/st2common/tests/unit/test_util_sandboxing.py
@@ -9,14 +9,33 @@ from oslo_config import cfg
 from st2common.constants.pack import SYSTEM_PACK_NAMES
 from st2common.util.sandboxing import get_sandbox_path
 from st2common.util.sandboxing import get_sandbox_python_path
+from st2common.util.sandboxing import get_sandbox_python_path_for_python_action
 from st2common.util.sandboxing import get_sandbox_python_binary_path
+
 import st2tests.config as tests_config
+
+__all__ = [
+    'SandboxingUtilsTestCase'
+]
 
 
 class SandboxingUtilsTestCase(unittest.TestCase):
+    def setUp(self):
+        super(SandboxingUtilsTestCase, self).setUp()
+
+        # Restore PATH and other variables before each test case
+        os.environ['PATH'] = self.old_path
+        os.environ['PYTHONPATH'] = self.old_python_path
+        sys.real_prefix = self.old_real_prefix
+
     @classmethod
     def setUpClass(cls):
         tests_config.parse_args()
+
+        # Store original values so we can restore them in setUp
+        cls.old_path = os.environ.get('PATH', '')
+        cls.old_python_path = os.environ.get('PYTHONPATH', '')
+        cls.old_real_prefix = sys.real_prefix
 
     def test_get_sandbox_python_binary_path(self):
         # Non-system content pack, should use pack specific virtualenv binary
@@ -30,25 +49,21 @@ class SandboxingUtilsTestCase(unittest.TestCase):
 
     def test_get_sandbox_path(self):
         # Mock the current PATH value
-        old_path = os.environ.get('PATH', '')
         os.environ['PATH'] = '/home/path1:/home/path2:/home/path3:'
 
         virtualenv_path = '/home/venv/test'
         result = get_sandbox_path(virtualenv_path=virtualenv_path)
         self.assertEqual(result, '/home/venv/test/bin/:/home/path1:/home/path2:/home/path3')
 
-        os.environ['PATH'] = old_path
-
     @mock.patch('st2common.util.sandboxing.get_python_lib')
     def test_get_sandbox_python_path(self, mock_get_python_lib):
-        # No inheritence
+        # No inheritance
         python_path = get_sandbox_python_path(inherit_from_parent=False,
                                               inherit_parent_virtualenv=False)
         self.assertEqual(python_path, ':')
 
         # Inherit python path from current process
         # Mock the current process python path
-        old_python_path = os.environ.get('PYTHONPATH', '')
         os.environ['PYTHONPATH'] = ':/data/test1:/data/test2'
 
         python_path = get_sandbox_python_path(inherit_from_parent=True,
@@ -56,7 +71,6 @@ class SandboxingUtilsTestCase(unittest.TestCase):
         self.assertEqual(python_path, ':/data/test1:/data/test2')
 
         # Inherit from current process and from virtualenv (not running inside virtualenv)
-        old_real_prefix = sys.real_prefix
         del sys.real_prefix
 
         python_path = get_sandbox_python_path(inherit_from_parent=True,
@@ -71,5 +85,90 @@ class SandboxingUtilsTestCase(unittest.TestCase):
         self.assertEqual(python_path, ':/data/test1:/data/test2:%s/virtualenvtest' %
                          (sys.prefix))
 
-        os.environ['PYTHONPATH'] = old_python_path
-        sys.real_prefix = old_real_prefix
+    @mock.patch('os.path.isdir', mock.Mock(return_value=True))
+    @mock.patch('os.listdir', mock.Mock(return_value=['python2.7']))
+    @mock.patch('st2common.util.sandboxing.get_python_lib')
+    def test_get_sandbox_python_path_for_python_action_python2_used_for_venv(self,
+            mock_get_python_lib):
+        # No inheritance
+        python_path = get_sandbox_python_path_for_python_action(pack='dummy_pack',
+                                                                inherit_from_parent=False,
+                                                                inherit_parent_virtualenv=False)
+
+        self.assertEqual(python_path, ':')
+
+        # Inherit python path from current process
+        # Mock the current process python path
+        os.environ['PYTHONPATH'] = ':/data/test1:/data/test2'
+
+        python_path = get_sandbox_python_path(inherit_from_parent=True,
+                                              inherit_parent_virtualenv=False)
+        self.assertEqual(python_path, ':/data/test1:/data/test2')
+
+        # Inherit from current process and from virtualenv (not running inside virtualenv)
+        del sys.real_prefix
+
+        python_path = get_sandbox_python_path(inherit_from_parent=True,
+                                              inherit_parent_virtualenv=False)
+        self.assertEqual(python_path, ':/data/test1:/data/test2')
+
+        # Inherit from current process and from virtualenv (running inside virtualenv)
+        sys.real_prefix = '/usr'
+        mock_get_python_lib.return_value = sys.prefix + '/virtualenvtest'
+        python_path = get_sandbox_python_path(inherit_from_parent=True,
+                                              inherit_parent_virtualenv=True)
+        self.assertEqual(python_path, ':/data/test1:/data/test2:%s/virtualenvtest' %
+                         (sys.prefix))
+
+    @mock.patch('os.path.isdir', mock.Mock(return_value=True))
+    @mock.patch('os.listdir', mock.Mock(return_value=['python3.6']))
+    @mock.patch('st2common.util.sandboxing.get_python_lib')
+    @mock.patch('st2common.util.sandboxing.get_pack_base_path',
+                mock.Mock(return_value='/tmp/packs/dummy_pack'))
+    @mock.patch('st2common.util.sandboxing.get_sandbox_virtualenv_path',
+                mock.Mock(return_value='/tmp/virtualenvs/dummy_pack'))
+    def test_get_sandbox_python_path_for_python_action_python3_used_for_venv(self,
+            mock_get_python_lib):
+        # No inheritance
+        python_path = get_sandbox_python_path_for_python_action(pack='dummy_pack',
+                                                                inherit_from_parent=False,
+                                                                inherit_parent_virtualenv=False)
+
+        split = python_path.strip(':').split(':')
+        self.assertEqual(len(split), 2)
+
+        # First entry should be python3 site-packages dir from venv
+        self.assertTrue('virtualenvs/dummy_pack/lib/python3.6/site-packages' in split[0])
+
+        # Second entry should be actions/lib dir from pack root directory
+        self.assertTrue('packs/dummy_pack/actions/lib/' in split[1])
+
+        # Inherit python path from current process
+        # Mock the current process python path
+        os.environ['PYTHONPATH'] = ':/data/test1:/data/test2'
+
+        python_path = get_sandbox_python_path_for_python_action(pack='dummy_pack',
+                                                                inherit_from_parent=True,
+                                                                inherit_parent_virtualenv=False)
+        expected = ('/tmp/virtualenvs/dummy_pack/lib/python3.6/site-packages:'
+                    '/tmp/packs/dummy_pack/actions/lib/::/data/test1:/data/test2')
+        self.assertEqual(python_path, expected)
+
+        # Inherit from current process and from virtualenv (not running inside virtualenv)
+        del sys.real_prefix
+
+        python_path = get_sandbox_python_path(inherit_from_parent=True,
+                                              inherit_parent_virtualenv=False)
+        self.assertEqual(python_path, ':/data/test1:/data/test2')
+
+        # Inherit from current process and from virtualenv (running inside virtualenv)
+        sys.real_prefix = '/usr'
+        mock_get_python_lib.return_value = sys.prefix + '/virtualenvtest'
+        python_path = get_sandbox_python_path_for_python_action(pack='dummy_pack',
+                                                                inherit_from_parent=True,
+                                                                inherit_parent_virtualenv=True)
+
+        expected = ('/tmp/virtualenvs/dummy_pack/lib/python3.6/site-packages:'
+                    '/tmp/packs/dummy_pack/actions/lib/::/data/test1:/data/test2:'
+                    '%s/virtualenvtest' % (sys.prefix))
+        self.assertEqual(python_path, expected)

--- a/st2common/tests/unit/test_virtualenvs.py
+++ b/st2common/tests/unit/test_virtualenvs.py
@@ -322,7 +322,7 @@ class VirtualenvUtilsTestCase(CleanFilesTestCase):
         actual_cmd = mock_run_command.call_args_list[0][1]['cmd']
         actual_cmd = ' '.join(actual_cmd)
 
-        self.assertEqual(mock_run_command.call_count, 2)
+        self.assertEqual(mock_run_command.call_count, 3)
         self.assertTrue('-p /usr/bin/python3' in actual_cmd)
 
     def assertVirtulenvExists(self, virtualenv_dir):

--- a/st2common/tests/unit/test_virtualenvs.py
+++ b/st2common/tests/unit/test_virtualenvs.py
@@ -319,11 +319,19 @@ class VirtualenvUtilsTestCase(CleanFilesTestCase):
                               include_setuptools=False, include_wheel=False,
                               use_python3=True)
 
+        self.assertEqual(mock_run_command.call_count, 3)
+
         actual_cmd = mock_run_command.call_args_list[0][1]['cmd']
         actual_cmd = ' '.join(actual_cmd)
-
-        self.assertEqual(mock_run_command.call_count, 3)
         self.assertTrue('-p /usr/bin/python3' in actual_cmd)
+
+        actual_cmd = mock_run_command.call_args_list[1][1]['cmd']
+        actual_cmd = ' '.join(actual_cmd)
+        self.assertTrue('pip install pyyaml' in actual_cmd)
+
+        actual_cmd = mock_run_command.call_args_list[2][1]['cmd']
+        actual_cmd = ' '.join(actual_cmd)
+        self.assertTrue('pip install' in actual_cmd)
 
     def assertVirtulenvExists(self, virtualenv_dir):
         self.assertTrue(os.path.exists(virtualenv_dir))

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume.yaml
@@ -3,7 +3,7 @@ chain:
         name: task1
         ref: core.local
         params:
-            cmd: "while [ -e '{{tempfile}}' ]; do sleep 0.1; done"
+            cmd: "while [ -e {{tempfile}} ]; do sleep 0.1; done"
             timeout: 180
         on-success: task2
     -


### PR DESCRIPTION
This pull request adds experimental and opt-in support for using Python 3 for pack actions.

It continues work from other PRs - https://github.com/StackStorm/st2/pull/3922, https://github.com/StackStorm/st2/pull/4016, https://github.com/StackStorm/st2/pull/4075.

Our code changes in the past were a bit too optimistic and it turned out a lot more work is still needed to get that feature working.

The scope and target audience for this feature didn't change - it's still intended for advanced users and it's opt in - user needs to pass in ``--python3`` flag to ``st2 pack install <pack name>`` CLI command and Python 3 binary will be used when creating virtual environment for that pack and for all the subsequent pack action executions.

As mentioned before, this feature is mostly meant as an experimental stop gap for advanced users until the whole platform supports Python 3 (aka StackStorm itself can run on Python 3).

We don't have any specific ETA for Python 3 support for the whole platform, but we are slowly and incrementally working towards it - every time I touch some code, I try to also make it work under Python 3 and and make sure tests for that code also run under Python 3 on Travis.

Once full platform support is there, this feature will become obsolete.

## Included Changes

To be able to make that feature work, I needed to make the following changes.

1. Explicitly install `pyyaml` into virtual environment created for a pack. `pyyaml` is one of those libraries which has 2 different code bases for Python 2 and 3 (not ideal, but it's the most widely used yaml parsing / serializing library for Python).

The version which is installed on the system and used by StackStorm components / services uses Python 2, but when user opts in to use Python 3 for a pack, we need to install version which is compatible with Python 3 into that pack virtual environment.

2. Re-order and add new members to `PYTHONPATH` environment variable used python runner actions. If pack is using Python 3 and `/opt/stackstorm/virtualenvs/<pack name>/lib/python3.x/site-packages` directory exists, we add it to the beginning of `PYTHONPATH` to ensure pack uses `pyyaml` and other libraries from that pack virtual environment (and so it doesn't inherit and use system ones which don't work with Python 3).

We also explicitly add `/opt/stackstorm/pack/actions/lib/` directory to PYTHONPATH when Python 3 is used - that is done implicitly and not needed when using Python 2, but it's needed when using Python 3. 

## Example Usage

### 1. Not using Python 3 (default behavior)

```bash
$ st2 run packs.setup_virtualenv packs=examples             
2018-05-28 13:57:14,306  WARNING - Auth API server is not available, skipping authentication.
....
id: 5b0c0abb0640fd0cd6d00546
status: succeeded
parameters: 
  packs:
  - examples
result: 
  exit_code: 0
  result: 'Successfuly set up virtualenv for the following packs: examples'
  stderr: 'st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Setting up virtualenv for pack "examples" (/opt/stackstorm/packs/examples)
    st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Removing virtualenv in "/opt/stackstorm/virtualenvs/examples"
    st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Creating virtualenv for pack "examples" in "/opt/stackstorm/virtualenvs/examples"
    st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Creating virtualenv in "/opt/stackstorm/virtualenvs/examples" using Python binary "/data/stanley/virtualenv/bin/python2.7"
    st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Running command "/data/stanley/virtualenv/bin/virtualenv -p /data/stanley/virtualenv/bin/python2.7 --system-site-packages --no-download /opt/stackstorm/virtualenvs/examples" to create virtualenv.
    st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Installing base requirements
    st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Installing requirement six>=1.9.0,<2.0 with command /opt/stackstorm/virtualenvs/examples/bin/pip install six>=1.9.0,<2.0.
    st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Installing pack specific requirements from "/opt/stackstorm/packs/examples/requirements.txt"
    st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Installing requirements from file /opt/stackstorm/packs/examples/requirements.txt with command /opt/stackstorm/virtualenvs/examples/bin/pip install -U -r /opt/stackstorm/packs/examples/requirements.txt.
    st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Virtualenv for pack "examples" successfully created in "/opt/stackstorm/virtualenvs/examples"
    '
  stdout: ''
$ st2 run examples.python_runner_print_python_version.
id: 5b0c0aca0640fd0cd6d00549
status: succeeded
parameters: None
result: 
  exit_code: 0
  result: null
  stderr: ''
  stdout: "Using Python executable: /opt/stackstorm/virtualenvs/examples/bin/python
Using Python version: 2.7.6 (default, Jun 22 2015, 17:58:13) 
[GCC 4.8.2]
"
```

### 2. Opting in and using Python 3 for a particular park

```bash
$ st2 run packs.setup_virtualenv packs=examples python3=true
id: 5b0c0af00640fd0cd6d0054c
status: succeeded
parameters: 
  packs:
  - examples
  python3: true
result: 
  exit_code: 0
  result: 'Successfuly set up virtualenv for the following packs: examples'
  stderr: 'st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Setting up virtualenv for pack "examples" (/opt/stackstorm/packs/examples)
    st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Removing virtualenv in "/opt/stackstorm/virtualenvs/examples"
    st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Creating virtualenv for pack "examples" in "/opt/stackstorm/virtualenvs/examples"
    st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Creating virtualenv in "/opt/stackstorm/virtualenvs/examples" using Python binary "/data/stanley/virtualenv/bin/python2.7"
    st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Running command "/data/stanley/virtualenv/bin/virtualenv -p /usr/bin/python3 --system-site-packages --no-download /opt/stackstorm/virtualenvs/examples" to create virtualenv.
    st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Installing base requirements
    st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Installing requirement six>=1.9.0,<2.0 with command /opt/stackstorm/virtualenvs/examples/bin/pip install six>=1.9.0,<2.0.
    st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Installing base Python 3requirements
    st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Installing requirement pyyaml>=3.12,<4.0 with command /opt/stackstorm/virtualenvs/examples/bin/pip install pyyaml>=3.12,<4.0.
    st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Installing pack specific requirements from "/opt/stackstorm/packs/examples/requirements.txt"
    st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Installing requirements from file /opt/stackstorm/packs/examples/requirements.txt with command /opt/stackstorm/virtualenvs/examples/bin/pip install -U -r /opt/stackstorm/packs/examples/requirements.txt.
    st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Virtualenv for pack "examples" successfully created in "/opt/stackstorm/virtualenvs/examples"
    '
  stdout: ''
$ st2 run examples.python_runner_print_python_version.
id: 5b0c0afc0640fd0cd6d0054f
status: succeeded
parameters: None
result: 
  exit_code: 0
  result: null
  stderr: ''
  stdout: "Using Python executable: /opt/stackstorm/virtualenvs/examples/bin/python
Using Python version: 3.4.3 (default, Sep 14 2016, 12:36:27) 
[GCC 4.8.4]
"
```

### TODO

 - [x] Unit tests
 - [x] Integration / end to end tests (st2tests)