### PR TITLE
Various v2.9.0 changes

### DIFF
--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -360,6 +360,7 @@ class ActionRunCommandMixin(object):
                 options = {'attributes': attr}
 
             options['json'] = args.json
+            options['yaml'] = args.yaml
             options['with_schema'] = args.with_schema
             options['attribute_transform_functions'] = self.attribute_transform_functions
             self.print_output(instance, formatter, **options)

--- a/st2client/st2client/config_parser.py
+++ b/st2client/st2client/config_parser.py
@@ -29,6 +29,7 @@ import io
 import six
 from six.moves.configparser import ConfigParser
 
+
 __all__ = [
     'CLIConfigParser',
 
@@ -60,6 +61,10 @@ CONFIG_FILE_OPTIONS = {
         'silence_ssl_warnings': {
             'type': 'bool',
             'default': False
+        },
+        'silence_schema_output': {
+            'type': 'bool',
+            'default': True
         }
     },
     'cli': {

--- a/st2client/st2client/formatters/execution.py
+++ b/st2client/st2client/formatters/execution.py
@@ -102,6 +102,7 @@ class ExecutionResult(formatters.Formatter):
                 }
 
                 rendered_schema = yaml.safe_dump(rendered_schema, default_flow_style=False)
+                output += '\n'
                 output += _print_bordered(
                     "This action does not have an output schema defined. Based "
                     "on the action output the following inferred schema was built:"

--- a/st2client/st2client/formatters/execution.py
+++ b/st2client/st2client/formatters/execution.py
@@ -22,6 +22,7 @@ import struct
 import yaml
 
 from st2client import formatters
+from st2client.config import get_config
 from st2client.utils import jsutil
 from st2client.utils import strutil
 from st2client.utils.color import DisplayColors
@@ -95,7 +96,7 @@ class ExecutionResult(formatters.Formatter):
                     (DisplayColors.colorize(attr, DisplayColors.BLUE), value)
 
             output_schema = entry.get('action', {}).get('output_schema')
-
+            schema_check = get_config()['general']['silence_schema_output']
             if not output_schema and kwargs.get('with_schema'):
                 rendered_schema = {
                     'output_schema': schema.render_output_schema_from_output(entry['result'])
@@ -104,12 +105,11 @@ class ExecutionResult(formatters.Formatter):
                 rendered_schema = yaml.safe_dump(rendered_schema, default_flow_style=False)
                 output += '\n'
                 output += _print_bordered(
-                    "This action does not have an output schema defined. Based "
-                    "on the action output the following inferred schema was built:"
+                    "Based on the action output the following inferred schema was built:"
                     "\n\n"
                     "%s" % rendered_schema
                 )
-            elif not output_schema:
+            elif not output_schema and not schema_check:
                 output += (
                     "\n\n** This action does not have an output_schema. "
                     "Run again with --with-schema to see a suggested schema."

--- a/st2client/tests/fixtures/execution_get_attributes.txt
+++ b/st2client/tests/fixtures/execution_get_attributes.txt
@@ -1,4 +1,2 @@
 status: succeeded (1s elapsed)
 end_timestamp: Tue, 02 Dec 2014 19:56:07 UTC
-
-** This action does not have an output_schema. Run again with --with-schema to see a suggested schema.

--- a/st2client/tests/fixtures/execution_get_default.txt
+++ b/st2client/tests/fixtures/execution_get_default.txt
@@ -16,5 +16,3 @@ result:
       3 packets transmitted, 3 received, 0% packet loss, time 1998ms
       rtt min/avg/max/mdev = 0.015/0.023/0.030/0.006 ms'
     succeeded: true
-
-** This action does not have an output_schema. Run again with --with-schema to see a suggested schema.

--- a/st2client/tests/fixtures/execution_unescape_newline.txt
+++ b/st2client/tests/fixtures/execution_unescape_newline.txt
@@ -11,5 +11,3 @@ Traceback (most recent call last):
     stdout: 'FOOBAR2
       '
     succeeded: true
-
-** This action does not have an output_schema. Run again with --with-schema to see a suggested schema.

--- a/st2client/tests/fixtures/execution_unicode.txt
+++ b/st2client/tests/fixtures/execution_unicode.txt
@@ -8,5 +8,3 @@ result:
   stderr: ''
   stdout: "‡"
   succeeded: true
-
-** This action does not have an output_schema. Run again with --with-schema to see a suggested schema.

--- a/st2client/tests/fixtures/execution_unicode_py3.txt
+++ b/st2client/tests/fixtures/execution_unicode_py3.txt
@@ -8,5 +8,3 @@ result:
   stderr: ''
   stdout: "\u2021"
   succeeded: true
-
-** This action does not have an output_schema. Run again with --with-schema to see a suggested schema.

--- a/st2client/tests/unit/test_config_parser.py
+++ b/st2client/tests/unit/test_config_parser.py
@@ -52,7 +52,8 @@ class CLIConfigParserTestCase(unittest2.TestCase):
                 'base_url': 'http://127.0.0.1',
                 'api_version': 'v1',
                 'cacert': 'cacartpath',
-                'silence_ssl_warnings': False
+                'silence_ssl_warnings': False,
+                'silence_schema_output': True
             },
             'cli': {
                 'debug': True,


### PR DESCRIPTION
Various changes based on the testing feedback:

* Don't print "action doesn't have an output schema" warning when user passed ``--yaml`` flag to ``st2 run`` command - when ``--yaml`` is flag is used, user wants a machine readable format.

## TODO

- [x] Decide on how to handle core actions - right now we print "no scheam defined" for all `core` / bundled actions which is not a good UX. Either add schema for core actions or similar.