### PR TITLE
Don't include log messages with log level "AUDIT" in regular service log file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,12 +23,14 @@ Changed
 
 * Changed the ``inquiries`` API path from ``/exp`` to ``/api/v1``. #4495
 * Update logging code so we exclude log messages with log level ``AUDIT`` from a default service
-  log file. Log messages with level ``AUDIT`` are already logged in a dedicated
-  ``<service>.audit.log`` file so there is no need for them to be duplicated in regular service log
-  file.
+  log file (e.g. ``st2api.log``). Log messages with level ``AUDIT`` are already logged in a
+  dedicated service audit log file (e.g. ``st2api.audit.log``) so there is no need for them to also
+  be duplicated and included in regular service log file.
 
   NOTE: To aid with debugging, audit log messages are also included in a regular log file when log
-  level is set to DEBUG. (improvement)
+  level is set to ``DEBUG`` or ``system.debug`` config option is set to ``True``.
+
+  Reported by Nick Maludy. (improvement) #4538 #4502
 
 Fixed
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,14 @@ Added
 Changed
 ~~~~~~~
 
-* Changed the ``inquiries`` API path from ``/exp`` to ``/api/v1`` #4495
+* Changed the ``inquiries`` API path from ``/exp`` to ``/api/v1``. #4495
+* Update logging code so we exclude log messages with log level ``AUDIT`` from a default service
+  log file. Log messages with level ``AUDIT`` are already logged in a dedicated
+  ``<service>.audit.log`` file so there is no need for them to be duplicated in regular service log
+  file.
+
+  NOTE: To aid with debugging, audit log messages are also included in a regular log file when log
+  level is set to DEBUG. (improvement)
 
 Fixed
 ~~~~~

--- a/st2common/st2common/log.py
+++ b/st2common/st2common/log.py
@@ -46,6 +46,9 @@ __all__ = [
     'ignore_statsd_log_messages'
 ]
 
+# NOTE: We set AUDIT to the highest log level which means AUDIT log messages will always be
+# included (e.g. also if log level is set to INFO). To avoid that, we need to explicitly filter
+# out AUDIT log level in service setup code.
 logging.AUDIT = logging.CRITICAL + 10
 logging.addLevelName(logging.AUDIT, 'AUDIT')
 

--- a/st2common/tests/integration/test_service_setup_log_level_filtering.py
+++ b/st2common/tests/integration/test_service_setup_log_level_filtering.py
@@ -76,7 +76,7 @@ class ServiceSetupLogLevelFilteringTestCase(IntegrationTestCase):
         self.add_process(process=process)
 
         # Give it some time to start up
-        eventlet.sleep(3)
+        eventlet.sleep(5)
         process.send_signal(signal.SIGKILL)
 
         # First 3 log lines are debug messages about the environment which are always logged
@@ -91,7 +91,7 @@ class ServiceSetupLogLevelFilteringTestCase(IntegrationTestCase):
         self.add_process(process=process)
 
         # Give it some time to start up
-        eventlet.sleep(3)
+        eventlet.sleep(5)
         process.send_signal(signal.SIGKILL)
 
         # First 3 log lines are debug messages about the environment which are always logged
@@ -106,7 +106,7 @@ class ServiceSetupLogLevelFilteringTestCase(IntegrationTestCase):
         self.add_process(process=process)
 
         # Give it some time to start up
-        eventlet.sleep(3)
+        eventlet.sleep(5)
         process.send_signal(signal.SIGKILL)
 
         # First 3 log lines are debug messages about the environment which are always logged

