### PR TITLE
[WIP] [DONT REVIEW] Service interface refactor

### DIFF
--- a/st2auth/st2auth/cmd/api.py
+++ b/st2auth/st2auth/cmd/api.py
@@ -15,14 +15,13 @@
 
 import eventlet
 import os
-import sys
 
 from oslo_config import cfg
 from eventlet import wsgi
 
 from st2common import log as logging
-from st2common.service_setup import setup as common_setup
-from st2common.service_setup import teardown as common_teardown
+from st2common.service import ActiveService
+from st2common.service import run_service
 from st2common.util.monkey_patch import monkey_patch
 from st2auth import config
 config.register_opts()
@@ -40,57 +39,53 @@ monkey_patch()
 LOG = logging.getLogger(__name__)
 
 
-def _setup():
-    common_setup(service='auth', config=config, setup_db=True, register_mq_exchanges=False,
-                 register_signal_handlers=True, register_internal_trigger_types=False,
-                 run_migrations=False)
+class AuthAPIHTTPService(ActiveService):
+    name = 'auth'
+    config = config
 
-    # Additional pre-run time checks
-    validate_auth_backend_is_correctly_configured()
+    setup_db = True
+    register_mq_exchanges = False
+    register_signal_handlers = True
+    register_internal_trigger_types = False
+    run_migrations = False
 
+    def setup(self):
+        super(AuthAPIHTTPService, self).setup()
 
-def _run_server():
-    host = cfg.CONF.auth.host
-    port = cfg.CONF.auth.port
-    use_ssl = cfg.CONF.auth.use_ssl
+        # Additional pre-run time checks
+        validate_auth_backend_is_correctly_configured()
 
-    cert_file_path = os.path.realpath(cfg.CONF.auth.cert)
-    key_file_path = os.path.realpath(cfg.CONF.auth.key)
+    def start(self):
+        super(AuthAPIHTTPService, self).start()
 
-    if use_ssl and not os.path.isfile(cert_file_path):
-        raise ValueError('Certificate file "%s" doesn\'t exist' % (cert_file_path))
+        use_ssl = cfg.CONF.auth.use_ssl
 
-    if use_ssl and not os.path.isfile(key_file_path):
-        raise ValueError('Private key file "%s" doesn\'t exist' % (key_file_path))
+        cert_file_path = os.path.realpath(cfg.CONF.auth.cert)
+        key_file_path = os.path.realpath(cfg.CONF.auth.key)
 
-    socket = eventlet.listen((host, port))
+        if use_ssl and not os.path.isfile(cert_file_path):
+            raise ValueError('Certificate file "%s" doesn\'t exist' % (cert_file_path))
 
-    if use_ssl:
-        socket = eventlet.wrap_ssl(socket,
-                                   certfile=cert_file_path,
-                                   keyfile=key_file_path,
-                                   server_side=True)
+        if use_ssl and not os.path.isfile(key_file_path):
+            raise ValueError('Private key file "%s" doesn\'t exist' % (key_file_path))
 
-    LOG.info('ST2 Auth API running in "%s" auth mode', cfg.CONF.auth.mode)
-    LOG.info('(PID=%s) ST2 Auth API is serving on %s://%s:%s.', os.getpid(),
-             'https' if use_ssl else 'http', host, port)
+        self._socket = eventlet.listen((self._host, self._port))
 
-    wsgi.server(socket, app.setup_app(), log=LOG, log_output=False)
-    return 0
+        if use_ssl:
+            self._socket = eventlet.wrap_ssl(self.socket,
+                                             certfile=cert_file_path,
+                                             keyfile=key_file_path,
+                                             server_side=True)
 
+        self.logger.info('StackStorm Auth API running in "%s" auth mode', cfg.CONF.auth.mode)
+        self.logger.info('(PID=%s) StackStorm Auth API is serving on %s://%s:%s.', self.pid,
+                         'https' if use_ssl else 'http', self._host, self._port)
 
-def _teardown():
-    common_teardown()
+        wsgi_app = app.setup_app()
+        self._server = wsgi.server(self._socket, wsgi_app, log=LOG, log_output=False)
 
 
 def main():
