### PR TITLE
Add filter actions by tag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,6 @@ Added
 Added
 ~~~~~
 
-  filter values are provided, all actions are returned. (new feature) #4219
 * Orchestra - new StackStorm-native workflow engine. This is currently in **beta**. (new feature)
 * Added metrics for collecting performance and health information about the various ST2 services
   and functions. (new feature) #4004 #2974

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,14 +4,19 @@ Changelog
 in development
 --------------
 
+Added
+~~~~~
 
-2.8.0 - July 05, 2018
+* Add new ``?tags``, query param filter to the ``/v1/actions`` API endpoint. This query parameter
+  allows users to filter out actions based on the tag name . By default, when no filter values are
+  provided, all actions are returned. (new feature) #4219
+
+2.8.0 - July 10, 2018
 ---------------------
 
 Added
 ~~~~~
-* Add new ``?tags``, query params to ``/v1/actions`` API endpoint. These query parameter allow
-  users to filter out actions to receive based on the tag name . By default, when no
+
   filter values are provided, all actions are returned. (new feature) #4219
 * Orchestra - new StackStorm-native workflow engine. This is currently in **beta**. (new feature)
 * Added metrics for collecting performance and health information about the various ST2 services

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ in development
 
 Added
 ~~~~~
-
+* Add new ``?tags``, query params to ``/v1/actions`` API endpoint. These query parameter allow
+  users to filter out actions to receive based on the tag name . By default, when no
+  filter values are provided, all actions are returned. (new feature) #4219
 * Orchestra - new StackStorm-native workflow engine. This is currently in **beta**. (new feature)
 * Added metrics for collecting performance and health information about the various ST2 services
   and functions. (new feature) #4004 #2974

--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -60,7 +60,8 @@ class ActionsController(resource.ContentPackResourceController):
     access = Action
     supported_filters = {
         'name': 'name',
-        'pack': 'pack'
+        'pack': 'pack',
+        'tags': 'name'
     }
 
     query_options = {

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -288,6 +288,10 @@ paths:
           in: query
           description: Action pack name filter
           type: string
+        - name: tags
+          in: query
+          description: Action tags name filter
+          type: string
       x-parameters:
         - name: user
           in: context

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -284,6 +284,10 @@ paths:
           in: query
           description: Action pack name filter
           type: string
+        - name: tags
+          in: query
+          description: Action tags name filter
+          type: string
       x-parameters:
         - name: user
           in: context


### PR DESCRIPTION
This PR adds the functionality to filter actions on `/api/v1/actions` endpoint by tags.
For example:
https://{host}/api/v1/actions?tags=test

Will return all actions that are tagged with the name test.
