### PR TITLE
Fix race when parallel inquiries set the execution status

### DIFF
--- a/st2common/st2common/services/workflows.py
+++ b/st2common/st2common/services/workflows.py
@@ -304,7 +304,9 @@ def request_resume(ac_ex_db):
         raise wf_exc.WorkflowExecutionIsCompletedException(str(wf_ex_db.id))
 
     if wf_ex_db.status in states.RUNNING_STATES:
-        raise wf_exc.WorkflowExecutionIsRunningException(str(wf_ex_db.id))
+        msg = '[%s] Workflow execution "%s" is not resumed because it is already active.'
+        LOG.info(msg, wf_ac_ex_id, str(wf_ex_db.id))
+        return
 
     conductor = deserialize_conductor(wf_ex_db)
 
@@ -312,7 +314,9 @@ def request_resume(ac_ex_db):
         raise wf_exc.WorkflowExecutionIsCompletedException(str(wf_ex_db.id))
 
     if conductor.get_workflow_state() in states.RUNNING_STATES:
-        raise wf_exc.WorkflowExecutionIsRunningException(str(wf_ex_db.id))
+        msg = '[%s] Workflow execution "%s" is not resumed because it is already active.'
+        LOG.info(msg, wf_ac_ex_id, str(wf_ex_db.id))
+        return
 
     conductor.request_workflow_state(states.RESUMING)
 

--- a/st2tests/integration/orquesta/base.py
+++ b/st2tests/integration/orquesta/base.py
@@ -101,7 +101,8 @@ class TestWorkflowExecution(unittest2.TestCase):
             if ex.status in action_constants.LIVEACTION_COMPLETED_STATES:
                 raise Exception(
                     'Execution is in completed state "%s" and '
-                    'does not match expected state(s).' % ex.status
+                    'does not match expected state(s). %s' %
+                    (ex.status, ex.result)
                 )
             else:
                 raise

--- a/st2tests/integration/orquesta/test_wiring_inquiry.py
+++ b/st2tests/integration/orquesta/test_wiring_inquiry.py
@@ -66,7 +66,7 @@ class InquiryWiringTest(base.TestWorkflowExecution):
         t1_ac_exs = self._wait_for_task(ex, 'ask_jack', ac_const.LIVEACTION_STATUS_SUCCEEDED)
 
         # Allow some time for the first inquiry to get processed.
-        eventlet.sleep(3)
+        eventlet.sleep(1)
 
         # Respond to the second inquiry.
         t2_ac_exs = self._wait_for_task(ex, 'ask_jill', ac_const.LIVEACTION_STATUS_PENDING)


### PR DESCRIPTION
When a workflow is paused and there are multiple requests to resume the workflow, there is a race and one of the request fails because the workflow is already in an active state. Instead of erroring, log the situation and there is no need to resume since the workflow is already active.