--- a/st2common/tests/integration/test_service_setup_log_level_filtering.py
+++ b/st2common/tests/integration/test_service_setup_log_level_filtering.py
@@ -1,0 +1,123 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import os
+import sys
+import signal
+
+import eventlet
+from eventlet.green import subprocess
+
+from st2tests.base import IntegrationTestCase
+from st2tests.fixturesloader import get_fixtures_base_path
+
+__all__ = [
+    'ServiceSetupLogLevelFilteringTestCase'
+]
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+FIXTURES_DIR = get_fixtures_base_path()
+
+ST2_CONFIG_INFO_LL_PATH = os.path.join(FIXTURES_DIR, 'conf/st2.tests.api.info_log_level.conf')
+ST2_CONFIG_INFO_LL_PATH = os.path.abspath(ST2_CONFIG_INFO_LL_PATH)
+
+ST2_CONFIG_DEBUG_LL_PATH = os.path.join(FIXTURES_DIR, 'conf/st2.tests.api.debug_log_level.conf')
+ST2_CONFIG_DEBUG_LL_PATH = os.path.abspath(ST2_CONFIG_DEBUG_LL_PATH)
+
+ST2_CONFIG_AUDIT_LL_PATH = os.path.join(FIXTURES_DIR, 'conf/st2.tests.api.audit_log_level.conf')
+ST2_CONFIG_AUDIT_LL_PATH = os.path.abspath(ST2_CONFIG_AUDIT_LL_PATH)
+
+ST2_CONFIG_SYSTEM_DEBUG_PATH = os.path.join(FIXTURES_DIR,
+                                            'conf/st2.tests.api.system_debug_true.conf')
+ST2_CONFIG_SYSTEM_DEBUG_PATH = os.path.abspath(ST2_CONFIG_SYSTEM_DEBUG_PATH)
+
+PYTHON_BINARY = sys.executable
+
+ST2API_BINARY = os.path.join(BASE_DIR, '../../../st2api/bin/st2api')
+ST2API_BINARY = os.path.abspath(ST2API_BINARY)
+
+CMD = [PYTHON_BINARY, ST2API_BINARY, '--config-file']
+
+
+class ServiceSetupLogLevelFilteringTestCase(IntegrationTestCase):
+    def test_audit_log_level_is_filtered_if_log_level_is_not_debug_or_audit(self):
+        # 1. INFO log level - audit messages should not be included
+        process = self._start_process(config_path=ST2_CONFIG_INFO_LL_PATH)
+        self.add_process(process=process)
+
+        # Give it some time to start up
+        eventlet.sleep(3)
+        process.send_signal(signal.SIGKILL)
+
+        # First 3 log lines are debug messages about the environment which are always logged
+        stdout = '\n'.join(process.stdout.read().split('\n')[3:])
+
+        self.assertTrue('INFO [-]' in stdout)
+        self.assertTrue('DEBUG [-]' not in stdout)
+        self.assertTrue('AUDIT [-]' not in stdout)
+
+        # 2. DEBUG log level - audit messages should be included
+        process = self._start_process(config_path=ST2_CONFIG_DEBUG_LL_PATH)
+        self.add_process(process=process)
+
+        # Give it some time to start up
+        eventlet.sleep(3)
+        process.send_signal(signal.SIGKILL)
+
+        # First 3 log lines are debug messages about the environment which are always logged
+        stdout = '\n'.join(process.stdout.read().split('\n')[3:])
+
+        self.assertTrue('INFO [-]' in stdout)
+        self.assertTrue('DEBUG [-]' in stdout)
+        self.assertTrue('AUDIT [-]' in stdout)
+
+        # 3. AUDIT log level - audit messages should be included
+        process = self._start_process(config_path=ST2_CONFIG_AUDIT_LL_PATH)
+        self.add_process(process=process)
+
+        # Give it some time to start up
+        eventlet.sleep(3)
+        process.send_signal(signal.SIGKILL)
+
+        # First 3 log lines are debug messages about the environment which are always logged
+        stdout = '\n'.join(process.stdout.read().split('\n')[3:])
+
+        self.assertTrue('INFO [-]' not in stdout)
+        self.assertTrue('DEBUG [-]' not in stdout)
+        self.assertTrue('AUDIT [-]' in stdout)
+
+        # 2. INFO log level but system.debug set to True
+        process = self._start_process(config_path=ST2_CONFIG_SYSTEM_DEBUG_PATH)
+        self.add_process(process=process)
+
+        # Give it some time to start up
+        eventlet.sleep(3)
+        process.send_signal(signal.SIGKILL)
+
+        # First 3 log lines are debug messages about the environment which are always logged
+        stdout = '\n'.join(process.stdout.read().split('\n')[3:])
+
+        self.assertTrue('INFO [-]' in stdout)
+        self.assertTrue('DEBUG [-]' in stdout)
+        self.assertTrue('AUDIT [-]' in stdout)
+
+    def _start_process(self, config_path):
+        cmd = CMD + [config_path]
+        process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                   shell=False, preexec_fn=os.setsid)
+        return process

