### PR TITLE
[WIP] Add new API endpoint which allows user to write arbitrary files to the pack directory on disk

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ Added
 
   Contributed by @aduca85 #4373
 * Add new ``POST /api/v1/packs/{ref_or_id}/files`` API endpoint which allows user to write
-  arbitrary files into the pack directory. (new feature)
+  arbitrary files into the pack directory. (new feature) #4440
 
 Changed
 ~~~~~~~
@@ -54,8 +54,8 @@ Changed
   argument (same as before). (improvement) #4396
 * Update various internal dependencies to latest stable versions (greenlet, pymongo, pytz,
   stevedore, tooz). #4410
-
-* Improve ``st2.conf`` migration for the new services by using prod-friendly logging settings by default #4415
+* Improve ``st2.conf`` migration for the new services by using prod-friendly logging settings by
+  default. #4415
 
 Fixed
 ~~~~~
@@ -88,7 +88,7 @@ Fixed
   https://github.com/StackStorm/orquesta/pull/98. (bug fix) #4426
 * Fix ``PackDB`` model and ensure ``files`` attribute value is always sorted and stable. Previously
   we didn't sort the value so even if the list of pack files wouldn't change on disk, value of this
-  attribute could change during ``st2-register-content`` script runs.
+  attribute could change during ``st2-register-content`` script runs. #4440
 
 2.9.1 - October 03, 2018
 ------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Added
   Response protocol) for older servers.
 
   Contributed by @aduca85 #4373
+* Add new ``POST /api/v1/packs/{ref_or_id}/files`` API endpoint which allows user to write
+  arbitrary files into the pack directory. (new feature)
 
 Changed
 ~~~~~~~
@@ -83,7 +85,10 @@ Fixed
 
   Reported by Nick Maludy (improvement) #4260
 * Fix string operations on unicode data in Orquest workflows, associated with PR
-  https://github.com/StackStorm/orquesta/pull/98. (bug fix)
+  https://github.com/StackStorm/orquesta/pull/98. (bug fix) #4426
+* Fix ``PackDB`` model and ensure ``files`` attribute value is always sorted and stable. Previously
+  we didn't sort the value so even if the list of pack files wouldn't change on disk, value of this
+  attribute could change during ``st2-register-content`` script runs.
 
 2.9.1 - October 03, 2018
 ------------------------

--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -159,6 +159,7 @@ class ActionsController(ContentPackResourceController, BaseDataFilesController):
         written_data_files = []
         if data_files:
             written_data_files = self._handle_data_files(pack_ref=action.pack,
+                                                         resource_type='action',
                                                          data_files=data_files)
 
         try:

--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -114,9 +114,9 @@ class ActionsController(ContentPackResourceController, BaseDataFilesController):
         data_files = getattr(action, 'data_files', [])
         written_data_files = []
         if data_files:
-            written_data_files = self._handle_data_files(pack_ref=action.pack,
-                                                         resource_type='action',
-                                                         data_files=data_files)
+            written_data_files, _ = self._handle_data_files(pack_ref=action.pack,
+                                                            resource_type='action',
+                                                            data_files=data_files)
 
         action_model = ActionAPI.to_model(action)
 
@@ -158,9 +158,9 @@ class ActionsController(ContentPackResourceController, BaseDataFilesController):
         data_files = getattr(action, 'data_files', [])
         written_data_files = []
         if data_files:
-            written_data_files = self._handle_data_files(pack_ref=action.pack,
-                                                         resource_type='action',
-                                                         data_files=data_files)
+            written_data_files, _ = self._handle_data_files(pack_ref=action.pack,
+                                                            resource_type='action',
+                                                            data_files=data_files)
 
         try:
             action_db = ActionAPI.to_model(action)

--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import os.path
-
 import six
 from mongoengine import ValidationError
 
@@ -23,33 +20,32 @@ from mongoengine import ValidationError
 #       that bubble up to this layer should be core Python exceptions or
 #       StackStorm defined exceptions.
 
-from st2api.controllers import resource
+from st2api.controllers.resource import ContentPackResourceController
 from st2api.controllers.v1.action_views import ActionViewsController
