### PR TITLE
Log which Python version and executable is used on service startup

### DIFF
--- a/st2common/st2common/service_setup.py
+++ b/st2common/st2common/service_setup.py
@@ -20,6 +20,7 @@ This module contains common service setup and teardown code.
 from __future__ import absolute_import
 
 import os
+import sys
 import traceback
 
 from oslo_config import cfg
@@ -80,6 +81,9 @@ def setup(service, config, setup_db=True, register_mq_exchanges=True,
         config.parse_args(config_args)
     else:
         config.parse_args()
+
+    version = '%s.%s.%s' % (sys.version_info[0], sys.version_info[1], sys.version_info[2])
+    LOG.debug('Using Python: %s (%s)' % (version, sys.executable))
 
     config_file_paths = cfg.CONF.config_file
     config_file_paths = [os.path.abspath(path) for path in config_file_paths]


### PR DESCRIPTION
This pull request updates service startup code to log which Python version and executable is used by that service (it uses DEBUG log level).

This will come handy in the future when we will support Python 2 and Python 3 (it will allow us to see which version of Python is used and also assert on it in the tests).