--- a/st2common/tests/integration/test_service_setup_log_level_filtering.py
+++ b/st2common/tests/integration/test_service_setup_log_level_filtering.py
@@ -65,7 +65,7 @@ class ServiceSetupLogLevelFilteringTestCase(IntegrationTestCase):
         process.send_signal(signal.SIGKILL)
 
         # First 3 log lines are debug messages about the environment which are always logged
-        stdout = '\n'.join(process.stdout.read().split('\n')[3:])
+        stdout = '\n'.join(process.stdout.read().decode('utf-8').split('\n')[3:])
 
         self.assertTrue('INFO [-]' in stdout)
         self.assertTrue('DEBUG [-]' not in stdout)
@@ -80,7 +80,7 @@ class ServiceSetupLogLevelFilteringTestCase(IntegrationTestCase):
         process.send_signal(signal.SIGKILL)
 
         # First 3 log lines are debug messages about the environment which are always logged
-        stdout = '\n'.join(process.stdout.read().split('\n')[3:])
+        stdout = '\n'.join(process.stdout.read().decode('utf-8').split('\n')[3:])
 
         self.assertTrue('INFO [-]' in stdout)
         self.assertTrue('DEBUG [-]' in stdout)
@@ -95,7 +95,7 @@ class ServiceSetupLogLevelFilteringTestCase(IntegrationTestCase):
         process.send_signal(signal.SIGKILL)
 
         # First 3 log lines are debug messages about the environment which are always logged
-        stdout = '\n'.join(process.stdout.read().split('\n')[3:])
+        stdout = '\n'.join(process.stdout.read().decode('utf-8').split('\n')[3:])
 
         self.assertTrue('INFO [-]' not in stdout)
         self.assertTrue('DEBUG [-]' not in stdout)
@@ -110,7 +110,7 @@ class ServiceSetupLogLevelFilteringTestCase(IntegrationTestCase):
         process.send_signal(signal.SIGKILL)
 
         # First 3 log lines are debug messages about the environment which are always logged
-        stdout = '\n'.join(process.stdout.read().split('\n')[3:])
+        stdout = '\n'.join(process.stdout.read().decode('utf-8').split('\n')[3:])
 
         self.assertTrue('INFO [-]' in stdout)
         self.assertTrue('DEBUG [-]' in stdout)

--- a/st2tests/st2tests/fixtures/conf/logging.api.audit.conf
+++ b/st2tests/st2tests/fixtures/conf/logging.api.audit.conf
@@ -1,0 +1,44 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=consoleHandler, fileHandler, auditHandler
+
+[formatters]
+keys=simpleConsoleFormatter, verboseConsoleFormatter, gelfFormatter
+
+[logger_root]
+level=AUDIT
+handlers=consoleHandler, fileHandler, auditHandler
+
+[handler_consoleHandler]
+class=StreamHandler
+level=AUDIT
+formatter=simpleConsoleFormatter
+args=(sys.stdout,)
+
+[handler_fileHandler]
+class=st2common.log.FormatNamedFileHandler
+level=AUDIT
+formatter=verboseConsoleFormatter
+args=("/tmp/st2api.{timestamp}.log",)
+
+[handler_auditHandler]
+class=st2common.log.FormatNamedFileHandler
+level=AUDIT
+formatter=gelfFormatter
+args=("/tmp/st2api.audit.{timestamp}.log",)
+
+[formatter_simpleConsoleFormatter]
+class=st2common.logging.formatters.ConsoleLogFormatter
+format=%(asctime)s %(levelname)s [-] %(message)s
+datefmt=
+
+[formatter_verboseConsoleFormatter]
+class=st2common.logging.formatters.ConsoleLogFormatter
+format=%(asctime)s %(thread)s %(levelname)s %(module)s [-] %(message)s
+datefmt=
+
+[formatter_gelfFormatter]
+class=st2common.logging.formatters.GelfLogFormatter
+format=%(message)s

