### PR TITLE
Update runner packages to read version from runner package local __init__.py file (v2.8)

### DIFF
--- a/contrib/runners/action_chain_runner/action_chain_runner/__init__.py
+++ b/contrib/runners/action_chain_runner/action_chain_runner/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__version__ = '2.8.1'

--- a/contrib/runners/action_chain_runner/setup.py
+++ b/contrib/runners/action_chain_runner/setup.py
@@ -23,6 +23,8 @@ from setuptools import find_packages
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 
+from action_chain_runner import __version__
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
 
@@ -31,7 +33,7 @@ install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 apply_vagrant_workaround()
 setup(
     name='stackstorm-runner-action-chain',
-    version='2.5.0',
+    version=__version__,
     description=('Action-Chain workflow action runner for StackStorm event-driven '
                  'automation platform'),
     author='StackStorm',

--- a/contrib/runners/announcement_runner/announcement_runner/__init__.py
+++ b/contrib/runners/announcement_runner/announcement_runner/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__version__ = '2.8.1'

--- a/contrib/runners/announcement_runner/setup.py
+++ b/contrib/runners/announcement_runner/setup.py
@@ -23,6 +23,8 @@ from setuptools import find_packages
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 
+from announcement_runner import __version__
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
 
@@ -31,7 +33,7 @@ install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 apply_vagrant_workaround()
 setup(
     name='stackstorm-runner-announcement',
-    version='2.5.0',
+    version=__version__,
     description=('Announcement action runner for StackStorm event-driven automation platform'),
     author='StackStorm',
     author_email='info@stackstorm.com',

--- a/contrib/runners/cloudslang_runner/cloudslang_runner/__init__.py
+++ b/contrib/runners/cloudslang_runner/cloudslang_runner/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__version__ = '2.8.1'

--- a/contrib/runners/cloudslang_runner/setup.py
+++ b/contrib/runners/cloudslang_runner/setup.py
@@ -23,6 +23,8 @@ from setuptools import find_packages
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 
+from cloudslang_runner import __version__
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
 
@@ -31,7 +33,7 @@ install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 apply_vagrant_workaround()
 setup(
     name='stackstorm-runner-cloudslang',
-    version='2.5.0',
+    version=__version__,
     description=('CloudSlang action runner for StackStorm event-driven automation platform'),
     author='StackStorm',
     author_email='info@stackstorm.com',

--- a/contrib/runners/http_runner/http_runner/__init__.py
+++ b/contrib/runners/http_runner/http_runner/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__version__ = '2.8.1'

--- a/contrib/runners/http_runner/setup.py
+++ b/contrib/runners/http_runner/setup.py
@@ -23,6 +23,8 @@ from setuptools import find_packages
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 
+from http_runner import __version__
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
 
@@ -31,7 +33,7 @@ install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 apply_vagrant_workaround()
 setup(
     name='stackstorm-runner-http',
-    version='2.5.0',
+    version=__version__,
     description=('HTTP(s) action runner for StackStorm event-driven automation platform'),
     author='StackStorm',
     author_email='info@stackstorm.com',

--- a/contrib/runners/inquirer_runner/inquirer_runner/__init__.py
+++ b/contrib/runners/inquirer_runner/inquirer_runner/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__version__ = '2.8.1'

--- a/contrib/runners/inquirer_runner/setup.py
+++ b/contrib/runners/inquirer_runner/setup.py
@@ -23,6 +23,8 @@ from setuptools import find_packages
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 
+from inquirer_runner import __version__
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
 
@@ -31,7 +33,7 @@ install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 apply_vagrant_workaround()
 setup(
     name='stackstorm-runner-inquirer',
-    version='2.5.0',
+    version=__version__,
     description=('Inquirer action runner for StackStorm event-driven automation platform'),
     author='StackStorm',
     author_email='info@stackstorm.com',

--- a/contrib/runners/local_runner/local_runner/__init__.py
+++ b/contrib/runners/local_runner/local_runner/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__version__ = '2.8.1'

--- a/contrib/runners/local_runner/setup.py
+++ b/contrib/runners/local_runner/setup.py
@@ -23,6 +23,8 @@ from setuptools import find_packages
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 
+from local_runner import __version__
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
 
@@ -31,7 +33,7 @@ install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 apply_vagrant_workaround()
 setup(
     name='stackstorm-runner-local',
-    version='2.5.0',
+    version=__version__,
     description=('Local Shell Command and Script action runner for StackStorm event-driven '
                  'automation platform'),
     author='StackStorm',

--- a/contrib/runners/mistral_v2/mistral_v2/__init__.py
+++ b/contrib/runners/mistral_v2/mistral_v2/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__version__ = '2.8.1'

--- a/contrib/runners/mistral_v2/setup.py
+++ b/contrib/runners/mistral_v2/setup.py
@@ -23,6 +23,8 @@ from setuptools import find_packages
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 
+from mistral_v2 import __version__
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
 
@@ -31,7 +33,7 @@ install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 apply_vagrant_workaround()
 setup(
     name='stackstorm-runner-mistral-v2',
-    version='2.5.0',
+    version=__version__,
     description=('Mistral v2 workflow action runner for StackStorm event-driven '
                  'automation platform'),
     author='StackStorm',

--- a/contrib/runners/noop_runner/noop_runner/__init__.py
+++ b/contrib/runners/noop_runner/noop_runner/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__version__ = '2.8.1'

--- a/contrib/runners/noop_runner/setup.py
+++ b/contrib/runners/noop_runner/setup.py
@@ -23,6 +23,8 @@ from setuptools import find_packages
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 
+from noop_runner import __version__
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
 
@@ -31,7 +33,7 @@ install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 apply_vagrant_workaround()
 setup(
     name='stackstorm-runner-noop',
-    version='2.5.0',
+    version=__version__,
     description=('No-Op action runner for StackStorm event-driven automation platform'),
     author='StackStorm',
     author_email='info@stackstorm.com',

--- a/contrib/runners/orchestra_runner/orchestra_runner/__init__.py
+++ b/contrib/runners/orchestra_runner/orchestra_runner/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__version__ = '2.8.1'

--- a/contrib/runners/orchestra_runner/setup.py
+++ b/contrib/runners/orchestra_runner/setup.py
@@ -23,6 +23,8 @@ from setuptools import find_packages
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 
+from orchestra_runner import __version__
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
 
@@ -31,7 +33,7 @@ install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 apply_vagrant_workaround()
 setup(
     name='stackstorm-runner-orchestra',
-    version='2.5.0',
+    version=__version__,
     description='Orchestra workflow runner for StackStorm event-driven automation platform',
     author='StackStorm',
     author_email='info@stackstorm.com',

--- a/contrib/runners/python_runner/python_runner/__init__.py
+++ b/contrib/runners/python_runner/python_runner/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__version__ = '2.8.1'

--- a/contrib/runners/python_runner/setup.py
+++ b/contrib/runners/python_runner/setup.py
@@ -23,6 +23,8 @@ from setuptools import find_packages
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 
+from python_runner import __version__
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
 
@@ -31,7 +33,7 @@ install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 apply_vagrant_workaround()
 setup(
     name='stackstorm-runner-python',
-    version='2.5.0',
+    version=__version__,
     description='Python action runner for StackStorm event-driven automation platform',
     author='StackStorm',
     author_email='info@stackstorm.com',

--- a/contrib/runners/remote_runner/remote_runner/__init__.py
+++ b/contrib/runners/remote_runner/remote_runner/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__version__ = '2.8.1'

--- a/contrib/runners/remote_runner/setup.py
+++ b/contrib/runners/remote_runner/setup.py
@@ -23,6 +23,8 @@ from setuptools import find_packages
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 
+from remote_runner import __version__
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
 
@@ -31,7 +33,7 @@ install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 apply_vagrant_workaround()
 setup(
     name='stackstorm-runner-remote',
-    version='2.5.0',
+    version=__version__,
     description=('Remote SSH shell command and script action runner for StackStorm event-driven '
                  'automation platform'),
     author='StackStorm',

--- a/contrib/runners/windows_runner/setup.py
+++ b/contrib/runners/windows_runner/setup.py
@@ -23,6 +23,8 @@ from setuptools import find_packages
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 
+from windows_runner import __version__
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
 
@@ -31,7 +33,7 @@ install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 apply_vagrant_workaround()
 setup(
     name='stackstorm-runner-windows',
-    version='2.5.0',
+    version=__version__,
     description=('Windows command and script action runner for StackStorm event-driven '
                  'automation platform'),
     author='StackStorm',

--- a/contrib/runners/windows_runner/windows_runner/__init__.py
+++ b/contrib/runners/windows_runner/windows_runner/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,3 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__version__ = '2.8.1'


### PR DESCRIPTION
This pull request backports changes from https://github.com/StackStorm/st2/pull/4239.

As discussed in https://github.com/StackStorm/st2cd/pull/340, we decided to backport those changes into v2.8. This way we keep things simple and don't need any special cases in the workflow if we need to do another 2.8.x patch release.