### PR TITLE
Add config for stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,7 +5,8 @@ daysUntilStale: 90
 
 # Number of days of inactivity before a stale Issue or Pull Request is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-daysUntilClose: 7
+# NOTE: This is set to false because we only mark issues as stale, but don't automatically close them.
+daysUntilClose: false
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
@@ -27,10 +28,11 @@ staleLabel: stale
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >
   Thanks for contributing to this issue. As it has been 90 days since the last activity,
-  we are automatically closing the issue in 7 days. This is often because the request was
-  already solved in some way and it just wasn't updated or it's no longer applicable. If
-  that's not the case, please respond before the issue is closed, or open a new one after.
-  We'll gladly take a look again!
+  we are automatically marking is as stale. If this issue is not relevant or applicable
+  anymore (problem has been fixed in a new version or similar), please close the issue
+  or let us know so we can close it. On the contrary, if the issue is still relevant,
+  there is nothing you need to do, but if you have any additional details or context which
+  would help us when working on this issue, please include it as a comment to this issue.
 
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -15,7 +15,6 @@ exemptLabels:
   - feature
   - bug
 
-
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: true
 

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,48 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 90
+
+# Number of days of inactivity before a stale Issue or Pull Request is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 7
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - WIP
+  - work in progress
+  - important
+  - feature-request
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: true
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: true
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  Thanks for contributing to this issue. As it has been 90 days since the last activity,
+  we are automatically closing the issue in 7 days. This is often because the request was
+  already solved in some way and it just wasn't updated or it's no longer applicable. If
+  that's not the case, please respond before the issue is closed, or open a new one after.
+  We'll gladly take a look again!
+
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+#closeComment: >
+#  Thanks for contributing to this issue. As it has been 90 days since the last activity, we are automatically closing the issue. This is often because the request was already solved in some way and it just wasn't updated or it's no longer applicable. If that's not the case, please do feel free to either reopen this issue or open a new one. We'll gladly take a look again! You can read more here: https://blog.travis-ci.com/2018-03-09-closing-old-issues
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+#only: issues

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -15,6 +15,7 @@ exemptLabels:
   - important
   - feature
   - bug
+  - enhancement
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: true

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -15,6 +15,7 @@ exemptLabels:
   - feature
   - bug
 
+
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: true
 

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -12,7 +12,8 @@ exemptLabels:
   - WIP
   - work in progress
   - important
-  - feature-request
+  - feature
+  - bug
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: true


### PR DESCRIPTION
This pull request adds config for stale bot (https://probot.github.io/apps/stale/) which will automatically mark and close issues and pull requests which haven't seen any activity for 90 days (issue is first marked after 90 days and if no one responses in 7 days, it's automatically closed).