### PR TITLE
Fix "proxy" authentication mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 in development
 --------------
 
+* Fix ``proxy`` st2auth authentication mode which has been inadvertently broken when we moved to
+  OpenAPI for the API layer. (bug fix) #4224
+
+in development
+--------------
+
 Added
 ~~~~~
 

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -4983,7 +4983,9 @@ definitions:
           type: string
     additionalProperties: false
   TokenRequest:
-    type: object
+    type:
+      - object
+      - 'string'
     properties:
       ttl:
         type:

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -4129,11 +4129,11 @@ paths:
             $ref: '#/definitions/TokenRequest'
       x-parameters:
         - name: remote_addr
-          in: environ
+          in: header
           description: source of the request
           type: string
         - name: remote_user
-          in: environ
+          in: header
           description: set externally to indicate user identity in case of proxy auth
           type: string
       responses:

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -4979,7 +4979,9 @@ definitions:
           type: string
     additionalProperties: false
   TokenRequest:
-    type: object
+    type:
+      - object
+      - 'string'
     properties:
       ttl:
         type:

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -4125,11 +4125,11 @@ paths:
             $ref: '#/definitions/TokenRequest'
       x-parameters:
         - name: remote_addr
-          in: environ
+          in: header
           description: source of the request
           type: string
         - name: remote_user
-          in: environ
+          in: header
           description: set externally to indicate user identity in case of proxy auth
           type: string
       responses:

--- a/st2common/st2common/router.py
+++ b/st2common/st2common/router.py
@@ -357,7 +357,6 @@ class Router(object):
                     req.body = b'{}'
 
                 try:
-
                     if content_type == 'application/json':
                         data = req.json
                     elif content_type == 'text/plain':

--- a/st2common/st2common/router.py
+++ b/st2common/st2common/router.py
@@ -347,16 +347,17 @@ class Router(object):
             elif source == 'request':
                 kw[argument_name] = getattr(req, name)
             elif source == 'body':
-                # Note: We also want to perform validation if no body is explicitly provided - in a
-                # lot of POST, PUT scenarios, body is mandatory
-                if not req.body:
-                    req.body = b'{}'
-
                 content_type = req.headers.get('Content-Type', 'application/json')
                 content_type = parse_content_type_header(content_type=content_type)[0]
                 schema = param['schema']
 
+                # Note: We also want to perform validation if no body is explicitly provided - in a
+                # lot of POST, PUT scenarios, body is mandatory
+                if not req.body and content_type == 'application/json':
+                    req.body = b'{}'
+
                 try:
+
                     if content_type == 'application/json':
                         data = req.json
                     elif content_type == 'text/plain':


### PR DESCRIPTION
While looking into why proxy authentication mode is not working for a user (https://forum.stackstorm.com/t/how-to-enable-the-proxy-authentication-mode/198), I discovered we inadvertently broke it while moving to the OpenAPI.

This pull request fixes that.

## TODO

- [ ] Unit tests for /v1/tokens API controller (existing test was mocking API layer so we didn't actually test headers are read in correctly)