### PR TITLE
Various Python 3 related fixes and changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -69,6 +69,12 @@ Fixed
   CLI incorrectly tried to parse that string as unicode escape sequence.
 
   Reported by James E. King III @jeking3 (bug fix) #4407
+* Fix a bug so ``timersengine`` config section in ``st2.conf`` has precedence over ``timer``
+  section if explicitly specified in the config file.
+
+  Also fix a bug with default config values for ``timer`` section being used if user only
+  specified ``timersengine`` section in the config. Previously user options were incorrectly
+  ignored in favor of the default values. (bug fix) #4424
 
 2.9.1 - October 03, 2018
 ------------------------

--- a/Makefile
+++ b/Makefile
@@ -829,6 +829,7 @@ ci-py3-unit:
 	@echo "==================== ci-py3-unit ===================="
 	@echo
 	NOSE_WITH_TIMER=$(NOSE_WITH_TIMER) tox -e py36-unit -vv
+	NOSE_WITH_TIMER=$(NOSE_WITH_TIMER) tox -e py36-packs -vv
 
 .PHONY: ci-py3-integration
 ci-py3-integration: requirements .ci-prepare-integration .ci-py3-integration

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ else
 	VIRTUALENV_ST2CLIENT_DIR ?= virtualenv-st2client
 endif
 
-PYTHON_VERSION = python2.7
+PYTHON_VERSION ?= python2.7
 
 BINARIES := bin
 
