### PR TITLE
Fix task with items but items list is empty for orquesta workflows

### DIFF
--- a/contrib/runners/orquesta_runner/in-requirements.txt
+++ b/contrib/runners/orquesta_runner/in-requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/StackStorm/orquesta.git@3d3fba127c1a26db61845cdbd9c2042198813e06#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@2e5cad1df13836459b8ae9273c75c73d7547c60d#egg=orquesta

--- a/contrib/runners/orquesta_runner/requirements.txt
+++ b/contrib/runners/orquesta_runner/requirements.txt
@@ -1,2 +1,2 @@
 # Don't edit this file. It's generated automatically!
-git+https://github.com/StackStorm/orquesta.git@3d3fba127c1a26db61845cdbd9c2042198813e06#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@2e5cad1df13836459b8ae9273c75c73d7547c60d#egg=orquesta

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ cryptography==2.4.1
 eventlet==0.24.1
 flex==6.13.2
 git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper
-git+https://github.com/StackStorm/orquesta.git@3d3fba127c1a26db61845cdbd9c2042198813e06#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@2e5cad1df13836459b8ae9273c75c73d7547c60d#egg=orquesta
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
 gitpython==2.1.11

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -9,7 +9,7 @@ jsonschema
 kombu
 mongoengine
 networkx
-git+https://github.com/StackStorm/orquesta.git@3d3fba127c1a26db61845cdbd9c2042198813e06#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@2e5cad1df13836459b8ae9273c75c73d7547c60d#egg=orquesta
 oslo.config
 paramiko
 pyyaml

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -3,7 +3,7 @@ apscheduler==3.5.3
 cryptography==2.4.1
 eventlet==0.24.1
 flex==6.13.2
-git+https://github.com/StackStorm/orquesta.git@3d3fba127c1a26db61845cdbd9c2042198813e06#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@2e5cad1df13836459b8ae9273c75c73d7547c60d#egg=orquesta
 greenlet==0.4.15
 ipaddr
 jinja2

--- a/st2common/st2common/models/db/workflow.py
+++ b/st2common/st2common/models/db/workflow.py
@@ -65,6 +65,8 @@ class TaskExecutionDB(stormbase.StormFoundationDB, stormbase.ChangeRevisionField
     task_spec = stormbase.EscapedDictField()
     delay = me.IntField(min_value=0)
     itemized = me.BooleanField(default=False)
+    items_count = me.IntField(min_value=0)
+    items_concurrency = me.IntField(min_value=1)
     context = stormbase.EscapedDictField()
     result = stormbase.EscapedDictField()
     status = me.StringField(required=True)


### PR DESCRIPTION
If the items list is empty, on transition to the task with items, orquesta fails to render the action specs correctly. For this use case, the orquesta conductor will now return the task spec with the list of action specs empty. The st2 workflow engine will recognize and handle this appropriately to set the task execution to completion in the conductor as well as the database records to progress the workflow execution to the next task(s).