### PR TITLE
Add missing logrotate entry for new st2workflowengine service

### DIFF
--- a/conf/logrotate.conf
+++ b/conf/logrotate.conf
@@ -110,6 +110,15 @@ notifempty
   endscript
 }
 
+## Workflow Engine
+/var/log/st2/st2workflowengine*.log {
+  daily
+  rotate 5
+  postrotate
+    st2ctl reopen-log-files st2workflowengine > /dev/null
+  endscript
+}
+
 ## Garbage collector
 /var/log/st2/st2garbagecollector*.log {
   daily


### PR DESCRIPTION
We were missing a logrotate entry for the new `st2workflowengine` service.