### PR TITLE
Fix an issue with friendly error not being thrown if validation failed on config item of type array

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -244,6 +244,10 @@ Fixed
   Reported by @SURAJTHEGREAT.
 * Fix st2 webhook get -h which was asking for a name or id as opposed to the URL of the webhook.
   Also, fix st2 webhook list to explicitly add a webhook column. (bugfix) #4048
+* Fix an issue with pack config validation code throwing a non-user friendly error message in case
+  config item of type array failed config schema validation. (bug fix) #4166 #4168
+
+  Reported by @NikosVlagoidis.
 
 2.6.0 - January 19, 2018
 ------------------------

--- a/st2common/st2common/util/pack.py
+++ b/st2common/st2common/util/pack.py
@@ -14,8 +14,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import re
+import collections
 
 from st2common.util import schema as util_schema
 from st2common.constants.pack import MANIFEST_FILE_NAME
@@ -109,7 +111,12 @@ def validate_config_against_schema(config_schema, config_object, config_path,
                                        allow_default_none=True)
     except jsonschema.ValidationError as e:
         attribute = getattr(e, 'path', [])
-        attribute = '.'.join(attribute)
+
+        if isinstance(attribute, (tuple, list, collections.Iterable)):
+            attribute = [str(item) for item in attribute]
+            attribute = '.'.join(attribute)
+        else:
+            attribute = str(attribute)
 
         msg = ('Failed validating attribute "%s" in config for pack "%s" (%s): %s' %
                (attribute, pack_name, config_path, str(e)))

--- a/st2tests/st2tests/fixtures/packs/configs/dummy_pack_19.yaml
+++ b/st2tests/st2tests/fixtures/packs/configs/dummy_pack_19.yaml
@@ -1,0 +1,7 @@
+---
+  instances:
+    -
+      uid: "test-uid-1"
+      alias: {'not': 'string'}
+      base_url: 'foo'
+      token: 'bar'

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_19/config.schema.yaml
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_19/config.schema.yaml
@@ -1,0 +1,27 @@
+---
+  instances:
+    type: "array"
+    required: false
+    items:
+      type: "object"
+      properties:
+          uid:
+              description: "a unique id for this instance"
+              type: "string"
+              required: false
+              secret: false
+          alias:
+              description: "an alias for this instance"
+              type: "string"
+              required: true
+              secret: false
+          base_url:
+              description: "Base Url"
+              type: "string"
+              secret: false
+              required: true
+          token:
+              description: "token"
+              type: "string"
+              secret: true
+              required: true

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_19/pack.yaml
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_19/pack.yaml
@@ -1,0 +1,7 @@
+---
+ref: dummy_pack_19_ref
+name : dummy_pack_19
+description : dummy pack
+version : 0.1.0
+author : st2-dev
+email : info@stackstorm.com


### PR DESCRIPTION
This pull request fixes an issue reported in #4166.

If config validation failed against the config schema and the item was an array, an unrelated exception was thrown instead of throwing a user-friendly error message.

Before:

> Failed to register config "/data/stanley/st2tests/st2tests/fixtures/packs/configs/dummy_pack_19.yaml" for pack "dummy_pack_19": sequence item 1: expected string or Unicode, int found

After

> Failed to register config "/data/stanley/st2tests/st2tests/fixtures/packs/configs/dummy_pack_19.yaml" for pack "dummy_pack_19": Failed validating attribute "instances.0.alias" in config for pack "dummy_pack_19" (/data/stanley/st2tests/st2tests/fixtures/packs/configs/dummy_pack_19.yaml): {'not': 'string'} is not of type u'string

Resolves #4166.