### PR TITLE
Add API endpoint and CLI command for orquesta workflow inspection

### DIFF
--- a/contrib/examples/actions/orquesta-fail-inspection-task-contents.yaml
+++ b/contrib/examples/actions/orquesta-fail-inspection-task-contents.yaml
@@ -1,0 +1,11 @@
+---
+name: orquesta-fail-inspection-task-contents
+description: A basic sequential workflow with inspection error(s).
+runner_type: orquesta
+entry_point: workflows/tests/orquesta-fail-inspection-task-contents.yaml
+enabled: true
+parameters:
+  name:
+    required: true
+    type: string
+    default: Lakshmi

--- a/contrib/examples/actions/workflows/tests/orquesta-fail-inspection-task-contents.yaml
+++ b/contrib/examples/actions/workflows/tests/orquesta-fail-inspection-task-contents.yaml
@@ -1,0 +1,35 @@
+version: 1.0
+  
+description: A basic sequential workflow with inspection error(s).
+
+input:
+  - name
+
+vars:
+  - greeting: null
+
+output:
+  - greeting: <% ctx().greeting %>
+
+tasks:
+  task1:
+    action: echo message=<% ctx().name %>
+    next:
+      - when: <% succeeded() %>
+        publish: greeting=<% result().stdout %>
+        do: task2
+  task2:
+    action: core.echoz
+    input:
+      message: "All your base are belong to us!"
+    next:
+      - when: <% succeeded() %>
+        publish:
+          - greeting: <% ctx("greeting") %>, <% result().stdout %>
+        do:
+          - task3
+  task3:
+    action: core.echo messages=<% ctx('greeting') %>
+    next:
+      - when: <% succeeded() %>
+        publish: greeting=<% result().stdout %>

--- a/st2api/st2api/controllers/v1/workflow_inspection.py
+++ b/st2api/st2api/controllers/v1/workflow_inspection.py
@@ -43,6 +43,8 @@ class WorkflowInspectionController(object):
         return st2_ctx
 
     def post(self, wf_def):
+        LOG.info('DATA @ METHOD: %s' % wf_def)
+
         # Load workflow definition into workflow spec model.
         spec_module = specs_loader.get_spec_module('native')
         wf_spec = spec_module.instantiate(wf_def)

--- a/st2api/st2api/controllers/v1/workflow_inspection.py
+++ b/st2api/st2api/controllers/v1/workflow_inspection.py
@@ -1,0 +1,60 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import uuid
+
+from orquesta.specs import loader as specs_loader
+from oslo_config import cfg
+
+from st2common import log as logging
+from st2common import router
+from st2common.services import workflows as workflow_service
+from st2common.util import api as api_utils
+
+
+LOG = logging.getLogger(__name__)
+
+
+class WorkflowInspectionController(object):
+
+    def mock_st2_ctx(self):
+        st2_ctx = {
+            'st2': {
+                'api_url': api_utils.get_full_public_api_url(),
+                'action_execution_id': uuid.uuid4().hex,
+                'user': cfg.CONF.system_user.user
+            }
+        }
+
+        return st2_ctx
+
+    def post(self, wf_def):
+        # Load workflow definition into workflow spec model.
+        spec_module = specs_loader.get_spec_module('native')
+        wf_spec = spec_module.instantiate(wf_def)
+
+        # Mock the st2 context that is typically passed to the workflow engine.
+        st2_ctx = self.mock_st2_ctx()
+
+        # Inspect the workflow spec and return the errors instead of raising exception.
+        errors = workflow_service.inspect(wf_spec, st2_ctx, raise_exception=False)
+
+        # Return the result of the inspection.
+        return router.Response(json=errors)
+
+
+workflow_inspection_controller = WorkflowInspectionController()

--- a/st2api/st2api/controllers/v1/workflow_inspection.py
+++ b/st2api/st2api/controllers/v1/workflow_inspection.py
@@ -43,8 +43,6 @@ class WorkflowInspectionController(object):
         return st2_ctx
 
     def post(self, wf_def):
-        LOG.info('DATA @ METHOD: %s' % wf_def)
-
         # Load workflow definition into workflow spec model.
         spec_module = specs_loader.get_spec_module('native')
         wf_spec = spec_module.instantiate(wf_def)

