### PR TITLE
Add single sensor mode to the sensor container service / process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
       python: 2.7
     - env: TASK="compilepy3 ci-py3-unit" CACHE_NAME=py3
       python: 3.6
+    - env: TASK="ci-py3-integration" CACHE_NAME=py3
+      python: 3.6
 addons:
   apt:
     sources:
@@ -55,7 +57,7 @@ before_install:
   - sudo pip install --upgrade "virtualenv==15.1.0"
 
 install:
-  - if [ "${TASK}" = 'compilepy3 ci-py3-unit' ]; then pip install "tox==3.0.0"; else make requirements; fi
+  - if [ "${TASK}" = 'compilepy3 ci-py3-unit' ] || [ "${TASK}" = 'ci-py3-integration' ]; then pip install "tox==3.0.0"; else make requirements; fi
   - if [ "${TASK}" = 'ci-unit' ] || [ "${TASK}" = 'ci-integration' ]; then pip install codecov; fi
   - if [ "${TASK}" = 'ci-unit' ] || [ "${TASK}" = 'ci-integration' ] || [ "${TASK}" = 'compilepy3 ci-py3-unit' ]; then sudo .circle/add-itest-user.sh; fi
 

--- a/Makefile
+++ b/Makefile
@@ -704,14 +704,14 @@ ci: ci-checks ci-unit ci-integration ci-mistral ci-packs-tests
 ci-checks: compile .generated-files-check .pylint .flake8 .bandit .st2client-dependencies-check .st2common-circular-dependencies-check circle-lint-api-spec .rst-check
 
 .PHONY: ci-py3-unit
-ci-py3-unit: .ci-prepare-integration
+ci-py3-unit:
 	@echo
 	@echo "==================== ci-py3-unit ===================="
 	@echo
 	tox -e py36-unit -vv
 
 .PHONY: ci-py3-integration
-ci-py3-integration: .ci-prepare-integration
+ci-py3-integration:
 	@echo
 	@echo "==================== ci-py3-integration ===================="
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -704,11 +704,18 @@ ci: ci-checks ci-unit ci-integration ci-mistral ci-packs-tests
 ci-checks: compile .generated-files-check .pylint .flake8 .bandit .st2client-dependencies-check .st2common-circular-dependencies-check circle-lint-api-spec .rst-check
 
 .PHONY: ci-py3-unit
-ci-py3-unit:
+ci-py3-unit: .ci-prepare-integration
 	@echo
 	@echo "==================== ci-py3-unit ===================="
 	@echo
-	tox -e py36 -vv
+	tox -e py36-unit -vv
+
+.PHONY: ci-py3-integration
+ci-py3-integration: .ci-prepare-integration
+	@echo
+	@echo "==================== ci-py3-integration ===================="
+	@echo
+	tox -e py36-integration -vv
 
 .PHONY: .rst-check
 .rst-check:

--- a/conf/st2.conf.sample
+++ b/conf/st2.conf.sample
@@ -257,6 +257,8 @@ draft = http://json-schema.org/draft-04/schema#
 [sensorcontainer]
 # Provider of sensor node partition config.
 partition_provider = {'name': 'default'}
+# Run in a single sensor mode where parent process exits when a sensor crashes / dies. This is useful in environments where partitioning, sensor process life cycle and failover is handled by a 3rd party service such as kubernetes.
+single_sensor_mode = False
 # location of the logging.conf file
 logging = conf/logging.sensorcontainer.conf
 # name of the sensor node.

--- a/conf/st2.tests.conf
+++ b/conf/st2.tests.conf
@@ -56,6 +56,7 @@ sleep_delay = 0.1
 [content]
 system_packs_base_path =
 packs_base_paths = st2tests/st2tests/fixtures/packs/
+system_runners_base_path = contrib/runners
 
 [syslog]
 host = 127.0.0.1

--- a/conf/st2.tests1.conf
+++ b/conf/st2.tests1.conf
@@ -42,6 +42,7 @@ base_path = /tmp
 [content]
 system_packs_base_path =
 packs_base_paths = st2tests/st2tests/fixtures/packs_1/
+system_runners_base_path = contrib/runners
 
 [syslog]
 host = 127.0.0.1

--- a/st2common/st2common/constants/scheduler.py
+++ b/st2common/st2common/constants/scheduler.py
@@ -13,9 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__all__ = ['SCHEDULER_ENABLED_LOG_LINE', 'SCHEDULER_DISABLED_LOG_LINE']
+__all__ = [
+    'SCHEDULER_ENABLED_LOG_LINE',
+    'SCHEDULER_DISABLED_LOG_LINE'
+]
 
 
 # Integration tests look for these loglines to validate scheduler enable/disable
-SCHEDULER_ENABLED_LOG_LINE = 'Scheduler is enabled.'
-SCHEDULER_DISABLED_LOG_LINE = 'Scheduler is disabled.'
+SCHEDULER_ENABLED_LOG_LINE = b'Scheduler is enabled.'
+SCHEDULER_DISABLED_LOG_LINE = b'Scheduler is disabled.'

--- a/st2common/st2common/router.py
+++ b/st2common/st2common/router.py
@@ -370,6 +370,11 @@ class Router(object):
                     detail = 'Failed to parse request body: %s' % str(e)
                     raise exc.HTTPBadRequest(detail=detail)
 
+                # Special case for Python 3
+                if six.PY3 and content_type == 'text/plain' and isinstance(data, six.binary_type):
+                    # Convert bytes to text type (string / unicode)
+                    data = data.decode('utf-8')
+
                 try:
                     CustomValidator(schema, resolver=self.spec_resolver).validate(data)
                 except (jsonschema.ValidationError, ValueError) as e:

--- a/st2common/tests/integration/test_register_content_script.py
+++ b/st2common/tests/integration/test_register_content_script.py
@@ -14,7 +14,9 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
+import sys
 import glob
 
 from st2tests.base import IntegrationTestCase
