### PR TITLE
Remove the delay parameter on action execution reruns

### DIFF
--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -415,9 +415,14 @@ class ActionExecutionReRunController(ActionExecutionsControllerMixin, ResourceCo
             raise ValueError('Task option is only supported for Mistral workflows.')
 
         # Merge in any parameters provided by the user
+        old_parameters = getattr(existing_execution, 'parameters', {})
+        old_parameters.pop('delay', None)
+
         new_parameters = {}
+
         if not no_merge:
-            new_parameters.update(getattr(existing_execution, 'parameters', {}))
+            new_parameters.update(old_parameters)
+
         new_parameters.update(spec_api.parameters)
 
         # Create object for the new execution


### PR DESCRIPTION
On rerunning a delayed action execution, the delay parameter is removed before the action execution is rerun.