### PR TITLE
Add log entry in workflow result on action execution failure

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -62,6 +62,7 @@ Added
   partial document updates instead of full document updates and by improving database document
   serialization and de-serialization performance. (improvement) #4030 #4331
 * Ported existing YAQL and Jinja functions from st2common to Orquesta. (new feature)
+* Add error entry in Orquesta workflow result on action execution failure. (improvement)
 
 Changed
 ~~~~~~~

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ eventlet==0.24.1
 flex==6.13.2
 git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper
 git+https://github.com/StackStorm/mongoengine.git@stackstorm_patched#egg=mongoengine
-git+https://github.com/StackStorm/orquesta.git@41692880f1733399ab36cf265857e00d0c7eec2c#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@99ef681b500791ebe8945abab53ddba834c4559d#egg=orquesta
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
 gitpython==2.1.11

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -12,7 +12,7 @@ kombu
 # See https://github.com/MongoEngine/mongoengine/pull/1833
 git+https://github.com/StackStorm/mongoengine.git@stackstorm_patched#egg=mongoengine
 networkx
-git+https://github.com/StackStorm/orquesta.git@41692880f1733399ab36cf265857e00d0c7eec2c#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@99ef681b500791ebe8945abab53ddba834c4559d#egg=orquesta
 oslo.config
 paramiko
 pyyaml

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -4,7 +4,7 @@ cryptography==2.3.1
 eventlet==0.24.1
 flex==6.13.2
 git+https://github.com/StackStorm/mongoengine.git@stackstorm_patched#egg=mongoengine
-git+https://github.com/StackStorm/orquesta.git@41692880f1733399ab36cf265857e00d0c7eec2c#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@99ef681b500791ebe8945abab53ddba834c4559d#egg=orquesta
 greenlet==0.4.14
 ipaddr
 jinja2

--- a/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/fail-task-execution.yaml
+++ b/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/fail-task-execution.yaml
@@ -1,0 +1,7 @@
+---
+name: fail-task-execution
+description: A basic workflow that fails task execution.
+pack: orquesta_tests
+runner_type: orquesta
+entry_point: workflows/fail-task-execution.yaml
+enabled: true

--- a/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/fail-task-execution.yaml
+++ b/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/fail-task-execution.yaml
@@ -1,0 +1,9 @@
+version: 1.0
+
+description: A basic workflow that fails task execution.
+
+tasks:
+  task1:
+    action: core.local
+    input:
+      cmd: '>&2 echo "boom!"; exit 1'


### PR DESCRIPTION
Add unit test to ensure that the error and result of an action execution failure for a task is logged in the orquesta workflow result.