### PR TITLE
core.http - allow all basic http methods

### DIFF
--- a/contrib/core/actions/http.yaml
+++ b/contrib/core/actions/http.yaml
@@ -36,6 +36,9 @@ parameters:
     - POST
     - PUT
     - DELETE
+    - TRACE
+    - OPTIONS
+    - PATCH
   params:
     description: Query params to be used with the HTTP request.
     type: object


### PR DESCRIPTION
Per https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Request_methods - allow all basic HTTP methods