### PR TITLE
Fix MongoDB successful connection logging

### DIFF
--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -114,11 +114,12 @@ def _db_connect(db_name, db_host, db_port, username=None, password=None,
                                                 username=username, password=password,
                                                 **ssl_kwargs)
 
-    # NOTE: In recent version of pymongo connect() method is lazy and not blocking (always
-    # returns success) so we need to issue a common / query to check if connection has been
-    # successfuly established
+    # NOTE: Since pymongo 3.0, connect() method is lazy and not blocking (always returns success)
+    # so we need to issue a command / query to check if connection has been
+    # successfuly established.
+    # See http://api.mongodb.com/python/current/api/pymongo/mongo_client.html for details
     try:
-        # The ismaster command is cheap and does not require auth.
+        # The ismaster command is cheap and does not require auth
         connection.admin.command('ismaster')
     except ConnectionFailure as e:
         LOG.error('Failed to connect to database "%s" @ "%s" as user "%s": %s' %

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -121,8 +121,8 @@ def _db_connect(db_name, db_host, db_port, username=None, password=None,
         # The ismaster command is cheap and does not require auth.
         connection.admin.command('ismaster')
     except ConnectionFailure as e:
-        LOG.error('Failed to connect to database "%s" @ "%s" as user "%s".' % (db_name,
-            host_string, str(username_string)))
+        LOG.error('Failed to connect to database "%s" @ "%s" as user "%s": %s' %
+                  (db_name, host_string, str(username_string), str(e)))
         raise e
 
     LOG.info('Successfully connected to database "%s" @ "%s" as user "%s".' % (

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -25,6 +25,7 @@ import mongoengine
 from mongoengine.queryset import visitor
 from pymongo import uri_parser
 from pymongo.errors import OperationFailure
+from pymongo.errors import ConnectionFailure
 
 from st2common import log as logging
 from st2common.util import isotime
@@ -112,6 +113,17 @@ def _db_connect(db_name, db_host, db_port, username=None, password=None,
                                                 port=db_port, tz_aware=True,
                                                 username=username, password=password,
                                                 **ssl_kwargs)
+
+    # NOTE: In recent version of pymongo connect() method is lazy and not blocking (always
+    # returns success) so we need to issue a common / query to check if connection has been
+    # successfuly established
+    try:
+        # The ismaster command is cheap and does not require auth.
+        connection.admin.command('ismaster')
+    except ConnectionFailure as e:
+        LOG.error('Failed to connect to database "%s" @ "%s" as user "%s".' % (db_name,
+            host_string, str(username_string)))
+        raise e
 
     LOG.info('Successfully connected to database "%s" @ "%s" as user "%s".' % (
         db_name, host_string, str(username_string)))


### PR DESCRIPTION
#4141 introduced logging of "successfully connected to MongoDB" messages.

While troubleshooting an unrelated issue today, I noticed those messages are always logged even if connection fails later on so those messages were confusing and not correct.

The reason for that is that `.connect()` method is lazy and not-blocking. It always returns immediately because connection is only established (and error thrown if that fails) on first query / command being issued.

From mongoengine docs (http://api.mongodb.com/python/current/api/pymongo/mongo_client.html):

> Note Starting with version 3.0 the MongoClient constructor no longer blocks while connecting to the server or servers, and it no longer raises ConnectionFailure if they are unavailable, nor ConfigurationError if the user’s credentials are wrong. Instead, the constructor returns immediately and launches the connection process on background threads. You can check if the server is available like this:

(as you can see, I used invalid localhost and port which results in connection refused error)

Before:

```bash
(virtualenv) vagrant@ubuntu-xenial:/data/stanley$ ./st2actions/bin/st2notifier --config-file conf/st2.dev.conf 
2018-06-07 09:16:15,384 DEBUG [-] Using config files: /data/stanley/conf/st2.dev.conf
2018-06-07 09:16:15,385 DEBUG [-] Using logging config: /data/stanley/st2actions/conf/logging.notifier.conf
2018-06-07 09:16:15,390 INFO [-] Connecting to database "st2" @ "localhost.a:555" as user "None".
2018-06-07 09:16:15,393 INFO [-] Successfully connected to database "st2" @ "localhost.a:555" as user "None".
2018-06-07 09:16:15,393 DEBUG [-] Ensuring database indexes...
2018-06-07 09:16:45,719 ERROR [-] (PID=23578) Results tracker quit due to exception.
Traceback (most recent call last):
  File "/data/stanley/st2actions/st2actions/cmd/st2notifier.py", line 57, in main
    _setup()
  File "/data/stanley/st2actions/st2actions/cmd/st2notifier.py", line 28, in _setup
    register_signal_handlers=True)
  File "/data/stanley/st2common/st2common/service_setup.py", line 115, in setup
    db_setup()
  File "/data/stanley/st2common/st2common/database_setup.py", line 56, in db_setup
    connection = db_init.db_setup_with_retry(**db_cfg)
  File "/data/stanley/st2common/st2common/persistence/db_init.py", line 75, in db_setup_with_retry
    ssl_match_hostname=ssl_match_hostname)
  File "/data/stanley/st2common/st2common/persistence/db_init.py", line 59, in db_func_with_retry
    return retrying_obj.call(db_func, *args, **kwargs)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/retrying.py", line 206, in call
    return attempt.get(self._wrap_exception)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/retrying.py", line 247, in get
    six.reraise(self.value[0], self.value[1], self.value[2])
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/retrying.py", line 200, in call
    attempt = Attempt(fn(*args, **kwargs), attempt_number, False)
  File "/data/stanley/st2common/st2common/models/db/__init__.py", line 137, in db_setup
    db_ensure_indexes()
  File "/data/stanley/st2common/st2common/models/db/__init__.py", line 178, in db_ensure_indexes
    raise exc_cls(msg)
ServerSelectionTimeoutError: Failed to ensure indexes for model "UserDB": localhost.a:555: [Errno -2] No address found

Traceback (most recent call last):
  File "/data/stanley/st2common/st2common/models/db/__init__.py", line 161, in db_ensure_indexes
    model_class.ensure_indexes()
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/mongoengine/document.py", line 808, in ensure_indexes
    collection = cls._get_collection()
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/mongoengine/document.py", line 206, in _get_collection
    cls.ensure_indexes()
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/mongoengine/document.py", line 836, in ensure_indexes
    collection.create_index(fields, background=background, **opts)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/pymongo/collection.py", line 1754, in create_index
    self.__create_index(keys, kwargs, session, **cmd_options)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/pymongo/collection.py", line 1642, in __create_index
    with self._socket_for_writes() as sock_info:
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/pymongo/collection.py", line 194, in _socket_for_writes
    return self.__database.client._socket_for_writes()
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/pymongo/mongo_client.py", line 968, in _socket_for_writes
    server = self._get_topology().select_server(writable_server_selector)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/pymongo/topology.py", line 224, in select_server
    address))
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/pymongo/topology.py", line 183, in select_servers
    selector, server_timeout, address)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/pymongo/topology.py", line 199, in _select_servers_loop
    self._error_message(selector))
ServerSelectionTimeoutError: localhost.a:555: [Errno -2] No address found
```

After:

```bash
(virtualenv) vagrant@ubuntu-xenial:/data/stanley$ ./st2actions/bin/st2notifier --config-file conf/st2.dev.conf 
2018-06-07 09:23:25,478 DEBUG [-] Using config files: /data/stanley/conf/st2.dev.conf
2018-06-07 09:23:25,479 DEBUG [-] Using logging config: /data/stanley/st2actions/conf/logging.notifier.conf
2018-06-07 09:23:25,486 INFO [-] Connecting to database "st2" @ "localhost.a:555" as user "None".
2018-06-07 09:23:55,506 ERROR [-] Failed to connect to database "st2" @ "localhost.a:555" as user "None".
2018-06-07 09:23:55,509 ERROR [-] (PID=23687) Results tracker quit due to exception.
Traceback (most recent call last):
  File "/data/stanley/st2actions/st2actions/cmd/st2notifier.py", line 57, in main
    _setup()
  File "/data/stanley/st2actions/st2actions/cmd/st2notifier.py", line 28, in _setup
    register_signal_handlers=True)
  File "/data/stanley/st2common/st2common/service_setup.py", line 115, in setup
    db_setup()
  File "/data/stanley/st2common/st2common/database_setup.py", line 56, in db_setup
    connection = db_init.db_setup_with_retry(**db_cfg)
  File "/data/stanley/st2common/st2common/persistence/db_init.py", line 75, in db_setup_with_retry
    ssl_match_hostname=ssl_match_hostname)
  File "/data/stanley/st2common/st2common/persistence/db_init.py", line 59, in db_func_with_retry
    return retrying_obj.call(db_func, *args, **kwargs)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/retrying.py", line 206, in call
    return attempt.get(self._wrap_exception)
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/retrying.py", line 247, in get
    six.reraise(self.value[0], self.value[1], self.value[2])
  File "/data/stanley/virtualenv/local/lib/python2.7/site-packages/retrying.py", line 200, in call
    attempt = Attempt(fn(*args, **kwargs), attempt_number, False)
  File "/data/stanley/st2common/st2common/models/db/__init__.py", line 142, in db_setup
    ssl_match_hostname=ssl_match_hostname)
  File "/data/stanley/st2common/st2common/models/db/__init__.py", line 126, in _db_connect
    raise e
ServerSelectionTimeoutError: localhost.a:555: [Errno -2] No address found

```