### PR TITLE
Changes for v2.9.1 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,6 @@ Changelog
 in development
 --------------
 
-
 Changed
 ~~~~~~~
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Changed
 * Speed up pack registration through the ``/v1/packs/register`` API endpoint. (improvement) #4342
 * Triggertypes API now sorts by trigger ref by default. ``st2 trigger list`` will now show a sorted
   list. (#4348)
+* Update ``st2-self-check`` script to include per-test timing information. (improvement) #4359
 
 Fixed
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,9 @@ Fixed
   We only support running Python runner actions from packs which use mixed Python environments
   (StackStorm components are running under Python 2 and particular a pack virtual environment is
   using Python 3). #4354
+* Update ``st2-pack-install`` and ``st2 pack install`` command so it works with local git repos
+  (``file://<path to local git repo>``) which are in a detached head state (e.g. specific revision
+  is checked out). (improvement) #4366
 
 2.9.0 - September 16, 2018
 --------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ in development
 --------------
 
 
+Changed
+~~~~~~~
+
+* Speed up pack registration through the ``/v1/packs/register`` API endpoint. (improvement) #4342
+
 2.9.0 - September 16, 2018
 --------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,12 @@ Changed
 ~~~~~~~
 
 * Speed up pack registration through the ``/v1/packs/register`` API endpoint. (improvement) #4342
+* Update ``st2sensorcontainer`` service to throw if user wants to run a sensor from a pack which is
+  using Python 3 virtual environment.
+
+  We only support running Python runner actions from packs which use mixed Python environments
+  (StackStorm components are running under Python 2 and particular a pack virtual environment is
+  using Python 3). #4354
 
 2.9.0 - September 16, 2018
 --------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,12 @@ Changed
 ~~~~~~~
 
 * Speed up pack registration through the ``/v1/packs/register`` API endpoint. (improvement) #4342
+* Triggertypes API now sorts by trigger ref by default. ``st2 trigger list`` will now show a sorted
+  list. (#4348)
+
+Fixed
+~~~~~
+
 * Update ``st2sensorcontainer`` service to throw if user wants to run a sensor from a pack which is
   using Python 3 virtual environment.
 

--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ lint-api-spec: requirements .lint-api-spec
 	@echo
 	@echo "================== Lint API spec ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate; st2common/bin/st2-validate-api-spec
+	. $(VIRTUALENV_DIR)/bin/activate; st2common/bin/st2-validate-api-spec --config-file conf/st2.dev.conf 
 
 .PHONY: generate-api-spec
 generate-api-spec: requirements .generate-api-spec

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ lint-api-spec: requirements .lint-api-spec
 generate-api-spec: requirements .generate-api-spec
 
 .PHONY: .generate-api-spec
-.generate-api-spec:
+.generate-api-spec: .lint-api-spec
 	@echo
 	@echo "================== Generate openapi.yaml file ===================="
 	@echo

--- a/contrib/packs/tests/test_action_download.py
+++ b/contrib/packs/tests/test_action_download.py
@@ -300,6 +300,9 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
         url = eval_repo_url("file:///home/vagrant/stackstorm-test")
         self.assertEqual(url, "file:///home/vagrant/stackstorm-test")
 
+        url = eval_repo_url("file://localhost/home/vagrant/stackstorm-test")
+        self.assertEqual(url, "file://localhost/home/vagrant/stackstorm-test")
+
         url = eval_repo_url('ssh://<user@host>/AutomationStackStorm')
         self.assertEqual(url, 'ssh://<user@host>/AutomationStackStorm')
 

--- a/contrib/packs/tests/test_action_download.py
+++ b/contrib/packs/tests/test_action_download.py
@@ -89,6 +89,7 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
         self.repo_base = tempfile.mkdtemp()
 
         self.repo_instance = mock.MagicMock()
+        type(self.repo_instance).active_branch = mock.Mock()
 
         def side_effect(url, to_path, **kwargs):
             # Since we have no way to pass pack name here, we would have to derive it from repo url
@@ -112,6 +113,10 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
         self.clone_from.assert_called_once_with(PACK_INDEX['test']['repo_url'],
                                                 os.path.join(os.path.expanduser('~'), temp_dir))
         self.assertTrue(os.path.isfile(os.path.join(self.repo_base, 'test/pack.yaml')))
+
+        self.repo_instance.git.checkout.assert_called()
+        self.repo_instance.git.branch.assert_called()
+        self.repo_instance.git.checkout.assert_called()
 
     def test_run_pack_download_existing_pack(self):
         action = self.get_action_instance()
@@ -363,3 +368,17 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
 
             result = action.run(packs=packs, abs_repo_base=self.repo_base)
             self.assertEqual(result, {'test': 'Success.'})
+
+    def test_run_pack_dowload_local_git_repo_detached_head_state(self):
+        action = self.get_action_instance()
+
+        type(self.repo_instance).active_branch = \
+            mock.PropertyMock(side_effect=TypeError('detached head'))
+
+        result = action.run(packs=['file:///stackstorm-test'], abs_repo_base=self.repo_base)
+        self.assertEqual(result, {'test': 'Success.'})
+
+        # Verify function has bailed out early
+        self.repo_instance.git.checkout.assert_not_called()
+        self.repo_instance.git.branch.assert_not_called()
+        self.repo_instance.git.checkout.assert_not_called()

--- a/st2actions/tests/unit/test_actions_registrar.py
+++ b/st2actions/tests/unit/test_actions_registrar.py
@@ -30,7 +30,7 @@ MOCK_RUNNER_TYPE_DB = RunnerTypeDB(name='run-local', runner_module='st2.runners.
 
 class ActionsRegistrarTest(tests_base.DbTestCase):
     @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(return_value=True))
-    @mock.patch.object(action_validator, '_get_runner_model',
+    @mock.patch.object(action_validator, 'get_runner_model',
                        mock.MagicMock(return_value=MOCK_RUNNER_TYPE_DB))
     def test_register_all_actions(self):
         try:
@@ -53,7 +53,7 @@ class ActionsRegistrarTest(tests_base.DbTestCase):
             pass
 
     @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(return_value=True))
-    @mock.patch.object(action_validator, '_get_runner_model',
+    @mock.patch.object(action_validator, 'get_runner_model',
                        mock.MagicMock(return_value=MOCK_RUNNER_TYPE_DB))
     def test_pack_name_missing(self):
         registrar = actions_registrar.ActionsRegistrar()
@@ -71,7 +71,7 @@ class ActionsRegistrarTest(tests_base.DbTestCase):
             Action.delete(action_db)
 
     @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(return_value=True))
-    @mock.patch.object(action_validator, '_get_runner_model',
+    @mock.patch.object(action_validator, 'get_runner_model',
                        mock.MagicMock(return_value=MOCK_RUNNER_TYPE_DB))
     def test_register_action_with_no_params(self):
         registrar = actions_registrar.ActionsRegistrar()
@@ -82,7 +82,7 @@ class ActionsRegistrarTest(tests_base.DbTestCase):
         self.assertEqual(registrar._register_action('dummy', action_file), None)
 
     @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(return_value=True))
-    @mock.patch.object(action_validator, '_get_runner_model',
+    @mock.patch.object(action_validator, 'get_runner_model',
                        mock.MagicMock(return_value=MOCK_RUNNER_TYPE_DB))
     def test_register_action_invalid_parameter_type_attribute(self):
         registrar = actions_registrar.ActionsRegistrar()
@@ -95,7 +95,7 @@ class ActionsRegistrarTest(tests_base.DbTestCase):
                                 registrar._register_action, 'dummy', action_file)
 
     @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(return_value=True))
-    @mock.patch.object(action_validator, '_get_runner_model',
+    @mock.patch.object(action_validator, 'get_runner_model',
                        mock.MagicMock(return_value=MOCK_RUNNER_TYPE_DB))
     def test_register_action_invalid_parameter_name(self):
         registrar = actions_registrar.ActionsRegistrar()
@@ -109,7 +109,7 @@ class ActionsRegistrarTest(tests_base.DbTestCase):
                                 registrar._register_action, 'dummy', action_file)
 
     @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(return_value=True))
