### PR TITLE
Fix config permissions on the config directory and the config file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,7 +46,7 @@ Changed
 ~~~~~~~
 
 * Update st2 CLI to create the configuration directory and file, and authentication tokens with
-  secure permissions (eg: readable only to owner)
+  secure permissions (eg: readable only to owner) #4173
 * Refactor the callback module for the post run in runner to be more generic. (improvement)
 * Update various Python dependencies to the latest stable versions (gunicorn, gitpython,
   python-gnupg, tooz, flex). #4110

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,8 @@ Added
 Changed
 ~~~~~~~
 
+* Update st2 CLI to create the configuration directory and file, and authentication tokens with
+  secure permissions (eg: readable only to owner)
 * Refactor the callback module for the post run in runner to be more generic. (improvement)
 * Update various Python dependencies to the latest stable versions (gunicorn, gitpython,
   python-gnupg, tooz, flex). #4110

--- a/st2client/st2client/base.py
+++ b/st2client/st2client/base.py
@@ -264,12 +264,8 @@ class BaseCLIApp(object):
             # Every user has access to this file which is dangerous
             message = ('Permissions (%s) for cached token file "%s" are too permissive. Please '
                        'restrict the permissions and make sure only your own user can read '
-                       'from or write to the file.'
-                       '\n\n'
-                       'You can fix this by running:'
-                       '\n\n'
-                       '    chmod o-rw %s')
-            self.LOG.warn(message % (file_st_mode, cached_token_path, cached_token_path))
+                       'from or write to the file.' % (file_st_mode, cached_token_path))
+            self.LOG.warn(message)
 
         with open(cached_token_path) as fp:
             data = fp.read()

--- a/st2client/st2client/commands/auth.py
+++ b/st2client/st2client/commands/auth.py
@@ -141,7 +141,6 @@ class LoginCommand(resource.ResourceCommand):
 
         with open(config_file, 'w') as cfg_file_out:
             config.write(cfg_file_out)
-        os.chmod(config_file, 0o660)
 
         return manager
 

--- a/st2client/st2client/commands/auth.py
+++ b/st2client/st2client/commands/auth.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 import getpass
 import json
 import logging
-import os
 
 import requests
 from six.moves.configparser import ConfigParser

--- a/st2client/st2client/commands/auth.py
+++ b/st2client/st2client/commands/auth.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 import getpass
 import json
 import logging
+import os
 
 import requests
 from six.moves.configparser import ConfigParser
@@ -140,6 +141,7 @@ class LoginCommand(resource.ResourceCommand):
 
         with open(config_file, 'w') as cfg_file_out:
             config.write(cfg_file_out)
+        os.chmod(config_file, 0o660)
 
         return manager
 

--- a/st2client/st2client/commands/auth.py
+++ b/st2client/st2client/commands/auth.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 import getpass
 import json
 import logging
+import os
 
 import requests
 from six.moves.configparser import ConfigParser
@@ -138,8 +139,12 @@ class LoginCommand(resource.ResourceCommand):
             # Remove any existing password from config
             config.remove_option('credentials', 'password')
 
+        config_existed = os.path.exists(config_file)
         with open(config_file, 'w') as cfg_file_out:
             config.write(cfg_file_out)
+        # If we created the config file, correct the permissions
+        if not config_existed:
+            os.chmod(config_file, 0o660)
 
         return manager
 

--- a/st2client/st2client/config_parser.py
+++ b/st2client/st2client/config_parser.py
@@ -150,7 +150,7 @@ class CLIConfigParser(object):
 
         if self.validate_config_permissions:
             # Make sure the directory permissions == 0o770
-            if bool(os.stat(config_dir_path).st_mode & 0o777 ^ 0o770):
+            if bool(os.stat(config_dir_path).st_mode & 0o7):
                 self.LOG.warn(
                     "The StackStorm configuration directory permissions are "
                     "insecure (too permissive): others have access.")
@@ -162,7 +162,7 @@ class CLIConfigParser(object):
                     "directory.")
 
             # Make sure the file permissions == 0o660
-            if bool(os.stat(self.config_file_path).st_mode & 0o667 ^ 0o660):
+            if bool(os.stat(self.config_file_path).st_mode & 0o7):
                 self.LOG.warn(
                     "The StackStorm configuration file permissions are "
                     "insecure: others have access.")

