### PR TITLE
Improve RabbitMQ connection retry code

### DIFF
--- a/st2common/st2common/transport/connection_retry_wrapper.py
+++ b/st2common/st2common/transport/connection_retry_wrapper.py
@@ -139,7 +139,6 @@ class ConnectionRetryWrapper(object):
                     raise
 
                 # -1, 0 and 1+ are handled properly by eventlet.sleep
-                wait = 1
                 self._logger.debug('Received RabbitMQ server error, sleeping for %s seconds '
                                    'before retrying: %s' % (wait, str(e)))
                 eventlet.sleep(wait)

--- a/st2common/st2common/transport/connection_retry_wrapper.py
+++ b/st2common/st2common/transport/connection_retry_wrapper.py
@@ -136,6 +136,7 @@ class ConnectionRetryWrapper(object):
                     raise
 
                 # -1, 0 and 1+ are handled properly by eventlet.sleep
+                wait = 1
                 self._logger.debug('Received RabbitMQ server error, sleeping for %s seconds '
                                    'before retrying: %s' % (wait, str(e)))
                 eventlet.sleep(wait)
@@ -146,10 +147,21 @@ class ConnectionRetryWrapper(object):
                 # entire ConnectionPool simultaneously but that would require writing our own
                 # ConnectionPool. If a server recovers it could happen that the same process
                 # ends up talking to separate nodes in a cluster.
-                connection.ensure_connection()
 
+                def log_error_on_conn_failure(exc, interval):
+                    self._logger.debug('Failed to re-establish connection to RabbitMQ server: %s' %
+                                       (str(e)))
+
+                try:
+                    # NOTE: This function blocks and tries to restablish a connection for
+                    # indefinetly if "max_retries" argument is not specified
+                    connection.ensure_connection(max_retries=5, errback=log_error_on_conn_failure)
+                except Exception:
+                    self._logger.exception('Connections to RabbitMQ cannot be re-established: %s',
+                                           str(e))
+                    raise
             except Exception as e:
-                self._logger.exception('Connections to rabbitmq cannot be re-established: %s',
+                self._logger.exception('Connections to RabbitMQ cannot be re-established: %s',
                                        str(e))
                 # Not being able to publish a message could be a significant issue for an app.
                 raise

--- a/st2common/st2common/transport/connection_retry_wrapper.py
+++ b/st2common/st2common/transport/connection_retry_wrapper.py
@@ -99,9 +99,12 @@ class ConnectionRetryWrapper(object):
             retry_wrapper.run(connection=connection, wrapped_callback=wrapped_callback)
 
     """
-    def __init__(self, cluster_size, logger):
+    def __init__(self, cluster_size, logger, ensure_max_retries=3):
         self._retry_context = ClusterRetryContext(cluster_size=cluster_size)
         self._logger = logger
+        # How many times to try to retrying establishing a connection in a place where we are
+        # calling connection.ensure_connection
+        self._ensure_max_retries = ensure_max_retries
 
     def errback(self, exc, interval):
         self._logger.error('Rabbitmq connection error: %s', exc.message)
@@ -149,13 +152,14 @@ class ConnectionRetryWrapper(object):
                 # ends up talking to separate nodes in a cluster.
 
                 def log_error_on_conn_failure(exc, interval):
-                    self._logger.debug('Failed to re-establish connection to RabbitMQ server: %s' %
-                                       (str(e)))
+                    self._logger.debug('Failed to re-establish connection to RabbitMQ server, '
+                                       'retrying in %s seconds: %s' % (interval, str(e)))
 
                 try:
                     # NOTE: This function blocks and tries to restablish a connection for
                     # indefinetly if "max_retries" argument is not specified
-                    connection.ensure_connection(max_retries=5, errback=log_error_on_conn_failure)
+                    connection.ensure_connection(max_retries=self._ensure_max_retries,
+                                                 errback=log_error_on_conn_failure)
                 except Exception:
                     self._logger.exception('Connections to RabbitMQ cannot be re-established: %s',
                                            str(e))


### PR DESCRIPTION
This pull request includes two improvements to our RabbitMQ connection retry code:

1. Fix the code so we don't try to re-establish a connection for indefinitely in a place where we are calling ``connection.ensure_connection``. Previously we didn't pass ``max_retries`` argument to that method so the connection was tried to be re-established for indefinitely and we didn't log any error.
2. Log an error which is received when failing to re-establish a connection on each retry attempt. This is intentionally logged as DEBUG because it's only fatal if we exhaust all the retry attempts and still fail to re-establish a connection (in that case we re-throw the exception and issue is considered as fatal).

This should help and give more insight in #4508 (it's likely that RabbitMQ server is not running there or similar).