### PR TITLE
Rename st2client.liveactions to st2client.executions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -71,6 +71,11 @@ Changed
 * Refactor Orquesta workflow to output on error. Depends on PR
   https://github.com/StackStorm/orquesta/pull/101 and https://github.com/StackStorm/orquesta/pull/102
   (improvement)
+* Rename ``st2client.liveactions`` to ``st2client.executions``. ``st2client.liveactions`` already
+  represented operations on execution objects, but it was incorrectly named.
+
+  For backward compatibility reasons, ``st2client.liveactions`` will stay as an alias for
+  ``st2client.executions`` and continue to work until it's fully removed in a future release.
 
 Fixed
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,10 @@ Added
   ``sensors/`` directory or via trigger definition file in ``triggers/`` directory. If
   ``metadata_file`` attribute on TriggerTypeDB model points to ``sensors/`` directory it means that
   trigger is registered via sensor definition. (new feature) #4445
+* Add new ``st2client.executions.get_children`` method for returning children execution objects for
+  a specific (parent) execution. (new feature) #4444
+
+  Contributed by Tristan Struthers (@trstruth).
 
 Changed
 ~~~~~~~

--- a/st2client/README.rst
+++ b/st2client/README.rst
@@ -81,7 +81,7 @@ Python Client
     >>> from st2client import models
     >>> client = Client(base_url='http://127.0.0.1')
     >>> rules = client.rules.get_all()
-    >>> executions = client.liveactions.get_all()
+    >>> executions = client.executions.get_all()
     >>> key_value_pair = client.keys.update(models.KeyValuePair(name='k1', value='v1'))
 
 The models Trigger, Rule, Action, Execution, and KeyValuePair are
@@ -89,8 +89,7 @@ defined under st2client.models. Please refer to the respective README
 section for these models for their schema.
 
 The resource managers for the models are instantiated under the client
-as **triggers**, **rules**, **actions**, **liveactions** (for executions),
-and **keys**.
+as **triggers**, **rules**, **actions**, **executions**, and **keys**.
 The operations get\_all, get\_by\_name, get\_by\_id, create, update, and
 delete are generally implemented for these resource managers.
 

--- a/st2client/st2client/client.py
+++ b/st2client/st2client/client.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 
 import os
 import logging
+import warnings
 
 import six
 
@@ -207,6 +208,8 @@ class Client(object):
     # backward compatibility reasons until v3.2.0
     @property
     def liveactions(self):
+        warnings.warn(('st2client.liveactions has been renamed to st2client.executions, please '
+                       'update your code'), DeprecationWarning)
         return self.executions
 
     @property

--- a/st2client/st2client/client.py
+++ b/st2client/st2client/client.py
@@ -25,7 +25,7 @@ from st2client.utils import httpclient
 from st2client.models.core import ResourceManager
 from st2client.models.core import ActionAliasResourceManager
 from st2client.models.core import ActionAliasExecutionManager
-from st2client.models.core import LiveActionResourceManager
+from st2client.models.core import ExecutionResourceManager
 from st2client.models.core import InquiryResourceManager
 from st2client.models.core import TriggerInstanceResourceManager
 from st2client.models.core import PackResourceManager
@@ -129,8 +129,8 @@ class Client(object):
             models.Config, self.endpoints['api'], cacert=self.cacert, debug=self.debug)
         self.managers['ConfigSchema'] = ResourceManager(
             models.ConfigSchema, self.endpoints['api'], cacert=self.cacert, debug=self.debug)
-        self.managers['LiveAction'] = LiveActionResourceManager(
-            models.LiveAction, self.endpoints['api'], cacert=self.cacert, debug=self.debug)
+        self.managers['Execution'] = ExecutionResourceManager(
+            models.Execution, self.endpoints['api'], cacert=self.cacert, debug=self.debug)
         self.managers['Inquiry'] = InquiryResourceManager(
             models.Inquiry, self.endpoints['exp'], cacert=self.cacert, debug=self.debug)
         self.managers['Pack'] = PackResourceManager(
@@ -200,8 +200,14 @@ class Client(object):
         return self.managers['KeyValuePair']
 
     @property
+    def executions(self):
+        return self.managers['Execution']
+
+    # NOTE: LiveAction has been deprecated in favor of Execution. It will be left here for
+    # backward compatibility reasons until v3.2.0
+    @property
     def liveactions(self):
-        return self.managers['LiveAction']
+        return self.executions
 
     @property
     def inquiries(self):

--- a/st2client/st2client/client.py
+++ b/st2client/st2client/client.py
@@ -132,6 +132,9 @@ class Client(object):
             models.ConfigSchema, self.endpoints['api'], cacert=self.cacert, debug=self.debug)
         self.managers['Execution'] = ExecutionResourceManager(
             models.Execution, self.endpoints['api'], cacert=self.cacert, debug=self.debug)
