### PR TITLE
Add the use_none function for Orquesta workflows

### DIFF
--- a/contrib/examples/actions/workflows/tests/orquesta-test-jinja-data-functions.yaml
+++ b/contrib/examples/actions/workflows/tests/orquesta-test-jinja-data-functions.yaml
@@ -4,6 +4,7 @@ description: A basic workflow testing data related functions.
 
 vars:
   - data_json_str_1: '{"foo": {"bar": "foobar"}}'
+  - none: null
 
 tasks:
   task1:
@@ -27,3 +28,5 @@ output:
   - data_yaml_str_2: '{{ yaml_dump(ctx("data_json_obj_3")) }}'
   - data_json_obj_4: '{{ yaml_parse(ctx("data_yaml_str_2")) }}'
   - data_json_str_3: '{{ json_dump(ctx("data_json_obj_4")) }}'
+  - data_none_str: '{{ use_none(ctx("none")) }}'
+  - data_str: '{{ use_none("foobar") }}'

--- a/contrib/examples/actions/workflows/tests/orquesta-test-yaql-data-functions.yaml
+++ b/contrib/examples/actions/workflows/tests/orquesta-test-yaql-data-functions.yaml
@@ -4,6 +4,7 @@ description: A basic workflow testing data related functions.
 
 vars:
   - data_json_str_1: '{"foo": {"bar": "foobar"}}'
+  - none: null
 
 tasks:
   task1:
@@ -20,3 +21,5 @@ output:
   - data_yaml_str_2: '<% yaml_dump(ctx("data_json_obj_3")) %>'
   - data_json_obj_4: '<% yaml_parse(ctx("data_yaml_str_2")) %>'
   - data_json_str_3: '<% json_dump(ctx("data_json_obj_4")) %>'
+  - data_none_str: '<% use_none(ctx("none")) %>'
+  - data_str: '<% use_none("foobar") %>'

--- a/contrib/runners/orquesta_runner/setup.py
+++ b/contrib/runners/orquesta_runner/setup.py
@@ -70,6 +70,7 @@ setup(
                 'st2common.expressions.functions.time:to_human_time_from_seconds'),
             'to_json_string = st2common.expressions.functions.data:to_json_string',
             'to_yaml_string = st2common.expressions.functions.data:to_yaml_string',
+            'use_none = st2common.expressions.functions.data:use_none',
             'version_compare = st2common.expressions.functions.version:version_compare',
             'version_more_than = st2common.expressions.functions.version:version_more_than',
             'version_less_than = st2common.expressions.functions.version:version_less_than',

--- a/contrib/runners/orquesta_runner/tests/unit/test_functions_common.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_functions_common.py
@@ -30,6 +30,7 @@ from tests.unit import base
 from st2common.bootstrap import actionsregistrar
 from st2common.bootstrap import runnersregistrar
 from st2common.constants import action as ac_const
+from st2common.expressions.functions import data as data_funcs
 from st2common.models.db import liveaction as lv_db_models
 from st2common.persistence import execution as ex_db_access
 from st2common.persistence import liveaction as lv_db_access
@@ -140,7 +141,9 @@ class OrquestaFunctionTest(st2tests.ExecutionDbTestCase):
             'data_json_obj_4': {'foo': {'bar': 'foobar'}},
             'data_yaml_str_1': 'foo:\n  bar: foobar\n',
             'data_yaml_str_2': 'foo:\n  bar: foobar\n',
-            'data_query_1': ['foobar']
+            'data_query_1': ['foobar'],
+            'data_none_str': data_funcs.NONE_MAGIC_VALUE,
+            'data_str': 'foobar'
         }
 
         self._execute_workflow(wf_name, expected_output)
@@ -159,7 +162,9 @@ class OrquestaFunctionTest(st2tests.ExecutionDbTestCase):
             'data_yaml_str_1': 'foo:\n  bar: foobar\n',
             'data_yaml_str_2': 'foo:\n  bar: foobar\n',
             'data_query_1': ['foobar'],
-            'data_pipe_str_1': '{"foo": {"bar": "foobar"}}'
+            'data_pipe_str_1': '{"foo": {"bar": "foobar"}}',
+            'data_none_str': data_funcs.NONE_MAGIC_VALUE,
+            'data_str': 'foobar'
         }
 
         self._execute_workflow(wf_name, expected_output)

--- a/st2common/st2common/expressions/functions/data.py
+++ b/st2common/st2common/expressions/functions/data.py
@@ -105,3 +105,11 @@ def jsonpath_query(value, query):
 
 def to_complex(value):
     return json.dumps(value)
+
+
+# Magic string to which None type is serialized when using use_none filter
+NONE_MAGIC_VALUE = '%*****__%NONE%__*****%'
+
+
+def use_none(value):
+    return NONE_MAGIC_VALUE if value is None else value

--- a/st2common/st2common/util/casts.py
+++ b/st2common/st2common/util/casts.py
@@ -20,8 +20,8 @@ import json
 
 import six
 
+from st2common.expressions.functions import data
 from st2common.util.compat import to_unicode
-from st2common.util.jinja import NONE_MAGIC_VALUE
 
 
 def _cast_object(x):
@@ -81,7 +81,7 @@ def _cast_none(x):
     """
     Cast function which serializes special magic string value which indicate "None" to None type.
     """
-    if isinstance(x, six.string_types) and x == NONE_MAGIC_VALUE:
+    if isinstance(x, six.string_types) and x == data.NONE_MAGIC_VALUE:
         return None
 
     return x