@@ -27,7 +29,7 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 SCRIPT_PATH = os.path.join(BASE_DIR, '../../bin/st2-register-content')
 SCRIPT_PATH = os.path.abspath(SCRIPT_PATH)
 
-BASE_CMD_ARGS = [SCRIPT_PATH, '--config-file=conf/st2.tests.conf', '-v']
+BASE_CMD_ARGS = [sys.executable, SCRIPT_PATH, '--config-file=conf/st2.tests.conf', '-v']
 BASE_REGISTER_ACTIONS_CMD_ARGS = BASE_CMD_ARGS + ['--register-actions']
 
 PACKS_PATH = get_fixtures_packs_base_path()

--- a/st2common/tests/integration/test_register_content_script.py
+++ b/st2common/tests/integration/test_register_content_script.py
@@ -115,7 +115,7 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
         # dir as packs_base_paths
         cmd = [SCRIPT_PATH, '--config-file=conf/st2.tests1.conf', '-v', '--register-sensors']
         exit_code, _, stderr = run_command(cmd=cmd)
-        self.assertTrue('Registered 0 sensors.' in stderr)
+        self.assertTrue('Registered 0 sensors.' in stderr, 'Actual stderr: %s' % (stderr))
         self.assertEqual(exit_code, 0)
 
         cmd = [SCRIPT_PATH, '--config-file=conf/st2.tests1.conf', '-v', '--register-all',
@@ -131,7 +131,7 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
         cmd = BASE_CMD_ARGS + ['--register-all', '--register-setup-virtualenvs',
                                '--register-no-fail-on-failure']
         exit_code, stdout, stderr = run_command(cmd=cmd)
-        self.assertTrue('Registering actions' in stderr)
+        self.assertTrue('Registering actions' in stderr, 'Actual stderr: %s' % (stderr))
         self.assertTrue('Registering rules' in stderr)
         self.assertTrue('Setup virtualenv for %s pack(s)' % (PACKS_COUNT) in stderr)
         self.assertEqual(exit_code, 0)

--- a/st2common/tests/integration/test_register_content_script.py
+++ b/st2common/tests/integration/test_register_content_script.py
@@ -113,13 +113,14 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
 
         # Note: We want to use a different config which sets fixtures/packs_1/
         # dir as packs_base_paths
-        cmd = [SCRIPT_PATH, '--config-file=conf/st2.tests1.conf', '-v', '--register-sensors']
+        cmd = [sys.executable, SCRIPT_PATH, '--config-file=conf/st2.tests1.conf', '-v',
+               '--register-sensors']
         exit_code, _, stderr = run_command(cmd=cmd)
         self.assertTrue('Registered 0 sensors.' in stderr, 'Actual stderr: %s' % (stderr))
         self.assertEqual(exit_code, 0)
 
-        cmd = [SCRIPT_PATH, '--config-file=conf/st2.tests1.conf', '-v', '--register-all',
-               '--register-no-fail-on-failure']
+        cmd = [sys.executable, SCRIPT_PATH, '--config-file=conf/st2.tests1.conf', '-v',
+               '--register-all', '--register-no-fail-on-failure']
         exit_code, _, stderr = run_command(cmd=cmd)
         self.assertTrue('Registered 0 actions.' in stderr)
         self.assertTrue('Registered 0 sensors.' in stderr)

--- a/st2debug/st2debug/cmd/submit_debug_info.py
+++ b/st2debug/st2debug/cmd/submit_debug_info.py
@@ -244,7 +244,7 @@ class DebugInfoCollector(object):
 
             # Prepend temp_dir_path to OUTPUT_PATHS
             output_paths = {}
-            for key, path in OUTPUT_PATHS.iteritems():
+            for key, path in six.iteritems(OUTPUT_PATHS):
                 output_paths[key] = os.path.join(self._temp_dir_path, path)
 
             # 2. Moves all the files to the temporary directory
@@ -489,7 +489,12 @@ class DebugInfoCollector(object):
         :return: Formatted filename.
         :rtype: ``str``
         """
-        return cmd.translate(None, """ !@#$%^&*()[]{};:,./<>?\|`~=+"'""")
+        if six.PY3:
+            cmd = cmd.translate(cmd.maketrans('', '', """ !@#$%^&*()[]{};:,./<>?\|`~=+"'"""))
+        else:
+            cmd = cmd.translate(None, """ !@#$%^&*()[]{};:,./<>?\|`~=+"'""")
+
+        return cmd
 
     @staticmethod
     def get_system_information():

--- a/st2debug/tests/integration/fixtures/configs/st2.conf
+++ b/st2debug/tests/integration/fixtures/configs/st2.conf
@@ -13,9 +13,6 @@ logging = st2api/conf/logging.conf
 username = ponies
 password = ponies
 
-[messaging]
-url = ponies
-
 [sensorcontainer]
 logging = st2reactor/conf/logging.sensorcontainer.conf
 

--- a/st2exporter/st2exporter/exporter/dumper.py
+++ b/st2exporter/st2exporter/exporter/dumper.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 
 import os
-import Queue
 
 import eventlet
+from six.moves import queue
 
 from st2common import log as logging
 from st2exporter.exporter.file_writer import TextFileWriter
@@ -94,7 +94,7 @@ class Dumper(object):
         for _ in range(self._batch_size):
             try:
                 item = self._queue.get(block=False)
-            except Queue.Empty:
+            except queue.Empty:
                 break
             else:
                 executions_to_write.append(item)

--- a/st2exporter/st2exporter/worker.py
+++ b/st2exporter/st2exporter/worker.py
@@ -13,9 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import Queue
-
 import eventlet
+from six.moves import queue
 from kombu import Connection
 from oslo_config import cfg
 
@@ -47,7 +46,7 @@ class ExecutionsExporter(consumers.MessageHandler):
 
     def __init__(self, connection, queues):
         super(ExecutionsExporter, self).__init__(connection, queues)
-        self.pending_executions = Queue.Queue()
+        self.pending_executions = queue.Queue()
         self._dumper = Dumper(queue=self.pending_executions,
                               export_dir=cfg.CONF.exporter.dump_dir)
         self._consumer_thread = None

--- a/st2exporter/tests/integration/test_dumper_integration.py
+++ b/st2exporter/tests/integration/test_dumper_integration.py
@@ -15,10 +15,11 @@
 
 import datetime
 import os
-import Queue
 
 import mock
 import six
+
+from six.moves import queue
 
 from st2common.models.api.execution import ActionExecutionAPI
 from st2common.persistence.marker import DumperMarker
@@ -47,7 +48,7 @@ class TestDumper(DbTestCase):
         execution_apis.append(ActionExecutionAPI(**execution))
 
     def get_queue(self):
-        executions_queue = Queue.Queue()
+        executions_queue = queue.Queue()
 
         for execution in self.execution_apis:
             executions_queue.put(execution)

--- a/st2exporter/tests/integration/test_export_worker.py
+++ b/st2exporter/tests/integration/test_export_worker.py
@@ -90,7 +90,7 @@ class TestExportWorker(DbTestCase):
 
     @mock.patch.object(os.path, 'exists', mock.MagicMock(return_value=True))
     def test_process(self):
-        some_execution = self.saved_executions.values()[5]
+        some_execution = list(self.saved_executions.values())[5]
         exec_exporter = ExecutionsExporter(None, None)
         self.assertEqual(exec_exporter.pending_executions.qsize(), 0)
         exec_exporter.process(some_execution)

--- a/st2exporter/tests/unit/test_dumper.py
+++ b/st2exporter/tests/unit/test_dumper.py
@@ -15,10 +15,10 @@
 
 import datetime
 import os
-import Queue
 
 import eventlet
 import mock
+from six.moves import queue
 
 from st2common.models.api.execution import ActionExecutionAPI
 from st2common.util import isotime
@@ -48,7 +48,7 @@ class TestDumper(EventletTestCase):
         execution_apis.append(ActionExecutionAPI(**execution))
 
     def get_queue(self):
-        executions_queue = Queue.Queue()
+        executions_queue = queue.Queue()
 
         for execution in self.execution_apis:
             executions_queue.put(execution)
@@ -88,7 +88,7 @@ class TestDumper(EventletTestCase):
 
     @mock.patch.object(os.path, 'exists', mock.MagicMock(return_value=True))
     def test_write_to_disk_empty_queue(self):
-        dumper = Dumper(queue=Queue.Queue(),
+        dumper = Dumper(queue=queue.Queue(),
                         export_dir='/tmp',
                         file_prefix='st2-stuff-', file_format='json')
         # We just make sure this doesn't blow up.

--- a/st2exporter/tests/unit/test_json_converter.py
+++ b/st2exporter/tests/unit/test_json_converter.py
@@ -36,7 +36,7 @@ class TestJsonConverter(unittest2.TestCase):
                                                     fixtures_dict=DESCENDANTS_FIXTURES)
 
     def test_convert(self):
-        executions_list = self.loaded_fixtures['executions'].values()
+        executions_list = list(self.loaded_fixtures['executions'].values())
         converter = JsonConverter()
         converted_doc = converter.convert(executions_list)
         self.assertTrue(type(converted_doc), 'string')

--- a/st2reactor/st2reactor/cmd/sensormanager.py
+++ b/st2reactor/st2reactor/cmd/sensormanager.py
@@ -54,12 +54,14 @@ def main():
     try:
         _setup()
 
-        if cfg.CONF.sensorcontainer.single_sensor_mode and not cfg.CONF.sensor_ref:
+        single_sensor_mode = (cfg.CONF.single_sensor_mode or
+                              cfg.CONF.sensorcontainer.single_sensor_mode)
+
+        if single_sensor_mode and not cfg.CONF.sensor_ref:
             raise ValueError('--sensor-ref argument must be provided when running in single '
                              'sensor mode')
 
         sensors_partitioner = get_sensors_partitioner()
-        single_sensor_mode = cfg.CONF.sensorcontainer.single_sensor_mode
         container_manager = SensorContainerManager(sensors_partitioner=sensors_partitioner,
                                                    single_sensor_mode=single_sensor_mode)
         return container_manager.run_sensors()

--- a/st2reactor/st2reactor/cmd/sensormanager.py
+++ b/st2reactor/st2reactor/cmd/sensormanager.py
@@ -14,8 +14,11 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import sys
+
+from oslo_config import cfg
 
 from st2common import log as logging
 from st2common.logging.misc import get_logger_name_for_module
@@ -50,8 +53,15 @@ def _teardown():
 def main():
     try:
         _setup()
+
+        if cfg.CONF.sensorcontainer.single_sensor_mode and not cfg.CONF.sensor_ref:
+            raise ValueError('--sensor-ref argument must be provided when running in single '
+                             'sensor mode')
+
         sensors_partitioner = get_sensors_partitioner()
-        container_manager = SensorContainerManager(sensors_partitioner=sensors_partitioner)
+        single_sensor_mode = cfg.CONF.sensorcontainer.single_sensor_mode
+        container_manager = SensorContainerManager(sensors_partitioner=sensors_partitioner,
+                                                   single_sensor_mode=single_sensor_mode)
         return container_manager.run_sensors()
     except SystemExit as exit_code:
         return exit_code

--- a/st2reactor/st2reactor/container/manager.py
+++ b/st2reactor/st2reactor/container/manager.py
@@ -65,9 +65,13 @@ class SensorContainerManager(object):
 
         LOG.info('(PID:%s) SensorContainer started.', os.getpid())
         self._setup_sigterm_handler()
-        self._spin_container_and_wait(sensors_to_run)
+
+        exit_code = self._spin_container_and_wait(sensors_to_run)
+        return exit_code
 
     def _spin_container_and_wait(self, sensors):
+        exit_code = 0
+
         try:
             self._sensor_container = ProcessSensorContainer(
                 sensors=sensors,
@@ -90,7 +94,9 @@ class SensorContainerManager(object):
             eventlet.kill(self._container_thread)
             self._container_thread = None
 
-            return 0
+            return exit_code
+
+        return exit_code
 
     def _setup_sigterm_handler(self):
 

--- a/st2reactor/st2reactor/container/partitioner_lookup.py
+++ b/st2reactor/st2reactor/container/partitioner_lookup.py
@@ -41,16 +41,19 @@ PROVIDERS = {
 
 def get_sensors_partitioner():
     if cfg.CONF.sensor_ref:
+        LOG.info('Running in single sensor mode, using a single sensor partitioner...')
         return SingleSensorPartitioner(sensor_ref=cfg.CONF.sensor_ref)
+
     partition_provider_config = copy.copy(cfg.CONF.sensorcontainer.partition_provider)
     partition_provider = partition_provider_config.pop('name')
     sensor_node_name = cfg.CONF.sensorcontainer.sensor_node_name
 
     provider = PROVIDERS.get(partition_provider.lower(), None)
-    LOG.info('Using partitioner %s with sensornode %s.', partition_provider, sensor_node_name)
     if not provider:
-        raise SensorPartitionerNotSupportedException(
-            'Partition provider %s not found.' % partition_provider)
+        raise SensorPartitionerNotSupportedException('Partition provider %s not found.' %
+                                                     (partition_provider))
+
+    LOG.info('Using partitioner %s with sensornode %s.', partition_provider, sensor_node_name)
 
     # pass in extra config with no analysis
     return provider(sensor_node_name=sensor_node_name, **partition_provider_config)

--- a/st2reactor/st2reactor/sensor/config.py
+++ b/st2reactor/st2reactor/sensor/config.py
@@ -82,7 +82,12 @@ def _register_sensor_container_opts(ignore_errors=False):
         cfg.StrOpt(
             'sensor-ref',
             help='Only run sensor with the provided reference. Value is of the form '
-                 '<pack>.<sensor-name> (e.g. linux.FileWatchSensor).')
+                 '<pack>.<sensor-name> (e.g. linux.FileWatchSensor).'),
+        cfg.BoolOpt(
+            'single-sensor-mode', default=False,
+            help='Run in a single sensor mode where parent process exits when a sensor crashes / '
+                 'dies. This is useful in environments where partitioning, sensor process life '
+                 'cycle and failover is handled by a 3rd party service such as kubernetes.')
     ]
 
     st2cfg.do_register_cli_opts(cli_opts, ignore_errors=ignore_errors)

--- a/st2reactor/st2reactor/sensor/config.py
+++ b/st2reactor/st2reactor/sensor/config.py
@@ -64,9 +64,9 @@ def _register_sensor_container_opts(ignore_errors=False):
             help='Provider of sensor node partition config.')
     ]
 
