### PR TITLE
Instrumentation improvements

### DIFF
--- a/conf/st2.conf.sample
+++ b/conf/st2.conf.sample
@@ -181,6 +181,8 @@ connection_retries = 10
 cluster_urls =  # comma separated list allowed here.
 
 [metrics]
+# Randomly sample and only send metrics for X% of metric operations to the backend. Default value of 1 means no sampling is done and all the metrics are sent to the backend. E.g. 0.1 would mean 10% of operations are sampled.
+sample_rate = 1
 # Destination server to connect to if driver requires connection.
 host = 127.0.0.1
 # Optional prefix which is prepended to all the metric names. Comes handy when you want to submit metrics from various environment to the same metric backend instance.

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -542,7 +542,13 @@ def register_opts(ignore_errors=False):
             'prefix', default=None,
             help='Optional prefix which is prepended to all the metric names. Comes handy when '
                  'you want to submit metrics from various environment to the same metric '
-                 'backend instance.')
+                 'backend instance.'),
+        cfg.FloatOpt(
+            'sample_rate', default=1,
+            help='Randomly sample and only send metrics for X% of metric operations to the '
+                 'backend. Default value of 1 means no sampling is done and all the metrics are '
+                 'sent to the backend. E.g. 0.1 would mean 10% of operations are sampled.')
+
     ]
 
     do_register_opts(metrics_opts, group='metrics', ignore_errors=ignore_errors)

--- a/st2common/st2common/metrics/drivers/statsd_driver.py
+++ b/st2common/st2common/metrics/drivers/statsd_driver.py
@@ -32,7 +32,8 @@ class StatsdDriver(BaseMetricsDriver):
     StatsD Implementation of the metrics driver
     """
     def __init__(self):
-        statsd.Connection.set_defaults(host=cfg.CONF.metrics.host, port=cfg.CONF.metrics.port)
+        statsd.Connection.set_defaults(host=cfg.CONF.metrics.host, port=cfg.CONF.metrics.port,
+                                       sample_rate=cfg.CONF.metrics.sample_rate)
 
         self._counters = {}
         self._timer = statsd.Timer('')

--- a/st2common/st2common/metrics/drivers/statsd_driver.py
+++ b/st2common/st2common/metrics/drivers/statsd_driver.py
@@ -54,7 +54,6 @@ class StatsdDriver(BaseMetricsDriver):
         assert isinstance(amount, Number)
 
         key = get_full_key_name(key)
-
         counter = statsd.Counter(key)
         counter.increment(delta=amount)
 

--- a/st2common/st2common/metrics/drivers/statsd_driver.py
+++ b/st2common/st2common/metrics/drivers/statsd_driver.py
@@ -35,9 +35,6 @@ class StatsdDriver(BaseMetricsDriver):
         statsd.Connection.set_defaults(host=cfg.CONF.metrics.host, port=cfg.CONF.metrics.port,
                                        sample_rate=cfg.CONF.metrics.sample_rate)
 
-        self._counters = {}
-        self._timer = statsd.Timer('')
-
     def time(self, key, time):
         """
         Timer metric
@@ -46,7 +43,8 @@ class StatsdDriver(BaseMetricsDriver):
         assert isinstance(time, Number)
 
         key = get_full_key_name(key)
-        self._timer.send(key, time)
+        timer = statsd.Timer('')
+        timer.send(key, time)
 
     def inc_counter(self, key, amount=1):
         """
@@ -56,8 +54,9 @@ class StatsdDriver(BaseMetricsDriver):
         assert isinstance(amount, Number)
 
         key = get_full_key_name(key)
-        self._counters[key] = self._counters.get(key, statsd.Counter(key))
-        self._counters[key] += amount
+
+        counter = statsd.Counter(key)
+        counter.increment(delta=amount)
 
     def dec_counter(self, key, amount=1):
         """
@@ -67,8 +66,8 @@ class StatsdDriver(BaseMetricsDriver):
         assert isinstance(amount, Number)
 
         key = get_full_key_name(key)
