### PR TITLE
Fix nginx 'proxy_pass' directive can't use URI in regex location

### DIFF
--- a/conf/nginx/st2.conf
+++ b/conf/nginx/st2.conf
@@ -76,14 +76,14 @@ server {
 
   # For backward compatibility reasons, rewrite requests from "/api/stream"
   # to "/stream/v1/stream" and "/api/v1/stream" to "/stream/v1/stream"
-  location ~* (/stream/|/api(/v\d)?/stream/?) {
+  rewrite ^/api/stream/?$ /stream/v1/stream break;
+  rewrite ^/api/(v\d)/stream/?$ /stream/$1/stream break;
+  location /stream/ {
     error_page 502 = @streamError;
 
     rewrite ^/stream/(.*)  /$1 break;
-    rewrite ^/api/stream/?$ /v1/stream break;
-    rewrite ^/api(/v\d)?/stream/?$ $1/stream break;
 
-    proxy_pass  http://127.0.0.1:9102;
+    proxy_pass  http://127.0.0.1:9102/;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Using regex for location doesn't allow to specify full URI for  `proxy_pass` (with trailing slash).

During Docker/K8s work we need to substitute the API_URL, AUTH_URL and STREAM_URL in nginx `st2.conf` replacing existing proxy endpoints.

And so we can't use dynamic URIs like `http://random-ip-or-domain:maybe-port/` because:
```
nginx: [emerg] "proxy_pass" cannot have URI part in location given by regular expression, or inside named location, or inside "if" statement, or inside "limit_except" block in /etc/nginx/conf.d/st2.conf:87
```

This small nginx config adjustment removing regex from `st2stream` location makes var substitution easier.

More on this:
* https://stackoverflow.com/questions/21662940/nginx-proxy-pass-cannot-have-uri-part-in-location
* https://serverfault.com/questions/649151/nginx-location-regex-doesnt-work-with-proxy-pass