### PR TITLE
Changed to activate cacert parameter when st2client sends requests to st2stream

### DIFF
--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -582,7 +582,7 @@ class WebhookManager(ResourceManager):
 
 
 class StreamManager(object):
-    def __init__(self, endpoint, cacert, debug):
+    def __init__(self, endpoint, cacert=None, debug=False):
         self._url = httpclient.get_url_without_trailing_slash(endpoint) + '/stream'
         self.debug = debug
         self.cacert = cacert
@@ -595,6 +595,7 @@ class StreamManager(object):
 
         url = self._url
         query_params = {}
+        request_params = {}
 
         if events and isinstance(events, six.string_types):
             events = [events]
@@ -608,10 +609,13 @@ class StreamManager(object):
         if events:
             query_params['events'] = ','.join(events)
 
+        if self.cacert is not None:
+            request_params['verify'] = self.cacert
+
         query_string = '?' + urllib.parse.urlencode(query_params)
         url = url + query_string
 
-        for message in SSEClient(url):
+        for message in SSEClient(url, **request_params):
 
             # If the execution on the API server takes too long, the message
             # can be empty. In this case, rerun the query.


### PR DESCRIPTION
This fixes #4361. The summary of this changes are below.

- Setting default parameter at 'cacert' and 'debug' of the StreamManager parameter to keep a consistency with other ResourceManagers.
- Adding a processing to pass 'cacert' parameter of StreamManager to the 'verify' parameter of SSEClient object to be able to specify a CA bundle for TLS certification.

We can confirm that #4361 will be solved by this change, which means we can activate 'cacert' option which is defined in the configuration, like following.
```bash
(virtualenv) ubuntu@ubuntu0:~$ cat .st2/config
[general]
silence_ssl_warnings = True
cacert = /etc/ssl/st2/st2.crt

[stream]
url = https://ubuntu0/stream/v1
(virtualenv) ubuntu@ubuntu0:~$ st2 pack remove zabbix

        [ succeeded ] unregister packs
        [ succeeded ] delete packs
```