### PR TITLE
Fix kombu release version

### DIFF
--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -5,7 +5,7 @@ greenlet==0.4.15
 # depend on rely
 eventlet==0.24.1
 gunicorn==19.9.0
-kombu==4.2.2
+kombu==4.2.2.post1
 # Note: amqp is used by kombu
 amqp==2.3.2
 # NOTE: Recent version substantially affect the performance and add big import time overhead

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ ipaddr
 jinja2
 jsonpath-rw==1.4.0
 jsonschema==2.6.0
-kombu==4.2.2
+kombu==4.2.2.post1
 lockfile==0.12.2
 mock==2.0.0
 mongoengine==0.16.3

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -9,7 +9,7 @@ ipaddr
 jinja2
 jsonpath-rw==1.4.0
 jsonschema==2.6.0
-kombu==4.2.2
+kombu==4.2.2.post1
 mongoengine==0.16.3
 networkx==1.11
 oslo.config<1.13,>=1.12.1


### PR DESCRIPTION
The Kombu team had a release issue, and accidentally published the wrong code as 4.2.2 to PyPi. They have fixed this, and pulled 4.2.2. 

https://github.com/celery/kombu/issues/966