### PR TITLE
Add new ?output_type and ?existing_only query param filter to /v1/api/executions/<id>/output API endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,15 @@ Added
   Keep in mind that the content itself still needs to be registered with StackStorm at some later
   point when access to RabbitMQ and MongoDB is available by running
   ``st2ctl reload --register-all``. (new feature) #3912 #4256
+* Add new ``/v1/stream/executions/<id>/output[?output_type=all|stdout|stderr]`` stream API
+  endpoint.
+
+  This API endpoint returns event source compatible response format.
+
+  For running executions it returns any output produced so far and any new output as it's produced.
+  Once the execution finishes, the connection is automatically closed.
+
+  For completed executions it returns all the output produced by the execution. (new feature)
 
 Changed
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,15 @@ Changed
 * The orquesta conductor implemented event based state machines to manage state transition of
   workflow execution. Interfaces to set workflow state and update task on action execution
   completion have changed and calls to those interfaces are changed accordingly. (improvement)
+* Change ``GET /v1/executions/<id>/output`` API endpoint so it never blocks and returns data
+  produced so far for running executions. Behavior for completed executions is the same and didn't
+  change - all data produced by the execution is returned in the raw format.
+
+  The streaming (block until execution has finished for running executions) behavior has been moved
+  to the new ``/stream/v1/executions/<id>/output`` API endpoint.
+
+  This way we are not mixing non-streaming (short lived) and streaming (long lived) connections
+  inside a single service (st2api). (improvement)
 
 Deprecated
 ~~~~~~~~~~

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -295,11 +295,6 @@ class ActionExecutionOutputController(ActionExecutionsControllerMixin, ResourceC
     }
     exclude_fields = []
 
