### PR TITLE
Add more logging for the workflow engine

### DIFF
--- a/st2common/st2common/services/workflows.py
+++ b/st2common/st2common/services/workflows.py
@@ -77,6 +77,9 @@ def inspect(wf_spec):
 
 
 def request(wf_def, ac_ex_db, st2_ctx):
+    wf_ac_ex_id = str(ac_ex_db.id)
+    LOG.info('[%s] Processing action execution request for workflow.', wf_ac_ex_id)
+
     # Load workflow definition into workflow spec model.
     spec_module = specs_loader.get_spec_module('native')
     wf_spec = spec_module.instantiate(wf_def)
@@ -127,12 +130,16 @@ def request(wf_def, ac_ex_db, st2_ctx):
 
     # Insert new record into the database and publish to the message bus.
     wf_ex_db = wf_db_access.WorkflowExecution.insert(wf_ex_db, publish=True)
+    LOG.info('[%s] Workflow execution "%s" created.', wf_ac_ex_id, str(wf_ex_db.id))
 
     return wf_ex_db
 
 
 @retrying.retry(retry_on_exception=wf_exc.retry_on_exceptions)
 def request_pause(ac_ex_db):
+    wf_ac_ex_id = str(ac_ex_db.id)
+    LOG.info('[%s] Processing pause request for workflow.', wf_ac_ex_id)
+
     wf_ex_dbs = wf_db_access.WorkflowExecution.query(action_execution=str(ac_ex_db.id))
 
     if not wf_ex_dbs:
@@ -158,11 +165,16 @@ def request_pause(ac_ex_db):
     wf_ex_db.flow = conductor.flow.serialize()
     wf_ex_db = wf_db_access.WorkflowExecution.update(wf_ex_db, publish=False)
 
+    LOG.info('[%s] Completed processing pause request for workflow.', wf_ac_ex_id)
+
     return wf_ex_db
 
 
 @retrying.retry(retry_on_exception=wf_exc.retry_on_exceptions)
 def request_resume(ac_ex_db):
+    wf_ac_ex_id = str(ac_ex_db.id)
+    LOG.info('[%s] Processing resume request for workflow.', wf_ac_ex_id)
+
     wf_ex_dbs = wf_db_access.WorkflowExecution.query(action_execution=str(ac_ex_db.id))
 
     if not wf_ex_dbs:
@@ -197,11 +209,16 @@ def request_resume(ac_ex_db):
     # Publish state change.
     wf_db_access.WorkflowExecution.publish_status(wf_ex_db)
 
+    LOG.info('[%s] Completed processing resume request for workflow.', wf_ac_ex_id)
+
     return wf_ex_db
 
 
 @retrying.retry(retry_on_exception=wf_exc.retry_on_exceptions)
 def request_cancellation(ac_ex_db):
+    wf_ac_ex_id = str(ac_ex_db.id)
+    LOG.info('[%s] Processing cancelation request for workflow.', wf_ac_ex_id)
+
     wf_ex_dbs = wf_db_access.WorkflowExecution.query(action_execution=str(ac_ex_db.id))
 
     if not wf_ex_dbs:
@@ -231,13 +248,19 @@ def request_cancellation(ac_ex_db):
     root_ac_ex_db = ac_svc.get_root_execution(ac_ex_db)
 
     if root_ac_ex_db != ac_ex_db and root_ac_ex_db.status not in ac_const.LIVEACTION_CANCEL_STATES:
+        LOG.info('[%s] Cascading cancelation request to parent workflow.', wf_ac_ex_id)
         root_lv_ac_db = lv_db_access.LiveAction.get(id=root_ac_ex_db.liveaction['id'])
         ac_svc.request_cancellation(root_lv_ac_db, None)
+
+    LOG.info('[%s] Completed processing cancelation request for workflow.', wf_ac_ex_id)
 
     return wf_ex_db
 
 
 def request_task_execution(wf_ex_db, task_id, task_spec, task_ctx, st2_ctx):
