### PR TITLE
Re-generate sample config

### DIFF
--- a/conf/st2.conf.sample
+++ b/conf/st2.conf.sample
@@ -324,3 +324,7 @@ local_timezone = America/Los_Angeles
 # Base https URL to access st2 Web UI. This is used to construct history URLs that are sent out when chatops is used to kick off executions.
 webui_base_url = https://localhost
 
+[workflow_engine]
+# Location of the logging configuration file.
+logging = conf/logging.workflowengine.conf
+

--- a/tools/config_gen.py
+++ b/tools/config_gen.py
@@ -27,6 +27,7 @@ from oslo_config import cfg
 CONFIGS = ['st2actions.config',
            'st2actions.notifier.config',
            'st2actions.resultstracker.config',
+           'st2actions.workflows.config',
            'st2api.config',
            'st2stream.config',
            'st2auth.config',


### PR DESCRIPTION
Sample config was missing new `workflow_engine` section.

Resolved #4233 reported by @nmaludy.