### PR TITLE
Speed up pack action registration through the /v1/packs/register API endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Added
   tests (#4347)
 
 
+Changed
+~~~~~~~
+
+* Speed up pack registration through the ``/v1/packs/register`` API endpoint. (improvement) #4342
+
 2.9.0 - September 16, 2018
 --------------------------
 

--- a/st2actions/tests/unit/test_actions_registrar.py
+++ b/st2actions/tests/unit/test_actions_registrar.py
@@ -30,7 +30,7 @@ MOCK_RUNNER_TYPE_DB = RunnerTypeDB(name='run-local', runner_module='st2.runners.
 
 class ActionsRegistrarTest(tests_base.DbTestCase):
     @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(return_value=True))
-    @mock.patch.object(action_validator, '_get_runner_model',
+    @mock.patch.object(action_validator, 'get_runner_model',
                        mock.MagicMock(return_value=MOCK_RUNNER_TYPE_DB))
     def test_register_all_actions(self):
         try:
@@ -53,7 +53,7 @@ class ActionsRegistrarTest(tests_base.DbTestCase):
             pass
 
     @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(return_value=True))
-    @mock.patch.object(action_validator, '_get_runner_model',
+    @mock.patch.object(action_validator, 'get_runner_model',
                        mock.MagicMock(return_value=MOCK_RUNNER_TYPE_DB))
     def test_pack_name_missing(self):
         registrar = actions_registrar.ActionsRegistrar()
@@ -71,7 +71,7 @@ class ActionsRegistrarTest(tests_base.DbTestCase):
             Action.delete(action_db)
 
     @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(return_value=True))
-    @mock.patch.object(action_validator, '_get_runner_model',
+    @mock.patch.object(action_validator, 'get_runner_model',
                        mock.MagicMock(return_value=MOCK_RUNNER_TYPE_DB))
     def test_register_action_with_no_params(self):
         registrar = actions_registrar.ActionsRegistrar()
@@ -82,7 +82,7 @@ class ActionsRegistrarTest(tests_base.DbTestCase):
         self.assertEqual(registrar._register_action('dummy', action_file), None)
 
     @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(return_value=True))
-    @mock.patch.object(action_validator, '_get_runner_model',
+    @mock.patch.object(action_validator, 'get_runner_model',
                        mock.MagicMock(return_value=MOCK_RUNNER_TYPE_DB))
     def test_register_action_invalid_parameter_type_attribute(self):
         registrar = actions_registrar.ActionsRegistrar()
@@ -95,7 +95,7 @@ class ActionsRegistrarTest(tests_base.DbTestCase):
                                 registrar._register_action, 'dummy', action_file)
 
     @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(return_value=True))
-    @mock.patch.object(action_validator, '_get_runner_model',
+    @mock.patch.object(action_validator, 'get_runner_model',
                        mock.MagicMock(return_value=MOCK_RUNNER_TYPE_DB))
     def test_register_action_invalid_parameter_name(self):
         registrar = actions_registrar.ActionsRegistrar()
@@ -109,7 +109,7 @@ class ActionsRegistrarTest(tests_base.DbTestCase):
                                 registrar._register_action, 'dummy', action_file)
 
     @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(return_value=True))
-    @mock.patch.object(action_validator, '_get_runner_model',
+    @mock.patch.object(action_validator, 'get_runner_model',
                        mock.MagicMock(return_value=MOCK_RUNNER_TYPE_DB))
     def test_invalid_params_schema(self):
         registrar = actions_registrar.ActionsRegistrar()
@@ -123,7 +123,7 @@ class ActionsRegistrarTest(tests_base.DbTestCase):
             pass
 
     @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(return_value=True))