-    CLOSE_STREAM_LIVEACTION_STATES = action_constants.LIVEACTION_COMPLETED_STATES + [
-        action_constants.LIVEACTION_STATUS_PAUSING,
-        action_constants.LIVEACTION_STATUS_RESUMING
-    ]
-
     def get_one(self, id, output_type='all', output_format='raw', existing_only=False,
                 requester_user=None):
         # Special case for id == "last"

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -396,7 +396,16 @@ class ActionExecutionOutputController(ActionExecutionsControllerMixin, ResourceC
             else:
                 app_iter = itertools.chain(existing_output_iter(), new_output_iter())
 
-            res = Response(content_type='text/plain', app_iter=app_iter)
+            if output_type == 'event_source':
+                headers = {
+                    'Cache-Control': 'no-cache'
+                }
+                content_type = 'text/event-stream'
+            else:
+                headers = {}
+                content_type = 'text/plain'
+
+            res = Response(content_type=content_type, headers=headers, app_iter=app_iter)
             return res
 
         res = make_response()

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -335,6 +335,8 @@ class ActionExecutionOutputController(ActionExecutionsControllerMixin, ResourceC
                 event = 'st2.execution.output__create'
                 result = 'event: %s\ndata: %s\n\n' % (event, json_encode(data, indent=None))
                 return result
+            else:
+                raise ValueError('Unsupported format: %s' % (output_format))
 
         def existing_output_iter():
             # Consume and return all of the existing lines
@@ -390,8 +392,6 @@ class ActionExecutionOutputController(ActionExecutionsControllerMixin, ResourceC
             if existing_only:
                 # Only return existing output produced by now and return immediately. Don't wait
                 # for execution to finish
-                print('laaaaa')
-                print(existing_only)
                 app_iter = existing_output_iter()
             else:
                 app_iter = itertools.chain(existing_output_iter(), new_output_iter())

--- a/st2api/tests/unit/controllers/v1/test_executions.py
+++ b/st2api/tests/unit/controllers/v1/test_executions.py
@@ -1160,13 +1160,6 @@ class ActionExecutionControllerTestCase(BaseActionExecutionControllerTestCase, F
 
 class ActionExecutionOutputControllerTestCase(BaseActionExecutionControllerTestCase,
                                               FunctionalTest):
-    def test_get_one_id_last_no_executions_in_the_database(self):
-        ActionExecution.query().delete()
-
-        resp = self.app.get('/v1/executions/last', expect_errors=True)
-        self.assertEqual(resp.status_int, http_client.BAD_REQUEST)
-        self.assertEqual(resp.json['faultstring'], 'No executions found in the database')
-
     def test_get_output_id_last_no_executions_in_the_database(self):
         ActionExecution.query().delete()
 

--- a/st2api/tests/unit/controllers/v1/test_executions.py
+++ b/st2api/tests/unit/controllers/v1/test_executions.py
@@ -16,10 +16,6 @@
 import copy
 import mock
 
-import six
-import eventlet
-import unittest2
-
 try:
     import simplejson as json
 except ImportError:
@@ -43,7 +39,6 @@ from st2common.transport.publishers import PoolPublisher
 from st2common.util import action_db as action_db_util
 from st2common.util import isotime
 from st2common.util import date as date_utils
-from st2common.stream.listener import get_listener
 import st2common.validators.api.action as action_validator
 from tests.base import BaseActionExecutionControllerTestCase
 from st2tests.api import SUPER_SECRET_PARAMETER
@@ -1179,14 +1174,8 @@ class ActionExecutionOutputControllerTestCase(BaseActionExecutionControllerTestC
         self.assertEqual(resp.status_int, http_client.BAD_REQUEST)
         self.assertEqual(resp.json['faultstring'], 'No executions found in the database')
 
-    @unittest2.skipIf(six.PY3, 'Skipping under Python 3 (closed iterator read issue)')
     def test_get_output_running_execution(self):
-        # Retrieve lister instance to avoid race with listener connection not being established
-        # early enough for tests to pass.
-        # NOTE: This only affects tests where listeners are not pre-initialized.
-        listener = get_listener(name='execution_output')
-        eventlet.sleep(1.0)
-
+        # Only the output produced so far should be returned
         # Test the execution output API endpoint for execution which is running (blocking)
         status = action_constants.LIVEACTION_STATUS_RUNNING
         timestamp = date_utils.get_datetime_utc_now()
@@ -1205,45 +1194,45 @@ class ActionExecutionOutputControllerTestCase(BaseActionExecutionControllerTestC
                              output_type='stdout',
                              data='stdout before start\n')
 
+        def insert_mock_data(data):
+            output_params['data'] = data
+            output_db = ActionExecutionOutputDB(**output_params)
+            ActionExecutionOutput.add_or_update(output_db)
+
         # Insert mock output object
         output_db = ActionExecutionOutputDB(**output_params)
         ActionExecutionOutput.add_or_update(output_db, publish=False)
 
-        def insert_mock_data():
-            output_params['data'] = 'stdout mid 1\n'
-            output_db = ActionExecutionOutputDB(**output_params)
-            ActionExecutionOutput.add_or_update(output_db)
-
-        # Since the API endpoint is blocking (connection is kept open until action finishes), we
-        # spawn an eventlet which eventually finishes the action.
-        def publish_action_finished(action_execution_db):
-            # Insert mock output object
-            output_params['data'] = 'stdout pre finish 1\n'
-            output_db = ActionExecutionOutputDB(**output_params)
-            ActionExecutionOutput.add_or_update(output_db)
-
-            eventlet.sleep(1.0)
-
-            # Transition execution to completed state so the connection closes
-            action_execution_db.status = action_constants.LIVEACTION_STATUS_SUCCEEDED
-            action_execution_db = ActionExecution.add_or_update(action_execution_db)
-
-        eventlet.spawn_after(0.2, insert_mock_data)
-        eventlet.spawn_after(1.5, publish_action_finished, action_execution_db)
-
-        # Retrieve data while execution is running - endpoint return new data once it's available
-        # and block until the execution finishes
+        # Retrieve data while execution is running - data produced so far should be retrieved
         resp = self.app.get('/v1/executions/%s/output' % (str(action_execution_db.id)),
                             expect_errors=False)
         self.assertEqual(resp.status_int, 200)
         lines = resp.text.strip().split('\n')
         lines = [line for line in lines if line.strip()]
-        self.assertEqual(len(lines), 3)
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0], 'stdout before start')
+
+        # Insert more data
+        insert_mock_data('stdout mid 1\n')
+
+        # Retrieve data while execution is running - data produced so far should be retrieved
+        resp = self.app.get('/v1/executions/%s/output' % (str(action_execution_db.id)),
+                            expect_errors=False)
+        self.assertEqual(resp.status_int, 200)
+        lines = resp.text.strip().split('\n')
+        lines = [line for line in lines if line.strip()]
+        self.assertEqual(len(lines), 2)
         self.assertEqual(lines[0], 'stdout before start')
         self.assertEqual(lines[1], 'stdout mid 1')
-        self.assertEqual(lines[2], 'stdout pre finish 1')
 
-        # Once the execution is in completed state, existing output should be returned immediately
+        # Insert more data
+        insert_mock_data('stdout pre finish 1\n')
+
+        # Transition execution to completed state
+        action_execution_db.status = action_constants.LIVEACTION_STATUS_SUCCEEDED
+        action_execution_db = ActionExecution.add_or_update(action_execution_db)
+
+        # Execution has finished
         resp = self.app.get('/v1/executions/%s/output' % (str(action_execution_db.id)),
                             expect_errors=False)
 
@@ -1255,9 +1244,6 @@ class ActionExecutionOutputControllerTestCase(BaseActionExecutionControllerTestC
         self.assertEqual(lines[1], 'stdout mid 1')
         self.assertEqual(lines[2], 'stdout pre finish 1')
 
-        listener.shutdown()
-
-    @unittest2.skipIf(six.PY3, 'Skipping under Python 3 (closed iterator read issue)')
     def test_get_output_finished_execution(self):
         # Test the execution output API endpoint for execution which has finished
         for status in action_constants.LIVEACTION_COMPLETED_STATES:

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -1160,10 +1160,26 @@ paths:
           required: true
         - name: output_type
           in: query
-          description: Type of output to retrieve. If not provided, all output type is returned.
-          type: array
-          items:
-            type: string
+          description: Type of output to retrieve (stdout, stderr). If not provided, all output type is returned.
+          type: enum
+          enum:
+            - "all"
+            - "stdout"
+            - "stderr"
+          default: all
+        - name: output_format
+          in: query
+          description: Output format. "raw" for raw output and "event_source" for EventSource format (new line delimited JSON).
+          type: enum
+          enum:
+            - "raw"
+            - "event_source"
+        default: raw
+        - name: existing_only
+          in: query
+          description: True for the endpoint to only return the existing output and return immediately. If False and execution is still running, the API endpoint will block until the execution finishes and return new output as it arrives.
+          type: boolean
+          default: false
       x-parameters:
         - name: user
           in: context

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -1149,7 +1149,6 @@ paths:
     get:
       operationId: st2api.controllers.v1.actionexecutions:action_execution_output_controller.get_one
       x-log-result: false
-      x-is-stream-endpoint: true
       description: |
         Retrieve execution output.
       parameters:
@@ -4238,7 +4237,39 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-
+  /stream/v1/executions/{id}/output:
+    get:
+      operationId: st2stream.controllers.v1.executions:action_execution_output_controller.get_one
+      x-permissions: stream_view
+      description: |
+        Action execution output event stream endpoint.
+      parameters:
+        - name: id
+          in: path
+          description: Execution id
+          type: string
+          required: true
+        - name: output_type
+          in: query
+          description: Type of output to retrieve (stdout, stderr). If not provided, all output type is returned.
+          type: string
+          enum:
+            - "all"
+            - "stdout"
+            - "stderr"
+          default: all
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
+      responses:
+        '200':
+          description: EventSource compatible stream of events
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
 
 definitions:
   Action:

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -1167,19 +1167,6 @@ paths:
             - "stdout"
             - "stderr"
           default: all
-        - name: output_format
-          in: query
-          description: Output format. "raw" for raw output and "event_source" for EventSource format (new line delimited JSON).
-          type: string
-          enum:
-            - "raw"
-            - "event_source"
-          default: raw
-        - name: existing_only
-          in: query
-          description: True for the endpoint to only return the existing output and return immediately. If False and execution is still running, the API endpoint will block until the execution finishes and return new output as it arrives.
-          type: boolean
-          default: false
       x-parameters:
         - name: user
           in: context

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -1161,7 +1161,7 @@ paths:
         - name: output_type
           in: query
           description: Type of output to retrieve (stdout, stderr). If not provided, all output type is returned.
-          type: enum
+          type: string
           enum:
             - "all"
             - "stdout"
@@ -1170,11 +1170,11 @@ paths:
         - name: output_format
           in: query
           description: Output format. "raw" for raw output and "event_source" for EventSource format (new line delimited JSON).
-          type: enum
+          type: string
           enum:
             - "raw"
             - "event_source"
-        default: raw
+          default: raw
         - name: existing_only
           in: query
           description: True for the endpoint to only return the existing output and return immediately. If False and execution is still running, the API endpoint will block until the execution finishes and return new output as it arrives.

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -1145,7 +1145,6 @@ paths:
     get:
       operationId: st2api.controllers.v1.actionexecutions:action_execution_output_controller.get_one
       x-log-result: false
-      x-is-stream-endpoint: true
       description: |
         Retrieve execution output.
       parameters:

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -4233,7 +4233,39 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-
+  /stream/v1/executions/{id}/output:
+    get:
+      operationId: st2stream.controllers.v1.executions:action_execution_output_controller.get_one
+      x-permissions: {{ PERMISSION_TYPE.STREAM_VIEW }}
+      description: |
+        Action execution output event stream endpoint.
+      parameters:
+        - name: id
+          in: path
+          description: Execution id
+          type: string
+          required: true
+        - name: output_type
+          in: query
+          description: Type of output to retrieve (stdout, stderr). If not provided, all output type is returned.
+          type: string
+          enum:
+            - "all"
+            - "stdout"
+            - "stderr"
+          default: all
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
+      responses:
+        '200':
+          description: EventSource compatible stream of events
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
 
 definitions:
   Action:

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -1163,19 +1163,6 @@ paths:
             - "stdout"
             - "stderr"
           default: all
-        - name: output_format
-          in: query
-          description: Output format. "raw" for raw output and "event_source" for EventSource format (new line delimited JSON).
-          type: string
-          enum:
-            - "raw"
-            - "event_source"
-          default: raw
-        - name: existing_only
-          in: query
-          description: True for the endpoint to only return the existing output and return immediately. If False and execution is still running, the API endpoint will block until the execution finishes and return new output as it arrives.
-          type: boolean
-          default: false
       x-parameters:
         - name: user
           in: context

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -1156,10 +1156,26 @@ paths:
           required: true
         - name: output_type
           in: query
-          description: Type of output to retrieve. If not provided, all output type is returned.
-          type: array
-          items:
-            type: string
+          description: Type of output to retrieve (stdout, stderr). If not provided, all output type is returned.
+          type: enum
+          enum:
+            - "all"
+            - "stdout"
+            - "stderr"
+          default: all
+        - name: output_format
+          in: query
+          description: Output format. "raw" for raw output and "event_source" for EventSource format (new line delimited JSON).
+          type: enum
+          enum:
+            - "raw"
+            - "event_source"
+          default: raw
+        - name: existing_only
+          in: query
+          description: True for the endpoint to only return the existing output and return immediately. If False and execution is still running, the API endpoint will block until the execution finishes and return new output as it arrives.
+          type: boolean
+          default: false
       x-parameters:
         - name: user
           in: context

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -1157,7 +1157,7 @@ paths:
         - name: output_type
           in: query
           description: Type of output to retrieve (stdout, stderr). If not provided, all output type is returned.
-          type: enum
+          type: string
           enum:
             - "all"
             - "stdout"
@@ -1166,7 +1166,7 @@ paths:
         - name: output_format
           in: query
           description: Output format. "raw" for raw output and "event_source" for EventSource format (new line delimited JSON).
-          type: enum
+          type: string
           enum:
             - "raw"
             - "event_source"

--- a/st2common/st2common/router.py
+++ b/st2common/st2common/router.py
@@ -40,6 +40,17 @@ from st2common.util.jsonify import json_encode
 from st2common.util.jsonify import get_json_type_for_python_value
 from st2common.util.http import parse_content_type_header
 
+__all__ = [
+    'Router',
+
+    'Response',
+
+    'NotFoundException',
+
+    'abort',
+    'abort_unauthorized',
+    'exc'
+]
 
 LOG = logging.getLogger(__name__)
 

--- a/st2common/st2common/service_setup.py
+++ b/st2common/st2common/service_setup.py
@@ -28,6 +28,7 @@ from oslo_config import cfg
 from st2common import log as logging
 from st2common.constants.logging import DEFAULT_LOGGING_CONF_PATH
 from st2common.transport.bootstrap_utils import register_exchanges_with_retry
+from st2common.transport.bootstrap_utils import register_kombu_serializers
 from st2common.signal_handlers import register_common_signal_handlers
 from st2common.util.debugging import enable_debugging
 from st2common.models.utils.profiling import enable_profiling
@@ -130,6 +131,8 @@ def setup(service, config, setup_db=True, register_mq_exchanges=True,
     # TODO: This is a "not so nice" workaround until we have a proper migration system in place
     if run_migrations:
         run_all_rbac_migrations()
+
+    register_kombu_serializers()
 
     metrics_initialize()
 

--- a/st2common/st2common/transport/publishers.py
+++ b/st2common/st2common/transport/publishers.py
@@ -53,7 +53,7 @@ class PoolPublisher(object):
                     'exchange': exchange,
                     'routing_key': routing_key,
                     'serializer': 'pickle',
-                    'content_encoding': 'utf-8' 
+                    'content_encoding': 'utf-8'
                 }
                 retry_wrapper.ensured(connection=connection,
                                       obj=producer,

--- a/st2common/st2common/transport/publishers.py
+++ b/st2common/st2common/transport/publishers.py
@@ -52,7 +52,8 @@ class PoolPublisher(object):
                     'body': payload,
                     'exchange': exchange,
                     'routing_key': routing_key,
-                    'serializer': 'pickle'
+                    'serializer': 'pickle',
+                    'content_encoding': 'utf-8' 
                 }
                 retry_wrapper.ensured(connection=connection,
                                       obj=producer,

--- a/st2stream/st2stream/controllers/v1/executions.py
+++ b/st2stream/st2stream/controllers/v1/executions.py
@@ -92,7 +92,7 @@ class ActionExecutionOutputStreamController(ResourceController):
 
         def new_output_iter():
             def noop_gen():
-                yield six.binary_type('')
+                yield six.binary_type(''.encode('utf-8'))
 
             # Bail out if execution has already completed / been paused
             if execution_db.status in self.CLOSE_STREAM_LIVEACTION_STATES:
@@ -121,7 +121,7 @@ class ActionExecutionOutputStreamController(ResourceController):
                             yield six.binary_type(output)
                         elif isinstance(model_api, ActionExecutionAPI):
                             if model_api.status in self.CLOSE_STREAM_LIVEACTION_STATES:
-                                yield six.binary_type('')
+                                yield six.binary_type(''.encode('utf-8'))
                                 break
                         else:
                             LOG.debug('Unrecognized message type: %s' % (model_api))

--- a/st2stream/st2stream/controllers/v1/executions.py
+++ b/st2stream/st2stream/controllers/v1/executions.py
@@ -1,0 +1,140 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+
+import six
+
+from st2api.controllers.resource import ResourceController
+from st2common import log as logging
+from st2common.constants import action as action_constants
+from st2common.models.db.execution import ActionExecutionOutputDB
+from st2common.models.api.execution import ActionExecutionAPI
+from st2common.models.api.execution import ActionExecutionOutputAPI
+from st2common.persistence.execution import ActionExecution
+from st2common.persistence.execution import ActionExecutionOutput
+from st2common.router import Response
+from st2common.util.jsonify import json_encode
+from st2common.rbac.types import PermissionType
+from st2common.stream.listener import get_listener
+
+__all__ = [
+    'ActionExecutionOutputStreamController'
+]
+
+LOG = logging.getLogger(__name__)
+
+
+class ActionExecutionOutputStreamController(ResourceController):
+    model = ActionExecutionAPI
+    access = ActionExecution
+
+    supported_filters = {
+        'output_type': 'output_type'
+    }
+
+    CLOSE_STREAM_LIVEACTION_STATES = action_constants.LIVEACTION_COMPLETED_STATES + [
+        action_constants.LIVEACTION_STATUS_PAUSING,
+        action_constants.LIVEACTION_STATUS_RESUMING
+    ]
+
+    def get_one(self, id, output_type='all', requester_user=None):
+        # Special case for id == "last"
+        if id == 'last':
+            execution_db = ActionExecution.query().order_by('-id').limit(1).first()
+
+            if not execution_db:
+                raise ValueError('No executions found in the database')
+
+            id = str(execution_db.id)
+
+        execution_db = self._get_one_by_id(id=id, requester_user=requester_user,
+                                           permission_type=PermissionType.EXECUTION_VIEW)
+        execution_id = str(execution_db.id)
+
+        query_filters = {}
+        if output_type and output_type != 'all':
+            query_filters['output_type'] = output_type
+
+        def format_output_object(output_db_or_api):
+            if isinstance(output_db_or_api, ActionExecutionOutputDB):
+                data = ActionExecutionOutputAPI.from_model(output_db_or_api)
+            elif isinstance(output_db_or_api, ActionExecutionOutputAPI):
+                data = output_db_or_api
+            else:
+                raise ValueError('Unsupported format: %s' % (type(output_db_or_api)))
+
+            event = 'st2.execution.output__create'
+            result = 'event: %s\ndata: %s\n\n' % (event, json_encode(data, indent=None))
+            return result
+
+        def existing_output_iter():
+            # Consume and return all of the existing lines
+            output_dbs = ActionExecutionOutput.query(execution_id=execution_id, **query_filters)
+
+            # Note: We return all at once instead of yield line by line to avoid multiple socket
+            # writes and to achieve better performance
+            output = [format_output_object(output_db) for output_db in output_dbs]
+            output = ''.join(output)
+            yield six.binary_type(output.encode('utf-8'))
+
+        def new_output_iter():
+            def noop_gen():
+                yield six.binary_type('')
+
+            # Bail out if execution has already completed / been paused
+            if execution_db.status in self.CLOSE_STREAM_LIVEACTION_STATES:
+                return noop_gen()
+
+            # Wait for and return any new line which may come in
+            execution_ids = [execution_id]
+            listener = get_listener(name='execution_output')  # pylint: disable=no-member
+            gen = listener.generator(execution_ids=execution_ids)
+
+            def format(gen):
+                for pack in gen:
+                    if not pack:
+                        continue
+                    else:
+                        (_, model_api) = pack
+
+                        # Note: gunicorn wsgi handler expect bytes, not unicode
+                        # pylint: disable=no-member
+                        if isinstance(model_api, ActionExecutionOutputAPI):
+                            if output_type and output_type != 'all' and \
+                               model_api.output_type != output_type:
+                                continue
+
+                            output = format_output_object(model_api).encode('utf-8')
+                            yield six.binary_type(output)
+                        elif isinstance(model_api, ActionExecutionAPI):
+                            if model_api.status in self.CLOSE_STREAM_LIVEACTION_STATES:
+                                yield six.binary_type('')
+                                break
+                        else:
+                            LOG.debug('Unrecognized message type: %s' % (model_api))
+
+            gen = format(gen)
+            return gen
+
+        def make_response():
+            app_iter = itertools.chain(existing_output_iter(), new_output_iter())
+            res = Response(content_type='text/event-stream', app_iter=app_iter)
+            return res
+
+        res = make_response()
+        return res
+
+action_execution_output_controller = ActionExecutionOutputStreamController()

--- a/st2stream/st2stream/controllers/v1/executions.py
+++ b/st2stream/st2stream/controllers/v1/executions.py
@@ -36,6 +36,10 @@ __all__ = [
 
 LOG = logging.getLogger(__name__)
 
+# Event which is returned when no more data will be produced on this stream endpoint before closing
+# the connection.
+NO_MORE_DATA_EVENT = 'event: EOF\ndata: \'\'\n\n'
+
 
 class ActionExecutionOutputStreamController(ResourceController):
     model = ActionExecutionAPI
@@ -92,7 +96,7 @@ class ActionExecutionOutputStreamController(ResourceController):
 
         def new_output_iter():
             def noop_gen():
-                yield six.binary_type(''.encode('utf-8'))
+                yield six.binary_type(NO_MORE_DATA_EVENT.encode('utf-8'))
 
             # Bail out if execution has already completed / been paused
             if execution_db.status in self.CLOSE_STREAM_LIVEACTION_STATES:
@@ -121,7 +125,7 @@ class ActionExecutionOutputStreamController(ResourceController):
                             yield six.binary_type(output)
                         elif isinstance(model_api, ActionExecutionAPI):
                             if model_api.status in self.CLOSE_STREAM_LIVEACTION_STATES:
-                                yield six.binary_type(''.encode('utf-8'))
+                                yield six.binary_type(NO_MORE_DATA_EVENT.encode('utf-8'))
                                 break
                         else:
                             LOG.debug('Unrecognized message type: %s' % (model_api))

--- a/st2stream/st2stream/controllers/v1/executions.py
+++ b/st2stream/st2stream/controllers/v1/executions.py
@@ -137,4 +137,5 @@ class ActionExecutionOutputStreamController(ResourceController):
         res = make_response()
         return res
 
+
 action_execution_output_controller = ActionExecutionOutputStreamController()

--- a/st2stream/tests/unit/controllers/v1/test_stream_execution_output.py
+++ b/st2stream/tests/unit/controllers/v1/test_stream_execution_output.py
@@ -15,8 +15,6 @@
 
 import json
 
-import six
-import unittest2
 import eventlet
 
 from six.moves import http_client
@@ -45,7 +43,6 @@ class ActionExecutionOutputStreamControllerTestCase(FunctionalTest):
         self.assertEqual(resp.status_int, http_client.BAD_REQUEST)
         self.assertEqual(resp.json['faultstring'], 'No executions found in the database')
 
-    @unittest2.skipIf(six.PY3, 'Skipping under Python 3 (closed iterator read issue)')
     def test_get_output_running_execution(self):
         # Retrieve lister instance to avoid race with listener connection not being established
         # early enough for tests to pass.
@@ -122,7 +119,6 @@ class ActionExecutionOutputStreamControllerTestCase(FunctionalTest):
 
         listener.shutdown()
 
-    @unittest2.skipIf(six.PY3, 'Skipping under Python 3 (closed iterator read issue)')
     def test_get_output_finished_execution(self):
         # Test the execution output API endpoint for execution which has finished
         for status in action_constants.LIVEACTION_COMPLETED_STATES:

--- a/st2stream/tests/unit/controllers/v1/test_stream_execution_output.py
+++ b/st2stream/tests/unit/controllers/v1/test_stream_execution_output.py
@@ -177,6 +177,11 @@ class ActionExecutionOutputStreamControllerTestCase(FunctionalTest):
         for line in lines:
             if 'data:' in line:
                 event_data = line[line.find('data: ') + len('data :'):].strip()
+
+                if len(event_data.strip("'")) == 0:
+                    # Skip EOF events:
+                    continue
+
                 event = json.loads(event_data)
                 events.append(event)
 

--- a/st2stream/tests/unit/controllers/v1/test_stream_execution_output.py
+++ b/st2stream/tests/unit/controllers/v1/test_stream_execution_output.py
@@ -1,0 +1,187 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import six
+import unittest2
+import eventlet
+
+from six.moves import http_client
+
+from st2common.constants import action as action_constants
+from st2common.models.db.execution import ActionExecutionDB
+from st2common.models.db.execution import ActionExecutionOutputDB
+from st2common.persistence.execution import ActionExecution
+from st2common.persistence.execution import ActionExecutionOutput
+from st2common.util import date as date_utils
+
+from st2common.stream.listener import get_listener
+
+from .base import FunctionalTest
+
+__all__ = [
+    'ActionExecutionOutputStreamControllerTestCase'
+]
+
+
+class ActionExecutionOutputStreamControllerTestCase(FunctionalTest):
+    def test_get_one_id_last_no_executions_in_the_database(self):
+        ActionExecution.query().delete()
+
+        resp = self.app.get('/v1/executions/last/output', expect_errors=True)
+        self.assertEqual(resp.status_int, http_client.BAD_REQUEST)
+        self.assertEqual(resp.json['faultstring'], 'No executions found in the database')
+
+    @unittest2.skipIf(six.PY3, 'Skipping under Python 3 (closed iterator read issue)')
+    def test_get_output_running_execution(self):
+        # Retrieve lister instance to avoid race with listener connection not being established
+        # early enough for tests to pass.
+        # NOTE: This only affects tests where listeners are not pre-initialized.
+        listener = get_listener(name='execution_output')
+        eventlet.sleep(1.0)
+
+        # Test the execution output API endpoint for execution which is running (blocking)
+        status = action_constants.LIVEACTION_STATUS_RUNNING
+        timestamp = date_utils.get_datetime_utc_now()
+        action_execution_db = ActionExecutionDB(start_timestamp=timestamp,
+                                                end_timestamp=timestamp,
+                                                status=status,
+                                                action={'ref': 'core.local'},
+                                                runner={'name': 'run-local'},
+                                                liveaction={'ref': 'foo'})
+        action_execution_db = ActionExecution.add_or_update(action_execution_db)
+
+        output_params = dict(execution_id=str(action_execution_db.id),
+                             action_ref='core.local',
+                             runner_ref='dummy',
+                             timestamp=timestamp,
+                             output_type='stdout',
+                             data='stdout before start\n')
+
+        # Insert mock output object
+        output_db = ActionExecutionOutputDB(**output_params)
+        ActionExecutionOutput.add_or_update(output_db, publish=False)
+
+        def insert_mock_data():
+            output_params['data'] = 'stdout mid 1\n'
+            output_db = ActionExecutionOutputDB(**output_params)
+            ActionExecutionOutput.add_or_update(output_db)
+
+        # Since the API endpoint is blocking (connection is kept open until action finishes), we
+        # spawn an eventlet which eventually finishes the action.
+        def publish_action_finished(action_execution_db):
+            # Insert mock output object
+            output_params['data'] = 'stdout pre finish 1\n'
+            output_db = ActionExecutionOutputDB(**output_params)
+            ActionExecutionOutput.add_or_update(output_db)
+
+            eventlet.sleep(1.0)
+
+            # Transition execution to completed state so the connection closes
+            action_execution_db.status = action_constants.LIVEACTION_STATUS_SUCCEEDED
+            action_execution_db = ActionExecution.add_or_update(action_execution_db)
+
+        eventlet.spawn_after(0.2, insert_mock_data)
+        eventlet.spawn_after(1.5, publish_action_finished, action_execution_db)
+
+        # Retrieve data while execution is running - endpoint return new data once it's available
+        # and block until the execution finishes
+        resp = self.app.get('/v1/executions/%s/output' % (str(action_execution_db.id)),
+                            expect_errors=False)
+        self.assertEqual(resp.status_int, 200)
+
+        events = self._parse_response(resp.text)
+        self.assertEqual(len(events), 3)
+        self.assertEqual(events[0]['data'], 'stdout before start\n')
+        self.assertEqual(events[1]['data'], 'stdout mid 1\n')
+        self.assertEqual(events[2]['data'], 'stdout pre finish 1\n')
+
+        # Once the execution is in completed state, existing output should be returned immediately
+        resp = self.app.get('/v1/executions/%s/output' % (str(action_execution_db.id)),
+                            expect_errors=False)
+        self.assertEqual(resp.status_int, 200)
+
+        events = self._parse_response(resp.text)
+        self.assertEqual(len(events), 3)
+        self.assertEqual(events[0]['data'], 'stdout before start\n')
+        self.assertEqual(events[1]['data'], 'stdout mid 1\n')
+        self.assertEqual(events[2]['data'], 'stdout pre finish 1\n')
+
+        listener.shutdown()
+
+    @unittest2.skipIf(six.PY3, 'Skipping under Python 3 (closed iterator read issue)')
+    def test_get_output_finished_execution(self):
+        # Test the execution output API endpoint for execution which has finished
+        for status in action_constants.LIVEACTION_COMPLETED_STATES:
+            # Insert mock execution and output objects
+            status = action_constants.LIVEACTION_STATUS_SUCCEEDED
+            timestamp = date_utils.get_datetime_utc_now()
+            action_execution_db = ActionExecutionDB(start_timestamp=timestamp,
+                                                    end_timestamp=timestamp,
+                                                    status=status,
+                                                    action={'ref': 'core.local'},
+                                                    runner={'name': 'run-local'},
+                                                    liveaction={'ref': 'foo'})
+            action_execution_db = ActionExecution.add_or_update(action_execution_db)
+
+            for i in range(1, 6):
+                stdout_db = ActionExecutionOutputDB(execution_id=str(action_execution_db.id),
+                                                    action_ref='core.local',
+                                                    runner_ref='dummy',
+                                                    timestamp=timestamp,
+                                                    output_type='stdout',
+                                                    data='stdout %s\n' % (i))
+                ActionExecutionOutput.add_or_update(stdout_db)
+
+            for i in range(10, 15):
+                stderr_db = ActionExecutionOutputDB(execution_id=str(action_execution_db.id),
+                                                    action_ref='core.local',
+                                                    runner_ref='dummy',
+                                                    timestamp=timestamp,
+                                                    output_type='stderr',
+                                                    data='stderr %s\n' % (i))
+                ActionExecutionOutput.add_or_update(stderr_db)
+
+            resp = self.app.get('/v1/executions/%s/output' % (str(action_execution_db.id)),
+                                expect_errors=False)
+            self.assertEqual(resp.status_int, 200)
+
+            events = self._parse_response(resp.text)
+            self.assertEqual(len(events), 10)
+            self.assertEqual(events[0]['data'], 'stdout 1\n')
+            self.assertEqual(events[9]['data'], 'stderr 14\n')
+
+            # Verify "last" short-hand id works
+            resp = self.app.get('/v1/executions/last/output', expect_errors=False)
+            self.assertEqual(resp.status_int, 200)
+
+            events = self._parse_response(resp.text)
+            self.assertEqual(len(events), 10)
+
+    def _parse_response(self, response):
+        """
+        Parse event stream response and return a list of events.
+        """
+        events = []
+
+        lines = response.strip().split('\n')
+        for line in lines:
+            if 'data:' in line:
+                event_data = line[line.find('data: ') + len('data :'):].strip()
+                event = json.loads(event_data)
+                events.append(event)
+
+        return events


### PR DESCRIPTION
This pull request adds new ``?output_type=[raw|event_source]`` and ``?existing_only=[true|false]`` query parameter filters to the ``/v1/api/executions/<id>/output`` API endpoint.

With this query parameters, user can control two things:

1. What type of output to receive

* ``raw`` for raw output data produced by the execution (default). This works well when user just wants to curl this endpoint, embed the output directly in a webpage or similar.
* ``event_source`` - for event source compatible format (new line delimited JSON). This comes handy when user is also interested in metadata such as timestamp and output type.

NOTE: ``event_source`` format can result in a slow response for actions which produced a lot of data because it means we need to format and JSON serialize every ActionExecutionOutputDB object. Sadly there is no easy way around it.

2. If they want the API endpoint to block or not.

It defaults to ``?existing_only=false`` which means the API endpoint will block until the execution finishes and write any new data when it arrives to the open connection.

Keep in mind that this only applies to executions which are still in running state.

This functionality was added to allow for a better integration with WebUI. Before this change, there was no way to retrieve output which execution produced so far if user wasn't listening to the stream API endpoint from the beginning when the execution started.

## TODO

- [x] Tests
- [ ] Update docs
- [ ] Add upgrade notes entry