### PR TITLE
?include_attributes regression fix for /v1/executions API endpoint, update openapi.yaml

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -86,6 +86,8 @@ Fixed
   Contributed by Nick Maludy (Encore Technologies).
 * Style clean up to transport queues module and various config modules. (improvement)
 * Fixed CLI help for ``st2 action-alias match`` and ``execute``. (#4174).
+* Fix regression in ``?include_attributes`` query param filter in the ``/v1/executions`` API
+  endpoint. (bug fix) #4226
 
 2.7.2 - May 16, 2018
 --------------------

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -728,7 +728,8 @@ class ActionExecutionsController(BaseResourceIsolationControllerMixin,
 
         limit = int(limit)
 
-        LOG.debug('Retrieving all action executions with filters=%s', raw_filters)
+        LOG.debug('Retrieving all action executions with filters=%s,exclude_fields=%s,'
+                  'include_fields=%s', raw_filters, exclude_fields, include_fields)
         return super(ActionExecutionsController, self)._get_all(exclude_fields=exclude_fields,
                                                                 include_fields=include_fields,
                                                                 from_model_kwargs=from_model_kwargs,

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -730,6 +730,7 @@ class ActionExecutionsController(BaseResourceIsolationControllerMixin,
 
         LOG.debug('Retrieving all action executions with filters=%s', raw_filters)
         return super(ActionExecutionsController, self)._get_all(exclude_fields=exclude_fields,
+                                                                include_fields=include_fields,
                                                                 from_model_kwargs=from_model_kwargs,
                                                                 sort=sort,
                                                                 offset=offset,

--- a/st2api/tests/unit/controllers/v1/test_executions.py
+++ b/st2api/tests/unit/controllers/v1/test_executions.py
@@ -426,8 +426,8 @@ class ActionExecutionControllerTestCase(BaseActionExecutionControllerTestCase, F
         # NOTE: start_timestamp attribute is always included since we sort on it
 
         # 2. Valid field (single)
-        resp = self.app.get('/v1/executions?include_attributes=id')
-        self.assertEqual(len(resp.json), 5)
+        resp = self.app.get('/v1/executions?include_attributes=id&limit=1')
+        self.assertEqual(len(resp.json), 1)
         self.assertEqual(len(resp.json[0].keys()), 2)
         self.assertTrue('id' in resp.json[0])
         self.assertTrue('start_timestamp' in resp.json[0])

--- a/st2api/tests/unit/controllers/v1/test_executions.py
+++ b/st2api/tests/unit/controllers/v1/test_executions.py
@@ -433,8 +433,8 @@ class ActionExecutionControllerTestCase(BaseActionExecutionControllerTestCase, F
         self.assertTrue('start_timestamp' in resp.json[0])
 
         # 3. Valid field (single)
-        resp = self.app.get('/v1/executions?include_attributes=id,status')
-        self.assertEqual(len(resp.json), 5)
+        resp = self.app.get('/v1/executions?include_attributes=id,status&limit=1')
+        self.assertEqual(len(resp.json), 2)
         self.assertEqual(len(resp.json[0].keys()), 3)
         self.assertTrue('id' in resp.json[0])
         self.assertTrue('start_timestamp' in resp.json[0])

--- a/st2api/tests/unit/controllers/v1/test_executions.py
+++ b/st2api/tests/unit/controllers/v1/test_executions.py
@@ -414,6 +414,32 @@ class ActionExecutionControllerTestCase(BaseActionExecutionControllerTestCase, F
         resp = self.app.get('/v1/executions/100', expect_errors=True)
         self.assertEqual(resp.status_int, 404)
 
+    def test_get_all_include_attributes_filter(self):
+        # 1. Invalid field
+        resp = self.app.get('/v1/executions?include_attributes=invalid', expect_errors=True)
+
+        expected_msg = ('Invalid or unsupported include attribute specified: '
+                        'Cannot resolve field "invalid"')
+        self.assertEqual(resp.status_int, 400)
+        self.assertEqual(resp.json['faultstring'], expected_msg)
+
+        # NOTE: start_timestamp attribute is always included since we sort on it
+
+        # 2. Valid field (single)
+        resp = self.app.get('/v1/executions?include_attributes=id')
+        self.assertEqual(len(resp.json), 5)
+        self.assertEqual(len(resp.json[0].keys()), 2)
+        self.assertTrue('id' in resp.json[0])
+        self.assertTrue('start_timestamp' in resp.json[0])
+
+        # 3. Valid field (single)
+        resp = self.app.get('/v1/executions?include_attributes=id,status')
+        self.assertEqual(len(resp.json), 5)
+        self.assertEqual(len(resp.json[0].keys()), 3)
+        self.assertTrue('id' in resp.json[0])
+        self.assertTrue('start_timestamp' in resp.json[0])
+        self.assertTrue('status' in resp.json[0])
+
     def test_post_delete(self):
         post_resp = self._do_post(LIVE_ACTION_1)
         self.assertEqual(post_resp.status_int, 201)

--- a/st2api/tests/unit/controllers/v1/test_executions.py
+++ b/st2api/tests/unit/controllers/v1/test_executions.py
@@ -434,7 +434,7 @@ class ActionExecutionControllerTestCase(BaseActionExecutionControllerTestCase, F
 
         # 3. Valid field (single)
         resp = self.app.get('/v1/executions?include_attributes=id,status&limit=1')
-        self.assertEqual(len(resp.json), 2)
+        self.assertEqual(len(resp.json), 1)
         self.assertEqual(len(resp.json[0].keys()), 3)
         self.assertTrue('id' in resp.json[0])
         self.assertTrue('start_timestamp' in resp.json[0])

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -4501,6 +4501,10 @@ definitions:
         $ref: '#/definitions/RunnerType'
       liveaction:
         $ref: '#/definitions/LiveAction'
+      task_execution:
+        type: string
+      workflow_execution:
+        type: string
       status:
         description: The current status of the action execution.
         type: string

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -4497,6 +4497,10 @@ definitions:
         $ref: '#/definitions/RunnerType'
       liveaction:
         $ref: '#/definitions/LiveAction'
+      task_execution:
+        type: string
+      workflow_execution:
+        type: string
       status:
         description: The current status of the action execution.
         type: string


### PR DESCRIPTION
This pull request includes two changes:

1. It fixes regression with `?include_attributes` query param filter in the `GET /v1/executions` API endpoint
2. Updates out of sync openapi.yaml file (it was missing some new orchestra related attributes on the Execution object)