### PR TITLE
Add amqp package to st2common

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Don't edit this file. It's generated automatically!
 RandomWords
+amqp==2.3.2
 apscheduler==3.5.3
 argcomplete
 bcrypt

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -31,3 +31,6 @@ jsonpath-rw
 python-statsd
 prometheus_client
 ujson
+# Note: amqp is used by kombu, this needs to be added here to be picked up by
+# requirements fixate script.
+amqp

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -1,4 +1,5 @@
 # Don't edit this file. It's generated automatically!
+amqp==2.3.2
 apscheduler==3.5.3
 cryptography==2.4.2
 eventlet==0.24.1


### PR DESCRIPTION
This PR adds the AMQP package to st2common. In a recent update to
py-amqp (https://github.com/celery/py-amqp/pull/214) there was an
additional check added that uses a rabbit capability that is not
available in the rabbit version shipped in RHEL 6. Even though we pin
the correct version of py-amqp in our fixed-requirements.txt the lack of
any package directly requiring it allowed it to be skipped when building
final requirements.txt. Adding the requirement to st2common will make
the correct pinned version show up in requirements.txt.