### PR TITLE
st2-self-check Option to skip Mistral & Orquesta tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 in development
 --------------
 
+Added
+~~~~~
+
+* Added ``-o`` and ``-m`` CLI options to ``st2-self-check`` script, to skip Orquesta and/or Mistral
+  tests (#4347)
+
 
 2.9.0 - September 16, 2018
 --------------------------

--- a/st2common/bin/st2-self-check
+++ b/st2common/bin/st2-self-check
@@ -19,20 +19,30 @@ function usage() {
   echo "Usage: $0"
   echo ""
   echo "Options:"
+  echo "  -o  Skip Orquesta tests"
+  echo "  -m  Skip Mistral tests"
   echo "  -w  Run Windows tests"
   echo "  -b Which branch of st2tests to use (defaults to master)"
   echo ""
   >&2
 }
 
+RUN_ORQUESTA_TESTS=true
+RUN_MISTRAL_TESTS=true
 RUN_WINDOWS_TESTS=false
 ST2_TESTS_BRANCH="master"
 
-while getopts "b:w" o
+while getopts "b:wom" o
 do
     case "${o}" in
         b)
             ST2_TESTS_BRANCH=${OPTARG}
+            ;;
+        o)
+            RUN_ORQUESTA_TESTS=false
+            ;;
+        m)
+            RUN_MISTRAL_TESTS=false
             ;;
         w)
             RUN_WINDOWS_TESTS=true
@@ -114,6 +124,12 @@ do
         continue
     fi
 
+    # Skip Mistral Inquiry test if we're not running Mistral tests
+    if [ ${RUN_MISTRAL_TESTS} = "false" ] && [ ${TEST} = "tests.test_inquiry_mistral" ]; then
+        echo "Skipping ${TEST}..."
+        continue
+    fi
+
     echo -n "Attempting Test ${TEST}..."
     st2 run ${TEST} protocol=${PROTOCOL} token=${ST2_AUTH_TOKEN} | grep "status" | grep -q "succeeded"
     if [ $? -ne 0 ]; then
@@ -124,22 +140,30 @@ do
     fi
 done
 
-echo -n "Attempting Example examples.mistral_examples..."
-st2 run examples.mistral_examples | grep "status" | grep -q "succeeded"
-if [ $? -ne 0 ]; then
-    echo -e "ERROR!"
-    ((ERRORS++))
+if [ ${RUN_MISTRAL_TESTS} = "true" ]; then
+    echo -n "Attempting Example examples.mistral_examples..."
+    st2 run examples.mistral_examples | grep "status" | grep -q "succeeded"
+    if [ $? -ne 0 ]; then
+        echo -e "ERROR!"
+        ((ERRORS++))
+    else
+        echo "OK!"
+    fi
 else
-    echo "OK!"
+    echo "Skipping examples.mistral_examples..."
 fi
 
-echo -n "Attempting Example examples.orquesta-examples..."
-st2 run examples.orquesta-examples | grep "status" | grep -q "succeeded"
-if [ $? -ne 0 ]; then
-    echo -e "ERROR!"
-    ((ERRORS++))
+if [ ${RUN_ORQUESTA_TESTS} = "true" ]; then
+    echo -n "Attempting Example examples.orquesta-examples..."
+    st2 run examples.orquesta-examples | grep "status" | grep -q "succeeded"
+    if [ $? -ne 0 ]; then
+        echo -e "ERROR!"
+        ((ERRORS++))
+    else
+        echo "OK!"
+    fi
 else
-    echo "OK!"
+    echo "Skipping examples.orquesta-examples..."
 fi
 
 if [ $ERRORS -ne 0 ]; then


### PR DESCRIPTION
Provide CLI options to skip Orquesta and/or Mistral tests in `st2-self-check`.

Default is still to **run** Orquesta & Mistral tests, and to **not** run Windows tests.

UX is not great, but it keeps defaults same as existing.

Resolves #4311