### PR TITLE
Allow user to run a subset of pack tests using st2-run-pack-tests script

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,17 +33,24 @@ Added
 
   Contributed by Tristan Struthers (@trstruth).
 * Add support for task delay in Orquesta workflows. #4459 (new feature)
-* Allow user to run a subset of pack tests by utilizing the new ``-m`` command line option in the
+* Allow user to run a subset of pack tests by utilizing the new ``-f`` command line option in the
   ``st2-run-pack-tests`` script.
 
   For example:
 
   1. Run all tests in a test file (module):
-     st2-run-pack-tests -j -x -p contrib/packs/ -m test_action_download
+
+     st2-run-pack-tests -j -x -p contrib/packs/ -f test_action_download
+
   2. Run a single test class
-     st2-run-pack-tests -j -x -p contrib/packs/ -m test_action_download:DownloadGitRepoActionTestCase
+
+     st2-run-pack-tests -j -x -p contrib/packs/ -f test_action_download:DownloadGitRepoActionTestCase
+
   3. Run a single test class method
-     st2-run-pack-tests -j -x -p contrib/packs/ -m test_action_download:DownloadGitRepoActionTestCase.test_run_pack_download
+
+     st2-run-pack-tests -j -x -p contrib/packs/ -f test_action_download:DownloadGitRepoActionTestCase.test_run_pack_download
+
+  (new feature) #4464
 
 Changed
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,7 +32,18 @@ Added
   a specific (parent) execution. (new feature) #4444
 
   Contributed by Tristan Struthers (@trstruth).
-* Add support for task delay in Orquesta workflows. (new feature)
+* Add support for task delay in Orquesta workflows. #4459 (new feature)
+* Allow user to run a subset of pack tests by utilizing the new ``-m`` command line option in the
+  ``st2-run-pack-tests`` script.
+
+  For example:
+
+  1. Run all tests in a test file (module):
+     st2-run-pack-tests -j -x -p contrib/packs/ -m test_action_download
+  2. Run a single test class
+     st2-run-pack-tests -j -x -p contrib/packs/ -m test_action_download:DownloadGitRepoActionTestCase
+  3. Run a single test class method
+     st2-run-pack-tests -j -x -p contrib/packs/ -m test_action_download:DownloadGitRepoActionTestCase.test_run_pack_download
 
 Changed
 ~~~~~~~