-    try:
-        _setup()
-        return _run_server()
-    except SystemExit as exit_code:
-        sys.exit(exit_code)
-    except Exception:
-        LOG.exception('(PID=%s) ST2 Auth API quit due to exception.', os.getpid())
-        return 1
-    finally:
-        _teardown()
+    service = AuthAPIHTTPService(logger=LOG, host=cfg.CONF.auth.host, port=cfg.CONF.auth.port)
+    exit_code = run_service(service=service)
+    return exit_code

--- a/st2common/st2common/service.py
+++ b/st2common/st2common/service.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import os
-import sys
 
 from st2common.service_setup import setup as common_setup
 from st2common.service_setup import teardown as common_teardown
@@ -92,8 +91,9 @@ def run_service(service):
         service.setup()
         service.start()
         return 0
-    except SystemExit as exit_code:
-        sys.exit(exit_code)
+    except (KeyboardInterrupt, SystemExit):
+        service.logger.info('(PID=%s) StackStorm %s stopped.', os.getpid(), service.name)
+        return 1
     except Exception:
         service.logger.exception('(PID=%s) StackStorm %s quit due to exception.', service.pid,
                                  service.name)

--- a/st2common/st2common/service.py
+++ b/st2common/st2common/service.py
@@ -90,8 +90,7 @@ def run_service(service):
 
     try:
         service.setup()
-        service.start()
-        return 0
+        return service.start()
     except (KeyboardInterrupt, SystemExit):
         service.logger.info('(PID=%s) StackStorm %s stopped.', os.getpid(), service.name)
         return FAILURE_EXIT_CODE

--- a/st2common/st2common/service.py
+++ b/st2common/st2common/service.py
@@ -15,6 +15,7 @@
 
 import os
 
+from st2common.constants.exit_codes import FAILURE_EXIT_CODE
 from st2common.service_setup import setup as common_setup
 from st2common.service_setup import teardown as common_teardown
 
@@ -33,7 +34,7 @@ class BaseService(object):
     setup_db = True
     register_mq_exchanges = True
     register_signal_handlers = True
-    register_internal_trigger_types = True
+    register_internal_trigger_types = False
     run_migrations = True
 
     def __init__(self, logger):
@@ -93,10 +94,10 @@ def run_service(service):
         return 0
     except (KeyboardInterrupt, SystemExit):
         service.logger.info('(PID=%s) StackStorm %s stopped.', os.getpid(), service.name)
-        return 1
+        return FAILURE_EXIT_CODE
     except Exception:
         service.logger.exception('(PID=%s) StackStorm %s quit due to exception.', service.pid,
                                  service.name)
-        return 1
+        return FAILURE_EXIT_CODE
     finally:
         service.stop()

--- a/st2common/st2common/service.py
+++ b/st2common/st2common/service.py
@@ -1,0 +1,102 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+
+from st2common.service_setup import setup as common_setup
+from st2common.service_setup import teardown as common_teardown
+
+__all__ = [
+    'ActiveService',
+    'PassiveService',
+
+    'run_service'
+]
+
+
+class BaseService(object):
+    name = None
+    config = None
+
+    setup_db = True
+    register_mq_exchanges = True
+    register_signal_handlers = True
+    register_internal_trigger_types = True
+    run_migrations = True
+
+    def __init__(self, logger):
+        self.logger = logger
+
+        self.pid = os.getpid()
+        self._started = False
+
+    def setup(self):
+        common_setup(service=self.name, config=self.config, setup_db=self.setup_db,
+                     register_mq_exchanges=self.register_mq_exchanges,
+                     register_signal_handlers=self.register_signal_handlers,
+                     register_internal_trigger_types=self.register_internal_trigger_types,
+                     run_migrations=self.run_migrations)
+
+    def start(self):
+        self._started = True
+
+    def stop(self):
+        self._started = False
+        common_teardown()
+
+
+class ActiveService(BaseService):
+    """
+    Service which listens on TCP / HTTP interface.
+    """
+    def __init__(self, logger, host, port):
+        super(ActiveService, self).__init__(logger=logger)
+
+        self._host = host
+        self._port = port
+
+        self._socket = None  # reference to the bound socket
+        self._server = None  # reference to the WSGI HTTP server
+
+
+class PassiveService(BaseService):
+    """
+    Service which doesn't listen on any port and just consumes messages of the messages bus.
+    """
+    pass
+
+
+def run_service(service):
+    """
+    Utility function for running a service.
+
+    This function takes care of starting the service and stop it on exception.
+
+    :return: Service exit code.
+    """
+
+    try:
+        service.setup()
+        service.start()
+        return 0
+    except SystemExit as exit_code:
+        sys.exit(exit_code)
+    except Exception:
+        service.logger.exception('(PID=%s) StackStorm %s quit due to exception.', service.pid,
+                                 service.name)
+        return 1
+    finally:
+        service.stop()

