### PR TITLE
Add new "metadata_file" attribute to all the pack resource models

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,16 @@ Added
   Response protocol) for older servers.
 
   Contributed by @aduca85 #4373
+* Add new ``metadata_file`` attribute to the following models: Action, Action Alias, Rule, Sensor,
+  TriggerType. Value of this attribute points to a metadata file for a specific resource (YAML file
+  which contains actual resource definition). Path is relative to the pack directory (e.g.
+  ``actions/my_action1.meta.yaml``, ``aliases/my_alias.yaml``, ``sensors/my_sensor.yaml``,
+  ``rules/my_rule.yaml``, ``triggers/my_trigger.yaml`` etc.).
+
+  Keep in mind that triggers can be registered in two ways - either via sensor definition file in
+  ``sensors/`` directory or via trigger definition file in ``triggers/`` directory. If
+  ``metadata_file`` attribute on TriggerTypeDB model points to ``sensors/`` directory it means that
+  trigger is registered via sensor definition. (new feature) #4445
 
 Changed
 ~~~~~~~

--- a/st2actions/tests/unit/test_actions_registrar.py
+++ b/st2actions/tests/unit/test_actions_registrar.py
@@ -14,6 +14,9 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
+import os
+
 import jsonschema
 import mock
 import yaml
@@ -25,11 +28,17 @@ from st2common.models.db.runner import RunnerTypeDB
 
 import st2tests.base as tests_base
 import st2tests.fixturesloader as fixtures_loader
+from st2tests.fixturesloader import get_fixtures_base_path
 
 MOCK_RUNNER_TYPE_DB = RunnerTypeDB(name='run-local', runner_module='st2.runners.local')
 
 
+# NOTE: We need to perform this patching because test fixtures are located outside of the packs
+# base paths directory. This will never happen outside the context of test fixtures.
+@mock.patch('st2common.content.utils.get_pack_base_path',
+            mock.Mock(return_value=os.path.join(get_fixtures_base_path(), 'generic')))
 class ActionsRegistrarTest(tests_base.DbTestCase):
+
     @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(return_value=True))
     @mock.patch.object(action_validator, 'get_runner_model',
                        mock.MagicMock(return_value=MOCK_RUNNER_TYPE_DB))
@@ -65,7 +74,7 @@ class ActionsRegistrarTest(tests_base.DbTestCase):
         loader = fixtures_loader.FixturesLoader()
         action_file = loader.get_fixture_file_path_abs(
             'generic', 'actions', 'action_3_pack_missing.yaml')
-        registrar._register_action('/opt/stackstorm/packs/dummy', 'dummy', action_file)
+        registrar._register_action('dummy', action_file)
         action_name = None
         with open(action_file, 'r') as fd:
             content = yaml.safe_load(fd)
@@ -84,8 +93,7 @@ class ActionsRegistrarTest(tests_base.DbTestCase):
         action_file = loader.get_fixture_file_path_abs(
             'generic', 'actions', 'action-with-no-parameters.yaml')
 
