### PR TITLE
Remove redundant action-aliases for pack install

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,15 @@ Changed
 
 * Changed the ``inquiries`` API path from ``/exp`` to ``/api/v1`` #4495
 
+Fixed
+~~~~~
+
+* Fixed the ``packs.pack_install`` / ``!pack install {{ packs }}`` action-alias to not have
+  redundant patterns. Previously this prevented it from being executed via
+  ``st2 action-alias execute 'pack install xxx'``. #4511
+
+  Contributed by Nick Maludy (Encore Technologies)
+  
 2.10.0 - December 13, 2018
 --------------------------
 

--- a/contrib/packs/aliases/pack_install.yaml
+++ b/contrib/packs/aliases/pack_install.yaml
@@ -4,10 +4,7 @@ action_ref: "packs.install"
 pack: "packs"
 description: "Install/upgrade StackStorm packs."
 formats:
-  - display: "pack install <pack>[,<pack>]"
-    representation:
-      - "pack install {{ packs }}"
-  - display: "pack install <gitUrl>[,<gitUrl>]"
+  - display: "pack install <pack_name|git_url>[,<pack_name|git_url>]"
     representation:
       - "pack install {{ packs }}"
 ack:

--- a/st2client/st2client/commands/action_alias.py
+++ b/st2client/st2client/commands/action_alias.py
@@ -63,13 +63,13 @@ class ActionAliasMatchCommand(resource.ResourceCommand):
     def __init__(self, resource, *args, **kwargs):
         super(ActionAliasMatchCommand, self).__init__(
             resource, 'match',
-            'Get the list of %s that match the command text.' %
-            resource.get_plural_display_name().lower(),
+            'Get the %s that match the command text.' %
+            resource.get_display_name().lower(),
             *args, **kwargs)
 
         self.parser.add_argument('match_text',
                                  metavar='command',
-                                 help=('Get the list of %s that match the command text.' %
+                                 help=('Get the %s that match the command text.' %
                                        resource.get_display_name().lower()))
         self.parser.add_argument('-a', '--attr', nargs='+',
                                  default=self.display_attributes,


### PR DESCRIPTION
Closes #4511 

This removes the redundant `pack install {{ packs }}` action-alias and instead replaces it with a single pattern.

After this fix, it is now possible to run the following:

```
$ st2 action-alias match 'pack install vsphere'
$ st2 action-alias execute -u st2admin 'pack install vsphere'
```

Also fixed the help text on `st2 action-alias match` to not imply that a list of matches is returned when in fact only a single match is returned.