--- a/st2tests/st2tests/fixtures/conf/logging.api.debug.conf
+++ b/st2tests/st2tests/fixtures/conf/logging.api.debug.conf
@@ -1,0 +1,44 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=consoleHandler, fileHandler, auditHandler
+
+[formatters]
+keys=simpleConsoleFormatter, verboseConsoleFormatter, gelfFormatter
+
+[logger_root]
+level=DEBUG
+handlers=consoleHandler, fileHandler, auditHandler
+
+[handler_consoleHandler]
+class=StreamHandler
+level=DEBUG
+formatter=simpleConsoleFormatter
+args=(sys.stdout,)
+
+[handler_fileHandler]
+class=st2common.log.FormatNamedFileHandler
+level=DEBUG
+formatter=verboseConsoleFormatter
+args=("/tmp/st2api.{timestamp}.log",)
+
+[handler_auditHandler]
+class=st2common.log.FormatNamedFileHandler
+level=AUDIT
+formatter=gelfFormatter
+args=("/tmp/st2api.audit.{timestamp}.log",)
+
+[formatter_simpleConsoleFormatter]
+class=st2common.logging.formatters.ConsoleLogFormatter
+format=%(asctime)s %(levelname)s [-] %(message)s
+datefmt=
+
+[formatter_verboseConsoleFormatter]
+class=st2common.logging.formatters.ConsoleLogFormatter
+format=%(asctime)s %(thread)s %(levelname)s %(module)s [-] %(message)s
+datefmt=
+
+[formatter_gelfFormatter]
+class=st2common.logging.formatters.GelfLogFormatter
+format=%(message)s

--- a/st2tests/st2tests/fixtures/conf/logging.api.info.conf
+++ b/st2tests/st2tests/fixtures/conf/logging.api.info.conf
@@ -1,0 +1,44 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=consoleHandler, fileHandler, auditHandler
+
+[formatters]
+keys=simpleConsoleFormatter, verboseConsoleFormatter, gelfFormatter
+
+[logger_root]
+level=INFO
+handlers=consoleHandler, fileHandler, auditHandler
+
+[handler_consoleHandler]
+class=StreamHandler
+level=INFO
+formatter=simpleConsoleFormatter
+args=(sys.stdout,)
+
+[handler_fileHandler]
+class=st2common.log.FormatNamedFileHandler
+level=INFO
+formatter=verboseConsoleFormatter
+args=("/tmp/st2api.{timestamp}.log",)
+
+[handler_auditHandler]
+class=st2common.log.FormatNamedFileHandler
+level=AUDIT
+formatter=gelfFormatter
+args=("/tmp/st2api.audit.{timestamp}.log",)
+
+[formatter_simpleConsoleFormatter]
+class=st2common.logging.formatters.ConsoleLogFormatter
+format=%(asctime)s %(levelname)s [-] %(message)s
+datefmt=
+
+[formatter_verboseConsoleFormatter]
+class=st2common.logging.formatters.ConsoleLogFormatter
+format=%(asctime)s %(thread)s %(levelname)s %(module)s [-] %(message)s
+datefmt=
+
+[formatter_gelfFormatter]
+class=st2common.logging.formatters.GelfLogFormatter
+format=%(message)s

