### PR TITLE
More Python 3 fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,13 +282,13 @@ clean: .cleanpycs
 compile:
 	@echo "======================= compile ========================"
 	@echo "------- Compile all .py files (syntax check test - Python 2) ------"
-	@if python -c 'import compileall,re; compileall.compile_dir(".", rx=re.compile(r"/virtualenv|virtualenv-osx|.tox"), quiet=True)' | grep .; then exit 1; else exit 0; fi
+	@if python -c 'import compileall,re; compileall.compile_dir(".", rx=re.compile(r"/virtualenv|virtualenv-osx|virtualenv-py3|.tox|.git"), quiet=True)' | grep .; then exit 1; else exit 0; fi
 
 .PHONY: compilepy3
 compilepy3:
 	@echo "======================= compile ========================"
 	@echo "------- Compile all .py files (syntax check test - Python 3) ------"
-	@if python3 -c 'import compileall,re; compileall.compile_dir(".", rx=re.compile(r"/virtualenv|virtualenv-osx|.tox|./st2tests/st2tests/fixtures/packs/test"), quiet=True)' | grep .; then exit 1; else exit 0; fi
+	@if python3 -c 'import compileall,re; compileall.compile_dir(".", rx=re.compile(r"/virtualenv|virtualenv-osx|virtualenv-py3|.tox|.git|./st2tests/st2tests/fixtures/packs/test"), quiet=True)' | grep .; then exit 1; else exit 0; fi
 
 .PHONY: .cleanpycs
 .cleanpycs:

--- a/contrib/examples/requirements.txt
+++ b/contrib/examples/requirements.txt
@@ -1,2 +1,3 @@
 requests
 beautifulsoup4
+flask

--- a/contrib/examples/sensors/echo_flask_app.py
+++ b/contrib/examples/sensors/echo_flask_app.py
@@ -30,7 +30,7 @@ class EchoFlaskSensor(Sensor):
 
         self._log.info('Listening for payload on http://{}:{}{}'.format(
             self._host, self._port, self._path))
-        self._app.run(host=self._host, port=self._port, threaded=True)
+        self._app.run(host=self._host, port=self._port, threaded=False)
 
     def cleanup(self):
         pass

--- a/contrib/examples/sensors/fibonacci_sensor.py
+++ b/contrib/examples/sensors/fibonacci_sensor.py
@@ -1,6 +1,6 @@
-from st2reactor.sensor.base import PollingSensor
+import os
 
-from environ import get_environ
+from st2reactor.sensor.base import PollingSensor
 
 
 class FibonacciSensor(PollingSensor):
@@ -30,7 +30,7 @@ class FibonacciSensor(PollingSensor):
         payload = {
             "count": self.count,
             "fibonacci": fib,
-            "pythonpath": get_environ("PYTHONPATH")
+            "pythonpath": os.environ.get("PYTHONPATH", None)
         }
 
         self.sensor_service.dispatch(trigger="examples.fibonacci", payload=payload)

--- a/st2common/bin/st2-run-pack-tests
+++ b/st2common/bin/st2-run-pack-tests
@@ -259,7 +259,7 @@ TESTS_PYTHON_PATH=()
 # 1. Add PYTHONPATH from StackStorm packages virtualenv (only applies when running on server when
 # StackStorm is installed using packages)
 if [ -f "${STACKSTORM_VIRTUALENV_PYTHON_BINARY}" ]; then
-    ST2_PYTHONPATH=$(${STACKSTORM_VIRTUALENV_PYTHON_BINARY} -c "import sys;print ':'.join([x for x in sys.path if x.strip()])")
+    ST2_PYTHONPATH=$(${STACKSTORM_VIRTUALENV_PYTHON_BINARY} -c "import sys;print(':'.join([x for x in sys.path if x.strip()]))")
     verbose_log "Adding entries from StackStorm virtualenv to PYTHONPATH: ${ST2_PYTHONPATH}"
 
     TESTS_PYTHON_PATH+=("${ST2_PYTHONPATH}")

--- a/st2common/bin/st2-self-check
+++ b/st2common/bin/st2-self-check
@@ -66,10 +66,10 @@ if [[ `id -u` != 0 ]]; then
   exit 1
 fi
 
-# Ubuntu Bionic packages ship without Mistral
-SUBTYPE=$(lsb_release -a 2>&1 | grep Codename | grep -v "LSB" | awk '{print $2}')
+# Installations which use Python 3 (e.g. Ubuntu Bionic) ship without Mistral
+PYTHON_VERSION=$(/opt/stackstorm/st2/bin/python --version 2>&1 | awk '{print $2'} | awk -F"." '{print $1}')
 
-if [ "${SUBTYPE}" = "bionic" ]; then
+if [ "${PYTHON_VERSION}" = "3" ]; then
     RUN_MISTRAL_TESTS=false
 fi
 

