### PR TITLE
Mark "password" http-runner parameter as secret (v2.8)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,9 @@ Fixed
   Reported by @jjm
 
   Contributed by Nick Maludy (Encore Technologies).
+* Mark ``password`` `http-runner`` parameter as a secret. (bug fix) #4245
+
+  Reported by @daniel-mckenna
 
 2.8.0 - July 10, 2018
 ---------------------

--- a/contrib/runners/http_runner/http_runner/runner.yaml
+++ b/contrib/runners/http_runner/http_runner/runner.yaml
@@ -24,6 +24,7 @@
     password:
       description: Password required by basic authentication.
       type: string
+      secret: true
     url:
       description: URL to the HTTP endpoint.
       required: true


### PR DESCRIPTION
Resolves #4244.

Thansk to @daniel-mckenna for reporting it.