### PR TITLE
Allow user to force terminal size used by the CLI formatters by setting environment variable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,10 +36,10 @@ Changed
 
   Contributed by Nick Maludy (Encore Technologies).
 * Update ``st2`` CLI to use a more sensible default terminal size for table formatting purposes if
-  we are unable to retrieve a terminal size using various system-specific approaches.
+  we are unable to retrieve terminal size using various system-specific approaches.
 
   Previously we would fall back to a very unfriendly default of 20 columns for a total terminal
-  width which would cause every table column to wrap and make output impossible / hard to read.
+  width. This would cause every table column to wrap and make output impossible / hard to read.
   (improvement) #4242
 
 Fixed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,14 +20,14 @@ Added
 * Add new ``?tags``, query param filter to the ``/v1/actions`` API endpoint. This query parameter
   allows users to filter out actions based on the tag name . By default, when no filter values are
   provided, all actions are returned. (new feature) #4219
-* Update ``st2`` CLI to it inspect ``LINES`` and ``COLUMNS`` environment variables first when
-  determining the terminal size. Previously those environment variables were checked second last
-  (after trying to retrieve terminal size using various OS specific methods and before falling back
-  to the default values).
+* Update ``st2`` CLI to inspect ``COLUMNS`` environment variable first when determining the
+  terminal size. Previously this environment variable was checked second last (after trying to
+  retrieve terminal size using various OS specific methods and before falling back to the default
+  value).
 
-  This approach is more performant and allows user to easily overwrite the default values or values
-  returned by the operating system checks - e.g. by running
-  ``LINES=80 COLUMNS=200 st2 action list``. (improvement) #4242
+  This approach is more performant and allows user to easily overwrite the default value or value
+  returned by the operating system checks - e.g. by running ``COLUMNS=200 st2 action list``.
+  (improvement) #4242
 
 Changed
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,9 +20,14 @@ Added
 * Add new ``?tags``, query param filter to the ``/v1/actions`` API endpoint. This query parameter
   allows users to filter out actions based on the tag name . By default, when no filter values are
   provided, all actions are returned. (new feature) #4219
-* Allow user to force terminal size to use by ``st2`` CLI for table formatting purposes by setting
-  ``ST2_CLI_FORCE_TERMINAL_SIZE=<lines,column>`` environment variable. For example,
-  ``ST2_CLI_FORCE_TERMINAL_SIZE=80,200 st2 action list``. (improvement) #4242
+* Update ``st2`` CLI to it inspect ``LINES`` and ``COLUMNS`` environment variables first when
+  determining the terminal size. Previously those environment variables were checked second last
+  (after trying to retrieve terminal size using various OS specific methods and before falling back
+  to the default values).
+
+  This approach is more performant and allows user to easily overwrite the default values or values
+  returned by the operating system checks - e.g. by running
+  ``LINES=80 COLUMNS=200 st2 action list``. (improvement) #4242
 
 Changed
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,16 +11,16 @@ Added
   The ``winrm-cmd`` runner executes Command Prompt commands remotely on Windows hosts using the
   WinRM protocol. The ``winrm-ps-cmd`` and ``winrm-ps-script`` runners execute PowerShell commands
   and scripts on remote Windows hosts using the WinRM protocol.
-  
+
   To accompany these new runners, there are two new actions ``core.winrm_cmd`` that executes remote
   Command Prompt commands along with ``core.winrm_ps_cmd`` that executes remote PowerShell commands.
   (new feature) #1636
-  
+
   Contributed by Nick Maludy (Encore Technologies).
 * Add new ``?tags``, query param filter to the ``/v1/actions`` API endpoint. This query parameter
   allows users to filter out actions based on the tag name . By default, when no filter values are
   provided, all actions are returned. (new feature) #4219
-  
+
 Changed
 ~~~~~~~
 
@@ -30,10 +30,9 @@ Changed
 * Migrated runners to using the ``in-requirements.txt`` pattern for "components" in the build
   system, so the ``Makefile`` correctly generates and installs runner dependencies during
   testing and packaging. (improvement) (bugfix) #4169
-  
+
   Contributed by Nick Maludy (Encore Technologies).
 