--- a/st2tests/st2tests/fixtures/conf/st2.tests.api.audit_log_level.conf
+++ b/st2tests/st2tests/fixtures/conf/st2.tests.api.audit_log_level.conf
@@ -1,0 +1,99 @@
+# Config file used by integration tests
+
+[database]
+db_name = st2-test
+
+[api]
+# Host and port to bind the API server.
+host = 127.0.0.1
+port = 9101
+logging = st2tests/st2tests/fixtures/conf/logging.api.audit.conf
+mask_secrets = False
+# allow_origin is required for handling CORS in st2 web UI.
+# allow_origin = http://myhost1.example.com:3000,http://myhost2.example.com:3000
+
+[sensorcontainer]
+logging = st2tests/conf/logging.sensorcontainer.conf
+sensor_node_name = sensornode1
+partition_provider = name:default
+
+[rulesengine]
+logging = st2reactor/conf/logging.rulesengine.conf
+
+[timersengine]
+logging = st2reactor/conf/logging.timersengine.conf
+
+[actionrunner]
+logging = st2actions/conf/logging.conf
+
+[auth]
+host = 127.0.0.1
+port = 9100
+use_ssl = False
+debug = False
+enable = False
+logging = st2tests/conf/logging.auth.conf
+
+mode = standalone
+backend = flat_file
+backend_kwargs = {"file_path": "st2auth/conf/htpasswd_dev"}
+
+# Base URL to the API endpoint excluding the version (e.g. http://myhost.net:9101/)
+api_url = http://127.0.0.1:9101/
+
+[system]
+debug = False
+# This way integration tests can write to this directory
+base_path = /tmp
+
+[garbagecollector]
+logging = st2reactor/conf/logging.garbagecollector.conf
+
+action_executions_ttl = 20
+action_executions_output_ttl = 10
+trigger_instances_ttl = 20
+purge_inquiries = True
+
+collection_interval = 1
+sleep_delay = 0.1
+
+[content]
+system_packs_base_path =
+packs_base_paths = st2tests/st2tests/fixtures/packs/
+
+[syslog]
+host = 127.0.0.1
+port = 514
+facility = local7
+protocol = udp
+
+[webui]
+# webui_base_url = https://mywebhost.domain
+
+[log]
+excludes = requests,paramiko
+redirect_stderr = False
+mask_secrets = False
+
+[system_user]
+user = stanley
+ssh_key_file = /home/vagrant/.ssh/stanley_rsa
+
+[messaging]
+url = amqp://guest:guest@127.0.0.1:5672/
+
+[ssh_runner]
+remote_dir = /tmp
+
+[resultstracker]
+logging = st2actions/conf/logging.resultstracker.conf
+query_interval = 0.1
+
+[notifier]
+logging = st2actions/conf/logging.notifier.conf
+
+[exporter]
+logging = st2exporter/conf/logging.exporter.conf
+
+[mistral]
+jitter_interval = 0