+    wf_ac_ex_id = wf_ex_db.action_execution
+    LOG.info('[%s] Processing task execution request for "%s".', wf_ac_ex_id, task_id)
+
     # Create a record for task execution.
     task_ex_db = wf_db_models.TaskExecutionDB(
         workflow_execution=str(wf_ex_db.id),
@@ -250,6 +273,8 @@ def request_task_execution(wf_ex_db, task_id, task_spec, task_ctx, st2_ctx):
 
     # Insert new record into the database.
     task_ex_db = wf_db_access.TaskExecution.insert(task_ex_db, publish=False)
+    task_ex_id = str(task_ex_db.id)
+    LOG.info('[%s] Task execution "%s" created for task "%s".', wf_ac_ex_id, task_ex_id, task_id)
 
     try:
         # Return here if no action is specified in task spec.
@@ -303,12 +328,20 @@ def request_task_execution(wf_ex_db, task_id, task_spec, task_ctx, st2_ctx):
         )
 
         # Request action execution.
-        ac_svc.request(lv_ac_db)
+        lv_ac_db, ac_ex_db = ac_svc.request(lv_ac_db)
+
+        LOG.info(
+            '[%s] Action execution "%s" requested for task "%s".',
+            wf_ac_ex_id,
+            str(ac_ex_db.id),
+            task_id
+        )
 
         # Set the task execution to running.
         task_ex_db.status = states.RUNNING
         task_ex_db = wf_db_access.TaskExecution.update(task_ex_db, publish=False)
     except Exception as e:
+        LOG.exception('[%s] Failed task execution for task "%s".', wf_ac_ex_id, task_id)
         result = {'errors': [{'message': str(e), 'task_id': task_ex_db.task_id}]}
         update_task_execution(str(task_ex_db.id), states.FAILED, result)
         raise e
@@ -325,7 +358,19 @@ def handle_action_execution_pause(ac_ex_db):
         )
 
     # Get related record identifiers.
+    wf_ex_id = ac_ex_db.context['orchestra']['workflow_execution_id']
     task_ex_id = ac_ex_db.context['orchestra']['task_execution_id']
+
+    # Get execution records for logging purposes.
+    wf_ex_db = wf_db_access.WorkflowExecution.get_by_id(wf_ex_id)
+    task_ex_db = wf_db_access.TaskExecution.get_by_id(task_ex_id)
+
+    LOG.info(
+        '[%s] Handling pause of action execution "%s" for task "%s".',
+        wf_ex_db.action_execution,
+        str(ac_ex_db.id),
+        task_ex_db.task_id
+    )
 
     # Updat task execution
     update_task_execution(task_ex_id, ac_ex_db.status)
@@ -341,8 +386,20 @@ def handle_action_execution_resume(ac_ex_db):
             '%s is not an orchestra workflow task.' % str(ac_ex_db.id)
         )
 
+    # Get related record identifiers.
     wf_ex_id = ac_ex_db.context['orchestra']['workflow_execution_id']
     task_ex_id = ac_ex_db.context['orchestra']['task_execution_id']
+
+    # Get execution records for logging purposes.
+    wf_ex_db = wf_db_access.WorkflowExecution.get_by_id(wf_ex_id)
+    task_ex_db = wf_db_access.TaskExecution.get_by_id(task_ex_id)
+
+    LOG.info(
+        '[%s] Handling resume of action execution "%s" for task "%s".',
+        wf_ex_db.action_execution,
+        str(ac_ex_db.id),
+        task_ex_db.task_id
+    )
 
     # Updat task execution to running.
     resume_task_execution(task_ex_id)
@@ -378,6 +435,17 @@ def handle_action_execution_completion(ac_ex_db):
     # Get related record identifiers.
     wf_ex_id = ac_ex_db.context['orchestra']['workflow_execution_id']
     task_ex_id = ac_ex_db.context['orchestra']['task_execution_id']
+
+    # Get execution records for logging purposes.
+    wf_ex_db = wf_db_access.WorkflowExecution.get_by_id(wf_ex_id)
+    task_ex_db = wf_db_access.TaskExecution.get_by_id(task_ex_id)
+
+    LOG.info(
+        '[%s] Handling completion of action execution "%s" for task "%s".',
+        wf_ex_db.action_execution,
+        str(ac_ex_db.id),
+        task_ex_db.task_id
+    )
 
     # Update task execution if completed.
     update_task_execution(task_ex_id, ac_ex_db.status, ac_ex_db.result)
