### PR TITLE
Workaround for intermediate failures

### DIFF
--- a/st2actions/tests/unit/policies/test_concurrency.py
+++ b/st2actions/tests/unit/policies/test_concurrency.py
@@ -114,6 +114,8 @@ class ConcurrencyPolicyTestCase(EventletTestCase, DbTestCase):
             liveaction = LiveActionDB(action='wolfpack.action-1', parameters={'actionstr': 'foo'})
             action_service.request(liveaction)
 
+        MockLiveActionPublisherNonBlocking.wait_all()
+
         # Since states are being processed asynchronously, wait for the
         # liveactions to go into scheduled states.
         for i in range(0, 100):
@@ -121,6 +123,8 @@ class ConcurrencyPolicyTestCase(EventletTestCase, DbTestCase):
             scheduled = [item for item in LiveAction.get_all() if item.status in SCHEDULED_STATES]
             if len(scheduled) == policy_db.parameters['threshold']:
                 break
+
+        MockLiveActionPublisherNonBlocking.wait_all()
 
         scheduled = [item for item in LiveAction.get_all() if item.status in SCHEDULED_STATES]
         self.assertEqual(len(scheduled), policy_db.parameters['threshold'])

--- a/st2actions/tests/unit/policies/test_concurrency.py
+++ b/st2actions/tests/unit/policies/test_concurrency.py
@@ -85,6 +85,12 @@ class ConcurrencyPolicyTestCase(EventletTestCase, DbTestCase):
         loader.save_fixtures_to_db(fixtures_pack=PACK,
                                    fixtures_dict=TEST_FIXTURES)
 
+    def setUp(self):
+        super(ConcurrencyPolicyTestCase, self).setUp()
+
+        # Wait for all threads to finish processing so there is no cross test polution
+        MockLiveActionPublisherNonBlocking.wait_all()
+
     def tearDown(self):
         for liveaction in LiveAction.get_all():
             action_service.update_status(
@@ -259,11 +265,15 @@ class ConcurrencyPolicyTestCase(EventletTestCase, DbTestCase):
 
         # Since states are being processed asynchronously, wait for the
         # liveactions to go into scheduled states.
+        MockLiveActionPublisherNonBlocking.wait_all()
+
         for i in range(0, 100):
             eventlet.sleep(1)
             scheduled = [item for item in LiveAction.get_all() if item.status in SCHEDULED_STATES]
             if len(scheduled) == policy_db.parameters['threshold']:
                 break
+
+        MockLiveActionPublisherNonBlocking.wait_all()
 
         scheduled = [item for item in LiveAction.get_all() if item.status in SCHEDULED_STATES]
         self.assertEqual(len(scheduled), policy_db.parameters['threshold'])

--- a/st2actions/tests/unit/policies/test_concurrency_by_attr.py
+++ b/st2actions/tests/unit/policies/test_concurrency_by_attr.py
@@ -85,6 +85,11 @@ class ConcurrencyByAttributePolicyTestCase(EventletTestCase, DbTestCase):
         loader.save_fixtures_to_db(fixtures_pack=PACK,
                                    fixtures_dict=TEST_FIXTURES)
 
+    def setUp(self):
+        super(ConcurrencyByAttributePolicyTestCase, self).setUp()
+
+        MockLiveActionPublisherNonBlocking.wait_all()
+
     def tearDown(self):
         for liveaction in LiveAction.get_all():
             action_service.update_status(
@@ -109,6 +114,8 @@ class ConcurrencyByAttributePolicyTestCase(EventletTestCase, DbTestCase):
             liveaction = LiveActionDB(action='wolfpack.action-1', parameters={'actionstr': 'fu'})
             action_service.request(liveaction)
 
+        MockLiveActionPublisherNonBlocking.wait_all()
+
         # Since states are being processed asynchronously, wait for the
         # liveactions to go into scheduled states.
         for i in range(0, 100):
@@ -116,6 +123,8 @@ class ConcurrencyByAttributePolicyTestCase(EventletTestCase, DbTestCase):
             scheduled = [item for item in LiveAction.get_all() if item.status in SCHEDULED_STATES]
             if len(scheduled) == policy_db.parameters['threshold']:
                 break
+
+        MockLiveActionPublisherNonBlocking.wait_all()
 
         scheduled = [item for item in LiveAction.get_all() if item.status in SCHEDULED_STATES]
         self.assertEqual(len(scheduled), policy_db.parameters['threshold'])
@@ -282,11 +291,15 @@ class ConcurrencyByAttributePolicyTestCase(EventletTestCase, DbTestCase):
 
         # Since states are being processed asynchronously, wait for the
         # liveactions to go into scheduled states.
+        MockLiveActionPublisherNonBlocking.wait_all()
+
         for i in range(0, 100):
             eventlet.sleep(1)
             scheduled = [item for item in LiveAction.get_all() if item.status in SCHEDULED_STATES]
             if len(scheduled) == policy_db.parameters['threshold']:
                 break
+
+        MockLiveActionPublisherNonBlocking.wait_all()
 
         scheduled = [item for item in LiveAction.get_all() if item.status in SCHEDULED_STATES]
         self.assertEqual(len(scheduled), policy_db.parameters['threshold'])


### PR DESCRIPTION
Just testing a change to see if it will help with a lot of intermediate failures of concurrency tests.