--- a/st2tests/st2tests/fixtures/conf/st2.tests.api.debug_log_level.conf
+++ b/st2tests/st2tests/fixtures/conf/st2.tests.api.debug_log_level.conf
@@ -1,0 +1,99 @@
+# Config file used by integration tests
+
+[database]
+db_name = st2-test
+
+[api]
+# Host and port to bind the API server.
+host = 127.0.0.1
+port = 9101
+logging = st2tests/st2tests/fixtures/conf/logging.api.debug.conf
+mask_secrets = False
+# allow_origin is required for handling CORS in st2 web UI.
+# allow_origin = http://myhost1.example.com:3000,http://myhost2.example.com:3000
+
+[sensorcontainer]
+logging = st2tests/conf/logging.sensorcontainer.conf
+sensor_node_name = sensornode1
+partition_provider = name:default
+
+[rulesengine]
+logging = st2reactor/conf/logging.rulesengine.conf
+
+[timersengine]
+logging = st2reactor/conf/logging.timersengine.conf
+
+[actionrunner]
+logging = st2actions/conf/logging.conf
+
+[auth]
+host = 127.0.0.1
+port = 9100
+use_ssl = False
+debug = False
+enable = False
+logging = st2tests/conf/logging.auth.conf
+
+mode = standalone
+backend = flat_file
+backend_kwargs = {"file_path": "st2auth/conf/htpasswd_dev"}
+
+# Base URL to the API endpoint excluding the version (e.g. http://myhost.net:9101/)
+api_url = http://127.0.0.1:9101/
+
+[system]
+debug = False
+# This way integration tests can write to this directory
+base_path = /tmp
+
+[garbagecollector]
+logging = st2reactor/conf/logging.garbagecollector.conf
+
+action_executions_ttl = 20
+action_executions_output_ttl = 10
+trigger_instances_ttl = 20
+purge_inquiries = True
+
+collection_interval = 1
+sleep_delay = 0.1
+
+[content]
+system_packs_base_path =
+packs_base_paths = st2tests/st2tests/fixtures/packs/
+
+[syslog]
+host = 127.0.0.1
+port = 514
+facility = local7
+protocol = udp
+
+[webui]
+# webui_base_url = https://mywebhost.domain
+
+[log]
+excludes = requests,paramiko
+redirect_stderr = False
+mask_secrets = False
+
+[system_user]
+user = stanley
+ssh_key_file = /home/vagrant/.ssh/stanley_rsa
+
+[messaging]
+url = amqp://guest:guest@127.0.0.1:5672/
+
+[ssh_runner]
+remote_dir = /tmp
+
+[resultstracker]
+logging = st2actions/conf/logging.resultstracker.conf
+query_interval = 0.1
+
+[notifier]
+logging = st2actions/conf/logging.notifier.conf
+
+[exporter]
+logging = st2exporter/conf/logging.exporter.conf
+
+[mistral]
+jitter_interval = 0

--- a/st2tests/st2tests/fixtures/conf/st2.tests.api.info_log_level.conf
+++ b/st2tests/st2tests/fixtures/conf/st2.tests.api.info_log_level.conf
@@ -1,0 +1,99 @@
+# Config file used by integration tests
+
+[database]
+db_name = st2-test
+
+[api]
+# Host and port to bind the API server.
+host = 127.0.0.1
+port = 9101
+logging = st2tests/st2tests/fixtures/conf/logging.api.info.conf
+mask_secrets = False
+# allow_origin is required for handling CORS in st2 web UI.
+# allow_origin = http://myhost1.example.com:3000,http://myhost2.example.com:3000
+
+[sensorcontainer]
+logging = st2tests/conf/logging.sensorcontainer.conf
+sensor_node_name = sensornode1
+partition_provider = name:default
+
+[rulesengine]
+logging = st2reactor/conf/logging.rulesengine.conf
+
+[timersengine]
+logging = st2reactor/conf/logging.timersengine.conf
+
+[actionrunner]
+logging = st2actions/conf/logging.conf
+
+[auth]
+host = 127.0.0.1
+port = 9100
+use_ssl = False
+debug = False
+enable = False
+logging = st2tests/conf/logging.auth.conf
+
+mode = standalone
+backend = flat_file
+backend_kwargs = {"file_path": "st2auth/conf/htpasswd_dev"}
+
+# Base URL to the API endpoint excluding the version (e.g. http://myhost.net:9101/)
+api_url = http://127.0.0.1:9101/
+
+[system]
+debug = False
+# This way integration tests can write to this directory
+base_path = /tmp
+
+[garbagecollector]
+logging = st2reactor/conf/logging.garbagecollector.conf
+
+action_executions_ttl = 20
+action_executions_output_ttl = 10
+trigger_instances_ttl = 20
+purge_inquiries = True
+
+collection_interval = 1
+sleep_delay = 0.1
+
+[content]
+system_packs_base_path =
+packs_base_paths = st2tests/st2tests/fixtures/packs/
+
+[syslog]
+host = 127.0.0.1
+port = 514
+facility = local7
+protocol = udp
+
+[webui]
+# webui_base_url = https://mywebhost.domain
+
+[log]
+excludes = requests,paramiko
+redirect_stderr = False
+mask_secrets = False
+
+[system_user]
+user = stanley
+ssh_key_file = /home/vagrant/.ssh/stanley_rsa
+
+[messaging]
+url = amqp://guest:guest@127.0.0.1:5672/
+
+[ssh_runner]
+remote_dir = /tmp
+
+[resultstracker]
+logging = st2actions/conf/logging.resultstracker.conf
+query_interval = 0.1
+
+[notifier]
+logging = st2actions/conf/logging.notifier.conf
+
+[exporter]
+logging = st2exporter/conf/logging.exporter.conf
+
+[mistral]
+jitter_interval = 0