-        self.assertEqual(registrar._register_action('/opt/stackstorm/packs/dummy', 'dummy',
-                                                    action_file), None)
+        self.assertEqual(registrar._register_action('dummy', action_file), None)
 
     @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(return_value=True))
     @mock.patch.object(action_validator, 'get_runner_model',
@@ -99,7 +107,7 @@ class ActionsRegistrarTest(tests_base.DbTestCase):
         expected_msg = '\'list\' is not valid under any of the given schema'
         self.assertRaisesRegexp(jsonschema.ValidationError, expected_msg,
                                 registrar._register_action,
-                                '/opt/stackstorm/packs/dummy', 'dummy', action_file)
+                                'dummy', action_file)
 
     @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(return_value=True))
     @mock.patch.object(action_validator, 'get_runner_model',
@@ -114,7 +122,7 @@ class ActionsRegistrarTest(tests_base.DbTestCase):
                         'parameter name are')
         self.assertRaisesRegexp(jsonschema.ValidationError, expected_msg,
                                 registrar._register_action,
-                                '/opt/stackstorm/packs/dummy', 'dummy', action_file)
+                                'generic', action_file)
 
     @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(return_value=True))
     @mock.patch.object(action_validator, 'get_runner_model',
@@ -125,7 +133,7 @@ class ActionsRegistrarTest(tests_base.DbTestCase):
         action_file = loader.get_fixture_file_path_abs(
             'generic', 'actions', 'action-invalid-schema-params.yaml')
         try:
-            registrar._register_action('/opt/stackstorm/packs/dummy', 'dummy', action_file)
+            registrar._register_action('generic', action_file)
             self.fail('Invalid action schema. Should have failed.')
         except jsonschema.ValidationError:
             pass
@@ -138,9 +146,9 @@ class ActionsRegistrarTest(tests_base.DbTestCase):
         loader = fixtures_loader.FixturesLoader()
         action_file = loader.get_fixture_file_path_abs(
             'generic', 'actions', 'action1.yaml')
-        registrar._register_action('/opt/stackstorm/packs/dummy', 'wolfpack', action_file)
+        registrar._register_action('wolfpack', action_file)
         # try registering again. this should not throw errors.
-        registrar._register_action('/opt/stackstorm/packs/dummy', 'wolfpack', action_file)
+        registrar._register_action('wolfpack', action_file)
         action_name = None
         with open(action_file, 'r') as fd:
             content = yaml.safe_load(fd)

--- a/st2actions/tests/unit/test_actions_registrar.py
+++ b/st2actions/tests/unit/test_actions_registrar.py
@@ -56,7 +56,7 @@ class ActionsRegistrarTest(tests_base.DbTestCase):
 
         # Assert metadata_file field is populated
         expected_path = 'actions/action-with-no-parameters.yaml'
-        self.assertTrue(all_actions_in_db[0].metadata_file.endswith(expected_path))
+        self.assertEqual(all_actions_in_db[0].metadata_file, expected_path)
 
     def test_register_actions_from_bad_pack(self):
         packs_base_path = tests_base.get_fixtures_path()

--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -39,7 +39,7 @@ from st2common.router import Response
 from st2common.validators.api.misc import validate_not_part_of_system_pack
 from st2common.content.utils import get_pack_base_path
 from st2common.content.utils import get_pack_resource_file_abs_path
-from st2common.content.utils import get_relative_path_to_pack
+from st2common.content.utils import get_relative_path_to_pack_file
 from st2common.transport.reactor import TriggerDispatcher
 from st2common.util.system_info import get_host_info
 import st2common.validators.api.action as action_validator
@@ -269,7 +269,7 @@ class ActionsController(resource.ContentPackResourceController):
         """
         file_paths = []  # A list of paths relative to the pack directory for new files
         for file_path in written_file_paths:
-            file_path = get_relative_path_to_pack(pack_ref=pack_ref, file_path=file_path)
+            file_path = get_relative_path_to_pack_file(pack_ref=pack_ref, file_path=file_path)
             file_paths.append(file_path)
 
         pack_db = Pack.get_by_ref(pack_ref)

--- a/st2api/tests/unit/controllers/v1/test_packs.py
+++ b/st2api/tests/unit/controllers/v1/test_packs.py
@@ -21,6 +21,7 @@ import mock
 from st2common.content.loader import ContentPackLoader
 from st2common.models.db.pack import PackDB
 from st2common.persistence.pack import Pack
+from st2common.persistence.action import Action
 from st2common.router import Response
 from st2common.services import packs as pack_service
 from st2api.controllers.v1.actionexecutions import ActionExecutionsControllerMixin
@@ -461,6 +462,10 @@ class PacksControllerTestCase(FunctionalTest,
         self.assertTrue(resp.json['actions'] >= 1)
         self.assertTrue(resp.json['sensors'] >= 1)
         self.assertTrue(resp.json['configs'] >= 1)
+
+        # Verify metadata_file attribute is set
+        action_dbs = Action.query(pack='dummy_pack_1')
+        self.assertEqual(action_dbs[0].metadata_file, 'actions/my_action.yaml')
 
         # Register 'all' resource types should try include any possible content for the pack
         resp = self.app.post_json('/v1/packs/register', {'packs': ['dummy_pack_1'],

--- a/st2common/st2common/bootstrap/actionsregistrar.py
+++ b/st2common/st2common/bootstrap/actionsregistrar.py
@@ -116,7 +116,7 @@ class ActionsRegistrar(ResourceRegistrar):
 
         return actions
 
-    def _register_action(self, pack_base_path, pack, action):
+    def _register_action(self, pack, action):
         content = self._meta_loader.load(action)
         pack_field = content.get('pack', None)
         if not pack_field:
@@ -128,7 +128,9 @@ class ActionsRegistrar(ResourceRegistrar):
 
         # Add in "metadata_file" attribute which stores path to the pack metadata file relative to
         # the pack directory
-        metadata_file = action.replace(pack_base_path, '')
+        metadata_file = content_utils.get_relative_path_to_pack_file(pack_ref=pack,
+                                                                     file_path=action,
+                                                                     use_pack_cache=True)
         content['metadata_file'] = metadata_file
 
         action_api = ActionAPI(**content)
@@ -187,14 +189,10 @@ class ActionsRegistrar(ResourceRegistrar):
 
     def _register_actions_from_pack(self, pack, actions):
         registered_count = 0
-
-        pack_base_path = content_utils.get_pack_base_path(pack_name=pack,
-                                                          include_trailing_slash=True)
-
         for action in actions:
             try:
                 LOG.debug('Loading action from %s.', action)
-                self._register_action(pack_base_path=pack_base_path, pack=pack, action=action)
+                self._register_action(pack=pack, action=action)
             except Exception as e:
                 if self._fail_on_failure:
                     msg = ('Failed to register action "%s" from pack "%s": %s' % (action, pack,

--- a/st2common/st2common/bootstrap/actionsregistrar.py
+++ b/st2common/st2common/bootstrap/actionsregistrar.py
@@ -188,10 +188,8 @@ class ActionsRegistrar(ResourceRegistrar):
     def _register_actions_from_pack(self, pack, actions):
         registered_count = 0
 
-        pack_base_path = content_utils.get_pack_base_path(pack_name=pack)
-
-        if not pack_base_path.endswith('/'):
-            pack_base_path += '/'
+        pack_base_path = content_utils.get_pack_base_path(pack_name=pack,
+                                                          include_trailing_slash=True)
 
         for action in actions:
             try:

--- a/st2common/st2common/bootstrap/actionsregistrar.py
+++ b/st2common/st2common/bootstrap/actionsregistrar.py
@@ -128,10 +128,14 @@ class ActionsRegistrar(ResourceRegistrar):
 
         # Add in "metadata_file" attribute which stores path to the pack metadata file relative to
         # the pack directory
-        metadata_file = content_utils.get_relative_path_to_pack_file(pack_ref=pack,
-                                                                     file_path=action,
-                                                                     use_pack_cache=True)
-        content['metadata_file'] = metadata_file
+        try:
+            metadata_file = content_utils.get_relative_path_to_pack_file(pack_ref=pack,
+                                                                         file_path=action,
+                                                                         use_pack_cache=True)
+        except ValueError:
+            LOG.exception('Failed to set metadata_file attribute for action "%s"' % (action))
+        else:
+            content['metadata_file'] = metadata_file
 
         action_api = ActionAPI(**content)
 

--- a/st2common/st2common/bootstrap/actionsregistrar.py
+++ b/st2common/st2common/bootstrap/actionsregistrar.py
@@ -128,14 +128,10 @@ class ActionsRegistrar(ResourceRegistrar):
 
         # Add in "metadata_file" attribute which stores path to the pack metadata file relative to
         # the pack directory
-        try:
-            metadata_file = content_utils.get_relative_path_to_pack_file(pack_ref=pack,
-                                                                         file_path=action,
-                                                                         use_pack_cache=True)
-        except ValueError:
-            LOG.exception('Failed to set metadata_file attribute for action "%s"' % (action))
-        else:
-            content['metadata_file'] = metadata_file
+        metadata_file = content_utils.get_relative_path_to_pack_file(pack_ref=pack,
+                                                                     file_path=action,
+                                                                     use_pack_cache=True)
+        content['metadata_file'] = metadata_file
 
         action_api = ActionAPI(**content)
 

--- a/st2common/st2common/bootstrap/aliasesregistrar.py
+++ b/st2common/st2common/bootstrap/aliasesregistrar.py
@@ -105,7 +105,7 @@ class AliasesRegistrar(ResourceRegistrar):
     def _get_aliases_from_pack(self, aliases_dir):
         return self.get_resources_from_pack(resources_dir=aliases_dir)
 
-    def _get_action_alias_db(self, pack_base_path, pack, action_alias):
+    def _get_action_alias_db(self, pack, action_alias):
         """
         Retrieve ActionAliasDB object.
         """
@@ -120,7 +120,9 @@ class AliasesRegistrar(ResourceRegistrar):
 
         # Add in "metadata_file" attribute which stores path to the pack metadata file relative to
         # the pack directory
-        metadata_file = action_alias.replace(pack_base_path, '')
+        metadata_file = content_utils.get_relative_path_to_pack_file(pack_ref=pack,
+                                                                     file_path=action_alias,
+                                                                     use_pack_cache=True)
         content['metadata_file'] = metadata_file
 
         action_alias_api = ActionAliasAPI(**content)
@@ -129,8 +131,8 @@ class AliasesRegistrar(ResourceRegistrar):
 
         return action_alias_db
 
-    def _register_action_alias(self, pack_base_path, pack, action_alias):
-        action_alias_db = self._get_action_alias_db(pack_base_path=pack_base_path, pack=pack,
+    def _register_action_alias(self, pack, action_alias):
+        action_alias_db = self._get_action_alias_db(pack=pack,
                                                     action_alias=action_alias)
 
         try:
@@ -150,15 +152,10 @@ class AliasesRegistrar(ResourceRegistrar):
     def _register_aliases_from_pack(self, pack, aliases):
         registered_count = 0
 
-        pack_base_path = content_utils.get_pack_base_path(pack_name=pack)
-
-        if not pack_base_path.endswith('/'):
-            pack_base_path += '/'
-
         for alias in aliases:
             try:
                 LOG.debug('Loading alias from %s.', alias)
-                self._register_action_alias(pack_base_path, pack, alias)
+                self._register_action_alias(pack, alias)
             except Exception as e:
                 if self._fail_on_failure:
                     msg = ('Failed to register alias "%s" from pack "%s": %s' % (alias, pack,

--- a/st2common/st2common/bootstrap/policiesregistrar.py
+++ b/st2common/st2common/bootstrap/policiesregistrar.py
@@ -115,14 +115,10 @@ class PolicyRegistrar(ResourceRegistrar):
     def _register_policies_from_pack(self, pack, policies):
         registered_count = 0
 
-        pack_base_path = content_utils.get_pack_base_path(pack_name=pack,
-                                                          include_trailing_slash=True)
-
         for policy in policies:
             try:
                 LOG.debug('Loading policy from %s.', policy)
-                self._register_policy(pack_base_path=pack_base_path, pack=pack,
-                                      policy=policy)
+                self._register_policy(pack=pack, policy=policy)
             except Exception as e:
                 if self._fail_on_failure:
                     msg = ('Failed to register policy "%s" from pack "%s": %s' % (policy, pack,
@@ -136,7 +132,7 @@ class PolicyRegistrar(ResourceRegistrar):
 
         return registered_count
 
-    def _register_policy(self, pack_base_path, pack, policy):
+    def _register_policy(self, pack, policy):
         content = self._meta_loader.load(policy)
         pack_field = content.get('pack', None)
         if not pack_field:
@@ -148,7 +144,9 @@ class PolicyRegistrar(ResourceRegistrar):
 
         # Add in "metadata_file" attribute which stores path to the pack metadata file relative to
         # the pack directory
-        metadata_file = policy.replace(pack_base_path, '')
+        metadata_file = content_utils.get_relative_path_to_pack_file(pack_ref=pack,
+                                                                     file_path=policy,
+                                                                     use_pack_cache=True)
         content['metadata_file'] = metadata_file
 
         policy_api = PolicyAPI(**content)

--- a/st2common/st2common/bootstrap/rulesregistrar.py
+++ b/st2common/st2common/bootstrap/rulesregistrar.py
@@ -106,6 +106,9 @@ class RulesRegistrar(ResourceRegistrar):
     def _register_rules_from_pack(self, pack, rules):
         registered_count = 0
 
+        pack_base_path = content_utils.get_pack_base_path(pack_name=pack,
+                                                          include_trailing_slash=True)
+
         # TODO: Refactor this monstrosity
         for rule in rules:
             LOG.debug('Loading rule from %s.', rule)
@@ -118,6 +121,12 @@ class RulesRegistrar(ResourceRegistrar):
                 if pack_field != pack:
                     raise Exception('Model is in pack "%s" but field "pack" is different: %s' %
                                     (pack, pack_field))
+
+                # Add in "metadata_file" attribute which stores path to the pack metadata file
+                # relative to the pack directory
+                metadata_file = rule.replace(pack_base_path, '')
+                content['metadata_file'] = metadata_file
+
                 rule_api = RuleAPI(**content)
                 rule_api.validate()
                 rule_db = RuleAPI.to_model(rule_api)

--- a/st2common/st2common/bootstrap/rulesregistrar.py
+++ b/st2common/st2common/bootstrap/rulesregistrar.py
@@ -106,9 +106,6 @@ class RulesRegistrar(ResourceRegistrar):
     def _register_rules_from_pack(self, pack, rules):
         registered_count = 0
 
-        pack_base_path = content_utils.get_pack_base_path(pack_name=pack,
-                                                          include_trailing_slash=True)
-
         # TODO: Refactor this monstrosity
         for rule in rules:
             LOG.debug('Loading rule from %s.', rule)
@@ -122,9 +119,9 @@ class RulesRegistrar(ResourceRegistrar):
                     raise Exception('Model is in pack "%s" but field "pack" is different: %s' %
                                     (pack, pack_field))
 
-                # Add in "metadata_file" attribute which stores path to the pack metadata file
-                # relative to the pack directory
-                metadata_file = rule.replace(pack_base_path, '')
+                metadata_file = content_utils.get_relative_path_to_pack_file(pack_ref=pack,
+                                                                     file_path=rule,
+                                                                     use_pack_cache=True)
                 content['metadata_file'] = metadata_file
 
                 rule_api = RuleAPI(**content)

--- a/st2common/st2common/bootstrap/sensorsregistrar.py
+++ b/st2common/st2common/bootstrap/sensorsregistrar.py
@@ -109,9 +109,11 @@ class SensorsRegistrar(ResourceRegistrar):
     def _register_sensors_from_pack(self, pack, sensors):
         registered_count = 0
 
+        pack_base_path = content_utils.get_pack_base_path(pack_name=pack,
+                                                          include_trailing_slash=True)
         for sensor in sensors:
             try:
-                self._register_sensor_from_pack(pack=pack, sensor=sensor)
+                self._register_sensor_from_pack(pack_base_path, pack=pack, sensor=sensor)
             except Exception as e:
                 if self._fail_on_failure:
                     msg = ('Failed to register sensor "%s" from pack "%s": %s' % (sensor, pack,
@@ -125,7 +127,7 @@ class SensorsRegistrar(ResourceRegistrar):
 
         return registered_count
 
-    def _register_sensor_from_pack(self, pack, sensor):
+    def _register_sensor_from_pack(self, pack_base_path, pack, sensor):
         sensor_metadata_file_path = sensor
 
         LOG.debug('Loading sensor from %s.', sensor_metadata_file_path)
@@ -142,6 +144,11 @@ class SensorsRegistrar(ResourceRegistrar):
         entry_point = content.get('entry_point', None)
         if not entry_point:
             raise ValueError('Sensor definition missing entry_point')
+
+        # Add in "metadata_file" attribute which stores path to the pack metadata file relative to
+        # the pack directory
+        metadata_file = sensor_metadata_file_path.replace(pack_base_path, '')
+        content['metadata_file'] = metadata_file
 
         sensors_dir = os.path.dirname(sensor_metadata_file_path)
         sensor_file_path = os.path.join(sensors_dir, entry_point)

--- a/st2common/st2common/bootstrap/sensorsregistrar.py
+++ b/st2common/st2common/bootstrap/sensorsregistrar.py
@@ -108,12 +108,9 @@ class SensorsRegistrar(ResourceRegistrar):
 
     def _register_sensors_from_pack(self, pack, sensors):
         registered_count = 0
-
-        pack_base_path = content_utils.get_pack_base_path(pack_name=pack,
-                                                          include_trailing_slash=True)
         for sensor in sensors:
             try:
-                self._register_sensor_from_pack(pack_base_path, pack=pack, sensor=sensor)
+                self._register_sensor_from_pack(pack=pack, sensor=sensor)
             except Exception as e:
                 if self._fail_on_failure:
                     msg = ('Failed to register sensor "%s" from pack "%s": %s' % (sensor, pack,
@@ -127,7 +124,7 @@ class SensorsRegistrar(ResourceRegistrar):
 
         return registered_count
 
-    def _register_sensor_from_pack(self, pack_base_path, pack, sensor):
+    def _register_sensor_from_pack(self, pack, sensor):
         sensor_metadata_file_path = sensor
 
         LOG.debug('Loading sensor from %s.', sensor_metadata_file_path)
@@ -147,7 +144,9 @@ class SensorsRegistrar(ResourceRegistrar):
 
         # Add in "metadata_file" attribute which stores path to the pack metadata file relative to
         # the pack directory
-        metadata_file = sensor_metadata_file_path.replace(pack_base_path, '')
+        metadata_file = content_utils.get_relative_path_to_pack_file(pack_ref=pack,
+                                                                     file_path=sensor,
+                                                                     use_pack_cache=True)
         content['metadata_file'] = metadata_file
 
         sensors_dir = os.path.dirname(sensor_metadata_file_path)

--- a/st2common/st2common/content/utils.py
+++ b/st2common/st2common/content/utils.py
@@ -127,7 +127,7 @@ def check_pack_content_directory_exists(pack, content_type):
     return False
 
 
-def get_pack_base_path(pack_name):
+def get_pack_base_path(pack_name, include_trailing_slash=False):
     """
     Return full absolute base path to the content pack directory.
 
@@ -140,6 +140,9 @@ def get_pack_base_path(pack_name):
     :param pack_name: Content pack name.
     :type pack_name: ``str``
 
+    :param include_trailing_slash: True to include trailing slash.
+    :type include_trailing_slash: ``bool``
+
     :rtype: ``str``
     """
     if not pack_name:
@@ -151,11 +154,18 @@ def get_pack_base_path(pack_name):
         pack_base_path = os.path.abspath(pack_base_path)
 
         if os.path.isdir(pack_base_path):
+            if include_trailing_slash and not pack_base_path.endswith(os.path.sep):
+                pack_base_path += os.path.sep
+
             return pack_base_path
 
     # Path with the provided name not found
     pack_base_path = os.path.join(packs_base_paths[0], quote_unix(pack_name))
     pack_base_path = os.path.abspath(pack_base_path)
+
+    if include_trailing_slash and not pack_base_path.endswith(os.path.sep):
+        pack_base_path += os.path.sep
+
     return pack_base_path
 
 

--- a/st2common/st2common/content/utils.py
+++ b/st2common/st2common/content/utils.py
@@ -31,7 +31,7 @@ __all__ = [
     'get_pack_directory',
     'get_pack_file_abs_path',
     'get_pack_resource_file_abs_path',
-    'get_relative_path_to_pack',
+    'get_relative_path_to_pack_file',
     'check_pack_directory_exists',
     'check_pack_content_directory_exists'
 ]
@@ -317,7 +317,7 @@ def get_pack_resource_file_abs_path(pack_ref, resource_type, file_path):
     return result
 
 
-def get_relative_path_to_pack(pack_ref, file_path):
+def get_relative_path_to_pack_file(pack_ref, file_path):
     """
     Retrieve a file path which is relative to the provided pack directory.
 

--- a/st2common/st2common/content/utils.py
+++ b/st2common/st2common/content/utils.py
@@ -321,6 +321,12 @@ def get_relative_path_to_pack(pack_ref, file_path):
     """
     Retrieve a file path which is relative to the provided pack directory.
 
+    :param pack_ref: Pack reference.
+    :type pack_ref: ``str``
+
+    :param file_path: Full absolute path to a pack file.
+    :type file_path: ``str``
+
     :rtype: ``str``
     """
     pack_base_path = get_pack_base_path(pack_name=pack_ref)

--- a/st2common/st2common/content/utils.py
+++ b/st2common/st2common/content/utils.py
@@ -346,9 +346,12 @@ def get_relative_path_to_pack_file(pack_ref, file_path, use_pack_cache=False):
     if not os.path.isabs(file_path):
         return file_path
 
+    file_path = os.path.abspath(file_path)
+
     common_prefix = os.path.commonprefix([pack_base_path, file_path])
     if common_prefix != pack_base_path:
-        raise ValueError('file_path is not located inside the pack directory')
+        raise ValueError('file_path (%s) is not located inside the pack directory (%s)' %
+                         (file_path, pack_base_path))
 
     relative_path = os.path.relpath(file_path, common_prefix)
     return relative_path

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -208,6 +208,11 @@ class ActionAPI(BaseAPI, APIUIDMixin):
                 "type": "string",
                 "default": ""
             },
