### PR TITLE
Pin orchestra to v0.1 release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,9 @@ cryptography==2.2.2
 eventlet==0.23.0
 flex==6.13.1
 git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper
-git+https://github.com/StackStorm/orchestra.git#egg=orchestra
 git+https://github.com/StackStorm/python-mistralclient.git@st2-2.8.1#egg=python-mistralclient
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
+git+https://github.com/stackstorm/orchestra.git@v0.1#egg=orchestra
 gitpython==2.1.10
 greenlet==0.4.13
 gunicorn==19.8.1

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -9,7 +9,7 @@ jsonschema
 kombu
 mongoengine
 networkx
-git+https://github.com/StackStorm/orchestra.git#egg=orchestra
+git+https://github.com/stackstorm/orchestra.git@v0.1#egg=orchestra
 oslo.config
 paramiko
 pyyaml

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -3,7 +3,7 @@ apscheduler==3.5.1
 cryptography==2.2.2
 eventlet==0.23.0
 flex==6.13.1
-git+https://github.com/StackStorm/orchestra.git#egg=orchestra
+git+https://github.com/stackstorm/orchestra.git@v0.1#egg=orchestra
 greenlet==0.4.13
 ipaddr
 jinja2


### PR DESCRIPTION
Pin the orchestra dependency to v0.1 release so changes to orchestra will not break future v2.8.x patch releases.