### PR TITLE
Update cryptography library to v2.3.0

### DIFF
--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -34,7 +34,7 @@ stevedore==1.28.0
 paramiko==2.4.1
 networkx==1.11
 python-keyczar==0.716
-cryptography==2.2.2
+cryptography==2.3.0
 retrying==1.3.3
 # Note: We use latest version of virtualenv which uses pip 9.0
 virtualenv==15.1.0


### PR DESCRIPTION
The version were used had a reported security vulnerability recently - https://cryptography.io/en/latest/changelog/#v2-3