### PR TITLE
UTF-8 encode both body and subject of email

### DIFF
--- a/contrib/core/actions/send_mail/send_mail
+++ b/contrib/core/actions/send_mail/send_mail
@@ -52,7 +52,7 @@ if [[ -z $trimmed && $SEND_EMPTY_BODY -eq 1 ]] || [[ -n $trimmed ]]; then
 cat <<EOF
 TO: ${TO}
 FROM: ${FROM}
-SUBJECT: =?UTF-8?q?${SUBJECT}?=
+SUBJECT: =?UTF-8?B?$(echo ${SUBJECT} | base64)?=
 EOF
 
 if [[ -n $ATTACHMENTS ]]; then

--- a/contrib/core/actions/send_mail/send_mail
+++ b/contrib/core/actions/send_mail/send_mail
@@ -52,7 +52,7 @@ if [[ -z $trimmed && $SEND_EMPTY_BODY -eq 1 ]] || [[ -n $trimmed ]]; then
 cat <<EOF
 TO: ${TO}
 FROM: ${FROM}
-SUBJECT: ${SUBJECT}
+SUBJECT: =?UTF-8?q?${SUBJECT}?=
 EOF
 
 if [[ -n $ATTACHMENTS ]]; then
@@ -83,7 +83,7 @@ EOF
 
   cat <<EOF
 --${boundary}
-Content-Type: ${CONTENT_TYPE}
+Content-Type: ${CONTENT_TYPE}; charset=UTF-8
 Content-Transfer-Encoding: 7bit
 Content-Disposition: inline
 
@@ -92,7 +92,7 @@ EOF
 else
 
   cat <<EOF
-Content-Type: ${CONTENT_TYPE}
+Content-Type: ${CONTENT_TYPE}; charset=UTF-8
 
 EOF
 


### PR DESCRIPTION
It seems that perhaps it is necessary to change the charset to UTF-8 in two places to get the body correctly encoded (exactly why this is so is a little bit unclear to me, I solved this by trail and error). I also added that the subject should be utf-8 encoded, to make sure that non-ascii characters are allowed there.