--- a/st2tests/st2tests/fixtures/conf/st2.tests.api.system_debug_true.conf
+++ b/st2tests/st2tests/fixtures/conf/st2.tests.api.system_debug_true.conf
@@ -1,0 +1,99 @@
+# Config file used by integration tests
+
+[database]
+db_name = st2-test
+
+[api]
+# Host and port to bind the API server.
+host = 127.0.0.1
+port = 9101
+logging = st2tests/st2tests/fixtures/conf/logging.api.info.conf
+mask_secrets = False
+# allow_origin is required for handling CORS in st2 web UI.
+# allow_origin = http://myhost1.example.com:3000,http://myhost2.example.com:3000
+
+[sensorcontainer]
+logging = st2tests/conf/logging.sensorcontainer.conf
+sensor_node_name = sensornode1
+partition_provider = name:default
+
+[rulesengine]
+logging = st2reactor/conf/logging.rulesengine.conf
+
+[timersengine]
+logging = st2reactor/conf/logging.timersengine.conf
+
+[actionrunner]
+logging = st2actions/conf/logging.conf
+
+[auth]
+host = 127.0.0.1
+port = 9100
+use_ssl = False
+debug = False
+enable = False
+logging = st2tests/conf/logging.auth.conf
+
+mode = standalone
+backend = flat_file
+backend_kwargs = {"file_path": "st2auth/conf/htpasswd_dev"}
+
+# Base URL to the API endpoint excluding the version (e.g. http://myhost.net:9101/)
+api_url = http://127.0.0.1:9101/
+
+[system]
+debug = True
+# This way integration tests can write to this directory
+base_path = /tmp
+
+[garbagecollector]
+logging = st2reactor/conf/logging.garbagecollector.conf
+
+action_executions_ttl = 20
+action_executions_output_ttl = 10
+trigger_instances_ttl = 20
+purge_inquiries = True
+
+collection_interval = 1
+sleep_delay = 0.1
+
+[content]
+system_packs_base_path =
+packs_base_paths = st2tests/st2tests/fixtures/packs/
+
+[syslog]
+host = 127.0.0.1
+port = 514
+facility = local7
+protocol = udp
+
+[webui]
+# webui_base_url = https://mywebhost.domain
+
+[log]
+excludes = requests,paramiko
+redirect_stderr = False
+mask_secrets = False
+
+[system_user]
+user = stanley
+ssh_key_file = /home/vagrant/.ssh/stanley_rsa
+
+[messaging]
+url = amqp://guest:guest@127.0.0.1:5672/
+
+[ssh_runner]
+remote_dir = /tmp
+
+[resultstracker]
+logging = st2actions/conf/logging.resultstracker.conf
+query_interval = 0.1
+
+[notifier]
+logging = st2actions/conf/logging.notifier.conf
+
+[exporter]
+logging = st2exporter/conf/logging.exporter.conf
+
+[mistral]
+jitter_interval = 0

