### PR TITLE
Fix Exception messages

### DIFF
--- a/contrib/runners/mistral_v2/mistral_v2/query.py
+++ b/contrib/runners/mistral_v2/mistral_v2/query.py
@@ -89,8 +89,8 @@ class MistralResultsQuerier(Querier):
 
         mistral_exec_id = query_context.get('mistral', {}).get('execution_id', None)
         if not mistral_exec_id:
-            raise Exception('[%s] Missing mistral workflow execution ID in query context. %s',
-                            execution_id, query_context)
+            raise Exception('[%s] Missing mistral workflow execution ID in query context. %s'
+                            % (execution_id, query_context))
 
         LOG.info('[%s] Querying mistral execution %s...', execution_id, mistral_exec_id)
 

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -748,7 +748,7 @@ class ActionRunCommandMixin(object):
                 try:
                     action = action_mgr.get_by_ref_or_id(args.ref_or_id, **kwargs)
                     if not action:
-                        raise resource.ResourceNotFoundError('Action %s not found', args.ref_or_id)
+                        raise resource.ResourceNotFoundError('Action %s not found' % args.ref_or_id)
                     runner_mgr = self.app.client.managers['RunnerType']
                     runner = runner_mgr.get_by_name(action.runner_type, **kwargs)
                     parameters, required, optional, _ = self._get_params_types(runner,

--- a/st2client/st2client/commands/keyvalue.py
+++ b/st2client/st2client/commands/keyvalue.py
@@ -220,8 +220,8 @@ class KeyValuePairDeleteCommand(resource.ResourceDeleteCommand):
         instance = self.get_resource(resource_id, **kwargs)
 
         if not instance:
-            raise resource.ResourceNotFoundError('KeyValuePair with id "%s" not found',
-                                                 resource_id)
+            raise resource.ResourceNotFoundError('KeyValuePair with id "%s" not found'
+                                                 % resource_id)
 
         instance.id = resource_id  # TODO: refactor and get rid of id
         self.manager.delete(instance, **kwargs)

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -304,7 +304,7 @@ class PackRemoveCommand(PackAsyncCommand):
             pack_instance = self.app.client.managers['Pack'].get_by_ref_or_id(packs[0], **kwargs)
 
             if pack_instance:
-                raise OperationFailureException('Pack %s has not been removed properly', packs[0])
+                raise OperationFailureException('Pack %s has not been removed properly' % packs[0])
 
             removed_pack_instance = next((pack for pack in all_pack_instances
                                          if pack.name == packs[0]), None)
@@ -320,8 +320,8 @@ class PackRemoveCommand(PackAsyncCommand):
                 if pack.name in packs:
                     pack_instances.append(pack)
                 if pack in remaining_pack_instances:
-                    raise OperationFailureException('Pack %s has not been removed properly',
-                                                    pack.name)
+                    raise OperationFailureException('Pack %s has not been removed properly'
+                                                    % pack.name)
 
             self.print_output(pack_instances, table.MultiColumnTable,
                               attributes=args.attr, widths=args.width,

--- a/st2common/st2common/metrics/base.py
+++ b/st2common/st2common/metrics/base.py
@@ -223,7 +223,7 @@ def metrics_initialize():
     try:
         METRICS = get_plugin_instance(PLUGIN_NAMESPACE, cfg.CONF.metrics.driver)
     except (NoMatches, MultipleMatches, NoSuchOptError) as error:
-        raise PluginLoadError('Error loading metrics driver. Check configuration: %s', error)
+        raise PluginLoadError('Error loading metrics driver. Check configuration: %s' % error)
 
     return METRICS
 

--- a/st2common/st2common/runners/paramiko_ssh_runner.py
+++ b/st2common/st2common/runners/paramiko_ssh_runner.py
@@ -88,8 +88,8 @@ class BaseParallelSSHRunner(ActionRunner, ShellRunnerMixin):
         hosts = self.runner_parameters.get(RUNNER_HOSTS, '').split(',')
         self._hosts = [h.strip() for h in hosts if len(h) > 0]
         if len(self._hosts) < 1:
-            raise ActionRunnerPreRunError('No hosts specified to run action for action %s.',
-                                          self.liveaction_id)
+            raise ActionRunnerPreRunError('No hosts specified to run action for action %s.'
+                                          % self.liveaction_id)
         self._username = self.runner_parameters.get(RUNNER_USERNAME, None)
         self._password = self.runner_parameters.get(RUNNER_PASSWORD, None)
         self._private_key = self.runner_parameters.get(RUNNER_PRIVATE_KEY, None)

--- a/st2common/st2common/services/datastore.py
+++ b/st2common/st2common/services/datastore.py
@@ -165,7 +165,7 @@ class BaseDatastoreService(object):
         :rtype: ``bool``
         """
         if scope != SYSTEM_SCOPE:
-            raise ValueError('Scope %s is unsupported.', scope)
+            raise ValueError('Scope %s is unsupported.' % scope)
 
         name = self._get_full_key_name(name=name, local=local)
 
@@ -208,7 +208,7 @@ class BaseDatastoreService(object):
         :rtype: ``bool``
         """
         if scope != SYSTEM_SCOPE:
-            raise ValueError('Scope %s is unsupported.', scope)
+            raise ValueError('Scope %s is unsupported.' % scope)
 
         name = self._get_full_key_name(name=name, local=local)
 

--- a/st2common/st2common/util/action_db.py
+++ b/st2common/st2common/util/action_db.py
@@ -197,8 +197,8 @@ def update_liveaction_status(status=None, result=None, context=None, end_timesta
 
     if status not in LIVEACTION_STATUSES:
         raise ValueError('Attempting to set status for LiveAction "%s" '
-                         'to unknown status string. Unknown status is "%s"',
-                         liveaction_db, status)
+                         'to unknown status string. Unknown status is "%s"'
+                         % (liveaction_db, status))
 
     if result and cfg.CONF.system.validate_output_schema and status == LIVEACTION_STATUS_SUCCEEDED:
         action_db = get_action_by_ref(liveaction_db.action)

--- a/st2common/st2common/util/reference.py
+++ b/st2common/st2common/util/reference.py
@@ -71,8 +71,8 @@ def get_resource_ref_from_model(model):
         name = model.name
         pack = model.pack
     except AttributeError:
-        raise Exception('Cannot build ResourceReference for model: %s. Name or pack missing.',
-                        model)
+        raise Exception('Cannot build ResourceReference for model: %s. Name or pack missing.'
+                        % model)
     return ResourceReference(name=name, pack=pack)
 
 

--- a/st2reactor/st2reactor/container/partitioners.py
+++ b/st2reactor/st2reactor/container/partitioners.py
@@ -114,8 +114,9 @@ class FileBasedPartitioner(DefaultPartitioner):
             partition_map = yaml.safe_load(f)
             sensor_refs = partition_map.get(self.sensor_node_name, None)
             if sensor_refs is None:
-                raise SensorPartitionMapMissingException('Sensor partition not found for %s in %s.',
-                                                         self.sensor_node_name, self.partition_file)
+                raise SensorPartitionMapMissingException('Sensor partition not found for %s in %s.'
+                                                         % (self.sensor_node_name,
+                                                            self.partition_file))
             self._supported_sensor_refs = set(sensor_refs)
             return self._supported_sensor_refs
 

--- a/st2reactor/st2reactor/container/utils.py
+++ b/st2reactor/st2reactor/container/utils.py
@@ -42,7 +42,7 @@ def create_trigger_instance(trigger, payload, occurrence_time, raise_on_no_trigg
     if not trigger_db:
         LOG.debug('No trigger in db for %s', trigger)
         if raise_on_no_trigger:
-            raise StackStormDBObjectNotFoundError('Trigger not found for %s', trigger)
+            raise StackStormDBObjectNotFoundError('Trigger not found for %s' % trigger)
         return None
 
     trigger_ref = trigger_db.get_reference().ref


### PR DESCRIPTION
We had a few instances where we did not properly format our Exception messages, leading to a literal `%s` in the raised Exception.

I used `pylint -s n --disable=all -e W0715` against all our code to identify all places where this happened.