### PR TITLE
Optimize performance of POST /v1/executions API endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,7 +49,10 @@ Added
   get all (list) API endpoints (actions, rules, trigger, executions, etc.). With this query
   parameter user can control which API model attributes (fields) to receive in the response. In
   situations where user is only interested in a subset of the model attributes, this allows for a
-  significantly reduced response size and for a better performance. (new feature) (improvement) #4300
+  significantly reduced response size and for a better performance. (new feature) (improvement)
+  #4300
+* Improve concurrent performance of schedule action execution (``POST /v1/executions``) API
+  endpoint. (improvement) #4030 #4331
 
 Changed
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,8 +51,11 @@ Added
   situations where user is only interested in a subset of the model attributes, this allows for a
   significantly reduced response size and for a better performance. (new feature) (improvement)
   #4300
-* Improve concurrent performance of schedule action execution (``POST /v1/executions``) API
-  endpoint. (improvement) #4030 #4331
+* Improve performance of schedule action execution (``POST /v1/executions``) API endpoint.
+
+  Performance was improved by reducing the number of duplicated database queries, using atomic
+  partial document updates instead of full document updates and by improving database document
+  serialization and de-serialization performance. (improvement) #4030 #4331
 
 Changed
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -71,7 +71,10 @@ Changed
   This way we are not mixing non-streaming (short lived) and streaming (long lived) connections
   inside a single service (st2api). (improvement)
 * Upgrade ``mongoengine`` (0.15.3) and ``pymongo`` (3.7.1) to the latest stable version. Those
-  changes will allow us to support MongoDB 3.6 in the near future. (improvement) #4292
+  changes will allow us to support MongoDB 3.6 in the near future.
+
+  New version of ``mongoengine`` should also offer better performance when inserting and updating
+  larger database objects (e.g. executions). (improvement) #4292
 * Trigger parameters and payload schema validation is now enabled by default
   (``system.validate_trigger_parameters`` and ``system.validate_trigger_payload`` config options
   now default to ``True``).

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -52,3 +52,4 @@ psutil==5.4.6
 python-statsd==2.1.0
 prometheus_client==0.1.1
 mock==2.0.0
+ujson==1.35

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,6 +53,7 @@ six==1.11.0
 sseclient==0.0.19
 stevedore==1.29.0
 tooz==1.62.0
+ujson==1.35
 unittest2
 webob==1.7.4
 webtest

--- a/st2actions/tests/unit/test_runner_container.py
+++ b/st2actions/tests/unit/test_runner_container.py
@@ -15,11 +15,8 @@
 
 from __future__ import absolute_import
 
-import six
 import mock
-import unittest2
 
-from bson.errors import InvalidStringData
 from oslo_config import cfg
 
 from st2common.constants import action as action_constants
@@ -34,9 +31,6 @@ from st2common.runners.base import PollingAsyncActionRunner
 from st2common.services import executions
 from st2common.util import date as date_utils
 from st2common.transport.publishers import PoolPublisher
-
-from local_runner import local_shell_command_runner
-from local_runner.local_shell_command_runner import LocalShellCommandRunner
 
 from st2tests.base import DbTestCase
 import st2tests.config as tests_config

--- a/st2actions/tests/unit/test_runner_container.py
+++ b/st2actions/tests/unit/test_runner_container.py
@@ -299,26 +299,6 @@ class RunnerContainerTest(DbTestCase):
             liveaction_db
         )
 
-    @unittest2.skipIf(six.PY3, 'non-utf8 works fine in MongoDB under Python 3')
-    @mock.patch.object(LocalShellCommandRunner, 'run', mock.MagicMock(
-        return_value=(action_constants.LIVEACTION_STATUS_SUCCEEDED, NON_UTF8_RESULT, None)))
-    @mock.patch('st2common.runners.base.register_runner',
-                mock.MagicMock(return_value=local_shell_command_runner))
-    def test_dispatch_non_utf8_result(self):
-        runner_container = get_runner_container()
-        params = {
-            'cmd': "python -c 'print \"\\x82\"'"
-        }
-        liveaction_db = self._get_liveaction_model(RunnerContainerTest.local_action_db, params)
-        liveaction_db = LiveAction.add_or_update(liveaction_db)
-        executions.create_execution_object(liveaction_db)
-
-        try:
-            runner_container.dispatch(liveaction_db)
-            self.fail('Mongo won\'t handle non UTF-8 strings. Should have failed.')
-        except InvalidStringData:
-            pass
-
     def test_dispatch_runner_failure(self):
         runner_container = get_runner_container()
         params = {

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -301,7 +301,7 @@ class ActionExecutionAttributeController(BaseActionExecutionNestedController):
                                                           permission_type=permission_type)
 
         result = getattr(action_exec_db, attribute, None)
-        return result
+        return Response(json=result, status=http_client.OK)
 
 
 class ActionExecutionOutputController(ActionExecutionsControllerMixin, ResourceController):

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -204,7 +204,6 @@ class ActionExecutionsControllerMixin(BaseRestControllerMixin):
         liveaction_db, actionexecution_db = action_service.create_request(liveaction=liveaction_db,
             action_db=action_db,
             runnertype_db=runnertype_db)
-        liveaction_db = LiveAction.add_or_update(liveaction_db, publish=False)
 
         _, actionexecution_db = action_service.publish_request(liveaction_db, actionexecution_db)
         mask_secrets = self._get_mask_secrets(requester_user, show_secrets=show_secrets)

--- a/st2api/st2api/controllers/v1/auth.py
+++ b/st2api/st2api/controllers/v1/auth.py
@@ -105,9 +105,8 @@ class ApiKeyController(BaseRestControllerMixin):
 
         limit = resource.validate_limit_query_param(limit, requester_user=requester_user)
 
-        api_key_dbs = ApiKey.get_all(limit=limit, offset=offset)
-
         try:
+            api_key_dbs = ApiKey.get_all(limit=limit, offset=offset)
             api_keys = [ApiKeyAPI.from_model(api_key_db, mask_secrets=mask_secrets)
                         for api_key_db in api_key_dbs]
         except OverflowError:

--- a/st2api/st2api/controllers/v1/keyvalue.py
+++ b/st2api/st2api/controllers/v1/keyvalue.py
@@ -16,6 +16,7 @@
 from oslo_config import cfg
 
 import six
