### PR TITLE
Acquire lock in workflow engine before handling action execution completion

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,6 +49,9 @@ Fixed
   items task. (bug fix) #4523
 * Fix orquesta workflow bug where context variables are being overwritten on task join. (bug fix)
   StackStorm/orquesta#112
+* Fix orquesta with items task performance issue. Workflow runtime increase significantly when a
+  with items task has many items and result in many retries on write conflicts. A distributed lock
+  is acquired before write operations to avoid write conflicts. (bug fix) Stackstorm/orquesta#125
 * Fix inadvertent regression in notifier service which would cause generic action trigger to only
   be dispatched for completed states even if custom states were specified using
   ``action_sensor.emit_when`` config option. (bug fix)

--- a/contrib/examples/actions/orquesta-with-items-concurrency.yaml
+++ b/contrib/examples/actions/orquesta-with-items-concurrency.yaml
@@ -12,3 +12,5 @@ parameters:
       - Lakshmi
       - Lindsay
       - Tomaz
+  concurrency:
+    type: integer

--- a/contrib/examples/actions/workflows/orquesta-with-items-concurrency.yaml
+++ b/contrib/examples/actions/workflows/orquesta-with-items-concurrency.yaml
@@ -4,12 +4,13 @@ description: A workflow demonstrating with items and concurrent processing.
 
 input:
   - members
+  - concurrency: 2
 
 tasks:
   task1:
     with:
       items: <% ctx(members) %>
-      concurrency: 2
+      concurrency: <% ctx(concurrency) %>
     action: core.echo message="<% item() %>, resistance is futile!"
 
 output:

--- a/st2common/st2common/services/workflows.py
+++ b/st2common/st2common/services/workflows.py
@@ -40,6 +40,7 @@ from st2common.persistence import execution as ex_db_access
 from st2common.persistence import workflow as wf_db_access
 from st2common.runners import utils as runners_utils
 from st2common.services import action as ac_svc
+from st2common.services import coordination as coord_svc
 from st2common.services import executions as ex_svc
 from st2common.util import action_db as action_utils
 from st2common.util import date as date_utils
@@ -722,36 +723,38 @@ def handle_action_execution_completion(ac_ex_db):
     wf_ex_id = ac_ex_db.context['orquesta']['workflow_execution_id']
     task_ex_id = ac_ex_db.context['orquesta']['task_execution_id']
 
-    # Get execution records for logging purposes.
-    wf_ex_db = wf_db_access.WorkflowExecution.get_by_id(wf_ex_id)
-    task_ex_db = wf_db_access.TaskExecution.get_by_id(task_ex_id)
+    # Acquire lock before write operations.
+    with coord_svc.get_coordinator().get_lock(wf_ex_id):
+        # Get execution records for logging purposes.
+        wf_ex_db = wf_db_access.WorkflowExecution.get_by_id(wf_ex_id)
+        task_ex_db = wf_db_access.TaskExecution.get_by_id(task_ex_id)
 
-    msg = ('[%s] Handling completion of action execution "%s" '
-           'in status "%s" for task "%s", route "%s".')
-    LOG.info(msg, wf_ex_db.action_execution, str(ac_ex_db.id), ac_ex_db.status,
-             task_ex_db.task_id, str(task_ex_db.task_route))
+        msg = ('[%s] Handling completion of action execution "%s" '
+               'in status "%s" for task "%s", route "%s".')
+        LOG.info(msg, wf_ex_db.action_execution, str(ac_ex_db.id), ac_ex_db.status,
+                 task_ex_db.task_id, str(task_ex_db.task_route))
 
-    # If task is currently paused and the action execution is skipped to
-    # completion, then transition task status to running first.
-    if task_ex_db.status == ac_const.LIVEACTION_STATUS_PAUSED:
-        resume_task_execution(task_ex_id)
+        # If task is currently paused and the action execution is skipped to
+        # completion, then transition task status to running first.
+        if task_ex_db.status == ac_const.LIVEACTION_STATUS_PAUSED:
+            resume_task_execution(task_ex_id)
 
-    # Update task execution if completed.
-    update_task_execution(task_ex_id, ac_ex_db.status, ac_ex_db.result, ac_ex_db.context)
+        # Update task execution if completed.
+        update_task_execution(task_ex_id, ac_ex_db.status, ac_ex_db.result, ac_ex_db.context)
 
-    # Update task flow in the workflow execution.
-    update_task_state(
-        task_ex_id,
-        ac_ex_db.status,
-        ac_ex_result=ac_ex_db.result,
-        ac_ex_ctx=ac_ex_db.context.get('orquesta')
-    )
+        # Update task flow in the workflow execution.
+        update_task_state(
+            task_ex_id,
+            ac_ex_db.status,
+            ac_ex_result=ac_ex_db.result,
+            ac_ex_ctx=ac_ex_db.context.get('orquesta')
+        )
 
-    # Request the next set of tasks if workflow execution is not complete.
-    request_next_tasks(wf_ex_db, task_ex_id=task_ex_id)
+        # Request the next set of tasks if workflow execution is not complete.
+        request_next_tasks(wf_ex_db, task_ex_id=task_ex_id)
 
-    # Update workflow execution if completed.
-    update_workflow_execution(wf_ex_id)
+        # Update workflow execution if completed.
+        update_workflow_execution(wf_ex_id)
 
 
 def deserialize_conductor(wf_ex_db):

--- a/st2tests/integration/orquesta/test_performance.py
+++ b/st2tests/integration/orquesta/test_performance.py
@@ -42,3 +42,21 @@ class WiringTest(base.TestWorkflowExecution):
             self.assertEqual(e.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
             self.assertIn('output', e.result)
             self.assertIn('vm_id', e.result['output'])
+
+    def test_with_items_load(self):
+        wf_name = 'examples.orquesta-with-items-concurrency'
+
+        num_items = 10
+        concurrency = 10
+        members = [str(i).zfill(5) for i in range(0, num_items)]
+        wf_input = {'members': members, 'concurrency': concurrency}
+
+        message = '%s, resistance is futile!'
+        expected_output = {'items': [message % i for i in members]}
+        expected_result = {'output': expected_output}
+
+        ex = self._execute_workflow(wf_name, wf_input)
+        ex = self._wait_for_completion(ex)
+
+        self.assertEqual(ex.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertDictEqual(ex.result, expected_result)


### PR DESCRIPTION
Acquire a distributed lock, keyed on workflow execution ID, in the workflow engine before handling the action execution completion. This avoids the performance hits from retrying write conflicts for workflows with a lot of parallelism such as a with items task with many items and no concurrency. The coordination service in st2 needs to be setup for the solution to take into effect.