### PR TITLE
Add default sorting to trigger types API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 in development
 --------------
 
+Changed
+~~~~~~~
+
+* Triggertypes API now sorts by trigger ref by default. ``st2 trigger list`` will now show a sorted
+  list. (#4348)
 
 2.9.0 - September 16, 2018
 --------------------------

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -53,6 +53,10 @@ class TriggerTypeController(resource.ContentPackResourceController):
         'sort': ['pack', 'name']
     }
 
+    query_options = {
+        'sort': ['ref']
+    }
+
     def get_all(self, exclude_attributes=None, include_attributes=None, sort=None, offset=0,
                 limit=None, requester_user=None, **raw_filters):
         return self._get_all(exclude_fields=exclude_attributes,


### PR DESCRIPTION
Trigger types were not sorted by default. 

Output could look like this:

```shell
+--------------------------------------+----------+-----------------------------------------------------+
| ref                                  | pack     | description                                         |
+--------------------------------------+----------+-----------------------------------------------------+
| core.st2.generic.actiontrigger       | core     | Trigger encapsulating the completion of an action   |
|                                      |          | execution.                                          |
| core.st2.generic.notifytrigger       | core     | Notification trigger.                               |
| core.st2.action.file_writen          | core     | Trigger encapsulating action file being written on  |
|                                      |          | disk.                                               |
| core.st2.generic.inquiry             | core     | Trigger indicating a new "inquiry" has entered      |
|                                      |          | "pending" status                                    |
| core.st2.IntervalTimer               | core     | Triggers on specified intervals. e.g. every 30s,    |
|                                      |          | 1week etc.                                          |
| core.st2.DateTimer                   | core     | Triggers exactly once when the current time matches |
|                                      |          | the specified time. e.g. timezone:UTC               |
|                                      |          | date:2014-12-31 23:59:59.                           |
| core.st2.key_value_pair.create       | core     | Trigger encapsulating datastore item creation.      |
| core.st2.CronTimer                   | core     | Triggers whenever current time matches the          |
|                                      |          | specified time constaints like a UNIX cron          |
|                                      |          | scheduler.                                          |
| core.st2.key_value_pair.update       | core     | Trigger encapsulating datastore set action.         |
| core.st2.key_value_pair.value_change | core     | Trigger encapsulating a change of datastore item    |
|                                      |          | value.                                              |
| core.st2.key_value_pair.delete       | core     | Trigger encapsulating datastore item deletion.      |
| core.st2.sensor.process_spawn        | core     | Trigger indicating sensor process is started up.    |
| core.st2.sensor.process_exit         | core     | Trigger indicating sensor process is stopped.       |
| linux.file_watch.line                | linux    | Trigger which indicates a new line has been         |
|                                      |          | detected                                            |
| core.st2.webhook                     | core     | Trigger type for registering webhooks that can      |
|                                      |          | consume arbitrary payload.                          |
| napalm.LLDPNeighborDecrease          | napalm   | Trigger which occurs when a device's LLDP neighbors |
|                                      |          | decrease                                            |
| examples.sample_trigger              | examples | Sample trigger                                      |
| examples.echoflasksensor             | examples | Echo flask sensor.                                  |
| examples.fibonacci                   | examples | A fibonacci trigger.                                |
| examples.polling_event               | examples | An example trigger.                                 |
| examples.event                       | examples | An example trigger.                                 |
| fixtures.test_passive_trigger.dummy  | fixtures |                                                     |
| fixtures.test_trigger.dummy          | fixtures |                                                     |
+--------------------------------------+----------+-----------------------------------------------------+
```

(note the position of `napalm.LLDPNeighborDecrease`.

After changes:

```shell
+--------------------------------------+----------+-----------------------------------------------------+
| ref                                  | pack     | description                                         |
+--------------------------------------+----------+-----------------------------------------------------+
| core.st2.CronTimer                   | core     | Triggers whenever current time matches the          |
|                                      |          | specified time constaints like a UNIX cron          |
|                                      |          | scheduler.                                          |
| core.st2.DateTimer                   | core     | Triggers exactly once when the current time matches |
|                                      |          | the specified time. e.g. timezone:UTC               |
|                                      |          | date:2014-12-31 23:59:59.                           |
| core.st2.IntervalTimer               | core     | Triggers on specified intervals. e.g. every 30s,    |
|                                      |          | 1week etc.                                          |
| core.st2.action.file_writen          | core     | Trigger encapsulating action file being written on  |
|                                      |          | disk.                                               |
| core.st2.generic.actiontrigger       | core     | Trigger encapsulating the completion of an action   |
|                                      |          | execution.                                          |
| core.st2.generic.inquiry             | core     | Trigger indicating a new "inquiry" has entered      |
|                                      |          | "pending" status                                    |
| core.st2.generic.notifytrigger       | core     | Notification trigger.                               |
| core.st2.key_value_pair.create       | core     | Trigger encapsulating datastore item creation.      |
| core.st2.key_value_pair.delete       | core     | Trigger encapsulating datastore item deletion.      |
| core.st2.key_value_pair.update       | core     | Trigger encapsulating datastore set action.         |
| core.st2.key_value_pair.value_change | core     | Trigger encapsulating a change of datastore item    |
|                                      |          | value.                                              |
| core.st2.sensor.process_exit         | core     | Trigger indicating sensor process is stopped.       |
| core.st2.sensor.process_spawn        | core     | Trigger indicating sensor process is started up.    |
| core.st2.webhook                     | core     | Trigger type for registering webhooks that can      |
|                                      |          | consume arbitrary payload.                          |
| examples.echoflasksensor             | examples | Echo flask sensor.                                  |
| examples.event                       | examples | An example trigger.                                 |
| examples.fibonacci                   | examples | A fibonacci trigger.                                |
| examples.polling_event               | examples | An example trigger.                                 |
| examples.sample_trigger              | examples | Sample trigger                                      |
| fixtures.test_passive_trigger.dummy  | fixtures |                                                     |
| fixtures.test_trigger.dummy          | fixtures |                                                     |
| linux.file_watch.line                | linux    | Trigger which indicates a new line has been         |
|                                      |          | detected                                            |
| napalm.LLDPNeighborDecrease          | napalm   | Trigger which occurs when a device's LLDP neighbors |
|                                      |          | decrease                                            |
+--------------------------------------+----------+-----------------------------------------------------+
```