--- a/st2common/st2common/services/healthz_server.py
+++ b/st2common/st2common/services/healthz_server.py
@@ -1,0 +1,63 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import eventlet
+from eventlet import wsgi
+
+from st2common import log as logging
+
+__all__ = [
+    'HealthZHTTPServer'
+]
+
+LOG = logging.getLogger(__name__)
+
+
+def handle_request(env, start_response):
+    path_info = env['PATH_INFO']
+
+    if path_info == '/healthz':
+        start_response('200 SUCCESS', [('Content-Type', 'application/json')])
+        return ''
+    else:
+        start_response('404 NOT FOUND', [('Content-Type', 'text/plain')])
+        return ''
+
+
+class HealthZHTTPServer(object):
+    """
+    HTTP server which exposes service health information over an HTTP interface.
+
+    NOTE: This server is doesn't run behind any authentication so it only listens on localhost by
+    default.
+    """
+
+    def __init__(self, host='127.0.0.1', port=5555):
+        self._host = host
+        self._port = port
+
+        self._started = False
+
+        self._sock = None
+        self._server = None
+
+    def start(self):
+        LOG.info('Healthz HTTP endpoint listening on %s:%s' % (self._host, self._port))
+
+        self._sock = eventlet.listen((self._host, self._port))
+        self._server = wsgi.server(self._sock, handle_request, log=LOG, log_output=False)
+
+    def stop(self):
+        self._started = False

--- a/st2common/tests/unit/test_logging.py
+++ b/st2common/tests/unit/test_logging.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 import unittest2
 
 from st2common.logging.misc import get_logger_name_for_module
-from st2reactor.cmd import sensormanager
+from st2reactor.cmd import sensorcontainer
 from python_runner import python_runner
 from st2common import runners
 
