### PR TITLE
Add jinja filter to manipulate paths (with changelog entry)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,10 @@ Added
   pack in question needs to support Python 3.
 
   Note 2: This feature is experimental and opt-in. (new feature) #4016 #3922 #4149
+* Add two new Jinja filters - ``basename`` (``os.path.basename``) and ``dirname``
+  (``os.path.dirname``). #4184
+
+  Contributed by Florian Reisinger (@reisingerf).
 
 Changed
 ~~~~~~~

--- a/st2common/st2common/jinja/filters/path.py
+++ b/st2common/st2common/jinja/filters/path.py
@@ -1,0 +1,29 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+import os
+
+__all__ = [
+    'basename',
+    'dirname'
+]
+
+
+def basename(path):
+    return os.path.basename(path)
+
+def dirname(path):
+    return os.path.dirname(path)

--- a/st2common/st2common/jinja/filters/path.py
+++ b/st2common/st2common/jinja/filters/path.py
@@ -25,5 +25,6 @@ __all__ = [
 def basename(path):
     return os.path.basename(path)
 
+
 def dirname(path):
     return os.path.dirname(path)

--- a/st2common/st2common/util/jinja.py
+++ b/st2common/st2common/util/jinja.py
@@ -62,6 +62,7 @@ def get_filters():
     from st2common.jinja.filters import version
     from st2common.jinja.filters import json_escape
     from st2common.jinja.filters import jsonpath_query
+    from st2common.jinja.filters import path
 
     # IMPORTANT NOTE - these filters were recently duplicated in st2mistral so that
     # they are also available in Mistral workflows. Please ensure any additions you
@@ -94,7 +95,10 @@ def get_filters():
         'use_none': use_none,
 
         'json_escape': json_escape.json_escape,
-        'jsonpath_query': jsonpath_query.jsonpath_query
+        'jsonpath_query': jsonpath_query.jsonpath_query,
+
+        'basename': path.basename,
+        'dirname': path.dirname
     }
 
 

--- a/st2common/tests/unit/test_jinja_render_path_filters.py
+++ b/st2common/tests/unit/test_jinja_render_path_filters.py
@@ -1,0 +1,49 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import absolute_import
+import unittest2
+
+from st2common.util import jinja as jinja_utils
+
+
+class JinjaUtilsPathFilterTestCase(unittest2.TestCase):
+
+    def test_basename(self):
+        env = jinja_utils.get_jinja_environment()
+
+        template = '{{k1 | basename}}'
+        actual = env.from_string(template).render({'k1': '/some/path/to/file.txt'})
+        self.assertEqual(actual, 'file.txt')
+
+        actual = env.from_string(template).render({'k1': '/some/path/to/dir'})
+        self.assertEqual(actual, 'dir')
+
+        actual = env.from_string(template).render({'k1': '/some/path/to/dir/'})
+        self.assertEqual(actual, 'dir')
+
+    def test_dirname(self):
+        env = jinja_utils.get_jinja_environment()
+
+        template = '{{k1 | dirname}}'
+        actual = env.from_string(template).render({'k1': '/some/path/to/file.txt'})
+        self.assertEqual(actual, '/some/path/to')
+
+        actual = env.from_string(template).render({'k1': '/some/path/to/dir'})
+        self.assertEqual(actual, '/some/path/to')
+
+        actual = env.from_string(template).render({'k1': '/some/path/to/dir/'})
+        self.assertEqual(actual, '/some/path/to')

--- a/st2common/tests/unit/test_jinja_render_path_filters.py
+++ b/st2common/tests/unit/test_jinja_render_path_filters.py
@@ -33,7 +33,7 @@ class JinjaUtilsPathFilterTestCase(unittest2.TestCase):
         self.assertEqual(actual, 'dir')
 
         actual = env.from_string(template).render({'k1': '/some/path/to/dir/'})
-        self.assertEqual(actual, 'dir')
+        self.assertEqual(actual, '')
 
     def test_dirname(self):
         env = jinja_utils.get_jinja_environment()
@@ -46,4 +46,4 @@ class JinjaUtilsPathFilterTestCase(unittest2.TestCase):
         self.assertEqual(actual, '/some/path/to')
 
         actual = env.from_string(template).render({'k1': '/some/path/to/dir/'})
-        self.assertEqual(actual, '/some/path/to')
+        self.assertEqual(actual, '/some/path/to/dir')


### PR DESCRIPTION
This pull request adds entry for dictionary in `st2common.util.jinja.get_filters` and also adds a corresponding changelog entry on top of #4184.

I decided to base this new PR on top of the existing one so we can merge that today and include it in v2.8.0.

Resolves #4184.