### PR TITLE
Stop raising Python exception when execution result is disabled.

### DIFF
--- a/contrib/chatops/CHANGES.md
+++ b/contrib/chatops/CHANGES.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.1] - 2018-11-06
+### Added
+- `note` to `post_result` output to inform if the action-alias execution result was enabled or disabled.
+
+### Changed
+- Ported `post_result` action-chain to orquesta for conditional branching.
+
 ## 0.3.0
 
 - Introduce the following new actions:

--- a/contrib/chatops/actions/format_execution_result.py
+++ b/contrib/chatops/actions/format_execution_result.py
@@ -26,7 +26,7 @@ class FormatResultAction(Action):
             'execution': execution
         }
         template = self.default_template
-        result = {}
+        result = {"enabled": True}
 
         alias_id = execution['context'].get('action_alias_ref', {}).get('id', None)
         if alias_id:
@@ -39,11 +39,12 @@ class FormatResultAction(Action):
             result_params = getattr(alias, 'result', None)
             if result_params:
                 if not result_params.get('enabled', True):
-                    raise Exception("Output of this template is disabled.")
-                if 'format' in alias.result:
-                    template = alias.result['format']
-                if 'extra' in alias.result:
-                    result['extra'] = jinja_utils.render_values(alias.result['extra'], context)
+                    result["enabled"] = False
+                else:
+                    if 'format' in alias.result:
+                        template = alias.result['format']
+                    if 'extra' in alias.result:
+                        result['extra'] = jinja_utils.render_values(alias.result['extra'], context)
 
         result['message'] = self.jinja.from_string(template).render(context)
 

--- a/contrib/chatops/actions/post_result.yaml
+++ b/contrib/chatops/actions/post_result.yaml
@@ -1,7 +1,7 @@
 ---
 name: "post_result"
 pack: chatops
-runner_type: "action-chain"
+runner_type: "orquesta"
 description: "Post an execution result to stream for chatops"
 enabled: true
 entry_point: "workflows/post_result.yaml"

--- a/contrib/chatops/actions/workflows/post_result.yaml
+++ b/contrib/chatops/actions/workflows/post_result.yaml
@@ -1,20 +1,47 @@
----
-chain:
-  -
-    name: "format_execution_result"
-    ref: "chatops.format_execution_result"
-    parameters:
-      execution_id: "{{execution_id}}"
-    publish:
-      message: "{{format_execution_result.result.message}}"
-      extra: "{% if 'extra' in format_execution_result.result %}{{format_execution_result.result.extra}}{% else %}{}{% endif %}"
-    on-success: "post_message"
-  -
-    name: "post_message"
-    ref: "chatops.post_message"
-    parameters:
-      user: "{{user}}"
-      channel: "{{channel}}"
-      whisper: "{{whisper}}"
-      message: "{{message}}"
-      extra: "{{extra}}"
+version: 1.0
+
+description: "Post an execution result to stream for chatops"
+
+input:
+  - user
+  - whisper
+  - execution_id
+  - channel
+
+tasks:
+    format_execution_result:
+      action: chatops.format_execution_result
+      input:
+        execution_id: "{{ ctx('execution_id') }}"
+      next:
+        -
+          when: "{{ result().result.enabled == true }}"
+          publish:
+            - message: "{{ result().result.message }}"
+            - extra: "{% if 'extra' in result().result %}{{ result().result.extra }}{% else %}{}{% endif %}"
+          do:
+            - post_message
+        -
+          when: "{{ result().result.enabled == false }}"
+          do:
+            - result_disabled
+
+    post_message:
+      action: chatops.post_message
+      input:
+        user: "{{ ctx('user') }}"
+        channel: "{{ ctx('channel') }}"
+        whisper: "{{ ctx('whisper') }}"
+        message: "{{ ctx('message') }}"
+        extra: "{{ ctx('extra') }}"
+      next:
+        - publish:
+            - msg: "Execution result has been posted."
+
+    result_disabled:
+      action: core.noop
+      next:
+        - publish:
+            - msg: "Execution result is disabled."
+output:
+  - note: "{{ ctx('msg') }}"

--- a/contrib/chatops/pack.yaml
+++ b/contrib/chatops/pack.yaml
@@ -1,8 +1,9 @@
 ---
 name: chatops
 description: ChatOps integration pack
-version: 1.0.0
+version: 1.0.1
 author: StackStorm, Inc.
 contributors:
   - Anthony Shaw <anthonyshaw@apache.org>
+  - Carlos <nzlosh@yahoo.com>
 email: info@stackstorm.com


### PR DESCRIPTION
The ChatOps pack is used to format execution results.  When the action-alias metadata is configured to disable execution result being returned to the chat backend, an exception is raised in `format_execution_result` which causes the action to be marked as failed.

The failed task and back track are unexpected and confusing because the action is following the requested behaviour of the user.  It seems more logical to have the action succeed even when execution_results are disabled in the action-alias metadata and simply not post the result back to the chat backend in this case.

This PR implements this behaviour with the following changes:

- Stop raising Python exception when execution result is disabled in action-alias.
- Port post_result to orquesta for conditional branching to decide to post the execution result or not.
- Bumped version to 1.0.1