### PR TITLE
Throw an exception if user wants to run a sensor from a pack which uses Python 3 virtual environment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,8 +8,17 @@ Added
 ~~~~~
 
 * Added ``-o`` and ``-m`` CLI options to ``st2-self-check`` script, to skip Orquesta and/or Mistral
-  tests (#4347)
+  tests. #4347
 
+Changed
+~~~~~~~
+
+* Update ``st2sensorcontainer`` service to throw if user wants to run a sensor from a pack which is
+  using Python 3 virtual environment.
+
+  We only support running Python runner actions from packs which use mixed Python environments
+  (StackStorm components are running under Python 2 and particular a pack virtual environment is
+  using Python 3). #4354
 
 2.9.0 - September 16, 2018
 --------------------------

--- a/st2common/st2common/constants/error_messages.py
+++ b/st2common/st2common/constants/error_messages.py
@@ -26,8 +26,9 @@ means, you can create a new virtual environment using the command:
 '''
 
 PACK_VIRTUALENV_USES_PYTHON3 = '''
-Virtual environment (%(virtualenv_path)s) for pack "%(pack)s" is using python3.
+Virtual environment (%(virtualenv_path)s) for pack "%(pack)s" is using Python 3.
 Using Python 3 virtual environments in mixed deployments is only supported for Python runner
 actions and not sensors. If you want to run this sensor, please re-recreate the
-virtualenv environment with python2 binary.
+virtual environment with python2 binary:
+"st2 run packs.setup_virtualenv packs=%(pack)s python3=false"
 '''

--- a/st2common/st2common/constants/error_messages.py
+++ b/st2common/st2common/constants/error_messages.py
@@ -13,9 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+__all__ = [
+    'PACK_VIRTUALENV_DOESNT_EXIST',
+    'PACK_VIRTUALENV_USES_PYTHON3'
+]
+
 PACK_VIRTUALENV_DOESNT_EXIST = '''
 The virtual environment (%(virtualenv_path)s) for pack "%(pack)s" does not exist. Normally this is
 created when you install a pack using "st2 pack install". If you installed your pack by some other
 means, you can create a new virtual environment using the command:
 "st2 run packs.setup_virtualenv packs=%(pack)s"
+'''
+
+PACK_VIRTUALENV_USES_PYTHON3 = '''
+Virtual environment (%(virtualenv_path)s) for pack "%(pack)s" is using python3.
+Using Python 3 virtual environments in mixed deployments is only supported for Python runner
+actions and not sensors. If you want to run this sensor, please re-recreate the
+virtualenv environment with python2 binary.
 '''

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -178,6 +178,9 @@ def is_pack_virtualenv_using_python3(pack):
     if virtualenv_path and os.path.isdir(virtualenv_path):
         pack_virtualenv_lib_path = os.path.join(virtualenv_path, 'lib')
 
+        if not os.path.exists(pack_virtualenv_lib_path):
+            return False, None
+
         virtualenv_directories = os.listdir(pack_virtualenv_lib_path)
         virtualenv_directories = [dir_name for dir_name in virtualenv_directories if
                                   fnmatch.fnmatch(dir_name, 'python3*')]

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 """
-Utility functions for our sandboxing model which is implemented on top of
-separate processes and virtualenv.
+Utility functions for our sandboxing model which is implemented on top of separate processes and
+virtual environments.
 """
 
 from __future__ import absolute_import
@@ -128,19 +128,17 @@ def get_sandbox_python_path(inherit_from_parent=True, inherit_parent_virtualenv=
 def get_sandbox_python_path_for_python_action(pack, inherit_from_parent=True,
                                               inherit_parent_virtualenv=True):
     """
-    Same as get_sandbox_python_path function, but it's intended to be used for Python runner actions
-    and also takes into account if a pack virtual environment uses Python 3.
+    Return sandbox PYTHONPATH for a particular Python runner action.
+
+    Same as get_sandbox_python_path() function, but it's intended to be used for Python runner
+    actions and also takes into account if a pack virtual environment uses Python 3.
     """
     sandbox_python_path = get_sandbox_python_path(
         inherit_from_parent=inherit_from_parent,
         inherit_parent_virtualenv=inherit_parent_virtualenv)
 
-    # If python3.? directory exists in pack virtualenv lib/ path it means Python 3 is used by
-    # that virtual environment and we take that in to account when constructing PYTHONPATH
     pack_base_path = get_pack_base_path(pack_name=pack)
     virtualenv_path = get_sandbox_virtualenv_path(pack=pack)
-
-    pack_actions_lib_paths = os.path.join(pack_base_path, 'actions/lib/')
 
     if not virtualenv_path:
         return sandbox_python_path
@@ -150,6 +148,7 @@ def get_sandbox_python_path_for_python_action(pack, inherit_from_parent=True,
         # Add Python 3 lib directory (lib/python3.x) in front of the PYTHONPATH. This way we avoid
         # issues with scripts trying to use packages / modules from Python 2.7 site-packages
         # directory instead of the versions from Python 3 stdlib.
+        pack_actions_lib_paths = os.path.join(pack_base_path, 'actions/lib/')
         pack_virtualenv_lib_path = os.path.join(virtualenv_path, 'lib')
         python3_lib_directory = os.path.join(pack_virtualenv_lib_path, virtualenv_directories[0])
 
@@ -167,9 +166,9 @@ def get_sandbox_python_path_for_python_action(pack, inherit_from_parent=True,
 
 def is_pack_virtualenv_using_python3(pack):
     """
-    Return True if a particular pack virtual environment is used Python 3.
+    Return True if a particular pack virtual environment is using Python 3.
 
-    :return: (uses_python3_bool, virtualenv_directories)
+    :return: (uses_python3_bool, virtualenv_lib_directories)
     :rtype: ``tuple``
     """
     # If python3.? directory exists in pack virtualenv lib/ path it means Python 3 is used by

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -141,16 +141,10 @@ def get_sandbox_python_path_for_python_action(pack, inherit_from_parent=True,
     pack_base_path = get_pack_base_path(pack_name=pack)
     virtualenv_path = get_sandbox_virtualenv_path(pack=pack)
 
-    if virtualenv_path and os.path.isdir(virtualenv_path):
-        pack_actions_lib_paths = os.path.join(pack_base_path, 'actions/lib/')
-        pack_virtualenv_lib_path = os.path.join(virtualenv_path, 'lib')
+    pack_actions_lib_paths = os.path.join(pack_base_path, 'actions/lib/')
+    pack_virtualenv_lib_path = os.path.join(virtualenv_path, 'lib')
 
-        virtualenv_directories = os.listdir(pack_virtualenv_lib_path)
-        virtualenv_directories = [dir_name for dir_name in virtualenv_directories if
-                                  fnmatch.fnmatch(dir_name, 'python3*')]
-        uses_python3 = bool(virtualenv_directories)
-    else:
-        uses_python3 = False
+    uses_python3, virtualenv_directories = is_pack_virtualenv_using_python3(pack=pack)
 
     if uses_python3:
         # Add Python 3 lib directory (lib/python3.x) in front of the PYTHONPATH. This way we avoid
@@ -176,8 +170,6 @@ def is_pack_virtualenv_using_python3(pack):
     """
     # If python3.? directory exists in pack virtualenv lib/ path it means Python 3 is used by
     # that virtual environment and we take that in to account when constructing PYTHONPATH
-    pack_base_path = get_pack_base_path(pack_name=pack)
-
     virtualenv_path = get_sandbox_virtualenv_path(pack=pack)
 
     if virtualenv_path and os.path.isdir(virtualenv_path):
@@ -189,8 +181,9 @@ def is_pack_virtualenv_using_python3(pack):
         uses_python3 = bool(virtualenv_directories)
     else:
         uses_python3 = False
+        virtualenv_directories = None
 
-    return uses_python3
+    return uses_python3, virtualenv_directories
 
 
 def get_sandbox_virtualenv_path(pack):

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -175,6 +175,9 @@ def is_pack_virtualenv_using_python3(pack):
     if virtualenv_path and os.path.isdir(virtualenv_path):
         pack_virtualenv_lib_path = os.path.join(virtualenv_path, 'lib')
 
+        if not os.path.exists(pack_virtualenv_lib_path):
+            return False, None
+
         virtualenv_directories = os.listdir(pack_virtualenv_lib_path)
         virtualenv_directories = [dir_name for dir_name in virtualenv_directories if
                                   fnmatch.fnmatch(dir_name, 'python3*')]

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -127,7 +127,6 @@ def get_sandbox_python_path(inherit_from_parent=True, inherit_parent_virtualenv=
 
 def get_sandbox_python_path_for_python_action(pack, inherit_from_parent=True,
                                               inherit_parent_virtualenv=True):
-
     """
     Same as get_sandbox_python_path function, but it's intended to be used for Python runner actions
     and also takes into account if a pack virtual environment uses Python 3.
@@ -142,14 +141,16 @@ def get_sandbox_python_path_for_python_action(pack, inherit_from_parent=True,
     virtualenv_path = get_sandbox_virtualenv_path(pack=pack)
 
     pack_actions_lib_paths = os.path.join(pack_base_path, 'actions/lib/')
-    pack_virtualenv_lib_path = os.path.join(virtualenv_path, 'lib')
+
+    if not virtualenv_path:
+        return sandbox_python_path
 
     uses_python3, virtualenv_directories = is_pack_virtualenv_using_python3(pack=pack)
-
     if uses_python3:
         # Add Python 3 lib directory (lib/python3.x) in front of the PYTHONPATH. This way we avoid
         # issues with scripts trying to use packages / modules from Python 2.7 site-packages
         # directory instead of the versions from Python 3 stdlib.
+        pack_virtualenv_lib_path = os.path.join(virtualenv_path, 'lib')
         python3_lib_directory = os.path.join(pack_virtualenv_lib_path, virtualenv_directories[0])
 
         # Add Python 3 site-packages directory (lib/python3.x/site-packages) in front of the Python
@@ -167,6 +168,9 @@ def get_sandbox_python_path_for_python_action(pack, inherit_from_parent=True,
 def is_pack_virtualenv_using_python3(pack):
     """
     Return True if a particular pack virtual environment is used Python 3.
+
+    :return: (uses_python3_bool, virtualenv_directories)
+    :rtype: ``tuple``
     """
     # If python3.? directory exists in pack virtualenv lib/ path it means Python 3 is used by
     # that virtual environment and we take that in to account when constructing PYTHONPATH
@@ -174,9 +178,6 @@ def is_pack_virtualenv_using_python3(pack):
 
     if virtualenv_path and os.path.isdir(virtualenv_path):
         pack_virtualenv_lib_path = os.path.join(virtualenv_path, 'lib')
-
-        if not os.path.exists(pack_virtualenv_lib_path):
-            return False, None
 
         virtualenv_directories = os.listdir(pack_virtualenv_lib_path)
         virtualenv_directories = [dir_name for dir_name in virtualenv_directories if

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -35,7 +35,9 @@ __all__ = [
     'get_sandbox_python_path',
     'get_sandbox_python_path_for_python_action',
     'get_sandbox_path',
-    'get_sandbox_virtualenv_path'
+    'get_sandbox_virtualenv_path',
+
+    'is_pack_virtualenv_using_python3'
 ]
 
 
@@ -166,6 +168,29 @@ def get_sandbox_python_path_for_python_action(pack, inherit_from_parent=True,
                                pack_actions_lib_paths + ':' + sandbox_python_path)
 
     return sandbox_python_path
+
+
+def is_pack_virtualenv_using_python3(pack):
+    """
+    Return True if a particular pack virtual environment is used Python 3.
+    """
+    # If python3.? directory exists in pack virtualenv lib/ path it means Python 3 is used by
+    # that virtual environment and we take that in to account when constructing PYTHONPATH
+    pack_base_path = get_pack_base_path(pack_name=pack)
+
+    virtualenv_path = get_sandbox_virtualenv_path(pack=pack)
+
+    if virtualenv_path and os.path.isdir(virtualenv_path):
+        pack_virtualenv_lib_path = os.path.join(virtualenv_path, 'lib')
+
+        virtualenv_directories = os.listdir(pack_virtualenv_lib_path)
+        virtualenv_directories = [dir_name for dir_name in virtualenv_directories if
+                                  fnmatch.fnmatch(dir_name, 'python3*')]
+        uses_python3 = bool(virtualenv_directories)
+    else:
+        uses_python3 = False
+
+    return uses_python3
 
 
 def get_sandbox_virtualenv_path(pack):

--- a/st2common/tests/unit/test_util_sandboxing.py
+++ b/st2common/tests/unit/test_util_sandboxing.py
@@ -129,6 +129,7 @@ class SandboxingUtilsTestCase(unittest.TestCase):
         self.assertEqual(python_path, ':/data/test1:/data/test2:%s/virtualenvtest' %
                          (sys.prefix))
 
+    @mock.patch('os.path.exists', mock.Mock(return_value=True))
     @mock.patch('os.path.isdir', mock.Mock(return_value=True))
     @mock.patch('os.listdir', mock.Mock(return_value=['python3.6']))
     @mock.patch('st2common.util.sandboxing.get_python_lib')

--- a/st2common/tests/unit/test_util_sandboxing.py
+++ b/st2common/tests/unit/test_util_sandboxing.py
@@ -11,6 +11,7 @@ from st2common.util.sandboxing import get_sandbox_path
 from st2common.util.sandboxing import get_sandbox_python_path
 from st2common.util.sandboxing import get_sandbox_python_path_for_python_action
 from st2common.util.sandboxing import get_sandbox_python_binary_path
+from st2common.util.sandboxing import is_pack_virtualenv_using_python3
 
 import st2tests.config as tests_config
 
@@ -96,6 +97,8 @@ class SandboxingUtilsTestCase(unittest.TestCase):
     @mock.patch('st2common.util.sandboxing.get_python_lib')
     def test_get_sandbox_python_path_for_python_action_python2_used_for_venv(self,
             mock_get_python_lib):
+        self.assertFalse(is_pack_virtualenv_using_python3(pack='dummy_pack')[0])
+
         # No inheritance
         python_path = get_sandbox_python_path_for_python_action(pack='dummy_pack',
                                                                 inherit_from_parent=False,
@@ -135,6 +138,8 @@ class SandboxingUtilsTestCase(unittest.TestCase):
                 mock.Mock(return_value='/tmp/virtualenvs/dummy_pack'))
     def test_get_sandbox_python_path_for_python_action_python3_used_for_venv(self,
             mock_get_python_lib):
+        self.assertTrue(is_pack_virtualenv_using_python3(pack='dummy_pack')[0])
+
         # No inheritance
         python_path = get_sandbox_python_path_for_python_action(pack='dummy_pack',
                                                                 inherit_from_parent=False,

--- a/st2reactor/st2reactor/container/process_container.py
+++ b/st2reactor/st2reactor/container/process_container.py
@@ -22,6 +22,7 @@ import subprocess
 
 from collections import defaultdict
 
+import six
 import eventlet
 from eventlet.support import greenlets as greenlet
 from oslo_config import cfg
@@ -289,7 +290,7 @@ class ProcessSensorContainer(object):
         # NOTE: Running sensors using Python 3 virtual environments is not supported
         uses_python3, _ = is_pack_virtualenv_using_python3(pack=sensor['pack'])
 
-        if uses_python3:
+        if uses_python3 and not six.PY3:
             format_values = {'pack': sensor['pack'], 'virtualenv_path': virtualenv_path}
             msg = PACK_VIRTUALENV_USES_PYTHON3 % format_values
             raise Exception(msg)

--- a/st2reactor/st2reactor/container/process_container.py
+++ b/st2reactor/st2reactor/container/process_container.py
@@ -287,7 +287,7 @@ class ProcessSensorContainer(object):
             raise Exception(msg)
 
         # NOTE: Running sensors using Python 3 virtual environments is not supported
-        uses_python3 = is_pack_virtualenv_using_python3(pack=sensor['pack'])
+        uses_python3, _ = is_pack_virtualenv_using_python3(pack=sensor['pack'])
 
         if uses_python3:
             format_values = {'pack': sensor['pack'], 'virtualenv_path': virtualenv_path}

--- a/st2reactor/st2reactor/container/process_container.py
+++ b/st2reactor/st2reactor/container/process_container.py
@@ -260,7 +260,7 @@ class ProcessSensorContainer(object):
             try:
                 self._spawn_sensor_process(sensor=sensor_obj)
             except Exception as e:
-                LOG.warning(e.message, exc_info=True)
+                LOG.warning(str(e), exc_info=True)
 
                 # Disable sensor which we are unable to start
                 del self._sensors[sensor_id]
@@ -439,7 +439,7 @@ class ProcessSensorContainer(object):
         try:
             self._spawn_sensor_process(sensor=sensor)
         except Exception as e:
-            LOG.warning(e.message, exc_info=True)
+            LOG.warning(str(e), exc_info=True)
 
             # Disable sensor which we are unable to start
             del self._sensors[sensor_id]

--- a/st2reactor/st2reactor/container/process_container.py
+++ b/st2reactor/st2reactor/container/process_container.py
@@ -28,6 +28,7 @@ from oslo_config import cfg
 
 from st2common import log as logging
 from st2common.constants.error_messages import PACK_VIRTUALENV_DOESNT_EXIST
+from st2common.constants.error_messages import PACK_VIRTUALENV_USES_PYTHON3
 from st2common.constants.system import API_URL_ENV_VARIABLE_NAME
 from st2common.constants.system import AUTH_TOKEN_ENV_VARIABLE_NAME
 from st2common.constants.triggers import (SENSOR_SPAWN_TRIGGER, SENSOR_EXIT_TRIGGER)
@@ -42,6 +43,7 @@ from st2common.util.shell import on_parent_exit
 from st2common.util.sandboxing import get_sandbox_python_path
 from st2common.util.sandboxing import get_sandbox_python_binary_path
 from st2common.util.sandboxing import get_sandbox_virtualenv_path
+from st2common.util.sandboxing import is_pack_virtualenv_using_python3
 
 __all__ = [
     'ProcessSensorContainer'
@@ -282,6 +284,14 @@ class ProcessSensorContainer(object):
         if virtualenv_path and not os.path.isdir(virtualenv_path):
             format_values = {'pack': sensor['pack'], 'virtualenv_path': virtualenv_path}
             msg = PACK_VIRTUALENV_DOESNT_EXIST % format_values
+            raise Exception(msg)
+
+        # NOTE: Running sensors using Python 3 virtual environments is not supported
+        uses_python3 = is_pack_virtualenv_using_python3(pack=sensor['pack'])
+
+        if uses_python3:
+            format_values = {'pack': sensor['pack'], 'virtualenv_path': virtualenv_path}
+            msg = PACK_VIRTUALENV_USES_PYTHON3 % format_values
             raise Exception(msg)
 
         trigger_type_refs = sensor['trigger_types'] or []


### PR DESCRIPTION
This pull request updates sensor container to fail and throw an exception if user runs StackStorm installation under Python 2 but creates a pack virtualenv using Python 3 and wants to run sensor from that pack.

We only support Python runner actions in such "mixed environments" and getting sensors to also work is simply too complicated for too little gain (I started on it in #4353, but gave up since it includes too many edge cases and it's simply fragile - sensors are much more complex than Python runner actions and depend on more StackStorm components code).

Supersedes #4353.

## TODO

- [x] Changelog entry
- [x] Tests