### PR TITLE
Add st2workflowengine logging conf to appropriate st2 conf files

### DIFF
--- a/conf/st2.package.conf
+++ b/conf/st2.package.conf
@@ -77,3 +77,6 @@ url = amqp://guest:guest@127.0.0.1:5672/
 
 [ssh_runner]
 remote_dir = /tmp
+
+[workflow_engine]
+logging = /etc/st2/logging.workflowengine.conf

--- a/conf/st2.prod.conf
+++ b/conf/st2.prod.conf
@@ -73,3 +73,6 @@ logging = /etc/st2actions/logging.resultstracker.conf
 
 [notifier]
 logging = /etc/st2actions/logging.notifier.conf
+
+[workflow_engine]
+logging = /etc/st2actions/logging.workflowengine.conf


### PR DESCRIPTION
Add the st2workflowengine logging configuration path to the st2.conf for packaging and production.