--- a/st2tests/st2tests/fixtures/conf/st2.tests.conf
+++ b/st2tests/st2tests/fixtures/conf/st2.tests.conf
@@ -1,0 +1,100 @@
+# Config file used by integration tests
+
+[database]
+db_name = st2-test
+
+[api]
+# Host and port to bind the API server.
+host = 127.0.0.1
+port = 9101
+logging = st2tests/conf/logging.api.conf
+mask_secrets = False
+# allow_origin is required for handling CORS in st2 web UI.
+# allow_origin = http://myhost1.example.com:3000,http://myhost2.example.com:3000
+
+[sensorcontainer]
+logging = st2tests/conf/logging.sensorcontainer.conf
+sensor_node_name = sensornode1
+partition_provider = name:default
+
+[rulesengine]
+logging = st2reactor/conf/logging.rulesengine.conf
+
+[timersengine]
+logging = st2reactor/conf/logging.timersengine.conf
+
+[actionrunner]
+logging = st2actions/conf/logging.conf
+
+[auth]
+host = 127.0.0.1
+port = 9100
+use_ssl = False
+debug = False
+enable = False
+logging = st2tests/conf/logging.auth.conf
+
+mode = standalone
+backend = flat_file
+backend_kwargs = {"file_path": "st2auth/conf/htpasswd_dev"}
+
+# Base URL to the API endpoint excluding the version (e.g. http://myhost.net:9101/)
+api_url = http://127.0.0.1:9101/
+
+[system]
+debug = False
+
+# This way integration tests can write to this directory
+base_path = /tmp
+
+[garbagecollector]
+logging = st2reactor/conf/logging.garbagecollector.conf
+
+action_executions_ttl = 20
+action_executions_output_ttl = 10
+trigger_instances_ttl = 20
+purge_inquiries = True
+
+collection_interval = 1
+sleep_delay = 0.1
+
+[content]
+system_packs_base_path =
+packs_base_paths = st2tests/st2tests/fixtures/packs/
+
+[syslog]
+host = 127.0.0.1
+port = 514
+facility = local7
+protocol = udp
+
+[webui]
+# webui_base_url = https://mywebhost.domain
+
+[log]
+excludes = requests,paramiko
+redirect_stderr = False
+mask_secrets = False
+
+[system_user]
+user = stanley
+ssh_key_file = /home/vagrant/.ssh/stanley_rsa
+
+[messaging]
+url = amqp://guest:guest@127.0.0.1:5672/
+
+[ssh_runner]
+remote_dir = /tmp
+
+[resultstracker]
+logging = st2actions/conf/logging.resultstracker.conf
+query_interval = 0.1
+
+[notifier]
+logging = st2actions/conf/logging.notifier.conf
+
+[exporter]
+logging = st2exporter/conf/logging.exporter.conf
+
+[mistral]
+jitter_interval = 0


### PR DESCRIPTION
This pull request resolves an issue with log messages with log level AUDIT ending up in regular service log file (``<service>.log``) in addition to the service audit log file (``<service>.audit.log``).

## Background

We implemented ``AUDIT`` log level by adding a new log level constant which contains the highest log level number (``CRITICAL`` + 10).

Default Python log level filtering works using "include log messages with log level <set> and above" approach. This means messages with ``AUDIT`` log level will always be included in the logs because ``AUDIT`` is the highest level.

In most cases that's not desired. That's especially true for production deployment where default log level is ``INFO`` and we have dedicated log file with audit log messages. We don't want audit log messages to also end up in the regular service log file where they just cause noise.

Implementation wise, I needed to implement it using a log filter - we exclude log messages with level ``AUDIT`` if log level is set to ``INFO`` or higher, but not to ``AUDIT``. I couldn't make a simpler change like setting ``AUDIT`` log level constant to lower than ``INFO``, because then we would have the opposite problem (non ``AUDIT`` messages would also end up in the audit log file).

NOTE: To aid with the debugging, ``AUDIT`` log messages are also included in a regular service log file if log level is set to ``DEBUG`` of if ``system.debug`` config option is set to ``True``. When debug is enabled there are many more log messages coming from other places so ``AUDIT`` should be the least of your concerns :)

Resolves #4502 (thanks to @nmaludy for reporting it).

## TODO

- [x] Integration tests