+        # NOTE: LiveAction has been deprecated in favor of Execution. It will be left here for
+        # backward compatibility reasons until v3.2.0
+        self.managers['LiveAction'] = self.managers['Execution']
         self.managers['Inquiry'] = InquiryResourceManager(
             models.Inquiry, self.endpoints['exp'], cacert=self.cacert, debug=self.debug)
         self.managers['Pack'] = PackResourceManager(

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -368,7 +368,7 @@ class ActionRunCommandMixin(object):
             self.print_output(instance, formatter, **options)
 
     def _run_and_print_child_task_list(self, execution, args, **kwargs):
-        action_exec_mgr = self.app.client.managers['LiveAction']
+        action_exec_mgr = self.app.client.managers['Execution']
 
         instance = execution
         options = {'attributes': ['id', 'action.ref', 'parameters', 'status', 'start_timestamp',
@@ -456,7 +456,7 @@ class ActionRunCommandMixin(object):
         if args.tail:
             # Start tailing new execution
             print('Tailing execution "%s"' % (str(execution.id)))
-            execution_manager = self.app.client.managers['LiveAction']
+            execution_manager = self.app.client.managers['Execution']
             stream_manager = self.app.client.managers['Stream']
             ActionExecutionTailCommand.tail_execution(execution=execution,
                                                       execution_manager=execution_manager,
@@ -734,7 +734,7 @@ class ActionRunCommandMixin(object):
     def _print_help(self, args, **kwargs):
         # Print appropriate help message if the help option is given.
         action_mgr = self.app.client.managers['Action']
-        action_exec_mgr = self.app.client.managers['LiveAction']
+        action_exec_mgr = self.app.client.managers['Execution']
 
         if args.help:
             action_ref_or_id = getattr(args, 'ref_or_id', None)
@@ -875,9 +875,9 @@ class ActionRunCommandMixin(object):
             task_name_key = 'context.mistral.task_name'
         elif context and 'orquesta' in context:
             task_name_key = 'context.orquesta.task_name'
-        # Use LiveAction as the object so that the formatter lookup does not change.
+        # Use Execution as the object so that the formatter lookup does not change.
         # AKA HACK!
-        return models.action.LiveAction(**{
+        return models.action.Execution(**{
             'id': task.id,
             'status': task.status,
             'task': jsutil.get_value(vars(task), task_name_key),
@@ -994,7 +994,7 @@ class ActionRunCommand(ActionRunCommandMixin, resource.ResourceCommand):
         action_parameters = self._get_action_parameters_from_args(action=action, runner=runner,
                                                                   args=args)
 
-        execution = models.LiveAction()
+        execution = models.Execution()
         execution.action = action_ref
         execution.parameters = action_parameters
         execution.user = args.user
@@ -1005,7 +1005,7 @@ class ActionRunCommand(ActionRunCommandMixin, resource.ResourceCommand):
         if args.trace_id:
             execution.context = {'trace_context': {'id_': args.trace_id}}
 
-        action_exec_mgr = self.app.client.managers['LiveAction']
+        action_exec_mgr = self.app.client.managers['Execution']
 
         execution = action_exec_mgr.create(execution, **kwargs)
         execution = self._get_execution_result(execution=execution,
@@ -1019,7 +1019,7 @@ class ActionExecutionBranch(resource.ResourceBranch):
 
     def __init__(self, description, app, subparsers, parent_parser=None):
         super(ActionExecutionBranch, self).__init__(
-            models.LiveAction, description, app, subparsers,
+            models.Execution, description, app, subparsers,
             parent_parser=parent_parser, read_only=True,
             commands={'list': ActionExecutionListCommand,
                       'get': ActionExecutionGetCommand})
@@ -1285,7 +1285,7 @@ class ActionExecutionReRunCommand(ActionRunCommandMixin, resource.ResourceComman
 
         action_mgr = self.app.client.managers['Action']
         runner_mgr = self.app.client.managers['RunnerType']
-        action_exec_mgr = self.app.client.managers['LiveAction']
+        action_exec_mgr = self.app.client.managers['Execution']
 
         action_ref = existing_execution.action['ref']
         action = action_mgr.get_by_ref_or_id(action_ref)

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -21,7 +21,7 @@ import yaml
 
 from st2client.models import Config
 from st2client.models import Pack
-from st2client.models import LiveAction
+from st2client.models import Execution
 from st2client.commands import resource
 from st2client.commands.resource import add_auth_token_to_kwargs_from_cli
 from st2client.commands.action import ActionRunCommandMixin
@@ -117,7 +117,7 @@ class PackAsyncCommand(ActionRunCommandMixin, resource.ResourceCommand):
         with term.TaskIndicator() as indicator:
             events = ['st2.execution__create', 'st2.execution__update']
             for event in stream_mgr.listen(events, **kwargs):
-                execution = LiveAction(**event)
+                execution = Execution(**event)
 
                 if execution.id == parent_id \
                         and execution.status in LIVEACTION_COMPLETED_STATES:
@@ -143,7 +143,7 @@ class PackAsyncCommand(ActionRunCommandMixin, resource.ResourceCommand):
             self._print_execution_details(execution=execution, args=args, **kwargs)
             sys.exit(1)
 
-        return self.app.client.managers['LiveAction'].get_by_id(parent_id, **kwargs)
+        return self.app.client.managers['Execution'].get_by_id(parent_id, **kwargs)
 
 
 class PackListCommand(resource.ResourceListCommand):

--- a/st2client/st2client/commands/trace.py
+++ b/st2client/st2client/commands/trace.py
@@ -15,7 +15,7 @@
 
 from __future__ import absolute_import
 
-from st2client.models import Resource, Trace, TriggerInstance, Rule, LiveAction
+from st2client.models import Resource, Trace, TriggerInstance, Rule, Execution
 from st2client.exceptions.operations import OperationFailureException
 from st2client.formatters import table
 from st2client.formatters import execution as execution_formatter
@@ -94,7 +94,7 @@ class SingleTraceDisplayMixin(object):
                                for rule in trace.rules])
         if any(attr in args.attr for attr in ACTION_EXECUTION_DISPLAY_OPTIONS):
             components.extend([Resource(**{'id': execution['object_id'],
-                                           'type': LiveAction._alias.lower(),
+                                           'type': Execution._alias.lower(),
                                            'ref': execution['ref'],
                                            'updated_at': execution['updated_at']})
                                for execution in trace.action_executions])

--- a/st2client/st2client/models/action.py
+++ b/st2client/st2client/models/action.py
@@ -36,10 +36,16 @@ class Action(core.Resource):
     _repr_attributes = ['name', 'pack', 'enabled', 'runner_type']
 
 
-class LiveAction(core.Resource):
+class Execution(core.Resource):
     _alias = 'Execution'
     _display_name = 'Action Execution'
     _url_path = 'executions'
     _plural = 'ActionExecutions'
     _plural_display_name = 'Action executions'
     _repr_attributes = ['status', 'action', 'start_timestamp', 'end_timestamp', 'parameters']
+
+
+# NOTE: LiveAction has been deprecated in favor of Execution. It will be left here for
+# backward compatibility reasons until v3.2.0
+class LiveAction(Execution):
+    pass

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -375,7 +375,7 @@ class ActionAliasExecutionManager(ResourceManager):
         return instance
 
 
-class LiveActionResourceManager(ResourceManager):
+class ExecutionResourceManager(ResourceManager):
     @add_auth_token_to_kwargs_from_env
     def re_run(self, execution_id, parameters=None, tasks=None, no_reset=None, **kwargs):
         url = '/%s/%s/re_run' % (self.resource.get_url_path_name(), execution_id)

--- a/st2client/tests/unit/test_client_executions.py
+++ b/st2client/tests/unit/test_client_executions.py
@@ -14,8 +14,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import json
 import logging
+import warnings
 import mock
 import unittest2
 
@@ -184,3 +186,13 @@ class TestExecutionResourceManager(unittest2.TestCase):
         }
 
         httpclient.HTTPClient.get.assert_called_with(url=endpoint, params=data)
+
+    def test_st2client_liveactions_has_been_deprecated_and_emits_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+
+            self.client.liveactions.get_all()
+
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
+            self.assertTrue('st2client.liveactions has been renamed' in str(w[0].message))

--- a/st2client/tests/unit/test_client_executions.py
+++ b/st2client/tests/unit/test_client_executions.py
@@ -187,6 +187,9 @@ class TestExecutionResourceManager(unittest2.TestCase):
 
         httpclient.HTTPClient.get.assert_called_with(url=endpoint, params=data)
 
+    @mock.patch.object(
+        models.ResourceManager, 'get_all',
+        mock.MagicMock(return_value=[models.Execution(**EXECUTION)]))
     def test_st2client_liveactions_has_been_deprecated_and_emits_warning(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')

--- a/st2client/tests/unit/test_client_executions.py
+++ b/st2client/tests/unit/test_client_executions.py
@@ -47,7 +47,7 @@ ACTION = {
     "pack": "mocke"
 }
 
-LIVE_ACTION = {
+EXECUTION = {
     "id": 12345,
     "action": {
         "ref": "mock.foobar"
@@ -57,16 +57,16 @@ LIVE_ACTION = {
 }
 
 
-class TestLiveActionResourceManager(unittest2.TestCase):
+class TestExecutionResourceManager(unittest2.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestLiveActionResourceManager, cls).setUpClass()
+        super(TestExecutionResourceManager, cls).setUpClass()
         cls.client = client.Client()
 
     @mock.patch.object(
         models.ResourceManager, 'get_by_id',
-        mock.MagicMock(return_value=models.LiveAction(**LIVE_ACTION)))
+        mock.MagicMock(return_value=models.Execution(**EXECUTION)))
     @mock.patch.object(
         models.ResourceManager, 'get_by_ref_or_id',
         mock.MagicMock(return_value=models.Action(**ACTION)))
@@ -75,11 +75,11 @@ class TestLiveActionResourceManager(unittest2.TestCase):
         mock.MagicMock(return_value=models.RunnerType(**RUNNER)))
     @mock.patch.object(
         httpclient.HTTPClient, 'post',
-        mock.MagicMock(return_value=base.FakeResponse(json.dumps(LIVE_ACTION), 200, 'OK')))
+        mock.MagicMock(return_value=base.FakeResponse(json.dumps(EXECUTION), 200, 'OK')))
     def test_rerun_with_no_params(self):
-        self.client.liveactions.re_run(LIVE_ACTION['id'], tasks=['foobar'])
+        self.client.executions.re_run(EXECUTION['id'], tasks=['foobar'])
 
-        endpoint = '/executions/%s/re_run' % LIVE_ACTION['id']
+        endpoint = '/executions/%s/re_run' % EXECUTION['id']
 
         data = {
             'tasks': ['foobar'],
@@ -91,7 +91,7 @@ class TestLiveActionResourceManager(unittest2.TestCase):
 
     @mock.patch.object(
         models.ResourceManager, 'get_by_id',
-        mock.MagicMock(return_value=models.LiveAction(**LIVE_ACTION)))
+        mock.MagicMock(return_value=models.Execution(**EXECUTION)))
     @mock.patch.object(
         models.ResourceManager, 'get_by_ref_or_id',
         mock.MagicMock(return_value=models.Action(**ACTION)))
@@ -100,19 +100,19 @@ class TestLiveActionResourceManager(unittest2.TestCase):
         mock.MagicMock(return_value=models.RunnerType(**RUNNER)))
     @mock.patch.object(
         httpclient.HTTPClient, 'post',
-        mock.MagicMock(return_value=base.FakeResponse(json.dumps(LIVE_ACTION), 200, 'OK')))
+        mock.MagicMock(return_value=base.FakeResponse(json.dumps(EXECUTION), 200, 'OK')))
     def test_rerun_with_params(self):
         params = {
             'var1': 'testing...'
         }
 
-        self.client.liveactions.re_run(
-            LIVE_ACTION['id'],
+        self.client.executions.re_run(
+            EXECUTION['id'],
             tasks=['foobar'],
             parameters=params
         )
 
-        endpoint = '/executions/%s/re_run' % LIVE_ACTION['id']
+        endpoint = '/executions/%s/re_run' % EXECUTION['id']
 
         data = {
             'tasks': ['foobar'],
@@ -124,7 +124,7 @@ class TestLiveActionResourceManager(unittest2.TestCase):
 
     @mock.patch.object(
         models.ResourceManager, 'get_by_id',
-        mock.MagicMock(return_value=models.LiveAction(**LIVE_ACTION)))
+        mock.MagicMock(return_value=models.Execution(**EXECUTION)))
     @mock.patch.object(
         models.ResourceManager, 'get_by_ref_or_id',
         mock.MagicMock(return_value=models.Action(**ACTION)))
@@ -133,11 +133,11 @@ class TestLiveActionResourceManager(unittest2.TestCase):
         mock.MagicMock(return_value=models.RunnerType(**RUNNER)))
     @mock.patch.object(
         httpclient.HTTPClient, 'put',
-        mock.MagicMock(return_value=base.FakeResponse(json.dumps(LIVE_ACTION), 200, 'OK')))
+        mock.MagicMock(return_value=base.FakeResponse(json.dumps(EXECUTION), 200, 'OK')))
     def test_pause(self):
-        self.client.liveactions.pause(LIVE_ACTION['id'])
+        self.client.executions.pause(EXECUTION['id'])
 
-        endpoint = '/executions/%s' % LIVE_ACTION['id']
+        endpoint = '/executions/%s' % EXECUTION['id']
 
         data = {
             'status': 'pausing'
@@ -147,7 +147,7 @@ class TestLiveActionResourceManager(unittest2.TestCase):
 
     @mock.patch.object(
         models.ResourceManager, 'get_by_id',
-        mock.MagicMock(return_value=models.LiveAction(**LIVE_ACTION)))
+        mock.MagicMock(return_value=models.Execution(**EXECUTION)))
     @mock.patch.object(
         models.ResourceManager, 'get_by_ref_or_id',
         mock.MagicMock(return_value=models.Action(**ACTION)))
@@ -156,11 +156,11 @@ class TestLiveActionResourceManager(unittest2.TestCase):
         mock.MagicMock(return_value=models.RunnerType(**RUNNER)))
     @mock.patch.object(
         httpclient.HTTPClient, 'put',
-        mock.MagicMock(return_value=base.FakeResponse(json.dumps(LIVE_ACTION), 200, 'OK')))
+        mock.MagicMock(return_value=base.FakeResponse(json.dumps(EXECUTION), 200, 'OK')))
     def test_resume(self):
-        self.client.liveactions.resume(LIVE_ACTION['id'])
+        self.client.executions.resume(EXECUTION['id'])
 
-        endpoint = '/executions/%s' % LIVE_ACTION['id']
+        endpoint = '/executions/%s' % EXECUTION['id']
 
         data = {
             'status': 'resuming'
@@ -173,11 +173,11 @@ class TestLiveActionResourceManager(unittest2.TestCase):
         mock.MagicMock(return_value='executions'))
     @mock.patch.object(
         httpclient.HTTPClient, 'get',
-        mock.MagicMock(return_value=base.FakeResponse(json.dumps([LIVE_ACTION]), 200, 'OK')))
+        mock.MagicMock(return_value=base.FakeResponse(json.dumps([EXECUTION]), 200, 'OK')))
     def test_get_children(self):
-        self.client.liveactions.get_children(LIVE_ACTION['id'])
+        self.client.executions.get_children(EXECUTION['id'])
 
-        endpoint = '/executions/%s/children' % LIVE_ACTION['id']
+        endpoint = '/executions/%s/children' % EXECUTION['id']
 
         data = {
             'depth': -1

--- a/st2client/tests/unit/test_client_executions.py
+++ b/st2client/tests/unit/test_client_executions.py
@@ -190,12 +190,13 @@ class TestExecutionResourceManager(unittest2.TestCase):
     @mock.patch.object(
         models.ResourceManager, 'get_all',
         mock.MagicMock(return_value=[models.Execution(**EXECUTION)]))
-    def test_st2client_liveactions_has_been_deprecated_and_emits_warning(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+    @mock.patch.object(warnings, 'warn')
+    def test_st2client_liveactions_has_been_deprecated_and_emits_warning(self, mock_warn):
+        self.assertEqual(mock_warn.call_args, None)
 
-            self.client.liveactions.get_all()
+        self.client.liveactions.get_all()
 
-            self.assertEqual(len(w), 1)
-            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-            self.assertTrue('st2client.liveactions has been renamed' in str(w[0].message))
+        expected_msg = 'st2client.liveactions has been renamed'
+        self.assertTrue(len(mock_warn.call_args_list) >= 1)
+        self.assertTrue(expected_msg in mock_warn.call_args_list[0][0][0])
+        self.assertEqual(mock_warn.call_args_list[0][0][1], DeprecationWarning)

--- a/st2tests/integration/mistral/base.py
+++ b/st2tests/integration/mistral/base.py
@@ -42,7 +42,7 @@ class TestWorkflowExecution(unittest2.TestCase):
 
     def _execute_workflow(self, action, parameters=None):
         ex = models.LiveAction(action=action, parameters=(parameters or {}))
-        ex = self.st2client.liveactions.create(ex)
+        ex = self.st2client.executions.create(ex)
         self.assertIsNotNone(ex.id)
         self.assertEqual(ex.action['ref'], action)
         self.assertIn(ex.status, LIVEACTION_LAUNCHED_STATUSES)
@@ -61,7 +61,7 @@ class TestWorkflowExecution(unittest2.TestCase):
                 raise ValueError('Status %s is not valid.' % state)
 
         try:
-            ex = self.st2client.liveactions.get_by_id(ex.id)
+            ex = self.st2client.executions.get_by_id(ex.id)
             self.assertIn(ex.status, states)
         except:
             if ex.status in action_constants.LIVEACTION_COMPLETED_STATES:
@@ -75,13 +75,13 @@ class TestWorkflowExecution(unittest2.TestCase):
         return ex
 
     def _get_children(self, ex):
-        return self.st2client.liveactions.query(parent=ex.id)
+        return self.st2client.executions.query(parent=ex.id)
 
     @retrying.retry(
         retry_on_exception=retry_on_exceptions,
         wait_fixed=3000, stop_max_delay=900000)
     def _wait_for_task(self, ex, task, status, num_task_exs=1):
-        ex = self.st2client.liveactions.get_by_id(ex.id)
+        ex = self.st2client.executions.get_by_id(ex.id)
 
         task_exs = [
             task_ex for task_ex in self._get_children(ex)

--- a/st2tests/integration/mistral/test_wiring_cancel.py
+++ b/st2tests/integration/mistral/test_wiring_cancel.py
@@ -53,7 +53,7 @@ class CancellationWiringTest(base.TestWorkflowExecution):
 
         # Cancel the workflow before the temp file is created. The workflow will be paused
         # but task1 will still be running to allow for graceful exit.
-        self.st2client.liveactions.delete(ex)
+        self.st2client.executions.delete(ex)
 
         # Expecting the ex to be canceling, waiting for task1 to be completed.
         ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_CANCELING)
@@ -82,7 +82,7 @@ class CancellationWiringTest(base.TestWorkflowExecution):
         task_exs = self._wait_for_task(ex, 'task1', action_constants.LIVEACTION_STATUS_RUNNING)
 
         # Cancel the task execution.
-        self.st2client.liveactions.delete(task_exs[0])
+        self.st2client.executions.delete(task_exs[0])
 
         # Wait for the task and parent workflow to be canceled.
         self._wait_for_task(ex, 'task1', action_constants.LIVEACTION_STATUS_CANCELED)
@@ -104,7 +104,7 @@ class CancellationWiringTest(base.TestWorkflowExecution):
 
         # Cancel the workflow before the temp file is created. The workflow will be canceled
         # but task1 will still be running to allow for graceful exit.
-        self.st2client.liveactions.delete(ex)
+        self.st2client.executions.delete(ex)
 
         # Expecting the ex to be canceling, waiting for task1 to be completed.
         ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_CANCELING)
@@ -134,7 +134,7 @@ class CancellationWiringTest(base.TestWorkflowExecution):
 
         # Cancel the workflow before the temp file is created. The workflow will be canceled
         # but task1 will still be running to allow for graceful exit.
-        self.st2client.liveactions.delete(ex)
+        self.st2client.executions.delete(ex)
 
         # Expecting the ex to be canceling, waiting for task1 to be completed.
         ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_CANCELING)
@@ -163,7 +163,7 @@ class CancellationWiringTest(base.TestWorkflowExecution):
         subwf_ex = task_exs[0]
 
         # Cancel the subworkflow action.
-        self.st2client.liveactions.delete(subwf_ex)
+        self.st2client.executions.delete(subwf_ex)
 
         # Expecting task1 and main workflow ex to be canceling.
         subwf_ex = self._wait_for_state(subwf_ex, action_constants.LIVEACTION_STATUS_CANCELING)
@@ -192,7 +192,7 @@ class CancellationWiringTest(base.TestWorkflowExecution):
         subwf_ex = task_exs[0]
 
         # Cancel the subworkflow action.
-        self.st2client.liveactions.delete(subwf_ex)
+        self.st2client.executions.delete(subwf_ex)
 
         # Expecting task1 and main workflow ex to be canceling.
         subwf_ex = self._wait_for_state(subwf_ex, action_constants.LIVEACTION_STATUS_CANCELING)
@@ -221,14 +221,14 @@ class CancellationWiringTest(base.TestWorkflowExecution):
 
         # Cancel the workflow before the temp file is created. The workflow will be canceled
         # but task1 will still be running to allow for graceful exit.
-        self.st2client.liveactions.delete(ex)
+        self.st2client.executions.delete(ex)
 
         # Expecting the ex to be cancelinging, waiting for task1 to be completed.
         ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_CANCELING)
 
         # Get the subworkflow ex. Since this is from an Action Chain, the task
         # context is not available like task of Mistral workflows. Therefore, query
-        # for the children liveactions of the chain to get the task execution.
+        # for the children executions of the chain to get the task execution.
         task_exs = self._get_children(ex)
         self.assertEqual(len(task_exs), 1)
         subwf_ex = self._wait_for_state(task_exs[0], action_constants.LIVEACTION_STATUS_CANCELING)
@@ -257,11 +257,11 @@ class CancellationWiringTest(base.TestWorkflowExecution):
         # Identify and cancel the task ex.
         # Get the subworkflow ex. Since this is from an Action Chain, the task
         # context is not available like task of Mistral workflows. Therefore, query
-        # for the children liveactions of the chain to get the task execution.
+        # for the children executions of the chain to get the task execution.
         task_exs = self._get_children(ex)
         self.assertEqual(len(task_exs), 1)
         subwf_ex = self._wait_for_state(task_exs[0], action_constants.LIVEACTION_STATUS_RUNNING)
-        self.st2client.liveactions.delete(subwf_ex)
+        self.st2client.executions.delete(subwf_ex)
 
         # Expecting task1 and main workflow ex to be canceling.
         subwf_ex = self._wait_for_state(subwf_ex, action_constants.LIVEACTION_STATUS_CANCELING)

--- a/st2tests/integration/mistral/test_wiring_pause_resume.py
+++ b/st2tests/integration/mistral/test_wiring_pause_resume.py
@@ -54,7 +54,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution):
 
         # Pause the workflow before the temp file is created. The workflow will be paused
         # but task1 will still be running to allow for graceful exit.