+            "metadata_file": {
+                "description": "Path to the metadata file relative to the pack directory.",
+                "type": "string",
+                "default": ""
+            },
             "pack": {
                 "description": "The content pack this action belongs to.",
                 "type": "string",
@@ -275,6 +280,7 @@ class ActionAPI(BaseAPI, APIUIDMixin):
         description = getattr(action, 'description', None)
         enabled = bool(getattr(action, 'enabled', True))
         entry_point = str(action.entry_point)
+        metadata_file = getattr(action, 'metadata_file', None)
         pack = str(action.pack)
         runner_type = {'name': str(action.runner_type)}
         parameters = getattr(action, 'parameters', dict())
@@ -292,7 +298,8 @@ class ActionAPI(BaseAPI, APIUIDMixin):
             notify = NotificationsHelper.to_model({})
 
         model = cls.model(name=name, description=description, enabled=enabled,
-                          entry_point=entry_point, pack=pack, runner_type=runner_type,
+                          entry_point=entry_point, metadata_file=metadata_file,
+                          pack=pack, runner_type=runner_type,
                           tags=tags, parameters=parameters, output_schema=output_schema,
                           notify=notify, ref=ref)
 

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -208,11 +208,6 @@ class ActionAPI(BaseAPI, APIUIDMixin):
                 "type": "string",
                 "default": ""
             },