--- a/st2client/st2client/config_parser.py
+++ b/st2client/st2client/config_parser.py
@@ -152,34 +152,20 @@ class CLIConfigParser(object):
             # Make sure the directory permissions == 0o770
             if bool(os.stat(config_dir_path).st_mode & 0o777 ^ 0o770):
                 self.LOG.warn(
-                    # TODO: Perfect place for an f-string
                     "The StackStorm configuration directory permissions are "
-                    "insecure (too permissive)."
-                    "\n\n"
-                    "You can fix this by running:"
-                    "\n\n"
-                    "    chmod 770 {config_dir}\n".format(config_dir=config_dir_path))
+                    "insecure (too permissive): others have access.")
 
             # Make sure the setgid bit is set on the directory
             if not bool(os.stat(config_dir_path).st_mode & 0o2000):
                 self.LOG.info(
-                    # TODO: Perfect place for an f-string
                     "The SGID bit is not set on the StackStorm configuration "
-                    "directory."
-                    "\n\n"
-                    "You can fix this by running:"
-                    "\n\n"
-                    "    chmod g+s {config_dir}\n".format(config_dir=config_dir_path))
+                    "directory.")
 
             # Make sure the file permissions == 0o660
-            if bool(os.stat(self.config_file_path).st_mode & 0o777 ^ 0o660):
+            if bool(os.stat(self.config_file_path).st_mode & 0o667 ^ 0o660):
                 self.LOG.warn(
-                    # TODO: Another perfect place for an f-string
-                    "The StackStorm configuration file permissions are insecure."
-                    "\n\n"
-                    "You can fix this by running:"
-                    "\n\n"
-                    "    chmod 660 {config_file}\n".format(config_file=self.config_file_path))
+                    "The StackStorm configuration file permissions are "
+                    "insecure: others have access.")
 
         config = ConfigParser()
         with io.open(self.config_file_path, 'r', encoding='utf8') as fp:

--- a/st2client/st2client/config_parser.py
+++ b/st2client/st2client/config_parser.py
@@ -121,13 +121,18 @@ for section, keys in six.iteritems(CONFIG_FILE_OPTIONS):
 
 
 class CLIConfigParser(object):
-    LOG = logging.getLogger(__name__)  # logger instance to use
-
-    def __init__(self, config_file_path, validate_config_exists=True):
+    def __init__(self, config_file_path, validate_config_exists=True,
+                 validate_config_permissions=True, log=None):
         if validate_config_exists and not os.path.isfile(config_file_path):
             raise ValueError('Config file "%s" doesn\'t exist')
 
+        if log is None:
+            log = logging.getLogger(__name__)
+            logging.basicConfig()
+
         self.config_file_path = config_file_path