@@ -28,8 +28,8 @@ __all__ = [
 
 class LoggingMiscUtilsTestCase(unittest2.TestCase):
     def test_get_logger_name_for_module(self):
-        logger_name = get_logger_name_for_module(sensormanager)
-        self.assertEqual(logger_name, 'st2reactor.cmd.sensormanager')
+        logger_name = get_logger_name_for_module(sensorcontainer)
+        self.assertEqual(logger_name, 'st2reactor.cmd.sensorcontainer')
 
         logger_name = get_logger_name_for_module(python_runner)
         result = logger_name.endswith('contrib.runners.python_runner.python_runner.python_runner')

--- a/st2reactor/bin/st2sensorcontainer
+++ b/st2reactor/bin/st2sensorcontainer
@@ -20,7 +20,7 @@
 
 import sys
 
-from st2reactor.cmd import sensormanager
+from st2reactor.cmd import sensorcontainer
 
 if __name__ == '__main__':
-    sys.exit(sensormanager.main())
+    sys.exit(sensorcontainer.main())

--- a/st2reactor/st2reactor/cmd/garbagecollector.py
+++ b/st2reactor/st2reactor/cmd/garbagecollector.py
@@ -34,6 +34,8 @@ __all__ = [
 
 monkey_patch()
 
+class GarbageCollectorService(PassiveService)
+
 
 LOGGER_NAME = get_logger_name_for_module(sys.modules[__name__])
 LOG = logging.getLogger(LOGGER_NAME)

--- a/st2reactor/st2reactor/cmd/rulesengine.py
+++ b/st2reactor/st2reactor/cmd/rulesengine.py
@@ -19,8 +19,8 @@ import sys
 
 from st2common import log as logging
 from st2common.logging.misc import get_logger_name_for_module
-from st2common.service_setup import setup as common_setup
-from st2common.service_setup import teardown as common_teardown
+from st2common.service import PassiveService
+from st2common.service import run_service
 from st2common.util.monkey_patch import monkey_patch
 from st2reactor.rules import config
 from st2reactor.rules import worker
@@ -32,41 +32,35 @@ LOGGER_NAME = get_logger_name_for_module(sys.modules[__name__])
 LOG = logging.getLogger(LOGGER_NAME)
 
 
-def _setup():
-    common_setup(service='rulesengine', config=config, setup_db=True, register_mq_exchanges=True,
-                 register_signal_handlers=True, register_internal_trigger_types=True)
+class RulesEngineService(PassiveService):
+    name = 'rulesengine'
+    config = config
 
+    setup_db = True
+    register_mq_exchanges = True
+    register_signal_handlers = True
+    register_internal_trigger_types = True
+    run_migrations = True
 
-def _teardown():
-    common_teardown()
+    def __init__(self, logger):
+        super(RulesEngineService, self).__init__(logger=logger)
 
+        self._worker = None
 
-def _run_worker():
-    LOG.info('(PID=%s) RulesEngine started.', os.getpid())
+    def start(self):
+        self.logger.info('(PID=%s) RulesEngine started.', os.getpid())
 
-    rules_engine_worker = worker.get_worker()
+        self._worker = worker.get_worker()
 
-    try:
-        rules_engine_worker.start()
-        return rules_engine_worker.wait()
-    except (KeyboardInterrupt, SystemExit):
-        LOG.info('(PID=%s) RulesEngine stopped.', os.getpid())
-        rules_engine_worker.shutdown()
-    except:
-        LOG.exception('(PID:%s) RulesEngine quit due to exception.', os.getpid())
-        return 1
+        self._worker.start()
+        self._worker.wait()
 
-    return 0
+    def stop(self):
+        if self._worker:
+            self._worker.shutdown()
 
 
 def main():
-    try:
-        _setup()
-        return _run_worker()
-    except SystemExit as exit_code:
-        sys.exit(exit_code)
-    except:
-        LOG.exception('(PID=%s) RulesEngine quit due to exception.', os.getpid())
-        return 1
-    finally:
-        _teardown()
+    service = RulesEngineService(logger=LOG)
+    exit_code = run_service(service=service)
+    return exit_code

--- a/st2reactor/st2reactor/cmd/sensorcontainer.py
+++ b/st2reactor/st2reactor/cmd/sensorcontainer.py
@@ -15,7 +15,6 @@
 
 from __future__ import absolute_import
 
-import os
 import sys
 
 from oslo_config import cfg
@@ -24,11 +23,7 @@ from st2common import log as logging
 from st2common.logging.misc import get_logger_name_for_module
 from st2common.service import PassiveService
 from st2common.service import run_service
-from st2common.service_setup import setup as common_setup
-from st2common.service_setup import teardown as common_teardown
 from st2common.util.monkey_patch import monkey_patch
-from st2common.exceptions.sensors import SensorNotFoundException
-from st2common.constants.exit_codes import FAILURE_EXIT_CODE
 from st2reactor.sensor import config
 from st2reactor.container.manager import SensorContainerManager
 from st2reactor.container.partitioner_lookup import get_sensors_partitioner
@@ -43,7 +38,7 @@ LOGGER_NAME = get_logger_name_for_module(sys.modules[__name__])
 LOG = logging.getLogger(LOGGER_NAME)
 
 
-class SensorManagerService(PassiveService):
+class SensorContainerService(PassiveService):
     name = 'sensorcontainer'
 
     config = config
@@ -68,6 +63,6 @@ class SensorManagerService(PassiveService):
 
 
 def main():
-    service = SensorManagerService(logger=LOG)
+    service = SensorContainerService(logger=LOG)
     exit_code = run_service(service=service)
     return exit_code

--- a/st2stream/st2stream/cmd/api.py
+++ b/st2stream/st2stream/cmd/api.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import sys
 
 import eventlet
@@ -21,8 +20,8 @@ from oslo_config import cfg
 from eventlet import wsgi
 
 from st2common import log as logging
-from st2common.service_setup import setup as common_setup
-from st2common.service_setup import teardown as common_teardown
+from st2common.service import ActiveService
+from st2common.service import run_service
 from st2common.stream.listener import get_listener_if_set
 from st2common.util.wsgi import shutdown_server_kill_pending_requests
 from st2stream.signal_handlers import register_stream_signal_handlers
@@ -48,52 +47,49 @@ LOG = logging.getLogger(__name__)
 WSGI_SERVER_REQUEST_SHUTDOWN_TIME = 2
 
 
-def _setup():
-    common_setup(service='stream', config=config, setup_db=True, register_mq_exchanges=True,
-                 register_signal_handlers=True, register_internal_trigger_types=False,
-                 run_migrations=False)
+class StreamAPIHTTPService(ActiveService):
+    name = 'stream'
+    config = config
 
+    setup_db = True
+    register_mq_exchanges = True
+    register_signal_handlers = True
+    register_internal_trigger_types = False
+    run_migrations = False
 
-def _run_server():
-    host = cfg.CONF.stream.host
-    port = cfg.CONF.stream.port
+    def start(self):
+        super(StreamAPIHTTPService, self).start()
 
-    LOG.info('(PID=%s) ST2 Stream API is serving on http://%s:%s.', os.getpid(), host, port)
+        LOG.info('(PID=%s) StackStorm Stream API is serving on http://%s:%s.', self.pid,
+                 self._host, self._port)
 
-    max_pool_size = eventlet.wsgi.DEFAULT_MAX_SIMULTANEOUS_REQUESTS
-    worker_pool = eventlet.GreenPool(max_pool_size)
-    sock = eventlet.listen((host, port))
+        max_pool_size = eventlet.wsgi.DEFAULT_MAX_SIMULTANEOUS_REQUESTS
+        worker_pool = eventlet.GreenPool(max_pool_size)
+        sock = eventlet.listen((self._host, self._port))
 
-    def queue_shutdown(signal_number, stack_frame):
-        eventlet.spawn_n(shutdown_server_kill_pending_requests, sock=sock,
-                         worker_pool=worker_pool, wait_time=WSGI_SERVER_REQUEST_SHUTDOWN_TIME)
+        def queue_shutdown(signal_number, stack_frame):
+            eventlet.spawn_n(shutdown_server_kill_pending_requests, sock=sock,
+                             worker_pool=worker_pool, wait_time=WSGI_SERVER_REQUEST_SHUTDOWN_TIME)
 
-    # We register a custom SIGINT handler which allows us to kill long running active requests.
-    # Note: Eventually we will support draining (waiting for short-running requests), but we
-    # will still want to kill long running stream requests.
-    register_stream_signal_handlers(handler_func=queue_shutdown)
+        # We register a custom SIGINT handler which allows us to kill long running active requests.
+        # Note: Eventually we will support draining (waiting for short-running requests), but we
+        # will still want to kill long running stream requests.
+        register_stream_signal_handlers(handler_func=queue_shutdown)
 
-    wsgi.server(sock, app.setup_app(), custom_pool=worker_pool)
-    return 0
+        wsgi_app = app.setup_app()
+        self._server = wsgi.server(sock, wsgi_app, custom_pool=worker_pool)
 
+    def stop(self):
+        super(StreamAPIHTTPService, self).stop()
 
-def _teardown():
-    common_teardown()
-
-
-def main():
-    try:
-        _setup()
-        return _run_server()
-    except SystemExit as exit_code:
-        sys.exit(exit_code)
-    except KeyboardInterrupt:
         listener = get_listener_if_set(name='stream')
 
         if listener:
             listener.shutdown()
-    except Exception:
-        LOG.exception('(PID=%s) ST2 Stream API quit due to exception.', os.getpid())
-        return 1
-    finally:
-        _teardown()
+
+
+def main():
+    service = StreamAPIHTTPService(logger=LOG, host=cfg.CONF.stream.host,
+                                   port=cfg.CONF.stream.port)
+    exit_code = run_service(service=service)
+    return exit_code


### PR DESCRIPTION
This pull request introduces a new class-based Service interface and updates all the existing services to use this new interface.

## Background / Details

Right now we don't have a strict service interface / abstraction and a service entry point is composed of a single "run_server" function.

This makes it very hard to introduce any kind of cross-service functionality or even functionality which needs to query existing service for status or similar (some of that would be possible, but would require a lot of abuse of module level constants, etc.).

This change will allow us to implement new HTTP service which will be running with each StackStorm service and expose service status.

I got some inspiration for the implementation from Twisted Service interface which also supports more complex things such as chaining and combining multiple services, but kept it simple enough.

## TODO

- [ ] Finish new service interface
- [ ] Port all the services to the new interface
- [ ] Prototype new HealthZ service status service