### PR TITLE
Update paramiko from vulnerable version

### DIFF
--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -28,7 +28,7 @@ pyinotify==0.9.6
 semver==2.8.1
 pytz==2018.5
 stevedore==1.29.0
-paramiko==2.4.1
+paramiko==2.4.2
 networkx==1.11
 python-keyczar==0.716
 cryptography==2.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ nose-parallel==0.2.1
 nose-timer==0.7.3
 oslo.config<1.13,>=1.12.1
 oslo.utils<=3.37.0,>=3.36.2
-paramiko==2.4.1
+paramiko==2.4.2
 passlib==1.7.1
 prettytable
 prometheus_client==0.1.1

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -13,7 +13,7 @@ jsonschema==2.6.0
 kombu==4.2.1
 networkx==1.11
 oslo.config<1.13,>=1.12.1
-paramiko==2.4.1
+paramiko==2.4.2
 prometheus_client==0.1.1
 pymongo==3.7.1
 python-dateutil


### PR DESCRIPTION
Current paramiko version has known vulnerability. This PR upgrades to non-vulnerable version.