-        self._counters[key] = self._counters.get(key, statsd.Counter(key))
-        self._counters[key] -= amount
+        counter = statsd.Counter(key)
+        counter.decrement(delta=amount)
 
     def set_gauge(self, key, value):
         """

--- a/st2common/st2common/middleware/instrumentation.py
+++ b/st2common/st2common/middleware/instrumentation.py
@@ -69,7 +69,7 @@ class RequestInstrumentationMiddleware(object):
 
             start_time = get_datetime_utc_now()
 
-            def hook(env):
+            def update_metrics_hook(env):
                 # Hook which is called at the very end after all the response has been sent and
                 # connection closed
                 time_delta = (get_datetime_utc_now() - start_time)
@@ -81,7 +81,9 @@ class RequestInstrumentationMiddleware(object):
                 # Decrease "current number of connections" gauge
                 metrics_driver.dec_gauge('stream.connections', 1)
 
-            environ['eventlet.posthooks'].append((hook, (), {}))
+            # NOTE: Some tests mock environ and there 'eventlet.posthooks' key is not available
+            if 'eventlet.posthooks' in environ:
+                environ['eventlet.posthooks'].append((update_metrics_hook, (), {}))
 
             return self.app(environ, start_response)
         else:

--- a/st2common/st2common/middleware/instrumentation.py
+++ b/st2common/st2common/middleware/instrumentation.py
@@ -43,10 +43,6 @@ class RequestInstrumentationMiddleware(object):
 
         metrics_driver = get_driver()
 
-        if request.content_length:
-            key = '%s.request.size' % (self._service_name)
-            metrics_driver.set_gauge(key, int(request.content_length))
-
         key = '%s.request.total' % (self._service_name)
         metrics_driver.inc_counter(key)
 
@@ -117,11 +113,6 @@ class ResponseInstrumentationMiddleware(object):
             metrics_driver = get_driver()
             metrics_driver.inc_counter('%s.response.status.%s' % (self._service_name,
                                                                   status_code))
-
-            content_length = dict(headers).get('Content-Length', None)
-            if content_length:
-                key = '%s.response.size' % (self._service_name)
-                metrics_driver.set_gauge(key, int(content_length))
 
             return start_response(status, headers, exc_info)
 

--- a/st2common/tests/unit/test_metrics.py
+++ b/st2common/tests/unit/test_metrics.py
@@ -64,7 +64,8 @@ class TestStatsDMetricsDriver(unittest2.TestCase):
 
         statsd.Connection.set_defaults.assert_called_once_with(
             host=cfg.CONF.metrics.host,
-            port=cfg.CONF.metrics.port
+            port=cfg.CONF.metrics.port,
+            sample_rate=1.0
         )
 
     def test_time(self):

--- a/st2common/tests/unit/test_metrics.py
+++ b/st2common/tests/unit/test_metrics.py
@@ -68,16 +68,18 @@ class TestStatsDMetricsDriver(unittest2.TestCase):
             sample_rate=1.0
         )
 
-    def test_time(self):
-        statsd = MagicMock()
-        self._driver._timer = statsd.Timer('')
+    @patch('st2common.metrics.drivers.statsd_driver.statsd')
+    def test_time(self, statsd):
+        mock_timer = MagicMock()
+        statsd.Timer('').send.side_effect = mock_timer
         params = ('test', 10)
         self._driver.time(*params)
-        statsd.Timer().send.assert_called_with('st2.test', 10)
+        statsd.Timer('').send.assert_called_with('st2.test', 10)
 
-    def test_time_with_float(self):
-        statsd = MagicMock()
-        self._driver._timer = statsd.Timer('')
+    @patch('st2common.metrics.drivers.statsd_driver.statsd')
+    def test_time_with_float(self, statsd):
+        mock_timer = MagicMock()
+        statsd.Timer('').send.side_effect = mock_timer
         params = ('test', 10.5)
         self._driver.time(*params)
         statsd.Timer().send.assert_called_with('st2.test', 10.5)
@@ -96,17 +98,17 @@ class TestStatsDMetricsDriver(unittest2.TestCase):
     def test_inc_counter_with_default_amount(self, statsd):
         key = 'test'
         mock_counter = MagicMock()
-        statsd.Counter(key).__iadd__.side_effect = mock_counter
+        statsd.Counter(key).increment.side_effect = mock_counter
         self._driver.inc_counter(key)
-        mock_counter.assert_called_once_with(1)
+        mock_counter.assert_called_once_with(delta=1)
 
     @patch('st2common.metrics.drivers.statsd_driver.statsd')
     def test_inc_counter_with_amount(self, statsd):
         params = ('test', 2)
         mock_counter = MagicMock()
-        statsd.Counter(params[0]).__iadd__.side_effect = mock_counter
+        statsd.Counter(params[0]).increment.side_effect = mock_counter
         self._driver.inc_counter(*params)
-        mock_counter.assert_called_once_with(params[1])
+        mock_counter.assert_called_once_with(delta=params[1])
 
     def test_inc_timer_with_invalid_key(self):
         params = (2, 2)
@@ -122,17 +124,17 @@ class TestStatsDMetricsDriver(unittest2.TestCase):
     def test_dec_timer_with_default_amount(self, statsd):
         key = 'test'
         mock_counter = MagicMock()
-        statsd.Counter().__isub__.side_effect = mock_counter
+        statsd.Counter().decrement.side_effect = mock_counter
         self._driver.dec_counter(key)
-        mock_counter.assert_called_once_with(1)
+        mock_counter.assert_called_once_with(delta=1)
 
     @patch('st2common.metrics.drivers.statsd_driver.statsd')
     def test_dec_timer_with_amount(self, statsd):
         params = ('test', 2)
         mock_counter = MagicMock()
-        statsd.Counter().__isub__.side_effect = mock_counter
+        statsd.Counter().decrement.side_effect = mock_counter
         self._driver.dec_counter(*params)
-        mock_counter.assert_called_once_with(params[1])
+        mock_counter.assert_called_once_with(delta=params[1])
 
     def test_dec_timer_with_invalid_key(self):
         params = (2, 2)


### PR DESCRIPTION
I went over the metrics and noticed that some stream service metrics are not accurate.

The reason for that is that stream endpoint reqiests are long running and middleware returns immediately instead of when connection is closed (when either server or client closes it). With those changes we will now have correct timing and request count information.

To be able to get accurate numbers, I needed to utilize eventlet posthook (there is no other way to achieve that - http://eventlet.net/doc/modules/wsgi.html#non-standard-extension-to-support-post-hooks).

I also added some other changes:

1. Allow user to specify sample rate. Comes handy in environments with tons of request where you want to reduce the load on metrics backend server and not send every single operation metrics to the backend.
2. Add new gauge metrics which measures current number of open stream connections.
3. Don't cache `Counter` objects. We use dynamic metrics keys in some places and caching `Counter` objects doesn't really gets us much, but it could potentially result in additional and unnecessary memory usage when a lot of dynamic metric keys are used.