### PR TITLE
Fix (workaround) for very slow test runs and timeouts on Travis CI

### DIFF
--- a/st2common/st2common/transport/connection_retry_wrapper.py
+++ b/st2common/st2common/transport/connection_retry_wrapper.py
@@ -41,7 +41,7 @@ class ClusterRetryContext(object):
         # during tests on Travis and block and slown down the tests
         # NOTE: This error is not fatal during tests and we can simply switch to a next connection
         # without sleeping.
-        if "CHANNEL_ERROR - second 'channel.open' seen" in e:
+        if "second 'channel.open' seen" in str(e):
             return False, -1
 
         should_stop = True

--- a/st2common/st2common/transport/connection_retry_wrapper.py
+++ b/st2common/st2common/transport/connection_retry_wrapper.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import eventlet
 
 __all__ = ['ConnectionRetryWrapper', 'ClusterRetryContext']
@@ -35,7 +36,14 @@ class ClusterRetryContext(object):
         # No of nodes attempted. Starts at 1 since the
         self._nodes_attempted = 1
 
-    def test_should_stop(self):
+    def test_should_stop(self, e=None):
+        # Special workaround for "(504) CHANNEL_ERROR - second 'channel.open' seen" which happens
+        # during tests on Travis and block and slown down the tests
+        # NOTE: This error is not fatal during tests and we can simply switch to a next connection
+        # without sleeping.
+        if "CHANNEL_ERROR - second 'channel.open' seen" in e:
+            return False, -1
+
         should_stop = True
         if self._nodes_attempted > self.cluster_size * self.cluster_retry:
             return should_stop, -1
@@ -126,7 +134,10 @@ class ConnectionRetryWrapper(object):
                 # be notified so raise.
                 if should_stop:
                     raise
+
                 # -1, 0 and 1+ are handled properly by eventlet.sleep
+                self._logger.debug('Received RabbitMQ server error, sleeping for %s seconds '
+                                   'before retrying: %s' % (wait, str(e)))
                 eventlet.sleep(wait)
 
                 connection.close()

--- a/st2common/st2common/transport/connection_retry_wrapper.py
+++ b/st2common/st2common/transport/connection_retry_wrapper.py
@@ -125,7 +125,7 @@ class ConnectionRetryWrapper(object):
                 wrapped_callback(connection=connection, channel=channel)
                 should_stop = True
             except connection.connection_errors + connection.channel_errors as e:
-                should_stop, wait = self._retry_context.test_should_stop()
+                should_stop, wait = self._retry_context.test_should_stop(e)
                 # reset channel to None to avoid any channel closing errors. At this point
                 # in case of an exception there should be no channel but that is better to
                 # guarantee.

--- a/st2common/tests/unit/test_connection_retry_wrapper.py
+++ b/st2common/tests/unit/test_connection_retry_wrapper.py
@@ -36,6 +36,19 @@ class TestClusterRetryContext(unittest.TestCase):
         self.assertTrue(should_stop, 'Done trying.')
         self.assertEqual(wait, -1)
 
+    def test_should_stop_second_channel_open_error_should_be_non_fatal(self):
+        retry_context = ClusterRetryContext(cluster_size=1)
+
+        e = Exception("(504) CHANNEL_ERROR - second 'channel.open' seen")
+        should_stop, wait = retry_context.test_should_stop(e=e)
+        self.assertFalse(should_stop)
+        self.assertEqual(wait, -1)
+
+        e = Exception("CHANNEL_ERROR - second 'channel.open' seen")
+        should_stop, wait = retry_context.test_should_stop(e=e)
+        self.assertFalse(should_stop)
+        self.assertEqual(wait, -1)
+
     def test_multiple_node_cluster_retry(self):
         cluster_size = 3
         last_index = cluster_size * 2


### PR DESCRIPTION
After spending a lot of time on Saturday and today I believe I managed to finally track down the issue with very slow tests on Travis.

