### PR TITLE
Fix race and random failures with unit tests for concurrency policy

### DIFF
--- a/st2actions/tests/unit/policies/test_concurrency.py
+++ b/st2actions/tests/unit/policies/test_concurrency.py
@@ -28,6 +28,7 @@ from st2common.persistence.action import LiveAction
 from st2common.persistence.execution_queue import ActionExecutionSchedulingQueue
 from st2common.persistence.policy import Policy
 from st2common.services import action as action_service
+from st2common.services import coordination
 from st2common.transport.liveaction import LiveActionPublisher
 from st2common.transport.publishers import CUDPublisher
 from st2common.bootstrap import runnersregistrar as runners_registrar
@@ -82,6 +83,7 @@ class ConcurrencyPolicyTestCase(EventletTestCase, ExecutionDbTestCase):
 
         # Override the coordinator to use the noop driver otherwise the tests will be blocked.
         tests_config.parse_args(coordinator_noop=True)
+        coordination.COORDINATOR = None
 
         # Register runners
         runners_registrar.register_runners()
@@ -92,6 +94,13 @@ class ConcurrencyPolicyTestCase(EventletTestCase, ExecutionDbTestCase):
         loader = FixturesLoader()
         loader.save_fixtures_to_db(fixtures_pack=PACK,
                                    fixtures_dict=TEST_FIXTURES)
+
+    @classmethod
+    def tearDownClass(cls):
+        # Reset the coordinator.
+        coordination.COORDINATOR = None
+
+        super(ConcurrencyPolicyTestCase, cls).tearDownClass()
 
     # NOTE: This monkey patch needs to happen again here because during tests for some reason this
     # method gets unpatched (test doing reload() or similar)

--- a/st2actions/tests/unit/policies/test_concurrency_by_attr.py
+++ b/st2actions/tests/unit/policies/test_concurrency_by_attr.py
@@ -27,6 +27,7 @@ from st2common.persistence.action import LiveAction
 from st2common.persistence.execution_queue import ActionExecutionSchedulingQueue
 from st2common.persistence.policy import Policy
 from st2common.services import action as action_service
+from st2common.services import coordination
 from st2common.transport.liveaction import LiveActionPublisher
 from st2common.transport.publishers import CUDPublisher
 from st2common.bootstrap import runnersregistrar as runners_registrar
@@ -81,6 +82,7 @@ class ConcurrencyByAttributePolicyTestCase(EventletTestCase, ExecutionDbTestCase
 
         # Override the coordinator to use the noop driver otherwise the tests will be blocked.
         tests_config.parse_args(coordinator_noop=True)
+        coordination.COORDINATOR = None
 
         # Register runners
         runners_registrar.register_runners()
@@ -91,6 +93,13 @@ class ConcurrencyByAttributePolicyTestCase(EventletTestCase, ExecutionDbTestCase
         loader = FixturesLoader()
         loader.save_fixtures_to_db(fixtures_pack=PACK,
                                    fixtures_dict=TEST_FIXTURES)
+
+    @classmethod
+    def tearDownClass(cls):
+        # Reset the coordinator.
+        coordination.COORDINATOR = None
+
+        super(ConcurrencyByAttributePolicyTestCase, cls).tearDownClass()
 
     # NOTE: This monkey patch needs to happen again here because during tests for some reason this
     # method gets unpatched (test doing reload() or similar)

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -28,12 +28,12 @@ CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
 
 
-def parse_args():
-    _setup_config_opts()
+def parse_args(coordinator_noop=False):
+    _setup_config_opts(coordinator_noop=coordinator_noop)
     CONF(args=[])
 
 
-def _setup_config_opts():
+def _setup_config_opts(coordinator_noop=False):
     cfg.CONF.reset()
 
     try:
@@ -43,15 +43,17 @@ def _setup_config_opts():
         # Some scripts register the options themselves which means registering them again will
         # cause a non-fatal exception
         return
-    _override_config_opts()
+
+    _override_config_opts(coordinator_noop=coordinator_noop)
 
 
-def _override_config_opts():
+def _override_config_opts(coordinator_noop=False):
     _override_db_opts()
     _override_common_opts()
     _override_api_opts()
     _override_keyvalue_opts()
     _override_scheduler_opts()
+    _override_coordinator_opts(noop=coordinator_noop)
 
 
 def _register_config_opts():
@@ -80,8 +82,6 @@ def _override_common_opts():
     CONF.set_override(name='packs_base_paths', override=packs_base_path, group='content')
     CONF.set_override(name='api_url', override='http://127.0.0.1', group='auth')
     CONF.set_override(name='mask_secrets', override=True, group='log')
-    CONF.set_override(name='url', override='zake://', group='coordination')
-    CONF.set_override(name='lock_timeout', override=1, group='coordination')
     CONF.set_override(name='jitter_interval', override=0, group='mistral')
     CONF.set_override(name='query_interval', override=0.1, group='resultstracker')
     CONF.set_override(name='stream_output', override=False, group='actionrunner')
@@ -103,6 +103,12 @@ def _override_keyvalue_opts():
 
 def _override_scheduler_opts():
     CONF.set_override(name='sleep_interval', group='scheduler', override=0.01)
+
+
+def _override_coordinator_opts(noop=False):
+    driver = None if noop else 'zake://'
+    CONF.set_override(name='url', override=driver, group='coordination')
+    CONF.set_override(name='lock_timeout', override=1, group='coordination')
 
 
 def _register_common_opts():

--- a/st2tests/st2tests/mocks/liveaction.py
+++ b/st2tests/st2tests/mocks/liveaction.py
@@ -123,6 +123,8 @@ class MockLiveActionPublisherSchedulingQueueOnly(object):
             if isinstance(payload, LiveActionDB):
                 if state == action_constants.LIVEACTION_STATUS_REQUESTED:
                     cls.process(payload)
+                else:
+                    worker.get_worker().process(payload)
         except Exception:
             traceback.print_exc()
             print(payload)


### PR DESCRIPTION
Fix race and random failures with unit tests for concurrency policy by using the scheduling only mock publisher and handling the processing of the scheduling queue manually. Use the noop coordinator driver to prevent blocking in the process. The lock mechanism should be unit tested elsewhere. The separation of concerns should improve the robustness of these tests.