### PR TITLE
Deprecate winexe-based Windows runners

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -105,6 +105,10 @@ Deprecated
   StackStorm codebase. The runner code will be moved to a separate repository, and no longer
   maintained by the core StackStorm team. Users will still be able to install and use this runner,
   but it will require additional steps to install.
+* The ``winexe``-based Windows runners are now deprecated. They will be removed in StackStorm 3.1.
+  They have been replaced by ``pywinrm``-based Windows runners. See
+  https://docs.stackstorm.com/latest/reference/runners.html#winrm-command-runner-winrm-cmd
+  for more on using these new runners.
 
 2.8.1 - July 18, 2018
 ---------------------


### PR DESCRIPTION
Deprecate winexe-based Windows runners, in favor of the new pywinrm-based runners. 

Not yet removing the old runners - will do that in version 3.1.