### PR TITLE
[WIP] Add test for using action_context in Jinja expressions within action metadata

### DIFF
--- a/contrib/examples/actions/orquesta-action-context.yaml
+++ b/contrib/examples/actions/orquesta-action-context.yaml
@@ -1,0 +1,7 @@
+---
+name: orquesta-action-context
+description: >
+  A sample workflow demonstrating use of st2 runtime context in action metadata
+runner_type: orquesta
+entry_point: workflows/orquesta-action-context.yaml
+enabled: true

--- a/contrib/examples/actions/orquesta-jinja-expr-in-action-metadata.yaml
+++ b/contrib/examples/actions/orquesta-jinja-expr-in-action-metadata.yaml
@@ -1,0 +1,14 @@
+---
+name: orquesta-jinja-expr-in-action-metadata
+description: >
+  Helper action for orquesta-action-context workflow. This action uses a Jinja
+  expression to calculate a default value for an immutable parameter. This
+  tests that the action_context is properly being passed in.
+  This action is inspired by st2cd.create_vm_role.
+runner_type: orquesta
+entry_point: workflows/orquesta-jinja-expr-in-action-metadata.yaml
+enabled: true
+parameters:
+  immutable_default_user:
+    type: string
+    default: "{{ 'api_user' in action_context and action_context.api_user or action_context.user }}"

--- a/contrib/examples/actions/workflows/orquesta-action-context.yaml
+++ b/contrib/examples/actions/workflows/orquesta-action-context.yaml
@@ -1,0 +1,7 @@
+---
+version: '1.0'
+description: >
+  A sample workflow demonstrating use of st2 runtime context in action metadata
+tasks:
+  echo_user:
+    action: examples.orquesta-jinja-expr-in-action-metadata

--- a/contrib/examples/actions/workflows/orquesta-jinja-expr-in-action-metadata.yaml
+++ b/contrib/examples/actions/workflows/orquesta-jinja-expr-in-action-metadata.yaml
@@ -1,0 +1,12 @@
+---
+version: '1.0'
+description: >
+  Test that Jinja expressions containing action_context references are properly
+  passed to Orquesta workflows
+input:
+  immutable_default_user
+tasks:
+  echo_user:
+    action: core.local
+    input:
+      cmd: echo <% ctx().immutable_default_user %>

--- a/st2tests/integration/orquesta/test_wiring.py
+++ b/st2tests/integration/orquesta/test_wiring.py
@@ -104,8 +104,8 @@ class WiringTest(base.TestWorkflowExecution):
         expected_output = ''
         expected_result = {'output': expected_output}
 
-        self.assertEqual(ex.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
         self.assertDictEqual(ex.result, expected_result)
+        self.assertEqual(ex.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
 
     def test_subworkflow(self):
         wf_name = 'examples.orquesta-subworkflow'

--- a/st2tests/integration/orquesta/test_wiring.py
+++ b/st2tests/integration/orquesta/test_wiring.py
@@ -95,6 +95,18 @@ class WiringTest(base.TestWorkflowExecution):
         self.assertEqual(ex.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
         self.assertDictEqual(ex.result, expected_result)
 
+    def test_action_context(self):
+        wf_name = 'examples.orquesta-action-context'
+
+        ex = self._execute_workflow(wf_name)
+        ex = self._wait_for_completion(ex)
+
+        expected_output = ''
+        expected_result = {'output': expected_output}
+
+        self.assertEqual(ex.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertDictEqual(ex.result, expected_result)
+
     def test_subworkflow(self):
         wf_name = 'examples.orquesta-subworkflow'
 


### PR DESCRIPTION
This PR exposes an issue where Orquesta does not expose the `action_context` to an action parameter that uses a Jinja expression: `Failed to render parameter "immutable_default_user": 'dict object' has no attribute 'user'`

That feature is used in [`st2cd.create_vm_role`](https://github.com/StackStorm/st2cd/blob/master/actions/create_vm_role.meta.yaml#L43) (ignore the weird indentation - that's from the YAML file itself):

```yaml
---
  name: "create_vm_role"
  runner_type: "mistral-v2"
  description: "Create a VM, add DNS, bootstrap puppet"
  enabled: true
  entry_point: "workflows/create_vm_role.yaml"
  parameters:
    ...
    creator:
      type: "string"
      default: "{{ 'api_user' in action_context and action_context.api_user or action_context.user }}"
immutable: true
```

The WF is currently successfully run by Mistral, but my Orquesta migration is running into this issue.

[Link](https://travis-ci.org/StackStorm/st2/jobs/453126614#L5996) to the exact error in the Travis log.