-            "metadata_file": {
-                "description": "Path to the metadata file relative to the pack directory.",
-                "type": "string",
-                "default": ""
-            },
             "pack": {
                 "description": "The content pack this action belongs to.",
                 "type": "string",
@@ -250,6 +245,11 @@ class ActionAPI(BaseAPI, APIUIDMixin):
                     "on-success": NotificationSubSchemaAPI
                 },
                 "additionalProperties": False
+            },
+            "metadata_file": {
+                "description": "Path to the metadata file relative to the pack directory.",
+                "type": "string",
+                "default": ""
             }
         },
         "additionalProperties": False
@@ -280,7 +280,6 @@ class ActionAPI(BaseAPI, APIUIDMixin):
         description = getattr(action, 'description', None)
         enabled = bool(getattr(action, 'enabled', True))
         entry_point = str(action.entry_point)
-        metadata_file = getattr(action, 'metadata_file', None)
         pack = str(action.pack)
         runner_type = {'name': str(action.runner_type)}
         parameters = getattr(action, 'parameters', dict())
@@ -297,11 +296,12 @@ class ActionAPI(BaseAPI, APIUIDMixin):
             # to use an empty document.
             notify = NotificationsHelper.to_model({})
 
+        metadata_file = getattr(action, 'metadata_file', None)
+
         model = cls.model(name=name, description=description, enabled=enabled,
-                          entry_point=entry_point, metadata_file=metadata_file,
-                          pack=pack, runner_type=runner_type,
+                          entry_point=entry_point, pack=pack, runner_type=runner_type,
                           tags=tags, parameters=parameters, output_schema=output_schema,
-                          notify=notify, ref=ref)
+                          notify=notify, ref=ref, metadata_file=metadata_file)
 
         return model
 
@@ -618,6 +618,11 @@ class ActionAliasAPI(BaseAPI, APIUIDMixin):
             "extra": {
                 "type": "object",
                 "description": "Extra parameters, usually adapter-specific."
+            },
+            "metadata_file": {
+                "description": "Path to the metadata file relative to the pack directory.",
+                "type": "string",
+                "default": ""
             }
         },
         "additionalProperties": False
@@ -635,10 +640,12 @@ class ActionAliasAPI(BaseAPI, APIUIDMixin):
         ack = getattr(alias, 'ack', None)
         result = getattr(alias, 'result', None)
         extra = getattr(alias, 'extra', None)
+        metadata_file = getattr(alias, 'metadata_file', None)
 
         model = cls.model(name=name, description=description, pack=pack, ref=ref,
                           enabled=enabled, action_ref=action_ref, formats=formats,
-                          ack=ack, result=result, extra=extra)
+                          ack=ack, result=result, extra=extra,
+                          metadata_file=metadata_file)
         return model
 
 

--- a/st2common/st2common/models/api/policy.py
+++ b/st2common/st2common/models/api/policy.py
@@ -138,6 +138,11 @@ class PolicyAPI(BaseAPI, APIUIDMixin):
                 },
                 'additionalProperties': False
 
+            },
+            "metadata_file": {
+                "description": "Path to the metadata file relative to the pack directory.",
+                "type": "string",
+                "default": ""
             }
         },
         "additionalProperties": False
@@ -175,4 +180,5 @@ class PolicyAPI(BaseAPI, APIUIDMixin):
                          enabled=getattr(instance, 'enabled', None),
                          resource_ref=str(instance.resource_ref),
                          policy_type=str(instance.policy_type),
-                         parameters=getattr(instance, 'parameters', dict()))
+                         parameters=getattr(instance, 'parameters', dict()),
+                         metadata_file=getattr(instance, 'metadata_file', None))

--- a/st2common/st2common/models/api/rule.py
+++ b/st2common/st2common/models/api/rule.py
@@ -197,6 +197,11 @@ class RuleAPI(BaseAPI, APIUIDMixin):
                 "description": "User associated metadata assigned to this object.",
                 "type": "array",
                 "items": {"type": "object"}
+            },
+            "metadata_file": {
+                "description": "Path to the metadata file relative to the pack directory.",
+                "type": "string",
+                "default": ""
             }
         },
         'additionalProperties': False
@@ -259,6 +264,7 @@ class RuleAPI(BaseAPI, APIUIDMixin):
         kwargs['enabled'] = getattr(rule, 'enabled', False)
         kwargs['context'] = getattr(rule, 'context', dict())
         kwargs['tags'] = TagsHelper.to_model(getattr(rule, 'tags', []))
+        kwargs['metadata_file'] = getattr(rule, 'metadata_file', None)
 
         model = cls.model(**kwargs)
         return model

--- a/st2common/st2common/models/api/sensor.py
+++ b/st2common/st2common/models/api/sensor.py
@@ -61,6 +61,11 @@ class SensorTypeAPI(BaseAPI):
             },
             'poll_interval': {
                 'type': 'number'
+            },
+            "metadata_file": {
+                "description": "Path to the metadata file relative to the pack directory.",
+                "type": "string",
+                "default": ""
             }
         },
         'additionalProperties': False

--- a/st2common/st2common/models/api/trigger.py
+++ b/st2common/st2common/models/api/trigger.py
@@ -63,6 +63,11 @@ class TriggerTypeAPI(BaseAPI):
                 'description': 'User associated metadata assigned to this object.',
                 'type': 'array',
                 'items': {'type': 'object'}
+            },
+            "metadata_file": {
+                "description": "Path to the metadata file relative to the pack directory.",
+                "type": "string",
+                "default": ""
             }
         },
         'additionalProperties': False
@@ -76,10 +81,11 @@ class TriggerTypeAPI(BaseAPI):
         payload_schema = getattr(trigger_type, 'payload_schema', {})
         parameters_schema = getattr(trigger_type, 'parameters_schema', {})
         tags = TagsHelper.to_model(getattr(trigger_type, 'tags', []))
+        metadata_file = getattr(trigger_type, 'metadata_file', None)
 
         model = cls.model(name=name, description=description, pack=pack,
                           payload_schema=payload_schema, parameters_schema=parameters_schema,
-                          tags=tags)
+                          tags=tags, metadata_file=metadata_file)
         return model
 
     @classmethod

--- a/st2common/st2common/models/db/action.py
+++ b/st2common/st2common/models/db/action.py
@@ -67,9 +67,6 @@ class ActionDB(stormbase.StormFoundationDB, stormbase.TagsMixin,
     entry_point = me.StringField(
         required=True,
         help_text='The entry point to the action.')
-    metadata_file = me.StringField(
-        required=False,
-        help_text='Path to the metadata file relative to the pack directory.')
     pack = me.StringField(
         required=False,
         help_text='Name of the content pack.',
@@ -88,7 +85,8 @@ class ActionDB(stormbase.StormFoundationDB, stormbase.TagsMixin,
             {'fields': ['name']},
             {'fields': ['pack']},
             {'fields': ['ref']},
-        ] + stormbase.TagsMixin.get_indices() + stormbase.UIDFieldMixin.get_indexes()
+        ] + stormbase.ContentPackResourceMixin.get_indexes() +
+            stormbase.TagsMixin.get_indices() + stormbase.UIDFieldMixin.get_indexes()
     }
 
     def __init__(self, *args, **values):

--- a/st2common/st2common/models/db/action.py
+++ b/st2common/st2common/models/db/action.py
@@ -86,7 +86,7 @@ class ActionDB(stormbase.StormFoundationDB, stormbase.TagsMixin,
             {'fields': ['pack']},
             {'fields': ['ref']},
         ] + (stormbase.ContentPackResourceMixin.get_indexes() +
-            stormbase.TagsMixin.get_indices() +
+            stormbase.TagsMixin.get_indexes() +
             stormbase.UIDFieldMixin.get_indexes())
     }
 

--- a/st2common/st2common/models/db/action.py
+++ b/st2common/st2common/models/db/action.py
@@ -85,8 +85,9 @@ class ActionDB(stormbase.StormFoundationDB, stormbase.TagsMixin,
             {'fields': ['name']},
             {'fields': ['pack']},
             {'fields': ['ref']},
-        ] + stormbase.ContentPackResourceMixin.get_indexes() +
-            stormbase.TagsMixin.get_indices() + stormbase.UIDFieldMixin.get_indexes()
+        ] + (stormbase.ContentPackResourceMixin.get_indexes() +
+            stormbase.TagsMixin.get_indices() +
+            stormbase.UIDFieldMixin.get_indexes())
     }
 
     def __init__(self, *args, **values):

--- a/st2common/st2common/models/db/action.py
+++ b/st2common/st2common/models/db/action.py
@@ -67,6 +67,9 @@ class ActionDB(stormbase.StormFoundationDB, stormbase.TagsMixin,
     entry_point = me.StringField(
         required=True,
         help_text='The entry point to the action.')
+    metadata_file = me.StringField(
+        required=False,
+        help_text='Path to the metadata file relative to the pack directory.')
     pack = me.StringField(
         required=False,
         help_text='Name of the content pack.',

--- a/st2common/st2common/models/db/actionalias.py
+++ b/st2common/st2common/models/db/actionalias.py
@@ -78,8 +78,8 @@ class ActionAliasDB(stormbase.StormFoundationDB, stormbase.ContentPackResourceMi
             {'fields': ['name']},
             {'fields': ['enabled']},
             {'fields': ['formats']},
-        ] + stormbase.ContentPackResourceMixin().get_indexes() +
-            stormbase.UIDFieldMixin.get_indexes()
+        ] + (stormbase.ContentPackResourceMixin().get_indexes() +
+             stormbase.UIDFieldMixin.get_indexes())
     }
 
     def __init__(self, *args, **values):

