### PR TITLE
Rename a misleading variable name

### DIFF
--- a/st2api/st2api/controllers/v1/pack_configs.py
+++ b/st2api/st2api/controllers/v1/pack_configs.py
@@ -94,7 +94,7 @@ class PackConfigsController(ResourceController, BaseRestControllerMixin):
 
         return self._get_one_by_pack_ref(pack_ref=pack_ref, from_model_kwargs=from_model_kwargs)
 
-    def put(self, pack_uninstall_request, pack_ref, requester_user, show_secrets=False):
+    def put(self, pack_config_content, pack_ref, requester_user, show_secrets=False):
         """
             Create a new config for a pack.
 
@@ -103,7 +103,7 @@ class PackConfigsController(ResourceController, BaseRestControllerMixin):
         """
 
         try:
-            config_api = ConfigAPI(pack=pack_ref, values=vars(pack_uninstall_request))
+            config_api = ConfigAPI(pack=pack_ref, values=vars(pack_config_content))
             config_api.validate(validate_against_schema=True)
         except jsonschema.ValidationError as e:
             raise ValueValidationException(str(e))

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -8,7 +8,7 @@ info:
   version: "1.0.0"
   title: StackStorm API
   description: |
-    
+
     ## Welcome
 
     Welcome to the StackStorm API Reference documentation! You can use the StackStorm API to integrate StackStorm with 3rd-party systems and custom applications. Example integrations include writing your own self-service user portal, or integrating with other orchestration systems.
@@ -197,7 +197,7 @@ info:
     Join our [Slack Community](https://stackstorm.com/community-signup) to get help from the engineering team and fellow users. You can also create issues against the main [StackStorm GitHub repo](https://github.com/StackStorm/st2/issues), or the [st2apidocs repo](https://github.com/StackStorm/st2apidocs) for documentation-specific issues.
 
     We also recommend reviewing the main [StackStorm documentation](https://docs.stackstorm.com/).
-    
+
 
 paths:
   /api/v1/:
@@ -1421,7 +1421,7 @@ paths:
   /api/v1/keys:
     get:
       operationId: st2api.controllers.v1.keyvalue:key_value_pair_controller.get_all
-      x-permissions: 
+      x-permissions:
       description: Returns a list of all key value pairs.
       parameters:
         - name: prefix
@@ -1987,7 +1987,7 @@ paths:
           description: Pack ref to create config.
           type: string
           required: true
-        - name: pack_uninstall_request
+        - name: pack_config_content
           in: body
           description: Pack config content
           schema:

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -1983,7 +1983,7 @@ paths:
           description: Pack ref to create config.
           type: string
           required: true
-        - name: pack_uninstall_request
+        - name: pack_config_content
           in: body
           description: Pack config content
           schema:


### PR DESCRIPTION
Rename pack_uninstall_request variable to pack_config_values as it was confusing.