### PR TITLE
Canceling workflow with subworkflow can lead to execution stuck in canceling state

### DIFF
--- a/st2common/st2common/services/action.py
+++ b/st2common/st2common/services/action.py
@@ -260,6 +260,12 @@ def request_cancellation(liveaction, requester):
 
     # Run cancelation sequence for liveaction that is in running state or
     # if the liveaction is operating under a workflow.
+    if 'parent' not in liveaction.context and action_constants.LIVEACTION_STATUS_RUNNING:
+        status = action_constants.LIVEACTION_STATUS_CANCELED
+        liveaction = update_status(liveaction, status, result=result)
+        execution = ActionExecution.get(liveaction__id=str(liveaction.id))
+        return (liveaction, execution)
+
     if ('parent' in liveaction.context or
             liveaction.status in action_constants.LIVEACTION_STATUS_RUNNING):
         status = action_constants.LIVEACTION_STATUS_CANCELING

--- a/st2common/st2common/services/action.py
+++ b/st2common/st2common/services/action.py
@@ -244,15 +244,12 @@ def request_cancellation(liveaction, requester):
     :return: (liveaction, execution)
     :rtype: tuple
     """
-    # Run cancellation for parent if it is in CANCELING status
+    # If action stuck in canceling, allow user to re-run cancel command
     if liveaction.status == action_constants.LIVEACTION_STATUS_CANCELING:
-        if 'parent' not in liveaction.context:
-            status = action_constants.LIVEACTION_STATUS_CANCELED
-            liveaction = update_status(liveaction, status)
-            execution = ActionExecution.get(liveaction__id=str(liveaction.id))
-            return (liveaction, execution)
-        else:
-            return liveaction
+        status = action_constants.LIVEACTION_STATUS_CANCELED
+        liveaction = update_status(liveaction, status)
+        execution = ActionExecution.get(liveaction__id=str(liveaction.id))
+        return (liveaction, execution)
 
     if liveaction.status not in action_constants.LIVEACTION_CANCELABLE_STATES:
         raise Exception(

--- a/st2common/st2common/services/workflows.py
+++ b/st2common/st2common/services/workflows.py
@@ -377,8 +377,6 @@ def request_cancellation(ac_ex_db):
     if conductor.get_workflow_state() in states.COMPLETED_STATES:
         raise wf_exc.WorkflowExecutionIsCompletedException(str(wf_ex_db.id))
 
-    conductor.request_workflow_state(states.CANCELED)
-
     # Write the updated workflow state and task flow to the database.
     wf_ex_db.status = conductor.get_workflow_state()
     wf_ex_db.flow = conductor.flow.serialize()
@@ -389,9 +387,7 @@ def request_cancellation(ac_ex_db):
 
     if root_ac_ex_db != ac_ex_db and root_ac_ex_db.status not in ac_const.LIVEACTION_CANCEL_STATES:
         LOG.info('[%s] Cascading cancellation request to parent workflow.', wf_ac_ex_id)
-        root_lv_ac_db = lv_db_access.LiveAction.get(id=root_ac_ex_db.liveaction['id'])
-        ac_svc.request_cancellation(root_lv_ac_db, None)
-    elif root_ac_ex_db == ac_ex_db and root_ac_ex_db.status == ac_const.LIVEACTION_STATUS_CANCELING:
+        conductor.request_workflow_state(states.CANCELED)
         root_lv_ac_db = lv_db_access.LiveAction.get(id=root_ac_ex_db.liveaction['id'])
         ac_svc.request_cancellation(root_lv_ac_db, None)
 


### PR DESCRIPTION
Fixes https://github.com/StackStorm/orquesta/issues/121
WIP
Canceling workflow with subworkflow can lead to execution stuck in canceling state

Since unit test calls `request_cancellation(lv_ac_db, requester)` with root `LiveAction`, when Workflow `request_cancellation` is called,  `LiveAction` status changed to 'canceling` but is marked as `canceled` in orquesta, and  `ac_svc.request_cancellation(root_lv_ac_db, None)` is not call to Cascading cancellation request to parent workflow. It is why it stack in `canceling` stage. Tried this area  to deal with this spacial case and failed other test cases.

Working in area around `services/action.py request_cancellation` and `service/workflows.py request_cancellation`