### PR TITLE
Don't submit metrics for any of the "get one" API endpoints

### DIFF
--- a/st2common/st2common/middleware/instrumentation.py
+++ b/st2common/st2common/middleware/instrumentation.py
@@ -55,7 +55,15 @@ class RequestInstrumentationMiddleware(object):
         # other endpoints because this would result in a lot of unique metrics which is an
         # anti-pattern and causes unnecessary load on the metrics server.
         submit_metrics = endpoint.get('x-submit-metrics', True)
-        if not submit_metrics:
+        operation_id = endpoint.get('operationId', None)
+        is_get_one_endpoint = (operation_id.endswith('.get') or operation_id.endswith('.get_one'))
+
+        if is_get_one_endpoint:
+            # NOTE: We don't submit metrics for any get one API endpoint since this would result
+            # in potentially too many unique metrics
+            submit_metrics = False
+
+        if not submit_metrics or ():
             LOG.debug('Not submitting request metrics for path: %s' % (request.path))
             return self.app(environ, start_response)
 

--- a/st2common/st2common/middleware/instrumentation.py
+++ b/st2common/st2common/middleware/instrumentation.py
@@ -56,14 +56,15 @@ class RequestInstrumentationMiddleware(object):
         # anti-pattern and causes unnecessary load on the metrics server.
         submit_metrics = endpoint.get('x-submit-metrics', True)
         operation_id = endpoint.get('operationId', None)
-        is_get_one_endpoint = (operation_id.endswith('.get') or operation_id.endswith('.get_one'))
+        is_get_one_endpoint = bool(operation_id) and (operation_id.endswith('.get') or
+                                                      operation_id.endswith('.get_one'))
 
         if is_get_one_endpoint:
             # NOTE: We don't submit metrics for any get one API endpoint since this would result
             # in potentially too many unique metrics
             submit_metrics = False
 
-        if not submit_metrics or ():
+        if not submit_metrics:
             LOG.debug('Not submitting request metrics for path: %s' % (request.path))
             return self.app(environ, start_response)
 

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -117,7 +117,10 @@ def get_sandbox_python_path(inherit_from_parent=True, inherit_parent_virtualenv=
     if inherit_parent_virtualenv and hasattr(sys, 'real_prefix'):
         # We are running inside virtualenv
         site_packages_dir = get_python_lib()
-        assert sys.prefix in site_packages_dir
+
+        sys_prefix = os.path.abspath(sys.prefix)
+        assert sys_prefix in site_packages_dir
+
         sandbox_python_path.append(site_packages_dir)
 
     sandbox_python_path = ':'.join(sandbox_python_path)


### PR DESCRIPTION
This pull request updates instrumentation middleware so we don't submit any request metrics for all the "get one" API endpoints.

Previously we manually excluded some of the "most offending" API endpoints (get a single execution, etc.), but it's the safest to simply skip submitting metrics for all of "get one" API endpoints.

Submitting metrics for those endpoints results in too many unique metrics which is an anti-pattern and doesn't scale.