### PR TITLE
Update st2-pack-install command so it allows users to install packs from local git repos in a detached head state

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,11 +15,14 @@ Changed
 
 * Triggertypes API now sorts by trigger ref by default. ``st2 trigger list`` will now show a sorted
   list. (#4348)
-
-Changed
-~~~~~~~
-
 * Speed up pack registration through the ``/v1/packs/register`` API endpoint. (improvement) #4342
+
+Fixed
+~~~~~
+
+* Update ``st2-pack-install`` and ``st2 pack install`` command so it works with local git repos
+  (``file://<path to local git repo>``) which are in a detached head state (e.g. specific revision
+  is checked out). (improvement) #4366
 
 2.9.0 - September 16, 2018
 --------------------------

--- a/contrib/packs/tests/test_action_download.py
+++ b/contrib/packs/tests/test_action_download.py
@@ -300,6 +300,9 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
         url = eval_repo_url("file:///home/vagrant/stackstorm-test")
         self.assertEqual(url, "file:///home/vagrant/stackstorm-test")
 
+        url = eval_repo_url("file://localhost/home/vagrant/stackstorm-test")
+        self.assertEqual(url, "file://localhost/home/vagrant/stackstorm-test")
+
         url = eval_repo_url('ssh://<user@host>/AutomationStackStorm')
         self.assertEqual(url, 'ssh://<user@host>/AutomationStackStorm')
 

--- a/contrib/packs/tests/test_action_download.py
+++ b/contrib/packs/tests/test_action_download.py
@@ -89,6 +89,7 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
         self.repo_base = tempfile.mkdtemp()
 
         self.repo_instance = mock.MagicMock()
+        type(self.repo_instance).active_branch = mock.Mock()
 
         def side_effect(url, to_path, **kwargs):
             # Since we have no way to pass pack name here, we would have to derive it from repo url
@@ -112,6 +113,10 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
         self.clone_from.assert_called_once_with(PACK_INDEX['test']['repo_url'],
                                                 os.path.join(os.path.expanduser('~'), temp_dir))
         self.assertTrue(os.path.isfile(os.path.join(self.repo_base, 'test/pack.yaml')))
+
+        self.repo_instance.git.checkout.assert_called()
+        self.repo_instance.git.branch.assert_called()
+        self.repo_instance.git.checkout.assert_called()
 
     def test_run_pack_download_existing_pack(self):
         action = self.get_action_instance()
@@ -363,3 +368,17 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
 
             result = action.run(packs=packs, abs_repo_base=self.repo_base)
             self.assertEqual(result, {'test': 'Success.'})
+
+    def test_run_pack_dowload_local_git_repo_detached_head_state(self):
+        action = self.get_action_instance()
+
+        type(self.repo_instance).active_branch = \
+            mock.PropertyMock(side_effect=TypeError('detached head'))
+
+        result = action.run(packs=['file:///stackstorm-test'], abs_repo_base=self.repo_base)
+        self.assertEqual(result, {'test': 'Success.'})
+
+        # Verify function has bailed out early
+        self.repo_instance.git.checkout.assert_not_called()
+        self.repo_instance.git.branch.assert_not_called()
+        self.repo_instance.git.checkout.assert_not_called()

--- a/st2common/st2common/util/pack_management.py
+++ b/st2common/st2common/util/pack_management.py
@@ -152,7 +152,7 @@ def clone_repo(temp_dir, repo_url, verify_ssl=True, ref='master'):
     # future.
     repo = Repo.clone_from(repo_url, temp_dir)
 
-    is_local_repo = repo_url.startswith('file:///')
+    is_local_repo = repo_url.startswith('file://')
 
     try:
         active_branch = repo.active_branch


### PR DESCRIPTION
This pull request updates ``st2-pack-install`` command to allow users install packs from a local directory on disk (`file:///<path>`) which are in a detached head state - aka user already checked out a specific commit / revision.

Fixes https://github.com/StackStorm/st2packs-dockerfiles/issues/4.

## TODO

- [x] Tests
- [x] Changelog entry