### PR TITLE
Fix make tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -396,10 +396,10 @@ tests: pytests
 pytests: compile requirements .flake8 .pylint .pytests-coverage
 
 .PHONY: .pytests
-.pytests: compile .configgen .generate-api-spec .unit-tests .itests clean
+.pytests: compile .configgen .generate-api-spec .unit-tests clean
 
 .PHONY: .pytests-coverage
-.pytests-coverage: .unit-tests-coverage-html .itests-coverage-html clean
+.pytests-coverage: .unit-tests-coverage-html clean
 
 .PHONY: unit-tests
 unit-tests: requirements .unit-tests

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,11 @@ PYTHON_VERSION = python2.7
 
 BINARIES := bin
 
-# All components are prefixed by st2
-COMPONENTS := $(wildcard st2*)
+# All components are prefixed by st2 and not .egg-info.
+COMPONENTS := $(shell ls -a | grep ^st2 | grep -v .egg-info)
 COMPONENTS_RUNNERS := $(wildcard contrib/runners/*)
 
-COMPONENTS_WITH_RUNNERS := $(wildcard st2*) $(COMPONENTS_RUNNERS)
+COMPONENTS_WITH_RUNNERS := $(COMPONENTS) $(COMPONENTS_RUNNERS)
 
 COMPONENTS_TEST_DIRS := $(wildcard st2*/tests) $(wildcard contrib/runners/*/tests)
 


### PR DESCRIPTION
The st2client.egg-info is included in the list of components and that caused errors when making requirements and running pylints on the components. The make tests command would abort at the pylint step and stop running unit tests. The wildcard function to identify the list of st2 components is replaced with a shell command to run ls and grep the entries that start with st2 but not end with .egg-info.

The itests step requires ci-prepare-integration so the currently pytests fail on itests. This patch reduce the scope of pytests to only run unit tests but expand the scope of make tests to cover specific steps from pytests, ci-unit, and ci-integration.