### PR TITLE
Add missing in-requirements.txt to orchestra runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 * Install Get yourself a clean 64-bit Linux box that fits the [system requirements](https://docs.stackstorm.com/install/system_requirements.html). Run the installer script:
 
-   ```
+   ```bash
    curl -sSL https://stackstorm.com/packages/install.sh | bash -s -- --user=st2admin --password=Ch@ngeMe
    ```
 * Read the docs: [https://docs.stackstorm.com/index.html](https://docs.stackstorm.com/install/index.html)

--- a/contrib/runners/orchestra_runner/in-requirements.txt
+++ b/contrib/runners/orchestra_runner/in-requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/StackStorm/orchestra.git#egg=orchestra

--- a/contrib/runners/orchestra_runner/requirements.txt
+++ b/contrib/runners/orchestra_runner/requirements.txt
@@ -1,1 +1,2 @@
+# Don't edit this file. It's generated automatically!
 git+https://github.com/StackStorm/orchestra.git#egg=orchestra

--- a/contrib/runners/winrm_runner/dist_utils.py
+++ b/contrib/runners/winrm_runner/dist_utils.py
@@ -54,13 +54,15 @@ __all__ = [
 ]
 
 
-def check_pip_version():
+def check_pip_version(min_version='6.0.0'):
     """
     Ensure that a minimum supported version of pip is installed.
     """
-    if StrictVersion(pip.__version__) < StrictVersion('6.0.0'):
-        print("Upgrade pip, your version `{0}' "
-              "is outdated:\n{1}".format(pip.__version__, GET_PIP))
+    if StrictVersion(pip.__version__) < StrictVersion(min_version):
+        print("Upgrade pip, your version '{0}' "
+              "is outdated. Minimum required version is '{1}':\n{2}".format(pip.__version__,
+                                                                            min_version,
+                                                                            GET_PIP))
         sys.exit(1)
 
 
@@ -71,8 +73,10 @@ def fetch_requirements(requirements_file_path):
     links = []
     reqs = []
     for req in parse_requirements(requirements_file_path, session=False):
-        if req.link:
-            links.append(str(req.link))
+        # Note: req.url was used before 9.0.0 and req.link is used in all the recent versions
+        link = getattr(req, 'link', getattr(req, 'url', None))
+        if link:
+            links.append(str(link))
         reqs.append(str(req.req))
     return (reqs, links)
 


### PR DESCRIPTION
#4169 changed how we handle runner `requirements.txt` files - we now generate them based on the `in-requirements.txt` file inside the runner package directory and based on the pinned dependency versions in `fixed-versions.txt` file.

This way it's consistent with other StackStorm components.

#4169 predated Orchestra changes so it was missing `in-requirements.txt` for the new orchestra runner Python package.