### PR TITLE
Add tests for unicode input to Orquesta workflows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -82,6 +82,7 @@ Fixed
   existing ``st2 pack show -j``.
 
   Reported by Nick Maludy (improvement) #4260
+* Fix string operations on unicode data in Orquest workflows. (bug fix)
 
 2.9.1 - October 03, 2018
 ------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -82,7 +82,8 @@ Fixed
   existing ``st2 pack show -j``.
 
   Reported by Nick Maludy (improvement) #4260
-* Fix string operations on unicode data in Orquest workflows. (bug fix)
+* Fix string operations on unicode data in Orquest workflows, associated with PR
+  https://github.com/StackStorm/orquesta/pull/98. (bug fix)
 
 2.9.1 - October 03, 2018
 ------------------------

--- a/contrib/runners/orquesta_runner/in-requirements.txt
+++ b/contrib/runners/orquesta_runner/in-requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/StackStorm/orquesta.git@73e06ae056914ccb17cf4a7ac3c5c8e78568c8cb#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@251d72113bd0586bc57529d340d0e62c8e575943#egg=orquesta

--- a/contrib/runners/orquesta_runner/in-requirements.txt
+++ b/contrib/runners/orquesta_runner/in-requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/StackStorm/orquesta.git@142a19ddabbeea6a8d9d10341ba70585114dc3b7#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@73e06ae056914ccb17cf4a7ac3c5c8e78568c8cb#egg=orquesta

--- a/contrib/runners/orquesta_runner/requirements.txt
+++ b/contrib/runners/orquesta_runner/requirements.txt
@@ -1,2 +1,2 @@
 # Don't edit this file. It's generated automatically!
-git+https://github.com/StackStorm/orquesta.git@142a19ddabbeea6a8d9d10341ba70585114dc3b7#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@73e06ae056914ccb17cf4a7ac3c5c8e78568c8cb#egg=orquesta

--- a/contrib/runners/orquesta_runner/requirements.txt
+++ b/contrib/runners/orquesta_runner/requirements.txt
@@ -1,2 +1,2 @@
 # Don't edit this file. It's generated automatically!
-git+https://github.com/StackStorm/orquesta.git@73e06ae056914ccb17cf4a7ac3c5c8e78568c8cb#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@251d72113bd0586bc57529d340d0e62c8e575943#egg=orquesta

--- a/contrib/runners/orquesta_runner/tests/unit/test_basic.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_basic.py
@@ -18,6 +18,7 @@
 from __future__ import absolute_import
 
 import mock
+import six
 
 from orquesta import states as wf_states
 