-        ex = self.st2client.liveactions.pause(ex.id)
+        ex = self.st2client.executions.pause(ex.id)
 
         # Expecting the ex to be pausing, waiting for task1 to be completed.
         ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_PAUSING)
@@ -67,7 +67,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution):
         ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_PAUSED)
 
         # Resume the ex.
-        ex = self.st2client.liveactions.resume(ex.id)
+        ex = self.st2client.executions.resume(ex.id)
 
         # Wait for completion.
         ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_SUCCEEDED)
@@ -81,7 +81,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution):
         ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_PAUSED)
 
         # Resume the ex.
-        ex = self.st2client.liveactions.resume(ex.id)
+        ex = self.st2client.executions.resume(ex.id)
 
         # Wait for completion.
         ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_SUCCEEDED)
@@ -96,7 +96,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution):
         ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_PAUSED)
 
         # Resume the ex.
-        ex = self.st2client.liveactions.resume(ex.id)
+        ex = self.st2client.executions.resume(ex.id)
 
         # Wait for completion.
         ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_SUCCEEDED)
@@ -115,7 +115,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution):
         self.assertEqual(len(task_exs), 1)
 
         # Resume the ex.
-        ex = self.st2client.liveactions.resume(ex.id)
+        ex = self.st2client.executions.resume(ex.id)
 
         # Wait for completion.
         ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_SUCCEEDED)