+import bson
 from mongoengine import ValidationError
 
 from st2api.controllers.resource import ResourceController
@@ -197,6 +198,11 @@ class KeyValuePairController(ResourceController):
                 )
             except StackStormDBObjectNotFoundError:
                 existing_kvp_api = None
+
+            # st2client sends invalid id when initially setting a key so we ignore those
+            id_ = kvp.__dict__.get('id', None)
+            if not existing_kvp_api and id_ and not bson.ObjectId.is_valid(id_):
+                del kvp.__dict__['id']
 
             kvp.name = key_ref
             kvp.scope = scope

--- a/st2api/tests/unit/controllers/v1/test_executions.py
+++ b/st2api/tests/unit/controllers/v1/test_executions.py
@@ -1208,13 +1208,30 @@ class ActionExecutionControllerTestCase(BaseActionExecutionControllerTestCase, F
     def test_get_single_attribute_success(self):
         exec_id = self.app.get('/v1/actionexecutions?limit=1').json[0]['id']
 
+        resp = self.app.get('/v1/executions/%s/attribute/status' % (exec_id))
+        self.assertEqual(resp.status_int, 200)
+        self.assertEqual(resp.json, 'requested')
+
         resp = self.app.get('/v1/executions/%s/attribute/result' % (exec_id))
-        self.assertEqual(resp.json, {})
+        self.assertEqual(resp.status_int, 200)
+        self.assertEqual(resp.json, None)
 
         resp = self.app.get('/v1/executions/%s/attribute/trigger_instance' % (exec_id))
-        self.assertEqual(resp.json, {})
+        self.assertEqual(resp.status_int, 200)
+        self.assertEqual(resp.json, None)
 
-    def test_get_single_attribute_failure_invalud_attribute(self):
+        data = {}
+        data['status'] = action_constants.LIVEACTION_STATUS_SUCCEEDED
+        data['result'] = {'foo': 'bar'}
+
+        resp = self.app.put_json('/v1/executions/%s' % (exec_id), data)
+        self.assertEqual(resp.status_int, 200)
+
+        resp = self.app.get('/v1/executions/%s/attribute/result' % (exec_id))
+        self.assertEqual(resp.status_int, 200)
+        self.assertEqual(resp.json, data['result'])
+
+    def test_get_single_attribute_failure_invalid_attribute(self):
         exec_id = self.app.get('/v1/actionexecutions?limit=1').json[0]['id']
 
         resp = self.app.get('/v1/executions/%s/attribute/start_timestamp' % (exec_id),

--- a/st2api/tests/unit/controllers/v1/test_triggerinstances.py
+++ b/st2api/tests/unit/controllers/v1/test_triggerinstances.py
@@ -22,6 +22,7 @@ from st2common.transport.publishers import PoolPublisher
 from st2common.persistence.trigger import TriggerInstance
 from st2common.models.db.trigger import TriggerInstanceDB
 from st2common.util import date as date_utils
+from st2common.util import isotime
 from st2api.controllers.v1.triggers import TriggerInstanceController
 
 from tests.base import FunctionalTest
@@ -74,10 +75,16 @@ class TriggerInstanceTestCase(FunctionalTest,
         self.assertEqual(resp.status_int, http_client.OK)
         timestamp_largest = resp.json[0]['occurrence_time']
         timestamp_middle = resp.json[1]['occurrence_time']
+
+        dt = isotime.parse(timestamp_largest)
+        dt = dt + datetime.timedelta(seconds=1)
+        timestamp_largest = isotime.format(dt, offset=False)
+
         resp = self.app.get('/v1/triggerinstances?timestamp_gt=%s' % timestamp_largest)
         # Since we sort trigger instances by time (latest first), the previous
         # get should return no trigger instances.
         self.assertEqual(len(resp.json), 0)
+
         resp = self.app.get('/v1/triggerinstances?timestamp_lt=%s' % (timestamp_middle))
         self.assertEqual(len(resp.json), 1)
 

--- a/st2client/st2client/models/keyvalue.py
+++ b/st2client/st2client/models/keyvalue.py
@@ -31,3 +31,10 @@ class KeyValuePair(core.Resource):
     _repr_attributes = ['name', 'value']
 
     # Note: This is a temporary hack until we refactor client and make it support non id PKs
+    def get_id(self):
+        return self.name
+
+    def set_id(self, value):
+        pass
+
+    id = property(get_id, set_id)

--- a/st2client/st2client/models/keyvalue.py
+++ b/st2client/st2client/models/keyvalue.py
@@ -32,10 +32,3 @@ class KeyValuePair(core.Resource):
 
     # Note: This is a temporary hack until we refactor client and make it support non id PKs
 
-    def get_id(self):
-        return self.name
-
-    def set_id(self, value):
-        self.name = value
-
-    id = property(get_id, set_id)

--- a/st2client/st2client/models/keyvalue.py
+++ b/st2client/st2client/models/keyvalue.py
@@ -31,4 +31,3 @@ class KeyValuePair(core.Resource):
     _repr_attributes = ['name', 'value']
 
     # Note: This is a temporary hack until we refactor client and make it support non id PKs
-

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -33,3 +33,4 @@ webob
 jsonpath-rw
 python-statsd
 prometheus_client
+ujson

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -25,5 +25,6 @@ routes==2.4.1
 semver==2.8.1
 six==1.11.0
 tooz==1.62.0
+ujson==1.35
 webob==1.7.4
 zake==0.2.2

--- a/st2common/st2common/models/api/base.py
+++ b/st2common/st2common/models/api/base.py
@@ -77,10 +77,12 @@ class BaseAPI(object):
 
     @classmethod
     def _from_model(cls, model, mask_secrets=False):
-        doc = util_mongodb.unescape_chars(model.to_mongo())
+        doc = model.to_mongo()
 
         if '_id' in doc:
             doc['id'] = str(doc.pop('_id'))
+
+        doc = util_mongodb.unescape_chars(doc)
 
         if mask_secrets and cfg.CONF.log.mask_secrets:
             doc = model.mask_secrets(value=doc)

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -439,7 +439,7 @@ class MongoDBAccess(object):
         return self._undo_dict_field_escape(instance)
 
     def add_or_update(self, instance, validate=True):
-        instance.save(validate=validate)
+        instance.save()
         return self._undo_dict_field_escape(instance)
 
     def update(self, instance, **kwargs):

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -438,8 +438,8 @@ class MongoDBAccess(object):
         instance = self.model.objects.insert(instance)
         return self._undo_dict_field_escape(instance)
 
-    def add_or_update(self, instance):
-        instance.save()
+    def add_or_update(self, instance, validate=True):
+        instance.save(validate=validate)
         return self._undo_dict_field_escape(instance)
 
     def update(self, instance, **kwargs):

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -439,7 +439,7 @@ class MongoDBAccess(object):
         return self._undo_dict_field_escape(instance)
 
     def add_or_update(self, instance, validate=True):
-        instance.save()
+        instance.save(validate=validate)
         return self._undo_dict_field_escape(instance)
 
     def update(self, instance, **kwargs):
@@ -545,8 +545,8 @@ class ChangeRevisionMongoDBAccess(MongoDBAccess):
 
         return self._undo_dict_field_escape(instance)
 
-    def add_or_update(self, instance):
-        return self.save(instance)
+    def add_or_update(self, instance, validate=True):
+        return self.save(instance, validate=validate)
 
     def update(self, instance, **kwargs):
         for k, v in six.iteritems(kwargs):
@@ -554,14 +554,14 @@ class ChangeRevisionMongoDBAccess(MongoDBAccess):
 
         return self.save(instance)
 
-    def save(self, instance):
+    def save(self, instance, validate=True):
         if not hasattr(instance, 'id') or not instance.id:
             return self.insert(instance)
         else:
             try:
                 save_condition = {'id': instance.id, 'rev': instance.rev}
                 instance.rev = instance.rev + 1
-                instance.save(save_condition=save_condition)
+                instance.save(save_condition=save_condition, validate=validate)
             except mongoengine.SaveConditionError:
                 raise db_exc.StackStormDBObjectWriteConflictError(instance)
 

--- a/st2common/st2common/persistence/auth.py
+++ b/st2common/st2common/persistence/auth.py
@@ -63,14 +63,14 @@ class Token(Access):
         return cls.impl
 
     @classmethod
-    def add_or_update(cls, model_object, publish=True):
+    def add_or_update(cls, model_object, publish=True, validate=True):
         if not getattr(model_object, 'user', None):
             raise ValueError('User is not provided in the token.')
         if not getattr(model_object, 'token', None):
             raise ValueError('Token value is not set.')
         if not getattr(model_object, 'expiry', None):
             raise ValueError('Token expiry is not provided in the token.')
-        return super(Token, cls).add_or_update(model_object, publish=publish)
+        return super(Token, cls).add_or_update(model_object, publish=publish, validate=validate)
 
     @classmethod
     def get(cls, value):

--- a/st2common/st2common/persistence/base.py
+++ b/st2common/st2common/persistence/base.py
@@ -163,7 +163,7 @@ class Access(object):
         return model_object
 
     @classmethod
-    def add_or_update(cls, model_object, publish=True, dispatch_trigger=True,
+    def add_or_update(cls, model_object, publish=True, dispatch_trigger=True, validate=True,
                       log_not_unique_error_as_debug=False):
         # Late import to avoid very expensive in-direct import (~1 second) when this function
         # is not called / used
@@ -171,7 +171,7 @@ class Access(object):
 
         pre_persist_id = model_object.id
         try:
-            model_object = cls._get_impl().add_or_update(model_object)
+            model_object = cls._get_impl().add_or_update(model_object, validate=validate)
         except NotUniqueError as e:
             if log_not_unique_error_as_debug:
                 LOG.debug('Conflict while trying to save in DB: %s.', str(e))

--- a/st2common/st2common/persistence/base.py
+++ b/st2common/st2common/persistence/base.py
@@ -163,7 +163,7 @@ class Access(object):
         return model_object
 
     @classmethod
-    def add_or_update(cls, model_object, publish=True, dispatch_trigger=True, validate=True,
+    def add_or_update(cls, model_object, publish=True, dispatch_trigger=True,
                       log_not_unique_error_as_debug=False):
         # Late import to avoid very expensive in-direct import (~1 second) when this function
         # is not called / used
@@ -171,7 +171,7 @@ class Access(object):
 
         pre_persist_id = model_object.id
         try:
-            model_object = cls._get_impl().add_or_update(model_object, validate=validate)
+            model_object = cls._get_impl().add_or_update(model_object)
         except NotUniqueError as e:
             if log_not_unique_error_as_debug:
                 LOG.debug('Conflict while trying to save in DB: %s.', str(e))

--- a/st2common/st2common/persistence/base.py
+++ b/st2common/st2common/persistence/base.py
@@ -163,7 +163,7 @@ class Access(object):
         return model_object
 
     @classmethod
-    def add_or_update(cls, model_object, publish=True, dispatch_trigger=True,
+    def add_or_update(cls, model_object, publish=True, dispatch_trigger=True, validate=True,
                       log_not_unique_error_as_debug=False):
         # Late import to avoid very expensive in-direct import (~1 second) when this function
         # is not called / used
@@ -171,7 +171,7 @@ class Access(object):
 
         pre_persist_id = model_object.id
         try:
-            model_object = cls._get_impl().add_or_update(model_object)
+            model_object = cls._get_impl().add_or_update(model_object, validate=True)
         except NotUniqueError as e:
             if log_not_unique_error_as_debug:
                 LOG.debug('Conflict while trying to save in DB: %s.', str(e))

--- a/st2common/st2common/persistence/keyvalue.py
+++ b/st2common/st2common/persistence/keyvalue.py
@@ -49,7 +49,7 @@ class KeyValuePair(Access):
     }
 
     @classmethod
-    def add_or_update(cls, model_object, publish=True, dispatch_trigger=True):
+    def add_or_update(cls, model_object, publish=True, dispatch_trigger=True, validate=True):
         """
         Note: We override add_or_update because we also want to publish high level "value_change"
         event for this resource.

--- a/st2common/st2common/services/action.py
+++ b/st2common/st2common/services/action.py
@@ -54,9 +54,17 @@ def _get_immutable_params(parameters):
     return [k for k, v in six.iteritems(parameters) if v.get('immutable', False)]
 
 
-def create_request(liveaction):
+def create_request(liveaction, action_db=None, runnertype_db=None):
     """
     Create an action execution.
+
+    :param action_db: Action model to operate one. If not provided, one is retrieved from the
+                      database using values from "liveaction".
+    :type action_db: :class:`ActionDB`
+
+    :param runnertype_db: Runner model to operate one. If not provided, one is retrieved from the
+                          database using values from "liveaction".
+    :type runnertype_db: :class:`RunnerTypeDB`
 
     :return: (liveaction, execution)
     :rtype: tuple
@@ -74,20 +82,23 @@ def create_request(liveaction):
         if parent_user:
             liveaction.context['user'] = parent_user
 
-    # Validate action.
-    action_db = action_utils.get_action_by_ref(liveaction.action)
+    # Validate action
+    if not action_db:
+        action_db = action_utils.get_action_by_ref(liveaction.action)
+
     if not action_db:
         raise ValueError('Action "%s" cannot be found.' % liveaction.action)
     if not action_db.enabled:
         raise ValueError('Unable to execute. Action "%s" is disabled.' % liveaction.action)
 
-    runnertype_db = action_utils.get_runnertype_by_name(action_db.runner_type['name'])
+    if not runnertype_db:
+        runnertype_db = action_utils.get_runnertype_by_name(action_db.runner_type['name'])
 
     if not hasattr(liveaction, 'parameters'):
         liveaction.parameters = dict()
 
     # Validate action parameters.
-    schema = util_schema.get_schema_for_action_parameters(action_db)
+    schema = util_schema.get_schema_for_action_parameters(action_db, runnertype_db)
     validator = util_schema.get_validator()
     util_schema.validate(liveaction.parameters, schema, validator, use_default=True,
                          allow_default_none=True)
@@ -117,7 +128,6 @@ def create_request(liveaction):
 
     # Publish creation after both liveaction and actionexecution are created.
     liveaction = LiveAction.add_or_update(liveaction, publish=False)
-
     # Get trace_db if it exists. This could throw. If it throws, we have to cleanup
     # liveaction object so we don't see things in requested mode.
     trace_db = None
@@ -127,7 +137,8 @@ def create_request(liveaction):
         _cleanup_liveaction(liveaction)
         raise trace_exc.TraceNotFoundException(str(e))
 
-    execution = executions.create_execution_object(liveaction, publish=False)
+    execution = executions.create_execution_object(liveaction=liveaction, action_db=action_db,
+                                                   runnertype_db=runnertype_db, publish=False)
 
     if trace_db:
         trace_service.add_or_update_given_trace_db(
@@ -153,7 +164,9 @@ def publish_request(liveaction, execution):
     LiveAction.publish_status(liveaction)
     ActionExecution.publish_create(execution)
 
-    extra = {'liveaction_db': liveaction, 'execution_db': execution}
+    # TODO: This results in two queries, optimize it
+    #extra = {'liveaction_db': liveaction, 'execution_db': execution}
+    extra = {}
     LOG.audit('Action execution requested. LiveAction.id=%s, ActionExecution.id=%s' %
               (liveaction.id, execution.id), extra=extra)
 

--- a/st2common/st2common/services/action.py
+++ b/st2common/st2common/services/action.py
@@ -165,7 +165,7 @@ def publish_request(liveaction, execution):
     ActionExecution.publish_create(execution)
 
     # TODO: This results in two queries, optimize it
-    #extra = {'liveaction_db': liveaction, 'execution_db': execution}
+    #  extra = {'liveaction_db': liveaction, 'execution_db': execution}
     extra = {}
     LOG.audit('Action execution requested. LiveAction.id=%s, ActionExecution.id=%s' %
               (liveaction.id, execution.id), extra=extra)

--- a/st2common/st2common/services/executions.py
+++ b/st2common/st2common/services/executions.py
@@ -146,8 +146,8 @@ def create_execution_object(liveaction, action_db=None, runnertype_db=None, publ
     execution.web_url = _get_web_url_for_execution(str(execution.id))
 
     # NOTE: User input data is already validate as part of the API request,
-    # other data is set by us. Skipping validation here makes operation 10%-305 faster
-    execution = ActionExecution.add_or_update(execution, publish=publish)
+    # other data is set by us. Skipping validation here makes operation 10%-30% faster
+    execution = ActionExecution.add_or_update(execution, publish=publish, validate=False)
 
     if parent and str(execution.id) not in parent.children:
         values = {}

--- a/st2common/st2common/services/executions.py
+++ b/st2common/st2common/services/executions.py
@@ -144,7 +144,10 @@ def create_execution_object(liveaction, action_db=None, runnertype_db=None, publ
     # TODO: Do 100% research this is fully safe and unique in distributed setups
     execution.id = ObjectId()
     execution.web_url = _get_web_url_for_execution(str(execution.id))
-    execution = ActionExecution.add_or_update(execution, publish=publish)
+
+    # NOTE: User input data is already validate as part of the API request,
+    # other data is set by us. Skipping validation here makes operation 10%-305 faster
+    execution = ActionExecution.add_or_update(execution, publish=publish, validate=False)
 
     if parent and str(execution.id) not in parent.children:
         values = {}

--- a/st2common/st2common/services/executions.py
+++ b/st2common/st2common/services/executions.py
@@ -139,6 +139,7 @@ def create_execution_object(liveaction, action_db=None, runnertype_db=None, publ
 
     attrs['log'] = [_create_execution_log_entry(liveaction['status'])]
 
+    # TODO: This object initialization takes 20-30or so ms
     execution = ActionExecutionDB(**attrs)
     # TODO: Do 100% research this is fully safe and unique in distributed setups
     execution.id = ObjectId()
@@ -154,15 +155,15 @@ def create_execution_object(liveaction, action_db=None, runnertype_db=None, publ
 
 
 def _get_parent_execution(child_liveaction_db):
-    parent_context = child_liveaction_db.context.get('parent', None)
+    parent_execution_id = child_liveaction_db.context.get('parent', {}).get('execution_id', None)
 
-    if parent_context:
-        parent_id = parent_context['execution_id']
+    if parent_execution_id:
         try:
-            return ActionExecution.get_by_id(parent_id)
+            return ActionExecution.get_by_id(parent_execution_id)
         except:
-            LOG.exception('No valid execution object found in db for id: %s' % parent_id)
+            LOG.exception('No valid execution object found in db for id: %s' % parent_execution_id)
             return None
+
     return None
 
 

--- a/st2common/st2common/services/executions.py
+++ b/st2common/st2common/services/executions.py
@@ -99,14 +99,17 @@ def _create_execution_log_entry(status):
     }
 
 
-def create_execution_object(liveaction, publish=True):
-    action_db = action_utils.get_action_by_ref(liveaction.action)
-    runner = RunnerType.get_by_name(action_db.runner_type['name'])
+def create_execution_object(liveaction, action_db=None, runnertype_db=None, publish=True):
+    if not action_db:
+        action_db = action_utils.get_action_by_ref(liveaction.action)
+
+    if not runnertype_db:
+        runnertype_db = RunnerType.get_by_name(action_db.runner_type['name'])
 
     attrs = {
         'action': vars(ActionAPI.from_model(action_db)),
         'parameters': liveaction['parameters'],
-        'runner': vars(RunnerTypeAPI.from_model(runner))
+        'runner': vars(RunnerTypeAPI.from_model(runnertype_db))
     }
     attrs.update(_decompose_liveaction(liveaction))
 

--- a/st2common/st2common/services/executions.py
+++ b/st2common/st2common/services/executions.py
@@ -145,11 +145,10 @@ def create_execution_object(liveaction, action_db=None, runnertype_db=None, publ
     execution.web_url = _get_web_url_for_execution(str(execution.id))
     execution = ActionExecution.add_or_update(execution, publish=publish)
 
-    if parent:
-        if str(execution.id) not in parent.children:
-            values = {}
-            values['push__children'] = str(execution.id)
-            ActionExecution.update(parent, **values)
+    if parent and str(execution.id) not in parent.children:
+        values = {}
+        values['push__children'] = str(execution.id)
+        ActionExecution.update(parent, **values)
 
     return execution
 

--- a/st2common/st2common/services/executions.py
+++ b/st2common/st2common/services/executions.py
@@ -147,7 +147,7 @@ def create_execution_object(liveaction, action_db=None, runnertype_db=None, publ
 
     # NOTE: User input data is already validate as part of the API request,
     # other data is set by us. Skipping validation here makes operation 10%-305 faster
-    execution = ActionExecution.add_or_update(execution, publish=publish, validate=False)
+    execution = ActionExecution.add_or_update(execution, publish=publish)
 
     if parent and str(execution.id) not in parent.children:
         values = {}

--- a/st2common/st2common/util/action_db.py
+++ b/st2common/st2common/util/action_db.py
@@ -229,6 +229,8 @@ def update_liveaction_status(status=None, result=None, context=None, end_timesta
     if runner_info:
         liveaction_db.runner_info = runner_info
 
+    # TODO: This is not efficient, perfon direct partial update and only update
+    # manipulated fields
     liveaction_db = LiveAction.add_or_update(liveaction_db)
 
     LOG.debug('Updated status for LiveAction object.', extra=extra)

--- a/st2common/st2common/util/action_db.py
+++ b/st2common/st2common/util/action_db.py
@@ -229,7 +229,7 @@ def update_liveaction_status(status=None, result=None, context=None, end_timesta
     if runner_info:
         liveaction_db.runner_info = runner_info
 
-    # TODO: This is not efficient, perfon direct partial update and only update
+    # TODO: This is not efficient. Perform direct partial update and only update
     # manipulated fields
     liveaction_db = LiveAction.add_or_update(liveaction_db)
 

--- a/st2common/st2common/util/isotime.py
+++ b/st2common/st2common/util/isotime.py
@@ -46,6 +46,10 @@ def format(dt, usec=True, offset=True):
     # pylint: disable=no-member
     if isinstance(dt, six.string_types):
         dt = parse(dt)
+    elif isinstance(dt, int):
+        # unix epoch
+        dt = datetime.datetime.fromtimestamp(dt)
+
     fmt = ISO8601_FORMAT_MICROSECOND if usec else ISO8601_FORMAT
     if offset:
         ost = dt.strftime('%z')

--- a/st2common/st2common/util/misc.py
+++ b/st2common/st2common/util/misc.py
@@ -173,14 +173,24 @@ def get_field_name_from_mongoengine_error(exc):
     return msg
 
 
-def fast_deepcopy(value):
+def fast_deepcopy(value, fall_back_to_deepcopy=True):
+    """
+    Perform a fast deepcopy of the provided value.
+
+    :param fall_back_to_deepcopy: True to fall back to copy.deepcopy() in case ujson throws an
+                                  exception.
+    :type fall_back_to_deepcopy: ``bool``
+    """
     # NOTE: ujson round-trip is up to 10 times faster on smaller and larger dicts compared
     # to copy.deepcopy(), but it has some edge cases with non-simple types such as datetimes -
     try:
         value = ujson.loads(ujson.dumps(value))
-    except (OverflowError, ValueError):
+    except (OverflowError, ValueError) as e:
         # NOTE: ujson doesn't support 5 or 6 bytes utf-8 sequences which we use
         # in our tests so we fall back to deep copy
+        if not fall_back_to_deepcopy:
+            raise e
+
         value = copy.deepcopy(value)
 
     return value

--- a/st2common/st2common/util/misc.py
+++ b/st2common/st2common/util/misc.py
@@ -18,18 +18,15 @@ from __future__ import absolute_import
 import os
 import re
 import sys
-import copy
 import collections
 
 import six
-import ujson
 
 __all__ = [
     'prefix_dict_keys',
     'compare_path_file_name',
     'lowercase_value',
-    'get_field_name_from_mongoengine_error',
-    'fast_deepcopy'
+    'get_field_name_from_mongoengine_error'
 ]
 
 
@@ -171,26 +168,3 @@ def get_field_name_from_mongoengine_error(exc):
         return match.groups()[0]
 
     return msg
-
-
-def fast_deepcopy(value, fall_back_to_deepcopy=True):
-    """
-    Perform a fast deepcopy of the provided value.
-
-    :param fall_back_to_deepcopy: True to fall back to copy.deepcopy() in case ujson throws an
-                                  exception.
-    :type fall_back_to_deepcopy: ``bool``
-    """
-    # NOTE: ujson round-trip is up to 10 times faster on smaller and larger dicts compared
-    # to copy.deepcopy(), but it has some edge cases with non-simple types such as datetimes -
-    try:
-        value = ujson.loads(ujson.dumps(value))
-    except (OverflowError, ValueError) as e:
-        # NOTE: ujson doesn't support 5 or 6 bytes utf-8 sequences which we use
-        # in our tests so we fall back to deep copy
-        if not fall_back_to_deepcopy:
-            raise e
-
-        value = copy.deepcopy(value)
-
-    return value

--- a/st2common/st2common/util/mongoescape.py
+++ b/st2common/st2common/util/mongoescape.py
@@ -69,11 +69,15 @@ def _translate_chars(field, translation):
 
 
 def escape_chars(field):
+    # TODO: This is slow on large dicts, figure out if we can safely manipulate original value
+    # instead of creating the copy
     value = copy.deepcopy(field)
     return _translate_chars(value, ESCAPE_TRANSLATION)
 
 
 def unescape_chars(field):
+    # TODO: This is slow on large dicts, figure out if we can safely manipulate original value
+    # instead of creating the copy
     value = copy.deepcopy(field)
     translated = _translate_chars(value, UNESCAPE_TRANSLATION)
     translated = _translate_chars(value, RULE_CRITERIA_UNESCAPE_TRANSLATION)

--- a/st2common/st2common/util/mongoescape.py
+++ b/st2common/st2common/util/mongoescape.py
@@ -73,11 +73,12 @@ def _translate_chars(field, translation):
 
 
 def escape_chars(field):
-    # TODO: This is slow on large dicts, figure out if we can safely manipulate original value
-    # instead of creating the copy
     if not isinstance(field, dict):
         return field
 
+    # NOTE: ujson round trip is up to 10 times faster on larger dicts compared
+    # to copy.deepcopy, but it has some edge cases with non-standard types such
+    # as datetimes - those are serialized as unix epoch values
     try:
         value = ujson.loads(ujson.dumps(field))
     except (OverflowError, ValueError):
@@ -89,11 +90,12 @@ def escape_chars(field):
 
 
 def unescape_chars(field):
-    # TODO: This is slow on large dicts, figure out if we can safely manipulate original value
-    # instead of creating the copy
     if not isinstance(field, dict):
         return field
 
+    # NOTE: ujson round trip is up to 10 times faster on larger dicts compared
+    # to copy.deepcopy, but it has some edge cases with non-standard types such
+    # as datetimes - those are serialized as unix epoch values
     try:
         value = ujson.loads(ujson.dumps(field))
     except (OverflowError, ValueError):

--- a/st2common/st2common/util/mongoescape.py
+++ b/st2common/st2common/util/mongoescape.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 import six
 from six.moves import zip
 
-from st2common.util.misc import fast_deepcopy
+from st2common.util.ujson import fast_deepcopy
 
 # http://docs.mongodb.org/manual/faq/developers/#faq-dollar-sign-escaping
 UNESCAPED = ['.', '$']

--- a/st2common/st2common/util/mongoescape.py
+++ b/st2common/st2common/util/mongoescape.py
@@ -15,6 +15,8 @@
 
 from __future__ import absolute_import
 
+import copy
+
 import ujson
 import six
 from six.moves import zip
@@ -76,7 +78,13 @@ def escape_chars(field):
     if not isinstance(field, dict):
         return field
 
-    value = ujson.loads(ujson.dumps(field))
+    try:
+        value = ujson.loads(ujson.dumps(field))
+    except (OverflowError, ValueError):
+        # NOTE: ujson doesn't support 5 or 6 bytes utf-8 sequences which we use
+        # in our tests so we fall back to deep copy
+        value = copy.deepcopy(field)
+
     return _translate_chars(value, ESCAPE_TRANSLATION)
 
 
@@ -86,7 +94,13 @@ def unescape_chars(field):
     if not isinstance(field, dict):
         return field
 
-    value = ujson.loads(ujson.dumps(field))
+    try:
+        value = ujson.loads(ujson.dumps(field))
+    except (OverflowError, ValueError):
+        # NOTE: ujson doesn't support 5 or 6 bytes utf-8 sequences which we use
+        # in our tests so we fall back to deep copy
+        value = copy.deepcopy(field)
+
     translated = _translate_chars(value, UNESCAPE_TRANSLATION)
     translated = _translate_chars(value, RULE_CRITERIA_UNESCAPE_TRANSLATION)
     return translated

--- a/st2common/st2common/util/mongoescape.py
+++ b/st2common/st2common/util/mongoescape.py
@@ -15,11 +15,10 @@
 
 from __future__ import absolute_import
 
-import copy
-
-import ujson
 import six
 from six.moves import zip
+
+from st2common.util.misc import fast_deepcopy
 
 # http://docs.mongodb.org/manual/faq/developers/#faq-dollar-sign-escaping
 UNESCAPED = ['.', '$']
@@ -76,16 +75,7 @@ def escape_chars(field):
     if not isinstance(field, dict):
         return field
 
-    # NOTE: ujson round trip is up to 10 times faster on larger dicts compared
-    # to copy.deepcopy, but it has some edge cases with non-standard types such
-    # as datetimes - those are serialized as unix epoch values
-    try:
-        value = ujson.loads(ujson.dumps(field))
-    except (OverflowError, ValueError):
-        # NOTE: ujson doesn't support 5 or 6 bytes utf-8 sequences which we use
-        # in our tests so we fall back to deep copy
-        value = copy.deepcopy(field)
-
+    value = fast_deepcopy(field)
     return _translate_chars(value, ESCAPE_TRANSLATION)
 
 
@@ -93,16 +83,7 @@ def unescape_chars(field):
     if not isinstance(field, dict):
         return field
 
-    # NOTE: ujson round trip is up to 10 times faster on larger dicts compared
-    # to copy.deepcopy, but it has some edge cases with non-standard types such
-    # as datetimes - those are serialized as unix epoch values
-    try:
-        value = ujson.loads(ujson.dumps(field))
-    except (OverflowError, ValueError):
-        # NOTE: ujson doesn't support 5 or 6 bytes utf-8 sequences which we use
-        # in our tests so we fall back to deep copy
-        value = copy.deepcopy(field)
-
+    value = fast_deepcopy(field)
     translated = _translate_chars(value, UNESCAPE_TRANSLATION)
     translated = _translate_chars(value, RULE_CRITERIA_UNESCAPE_TRANSLATION)
     return translated

--- a/st2common/st2common/util/mongoescape.py
+++ b/st2common/st2common/util/mongoescape.py
@@ -14,7 +14,8 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import copy
+
+import ujson
 import six
 from six.moves import zip
 
@@ -52,7 +53,8 @@ def _translate_chars(field, translation):
         newkey = oldkey
 
         for t_k, t_v in six.iteritems(translation):
-            newkey = newkey.replace(t_k, t_v)
+            if t_k in newkey:
+                newkey = newkey.replace(t_k, t_v)
 
         if newkey != oldkey:
             work_field[newkey] = value
@@ -71,14 +73,20 @@ def _translate_chars(field, translation):
 def escape_chars(field):
     # TODO: This is slow on large dicts, figure out if we can safely manipulate original value
     # instead of creating the copy
-    value = copy.deepcopy(field)
+    if not isinstance(field, dict):
+        return field
+
+    value = ujson.loads(ujson.dumps(field))
     return _translate_chars(value, ESCAPE_TRANSLATION)
 
 
 def unescape_chars(field):
     # TODO: This is slow on large dicts, figure out if we can safely manipulate original value
     # instead of creating the copy
-    value = copy.deepcopy(field)
+    if not isinstance(field, dict):
+        return field
+
+    value = ujson.loads(ujson.dumps(field))
     translated = _translate_chars(value, UNESCAPE_TRANSLATION)
     translated = _translate_chars(value, RULE_CRITERIA_UNESCAPE_TRANSLATION)
     return translated

--- a/st2common/st2common/util/schema/__init__.py
+++ b/st2common/st2common/util/schema/__init__.py
@@ -322,31 +322,32 @@ def validate_runner_parameter_attribute_override(action_ref, param_name, attr_na
     return True
 
 
-def get_schema_for_action_parameters(action_db):
+def get_schema_for_action_parameters(action_db, runnertype_db=None):
     """
     Dynamically construct JSON schema for the provided action from the parameters metadata.
 
     Note: This schema is used to validate parameters which are passed to the action.
     """
-    from st2common.util.action_db import get_runnertype_by_name
-    runner_type = get_runnertype_by_name(action_db.runner_type['name'])
+    if not runnertype_db:
+        from st2common.util.action_db import get_runnertype_by_name
+        runnertype_db = get_runnertype_by_name(action_db.runner_type['name'])
 
     # Note: We need to perform a deep merge because user can only specify a single parameter
     # attribute when overriding it in an action metadata.
     parameters_schema = {}
-    deep_update(parameters_schema, runner_type.runner_parameters)
+    deep_update(parameters_schema, runnertype_db.runner_parameters)
     deep_update(parameters_schema, action_db.parameters)
 
     # Perform validation, make sure user is not providing parameters which can't
     # be overriden
-    runner_parameter_names = list(runner_type.runner_parameters.keys())
+    runner_parameter_names = list(runnertype_db.runner_parameters.keys())
 
     for name, schema in six.iteritems(action_db.parameters):
         if name not in runner_parameter_names:
             continue
 
         for attribute, value in six.iteritems(schema):
-            runner_param_value = runner_type.runner_parameters[name].get(attribute)
+            runner_param_value = runnertype_db.runner_parameters[name].get(attribute)
             validate_runner_parameter_attribute_override(action_ref=action_db.ref,
                                                          param_name=name,
                                                          attr_name=attribute,

--- a/st2common/st2common/util/ujson.py
+++ b/st2common/st2common/util/ujson.py
@@ -32,9 +32,6 @@ def fast_deepcopy(value, fall_back_to_deepcopy=True):
                                   exception.
     :type fall_back_to_deepcopy: ``bool``
     """
-    # NOTE: We perform a lazy import to avoid issues with Python 3 virtualenvs on Python 2
-    # deployments
-
     # NOTE: ujson round-trip is up to 10 times faster on smaller and larger dicts compared
     # to copy.deepcopy(), but it has some edge cases with non-simple types such as datetimes -
     try:

--- a/st2common/st2common/util/ujson.py
+++ b/st2common/st2common/util/ujson.py
@@ -1,0 +1,50 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import copy
+
+import ujson
+
+__all__ = [
+    'fast_deepcopy'
+]
+
+
+def fast_deepcopy(value, fall_back_to_deepcopy=False):
+    """
+    Perform a fast deepcopy of the provided value.
+
+    :param fall_back_to_deepcopy: True to fall back to copy.deepcopy() in case ujson throws an
+                                  exception.
+    :type fall_back_to_deepcopy: ``bool``
+    """
+    # NOTE: We perform a lazy import to avoid issues with Python 3 virtualenvs on Python 2
+    # deployments
+
+    # NOTE: ujson round-trip is up to 10 times faster on smaller and larger dicts compared
+    # to copy.deepcopy(), but it has some edge cases with non-simple types such as datetimes -
+    try:
+        value = ujson.loads(ujson.dumps(value))
+    except (OverflowError, ValueError) as e:
+        # NOTE: ujson doesn't support 5 or 6 bytes utf-8 sequences which we use
+        # in our tests so we fall back to deep copy
+        if not fall_back_to_deepcopy:
+            raise e
+
+        value = copy.deepcopy(value)
+
+    return value

--- a/st2common/st2common/util/ujson.py
+++ b/st2common/st2common/util/ujson.py
@@ -24,7 +24,7 @@ __all__ = [
 ]
 
 
-def fast_deepcopy(value, fall_back_to_deepcopy=False):
+def fast_deepcopy(value, fall_back_to_deepcopy=True):
     """
     Perform a fast deepcopy of the provided value.
 

--- a/st2common/tests/unit/test_logger.py
+++ b/st2common/tests/unit/test_logger.py
@@ -249,11 +249,12 @@ class ConsoleLogFormatterTestCase(unittest.TestCase):
         # Add "extra" attributes
         record._action_execution_db = mock_action_execution_db
 
-        expected_msg_part = "'parameters': {'parameter1': 'value1', 'parameter2': '********'}"
+        expected_msg_part = (r"'parameters': {u?'parameter1': u?'value1', "
+                             "u?'parameter2': u?'\*\*\*\*\*\*\*\*'}")
 
         message = formatter.format(record=record)
         self.assertTrue('test message 1' in message)
-        self.assertTrue(expected_msg_part in message)
+        self.assertRegexpMatches(message, expected_msg_part)
 
 
 class GelfLogFormatterTestCase(unittest.TestCase):

--- a/st2common/tests/unit/test_misc_utils.py
+++ b/st2common/tests/unit/test_misc_utils.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -14,11 +15,13 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import unittest2
 
 from st2common.util.misc import rstrip_last_char
 from st2common.util.misc import strip_shell_chars
 from st2common.util.misc import lowercase_value
+from st2common.util.ujson import fast_deepcopy
 
 __all__ = [
     'MiscUtilTestCase'
@@ -71,3 +74,24 @@ class MiscUtilTestCase(unittest2.TestCase):
             'teste': 'teste'
         }
         self.assertEqual(expected_value, lowercase_value(value=value))
+
+    def test_fast_deepcopy(self):
+        values = [
+            'a',
+            u'٩(̾●̮̮̃̾•̃̾)۶',
+            1,
+            [1, 2, '3', 'b'],
+            {'a': 1, 'b': '3333', 'c': 'd'},
+        ]
+        expected_values = [
+            'a',
+            u'٩(̾●̮̮̃̾•̃̾)۶',
+            1,
+            [1, 2, '3', 'b'],
+            {'a': 1, 'b': '3333', 'c': 'd'},
+        ]
+
+        for value, expected_value in zip(values, expected_values):
+            result = fast_deepcopy(value)
+            self.assertEqual(result, value)
+            self.assertEqual(result, expected_value)

--- a/st2common/tests/unit/test_misc_utils.py
+++ b/st2common/tests/unit/test_misc_utils.py
@@ -16,6 +16,12 @@
 
 from __future__ import absolute_import
 
+import json
+import copy
+import string
+import random
+from timeit import default_timer as timer
+
 import unittest2
 
 from st2common.util.misc import rstrip_last_char
@@ -29,7 +35,6 @@ __all__ = [
 
 
 class MiscUtilTestCase(unittest2.TestCase):
-
     def test_rstrip_last_char(self):
         self.assertEqual(rstrip_last_char(None, '\n'), None)
         self.assertEqual(rstrip_last_char('stuff', None), 'stuff')
@@ -75,7 +80,7 @@ class MiscUtilTestCase(unittest2.TestCase):
         }
         self.assertEqual(expected_value, lowercase_value(value=value))
 
-    def test_fast_deepcopy(self):
+    def test_fast_deepcopy_success(self):
         values = [
             'a',
             u'٩(̾●̮̮̃̾•̃̾)۶',
@@ -95,3 +100,78 @@ class MiscUtilTestCase(unittest2.TestCase):
             result = fast_deepcopy(value)
             self.assertEqual(result, value)
             self.assertEqual(result, expected_value)
+
+    def test_fast_deepcopy_is_faster_than_copy_deepcopy(self):
+        def random_string(N):
+            return ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(N))
+
+        def random_dict(width=5, height=5, levels=2):
+            dct = {}
+            lst = [random_string(4) for i in range(width)]
+            lst2 = [random.randint(0, 10000) for i in range(width)]
+            lst3 = [bool(random.randint(0, 1)) for i in range(width)]
+            for j in range(height):
+                dct[str(j)] = lst
+                dct[str(width + j)] = lst2
+                dct[str(2 * width + j)] = lst3
+
+            for i in range(levels):
+                new_dct = {}
+                for j in range(height):
+                    new_dct[str(j)] = dct
+                dct = json.loads(json.dumps(new_dct))
+
+            return new_dct
+
+        error_msg = 'fast_deepcopy is not faster than copy.deepcopy'
+
+        # 1. Smaller dict
+        data = random_dict(width=10, levels=2, height=2)
+
+        # fast_deepcopy
+        start = timer()
+        fast_deepcopy(data)
+        end = timer()
+        duration_1 = (end - start)
+
+        # copy.deepcopy
+        start = timer()
+        copy.deepcopy(data)
+        end = timer()
+        duration_2 = (end - start)
+
+        self.assertTrue(duration_1 < duration_2, error_msg)
+
+        # 2. Medium sized dict
+        data = random_dict(width=20, levels=3, height=4)
+
+        # fast_deepcopy
+        start = timer()
+        fast_deepcopy(data)
+        end = timer()
+        duration_1 = (end - start)
+
+        # copy.deepcopy
+        start = timer()
+        copy.deepcopy(data)
+        end = timer()
+        duration_2 = (end - start)
+
+        self.assertTrue(duration_1 < duration_2, error_msg)
+
+        # 3. Larger dict
+        data = random_dict(width=30, levels=5, height=4)
+
+        # fast_deepcopy
+        start = timer()
+        fast_deepcopy(data)
+        end = timer()
+        duration_1 = (end - start)
+
+        # copy.deepcopy
+        start = timer()
+        copy.deepcopy(data)
+        end = timer()
+        duration_2 = (end - start)
+
+        self.assertTrue(duration_1 < duration_2, error_msg)


### PR DESCRIPTION
This pull request optimizes performance of ``POST /v1/executions`` API endpoints by doing various things:

- [x] Removing unnecessary / duplicated queries (from 14 to 3 queries which are all essential now)
- [x] Perform partial document updates instead of updating whole documents where possible
- [x] Skip double validation where it's not needed
- [x] Use ujson round-trip when creating a deep copy of dictionaries we perform mongodb special character escaping on. I've done testing with various dictionary sizes, including actual executions and the speed up can be 10x compared to `copy.deepcopy()`. It has some edge cases with special types, notably `datetime`, but I believe I found a good work-around for that.

We are trading a bit of code readability and maintainability for performance, but that's needed here because the code was / is very wasteful and the performance is really bad. And this bad performance has cascading effect on Mistral and everything else which schedules executions through the API.

Related issue #4030.