@@ -45,8 +45,6 @@ COMPONENTS_TEST_MODULES_COMMA := $(subst $(space_char),$(comma),$(COMPONENTS_TES
 
 COVERAGE_GLOBS := .coverage.unit.* .coverage.integration.* .coverage.mistral.*
 COVERAGE_GLOBS_QUOTED := $(foreach glob,$(COVERAGE_GLOBS),'$(glob)')
-
-PYTHON_TARGET := 2.7
 
 REQUIREMENTS := test-requirements.txt requirements.txt
 PIP_OPTIONS := $(ST2_PIP_OPTIONS)

--- a/conf/st2.conf.sample
+++ b/conf/st2.conf.sample
@@ -325,12 +325,12 @@ ssh_key_file = /home/stanley/.ssh/stanley_rsa
 user = stanley
 
 [timer]
-# Specify to enable timer service.
-enable = True
-# Timezone pertaining to the location where st2 is run.
-local_timezone = America/Los_Angeles
-# Location of the logging configuration file.
-logging = /etc/st2/logging.timersengine.conf
+# Specify to enable timer service. NOTE: Deprecated in favor of timersengine.enable
+enable = None
+# Timezone pertaining to the location where st2 is run. NOTE: Deprecated in favor of timersengine.local_timezone
+local_timezone = None
+# Location of the logging configuration file. NOTE: Deprecated in favor of timersengine.logging
+logging = None
 
 [timersengine]
 # Specify to enable timer service.

--- a/contrib/packs/tests/test_action_download.py
+++ b/contrib/packs/tests/test_action_download.py
@@ -107,7 +107,7 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
     def test_run_pack_download(self):
         action = self.get_action_instance()
         result = action.run(packs=['test'], abs_repo_base=self.repo_base)
-        temp_dir = hashlib.md5(PACK_INDEX['test']['repo_url']).hexdigest()
+        temp_dir = hashlib.md5(PACK_INDEX['test']['repo_url'].encode()).hexdigest()
 
         self.assertEqual(result, {'test': 'Success.'})
         self.clone_from.assert_called_once_with(PACK_INDEX['test']['repo_url'],
@@ -131,8 +131,8 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
         action = self.get_action_instance()
         result = action.run(packs=['test', 'test2'], abs_repo_base=self.repo_base)
         temp_dirs = [
-            hashlib.md5(PACK_INDEX['test']['repo_url']).hexdigest(),
-            hashlib.md5(PACK_INDEX['test2']['repo_url']).hexdigest()
+            hashlib.md5(PACK_INDEX['test']['repo_url'].encode()).hexdigest(),
+            hashlib.md5(PACK_INDEX['test2']['repo_url'].encode()).hexdigest()
         ]
 
         self.assertEqual(result, {'test': 'Success.', 'test2': 'Success.'})
@@ -160,7 +160,7 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
 
     def test_run_pack_lock_is_already_acquired(self):
         action = self.get_action_instance()
-        temp_dir = hashlib.md5(PACK_INDEX['test']['repo_url']).hexdigest()
+        temp_dir = hashlib.md5(PACK_INDEX['test']['repo_url'].encode()).hexdigest()
 
         original_acquire = LockFile.acquire
 
@@ -186,7 +186,7 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
     def test_run_pack_lock_is_already_acquired_force_flag(self):
         # Lock is already acquired but force is true so it should be deleted and released
         action = self.get_action_instance()
-        temp_dir = hashlib.md5(PACK_INDEX['test']['repo_url']).hexdigest()
+        temp_dir = hashlib.md5(PACK_INDEX['test']['repo_url'].encode()).hexdigest()
 
         original_acquire = LockFile.acquire
 

--- a/st2actions/st2actions/notifier/scheduler.py
+++ b/st2actions/st2actions/notifier/scheduler.py
@@ -37,7 +37,8 @@ LOG = logging.getLogger(__name__)
 
 
 def get_rescheduler():
-    timer = BlockingScheduler()
+    local_tz = cfg.CONF.timer.local_timezone or cfg.CONF.timersengine.local_timezone
+    timer = BlockingScheduler(timezone=local_tz)
 
     time_spec = {
         'seconds': cfg.CONF.scheduler.rescheduling_interval,

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -571,7 +571,8 @@ def register_opts(ignore_errors=False):
     timer_logging_opts = [
         cfg.StrOpt(
             'logging', default=None,
-            help='Location of the logging configuration file.')
+            help='Location of the logging configuration file. '
+                 'NOTE: Deprecated in favor of timersengine.logging'),
     ]
 
     timers_engine_logging_opts = [
@@ -589,10 +590,12 @@ def register_opts(ignore_errors=False):
     timer_opts = [
         cfg.StrOpt(
             'local_timezone', default=None,
-            help='Timezone pertaining to the location where st2 is run.'),
+            help='Timezone pertaining to the location where st2 is run. '
+                 'NOTE: Deprecated in favor of timersengine.local_timezone'),
         cfg.BoolOpt(
             'enable', default=None,
-            help='Specify to enable timer service.')
+            help='Specify to enable timer service. '
+                 'NOTE: Deprecated in favor of timersengine.enable'),
     ]
 
     timers_engine_opts = [

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -568,16 +568,34 @@ def register_opts(ignore_errors=False):
     do_register_opts(metrics_opts, group='metrics', ignore_errors=ignore_errors)
 
     # Common timers engine options
-    logging_opts = [
+    timer_logging_opts = [
+        cfg.StrOpt(
+            'logging', default=None,
+            help='Location of the logging configuration file.')
+    ]
+
+    timers_engine_logging_opts = [
         cfg.StrOpt(
             'logging', default='/etc/st2/logging.timersengine.conf',
             help='Location of the logging configuration file.')
     ]
 
-    do_register_opts(logging_opts, group='timer', ignore_errors=ignore_errors)
-    do_register_opts(logging_opts, group='timersengine', ignore_errors=ignore_errors)
+    do_register_opts(timer_logging_opts, group='timer', ignore_errors=ignore_errors)
+    do_register_opts(timers_engine_logging_opts, group='timersengine', ignore_errors=ignore_errors)
 
+    # NOTE: We default old style deprecated "timer" options to None so our code
+    # works correclty and "timersengine" has precedence over "timers"
+    # NOTE: "timer" section will be removed in v3.1
     timer_opts = [
+        cfg.StrOpt(
+            'local_timezone', default=None,
+            help='Timezone pertaining to the location where st2 is run.'),
+        cfg.BoolOpt(
+            'enable', default=None,
+            help='Specify to enable timer service.')
+    ]
+
+    timers_engine_opts = [
         cfg.StrOpt(
             'local_timezone', default='America/Los_Angeles',
             help='Timezone pertaining to the location where st2 is run.'),
@@ -585,9 +603,8 @@ def register_opts(ignore_errors=False):
             'enable', default=True,
             help='Specify to enable timer service.')
     ]
-
     do_register_opts(timer_opts, group='timer', ignore_errors=ignore_errors)
-    do_register_opts(timer_opts, group='timersengine', ignore_errors=ignore_errors)
+    do_register_opts(timers_engine_opts, group='timersengine', ignore_errors=ignore_errors)
 
 
 def parse_args(args=None):

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -567,6 +567,28 @@ def register_opts(ignore_errors=False):
 
     do_register_opts(metrics_opts, group='metrics', ignore_errors=ignore_errors)
 
+    # Common timers engine options
+    logging_opts = [
+        cfg.StrOpt(
+            'logging', default='/etc/st2/logging.timersengine.conf',
+            help='Location of the logging configuration file.')
+    ]
+
+    do_register_opts(logging_opts, group='timer', ignore_errors=ignore_errors)
+    do_register_opts(logging_opts, group='timersengine', ignore_errors=ignore_errors)
+
+    timer_opts = [
+        cfg.StrOpt(
+            'local_timezone', default='America/Los_Angeles',
+            help='Timezone pertaining to the location where st2 is run.'),
+        cfg.BoolOpt(
+            'enable', default=True,
+            help='Specify to enable timer service.')
+    ]
+
+    do_register_opts(timer_opts, group='timer', ignore_errors=ignore_errors)
+    do_register_opts(timer_opts, group='timersengine', ignore_errors=ignore_errors)
+
 
 def parse_args(args=None):
     register_opts()

--- a/st2common/st2common/models/db/trace.py
+++ b/st2common/st2common/models/db/trace.py
@@ -99,14 +99,14 @@ class TraceDB(stormbase.StormFoundationDB, stormbase.UIDFieldMixin):
         parts = []
         parts.append(self.RESOURCE_TYPE)
 
-        componenets_hash = hashlib.md5()
-        componenets_hash.update(str(self.trace_tag).encode())
-        componenets_hash.update(str(self.trigger_instances).encode())
-        componenets_hash.update(str(self.rules).encode())
-        componenets_hash.update(str(self.action_executions).encode())
-        componenets_hash.update(str(self.start_timestamp).encode())
+        components_hash = hashlib.md5()
+        components_hash.update(str(self.trace_tag).encode())
+        components_hash.update(str(self.trigger_instances).encode())
+        components_hash.update(str(self.rules).encode())
+        components_hash.update(str(self.action_executions).encode())
+        components_hash.update(str(self.start_timestamp).encode())
 
-        parts.append(componenets_hash.hexdigest())
+        parts.append(components_hash.hexdigest())
 
         uid = self.UID_SEPARATOR.join(parts)
         return uid

--- a/st2common/st2common/util/pack_management.py
+++ b/st2common/st2common/util/pack_management.py
@@ -96,7 +96,7 @@ def download_pack(pack, abs_repo_base='/opt/stackstorm/packs', verify_ssl=True, 
 
     result = [pack_url, None, None]
 
-    temp_dir_name = hashlib.md5(pack_url).hexdigest()
+    temp_dir_name = hashlib.md5(pack_url.encode()).hexdigest()
     lock_file = LockFile('/tmp/%s' % (temp_dir_name))
     lock_file_path = lock_file.lock_file
 

--- a/st2reactor/st2reactor/garbage_collector/base.py
+++ b/st2reactor/st2reactor/garbage_collector/base.py
@@ -132,21 +132,22 @@ class GarbageCollectorService(object):
 
         # Note: We sleep for a bit between garbage collection of each object type to prevent busy
         # waiting
-        if self._action_executions_ttl >= MINIMUM_TTL_DAYS:
+        if self._action_executions_ttl and self._action_executions_ttl >= MINIMUM_TTL_DAYS:
             self._purge_action_executions()
             eventlet.sleep(self._sleep_delay)
         else:
             LOG.debug('Skipping garbage collection for action executions since it\'s not '
                       'configured')
 
-        if self._action_executions_output_ttl >= MINIMUM_TTL_DAYS_EXECUTION_OUTPUT:
+        if self._action_executions_output_ttl and \
+                self._action_executions_output_ttl >= MINIMUM_TTL_DAYS_EXECUTION_OUTPUT:
             self._purge_action_executions_output()
             eventlet.sleep(self._sleep_delay)
         else:
             LOG.debug('Skipping garbage collection for action executions output since it\'s not '
                       'configured')
 
-        if self._trigger_instances_ttl >= MINIMUM_TTL_DAYS:
+        if self._trigger_instances_ttl and self._trigger_instances_ttl >= MINIMUM_TTL_DAYS:
             self._purge_trigger_instances()
             eventlet.sleep(self._sleep_delay)
         else:

--- a/st2reactor/st2reactor/timer/config.py
+++ b/st2reactor/st2reactor/timer/config.py
@@ -31,7 +31,6 @@ def parse_args(args=None):
 
 def register_opts():
     _register_common_opts()
-    _register_timers_engine_opts()
 
 
 def get_logging_config_path():
@@ -40,32 +39,6 @@ def get_logging_config_path():
 
 def _register_common_opts():
     common_config.register_opts()
-
-
-def _register_timers_engine_opts():
-    # We want backward compatibility with configuration. So register logging configuration options
-    # under ``timer`` section as well as ``timersengine``.
-    logging_opts = [
-        cfg.StrOpt(
-            'logging', default='/etc/st2/logging.timersengine.conf',
-            help='Location of the logging configuration file.')
-    ]
-
-    CONF.register_opts(logging_opts, group='timer')
-    CONF.register_opts(logging_opts, group='timersengine')
-
-    timer_opts = [
-        cfg.StrOpt(
-            'local_timezone', default='America/Los_Angeles',
-            help='Timezone pertaining to the location where st2 is run.'),
-        cfg.BoolOpt(
-            'enable', default=True,
-            help='Specify to enable timer service.')
-    ]
-
-    CONF.register_opts(timer_opts, group='timer')
-    CONF.register_opts(timer_opts, group='timersengine')
-    CONF.register_opts(logging_opts, group='timersengine')
 
 
 register_opts()

--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -402,7 +402,7 @@ function st2stop(){
     fi
 
     if [ "${use_gunicorn}" = true ]; then
-        pids=`ps -ef | grep "gunicorn_config.py" | awk '{print $2}'`
+        pids=`ps -ef | grep "wsgi:application" | awk '{print $2}'`
         if [ -n "$pids" ]; then
             echo "Killing gunicorn processes"
             # true ensures that any failure to kill a process which does not exist will not lead

--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -59,10 +59,14 @@ function init(){
         ST2_REPO=${CURRENT_DIR}/${COMMAND_PATH}/..
     fi
 
-    VENV=${ST2_REPO}/virtualenv
+    VIRTUALENV=${VIRTUALENV:-${ST2_REPO}/virtualenv}
+
+    VENV=${VIRTUALENV}
     PY=${VENV}/bin/python
+    PYTHON_VERSION=$(${PY} --version 2>&1)
+
     echo "Using virtualenv: ${VENV}"
-    echo "Using python: ${PY}"
+    echo "Using python: ${PY} (${PYTHON_VERSION})"
 
     if [ -z "$ST2_CONF" ]; then
         ST2_CONF=${ST2_REPO}/conf/st2.dev.conf

--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -60,12 +60,10 @@ function init(){
     fi
 
     VIRTUALENV=${VIRTUALENV:-${ST2_REPO}/virtualenv}
-
-    VENV=${VIRTUALENV}
-    PY=${VENV}/bin/python
+    PY=${VIRTUALENV}/bin/python
     PYTHON_VERSION=$(${PY} --version 2>&1)
 
-    echo "Using virtualenv: ${VENV}"
+    echo "Using virtualenv: ${VIRTUALENV}"
     echo "Using python: ${PY} (${PYTHON_VERSION})"
 
     if [ -z "$ST2_CONF" ]; then
@@ -155,7 +153,7 @@ function st2start(){
     # that this script is located under st2/tools.
 
     # Change working directory to the root of the repo.
-    echo "Changing working directory to ${ST2_REPO}..."
+    echo "Changing working directory to ${ST2_REPO}"
     cd ${ST2_REPO}
 
     BASE_DIR=$(grep 'base_path' ${ST2_CONF} \
@@ -209,7 +207,7 @@ function st2start(){
     fi
 
     # activate virtualenv to set PYTHONPATH
-    source ./virtualenv/bin/activate
+    source ${VIRTUALENV}/bin/activate
 
     # Kill existing st2 screens
     screen -wipe
@@ -230,10 +228,10 @@ function st2start(){
     if [ "${use_gunicorn}" = true ]; then
         echo '  using gunicorn to run st2-api...'
         export ST2_CONFIG_PATH=${ST2_CONF}
-        screen -d -m -S st2-api ./virtualenv/bin/gunicorn \
+        screen -d -m -S st2-api ${VIRTUALENV}/bin/gunicorn \
             st2api.wsgi:application -k eventlet -b "$BINDING_ADDRESS:9101" --workers 1
     else
-        screen -d -m -S st2-api ./virtualenv/bin/python \
+        screen -d -m -S st2-api ${VIRTUALENV}/bin/python \
             ./st2api/bin/st2api \
             --config-file $ST2_CONF
     fi
@@ -242,17 +240,17 @@ function st2start(){
     if [ "${use_gunicorn}" = true ]; then
         echo '  using gunicorn to run st2-stream'
         export ST2_CONFIG_PATH=${ST2_CONF}
-        screen -d -m -S st2-stream ./virtualenv/bin/gunicorn \
+        screen -d -m -S st2-stream ${VIRTUALENV}/bin/gunicorn \
             st2stream.wsgi:application -k eventlet -b "$BINDING_ADDRESS:9102" --workers 1
     else
-        screen -d -m -S st2-stream ./virtualenv/bin/python \
+        screen -d -m -S st2-stream ${VIRTUALENV}/bin/python \
             ./st2stream/bin/st2stream \
             --config-file $ST2_CONF
     fi
 
     # Run the workflow engine server
     echo 'Starting screen session st2-workflow'
-    screen -d -m -S st2-workflow ./virtualenv/bin/python \
+    screen -d -m -S st2-workflow ${VIRTUALENV}/bin/python \
         ./st2actions/bin/st2workflowengine \
         --config-file $ST2_CONF
 
@@ -264,44 +262,44 @@ function st2start(){
         RUNNER_NAME=st2-actionrunner-$i
         RUNNER_SCREENS+=($RUNNER_NAME)
         echo '  starting '$RUNNER_NAME'...'
-        screen -d -m -S $RUNNER_NAME ./virtualenv/bin/python \
+        screen -d -m -S $RUNNER_NAME ${VIRTUALENV}/bin/python \
             ./st2actions/bin/st2actionrunner \
             --config-file $ST2_CONF
     done
 
     # Run the scheduler server
     echo 'Starting screen session st2-scheduler'
-    screen -d -m -S st2-scheduler ./virtualenv/bin/python \
+    screen -d -m -S st2-scheduler ${VIRTUALENV}/bin/python \
         ./st2actions/bin/st2scheduler \
         --config-file $ST2_CONF
 
     # Run the sensor container server
     echo 'Starting screen session st2-sensorcontainer'
-    screen -d -m -S st2-sensorcontainer ./virtualenv/bin/python \
+    screen -d -m -S st2-sensorcontainer ${VIRTUALENV}/bin/python \
         ./st2reactor/bin/st2sensorcontainer \
         --config-file $ST2_CONF
 
     # Run the rules engine server
     echo 'Starting screen session st2-rulesengine...'
-    screen -d -m -S st2-rulesengine ./virtualenv/bin/python \
+    screen -d -m -S st2-rulesengine ${VIRTUALENV}/bin/python \
         ./st2reactor/bin/st2rulesengine \
         --config-file $ST2_CONF
 
     # Run the timer engine server
     echo 'Starting screen session st2-timersengine...'
-    screen -d -m -S st2-timersengine ./virtualenv/bin/python \
+    screen -d -m -S st2-timersengine ${VIRTUALENV}/bin/python \
         ./st2reactor/bin/st2timersengine \
         --config-file $ST2_CONF
 
     # Run the results tracker
     echo 'Starting screen session st2-resultstracker...'
-    screen -d -m -S st2-resultstracker ./virtualenv/bin/python \
+    screen -d -m -S st2-resultstracker ${VIRTUALENV}/bin/python \
         ./st2actions/bin/st2resultstracker \
         --config-file $ST2_CONF
 
     # Run the actions notifier
     echo 'Starting screen session st2-notifier...'
-    screen -d -m -S st2-notifier ./virtualenv/bin/python \
+    screen -d -m -S st2-notifier ${VIRTUALENV}/bin/python \
         ./st2actions/bin/st2notifier \
         --config-file $ST2_CONF
 
@@ -310,10 +308,10 @@ function st2start(){
     if [ "${use_gunicorn}" = true ]; then
         echo '  using gunicorn to run st2-auth...'
         export ST2_CONFIG_PATH=${ST2_CONF}
-        screen -d -m -S st2-auth ./virtualenv/bin/gunicorn \
+        screen -d -m -S st2-auth ${VIRTUALENV}/bin/gunicorn \
             st2auth.wsgi:application -k eventlet -b "$BINDING_ADDRESS:9100" --workers 1
     else
-        screen -d -m -S st2-auth ./virtualenv/bin/python \
+        screen -d -m -S st2-auth ${VIRTUALENV}/bin/python \
             ./st2auth/bin/st2auth \
             --config-file $ST2_CONF
     fi
@@ -324,7 +322,7 @@ function st2start(){
         sudo mkdir -p $EXPORTS_DIR
         sudo chown -R ${CURRENT_USER}:${CURRENT_USER_GROUP} $EXPORTS_DIR
         echo 'Starting screen session st2-exporter...'
-        screen -d -m -S st2-exporter ./virtualenv/bin/python \
+        screen -d -m -S st2-exporter ${VIRTUALENV}/bin/python \
             ./st2exporter/bin/st2exporter \
             --config-file $ST2_CONF
     fi
@@ -381,7 +379,7 @@ function st2start(){
     if [ "$load_content" = true ]; then
         # Register contents
         echo 'Registering sensors, runners, actions, rules, aliases, and policies...'
-        ./virtualenv/bin/python \
+        ${VIRTUALENV}/bin/python \
             ./st2common/bin/st2-register-content \
             --config-file $ST2_CONF --register-all
     fi
@@ -419,7 +417,7 @@ function st2stop(){
 
 function st2clean(){
     # clean mongo
-    . ${VENV}/bin/activate
+    . ${VIRTUALENV}/bin/activate
     python ${ST2_REPO}/st2common/bin/st2-cleanup-db --config-file $ST2_CONF
     deactivate
 

--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -267,6 +267,12 @@ function st2start(){
             --config-file $ST2_CONF
     done
 
+    # Run the garbage collector service
+    echo 'Starting screen session st2-garbagecollector'
+    screen -d -m -S st2-garbagecollector ${VIRTUALENV}/bin/python \
+        ./st2reactor/bin/st2garbagecollector \
+        --config-file $ST2_CONF
+
     # Run the scheduler server
     echo 'Starting screen session st2-scheduler'
     screen -d -m -S st2-scheduler ${VIRTUALENV}/bin/python \
@@ -360,6 +366,7 @@ function st2start(){
         "st2-auth"
         "st2-timersengine"
         "st2-scheduler"
+        "st2-garbagecollector"
     )
 
     if [ "${include_mistral}" = true ]; then

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ deps = virtualenv
        -e{toxinidir}/st2client
        -e{toxinidir}/st2common
 commands =
+    st2-run-pack-tests -c -t -x -p contrib/packs
     nosetests --rednose --immediate -sv st2actions/tests/unit/
     nosetests --rednose --immediate -sv st2auth/tests/unit/
     nosetests --rednose --immediate -sv st2api/tests/unit/controllers/v1/
@@ -52,6 +53,26 @@ commands =
     nosetests --rednose --immediate -sv contrib/runners/python_runner/tests/unit/
     nosetests --rednose --immediate -sv contrib/runners/windows_runner/tests/unit/
     nosetests --rednose --immediate -sv contrib/runners/winrm_runner/tests/unit/
+
+# Python 3 tasks
+[testenv:py36-packs]
+basepython = python3.6
+setenv = PYTHONPATH = {toxinidir}/external:{toxinidir}/st2common:{toxinidir}/st2api:{toxinidir}/st2actions:{toxinidir}/st2exporter:{toxinidir}/st2reactor:{toxinidir}/st2tests:{toxinidir}/contrib/runners/action_chain_runner:{toxinidir}/contrib/runners/local_runner:{toxinidir}/contrib/runners/windows_runner:{toxinidir}/contrib/runners/python_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/noop_runner:{toxinidir}/contrib/runners/announcement_runner:{toxinidir}/contrib/runners/remote_runner:{toxinidir}/contrib/runners/remote_runner:{toxinidir}/contrib/runners/mistral_v2:{toxinidir}/contrib/runners/orquesta_runner:{toxinidir}/contrib/runners/inquirer_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/cloudslang_runner:{toxinidir}/contrib/runners/winrm_runner
+         VIRTUALENV_DIR = {envdir}
+passenv = NOSE_WITH_TIMER TRAVIS
+install_command = pip install -U --force-reinstall {opts} {packages}
+deps = virtualenv
+       -r{toxinidir}/requirements.txt
+       -e{toxinidir}/st2client
+       -e{toxinidir}/st2common
+commands =
+    st2-run-pack-tests -c -t -x -p contrib/packs
+    st2-run-pack-tests -c -t -x -p contrib/core
+    st2-run-pack-tests -c -t -x -p contrib/default
+    st2-run-pack-tests -c -t -x -p contrib/chatops
+    st2-run-pack-tests -c -t -x -p contrib/examples
+    st2-run-pack-tests -c -t -x -p contrib/linux
+    st2-run-pack-tests -c -t -x -p contrib/hello_st2
 
 [testenv:py36-integration]
 basepython = python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,6 @@ deps = virtualenv
        -e{toxinidir}/st2client
        -e{toxinidir}/st2common
 commands =
-    st2-run-pack-tests -c -t -x -p contrib/packs
     nosetests --rednose --immediate -sv st2actions/tests/unit/
     nosetests --rednose --immediate -sv st2auth/tests/unit/
     nosetests --rednose --immediate -sv st2api/tests/unit/controllers/v1/


### PR DESCRIPTION
I uncovered some more Python 3 related issues while working on Bionic pacakges.

This pull request includes the following changes / fixes:

1. Add missing ``st2garbagecollector`` service to launchdev script
2. Fix launchdev script so it actually uses `VIRTUALENV` environment variable - this allows people to use it with a Python 3 virtual environment
3. Fix ``st2-pack-install`` so it works under Python 3
4. Make sure we run pack tests on Travis under Python 3
5. Correctly pass ``timezone`` kwarg to ``BlockingScheduler`` class constructor