+        self.validate_config_permissions = validate_config_permissions
+        self.LOG = log
 
     def parse(self):
         """
@@ -143,37 +148,38 @@ class CLIConfigParser(object):
 
         config_dir_path = os.path.dirname(self.config_file_path)
 
-        # Make sure the directory permissions == 0o770
-        if bool(os.stat(config_dir_path).st_mode & 0o777 ^ 0o770):
-            self.LOG.warn(
-                # TODO: Perfect place for an f-string
-                "The StackStorm configuration directory permissions are "
-                "insecure (too permissive)."
-                "\n\n"
-                "You can fix this by running:"
-                "\n\n"
-                "chmod 770 {config_dir}".format(config_dir=config_dir_path))
+        if self.validate_config_permissions:
+            # Make sure the directory permissions == 0o770
+            if bool(os.stat(config_dir_path).st_mode & 0o777 ^ 0o770):
+                self.LOG.warn(
+                    # TODO: Perfect place for an f-string
+                    "The StackStorm configuration directory permissions are "
+                    "insecure (too permissive)."
+                    "\n\n"
+                    "You can fix this by running:"
+                    "\n\n"
+                    "    chmod 770 {config_dir}\n".format(config_dir=config_dir_path))
 
-        # Make sure the setgid bit is set on the directory
-        if not bool(os.stat(config_dir_path).st_mode & 0o2000):
-            self.LOG.info(
-                # TODO: Perfect place for an f-string
-                "The SGID bit is not set on the StackStorm configuration "
-                "directory."
-                "\n\n"
-                "You can fix this by running:"
-                "\n\n"
-                "chmod g+s {config_dir}".format(config_dir=config_dir_path))
+            # Make sure the setgid bit is set on the directory
+            if not bool(os.stat(config_dir_path).st_mode & 0o2000):
+                self.LOG.info(
+                    # TODO: Perfect place for an f-string
+                    "The SGID bit is not set on the StackStorm configuration "
+                    "directory."
+                    "\n\n"
+                    "You can fix this by running:"
+                    "\n\n"
+                    "    chmod g+s {config_dir}\n".format(config_dir=config_dir_path))
 
-        # Make sure the file permissions == 0o660
-        if bool(os.stat(self.config_file_path).st_mode & 0o777 ^ 0o660):
-            self.LOG.warn(
-                # TODO: Another perfect place for an f-string
-                "The StackStorm configuration file permissions are insecure."
-                "\n\n"
-                "You can fix this by running:"
-                "\n\n"
-                "chmod 660 {config_file}".format(config_file=self.config_file_path))
+            # Make sure the file permissions == 0o660
+            if bool(os.stat(self.config_file_path).st_mode & 0o777 ^ 0o660):
+                self.LOG.warn(
+                    # TODO: Another perfect place for an f-string
+                    "The StackStorm configuration file permissions are insecure."
+                    "\n\n"
+                    "You can fix this by running:"
+                    "\n\n"
+                    "    chmod 660 {config_file}\n".format(config_file=self.config_file_path))
 
         config = ConfigParser()
         with io.open(self.config_file_path, 'r', encoding='utf8') as fp:

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -365,7 +365,7 @@ class Shell(BaseCLIApp):
             return 3
 
         # Parse config and store it in the config module
-        config = self._parse_config_file(args=args)
+        config = self._parse_config_file(args=args, validate_config_permissions=False)
         set_config(config=config)
 
         self._check_locale_and_print_warning()

--- a/st2client/tests/unit/test_config_parser.py
+++ b/st2client/tests/unit/test_config_parser.py
@@ -39,164 +39,6 @@ class CLIConfigParserTestCase(unittest2.TestCase):
         self.assertRaises(ValueError, CLIConfigParser, config_file_path='doestnotexist',
                           validate_config_exists=True)
 
-    def test_correct_permissions_emit_no_warnings(self):
-        TEMP_FILE_PATH = os.path.join('st2config', '.st2', 'config')
-        TEMP_CONFIG_DIR = os.path.dirname(TEMP_FILE_PATH)
-
-        if os.path.exists(TEMP_FILE_PATH):
-            os.remove(TEMP_FILE_PATH)
-        self.assertFalse(os.path.exists(TEMP_FILE_PATH))
-
-        if os.path.exists(TEMP_CONFIG_DIR):
-            os.removedirs(TEMP_CONFIG_DIR)
-        self.assertFalse(os.path.exists(TEMP_CONFIG_DIR))
-
-        try:
-            # Setup the config directory
-            os.makedirs(TEMP_CONFIG_DIR)
-            os.chmod(TEMP_CONFIG_DIR, 0o2770)
-
-            self.assertEqual(os.stat(TEMP_CONFIG_DIR).st_mode & 0o7777, 0o2770)
-
-            # Setup the config file
-            shutil.copyfile(CONFIG_FILE_PATH_FULL, TEMP_FILE_PATH)
-            os.chmod(TEMP_FILE_PATH, 0o660)
-
-            self.assertEqual(os.stat(TEMP_FILE_PATH).st_mode & 0o777, 0o660)
-
-            parser = CLIConfigParser(config_file_path=TEMP_FILE_PATH, validate_config_exists=True)
-            parser.LOG = mock.Mock()
-
-            result = parser.parse()  # noqa F841
-
-            self.assertEqual(parser.LOG.warn.call_count, 0)
-
-            # Make sure we left the file alone
-            self.assertTrue(os.path.exists(TEMP_FILE_PATH))
-            self.assertEqual(os.stat(TEMP_FILE_PATH).st_mode & 0o777, 0o660)
-
-            self.assertTrue(os.path.exists(TEMP_CONFIG_DIR))
-            self.assertEqual(os.stat(TEMP_CONFIG_DIR).st_mode & 0o7777, 0o2770)
-        finally:
-            if os.path.exists(TEMP_FILE_PATH):
-                os.remove(TEMP_FILE_PATH)
-                self.assertFalse(os.path.exists(TEMP_FILE_PATH))
-
-            if os.path.exists(TEMP_CONFIG_DIR):
-                os.removedirs(TEMP_CONFIG_DIR)
-                self.assertFalse(os.path.exists(TEMP_FILE_PATH))
-
-    def test_warn_on_bad_config_permissions(self):
-        TEMP_FILE_PATH = os.path.join('st2config', '.st2', 'config')
-        TEMP_CONFIG_DIR = os.path.dirname(TEMP_FILE_PATH)
-
-        if os.path.exists(TEMP_FILE_PATH):
-            os.remove(TEMP_FILE_PATH)
-        self.assertFalse(os.path.exists(TEMP_FILE_PATH))
-
-        if os.path.exists(TEMP_CONFIG_DIR):
-            os.removedirs(TEMP_CONFIG_DIR)
-        self.assertFalse(os.path.exists(TEMP_CONFIG_DIR))
-
-        try:
-            # Setup the config directory
-            os.makedirs(TEMP_CONFIG_DIR)
-            os.chmod(TEMP_CONFIG_DIR, 0o0755)
-
-            self.assertNotEqual(os.stat(TEMP_CONFIG_DIR).st_mode & 0o7777, 0o0770)
-
-            # Setup the config file
-            shutil.copyfile(CONFIG_FILE_PATH_FULL, TEMP_FILE_PATH)
-            os.chmod(TEMP_FILE_PATH, 0o664)
-
-            self.assertNotEqual(os.stat(TEMP_FILE_PATH).st_mode & 0o777, 0o770)
-
-            parser = CLIConfigParser(config_file_path=TEMP_FILE_PATH, validate_config_exists=True)
-            parser.LOG = mock.Mock()
-
-            result = parser.parse()  # noqa F841
-
-            self.assertEqual(parser.LOG.info.call_count, 1)
-
-            self.assertEqual(
-                "The SGID bit is not set on the StackStorm configuration directory.",
-                parser.LOG.info.call_args_list[0][0][0])
-
-            self.assertEqual(parser.LOG.warn.call_count, 2)
-            self.assertEqual(
-                "The StackStorm configuration directory permissions are insecure "
-                "(too permissive): others have access.",
-                parser.LOG.warn.call_args_list[0][0][0])
-
-            self.assertEqual(
-                "The StackStorm configuration file permissions are insecure: others have access.",
-                parser.LOG.warn.call_args_list[1][0][0])
-
-            # Make sure we left the file alone
-            self.assertTrue(os.path.exists(TEMP_FILE_PATH))
-            self.assertEqual(os.stat(TEMP_FILE_PATH).st_mode & 0o777, 0o664)
-
-            self.assertTrue(os.path.exists(TEMP_CONFIG_DIR))
-            self.assertEqual(os.stat(TEMP_CONFIG_DIR).st_mode & 0o7777, 0o0755)
-        finally:
-            if os.path.exists(TEMP_FILE_PATH):
-                os.remove(TEMP_FILE_PATH)
-                self.assertFalse(os.path.exists(TEMP_FILE_PATH))
-
-            if os.path.exists(TEMP_CONFIG_DIR):
-                os.removedirs(TEMP_CONFIG_DIR)
-                self.assertFalse(os.path.exists(TEMP_FILE_PATH))
-
-    def test_disable_permissions_warnings(self):
-        TEMP_FILE_PATH = os.path.join('st2config', '.st2', 'config')
-        TEMP_CONFIG_DIR = os.path.dirname(TEMP_FILE_PATH)
-
-        if os.path.exists(TEMP_FILE_PATH):
-            os.remove(TEMP_FILE_PATH)
-        self.assertFalse(os.path.exists(TEMP_FILE_PATH))
-
-        if os.path.exists(TEMP_CONFIG_DIR):
-            os.removedirs(TEMP_CONFIG_DIR)
-        self.assertFalse(os.path.exists(TEMP_CONFIG_DIR))
-
-        try:
-            # Setup the config directory
-            os.makedirs(TEMP_CONFIG_DIR)
-            os.chmod(TEMP_CONFIG_DIR, 0o0755)
-
-            self.assertNotEqual(os.stat(TEMP_CONFIG_DIR).st_mode & 0o7777, 0o0770)
-
-            # Setup the config file
-            shutil.copyfile(CONFIG_FILE_PATH_FULL, TEMP_FILE_PATH)
-            os.chmod(TEMP_FILE_PATH, 0o664)
-
-            self.assertNotEqual(os.stat(TEMP_FILE_PATH).st_mode & 0o777, 0o770)
-
-            parser = CLIConfigParser(config_file_path=TEMP_FILE_PATH,
-                                     validate_config_exists=True,
-                                     validate_config_permissions=False)
-            parser.LOG = mock.Mock()
-
-            result = parser.parse()  # noqa F841
-
-            self.assertEqual(parser.LOG.info.call_count, 0)
-            self.assertEqual(parser.LOG.warn.call_count, 0)
-
-            # Make sure we left the file alone
-            self.assertTrue(os.path.exists(TEMP_FILE_PATH))
-            self.assertEqual(os.stat(TEMP_FILE_PATH).st_mode & 0o777, 0o664)
-
-            self.assertTrue(os.path.exists(TEMP_CONFIG_DIR))
-            self.assertEqual(os.stat(TEMP_CONFIG_DIR).st_mode & 0o7777, 0o0755)
-        finally:
-            if os.path.exists(TEMP_FILE_PATH):
-                os.remove(TEMP_FILE_PATH)
-                self.assertFalse(os.path.exists(TEMP_FILE_PATH))
-
-            if os.path.exists(TEMP_CONFIG_DIR):
-                os.removedirs(TEMP_CONFIG_DIR)
-                self.assertFalse(os.path.exists(TEMP_FILE_PATH))
-
     def test_parse(self):
         # File doesn't exist
         parser = CLIConfigParser(config_file_path='doesnotexist', validate_config_exists=False)
@@ -252,3 +94,163 @@ class CLIConfigParserTestCase(unittest2.TestCase):
             self.assertEqual(config['credentials']['password'], '密码')
         else:
             self.assertEqual(config['credentials']['password'], u'\u5bc6\u7801')
+
+
+class CLIConfigPermissionsTestCase(unittest2.TestCase):
+    def setUp(self):
+        self.TEMP_FILE_PATH = os.path.join('st2config', '.st2', 'config')
+        self.TEMP_CONFIG_DIR = os.path.dirname(self.TEMP_FILE_PATH)
+
+        if os.path.exists(self.TEMP_FILE_PATH):
+            os.remove(self.TEMP_FILE_PATH)
+        self.assertFalse(os.path.exists(self.TEMP_FILE_PATH))
+
+        if os.path.exists(self.TEMP_CONFIG_DIR):
+            os.removedirs(self.TEMP_CONFIG_DIR)
+        self.assertFalse(os.path.exists(self.TEMP_CONFIG_DIR))
+
+        # Setup the config directory
+        os.makedirs(self.TEMP_CONFIG_DIR)
+
+        # Copy the config file
+        shutil.copyfile(CONFIG_FILE_PATH_FULL, self.TEMP_FILE_PATH)
+
+    def tearDown(self):
+        if os.path.exists(self.TEMP_FILE_PATH):
+            os.remove(self.TEMP_FILE_PATH)
+            self.assertFalse(os.path.exists(self.TEMP_FILE_PATH))
+
+        if os.path.exists(self.TEMP_CONFIG_DIR):
+            os.removedirs(self.TEMP_CONFIG_DIR)
+            self.assertFalse(os.path.exists(self.TEMP_CONFIG_DIR))
+
+    def test_correct_permissions_emit_no_warnings(self):
+        os.chmod(self.TEMP_CONFIG_DIR, 0o2770)
+
+        self.assertEqual(os.stat(self.TEMP_CONFIG_DIR).st_mode & 0o7777, 0o2770)
+
+        # Setup the config file
+        os.chmod(self.TEMP_FILE_PATH, 0o660)
+
+        self.assertEqual(os.stat(self.TEMP_FILE_PATH).st_mode & 0o777, 0o660)
+
+        parser = CLIConfigParser(config_file_path=self.TEMP_FILE_PATH, validate_config_exists=True)
+        parser.LOG = mock.Mock()
+
+        result = parser.parse()  # noqa F841
+
+        self.assertEqual(parser.LOG.warn.call_count, 0)
+
+        # Make sure we left the file alone
+        self.assertTrue(os.path.exists(self.TEMP_FILE_PATH))
+        self.assertEqual(os.stat(self.TEMP_FILE_PATH).st_mode & 0o777, 0o660)
+
+        self.assertTrue(os.path.exists(self.TEMP_CONFIG_DIR))
+        self.assertEqual(os.stat(self.TEMP_CONFIG_DIR).st_mode & 0o7777, 0o2770)
+
+    def test_weird_but_correct_permissions_emit_no_warnings(self):
+        os.chmod(self.TEMP_CONFIG_DIR, 0o2770)
+
+        self.assertEqual(os.stat(self.TEMP_CONFIG_DIR).st_mode & 0o7777, 0o2770)
+
+        # 1. Config file: 0o640
+        os.chmod(self.TEMP_FILE_PATH, 0o640)
+
+        self.assertEqual(os.stat(self.TEMP_FILE_PATH).st_mode & 0o777, 0o640)
+
+        parser = CLIConfigParser(config_file_path=self.TEMP_FILE_PATH, validate_config_exists=True)
+        parser.LOG = mock.Mock()
+
+        result = parser.parse()  # noqa F841
+
+        self.assertEqual(parser.LOG.warn.call_count, 0)
+
+        # Make sure we left the file alone
+        self.assertTrue(os.path.exists(self.TEMP_FILE_PATH))
+        self.assertEqual(os.stat(self.TEMP_FILE_PATH).st_mode & 0o777, 0o640)
+
+        # 2. Config file: 0o600
+        os.chmod(self.TEMP_FILE_PATH, 0o600)
+
+        self.assertEqual(os.stat(self.TEMP_FILE_PATH).st_mode & 0o777, 0o600)
+
+        parser = CLIConfigParser(config_file_path=self.TEMP_FILE_PATH, validate_config_exists=True)
+        parser.LOG = mock.Mock()
+
+        result = parser.parse()  # noqa F841
+
+        self.assertEqual(parser.LOG.warn.call_count, 0)
+
+        # Make sure we left the file alone
+        self.assertTrue(os.path.exists(self.TEMP_FILE_PATH))
+        self.assertEqual(os.stat(self.TEMP_FILE_PATH).st_mode & 0o777, 0o600)
+
+        self.assertTrue(os.path.exists(self.TEMP_CONFIG_DIR))
+        self.assertEqual(os.stat(self.TEMP_CONFIG_DIR).st_mode & 0o7777, 0o2770)
+
+    def test_warn_on_bad_config_permissions(self):
+        # Setup the config directory
+        os.chmod(self.TEMP_CONFIG_DIR, 0o0755)
+
+        self.assertNotEqual(os.stat(self.TEMP_CONFIG_DIR).st_mode & 0o7777, 0o0770)
+
+        # Setup the config file
+        os.chmod(self.TEMP_FILE_PATH, 0o664)
+
+        self.assertNotEqual(os.stat(self.TEMP_FILE_PATH).st_mode & 0o777, 0o770)
+
+        parser = CLIConfigParser(config_file_path=self.TEMP_FILE_PATH, validate_config_exists=True)
+        parser.LOG = mock.Mock()
+
+        result = parser.parse()  # noqa F841
+
+        self.assertEqual(parser.LOG.info.call_count, 1)
+
+        self.assertEqual(
+            "The SGID bit is not set on the StackStorm configuration directory.",
+            parser.LOG.info.call_args_list[0][0][0])
+
+        self.assertEqual(parser.LOG.warn.call_count, 2)
+        self.assertEqual(
+            "The StackStorm configuration directory permissions are insecure "
+            "(too permissive): others have access.",
+            parser.LOG.warn.call_args_list[0][0][0])
+
+        self.assertEqual(
+            "The StackStorm configuration file permissions are insecure: others have access.",
+            parser.LOG.warn.call_args_list[1][0][0])
+
+        # Make sure we left the file alone
+        self.assertTrue(os.path.exists(self.TEMP_FILE_PATH))
+        self.assertEqual(os.stat(self.TEMP_FILE_PATH).st_mode & 0o777, 0o664)
+
+        self.assertTrue(os.path.exists(self.TEMP_CONFIG_DIR))
+        self.assertEqual(os.stat(self.TEMP_CONFIG_DIR).st_mode & 0o7777, 0o0755)
+
+    def test_disable_permissions_warnings(self):
+        # Setup the config directory
+        os.chmod(self.TEMP_CONFIG_DIR, 0o0755)
+
+        self.assertNotEqual(os.stat(self.TEMP_CONFIG_DIR).st_mode & 0o7777, 0o0770)
+
+        # Setup the config file
+        os.chmod(self.TEMP_FILE_PATH, 0o664)
+
+        self.assertNotEqual(os.stat(self.TEMP_FILE_PATH).st_mode & 0o777, 0o770)
+
+        parser = CLIConfigParser(config_file_path=self.TEMP_FILE_PATH,
+                                 validate_config_exists=True,
+                                 validate_config_permissions=False)
+        parser.LOG = mock.Mock()
+
+        result = parser.parse()  # noqa F841
+
+        self.assertEqual(parser.LOG.info.call_count, 0)
+        self.assertEqual(parser.LOG.warn.call_count, 0)
+
+        # Make sure we left the file alone
+        self.assertTrue(os.path.exists(self.TEMP_FILE_PATH))
+        self.assertEqual(os.stat(self.TEMP_FILE_PATH).st_mode & 0o777, 0o664)
+
+        self.assertTrue(os.path.exists(self.TEMP_CONFIG_DIR))
+        self.assertEqual(os.stat(self.TEMP_CONFIG_DIR).st_mode & 0o7777, 0o0755)

--- a/st2client/tests/unit/test_config_parser.py
+++ b/st2client/tests/unit/test_config_parser.py
@@ -119,29 +119,17 @@ class CLIConfigParserTestCase(unittest2.TestCase):
             self.assertEqual(parser.LOG.info.call_count, 1)
 
             self.assertEqual(
-                "The SGID bit is not set on the StackStorm configuration directory."
-                "\n\n"
-                "You can fix this by running:"
-                "\n\n"
-                "    chmod g+s {config_dir}\n".format(config_dir=TEMP_CONFIG_DIR),
+                "The SGID bit is not set on the StackStorm configuration directory.",
                 parser.LOG.info.call_args_list[0][0][0])
 
             self.assertEqual(parser.LOG.warn.call_count, 2)
             self.assertEqual(
                 "The StackStorm configuration directory permissions are insecure "
-                "(too permissive)."
-                "\n\n"
-                "You can fix this by running:"
-                "\n\n"
-                "    chmod 770 {config_dir}\n".format(config_dir=TEMP_CONFIG_DIR),
+                "(too permissive): others have access.",
                 parser.LOG.warn.call_args_list[0][0][0])
 
             self.assertEqual(
-                "The StackStorm configuration file permissions are insecure."
-                "\n\n"
-                "You can fix this by running:"
-                "\n\n"
-                "    chmod 660 {config_file}\n".format(config_file=TEMP_FILE_PATH),
+                "The StackStorm configuration file permissions are insecure: others have access.",
                 parser.LOG.warn.call_args_list[1][0][0])
 
             # Make sure we left the file alone

--- a/st2client/tests/unit/test_shell.py
+++ b/st2client/tests/unit/test_shell.py
@@ -465,8 +465,12 @@ class ShellTestCase(base.BaseCLITestCase):
 class CLITokenCachingTestCase(unittest2.TestCase):
     def setUp(self):
         super(CLITokenCachingTestCase, self).setUp()
-        self._mock_config_directory_path = tempfile.mkdtemp()
+        self._mock_temp_dir_path = tempfile.mkdtemp()
+        self._mock_config_directory_path = os.path.join(self._mock_temp_dir_path, 'testconfig')
         self._mock_config_path = os.path.join(self._mock_config_directory_path, 'config')
+
+        os.makedirs(self._mock_config_directory_path)
+
         self._p1 = mock.patch('st2client.base.ST2_CONFIG_DIRECTORY',
                               self._mock_config_directory_path)
         self._p2 = mock.patch('st2client.base.ST2_CONFIG_PATH',
@@ -508,7 +512,7 @@ class CLITokenCachingTestCase(unittest2.TestCase):
             fp.write(json.dumps(data))
 
         # 1. Current user doesn't have read access to the config directory
-        os.chmod(self._mock_config_directory_path, 0000)
+        os.chmod(self._mock_config_directory_path, 0o000)
 
         shell.LOG = mock.Mock()
         result = shell._get_cached_auth_token(client=client, username=username,
@@ -524,7 +528,7 @@ class CLITokenCachingTestCase(unittest2.TestCase):
 
         # 2. Read access on the directory, but not on the cached token file
         os.chmod(self._mock_config_directory_path, 0o777)  # nosec
-        os.chmod(cached_token_path, 0000)
+        os.chmod(cached_token_path, 0o000)
 
         shell.LOG = mock.Mock()
         result = shell._get_cached_auth_token(client=client, username=username,
@@ -570,7 +574,7 @@ class CLITokenCachingTestCase(unittest2.TestCase):
             fp.write(json.dumps(data))
 
         # 1. Current user has no write access to the parent directory
-        os.chmod(self._mock_config_directory_path, 0000)
+        os.chmod(self._mock_config_directory_path, 0o000)
 
         shell.LOG = mock.Mock()
         shell._cache_auth_token(token_obj=token_db)
@@ -584,7 +588,7 @@ class CLITokenCachingTestCase(unittest2.TestCase):
 
         # 2. Current user has no write access to the cached token file
         os.chmod(self._mock_config_directory_path, 0o777)  # nosec
-        os.chmod(cached_token_path, 0000)
+        os.chmod(cached_token_path, 0o000)
 
         shell.LOG = mock.Mock()
         shell._cache_auth_token(token_obj=token_db)

--- a/st2client/tests/unit/test_shell.py
+++ b/st2client/tests/unit/test_shell.py
@@ -489,7 +489,19 @@ class ShellTestCase(base.BaseCLITestCase):
         shell.run(['--config-file', mock_config_path, 'action', 'list'])
 
         self.assertEqual(shell.LOG.warn.call_count, 2)
-        self.assertEqual(shell.LOG.info.call_count, 1)
+        self.assertEqual(
+            shell.LOG.warn.call_args_list[0][0][0][:63],
+            'The StackStorm configuration directory permissions are insecure')
+        self.assertEqual(
+            shell.LOG.warn.call_args_list[1][0][0][:59],
+            'The StackStorm configuration file permissions are insecure.')
+
+        self.assertEqual(shell.LOG.info.call_count, 2)
+        self.assertEqual(
+            shell.LOG.info.call_args_list[0][0][0][:19], "The SGID bit is not")
+
+        self.assertEqual(
+            shell.LOG.info.call_args_list[1][0][0], 'Skipping parsing CLI config')
 
 
 class CLITokenCachingTestCase(unittest2.TestCase):

--- a/st2client/tests/unit/test_shell.py
+++ b/st2client/tests/unit/test_shell.py
@@ -493,12 +493,13 @@ class ShellTestCase(base.BaseCLITestCase):
             shell.LOG.warn.call_args_list[0][0][0][:63],
             'The StackStorm configuration directory permissions are insecure')
         self.assertEqual(
-            shell.LOG.warn.call_args_list[1][0][0][:59],
-            'The StackStorm configuration file permissions are insecure.')
+            shell.LOG.warn.call_args_list[1][0][0][:58],
+            'The StackStorm configuration file permissions are insecure')
 
         self.assertEqual(shell.LOG.info.call_count, 2)
         self.assertEqual(
-            shell.LOG.info.call_args_list[0][0][0][:19], "The SGID bit is not")
+            shell.LOG.info.call_args_list[0][0][0], "The SGID bit is not "
+            "set on the StackStorm configuration directory.")
 
         self.assertEqual(
             shell.LOG.info.call_args_list[1][0][0], 'Skipping parsing CLI config')


### PR DESCRIPTION
Fixes #4144.

This ensures that we create the config directory and file with the proper permissions.

It also tweaks the `st2 login` command to check the permissions on the config file (`~/.st2/config`) and directory (`~/.st2`) every time it is run, and then automatically fix permissions if they are too permissive. It does use the `warnings` module to warn the user about this, but does not give them a chance to opt out or turn the behavior off.

Automatically fixing the directory/file permissions assumes that there is no good reason for a process owned by another user or group to need read access to the config file. That is a very large assumption, so I'm inviting discussion about that.

The options are:

1. simply "warn the user" into fixing the config permissions, but not automatically fix it ourselves
2. use environment variables or command line flags to control warnings and automatic fixing behavior
3. warn the user and automatically fix it ourselves all the time
4. fix it automatically without warning

I have chosen option 3 here.