@@ -137,7 +137,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution):
 
         # Pause the workflow before the temp file is created. The workflow will be paused
         # but task1 will still be running to allow for graceful exit.
-        ex = self.st2client.liveactions.pause(ex.id)
+        ex = self.st2client.executions.pause(ex.id)
 
         # Expecting the ex to be pausing, waiting for task1 to be completed.
         ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_PAUSING)
@@ -152,7 +152,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution):
         ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_PAUSED)
 
         # Resume the parent ex.
-        ex = self.st2client.liveactions.resume(ex.id)
+        ex = self.st2client.executions.resume(ex.id)
 
         # Wait for completion.
         subwf_ex = self._wait_for_state(subwf_ex, action_constants.LIVEACTION_STATUS_SUCCEEDED)
@@ -177,7 +177,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution):
 
         # Pause the main workflow before the temp file is created.
         # The subworkflow will also pause.
-        ex = self.st2client.liveactions.pause(ex.id)
+        ex = self.st2client.executions.pause(ex.id)
 
         # Expecting the ex to be pausing, waiting for task1 to be completed.
         ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_PAUSING)
@@ -191,7 +191,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution):
         ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_PAUSED)
 
         # Resume the parent ex.
-        ex = self.st2client.liveactions.resume(ex.id)
+        ex = self.st2client.executions.resume(ex.id)
 
         # Wait for completion.
         ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_SUCCEEDED)
