### PR TITLE
Don't print statsd log messages unless debug / verbose mode is used

### DIFF
--- a/st2common/st2common/service_setup.py
+++ b/st2common/st2common/service_setup.py
@@ -98,9 +98,16 @@ def setup(service, config, setup_db=True, register_mq_exchanges=True,
 
     LOG.debug('Using logging config: %s', logging_config_path)
 
+    is_debug_enabled = (cfg.CONF.debug or cfg.CONF.system.debug)
+
+    excluded_logger_names = list(cfg.CONF.log.excludes)
+
+    if not is_debug_enabled:
+        excluded_logger_names.append('statsd')
+
     try:
         logging.setup(logging_config_path, redirect_stderr=cfg.CONF.log.redirect_stderr,
-                      excludes=cfg.CONF.log.excludes)
+                      excludes=excluded_logger_names)
     except KeyError as e:
         tb_msg = traceback.format_exc()
         if 'log.setLevel' in tb_msg:
@@ -110,7 +117,7 @@ def setup(service, config, setup_db=True, register_mq_exchanges=True,
         else:
             raise e
 
-    if cfg.CONF.debug or cfg.CONF.system.debug:
+    if is_debug_enabled:
         enable_debugging()
 
     if cfg.CONF.profile:


### PR DESCRIPTION
This pull request updates our code so we don't print log messages generated by statsd client (when statsd metrics driver is used) if debug / verbose mode is not enabled.

Statsd client logs all the operations under ``INFO`` by default and that causes a lot of noise in the log files. Those log messages are not desired unless running in debug / verbose mode.

This also fixes `st2-register-content` "regression".

```bash
(virtualenv) vagrant@ubuntu-xenial:/data/stanley$ python ./st2common/bin/st2-register-content --register-actions --config-file conf/st2.dev.conf 
2018-11-13 16:06:55,826 INFO [-] Connecting to database "st2" @ "127.0.0.1:27017" as user "None".
2018-11-13 16:06:55,832 INFO [-] Successfully connected to database "st2" @ "127.0.0.1:27017" as user "None".
2018-11-13 16:06:56,105 INFO [-] st2.amqp.pool_publisher.publish_with_retries.st2.trigger: 22.95600000ms
2018-11-13 16:06:56,105 INFO [-] st2.amqp.publish.update: 23.81000000ms
2018-11-13 16:06:56,128 INFO [-] st2.amqp.pool_publisher.publish_with_retries.st2.trigger: 8.55600000ms
2018-11-13 16:06:56,129 INFO [-] st2.amqp.publish.update: 9.16700000ms
2018-11-13 16:06:56,159 INFO [-] st2.amqp.pool_publisher.publish_with_retries.st2.trigger: 1.96500000ms
2018-11-13 16:06:56,159 INFO [-] st2.amqp.publish.update: 2.34900000ms
2018-11-13 16:06:56,185 INFO [-] st2.amqp.pool_publisher.publish_with_retries.st2.trigger: 7.85500000ms
2018-11-13 16:06:56,186 INFO [-] st2.amqp.publish.update: 8.47800000ms
2018-11-13 16:06:56,212 INFO [-] st2.amqp.pool_publisher.publish_with_retries.st2.trigger: 3.88400000ms
2018-11-13 16:06:56,213 INFO [-] st2.amqp.publish.update: 4.22300000ms
2018-11-13 16:06:56,236 INFO [-] st2.amqp.pool_publisher.publish_with_retries.st2.trigger: 3.19800000ms
2018-11-13 16:06:56,237 INFO [-] st2.amqp.publish.update: 3.63800000ms
2018-11-13 16:06:56,259 INFO [-] st2.amqp.pool_publisher.publish_with_retries.st2.trigger: 5.47000000ms
2018-11-13 16:06:56,259 INFO [-] st2.amqp.publish.update: 6.28000000ms
2018-11-13 16:06:56,283 INFO [-] st2.amqp.pool_publisher.publish_with_retries.st2.trigger: 3.02200000ms
2018-11-13 16:06:56,284 INFO [-] st2.amqp.publish.update: 3.39700000ms
2018-11-13 16:06:56,307 INFO [-] st2.amqp.pool_publisher.publish_with_retries.st2.trigger: 5.45000000ms
2018-11-13 16:06:56,307 INFO [-] st2.amqp.publish.update: 6.59100000ms
2018-11-13 16:06:56,331 INFO [-] st2.amqp.pool_publisher.publish_with_retries.st2.trigger: 4.71300000ms
2018-11-13 16:06:56,332 INFO [-] st2.amqp.publish.update: 5.28400000ms
2018-11-13 16:06:56,333 INFO [-] =========================================================
2018-11-13 16:06:56,333 INFO [-] ############## Registering runners ######################
2018-11-13 16:06:56,333 INFO [-] =========================================================
2018-11-13 16:06:56,769 INFO [-] Generating grammar tables from /usr/lib/python2.7/lib2to3/Grammar.txt
2018-11-13 16:06:56,790 INFO [-] Generating grammar tables from /usr/lib/python2.7/lib2to3/PatternGrammar.txt
2018-11-13 16:06:57,700 INFO [-] st2.st2.register.runners: 1366.99800000ms
2018-11-13 16:06:57,701 INFO [-] Registered 18 runners.
2018-11-13 16:06:57,702 INFO [-] =========================================================
2018-11-13 16:06:57,702 INFO [-] ############## Registering actions ######################
2018-11-13 16:06:57,703 INFO [-] =========================================================
2018-11-13 16:07:06,978 INFO [-] st2.st2.register.actions: 9274.77600000ms
2018-11-13 16:07:06,978 INFO [-] Registered 322 actions.
```

After:

```bash
(virtualenv) vagrant@ubuntu-xenial:/data/stanley$ python ./st2common/bin/st2-register-content --register-actions --config-file conf/st2.dev.conf
2018-11-13 16:35:20,581 INFO [-] Connecting to database "st2" @ "127.0.0.1:27017" as user "None".
2018-11-13 16:35:20,587 INFO [-] Successfully connected to database "st2" @ "127.0.0.1:27017" as user "None".
2018-11-13 16:35:21,055 INFO [-] =========================================================
2018-11-13 16:35:21,055 INFO [-] ############## Registering runners ######################
2018-11-13 16:35:21,056 INFO [-] =========================================================
2018-11-13 16:35:21,290 INFO [-] Generating grammar tables from /usr/lib/python2.7/lib2to3/Grammar.txt
2018-11-13 16:35:21,314 INFO [-] Generating grammar tables from /usr/lib/python2.7/lib2to3/PatternGrammar.txt
2018-11-13 16:35:22,208 INFO [-] Registered 18 runners.
2018-11-13 16:35:22,209 INFO [-] =========================================================
2018-11-13 16:35:22,210 INFO [-] ############## Registering actions ######################
2018-11-13 16:35:22,210 INFO [-] =========================================================
2018-11-13 16:35:29,783 INFO [-] Registered 322 actions.
```

NOTE: If user runs StackStorm service with ``--debug`` flag or ``st2-register-content`` script with ``--verbose`` flags those messages will still be printed.