### PR TITLE
Disable the unit test test_fast_deepcopy_is_faster_than_copy_deepcopy

### DIFF
--- a/st2common/tests/unit/test_misc_utils.py
+++ b/st2common/tests/unit/test_misc_utils.py
@@ -101,6 +101,7 @@ class MiscUtilTestCase(unittest2.TestCase):
             self.assertEqual(result, value)
             self.assertEqual(result, expected_value)
 
+    @unittest2.skip()
     def test_fast_deepcopy_is_faster_than_copy_deepcopy(self):
         def random_string(N):
             return ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(N))


### PR DESCRIPTION
Temporary disable the unit test test_fast_deepcopy_is_faster_than_copy_deepcopy because it keeps failing in travis, possible due to noisy neighbor or similar issue.