### PR TITLE
Fix for intermediate test failure

### DIFF
--- a/st2actions/tests/unit/policies/test_concurrency.py
+++ b/st2actions/tests/unit/policies/test_concurrency.py
@@ -92,6 +92,8 @@ class ConcurrencyPolicyTestCase(EventletTestCase, DbTestCase):
         MockLiveActionPublisherNonBlocking.wait_all()
 
     def tearDown(self):
+        MockLiveActionPublisherNonBlocking.wait_all()
+
         for liveaction in LiveAction.get_all():
             action_service.update_status(
                 liveaction, action_constants.LIVEACTION_STATUS_CANCELED)

--- a/st2api/tests/unit/controllers/v1/test_executions_auth.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_auth.py
@@ -73,11 +73,10 @@ LIVE_ACTION_1 = {
     }
 }
 
-# NOTE: We use a longer expiry time because this variable is initialized on
-# module import (aka when nosetests or similar imports this module before
-# running the tests).
-# Depending on when the import happens, token could expire already and tests
-# fail.
+# NOTE: We use a longer expiry time because this variable is initialized on module import (aka
+# when nosetests or similar imports this module before running the tests.
+# Depending on when the import happens and when the tests actually run, token could already expire
+# by that time and the tests would fail.
 NOW = date_utils.get_datetime_utc_now()
 EXPIRY = NOW + datetime.timedelta(seconds=1000)
 SYS_TOKEN = TokenDB(id=bson.ObjectId(), user='system', token=uuid.uuid4().hex, expiry=EXPIRY)

--- a/st2api/tests/unit/controllers/v1/test_executions_auth.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_auth.py
@@ -73,8 +73,13 @@ LIVE_ACTION_1 = {
     }
 }
 
+# NOTE: We use a longer expiry time because this variable is initialized on
+# module import (aka when nosetests or similar imports this module before
+# running the tests).
+# Depending on when the import happens, token could expire already and tests
+# fail.
 NOW = date_utils.get_datetime_utc_now()
-EXPIRY = NOW + datetime.timedelta(seconds=300)
+EXPIRY = NOW + datetime.timedelta(seconds=1000)
 SYS_TOKEN = TokenDB(id=bson.ObjectId(), user='system', token=uuid.uuid4().hex, expiry=EXPIRY)
 USR_TOKEN = TokenDB(id=bson.ObjectId(), user='tokenuser', token=uuid.uuid4().hex, expiry=EXPIRY)
 


### PR DESCRIPTION
This pull request fixes another one of those tests which fail every now and then.

This time I finally managed to track down the root cause. We create token and assign ``EXPIRY`` variable in a module level context.

This means that the variable will get assigned and evaluated when module is imported (either by some test case or by nosetests runner).

Test modules are imported by nosetests before running the tests and all the tests run inside the same process. This means that depending on when the nose imports the module and before the tests inside that module actually run, token could already expire by then.

Fix uses a much larger expiry time which means this won't happen anymore.

![screenshot from 2018-10-30 14-08-50](https://user-images.githubusercontent.com/125088/47720088-59ae7c80-dc4d-11e8-9d3d-3978b98ff0d4.png)
