### PR TITLE
Changelog entry for #4315

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,7 +49,13 @@ Added
   get all (list) API endpoints (actions, rules, trigger, executions, etc.). With this query
   parameter user can control which API model attributes (fields) to receive in the response. In
   situations where user is only interested in a subset of the model attributes, this allows for a
-  significantly reduced response size and for a better performance. (new feature) (improvement) #4300
+  significantly reduced response size and for a better performance. (new feature) (improvement)
+  #4300
+* Add new ``action_sensor.emit_when`` config option which allows user to specify action status for
+  which actiontrigger is emitted. For backward compatibility reasons it defaults to all the action
+  completed states. (improvement) #4312 #4315
+
+  Contributed by Shu Sugimoto.
 
 Changed
 ~~~~~~~
@@ -104,6 +110,10 @@ Fixed
   CentOS. (bug fix) #4297
 * Fix a bug with action runner throwing an exception and failing to run an action if there was an
   empty pack config inside ``/opt/stackstorm/configs/``. (bug fix) #4325
+* Fix ``action_sensor.enable`` config option so it works correctly if user sets this option to a
+  non-default value of ``True``. (bug fix) #4312 #4315
+
+  Contributed by Shu Sugimoto.
 
 Deprecated
 ~~~~~~~~~~

--- a/conf/st2.conf.sample
+++ b/conf/st2.conf.sample
@@ -4,8 +4,8 @@
 [action_sensor]
 # Whether to enable or disable the ability to post a trigger on action.
 enable = True
-# List of execution statuses that a trigger will be emitted. If not specified, it defaults to action completion.
-emit_when =  # comma separated list allowed here.
+# List of execution statuses for which a trigger will be emitted. 
+emit_when = succeeded,failed,timeout,canceled,abandoned # comma separated list allowed here.
 
 [actionrunner]
 # Internal pool size for dispatcher used by regular actions.

--- a/st2actions/st2actions/notifier/notifier.py
+++ b/st2actions/st2actions/notifier/notifier.py
@@ -234,16 +234,10 @@ class Notifier(consumers.MessageHandler):
         extra = {'execution': execution_db}
 
         target_statuses = cfg.CONF.action_sensor.emit_when
-        if not target_statuses:
-            if execution_db.status not in LIVEACTION_COMPLETED_STATES:
-                msg = 'Skip action execution "%s" because state "%s" is not in a completed state.'
-                LOG.debug(msg % (execution_id, execution_db.status), extra=extra)
-                return
-        else:
-            if execution_db.status not in target_statuses:
-                msg = 'Skip action execution "%s" because state "%s" is not in %s'
-                LOG.debug(msg % (execution_id, execution_db.status, target_statuses), extra=extra)
-                return
+        if execution_db.status not in target_statuses:
+            msg = 'Skip action execution "%s" because state "%s" is not in %s'
+            LOG.debug(msg % (execution_id, execution_db.status, target_statuses), extra=extra)
+            return
 
         payload = {'execution_id': execution_id,
                    'status': liveaction_db.status,

--- a/st2actions/tests/unit/test_notifier.py
+++ b/st2actions/tests/unit/test_notifier.py
@@ -204,14 +204,12 @@ class NotifierTestCase(CleanDbTestCase):
                                          trace_context={})
         notifier.process(execution)
 
-    @mock.patch('oslo_config.cfg.CONF.action_sensor', mock.MagicMock(
-        emit_when=[]))
     @mock.patch.object(Notifier, '_get_runner_ref', mock.MagicMock(
         return_value='run-local-cmd'))
     @mock.patch.object(Notifier, '_get_trace_context', mock.MagicMock(
         return_value={}))
     @mock.patch('st2common.transport.reactor.TriggerDispatcher.dispatch')
-    def test_post_generic_trigger(self, dispatch):
+    def test_post_generic_trigger_emit_when_default_value_is_used(self, dispatch):
         for status in LIVEACTION_STATUSES:
             liveaction_db = LiveActionDB(action='core.local')
             liveaction_db.status = status

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -24,6 +24,7 @@ from distutils.spawn import find_executable
 from st2common.constants.system import VERSION_STRING
 from st2common.constants.system import DEFAULT_CONFIG_FILE_PATH
 from st2common.constants.runners import PYTHON_RUNNER_DEFAULT_LOG_LEVEL
+from st2common.constants.action import LIVEACTION_COMPLETED_STATES
 
 __all__ = [
     'do_register_opts',
@@ -389,9 +390,8 @@ def register_opts(ignore_errors=False):
             'enable', default=True,
             help='Whether to enable or disable the ability to post a trigger on action.'),
         cfg.ListOpt(
-            'emit_when', default=[],
-            help='List of execution statuses that a trigger will be emitted. '
-                 'If not specified, it defaults to action completion.'),
+            'emit_when', default=LIVEACTION_COMPLETED_STATES,
+            help='List of execution statuses for which a trigger will be emitted. ')
     ]
 
     do_register_opts(action_sensor_opts, group='action_sensor')


### PR DESCRIPTION
This pull request adds a changelog entry for #4315.

In addition to that, it defaults ``action_sensor.emit_when`` config option to live action completed states. 

This way the default value is explicit and user doesn't need to dig through the code to figure out what happens if no value is specified.