### PR TITLE
Apply the orquesta execution graph performance fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,10 @@ Changed
 Fixed
 ~~~~~
 
+* Refactored orquesta execution graph to fix performance issue for workflows with many
+  references to non-join tasks. st2workflowengine and DB models are refactored accordingly.
+  (improvement) StackStorm/orquesta#122.
+
 2.10.2 - February 21, 2019
 --------------------------
 

--- a/contrib/examples/actions/workflows/tests/orquesta-test-jinja-task-functions.yaml
+++ b/contrib/examples/actions/workflows/tests/orquesta-test-jinja-task-functions.yaml
@@ -46,12 +46,12 @@ tasks:
   task7:
     action: core.echo
     input:
-      message: '{{ task("task6").task_id }}'
+      message: '{{ task("task6").task_id + "__" + task("task6").route|string }}'
 
 output:
   - this_task_no_arg: '{{ ctx("this_task_no_arg") }}'
   - this_task_by_name: '{{ ctx("this_task_by_name") }}'
   - that_task_by_name: '{{ task("task1").task_id }}'
   - last_task3_result: '{{ task("task3").result.stdout }}'
-  - task7__1__parent: '{{ task("task7__1").result.stdout }}'
-  - task7__2__parent: '{{ task("task7__2").result.stdout }}'
+  - task7__2__parent: '{{ task("task7", route=2).result.stdout }}'
+  - task7__3__parent: '{{ task("task7", route=3).result.stdout }}'

--- a/contrib/examples/actions/workflows/tests/orquesta-test-yaql-task-functions.yaml
+++ b/contrib/examples/actions/workflows/tests/orquesta-test-yaql-task-functions.yaml
@@ -46,12 +46,12 @@ tasks:
   task7:
     action: core.echo
     input:
-      message: '<% task("task6").task_id %>'
+      message: '<% task("task6").task_id + "__" + str(task("task6").route) %>'
 
 output:
   - this_task_no_arg: '<% ctx("this_task_no_arg") %>'
   - this_task_by_name: '<% ctx("this_task_by_name") %>'
   - that_task_by_name: '<% task("task1").task_id %>'
   - last_task3_result: '<% task("task3").result.stdout %>'
-  - task7__1__parent: '<% task("task7__1").result.stdout %>'
-  - task7__2__parent: '<% task("task7__2").result.stdout %>'
+  - task7__2__parent: '<% task("task7", route=>2).result.stdout %>'
+  - task7__3__parent: '<% task("task7", route=>3).result.stdout %>'

--- a/contrib/runners/orquesta_runner/in-requirements.txt
+++ b/contrib/runners/orquesta_runner/in-requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/StackStorm/orquesta.git@fix-exec-graph#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@e6c07fda6851f0d860aa8aef99a67b5b2a0156ce#egg=orquesta

--- a/contrib/runners/orquesta_runner/in-requirements.txt
+++ b/contrib/runners/orquesta_runner/in-requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/StackStorm/orquesta.git@v0.4#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@fix-exec-graph#egg=orquesta

--- a/contrib/runners/orquesta_runner/requirements.txt
+++ b/contrib/runners/orquesta_runner/requirements.txt
@@ -1,2 +1,2 @@
 # Don't edit this file. It's generated automatically!
-git+https://github.com/StackStorm/orquesta.git@v0.4#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@fix-exec-graph#egg=orquesta

--- a/contrib/runners/orquesta_runner/requirements.txt
+++ b/contrib/runners/orquesta_runner/requirements.txt
@@ -1,2 +1,2 @@
 # Don't edit this file. It's generated automatically!
-git+https://github.com/StackStorm/orquesta.git@fix-exec-graph#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@e6c07fda6851f0d860aa8aef99a67b5b2a0156ce#egg=orquesta

--- a/contrib/runners/orquesta_runner/tests/unit/test_error_handling.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_error_handling.py
@@ -235,7 +235,8 @@ class OrquestaErrorHandlingTest(st2tests.ExecutionDbTestCase):
                     '\'<% ctx().func.value %>\'. NoFunctionRegisteredException: '
                     'Unknown function "#property#value"'
                 ),
-                'task_id': 'task1'
+                'task_id': 'task1',
+                'route': 0
             }
         ]
 
@@ -270,7 +271,8 @@ class OrquestaErrorHandlingTest(st2tests.ExecutionDbTestCase):
                     '\'<% ctx().msg1.value %>\'. NoFunctionRegisteredException: '
                     'Unknown function "#property#value"'
                 ),
