### PR TITLE
Fix random failing orquesta unit tests

### DIFF
--- a/contrib/examples/actions/workflows/tests/orquesta-test-jinja-task-functions.yaml
+++ b/contrib/examples/actions/workflows/tests/orquesta-test-jinja-task-functions.yaml
@@ -13,13 +13,16 @@ tasks:
       - publish:
           - this_task_no_arg: '{{ task().task_id }}'
           - this_task_by_name: '{{ task("task1").task_id }}'
-
-  # Test task function in a cycle.
+        do: task2
   task2:
     action: core.noop
-    next:
-      - do: task3
+
+  # Test task function in a cycle.
   task3:
+    action: core.noop
+    next:
+      - do: task4
+  task4:
     action: core.local
     input:
       cmd: 'echo "{{ ctx("loop") }}"; sleep 1'
@@ -27,31 +30,34 @@ tasks:
       - when: '{{ ctx("loop") == true }}'
         publish:
           - loop: False
-        do: task3
+        do: task4
       - when: '{{ ctx("loop") != true }}'
-
-  # Test task function in a reuse (split).
-  task4:
-    action: core.noop
-    next:
-      - do: task6
+        do: task5
   task5:
     action: core.noop
-    next:
-      - do: task6
+
+  # Test task function in a reuse (split).
   task6:
     action: core.noop
     next:
-      - do: task7
+      - do: task8
   task7:
+    action: core.noop
+    next:
+      - do: task8
+  task8:
+    action: core.noop
+    next:
+      - do: task9
+  task9:
     action: core.echo
     input:
-      message: '{{ task("task6").task_id + "__" + task("task6").route|string }}'
+      message: '{{ task("task8").task_id + "__" + task("task8").route|string }}'
 
 output:
   - this_task_no_arg: '{{ ctx("this_task_no_arg") }}'
   - this_task_by_name: '{{ ctx("this_task_by_name") }}'
   - that_task_by_name: '{{ task("task1").task_id }}'
-  - last_task3_result: '{{ task("task3").result.stdout }}'
-  - task7__2__parent: '{{ task("task7", route=2).result.stdout }}'
-  - task7__3__parent: '{{ task("task7", route=3).result.stdout }}'
+  - last_task4_result: '{{ task("task4").result.stdout }}'
+  - task9__1__parent: '{{ task("task9", route=1).result.stdout }}'
+  - task9__2__parent: '{{ task("task9", route=2).result.stdout }}'

--- a/contrib/examples/actions/workflows/tests/orquesta-test-yaql-task-functions.yaml
+++ b/contrib/examples/actions/workflows/tests/orquesta-test-yaql-task-functions.yaml
@@ -13,13 +13,16 @@ tasks:
       - publish:
           - this_task_no_arg: '<% task().task_id %>'
           - this_task_by_name: '<% task("task1").task_id %>'
-
-  # Test task function in a cycle.
+        do: task2
   task2:
     action: core.noop
-    next:
-      - do: task3
+
+  # Test task function in a cycle.
   task3:
+    action: core.noop
+    next:
+      - do: task4
+  task4:
     action: core.local
     input:
       cmd: 'echo "<% ctx("loop") %>"; sleep 1'
@@ -27,31 +30,34 @@ tasks:
       - when: '<% ctx("loop") = true %>'
         publish:
           - loop: False
-        do: task3
+        do: task4
       - when: '<% ctx("loop") != true %>'
-
-  # Test task function in a reuse (split).
-  task4:
-    action: core.noop
-    next:
-      - do: task6
+        do: task5
   task5:
     action: core.noop
-    next:
-      - do: task6
+
+  # Test task function in a reuse (split).
   task6:
     action: core.noop
     next:
-      - do: task7
+      - do: task8
   task7:
+    action: core.noop
+    next:
+      - do: task8
+  task8:
+    action: core.noop
+    next:
+      - do: task9
+  task9:
     action: core.echo
     input:
-      message: '<% task("task6").task_id + "__" + str(task("task6").route) %>'
+      message: '<% task("task8").task_id + "__" + str(task("task8").route) %>'
 
 output:
   - this_task_no_arg: '<% ctx("this_task_no_arg") %>'
   - this_task_by_name: '<% ctx("this_task_by_name") %>'
   - that_task_by_name: '<% task("task1").task_id %>'
