### PR TITLE
Improvements to the rendering of default parameter values which contain Jinja expression and filters

### DIFF
--- a/st2common/st2common/jinja/filters/data.py
+++ b/st2common/st2common/jinja/filters/data.py
@@ -14,8 +14,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import json
 import yaml
+import six
 
 __all__ = [
     'from_json_string',
@@ -26,11 +28,11 @@ __all__ = [
 
 
 def from_json_string(value):
-    return json.loads(value)
+    return json.loads(six.text_type(value))
 
 
 def from_yaml_string(value):
-    return yaml.safe_load(value)
+    return yaml.safe_load(six.text_type(value))
 
 
 def to_json_string(value, indent=4, sort_keys=False, separators=(',', ':')):

--- a/st2common/tests/unit/test_jinja_render_data_filters.py
+++ b/st2common/tests/unit/test_jinja_render_data_filters.py
@@ -18,7 +18,9 @@ import json
 import unittest2
 import yaml
 
+from st2common.constants.keyvalue import FULL_SYSTEM_SCOPE
 from st2common.util import jinja as jinja_utils
+from st2common.services.keyvalues import KeyValueLookup
 
 
 class JinjaUtilsDataFilterTestCase(unittest2.TestCase):
@@ -34,6 +36,19 @@ class JinjaUtilsDataFilterTestCase(unittest2.TestCase):
         obj = eval(obj_str)
         self.assertDictEqual(obj, expected_obj)
 
+        # With KeyValueLookup object
+        env = jinja_utils.get_jinja_environment()
+        obj_json_str = '["a", "b", "c"]'
+        expected_obj = ['a', 'b', 'c']
+
+        template = '{{ k1 | from_json_string}}'
+
+        lookup = KeyValueLookup(scope=FULL_SYSTEM_SCOPE, key_prefix='a')
+        lookup._value_cache['a'] = obj_json_str
+        obj_str = env.from_string(template).render({'k1': lookup})
+        obj = eval(obj_str)
+        self.assertEqual(obj, expected_obj)
+
     def test_filter_from_yaml_string(self):
         env = jinja_utils.get_jinja_environment()
         expected_obj = {'a': 'b', 'c': {'d': 'e', 'f': 1, 'g': True}}
@@ -48,6 +63,22 @@ class JinjaUtilsDataFilterTestCase(unittest2.TestCase):
         obj_str = env.from_string(template).render({'k1': obj_yaml_str})
         obj = eval(obj_str)
         self.assertDictEqual(obj, expected_obj)
+
+        # With KeyValueLookup object
+        env = jinja_utils.get_jinja_environment()
+        obj_yaml_str = ("---\n"
+                        "- a\n"
+                        "- b\n"
+                        "- c\n")
+        expected_obj = ['a', 'b', 'c']
+
+        template = '{{ k1 | from_yaml_string }}'
+
+        lookup = KeyValueLookup(scope=FULL_SYSTEM_SCOPE, key_prefix='b')
+        lookup._value_cache['b'] = obj_yaml_str
+        obj_str = env.from_string(template).render({'k1': lookup})
+        obj = eval(obj_str)
+        self.assertEqual(obj, expected_obj)
 
     def test_filter_to_json_string(self):
         env = jinja_utils.get_jinja_environment()

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume.yaml
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/actions/chains/test_pause_resume.yaml
@@ -3,7 +3,7 @@ chain:
         name: task1
         ref: core.local
         params:
-            cmd: "while [ -e '{{tempfile}}' ]; do sleep 0.1; done"
+            cmd: "while [ -e {{tempfile}} ]; do sleep 0.1; done"
             timeout: 180
         on-success: task2
     -


### PR DESCRIPTION
This pull request makes the following example work:

```yaml
---
description: Run a local linux command
enabled: true
runner_type: mistral-v2
entry_point: workflows/render_test.yaml
name: render_test
pack: default
parameters:
  cmd:
    required: true
    type: string
  timeout:
    type: integer
    default: 60
  kv_array:
    type: array
    default: "{{ st2kv.system.kv_array | from_json_string }}"
  kv_object:
    type: object
    default: "{{ st2kv.system.kv_object | from_json_string }}"
```

As mentioned in #4153, `from_json_string` filter cast call is not really needed since the value is already automatically cast based on the parameter type definition, but it doesn't hurt either.

This way both approaches are supported (one without a cast and one without explicit cast).

## TODO

- [x] Tests