-    # Other options
     st2cfg.do_register_opts(partition_opts, group='sensorcontainer', ignore_errors=ignore_errors)
 
+    # Other options
     other_opts = [
         cfg.BoolOpt(
             'single_sensor_mode', default=False,

--- a/st2reactor/st2reactor/sensor/config.py
+++ b/st2reactor/st2reactor/sensor/config.py
@@ -52,6 +52,7 @@ def _register_sensor_container_opts(ignore_errors=False):
 
     st2cfg.do_register_opts(logging_opts, group='sensorcontainer', ignore_errors=ignore_errors)
 
+    # Partitioning options
     partition_opts = [
         cfg.StrOpt(
             'sensor_node_name', default='sensornode1',
@@ -63,13 +64,28 @@ def _register_sensor_container_opts(ignore_errors=False):
             help='Provider of sensor node partition config.')
     ]
 
+    # Other options
     st2cfg.do_register_opts(partition_opts, group='sensorcontainer', ignore_errors=ignore_errors)
 
-    sensor_test_opt = cfg.StrOpt(
-        'sensor-ref',
-        help='Only run sensor with the provided reference. Value is of the form pack.sensor-name.')
+    other_opts = [
+        cfg.BoolOpt(
+            'single_sensor_mode', default=False,
+            help='Run in a single sensor mode where parent process exits when a sensor crashes / '
+                 'dies. This is useful in environments where partitioning, sensor process life '
+                 'cycle and failover is handled by a 3rd party service such as kubernetes.')
+    ]
 
-    st2cfg.do_register_cli_opts(sensor_test_opt, ignore_errors=ignore_errors)
+    st2cfg.do_register_opts(other_opts, group='sensorcontainer', ignore_errors=ignore_errors)
+
+    # CLI options
+    cli_opts = [
+        cfg.StrOpt(
+            'sensor-ref',
+            help='Only run sensor with the provided reference. Value is of the form '
+                 '<pack>.<sensor-name> (e.g. linux.FileWatchSensor).')
+    ]
+
+    st2cfg.do_register_cli_opts(cli_opts, ignore_errors=ignore_errors)
 
 
 register_opts(ignore_errors=True)

--- a/st2reactor/tests/integration/test_garbage_collector.py
+++ b/st2reactor/tests/integration/test_garbage_collector.py
@@ -14,7 +14,9 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
+import sys
 import signal
 import datetime
 
@@ -43,14 +45,20 @@ __all__ = [
 
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
 ST2_CONFIG_PATH = os.path.join(BASE_DIR, '../../../conf/st2.tests.conf')
 ST2_CONFIG_PATH = os.path.abspath(ST2_CONFIG_PATH)
+
 INQUIRY_CONFIG_PATH = os.path.join(BASE_DIR, '../../../conf/st2.tests2.conf')
 INQUIRY_CONFIG_PATH = os.path.abspath(INQUIRY_CONFIG_PATH)
+
+PYTHON_BINARY = sys.executable
+
 BINARY = os.path.join(BASE_DIR, '../../../st2reactor/bin/st2garbagecollector')
 BINARY = os.path.abspath(BINARY)
-CMD = [BINARY, '--config-file', ST2_CONFIG_PATH]
-CMD_INQUIRY = [BINARY, '--config-file', INQUIRY_CONFIG_PATH]
+
+CMD = [PYTHON_BINARY, BINARY, '--config-file', ST2_CONFIG_PATH]
+CMD_INQUIRY = [PYTHON_BINARY, BINARY, '--config-file', INQUIRY_CONFIG_PATH]
 
 TEST_FIXTURES = {
     'runners': ['inquirer.yaml'],

--- a/st2reactor/tests/integration/test_sensor_container.py
+++ b/st2reactor/tests/integration/test_sensor_container.py
@@ -16,7 +16,6 @@
 from __future__ import absolute_import
 import os
 import signal
-import unittest2
 
 import psutil
 import eventlet
@@ -48,7 +47,7 @@ DEFAULT_CMD = [BINARY, '--config-file', ST2_CONFIG_PATH,
                '--sensor-ref=examples.SamplePollingSensor']
 
 
-#@unittest2.skipIf(True, 'Skipped until we improve integration tests setup')
+# @unittest2.skipIf(True, 'Skipped until we improve integration tests setup')
 class SensorContainerTestCase(IntegrationTestCase):
     """
     Note: For those tests MongoDB must be running, virtualenv must exist for

--- a/st2reactor/tests/integration/test_sensor_container.py
+++ b/st2reactor/tests/integration/test_sensor_container.py
@@ -14,7 +14,9 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
+import sys
 import signal
 
 import psutil
@@ -38,13 +40,20 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 ST2_CONFIG_PATH = os.path.join(BASE_DIR, '../../../conf/st2.tests.conf')
 ST2_CONFIG_PATH = os.path.abspath(ST2_CONFIG_PATH)
 
+PYTHON_BINARY = sys.executable
+
 BINARY = os.path.join(BASE_DIR, '../../../st2reactor/bin/st2sensorcontainer')
 BINARY = os.path.abspath(BINARY)
 
 PACKS_BASE_PATH = os.path.join(BASE_DIR, '../../../contrib')
 
-DEFAULT_CMD = [BINARY, '--config-file', ST2_CONFIG_PATH,
-               '--sensor-ref=examples.SamplePollingSensor']
+DEFAULT_CMD = [
+    PYTHON_BINARY,
+    BINARY,
+    '--config-file',
+    ST2_CONFIG_PATH,
+    '--sensor-ref=examples.SamplePollingSensor'
+]
 
 
 # @unittest2.skipIf(True, 'Skipped until we improve integration tests setup')

--- a/st2reactor/tests/integration/test_sensor_container.py
+++ b/st2reactor/tests/integration/test_sensor_container.py
@@ -164,8 +164,8 @@ class SensorContainerTestCase(IntegrationTestCase):
         eventlet.sleep(4)
 
         stdout = process.stdout.read()
-        self.assertTrue(('--sensor-ref argument must be provided when running in single sensor '
-                         'mode') in stdout)
+        self.assertTrue((b'--sensor-ref argument must be provided when running in single sensor '
+                         b'mode') in stdout)
         self.assertProcessExited(proc=pp)
         self.remove_process(process=process)
 
@@ -182,9 +182,9 @@ class SensorContainerTestCase(IntegrationTestCase):
         # Container should exit and not respawn a sensor in single sensor mode
         stdout = process.stdout.read()
 
-        self.assertTrue('Process for sensor examples.SampleSensorExit has exited with code 110')
-        self.assertTrue('Not respawning a sensor since running in single sensor mode')
-        self.assertTrue('Process container quit with exit_code 110.')
+        self.assertTrue(b'Process for sensor examples.SampleSensorExit has exited with code 110')
+        self.assertTrue(b'Not respawning a sensor since running in single sensor mode')
+        self.assertTrue(b'Process container quit with exit_code 110.')
 
         eventlet.sleep(2)
         self.assertProcessExited(proc=pp)

--- a/st2reactor/tests/integration/test_sensor_container.py
+++ b/st2reactor/tests/integration/test_sensor_container.py
@@ -82,7 +82,10 @@ class SensorContainerTestCase(IntegrationTestCase):
 
         # Create virtualenv for examples pack
         virtualenv_path = '/tmp/virtualenvs/examples'
-        cmd = ['virtualenv', '--system-site-packages', virtualenv_path]
+
+        run_command(cmd=['rm', '-rf', virtualenv_path])
+
+        cmd = ['virtualenv', '--system-site-packages', '--python', PYTHON_BINARY, virtualenv_path]
         run_command(cmd=cmd)
 
     def test_child_processes_are_killed_on_sigint(self):
@@ -97,7 +100,7 @@ class SensorContainerTestCase(IntegrationTestCase):
         # Verify container process and children sensor / wrapper processes are running
         pp = psutil.Process(process.pid)
         children_pp = pp.children()
-        self.assertEqual(pp.cmdline()[1:], DEFAULT_CMD)
+        self.assertEqual(pp.cmdline()[1:], DEFAULT_CMD[1:])
         self.assertEqual(len(children_pp), 1)
 
         # Send SIGINT
@@ -122,7 +125,7 @@ class SensorContainerTestCase(IntegrationTestCase):
         # Verify container process and children sensor / wrapper processes are running
         pp = psutil.Process(process.pid)
         children_pp = pp.children()
-        self.assertEqual(pp.cmdline()[1:], DEFAULT_CMD)
+        self.assertEqual(pp.cmdline()[1:], DEFAULT_CMD[1:])
         self.assertEqual(len(children_pp), 1)
 
         # Send SIGTERM
@@ -147,7 +150,7 @@ class SensorContainerTestCase(IntegrationTestCase):
         # Verify container process and children sensor / wrapper processes are running
         pp = psutil.Process(process.pid)
         children_pp = pp.children()
-        self.assertEqual(pp.cmdline()[1:], DEFAULT_CMD)
+        self.assertEqual(pp.cmdline()[1:], DEFAULT_CMD[1:])
         self.assertEqual(len(children_pp), 1)
 
         # Send SIGKILL
@@ -164,7 +167,7 @@ class SensorContainerTestCase(IntegrationTestCase):
 
     def test_single_sensor_mode(self):
         # 1. --sensor-ref not provided
-        cmd = [BINARY, '--config-file', ST2_CONFIG_PATH, '--single-sensor-mode']
+        cmd = [PYTHON_BINARY, BINARY, '--config-file', ST2_CONFIG_PATH, '--single-sensor-mode']
 
         process = self._start_sensor_container(cmd=cmd)
         pp = psutil.Process(process.pid)

--- a/st2reactor/tests/integration/test_sensor_container.py
+++ b/st2reactor/tests/integration/test_sensor_container.py
@@ -133,7 +133,7 @@ class SensorContainerTestCase(IntegrationTestCase):
         process = self._start_sensor_container()
 
         # Give it some time to start up
-        eventlet.sleep(3)
+        eventlet.sleep(4)
 
         # Verify container process and children sensor / wrapper processes are running
         pp = psutil.Process(process.pid)
@@ -161,7 +161,7 @@ class SensorContainerTestCase(IntegrationTestCase):
         pp = psutil.Process(process.pid)
 
         # Give it some time to start up
-        eventlet.sleep(3)
+        eventlet.sleep(4)
 
         stdout = process.stdout.read()
         self.assertTrue(('--sensor-ref argument must be provided when running in single sensor '

--- a/st2reactor/tests/integration/test_sensor_container.py
+++ b/st2reactor/tests/integration/test_sensor_container.py
@@ -80,7 +80,7 @@ class SensorContainerTestCase(IntegrationTestCase):
         process = self._start_sensor_container()
 
         # Give it some time to start up
-        eventlet.sleep(3)
+        eventlet.sleep(5)
 
         # Assert process has started and is running
         self.assertProcessIsRunning(process=process)
@@ -96,7 +96,7 @@ class SensorContainerTestCase(IntegrationTestCase):
 
         # SIGINT causes graceful shutdown so give it some time to gracefuly shut down the sensor
         # child processes
-        eventlet.sleep(PROCESS_EXIT_TIMEOUT + 1)
+        eventlet.sleep(PROCESS_EXIT_TIMEOUT + 2)
 
         # Verify parent and children processes have exited
         self.assertProcessExited(proc=pp)

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -279,11 +279,26 @@ def _register_sensor_container_opts():
 
     _register_opts(partition_opts, group='sensorcontainer')
 
-    sensor_test_opt = cfg.StrOpt(
-        'sensor-ref',
-        help='Only run sensor with the provided reference. Value is of the form pack.sensor-name.')
+    # Other options
+    other_opts = [
+        cfg.BoolOpt(
+            'single_sensor_mode', default=False,
+            help='Run in a single sensor mode where parent process exits when a sensor crashes / '
+                 'dies. This is useful in environments where partitioning, sensor process life '
+                 'cycle and failover is handled by a 3rd party service such as kubernetes.')
+    ]
 
-    _register_cli_opts([sensor_test_opt])
+    _register_opts(other_opts, group='sensorcontainer')
+
+    # CLI options
+    cli_opts = [
+        cfg.StrOpt(
+            'sensor-ref',
+            help='Only run sensor with the provided reference. Value is of the form '
+                 '<pack>.<sensor-name> (e.g. linux.FileWatchSensor).')
+    ]
+
+    _register_cli_opts(cli_opts)
 
 
 def _register_opts(opts, group=None):

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -295,7 +295,12 @@ def _register_sensor_container_opts():
         cfg.StrOpt(
             'sensor-ref',
             help='Only run sensor with the provided reference. Value is of the form '
-                 '<pack>.<sensor-name> (e.g. linux.FileWatchSensor).')
+                 '<pack>.<sensor-name> (e.g. linux.FileWatchSensor).'),
+        cfg.BoolOpt(
+            'single-sensor-mode', default=False,
+            help='Run in a single sensor mode where parent process exits when a sensor crashes / '
+                 'dies. This is useful in environments where partitioning, sensor process life '
+                 'cycle and failover is handled by a 3rd party service such as kubernetes.')
     ]
 
     _register_cli_opts(cli_opts)

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ commands =
     nosetests --with-timer --rednose -sv st2exporter/tests/unit/
     nosetests --with-timer --rednose -sv st2reactor/tests/unit/
     nosetests --with-timer --rednose -sv st2api/tests/unit/controllers/v1/
-    nosetests --with-timer --rednose -sv --ignore-files=test_validator_mistral.* st2api/tests/unit/controllers/exp/
+    nosetests --with-timer --rednose -sv st2api/tests/unit/controllers/exp/
     nosetests --with-timer --rednose -sv st2common/tests/unit/
     nosetests --with-timer --rednose -sv contrib/runners/action_chain_runner/tests/unit/ contrib/runners/action_chain_runner/tests/integration/
     nosetests --with-timer --rednose -sv contrib/runners/cloudslang_runner/tests/unit/

--- a/tox.ini
+++ b/tox.ini
@@ -25,10 +25,9 @@ commands =
     nosetests -sv st2common/tests/unit
     nosetests -sv st2reactor/tests/unit
     nosetests -sv st2tests/tests/unit
-
 [testenv:py36-unit]
 basepython = python3.6
-setenv = PYTHONPATH = {toxinidir}/external:{toxinidir}/st2common:{toxinidir}/st2api:{toxinidir}/st2actions:{toxinidir}/st2reactor:{toxinidir}/st2tests:{toxinidir}/contrib/runners/action_chain_runner:{toxinidir}/contrib/runners/local_runner:{toxinidir}/contrib/runners/windows_runner:{toxinidir}/contrib/runners/python_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/noop_runner:{toxinidir}/contrib/runners/announcement_runner:{toxinidir}/contrib/runners/remote_script_runner:{toxinidir}/contrib/runners/remote_command_runner:{toxinidir}/contrib/runners/mistral_v2:{toxinidir}/contrib/runners/inquirer_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/cloudslang_runner
+setenv = PYTHONPATH = {toxinidir}/external:{toxinidir}/st2common:{toxinidir}/st2api:{toxinidir}/st2actions:{toxinidir}/st2exporter:{toxinidir}/st2reactor:{toxinidir}/st2tests:{toxinidir}/contrib/runners/action_chain_runner:{toxinidir}/contrib/runners/local_runner:{toxinidir}/contrib/runners/windows_runner:{toxinidir}/contrib/runners/python_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/noop_runner:{toxinidir}/contrib/runners/announcement_runner:{toxinidir}/contrib/runners/remote_script_runner:{toxinidir}/contrib/runners/remote_command_runner:{toxinidir}/contrib/runners/mistral_v2:{toxinidir}/contrib/runners/inquirer_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/cloudslang_runner
          VIRTUALENV_DIR = {envdir}
 install_command = pip install -U --force-reinstall {opts} {packages}
 deps = virtualenv
@@ -37,6 +36,7 @@ deps = virtualenv
        -e{toxinidir}/st2common
 commands =
     nosetests --with-timer --rednose -sv st2client/tests/unit/
+    nosetests --with-timer --rednose -sv st2exporter/tests/unit/
     nosetests --with-timer --rednose -sv st2reactor/tests/unit/
     nosetests --with-timer --rednose -sv st2api/tests/unit/controllers/v1/
     nosetests --with-timer --rednose -sv --ignore-files=test_validator_mistral.* st2api/tests/unit/controllers/exp/
@@ -54,7 +54,7 @@ commands =
 
 [testenv:py36-integration]
 basepython = python3.6
-setenv = PYTHONPATH = {toxinidir}/external:{toxinidir}/st2common:{toxinidir}/st2api:{toxinidir}/st2actions:{toxinidir}/st2reactor:{toxinidir}/st2tests:{toxinidir}/contrib/runners/action_chain_runner:{toxinidir}/contrib/runners/local_runner:{toxinidir}/contrib/runners/windows_runner:{toxinidir}/contrib/runners/python_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/noop_runner:{toxinidir}/contrib/runners/announcement_runner:{toxinidir}/contrib/runners/remote_script_runner:{toxinidir}/contrib/runners/remote_command_runner:{toxinidir}/contrib/runners/mistral_v2:{toxinidir}/contrib/runners/inquirer_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/cloudslang_runner
+setenv = PYTHONPATH = {toxinidir}/external:{toxinidir}/st2common:{toxinidir}/st2api:{toxinidir}/st2actions:{toxinidir}/st2exporter:{toxinidir}/st2reactor:{toxinidir}/st2tests:{toxinidir}/contrib/runners/action_chain_runner:{toxinidir}/contrib/runners/local_runner:{toxinidir}/contrib/runners/windows_runner:{toxinidir}/contrib/runners/python_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/noop_runner:{toxinidir}/contrib/runners/announcement_runner:{toxinidir}/contrib/runners/remote_script_runner:{toxinidir}/contrib/runners/remote_command_runner:{toxinidir}/contrib/runners/mistral_v2:{toxinidir}/contrib/runners/inquirer_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/cloudslang_runner
          VIRTUALENV_DIR = {envdir}
 install_command = pip install -U --force-reinstall {opts} {packages}
 deps = virtualenv
@@ -63,6 +63,7 @@ deps = virtualenv
        -e{toxinidir}/st2common
 commands =
     nosetests --with-timer --rednose -sv st2reactor/tests/integration/
+    nosetests --with-timer --rednose -sv st2exporter/tests/integration/
 
 [testenv:venv]
 commands = {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ deps = virtualenv
        -e{toxinidir}/st2common
 commands =
     nosetests --with-timer --rednose -sv st2client/tests/unit/
+    nosetests --with-timer --rednose -sv st2debug/tests/unit/
     nosetests --with-timer --rednose -sv st2exporter/tests/unit/
     nosetests --with-timer --rednose -sv st2reactor/tests/unit/
     nosetests --with-timer --rednose -sv st2api/tests/unit/controllers/v1/
@@ -62,8 +63,9 @@ deps = virtualenv
        -e{toxinidir}/st2client
        -e{toxinidir}/st2common
 commands =
-    nosetests --with-timer --rednose -sv st2reactor/tests/integration/
+    nosetests --with-timer --rednose -sv st2debug/tests/integration/
     nosetests --with-timer --rednose -sv st2exporter/tests/integration/
+    nosetests --with-timer --rednose -sv st2reactor/tests/integration/
 
 [testenv:venv]
 commands = {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -63,6 +63,8 @@ deps = virtualenv
        -e{toxinidir}/st2client
        -e{toxinidir}/st2common
 commands =
+    nosetests --with-timer --rednose -sv st2api/tests/integration/
+    nosetests --with-timer --rednose -sv st2common/tests/integration/
     nosetests --with-timer --rednose -sv st2debug/tests/integration/
     nosetests --with-timer --rednose -sv st2exporter/tests/integration/
     nosetests --with-timer --rednose -sv st2reactor/tests/integration/

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ commands =
     nosetests -sv st2reactor/tests/unit
     nosetests -sv st2tests/tests/unit
 
-[testenv:py36]
+[testenv:py36-unit]
 basepython = python3.6
 setenv = PYTHONPATH = {toxinidir}/external:{toxinidir}/st2common:{toxinidir}/st2api:{toxinidir}/st2actions:{toxinidir}/st2reactor:{toxinidir}/st2tests:{toxinidir}/contrib/runners/action_chain_runner:{toxinidir}/contrib/runners/local_runner:{toxinidir}/contrib/runners/windows_runner:{toxinidir}/contrib/runners/python_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/noop_runner:{toxinidir}/contrib/runners/announcement_runner:{toxinidir}/contrib/runners/remote_script_runner:{toxinidir}/contrib/runners/remote_command_runner:{toxinidir}/contrib/runners/mistral_v2:{toxinidir}/contrib/runners/inquirer_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/cloudslang_runner
          VIRTUALENV_DIR = {envdir}
@@ -38,7 +38,6 @@ deps = virtualenv
 commands =
     nosetests --with-timer --rednose -sv st2client/tests/unit/
     nosetests --with-timer --rednose -sv st2reactor/tests/unit/
-    nosetests --with-timer --rednose -sv st2reactor/tests/integration/
     nosetests --with-timer --rednose -sv st2api/tests/unit/controllers/v1/
     nosetests --with-timer --rednose -sv --ignore-files=test_validator_mistral.* st2api/tests/unit/controllers/exp/
     nosetests --with-timer --rednose -sv st2common/tests/unit/
@@ -52,6 +51,18 @@ commands =
     nosetests --with-timer --rednose -sv contrib/runners/mistral_v2/tests/unit/ contrib/runners/mistral_v2/tests/integration/
     nosetests --with-timer --rednose -sv contrib/runners/python_runner/tests/unit/ contrib/runners/python_runner/tests/integration/
     nosetests --with-timer --rednose -sv contrib/runners/windows_runner/tests/unit/
+
+[testenv:py36-integration]
+basepython = python3.6
+setenv = PYTHONPATH = {toxinidir}/external:{toxinidir}/st2common:{toxinidir}/st2api:{toxinidir}/st2actions:{toxinidir}/st2reactor:{toxinidir}/st2tests:{toxinidir}/contrib/runners/action_chain_runner:{toxinidir}/contrib/runners/local_runner:{toxinidir}/contrib/runners/windows_runner:{toxinidir}/contrib/runners/python_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/noop_runner:{toxinidir}/contrib/runners/announcement_runner:{toxinidir}/contrib/runners/remote_script_runner:{toxinidir}/contrib/runners/remote_command_runner:{toxinidir}/contrib/runners/mistral_v2:{toxinidir}/contrib/runners/inquirer_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/cloudslang_runner
+         VIRTUALENV_DIR = {envdir}
+install_command = pip install -U --force-reinstall {opts} {packages}
+deps = virtualenv
+       -r{toxinidir}/requirements.txt
+       -e{toxinidir}/st2client
+       -e{toxinidir}/st2common
+commands =
+    nosetests --with-timer --rednose -sv st2reactor/tests/integration/
 
 [testenv:venv]
 commands = {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ deps = virtualenv
 commands =
     nosetests --with-timer --rednose -sv st2client/tests/unit/
     nosetests --with-timer --rednose -sv st2reactor/tests/unit/
-    nosetests --with-timer --rednose -sv st2reactor/tests/integration/ --ignore-files=test_garbage_collector.*
+    nosetests --with-timer --rednose -sv st2reactor/tests/integration/
     nosetests --with-timer --rednose -sv st2api/tests/unit/controllers/v1/
     nosetests --with-timer --rednose -sv --ignore-files=test_validator_mistral.* st2api/tests/unit/controllers/exp/
     nosetests --with-timer --rednose -sv st2common/tests/unit/

--- a/tox.ini
+++ b/tox.ini
@@ -63,6 +63,7 @@ deps = virtualenv
        -e{toxinidir}/st2client
        -e{toxinidir}/st2common
 commands =
+    nosetests --with-timer --rednose -sv st2actions/tests/integration/
     nosetests --with-timer --rednose -sv st2api/tests/integration/
     nosetests --with-timer --rednose -sv st2common/tests/integration/
     nosetests --with-timer --rednose -sv st2debug/tests/integration/

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ commands =
 
 [testenv:py36-integration]
 basepython = python3.6
-setenv = PYTHONPATH = {toxinidir}/external:{toxinidir}/st2common:{toxinidir}/st2api:{toxinidir}/st2actions:{toxinidir}/st2exporter:{toxinidir}/st2reactor:{toxinidir}/st2tests:{toxinidir}/contrib/runners/action_chain_runner:{toxinidir}/contrib/runners/local_runner:{toxinidir}/contrib/runners/windows_runner:{toxinidir}/contrib/runners/python_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/noop_runner:{toxinidir}/contrib/runners/announcement_runner:{toxinidir}/contrib/runners/remote_script_runner:{toxinidir}/contrib/runners/remote_command_runner:{toxinidir}/contrib/runners/mistral_v2:{toxinidir}/contrib/runners/inquirer_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/cloudslang_runner
+setenv = PYTHONPATH = {toxinidir}/external:{toxinidir}/st2common:{toxinidir}/st2auth:{toxinidir}/st2api:{toxinidir}/st2actions:{toxinidir}/st2exporter:{toxinidir}/st2reactor:{toxinidir}/st2tests:{toxinidir}/contrib/runners/action_chain_runner:{toxinidir}/contrib/runners/local_runner:{toxinidir}/contrib/runners/windows_runner:{toxinidir}/contrib/runners/python_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/noop_runner:{toxinidir}/contrib/runners/announcement_runner:{toxinidir}/contrib/runners/remote_script_runner:{toxinidir}/contrib/runners/remote_command_runner:{toxinidir}/contrib/runners/mistral_v2:{toxinidir}/contrib/runners/inquirer_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/cloudslang_runner
          VIRTUALENV_DIR = {envdir}
 install_command = pip install -U --force-reinstall {opts} {packages}
 deps = virtualenv


### PR DESCRIPTION
This pull request adds single sensor mode to the sensor container service (enabled via ``sensorcontainer.single_sensor_mode`` config option).

When this flag is set, sensor container process doesn't manage lifecycle of a sensor processes and respawn them if a sensor exits / crashes, but it exits itself and propagates sensor exit code to the parent sensor container process.

This comes handy in scenarios when a sensor life cycle and failover is handled by an external service such as Kubernetes / Mesos / monitoring + bash scripts / ...

Note: This flag needs to be used in combination with ``--sensor-ref`` CLI option since without it it doesn't make sense.

## TODO

- [x] Tests
- [ ] Documentation