### PR TITLE
Fix for ?scope=all and ?user=<username> query parameter handling in /v1/keys API endpoint

### DIFF
--- a/st2api/st2api/controllers/v1/keyvalue.py
+++ b/st2api/st2api/controllers/v1/keyvalue.py
@@ -154,6 +154,7 @@ class KeyValuePairController(ResourceController):
             # Special case for ALL_SCOPE
             # 1. Retrieve system scoped values
             raw_filters['scope'] = FULL_SYSTEM_SCOPE
+            raw_filters['prefix'] = prefix
 
             assert 'scope' in raw_filters
             kvp_apis_system = super(KeyValuePairController, self)._get_all(
@@ -172,8 +173,7 @@ class KeyValuePairController(ResourceController):
                 # Retrieve values scoped to the current user
                 prefix = get_key_reference(name=prefix or '', scope=USER_SCOPE, user=user)
                 raw_filters['prefix'] = prefix
-
-            if not is_admin or (is_admin and user_query_param_filter):
+            elif not is_admin or (is_admin and user_query_param_filter):
                 # Retrieve values scoped to the current or the provided user
                 prefix = get_key_reference(name=prefix or '', scope=USER_SCOPE, user=user)
                 raw_filters['prefix'] = prefix

--- a/st2api/st2api/controllers/v1/keyvalue.py
+++ b/st2api/st2api/controllers/v1/keyvalue.py
@@ -168,6 +168,11 @@ class KeyValuePairController(ResourceController):
             # authenticated user is admin and if ?user is provided)
             raw_filters['scope'] = FULL_USER_SCOPE
 
+            if not cfg.CONF.rbac.enable:
+                # Retrieve values scoped to the current user
+                prefix = get_key_reference(name=prefix or '', scope=USER_SCOPE, user=user)
+                raw_filters['prefix'] = prefix
+
             if not is_admin or (is_admin and user_query_param_filter):
                 # Retrieve values scoped to the current or the provided user
                 prefix = get_key_reference(name=prefix or '', scope=USER_SCOPE, user=user)

--- a/st2api/st2api/controllers/v1/keyvalue.py
+++ b/st2api/st2api/controllers/v1/keyvalue.py
@@ -93,7 +93,8 @@ class KeyValuePairController(ResourceController):
 
         # Validate that the authenticated user is admin if user query param is provided
         assert_user_is_admin_if_user_query_param_is_provided(user_db=requester_user,
-                                                             user=user)
+                                                             user=user,
+                                                             require_rbac=True)
 
         key_ref = get_key_reference(scope=scope, name=name, user=user)
         from_model_kwargs = {'mask_secrets': not decrypt}
@@ -140,7 +141,8 @@ class KeyValuePairController(ResourceController):
 
         # Validate that the authenticated user is admin if user query param is provided
         assert_user_is_admin_if_user_query_param_is_provided(user_db=requester_user,
-                                                             user=user)
+                                                             user=user,
+                                                             require_rbac=True)
 
         from_model_kwargs = {'mask_secrets': not decrypt}
 
@@ -231,7 +233,8 @@ class KeyValuePairController(ResourceController):
 
         # Validate that the authenticated user is admin if user query param is provided
         assert_user_is_admin_if_user_query_param_is_provided(user_db=requester_user,
-                                                             user=user)
+                                                             user=user,
+                                                             require_rbac=True)
 
         key_ref = get_key_reference(scope=scope, name=name, user=user)
         lock_name = self._get_lock_name_for_key(name=key_ref, scope=scope)
@@ -301,7 +304,8 @@ class KeyValuePairController(ResourceController):
 
         # Validate that the authenticated user is admin if user query param is provided
         assert_user_is_admin_if_user_query_param_is_provided(user_db=requester_user,
-                                                             user=user)
+                                                             user=user,
+                                                             require_rbac=True)
 
         key_ref = get_key_reference(scope=scope, name=name, user=user)
         lock_name = self._get_lock_name_for_key(name=key_ref, scope=scope)

--- a/st2api/tests/unit/controllers/v1/test_kvps.py
+++ b/st2api/tests/unit/controllers/v1/test_kvps.py
@@ -104,7 +104,6 @@ class KeyValuePairControllerTestCase(FunctionalTest):
         self.assertEqual(put_resp.json['scope'], 'st2kv.system')
 
         # user1 scoped keys