@@ -283,10 +284,8 @@ class OrquestaRunnerTest(st2tests.DbTestCase):
         self.assertEqual(ac_ex_db.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
 
         # Check workflow output.
-        expected_output = {
-            'msg': '%s, All your base are belong to us!' % wf_input['who'].decode('utf-8')
-        }
-
+        wf_input_val = wf_input['who'].decode('utf-8') if six.PY2 else wf_input['who']
+        expected_output = {'msg': '%s, All your base are belong to us!' % wf_input_val}
         self.assertDictEqual(wf_ex_db.output, expected_output)
 
         # Check liveaction and action execution result.

--- a/contrib/runners/orquesta_runner/tests/unit/test_basic.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_basic.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Licensed to the StackStorm, Inc ('StackStorm') under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -226,6 +228,64 @@ class OrquestaRunnerTest(st2tests.DbTestCase):
 
         # Check workflow output.
         expected_output = {'msg': '%s, All your base are belong to us!' % wf_input['who']}
+
+        self.assertDictEqual(wf_ex_db.output, expected_output)
+
+        # Check liveaction and action execution result.
+        expected_result = {'output': expected_output}
+
+        self.assertDictEqual(lv_ac_db.result, expected_result)
+        self.assertDictEqual(ac_ex_db.result, expected_result)
+
+    def test_run_workflow_with_unicode_input(self):
+        wf_meta = base.get_wf_fixture_meta_data(TEST_PACK_PATH, 'sequential.yaml')
+        wf_input = {'who': '薩諾斯'}
+        lv_ac_db = lv_db_models.LiveActionDB(action=wf_meta['name'], parameters=wf_input)
+        lv_ac_db, ac_ex_db = ac_svc.request(lv_ac_db)
+        wf_ex_db = wf_db_access.WorkflowExecution.query(action_execution=str(ac_ex_db.id))[0]
+
+        # Process task1.
+        query_filters = {'workflow_execution': str(wf_ex_db.id), 'task_id': 'task1'}
+        tk1_ex_db = wf_db_access.TaskExecution.query(**query_filters)[0]
+        tk1_ac_ex_db = ex_db_access.ActionExecution.query(task_execution=str(tk1_ex_db.id))[0]
+        tk1_lv_ac_db = lv_db_access.LiveAction.get_by_id(tk1_ac_ex_db.liveaction['id'])
+        self.assertEqual(tk1_lv_ac_db.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
+        wf_svc.handle_action_execution_completion(tk1_ac_ex_db)
+        tk1_ex_db = wf_db_access.TaskExecution.get_by_id(tk1_ex_db.id)
+        self.assertEqual(tk1_ex_db.status, wf_states.SUCCEEDED)
+
+        # Process task2.
+        query_filters = {'workflow_execution': str(wf_ex_db.id), 'task_id': 'task2'}
+        tk2_ex_db = wf_db_access.TaskExecution.query(**query_filters)[0]
+        tk2_ac_ex_db = ex_db_access.ActionExecution.query(task_execution=str(tk2_ex_db.id))[0]
+        tk2_lv_ac_db = lv_db_access.LiveAction.get_by_id(tk2_ac_ex_db.liveaction['id'])
+        self.assertEqual(tk2_lv_ac_db.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
+        wf_svc.handle_action_execution_completion(tk2_ac_ex_db)
+        tk2_ex_db = wf_db_access.TaskExecution.get_by_id(tk2_ex_db.id)
+        self.assertEqual(tk2_ex_db.status, wf_states.SUCCEEDED)
+
+        # Process task3.
+        query_filters = {'workflow_execution': str(wf_ex_db.id), 'task_id': 'task3'}
+        tk3_ex_db = wf_db_access.TaskExecution.query(**query_filters)[0]
+        tk3_ac_ex_db = ex_db_access.ActionExecution.query(task_execution=str(tk3_ex_db.id))[0]
+        tk3_lv_ac_db = lv_db_access.LiveAction.get_by_id(tk3_ac_ex_db.liveaction['id'])
+        self.assertEqual(tk3_lv_ac_db.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
+        wf_svc.handle_action_execution_completion(tk3_ac_ex_db)
+        tk3_ex_db = wf_db_access.TaskExecution.get_by_id(tk3_ex_db.id)
+        self.assertEqual(tk3_ex_db.status, wf_states.SUCCEEDED)
+
+        # Assert workflow is completed.
+        wf_ex_db = wf_db_access.WorkflowExecution.get_by_id(wf_ex_db.id)
+        self.assertEqual(wf_ex_db.status, wf_states.SUCCEEDED)
+        lv_ac_db = lv_db_access.LiveAction.get_by_id(str(lv_ac_db.id))
+        self.assertEqual(lv_ac_db.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
+        ac_ex_db = ex_db_access.ActionExecution.get_by_id(str(ac_ex_db.id))
+        self.assertEqual(ac_ex_db.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
+
+        # Check workflow output.
+        expected_output = {
+            'msg': '%s, All your base are belong to us!' % wf_input['who'].decode('utf-8')
+        }
 
         self.assertDictEqual(wf_ex_db.output, expected_output)
 

--- a/contrib/runners/orquesta_runner/tests/unit/test_error_handling.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_error_handling.py
@@ -159,7 +159,10 @@ class OrquestaErrorHandlingTest(st2tests.DbTestCase):
     def test_fail_input_rendering(self):
         expected_errors = [
             {
-                'message': 'Unknown function "#property#value"'
+                'message': (
+                    'Unable to evaluate expression \'<% abs(4).value %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#value"'
+                )
             }
         ]
 
@@ -188,7 +191,10 @@ class OrquestaErrorHandlingTest(st2tests.DbTestCase):
     def test_fail_vars_rendering(self):
         expected_errors = [
             {
-                'message': 'Unknown function "#property#value"'
+                'message': (
+                    'Unable to evaluate expression \'<% abs(4).value %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#value"'
+                )
             }
         ]
 
@@ -217,7 +223,10 @@ class OrquestaErrorHandlingTest(st2tests.DbTestCase):
     def test_fail_start_task_action(self):
         expected_errors = [
             {
-                'message': 'Unknown function "#property#value"',
+                'message': (
+                    'Unable to evaluate expression \'<% ctx().func.value %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#value"'
+                ),
                 'task_id': 'task1'
             }
         ]
@@ -247,7 +256,10 @@ class OrquestaErrorHandlingTest(st2tests.DbTestCase):
     def test_fail_start_task_input_expr_eval(self):
         expected_errors = [
             {
-                'message': 'Unknown function "#property#value"',
+                'message': (
+                    'Unable to evaluate expression \'<% ctx().msg1.value %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#value"'
+                ),
                 'task_id': 'task1'
             }
         ]
@@ -316,7 +328,10 @@ class OrquestaErrorHandlingTest(st2tests.DbTestCase):
     def test_fail_next_task_action(self):
         expected_errors = [
             {
-                'message': 'Unknown function "#property#value"',
+                'message': (
+                    'Unable to evaluate expression \'<% ctx().func.value %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#value"'
+                ),
                 'task_id': 'task2'
             }
         ]
@@ -356,7 +371,10 @@ class OrquestaErrorHandlingTest(st2tests.DbTestCase):
     def test_fail_next_task_input_expr_eval(self):
         expected_errors = [
             {
-                'message': 'Unknown function "#property#value"',
+                'message': (
+                    'Unable to evaluate expression \'<% ctx().msg2.value %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#value"'
+                ),
                 'task_id': 'task2'
             }
         ]
@@ -530,7 +548,10 @@ class OrquestaErrorHandlingTest(st2tests.DbTestCase):
     def test_fail_task_publish(self):
         expected_errors = [
             {
-                'message': 'Unknown function "foobar"',
+                'message': (
+                    'Unable to evaluate expression \'<% foobar() %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "foobar"'
+                ),
                 'task_transition_id': 'task2__0',
                 'task_id': 'task1'
             }
@@ -570,7 +591,10 @@ class OrquestaErrorHandlingTest(st2tests.DbTestCase):
     def test_fail_output_rendering(self):
         expected_errors = [
             {
-                'message': 'Unknown function "#property#value"'
+                'message': (
+                    'Unable to evaluate expression \'<% abs(4).value %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#value"'
+                )
             }
         ]
 

--- a/contrib/runners/orquesta_runner/tests/unit/test_functions_task.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_functions_task.py
@@ -196,7 +196,10 @@ class OrquestaFunctionTest(st2tests.DbTestCase):
 
         expected_errors = [
             {
-                'message': 'Unable to find task execution for "task0".',
+                'message': (
+                    'Unable to evaluate expression \'<% task("task0") %>\'. '
+                    'ExpressionEvaluationException: Unable to find task execution for "task0".'
+                ),
                 'task_transition_id': 'noop__0',
                 'task_id': 'task1'
             }
@@ -219,7 +222,10 @@ class OrquestaFunctionTest(st2tests.DbTestCase):
 
         expected_errors = [
             {
-                'message': 'Unable to find task execution for "task0".',
+                'message': (
+                    'Unable to evaluate expression \'{{ task("task0") }}\'. '
+                    'ExpressionEvaluationException: Unable to find task execution for "task0".'
+                ),
                 'task_transition_id': 'noop__0',
                 'task_id': 'task1'
             }

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ eventlet==0.24.1
 flex==6.13.2
 git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper
 git+https://github.com/StackStorm/mongoengine.git@stackstorm_patched#egg=mongoengine
-git+https://github.com/StackStorm/orquesta.git@73e06ae056914ccb17cf4a7ac3c5c8e78568c8cb#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@251d72113bd0586bc57529d340d0e62c8e575943#egg=orquesta
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
 gitpython==2.1.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ eventlet==0.24.1
 flex==6.13.2
 git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper
 git+https://github.com/StackStorm/mongoengine.git@stackstorm_patched#egg=mongoengine
-git+https://github.com/StackStorm/orquesta.git@142a19ddabbeea6a8d9d10341ba70585114dc3b7#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@73e06ae056914ccb17cf4a7ac3c5c8e78568c8cb#egg=orquesta
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
 gitpython==2.1.11

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -12,7 +12,7 @@ kombu
 # See https://github.com/MongoEngine/mongoengine/pull/1833
 git+https://github.com/StackStorm/mongoengine.git@stackstorm_patched#egg=mongoengine
 networkx
-git+https://github.com/StackStorm/orquesta.git@142a19ddabbeea6a8d9d10341ba70585114dc3b7#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@73e06ae056914ccb17cf4a7ac3c5c8e78568c8cb#egg=orquesta
 oslo.config
 paramiko
 pyyaml

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -12,7 +12,7 @@ kombu
 # See https://github.com/MongoEngine/mongoengine/pull/1833
 git+https://github.com/StackStorm/mongoengine.git@stackstorm_patched#egg=mongoengine
 networkx
-git+https://github.com/StackStorm/orquesta.git@73e06ae056914ccb17cf4a7ac3c5c8e78568c8cb#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@251d72113bd0586bc57529d340d0e62c8e575943#egg=orquesta
 oslo.config
 paramiko
 pyyaml

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -4,7 +4,7 @@ cryptography==2.3.1
 eventlet==0.24.1
 flex==6.13.2
 git+https://github.com/StackStorm/mongoengine.git@stackstorm_patched#egg=mongoengine
-git+https://github.com/StackStorm/orquesta.git@142a19ddabbeea6a8d9d10341ba70585114dc3b7#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@73e06ae056914ccb17cf4a7ac3c5c8e78568c8cb#egg=orquesta
 greenlet==0.4.15
 ipaddr
 jinja2

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -4,7 +4,7 @@ cryptography==2.3.1
 eventlet==0.24.1
 flex==6.13.2
 git+https://github.com/StackStorm/mongoengine.git@stackstorm_patched#egg=mongoengine
-git+https://github.com/StackStorm/orquesta.git@73e06ae056914ccb17cf4a7ac3c5c8e78568c8cb#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@251d72113bd0586bc57529d340d0e62c8e575943#egg=orquesta
 greenlet==0.4.15
 ipaddr
 jinja2

--- a/st2tests/integration/orquesta/test_wiring_data_flow.py
+++ b/st2tests/integration/orquesta/test_wiring_data_flow.py
@@ -57,6 +57,22 @@ class WiringTest(base.TestWorkflowExecution):
         self.assertEqual(ex.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
         self.assertDictEqual(ex.result, expected_result)
 
+    def test_data_flow_unicode_concat_with_ascii(self):
+        wf_name = 'examples.orquesta-sequential'
+        wf_input = {'name': '薩諾斯'}
+
+        expected_output = {
+            'greeting': '%s, All your base are belong to us!' % wf_input['name'].decode('utf-8')
+        }
+
+        expected_result = {'output': expected_output}
+
+        ex = self._execute_workflow(wf_name, wf_input)
+        ex = self._wait_for_completion(ex)
+
+        self.assertEqual(ex.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertDictEqual(ex.result, expected_result)
+
     def test_data_flow_big_data_size(self):
         wf_name = 'examples.orquesta-data-flow'
 

--- a/st2tests/integration/orquesta/test_wiring_data_flow.py
+++ b/st2tests/integration/orquesta/test_wiring_data_flow.py
@@ -18,6 +18,7 @@
 from __future__ import absolute_import
 
 import random
+import six
 import string
 
 from integration.orquesta import base
@@ -45,8 +46,8 @@ class WiringTest(base.TestWorkflowExecution):
         wf_input = {'a1': '床前明月光 疑是地上霜 舉頭望明月 低頭思故鄉'}
 
         expected_output = {
-            'a5': wf_input['a1'].decode('utf-8'),
-            'b5': wf_input['a1'].decode('utf-8')
+            'a5': wf_input['a1'].decode('utf-8') if six.PY2 else wf_input['a1'],
+            'b5': wf_input['a1'].decode('utf-8') if six.PY2 else wf_input['a1']
         }
 
         expected_result = {'output': expected_output}
@@ -62,7 +63,9 @@ class WiringTest(base.TestWorkflowExecution):
         wf_input = {'name': '薩諾斯'}
 
         expected_output = {
-            'greeting': '%s, All your base are belong to us!' % wf_input['name'].decode('utf-8')
+            'greeting': '%s, All your base are belong to us!' % (
+                wf_input['name'].decode('utf-8') if six.PY2 else wf_input['name']
+            )
         }
 
         expected_result = {'output': expected_output}

--- a/st2tests/integration/orquesta/test_wiring_error_handling.py
+++ b/st2tests/integration/orquesta/test_wiring_error_handling.py
@@ -69,21 +69,46 @@ class ErrorHandlingTest(base.TestWorkflowExecution):
         self.assertDictEqual(ex.result, {'errors': expected_errors, 'output': None})
 
     def test_input_error(self):
-        expected_errors = [{'message': 'Unknown function "#property#value"'}]
+        expected_errors = [
+            {
+                'message': (
+                    'Unable to evaluate expression \'<% abs(8).value %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#value"'
+                ),
+            }
+        ]
+
         ex = self._execute_workflow('examples.orquesta-fail-input-rendering')
         ex = self._wait_for_completion(ex)
         self.assertEqual(ex.status, ac_const.LIVEACTION_STATUS_FAILED)
         self.assertDictEqual(ex.result, {'errors': expected_errors, 'output': None})
 
     def test_vars_error(self):
-        expected_errors = [{'message': 'Unknown function "#property#value"'}]
+        expected_errors = [
+            {
+                'message': (
+                    'Unable to evaluate expression \'<% abs(8).value %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#value"'
+                )
+            }
+        ]
+
         ex = self._execute_workflow('examples.orquesta-fail-vars-rendering')
         ex = self._wait_for_completion(ex)
         self.assertEqual(ex.status, ac_const.LIVEACTION_STATUS_FAILED)
         self.assertDictEqual(ex.result, {'errors': expected_errors, 'output': None})
 
     def test_start_task_error(self):
-        expected_errors = [{'message': 'Unknown function "#property#value"', 'task_id': 'task1'}]
+        expected_errors = [
+            {
+                'message': (
+                    'Unable to evaluate expression \'<% ctx().name.value %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#value"'
+                ),
+                'task_id': 'task1'
+            }
+        ]
+
         ex = self._execute_workflow('examples.orquesta-fail-start-task')
         ex = self._wait_for_completion(ex)
         self.assertEqual(ex.status, ac_const.LIVEACTION_STATUS_FAILED)
@@ -124,7 +149,15 @@ class ErrorHandlingTest(base.TestWorkflowExecution):
         self.assertDictEqual(ex.result, {'errors': expected_errors, 'output': None})
 
     def test_output_error(self):
-        expected_errors = [{'message': 'Unknown function "#property#value"'}]
+        expected_errors = [
+            {
+                'message': (
+                    'Unable to evaluate expression \'<% abs(8).value %>\'. '
+                    'NoFunctionRegisteredException: Unknown function "#property#value"'
+                )
+            }
+        ]
+
         ex = self._execute_workflow('examples.orquesta-fail-output-rendering')
         ex = self._wait_for_completion(ex)
         self.assertEqual(ex.status, ac_const.LIVEACTION_STATUS_FAILED)

--- a/st2tests/integration/orquesta/test_wiring_functions_task.py
+++ b/st2tests/integration/orquesta/test_wiring_functions_task.py
@@ -61,7 +61,10 @@ class FunctionsWiringTest(base.TestWorkflowExecution):
 
         expected_errors = [
             {
-                'message': 'Unable to find task execution for "task0".',
+                'message': (
+                    'Unable to evaluate expression \'<% task("task0") %>\'. '
+                    'ExpressionEvaluationException: Unable to find task execution for "task0".'
+                ),
                 'task_transition_id': 'noop__0',
                 'task_id': 'task1'
             }
@@ -83,7 +86,10 @@ class FunctionsWiringTest(base.TestWorkflowExecution):
 
         expected_errors = [
             {
-                'message': 'Unable to find task execution for "task0".',
+                'message': (
+                    'Unable to evaluate expression \'{{ task("task0") }}\'. '
+                    'ExpressionEvaluationException: Unable to find task execution for "task0".'
+                ),
                 'task_transition_id': 'noop__0',
                 'task_id': 'task1'
             }

--- a/tox.ini
+++ b/tox.ini
@@ -94,5 +94,5 @@ commands =
     nosetests --rednose --immediate -sv contrib/runners/local_runner/tests/integration/
     nosetests --rednose --immediate -sv contrib/runners/mistral_v2/tests/integration/
     nosetests --rednose --immediate -sv contrib/runners/orquesta_runner/tests/integration/
-	nosetests --rednose --immediate -sv st2tests/integration/orquesta/
+    nosetests --rednose --immediate -sv st2tests/integration/orquesta/
     nosetests --rednose --immediate -sv contrib/runners/python_runner/tests/integration/

--- a/tox.ini
+++ b/tox.ini
@@ -94,4 +94,5 @@ commands =
     nosetests --rednose --immediate -sv contrib/runners/local_runner/tests/integration/
     nosetests --rednose --immediate -sv contrib/runners/mistral_v2/tests/integration/
     nosetests --rednose --immediate -sv contrib/runners/orquesta_runner/tests/integration/
+	nosetests --rednose --immediate -sv st2tests/integration/orquesta/
     nosetests --rednose --immediate -sv contrib/runners/python_runner/tests/integration/


### PR DESCRIPTION
Add tests to ensure input with unicode data is processed and output correctly in Orquesta workflows.