--- a/st2common/st2common/models/db/actionalias.py
+++ b/st2common/st2common/models/db/actionalias.py
@@ -78,7 +78,8 @@ class ActionAliasDB(stormbase.StormFoundationDB, stormbase.ContentPackResourceMi
             {'fields': ['name']},
             {'fields': ['enabled']},
             {'fields': ['formats']},
-        ] + stormbase.UIDFieldMixin.get_indexes()
+        ] + stormbase.ContentPackResourceMixin().get_indexes() +
+            stormbase.UIDFieldMixin.get_indexes()
     }
 
     def __init__(self, *args, **values):

--- a/st2common/st2common/models/db/rule.py
+++ b/st2common/st2common/models/db/rule.py
@@ -98,7 +98,7 @@ class RuleDB(stormbase.StormFoundationDB, stormbase.TagsMixin,
             {'fields': ['trigger']},
             {'fields': ['context.user']},
         ] + (stormbase.ContentPackResourceMixin.get_indexes() +
-             stormbase.TagsMixin.get_indices() +
+             stormbase.TagsMixin.get_indexes() +
              stormbase.UIDFieldMixin.get_indexes())
     }
 

--- a/st2common/st2common/models/db/rule.py
+++ b/st2common/st2common/models/db/rule.py
@@ -97,7 +97,8 @@ class RuleDB(stormbase.StormFoundationDB, stormbase.TagsMixin,
             {'fields': ['action.ref']},
             {'fields': ['trigger']},
             {'fields': ['context.user']},
-        ] + stormbase.TagsMixin.get_indices() + stormbase.UIDFieldMixin.get_indexes()
+        ] + stormbase.ContentPackResourceMixin.get_indexes() + stormbase.TagsMixin.get_indices() +
+            stormbase.UIDFieldMixin.get_indexes()
     }
 
     def __init__(self, *args, **values):

--- a/st2common/st2common/models/db/rule.py
+++ b/st2common/st2common/models/db/rule.py
@@ -97,8 +97,9 @@ class RuleDB(stormbase.StormFoundationDB, stormbase.TagsMixin,
             {'fields': ['action.ref']},
             {'fields': ['trigger']},
             {'fields': ['context.user']},
-        ] + stormbase.ContentPackResourceMixin.get_indexes() + stormbase.TagsMixin.get_indices() +
-            stormbase.UIDFieldMixin.get_indexes()
+        ] + (stormbase.ContentPackResourceMixin.get_indexes() +
+             stormbase.TagsMixin.get_indices() +
+             stormbase.UIDFieldMixin.get_indexes())
     }
 
     def __init__(self, *args, **values):

--- a/st2common/st2common/models/db/rule_enforcement.py
+++ b/st2common/st2common/models/db/rule_enforcement.py
@@ -75,7 +75,7 @@ class RuleEnforcementDB(stormbase.StormFoundationDB, stormbase.TagsMixin):
             {'fields': ['-enforced_at']},
             {'fields': ['-enforced_at', 'rule.ref']},
             {'fields': ['status']},
-        ] + stormbase.TagsMixin.get_indices()
+        ] + stormbase.TagsMixin.get_indexes()
     }
 
     def __init__(self, *args, **values):

--- a/st2common/st2common/models/db/sensor.py
+++ b/st2common/st2common/models/db/sensor.py
@@ -57,8 +57,8 @@ class SensorTypeDB(stormbase.StormBaseDB, stormbase.ContentPackResourceMixin,
             {'fields': ['name']},
             {'fields': ['enabled']},
             {'fields': ['trigger_types']},
-        ] + stormbase.ContentPackResourceMixin.get_indexes() +
-             stormbase.UIDFieldMixin.get_indexes()
+        ] + (stormbase.ContentPackResourceMixin.get_indexes() +
+             stormbase.UIDFieldMixin.get_indexes())
     }
 
     def __init__(self, *args, **values):

--- a/st2common/st2common/models/db/sensor.py
+++ b/st2common/st2common/models/db/sensor.py
@@ -57,7 +57,8 @@ class SensorTypeDB(stormbase.StormBaseDB, stormbase.ContentPackResourceMixin,
             {'fields': ['name']},
             {'fields': ['enabled']},
             {'fields': ['trigger_types']},
-        ] + stormbase.UIDFieldMixin.get_indexes()
+        ] + stormbase.ContentPackResourceMixin.get_indexes() +
+             stormbase.UIDFieldMixin.get_indexes()
     }
 
     def __init__(self, *args, **values):

--- a/st2common/st2common/models/db/stormbase.py
+++ b/st2common/st2common/models/db/stormbase.py
@@ -250,6 +250,11 @@ class ContentPackResourceMixin(object):
     Mixin class provides utility methods for models which belong to a pack.
     """
 
+    metadata_file = me.StringField(
+        required=False,
+        help_text=('Path to the metadata file (file on disk which contains resource definition) '
+                   'relative to the pack directory.'))
+
     def get_pack_uid(self):
         """
         Return an UID of a pack this resource belongs to.
@@ -272,6 +277,14 @@ class ContentPackResourceMixin(object):
             ref = ResourceReference(pack=self.pack, name=self.name)
 
         return ref
+
+    @classmethod
+    def get_indexes(cls):
+        return [
+            {
+                'fields': ['metadata_file'],
+            }
+        ]
 
 
 class ChangeRevisionFieldMixin(object):

--- a/st2common/st2common/models/db/stormbase.py
+++ b/st2common/st2common/models/db/stormbase.py
@@ -167,7 +167,7 @@ class TagsMixin(object):
     tags = me.ListField(field=me.EmbeddedDocumentField(TagField))
 
     @classmethod
-    def get_indices(cls):
+    def get_indexes(cls):
         return ['tags.name', 'tags.value']
 
 

--- a/st2common/st2common/models/db/trigger.py
+++ b/st2common/st2common/models/db/trigger.py
@@ -55,7 +55,7 @@ class TriggerTypeDB(stormbase.StormBaseDB,
 
     meta = {
         'indexes': (stormbase.ContentPackResourceMixin.get_indexes() +
-                    stormbase.TagsMixin.get_indices() +
+                    stormbase.TagsMixin.get_indexes() +
                     stormbase.UIDFieldMixin.get_indexes())
     }
 

--- a/st2common/st2common/models/db/trigger.py
+++ b/st2common/st2common/models/db/trigger.py
@@ -54,9 +54,9 @@ class TriggerTypeDB(stormbase.StormBaseDB,
     parameters_schema = me.DictField(default={})
 
     meta = {
-        'indexes': stormbase.ContentPackResourceMixin.get_indexes() +
-                   stormbase.TagsMixin.get_indices() +
-                   stormbase.UIDFieldMixin.get_indexes()
+        'indexes': (stormbase.ContentPackResourceMixin.get_indexes() +
+                    stormbase.TagsMixin.get_indices() +
+                    stormbase.UIDFieldMixin.get_indexes())
     }
 
     def __init__(self, *args, **values):

--- a/st2common/st2common/models/db/trigger.py
+++ b/st2common/st2common/models/db/trigger.py
@@ -54,7 +54,9 @@ class TriggerTypeDB(stormbase.StormBaseDB,
     parameters_schema = me.DictField(default={})
 
     meta = {
-        'indexes': stormbase.TagsMixin.get_indices() + stormbase.UIDFieldMixin.get_indexes()
+        'indexes': stormbase.ContentPackResourceMixin.get_indexes() +
+                   stormbase.TagsMixin.get_indices() +
+                   stormbase.UIDFieldMixin.get_indexes()
     }
 
     def __init__(self, *args, **values):

--- a/st2common/st2common/models/utils/sensor_type_utils.py
+++ b/st2common/st2common/models/utils/sensor_type_utils.py
@@ -46,15 +46,18 @@ def to_sensor_db_model(sensor_api_model=None):
     trigger_types = getattr(sensor_api_model, 'trigger_types', [])
     poll_interval = getattr(sensor_api_model, 'poll_interval', None)
     enabled = getattr(sensor_api_model, 'enabled', True)
+    metadata_file = getattr(sensor_api_model, 'metadata_file', None)
 
     poll_interval = getattr(sensor_api_model, 'poll_interval', None)
     if poll_interval and (poll_interval < MINIMUM_POLL_INTERVAL):
         raise ValueError('Minimum possible poll_interval is %s seconds' %
                          (MINIMUM_POLL_INTERVAL))
 
-    # Add pack to each trigger type item
+    # Add pack and metadata fileto each trigger type item
     for trigger_type in trigger_types:
         trigger_type['pack'] = pack
+        trigger_type['metadata_file'] = metadata_file
+
     trigger_type_refs = create_trigger_types(trigger_types)
 
     return _create_sensor_type(pack=pack,
@@ -64,10 +67,11 @@ def to_sensor_db_model(sensor_api_model=None):
                                entry_point=entry_point,
                                trigger_types=trigger_type_refs,
                                poll_interval=poll_interval,
-                               enabled=enabled)
+                               enabled=enabled,
+                               metadata_file=metadata_file)
 
 
-def create_trigger_types(trigger_types):
+def create_trigger_types(trigger_types, metadata_file=None):
     if not trigger_types:
         return []
 
@@ -84,12 +88,13 @@ def create_trigger_types(trigger_types):
 
 
 def _create_sensor_type(pack=None, name=None, description=None, artifact_uri=None,
-                        entry_point=None, trigger_types=None, poll_interval=10, enabled=True):
+                        entry_point=None, trigger_types=None, poll_interval=10,
+                        enabled=True, metadata_file=None):
 
     sensor_type = SensorTypeDB(pack=pack, name=name, description=description,
                                artifact_uri=artifact_uri, entry_point=entry_point,
                                poll_interval=poll_interval, enabled=enabled,
-                               trigger_types=trigger_types)
+                               trigger_types=trigger_types, metadata_file=metadata_file)
     return sensor_type
 
 

