### PR TITLE
NGINX: Use 308 redirect rather than 301

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -107,6 +107,8 @@ Changed
 * Improve ``st2 execution tail`` CLI command so it also supports Orquesta workflows and arbitrarily
   nested workflows. Also fix the command so it doesn't include data from other unrelated running
   executions. (improvement) #4328
+* Change default NGINX configuration to use HTTP 308 redirect, rather than 301, for plaintext requests.
+  #4335
 
 Fixed
 ~~~~~

--- a/conf/nginx/st2.conf
+++ b/conf/nginx/st2.conf
@@ -13,7 +13,7 @@ server {
   add_header X-Content-Type-Options nosniff;
 
   if ($ssl_protocol = "") {
-       return 301 https://$host$request_uri;
+       return 308 https://$host$request_uri;
   }
 
   index  index.html;


### PR DESCRIPTION
Our default NGINX configuration redirects `http://` requests to `https://`. This uses a 301 redirect. When clients see this, they will either switch PUT/POST requests to GET, or they may continue with PUT/POST, but with no payload.

This change uses [HTTP 308](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/308) instead. The request method and body will be unchanged.

This will reduce confusion for people using custom code that targets `http://<ST2>/`, rather than `https://<ST2>`