### PR TITLE
Fix hello_st2 greet action

### DIFF
--- a/contrib/hello_st2/actions/greet.yaml
+++ b/contrib/hello_st2/actions/greet.yaml
@@ -1,7 +1,7 @@
 ---
 name: greet
 pack: hello_st2
-runner_type: "local-shell-cmd"
+runner_type: "local-shell-script"
 description: Greet StackStorm!
 enabled: true
 entry_point: greet.sh


### PR DESCRIPTION
Somehow our example `hello_st2.greet` action had the wrong runner type, and no-one noticed for years.

Fixes https://github.com/StackStorm/st2/issues/4296