### PR TITLE
Fix improper CORS return

### DIFF
--- a/st2api/tests/unit/controllers/v1/test_base.py
+++ b/st2api/tests/unit/controllers/v1/test_base.py
@@ -51,8 +51,8 @@ class TestBase(FunctionalTest):
             'origin': 'http://xss'
         })
         self.assertEqual(response.status_int, 200)
-        self.assertEqual(response.headers['Access-Control-Allow-Origin'],
-                         'null')
+        self.assertEqual(response.headers.get('Access-Control-Allow-Origin'),
+                        'http://127.0.0.1:3000')
 
     def test_wildcard_origin(self):
         try:

--- a/st2common/st2common/middleware/cors.py
+++ b/st2common/st2common/middleware/cors.py
@@ -66,7 +66,7 @@ class CorsMiddleware(object):
                     origin_allowed = origin
                 else:
                     # See http://www.w3.org/TR/cors/#access-control-allow-origin-response-header
-                    origin_allowed = origin if origin in origins else 'null'
+                    origin_allowed = origin if origin in origins else list(origins)[0]
             else:
                 origin_allowed = list(origins)[0]
 


### PR DESCRIPTION
Prior to this commit if you sent a request from an origin not listed in `allowed_origins` we would respond with `null` for the `Access-Control-Allow-Origin` header. Per [mozilla's documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#Directives) `null` should not be used as some clients will allow the request to go through. This PR returns the first of our allowed origins if the requesting origin is not a supported origin.