### PR TITLE
Added include_attributes and exclude_attributes to GET /api/v1/executions/{id}

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,8 +15,8 @@ Added
   (``pack.yaml``). With this attribute pack declares which major Python versions it supports and
   works with (e.g. ``2`` and ``3``).
 
-   For backward compatibility reasons, if pack metadata file doesn't contain that attribute, it's
-   assumed it only works with Python 2. (new feature) #4474
+  For backward compatibility reasons, if pack metadata file doesn't contain that attribute, it's
+  assumed it only works with Python 2. (new feature) #4474
 * Update service bootstrap code and make sure all the services register in a service registry once
   they come online and become available.
 
@@ -26,14 +26,14 @@ Added
   ``GET /v1/service_registry/groups/<group_id>/members`` API endpoint for listing available service
   registry groups and members.
 
-  NOTE: This API endpoint is behind a RBAC control check and can only be views by the admins.
-  (new feature) #4548
+  Also add corresponding CLI commands - ``st2 service-registry group list``, ``st2 service registry
+  member list [--group-id=<group id>]``
 
-  Also add corresponding CLI commands - ``st2 service-registry group list``,
-  ``st2 service registry member list [--group-id=<group id>]``
- * Add support for ``include_attributes`` and ``exclude_attributes`` to the API endpoint
-  ``GET /api/v1/executions/{id}``. Also update ``st2 execution get`` CLI command so it only
-  retrieves attributes which are displayed. (new feature) #4497
+  NOTE: This API endpoint is behind an RBAC wall and can only be viewed by the admins. (new feature)
+  #4548
+* Add support for ``?include_attributes`` and ``?exclude_attributes`` query param filter to the
+  ``GET /api/v1/executions/{id}`` API endpoint. Also update ``st2 execution get`` CLI command so it
+  only retrieves attributes which are displayed. (new feature) #4497
 
   Contributed by Nick Maludy (@nmaludy Encore Technologies)
 * Adding ``Cache-Control`` header to all API responses so clients will favor
@@ -45,14 +45,14 @@ Added
 
   ``st2 key load`` CLI command has also been updated so it knows how to work with values which are
   already encrypted. This means that ``st2 key list -n 100 -j < data.json ; st2 key load
-  data.json`` will now also work out of the box for encrypted datastore values (value which have
-  ``encrypted: True`` and ``secret: True`` attributes will be treated as pre-encrypted values as
-  treated as such).
+  data.json`` will now also work out of the box for encrypted datastore values (values which have
+  ``encrypted: True`` and ``secret: True`` attribute will be treated as already encrypted and used
+  as-is).
 
   The most common use case for this feature is migrating / restoring datastore values from one
   StackStorm instance to another which uses the same crypto key.
 
-  Contributed by Nick Maludy (Encore Technologies)
+  Contributed by Nick Maludy (Encore Technologies) #4547
 
 Changed
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,8 +31,9 @@ Added
 
   Also add corresponding CLI commands - ``st2 service-registry group list``,
   ``st2 service registry member list [--group-id=<group id>]``
- * Add support for ``include_attributes`` and ``exclude_attributes`` for the API endpoint
-  ``GET /api/v1/executions/{id}``. (new feature) #4497
+ * Add support for ``include_attributes`` and ``exclude_attributes`` to the API endpoint
+  ``GET /api/v1/executions/{id}``. Also update ``st2 execution get`` CLI command so it only
+  retrieves attributes which are displayed. (new feature) #4497
 
   Contributed by Nick Maludy (@nmaludy Encore Technologies)
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,9 +31,10 @@ Added
 
   Also add corresponding CLI commands - ``st2 service-registry group list``,
   ``st2 service registry member list [--group-id=<group id>]``
+ * Add support for ``include_attributes`` and ``exclude_attributes`` for the API endpoint
+  ``GET /api/v1/executions/{id}``. (new feature) #4497
 
-* Adding ``Cache-Control`` header to all API responses so clients will favor
-  refresh from API instead of using cached version.
+  Contributed by Nick Maludy (@nmaludy Encore Technologies)
 
 Changed
 ~~~~~~~

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -265,13 +265,16 @@ class ResourceController(object):
         return item
 
     def _get_one_by_id(self, id, requester_user, permission_type, exclude_fields=None,
-                       from_model_kwargs=None):
+                       include_fields=None, from_model_kwargs=None):
         """
         :param exclude_fields: A list of object fields to exclude.
         :type exclude_fields: ``list``
+        :param include_fields: A list of object fields to include.
+        :type include_fields: ``list``
         """
 
-        instance = self._get_by_id(resource_id=id, exclude_fields=exclude_fields)
+        instance = self._get_by_id(resource_id=id, exclude_fields=exclude_fields,
+                                   include_fields=include_fields)
 
         if permission_type:
             rbac_utils.assert_user_has_resource_db_permission(user_db=requester_user,
@@ -299,13 +302,16 @@ class ResourceController(object):
         return result
 
     def _get_one_by_name_or_id(self, name_or_id, requester_user, permission_type,
-                               exclude_fields=None, from_model_kwargs=None):
+                               exclude_fields=None, include_fields=None, from_model_kwargs=None):
         """
         :param exclude_fields: A list of object fields to exclude.
         :type exclude_fields: ``list``
+        :param include_fields: A list of object fields to include.
+        :type include_fields: ``list``
         """
 