-                'task_id': 'task1'
+                'task_id': 'task1',
+                'route': 0
             }
         ]
 
@@ -309,7 +311,8 @@ class OrquestaErrorHandlingTest(st2tests.ExecutionDbTestCase):
             {
                 'type': 'error',
                 'message': msg,
-                'task_id': 'task1'
+                'task_id': 'task1',
+                'route': 0
             }
         ]
 
@@ -347,7 +350,8 @@ class OrquestaErrorHandlingTest(st2tests.ExecutionDbTestCase):
                     '\'<% ctx().func.value %>\'. NoFunctionRegisteredException: '
                     'Unknown function "#property#value"'
                 ),
-                'task_id': 'task2'
+                'task_id': 'task2',
+                'route': 0
             }
         ]
 
@@ -392,7 +396,8 @@ class OrquestaErrorHandlingTest(st2tests.ExecutionDbTestCase):
                     '\'<% ctx().msg2.value %>\'. NoFunctionRegisteredException: '
                     'Unknown function "#property#value"'
                 ),
-                'task_id': 'task2'
+                'task_id': 'task2',
+                'route': 0
             }
         ]
 
@@ -440,7 +445,8 @@ class OrquestaErrorHandlingTest(st2tests.ExecutionDbTestCase):
             {
                 'type': 'error',
                 'message': msg,
-                'task_id': 'task2'
+                'task_id': 'task2',
+                'route': 0
             }
         ]
 
@@ -531,8 +537,9 @@ class OrquestaErrorHandlingTest(st2tests.ExecutionDbTestCase):
                     "YaqlEvaluationException: Unable to resolve key 'foobar' in expression "
                     "'<% succeeded() and result().foobar %>' from context."
                 ),
-                'task_transition_id': 'task2__0',
-                'task_id': 'task1'
+                'task_transition_id': 'task2__t0',
+                'task_id': 'task1',
+                'route': 0
             }
         ]
 
@@ -576,8 +583,9 @@ class OrquestaErrorHandlingTest(st2tests.ExecutionDbTestCase):
                     '\'<% foobar() %>\'. NoFunctionRegisteredException: '
                     'Unknown function "foobar"'
                 ),
-                'task_transition_id': 'task2__0',
-                'task_id': 'task1'
+                'task_transition_id': 'task2__t0',
+                'task_id': 'task1',
+                'route': 0
             }
         ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cryptography==2.4.2
 eventlet==0.24.1
 flex==6.14.0
 git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper
-git+https://github.com/StackStorm/orquesta.git@fix-exec-graph#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@e6c07fda6851f0d860aa8aef99a67b5b2a0156ce#egg=orquesta
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
 gitpython==2.1.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cryptography==2.4.2
 eventlet==0.24.1
 flex==6.14.0
 git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper
-git+https://github.com/StackStorm/orquesta.git@v0.4#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@fix-exec-graph#egg=orquesta
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
 gitpython==2.1.11

--- a/st2actions/st2actions/workflows/workflows.py
+++ b/st2actions/st2actions/workflows/workflows.py
@@ -106,16 +106,10 @@ class WorkflowExecutionHandler(consumers.VariableMessageHandler):
 
         # Skip if task execution is already in completed state.
         if task_ex_db.status in states.COMPLETED_STATES:
-            LOG.info(
-                '[%s] Action execution "%s" for task "%s" is not processed because '
-                'task execution "%s" is already in completed state "%s".',
-                wf_ac_ex_id,
-                str(ac_ex_db.id),
-                task_ex_db.task_id,
-                str(task_ex_db.id),
-                task_ex_db.status
-            )
-
+            msg = ('[%s] Action execution "%s" for task "%s (%s)", route "%s", is not processed '
+                   'because task execution "%s" is already in completed state "%s".')
+            LOG.info(msg, wf_ac_ex_id, str(ac_ex_db.id), task_ex_db.task_id,
+                     str(task_ex_db.task_route), str(task_ex_db.id), task_ex_db.status)
             return
 
         # Process pending request on the action execution.

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -9,7 +9,7 @@ jsonschema
 kombu
 mongoengine
 networkx
-git+https://github.com/StackStorm/orquesta.git@fix-exec-graph#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@e6c07fda6851f0d860aa8aef99a67b5b2a0156ce#egg=orquesta
 oslo.config
 paramiko
 pyyaml

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -9,7 +9,7 @@ jsonschema
 kombu
 mongoengine
 networkx
