### PR TITLE
Fix st2timersengine screen session typo in launchdev

### DIFF
--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -285,7 +285,7 @@ function st2start(){
 
     # Run the timer engine server
     echo 'Starting screen session st2-timersengine...'
-    screen -d -m -S st2-rulesengine ./virtualenv/bin/python \
+    screen -d -m -S st2-timersengine ./virtualenv/bin/python \
         ./st2reactor/bin/st2timersengine \
         --config-file $ST2_CONF
 


### PR DESCRIPTION
Fix the name of the screen session for st2-timersengine otherwise launchdev complains that st2timersengine did not start.