--- a/st2common/bin/st2-self-check
+++ b/st2common/bin/st2-self-check
@@ -66,6 +66,13 @@ if [[ `id -u` != 0 ]]; then
   exit 1
 fi
 
+# Ubuntu Bionic packages ship without Mistral
+SUBTYPE=$(lsb_release -a 2>&1 | grep Codename | grep -v "LSB" | awk '{print $2}')
+
+if [ "${SUBTYPE}" = "bionic" ]; then
+    RUN_MISTRAL_TESTS=false
+fi
+
 ERRORS=0
 PACKS="tests examples"
 

--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -17,7 +17,7 @@
 COMPONENTS="st2actionrunner st2api st2stream st2auth st2garbagecollector st2notifier st2resultstracker st2rulesengine st2sensorcontainer st2chatops st2timersengine st2workflowengine st2scheduler mistral"
 ST2_CONF="/etc/st2/st2.conf"
 
-# Ubuntu Bionic packages skip without Mistral
+# Ubuntu Bionic packages ship without Mistral
 SUBTYPE=$(lsb_release -a 2>&1 | grep Codename | grep -v "LSB" | awk '{print $2}')
 
 if [ "${SUBTYPE}" = "bionic" ]; then

--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -17,6 +17,13 @@
 COMPONENTS="st2actionrunner st2api st2stream st2auth st2garbagecollector st2notifier st2resultstracker st2rulesengine st2sensorcontainer st2chatops st2timersengine st2workflowengine st2scheduler mistral"
 ST2_CONF="/etc/st2/st2.conf"
 
+# Ubuntu Bionic packages skip without Mistral
+SUBTYPE=$(lsb_release -a 2>&1 | grep Codename | grep -v "LSB" | awk '{print $2}')
+
+if [ "${SUBTYPE}" = "bionic" ]; then
+    COMPONENTS=${COMPONENTS/mistral}
+fi
+
 # Ensure global environment is sourced if exists
 # Does not happen consistently with all OSes we support.
 [ -r /etc/environment ] && source /etc/environment

--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -17,10 +17,10 @@
 COMPONENTS="st2actionrunner st2api st2stream st2auth st2garbagecollector st2notifier st2resultstracker st2rulesengine st2sensorcontainer st2chatops st2timersengine st2workflowengine st2scheduler mistral"
 ST2_CONF="/etc/st2/st2.conf"
 
-# Ubuntu Bionic packages ship without Mistral
-SUBTYPE=$(lsb_release -a 2>&1 | grep Codename | grep -v "LSB" | awk '{print $2}')
+# Installations which use Python 3 (e.g. Ubuntu Bionic) ship without Mistral
+PYTHON_VERSION=$(/opt/stackstorm/st2/bin/python --version 2>&1 | awk '{print $2'} | awk -F"." '{print $1}')
 
-if [ "${SUBTYPE}" = "bionic" ]; then
+if [ "${PYTHON_VERSION}" = "3" ]; then
     COMPONENTS=${COMPONENTS/mistral}
 fi
 

--- a/st2common/st2common/util/monkey_patch.py
+++ b/st2common/st2common/util/monkey_patch.py
@@ -31,17 +31,23 @@ USE_DEBUGGER_FLAG = '--use-debugger'
 PARENT_ARGS_FLAG = '--parent-args='
 
 
-def monkey_patch():
+def monkey_patch(patch_thread=None):
     """
     Function which performs eventlet monkey patching and also takes into account "--use-debugger"
     argument in the command line arguments.
 
     If this argument is found, no monkey patching is performed for the thread module. This allows
     user to use remote debuggers.
+
+    :param patch_thread: True to also patch the thread module. If not provided, thread module is
+                         patched unless debugger is used.
+    :type patch_thread: ``bool``
     """
     import eventlet
 
-    patch_thread = not is_use_debugger_flag_provided()
+    if patch_thread is None:
+        patch_thread = not is_use_debugger_flag_provided()
+
     eventlet.monkey_patch(os=True, select=True, socket=True, thread=patch_thread, time=True)
 
 


### PR DESCRIPTION
Python 3 related fixes for various issues which were discovered by new Ubuntu Bionic packages which use Python 3.

* Fix st2-run-pack-tests so it works under Python 3
* Fix various code so it works under Python 3
* Disable threaded mode for flask dev server in example sensor since it blocks the event loop (I noticed this via other sensor which also uses flask dev server which is used by self check)
* Update ``st2ctl`` and ``st2-self-check`` to take into account that Mistral is not present on Ubuntu Bionic. Per our discussion with Slack, I decided to go with a simple distro check. We can adjust / improve that in the future, when we drop support for Mistral in other distros.