-        instance = self._get_by_name_or_id(name_or_id=name_or_id, exclude_fields=exclude_fields)
+        instance = self._get_by_name_or_id(name_or_id=name_or_id, exclude_fields=exclude_fields,
+                                           include_fields=include_fields)
 
         if permission_type:
             rbac_utils.assert_user_has_resource_db_permission(user_db=requester_user,

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -517,7 +517,8 @@ class ActionExecutionsController(BaseResourceIsolationControllerMixin,
                                            advanced_filters=advanced_filters,
                                            requester_user=requester_user)
 
-    def get_one(self, id, requester_user, exclude_attributes=None, show_secrets=False):
+    def get_one(self, id, requester_user, exclude_attributes=None, include_attributes=None,
+                show_secrets=False):
         """
         Retrieve a single execution.
 
@@ -528,6 +529,7 @@ class ActionExecutionsController(BaseResourceIsolationControllerMixin,
         :type exclude_attributes: ``list``
         """
         exclude_fields = self._validate_exclude_fields(exclude_fields=exclude_attributes)
+        include_fields = self._validate_include_fields(include_fields=include_attributes)
 
         from_model_kwargs = {
             'mask_secrets': self._get_mask_secrets(requester_user, show_secrets=show_secrets)
@@ -543,6 +545,7 @@ class ActionExecutionsController(BaseResourceIsolationControllerMixin,
             id = str(execution_db.id)
 
         return self._get_one_by_id(id=id, exclude_fields=exclude_fields,
+                                   include_fields=include_fields,
                                    requester_user=requester_user,
                                    from_model_kwargs=from_model_kwargs,
                                    permission_type=PermissionType.EXECUTION_VIEW)

--- a/st2api/tests/unit/controllers/v1/test_executions.py
+++ b/st2api/tests/unit/controllers/v1/test_executions.py
@@ -1297,6 +1297,98 @@ class ActionExecutionControllerTestCase(BaseActionExecutionControllerTestCase, F
         self.assertTrue('Invalid attribute "start_timestamp" specified.' in
                         resp.json['faultstring'])
 
+    def test_get_single_include_attributes_and_secret_parameters(self):
+        # Verify that secret parameters are correctly masked when using ?include_attributes filter
+        self._do_post(LIVE_ACTION_WITH_SECRET_PARAM)
+        exec_id = self.app.get('/v1/actionexecutions?limit=1').json[0]['id']
+
+        # FYI, the response always contains the 'id' parameter
+        urls = [
+            {
+                'url': '/v1/executions/%s?include_attributes=parameters' % (exec_id),
+                'expected_parameters': ['id', 'parameters'],
+            },
+            {
+                'url': '/v1/executions/%s?include_attributes=parameters,action' % (exec_id),
+                'expected_parameters': ['id', 'parameters', 'action'],
+            },
+            {
+                'url': '/v1/executions/%s?include_attributes=parameters,runner' % (exec_id),
+                'expected_parameters': ['id', 'parameters', 'runner'],
+            },
+            {
+                'url': '/v1/executions/%s?include_attributes=parameters,action,runner' % (exec_id),
+                'expected_parameters': ['id', 'parameters', 'action', 'runner'],
+            }
+        ]
+
+        for item in urls:
+            url = item['url']
+            resp = self.app.get(url)
+
+            self.assertTrue('parameters' in resp.json)
+            self.assertEqual(resp.json['parameters']['a'], 'param a')
+            self.assertEqual(resp.json['parameters']['d'], MASKED_ATTRIBUTE_VALUE)
+            self.assertEqual(resp.json['parameters']['password'], MASKED_ATTRIBUTE_VALUE)
+            self.assertEqual(resp.json['parameters']['hosts'], 'localhost')
+
+            # ensure that the response has only the keys we epect, no more, no less
+            resp_keys = set(resp.json.keys())
+            expected_params = set(item['expected_parameters'])
+            diff = resp_keys.symmetric_difference(expected_params)
+            self.assertEqual(diff, set())
+
+        # With ?show_secrets=True
+        urls = [
+            {
+                'url': '/v1/executions/%s?&include_attributes=parameters' % (exec_id),
+                'expected_parameters': ['id', 'parameters'],
+            },
+            {
+                'url': '/v1/executions/%s?include_attributes=parameters,action' % (exec_id),
+                'expected_parameters': ['id', 'parameters', 'action'],
+            },
+            {
+                'url': '/v1/executions/%s?include_attributes=parameters,runner' % (exec_id),
+                'expected_parameters': ['id', 'parameters', 'runner'],
+            },
+            {
+                'url': '/v1/executions/%s?include_attributes=parameters,action,runner' % (exec_id),
+                'expected_parameters': ['id', 'parameters', 'action', 'runner'],
+            },
+        ]
+
+        for item in urls:
+            url = item['url']
+            resp = self.app.get(url + '&show_secrets=True')
+
+            self.assertTrue('parameters' in resp.json)
+            self.assertEqual(resp.json['parameters']['a'], 'param a')
+            self.assertEqual(resp.json['parameters']['d'], 'secretpassword1')
+            self.assertEqual(resp.json['parameters']['password'], 'secretpassword2')
+            self.assertEqual(resp.json['parameters']['hosts'], 'localhost')
+
+            # ensure that the response has only the keys we epect, no more, no less
+            resp_keys = set(resp.json.keys())
+            expected_params = set(item['expected_parameters'])
+            diff = resp_keys.symmetric_difference(expected_params)
+            self.assertEqual(diff, set())
+
+        # NOTE: We don't allow exclusion of attributes such as "action" and "runner" because
+        # that would break secrets masking
+        urls = [
+            '/v1/executions/%s?limit=1&exclude_attributes=action',
+            '/v1/executions/%s?limit=1&exclude_attributes=runner',
+            '/v1/executions/%s?limit=1&exclude_attributes=action,runner',
+        ]
+
+        for url in urls:
+            resp = self.app.get(url, expect_errors=True)
+
+            self.assertEqual(resp.status_int, 400)
+            self.assertTrue('Invalid or unsupported exclude attribute specified:' in
+                            resp.json['faultstring'])
+
     def _insert_mock_models(self):
         execution_1_id = self._get_actionexecution_id(self._do_post(LIVE_ACTION_1))
         execution_2_id = self._get_actionexecution_id(self._do_post(LIVE_ACTION_2))

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -1165,6 +1165,8 @@ class ActionExecutionListCommand(ResourceViewCommand):
 class ActionExecutionGetCommand(ActionRunCommandMixin, ResourceViewCommand):
     display_attributes = ['id', 'action.ref', 'context.user', 'parameters', 'status',
                           'start_timestamp', 'end_timestamp', 'result', 'liveaction']
+    include_attributes = ['action.ref', 'action.runner_type', 'start_timestamp',
+                          'end_timestamp']
 
     def __init__(self, resource, *args, **kwargs):
         super(ActionExecutionGetCommand, self).__init__(
@@ -1181,7 +1183,8 @@ class ActionExecutionGetCommand(ActionRunCommandMixin, ResourceViewCommand):
     @add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
         # We only retrieve attributes which are needed to speed things up
-        include_attributes = self._get_include_attributes(args=args)
+        include_attributes = self._get_include_attributes(args=args,
+                                                          extra_attributes=self.include_attributes)
         if include_attributes:
             include_attributes = ','.join(include_attributes)
             kwargs['params'] = {'include_attributes': include_attributes}

--- a/st2client/st2client/commands/resource.py
+++ b/st2client/st2client/commands/resource.py
@@ -242,14 +242,22 @@ class ResourceViewCommand(ResourceCommand):
     """
 
     @classmethod
-    def _get_include_attributes(cls, args):
+    def _get_include_attributes(cls, args, extra_attributes=None):
         """
         Return a list of attributes to send to the API using ?include_attributes filter.
 
         If None / empty list is returned it's assumed no filtering is to be performed and all
         attributes are to be retrieved.
+
+        :param extra_attributes: Additional include attributes which should always be included.
+        :type extra_attributes: ``list`` of ``str``
         """
+        extra_attributes = extra_attributes or []
+
         include_attributes = []
+
+        if extra_attributes:
+            include_attributes.extend(extra_attributes)
 
         # If user specifies which attributes to retrieve via CLI --attr / -a argument, take that
         # into account

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -1077,6 +1077,20 @@ paths:
           description: Entity id
           type: string
           required: true
+        - name: exclude_attributes
+          in: query
+          description: List of attributes to exclude
+          type: array
+          items:
+            type: string
+          required: false
+        - name: include_attributes
+          in: query
+          description: List of attributes to include
+          type: array
+          items:
+            type: string
+          required: false
         - name: show_secrets
           in: query
           description: Show secrets in plain text

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -1073,6 +1073,20 @@ paths:
           description: Entity id
           type: string
           required: true
+        - name: exclude_attributes
+          in: query
+          description: List of attributes to exclude
+          type: array
+          items:
+            type: string
+          required: false
+        - name: include_attributes
+          in: query
+          description: List of attributes to include
+          type: array
+          items:
+            type: string
+          required: false
         - name: show_secrets
           in: query
           description: Show secrets in plain text

--- a/st2common/st2common/router.py
+++ b/st2common/st2common/router.py
@@ -666,7 +666,7 @@ class Router(object):
                 result.append(item)
         elif isinstance(data, dict):
             # get_one response
-            result = process_item(item)
+            result = process_item(data)
         else:
             raise ValueError('Unsupported type: %s' % (type(data)))
 


### PR DESCRIPTION
Previously `GET /api/v1/executions/{id}` did not have the `include_attributes` or `exclude_attributes` query parameters, meaning it couldn't filter the output of large executions. This PR adds that ability.

@Kami are any other modifications necessary?

**TODO**
- [x] Tests