-  - last_task3_result: '<% task("task3").result.stdout %>'
-  - task7__2__parent: '<% task("task7", route=>2).result.stdout %>'
-  - task7__3__parent: '<% task("task7", route=>3).result.stdout %>'
+  - last_task4_result: '<% task("task4").result.stdout %>'
+  - task9__1__parent: '<% task("task9", route=>1).result.stdout %>'
+  - task9__2__parent: '<% task("task9", route=>2).result.stdout %>'

--- a/contrib/runners/orquesta_runner/tests/unit/test_functions_task.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_functions_task.py
@@ -147,21 +147,23 @@ class OrquestaFunctionTest(st2tests.ExecutionDbTestCase):
 
         expected_task_sequence = [
             ('task1', 0),
+            ('task3', 0),
+            ('task6', 0),
+            ('task7', 0),
             ('task2', 0),
             ('task4', 0),
-            ('task5', 0),
-            ('task3', 0),
-            ('task6', 2),
-            ('task6', 3),
-            ('task3', 0),
-            ('task7', 2),
-            ('task7', 3)
+            ('task8', 1),
+            ('task8', 2),
+            ('task4', 0),
+            ('task9', 1),
+            ('task9', 2),
+            ('task5', 0)
         ]
 
         expected_output = {
-            'last_task3_result': 'False',
-            'task7__2__parent': 'task6__2',
-            'task7__3__parent': 'task6__3',
+            'last_task4_result': 'False',
+            'task9__1__parent': 'task8__1',
+            'task9__2__parent': 'task8__2',
             'that_task_by_name': 'task1',
             'this_task_by_name': 'task1',
             'this_task_no_arg': 'task1'
@@ -174,21 +176,23 @@ class OrquestaFunctionTest(st2tests.ExecutionDbTestCase):
 
         expected_task_sequence = [
             ('task1', 0),
+            ('task3', 0),
+            ('task6', 0),
+            ('task7', 0),
             ('task2', 0),
             ('task4', 0),
-            ('task5', 0),
-            ('task3', 0),
-            ('task6', 2),
-            ('task6', 3),
-            ('task3', 0),
-            ('task7', 2),
-            ('task7', 3)
+            ('task8', 1),
+            ('task8', 2),
+            ('task4', 0),
+            ('task9', 1),
+            ('task9', 2),
+            ('task5', 0)
         ]
 
         expected_output = {
-            'last_task3_result': 'False',
-            'task7__2__parent': 'task6__2',
-            'task7__3__parent': 'task6__3',
+            'last_task4_result': 'False',
+            'task9__1__parent': 'task8__1',
+            'task9__2__parent': 'task8__2',
             'that_task_by_name': 'task1',
             'this_task_by_name': 'task1',
             'this_task_no_arg': 'task1'

--- a/st2tests/integration/orquesta/test_wiring_functions_task.py
+++ b/st2tests/integration/orquesta/test_wiring_functions_task.py
@@ -26,9 +26,9 @@ class FunctionsWiringTest(base.TestWorkflowExecution):
         wf_name = 'examples.orquesta-test-yaql-task-functions'
 
         expected_output = {
-            'last_task3_result': 'False',
-            'task7__2__parent': 'task6__2',
-            'task7__3__parent': 'task6__3',
+            'last_task4_result': 'False',
+            'task9__1__parent': 'task8__1',
+            'task9__2__parent': 'task8__2',
             'that_task_by_name': 'task1',
             'this_task_by_name': 'task1',
             'this_task_no_arg': 'task1'
@@ -42,9 +42,9 @@ class FunctionsWiringTest(base.TestWorkflowExecution):
         wf_name = 'examples.orquesta-test-jinja-task-functions'
 
         expected_output = {
-            'last_task3_result': 'False',
-            'task7__2__parent': 'task6__2',
-            'task7__3__parent': 'task6__3',
+            'last_task4_result': 'False',
+            'task9__1__parent': 'task8__1',
+            'task9__2__parent': 'task8__2',
             'that_task_by_name': 'task1',
             'this_task_by_name': 'task1',
             'this_task_no_arg': 'task1'

--- a/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/jinja-task-functions.yaml
+++ b/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/jinja-task-functions.yaml
@@ -13,13 +13,16 @@ tasks:
       - publish:
           - this_task_no_arg: '{{ task().task_id }}'
           - this_task_by_name: '{{ task("task1").task_id }}'
-
-  # Test task function in a cycle.
+        do: task2
   task2:
     action: core.noop
-    next:
-      - do: task3
+
+  # Test task function in a cycle.
   task3:
+    action: core.noop
+    next:
+      - do: task4
+  task4:
     action: core.local
     input:
       cmd: 'echo "{{ ctx("loop") }}"; sleep 1'
@@ -27,31 +30,34 @@ tasks:
       - when: '{{ ctx("loop") == true }}'
         publish:
           - loop: False
-        do: task3
+        do: task4
       - when: '{{ ctx("loop") != true }}'
-
-  # Test task function in a reuse (split).
-  task4:
-    action: core.noop
-    next:
-      - do: task6
+        do: task5
   task5:
     action: core.noop
-    next:
-      - do: task6
+
+  # Test task function in a reuse (split).
   task6:
     action: core.noop
     next:
-      - do: task7
+      - do: task8
   task7:
+    action: core.noop
+    next:
+      - do: task8
+  task8:
+    action: core.noop
+    next:
+      - do: task9
+  task9:
     action: core.echo
     input:
-      message: '{{ task("task6").task_id + "__" + task("task6").route|string }}'
+      message: '{{ task("task8").task_id + "__" + task("task8").route|string }}'
 
 output:
   - this_task_no_arg: '{{ ctx("this_task_no_arg") }}'
   - this_task_by_name: '{{ ctx("this_task_by_name") }}'
   - that_task_by_name: '{{ task("task1").task_id }}'
-  - last_task3_result: '{{ task("task3").result.stdout }}'
-  - task7__2__parent: '{{ task("task7", route=2).result.stdout }}'
-  - task7__3__parent: '{{ task("task7", route=3).result.stdout }}'
+  - last_task4_result: '{{ task("task4").result.stdout }}'
+  - task9__1__parent: '{{ task("task9", route=1).result.stdout }}'
+  - task9__2__parent: '{{ task("task9", route=2).result.stdout }}'

--- a/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/yaql-task-functions.yaml
+++ b/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/yaql-task-functions.yaml
@@ -13,13 +13,16 @@ tasks:
       - publish:
           - this_task_no_arg: '<% task().task_id %>'
           - this_task_by_name: '<% task("task1").task_id %>'
-
-  # Test task function in a cycle.
+        do: task2
   task2:
     action: core.noop
-    next:
-      - do: task3
+
+  # Test task function in a cycle.
   task3:
+    action: core.noop
+    next:
+      - do: task4
+  task4:
     action: core.local
     input:
       cmd: 'echo "<% ctx("loop") %>"; sleep 1'
@@ -27,31 +30,34 @@ tasks:
       - when: '<% ctx("loop") = true %>'
         publish:
           - loop: False
-        do: task3
+        do: task4
       - when: '<% ctx("loop") != true %>'
-
-  # Test task function in a reuse (split).
-  task4:
-    action: core.noop
-    next:
-      - do: task6
+        do: task5
   task5:
     action: core.noop
-    next:
-      - do: task6
+
+  # Test task function in a reuse (split).
   task6:
     action: core.noop
     next:
-      - do: task7
+      - do: task8
   task7:
+    action: core.noop
+    next:
+      - do: task8
+  task8:
+    action: core.noop
+    next:
+      - do: task9
+  task9:
     action: core.echo
     input:
-      message: '<% task("task6").task_id + "__" + str(task("task6").route) %>'
+      message: '<% task("task8").task_id + "__" + str(task("task8").route) %>'
 
 output:
   - this_task_no_arg: '<% ctx("this_task_no_arg") %>'
   - this_task_by_name: '<% ctx("this_task_by_name") %>'
   - that_task_by_name: '<% task("task1").task_id %>'
-  - last_task3_result: '<% task("task3").result.stdout %>'
-  - task7__2__parent: '<% task("task7", route=>2).result.stdout %>'
-  - task7__3__parent: '<% task("task7", route=>3).result.stdout %>'
+  - last_task4_result: '<% task("task4").result.stdout %>'
+  - task9__1__parent: '<% task("task9", route=>1).result.stdout %>'
+  - task9__2__parent: '<% task("task9", route=>2).result.stdout %>'


### PR DESCRIPTION
The task function related unit tests are randomly failing because the route ID changes depending on the order of action execution. The workflows are rewritten to be more deterministic.