### PR TITLE
Suppress statsd library debug log messages in sensor container when DEBUG mode is not enabled

### DIFF
--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -200,6 +200,10 @@ class SensorWrapper(object):
 
         if '--debug' in parent_args:
             set_log_level_for_all_loggers()
+        else:
+            # NOTE: statsd logger logs everything by default under INFO so we ignore those log
+            # messages unless verbose / debug mode is used
+            logging.ignore_statsd_log_messages()
 
         self._sensor_instance = self._get_sensor_instance()
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
-coverage==5.0a4
+# NOTE: codecov only supports coverage==4.5.2
+coverage==4.5.2
 pep8==1.7.1
 flake8==3.6.0
 astroid==1.6.5


### PR DESCRIPTION
This pull request fixes an issue with statsd debug log messages ending up in st2sensorcontainer log even when debug mode was disabled.

### Background

#4441 fixes that for majority of the services and scripts, but not for st2sensorcontainer. Sensor container is a bit special because it spawns sensors in a dedicated child processes which means we need to perform that monkey patching again in the child process to avoid those log messages.

Before:

```
2019-01-24 12:35:23,747 DEBUG [-] Using Python: 2.7.12 (/opt/stackstorm/st2/bin/python)
2019-01-24 12:35:23,747 DEBUG [-] Using config files: /etc/st2/st2.conf
2019-01-24 12:35:23,747 DEBUG [-] Using logging config: /etc/st2/logging.sensorcontainer.conf
2019-01-24 12:35:23,753 INFO [-] Connecting to database "st2" @ "127.0.0.1:27017" as user "None".
2019-01-24 12:35:23,755 INFO [-] Successfully connected to database "st2" @ "127.0.0.1:27017" as user "None".
2019-01-24 12:35:23,868 INFO [-] Running in single sensor mode, using a single sensor partitioner...
2019-01-24 12:35:23,870 INFO [-] Setting up container to run 1 sensors.
2019-01-24 12:35:23,870 INFO [-] 	Sensors list - [u'fixtures.TestPollingSensor'].
2019-01-24 12:35:23,870 INFO [-] (PID:19859) SensorContainer started.
2019-01-24 12:35:23,870 INFO [-] Running sensor fixtures.TestPollingSensor
2019-01-24 12:35:23,877 AUDIT [-] Access granted to "sensors_container" with the token set to expire at "2019-01-25T12:35:23.876977Z". (username='sensors_container',token_expiration='2019-01-25T12:35:23.876977Z')
2019-01-24 12:35:23,878 WARNING [-] "auth.api_url" configuration option is not configured
2019-01-24 12:35:23,887 INFO [-] Connected to amqp://guest:**@127.0.0.1:5672//
2019-01-24 12:35:23,889 INFO [-] Sensor fixtures.TestPollingSensor started
2019-01-24 12:35:24,394 INFO [-] Found config for sensor "TestPollingSensor"
2019-01-24 12:35:24,394 INFO [-] Watcher started
2019-01-24 12:35:24,395 INFO [-] Running sensor initialization code
2019-01-24 12:35:24,395 INFO [-] Running sensor in active mode (poll interval=5s)
2019-01-24 12:35:24,408 INFO [-] Connected to amqp://guest:**@127.0.0.1:5672//
KeyboardInterrupt
2019-01-24 12:20:09,096 INFO [-] st2.cicd.amqp.pool_publisher.publish_with_retries.st2.trigger: 3.09700000ms
2019-01-24 12:20:09,096 INFO [-] st2.cicd.amqp.publish.update: 3.36700000ms
2019-01-24 12:20:09,101 INFO [-] st2.cicd.amqp.pool_publisher.publish_with_retries.st2.trigger: 1.33500000ms
2019-01-24 12:20:09,101 INFO [-] st2.cicd.amqp.publish.update: 1.56800000ms
2019-01-24 12:20:09,121 INFO [-] st2.cicd.amqp.pool_publisher.publish_with_retries.st2.trigger: 1.43900000ms
2019-01-24 12:20:09,121 INFO [-] st2.cicd.amqp.publish.update: 1.67300000ms
2019-01-24 12:20:09,126 INFO [-] st2.cicd.amqp.pool_publisher.publish_with_retries.st2.trigger: 1.22700000ms
2019-01-24 12:20:09,126 INFO [-] st2.cicd.amqp.publish.update: 1.45500000ms
2019-01-24 12:20:09,146 INFO [-] st2.cicd.amqp.pool_publisher.publish_with_retries.st2.trigger: 2.19000000ms
2019-01-24 12:20:09,147 INFO [-] st2.cicd.amqp.publish.update: 2.45200000ms
2019-01-24 12:20:09,152 INFO [-] st2.cicd.amqp.pool_publisher.publish_with_retries.st2.trigger: 1.19100000ms
2019-01-24 12:20:09,152 INFO [-] st2.cicd.amqp.publish.update: 1.42900000ms
2019-01-24 12:20:09,173 INFO [-] st2.cicd.amqp.pool_publisher.publish_with_retries.st2.trigger: 2.04800000ms
...
```

After:

```bash
/opt/stackstorm/st2/bin/st2sensorcontainer --sensor-ref=fixtures.TestPollingSensor --single-sensor-mode --debug
2019-01-24 12:35:23,747 DEBUG [-] Using Python: 2.7.12 (/opt/stackstorm/st2/bin/python)
2019-01-24 12:35:23,747 DEBUG [-] Using config files: /etc/st2/st2.conf
2019-01-24 12:35:23,747 DEBUG [-] Using logging config: /etc/st2/logging.sensorcontainer.conf
aaaa
2019-01-24 12:35:23,753 INFO [-] Connecting to database "st2" @ "127.0.0.1:27017" as user "None".
2019-01-24 12:35:23,755 INFO [-] Successfully connected to database "st2" @ "127.0.0.1:27017" as user "None".
2019-01-24 12:35:23,868 INFO [-] Running in single sensor mode, using a single sensor partitioner...
2019-01-24 12:35:23,870 INFO [-] Setting up container to run 1 sensors.
2019-01-24 12:35:23,870 INFO [-] 	Sensors list - [u'fixtures.TestPollingSensor'].
2019-01-24 12:35:23,870 INFO [-] (PID:19859) SensorContainer started.
2019-01-24 12:35:23,870 INFO [-] Running sensor fixtures.TestPollingSensor
2019-01-24 12:35:23,877 AUDIT [-] Access granted to "sensors_container" with the token set to expire at "2019-01-25T12:35:23.876977Z". (username='sensors_container',token_expiration='2019-01-25T12:35:23.876977Z')
2019-01-24 12:35:23,878 WARNING [-] "auth.api_url" configuration option is not configured
2019-01-24 12:35:23,887 INFO [-] Connected to amqp://guest:**@127.0.0.1:5672//
2019-01-24 12:35:23,889 INFO [-] Sensor fixtures.TestPollingSensor started
2019-01-24 12:35:24,394 INFO [-] Found config for sensor "TestPollingSensor"
2019-01-24 12:35:24,394 INFO [-] Watcher started
2019-01-24 12:35:24,395 INFO [-] Running sensor initialization code
2019-01-24 12:35:24,395 INFO [-] Running sensor in active mode (poll interval=5s)
2019-01-24 12:35:24,408 INFO [-] Connected to amqp://guest:**@127.0.0.1:5672//
```
