### PR TITLE
Python versions changelog entry

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,8 +9,14 @@ Added
 
 * Allow access to user-scoped datastore items using ``{{ st2kv.user.<key name> }}`` Jinja template
   notation inside the action parameter default values. (improvement) #4463
-  
+
   Contributed by Hiroyasu OHYAMA (@userlocalhost).
+* Add support for new ``python_versions`` (``list`` of ``string``) attribute to pack metadata file
+  (``pack.yaml``). With this attribute pack declares which major Python versions it supports and
+  works with (e.g. ``2`` and ``3``).
+
+   For backward compatibility reasons, if pack metadata file doesn't contain that attribute, it's
+   assumed it only works with Python 2. (new feature) #4474
 
 2.10.0 - December 13, 2018
 --------------------------

--- a/contrib/chatops/pack.yaml
+++ b/contrib/chatops/pack.yaml
@@ -2,6 +2,9 @@
 name: chatops
 description: ChatOps integration pack
 version: 1.0.1
+python_versions:
+  - "2"
+  - "3"
 author: StackStorm, Inc.
 contributors:
   - Anthony Shaw <anthonyshaw@apache.org>

--- a/contrib/core/pack.yaml
+++ b/contrib/core/pack.yaml
@@ -2,5 +2,8 @@
 name : core
 description : Basic core actions.
 version : 1.0.0
+python_versions:
+  - "2"
+  - "3"
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/contrib/hello_st2/pack.yaml
+++ b/contrib/hello_st2/pack.yaml
@@ -6,5 +6,8 @@ keywords:
     - example
     - test
 version: 0.1.0
+python_versions:
+  - "2"
+  - "3"
 author: StackStorm, Inc.
 email: info@stackstorm.com

--- a/contrib/linux/pack.yaml
+++ b/contrib/linux/pack.yaml
@@ -17,5 +17,8 @@ keywords:
   - processes
   - ps
 version : 1.0.1
+python_versions:
+  - "2"
+  - "3"
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/contrib/packs/pack.yaml
+++ b/contrib/packs/pack.yaml
@@ -2,5 +2,8 @@
 name : packs
 description : Pack management functionality.
 version : 1.0.1
+python_versions:
+  - "2"
+  - "3"
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
This pull request adds missing changelog entry for change in #4474.

In addition to that, it adds ``python_versions`` attribute for all the core packs which are bundled with StackStorm in this repo.