-git+https://github.com/StackStorm/orquesta.git@v0.4#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@fix-exec-graph#egg=orquesta
 oslo.config
 paramiko
 pyyaml

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -4,7 +4,7 @@ apscheduler==3.5.3
 cryptography==2.4.2
 eventlet==0.24.1
 flex==6.14.0
-git+https://github.com/StackStorm/orquesta.git@fix-exec-graph#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@e6c07fda6851f0d860aa8aef99a67b5b2a0156ce#egg=orquesta
 greenlet==0.4.15
 ipaddr
 jinja2

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -4,7 +4,7 @@ apscheduler==3.5.3
 cryptography==2.4.2
 eventlet==0.24.1
 flex==6.14.0
-git+https://github.com/StackStorm/orquesta.git@v0.4#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@fix-exec-graph#egg=orquesta
 greenlet==0.4.15
 ipaddr
 jinja2

--- a/st2common/st2common/models/db/workflow.py
+++ b/st2common/st2common/models/db/workflow.py
@@ -62,6 +62,7 @@ class TaskExecutionDB(stormbase.StormFoundationDB, stormbase.ChangeRevisionField
     workflow_execution = me.StringField(required=True)
     task_name = me.StringField(required=True)
     task_id = me.StringField(required=True)
+    task_route = me.IntField(required=True, min_value=0)
     task_spec = stormbase.EscapedDictField()
     delay = me.IntField(min_value=0)
     itemized = me.BooleanField(default=False)
@@ -77,7 +78,9 @@ class TaskExecutionDB(stormbase.StormFoundationDB, stormbase.ChangeRevisionField
         'indexes': [
             {'fields': ['workflow_execution']},
             {'fields': ['task_id']},
-            {'fields': ['workflow_execution', 'task_id']}
+            {'fields': ['task_id', 'task_route']},
+            {'fields': ['workflow_execution', 'task_id']},
+            {'fields': ['workflow_execution', 'task_id', 'task_route']}
         ]
     }
 

--- a/st2common/tests/unit/services/test_workflow_cancellation.py
+++ b/st2common/tests/unit/services/test_workflow_cancellation.py
@@ -21,6 +21,9 @@ from orquesta import states as wf_lib_states
 
 import st2tests
 
+import st2tests.config as tests_config
+tests_config.parse_args()
+
 from st2common.bootstrap import actionsregistrar
 from st2common.bootstrap import runnersregistrar
 from st2common.models.db import liveaction as lv_db_models
@@ -94,8 +97,9 @@ class WorkflowExecutionCancellationTest(st2tests.WorkflowTestCase):
         wf_ex_db = self.prep_wf_ex(wf_ex_db)
 
         # Manually request task executions.
-        self.run_workflow_step(wf_ex_db, 'task1')
-        self.assert_task_running('task2')
+        task_route = 0
+        self.run_workflow_step(wf_ex_db, 'task1', task_route)
+        self.assert_task_running('task2', task_route)
 
         # Cancel the workflow when there is still active task(s).
         wf_ex_db = wf_svc.request_cancellation(ac_ex_db)
@@ -104,8 +108,8 @@ class WorkflowExecutionCancellationTest(st2tests.WorkflowTestCase):
         self.assertEqual(wf_ex_db.status, wf_lib_states.CANCELING)
 
         # Manually complete the task and ensure workflow is canceled.
-        self.run_workflow_step(wf_ex_db, 'task2')
-        self.assert_task_not_started('task3')
+        self.run_workflow_step(wf_ex_db, 'task2', task_route)
+        self.assert_task_not_started('task3', task_route)
         conductor, wf_ex_db = wf_svc.refresh_conductor(str(wf_ex_db.id))
         self.assertEqual(conductor.get_workflow_state(), wf_lib_states.CANCELED)
         self.assertEqual(wf_ex_db.status, wf_lib_states.CANCELED)

--- a/st2common/tests/unit/services/test_workflow_write_conflict.py
+++ b/st2common/tests/unit/services/test_workflow_write_conflict.py
@@ -23,6 +23,9 @@ from orquesta import states as wf_lib_states
 
 import st2tests
 
+import st2tests.config as tests_config
+tests_config.parse_args()
+
 from st2common.bootstrap import actionsregistrar
 from st2common.bootstrap import runnersregistrar
 from st2common.exceptions import db as db_exc
@@ -123,20 +126,21 @@ class WorkflowExecutionWriteConflictTest(st2tests.WorkflowTestCase):
         wf_ex_db = self.prep_wf_ex(wf_ex_db)
 
         # Manually request task executions.
-        self.run_workflow_step(wf_ex_db, 'task1')
-        self.assert_task_running('task2')
-        self.assert_task_running('task4')
-        self.run_workflow_step(wf_ex_db, 'task2')
-        self.assert_task_running('task3')
-        self.run_workflow_step(wf_ex_db, 'task4')
-        self.assert_task_running('task5')
-        self.run_workflow_step(wf_ex_db, 'task3')
-        self.assert_task_not_started('task6')
-        self.run_workflow_step(wf_ex_db, 'task5')
-        self.assert_task_running('task6')
-        self.run_workflow_step(wf_ex_db, 'task6')
-        self.assert_task_running('task7')
-        self.run_workflow_step(wf_ex_db, 'task7')
+        task_route = 0
+        self.run_workflow_step(wf_ex_db, 'task1', task_route)
+        self.assert_task_running('task2', task_route)
+        self.assert_task_running('task4', task_route)
+        self.run_workflow_step(wf_ex_db, 'task2', task_route)
+        self.assert_task_running('task3', task_route)
+        self.run_workflow_step(wf_ex_db, 'task4', task_route)
+        self.assert_task_running('task5', task_route)
+        self.run_workflow_step(wf_ex_db, 'task3', task_route)
+        self.assert_task_not_started('task6', task_route)
+        self.run_workflow_step(wf_ex_db, 'task5', task_route)
+        self.assert_task_running('task6', task_route)
+        self.run_workflow_step(wf_ex_db, 'task6', task_route)
+        self.assert_task_running('task7', task_route)
+        self.run_workflow_step(wf_ex_db, 'task7', task_route)
         self.assert_workflow_completed(str(wf_ex_db.id), state=wf_lib_states.SUCCEEDED)
 
         # Ensure retry happened.

--- a/st2common/tests/unit/test_db_task.py
+++ b/st2common/tests/unit/test_db_task.py
@@ -35,6 +35,7 @@ class TaskExecutionModelTest(st2tests.DbTestCase):
         initial.workflow_execution = uuid.uuid4().hex
         initial.task_name = 't1'
         initial.task_id = 't1'
+        initial.task_route = 0
         initial.task_spec = {'tasks': {'t1': 'some task'}}
         initial.delay = 180
         initial.status = 'requested'
@@ -50,6 +51,7 @@ class TaskExecutionModelTest(st2tests.DbTestCase):
         self.assertEqual(created.workflow_execution, retrieved.workflow_execution)
         self.assertEqual(created.task_name, retrieved.task_name)
         self.assertEqual(created.task_id, retrieved.task_id)
+        self.assertEqual(created.task_route, retrieved.task_route)
         self.assertDictEqual(created.task_spec, retrieved.task_spec)
         self.assertEqual(created.delay, retrieved.delay)
         self.assertFalse(created.itemized)
@@ -67,6 +69,7 @@ class TaskExecutionModelTest(st2tests.DbTestCase):
         self.assertEqual(updated.workflow_execution, retrieved.workflow_execution)
         self.assertEqual(updated.task_name, retrieved.task_name)
         self.assertEqual(updated.task_id, retrieved.task_id)
+        self.assertEqual(updated.task_route, retrieved.task_route)
         self.assertDictEqual(updated.task_spec, retrieved.task_spec)
         self.assertEqual(updated.delay, retrieved.delay)
         self.assertEqual(updated.itemized, retrieved.itemized)
@@ -86,6 +89,7 @@ class TaskExecutionModelTest(st2tests.DbTestCase):
         self.assertEqual(updated.workflow_execution, retrieved.workflow_execution)
         self.assertEqual(updated.task_name, retrieved.task_name)
         self.assertEqual(updated.task_id, retrieved.task_id)
+        self.assertEqual(updated.task_route, retrieved.task_route)
         self.assertDictEqual(updated.task_spec, retrieved.task_spec)
         self.assertEqual(updated.delay, retrieved.delay)
         self.assertEqual(updated.itemized, retrieved.itemized)
@@ -109,6 +113,7 @@ class TaskExecutionModelTest(st2tests.DbTestCase):
         initial.workflow_execution = uuid.uuid4().hex
         initial.task_name = 't1'
         initial.task_id = 't1'
+        initial.task_route = 0
         initial.task_spec = {'tasks': {'t1': 'some task'}}
         initial.delay = 180
         initial.itemized = True
@@ -125,6 +130,7 @@ class TaskExecutionModelTest(st2tests.DbTestCase):
         self.assertEqual(created.workflow_execution, retrieved.workflow_execution)
         self.assertEqual(created.task_name, retrieved.task_name)
         self.assertEqual(created.task_id, retrieved.task_id)
+        self.assertEqual(created.task_route, retrieved.task_route)
         self.assertDictEqual(created.task_spec, retrieved.task_spec)
         self.assertEqual(created.delay, retrieved.delay)
         self.assertTrue(created.itemized)
@@ -142,6 +148,7 @@ class TaskExecutionModelTest(st2tests.DbTestCase):
         self.assertEqual(updated.workflow_execution, retrieved.workflow_execution)
         self.assertEqual(updated.task_name, retrieved.task_name)
         self.assertEqual(updated.task_id, retrieved.task_id)
+        self.assertEqual(updated.task_route, retrieved.task_route)
         self.assertDictEqual(updated.task_spec, retrieved.task_spec)
         self.assertEqual(updated.delay, retrieved.delay)
         self.assertEqual(updated.itemized, retrieved.itemized)
@@ -161,6 +168,7 @@ class TaskExecutionModelTest(st2tests.DbTestCase):
         self.assertEqual(updated.workflow_execution, retrieved.workflow_execution)
         self.assertEqual(updated.task_name, retrieved.task_name)
         self.assertEqual(updated.task_id, retrieved.task_id)
+        self.assertEqual(updated.task_route, retrieved.task_route)
         self.assertDictEqual(updated.task_spec, retrieved.task_spec)
         self.assertEqual(updated.delay, retrieved.delay)
         self.assertEqual(updated.itemized, retrieved.itemized)
@@ -184,6 +192,7 @@ class TaskExecutionModelTest(st2tests.DbTestCase):
         initial.workflow_execution = uuid.uuid4().hex
         initial.task_name = 't1'
         initial.task_id = 't1'
+        initial.task_route = 0
         initial.task_spec = {'tasks': {'t1': 'some task'}}
         initial.delay = 180
         initial.status = 'requested'
@@ -207,6 +216,7 @@ class TaskExecutionModelTest(st2tests.DbTestCase):
         self.assertEqual(updated.workflow_execution, retrieved1.workflow_execution)
         self.assertEqual(updated.task_name, retrieved1.task_name)
         self.assertEqual(updated.task_id, retrieved1.task_id)
+        self.assertEqual(updated.task_route, retrieved1.task_route)
         self.assertDictEqual(updated.task_spec, retrieved1.task_spec)
         self.assertEqual(updated.delay, retrieved1.delay)
         self.assertEqual(updated.itemized, retrieved1.itemized)

--- a/st2tests/integration/orquesta/test_wiring_error_handling.py
+++ b/st2tests/integration/orquesta/test_wiring_error_handling.py
@@ -111,7 +111,8 @@ class ErrorHandlingTest(base.TestWorkflowExecution):
                     '\'<% ctx().name.value %>\'. NoFunctionRegisteredException: '
                     'Unknown function "#property#value"'
                 ),