--- a/st2api/tests/unit/controllers/v1/test_workflow_inspection.py
+++ b/st2api/tests/unit/controllers/v1/test_workflow_inspection.py
@@ -59,57 +59,53 @@ class WorkflowInspectionControllerTest(st2api_tests.FunctionalTest, st2tests.Wor
         wf_meta = self.get_wf_fixture_meta_data(TEST_PACK_PATH, wf_file)
         wf_def = self.get_wf_def(TEST_PACK_PATH, wf_meta)
 
-        expected_errors = {}
+        expected_errors = []
         response = self._do_post(wf_def, expect_errors=False)
         self.assertEqual(http_client.OK, response.status_int)
-        self.assertDictEqual(response.json, expected_errors)
+        self.assertListEqual(response.json, expected_errors)
 
     def test_inspection_return_errors(self):
         wf_file = 'fail-inspection.yaml'
         wf_meta = self.get_wf_fixture_meta_data(TEST_PACK_PATH, wf_file)
         wf_def = self.get_wf_def(TEST_PACK_PATH, wf_meta)
 
-        expected_errors = {
-            'context': [
-                {
-                    'type': 'yaql',
-                    'expression': '<% ctx().foobar %>',
-                    'message': 'Variable "foobar" is referenced before assignment.',
-                    'schema_path': 'properties.tasks.patternProperties.^\w+$.properties.input',
-                    'spec_path': 'tasks.task1.input',
-                }
-            ],
-            'expressions': [
-                {
-                    'type': 'yaql',
-                    'expression': '<% <% succeeded() %>',
-                    'message': (
-                        'Parse error: unexpected \'<\' at '
-                        'position 0 of expression \'<% succeeded()\''
-                    ),
-                    'schema_path': (
-                        'properties.tasks.patternProperties.^\w+$.'
-                        'properties.next.items.properties.when'
-                    ),
-                    'spec_path': 'tasks.task2.next[0].when'
-                }
-            ],
-            'syntax': [
-                {
-                    'message': '[{\'cmd\': \'echo <% ctx().macro %>\'}] is not of type \'object\'',
-                    'schema_path': 'properties.tasks.patternProperties.^\w+$.properties.input.type',
-                    'spec_path': 'tasks.task2.input'
-                }
-            ],
-            'contents': [
-                {
-                    'message': 'The action "std.noop" is not registered in the database.',
-                    'schema_path': 'properties.tasks.patternProperties.^\w+$.properties.action',
-                    'spec_path': 'tasks.task3.action'
-                }
-            ]
-        }
+        expected_errors = [
+            {
+                'type': 'content',
+                'message': 'The action "std.noop" is not registered in the database.',
+                'schema_path': 'properties.tasks.patternProperties.^\w+$.properties.action',
+                'spec_path': 'tasks.task3.action'
+            },
+            {
+                'type': 'context',
+                'language': 'yaql',
+                'expression': '<% ctx().foobar %>',
+                'message': 'Variable "foobar" is referenced before assignment.',
+                'schema_path': 'properties.tasks.patternProperties.^\w+$.properties.input',
+                'spec_path': 'tasks.task1.input',
+            },
+            {
+                'type': 'expression',
+                'language': 'yaql',
+                'expression': '<% <% succeeded() %>',
+                'message': (
+                    'Parse error: unexpected \'<\' at '
+                    'position 0 of expression \'<% succeeded()\''
+                ),
+                'schema_path': (
+                    'properties.tasks.patternProperties.^\w+$.'
+                    'properties.next.items.properties.when'
+                ),
+                'spec_path': 'tasks.task2.next[0].when'
+            },
+            {
+                'type': 'syntax',
+                'message': '[{\'cmd\': \'echo <% ctx().macro %>\'}] is not of type \'object\'',
+                'schema_path': 'properties.tasks.patternProperties.^\w+$.properties.input.type',
+                'spec_path': 'tasks.task2.input'
+            }
+        ]
 
         response = self._do_post(wf_def, expect_errors=False)
         self.assertEqual(http_client.OK, response.status_int)
-        self.assertDictEqual(response.json, expected_errors)
+        self.assertListEqual(response.json, expected_errors)

--- a/st2api/tests/unit/controllers/v1/test_workflow_inspection.py
+++ b/st2api/tests/unit/controllers/v1/test_workflow_inspection.py
@@ -1,0 +1,115 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from six.moves import http_client
+
+from st2common.bootstrap import actionsregistrar
+from st2common.bootstrap import runnersregistrar
+
+import st2tests
+import tests as st2api_tests
+
+
+TEST_PACK = 'orquesta_tests'
+TEST_PACK_PATH = st2tests.fixturesloader.get_fixtures_packs_base_path() + '/' + TEST_PACK
+PACKS = [TEST_PACK_PATH, st2tests.fixturesloader.get_fixtures_packs_base_path() + '/core']
+
+
+class WorkflowInspectionControllerTest(st2api_tests.FunctionalTest, st2tests.WorkflowTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(WorkflowInspectionControllerTest, cls).setUpClass()
+        st2tests.WorkflowTestCase.setUpClass()
+
+        # Register runners.
+        runnersregistrar.register_runners()
+
+        # Register test pack(s).
+        actions_registrar = actionsregistrar.ActionsRegistrar(
+            use_pack_cache=False,
+            fail_on_failure=True
+        )
+
+        for pack in PACKS:
+            actions_registrar.register_from_pack(pack)
+
+    def _do_post(self, wf_def, expect_errors=False):
+        return self.app.post(
+            '/v1/workflows/inspection',
+            wf_def,
+            expect_errors=expect_errors,
+            content_type='text/plain'
+        )
+
+    def test_inspection(self):
+        wf_file = 'sequential.yaml'
+        wf_meta = self.get_wf_fixture_meta_data(TEST_PACK_PATH, wf_file)
+        wf_def = self.get_wf_def(TEST_PACK_PATH, wf_meta)
+
+        expected_errors = {}
+        response = self._do_post(wf_def, expect_errors=False)
+        self.assertEqual(http_client.OK, response.status_int)
+        self.assertDictEqual(response.json, expected_errors)
+
+    def test_inspection_return_errors(self):
+        wf_file = 'fail-inspection.yaml'
+        wf_meta = self.get_wf_fixture_meta_data(TEST_PACK_PATH, wf_file)
+        wf_def = self.get_wf_def(TEST_PACK_PATH, wf_meta)
+
+        expected_errors = {
+            'context': [
+                {
+                    'type': 'yaql',
+                    'expression': '<% ctx().foobar %>',
+                    'message': 'Variable "foobar" is referenced before assignment.',
+                    'schema_path': 'properties.tasks.patternProperties.^\w+$.properties.input',
+                    'spec_path': 'tasks.task1.input',
+                }
+            ],
+            'expressions': [
+                {
+                    'type': 'yaql',
+                    'expression': '<% <% succeeded() %>',
+                    'message': (
+                        'Parse error: unexpected \'<\' at '
+                        'position 0 of expression \'<% succeeded()\''
+                    ),
+                    'schema_path': (
+                        'properties.tasks.patternProperties.^\w+$.'
+                        'properties.next.items.properties.when'
+                    ),
+                    'spec_path': 'tasks.task2.next[0].when'
+                }
+            ],
+            'syntax': [
+                {
+                    'message': '[{\'cmd\': \'echo <% ctx().macro %>\'}] is not of type \'object\'',
+                    'schema_path': 'properties.tasks.patternProperties.^\w+$.properties.input.type',
+                    'spec_path': 'tasks.task2.input'
+                }
+            ],
+            'contents': [
+                {
+                    'message': 'The action "std.noop" is not registered in the database.',
+                    'schema_path': 'properties.tasks.patternProperties.^\w+$.properties.action',
+                    'spec_path': 'tasks.task3.action'
+                }
+            ]
+        }
+
+        response = self._do_post(wf_def, expect_errors=False)
+        self.assertEqual(http_client.OK, response.status_int)
+        self.assertDictEqual(response.json, expected_errors)

--- a/st2api/tests/unit/controllers/v1/test_workflow_inspection.py
+++ b/st2api/tests/unit/controllers/v1/test_workflow_inspection.py
@@ -48,7 +48,7 @@ class WorkflowInspectionControllerTest(st2api_tests.FunctionalTest, st2tests.Wor
 
     def _do_post(self, wf_def, expect_errors=False):
         return self.app.post(
-            '/v1/workflows/inspection',
+            '/v1/workflows/inspect',
             wf_def,
             expect_errors=expect_errors,
             content_type='text/plain'

--- a/st2client/st2client/client.py
+++ b/st2client/st2client/client.py
@@ -32,6 +32,7 @@ from st2client.models.core import PackResourceManager
 from st2client.models.core import ConfigManager
 from st2client.models.core import WebhookManager
 from st2client.models.core import StreamManager
+from st2client.models.core import WorkflowManager
 from st2client.models.core import add_auth_token_to_kwargs_from_env
 
 
@@ -160,6 +161,8 @@ class Client(object):
             models.RuleEnforcement, self.endpoints['api'], cacert=self.cacert, debug=self.debug)
         self.managers['Stream'] = StreamManager(
             self.endpoints['stream'], cacert=self.cacert, debug=self.debug)
+        self.managers['Workflow'] = WorkflowManager(
+            self.endpoints['api'], cacert=self.cacert, debug=self.debug)
 
         # RBAC
         self.managers['Role'] = ResourceManager(
@@ -251,3 +254,7 @@ class Client(object):
     @property
     def webhooks(self):
         return self.managers['Webhook']
+
+    @property
+    def workflows(self):
+        return self.managers['Workflow']

--- a/st2client/st2client/commands/workflow.py
+++ b/st2client/st2client/commands/workflow.py
@@ -101,8 +101,8 @@ class WorkflowInspectionCommand(commands.Command):
     def run_and_print(self, args, **kwargs):
         errors = self.run(args, **kwargs)
 
-        if not isinstance(errors, dict):
-            raise TypeError('The inspection result is not type of dict: %s' % errors)
+        if not isinstance(errors, list):
+            raise TypeError('The inspection result is not type of list: %s' % errors)
 
         if not errors:
             print('No errors found in workflow definition.')

--- a/st2client/st2client/commands/workflow.py
+++ b/st2client/st2client/commands/workflow.py
@@ -105,7 +105,7 @@ class WorkflowInspectionCommand(commands.Command):
             raise TypeError('The inspection result is not type of dict: %s' % errors)
 
         if not errors:
-            print 'No errors found in workflow definition.'
+            print('No errors found in workflow definition.')
             return
 
         print(yaml.safe_dump(errors, default_flow_style=False, allow_unicode=True))

--- a/st2client/st2client/commands/workflow.py
+++ b/st2client/st2client/commands/workflow.py
@@ -1,0 +1,111 @@
+
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import logging
+import os
+import yaml
+
+from st2client import commands
+
+
+LOG = logging.getLogger(__name__)
+
+
+class WorkflowBranch(commands.Branch):
+
+    def __init__(self, description, app, subparsers, parent_parser=None):
+        super(WorkflowBranch, self).__init__(
+            'workflow', description, app, subparsers,
+            parent_parser=parent_parser
+        )
+
+        # Add subparser to register subcommands for managing workflows.
+        help_message = 'List of commands for managing workflows.'
+        self.subparsers = self.parser.add_subparsers(help=help_message)
+
+        # Register workflow commands.
+        self.commands['inspect'] = WorkflowInspectionCommand(self.app, self.subparsers)
+
+
+class WorkflowInspectionCommand(commands.Command):
+
+    def __init__(self, *args, **kwargs):
+        name = 'inspect'
+        description = 'Inspect workflow definition and return the list of errors if any.'
+        args = tuple([name, description] + list(args))
+        super(WorkflowInspectionCommand, self).__init__(*args, **kwargs)
+
+        # Add argument options.
+        arg_group = self.parser.add_mutually_exclusive_group()
+
+        arg_group.add_argument(
+            '--file',
+            dest='file',
+            help='Local file path to the workflow definition.'
+        )
+
+        arg_group.add_argument(
+            '--action',
+            dest='action',
+            help='Reference name for the registered action. This option works only if the file '
+                 'referenced by the entry point is installed locally under /opt/stackstorm/packs.'
+        )
+
+    @property
+    def manager(self):
+        return self.app.client.managers['Workflow']
+
+    def get_file_content(self, file_path):
+        if not os.path.isfile(file_path):
+            raise Exception('File "%s" does not exist on local system.' % file_path)
+
+        with open(file_path, 'r') as f:
+            content = f.read()
+
+        return content
+
+    def run(self, args, **kwargs):
+        wf_def_file = args.file
+
+        # If file path not provided, try the action reference. This only works if the command
+        # is executed locally where the content is stored.
+        if not wf_def_file:
+            action_ref = args.action
+            action_manager = self.app.client.managers['Action']
+            action = action_manager.get_by_ref_or_id(ref_or_id=action_ref)
+
+            if not action:
+                raise Exception('Unable to identify action "%s".' % action_ref)
+
+            wf_def_file = '/opt/stackstorm/packs/' + action.pack + '/actions/' + action.entry_point
+
+        wf_def = self.get_file_content(wf_def_file)
+
+        return self.manager.inspect(wf_def, **kwargs)
+
+    def run_and_print(self, args, **kwargs):
+        errors = self.run(args, **kwargs)
+
+        if not isinstance(errors, dict):
+            raise TypeError('The inspection result is not type of dict: %s' % errors)
+
+        if not errors:
+            print 'No errors found in workflow definition.'
+            return
+
+        print(yaml.safe_dump(errors, default_flow_style=False, allow_unicode=True))

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -619,3 +619,45 @@ class StreamManager(object):
                 continue
 
             yield json.loads(message.data)
+
+
+class WorkflowManager(object):
+    def __init__(self, endpoint, cacert, debug):
+        self.debug = debug
+        self.cacert = cacert
+        self.endpoint = endpoint + '/workflows'
+        self.client = httpclient.HTTPClient(root=self.endpoint, cacert=cacert, debug=debug)
+
+    @staticmethod
+    def handle_error(response):
+        try:
+            content = response.json()
+            fault = content.get('faultstring', '') if content else ''
+
+            if fault:
+                response.reason += '\nMESSAGE: %s' % fault
+        except Exception as e:
+            response.reason += (
+                '\nUnable to retrieve detailed message '
+                'from the HTTP response. %s\n' % str(e)
+            )
+
+        response.raise_for_status()
+
+    def inspect(self, definition, **kwargs):
+        url = '/inspection'
+
+        if not isinstance(definition, six.string_types):
+            raise TypeError('Workflow definition is not type of string.')
+
+        if 'headers' not in kwargs:
+            kwargs['headers'] = {}
+
+        kwargs['headers']['content-type'] = 'text/plain'
+
+        response = self.client.post_raw(url, definition, **kwargs)
+
+        if response.status_code != http_client.OK:
+            self.handle_error(response)
+
+        return response.json()

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -645,7 +645,7 @@ class WorkflowManager(object):
         response.raise_for_status()
 
     def inspect(self, definition, **kwargs):
-        url = '/inspection'
+        url = '/inspect'
 
         if not isinstance(definition, six.string_types):
             raise TypeError('Workflow definition is not type of string.')

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -57,6 +57,7 @@ from st2client.commands import webhook
 from st2client.commands import rule
 from st2client.commands import rule_enforcement
 from st2client.commands import rbac
+from st2client.commands import workflow
 from st2client.config import set_config
 from st2client.exceptions.operations import OperationFailureException
 from st2client.utils.logging import LogLevelFilter, set_log_level_for_all_loggers
@@ -330,6 +331,11 @@ class Shell(BaseCLIApp):
 
         self.commands['rule-enforcement'] = rule_enforcement.RuleEnforcementBranch(
             'Models that represent enforcement of rules.',
+            self, self.subparsers)
+
+        self.commands['workflow'] = workflow.WorkflowBranch(
+            'Commands for workflow authoring related operations. '
+            'Only orquesta workflows are supported.',
             self, self.subparsers)
 
         # RBAC

--- a/st2client/tests/unit/test_client.py
+++ b/st2client/tests/unit/test_client.py
@@ -25,6 +25,8 @@ from st2client.client import Client
 
 LOG = logging.getLogger(__name__)
 
+NONRESOURCES = ['workflows']
+
 
 class TestClientEndpoints(unittest2.TestCase):
 
@@ -48,7 +50,9 @@ class TestClientEndpoints(unittest2.TestCase):
         for property_name in property_names:
             manager = getattr(client, property_name, None)
             self.assertIsNotNone(manager)
-            self.assertIsInstance(manager, models.ResourceManager)
+
+            if property_name not in NONRESOURCES:
+                self.assertIsInstance(manager, models.ResourceManager)
 
     def test_default(self):
         base_url = 'http://127.0.0.1'

--- a/st2client/tests/unit/test_shell.py
+++ b/st2client/tests/unit/test_shell.py
@@ -374,6 +374,14 @@ class ShellTestCase(base.BaseCLITestCase):
         ]
         self._validate_parser(args_list)
 
+    def test_workflow(self):
+        args_list = [
+            ['workflow', 'inspect', '--file', '/path/to/workflow/definition'],
+            ['workflow', 'inspect', '--action', 'mock.foobar']
+        ]
+
+        self._validate_parser(args_list)
+
     @mock.patch('sys.exit', mock.Mock())
     @mock.patch('st2client.shell.__version__', 'v2.8.0')
     def test_get_version_no_package_metadata_file_stable_version(self):

--- a/st2client/tests/unit/test_workflow.py
+++ b/st2client/tests/unit/test_workflow.py
@@ -76,7 +76,7 @@ class WorkflowCommandTestCase(st2cli_tests.BaseCLITestCase):
             self.assertEqual(retcode, 0)
 
             httpclient.HTTPClient.post_raw.assert_called_with(
-                '/inspection',
+                '/inspect',
                 MOCK_WF_DEF,
                 headers={'content-type': 'text/plain'}
             )
@@ -109,7 +109,7 @@ class WorkflowCommandTestCase(st2cli_tests.BaseCLITestCase):
         self.assertEqual(retcode, 0)
 
         httpclient.HTTPClient.post_raw.assert_called_with(
-            '/inspection',
+            '/inspect',
             MOCK_WF_DEF,
             headers={'content-type': 'text/plain'}
         )

--- a/st2client/tests/unit/test_workflow.py
+++ b/st2client/tests/unit/test_workflow.py
@@ -1,0 +1,128 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import json
+import logging
+import mock
+import os
+import tempfile
+
+from st2client.commands import workflow
+from st2client import shell
+from st2client import models
+from st2client.utils import httpclient
+from tests import base as st2cli_tests
+
+
+LOG = logging.getLogger(__name__)
+
+MOCK_ACTION = {
+    'ref': 'mock.foobar',
+    'runner_type': 'mock-runner',
+    'pack': 'mock',
+    'name': 'foobar',
+    'parameters': {},
+    'enabled': True,
+    'entry_point': 'workflows/foobar.yaml'
+}
+
+MOCK_WF_DEF = """
+version: 1.0
+description: A basic sequential workflow.
+tasks:
+  task1:
+    action: core.echo message="Hello, World!"
+"""
+
+MOCK_RESULT = {}
+
+
+def get_by_ref(**kwargs):
+    return models.Action(**MOCK_ACTION)
+
+
+class WorkflowCommandTestCase(st2cli_tests.BaseCLITestCase):
+
+    def __init__(self, *args, **kwargs):
+        super(WorkflowCommandTestCase, self).__init__(*args, **kwargs)
+        self.shell = shell.Shell()
+
+    @mock.patch.object(
+        httpclient.HTTPClient, 'post_raw',
+        mock.MagicMock(return_value=st2cli_tests.FakeResponse(json.dumps(MOCK_RESULT), 200, 'OK')))
+    def test_inspect_file(self):
+        fd, path = tempfile.mkstemp(suffix='.yaml')
+
+        try:
+            with open(path, 'a') as f:
+                f.write(MOCK_WF_DEF)
+
+            retcode = self.shell.run(['workflow', 'inspect', '--file', path])
+
+            self.assertEqual(retcode, 0)
+
+            httpclient.HTTPClient.post_raw.assert_called_with(
+                '/inspection',
+                MOCK_WF_DEF,
+                headers={'content-type': 'text/plain'}
+            )
+        finally:
+            os.close(fd)
+            os.unlink(path)
+
+    @mock.patch.object(
+        httpclient.HTTPClient, 'post_raw',
+        mock.MagicMock(return_value=st2cli_tests.FakeResponse(json.dumps(MOCK_RESULT), 200, 'OK')))
+    def test_inspect_bad_file(self):
+        retcode = self.shell.run(['workflow', 'inspect', '--file', '/tmp/foobar'])
+
+        self.assertEqual(retcode, 1)
+        self.assertIn('does not exist', self.stdout.getvalue())
+        self.assertFalse(httpclient.HTTPClient.post_raw.called)
+
+    @mock.patch.object(
+        models.ResourceManager, 'get_by_ref_or_id',
+        mock.MagicMock(side_effect=get_by_ref))
+    @mock.patch.object(
+        workflow.WorkflowInspectionCommand, 'get_file_content',
+        mock.MagicMock(return_value=MOCK_WF_DEF))
+    @mock.patch.object(
+        httpclient.HTTPClient, 'post_raw',
+        mock.MagicMock(return_value=st2cli_tests.FakeResponse(json.dumps(MOCK_RESULT), 200, 'OK')))
+    def test_inspect_action(self):
+        retcode = self.shell.run(['workflow', 'inspect', '--action', 'mock.foobar'])
+
+        self.assertEqual(retcode, 0)
+
+        httpclient.HTTPClient.post_raw.assert_called_with(
+            '/inspection',
+            MOCK_WF_DEF,
+            headers={'content-type': 'text/plain'}
+        )
+
+    @mock.patch.object(
+        models.ResourceManager, 'get_by_ref_or_id',
+        mock.MagicMock(return_value=None))
+    @mock.patch.object(
+        httpclient.HTTPClient, 'post_raw',
+        mock.MagicMock(return_value=st2cli_tests.FakeResponse(json.dumps(MOCK_RESULT), 200, 'OK')))
+    def test_inspect_bad_action(self):
+        retcode = self.shell.run(['workflow', 'inspect', '--action', 'mock.foobar'])
+
+        self.assertEqual(retcode, 1)
+        self.assertIn('Unable to identify action', self.stdout.getvalue())
+        self.assertFalse(httpclient.HTTPClient.post_raw.called)

--- a/st2client/tests/unit/test_workflow.py
+++ b/st2client/tests/unit/test_workflow.py
@@ -48,7 +48,7 @@ tasks:
     action: core.echo message="Hello, World!"
 """
 
-MOCK_RESULT = {}
+MOCK_RESULT = []
 
 
 def get_by_ref(**kwargs):

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -4084,6 +4084,47 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+  /api/v1/workflows/inspection:
+    post:
+      operationId: st2api.controllers.v1.workflow_inspection:workflow_inspection_controller.post
+      description: Inspect workflow definition (support orquesta workflow only).
+      parameters:
+        - name: wf_def
+          in: body
+          description: Workflow definition in YAML
+          schema:
+            type: string
+      responses:
+        '200':
+          description: List of inspection errors separated by categories.
+          schema:
+            $ref: '#/definitions/WorkflowInspectionErrors'
+          examples:
+            application/json:
+              contents:
+                - message: "The action \"std.noop\" is not registered in the database."
+                  schema_path: "properties.tasks.patternProperties.^\\w+$.properties.action"
+                  spec_path: "tasks.task3.action"
+              context:
+                - expression: "<% ctx().foobar %>"
+                  message: "Variable \"foobar\" is referenced before assignment."
+                  schema_path: "properties.tasks.patternProperties.^\\w+$.properties.input"
+                  spec_path: "tasks.task1.input"
+                  type: "yaql"
+              expressions:
+                - expression: "<% <% succeeded() %>"
+                  message: "Parse error: unexpected '<' at position 0 of expression '<% succeeded()'"
+                  schema_path: "properties.tasks.patternProperties.^\\w+$.properties.next.items.properties.when"
+                  spec_path: "tasks.task2.next[0].when"
+                  type: "yaql"
+              syntax:
+                - message: "[{'cmd': 'echo <% ctx().macro %>'}] is not of type 'object'"
+                  schema_path: "properties.tasks.patternProperties.^\\w+$.properties.input.type"
+                  spec_path: "tasks.task2.input"
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
 
   /api/exp/validation/mistral:
     post:
@@ -5080,6 +5121,39 @@ definitions:
       enabled:
         type: boolean
         default: True
+
+  WorkflowInspectionError:
+    type: object
+    properties:
+      type:
+        type: string
+      message:
+        type: string
+      schema_path:
+        type: string
+      spec_path:
+        type: string
+      expression:
+        type: string
+  WorkflowInspectionErrors:
+    type: object
+    properties:
+      contents:
+        type: array
+        items:
+          $ref: '#/definitions/WorkflowInspectionError'
+      context:
+        type: array
+        items:
+          $ref: '#/definitions/WorkflowInspectionError'
+      expressions:
+        type: array
+        items:
+          $ref: '#/definitions/WorkflowInspectionError'
+      syntax:
+        type: array
+        items:
+          $ref: '#/definitions/WorkflowInspectionError'
 
   ValidationError:
     type: object

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -4084,7 +4084,7 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-  /api/v1/workflows/inspection:
+  /api/v1/workflows/inspect:
     post:
       operationId: st2api.controllers.v1.workflow_inspection:workflow_inspection_controller.post
       description: Inspect workflow definition (support orquesta workflow only).

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -4101,26 +4101,26 @@ paths:
             $ref: '#/definitions/WorkflowInspectionErrors'
           examples:
             application/json:
-              contents:
-                - message: "The action \"std.noop\" is not registered in the database."
-                  schema_path: "properties.tasks.patternProperties.^\\w+$.properties.action"
-                  spec_path: "tasks.task3.action"
-              context:
-                - expression: "<% ctx().foobar %>"
-                  message: "Variable \"foobar\" is referenced before assignment."
-                  schema_path: "properties.tasks.patternProperties.^\\w+$.properties.input"
-                  spec_path: "tasks.task1.input"
-                  type: "yaql"
-              expressions:
-                - expression: "<% <% succeeded() %>"
-                  message: "Parse error: unexpected '<' at position 0 of expression '<% succeeded()'"
-                  schema_path: "properties.tasks.patternProperties.^\\w+$.properties.next.items.properties.when"
-                  spec_path: "tasks.task2.next[0].when"
-                  type: "yaql"
-              syntax:
-                - message: "[{'cmd': 'echo <% ctx().macro %>'}] is not of type 'object'"
-                  schema_path: "properties.tasks.patternProperties.^\\w+$.properties.input.type"
-                  spec_path: "tasks.task2.input"
+              - type: "content"
+                message: "The action \"std.noop\" is not registered in the database."
+                schema_path: "properties.tasks.patternProperties.^\\w+$.properties.action"
+                spec_path: "tasks.task3.action"
+              - type: "context"
+                language: "yaql"
+                expression: "<% ctx().foobar %>"
+                message: "Variable \"foobar\" is referenced before assignment."
+                schema_path: "properties.tasks.patternProperties.^\\w+$.properties.input"
+                spec_path: "tasks.task1.input"
+              - type: "expression"
+                language: "yaql"
+                expression: "<% <% succeeded() %>"
+                message: "Parse error: unexpected '<' at position 0 of expression '<% succeeded()'"
+                schema_path: "properties.tasks.patternProperties.^\\w+$.properties.next.items.properties.when"
+                spec_path: "tasks.task2.next[0].when"
+              - type: "syntax"
+                message: "[{'cmd': 'echo <% ctx().macro %>'}] is not of type 'object'"
+                schema_path: "properties.tasks.patternProperties.^\\w+$.properties.input.type"
+                spec_path: "tasks.task2.input"
         default:
           description: Unexpected error
           schema:
@@ -5127,33 +5127,20 @@ definitions:
     properties:
       type:
         type: string
+      language:
+        type: string
+      expression:
+        type: string
       message:
         type: string
       schema_path:
         type: string
       spec_path:
         type: string
-      expression:
-        type: string
   WorkflowInspectionErrors:
-    type: object
-    properties:
-      contents:
-        type: array
-        items:
-          $ref: '#/definitions/WorkflowInspectionError'
-      context:
-        type: array
-        items:
-          $ref: '#/definitions/WorkflowInspectionError'
-      expressions:
-        type: array
-        items:
-          $ref: '#/definitions/WorkflowInspectionError'
-      syntax:
-        type: array
-        items:
-          $ref: '#/definitions/WorkflowInspectionError'
+    type: array
+    items:
+      $ref: '#/definitions/WorkflowInspectionError'
 
   ValidationError:
     type: object

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -4080,7 +4080,7 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-  /api/v1/workflows/inspection:
+  /api/v1/workflows/inspect:
     post:
       operationId: st2api.controllers.v1.workflow_inspection:workflow_inspection_controller.post
       description: Inspect workflow definition (support orquesta workflow only).

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -4097,26 +4097,26 @@ paths:
             $ref: '#/definitions/WorkflowInspectionErrors'
           examples:
             application/json:
-              contents:
-                - message: "The action \"std.noop\" is not registered in the database."
-                  schema_path: "properties.tasks.patternProperties.^\\w+$.properties.action"
-                  spec_path: "tasks.task3.action"
-              context:
-                - expression: "<% ctx().foobar %>"
-                  message: "Variable \"foobar\" is referenced before assignment."
-                  schema_path: "properties.tasks.patternProperties.^\\w+$.properties.input"
-                  spec_path: "tasks.task1.input"
-                  type: "yaql"
-              expressions:
-                - expression: "<% <% succeeded() %>"
-                  message: "Parse error: unexpected '<' at position 0 of expression '<% succeeded()'"
-                  schema_path: "properties.tasks.patternProperties.^\\w+$.properties.next.items.properties.when"
-                  spec_path: "tasks.task2.next[0].when"
-                  type: "yaql"
-              syntax:
-                - message: "[{'cmd': 'echo <% ctx().macro %>'}] is not of type 'object'"
-                  schema_path: "properties.tasks.patternProperties.^\\w+$.properties.input.type"
-                  spec_path: "tasks.task2.input"
+              - type: "content"
+                message: "The action \"std.noop\" is not registered in the database."
+                schema_path: "properties.tasks.patternProperties.^\\w+$.properties.action"
+                spec_path: "tasks.task3.action"
+              - type: "context"
+                language: "yaql"
+                expression: "<% ctx().foobar %>"
+                message: "Variable \"foobar\" is referenced before assignment."
+                schema_path: "properties.tasks.patternProperties.^\\w+$.properties.input"
+                spec_path: "tasks.task1.input"
+              - type: "expression"
+                language: "yaql"
+                expression: "<% <% succeeded() %>"
+                message: "Parse error: unexpected '<' at position 0 of expression '<% succeeded()'"
+                schema_path: "properties.tasks.patternProperties.^\\w+$.properties.next.items.properties.when"
+                spec_path: "tasks.task2.next[0].when"
+              - type: "syntax"
+                message: "[{'cmd': 'echo <% ctx().macro %>'}] is not of type 'object'"
+                schema_path: "properties.tasks.patternProperties.^\\w+$.properties.input.type"
+                spec_path: "tasks.task2.input"
         default:
           description: Unexpected error
           schema:
@@ -5123,33 +5123,20 @@ definitions:
     properties:
       type:
         type: string
+      language:
+        type: string
+      expression:
+        type: string
       message:
         type: string
       schema_path:
         type: string
       spec_path:
         type: string
-      expression:
-        type: string
   WorkflowInspectionErrors:
-    type: object
-    properties:
-      contents:
-        type: array
-        items:
-          $ref: '#/definitions/WorkflowInspectionError'
-      context:
-        type: array
-        items:
-          $ref: '#/definitions/WorkflowInspectionError'
-      expressions:
-        type: array
-        items:
-          $ref: '#/definitions/WorkflowInspectionError'
-      syntax:
-        type: array
-        items:
-          $ref: '#/definitions/WorkflowInspectionError'
+    type: array
+    items:
+      $ref: '#/definitions/WorkflowInspectionError'
 
   ValidationError:
     type: object

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -4080,6 +4080,47 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+  /api/v1/workflows/inspection:
+    post:
+      operationId: st2api.controllers.v1.workflow_inspection:workflow_inspection_controller.post
+      description: Inspect workflow definition (support orquesta workflow only).
+      parameters:
+        - name: wf_def
+          in: body
+          description: Workflow definition in YAML
+          schema:
+            type: string
+      responses:
+        '200':
+          description: List of inspection errors separated by categories.
+          schema:
+            $ref: '#/definitions/WorkflowInspectionErrors'
+          examples:
+            application/json:
+              contents:
+                - message: "The action \"std.noop\" is not registered in the database."
+                  schema_path: "properties.tasks.patternProperties.^\\w+$.properties.action"
+                  spec_path: "tasks.task3.action"
+              context:
+                - expression: "<% ctx().foobar %>"
+                  message: "Variable \"foobar\" is referenced before assignment."
+                  schema_path: "properties.tasks.patternProperties.^\\w+$.properties.input"
+                  spec_path: "tasks.task1.input"
+                  type: "yaql"
+              expressions:
+                - expression: "<% <% succeeded() %>"
+                  message: "Parse error: unexpected '<' at position 0 of expression '<% succeeded()'"
+                  schema_path: "properties.tasks.patternProperties.^\\w+$.properties.next.items.properties.when"
+                  spec_path: "tasks.task2.next[0].when"
+                  type: "yaql"
+              syntax:
+                - message: "[{'cmd': 'echo <% ctx().macro %>'}] is not of type 'object'"
+                  schema_path: "properties.tasks.patternProperties.^\\w+$.properties.input.type"
+                  spec_path: "tasks.task2.input"
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
 
   /api/exp/validation/mistral:
     post:
@@ -5076,6 +5117,39 @@ definitions:
       enabled:
         type: boolean
         default: True
+
+  WorkflowInspectionError:
+    type: object
+    properties:
+      type:
+        type: string
+      message:
+        type: string
+      schema_path:
+        type: string
+      spec_path:
+        type: string
+      expression:
+        type: string
+  WorkflowInspectionErrors:
+    type: object
+    properties:
+      contents:
+        type: array
+        items:
+          $ref: '#/definitions/WorkflowInspectionError'
+      context:
+        type: array
+        items:
+          $ref: '#/definitions/WorkflowInspectionError'
+      expressions:
+        type: array
+        items:
+          $ref: '#/definitions/WorkflowInspectionError'
+      syntax:
+        type: array
+        items:
+          $ref: '#/definitions/WorkflowInspectionError'
 
   ValidationError:
     type: object

--- a/st2common/st2common/router.py
+++ b/st2common/st2common/router.py
@@ -365,13 +365,15 @@ class Router(object):
 
                 # NOTE: HACK: Workaround for eventlet wsgi server which sets Content-Type to
                 # text/plain if Content-Type is not provided in the request.
-                # All ouf our API endpoints except /exp/validation/mistral expect application/json
-                # so we explicitly set it to that if not provided (set to text/plain by the base
-                # http server) and if it's not /exp/validation/mistral API endpoint
+                # All ouf our API endpoints except /v1/workflows/inspection and
+                # /exp/validation/mistral expect application/json so we explicitly set it to that
+                # if not provided (set to text/plain by the base http server) and if it's not
+                # /v1/workflows/inspection and /exp/validation/mistral API endpoints.
                 if not self.is_gunicorn and content_type == 'text/plain':
                     operation_id = endpoint['operationId']
 
-                    if 'mistral_validation_controller' not in operation_id:
+                    if ('workflow_inspection_controller' not in operation_id and
+                            'mistral_validation_controller' not in operation_id):
                         content_type = 'application/json'
 
                 # Note: We also want to perform validation if no body is explicitly provided - in a

--- a/st2common/st2common/services/workflows.py
+++ b/st2common/st2common/services/workflows.py
@@ -53,7 +53,7 @@ def is_action_execution_under_workflow_context(ac_ex_db):
     return 'orquesta' in ac_ex_db.context
 
 
-def inspect(wf_spec, st2_ctx):
+def inspect(wf_spec, st2_ctx, raise_exception=True):
     errors = wf_spec.inspect(app_ctx=st2_ctx, raise_exception=False)
 
     content_errors = sorted(inspect_task_contents(wf_spec), key=lambda e: e['schema_path'])
@@ -61,8 +61,10 @@ def inspect(wf_spec, st2_ctx):
     if content_errors:
         errors['contents'] = content_errors
 
-    if errors:
+    if errors and raise_exception:
         raise orquesta_exc.WorkflowInspectionError(errors)
+
+    return errors
 
 
 def inspect_task_contents(wf_spec):
@@ -151,7 +153,7 @@ def request(wf_def, ac_ex_db, st2_ctx):
     wf_spec = spec_module.instantiate(wf_def)
 
     # Inspect the workflow spec.
-    inspect(wf_spec, st2_ctx)
+    inspect(wf_spec, st2_ctx, raise_exception=True)
 
     # Identify the action to execute.
     action_db = action_utils.get_action_by_ref(ref=ac_ex_db.action['ref'])

--- a/st2common/st2common/services/workflows.py
+++ b/st2common/st2common/services/workflows.py
@@ -17,10 +17,12 @@ from __future__ import absolute_import
 
 import copy
 import retrying
+import six
 
 from orquesta import conducting
 from orquesta import events
 from orquesta import exceptions as orquesta_exc
+from orquesta.expressions import base as expressions
 from orquesta.specs import loader as specs_loader
 from orquesta import states
 
@@ -30,12 +32,14 @@ from st2common.exceptions import workflow as wf_exc
 from st2common import log as logging
 from st2common.models.db import liveaction as lv_db_models
 from st2common.models.db import workflow as wf_db_models
+from st2common.models.system import common as sys_models
+from st2common.models.utils import action_param_utils
 from st2common.persistence import liveaction as lv_db_access
 from st2common.persistence import execution as ex_db_access
 from st2common.persistence import workflow as wf_db_access
 from st2common.services import action as ac_svc
 from st2common.services import executions as ex_svc
-from st2common.util import action_db as ac_db_util
+from st2common.util import action_db as action_utils
 from st2common.util import date as date_utils
 from st2common.util import param as param_utils
 
@@ -52,8 +56,90 @@ def is_action_execution_under_workflow_context(ac_ex_db):
 def inspect(wf_spec, st2_ctx):
     errors = wf_spec.inspect(app_ctx=st2_ctx, raise_exception=False)
 
+    content_errors = sorted(inspect_task_contents(wf_spec), key=lambda e: e['schema_path'])
+
+    if content_errors:
+        errors['contents'] = content_errors
+
     if errors:
         raise orquesta_exc.WorkflowInspectionError(errors)
+
+
+def inspect_task_contents(wf_spec):
+    result = []
+    spec_path = 'tasks'
+    schema_path = 'properties.tasks.patternProperties.^\\w+$'
+    action_schema_path = schema_path + '.properties.action'
+    action_input_schema_path = schema_path + '.properties.input'
+
+    def is_action_an_expression(action):
+        if isinstance(action, six.string_types):
+            for name, evaluator in six.iteritems(expressions.get_evaluators()):
+                if evaluator.has_expressions(action):
+                    return True
+
+    for task_name, task_spec in six.iteritems(wf_spec.tasks):
+        action_ref = getattr(task_spec, 'action', None)
+        action_spec_path = spec_path + '.' + task_name + '.action'
+        action_input_spec_path = spec_path + '.' + task_name + '.input'
+
+        # Move on if action is empty or an expression.
+        if not action_ref or is_action_an_expression(action_ref):
+            continue
+
+        # Check that the format of the action is a valid resource reference.
+        if not sys_models.ResourceReference.is_resource_reference(action_ref):
+            entry = {
+                'message': 'The action reference "%s" is not formatted correctly.' % action_ref,
+                'spec_path': action_spec_path,
+                'schema_path': action_schema_path
+            }
+
+            result.append(entry)
+            continue
+
+        # Check that the action is registered in the database.
+        if not action_utils.get_action_by_ref(ref=action_ref):
+            entry = {
+                'message': 'The action "%s" is not registered in the database.' % action_ref,
+                'spec_path': action_spec_path,
+                'schema_path': action_schema_path
+            }
+
+            result.append(entry)
+            continue
+
+        # Check the action parameters.
+        params = getattr(task_spec, 'input', None) or {}
+
+        if params and not isinstance(params, dict):
+            continue
+
+        requires, unexpected = action_param_utils.validate_action_parameters(action_ref, params)
+
+        for param in requires:
+            message = 'Action "%s" is missing required input "%s".' % (action_ref, param)
+
+            entry = {
+                'message': message,
+                'spec_path': action_input_spec_path,
+                'schema_path': action_input_schema_path
+            }
+
+            result.append(entry)
+
+        for param in unexpected:
+            message = 'Action "%s" has unexpected input "%s".' % (action_ref, param)
+
+            entry = {
+                'message': message,
+                'spec_path': action_input_spec_path + '.' + param,
+                'schema_path': action_input_schema_path + '.patternProperties.^\\w+$'
+            }
+
+            result.append(entry)
+
+    return result
 
 
 def request(wf_def, ac_ex_db, st2_ctx):
@@ -68,14 +154,14 @@ def request(wf_def, ac_ex_db, st2_ctx):
     inspect(wf_spec, st2_ctx)
 
     # Identify the action to execute.
-    action_db = ac_db_util.get_action_by_ref(ref=ac_ex_db.action['ref'])
+    action_db = action_utils.get_action_by_ref(ref=ac_ex_db.action['ref'])
 
     if not action_db:
         error = 'Unable to find action "%s".' % ac_ex_db.action['ref']
         raise ac_exc.InvalidActionReferencedException(error)
 
     # Identify the runner for the action.
-    runner_type_db = ac_db_util.get_runnertype_by_name(action_db.runner_type['name'])
+    runner_type_db = action_utils.get_runnertype_by_name(action_db.runner_type['name'])
 
     # Render action execution parameters.
     runner_params, action_params = param_utils.render_final_params(
@@ -271,14 +357,14 @@ def request_task_execution(wf_ex_db, task_id, task_spec, task_ctx, st2_ctx):
             return wf_db_access.TaskExecution.get_by_id(str(task_ex_db.id))
 
         # Identify the action to execute.
-        action_db = ac_db_util.get_action_by_ref(ref=task_spec.action)
+        action_db = action_utils.get_action_by_ref(ref=task_spec.action)
 
         if not action_db:
             error = 'Unable to find action "%s".' % task_spec.action
             raise ac_exc.InvalidActionReferencedException(error)
 
         # Identify the runner for the action.
-        runner_type_db = ac_db_util.get_runnertype_by_name(action_db.runner_type['name'])
+        runner_type_db = action_utils.get_runnertype_by_name(action_db.runner_type['name'])
 
         # Set context for the action execution.
         ac_ex_ctx = {
@@ -414,7 +500,7 @@ def handle_action_execution_resume(ac_ex_db):
         parent_ac_ex_db = ex_db_access.ActionExecution.get_by_id(parent_ac_ex_id)
 
         if parent_ac_ex_db.status == ac_const.LIVEACTION_STATUS_PAUSED:
-            ac_db_util.update_liveaction_status(
+            action_utils.update_liveaction_status(
                 liveaction_id=parent_ac_ex_db.liveaction['id'],
                 status=ac_const.LIVEACTION_STATUS_RUNNING,
                 publish=False)
@@ -679,7 +765,7 @@ def update_execution_records(wf_ex_db, conductor, update_lv_ac_on_states=None,
 
     # Update the corresponding liveaction and action execution for the workflow.
     wf_ac_ex_db = ex_db_access.ActionExecution.get_by_id(wf_ex_db.action_execution)
-    wf_lv_ac_db = ac_db_util.get_liveaction_by_id(wf_ac_ex_db.liveaction['id'])
+    wf_lv_ac_db = action_utils.get_liveaction_by_id(wf_ac_ex_db.liveaction['id'])
 
     # Gather result for liveaction and action execution.
     result = {'output': wf_ex_db.output or None}
@@ -704,7 +790,7 @@ def update_execution_records(wf_ex_db, conductor, update_lv_ac_on_states=None,
         msg = '[%s] Workflow action execution status change %s be published.'
         LOG.debug(msg, wf_ac_ex_id, 'will' if pub_ac_ex else 'will not')
 
-    wf_lv_ac_db = ac_db_util.update_liveaction_status(
+    wf_lv_ac_db = action_utils.update_liveaction_status(
         status=wf_ex_db.status,
         result=result,
         end_timestamp=wf_ex_db.end_timestamp,

--- a/st2common/st2common/services/workflows.py
+++ b/st2common/st2common/services/workflows.py
@@ -67,8 +67,9 @@ def format_inspection_result(result):
     # For context and expression errors, rename the attribute from type to language.
     for category in ['context', 'expressions']:
         for entry in result.get(category, []):
-            entry['language'] = entry['type']
-            del entry['type']
+            if 'language' not in entry:
+                entry['language'] = entry['type']
+                del entry['type']
 
     # For all categories, put the category value in the type attribute.
     for category, entries in six.iteritems(result):

--- a/st2tests/integration/orquesta/test_wiring_error_handling.py
+++ b/st2tests/integration/orquesta/test_wiring_error_handling.py
@@ -23,46 +23,42 @@ from st2common.constants import action as ac_const
 class ErrorHandlingTest(base.TestWorkflowExecution):
 
     def test_inspection_error(self):
-        expected_errors = {
-            'context': [
-                {
-                    'type': 'yaql',
-                    'expression': '<% ctx().foobar %>',
-                    'message': 'Variable "foobar" is referenced before assignment.',
-                    'schema_path': 'properties.tasks.patternProperties.^\w+$.properties.input',
-                    'spec_path': 'tasks.task1.input',
-                }
-            ],
-            'expressions': [
-                {
-                    'type': 'yaql',
-                    'expression': '<% <% succeeded() %>',
-                    'message': (
-                        'Parse error: unexpected \'<\' at '
-                        'position 0 of expression \'<% succeeded()\''
-                    ),
-                    'schema_path': (
-                        'properties.tasks.patternProperties.^\w+$.'
-                        'properties.next.items.properties.when'
-                    ),
-                    'spec_path': 'tasks.task2.next[0].when'
-                }
-            ],
-            'syntax': [
-                {
-                    'message': '[{\'cmd\': \'echo <% ctx().macro %>\'}] is not of type \'object\'',
-                    'schema_path': 'properties.tasks.patternProperties.^\w+$.properties.input.type',
-                    'spec_path': 'tasks.task2.input'
-                }
-            ],
-            'contents': [
-                {
-                    'message': 'The action "std.noop" is not registered in the database.',
-                    'schema_path': 'properties.tasks.patternProperties.^\w+$.properties.action',
-                    'spec_path': 'tasks.task3.action'
-                }
-            ]
-        }
+        expected_errors = [
+            {
+                'type': 'content',
+                'message': 'The action "std.noop" is not registered in the database.',
+                'schema_path': 'properties.tasks.patternProperties.^\w+$.properties.action',
+                'spec_path': 'tasks.task3.action'
+            },
+            {
+                'type': 'context',
+                'language': 'yaql',
+                'expression': '<% ctx().foobar %>',
+                'message': 'Variable "foobar" is referenced before assignment.',
+                'schema_path': 'properties.tasks.patternProperties.^\w+$.properties.input',
+                'spec_path': 'tasks.task1.input',
+            },
+            {
+                'type': 'expression',
+                'language': 'yaql',
+                'expression': '<% <% succeeded() %>',
+                'message': (
+                    'Parse error: unexpected \'<\' at '
+                    'position 0 of expression \'<% succeeded()\''
+                ),
+                'schema_path': (
+                    'properties.tasks.patternProperties.^\w+$.'
+                    'properties.next.items.properties.when'
+                ),
+                'spec_path': 'tasks.task2.next[0].when'
+            },
+            {
+                'type': 'syntax',
+                'message': '[{\'cmd\': \'echo <% ctx().macro %>\'}] is not of type \'object\'',
+                'schema_path': 'properties.tasks.patternProperties.^\w+$.properties.input.type',
+                'spec_path': 'tasks.task2.input'
+            }
+        ]
 
         ex = self._execute_workflow('examples.orquesta-fail-inspection')
         ex = self._wait_for_completion(ex)
@@ -132,33 +128,35 @@ class ErrorHandlingTest(base.TestWorkflowExecution):
         self.assertDictEqual(ex.result, {'errors': expected_errors, 'output': None})
 
     def test_task_content_errors(self):
-        expected_errors = {
-            'contents': [
-                {
-                    'message': 'The action reference "echo" is not formatted correctly.',
-                    'schema_path': 'properties.tasks.patternProperties.^\w+$.properties.action',
-                    'spec_path': 'tasks.task1.action'
-                },
-                {
-                    'message': 'The action "core.echoz" is not registered in the database.',
-                    'schema_path': 'properties.tasks.patternProperties.^\w+$.properties.action',
-                    'spec_path': 'tasks.task2.action'
-                },
-                {
-                    'message': 'Action "core.echo" is missing required input "message".',
-                    'schema_path': 'properties.tasks.patternProperties.^\w+$.properties.input',
-                    'spec_path': 'tasks.task3.input'
-                },
-                {
-                    'message': 'Action "core.echo" has unexpected input "messages".',
-                    'schema_path': (
-                        'properties.tasks.patternProperties.^\w+$.properties.input.'
-                        'patternProperties.^\w+$'
-                    ),
-                    'spec_path': 'tasks.task3.input.messages'
-                }
-            ]
-        }
+        expected_errors = [
+            {
+                'type': 'content',
+                'message': 'The action reference "echo" is not formatted correctly.',
+                'schema_path': 'properties.tasks.patternProperties.^\w+$.properties.action',
+                'spec_path': 'tasks.task1.action'
+            },
+            {
+                'type': 'content',
+                'message': 'The action "core.echoz" is not registered in the database.',
+                'schema_path': 'properties.tasks.patternProperties.^\w+$.properties.action',
+                'spec_path': 'tasks.task2.action'
+            },
+            {
+                'type': 'content',
+                'message': 'Action "core.echo" is missing required input "message".',
+                'schema_path': 'properties.tasks.patternProperties.^\w+$.properties.input',
+                'spec_path': 'tasks.task3.input'
+            },
+            {
+                'type': 'content',
+                'message': 'Action "core.echo" has unexpected input "messages".',
+                'schema_path': (
+                    'properties.tasks.patternProperties.^\w+$.properties.input.'
+                    'patternProperties.^\w+$'
+                ),
+                'spec_path': 'tasks.task3.input.messages'
+            }
+        ]
 
         ex = self._execute_workflow('examples.orquesta-fail-inspection-task-contents')
         ex = self._wait_for_completion(ex)

--- a/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/fail-inspection-action-db.yaml
+++ b/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/fail-inspection-action-db.yaml
@@ -1,0 +1,12 @@
+---
+name: fail-inspection-action-db
+description: A basic sequential workflow with inspection error(s).
+pack: orquesta_tests
+runner_type: orquesta
+entry_point: workflows/fail-inspection-action-db.yaml
+enabled: true
+parameters:
+  who:
+    required: true
+    type: string
+    default: Stanley

--- a/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/fail-inspection-action-ref.yaml
+++ b/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/fail-inspection-action-ref.yaml
@@ -1,0 +1,12 @@
+---
+name: fail-inspection-action-ref
+description: A basic sequential workflow with inspection error(s).
+pack: orquesta_tests
+runner_type: orquesta
+entry_point: workflows/fail-inspection-action-ref.yaml
+enabled: true
+parameters:
+  who:
+    required: true
+    type: string
+    default: Stanley

--- a/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/fail-inspection-missing-required-action-param.yaml
+++ b/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/fail-inspection-missing-required-action-param.yaml
@@ -1,0 +1,12 @@
+---
+name: fail-inspection-missing-required-action-param
+description: A basic sequential workflow with inspection error(s).
+pack: orquesta_tests
+runner_type: orquesta
+entry_point: workflows/fail-inspection-missing-required-action-param.yaml
+enabled: true
+parameters:
+  who:
+    required: true
+    type: string
+    default: Stanley

--- a/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/fail-inspection-unexpected-action-param.yaml
+++ b/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/fail-inspection-unexpected-action-param.yaml
@@ -1,0 +1,12 @@
+---
+name: fail-inspection-unexpected-action-param
+description: A basic sequential workflow with inspection error(s).
+pack: orquesta_tests
+runner_type: orquesta
+entry_point: workflows/fail-inspection-unexpected-action-param.yaml
+enabled: true
+parameters:
+  who:
+    required: true
+    type: string
+    default: Stanley

--- a/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/fail-inspection-action-db.yaml
+++ b/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/fail-inspection-action-db.yaml
@@ -1,0 +1,38 @@
+version: 1.0
+
+description: A basic sequential workflow.
+
+input:
+  - who
+
+vars:
+  - msg1: "Veni, vidi, vici."
+  - msg2: "Resistance is futile!"
+  - msg3: "All your base are belong to us!"
+
+output:
+  - msg: <% ctx().message %>
+
+tasks:
+  task1:
+    action: core.echoz
+    input:
+        message: <% ctx().msg1 %>
+    next:
+      - when: <% succeeded() %>
+        do:
+          - task2
+  task2:
+    action: core.echo
+    input:
+        message: <% ctx().msg2 %>
+    next:
+      - when: <% succeeded() %>
+        do: task3
+  task3:
+    action: core.echo
+    input:
+        message: <% ctx().who %>, <% ctx().msg3 %>
+    next:
+      - when: <% succeeded() %>
+        publish: message=<% result().stdout %>

--- a/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/fail-inspection-action-ref.yaml
+++ b/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/fail-inspection-action-ref.yaml
@@ -1,0 +1,38 @@
+version: 1.0
+
+description: A basic sequential workflow.
+
+input:
+  - who
+
+vars:
+  - msg1: "Veni, vidi, vici."
+  - msg2: "Resistance is futile!"
+  - msg3: "All your base are belong to us!"
+
+output:
+  - msg: <% ctx().message %>
+
+tasks:
+  task1:
+    action: echo
+    input:
+        message: <% ctx().msg1 %>
+    next:
+      - when: <% succeeded() %>
+        do:
+          - task2
+  task2:
+    action: core.echo
+    input:
+        message: <% ctx().msg2 %>
+    next:
+      - when: <% succeeded() %>
+        do: task3
+  task3:
+    action: core.echo
+    input:
+        message: <% ctx().who %>, <% ctx().msg3 %>
+    next:
+      - when: <% succeeded() %>
+        publish: message=<% result().stdout %>

--- a/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/fail-inspection-missing-required-action-param.yaml
+++ b/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/fail-inspection-missing-required-action-param.yaml
@@ -1,0 +1,36 @@
+version: 1.0
+
+description: A basic sequential workflow.
+
+input:
+  - who
+
+vars:
+  - msg1: "Veni, vidi, vici."
+  - msg2: "Resistance is futile!"
+  - msg3: "All your base are belong to us!"
+
+output:
+  - msg: <% ctx().message %>
+
+tasks:
+  task1:
+    action: core.echo
+    next:
+      - when: <% succeeded() %>
+        do:
+          - task2
+  task2:
+    action: core.echo
+    input:
+        message: <% ctx().msg2 %>
+    next:
+      - when: <% succeeded() %>
+        do: task3
+  task3:
+    action: core.echo
+    input:
+        message: <% ctx().who %>, <% ctx().msg3 %>
+    next:
+      - when: <% succeeded() %>
+        publish: message=<% result().stdout %>

--- a/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/fail-inspection-unexpected-action-param.yaml
+++ b/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/fail-inspection-unexpected-action-param.yaml
@@ -1,0 +1,38 @@
+version: 1.0
+
+description: A basic sequential workflow.
+
+input:
+  - who
+
+vars:
+  - msg1: "Veni, vidi, vici."
+  - msg2: "Resistance is futile!"
+  - msg3: "All your base are belong to us!"
+
+output:
+  - msg: <% ctx().message %>
+
+tasks:
+  task1:
+    action: core.echo
+    input:
+        messages: <% ctx().msg1 %>
+    next:
+      - when: <% succeeded() %>
+        do:
+          - task2
+  task2:
+    action: core.echo
+    input:
+        message: <% ctx().msg2 %>
+    next:
+      - when: <% succeeded() %>
+        do: task3
+  task3:
+    action: core.echo
+    input:
+        message: <% ctx().who %>, <% ctx().msg3 %>
+    next:
+      - when: <% succeeded() %>
+        publish: message=<% result().stdout %>


### PR DESCRIPTION
Add `/v1/workflows/inspect` endpoint in the API and a POST method to inspect workflow definition and return errors found. Add a `st2 workflow inspect` command that uses the API endpoint for workflow inspection.