### PR TITLE
Add trigger type reference based filtering to the /v1/triggerinstances API endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,8 @@ Added
   values - ``succeeded`` (trigger instance matched a rule and action execution was triggered
   successfully), ``failed`` (trigger instance matched a rule, but it didn't result in an action
   execution due to Jinja rendering failure or other exception). (improvement) #4134
+* Add trigger type reference based filtering to the ``/v1/triggerinstances`` API endpoint - e.g.
+  ``/v1/triggerinstances?trigger_type=core.st2.webhook``. (new feature) #4151
 
 Changed
 ~~~~~~~

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -181,7 +181,13 @@ class ResourceController(object):
             if k in ['id', 'name'] and isinstance(filter_value, list):
                 filters[k + '__in'] = filter_value
             else:
-                filters['__'.join(v.split('.'))] = filter_value
+                field_name_split = v.split('.')
+
+                # Make sure filter value is a list when using "in" filter
+                if field_name_split[-1] == 'in' and not isinstance(filter_value, (list, tuple)):
+                    filter_value = [filter_value]
+
+                filters['__'.join(field_name_split)] = filter_value
 
         if advanced_filters:
             for token in advanced_filters.split(' '):

--- a/st2api/tests/unit/controllers/v1/test_triggerinstances.py
+++ b/st2api/tests/unit/controllers/v1/test_triggerinstances.py
@@ -73,6 +73,22 @@ class TestTriggerController(FunctionalTest):
         resp = self.app.get('/v1/triggerinstances?timestamp_lt=%s' % (timestamp_middle))
         self.assertEqual(len(resp.json), 1)
 
+    def test_get_all_trigger_type_ref_filtering(self):
+        # 1. Invalid / inexistent trigger type ref
+        resp = self.app.get('/v1/triggerinstances?trigger_type=foo.bar.invalid')
+        self.assertEqual(resp.status_int, http_client.OK)
+        self.assertEqual(len(resp.json), 0)
+
+        # 2. Valid trigger type ref with corresponding trigger instances
+        resp = self.app.get('/v1/triggerinstances?trigger_type=dummy_pack_1.st2.test.triggertype0')
+        self.assertEqual(resp.status_int, http_client.OK)
+        self.assertEqual(len(resp.json), 1)
+
+        # 3. Valid trigger type ref with no corresponding trigger instances
+        resp = self.app.get('/v1/triggerinstances?trigger_type=dummy_pack_1.st2.test.triggertype3')
+        self.assertEqual(resp.status_int, http_client.OK)
+        self.assertEqual(len(resp.json), 0)
+
     def test_reemit_trigger_instance(self):
         resp = self.app.get('/v1/triggerinstances')
         self.assertEqual(resp.status_int, http_client.OK)
@@ -127,9 +143,17 @@ class TestTriggerController(FunctionalTest):
             'payload_schema': {'tp1': None, 'tp2': None, 'tp3': None},
             'parameters_schema': {'param1': {'type': 'object'}}
         }
+        TRIGGERTYPE_3 = {
+            'name': 'st2.test.triggertype3',
+            'pack': 'dummy_pack_1',
+            'description': 'test trigger',
+            'payload_schema': {'tp1': None, 'tp2': None, 'tp3': None},
+            'parameters_schema': {'param1': {'type': 'object'}}
+        }
         cls.app.post_json('/v1/triggertypes', TRIGGERTYPE_0, expect_errors=False)
         cls.app.post_json('/v1/triggertypes', TRIGGERTYPE_1, expect_errors=False)
         cls.app.post_json('/v1/triggertypes', TRIGGERTYPE_2, expect_errors=False)
+        cls.app.post_json('/v1/triggertypes', TRIGGERTYPE_3, expect_errors=False)
 
     @classmethod
     def _setupTriggers(cls):

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -3918,6 +3918,10 @@ paths:
           description: Start timestamp greater than filter
           type: string
           pattern: ^\d{4}\-\d{2}\-\d{2}(\s|T)\d{2}:\d{2}:\d{2}(\.\d{3,6})?(Z|\+00|\+0000|\+00:00)$
+        - name: trigger_type
+          in: query
+          description: Trigger type filter
+          type: string
       x-parameters:
         - name: user
           in: context

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -3914,6 +3914,10 @@ paths:
           description: Start timestamp greater than filter
           type: string
           pattern: {{ ISO8601_UTC_REGEX }}
+        - name: trigger_type
+          in: query
+          description: Trigger type filter
+          type: string
       x-parameters:
         - name: user
           in: context


### PR DESCRIPTION
This pull request adds TriggerType reference based filtering to the `/v1/triggerinstances` API endpoint as discussed with @enykeev.

Example usage - `curl http://127.0.0.1:9101/v1/triggerinstances?trigger_type=core.st2.generic.actiontrigger`.

Note on the implementation detail - We only store Trigger reference on the TriggerInstance object so to be able to filter on TriggerType reference we need to do that via Trigger reference on the TriggerInstance object.

In relational database that would be a simple join and in non-relational database that would be a simple query in case Trigger is correctly denormalized and trigger reference also stored on the TriggerInstance object (that's not the case for our schema right now).

Recent versions of MongoDB also support simple aggregate queries and joins, but our API filtering code is not designed to support it yet so I went with a simpler "two queries" approach.

That works fine in this scenario because there will likely never be many thousand of Trigger objects in the database.