-                'task_id': 'task1'
+                'task_id': 'task1',
+                'route': 0
             }
         ]
 
@@ -128,8 +129,9 @@ class ErrorHandlingTest(base.TestWorkflowExecution):
                     'YaqlEvaluationException: Unable to resolve key \'value\' '
                     'in expression \'<% succeeded() and result().value %>\' from context.'
                 ),
-                'task_transition_id': 'task2__0',
-                'task_id': 'task1'
+                'task_transition_id': 'task2__t0',
+                'task_id': 'task1',
+                'route': 0
             }
         ]
 
@@ -150,8 +152,9 @@ class ErrorHandlingTest(base.TestWorkflowExecution):
                     'YaqlEvaluationException: Unable to resolve key \'value\' '
                     'in expression \'<% result().value %>\' from context.'
                 ),
-                'task_transition_id': 'task2__0',
-                'task_id': 'task1'
+                'task_transition_id': 'task2__t0',
+                'task_id': 'task1',
+                'route': 0
             }
         ]
 

--- a/st2tests/integration/orquesta/test_wiring_functions_task.py
+++ b/st2tests/integration/orquesta/test_wiring_functions_task.py
@@ -27,8 +27,8 @@ class FunctionsWiringTest(base.TestWorkflowExecution):
 
         expected_output = {
             'last_task3_result': 'False',
-            'task7__1__parent': 'task6__1',
             'task7__2__parent': 'task6__2',
+            'task7__3__parent': 'task6__3',
             'that_task_by_name': 'task1',
             'this_task_by_name': 'task1',
             'this_task_no_arg': 'task1'
@@ -43,8 +43,8 @@ class FunctionsWiringTest(base.TestWorkflowExecution):
 
         expected_output = {
             'last_task3_result': 'False',
-            'task7__1__parent': 'task6__1',
             'task7__2__parent': 'task6__2',
+            'task7__3__parent': 'task6__3',
             'that_task_by_name': 'task1',
             'this_task_by_name': 'task1',
             'this_task_no_arg': 'task1'
@@ -67,8 +67,9 @@ class FunctionsWiringTest(base.TestWorkflowExecution):
                     '\'<% task("task0") %>\'. ExpressionEvaluationException: '
                     'Unable to find task execution for "task0".'
                 ),
-                'task_transition_id': 'noop__0',
-                'task_id': 'task1'
+                'task_transition_id': 'noop__t0',
+                'task_id': 'task1',
+                'route': 0
             }
         ]
 