-        print('1111111111')
         self.use_user(user_db_1)
 
         put_resp = self.__do_put('user1', {'name': 'user1', 'value': 'user1',

--- a/st2common/st2common/rbac/utils.py
+++ b/st2common/st2common/rbac/utils.py
@@ -225,16 +225,22 @@ def assert_user_has_rule_trigger_and_action_permission(user_db, rule_api):
     return True
 
 
-def assert_user_is_admin_if_user_query_param_is_provided(user_db, user):
+def assert_user_is_admin_if_user_query_param_is_provided(user_db, user, require_rbac=False):
     """
     Function which asserts that the request user is administator if "user" query parameter is
     provided and doesn't match the current user.
     """
     is_admin = user_is_admin(user_db=user_db)
+    is_rbac_enabled = bool(cfg.CONF.rbac.enable)
 
-    if user != user_db.name and not is_admin:
-        msg = '"user" attribute can only be provided by admins'
-        raise AccessDeniedError(message=msg, user_db=user_db)
+    if user != user_db.name:
+        if require_rbac and not is_rbac_enabled:
+            msg = '"user" attribute can only be provided by admins when RBAC is enabled'
+            raise AccessDeniedError(message=msg, user_db=user_db)
+
+        if not is_admin:
+            msg = '"user" attribute can only be provided by admins'
+            raise AccessDeniedError(message=msg, user_db=user_db)
 
 
 def user_is_admin(user_db):

--- a/st2tests/st2tests/api.py
+++ b/st2tests/st2tests/api.py
@@ -111,9 +111,12 @@ class BaseFunctionalTest(DbTestCase):
     def tearDown(self):
         super(BaseFunctionalTest, self).tearDown()
 
+        # Reset mock context for API requests
         if getattr(self, 'request_context_mock', None):
             self.request_context_mock.stop()
-            del(Router.mock_context)
+
+            if hasattr(Router, 'mock_context'):
+                del(Router.mock_context)
 
     @classmethod
     def _do_setUpClass(cls):
@@ -201,10 +204,3 @@ class BaseAPIControllerWithRBACTestCase(BaseFunctionalTest, CleanDbTestCase):
             user=user_2_db.name, role=SystemRole.ADMIN,
             source='assignments/%s.yaml' % user_2_db.name)
         UserRoleAssignment.add_or_update(role_assignment_db)
-
-    def tearDown(self):
-        super(BaseAPIControllerWithRBACTestCase, self).tearDown()
-
-        if getattr(self, 'request_context_mock', None):
-            self.request_context_mock.stop()
-            del(Router.mock_context)

--- a/st2tests/st2tests/api.py
+++ b/st2tests/st2tests/api.py
@@ -108,6 +108,13 @@ class BaseFunctionalTest(DbTestCase):
         super(BaseFunctionalTest, cls).setUpClass()
         cls._do_setUpClass()
 
+    def tearDown(self):
+        super(BaseFunctionalTest, self).tearDown()
+
+        if getattr(self, 'request_context_mock', None):
+            self.request_context_mock.stop()
+            del(Router.mock_context)
+
     @classmethod
     def _do_setUpClass(cls):
         tests_config.parse_args()
@@ -122,6 +129,23 @@ class BaseFunctionalTest(DbTestCase):
             runners_registrar.register_runners()
 
         cls.app = TestApp(cls.app_module.setup_app())
+
+    def use_user(self, user_db):
+        """
+        Select a user which is to be used by the HTTP request following this call.
+        """
+        if not user_db:
+            raise ValueError('"user_db" is mandatory')
+
+        mock_context = {
+            'user': user_db,
+            'auth_info': {
+                'method': 'authentication token',
+                'location': 'header'
+            }
+        }
+        self.request_context_mock = mock.PropertyMock(return_value=mock_context)
+        Router.mock_context = self.request_context_mock
 
 
 class BaseAPIControllerWithRBACTestCase(BaseFunctionalTest, CleanDbTestCase):
@@ -184,20 +208,3 @@ class BaseAPIControllerWithRBACTestCase(BaseFunctionalTest, CleanDbTestCase):
         if getattr(self, 'request_context_mock', None):
             self.request_context_mock.stop()
             del(Router.mock_context)
-
-    def use_user(self, user_db):
-        """
-        Select a user which is to be used by the HTTP request following this call.
-        """
-        if not user_db:
-            raise ValueError('"user_db" is mandatory')
-
-        mock_context = {
-            'user': user_db,
-            'auth_info': {
-                'method': 'authentication token',
-                'location': 'header'
-            }
-        }
-        self.request_context_mock = mock.PropertyMock(return_value=mock_context)
-        Router.mock_context = self.request_context_mock


### PR DESCRIPTION
``GET /v1/keys`` API endpoint (get all / view keys) API endpoint incorrectly handled ``?scope=all`` and ``?user=<username>`` query parameter.

Enterprise deployments with RBAC enabled are not affected because there only admin users are allowed to use ``?scope=all`` query parameter.

This pull request fixes that.