-  
 Fixed
 ~~~~~
 
@@ -41,7 +40,7 @@ Fixed
   Reported by @jjm
 
   Contributed by Nick Maludy (Encore Technologies).
-  
+
 2.8.0 - July 10, 2018
 ---------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,9 @@ Added
 * Add new ``?tags``, query param filter to the ``/v1/actions`` API endpoint. This query parameter
   allows users to filter out actions based on the tag name . By default, when no filter values are
   provided, all actions are returned. (new feature) #4219
+* Allow user to force terminal size to use by ``st2`` CLI for table formatting purposes by setting
+  ``ST2_CLI_FORCE_TERMINAL_SIZE=<lines,column>`` environment variable. For example,
+  ``ST2_CLI_FORCE_TERMINAL_SIZE=80,200 st2 action list``. (improvement) #4242
 
 Changed
 ~~~~~~~
@@ -32,6 +35,12 @@ Changed
   testing and packaging. (improvement) (bugfix) #4169
 
   Contributed by Nick Maludy (Encore Technologies).
+* Update ``st2`` CLI to use a more sensible default terminal size for table formatting purposes if
+  we are unable to retrieve a terminal size using various system-specific approaches.
+
+  Previously we would fall back to a very unfriendly default of 20 columns for a total terminal
+  width which would cause every table column to wrap and make output impossible / hard to read.
+  (improvement) #4242
 
 Fixed
 ~~~~~

--- a/st2client/st2client/formatters/table.py
+++ b/st2client/st2client/formatters/table.py
@@ -27,7 +27,7 @@ from six.moves import range
 
 from st2client import formatters
 from st2client.utils import strutil
-from st2client.utils.terminal import get_terminal_size
+from st2client.utils.terminal import get_terminal_size_columns
 
 
 LOG = logging.getLogger(__name__)
@@ -65,7 +65,7 @@ class MultiColumnTable(formatters.Formatter):
 
         if not widths and attributes:
             # Dynamically calculate column size based on the terminal size
-            lines, cols = get_terminal_size()
+            cols = get_terminal_size_columns()
 
             if attributes[0] == 'id':
                 # consume iterator and save as entries so collection is accessible later.

--- a/st2client/st2client/utils/terminal.py
+++ b/st2client/st2client/utils/terminal.py
@@ -27,7 +27,7 @@ __all__ = [
 ]
 
 
-def get_terminal_size(default=(80, 20)):
+def get_terminal_size(default=(80, 200)):
     """
     :return: (lines, cols)
     """

--- a/st2client/st2client/utils/terminal.py
+++ b/st2client/st2client/utils/terminal.py
@@ -26,55 +26,53 @@ DEFAULT_TERMINAL_SIZE_LINES = 80
 DEFAULT_TERMINAL_SIZE_COLUMNS = 150
 
 __all__ = [
-    'get_terminal_size'
+    'get_terminal_size_columns'
 ]
 
 
-def get_terminal_size(default=(DEFAULT_TERMINAL_SIZE_LINES, DEFAULT_TERMINAL_SIZE_COLUMNS)):
+def get_terminal_size_columns(default=DEFAULT_TERMINAL_SIZE_COLUMNS):
     """
-    Try to retrieve a default terminal size using various system specific approaches.
+    Try to retrieve COLUMNS value of terminal size using various system specific approaches.
 
     If terminal size can't be retrieved, default value is returned.
 
-    NOTE 1: LINES and COLUMNS environment variables are checked first, if those values are not set /
-    available, other methods are tried.
+    NOTE 1: COLUMNS environment variable is checked first, if the value is not set / available,
+            other methods are tried.
 
-    NOTE 2: This method requires both environment variables to be specified together.
-
-    :return: (lines, cols)
+    :rtype: ``int``
+    :return: columns
     """
-    # 1. Try LINES and COLUMNS environment variables first like in upstream Python 3 method -
+    # 1. Try COLUMNS environment variable first like in upstream Python 3 method -
     # https://github.com/python/cpython/blob/master/Lib/shutil.py#L1203
     # This way it's consistent with upstream implementation. In the past, our implementation
     # checked those variables at the end as a fall back.
     try:
