### PR TITLE
Upgrade python-gnupg dependency

### DIFF
--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -22,7 +22,7 @@ pymongo==3.7.2
 mongoengine==0.16.3
 passlib==1.7.1
 lockfile==0.12.2
-python-gnupg==0.4.3
+python-gnupg==0.4.4
 jsonpath-rw==1.4.0
 pyinotify==0.9.6
 semver==2.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ pymongo==3.7.2
 pyrabbit
 python-dateutil==2.7.5
 python-editor==1.0.3
-python-gnupg==0.4.3
+python-gnupg==0.4.4
 python-json-logger
 python-statsd==2.1.0
 pytz==2018.7


### PR DESCRIPTION
This pull request updates ``python-gnugpg`` dependency we use to the latest version.

Previous version contains a security vulnerability - https://blog.hackeriet.no/cve-2019-6690-python-gnupg-vulnerability/, https://mail.python.org/pipermail/python-announce-list/2019-January/012154.html.

NOTE: This security vulnerability itself doesn't affect us because we only this library in an isolated scenario (encrypting debug tarball without using a passphrase), but it's still a good idea to upgrade it.

Thanks to @jfunction for reporting this.