### PR TITLE
Fix regression with generic action notify trigger in notifier service

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,13 +30,13 @@ Changed
   to make it easier for developers to understand. (improvement)
 * Update Python runner code so it prioritizes libraries from pack virtual environment over StackStorm
   system dependencies.
-  
+
   For example, if pack depends on ``six==1.11.0`` in pack ``requirements.txt``, but StackStorm depends
   on ``six==1.10.0``, ``six==1.11.0`` will be used when running Python actions from that pack.
-  
+
   Keep in mind that will not work correctly if pack depends on a library which brakes functionality used
   by Python action wrapper code.
-  
+
   Contributed by Hiroyasu OHYAMA (@userlocalhost). #4571
 
 Fixed
@@ -49,6 +49,11 @@ Fixed
   with items task. (bug fix) #4523
 * Fix orquesta workflow bug where context variables are being overwritten on task join.
   (bug fix) StackStorm/orquesta#112
+* Fix inadvertent regression in notifier service which would cause generic action trigger to only
+  be dispatched for completed states even if custom states were specified using
+  ``action_sensor.emit_when`` config option. (bug fix)
+
+  Reported by Shu Sugimoto (@shusugmt). #4591
 
 2.10.3 - March 06, 2019
 -----------------------
@@ -60,7 +65,7 @@ Fixed
   with ``null`` for the ``Access-Control-Allow-Origin`` header. The fix returns the first of our
   allowed origins if the requesting origin is not a supported origin. Reported by Barak Tawily.
   (bug fix)
-  
+
 2.9.3 - March 06, 2019
 -----------------------
 
@@ -134,7 +139,7 @@ Fixed
   Reported by @johandahlberg (bug fix) #4533
 * Fix ``core.sendmail`` action so it specifies ``charset=UTF-8`` in the ``Content-Type`` email
   header. This way it works correctly when an email subject and / or body contains unicode data.
- 
+
   Reported by @johandahlberg (bug fix) #4533 4534
 
 * Fix CLI ``st2 apikey load`` not being idempotent and API endpoint ``/api/v1/apikeys`` not

--- a/st2actions/st2actions/notifier/notifier.py
+++ b/st2actions/st2actions/notifier/notifier.py
@@ -97,10 +97,10 @@ class Notifier(consumers.MessageHandler):
                     self._post_notify_triggers(liveaction_db=liveaction_db,
                                                execution_db=execution_db)
 
-            if cfg.CONF.action_sensor.enable:
-                with CounterWithTimer(key='notifier.generic_trigger.post'):
-                    self._post_generic_trigger(liveaction_db=liveaction_db,
-                                               execution_db=execution_db)
+        if cfg.CONF.action_sensor.enable:
+            with CounterWithTimer(key='notifier.generic_trigger.post'):
+                self._post_generic_trigger(liveaction_db=liveaction_db,
+                                           execution_db=execution_db)
 
     def _get_execution_for_liveaction(self, liveaction):
         execution = ActionExecution.get(liveaction__id=str(liveaction.id))


### PR DESCRIPTION
Change in #4536 inadvertently introduced a regression inside notifier service which would cause generic action notify trigger to only be dispatched for completed states even if custom states were specified using ``action_sensor.emit_when`` config option.

Tests didn't catch this issue, because we only had tests for ``_post_generic_trigger`` method, but not for main ``process()`` one where the issue lived.

Thanks to Shu Sugimoto (@shusugmt) for reporting this issue.