### PR TITLE
Remove unused and obsolete tasks from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-# envlist = py26,py27,py34,flake8-py2,flake8-py3,pylint,pylint3
-envlist = py27,flake8-py2,py35
+envlist = py36-unit,py36-integration
 skipsdist = true
 skip_missing_interpreters=true
 
@@ -17,14 +16,8 @@ deps = -r{toxinidir}/requirements.txt
        -e{toxinidir}/st2client
        -e{toxinidir}/st2common
        -e{toxinidir}/st2reactor
-commands =
-    nosetests -sv st2actions/tests/unit
-    nosetests -sv st2api/tests/unit
-    nosetests -sv st2auth/tests/unit
-    nosetests -sv st2client/tests/unit
-    nosetests -sv st2common/tests/unit
-    nosetests -sv st2reactor/tests/unit
-    nosetests -sv st2tests/tests/unit
+
+# Python 3 tasks
 [testenv:py36-unit]
 basepython = python3.6
 setenv = PYTHONPATH = {toxinidir}/external:{toxinidir}/st2common:{toxinidir}/st2api:{toxinidir}/st2actions:{toxinidir}/st2exporter:{toxinidir}/st2reactor:{toxinidir}/st2tests:{toxinidir}/contrib/runners/action_chain_runner:{toxinidir}/contrib/runners/local_runner:{toxinidir}/contrib/runners/windows_runner:{toxinidir}/contrib/runners/python_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/noop_runner:{toxinidir}/contrib/runners/announcement_runner:{toxinidir}/contrib/runners/remote_runner:{toxinidir}/contrib/runners/remote_runner:{toxinidir}/contrib/runners/mistral_v2:{toxinidir}/contrib/runners/orchestra:{toxinidir}/contrib/runners/inquirer_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/cloudslang_runner
@@ -78,29 +71,3 @@ commands =
     nosetests --with-timer --rednose -sv contrib/runners/mistral_v2/tests/integration/
     nosetests --with-timer --rednose -sv contrib/runners/orchestra_runner/tests/integration/
     nosetests --with-timer --rednose -sv contrib/runners/python_runner/tests/integration/
-
-[testenv:venv]
-commands = {posargs}
-
-[testenv:pylint]
-setenv = VIRTUALENV_DIR = {envdir}
-basepython = python2.7
-deps = pylint
-commands = pylint -E --rcfile=./lint-configs/python/.pylintrc st2actions st2api st2auth st2client st2common st2reactor st2tests
-
-[testenv:pylint3]
-setenv = VIRTUALENV_DIR = {envdir}
-basepython = python3.4
-deps = pylint
-commands = pylint -E --rcfile=./lint-configs/python/.pylintrc st2actions st2api st2auth st2client st2common st2reactor st2tests
-
-[testenv:flake8-py2]
-deps = flake8
-commands =
-    flake8 --config {toxinidir}/lint-configs/python/.flake8 st2actions st2api st2auth st2client st2common st2reactor st2tests
-
-[testenv:flake8-py3]
-basepython = py3: python3.4
-deps = flake8
-commands =
-    flake8 --config {toxinidir}/.flake8 st2actions st2api st2auth st2client st2common st2reactor st2tests contrib/runners


### PR DESCRIPTION
This pull request removes old and used tasks from tox.ini.

Right now only `py3-unit` and `py3-integration` tasks are used. For Python 2.7 we mostly use make targets.

For consistently reasons we should probably move other Python 2.7 lint and test targets into tox.ini (or vise versa).