### PR TITLE
[DONT MERGE] Try using mmapv1 storage engine on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ before_script:
   # Use a custom mongod.conf which uses various speed optimizations
   - sudo cp scripts/travis/mongod.conf /etc/mongod.conf
   # Clean up any old MongoDB 3.4 data files laying around and make sure mongodb user can write to it
-  - sudo rm -rf /var/lib/mongodb ; sudo mkdir /var/lib/mongodb ; sudo chown -R mongodb:mongodb /var/lib/mongodb
+  - sudo rm -rf /var/lib/mongodb ; sudo mkdir /var/lib/mongodb ; sudo mkdir /var/lib/mongodb/journal ; sudo chown -R mongodb:mongodb /var/lib/mongodb
   - sudo service mongod restart ; sleep 5
   - sudo service mongod status
   - tail -30 /var/log/mongodb/mongod.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,7 @@ before_script:
   # Clean up any old MongoDB 3.4 data files laying around and make sure mongodb user can write to it
   - sudo rm -rf /var/lib/mongodb ; sudo mkdir /var/lib/mongodb ; sudo mkdir /var/lib/mongodb/journal ; sudo chown -R mongodb:mongodb /var/lib/mongodb
   - sudo service mongod restart ; sleep 5
+  - sudo service mongod start ; sleep 10
   - sudo service mongod status
   - tail -30 /var/log/mongodb/mongod.log
   - mongod --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,8 +102,8 @@ before_script:
   # Use a custom mongod.conf which uses various speed optimizations
   - sudo cp scripts/travis/mongod.conf /etc/mongod.conf
   # Clean up any old MongoDB 3.4 data files laying around and make sure mongodb user can write to it
+  - sudo service mongod stop; sleep 10
   - sudo rm -rf /var/lib/mongodb ; sudo mkdir /var/lib/mongodb ; sudo mkdir /var/lib/mongodb/journal ; sudo chown -R mongodb:mongodb /var/lib/mongodb
-  - sudo service mongod restart ; sleep 5
   - sudo service mongod start ; sleep 10
   - sudo service mongod status
   - tail -30 /var/log/mongodb/mongod.log

--- a/scripts/travis/mongod.conf
+++ b/scripts/travis/mongod.conf
@@ -43,6 +43,7 @@ net:
 #    --notablescan --dbpath ${DATA_DIR} --bind_ip 127.0.0.1 &> /tmp/mongodb.log &
 
 storage:
+  engine: mmapv1
   dbPath: /var/lib/mongodb
   indexBuildRetry: false
   journal:
@@ -51,6 +52,7 @@ storage:
   syncPeriodSecs: 0
 
 security:
+  authorization: false
   javascriptEnabled: false
 
 setParameter:


### PR DESCRIPTION
This pull request updates MongoDB config so we try and use `mmapv1` storage engine on Travis.

I'm just curious if it will help make builds faster.

On a related note, sadly unit tests running under MongoDB 3.6 are consitently 40-60% slower than the ones running under 3.4.

I wonder if it's related to https://jira.mongodb.org/browse/SERVER-24580.