+from st2api.controllers.v1.data_files import BaseDataFilesController
 from st2common import log as logging
-from st2common.constants.triggers import ACTION_FILE_WRITTEN_TRIGGER
 from st2common.exceptions.action import InvalidActionParameterException
 from st2common.exceptions.apivalidation import ValueValidationException
 from st2common.persistence.action import Action
 from st2common.models.api.action import ActionAPI
-from st2common.persistence.pack import Pack
 from st2common.rbac.types import PermissionType
 from st2common.rbac import utils as rbac_utils
 from st2common.router import abort
 from st2common.router import Response
 from st2common.validators.api.misc import validate_not_part_of_system_pack
-from st2common.content.utils import get_pack_base_path
-from st2common.content.utils import get_pack_resource_file_abs_path
-from st2common.content.utils import get_relative_path_to_pack
 from st2common.transport.reactor import TriggerDispatcher
-from st2common.util.system_info import get_host_info
 import st2common.validators.api.action as action_validator
+
+__all__ = [
+    'ActionsController'
+]
 
 http_client = six.moves.http_client
 
 LOG = logging.getLogger(__name__)
 
 
-class ActionsController(resource.ContentPackResourceController):
+class ActionsController(ContentPackResourceController, BaseDataFilesController):
     """
         Implements the RESTful web endpoint that handles
         the lifecycle of Actions in the system.
@@ -119,6 +115,7 @@ class ActionsController(resource.ContentPackResourceController):
         written_data_files = []
         if data_files:
             written_data_files = self._handle_data_files(pack_ref=action.pack,
+                                                         resource_type='action',
                                                          data_files=data_files)
 
         action_model = ActionAPI.to_model(action)
@@ -222,93 +219,6 @@ class ActionsController(resource.ContentPackResourceController):
         extra = {'action_db': action_db}
         LOG.audit('Action deleted. Action.id=%s' % (action_db.id), extra=extra)
         return Response(status=http_client.NO_CONTENT)
-
-    def _handle_data_files(self, pack_ref, data_files):
-        """
-        Method for handling action data files.
-
-        This method performs two tasks:
-
-        1. Writes files to disk
-        2. Updates affected PackDB model
-        """
-        # Write files to disk
-        written_file_paths = self._write_data_files_to_disk(pack_ref=pack_ref,
-                                                            data_files=data_files)
-
-        # Update affected PackDB model (update a list of files)
-        # Update PackDB
-        self._update_pack_model(pack_ref=pack_ref, data_files=data_files,
-                                written_file_paths=written_file_paths)
-
-        return written_file_paths
-
-    def _write_data_files_to_disk(self, pack_ref, data_files):
-        """
-        Write files to disk.
-        """
-        written_file_paths = []
-
-        for data_file in data_files:
-            file_path = data_file['file_path']
-            content = data_file['content']
-
-            file_path = get_pack_resource_file_abs_path(pack_ref=pack_ref,
-                                                        resource_type='action',
-                                                        file_path=file_path)
-
-            LOG.debug('Writing data file "%s" to "%s"' % (str(data_file), file_path))
-            self._write_data_file(pack_ref=pack_ref, file_path=file_path, content=content)
-            written_file_paths.append(file_path)
-
-        return written_file_paths
-
-    def _update_pack_model(self, pack_ref, data_files, written_file_paths):
-        """
-        Update PackDB models (update files list).
-        """
-        file_paths = []  # A list of paths relative to the pack directory for new files
-        for file_path in written_file_paths:
-            file_path = get_relative_path_to_pack(pack_ref=pack_ref, file_path=file_path)
-            file_paths.append(file_path)
-
-        pack_db = Pack.get_by_ref(pack_ref)
-        pack_db.files = set(pack_db.files)
-        pack_db.files.update(set(file_paths))
-        pack_db.files = list(pack_db.files)
-        pack_db = Pack.add_or_update(pack_db)
-
-        return pack_db
-
-    def _write_data_file(self, pack_ref, file_path, content):
-        """
-        Write data file on disk.
-        """
-        # Throw if pack directory doesn't exist
-        pack_base_path = get_pack_base_path(pack_name=pack_ref)
-        if not os.path.isdir(pack_base_path):
-            raise ValueError('Directory for pack "%s" doesn\'t exist' % (pack_ref))
-
-        # Create pack sub-directory tree if it doesn't exist
-        directory = os.path.dirname(file_path)
-
-        if not os.path.isdir(directory):
-            os.makedirs(directory)
-
-        with open(file_path, 'w') as fp:
-            fp.write(content)
-
-    def _dispatch_trigger_for_written_data_files(self, action_db, written_data_files):
-        trigger = ACTION_FILE_WRITTEN_TRIGGER['name']
-        host_info = get_host_info()
-
-        for file_path in written_data_files:
-            payload = {
-                'ref': action_db.ref,
-                'file_path': file_path,
-                'host_info': host_info
-            }
-            self._trigger_dispatcher.dispatch(trigger=trigger, payload=payload)
 
 
 actions_controller = ActionsController()

--- a/st2api/st2api/controllers/v1/data_files.py
+++ b/st2api/st2api/controllers/v1/data_files.py
@@ -1,0 +1,134 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import os.path
+
+import six
+
+from st2common import log as logging
+from st2common.constants.triggers import ACTION_FILE_WRITTEN_TRIGGER
+from st2common.persistence.pack import Pack
+from st2common.content.utils import get_pack_base_path
+from st2common.content.utils import get_pack_file_abs_path
+from st2common.content.utils import get_pack_resource_file_abs_path
+from st2common.content.utils import get_relative_path_to_pack
+from st2common.util.system_info import get_host_info
+
+
+__all__ = [
+    'BaseDataFilesController'
+]
+
+http_client = six.moves.http_client
+
+LOG = logging.getLogger(__name__)
+
+
+class BaseDataFilesController(object):
+    """
+    Base controller for writting raw files to disk.
+    """
+
+    def _handle_data_files(self, pack_ref, data_files, resource_type=None):
+        """
+        Method for handling action data files.
+
+        This method performs two tasks:
+
+        1. Writes files to disk
+        2. Updates affected PackDB model
+        """
+        # Write files to disk
+        written_file_paths = self._write_data_files_to_disk(pack_ref=pack_ref,
+                                                            data_files=data_files,
+                                                            resource_type=resource_type)
+
+        # Update affected PackDB model (update a list of files) Update PackDB
+        pack_db = self._update_pack_model(pack_ref=pack_ref, data_files=data_files,
+                                          written_file_paths=written_file_paths)
+
+        return written_file_paths, pack_db
+
+    def _write_data_files_to_disk(self, pack_ref, data_files, resource_type=None):
+        """
+        Write files to disk.
+        """
+        written_file_paths = []
+
+        for data_file in data_files:
+            file_path = data_file['file_path']
+            content = data_file['content']
+
+            if resource_type:
+                file_path = get_pack_resource_file_abs_path(pack_ref=pack_ref,
+                                                            resource_type=resource_type,
+                                                            file_path=file_path)
+            else:
+                file_path = get_pack_file_abs_path(pack_ref=pack_ref,
+                                                   file_path=file_path)
+
+            LOG.debug('Writing data file "%s" to "%s"' % (str(data_file), file_path))
+            self._write_data_file(pack_ref=pack_ref, file_path=file_path, content=content)
+            written_file_paths.append(file_path)
+
+        return written_file_paths
+
+    def _write_data_file(self, pack_ref, file_path, content):
+        """
+        Write data file on disk.
+        """
+        # Throw if pack directory doesn't exist
+        pack_base_path = get_pack_base_path(pack_name=pack_ref)
+        if not os.path.isdir(pack_base_path):
+            raise ValueError('Directory for pack "%s" doesn\'t exist' % (pack_ref))
+
+        # Create pack sub-directory tree if it doesn't exist
+        directory = os.path.dirname(file_path)
+
+        if not os.path.isdir(directory):
+            os.makedirs(directory)
+
+        with open(file_path, 'w') as fp:
+            fp.write(content)
+
+    def _dispatch_trigger_for_written_data_files(self, action_db, written_data_files):
+        trigger = ACTION_FILE_WRITTEN_TRIGGER['name']
+        host_info = get_host_info()
+
+        for file_path in written_data_files:
+            payload = {
+                'ref': action_db.ref,
+                'file_path': file_path,
+                'host_info': host_info
+            }
+            self._trigger_dispatcher.dispatch(trigger=trigger, payload=payload)
+
+    def _update_pack_model(self, pack_ref, data_files, written_file_paths):
+        """
+        Update PackDB models (update files list).
+        """
+        file_paths = []  # A list of paths relative to the pack directory for new files
+        for file_path in written_file_paths:
+            file_path = get_relative_path_to_pack(pack_ref=pack_ref, file_path=file_path)
+            file_paths.append(file_path)
+
+        pack_db = Pack.get_by_ref(pack_ref)
+        pack_db.files = set(pack_db.files)
+        pack_db.files.update(set(file_paths))
+        pack_db.files = list(pack_db.files)
+        pack_db = Pack.add_or_update(pack_db)
+
+        return pack_db

--- a/st2api/st2api/controllers/v1/data_files.py
+++ b/st2api/st2api/controllers/v1/data_files.py
@@ -128,7 +128,7 @@ class BaseDataFilesController(object):
         pack_db = Pack.get_by_ref(pack_ref)
         pack_db.files = set(pack_db.files)
         pack_db.files.update(set(file_paths))
-        pack_db.files = list(pack_db.files)
+        pack_db.files = sorted(list(pack_db.files))
         pack_db = Pack.add_or_update(pack_db)
 
         return pack_db

--- a/st2api/tests/unit/controllers/v1/test_actions.py
+++ b/st2api/tests/unit/controllers/v1/test_actions.py
@@ -284,7 +284,8 @@ class ActionsControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclu
     register_packs = True
 
     to_delete_files = [
-        os.path.join(get_fixtures_packs_base_path(), 'dummy_pack_1/actions/filea.txt')
+        os.path.join(get_fixtures_packs_base_path(), 'dummy_pack_1/actions/filea.txt'),
+        os.path.join(get_fixtures_packs_base_path(), 'dummy_pack_1/actions/fileb.txt')
     ]
 
     @mock.patch.object(action_validator, 'validate_action', mock.MagicMock(
@@ -483,12 +484,17 @@ class ActionsControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclu
         # Verify initial state
         pack_db = Pack.get_by_ref(ACTION_12['pack'])
         self.assertTrue('actions/filea.txt' not in pack_db.files)
+        self.assertTrue('actions/fileb.txt' not in pack_db.files)
 
         action = copy.deepcopy(ACTION_12)
         action['data_files'] = [
             {
                 'file_path': 'filea.txt',
-                'content': 'test content'
+                'content': 'test content a'
+            },
+            {
+                'file_path': 'fileb.txt',
+                'content': 'test content b'
             }
         ]
         post_resp = self.__do_post(action)
@@ -496,10 +502,12 @@ class ActionsControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclu
         # Verify file has been written on disk
         for file_path in self.to_delete_files:
             self.assertTrue(os.path.exists(file_path))
+            self.assertTrue('test content' in open(file_path).read())
 
         # Verify PackDB.files has been updated
         pack_db = Pack.get_by_ref(ACTION_12['pack'])
         self.assertTrue('actions/filea.txt' in pack_db.files)
+        self.assertTrue('actions/fileb.txt' in pack_db.files)
         self.__do_delete(self.__get_action_id(post_resp))
 
     @mock.patch.object(action_validator, 'validate_action', mock.MagicMock(

--- a/st2api/tests/unit/controllers/v1/test_actions.py
+++ b/st2api/tests/unit/controllers/v1/test_actions.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 import os
 import os.path
 import copy
@@ -535,6 +536,21 @@ class ActionsControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclu
         self.assertTrue('actions/fileb.txt' in pack_db.files)
 
         self.__do_delete(action_id)
+
+    def test_post_include_data_files_non_relative_path(self):
+        action = copy.deepcopy(ACTION_12)
+        action['data_files'] = [
+            {
+                'file_path': '/tmp/not/relative/filea.txt',
+                'content': 'test content a'
+            }
+        ]
+
+        post_resp = self.__do_post(action, expect_errors=True)
+
+        expected = (r'Invalid file path: .*?\. File path needs to be relative '
+                    'to the pack actions directory')
+        self.assertTrue(re.match(expected, post_resp.json['faultstring']))
 
     @mock.patch.object(action_validator, 'validate_action', mock.MagicMock(
         return_value=True))

--- a/st2common/st2common/bootstrap/base.py
+++ b/st2common/st2common/bootstrap/base.py
@@ -178,6 +178,8 @@ class ResourceRegistrar(object):
 
         # Include a list of pack files
         pack_file_list = get_file_list(directory=pack_dir, exclude_patterns=EXCLUDE_FILE_PATTERNS)
+        pack_file_list = sorted(pack_file_list)
+
         content['files'] = pack_file_list
         content['path'] = pack_dir
 

--- a/st2common/st2common/content/utils.py
+++ b/st2common/st2common/content/utils.py
@@ -297,6 +297,10 @@ def get_pack_resource_file_abs_path(pack_ref, resource_type, file_path):
         path_components.append('sensors/')
     elif resource_type == 'rule':
         path_components.append('rules/')
+    elif resource_type == 'trigger':
+        path_components.append('trigger/')
+    elif resource_type == 'alias':
+        path_components.append('aliases/')
     else:
         raise ValueError('Invalid resource type: %s' % (resource_type))
 

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -1720,6 +1720,36 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+  /api/v1/packs/{ref_or_id}/files:
+    post:
+      operationId: st2api.controllers.v1.packs:packs_controller.files.post
+      x-requirements:
+        file_path: .*
+      x-log-result: false
+      x-submit-metrics: false
+      description: Write arbitrary files to pack directory on disk.
+      parameters:
+        - name: ref_or_id
+          in: path
+          description: Reference of the pack.
+          type: string
+          required: true
+        - name: body
+          in: body
+          schema:
+            $ref: '#/definitions/DataFilesSubSchema'
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
+      responses:
+        '200':
+          description: A list of the files which have been written to the disk.
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
   /api/v1/packs/install:
     post:
       operationId: st2api.controllers.v1.packs:packs_controller.install.post

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -1716,6 +1716,36 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+  /api/v1/packs/{ref_or_id}/files:
+    post:
+      operationId: st2api.controllers.v1.packs:packs_controller.files.post
+      x-requirements:
+        file_path: .*
+      x-log-result: false
+      x-submit-metrics: false
+      description: Write arbitrary files to pack directory on disk.
+      parameters:
+        - name: ref_or_id
+          in: path
+          description: Reference of the pack.
+          type: string
+          required: true
+        - name: body
+          in: body
+          schema:
+            $ref: '#/definitions/DataFilesSubSchema'
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
+      responses:
+        '200':
+          description: A list of the files which have been written to the disk.
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
   /api/v1/packs/install:
     post:
       operationId: st2api.controllers.v1.packs:packs_controller.install.post


### PR DESCRIPTION
This pull request adds new ``POST /api/v1/packs/<pack ref>/files`` API endpoint which allows user with the correct RBAC permission (``PACK_MODIFY``) to write an arbitrary file in the pack directory on disk.

We already have ``data_files`` attribute in the POST and PUT (create, update) action API endpoint which allows user to write arbitrary action data files to the pack actions directory.

The difference between the existing API endpoints and the new one is that the existing one only allows user to write non-metadata action related files to disk (e.g. scripts, workflow definitions, etc.).

New endpoint allows user to write arbitrary files to the pack directory on disk, including action metadata files.

Keep in mind that if the user writes raw YAML action metadata file to the pack directory on disk, this change won't be reflected in the actions API and database until content in the database is synced with the content on disk.

The change utilizes existing code for handling and writing data files, so it should have no negative security implications (we only allow user to write inside a pack sub-directory, etc.).

Here is an example usage taking into account the context on how it will be used inside st2flow - https://gist.github.com/Kami/5226ca5f153fda4ec919abef0d34c9a6.

## Other changes

* Ensure we always sort value of ``PackDB.files`` attribute so the order is stable and doesn't change during register runs if the content on disk doesn't change.

## TODO

- [ ] Tests