-        lines = os.environ['LINES']
         columns = os.environ['COLUMNS']
-
-        return int(lines), int(columns)
-    except:
+        return int(columns)
+    except (KeyError, ValueError):
         pass
 
     def ioctl_GWINSZ(fd):
         import fcntl
         import termios
+        # Return a tuple (lines, columns)
         return struct.unpack('hh', fcntl.ioctl(fd, termios.TIOCGWINSZ, '1234'))
 
     # 2. try stdin, stdout, stderr
     for fd in (0, 1, 2):
         try:
-            return ioctl_GWINSZ(fd)
-        except:
+            return ioctl_GWINSZ(fd)[1]
+        except Exception:
             pass
 
     # 3. try os.ctermid()
     try:
         fd = os.open(os.ctermid(), os.O_RDONLY)
         try:
-            return ioctl_GWINSZ(fd)
+            return ioctl_GWINSZ(fd)[1]
         finally:
             os.close(fd)
-    except:
+    except Exception:
         pass
 
     # 4. try `stty size`
@@ -85,11 +83,11 @@ def get_terminal_size(default=(DEFAULT_TERMINAL_SIZE_LINES, DEFAULT_TERMINAL_SIZ
                                    stderr=open(os.devnull, 'w'))
         result = process.communicate()
         if process.returncode == 0:
-            return tuple(int(x) for x in result[0].split())
-    except:
+            return tuple(int(x) for x in result[0].split())[1]
+    except Exception:
         pass
 
-    # 5. return default value
+    # 5. return default fallback value
     return default
 
 

--- a/st2client/st2client/utils/terminal.py
+++ b/st2client/st2client/utils/terminal.py
@@ -27,7 +27,7 @@ __all__ = [
 ]
 
 
-def get_terminal_size(default=(80, 200)):
+def get_terminal_size(default=(80, 150)):
     """
     :return: (lines, cols)
     """

--- a/st2client/st2client/utils/terminal.py
+++ b/st2client/st2client/utils/terminal.py
@@ -22,10 +22,11 @@ import sys
 
 from st2client.utils.color import format_status
 
-DEFAULT_TERMINAL_SIZE_LINES = 80
 DEFAULT_TERMINAL_SIZE_COLUMNS = 150
 
 __all__ = [
+    'DEFAULT_TERMINAL_SIZE_COLUMNS',
+
     'get_terminal_size_columns'
 ]
 

--- a/st2client/st2client/utils/terminal.py
+++ b/st2client/st2client/utils/terminal.py
@@ -43,7 +43,7 @@ def get_terminal_size(default=(DEFAULT_TERMINAL_SIZE_LINES, DEFAULT_TERMINAL_SIZ
 
     :return: (lines, cols)
     """
-    # Try LINES and COLUMNS environment variables first like in upstream Python 3 method -
+    # 1. Try LINES and COLUMNS environment variables first like in upstream Python 3 method -
     # https://github.com/python/cpython/blob/master/Lib/shutil.py#L1203
     # This way it's consistent with upstream implementation. In the past, our implementation
     # checked those variables at the end as a fall back.
@@ -60,14 +60,14 @@ def get_terminal_size(default=(DEFAULT_TERMINAL_SIZE_LINES, DEFAULT_TERMINAL_SIZ
         import termios
         return struct.unpack('hh', fcntl.ioctl(fd, termios.TIOCGWINSZ, '1234'))
 
-    # try stdin, stdout, stderr
+    # 2. try stdin, stdout, stderr
     for fd in (0, 1, 2):
         try:
             return ioctl_GWINSZ(fd)
         except:
             pass
 
-    # try os.ctermid()
+    # 3. try os.ctermid()
     try:
         fd = os.open(os.ctermid(), os.O_RDONLY)
         try:
@@ -77,7 +77,7 @@ def get_terminal_size(default=(DEFAULT_TERMINAL_SIZE_LINES, DEFAULT_TERMINAL_SIZ
     except:
         pass
 
-    # try `stty size`
+    # 4. try `stty size`
     try:
         process = subprocess.Popen(['stty', 'size'],
                                    shell=False,
@@ -89,7 +89,7 @@ def get_terminal_size(default=(DEFAULT_TERMINAL_SIZE_LINES, DEFAULT_TERMINAL_SIZ
     except:
         pass
 
-    # return default value
+    # 5. return default value
     return default
 
 

--- a/st2client/st2client/utils/terminal.py
+++ b/st2client/st2client/utils/terminal.py
@@ -36,8 +36,10 @@ def get_terminal_size(default=(DEFAULT_TERMINAL_SIZE_LINES, DEFAULT_TERMINAL_SIZ
 
     If terminal size can't be retrieved, default value is returned.
 
-    NOTE: LINES and COLUMNS environment variables are checked first, if those values are not set /
+    NOTE 1: LINES and COLUMNS environment variables are checked first, if those values are not set /
     available, other methods are tried.
+
+    NOTE 2: This method requires both environment variables to be specified together.
 
     :return: (lines, cols)
     """

--- a/st2client/st2client/utils/terminal.py
+++ b/st2client/st2client/utils/terminal.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import struct
 import subprocess
@@ -30,6 +31,16 @@ def get_terminal_size(default=(80, 20)):
     """
     :return: (lines, cols)
     """
+    # Allow user to force terminal size using a environment variables
+    # E.g. ST2_CLI_FORCE_TERMINAL_SIZE=80,200 # lines, columns
+    force_terminal_size = os.environ.get('ST2_CLI_FORCE_TERMINAL_SIZE', None)
+    if force_terminal_size:
+        split = force_terminal_size.split(',')
+        lines = split[0]
+        columns = split[1] if len(split) >= 2 else default[1]
+
+        return lines, columns
+
     def ioctl_GWINSZ(fd):
         import fcntl
         import termios

--- a/st2client/st2client/utils/terminal.py
+++ b/st2client/st2client/utils/terminal.py
@@ -36,8 +36,8 @@ def get_terminal_size(default=(80, 150)):
     force_terminal_size = os.environ.get('ST2_CLI_FORCE_TERMINAL_SIZE', None)
     if force_terminal_size:
         split = force_terminal_size.split(',')
-        lines = split[0]
-        columns = split[1] if len(split) >= 2 else default[1]
+        lines = int(split[0])
+        columns = int(split[1] if len(split) >= 2 else default[1])
 
         return lines, columns
 

--- a/st2client/tests/unit/test_util_terminal.py
+++ b/st2client/tests/unit/test_util_terminal.py
@@ -1,0 +1,62 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import os
+
+import unittest2
+import mock
+
+from st2client.utils.terminal import DEFAULT_TERMINAL_SIZE_LINES
+from st2client.utils.terminal import DEFAULT_TERMINAL_SIZE_COLUMNS
+from st2client.utils.terminal import get_terminal_size
+
+__all__ = [
+    'TerminalUtilsTestCase'
+]
+
+
+class TerminalUtilsTestCase(unittest2.TestCase):
+    @mock.patch.dict(os.environ, {'LINES': '111', 'COLUMNS': '222'})
+    def test_get_terminal_size_lines_columns_environment_variable_have_precedence(self):
+        # Verify that LINES and COLUMNS environment variables have precedence over other approaches
+        lines, columns = get_terminal_size()
+
+        self.assertEqual(lines, 111)
+        self.assertEqual(columns, 222)
+
+    @mock.patch('struct.unpack', mock.Mock(side_effect=Exception('a')))
+    @mock.patch('subprocess.Popen')
+    def test_get_terminal_size_subprocess_popen_is_used(self, mock_popen):
+        mock_communicate = mock.Mock(return_value=['555 666'])
+
+        mock_process = mock.Mock()
+        mock_process.returncode = 0
+        mock_process.communicate = mock_communicate
+
+        mock_popen.return_value = mock_process
+
+        lines, columns = get_terminal_size()
+        self.assertEqual(lines, 555)
+        self.assertEqual(columns, 666)
+
+    @mock.patch('struct.unpack', mock.Mock(side_effect=Exception('a')))
+    @mock.patch('subprocess.Popen', mock.Mock(side_effect=Exception('b')))
+    def test_get_terminal_size_default_values_are_used(self):
+        lines, columns = get_terminal_size()
+
+        self.assertEqual(lines, DEFAULT_TERMINAL_SIZE_LINES)
+        self.assertEqual(columns, DEFAULT_TERMINAL_SIZE_COLUMNS)

--- a/st2client/tests/unit/test_util_terminal.py
+++ b/st2client/tests/unit/test_util_terminal.py
@@ -20,9 +20,8 @@ import os
 import unittest2
 import mock
 
-from st2client.utils.terminal import DEFAULT_TERMINAL_SIZE_LINES
 from st2client.utils.terminal import DEFAULT_TERMINAL_SIZE_COLUMNS
-from st2client.utils.terminal import get_terminal_size
+from st2client.utils.terminal import get_terminal_size_columns
 
 __all__ = [
     'TerminalUtilsTestCase'
@@ -31,12 +30,16 @@ __all__ = [
 
 class TerminalUtilsTestCase(unittest2.TestCase):
     @mock.patch.dict(os.environ, {'LINES': '111', 'COLUMNS': '222'})
-    def test_get_terminal_size_lines_columns_environment_variable_have_precedence(self):
-        # Verify that LINES and COLUMNS environment variables have precedence over other approaches
-        lines, columns = get_terminal_size()
+    def test_get_terminal_size_columns_columns_environment_variable_has_precedence(self):
+        # Verify that COLUMNS environment variables has precedence over other approaches
+        columns = get_terminal_size_columns()
 
-        self.assertEqual(lines, 111)
         self.assertEqual(columns, 222)
+
+    @mock.patch('struct.unpack', mock.Mock(return_value=(333, 444)))
+    def test_get_terminal_size_columns_stdout_is_used(self):
+        columns = get_terminal_size_columns()
+        self.assertEqual(columns, 444)
 
     @mock.patch('struct.unpack', mock.Mock(side_effect=Exception('a')))
     @mock.patch('subprocess.Popen')
@@ -49,14 +52,12 @@ class TerminalUtilsTestCase(unittest2.TestCase):
 
         mock_popen.return_value = mock_process
 
-        lines, columns = get_terminal_size()
-        self.assertEqual(lines, 555)
+        columns = get_terminal_size_columns()
         self.assertEqual(columns, 666)
 
     @mock.patch('struct.unpack', mock.Mock(side_effect=Exception('a')))
     @mock.patch('subprocess.Popen', mock.Mock(side_effect=Exception('b')))
     def test_get_terminal_size_default_values_are_used(self):
-        lines, columns = get_terminal_size()
+        columns = get_terminal_size_columns()
 
-        self.assertEqual(lines, DEFAULT_TERMINAL_SIZE_LINES)
         self.assertEqual(columns, DEFAULT_TERMINAL_SIZE_COLUMNS)


### PR DESCRIPTION
Right now, we try various approaches to obtain terminal size used by the CLI for table formatting purposes.

If none of that approaches work, we fall back to a default hard coded size (10 lines, 20 columns).

This pull request improves on that in two ways:

1. It uses a more reasonable default size. `20` columns for a total terminal width is simply a bad default. It means pretty much every table cell / column will wrap at couple of characters which will make output unreadable when we are unable to retrieve a terminal size.
2. Allows user to force terminal size using `ST2_CLI_FORCE_TERMINAL_SIZE=<lines,columns>` environment variable.

We have experienced this "issue" a lot in our end to end tests for a long time. Since those test commands don't run using shell, we fail to obtain a terminal size and we fall back to a really bad default which results in an unreadable output like that:

Before:

![screenshot from 2018-07-13 14-07-45](https://user-images.githubusercontent.com/125088/42690865-354afb22-86a6-11e8-8a90-7d32f2b34e16.png)

After:

![screenshot from 2018-07-13 14-08-06](https://user-images.githubusercontent.com/125088/42690872-3a6bcf1e-86a6-11e8-9903-ecc6ead1a20f.png)

Keep in mind that those actions run on a remote host which is later destroyed so we can't simply re-retrieve the output which means we are stuck with troubleshooting / debugging from this very hard to read output.

## TODO

- [x] Changelog entry