### PR TITLE
Fix cascade of workflow user context to orquesta tasks

### DIFF
--- a/contrib/runners/orquesta_runner/tests/unit/test_basic.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_basic.py
@@ -99,6 +99,7 @@ class OrquestaRunnerTest(st2tests.DbTestCase):
         return runners.get_runner(runner_name, runner_name).__class__
 
     def test_run_workflow(self):
+        username = 'stanley'
         wf_meta = base.get_wf_fixture_meta_data(TEST_PACK_PATH, 'sequential.yaml')
         wf_input = {'who': 'Thanos'}
         lv_ac_db = lv_db_models.LiveActionDB(action=wf_meta['name'], parameters=wf_input)
@@ -129,7 +130,7 @@ class OrquestaRunnerTest(st2tests.DbTestCase):
                 'workflow_execution_id': str(wf_ex_db.id),
                 'action_execution_id': str(ac_ex_db.id),
                 'api_url': 'http://127.0.0.1/v1',
-                'user': 'stanley'
+                'user': username
             }
         }
 
@@ -163,6 +164,7 @@ class OrquestaRunnerTest(st2tests.DbTestCase):
         tk1_ex_db = wf_db_access.TaskExecution.query(**query_filters)[0]
         tk1_ac_ex_db = ex_db_access.ActionExecution.query(task_execution=str(tk1_ex_db.id))[0]
         tk1_lv_ac_db = lv_db_access.LiveAction.get_by_id(tk1_ac_ex_db.liveaction['id'])
+        self.assertEqual(tk1_lv_ac_db.context.get('user'), username)
         self.assertEqual(tk1_lv_ac_db.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
         self.assertTrue(wf_svc.is_action_execution_under_workflow_context(tk1_ac_ex_db))
 
@@ -180,6 +182,7 @@ class OrquestaRunnerTest(st2tests.DbTestCase):
         tk2_ex_db = wf_db_access.TaskExecution.query(**query_filters)[0]
         tk2_ac_ex_db = ex_db_access.ActionExecution.query(task_execution=str(tk2_ex_db.id))[0]
         tk2_lv_ac_db = lv_db_access.LiveAction.get_by_id(tk2_ac_ex_db.liveaction['id'])
+        self.assertEqual(tk2_lv_ac_db.context.get('user'), username)
         self.assertEqual(tk2_lv_ac_db.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
         self.assertTrue(wf_svc.is_action_execution_under_workflow_context(tk2_ac_ex_db))
 
@@ -197,6 +200,7 @@ class OrquestaRunnerTest(st2tests.DbTestCase):
         tk3_ex_db = wf_db_access.TaskExecution.query(**query_filters)[0]
         tk3_ac_ex_db = ex_db_access.ActionExecution.query(task_execution=str(tk3_ex_db.id))[0]
         tk3_lv_ac_db = lv_db_access.LiveAction.get_by_id(tk3_ac_ex_db.liveaction['id'])
+        self.assertEqual(tk3_lv_ac_db.context.get('user'), username)
         self.assertEqual(tk3_lv_ac_db.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
         self.assertTrue(wf_svc.is_action_execution_under_workflow_context(tk3_ac_ex_db))
 

--- a/st2common/st2common/services/workflows.py
+++ b/st2common/st2common/services/workflows.py
@@ -813,7 +813,8 @@ def request_next_tasks(wf_ex_db, task_ex_id=None):
         for task in next_tasks:
             try:
                 LOG.info('[%s] Requesting execution for task "%s".', wf_ac_ex_id, task['id'])
-                st2_ctx = {'execution_id': wf_ex_db.action_execution}
+                root_st2_ctx = wf_ex_db.context.get('st2', {})
+                st2_ctx = {'execution_id': wf_ac_ex_id, 'user': root_st2_ctx.get('user')}
                 request_task_execution(wf_ex_db, st2_ctx, task)
             except Exception as e:
                 LOG.exception('[%s] Failed task execution for "%s".', wf_ac_ex_id, task['id'])


### PR DESCRIPTION
The orquesta workflow user context is not cascaded down to the tasks which lead to failure in accessing user content via the action service in python actions. This fix takes the user context from the workflow execution and pass it to the task execution and subsequently setting the user context in the liveaction.