### PR TITLE
Ignore CryptographyDeprecationWarning deprecation warning in st2 CLI

### DIFF
--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -22,6 +22,11 @@ Command-line interface to StackStorm.
 from __future__ import print_function
 from __future__ import absolute_import
 
+# Ignore CryptographyDeprecationWarning warnings which appear on our Ubuntu build server
+import warnings
+from cryptography.utils import CryptographyDeprecationWarning
+warnings.filterwarnings("ignore", category=CryptographyDeprecationWarning)
+
 import os
 import sys
 import argcomplete


### PR DESCRIPTION
Latest version of `cryptography` started warning if `hmac` module doesn't have `compare_digest` function.

This is the case for one of our Ubuntu build servers which likely runs old 2.7.x version. This pull request silences those warnings for now, since they are not fatal yet.

This should fix the failing Ubuntu daily build.

Eventually we should also look into ensuring that our Ubuntu build slave host runs latest 2.7.x release.