--- a/st2common/st2common/services/triggers.py
+++ b/st2common/st2common/services/triggers.py
@@ -418,14 +418,15 @@ def create_or_update_trigger_type_db(trigger_type):
 
 
 def _create_trigger_type(pack, name, description=None, payload_schema=None,
-                         parameters_schema=None, tags=None):
+                         parameters_schema=None, tags=None, metadata_file=None):
     trigger_type = {
         'name': name,
         'pack': pack,
         'description': description,
         'payload_schema': payload_schema,
         'parameters_schema': parameters_schema,
-        'tags': tags
+        'tags': tags,
+        'metadata_file': metadata_file
     }
 
     return create_or_update_trigger_type_db(trigger_type=trigger_type)
@@ -474,6 +475,7 @@ def _add_trigger_models(trigger_type):
     parameters_schema = trigger_type['parameters_schema'] \
         if 'parameters_schema' in trigger_type else {}
     tags = trigger_type.get('tags', [])
+    metadata_file = trigger_type.get('metadata_file', None)
 
     trigger_type = _create_trigger_type(
         pack=pack,
@@ -481,7 +483,8 @@ def _add_trigger_models(trigger_type):
         description=description,
         payload_schema=payload_schema,
         parameters_schema=parameters_schema,
-        tags=tags
+        tags=tags,
+        metadata_file=metadata_file,
     )
     trigger = _create_trigger(trigger_type=trigger_type)
     return (trigger_type, trigger)

--- a/st2common/tests/unit/test_aliasesregistrar.py
+++ b/st2common/tests/unit/test_aliasesregistrar.py
@@ -17,7 +17,14 @@ from __future__ import absolute_import
 import os
 
 from st2common.bootstrap import aliasesregistrar
