### PR TITLE
Exit with exit code 1 when st2 login fails

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,8 @@ Fixed
 * Update ``st2-pack-install`` and ``st2 pack install`` command so it works with local git repos
   (``file://<path to local git repo>``) which are in a detached head state (e.g. specific revision
   is checked out). (improvement) #4366
+* st2 login now exits with non zero exit code when login fails due to invalid credentials.
+  (improvement) #4338
 
 2.9.0 - September 16, 2018
 --------------------------

--- a/st2client/st2client/commands/auth.py
+++ b/st2client/st2client/commands/auth.py
@@ -152,11 +152,10 @@ class LoginCommand(resource.ResourceCommand):
         try:
             self.run(args, **kwargs)
         except Exception as e:
-            print('Failed to log in as %s: %s' % (args.username, str(e)))
             if self.app.client.debug:
                 raise
 
-            return
+            raise Exception('Failed to log in as %s: %s' % (args.username, str(e)))
 
         print('Logged in as %s' % (args.username))
 

--- a/st2client/tests/unit/test_auth.py
+++ b/st2client/tests/unit/test_auth.py
@@ -289,7 +289,7 @@ class TestLoginUncaughtException(TestLoginBase):
 
         self.assertTrue('Failed to log in as %s' % expected_username in self.stdout.getvalue())
         self.assertTrue('Logged in as' not in self.stdout.getvalue())
-        self.assertEqual(retcode, 0)
+        self.assertEqual(retcode, 1)
 
 
 class TestAuthToken(base.BaseCLITestCase):


### PR DESCRIPTION
closes: https://github.com/StackStorm/st2/issues/4338

## Successful login

```
(virtualenv) root@aca37a80cae2:/st2# st2 login testu -p testp
Logged in as testu

Note: You didn't use --write-password option so the password hasn't been stored in the client config and you will need to login again in 24 hours when the auth token expires.
As an alternative, you can run st2 login command with the "--write-password" flag, but keep it mind this will cause it to store the password in plain-text in the client config file (~/.st2/config).
(virtualenv) root@aca37a80cae2:/st2# echo $?
0
(virtualenv) root@aca37a80cae2:/st2# 
```

## Unsuccessful login

```
(virtualenv) root@aca37a80cae2:/st2# st2 login kanye -p 00000 
ERROR: Failed to log in as kanye: 401 Client Error: Unauthorized
MESSAGE: Invalid or missing credentials for url: http://127.0.0.1:9100/tokens

(virtualenv) root@aca37a80cae2:/st2# echo $?
1
(virtualenv) root@aca37a80cae2:/st2# 
```

## Unsuccessful login with --debug

```
(virtualenv) root@aca37a80cae2:/st2# st2 --debug login kanye -p 00000        
# -------- begin 140563055156624 request ----------
curl -X POST -H  'Connection: keep-alive' -H  'Accept-Encoding: gzip, deflate' -H  'Accept: */*' -H  'User-Agent: python-requests/2.14.2' -H  'content-type: application/json' -H  'Content-Length: 2' -H  'Authorization: Basic a2FueWU6MDAwMDA=' --data-binary '{}' http://127.0.0.1:9100/tokens
# -------- begin 140563055156624 response ----------
{
    "faultstring": "Invalid or missing credentials"
}
# -------- end 140563055156624 response ------------

ERROR: 401 Client Error: Unauthorized
MESSAGE: Invalid or missing credentials for url: http://127.0.0.1:9100/tokens

CLI settings:
----------------
Config file path: /root/.st2/config
Client settings:
----------------
ST2_BASE_URL: http://127.0.0.1
ST2_AUTH_URL: http://127.0.0.1:9100
ST2_API_URL: http://127.0.0.1:9101/v1
ST2_STREAM_URL: http://127.0.0.1:9102/v1
ST2_AUTH_TOKEN: None

Proxy settings:
---------------
HTTP_PROXY: 
HTTPS_PROXY: 

Traceback (most recent call last):
  File "/st2/st2client/st2client/shell.py", line 402, in run
    func(args)
  File "/st2/st2client/st2client/commands/auth.py", line 153, in run_and_print
    self.run(args, **kwargs)
  File "/st2/st2client/st2client/commands/auth.py", line 124, in run
    manager = self.manager.create(instance, auth=(args.username, args.password), **kwargs)
  File "/st2/st2client/st2client/models/core.py", line 40, in decorate
    return func(*args, **kwargs)
  File "/st2/st2client/st2client/models/core.py", line 306, in create
    self.handle_error(response)
  File "/st2/st2client/st2client/models/core.py", line 166, in handle_error
    response.raise_for_status()
  File "/st2/virtualenv/local/lib/python2.7/site-packages/requests-2.14.2-py2.7.egg/requests/models.py", line 928, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
HTTPError: 401 Client Error: Unauthorized
MESSAGE: Invalid or missing credentials for url: http://127.0.0.1:9100/tokens
(virtualenv) root@aca37a80cae2:/st2# echo $?
1
(virtualenv) root@aca37a80cae2:/st2# 
```

## Successful login with --debug

```
(virtualenv) root@aca37a80cae2:/st2# st2 --debug login testu -p testp        
# -------- begin 140378474724752 request ----------
curl -X POST -H  'Connection: keep-alive' -H  'Accept-Encoding: gzip, deflate' -H  'Accept: */*' -H  'User-Agent: python-requests/2.14.2' -H  'content-type: application/json' -H  'Content-Length: 2' -H  'Authorization: Basic dGVzdHU6dGVzdHA=' --data-binary '{}' http://127.0.0.1:9100/tokens
# -------- begin 140378474724752 response ----------
{
    "service": false,
    "expiry": "2018-10-13T15:18:52.240346Z",
    "token": "aaf65c6d57554c2e8cba82f5b652fb0b",
    "user": "testu",
    "id": "5bc0bb5c84981a47eb12c35b",
    "metadata": {}
}
# -------- end 140378474724752 response ------------

No handlers could be found for logger "st2client.base"
Logged in as testu

Note: You didn't use --write-password option so the password hasn't been stored in the client config and you will need to login again in 24 hours when the auth token expires.
As an alternative, you can run st2 login command with the "--write-password" flag, but keep it mind this will cause it to store the password in plain-text in the client config file (~/.st2/config).
(virtualenv) root@aca37a80cae2:/st2# echo $?
0
(virtualenv) root@aca37a80cae2:/st2# 
```