### PR TITLE
Update Execution model in openapi

### DIFF
--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -4501,6 +4501,12 @@ definitions:
         $ref: '#/definitions/RunnerType'
       liveaction:
         $ref: '#/definitions/LiveAction'
+      workflow_execution:
+        type: string
+        required: False
+      task_execution:
+        type: string
+        required: False
       status:
         description: The current status of the action execution.
         type: string

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -4497,6 +4497,12 @@ definitions:
         $ref: '#/definitions/RunnerType'
       liveaction:
         $ref: '#/definitions/LiveAction'
+      workflow_execution:
+        type: string
+        required: False
+      task_execution:
+        type: string
+        required: False
       status:
         description: The current status of the action execution.
         type: string


### PR DESCRIPTION
As part of the Orchestra changes, workflow_execution and task_execution attributes are added to the ActionExecution model. Add these two optional fields to the openapi spec.