@@ -211,7 +211,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution):
 
         # Pause the workflow before the temp file is created. The workflow will be paused
         # but task1 will still be running to allow for graceful exit.
-        ex = self.st2client.liveactions.pause(ex.id)
+        ex = self.st2client.executions.pause(ex.id)
 
         # Expecting the ex to be pausing, waiting for task1 to be completed.
         ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_PAUSING)
@@ -226,7 +226,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution):
         ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_PAUSED)
 
         # Resume the parent ex.
-        ex = self.st2client.liveactions.resume(ex.id)
+        ex = self.st2client.executions.resume(ex.id)
 
         # Wait for completion.
         subwf_ex = self._wait_for_state(subwf_ex, action_constants.LIVEACTION_STATUS_SUCCEEDED)
@@ -251,7 +251,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution):
 
         # Pause the workflow before the temp file is created. The workflow will be paused
         # but task1 will still be running to allow for graceful exit.
-        ex = self.st2client.liveactions.pause(ex.id)
+        ex = self.st2client.executions.pause(ex.id)
 
         # Expecting the ex to be pausing, waiting for task1 to be completed.
         subwf_ex = self._wait_for_state(subwf_ex, action_constants.LIVEACTION_STATUS_PAUSING)
@@ -266,7 +266,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution):
         ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_PAUSED)
 
         # Resume the parent ex.
-        ex = self.st2client.liveactions.resume(ex.id)
+        ex = self.st2client.executions.resume(ex.id)
 
         # Wait for completion.
         subwf_ex = self._wait_for_state(subwf_ex, action_constants.LIVEACTION_STATUS_SUCCEEDED)

--- a/st2tests/integration/mistral/test_wiring_rerun.py
+++ b/st2tests/integration/mistral/test_wiring_rerun.py
@@ -56,7 +56,7 @@ class RerunWiringTest(base.TestWorkflowExecution):
         with open(path, 'w') as f:
             f.write('0')
 
-        ex = self.st2client.liveactions.re_run(orig_st2_ex_id)
+        ex = self.st2client.executions.re_run(orig_st2_ex_id)
         self.assertNotEqual(ex.id, orig_st2_ex_id)
         ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_SUCCEEDED)
         self.assertNotEqual(ex.context['mistral']['execution_id'], orig_wf_ex_id)
@@ -77,7 +77,7 @@ class RerunWiringTest(base.TestWorkflowExecution):
         with open(path, 'w') as f:
             f.write('0')
 
-        ex = self.st2client.liveactions.re_run(orig_st2_ex_id, tasks=['task1'])
+        ex = self.st2client.executions.re_run(orig_st2_ex_id, tasks=['task1'])
         self.assertNotEqual(ex.id, orig_st2_ex_id)
         ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_SUCCEEDED)
         self.assertEqual(ex.context['mistral']['execution_id'], orig_wf_ex_id)
