### PR TITLE
Remove pip list warning

### DIFF
--- a/st2common/bin/st2-run-pack-tests
+++ b/st2common/bin/st2-run-pack-tests
@@ -230,7 +230,7 @@ if [ "${JUST_TESTS}" = false ]; then
     fi
 
     # Install global test dependencies
-    INSTALLED_PIP_PACKAGES=$(pip list)
+    INSTALLED_PIP_PACKAGES=$(pip list --format legacy)
 
     echo "Installing global pack test dependencies..."
     for((i = 0; i < ${#PACK_TEST_PYTHON_DEPENDENCIES_NAMES[@]}; i++)); do
@@ -283,7 +283,7 @@ verbose_log "Virtualenv activated=${VIRTUALENV_ACTIVATED}"
 verbose_log "Installed Python dependencies:"
 
 if [ ${VERBOSE} = true ]; then
-    pip list
+    pip list --format columns
 fi
 
 echo "Running tests..."


### PR DESCRIPTION
`pip` is going to change the format for `pip list` in future. 

Using current versions of `pip`, we get this DEPRECATION warning:

```shell
lindsaysmacbook:st2 lhill$ pip --version
pip 9.0.1 from /Library/Python/2.7/site-packages (python 2.7)
lindsaysmacbook:st2 lhill$ pip list > /dev/null
DEPRECATION: The default format will switch to columns in the future. You can use --format=(legacy|columns) (or define a format=(legacy|columns) in your pip.conf under the [list] section) to disable this warning.
You are using pip version 9.0.1, however version 10.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
lindsaysmacbook:st2 lhill$
```

This can be seen when running `st2-run-pack-tests`
```shell
Running tests for pack: repo
Installing dependencies from st2 repository...
DEPRECATION: The default format will switch to columns in the future. You can use --format=(legacy|columns) (or define a format=(legacy|columns) in your pip.conf under the [list] section) to disable this warning.
You are using pip version 9.0.3, however version 10.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Installing global pack test dependencies...
Installing pack-specific dependencies...
Installing pack-specific test dependencies...
Running tests...
```

(example above from https://circleci.com/gh/StackStorm-Exchange/stackstorm-cisco_aci/26?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link).

To prevent future surprises, this change is explicit about format for `pip list`. We could probably use either, but better to avoid surprises. After this change, typical output should look like this:

```shell
Running tests for pack: repo
Installing dependencies from st2 repository...
DEPRECATION: The default format will switch to columns in the future. You can use --format=(legacy|columns) (or define a format=(legacy|columns) in your pip.conf under the [list] section) to disable this warning.
You are using pip version 9.0.3, however version 10.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Installing global pack test dependencies...
Installing pack-specific dependencies...
Installing pack-specific test dependencies...
Running tests...
```