### PR TITLE
Remove duplicated apt-get update from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,13 +76,12 @@ cache:
     #- .tox/
 
 before_install:
-  # Work around for Travis timeout issues, see https://github.com/travis-ci/travis-ci/issues/9112
-  - sudo apt-get update --option Acquire::Retries=100 --option Acquire::http::Timeout="60"
   # 1. Install MongoDB 3.4 and latest version of git
   - sudo add-apt-repository -y ppa:git-core/ppa
   - curl https://www.mongodb.org/static/pgp/server-3.4.asc | sudo apt-key add -
   - echo "deb [arch=amd64] http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.4 multiverse" | sudo tee -a /etc/apt/sources.list
-  - sudo apt-get update -qq
+  # Work around for Travis timeout issues, see https://github.com/travis-ci/travis-ci/issues/9112
+  - sudo apt-get update --option Acquire::Retries=100 --option Acquire::http::Timeout="60"
   - sudo apt-get install mongodb-org-server mongodb-org-shell git -y
   - pip install --upgrade "pip>=9.0,<9.1"
   - sudo pip install --upgrade "virtualenv==15.1.0"


### PR DESCRIPTION
No need to run `apt-get update` twice.

Caught by @armab.