@@ -94,8 +95,9 @@ class FunctionsWiringTest(base.TestWorkflowExecution):
                     '\'{{ task("task0") }}\'. ExpressionEvaluationException: '
                     'Unable to find task execution for "task0".'
                 ),
-                'task_transition_id': 'noop__0',
-                'task_id': 'task1'
+                'task_transition_id': 'noop__t0',
+                'task_id': 'task1',
+                'route': 0
             }
         ]
 

--- a/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/jinja-task-functions.yaml
+++ b/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/jinja-task-functions.yaml
@@ -29,9 +29,6 @@ tasks:
           - loop: False
         do: task3
       - when: '{{ ctx("loop") != true }}'
-        do: task4
-  task4:
-    action: core.noop
 
   # Test task function in a reuse (split).
   task4:
@@ -49,12 +46,12 @@ tasks:
   task7:
     action: core.echo
     input:
-      message: '{{ task("task6").task_id }}'
+      message: '{{ task("task6").task_id + "__" + task("task6").route|string }}'
 
 output:
   - this_task_no_arg: '{{ ctx("this_task_no_arg") }}'
   - this_task_by_name: '{{ ctx("this_task_by_name") }}'
   - that_task_by_name: '{{ task("task1").task_id }}'
   - last_task3_result: '{{ task("task3").result.stdout }}'