@@ -99,7 +99,7 @@ class RerunWiringTest(base.TestWorkflowExecution):
         with open(path, 'w') as f:
             f.write('0')
 
-        ex = self.st2client.liveactions.re_run(orig_st2_ex_id, tasks=['task1.task1'])
+        ex = self.st2client.executions.re_run(orig_st2_ex_id, tasks=['task1.task1'])
         self.assertNotEqual(ex.id, orig_st2_ex_id)
         ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_SUCCEEDED)
         self.assertEqual(ex.context['mistral']['execution_id'], orig_wf_ex_id)
@@ -121,13 +121,13 @@ class RerunWiringTest(base.TestWorkflowExecution):
         with open(path, 'w') as f:
             f.write('0')
 
-        ex = self.st2client.liveactions.re_run(orig_st2_ex_id, tasks=['task1'])
+        ex = self.st2client.executions.re_run(orig_st2_ex_id, tasks=['task1'])
         self.assertNotEqual(ex.id, orig_st2_ex_id)
         ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_SUCCEEDED)
         self.assertEqual(ex.context['mistral']['execution_id'], orig_wf_ex_id)
         self.assertEqual(len(ex.result.get('tasks', [])), 1)
 
-        children = self.st2client.liveactions.get_property(ex.id, 'children')
+        children = self.st2client.executions.get_property(ex.id, 'children')
         self.assertEqual(len(children), 4)
 
     def test_rerun_and_resume_with_items_task(self):
@@ -146,7 +146,7 @@ class RerunWiringTest(base.TestWorkflowExecution):
         with open(path, 'w') as f:
             f.write('0')
 
-        ex = self.st2client.liveactions.re_run(
+        ex = self.st2client.executions.re_run(
             orig_st2_ex_id,
             tasks=['task1'],
             no_reset=['task1']
@@ -157,7 +157,7 @@ class RerunWiringTest(base.TestWorkflowExecution):
         self.assertEqual(ex.context['mistral']['execution_id'], orig_wf_ex_id)
         self.assertEqual(len(ex.result.get('tasks', [])), 1)
 
-        children = self.st2client.liveactions.get_property(ex.id, 'children')
+        children = self.st2client.executions.get_property(ex.id, 'children')
         self.assertEqual(len(children), 2)
 
     def test_rerun_subflow_and_reset_with_items_task(self):
@@ -176,13 +176,13 @@ class RerunWiringTest(base.TestWorkflowExecution):
         with open(path, 'w') as f:
             f.write('0')
 
-        ex = self.st2client.liveactions.re_run(orig_st2_ex_id, tasks=['task1.task1'])
+        ex = self.st2client.executions.re_run(orig_st2_ex_id, tasks=['task1.task1'])
         self.assertNotEqual(ex.id, orig_st2_ex_id)
         ex = self._wait_for_state(ex, action_constants.LIVEACTION_STATUS_SUCCEEDED)
         self.assertEqual(ex.context['mistral']['execution_id'], orig_wf_ex_id)
         self.assertEqual(len(ex.result.get('tasks', [])), 1)
 
-        children = self.st2client.liveactions.get_property(ex.id, 'children')
+        children = self.st2client.executions.get_property(ex.id, 'children')
         self.assertEqual(len(children), 4)
 
     def test_rerun_subflow_and_resume_with_items_task(self):
@@ -201,7 +201,7 @@ class RerunWiringTest(base.TestWorkflowExecution):
         with open(path, 'w') as f:
             f.write('0')
 
-        ex = self.st2client.liveactions.re_run(
+        ex = self.st2client.executions.re_run(
             orig_st2_ex_id,
             tasks=['task1.task1'],
             no_reset=['task1.task1']
@@ -212,5 +212,5 @@ class RerunWiringTest(base.TestWorkflowExecution):
         self.assertEqual(ex.context['mistral']['execution_id'], orig_wf_ex_id)
         self.assertEqual(len(ex.result.get('tasks', [])), 1)
 
-        children = self.st2client.liveactions.get_property(ex.id, 'children')
+        children = self.st2client.executions.get_property(ex.id, 'children')
         self.assertEqual(len(children), 2)

--- a/st2tests/integration/orquesta/base.py
+++ b/st2tests/integration/orquesta/base.py
@@ -63,7 +63,7 @@ class TestWorkflowExecution(unittest2.TestCase):
                           expected_status=None, expected_result=None):
 
         ex = models.LiveAction(action=action, parameters=(parameters or {}))
-        ex = self.st2client.liveactions.create(ex)
+        ex = self.st2client.executions.create(ex)
         self.assertIsNotNone(ex.id)
         self.assertEqual(ex.action['ref'], action)
         self.assertIn(ex.status, LIVEACTION_LAUNCHED_STATUSES)
@@ -95,7 +95,7 @@ class TestWorkflowExecution(unittest2.TestCase):
                 raise ValueError('Status %s is not valid.' % state)
 
         try:
-            ex = self.st2client.liveactions.get_by_id(ex.id)
+            ex = self.st2client.executions.get_by_id(ex.id)
             self.assertIn(ex.status, states)
         except:
             if ex.status in action_constants.LIVEACTION_COMPLETED_STATES:
@@ -110,13 +110,13 @@ class TestWorkflowExecution(unittest2.TestCase):
         return ex
 
     def _get_children(self, ex):
-        return self.st2client.liveactions.query(parent=ex.id)
+        return self.st2client.executions.query(parent=ex.id)
 
     @retrying.retry(
         retry_on_exception=retry_on_exceptions,
         wait_fixed=3000, stop_max_delay=900000)
     def _wait_for_task(self, ex, task, status=None, num_task_exs=1):
-        ex = self.st2client.liveactions.get_by_id(ex.id)
+        ex = self.st2client.executions.get_by_id(ex.id)
 
         task_exs = [
             task_ex for task_ex in self._get_children(ex)

--- a/st2tests/integration/orquesta/test_wiring_cancel.py
+++ b/st2tests/integration/orquesta/test_wiring_cancel.py
@@ -50,7 +50,7 @@ class CancellationWiringTest(base.TestWorkflowExecution, base.WorkflowControlTes
 
         # Cancel the workflow before the temp file is created. The workflow will be paused
         # but task1 will still be running to allow for graceful exit.
-        self.st2client.liveactions.delete(ex)
+        self.st2client.executions.delete(ex)
 
         # Expecting the ex to be canceling, waiting for task1 to be completed.
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_CANCELING)
@@ -79,7 +79,7 @@ class CancellationWiringTest(base.TestWorkflowExecution, base.WorkflowControlTes
         task_exs = self._wait_for_task(ex, 'task1', ac_const.LIVEACTION_STATUS_RUNNING)
 
         # Cancel the task execution.
-        self.st2client.liveactions.delete(task_exs[0])
+        self.st2client.executions.delete(task_exs[0])
 
         # Wait for the task and parent workflow to be canceled.
         self._wait_for_task(ex, 'task1', ac_const.LIVEACTION_STATUS_CANCELED)
@@ -101,7 +101,7 @@ class CancellationWiringTest(base.TestWorkflowExecution, base.WorkflowControlTes
 
         # Cancel the workflow before the temp file is deleted. The workflow will be canceled
         # but task1 will still be running to allow for graceful exit.
-        self.st2client.liveactions.delete(ex)
+        self.st2client.executions.delete(ex)
 
         # Expecting the ex to be canceling, waiting for task1 to be completed.
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_CANCELING)
@@ -131,7 +131,7 @@ class CancellationWiringTest(base.TestWorkflowExecution, base.WorkflowControlTes
 
         # Cancel the workflow before the temp file is deleted. The workflow will be canceled
         # but task1 will still be running to allow for graceful exit.
-        self.st2client.liveactions.delete(subwf_ex)
+        self.st2client.executions.delete(subwf_ex)
 
         # Assert subworkflow is canceling.
         subwf_ex = self._wait_for_state(subwf_ex, ac_const.LIVEACTION_STATUS_CANCELING)
@@ -165,7 +165,7 @@ class CancellationWiringTest(base.TestWorkflowExecution, base.WorkflowControlTes
 
         # Cancel the workflow before the temp file is deleted. The workflow will be canceled
         # but task1 will still be running to allow for graceful exit.
-        self.st2client.liveactions.delete(subwf_ex_1)
+        self.st2client.executions.delete(subwf_ex_1)
 
         # Assert subworkflow is canceling.
         subwf_ex_1 = self._wait_for_state(subwf_ex_1, ac_const.LIVEACTION_STATUS_CANCELING)

--- a/st2tests/integration/orquesta/test_wiring_pause_and_resume.py
+++ b/st2tests/integration/orquesta/test_wiring_pause_and_resume.py
@@ -53,7 +53,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution, base.WorkflowControlTest
 
         # Cancel the workflow before the temp file is deleted. The workflow will be paused
         # but task1 will still be running to allow for graceful exit.
-        self.st2client.liveactions.pause(ex.id)
+        self.st2client.executions.pause(ex.id)
 
         # Expecting the ex to be canceling, waiting for task1 to be completed.
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_PAUSING)
@@ -66,7 +66,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution, base.WorkflowControlTest
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_PAUSED)
 
         # Resume the ex.
-        ex = self.st2client.liveactions.resume(ex.id)
+        ex = self.st2client.executions.resume(ex.id)
 
         # Wait for completion.
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_SUCCEEDED)
@@ -84,7 +84,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution, base.WorkflowControlTest
 
         # Pause the workflow before the temp file is deleted. The workflow will be paused
         # but task1 will still be running to allow for graceful exit.
-        ex = self.st2client.liveactions.pause(ex.id)
+        ex = self.st2client.executions.pause(ex.id)
 
         # Expecting the ex to be pausing, waiting for task1 to be completed.
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_PAUSING)
@@ -99,7 +99,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution, base.WorkflowControlTest
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_PAUSED)
 
         # Resume the parent ex.
-        ex = self.st2client.liveactions.resume(ex.id)
+        ex = self.st2client.executions.resume(ex.id)
 
         # Wait for completion.
         tk_ac_ex = self._wait_for_state(tk_ac_ex, ac_const.LIVEACTION_STATUS_SUCCEEDED)
@@ -121,7 +121,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution, base.WorkflowControlTest
 
         # Pause the workflow before the temp files are deleted. The workflow will be paused
         # but task1 will still be running to allow for graceful exit.
-        ex = self.st2client.liveactions.pause(ex.id)
+        ex = self.st2client.executions.pause(ex.id)
 
         # Expecting the ex to be pausing, waiting for task1 to be completed.
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_PAUSING)
@@ -147,7 +147,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution, base.WorkflowControlTest
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_PAUSED)
 
         # Resume the parent ex.