-    @mock.patch.object(action_validator, '_get_runner_model',
+    @mock.patch.object(action_validator, 'get_runner_model',
                        mock.MagicMock(return_value=MOCK_RUNNER_TYPE_DB))
     def test_invalid_params_schema(self):
         registrar = actions_registrar.ActionsRegistrar()
@@ -123,7 +123,7 @@ class ActionsRegistrarTest(tests_base.DbTestCase):
             pass
 
     @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(return_value=True))
-    @mock.patch.object(action_validator, '_get_runner_model',
+    @mock.patch.object(action_validator, 'get_runner_model',
                        mock.MagicMock(return_value=MOCK_RUNNER_TYPE_DB))
     def test_action_update(self):
         registrar = actions_registrar.ActionsRegistrar()

--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -181,6 +181,7 @@ class PackRegisterController(object):
         for type, (Registrar, name) in six.iteritems(ENTITIES):
             if type in types or name in types:
                 registrar = Registrar(use_pack_cache=use_pack_cache,
+                                      use_runners_cache=True,
                                       fail_on_failure=fail_on_failure)
                 if packs:
                     for pack in packs:

--- a/st2common/bin/st2-self-check
+++ b/st2common/bin/st2-self-check
@@ -115,31 +115,49 @@ do
     fi
 
     echo -n "Attempting Test ${TEST}..."
+
+    START_TS=$(date +%s)
     st2 run ${TEST} protocol=${PROTOCOL} token=${ST2_AUTH_TOKEN} | grep "status" | grep -q "succeeded"
-    if [ $? -ne 0 ]; then
-        echo -e "ERROR!"
+    EXIT_CODE=$?
+    END_TS=$(date +%s)
+    DURATION=$(expr ${END_TS} - ${START_TS})
+
+    if [ ${EXIT_CODE} -ne 0 ]; then
+        echo -e "ERROR! (${DURATION}s)"
         ((ERRORS++))
     else
-        echo "OK!"
+        echo "OK!  (${DURATION}s)"
     fi
 done
 
 echo -n "Attempting Example examples.mistral_examples..."
+
+START_TS=$(date +%s)
 st2 run examples.mistral_examples | grep "status" | grep -q "succeeded"
-if [ $? -ne 0 ]; then
-    echo -e "ERROR!"
+EXIT_CODE=$?
+END_TS=$(date +%s)
+DURATION=$(expr ${END_TS} - ${START_TS})
+
+if [ ${EXIT_CODE} -ne 0 ]; then
+    echo -e "ERROR! (${DURATION}s)"
     ((ERRORS++))
 else
-    echo "OK!"
+    echo "OK!  (${DURATION}s)"
 fi
 
 echo -n "Attempting Example examples.orquesta-examples..."
+
+START_TS=$(date +%s)
 st2 run examples.orquesta-examples | grep "status" | grep -q "succeeded"
-if [ $? -ne 0 ]; then
-    echo -e "ERROR!"
+EXIT_CODE=$?
+END_TS=$(date +%s)
+DURATION=$(expr ${END_TS} - ${START_TS})
+
+if [ ${EXIT_CODE} -ne 0 ]; then
+    echo -e "ERROR! (${DURATION}s)"
     ((ERRORS++))
 else
-    echo "OK!"
+    echo "OK!  (${DURATION}s)"
 fi
 
 if [ $ERRORS -ne 0 ]; then

--- a/st2common/st2common/bootstrap/base.py
+++ b/st2common/st2common/bootstrap/base.py
@@ -54,21 +54,29 @@ EXCLUDE_FILE_PATTERNS = [
 class ResourceRegistrar(object):
     ALLOWED_EXTENSIONS = []
 
-    def __init__(self, use_pack_cache=True, fail_on_failure=False):
+    def __init__(self, use_pack_cache=True, use_runners_cache=False, fail_on_failure=False):
         """
         :param use_pack_cache: True to cache which packs have been registered in memory and making
                                 sure packs are only registered once.
         :type use_pack_cache: ``bool``
 
+        :param use_runners_cache: True to cache RunnerTypeDB objects in memory to reduce load on
+                                  the database.
+        :type use_runners_cache: ``bool``
+
         :param fail_on_failure: Throw an exception if resource registration fails.
         :type fail_on_failure: ``bool``
         """
         self._use_pack_cache = use_pack_cache
+        self._use_runners_cache = use_runners_cache
         self._fail_on_failure = fail_on_failure
 
         self._meta_loader = MetaLoader()
         self._pack_loader = ContentPackLoader()
         self._runner_loader = RunnersLoader()
+
+        # Maps runner name -> RunnerTypeDB
+        self._runner_type_db_cache = {}
 
     def get_resources_from_pack(self, resources_dir):
         resources = []

--- a/st2common/st2common/bootstrap/configsregistrar.py
+++ b/st2common/st2common/bootstrap/configsregistrar.py
@@ -42,8 +42,10 @@ class ConfigsRegistrar(ResourceRegistrar):
 
     ALLOWED_EXTENSIONS = ALLOWED_EXTS
 
-    def __init__(self, use_pack_cache=True, fail_on_failure=False, validate_configs=True):
+    def __init__(self, use_pack_cache=True, use_runners_cache=False, fail_on_failure=False,
+                 validate_configs=True):
         super(ConfigsRegistrar, self).__init__(use_pack_cache=use_pack_cache,
+                                               use_runners_cache=use_runners_cache,
                                                fail_on_failure=fail_on_failure)
 
         self._validate_configs = validate_configs

--- a/st2common/st2common/cmd/generate_api_spec.py
+++ b/st2common/st2common/cmd/generate_api_spec.py
@@ -39,7 +39,6 @@ def setup():
 def generate_spec():
     spec_string = spec_loader.generate_spec('st2common', 'openapi.yaml.j2')
     print(spec_string)
-    spec_loader.load_spec('st2common', 'openapi.yaml.j2')
 
 
 def teartown():

--- a/st2common/st2common/cmd/generate_api_spec.py
+++ b/st2common/st2common/cmd/generate_api_spec.py
@@ -25,7 +25,6 @@ from st2common.util import spec_loader
 from st2common.script_setup import setup as common_setup
 from st2common.script_setup import teardown as common_teardown
 
-
 __all__ = [
     'main'
 ]
@@ -40,6 +39,7 @@ def setup():
 def generate_spec():
     spec_string = spec_loader.generate_spec('st2common', 'openapi.yaml.j2')
     print(spec_string)
+    spec_loader.load_spec('st2common', 'openapi.yaml.j2')
 
 
 def teartown():
@@ -52,8 +52,8 @@ def main():
     try:
         generate_spec()
         ret = 0
-    except Exception as e:
-        LOG.error(e.message)
+    except Exception:
+        LOG.error('Failed to generate openapi.yaml file', exc_info=True)
         ret = 1
     finally:
         teartown()

--- a/st2common/st2common/cmd/validate_api_spec.py
+++ b/st2common/st2common/cmd/validate_api_spec.py
@@ -111,7 +111,11 @@ def main():
     setup()
 
     try:
+        # 1. Validate there are no duplicates keys in the YAML file
         spec_loader.load_spec('st2common', 'openapi.yaml.j2', allow_duplicate_keys=False)
+
+        # 2. Validate schema (currently broken)
+        # validate_spec()
         ret = 0
     except Exception:
         LOG.error('Failed to validate openapi.yaml file', exc_info=True)

--- a/st2common/st2common/cmd/validate_api_spec.py
+++ b/st2common/st2common/cmd/validate_api_spec.py
@@ -111,9 +111,10 @@ def main():
     setup()
 
     try:
-        ret = validate_spec()
-    except Exception as e:
-        LOG.error(e.message)
+        spec_loader.load_spec('st2common', 'openapi.yaml.j2', allow_duplicate_keys=False)
+        ret = 0
+    except Exception:
+        LOG.error('Failed to validate openapi.yaml file', exc_info=True)
         ret = 1
     finally:
         teartown()

--- a/st2common/st2common/constants/error_messages.py
+++ b/st2common/st2common/constants/error_messages.py
@@ -26,8 +26,9 @@ means, you can create a new virtual environment using the command:
 '''
 
 PACK_VIRTUALENV_USES_PYTHON3 = '''
-Virtual environment (%(virtualenv_path)s) for pack "%(pack)s" is using python3.
+Virtual environment (%(virtualenv_path)s) for pack "%(pack)s" is using Python 3.
 Using Python 3 virtual environments in mixed deployments is only supported for Python runner
 actions and not sensors. If you want to run this sensor, please re-recreate the
-virtualenv environment with python2 binary.
+virtual environment with the python2 binary:
+"st2 run packs.setup_virtualenv packs=%(pack)s python3=false"
 '''

--- a/st2common/st2common/constants/error_messages.py
+++ b/st2common/st2common/constants/error_messages.py
@@ -13,9 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+__all__ = [
+    'PACK_VIRTUALENV_DOESNT_EXIST',
+    'PACK_VIRTUALENV_USES_PYTHON3'
+]
+
 PACK_VIRTUALENV_DOESNT_EXIST = '''
 The virtual environment (%(virtualenv_path)s) for pack "%(pack)s" does not exist. Normally this is
 created when you install a pack using "st2 pack install". If you installed your pack by some other
 means, you can create a new virtual environment using the command:
 "st2 run packs.setup_virtualenv packs=%(pack)s"
+'''
+
+PACK_VIRTUALENV_USES_PYTHON3 = '''
+Virtual environment (%(virtualenv_path)s) for pack "%(pack)s" is using python3.
+Using Python 3 virtual environments in mixed deployments is only supported for Python runner
+actions and not sensors. If you want to run this sensor, please re-recreate the
+virtualenv environment with python2 binary.
 '''

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -1313,7 +1313,6 @@ paths:
           in: context
           x-as: requester_user
           description: User performing the operation.
-      x-submit-metrics: false
       responses:
         '200':
           description: Execution attribute requested

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -1309,7 +1309,6 @@ paths:
           in: context
           x-as: requester_user
           description: User performing the operation.
-      x-submit-metrics: false
       responses:
         '200':
           description: Execution attribute requested

--- a/st2common/st2common/util/pack_management.py
+++ b/st2common/st2common/util/pack_management.py
@@ -152,7 +152,7 @@ def clone_repo(temp_dir, repo_url, verify_ssl=True, ref='master'):
     # future.
     repo = Repo.clone_from(repo_url, temp_dir)
 
-    is_local_repo = repo_url.startswith('file:///')
+    is_local_repo = repo_url.startswith('file://')
 
     try:
         active_branch = repo.active_branch

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -178,6 +178,9 @@ def is_pack_virtualenv_using_python3(pack):
     if virtualenv_path and os.path.isdir(virtualenv_path):
         pack_virtualenv_lib_path = os.path.join(virtualenv_path, 'lib')
 
+        if not os.path.exists(pack_virtualenv_lib_path):
+            return False, None
+
         virtualenv_directories = os.listdir(pack_virtualenv_lib_path)
         virtualenv_directories = [dir_name for dir_name in virtualenv_directories if
                                   fnmatch.fnmatch(dir_name, 'python3*')]

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 """
-Utility functions for our sandboxing model which is implemented on top of
-separate processes and virtualenv.
+Utility functions for our sandboxing model which is implemented on top of separate processes and
+virtual environments.
 """
 
 from __future__ import absolute_import
@@ -128,19 +128,17 @@ def get_sandbox_python_path(inherit_from_parent=True, inherit_parent_virtualenv=
 def get_sandbox_python_path_for_python_action(pack, inherit_from_parent=True,
                                               inherit_parent_virtualenv=True):
     """
-    Same as get_sandbox_python_path function, but it's intended to be used for Python runner actions
-    and also takes into account if a pack virtual environment uses Python 3.
+    Return sandbox PYTHONPATH for a particular Python runner action.
+
+    Same as get_sandbox_python_path() function, but it's intended to be used for Python runner
+    actions and also takes into account if a pack virtual environment uses Python 3.
     """
     sandbox_python_path = get_sandbox_python_path(
         inherit_from_parent=inherit_from_parent,
         inherit_parent_virtualenv=inherit_parent_virtualenv)
 
-    # If python3.? directory exists in pack virtualenv lib/ path it means Python 3 is used by
-    # that virtual environment and we take that in to account when constructing PYTHONPATH
     pack_base_path = get_pack_base_path(pack_name=pack)
     virtualenv_path = get_sandbox_virtualenv_path(pack=pack)
-
-    pack_actions_lib_paths = os.path.join(pack_base_path, 'actions/lib/')
 
     if not virtualenv_path:
         return sandbox_python_path
@@ -150,6 +148,7 @@ def get_sandbox_python_path_for_python_action(pack, inherit_from_parent=True,
         # Add Python 3 lib directory (lib/python3.x) in front of the PYTHONPATH. This way we avoid
         # issues with scripts trying to use packages / modules from Python 2.7 site-packages
         # directory instead of the versions from Python 3 stdlib.
+        pack_actions_lib_paths = os.path.join(pack_base_path, 'actions/lib/')
         pack_virtualenv_lib_path = os.path.join(virtualenv_path, 'lib')
         python3_lib_directory = os.path.join(pack_virtualenv_lib_path, virtualenv_directories[0])
 
@@ -167,9 +166,9 @@ def get_sandbox_python_path_for_python_action(pack, inherit_from_parent=True,
 
 def is_pack_virtualenv_using_python3(pack):
     """
-    Return True if a particular pack virtual environment is used Python 3.
+    Return True if a particular pack virtual environment is using Python 3.
 
-    :return: (uses_python3_bool, virtualenv_directories)
+    :return: (uses_python3_bool, virtualenv_lib_directories)
     :rtype: ``tuple``
     """
     # If python3.? directory exists in pack virtualenv lib/ path it means Python 3 is used by

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -141,16 +141,10 @@ def get_sandbox_python_path_for_python_action(pack, inherit_from_parent=True,
     pack_base_path = get_pack_base_path(pack_name=pack)
     virtualenv_path = get_sandbox_virtualenv_path(pack=pack)
 
-    if virtualenv_path and os.path.isdir(virtualenv_path):
-        pack_actions_lib_paths = os.path.join(pack_base_path, 'actions/lib/')
-        pack_virtualenv_lib_path = os.path.join(virtualenv_path, 'lib')
+    pack_actions_lib_paths = os.path.join(pack_base_path, 'actions/lib/')
+    pack_virtualenv_lib_path = os.path.join(virtualenv_path, 'lib')
 
-        virtualenv_directories = os.listdir(pack_virtualenv_lib_path)
-        virtualenv_directories = [dir_name for dir_name in virtualenv_directories if
-                                  fnmatch.fnmatch(dir_name, 'python3*')]
-        uses_python3 = bool(virtualenv_directories)
-    else:
-        uses_python3 = False
+    uses_python3, virtualenv_directories = is_pack_virtualenv_using_python3(pack=pack)
 
     if uses_python3:
         # Add Python 3 lib directory (lib/python3.x) in front of the PYTHONPATH. This way we avoid
@@ -176,8 +170,6 @@ def is_pack_virtualenv_using_python3(pack):
     """
     # If python3.? directory exists in pack virtualenv lib/ path it means Python 3 is used by
     # that virtual environment and we take that in to account when constructing PYTHONPATH
-    pack_base_path = get_pack_base_path(pack_name=pack)
-
     virtualenv_path = get_sandbox_virtualenv_path(pack=pack)
 
     if virtualenv_path and os.path.isdir(virtualenv_path):
@@ -189,8 +181,9 @@ def is_pack_virtualenv_using_python3(pack):
         uses_python3 = bool(virtualenv_directories)
     else:
         uses_python3 = False
+        virtualenv_directories = None
 
-    return uses_python3
+    return uses_python3, virtualenv_directories
 
 
 def get_sandbox_virtualenv_path(pack):

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -175,6 +175,9 @@ def is_pack_virtualenv_using_python3(pack):
     if virtualenv_path and os.path.isdir(virtualenv_path):
         pack_virtualenv_lib_path = os.path.join(virtualenv_path, 'lib')
 
+        if not os.path.exists(pack_virtualenv_lib_path):
+            return False, None
+
         virtualenv_directories = os.listdir(pack_virtualenv_lib_path)
         virtualenv_directories = [dir_name for dir_name in virtualenv_directories if
                                   fnmatch.fnmatch(dir_name, 'python3*')]

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -127,7 +127,6 @@ def get_sandbox_python_path(inherit_from_parent=True, inherit_parent_virtualenv=
 
 def get_sandbox_python_path_for_python_action(pack, inherit_from_parent=True,
                                               inherit_parent_virtualenv=True):
-
     """
     Same as get_sandbox_python_path function, but it's intended to be used for Python runner actions
     and also takes into account if a pack virtual environment uses Python 3.
@@ -142,14 +141,16 @@ def get_sandbox_python_path_for_python_action(pack, inherit_from_parent=True,
     virtualenv_path = get_sandbox_virtualenv_path(pack=pack)
 
     pack_actions_lib_paths = os.path.join(pack_base_path, 'actions/lib/')
-    pack_virtualenv_lib_path = os.path.join(virtualenv_path, 'lib')
+
+    if not virtualenv_path:
+        return sandbox_python_path
 
     uses_python3, virtualenv_directories = is_pack_virtualenv_using_python3(pack=pack)
-
     if uses_python3:
         # Add Python 3 lib directory (lib/python3.x) in front of the PYTHONPATH. This way we avoid
         # issues with scripts trying to use packages / modules from Python 2.7 site-packages
         # directory instead of the versions from Python 3 stdlib.
+        pack_virtualenv_lib_path = os.path.join(virtualenv_path, 'lib')
         python3_lib_directory = os.path.join(pack_virtualenv_lib_path, virtualenv_directories[0])
 
         # Add Python 3 site-packages directory (lib/python3.x/site-packages) in front of the Python
@@ -167,6 +168,9 @@ def get_sandbox_python_path_for_python_action(pack, inherit_from_parent=True,
 def is_pack_virtualenv_using_python3(pack):
     """
     Return True if a particular pack virtual environment is used Python 3.
+
+    :return: (uses_python3_bool, virtualenv_directories)
+    :rtype: ``tuple``
     """
     # If python3.? directory exists in pack virtualenv lib/ path it means Python 3 is used by
     # that virtual environment and we take that in to account when constructing PYTHONPATH
@@ -174,9 +178,6 @@ def is_pack_virtualenv_using_python3(pack):
 
     if virtualenv_path and os.path.isdir(virtualenv_path):
         pack_virtualenv_lib_path = os.path.join(virtualenv_path, 'lib')
-
-        if not os.path.exists(pack_virtualenv_lib_path):
-            return False, None
 
         virtualenv_directories = os.listdir(pack_virtualenv_lib_path)
         virtualenv_directories = [dir_name for dir_name in virtualenv_directories if

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -35,7 +35,9 @@ __all__ = [
     'get_sandbox_python_path',
     'get_sandbox_python_path_for_python_action',
     'get_sandbox_path',
-    'get_sandbox_virtualenv_path'
+    'get_sandbox_virtualenv_path',
+
+    'is_pack_virtualenv_using_python3'
 ]
 
 
@@ -166,6 +168,29 @@ def get_sandbox_python_path_for_python_action(pack, inherit_from_parent=True,
                                pack_actions_lib_paths + ':' + sandbox_python_path)
 
     return sandbox_python_path
+
+
+def is_pack_virtualenv_using_python3(pack):
+    """
+    Return True if a particular pack virtual environment is used Python 3.
+    """
+    # If python3.? directory exists in pack virtualenv lib/ path it means Python 3 is used by
+    # that virtual environment and we take that in to account when constructing PYTHONPATH
+    pack_base_path = get_pack_base_path(pack_name=pack)
+
+    virtualenv_path = get_sandbox_virtualenv_path(pack=pack)
+
+    if virtualenv_path and os.path.isdir(virtualenv_path):
+        pack_virtualenv_lib_path = os.path.join(virtualenv_path, 'lib')
+
+        virtualenv_directories = os.listdir(pack_virtualenv_lib_path)
+        virtualenv_directories = [dir_name for dir_name in virtualenv_directories if
+                                  fnmatch.fnmatch(dir_name, 'python3*')]
+        uses_python3 = bool(virtualenv_directories)
+    else:
+        uses_python3 = False
+
+    return uses_python3
 
 
 def get_sandbox_virtualenv_path(pack):

--- a/st2common/st2common/util/spec_loader.py
+++ b/st2common/st2common/util/spec_loader.py
@@ -60,7 +60,7 @@ class UniqueKeyLoader(Loader):
             key = self.construct_object(key_node, deep=deep)
             try:
                 hash(key)
-            except TypeError, exc:
+            except TypeError as exc:
                 raise ConstructorError("while constructing a mapping", node.start_mark,
                        "found unacceptable key (%s)" % exc, key_node.start_mark)
             # check for duplicate keys

--- a/st2common/st2common/util/spec_loader.py
+++ b/st2common/st2common/util/spec_loader.py
@@ -19,8 +19,17 @@ import pkg_resources
 import jinja2
 import yaml
 
+from yaml.constructor import ConstructorError
+from yaml.nodes import MappingNode
+
+try:
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
+
 import st2common.constants.pack
 import st2common.constants.action
+
 from st2common.rbac.types import PermissionType
 from st2common.util import isotime
 
@@ -37,8 +46,40 @@ ARGUMENTS = {
 }
 
 
-def load_spec(module_name, spec_file):
+class UniqueKeyLoader(Loader):
+    """
+    YAML loader which throws on a duplicate key.
+    """
+    def construct_mapping(self, node, deep=False):
+        if not isinstance(node, MappingNode):
+            raise ConstructorError(None, None,
+                    "expected a mapping node, but found %s" % node.id,
+                    node.start_mark)
+        mapping = {}
+        for key_node, value_node in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            try:
+                hash(key)
+            except TypeError, exc:
+                raise ConstructorError("while constructing a mapping", node.start_mark,
+                       "found unacceptable key (%s)" % exc, key_node.start_mark)
+            # check for duplicate keys
+            if key in mapping:
+                raise ConstructorError("while constructing a mapping", node.start_mark,
+                       "found duplicate key", key_node.start_mark)
+            value = self.construct_object(value_node, deep=deep)
+            mapping[key] = value
+        return mapping
+
+
+def load_spec(module_name, spec_file, allow_duplicate_keys=False):
     spec_string = generate_spec(module_name, spec_file)
+
+    # 1. Check for duplicate keys
+    if not allow_duplicate_keys:
+        yaml.load(spec_string, UniqueKeyLoader)
+
+    # 2. Generate actual spec
     spec = yaml.safe_load(spec_string)
     return spec
 

--- a/st2common/st2common/validators/api/action.py
+++ b/st2common/st2common/validators/api/action.py
@@ -26,12 +26,25 @@ from st2common.content.utils import check_pack_content_directory_exists
 from st2common.models.system.common import ResourceReference
 from six.moves import range
 
+__all__ = [
+    'validate_action',
+    'get_runner_model'
+]
+
 
 LOG = logging.getLogger(__name__)
 
 
-def validate_action(action_api):
-    runner_db = _get_runner_model(action_api)
+def validate_action(action_api, runner_type_db=None):
+    """
+    :param runner_type_db: RunnerTypeDB object belonging to this action. If not provided, it's 
+                           retrieved from the database.
+    :type runner_type_db: :class:`RunnerTypeDB`
+    """
+    if not runner_type_db:
+        runner_db = get_runner_model(action_api)
+    else:
+        runner_db = runner_type_db
 
     # Check if pack is valid.
     if not _is_valid_pack(action_api.pack):
@@ -47,7 +60,7 @@ def validate_action(action_api):
     _validate_parameters(action_ref, action_api.parameters, runner_db.runner_parameters)
 
 
-def _get_runner_model(action_api):
+def get_runner_model(action_api):
     runner_db = None
     # Check if runner exists.
     try:

--- a/st2common/st2common/validators/api/action.py
+++ b/st2common/st2common/validators/api/action.py
@@ -37,7 +37,7 @@ LOG = logging.getLogger(__name__)
 
 def validate_action(action_api, runner_type_db=None):
     """
-    :param runner_type_db: RunnerTypeDB object belonging to this action. If not provided, it's 
+    :param runner_type_db: RunnerTypeDB object belonging to this action. If not provided, it's
                            retrieved from the database.
     :type runner_type_db: :class:`RunnerTypeDB`
     """

--- a/st2common/tests/unit/test_util_sandboxing.py
+++ b/st2common/tests/unit/test_util_sandboxing.py
@@ -129,6 +129,7 @@ class SandboxingUtilsTestCase(unittest.TestCase):
         self.assertEqual(python_path, ':/data/test1:/data/test2:%s/virtualenvtest' %
                          (sys.prefix))
 
+    @mock.patch('os.path.exists', mock.Mock(return_value=True))
     @mock.patch('os.path.isdir', mock.Mock(return_value=True))
     @mock.patch('os.listdir', mock.Mock(return_value=['python3.6']))
     @mock.patch('st2common.util.sandboxing.get_python_lib')

--- a/st2common/tests/unit/test_util_sandboxing.py
+++ b/st2common/tests/unit/test_util_sandboxing.py
@@ -11,6 +11,7 @@ from st2common.util.sandboxing import get_sandbox_path
 from st2common.util.sandboxing import get_sandbox_python_path
 from st2common.util.sandboxing import get_sandbox_python_path_for_python_action
 from st2common.util.sandboxing import get_sandbox_python_binary_path
+from st2common.util.sandboxing import is_pack_virtualenv_using_python3
 
 import st2tests.config as tests_config
 
@@ -96,6 +97,8 @@ class SandboxingUtilsTestCase(unittest.TestCase):
     @mock.patch('st2common.util.sandboxing.get_python_lib')
     def test_get_sandbox_python_path_for_python_action_python2_used_for_venv(self,
             mock_get_python_lib):
+        self.assertFalse(is_pack_virtualenv_using_python3(pack='dummy_pack')[0])
+
         # No inheritance
         python_path = get_sandbox_python_path_for_python_action(pack='dummy_pack',
                                                                 inherit_from_parent=False,
@@ -135,6 +138,8 @@ class SandboxingUtilsTestCase(unittest.TestCase):
                 mock.Mock(return_value='/tmp/virtualenvs/dummy_pack'))
     def test_get_sandbox_python_path_for_python_action_python3_used_for_venv(self,
             mock_get_python_lib):
+        self.assertTrue(is_pack_virtualenv_using_python3(pack='dummy_pack')[0])
+
         # No inheritance
         python_path = get_sandbox_python_path_for_python_action(pack='dummy_pack',
                                                                 inherit_from_parent=False,

--- a/st2reactor/st2reactor/container/process_container.py
+++ b/st2reactor/st2reactor/container/process_container.py
@@ -22,6 +22,7 @@ import subprocess
 
 from collections import defaultdict
 
+import six
 import eventlet
 from eventlet.support import greenlets as greenlet
 from oslo_config import cfg
@@ -289,7 +290,7 @@ class ProcessSensorContainer(object):
         # NOTE: Running sensors using Python 3 virtual environments is not supported
         uses_python3, _ = is_pack_virtualenv_using_python3(pack=sensor['pack'])
 
-        if uses_python3:
+        if uses_python3 and not six.PY3:
             format_values = {'pack': sensor['pack'], 'virtualenv_path': virtualenv_path}
             msg = PACK_VIRTUALENV_USES_PYTHON3 % format_values
             raise Exception(msg)

--- a/st2reactor/st2reactor/container/process_container.py
+++ b/st2reactor/st2reactor/container/process_container.py
@@ -287,7 +287,7 @@ class ProcessSensorContainer(object):
             raise Exception(msg)
 
         # NOTE: Running sensors using Python 3 virtual environments is not supported
-        uses_python3 = is_pack_virtualenv_using_python3(pack=sensor['pack'])
+        uses_python3, _ = is_pack_virtualenv_using_python3(pack=sensor['pack'])
 
         if uses_python3:
             format_values = {'pack': sensor['pack'], 'virtualenv_path': virtualenv_path}

--- a/st2reactor/st2reactor/container/process_container.py
+++ b/st2reactor/st2reactor/container/process_container.py
@@ -260,7 +260,7 @@ class ProcessSensorContainer(object):
             try:
                 self._spawn_sensor_process(sensor=sensor_obj)
             except Exception as e:
-                LOG.warning(e.message, exc_info=True)
+                LOG.warning(str(e), exc_info=True)
 
                 # Disable sensor which we are unable to start
                 del self._sensors[sensor_id]
@@ -439,7 +439,7 @@ class ProcessSensorContainer(object):
         try:
             self._spawn_sensor_process(sensor=sensor)
         except Exception as e:
-            LOG.warning(e.message, exc_info=True)
+            LOG.warning(str(e), exc_info=True)
 
             # Disable sensor which we are unable to start
             del self._sensors[sensor_id]

--- a/st2reactor/st2reactor/container/process_container.py
+++ b/st2reactor/st2reactor/container/process_container.py
@@ -28,6 +28,7 @@ from oslo_config import cfg
 
 from st2common import log as logging
 from st2common.constants.error_messages import PACK_VIRTUALENV_DOESNT_EXIST
+from st2common.constants.error_messages import PACK_VIRTUALENV_USES_PYTHON3
 from st2common.constants.system import API_URL_ENV_VARIABLE_NAME
 from st2common.constants.system import AUTH_TOKEN_ENV_VARIABLE_NAME
 from st2common.constants.triggers import (SENSOR_SPAWN_TRIGGER, SENSOR_EXIT_TRIGGER)
@@ -42,6 +43,7 @@ from st2common.util.shell import on_parent_exit
 from st2common.util.sandboxing import get_sandbox_python_path
 from st2common.util.sandboxing import get_sandbox_python_binary_path
 from st2common.util.sandboxing import get_sandbox_virtualenv_path
+from st2common.util.sandboxing import is_pack_virtualenv_using_python3
 
 __all__ = [
     'ProcessSensorContainer'
@@ -282,6 +284,14 @@ class ProcessSensorContainer(object):
         if virtualenv_path and not os.path.isdir(virtualenv_path):
             format_values = {'pack': sensor['pack'], 'virtualenv_path': virtualenv_path}
             msg = PACK_VIRTUALENV_DOESNT_EXIST % format_values
+            raise Exception(msg)
+
+        # NOTE: Running sensors using Python 3 virtual environments is not supported
+        uses_python3 = is_pack_virtualenv_using_python3(pack=sensor['pack'])
+
+        if uses_python3:
+            format_values = {'pack': sensor['pack'], 'virtualenv_path': virtualenv_path}
+            msg = PACK_VIRTUALENV_USES_PYTHON3 % format_values
             raise Exception(msg)
 
         trigger_type_refs = sensor['trigger_types'] or []

--- a/st2reactor/tests/integration/test_sensor_watcher.py
+++ b/st2reactor/tests/integration/test_sensor_watcher.py
@@ -53,7 +53,7 @@ class SensorWatcherTestCase(IntegrationTestCase):
         while not done:
             eventlet.sleep(0.01)
             sw_queues = self._get_sensor_watcher_amqp_queues(queue_name='st2.sensor.watch.covfefe')
-            done = len(sw_queues) > 0 or (monotonic() - start() < 5)
+            done = len(sw_queues) > 0 or ((monotonic() - start) < 5)
 
         sensor_watcher.stop()
         sw_queues = self._get_sensor_watcher_amqp_queues(queue_name='st2.sensor.watch.covfefe')


### PR DESCRIPTION
Included changes:

* Speed up pack action registration through the /v1/packs/register API endpoint - #4342
* Fixing openapi definition - #4357 
* Throw an exception if user wants to run a sensor from a pack which uses Python 3 virtual environment - #4354 
* Update st2-pack-install command so it allows users to install packs from local git repos in a detached head state - #4366 
* Update st2-self-check to include task timing information - #4359