-  - task7__1__parent: '{{ task("task7__1").result.stdout }}'
-  - task7__2__parent: '{{ task("task7__2").result.stdout }}'
+  - task7__2__parent: '{{ task("task7", route=2).result.stdout }}'
+  - task7__3__parent: '{{ task("task7", route=3).result.stdout }}'

--- a/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/yaql-task-functions.yaml
+++ b/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/yaql-task-functions.yaml
@@ -46,12 +46,12 @@ tasks:
   task7:
     action: core.echo
     input:
-      message: '<% task("task6").task_id %>'
+      message: '<% task("task6").task_id + "__" + str(task("task6").route) %>'
 
 output:
   - this_task_no_arg: '<% ctx("this_task_no_arg") %>'
   - this_task_by_name: '<% ctx("this_task_by_name") %>'
   - that_task_by_name: '<% task("task1").task_id %>'
   - last_task3_result: '<% task("task3").result.stdout %>'
-  - task7__1__parent: '<% task("task7__1").result.stdout %>'
-  - task7__2__parent: '<% task("task7__2").result.stdout %>'
+  - task7__2__parent: '<% task("task7", route=>2).result.stdout %>'
+  - task7__3__parent: '<% task("task7", route=>3).result.stdout %>'


### PR DESCRIPTION
Refactor workflow engine and database to accommodate routing info. Add route to the task execution table and save the route info from the task execution requests from orquesta conductor. Pass route to orquesta conductor when updating task flow. Refactor the custom task function for YAQL and Jinja to identify the correct task and use the task and route info to query the database for the task result and other data.