### PR TITLE
Fix a typo, we should increment a counter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -84,7 +84,8 @@ Changed
   way to find out about this failure would be to inspect the ``st2rulesengine`` service logs.
   (improvement) #4231
 * Improve code metric instrumentation and instrument code and various services with more metrics.
-  (improvement) #4310
+  Also document various exposed metrics. Documentation can be found at
+  https://docs.stackstorm.com/latest/reference/metrics.html (improvement) #4310
 * Add new ``metrics.prefix`` config option. With this option user can specify an optional prefix
   which is prepended to each metric key (name). This comes handy in scenarios where user wants to
   submit metrics from multiple environments / deployments (e.g. testing, staging, dev) to the same

--- a/conf/metrics/carbon/storage-aggregation.conf
+++ b/conf/metrics/carbon/storage-aggregation.conf
@@ -26,11 +26,6 @@ pattern = \.count$
 xFilesFactor = 0
 aggregationMethod = sum
 
-[count_legacy]
-pattern = ^stats_counts.*
-xFilesFactor = 0
-aggregationMethod = sum
-
 [lower]
 pattern = \.lower(_\d+)?$
 xFilesFactor = 0.1

--- a/st2actions/st2actions/workflows/workflows.py
+++ b/st2actions/st2actions/workflows/workflows.py
@@ -49,11 +49,11 @@ class WorkflowExecutionHandler(consumers.VariableMessageHandler):
     def __init__(self, connection, queues):
         super(WorkflowExecutionHandler, self).__init__(connection, queues)
 
-        def handle_workflow_execution_with_instrumentation(self, wf_ex_db):
+        def handle_workflow_execution_with_instrumentation(wf_ex_db):
             with CounterWithTimer(key='orquesta.workflow.executions'):
                 return self.handle_workflow_execution(wf_ex_db=wf_ex_db)
 
-        def handle_action_execution_with_instrumentation(self, ac_ex_db):
+        def handle_action_execution_with_instrumentation(ac_ex_db):
             with CounterWithTimer(key='orquesta.action.executions'):
                 return self.handle_action_execution(ac_ex_db=ac_ex_db)
 

--- a/st2common/st2common/util/action_db.py
+++ b/st2common/st2common/util/action_db.py
@@ -202,7 +202,7 @@ def update_liveaction_status(status=None, result=None, context=None, end_timesta
     # If status is provided then we need to increment the timer because the action
     # is transitioning into this new state
     if status:
-        get_driver().dec_counter('action.executions.%s' % (status))
+        get_driver().inc_counter('action.executions.%s' % (status))
 
     extra = {'liveaction_db': liveaction_db}
     LOG.debug('Updating ActionExection: "%s" with status="%s"', liveaction_db.id, status,

--- a/st2reactor/st2reactor/rules/worker.py
+++ b/st2reactor/st2reactor/rules/worker.py
@@ -87,7 +87,7 @@ class TriggerInstanceDispatcher(consumers.StagedMessageHandler):
                 trigger_instance, trigger_constants.TRIGGER_INSTANCE_PROCESSING)
 
             with CounterWithTimer(key='rule.processed'):
-                with Timer(key='triggerinstance.%s.processed' % (trigger_instance.id)):
+                with Timer(key='trigger.%s.processed' % (trigger_instance.trigger)):
                     self.rules_engine.handle_trigger_instance(trigger_instance)
 
             container_utils.update_trigger_instance_status(


### PR DESCRIPTION
Noticed that per execution status graphs are off, then I found this typo in the code.

As discussed on Slack yesterday, this PR also changes rules engine per trigger instance metric to per trigger metric.

Each trigger instance is unique and having many unique metrics is an anti-pattern. And since we are talking of potentially many, many trigger instances total, this would have a big negative performance overhead on any metrics backend.

And while at it, I also added some basic instrumentation to the new workflow engine service.