### PR TITLE
Don't run tests under MongoDB 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,20 +34,20 @@ matrix:
     - env: TASK=ci-unit CACHE_NAME=py2 COMMAND_THRESHOLD=700
       python: 2.7
       name: "Unit Tests (Python 2.7 MongoDB 3.4)"
-    - env: TASK=ci-unit CACHE_NAME=py2 COMMAND_THRESHOLD=700
-      python: 2.7
-      name: "Unit Tests (Python 2.7 MongoDB 3.6)"
-      addons:
-        apt:
-          sources:
-            - mongodb-upstart
-            - sourceline: 'deb [arch=amd64] http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.6 multiverse'
-              key_url: 'https://www.mongodb.org/static/pgp/server-3.6.asc'
-            - sourceline: 'ppa:git-core/ppa'
-          packages:
-            - mongodb-org-server
-            - mongodb-org-shell
-            - git
+    #- env: TASK=ci-unit CACHE_NAME=py2 COMMAND_THRESHOLD=700
+      #python: 2.7
+      #name: "Unit Tests (Python 2.7 MongoDB 3.6)"
+      #addons:
+      #  apt:
+      #    sources:
+      #      - mongodb-upstart
+      #      - sourceline: 'deb [arch=amd64] http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.6 multiverse'
+      #        key_url: 'https://www.mongodb.org/static/pgp/server-3.6.asc'
+      #      - sourceline: 'ppa:git-core/ppa'
+      #    packages:
+      #      - mongodb-org-server
+      #      - mongodb-org-shell
+      #      - git
     - env: TASK=ci-integration CACHE_NAME=py2 COMMAND_THRESHOLD=700
       python: 2.7
       name: "Integration Tests (Python 2.7)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ branches:
 
 env:
   global:
-    - CACHE_NAME=JOB1
     # NOTE: We only enable coverage for master builds and not pull requests
     # since it has huge performance overhead (etests are 50% or so slower)
     - ENABLE_COVERAGE=$([ "${TRAVIS_PULL_REQUEST}" = "false" ] && echo "yes" || echo "no")


### PR DESCRIPTION
I'm disabling running tests under MongoDB 3.6 until we figure out why tests are 30%-40% slower compared to 3.4.

See https://github.com/StackStorm/st2/issues/4098#issuecomment-410712729 for details.