### PR TITLE
Fix orquesta with items task stuck in running

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,8 @@ Fixed
 * Refactored orquesta execution graph to fix performance issue for workflows with many
   references to non-join tasks. st2workflowengine and DB models are refactored accordingly.
   (improvement) StackStorm/orquesta#122.
+* Fix orquesta workflow stuck in running status when one or more items failed execution for a
+  with items task. (bug fix) #4523
 
 2.10.2 - February 21, 2019
 --------------------------

--- a/contrib/examples/actions/orquesta-test-with-items-failure.yaml
+++ b/contrib/examples/actions/orquesta-test-with-items-failure.yaml
@@ -1,0 +1,6 @@
+---
+name: orquesta-test-with-items-failure
+description: A workflow for testing items failure.
+runner_type: orquesta
+entry_point: workflows/tests/orquesta-test-with-items-failure.yaml
+enabled: true

--- a/contrib/examples/actions/workflows/tests/orquesta-test-with-items-failure.yaml
+++ b/contrib/examples/actions/workflows/tests/orquesta-test-with-items-failure.yaml
@@ -1,0 +1,6 @@
+version: 1.0
+
+tasks:
+  task1:
+    with: <% range(0,10) %>
+    action: core.local cmd="exit $((<% item() %> % 2))"

--- a/contrib/runners/orquesta_runner/in-requirements.txt
+++ b/contrib/runners/orquesta_runner/in-requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/StackStorm/orquesta.git@e6c07fda6851f0d860aa8aef99a67b5b2a0156ce#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@5151f38877ac7d05d0576c183900f780a7556539#egg=orquesta

--- a/contrib/runners/orquesta_runner/requirements.txt
+++ b/contrib/runners/orquesta_runner/requirements.txt
@@ -1,2 +1,2 @@
 # Don't edit this file. It's generated automatically!
-git+https://github.com/StackStorm/orquesta.git@e6c07fda6851f0d860aa8aef99a67b5b2a0156ce#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@5151f38877ac7d05d0576c183900f780a7556539#egg=orquesta

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cryptography==2.4.2
 eventlet==0.24.1
 flex==6.14.0
 git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper
-git+https://github.com/StackStorm/orquesta.git@e6c07fda6851f0d860aa8aef99a67b5b2a0156ce#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@5151f38877ac7d05d0576c183900f780a7556539#egg=orquesta
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
 gitpython==2.1.11

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -9,7 +9,7 @@ jsonschema
 kombu
 mongoengine
 networkx
-git+https://github.com/StackStorm/orquesta.git@e6c07fda6851f0d860aa8aef99a67b5b2a0156ce#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@5151f38877ac7d05d0576c183900f780a7556539#egg=orquesta
 oslo.config
 paramiko
 pyyaml

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -4,7 +4,7 @@ apscheduler==3.5.3
 cryptography==2.4.2
 eventlet==0.24.1
 flex==6.14.0
-git+https://github.com/StackStorm/orquesta.git@e6c07fda6851f0d860aa8aef99a67b5b2a0156ce#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@5151f38877ac7d05d0576c183900f780a7556539#egg=orquesta
 greenlet==0.4.15
 ipaddr
 jinja2

--- a/st2tests/integration/orquesta/test_wiring_with_items.py
+++ b/st2tests/integration/orquesta/test_wiring_with_items.py
@@ -55,6 +55,16 @@ class WithItemsWiringTest(base.TestWorkflowExecution):
         self.assertEqual(ex.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
         self.assertDictEqual(ex.result, expected_result)
 
+    def test_with_items_failure(self):
+        wf_name = 'examples.orquesta-test-with-items-failure'
+
+        ex = self._execute_workflow(wf_name)
+        ex = self._wait_for_completion(ex)
+
+        self._wait_for_task(ex, 'task1', num_task_exs=10)
+
+        self.assertEqual(ex.status, ac_const.LIVEACTION_STATUS_FAILED)
+
     def test_with_items_concurrency(self):
         wf_name = 'examples.orquesta-test-with-items'
 

--- a/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/with-items-failure.yaml
+++ b/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/with-items-failure.yaml
@@ -1,0 +1,7 @@
+---
+name: with-items-failure
+description: A workflow demonstrating items failure.
+pack: orquesta_tests
+runner_type: orquesta
+entry_point: workflows/with-items-failure.yaml
+enabled: true

--- a/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/with-items-failure.yaml
+++ b/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/with-items-failure.yaml
@@ -1,0 +1,6 @@
+version: 1.0
+
+tasks:
+  task1:
+    with: <% range(0,10) %>
+    action: core.local cmd="exit $((<% item() %> % 2))"


### PR DESCRIPTION
When one or more items fail in a with items task in an orquesta workflow, the task will be stuck in running. This patch updates requirement to the commit with the fix. Unit and integration tests are also included to cover the test case. Fixes #4523.