-        ex = self.st2client.liveactions.resume(ex.id)
+        ex = self.st2client.executions.resume(ex.id)
 
         # Wait for completion.
         tk1_ac_ex = self._wait_for_state(tk1_ac_ex, ac_const.LIVEACTION_STATUS_SUCCEEDED)
@@ -167,7 +167,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution, base.WorkflowControlTest
 
         # Pause the subworkflow before the temp file is deleted. The task will be
         # paused but workflow will still be running.
-        tk_ac_ex = self.st2client.liveactions.pause(tk_exs[0].id)
+        tk_ac_ex = self.st2client.executions.pause(tk_exs[0].id)
 
         # Expecting the workflow is still running and task1 is pausing.
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_RUNNING)
@@ -182,7 +182,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution, base.WorkflowControlTest
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_PAUSED)
 
         # Resume the task.
-        tk_ac_ex = self.st2client.liveactions.resume(tk_ac_ex.id)
+        tk_ac_ex = self.st2client.executions.resume(tk_ac_ex.id)
 
         # Wait for completion.
         tk_ac_ex = self._wait_for_state(tk_ac_ex, ac_const.LIVEACTION_STATUS_SUCCEEDED)
@@ -204,7 +204,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution, base.WorkflowControlTest
 
         # Pause the subworkflow before the temp file is deleted. The task will be
         # paused but workflow and the other subworkflow will still be running.
-        tk1_ac_ex = self.st2client.liveactions.pause(tk1_exs[0].id)
+        tk1_ac_ex = self.st2client.executions.pause(tk1_exs[0].id)
 
         # Expecting the workflow is still running and task1 is pausing.
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_RUNNING)
@@ -231,7 +231,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution, base.WorkflowControlTest
         tk2_ac_ex = self._wait_for_state(tk2_ac_ex, ac_const.LIVEACTION_STATUS_SUCCEEDED)
 
         # Resume the subworkflow.
-        tk1_ac_ex = self.st2client.liveactions.resume(tk1_ac_ex.id)
+        tk1_ac_ex = self.st2client.executions.resume(tk1_ac_ex.id)
 
         # Wait for completion.
         tk1_ac_ex = self._wait_for_state(tk1_ac_ex, ac_const.LIVEACTION_STATUS_SUCCEEDED)
@@ -254,7 +254,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution, base.WorkflowControlTest
 
         # Pause the subworkflow before the temp file is deleted. The task will be
         # paused but workflow and the other subworkflow will still be running.
-        tk1_ac_ex = self.st2client.liveactions.pause(tk1_exs[0].id)
+        tk1_ac_ex = self.st2client.executions.pause(tk1_exs[0].id)
 
         # Expecting the workflow is still running and task1 is pausing.
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_RUNNING)
@@ -272,7 +272,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution, base.WorkflowControlTest
         tk2_ac_ex = self._wait_for_state(tk2_ac_ex, ac_const.LIVEACTION_STATUS_RUNNING)
 
         # Resume the subworkflow.
