### PR TITLE
Fix default config file location for some services

### DIFF
--- a/st2actions/st2actions/config.py
+++ b/st2actions/st2actions/config.py
@@ -22,12 +22,14 @@ from oslo_config import cfg
 
 import st2common.config as common_config
 from st2common.constants.system import VERSION_STRING
+from st2common.constants.system import DEFAULT_CONFIG_FILE_PATH
 
 CONF = cfg.CONF
 
 
 def parse_args(args=None):
-    CONF(args=args, version=VERSION_STRING)
+    CONF(args=args, version=VERSION_STRING,
+         default_config_files=[DEFAULT_CONFIG_FILE_PATH])
 
 
 def register_opts():

--- a/st2actions/st2actions/scheduler/config.py
+++ b/st2actions/st2actions/scheduler/config.py
@@ -19,6 +19,7 @@ from oslo_config import cfg
 
 from st2common import config as common_config
 from st2common.constants import system as sys_constants
+from st2common.constants.system import DEFAULT_CONFIG_FILE_PATH
 from st2common import log as logging
 
 
@@ -26,7 +27,8 @@ LOG = logging.getLogger(__name__)
 
 
 def parse_args(args=None):
-    cfg.CONF(args=args, version=sys_constants.VERSION_STRING)
+    cfg.CONF(args=args, version=sys_constants.VERSION_STRING,
+             default_config_files=[DEFAULT_CONFIG_FILE_PATH])
 
 
 def register_opts():

--- a/st2actions/st2actions/workflows/config.py
+++ b/st2actions/st2actions/workflows/config.py
@@ -19,10 +19,12 @@ from oslo_config import cfg
 
 from st2common import config as common_config
 from st2common.constants import system as sys_constants
+from st2common.constants.system import DEFAULT_CONFIG_FILE_PATH
 
 
 def parse_args(args=None):
-    cfg.CONF(args=args, version=sys_constants.VERSION_STRING)
+    cfg.CONF(args=args, version=sys_constants.VERSION_STRING,
+             default_config_files=[DEFAULT_CONFIG_FILE_PATH])
 
 
 def register_opts():


### PR DESCRIPTION
Some services (``st2actionrunner``, ``st2scheduler``, ``st2workflowengine``) didn't specify a default path to the config file (``/etc/st2/st2.conf``) so they would fail to start (e.g. in a dev environment) if ``--config-file`` argument was not explicitly provided.

Other services already correctly handle that.

This pull request fixes that.

Related to #4111.