-from st2tests import DbTestCase, fixturesloader
+from st2common.persistence.action import ActionAlias
+
+from st2tests import DbTestCase
+from st2tests import fixturesloader
+
+__all__ = [
+    'TestAliasRegistrar'
+]
 
 
 ALIASES_FIXTURE_PACK_PATH = os.path.join(fixturesloader.get_fixtures_packs_base_path(),
@@ -31,3 +38,6 @@ class TestAliasRegistrar(DbTestCase):
         count = aliasesregistrar.register_aliases(pack_dir=ALIASES_FIXTURE_PACK_PATH)
         # expect all files to contain be aliases
         self.assertEqual(count, len(os.listdir(ALIASES_FIXTURE_PATH)))
+
+        action_alias_dbs = ActionAlias.get_all()
+        self.assertEqual(action_alias_dbs[0].metadata_file, 'aliases/alias1.yaml')

--- a/st2common/tests/unit/test_content_utils.py
+++ b/st2common/tests/unit/test_content_utils.py
@@ -224,7 +224,7 @@ class ContentUtilsTestCase(unittest2.TestCase):
         self.assertEqual(result, 'actions/lib/foo2.py')
 
         # 2. Invalid path - outside pack directory
-        expected_msg = 'file_path is not located inside the pack directory'
+        expected_msg = r'file_path (.*?) is not located inside the pack directory (.*?)'
 
         file_path = os.path.join(packs_base_paths, 'dummy_pack_2/actions/lib/foo.py')
         self.assertRaisesRegexp(ValueError, expected_msg, get_relative_path_to_pack_file,

--- a/st2common/tests/unit/test_content_utils.py
+++ b/st2common/tests/unit/test_content_utils.py
@@ -28,6 +28,7 @@ from st2common.content.utils import get_pack_resource_file_abs_path
 from st2common.content.utils import get_pack_file_abs_path
 from st2common.content.utils import get_entry_point_abs_path
 from st2common.content.utils import get_action_libs_abs_path
+from st2common.content.utils import get_relative_path_to_pack
 from st2tests import config as tests_config
 from st2tests.fixturesloader import get_fixtures_packs_base_path
 
@@ -198,3 +199,46 @@ class ContentUtilsTestCase(unittest2.TestCase):
         expected_path = os.path.join('/tests/packs/foo/tmp', ACTION_LIBS_DIR)
         self.assertEqual(acutal_path, expected_path, 'Action libs path doesn\'t match.')
         cfg.CONF.content.system_packs_base_path = orig_path
+
+    def test_get_relative_path_to_pack(self):
+        packs_base_paths = get_fixtures_packs_base_path()
+
+        pack_ref = 'dummy_pack_1'
+
+        # 1. Valid paths
+        file_path = os.path.join(packs_base_paths, 'dummy_pack_1/pack.yaml')
+        result = get_relative_path_to_pack(pack_ref=pack_ref, file_path=file_path)
+        self.assertEqual(result, 'pack.yaml')
+
+        file_path = os.path.join(packs_base_paths, 'dummy_pack_1/actions/action.meta.yaml')
+        result = get_relative_path_to_pack(pack_ref=pack_ref, file_path=file_path)
+        self.assertEqual(result, 'actions/action.meta.yaml')
+
+        file_path = os.path.join(packs_base_paths, 'dummy_pack_1/actions/lib/foo.py')
+        result = get_relative_path_to_pack(pack_ref=pack_ref, file_path=file_path)
+        self.assertEqual(result, 'actions/lib/foo.py')
+
+        # Already relative
+
+        file_path = 'actions/lib/foo2.py'
+        result = get_relative_path_to_pack(pack_ref=pack_ref, file_path=file_path)
+        self.assertEqual(result, 'actions/lib/foo2.py')
+
+        # 2. Invalid path - outside pack directory
+        expected_msg = 'file_path is not located inside the pack directory'
+
+        file_path = os.path.join(packs_base_paths, 'dummy_pack_2/actions/lib/foo.py')
+        self.assertRaisesRegexp(ValueError, expected_msg, get_relative_path_to_pack,
+                                pack_ref=pack_ref, file_path=file_path)
+
+        file_path = '/tmp/foo/bar.py'
+        self.assertRaisesRegexp(ValueError, expected_msg, get_relative_path_to_pack,
+                                pack_ref=pack_ref, file_path=file_path)
+
+        file_path = os.path.join(packs_base_paths, '../dummy_pack_1/pack.yaml')
+        self.assertRaisesRegexp(ValueError, expected_msg, get_relative_path_to_pack,
+                                pack_ref=pack_ref, file_path=file_path)
+
+        file_path = os.path.join(packs_base_paths, '../../dummy_pack_1/pack.yaml')
+        self.assertRaisesRegexp(ValueError, expected_msg, get_relative_path_to_pack,
+                                pack_ref=pack_ref, file_path=file_path)

--- a/st2common/tests/unit/test_content_utils.py
+++ b/st2common/tests/unit/test_content_utils.py
@@ -28,7 +28,7 @@ from st2common.content.utils import get_pack_resource_file_abs_path
 from st2common.content.utils import get_pack_file_abs_path
 from st2common.content.utils import get_entry_point_abs_path
 from st2common.content.utils import get_action_libs_abs_path
-from st2common.content.utils import get_relative_path_to_pack
+from st2common.content.utils import get_relative_path_to_pack_file
 from st2tests import config as tests_config
 from st2tests.fixturesloader import get_fixtures_packs_base_path
 
@@ -200,45 +200,45 @@ class ContentUtilsTestCase(unittest2.TestCase):
         self.assertEqual(acutal_path, expected_path, 'Action libs path doesn\'t match.')
         cfg.CONF.content.system_packs_base_path = orig_path
 
-    def test_get_relative_path_to_pack(self):
+    def test_get_relative_path_to_pack_file(self):
         packs_base_paths = get_fixtures_packs_base_path()
 
         pack_ref = 'dummy_pack_1'
 
         # 1. Valid paths
         file_path = os.path.join(packs_base_paths, 'dummy_pack_1/pack.yaml')
-        result = get_relative_path_to_pack(pack_ref=pack_ref, file_path=file_path)
+        result = get_relative_path_to_pack_file(pack_ref=pack_ref, file_path=file_path)
         self.assertEqual(result, 'pack.yaml')
 
         file_path = os.path.join(packs_base_paths, 'dummy_pack_1/actions/action.meta.yaml')
-        result = get_relative_path_to_pack(pack_ref=pack_ref, file_path=file_path)
+        result = get_relative_path_to_pack_file(pack_ref=pack_ref, file_path=file_path)
         self.assertEqual(result, 'actions/action.meta.yaml')
 
         file_path = os.path.join(packs_base_paths, 'dummy_pack_1/actions/lib/foo.py')
-        result = get_relative_path_to_pack(pack_ref=pack_ref, file_path=file_path)
+        result = get_relative_path_to_pack_file(pack_ref=pack_ref, file_path=file_path)
         self.assertEqual(result, 'actions/lib/foo.py')
 
         # Already relative
 
         file_path = 'actions/lib/foo2.py'
-        result = get_relative_path_to_pack(pack_ref=pack_ref, file_path=file_path)
+        result = get_relative_path_to_pack_file(pack_ref=pack_ref, file_path=file_path)
         self.assertEqual(result, 'actions/lib/foo2.py')
 
         # 2. Invalid path - outside pack directory
         expected_msg = 'file_path is not located inside the pack directory'
 
         file_path = os.path.join(packs_base_paths, 'dummy_pack_2/actions/lib/foo.py')
-        self.assertRaisesRegexp(ValueError, expected_msg, get_relative_path_to_pack,
+        self.assertRaisesRegexp(ValueError, expected_msg, get_relative_path_to_pack_file,
                                 pack_ref=pack_ref, file_path=file_path)
 
         file_path = '/tmp/foo/bar.py'
-        self.assertRaisesRegexp(ValueError, expected_msg, get_relative_path_to_pack,
+        self.assertRaisesRegexp(ValueError, expected_msg, get_relative_path_to_pack_file,
                                 pack_ref=pack_ref, file_path=file_path)
 
         file_path = os.path.join(packs_base_paths, '../dummy_pack_1/pack.yaml')
-        self.assertRaisesRegexp(ValueError, expected_msg, get_relative_path_to_pack,
+        self.assertRaisesRegexp(ValueError, expected_msg, get_relative_path_to_pack_file,
                                 pack_ref=pack_ref, file_path=file_path)
 
         file_path = os.path.join(packs_base_paths, '../../dummy_pack_1/pack.yaml')
-        self.assertRaisesRegexp(ValueError, expected_msg, get_relative_path_to_pack,
+        self.assertRaisesRegexp(ValueError, expected_msg, get_relative_path_to_pack_file,
                                 pack_ref=pack_ref, file_path=file_path)

--- a/st2common/tests/unit/test_content_utils.py
+++ b/st2common/tests/unit/test_content_utils.py
@@ -219,7 +219,6 @@ class ContentUtilsTestCase(unittest2.TestCase):
         self.assertEqual(result, 'actions/lib/foo.py')
 
         # Already relative
-
         file_path = 'actions/lib/foo2.py'
         result = get_relative_path_to_pack_file(pack_ref=pack_ref, file_path=file_path)
         self.assertEqual(result, 'actions/lib/foo2.py')

--- a/st2common/tests/unit/test_policies_registrar.py
+++ b/st2common/tests/unit/test_policies_registrar.py
@@ -130,6 +130,7 @@ class PoliciesRegistrarTestCase(CleanDbTestCase):
         self.assertEqual(p1.policy_type, 'action.concurrency')
         # Verify that a default value for parameter "action" which isn't provided in the file is set
         self.assertEqual(p1.parameters['action'], 'delay')
+        self.assertEqual(p1.metadata_file, 'policies/policy_1.yaml')
 
         p2 = Policy.get_by_ref('dummy_pack_1.test_policy_2')
         self.assertEqual(p2, None)

--- a/st2common/tests/unit/test_policies_registrar.py
+++ b/st2common/tests/unit/test_policies_registrar.py
@@ -142,6 +142,7 @@ class PoliciesRegistrarTestCase(CleanDbTestCase):
 
         expected_msg = 'Referenced policy_type "action.mock_policy_error" doesnt exist'
         self.assertRaisesRegexp(ValueError, expected_msg, registrar._register_policy,
+                                pack_base_path='/opt/stackstorm/packs/dummy_pack_1',
                                 pack='dummy_pack_1', policy=policy_path)
 
     def test_make_sure_policy_parameters_are_validated_during_register(self):
@@ -152,5 +153,7 @@ class PoliciesRegistrarTestCase(CleanDbTestCase):
 
         expected_msg = '100 is greater than the maximum of 5'
         self.assertRaisesRegexp(jsonschema.ValidationError, expected_msg,
-                                registrar._register_policy, pack='dummy_pack_2',
+                                registrar._register_policy,
+                                pack_base_path='/opt/stackstorm/packs/dummy_pack_1',
+                                pack='dummy_pack_2',
                                 policy=policy_path)

--- a/st2common/tests/unit/test_policies_registrar.py
+++ b/st2common/tests/unit/test_policies_registrar.py
@@ -142,7 +142,6 @@ class PoliciesRegistrarTestCase(CleanDbTestCase):
 
         expected_msg = 'Referenced policy_type "action.mock_policy_error" doesnt exist'
         self.assertRaisesRegexp(ValueError, expected_msg, registrar._register_policy,
-                                pack_base_path='/opt/stackstorm/packs/dummy_pack_1',
                                 pack='dummy_pack_1', policy=policy_path)
 
     def test_make_sure_policy_parameters_are_validated_during_register(self):
@@ -154,6 +153,5 @@ class PoliciesRegistrarTestCase(CleanDbTestCase):
         expected_msg = '100 is greater than the maximum of 5'
         self.assertRaisesRegexp(jsonschema.ValidationError, expected_msg,
                                 registrar._register_policy,
-                                pack_base_path='/opt/stackstorm/packs/dummy_pack_1',
                                 pack='dummy_pack_2',
                                 policy=policy_path)

--- a/st2reactor/tests/integration/test_sensor_container.py
+++ b/st2reactor/tests/integration/test_sensor_container.py
@@ -19,6 +19,7 @@ import os
 import sys
 import signal
 
+import mock
 import psutil
 import eventlet
 from eventlet.green import subprocess
@@ -45,7 +46,7 @@ PYTHON_BINARY = sys.executable
 BINARY = os.path.join(BASE_DIR, '../../../st2reactor/bin/st2sensorcontainer')
 BINARY = os.path.abspath(BINARY)
 
-PACKS_BASE_PATH = os.path.join(BASE_DIR, '../../../contrib')
+PACKS_BASE_PATH = os.path.abspath(os.path.join(BASE_DIR, '../../../contrib'))
 
 DEFAULT_CMD = [
     PYTHON_BINARY,
@@ -56,7 +57,6 @@ DEFAULT_CMD = [
 ]
 
 
-# @unittest2.skipIf(True, 'Skipped until we improve integration tests setup')
 class SensorContainerTestCase(IntegrationTestCase):
     """
     Note: For those tests MongoDB must be running, virtualenv must exist for
@@ -76,6 +76,10 @@ class SensorContainerTestCase(IntegrationTestCase):
         cls.db_connection = db_setup(
             cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
             username=username, password=password, ensure_indexes=False)
+
+        # NOTE: We need to perform this patching because test fixtures are located outside of the packs
+        # base paths directory. This will never happen outside the context of test fixtures.
+        cfg.CONF.content.packs_base_paths = PACKS_BASE_PATH
 
         # Register sensors
         register_sensors(packs_base_paths=[PACKS_BASE_PATH], use_pack_cache=False)

--- a/st2reactor/tests/integration/test_sensor_container.py
+++ b/st2reactor/tests/integration/test_sensor_container.py
@@ -19,7 +19,6 @@ import os
 import sys
 import signal
 
-import mock
 import psutil
 import eventlet
 from eventlet.green import subprocess
@@ -77,8 +76,8 @@ class SensorContainerTestCase(IntegrationTestCase):
             cfg.CONF.database.db_name, cfg.CONF.database.host, cfg.CONF.database.port,
             username=username, password=password, ensure_indexes=False)
 
-        # NOTE: We need to perform this patching because test fixtures are located outside of the packs
-        # base paths directory. This will never happen outside the context of test fixtures.
+        # NOTE: We need to perform this patching because test fixtures are located outside of the
+        # packs base paths directory. This will never happen outside the context of test fixtures.
         cfg.CONF.content.packs_base_paths = PACKS_BASE_PATH
 
         # Register sensors

--- a/st2reactor/tests/unit/test_sensor_and_rule_registration.py
+++ b/st2reactor/tests/unit/test_sensor_and_rule_registration.py
@@ -55,10 +55,12 @@ class SensorRegistrationTestCase(DbTestCase):
         self.assertEqual(sensor_dbs[0].name, 'TestSensor')
         self.assertEqual(sensor_dbs[0].poll_interval, 10)
         self.assertTrue(sensor_dbs[0].enabled)
+        self.assertTrue(sensor_dbs[0].metadata_file.endswith('sensors/test_sensor_1.yaml'))
 
         self.assertEqual(sensor_dbs[1].name, 'TestSensorDisabled')
         self.assertEqual(sensor_dbs[1].poll_interval, 10)
         self.assertFalse(sensor_dbs[1].enabled)
+        self.assertTrue(sensor_dbs[0].metadata_file.endswith('sensors/test_sensor_1.yaml'))
 
         self.assertEqual(trigger_type_dbs[0].name, 'trigger_type_1')
         self.assertEqual(trigger_type_dbs[0].pack, 'pack_with_sensor')
@@ -68,6 +70,11 @@ class SensorRegistrationTestCase(DbTestCase):
         self.assertEqual(len(trigger_type_dbs[1].tags), 2)
         self.assertEqual(trigger_type_dbs[1].tags[0].name, 'tag1name')
         self.assertEqual(trigger_type_dbs[1].tags[0].value, 'tag1 value')
+
+        # Triggered which are registered via sensors have metadata_file pointing to the sensor
+        # definition file
+        self.assertTrue('sensors/' in trigger_type_dbs[0].metadata_file)
+        self.assertTrue('sensors/' in trigger_type_dbs[1].metadata_file)
 
         # Verify second call to registration doesn't create a duplicate objects
         registrar.register_from_packs(base_dirs=[PACKS_DIR])

--- a/st2reactor/tests/unit/test_sensor_and_rule_registration.py
+++ b/st2reactor/tests/unit/test_sensor_and_rule_registration.py
@@ -27,10 +27,19 @@ from st2common.transport.publishers import PoolPublisher
 from st2common.bootstrap.sensorsregistrar import SensorsRegistrar
 from st2common.bootstrap.rulesregistrar import RulesRegistrar
 
+__all__ = [
+    'SensorRegistrationTestCase',
+    'RuleRegistrationTestCase'
+]
+
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
-PACKS_DIR = os.path.join(CURRENT_DIR, '../fixtures/packs')
+PACKS_DIR = os.path.abspath(os.path.join(CURRENT_DIR, '../fixtures/packs'))
 
 
+# NOTE: We need to perform this patching because test fixtures are located outside of the packs
+# base paths directory. This will never happen outside the context of test fixtures.
+@mock.patch('st2common.content.utils.get_pack_base_path',
+            mock.Mock(return_value=os.path.join(PACKS_DIR, 'pack_with_sensor')))
 class SensorRegistrationTestCase(DbTestCase):
 
     @mock.patch.object(PoolPublisher, 'publish', mock.MagicMock())
@@ -126,6 +135,10 @@ class SensorRegistrationTestCase(DbTestCase):
         self.assertEqual(trigger_type_dbs[1].description, 'test 2')
 
 
+# NOTE: We need to perform this patching because test fixtures are located outside of the packs
+# base paths directory. This will never happen outside the context of test fixtures.
+@mock.patch('st2common.content.utils.get_pack_base_path',
+            mock.Mock(return_value=os.path.join(PACKS_DIR, 'pack_with_rules')))
 class RuleRegistrationTestCase(DbTestCase):
     def test_register_rules(self):
         # Verify DB is empty at the beginning

--- a/st2reactor/tests/unit/test_sensor_and_rule_registration.py
+++ b/st2reactor/tests/unit/test_sensor_and_rule_registration.py
@@ -64,12 +64,12 @@ class SensorRegistrationTestCase(DbTestCase):
         self.assertEqual(sensor_dbs[0].name, 'TestSensor')
         self.assertEqual(sensor_dbs[0].poll_interval, 10)
         self.assertTrue(sensor_dbs[0].enabled)
-        self.assertTrue(sensor_dbs[0].metadata_file.endswith('sensors/test_sensor_1.yaml'))
+        self.assertEqual(sensor_dbs[0].metadata_file, 'sensors/test_sensor_1.yaml')
 
         self.assertEqual(sensor_dbs[1].name, 'TestSensorDisabled')
         self.assertEqual(sensor_dbs[1].poll_interval, 10)
         self.assertFalse(sensor_dbs[1].enabled)
-        self.assertTrue(sensor_dbs[0].metadata_file.endswith('sensors/test_sensor_1.yaml'))
+        self.assertEqual(sensor_dbs[1].metadata_file, 'sensors/test_sensor_2.yaml')
 
         self.assertEqual(trigger_type_dbs[0].name, 'trigger_type_1')
         self.assertEqual(trigger_type_dbs[0].pack, 'pack_with_sensor')
@@ -82,8 +82,8 @@ class SensorRegistrationTestCase(DbTestCase):
 
         # Triggered which are registered via sensors have metadata_file pointing to the sensor
         # definition file
-        self.assertTrue('sensors/' in trigger_type_dbs[0].metadata_file)
-        self.assertTrue('sensors/' in trigger_type_dbs[1].metadata_file)
+        self.assertEqual(trigger_type_dbs[0].metadata_file, 'sensors/test_sensor_1.yaml')
+        self.assertEqual(trigger_type_dbs[1].metadata_file, 'sensors/test_sensor_1.yaml')
 
         # Verify second call to registration doesn't create a duplicate objects
         registrar.register_from_packs(base_dirs=[PACKS_DIR])

--- a/st2tests/st2tests/action_aliases.py
+++ b/st2tests/st2tests/action_aliases.py
@@ -119,7 +119,8 @@ class BaseActionAliasTestCase(BasePackResourceTestCase):
         aliases = registrar._get_aliases_from_pack(aliases_dir=aliases_path)
         for alias_path in aliases:
             action_alias_db = registrar._get_action_alias_db(pack=pack,
-                                                             action_alias=alias_path)
+                                                             action_alias=alias_path,
+                                                             ignore_metadata_file_error=True)
 
             if action_alias_db.name == name:
                 return action_alias_db

--- a/st2tests/st2tests/action_aliases.py
+++ b/st2tests/st2tests/action_aliases.py
@@ -118,7 +118,8 @@ class BaseActionAliasTestCase(BasePackResourceTestCase):
                                                          content_type='aliases')
         aliases = registrar._get_aliases_from_pack(aliases_dir=aliases_path)
         for alias_path in aliases:
-            action_alias_db = registrar._get_action_alias_db(pack=pack,
+            action_alias_db = registrar._get_action_alias_db(pack_base_path=base_pack_path,
+                                                             pack=pack,
                                                              action_alias=alias_path)
 
             if action_alias_db.name == name:

--- a/st2tests/st2tests/action_aliases.py
+++ b/st2tests/st2tests/action_aliases.py
@@ -118,8 +118,7 @@ class BaseActionAliasTestCase(BasePackResourceTestCase):
                                                          content_type='aliases')
         aliases = registrar._get_aliases_from_pack(aliases_dir=aliases_path)
         for alias_path in aliases:
-            action_alias_db = registrar._get_action_alias_db(pack_base_path=base_pack_path,
-                                                             pack=pack,
+            action_alias_db = registrar._get_action_alias_db(pack=pack,
                                                              action_alias=alias_path)
 
             if action_alias_db.name == name:

--- a/tools/migrate_rules_to_include_pack.py
+++ b/tools/migrate_rules_to_include_pack.py
@@ -55,7 +55,7 @@ class Migration(object):
                                   help_text=u'Flag indicating whether the rule is enabled.')
 
         meta = {
-            'indexes': stormbase.TagsMixin.get_indices()
+            'indexes': stormbase.TagsMixin.get_indexes()
         }
 
 
@@ -81,7 +81,7 @@ class RuleDB(stormbase.StormBaseDB, stormbase.TagsMixin):
                               help_text=u'Flag indicating whether the rule is enabled.')
 
     meta = {
-        'indexes': stormbase.TagsMixin.get_indices()
+        'indexes': stormbase.TagsMixin.get_indexes()
     }
 
 


### PR DESCRIPTION
This pull request adds new ``metadata_file`` attribute to all the pack resource models which can be registered by the user (action, action alias, rule, sensor type, trigger type, policy).

This attribute contains path to the pack YAML metadata file which is relative to the pack directory.

For example if the pack action metadata file absolute path is ``/opt/stackstorm/packs/mypack/actions/myaction.yaml``, ``metadata_file`` attribute value for that action would be ``actions/myaction.yaml``.

Keep in mind that this attribute will be empty for resources which are created via API and not registered via definition file on disk.

This change is needed by st2flow so it can retrieve path to a particular action metadata file and then retrieve raw action metadata YAML file content.

This attribute is also useful outside the context of st2flow since it allow us to easily see which resource is registered via API and which via YAML definition on disk (and potentially implement export script or at least "diff" script utilizing that attribute in the future).

Related to https://github.com/StackStorm/st2/pull/4440.

## Other changes

* Ensure we always sort value of ``PackDB.files`` attribute so the order is stable and doesn't change during register runs if the content on disk doesn't change.

## TODO

- [x] Tests