### PR TITLE
Fix Python 3 compatibility issue in the RBAC definitions loader

### DIFF
--- a/st2common/st2common/rbac/loader.py
+++ b/st2common/st2common/rbac/loader.py
@@ -18,8 +18,10 @@ Module for loading RBAC role definitions and grants from the filesystem.
 """
 
 from __future__ import absolute_import
+
 import os
 import glob
+import functools
 
 from oslo_config import cfg
 
@@ -204,7 +206,7 @@ class RBACDefinitionsLoader(object):
         """
         glob_str = self._role_definitions_path + '*.yaml'
         file_paths = glob.glob(glob_str)
-        file_paths = sorted(file_paths, cmp=compare_path_file_name)
+        file_paths = sorted(file_paths, key=functools.cmp_to_key(compare_path_file_name))
         return file_paths
 
     def _get_role_assiginments_file_paths(self):
@@ -217,7 +219,7 @@ class RBACDefinitionsLoader(object):
         """
         glob_str = self._role_assignments_path + '*.yaml'
         file_paths = glob.glob(glob_str)
-        file_paths = sorted(file_paths, cmp=compare_path_file_name)
+        file_paths = sorted(file_paths, key=functools.cmp_to_key(compare_path_file_name))
         return file_paths
 
     def _get_group_to_role_maps_file_paths(self):
@@ -228,5 +230,5 @@ class RBACDefinitionsLoader(object):
         """
         glob_str = self._role_maps_path + '*.yaml'
         file_paths = glob.glob(glob_str)
-        file_paths = sorted(file_paths, cmp=compare_path_file_name)
+        file_paths = sorted(file_paths, key=functools.cmp_to_key(compare_path_file_name))
         return file_paths

--- a/st2common/st2common/util/misc.py
+++ b/st2common/st2common/util/misc.py
@@ -60,7 +60,7 @@ def compare_path_file_name(file_path_a, file_path_b):
     file_name_a = os.path.basename(file_path_a)
     file_name_b = os.path.basename(file_path_b)
 
-    return cmp(file_name_a, file_name_b)
+    return (file_name_a > file_name_b) - (file_name_a < file_name_b)
 
 
 def strip_shell_chars(input_str):

--- a/st2common/st2common/util/misc.py
+++ b/st2common/st2common/util/misc.py
@@ -60,7 +60,7 @@ def compare_path_file_name(file_path_a, file_path_b):
     file_name_a = os.path.basename(file_path_a)
     file_name_b = os.path.basename(file_path_b)
 
-    return file_name_a < file_name_b
+    return cmp(file_name_a, file_name_b)
 
 
 def strip_shell_chars(input_str):

--- a/st2common/tests/unit/test_rbac_loader.py
+++ b/st2common/tests/unit/test_rbac_loader.py
@@ -253,3 +253,30 @@ class RBACDefinitionsLoaderTestCase(unittest2.TestCase):
         self.assertEqual(role_mapping_api.description, 'Grant 3 roles to stormers group members')
         self.assertFalse(role_mapping_api.enabled)
         self.assertEqual(role_mapping_api.file_path, 'mappings/mapping_two.yaml')
+
+    @mock.patch('glob.glob')
+    def test_file_paths_sorting(self, mock_glob):
+        mock_glob.return_value = [
+            '/tmp/bar/d.yaml',
+            '/tmp/bar/c.yaml',
+            '/tmp/foo/a.yaml',
+            '/tmp/a/f.yaml'
+        ]
+
+        expected_result = [
+            '/tmp/foo/a.yaml',
+            '/tmp/bar/c.yaml',
+            '/tmp/bar/d.yaml',
+            '/tmp/a/f.yaml'
+        ]
+
+        loader = RBACDefinitionsLoader()
+
+        file_paths = loader._get_role_definitions_file_paths()
+        self.assertEqual(file_paths, expected_result)
+
+        file_paths = loader._get_role_assiginments_file_paths()
+        self.assertEqual(file_paths, expected_result)
+
+        file_paths = loader._get_group_to_role_maps_file_paths()
+        self.assertEqual(file_paths, expected_result)


### PR DESCRIPTION
This pull request fixes Python 3 compatibility in the RBAC definitions loader.

I found this issue while testing new enterprise packages on Ubuntu Bionic.

I also added tests so such issue will be caught autocratically in the future.