### PR TITLE
Fix 'st2 key load' that errors when importing an empty file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ Fixed
   is checked out). (improvement) #4366
 * st2 login now exits with non zero exit code when login fails due to invalid credentials.
   (improvement) #4338
+* Fix ``st2 key load`` that errors when importing an empty file #4393
 
 2.9.0 - September 16, 2018
 --------------------------

--- a/st2client/st2client/commands/keyvalue.py
+++ b/st2client/st2client/commands/keyvalue.py
@@ -294,12 +294,16 @@ class KeyValuePairLoadCommand(resource.ResourceCommand):
         # load the data (JSON/YAML) from the file
         kvps = resource.load_meta_file(file_path)
 
+        instances = []
+        # bail out if file was empty
+        if not kvps:
+            return instances
+
         # if the data is not a list (ie. it's a single entry)
         # then make it a list so our process loop is generic
         if not isinstance(kvps, list):
             kvps = [kvps]
 
-        instances = []
         for item in kvps:
             # parse required KeyValuePair properties
             name = item['name']

--- a/st2client/tests/unit/test_keyvalue.py
+++ b/st2client/tests/unit/test_keyvalue.py
@@ -333,3 +333,16 @@ class TestKeyValueLoad(TestKeyValueBase):
         finally:
             os.close(fd)
             os.unlink(path)
+
+    def test_load_keyvalue_empty_file(self):
+        """
+        Loading K/V from an empty file shouldn't throw an error
+        """
+        fd, path = tempfile.mkstemp(suffix='.yaml')
+        try:
+            args = ['key', 'load', path]
+            retcode = self.shell.run(args)
+            self.assertEqual(retcode, 0)
+        finally:
+            os.close(fd)
+            os.unlink(path)

--- a/st2client/tests/unit/test_keyvalue.py
+++ b/st2client/tests/unit/test_keyvalue.py
@@ -342,6 +342,7 @@ class TestKeyValueLoad(TestKeyValueBase):
         try:
             args = ['key', 'load', path]
             retcode = self.shell.run(args)
+            self.assertTrue('No matching items found' in self.stdout.getvalue())
             self.assertEqual(retcode, 0)
         finally:
             os.close(fd)

--- a/st2client/tests/unit/test_keyvalue.py
+++ b/st2client/tests/unit/test_keyvalue.py
@@ -342,7 +342,7 @@ class TestKeyValueLoad(TestKeyValueBase):
         try:
             args = ['key', 'load', path]
             retcode = self.shell.run(args)
-            self.assertTrue('No matching items found' in self.stdout.getvalue())
+            self.assertIn('No matching items found', self.stdout.getvalue())
             self.assertEqual(retcode, 0)
         finally:
             os.close(fd)


### PR DESCRIPTION
> A small bug, found during the https://github.com/StackStorm/stackstorm-ha/pull/30 K8s work

Loading K/V from an empty file throws an error and fails with non-zero exit code.

### Error
```
$ touch st2kv.yaml
$ st2 key load st2kv.yaml 
ERROR: 'NoneType' object has no attribute '__getitem__'

$ echo $?
1
```

### Fixed version
```
$ st2 key load st2kv.yaml 
No matching items found
```
