### PR TITLE
Update st2-self-check to include task timing information

### DIFF
--- a/st2common/bin/st2-self-check
+++ b/st2common/bin/st2-self-check
@@ -131,23 +131,33 @@ do
     fi
 
     echo -n "Attempting Test ${TEST}..."
+
+    START_TS=$(date +%s)
     st2 run ${TEST} protocol=${PROTOCOL} token=${ST2_AUTH_TOKEN} | grep "status" | grep -q "succeeded"
+    END_TS=$(date +%s)
+    DURATION=$(expr ${END_TS} - ${START_TS})
+
     if [ $? -ne 0 ]; then
-        echo -e "ERROR!"
+        echo -e "ERROR! (${DURATION}s)"
         ((ERRORS++))
     else
-        echo "OK!"
+        echo "OK! (${DURATION}s)"
     fi
 done
 
 if [ ${RUN_MISTRAL_TESTS} = "true" ]; then
     echo -n "Attempting Example examples.mistral_examples..."
+
+    START_TS=$(date +%s)
     st2 run examples.mistral_examples | grep "status" | grep -q "succeeded"
+    END_TS=$(date +%s)
+    DURATION=$(expr ${END_TS} - ${START_TS})
+
     if [ $? -ne 0 ]; then
-        echo -e "ERROR!"
+        echo -e "ERROR! (${DURATION}s)"
         ((ERRORS++))
     else
-        echo "OK!"
+        echo "OK! (${DURATION}s)"
     fi
 else
     echo "Skipping examples.mistral_examples..."
@@ -155,12 +165,17 @@ fi
 
 if [ ${RUN_ORQUESTA_TESTS} = "true" ]; then
     echo -n "Attempting Example examples.orquesta-examples..."
+
+    START_TS=$(date +%s)
     st2 run examples.orquesta-examples | grep "status" | grep -q "succeeded"
+    END_TS=$(date +%s)
+    DURATION=$(expr ${END_TS} - ${START_TS})
+
     if [ $? -ne 0 ]; then
-        echo -e "ERROR!"
+        echo -e "ERROR! (${DURATION}s)"
         ((ERRORS++))
     else
-        echo "OK!"
+        echo "OK! (${DURATION}s)"
     fi
 else
     echo "Skipping examples.orquesta-examples..."


### PR DESCRIPTION
This pull request updates `st2-self-check` script to include timing info for each action we run.

People complained this script is taking a long time and this will allow us at a glance to identify tasks which take a long time and refactor / improve them.

```bash
~
Attempting Test tests.test_inquiry_chain...OK! (37s)
Attempting Test tests.test_inquiry_mistral...OK! (36s)
Attempting Test tests.test_key_triggers...OK! (33s)
Attempting Test tests.test_pack_install_tool...OK! (11s)
Attempting Test tests.test_packs_pack...OK! (72s)
Attempting Test tests.test_quickstart...OK! (19s)
Attempting Test tests.test_quickstart_key...OK! (7s)
Attempting Test tests.test_quickstart_local_script_actions...OK! (12s)
Attempting Test tests.test_quickstart_passive_sensor...OK! (7s)
Attempting Test tests.test_quickstart_polling_sensor...OK! (4s)
Attempting Test tests.test_quickstart_python_actions...OK! (11s)
Attempting Test tests.test_quickstart_remote_script_actions...OK! (13s)
Attempting Test tests.test_quickstart_rules...OK! (61s)
Attempting Test tests.test_quickstart_trace...OK! (16s)
Attempting Test tests.test_run_pack_tests_tool...OK! (35s)
Attempting Test tests.test_timer_rule...OK! (39s)
Skipping tests.test_windows_runners...
Attempting Test tests.test_winrm_runners...OK! (5s)
Attempting Example examples.mistral_examples...OK! (16s)
Attempting Example examples.orquesta-examples...OK! (7s)
SELF CHECK SUCCEEDED!
st2-self-check succeeded.
```