### PR TITLE
"st2 execution tail" CLI command improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -90,6 +90,9 @@ Changed
   which is prepended to each metric key (name). This comes handy in scenarios where user wants to
   submit metrics from multiple environments / deployments (e.g. testing, staging, dev) to the same
   backend instance. (improvement) #4310
+* Improve ``st2 execution tail`` CLI command so it also supports Orquesta workflows and arbitrarily
+  nested workflows. Also fix the command so it doesn't include data from other unrelated running
+  executions. (improvement) #4328
 
 Fixed
 ~~~~~

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -1563,6 +1563,10 @@ class ActionExecutionTailCommand(resource.ResourceCommand):
             result['parent_execution_id'] = context.get('parent', {}).get('execution_id', None)
             result['execution_id'] = event['id']
             result['task_name'] = context.get('mistral', {}).get('task_name', 'unknown')
+        elif 'orquesta' in context:
+            result['parent_execution_id'] = context.get('parent', {}).get('execution_id', None)
+            result['execution_id'] = event['id']
+            result['task_name'] = context.get('orquesta', {}).get('task_name', 'unknown')
         else:
             # Action chain workflow
             result['parent_execution_id'] = context.get('parent', {}).get('execution_id', None)

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -25,7 +25,6 @@ import calendar
 import time
 import six
 import sys
-import sets
 
 from os.path import join as pjoin
 
@@ -1496,7 +1495,7 @@ class ActionExecutionTailCommand(resource.ResourceCommand):
         # We keep track of all the workflow executions which could contain children
         # For simplicity, we simply keep track of all the execution ids which belong to a
         # particular workflow
-        workflow_execution_ids = sets.Set([parent_execution_id])
+        workflow_execution_ids = set([parent_execution_id])
 
         # Retrieve parent execution object so we can keep track of any existing children
         # executions (only applies to already running executions)

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -1477,7 +1477,11 @@ class ActionExecutionTailCommand(resource.ResourceCommand):
         execution_id = str(execution.id)
 
         # Indicates if the execution we are tailing is a child execution in a workflow
-        is_tailing_execution_child_execution = bool(getattr(execution, 'parent', None))
+        context = cls.get_normalized_context_execution_task_event(execution.__dict__)
+        has_parent_attribute = bool(getattr(execution, 'parent', None))
+        has_parent_execution_id = bool(context['parent_execution_id'])
+
+        is_tailing_execution_child_execution = has_parent_attribute or has_parent_execution_id
 
         # Note: For non-workflow actions child_execution_id always matches parent_execution_id so
         # we don't need to do any other checks to determine if executions represents a workflow
@@ -1514,7 +1518,7 @@ class ActionExecutionTailCommand(resource.ResourceCommand):
             is_execution_event = status is not None
 
             if is_execution_event:
-                context = cls.get_normalized_context_execution_task_event(event=event)
+                context = cls.get_normalized_context_execution_task_event(event)
                 task_execution_id = context['execution_id']
                 task_name = context['task_name']
                 task_parent_execution_id = context['parent_execution_id']
@@ -1583,8 +1587,7 @@ class ActionExecutionTailCommand(resource.ResourceCommand):
     @classmethod
     def get_normalized_context_execution_task_event(cls, event):
         """
-        Return a dictionary with normalized context attributes for Action-Chain and Mistral
-        workflows.
+        Return a dictionary with normalized context attributes for execution event or object.
         """
         context = event.get('context', {})
 

--- a/st2client/tests/unit/test_execution_tail_command.py
+++ b/st2client/tests/unit/test_execution_tail_command.py
@@ -197,7 +197,7 @@ MOCK_LIVEACTION_4_CHILD_1_OUTPUT_1 = {
 }
 
 MOCK_LIVEACTION_4_CHILD_1_OUTPUT_2 = {
-    'execution_id': 'mistral',
+    'execution_id': 'idmistralchild1',
     'timestamp': '1505732598',
     'output_type': 'stderr',
     'data': 'line mistral 5\n'
@@ -244,7 +244,7 @@ MOCK_LIVEACTION_4_CHILD_2_TIMED_OUT = {
 }
 
 MOCK_LIVEACTION_4_CHILD_2_OUTPUT_1 = {
-    'execution_id': 'idchild2',
+    'execution_id': 'idmistralchild2',
     'timestamp': '1505732598',
     'output_type': 'stdout',
     'data': 'line mistral 100\n'
@@ -532,6 +532,23 @@ Execution idfoo4 has completed (status=succeeded).
             MOCK_LIVEACTION_4_CHILD_1_1_OUTPUT_1,
             MOCK_LIVEACTION_4_CHILD_1_1_OUTPUT_2,
 
+            # Another execution has started, this output should not be included
+            MOCK_LIVEACTION_3_RUNNING,
+
+            # Child task 1 started running
+            MOCK_LIVEACTION_3_CHILD_1_RUNNING,
+
+            # Output produced by the child task
+            MOCK_LIVEACTION_3_CHILD_1_OUTPUT_1,
+            MOCK_LIVEACTION_3_CHILD_1_OUTPUT_2,
+
+            # Child task 1 finished
+            MOCK_LIVEACTION_3_CHILD_1_SUCCEEDED,
+
+            # Parent workflow task finished
+            MOCK_LIVEACTION_3_SUCCEDED,
+            # End another execution
+
             # Child task 1 has finished
             MOCK_LIVEACTION_4_CHILD_1_1_SUCCEEDED,
 
@@ -585,5 +602,6 @@ Child execution (task=task_2) idmistralchild2 has finished (status=timeout).
 
 Execution idfoo4 has completed (status=succeeded).
 """.lstrip()
+
         self.assertEqual(stdout, expected_result)
         self.assertEqual(stderr, '')

--- a/st2client/tests/unit/test_execution_tail_command.py
+++ b/st2client/tests/unit/test_execution_tail_command.py
@@ -608,7 +608,7 @@ Execution idfoo4 has completed (status=succeeded).
 
     @mock.patch.object(
         httpclient.HTTPClient, 'get',
-        mock.MagicMock(return_value=base.FakeResponse(json.dumps(MOCK_LIVEACTION_4_RUNNING),
+        mock.MagicMock(return_value=base.FakeResponse(json.dumps(MOCK_LIVEACTION_4_CHILD_2_RUNNING),
                                                      200, 'OK')))
     @mock.patch('st2client.client.StreamManager', autospec=True)
     def test_tail_child_execution_directly(self, mock_stream_manager):
@@ -620,6 +620,13 @@ Execution idfoo4 has completed (status=succeeded).
 
             # Output produced by child task
             MOCK_LIVEACTION_4_CHILD_2_OUTPUT_1,
+
+            # Other executions should not interfere
+            # Child task 1 started running
+            MOCK_LIVEACTION_3_CHILD_1_RUNNING,
+
+            # Child task 1 finished (sub workflow)
+            MOCK_LIVEACTION_4_CHILD_1_SUCCEEDED,
 
             # Child task 2 finished
             MOCK_LIVEACTION_4_CHILD_2_TIMED_OUT


### PR DESCRIPTION
This pull request includes various improvements to the ``st2 execution tail`` CLI command:

1. Support for Orquesta workflows
2. Support for arbitrary nested workflows
3. Correct filtering - previously if user was tailing execution "X" and other executions were also running, data from other executions would incorrectly be included in the output

## TODO

- [x] Tests

Resolves #4267.