### PR TITLE
[WIP] Fix sensor issues when pack is using Python 3 virtualenv but installation is using Python 2

### DIFF
--- a/st2common/st2common/constants/pack.py
+++ b/st2common/st2common/constants/pack.py
@@ -90,7 +90,12 @@ BASE_PACK_REQUIREMENTS = [
 # Python requirements which are common to all the packs and need to be installed
 # for Python 3 pack virtual environments to work
 BASE_PACK_PYTHON3_REQUIREMENTS = [
-    'pyyaml>=3.12,<4.0'
+    'pyyaml==3.13',
+    'pycrypto==2.6.1',
+    'greenlet==0.4.14',
+    'eventlet==0.24.1',
+    'kombu==4.2.1',
+    'typing'
 ]
 
 # Name of the pack manifest file

--- a/st2reactor/st2reactor/container/process_container.py
+++ b/st2reactor/st2reactor/container/process_container.py
@@ -39,7 +39,7 @@ from st2common.transport.reactor import TriggerDispatcher
 from st2common.util.api import get_full_public_api_url
 from st2common.util.pack import get_pack_common_libs_path_for_pack_ref
 from st2common.util.shell import on_parent_exit
-from st2common.util.sandboxing import get_sandbox_python_path
+from st2common.util.sandboxing import get_sandbox_python_path_for_python_sensor
 from st2common.util.sandboxing import get_sandbox_python_binary_path
 from st2common.util.sandboxing import get_sandbox_virtualenv_path
 
@@ -302,8 +302,10 @@ class ProcessSensorContainer(object):
         if sensor['poll_interval']:
             args.append('--poll-interval=%s' % (sensor['poll_interval']))
 
-        sandbox_python_path = get_sandbox_python_path(inherit_from_parent=True,
-                                                      inherit_parent_virtualenv=True)
+        sandbox_python_path = get_sandbox_python_path_for_python_sensor(
+                pack=sensor['pack'],
+                inherit_from_parent=True,
+                inherit_parent_virtualenv=True)
 
         if self._enable_common_pack_libs:
             pack_common_libs_path = get_pack_common_libs_path_for_pack_ref(pack_ref=pack_ref)


### PR DESCRIPTION
This pull request fixes an issue with sensors not running when a particular pack is using Python 3 virtual environment, but installation is running under Python 2.

(Note: This was a stop gap solution and in the future, we plan support full Python 3 deployments because mixing two versions is quite fragile and has a lot of edge cases)