-    @mock.patch.object(action_validator, '_get_runner_model',
+    @mock.patch.object(action_validator, 'get_runner_model',
                        mock.MagicMock(return_value=MOCK_RUNNER_TYPE_DB))
     def test_action_update(self):
         registrar = actions_registrar.ActionsRegistrar()

--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -181,6 +181,7 @@ class PackRegisterController(object):
         for type, (Registrar, name) in six.iteritems(ENTITIES):
             if type in types or name in types:
                 registrar = Registrar(use_pack_cache=use_pack_cache,
+                                      use_runners_cache=True,
                                       fail_on_failure=fail_on_failure)
                 if packs:
                     for pack in packs:

--- a/st2common/st2common/bootstrap/base.py
+++ b/st2common/st2common/bootstrap/base.py
@@ -54,21 +54,29 @@ EXCLUDE_FILE_PATTERNS = [
 class ResourceRegistrar(object):
     ALLOWED_EXTENSIONS = []
 
-    def __init__(self, use_pack_cache=True, fail_on_failure=False):
+    def __init__(self, use_pack_cache=True, use_runners_cache=False, fail_on_failure=False):
         """
         :param use_pack_cache: True to cache which packs have been registered in memory and making
                                 sure packs are only registered once.
         :type use_pack_cache: ``bool``
 
+        :param use_runners_cache: True to cache RunnerTypeDB objects in memory to reduce load on
+                                  the database.
+        :type use_runners_cache: ``bool``
+
         :param fail_on_failure: Throw an exception if resource registration fails.
         :type fail_on_failure: ``bool``
         """
         self._use_pack_cache = use_pack_cache
+        self._use_runners_cache = use_runners_cache
         self._fail_on_failure = fail_on_failure
 
         self._meta_loader = MetaLoader()
         self._pack_loader = ContentPackLoader()
         self._runner_loader = RunnersLoader()
+
+        # Maps runner name -> RunnerTypeDB
+        self._runner_type_db_cache = {}
 
     def get_resources_from_pack(self, resources_dir):
         resources = []

--- a/st2common/st2common/bootstrap/configsregistrar.py
+++ b/st2common/st2common/bootstrap/configsregistrar.py
@@ -42,8 +42,10 @@ class ConfigsRegistrar(ResourceRegistrar):
 
     ALLOWED_EXTENSIONS = ALLOWED_EXTS
 
-    def __init__(self, use_pack_cache=True, fail_on_failure=False, validate_configs=True):
+    def __init__(self, use_pack_cache=True, use_runners_cache=False, fail_on_failure=False,
+                 validate_configs=True):
         super(ConfigsRegistrar, self).__init__(use_pack_cache=use_pack_cache,
+                                               use_runners_cache=use_runners_cache,
                                                fail_on_failure=fail_on_failure)
 
         self._validate_configs = validate_configs

--- a/st2common/st2common/validators/api/action.py
+++ b/st2common/st2common/validators/api/action.py
@@ -26,12 +26,25 @@ from st2common.content.utils import check_pack_content_directory_exists
 from st2common.models.system.common import ResourceReference
 from six.moves import range
 
+__all__ = [
+    'validate_action',
+    'get_runner_model'
+]
+
 
 LOG = logging.getLogger(__name__)
 
 
-def validate_action(action_api):
-    runner_db = _get_runner_model(action_api)
+def validate_action(action_api, runner_type_db=None):
+    """
+    :param runner_type_db: RunnerTypeDB object belonging to this action. If not provided, it's 
+                           retrieved from the database.
+    :type runner_type_db: :class:`RunnerTypeDB`
+    """
+    if not runner_type_db:
+        runner_db = get_runner_model(action_api)
+    else:
+        runner_db = runner_type_db
 
     # Check if pack is valid.
     if not _is_valid_pack(action_api.pack):
@@ -47,7 +60,7 @@ def validate_action(action_api):
     _validate_parameters(action_ref, action_api.parameters, runner_db.runner_parameters)
 
 
-def _get_runner_model(action_api):
+def get_runner_model(action_api):
     runner_db = None
     # Check if runner exists.
     try:

--- a/st2common/st2common/validators/api/action.py
+++ b/st2common/st2common/validators/api/action.py
@@ -37,7 +37,7 @@ LOG = logging.getLogger(__name__)
 
 def validate_action(action_api, runner_type_db=None):
     """
-    :param runner_type_db: RunnerTypeDB object belonging to this action. If not provided, it's 
+    :param runner_type_db: RunnerTypeDB object belonging to this action. If not provided, it's
                            retrieved from the database.
     :type runner_type_db: :class:`RunnerTypeDB`
     """


### PR DESCRIPTION
This pull request speeds up registering pack actions through the ``/v1/packs/register`` API endpoint (e.g. when using `st2 pack install` command).

We do that by caching `RunnerTypeDB` objects in memory for each "register session" (aka each time user hits ``/v1/packs/register`` API endpoint). Since we re-initialize the cache on each API request, this means there are no issues with potential stale cache, but we still see benefits when registering packs with a lot of resources.

This helps in situations where pack has a lot of actions such as the ``aws`` pack. Previously RunnerTypeDB was retrieved from the database ``N`` times where ``N`` is number of actions in a pack and now it's only retrieved ``M`` times where ``M`` is number of unique runners referenced by actions in a particular pack (in ``aws`` pack that's 1 - Python runner).

Some hard data.

Before this change:

```bash
2018-09-14 10:29:23,180 INFO [-] 8f73eafd-f38c-432e-9156-ca7f1d8f67ae - 200 194 114645.359ms (content_length=194,request_id='8f73eafd-f38c-432e-9156-ca7f1d8f67ae',runtime=114645.359,remote_addr='127.0.0.1',status=200,method='POST',path='/packs/register')
```

After this change:

```bash
2018-09-14 10:31:51,825 INFO [-] 2860c91e-f93e-48df-ba1a-465d5bf3f4ed - 200 194 96030.742ms (content_length=194,request_id='2860c91e-f93e-48df-ba1a-465d5bf3f4ed',runtime=96030.742,remote_addr='127.0.0.1',status=200,method='POST',path='/packs/register')
```
So around ~18 seconds improvement.

96 seconds is still a very long time, but the whole platform was not designed around "packs with many actions" in mind. Just reading and validating all the action metadata from disk takes around ~60 seconds (not taking into account saving this metadata to the database).