### PR TITLE
Add cache control header

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,9 @@ Added
    For backward compatibility reasons, if pack metadata file doesn't contain that attribute, it's
    assumed it only works with Python 2. (new feature) #4474
 
+* Adding ``Cache-Control`` header to all API responses so clients will favor
+  refresh from API instead of using cached version.
+
 Changed
 ~~~~~~~
 

--- a/st2api/st2api/app.py
+++ b/st2api/st2api/app.py
@@ -20,6 +20,7 @@ from st2common import log as logging
 from st2common.middleware.streaming import StreamingMiddleware
 from st2common.middleware.error_handling import ErrorHandlingMiddleware
 from st2common.middleware.cors import CorsMiddleware
+from st2common.middleware.cache import CacheMiddleware
 from st2common.middleware.request_id import RequestIDMiddleware
 from st2common.middleware.logging import LoggingMiddleware
 from st2common.middleware.instrumentation import RequestInstrumentationMiddleware
@@ -76,6 +77,7 @@ def setup_app(config={}):
     app = StreamingMiddleware(app, path_whitelist=['/v1/executions/*/output*'])
     app = ErrorHandlingMiddleware(app)
     app = CorsMiddleware(app)
+    app = CacheMiddleware(app)
     app = LoggingMiddleware(app, router)
     app = ResponseInstrumentationMiddleware(app, router, service_name='api')
     app = RequestIDMiddleware(app)

--- a/st2api/tests/unit/controllers/v1/test_base.py
+++ b/st2api/tests/unit/controllers/v1/test_base.py
@@ -16,6 +16,8 @@
 from oslo_config import cfg
 from tests import FunctionalTest
 
+from st2common.constants.api import CACHE_CONTROL_HEADER
+
 
 class TestBase(FunctionalTest):
     def test_defaults(self):
@@ -93,3 +95,11 @@ class TestBase(FunctionalTest):
         resp = self.app.get('/v1/executions/577f775b0640fd1451f2030b/re_run/a/b',
                             expect_errors=True)
         self.assertEqual(resp.status_int, 404)
+
+    def test_cache_control_present(self):
+        resp = self.app.options('/v1/executions/')
+        self.assertEqual(resp.status_int, 200)
+
+        self.assertIsInstance(CACHE_CONTROL_HEADER, str)
+        self.assertEqual(resp.headers['Cache-Control'],
+                         CACHE_CONTROL_HEADER)

--- a/st2common/st2common/constants/api.py
+++ b/st2common/st2common/constants/api.py
@@ -21,3 +21,5 @@ __all__ = [
 DEFAULT_API_VERSION = 'v1'
 
 REQUEST_ID_HEADER = 'X-Request-ID'
+
+CACHE_CONTROL_HEADER = 'no-cache'

--- a/st2common/st2common/middleware/cache.py
+++ b/st2common/st2common/middleware/cache.py
@@ -1,0 +1,32 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from webob.headers import ResponseHeaders
+
+
+class CacheMiddleware(object):
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        def custom_start_response(status, headers, exc_info=None):
+            headers = ResponseHeaders(headers)
+
+            headers['Cache-Control'] = 'no-cache'
+
+            return start_response(status, headers._items, exc_info)
+
+        return self.app(environ, custom_start_response)

--- a/st2common/st2common/middleware/cache.py
+++ b/st2common/st2common/middleware/cache.py
@@ -16,6 +16,8 @@
 from __future__ import absolute_import
 from webob.headers import ResponseHeaders
 
+from st2common.constants.api import CACHE_CONTROL_HEADER
+
 
 class CacheMiddleware(object):
     def __init__(self, app):
@@ -25,7 +27,7 @@ class CacheMiddleware(object):
         def custom_start_response(status, headers, exc_info=None):
             headers = ResponseHeaders(headers)
 
-            headers['Cache-Control'] = 'no-cache'
+            headers['Cache-Control'] = CACHE_CONTROL_HEADER
 
             return start_response(status, headers._items, exc_info)
 


### PR DESCRIPTION
This PR adds cache control header so that clients will always refresh their data from the API instead of favoring cached version. This was encountered in ST2Flow 2.0 development, loading workflows from the API.