-        tk1_ac_ex = self.st2client.liveactions.resume(tk1_ac_ex.id)
+        tk1_ac_ex = self.st2client.executions.resume(tk1_ac_ex.id)
 
         # The subworkflow will succeed while the other subworkflow is still running.
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_RUNNING)
@@ -304,7 +304,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution, base.WorkflowControlTest
 
         # Pause the subworkflow before the temp file is deleted. The task will be
         # paused but workflow and the other subworkflow will still be running.
-        tk1_ac_ex = self.st2client.liveactions.pause(tk1_exs[0].id)
+        tk1_ac_ex = self.st2client.executions.pause(tk1_exs[0].id)
 
         # Expecting the workflow is still running and task1 is pausing.
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_RUNNING)
@@ -313,7 +313,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution, base.WorkflowControlTest
 
         # Pause the other subworkflow before the temp file is deleted. The main
         # workflow will still running because pause is initiated downstream.
-        tk2_ac_ex = self.st2client.liveactions.pause(tk2_exs[0].id)
+        tk2_ac_ex = self.st2client.executions.pause(tk2_exs[0].id)
 
         # Expecting workflow and subworkflows are pausing.
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_RUNNING)
@@ -333,7 +333,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution, base.WorkflowControlTest
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_PAUSED)
 
         # Resume the subworkflow.
-        tk1_ac_ex = self.st2client.liveactions.resume(tk1_ac_ex.id)
+        tk1_ac_ex = self.st2client.executions.resume(tk1_ac_ex.id)
 
         # The subworkflow will succeed while the other subworkflow is still paused.
         tk1_ac_ex = self._wait_for_state(tk1_ac_ex, ac_const.LIVEACTION_STATUS_SUCCEEDED)
@@ -341,7 +341,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution, base.WorkflowControlTest
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_PAUSED)
 
         # Resume the other subworkflow.
-        tk2_ac_ex = self.st2client.liveactions.resume(tk2_ac_ex.id)
+        tk2_ac_ex = self.st2client.executions.resume(tk2_ac_ex.id)
 
         # Wait for completion.
         tk1_ac_ex = self._wait_for_state(tk1_ac_ex, ac_const.LIVEACTION_STATUS_SUCCEEDED)
@@ -364,7 +364,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution, base.WorkflowControlTest
 
         # Pause the subworkflow before the temp file is deleted. The task will be
         # paused but workflow and the other subworkflow will still be running.
-        tk1_ac_ex = self.st2client.liveactions.pause(tk1_exs[0].id)
+        tk1_ac_ex = self.st2client.executions.pause(tk1_exs[0].id)
 
         # Expecting the workflow is still running and task1 is pausing.
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_RUNNING)
@@ -373,7 +373,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution, base.WorkflowControlTest
 
         # Pause the other subworkflow before the temp file is deleted. The main
         # workflow will still running because pause is initiated downstream.
-        tk2_ac_ex = self.st2client.liveactions.pause(tk2_exs[0].id)
+        tk2_ac_ex = self.st2client.executions.pause(tk2_exs[0].id)
 
         # Expecting workflow and subworkflows are pausing.
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_RUNNING)
@@ -393,7 +393,7 @@ class PauseResumeWiringTest(base.TestWorkflowExecution, base.WorkflowControlTest
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_PAUSED)
 
         # Resume the parent workflow.
-        ex = self.st2client.liveactions.resume(ex.id)
+        ex = self.st2client.executions.resume(ex.id)
 
         # Wait for completion.
         tk1_ac_ex = self._wait_for_state(tk1_ac_ex, ac_const.LIVEACTION_STATUS_SUCCEEDED)

--- a/st2tests/integration/orquesta/test_wiring_with_items.py
+++ b/st2tests/integration/orquesta/test_wiring_with_items.py
@@ -103,7 +103,7 @@ class WithItemsWiringTest(base.TestWorkflowExecution):
         ex = self._wait_for_state(ex, [ac_const.LIVEACTION_STATUS_RUNNING])
 
         # Cancel the workflow execution.
-        self.st2client.liveactions.delete(ex)
+        self.st2client.executions.delete(ex)
 
         # Expecting the ex to be canceling, waiting for task1 to complete.
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_CANCELING)
@@ -149,7 +149,7 @@ class WithItemsWiringTest(base.TestWorkflowExecution):
         )
 
         # Cancel the workflow execution.
-        self.st2client.liveactions.delete(ex)
+        self.st2client.executions.delete(ex)
 
         # Expecting the ex to be canceling, waiting for task1 to complete.
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_CANCELING)
@@ -186,7 +186,7 @@ class WithItemsWiringTest(base.TestWorkflowExecution):
         ex = self._wait_for_state(ex, [ac_const.LIVEACTION_STATUS_RUNNING])
 
         # Pause the workflow execution.
-        self.st2client.liveactions.pause(ex.id)
+        self.st2client.executions.pause(ex.id)
 
         # Expecting the ex to be pausing, waiting for task1 to complete.
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_PAUSING)
@@ -208,7 +208,7 @@ class WithItemsWiringTest(base.TestWorkflowExecution):
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_PAUSED)
 
         # Resume the workflow execution.
-        ex = self.st2client.liveactions.resume(ex.id)
+        ex = self.st2client.executions.resume(ex.id)
 
         # Wait for completion.
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_SUCCEEDED)
@@ -230,7 +230,7 @@ class WithItemsWiringTest(base.TestWorkflowExecution):
         ex = self._wait_for_state(ex, [ac_const.LIVEACTION_STATUS_RUNNING])
 
         # Pause the workflow execution.
-        self.st2client.liveactions.pause(ex.id)
+        self.st2client.executions.pause(ex.id)
 
         # Expecting the ex to be pausing, waiting for task1 to complete.
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_PAUSING)
@@ -252,7 +252,7 @@ class WithItemsWiringTest(base.TestWorkflowExecution):
         ex = self._wait_for_state(ex, ac_const.LIVEACTION_STATUS_PAUSED)
 
         # Resume the workflow execution.
-        ex = self.st2client.liveactions.resume(ex.id)
+        ex = self.st2client.executions.resume(ex.id)
 
         # Delete the remaining temporary files.
         for f in self.tempfiles[concurrency:]:


### PR DESCRIPTION
This pull request updates Python st2client resource manager name from ``st2client.liveactions`` to ``st2client.executions``.

``st2client.liveactions`` manager already represented operations on execution objects, but it was incorrectly named (leftover from a long time ago when we introduced a concept of LiveActions).

For backward compatibility reasons, ``st2client.liveactions.{method name}`` will continue to work for a while until it's fully removed in a future release (v3.2.0).

Thanks to @trstruth for bringing this up in #4444. This should have been done a long time ago.

## TODO

- [x] Add upgrade notes entry - https://github.com/StackStorm/st2docs/pull/824