### PR TITLE
Update runner packages to read version from runner package local __init__.py file

### DIFF
--- a/contrib/runners/action_chain_runner/action_chain_runner/__init__.py
+++ b/contrib/runners/action_chain_runner/action_chain_runner/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__version__ = '2.9dev'

--- a/contrib/runners/action_chain_runner/setup.py
+++ b/contrib/runners/action_chain_runner/setup.py
@@ -23,6 +23,8 @@ from setuptools import find_packages
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 
+from action_chain_runner import __version__
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
 
@@ -31,7 +33,7 @@ install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 apply_vagrant_workaround()
 setup(
     name='stackstorm-runner-action-chain',
-    version='2.5.0',
+    version=__version__,
     description=('Action-Chain workflow action runner for StackStorm event-driven '
                  'automation platform'),
     author='StackStorm',

--- a/contrib/runners/announcement_runner/announcement_runner/__init__.py
+++ b/contrib/runners/announcement_runner/announcement_runner/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__version__ = '2.9dev'

--- a/contrib/runners/announcement_runner/setup.py
+++ b/contrib/runners/announcement_runner/setup.py
@@ -23,6 +23,8 @@ from setuptools import find_packages
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 
+from announcement_runner import __version__
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
 
@@ -31,7 +33,7 @@ install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 apply_vagrant_workaround()
 setup(
     name='stackstorm-runner-announcement',
-    version='2.5.0',
+    version=__version__,
     description=('Announcement action runner for StackStorm event-driven automation platform'),
     author='StackStorm',
     author_email='info@stackstorm.com',

--- a/contrib/runners/cloudslang_runner/cloudslang_runner/__init__.py
+++ b/contrib/runners/cloudslang_runner/cloudslang_runner/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__version__ = '2.9dev'

--- a/contrib/runners/cloudslang_runner/setup.py
+++ b/contrib/runners/cloudslang_runner/setup.py
@@ -23,6 +23,8 @@ from setuptools import find_packages
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 
+from cloudslang_runner import __version__
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
 
@@ -31,7 +33,7 @@ install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 apply_vagrant_workaround()
 setup(
     name='stackstorm-runner-cloudslang',
-    version='2.5.0',
+    version=__version__,
     description=('CloudSlang action runner for StackStorm event-driven automation platform'),
     author='StackStorm',
     author_email='info@stackstorm.com',

--- a/contrib/runners/http_runner/http_runner/__init__.py
+++ b/contrib/runners/http_runner/http_runner/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__version__ = '2.9dev'

--- a/contrib/runners/http_runner/setup.py
+++ b/contrib/runners/http_runner/setup.py
@@ -23,6 +23,8 @@ from setuptools import find_packages
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 
+from http_runner import __version__
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
 
@@ -31,7 +33,7 @@ install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 apply_vagrant_workaround()
 setup(
     name='stackstorm-runner-http',
-    version='2.5.0',
+    version=__version__,
     description=('HTTP(s) action runner for StackStorm event-driven automation platform'),
     author='StackStorm',
     author_email='info@stackstorm.com',

--- a/contrib/runners/inquirer_runner/inquirer_runner/__init__.py
+++ b/contrib/runners/inquirer_runner/inquirer_runner/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__version__ = '2.9dev'

--- a/contrib/runners/inquirer_runner/setup.py
+++ b/contrib/runners/inquirer_runner/setup.py
@@ -23,6 +23,8 @@ from setuptools import find_packages
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 
+from inquirer_runner import __version__
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
 
@@ -31,7 +33,7 @@ install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 apply_vagrant_workaround()
 setup(
     name='stackstorm-runner-inquirer',
-    version='2.5.0',
+    version=__version__,
     description=('Inquirer action runner for StackStorm event-driven automation platform'),
     author='StackStorm',
     author_email='info@stackstorm.com',

--- a/contrib/runners/local_runner/local_runner/__init__.py
+++ b/contrib/runners/local_runner/local_runner/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__version__ = '2.9dev'

--- a/contrib/runners/local_runner/setup.py
+++ b/contrib/runners/local_runner/setup.py
@@ -23,6 +23,8 @@ from setuptools import find_packages
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 
+from local_runner import __version__
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
 
@@ -31,7 +33,7 @@ install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 apply_vagrant_workaround()
 setup(
     name='stackstorm-runner-local',
-    version='2.5.0',
+    version=__version__,
     description=('Local Shell Command and Script action runner for StackStorm event-driven '
                  'automation platform'),
     author='StackStorm',

--- a/contrib/runners/mistral_v2/mistral_v2/__init__.py
+++ b/contrib/runners/mistral_v2/mistral_v2/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__version__ = '2.9dev'

--- a/contrib/runners/mistral_v2/setup.py
+++ b/contrib/runners/mistral_v2/setup.py
@@ -23,6 +23,8 @@ from setuptools import find_packages
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 
+from mistral_v2 import __version__
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
 
@@ -31,7 +33,7 @@ install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 apply_vagrant_workaround()
 setup(
     name='stackstorm-runner-mistral-v2',
-    version='2.5.0',
+    version=__version__,
     description=('Mistral v2 workflow action runner for StackStorm event-driven '
                  'automation platform'),
     author='StackStorm',

--- a/contrib/runners/noop_runner/noop_runner/__init__.py
+++ b/contrib/runners/noop_runner/noop_runner/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__version__ = '2.9dev'

--- a/contrib/runners/noop_runner/setup.py
+++ b/contrib/runners/noop_runner/setup.py
@@ -23,6 +23,8 @@ from setuptools import find_packages
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 
+from noop_runner import __version__
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
 
@@ -31,7 +33,7 @@ install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 apply_vagrant_workaround()
 setup(
     name='stackstorm-runner-noop',
-    version='2.5.0',
+    version=__version__,
     description=('No-Op action runner for StackStorm event-driven automation platform'),
     author='StackStorm',
     author_email='info@stackstorm.com',

--- a/contrib/runners/orchestra_runner/orchestra_runner/__init__.py
+++ b/contrib/runners/orchestra_runner/orchestra_runner/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__version__ = '2.9dev'

--- a/contrib/runners/orchestra_runner/setup.py
+++ b/contrib/runners/orchestra_runner/setup.py
@@ -23,6 +23,8 @@ from setuptools import find_packages
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 
+from orchestra_runner import __version__
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
 
@@ -31,7 +33,7 @@ install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 apply_vagrant_workaround()
 setup(
     name='stackstorm-runner-orchestra',
-    version='2.5.0',
+    version=__version__,
     description='Orchestra workflow runner for StackStorm event-driven automation platform',
     author='StackStorm',
     author_email='info@stackstorm.com',

--- a/contrib/runners/python_runner/python_runner/__init__.py
+++ b/contrib/runners/python_runner/python_runner/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__version__ = '2.9dev'

--- a/contrib/runners/python_runner/setup.py
+++ b/contrib/runners/python_runner/setup.py
@@ -23,6 +23,8 @@ from setuptools import find_packages
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 
+from python_runner import __version__
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
 
@@ -31,7 +33,7 @@ install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 apply_vagrant_workaround()
 setup(
     name='stackstorm-runner-python',
-    version='2.5.0',
+    version=__version__,
     description='Python action runner for StackStorm event-driven automation platform',
     author='StackStorm',
     author_email='info@stackstorm.com',

--- a/contrib/runners/remote_runner/remote_runner/__init__.py
+++ b/contrib/runners/remote_runner/remote_runner/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__version__ = '2.9dev'

--- a/contrib/runners/remote_runner/setup.py
+++ b/contrib/runners/remote_runner/setup.py
@@ -23,6 +23,8 @@ from setuptools import find_packages
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 
+from remote_runner import __version__
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
 
@@ -31,7 +33,7 @@ install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 apply_vagrant_workaround()
 setup(
     name='stackstorm-runner-remote',
-    version='2.5.0',
+    version=__version__,
     description=('Remote SSH shell command and script action runner for StackStorm event-driven '
                  'automation platform'),
     author='StackStorm',

--- a/contrib/runners/windows_runner/setup.py
+++ b/contrib/runners/windows_runner/setup.py
@@ -23,6 +23,8 @@ from setuptools import find_packages
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 
+from windows_runner import __version__
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
 
@@ -31,7 +33,7 @@ install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 apply_vagrant_workaround()
 setup(
     name='stackstorm-runner-windows',
-    version='2.5.0',
+    version=__version__,
     description=('Windows command and script action runner for StackStorm event-driven '
                  'automation platform'),
     author='StackStorm',

--- a/contrib/runners/windows_runner/windows_runner/__init__.py
+++ b/contrib/runners/windows_runner/windows_runner/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__version__ = '2.9dev'

--- a/contrib/runners/winrm_runner/setup.py
+++ b/contrib/runners/winrm_runner/setup.py
@@ -23,6 +23,8 @@ from setuptools import find_packages
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 
+from winrm_runner import __version__
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
 
@@ -31,7 +33,7 @@ install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 apply_vagrant_workaround()
 setup(
     name='stackstorm-runner-winrm',
-    version='2.8.0',
+    version=__version__,
     description=('WinRM shell command and PowerShell script action runner for'
                  ' the StackStorm event-driven automation platform'),
     author='StackStorm',

--- a/contrib/runners/winrm_runner/winrm_runner/__init__.py
+++ b/contrib/runners/winrm_runner/winrm_runner/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = '2.9dev'


### PR DESCRIPTION
This pull request updates all the runner packages to they read their version from the runner package local `__init__.py` file.

Sadly we can't go with approach in #4211 due to a cyclic dependency issue (which right now only exists for orchestra runner, but once we move to dynamic stevedore loading will exist for every runner package if we make runners depend directly on st2common) - https://github.com/StackStorm/st2/pull/4211#issuecomment-404437539.

This way it's consistent with `st2client`.

Second part of this change is updating st2cd release workflow so it also updates version for all the runner packages (in the same place where we set version for st2common and st2client).