### PR TITLE
Streaming and tailing output

### DIFF
--- a/contrib/runners/python_runner/python_runner/python_action_wrapper.py
+++ b/contrib/runners/python_runner/python_runner/python_action_wrapper.py
@@ -238,7 +238,7 @@ class PythonActionWrapper(object):
         action_cls = actions_cls[0] if actions_cls and len(actions_cls) > 0 else None
 
         if not action_cls:
-            raise Exception('File "%s" has no action class or the file doesn\'t exist.' %
+            raise Exception('File "%s" has no action class or the file does\'t exist.' %
                             (self._file_path))
 
         # Retrieve name of the action class

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -63,6 +63,8 @@ from st2client.exceptions.operations import OperationFailureException
 from st2client.utils.logging import LogLevelFilter, set_log_level_for_all_loggers
 from st2client.commands.auth import TokenCreateCommand
 from st2client.commands.auth import LoginCommand
+from st2common.database_setup import db_setup
+from st2common.database_setup import db_teardown
 
 
 __all__ = [
@@ -389,6 +391,7 @@ class Shell(BaseCLIApp):
 
             # Set up client.
             self.client = self.get_client(args=args, debug=debug)
+            self.client.db_access = db_setup()
 
             # TODO: This is not so nice work-around for Python 3 because of a breaking change in
             # Python 3 - https://bugs.python.org/issue16308
@@ -415,6 +418,8 @@ class Shell(BaseCLIApp):
                 self._print_debug_info(args=args)
 
             return exit_code
+        finally:
+            db_teardown()
 
     def _print_config(self, args):
         config = self._parse_config_file(args=args)

--- a/st2common/st2common/models/api/execution.py
+++ b/st2common/st2common/models/api/execution.py
@@ -224,6 +224,9 @@ class ActionExecutionOutputAPI(BaseAPI):
             },
             'delay': {
                 'type': 'integer'
+            },
+            'next_tasks': {
+                'type': 'string'
             }
         },
         'additionalProperties': False

--- a/st2common/st2common/models/db/execution.py
+++ b/st2common/st2common/models/db/execution.py
@@ -182,6 +182,7 @@ class ActionExecutionOutputDB(stormbase.StormFoundationDB):
     delay = me.IntField()
 
     data = me.StringField()
+    next_tasks = me.StringField()
 
     meta = {
         'indexes': [

--- a/st2common/st2common/models/db/workflow.py
+++ b/st2common/st2common/models/db/workflow.py
@@ -72,6 +72,7 @@ class TaskExecutionDB(stormbase.StormFoundationDB, stormbase.ChangeRevisionField
     status = me.StringField(required=True)
     start_timestamp = db_field_types.ComplexDateTimeField(default=date_utils.get_datetime_utc_now)
     end_timestamp = db_field_types.ComplexDateTimeField()
+    log = me.ListField(field=me.DictField())
 
     meta = {
         'indexes': [


### PR DESCRIPTION
Fixes https://github.com/StackStorm/orquesta/issues/109
Streaming and tailing output

First submission:
1. Insert an entry next_tasks in the "execution_output_d_b" for identified the following set of tasks to execute
2. Insert an entry logs in task_execution_d_b for task execution status changes for "requested", "running" and "succeeded".
3. Access DB from shell commands/action.py
4. Format run --tail command (under construction)