--- a/st2common/bin/st2-run-pack-tests
+++ b/st2common/bin/st2-run-pack-tests
@@ -216,12 +216,12 @@ fi
 if [ ${ST2_REPO_PATH} ]; then
     ST2_REPO_PATH=${ST2_REPO_PATH:-/tmp/st2}
     ST2_COMPONENTS=$(find ${ST2_REPO_PATH}/* -maxdepth 0 -name "st2*" -type d)
-    ST2_RUNNERS=$(find ${ST2_REPO_PATH}/contrib/runners/* -maxdepth 0 -type d)
+    ST2_RUNNERS=$(find ${ST2_REPO_PATH}/contrib/runners/* -maxdepth 0 -type d 2> /dev/null)
     PACK_PYTHONPATH="$(join ":" ${ST2_COMPONENTS}):$(join ":" ${ST2_RUNNERS}):${SENSORS_PATH}:${ACTIONS_PATH}:${ETC_PATH}"
 else
     # ST2_REPO_PATH not provided, assume all the st2 component packages are
     # already in PYTHONPATH
-    ST2_RUNNERS=$(find /opt/stackstorm/runners/* -maxdepth 0 -type d)
+    ST2_RUNNERS=$(find /opt/stackstorm/runners/* -maxdepth 0 -type d 2> /dev/null)
     PACK_PYTHONPATH="$(join ":" ${ST2_COMPONENTS}):$(join ":" ${ST2_RUNNERS}):${SENSORS_PATH}:${ACTIONS_PATH}:${ETC_PATH}"
 fi
 

--- a/st2common/bin/st2-run-pack-tests
+++ b/st2common/bin/st2-run-pack-tests
@@ -71,8 +71,8 @@ STACKSTORM_VIRTUALENV_PYTHON_BINARY="${STACKSTORM_VIRTUALENV_BIN}/python"
 ####################
 
 function usage() {
-    echo "Usage: $0  [-c] [-j] [-t] [-v] [-x] -p <path to pack> [-m <test file module / class / method>]" >&2
-    echo "  -m : Run a specific test file or test class method (e.g. -m test_action_download:DownloadGitRepoActionTestCase.test_run_pack_download)" >&2
+    echo "Usage: $0  [-c] [-j] [-t] [-v] [-x] -p <path to pack> [-f <test file module / class / method>]" >&2
+    echo "  -f : Run a specific test file or test class method (e.g. -f test_action_download:DownloadGitRepoActionTestCase.test_run_pack_download)" >&2
     echo "  -c : Run tests with code coverage reporting enabled" >&2
     echo "  -j : Just run tests. Use previously installed dependencies" >&2
     echo "       and virtualenv, if any, for subsequent test runs." >&2
@@ -81,12 +81,12 @@ function usage() {
     echo "  -x : Do not create virtualenv for test for tests, e.g. when running in existing one." >&2
 }
 
-while getopts ":p:m:xjvct" o; do
+while getopts ":p:f:xjvct" o; do
     case "${o}" in
         p)
             PACK_PATH=${OPTARG}
             ;;
-        m)
+        f)
             TEST_LOCATION=${OPTARG}
             ;;
         x)

--- a/st2common/bin/st2-run-pack-tests
+++ b/st2common/bin/st2-run-pack-tests
@@ -71,7 +71,8 @@ STACKSTORM_VIRTUALENV_PYTHON_BINARY="${STACKSTORM_VIRTUALENV_BIN}/python"
 ####################
 
 function usage() {
-    echo "Usage: $0  [-c] [-j] [-t] [-v] [-x] -p <path to pack>" >&2
+    echo "Usage: $0  [-c] [-j] [-t] [-v] [-x] -p <path to pack> [-m <test file path>]" >&2
+    echo "  -m : Run a specific test file or test" >&2
     echo "  -c : Run tests with code coverage reporting enabled" >&2
     echo "  -j : Just run tests. Use previously installed dependencies" >&2
     echo "       and virtualenv, if any, for subsequent test runs." >&2
@@ -80,10 +81,13 @@ function usage() {
     echo "  -x : Do not create virtualenv for test for tests, e.g. when running in existing one." >&2
 }
 
-while getopts ":p:xjvct" o; do
+while getopts ":p:m:xjvct" o; do
     case "${o}" in
         p)
             PACK_PATH=${OPTARG}
+            ;;
+        m)
+            TEST_LOCATION=${OPTARG}
             ;;
         x)
             CREATE_VIRTUALENV=false
@@ -273,6 +277,11 @@ if [ ! -z "${PYTHONPATH}" ]; then
     TESTS_PYTHON_PATH+=("${PYTHONPATH}")
 fi
 
+# 4. Add in tests path if test file is provided
+if [ ! -z "${TEST_LOCATION}" ]; then
+    TESTS_PYTHON_PATH+=("${PACK_TESTS_PATH}")
+fi
+
 TESTS_PYTHON_PATH="$(join ":" ${TESTS_PYTHON_PATH[@]})"
 
 export PYTHONPATH="${TESTS_PYTHON_PATH}"
@@ -325,7 +334,13 @@ fi
 pushd ${PACK_PATH} > /dev/null
 
 # Execute the tests
-nosetests ${NOSE_OPTS[@]} ${PACK_TESTS_PATH}
+if [ "${TEST_LOCATION}" ]; then
+    # Run a specific test file, class or method
+    nosetests ${NOSE_OPTS[@]} ${TEST_LOCATION}
+else
+    # Run all tests inside the pack
+    nosetests ${NOSE_OPTS[@]} ${PACK_TESTS_PATH}
+fi
 TESTS_EXIT_CODE=$?
 
 popd  > /dev/null # ${PACK_PATH}

--- a/st2common/bin/st2-run-pack-tests
+++ b/st2common/bin/st2-run-pack-tests
@@ -71,8 +71,8 @@ STACKSTORM_VIRTUALENV_PYTHON_BINARY="${STACKSTORM_VIRTUALENV_BIN}/python"
 ####################
 
 function usage() {
-    echo "Usage: $0  [-c] [-j] [-t] [-v] [-x] -p <path to pack> [-m <test file path>]" >&2
-    echo "  -m : Run a specific test file or test" >&2
+    echo "Usage: $0  [-c] [-j] [-t] [-v] [-x] -p <path to pack> [-m <test file module / class / method>]" >&2
+    echo "  -m : Run a specific test file or test class method (e.g. -m test_action_download:DownloadGitRepoActionTestCase.test_run_pack_download)" >&2
     echo "  -c : Run tests with code coverage reporting enabled" >&2
     echo "  -j : Just run tests. Use previously installed dependencies" >&2
     echo "       and virtualenv, if any, for subsequent test runs." >&2


### PR DESCRIPTION
This pull request adds new ``-f`` flag to the ``st2-run-pack-tests`` script which allows users to run a subset of tests from a particular file.

For example:

1. Run all tests in a test file (module):

```bash
st2-run-pack-tests -j -x -p contrib/packs/ -f test_action_download
```

2. Run a single test class

```bash
st2-run-pack-tests -j -x -p contrib/packs/ -f test_action_download:DownloadGitRepoActionTestCase
```

3. Run a single test class method

```bash
st2-run-pack-tests -j -x -p contrib/packs/ -f test_action_download:DownloadGitRepoActionTestCase.test_run_pack_download
```

Before those change it was only possible to run all the tests from a particular pack which was rather slow and time consuming when working on a specific test.