@@ -543,6 +611,9 @@ def fail_workflow_execution(wf_ex_id, exception, task_id=None):
 def update_execution_records(wf_ex_db, conductor, update_lv_ac_on_states=None,
                              pub_wf_ex=False, pub_lv_ac=True, pub_ac_ex=True):
 
+    wf_ac_ex_id = wf_ex_db.action_execution
+    wf_old_status = wf_ex_db.status
+
     # Update timestamp and output if workflow is completed.
     if conductor.get_workflow_state() in states.COMPLETED_STATES:
         wf_ex_db.end_timestamp = date_utils.get_datetime_utc_now()
@@ -553,6 +624,15 @@ def update_execution_records(wf_ex_db, conductor, update_lv_ac_on_states=None,
     wf_ex_db.errors = copy.deepcopy(conductor.errors)
     wf_ex_db.flow = conductor.flow.serialize()
     wf_ex_db = wf_db_access.WorkflowExecution.update(wf_ex_db, publish=pub_wf_ex)
+
+    # Add log entry if status changed.
+    if wf_old_status != wf_ex_db.status:
+        LOG.info(
+            '[%s] Updated workflow execution from state "%s" to "%s".',
+            wf_ac_ex_id,
+            wf_old_status,
+            wf_ex_db.status
+        )
 
     # Return if workflow execution status is not specified in update_lv_ac_on_states.
     if isinstance(update_lv_ac_on_states, list) and wf_ex_db.status not in update_lv_ac_on_states:
@@ -567,6 +647,13 @@ def update_execution_records(wf_ex_db, conductor, update_lv_ac_on_states=None,
 
     if wf_ex_db.status in states.ABENDED_STATES:
         result['errors'] = wf_ex_db.errors
+
+        for wf_ex_error in wf_ex_db.errors:
+            LOG.error(
+                '[%s] Workflow execution completed with errors.',
+                wf_ac_ex_id,
+                extra=wf_ex_error
+            )
 
     # Sync update with corresponding liveaction and action execution.
     wf_lv_ac_db = ac_db_util.update_liveaction_status(


### PR DESCRIPTION
Add more logging in st2workflowengine and st2notifier to be able to trace workflow execution from log messages.

Note: The root action execution ID is used for the identifier to grep from logs.

### Example for a workflow execution that failed.

```

ubuntu@cadmus:~/projects/stackstorm/st2$ st2 run examples.orchestra-fail-input-rendering
.
id: 5b3296148006e62048ad4525
action.ref: examples.orchestra-fail-input-rendering
parameters: None
status: failed
start_timestamp: Tue, 26 Jun 2018 19:37:55 UTC
end_timestamp: Tue, 26 Jun 2018 19:37:56 UTC
result: 
  errors:
  - message: Unknown function "#property#value"
  output: null

ubuntu@cadmus:~/projects/stackstorm/st2$ tail -n 100 ./logs/st2workflowengine.log | grep 5b3296148006e62048ad4525
2018-06-26 19:37:56,349 139832784608144 INFO workflows [-] [5b3296148006e62048ad4525] Processing request for workflow execution.
2018-06-26 19:37:56,368 139832784608144 INFO workflows [-] [5b3296148006e62048ad4525] No next tasks identified for workflow execution.
2018-06-26 19:37:56,397 139832784608144 ERROR workflows [-] [5b3296148006e62048ad4525] Workflow execution completed with errors. (message=u'Unknown function "#property#value"')
2018-06-26 19:37:56,508 139832784608144 INFO workflows [-] [5b3296148006e62048ad4525] Workflow execution is in completed state "failed".
```

### Example of a successful run.

```
ubuntu@cadmus:~/projects/stackstorm/st2$ tail -n 100 ./logs/st2workflowengine.log | grep 5b3296148006e62048ad4525
2018-06-26 19:37:56,349 139832784608144 INFO workflows [-] [5b3296148006e62048ad4525] Processing request for workflow execution.
2018-06-26 19:37:56,368 139832784608144 INFO workflows [-] [5b3296148006e62048ad4525] No next tasks identified for workflow execution.
2018-06-26 19:37:56,397 139832784608144 ERROR workflows [-] [5b3296148006e62048ad4525] Workflow execution completed with errors. (message=u'Unknown function "#property#value"')
2018-06-26 19:37:56,508 139832784608144 INFO workflows [-] [5b3296148006e62048ad4525] Workflow execution is in completed state "failed".

ubuntu@cadmus:~/projects/stackstorm/st2$ st2 run examples.orchestra-join
....
id: 5b32970a8006e62048ad4528
action.ref: examples.orchestra-join
parameters: None
status: succeeded
start_timestamp: Tue, 26 Jun 2018 19:42:02 UTC
end_timestamp: Tue, 26 Jun 2018 19:42:09 UTC
result: 
  output:
    messages:
    - Fee fi fo fum
    - I smell the blood of an English man
    - Be alive, or be he dead
    - I'll grind his bones to make my bread
+--------------------------+------------------------+--------+-----------+-----------------+
| id                       | status                 | task   | action    | start_timestamp |
+--------------------------+------------------------+--------+-----------+-----------------+
| 5b32970b8006e61ff965db96 | succeeded (0s elapsed) | task1  | core.noop | Tue, 26 Jun     |
|                          |                        |        |           | 2018 19:42:03   |
|                          |                        |        |           | UTC             |
| 5b32970c8006e6200cb1a8ee | succeeded (0s elapsed) | task2  | core.echo | Tue, 26 Jun     |
|                          |                        |        |           | 2018 19:42:04   |
|                          |                        |        |           | UTC             |
| 5b32970c8006e6200cb1a8f1 | succeeded (1s elapsed) | task4  | core.echo | Tue, 26 Jun     |
|                          |                        |        |           | 2018 19:42:04   |
|                          |                        |        |           | UTC             |
| 5b32970c8006e6200cb1a8f4 | succeeded (1s elapsed) | task6  | core.noop | Tue, 26 Jun     |
|                          |                        |        |           | 2018 19:42:04   |
|                          |                        |        |           | UTC             |
| 5b32970c8006e6200cb1a8f7 | succeeded (1s elapsed) | task8  | core.noop | Tue, 26 Jun     |
|                          |                        |        |           | 2018 19:42:04   |
|                          |                        |        |           | UTC             |
| 5b32970d8006e6200cb1a8fa | succeeded (1s elapsed) | task3  | core.echo | Tue, 26 Jun     |
|                          |                        |        |           | 2018 19:42:05   |
|                          |                        |        |           | UTC             |
| 5b32970e8006e6200cb1a8fe | succeeded (1s elapsed) | task5  | core.noop | Tue, 26 Jun     |
|                          |                        |        |           | 2018 19:42:06   |
|                          |                        |        |           | UTC             |
| 5b32970f8006e6200cb1a900 | succeeded (1s elapsed) | task9  | core.noop | Tue, 26 Jun     |
|                          |                        |        |           | 2018 19:42:06   |
|                          |                        |        |           | UTC             |
| 5b32970f8006e6200cb1a903 | succeeded (1s elapsed) | task7  | core.echo | Tue, 26 Jun     |
|                          |                        |        |           | 2018 19:42:07   |
|                          |                        |        |           | UTC             |
| 5b3297108006e6200cb1a906 | succeeded (1s elapsed) | task10 | core.noop | Tue, 26 Jun     |
|                          |                        |        |           | 2018 19:42:08   |
|                          |                        |        |           | UTC             |
+--------------------------+------------------------+--------+-----------+-----------------+
ubuntu@cadmus:~/projects/stackstorm/st2$ tail -n 1000 ./logs/st2workflowengine.log | grep "\[5b32970a8006e62048ad4528\]"
2018-06-26 19:42:03,233 139832784607504 INFO workflows [-] [5b32970a8006e62048ad4528] Processing request for workflow execution.
2018-06-26 19:42:03,265 139832784607504 INFO workflows [-] [5b32970a8006e62048ad4528] Mark task "task1" as running.
2018-06-26 19:42:03,313 139832784607504 INFO workflows [-] [5b32970a8006e62048ad4528] Updated workflow execution from state "requested" to "running".
2018-06-26 19:42:03,375 139832784607504 INFO workflows [-] [5b32970a8006e62048ad4528] Requesting execution for task "task1".
2018-06-26 19:42:03,376 139832784607504 INFO workflows [-] [5b32970a8006e62048ad4528] Processing task execution request for "task1".
2018-06-26 19:42:03,390 139832784607504 INFO workflows [-] [5b32970a8006e62048ad4528] Task execution "5b32970b8006e61ff965db94" created for task "task1".
2018-06-26 19:42:03,535 139832784607504 INFO workflows [-] [5b32970a8006e62048ad4528] Action execution "5b32970b8006e61ff965db96" requested for task "task1".
2018-06-26 19:42:03,544 139832784607504 INFO workflows [-] [5b32970a8006e62048ad4528] Identifying more tasks for workflow execution.
ubuntu@cadmus:~/projects/stackstorm/st2$ tail -n 1000 ./logs/st2notifier.log | grep "\[5b32970a8006e62048ad4528\]"
2018-06-26 19:42:03,818 140001938553904 INFO workflows [-] [5b32970a8006e62048ad4528] Handling completion of action execution "5b32970b8006e61ff965db96" for task "task1".
2018-06-26 19:42:03,987 140001938553904 INFO workflows [-] [5b32970a8006e62048ad4528] Processing task execution request for "task2".
2018-06-26 19:42:03,991 140001938553904 INFO workflows [-] [5b32970a8006e62048ad4528] Task execution "5b32970b8006e6200cb1a8ec" created for task "task2".
2018-06-26 19:42:04,168 140001938553904 INFO workflows [-] [5b32970a8006e62048ad4528] Action execution "5b32970c8006e6200cb1a8ee" requested for task "task2".
2018-06-26 19:42:04,175 140001938553904 INFO workflows [-] [5b32970a8006e62048ad4528] Processing task execution request for "task4".
2018-06-26 19:42:04,179 140001938553904 INFO workflows [-] [5b32970a8006e62048ad4528] Task execution "5b32970c8006e6200cb1a8ef" created for task "task4".
2018-06-26 19:42:04,383 140001938553904 INFO workflows [-] [5b32970a8006e62048ad4528] Action execution "5b32970c8006e6200cb1a8f1" requested for task "task4".
2018-06-26 19:42:04,391 140001938553904 INFO workflows [-] [5b32970a8006e62048ad4528] Processing task execution request for "task6".
2018-06-26 19:42:04,396 140001938553904 INFO workflows [-] [5b32970a8006e62048ad4528] Task execution "5b32970c8006e6200cb1a8f2" created for task "task6".
2018-06-26 19:42:04,538 140001938553904 INFO workflows [-] [5b32970a8006e62048ad4528] Action execution "5b32970c8006e6200cb1a8f4" requested for task "task6".
2018-06-26 19:42:04,546 140001938553904 INFO workflows [-] [5b32970a8006e62048ad4528] Processing task execution request for "task8".
2018-06-26 19:42:04,551 140001938553904 INFO workflows [-] [5b32970a8006e62048ad4528] Task execution "5b32970c8006e6200cb1a8f5" created for task "task8".
2018-06-26 19:42:04,830 140001938553904 INFO workflows [-] [5b32970a8006e62048ad4528] Action execution "5b32970c8006e6200cb1a8f7" requested for task "task8".
2018-06-26 19:42:04,996 140001936059920 INFO workflows [-] [5b32970a8006e62048ad4528] Handling completion of action execution "5b32970c8006e6200cb1a8ee" for task "task2".
2018-06-26 19:42:05,459 140001936059920 INFO workflows [-] [5b32970a8006e62048ad4528] Processing task execution request for "task3".
2018-06-26 19:42:05,504 140001936059920 INFO workflows [-] [5b32970a8006e62048ad4528] Task execution "5b32970d8006e6200cb1a8f8" created for task "task3".
2018-06-26 19:42:05,534 140001935553712 INFO workflows [-] [5b32970a8006e62048ad4528] Handling completion of action execution "5b32970c8006e6200cb1a8f1" for task "task4".
2018-06-26 19:42:05,844 140001935553872 INFO workflows [-] [5b32970a8006e62048ad4528] Handling completion of action execution "5b32970c8006e6200cb1a8f7" for task "task8".
2018-06-26 19:42:06,012 140001935556112 INFO workflows [-] [5b32970a8006e62048ad4528] Handling completion of action execution "5b32970c8006e6200cb1a8f4" for task "task6".
2018-06-26 19:42:06,301 140001935553712 INFO workflows [-] [5b32970a8006e62048ad4528] Processing task execution request for "task5".
2018-06-26 19:42:06,337 140001935553712 INFO workflows [-] [5b32970a8006e62048ad4528] Task execution "5b32970e8006e6200cb1a8fb" created for task "task5".
2018-06-26 19:42:06,367 140001935553872 INFO workflows [-] [5b32970a8006e62048ad4528] Processing task execution request for "task9".
2018-06-26 19:42:06,462 140001935553872 INFO workflows [-] [5b32970a8006e62048ad4528] Task execution "5b32970e8006e6200cb1a8fc" created for task "task9".
2018-06-26 19:42:06,487 140001936059920 INFO workflows [-] [5b32970a8006e62048ad4528] Action execution "5b32970d8006e6200cb1a8fa" requested for task "task3".
2018-06-26 19:42:06,857 140001935553712 INFO workflows [-] [5b32970a8006e62048ad4528] Action execution "5b32970e8006e6200cb1a8fe" requested for task "task5".
2018-06-26 19:42:06,963 140001934659088 INFO workflows [-] [5b32970a8006e62048ad4528] Handling completion of action execution "5b32970d8006e6200cb1a8fa" for task "task3".
2018-06-26 19:42:07,200 140001935556112 INFO workflows [-] [5b32970a8006e62048ad4528] Processing task execution request for "task7".
2018-06-26 19:42:07,252 140001935556112 INFO workflows [-] [5b32970a8006e62048ad4528] Task execution "5b32970f8006e6200cb1a901" created for task "task7".
2018-06-26 19:42:07,397 140001933809456 INFO workflows [-] [5b32970a8006e62048ad4528] Handling completion of action execution "5b32970e8006e6200cb1a8fe" for task "task5".
2018-06-26 19:42:07,812 140001935553872 INFO workflows [-] [5b32970a8006e62048ad4528] Action execution "5b32970f8006e6200cb1a900" requested for task "task9".
2018-06-26 19:42:08,002 140001935553072 INFO workflows [-] [5b32970a8006e62048ad4528] Handling completion of action execution "5b32970f8006e6200cb1a900" for task "task9".
2018-06-26 19:42:08,388 140001935556112 INFO workflows [-] [5b32970a8006e62048ad4528] Action execution "5b32970f8006e6200cb1a903" requested for task "task7".
2018-06-26 19:42:08,659 140001935556112 INFO workflows [-] [5b32970a8006e62048ad4528] Handling completion of action execution "5b32970f8006e6200cb1a903" for task "task7".
2018-06-26 19:42:08,839 140001935556112 INFO workflows [-] [5b32970a8006e62048ad4528] Processing task execution request for "task10".
2018-06-26 19:42:08,864 140001935556112 INFO workflows [-] [5b32970a8006e62048ad4528] Task execution "5b3297108006e6200cb1a904" created for task "task10".
2018-06-26 19:42:09,032 140001935556112 INFO workflows [-] [5b32970a8006e62048ad4528] Action execution "5b3297108006e6200cb1a906" requested for task "task10".
2018-06-26 19:42:09,377 140001934657008 INFO workflows [-] [5b32970a8006e62048ad4528] Handling completion of action execution "5b3297108006e6200cb1a906" for task "task10".
2018-06-26 19:42:09,498 140001934657008 INFO workflows [-] [5b32970a8006e62048ad4528] Updated workflow execution from state "running" to "succeeded".
```