### PR TITLE
Add a basic example for orchestra runner

### DIFF
--- a/contrib/examples/actions/orchestra-basic.yaml
+++ b/contrib/examples/actions/orchestra-basic.yaml
@@ -1,0 +1,14 @@
+---
+name: orchestra-basic
+pack: examples
+description: Run a local linux command
+runner_type: orchestra
+entry_point: workflows/orchestra-basic.yaml
+enabled: true
+parameters:
+  cmd:
+    required: true
+    type: string
+  timeout:
+    type: integer
+    default: 60

--- a/contrib/examples/actions/workflows/orchestra-basic.yaml
+++ b/contrib/examples/actions/workflows/orchestra-basic.yaml
@@ -1,0 +1,19 @@
+version: 1.0
+
+description: A basic workflow that runs an arbitrary linux command.
+
+input:
+  - cmd
+  - timeout
+
+tasks:
+  task1:
+    action: core.local cmd=<% ctx(cmd) %> timeout=<% ctx(timeout) %>
+    next:
+      - when: <% succeeded() %>
+        publish:
+          - stdout: <% result().stdout %>
+          - stderr: <% result().stderr %>
+
+output:
+  - stdout: <% ctx(stdout) %>


### PR DESCRIPTION
Add a basic workflow examples.orchestra-basic which is equivalent to the examples.mistral-basic.