### PR TITLE
Try a workaround for RabbitMQ SSL integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ matrix:
       name: "Integration Tests (Python 3.6)"
 
 addons:
+  hostname: localhost
   apt:
     sources:
       - mongodb-upstart
@@ -101,6 +102,8 @@ before_install:
 
 install:
   - ./scripts/travis/install-requirements.sh
+  # Work around for old openssl issues on Ubuntu Precise
+  - virtualenv/bin/pip install "ndg-httpsclient"
   - if [ "${TASK}" = 'ci-unit' ] || [ "${TASK}" = 'ci-integration' ] || [ "${TASK}" = 'ci-checks ci-packs-tests' ] || [ "${TASK}" = 'compilepy3 ci-py3-unit' ] || [ "${TASK}" = 'ci-py3-integration' ]; then sudo .circle/add-itest-user.sh; fi
 
 # Let's enable rabbitmqadmin

--- a/st2common/st2common/transport/utils.py
+++ b/st2common/st2common/transport/utils.py
@@ -67,11 +67,11 @@ def get_connection(urls=None, connection_kwargs=None):
     # NOTE: "connection_kwargs" argument passed to this function has precedence over config values
     if len(ssl_kwargs) == 1 and ssl_kwargs['ssl'] is True:
         kwargs.update({'ssl': True})
-        kwargs['ssl']['ssl_version'] = ssl_lib.PROTOCOL_TLSv1
+        kwargs['ssl']['ssl_version'] = ssl_lib.PROTOCOL_TLSv1_1
     elif len(ssl_kwargs) >= 2:
         ssl_kwargs.pop('ssl')
         kwargs.update({'ssl': ssl_kwargs})
-        kwargs['ssl']['ssl_version'] = ssl_lib.PROTOCOL_TLSv1
+        kwargs['ssl']['ssl_version'] = ssl_lib.PROTOCOL_TLSv1_1
 
     kwargs['login_method'] = cfg.CONF.messaging.login_method
 

--- a/st2common/st2common/transport/utils.py
+++ b/st2common/st2common/transport/utils.py
@@ -67,9 +67,11 @@ def get_connection(urls=None, connection_kwargs=None):
     # NOTE: "connection_kwargs" argument passed to this function has precedence over config values
     if len(ssl_kwargs) == 1 and ssl_kwargs['ssl'] is True:
         kwargs.update({'ssl': True})
+        kwargs['ssl']['ssl_version'] = ssl_lib.PROTOCOL_TLSv1
     elif len(ssl_kwargs) >= 2:
         ssl_kwargs.pop('ssl')
         kwargs.update({'ssl': ssl_kwargs})
+        kwargs['ssl']['ssl_version'] = ssl_lib.PROTOCOL_TLSv1
 
     kwargs['login_method'] = cfg.CONF.messaging.login_method
 

--- a/st2common/tests/integration/test_rabbitmq_ssl_listener.py
+++ b/st2common/tests/integration/test_rabbitmq_ssl_listener.py
@@ -41,8 +41,7 @@ SSL_LISTENER_PORT = 5671
 # expose RabbitMQ SSL listener by default
 # TODO: Re-enable once we upgrade Travis from Precise to Xenial where latest version of RabbitMQ
 # and OpenSSL is available
-@unittest2.skip('Skipping until we upgrade to Xenial on Travis')
-# @unittest2.skipIf(not ON_TRAVIS, 'Skipping tests because not running on Travis')
+@unittest2.skipIf(not ON_TRAVIS, 'Skipping tests because not running on Travis')
 class RabbitMQTLSListenerTestCase(unittest2.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Just playing around to see if I can get RabbitMQ ssl integration tests to pass on ancient Ubuntu Precise.