### PR TITLE
Add jinja filter to manipulate paths

### DIFF
--- a/st2common/st2common/jinja/filters/path.py
+++ b/st2common/st2common/jinja/filters/path.py
@@ -1,0 +1,29 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+import os
+
+__all__ = [
+    'basename',
+    'dirname'
+]
+
+
+def basename(path):
+    return os.path.basename(path)
+
+def dirname(path):
+    return os.path.dirname(path)

--- a/st2common/st2common/jinja/filters/path.py
+++ b/st2common/st2common/jinja/filters/path.py
@@ -25,5 +25,6 @@ __all__ = [
 def basename(path):
     return os.path.basename(path)
 
+
 def dirname(path):
     return os.path.dirname(path)

--- a/st2common/tests/unit/test_jinja_render_path_filters.py
+++ b/st2common/tests/unit/test_jinja_render_path_filters.py
@@ -1,0 +1,49 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import absolute_import
+import unittest2
+
+from st2common.util import jinja as jinja_utils
+
+
+class JinjaUtilsPathFilterTestCase(unittest2.TestCase):
+
+    def test_basename(self):
+        env = jinja_utils.get_jinja_environment()
+
+        template = '{{k1 | basename}}'
+        actual = env.from_string(template).render({'k1': '/some/path/to/file.txt'})
+        self.assertEqual(actual, 'file.txt')
+
+        actual = env.from_string(template).render({'k1': '/some/path/to/dir'})
+        self.assertEqual(actual, 'dir')
+
+        actual = env.from_string(template).render({'k1': '/some/path/to/dir/'})
+        self.assertEqual(actual, 'dir')
+
+    def test_dirname(self):
+        env = jinja_utils.get_jinja_environment()
+
+        template = '{{k1 | dirname}}'
+        actual = env.from_string(template).render({'k1': '/some/path/to/file.txt'})
+        self.assertEqual(actual, '/some/path/to')
+
+        actual = env.from_string(template).render({'k1': '/some/path/to/dir'})
+        self.assertEqual(actual, '/some/path/to')
+
+        actual = env.from_string(template).render({'k1': '/some/path/to/dir/'})
+        self.assertEqual(actual, '/some/path/to')


### PR DESCRIPTION
I was looking for a jinja filter that could get me the basename or dirname of a linux path string. I have outlined in this pull request how that could look like. Happy for any feedback!