### PR TITLE
Improvements to the st2-inject-trigger-instances script

### DIFF
--- a/tools/st2-inject-trigger-instances.py
+++ b/tools/st2-inject-trigger-instances.py
@@ -62,6 +62,8 @@ def _inject_instances(trigger, rate_per_trigger, duration, payload=None, max_thr
         dispatcher.dispatch(trigger, payload)
 
         if rate_per_trigger:
+            # NOTE: We decrease sleep delay for 56% to take into account overhead / delay because
+            # of the call to dispatchet.dispatch method.
             delta = random.expovariate(rate_per_trigger)
             eventlet.sleep(delta * 0.56)
 
@@ -75,7 +77,7 @@ def _inject_instances(trigger, rate_per_trigger, duration, payload=None, max_thr
 
     # NOTE: Due the way this script works (allows user to specify a rate, actual rate will always
     # be a bit lower than the requested one)
-    if rate_per_trigger and (actual_rate < (rate_per_trigger * 0.60)):
+    if rate_per_trigger and (actual_rate < rate_per_trigger):
         print('')
         print('Warning, requested rate was %s triggers / second, but only achieved %s '
               'triggers / second' % (rate_per_trigger, actual_rate))

--- a/tools/st2-inject-trigger-instances.py
+++ b/tools/st2-inject-trigger-instances.py
@@ -63,7 +63,7 @@ def _inject_instances(trigger, rate_per_trigger, duration, payload=None, max_thr
 
         if rate_per_trigger:
             delta = random.expovariate(rate_per_trigger)
-            eventlet.sleep(delta)
+            eventlet.sleep(delta * 0.56)
 
         elapsed = (date_utils.get_datetime_utc_now() - start).seconds
         count += 1

--- a/tools/st2-inject-trigger-instances.py
+++ b/tools/st2-inject-trigger-instances.py
@@ -75,9 +75,9 @@ def _inject_instances(trigger, rate_per_trigger, duration, payload=None, max_thr
     print('%s: Emitted %d triggers in %d seconds (actual rate=%s triggers / second)' %
           (trigger, count, elapsed, actual_rate))
 
-    # NOTE: Due the way this script works (allows user to specify a rate, actual rate will always
-    # be a bit lower than the requested one)
-    if rate_per_trigger and (actual_rate < rate_per_trigger):
+    # NOTE: Due to the overhead of dispatcher.dispatch call, we allow for 10% of deviation from
+    # requested rate before warning
+    if rate_per_trigger and (actual_rate < (rate_per_trigger * 0.9)):
         print('')
         print('Warning, requested rate was %s triggers / second, but only achieved %s '
               'triggers / second' % (rate_per_trigger, actual_rate))

--- a/tools/st2-inject-trigger-instances.py
+++ b/tools/st2-inject-trigger-instances.py
@@ -68,7 +68,7 @@ def _inject_instances(trigger, rate_per_trigger, duration, payload=None, max_thr
         elapsed = (date_utils.get_datetime_utc_now() - start).seconds
         count += 1
 
-    actual_rate = (count / elapsed)
+    actual_rate = int(count / elapsed)
 
     print('%s: Emitted %d triggers in %d seconds (actual rate=%s triggers / second)' %
           (trigger, count, elapsed, actual_rate))


### PR DESCRIPTION
Various improvements to the `st2-trigger-instances` script which is used to benchmark StackStorm (rules engine).

1. Specify duration in seconds
2. Reduce `random.expovariate` sleep by 55% to allow script to actually achieve rate requested by the user (that is, when requested rate is smaller than the max possible rate on that configuration). Previously actual achieved rate was always 50% or so less than the requested one, due to the overhead of `dispatcher.dispatch` call. (`eventlet.sleep(delta)` would only work correctly if duration of `dispatcher.dispatch` was zero aka no op). Keep in mind that the actual achieves rate might still be a bit less or a bit more than the requested one, but it will be much closer than before.
3. Add ``--max-throughput`` option which allows user to achieve maximum possible injection rate.