--- a/st2common/st2common/util/jinja.py
+++ b/st2common/st2common/util/jinja.py
@@ -28,8 +28,6 @@ __all__ = [
     'is_jinja_expression'
 ]
 
-# Magic string to which None type is serialized when using use_none filter
-NONE_MAGIC_VALUE = '%*****__%NONE%__*****%'
 
 JINJA_EXPRESSIONS_START_MARKERS = [
     '{{',
@@ -43,13 +41,6 @@ JINJA_BLOCK_REGEX_PTRN = re.compile(JINJA_BLOCK_REGEX)
 
 
 LOG = logging.getLogger(__name__)
-
-
-def use_none(value):
-    if value is None:
-        return NONE_MAGIC_VALUE
-
-    return value
 
 
 def get_filters():
@@ -91,7 +82,7 @@ def get_filters():
         'version_bump_minor': version.version_bump_minor,
         'version_bump_patch': version.version_bump_patch,
         'version_strip_patch': version.version_strip_patch,
-        'use_none': use_none,
+        'use_none': data.use_none,
 
         'basename': path.basename,
         'dirname': path.dirname

--- a/st2reactor/tests/unit/test_enforce.py
+++ b/st2reactor/tests/unit/test_enforce.py
@@ -21,6 +21,7 @@ from st2common.constants import action as action_constants
 from st2common.constants.keyvalue import FULL_SYSTEM_SCOPE
 from st2common.constants.rule_enforcement import RULE_ENFORCEMENT_STATUS_SUCCEEDED
 from st2common.constants.rule_enforcement import RULE_ENFORCEMENT_STATUS_FAILED
+from st2common.expressions.functions import data
 from st2common.models.db.trigger import TriggerInstanceDB
 from st2common.models.db.execution import ActionExecutionDB
 from st2common.models.db.liveaction import LiveActionDB
@@ -32,7 +33,6 @@ from st2common.bootstrap import runnersregistrar as runners_registrar
 from st2common.util import casts
 from st2common.util import reference
 from st2common.util import date as date_utils
-from st2common.util.jinja import NONE_MAGIC_VALUE
 from st2reactor.rules.enforcer import RuleEnforcer
 
 from st2tests import DbTestCase
@@ -189,7 +189,7 @@ class RuleEnforcerTestCase(BaseRuleEnforcerTestCase):
         mock_trigger_instance.payload = {'t1_p': None}
 
         def mock_cast_string(x):
-            assert x == NONE_MAGIC_VALUE
+            assert x == data.NONE_MAGIC_VALUE
             return casts._cast_string(x)
         casts.CASTS['string'] = mock_cast_string
 

--- a/st2tests/integration/orquesta/test_wiring_functions.py
+++ b/st2tests/integration/orquesta/test_wiring_functions.py
@@ -33,7 +33,9 @@ class FunctionsWiringTest(base.TestWorkflowExecution):
             'data_json_obj_4': {'foo': {'bar': 'foobar'}},
             'data_yaml_str_1': 'foo:\n  bar: foobar\n',
             'data_yaml_str_2': 'foo:\n  bar: foobar\n',
-            'data_query_1': ['foobar']
+            'data_query_1': ['foobar'],
+            'data_none_str': '%*****__%NONE%__*****%',
+            'data_str': 'foobar'
         }
 
         expected_result = {'output': expected_output}
@@ -54,7 +56,9 @@ class FunctionsWiringTest(base.TestWorkflowExecution):
             'data_yaml_str_1': 'foo:\n  bar: foobar\n',
             'data_yaml_str_2': 'foo:\n  bar: foobar\n',
             'data_query_1': ['foobar'],
-            'data_pipe_str_1': '{"foo": {"bar": "foobar"}}'
+            'data_pipe_str_1': '{"foo": {"bar": "foobar"}}',
+            'data_none_str': '%*****__%NONE%__*****%',
+            'data_str': 'foobar'
         }
 
         expected_result = {'output': expected_output}

--- a/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/jinja-data-functions.yaml
+++ b/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/jinja-data-functions.yaml
@@ -4,6 +4,7 @@ description: A basic workflow testing data related functions.
 
 vars:
   - data_json_str_1: '{"foo": {"bar": "foobar"}}'
+  - none: null
 
 tasks:
   task1:
@@ -27,3 +28,5 @@ output:
   - data_yaml_str_2: '{{ yaml_dump(ctx("data_json_obj_3")) }}'
   - data_json_obj_4: '{{ yaml_parse(ctx("data_yaml_str_2")) }}'
   - data_json_str_3: '{{ json_dump(ctx("data_json_obj_4")) }}'
+  - data_none_str: '{{ use_none(ctx("none")) }}'
+  - data_str: '{{ use_none("foobar") }}'

--- a/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/yaql-data-functions.yaml
+++ b/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/yaql-data-functions.yaml
@@ -4,6 +4,7 @@ description: A basic workflow testing data related functions.
 
 vars:
   - data_json_str_1: '{"foo": {"bar": "foobar"}}'
+  - none: null
 
 tasks:
   task1:
@@ -20,3 +21,5 @@ output:
   - data_yaml_str_2: '<% yaml_dump(ctx("data_json_obj_3")) %>'
   - data_json_obj_4: '<% yaml_parse(ctx("data_yaml_str_2")) %>'
   - data_json_str_3: '<% json_dump(ctx("data_json_obj_4")) %>'
+  - data_none_str: '<% use_none(ctx("none")) %>'
+  - data_str: '<% use_none("foobar") %>'


### PR DESCRIPTION
Move the use_none function to the common functions module. Register the use_none function in Orquesta. Add unit and integration tests for the use_none function.