### PR TITLE
Add st2workflowengine to st2ctl

### DIFF
--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-COMPONENTS="st2actionrunner st2api st2stream st2auth st2garbagecollector st2notifier st2resultstracker st2rulesengine st2sensorcontainer st2chatops mistral"
+COMPONENTS="st2actionrunner st2api st2stream st2auth st2garbagecollector st2notifier st2resultstracker st2rulesengine st2sensorcontainer st2chatops mistral st2workflowengine"
 ST2_CONF="/etc/st2/st2.conf"
 
 # Ensure global environment is sourced if exists


### PR DESCRIPTION
Add st2workflowengine to the list of service components in st2ctl.