It turns out that on Travis RabbitMQ throws a non-fatal ``Channel.open: (504) CHANNEL_ERROR - second 'channel.open' seen`` error when using our connection retry wrapper code which causes the code to "hang" and sleep for 10 seconds here https://github.com/StackStorm/st2/blob/master/st2common/st2common/transport/connection_retry_wrapper.py#L130 (the issue can be reproduced 100% of the time on Travis).

This happens very often so tests are up to 20 times and more slower on Travis than locally.

For example:

```bash

Local VM:

(virtualenv) vagrant@ubuntu-xenial:/data/stanley$ nosetests --with-timer --rednose --immediate -sv st2actions/tests/unit/test_scheduler.py
test_create_from_liveaction (tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest) ... passed
test_failed_next_item (tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest) ... passed
test_garbage_collection (tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest) ... passed
test_next_execution (tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest) ... passed
test_next_executions_empty (tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest) ... passed
test_no_double_entries (tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest) ... passed
test_no_processing_of_non_requested_actions (tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest) ... passed
test_processing_when_task_completed (tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest) ... passed

TEST RESULT OUTPUT:

[success] 19.82% tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest.test_processing_when_task_completed: 1.3436s
[success] 19.79% tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest.test_no_processing_of_non_requested_actions: 1.3413s
[success] 14.81% tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest.test_failed_next_item: 1.0039s
[success] 12.30% tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest.test_next_execution: 0.8336s
[success] 11.67% tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest.test_garbage_collection: 0.7914s
[success] 10.53% tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest.test_no_double_entries: 0.7141s
[success] 8.45% tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest.test_next_executions_empty: 0.5731s
[success] 2.63% tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest.test_create_from_liveaction: 0.1780s
-----------------------------------------------------------------------------
8 tests run in 8.990 seconds (8 tests passed)

(virtualenv) travis@travis-job-4fb692bd-c140-4460-b3c1-76ca77e1819b:~/build/StackStorm/st2$ nosetests --with-timer --rednose --immediate -sv st2actions/tests/unit/test_scheduler.py
test_create_from_liveaction (tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest) ... passed
test_failed_next_item (tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest) ... passed
test_garbage_collection (tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest) ... passed
test_next_execution (tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest) ... passed
test_next_executions_empty (tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest) ... passed
test_no_double_entries (tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest) ... passed
test_no_processing_of_non_requested_actions (tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest) ... passed
test_processing_when_task_completed (tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest) ... passed

TEST RESULT OUTPUT:

[success] 64.62% tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest.test_no_processing_of_non_requested_actions: 103.8978s
[success] 8.10% tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest.test_next_execution: 13.0182s
[success] 8.08% tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest.test_failed_next_item: 12.9914s
[success] 8.00% tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest.test_garbage_collection: 12.8685s
[success] 7.98% tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest.test_processing_when_task_completed: 12.8290s
[success] 1.49% tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest.test_no_double_entries: 2.3939s
[success] 1.22% tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest.test_next_executions_empty: 1.9665s
[success] 0.51% tests.unit.test_scheduler.ActionExecutionSchedulingQueueItemDBTest.test_create_from_liveaction: 0.8142s
-----------------------------------------------------------------------------
8 tests run in 162.401 seconds (8 tests passed)
```

I haven't been able to track down the root cause yet aka why RabbitMQ throws that error on Travis, but not locally or on some other environment. Good news is that the workaround should be safe to use and appears to have no negative side affects. I tried things such as installing latest and previous RabbitMQ server version on Travis, but nothing made a difference. It could indicate that the issue is related to unique networking setup on Travis VMs or similar.

It appears that that issue has been present on Travis for quite a long time, but it got so bad recently we couldn't even get tests to pass due to the timing issues.

The workaround for the issue is available in 56b216b, da9177a1cc105d7c98f2e7957bbec890faef1f99.

I also have some other "related" PRs open, like switching from Precise to Xenial on Travis, etc. which I plan to finish now with that fix in place.