### PR TITLE
Treat any statsd metric driver related errors as non-fatal (just log the errors)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -63,6 +63,13 @@ Fixed
   (bug fix) #4570
 * Add missing default config location (``/etc/st2/st2.conf``) to the following services:
   ``st2actionrunner``, ``st2scheduler``, ``st2workflowengine``. (bug fix) #4596
+* Update statsd metrics driver so any exception thrown by statsd library is treated as non fatal.
+
+  Previously there was an edge case if user used a hostname instead of an IP address for metrics
+  backend server address. In such scenario, if hostname DNS resolution failed, statsd driver would
+  throw the exception which would propagate all the way up and break the application. (bug fix) #4597
+
+  Reported by Chris McKenzie.
 
 2.10.3 - March 06, 2019
 -----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,6 +56,8 @@ Fixed
 * Make sure we don't log auth token and api key inside st2api log file if those values are provided
   via query parameter and not header (``?x-auth-token=foo``, ``?st2-api-key=bar``). (bug fix) #4592
   #4589
+* Add missing default config location (``/etc/st2/st2.conf``) to the following services:
+  ``st2actionrunner``, ``st2scheduler``, ``st2workflowengine``. (bug fix) #4596
 
 2.10.3 - March 06, 2019
 -----------------------

--- a/st2common/st2common/metrics/drivers/statsd_driver.py
+++ b/st2common/st2common/metrics/drivers/statsd_driver.py
@@ -32,6 +32,8 @@ LOG = logging.getLogger(__name__)
 # Which exceptions thrown by statsd library should be considered as non-fatal
 NON_FATAL_EXC_CLASSES = [
     socket.error,
+    IOError,
+    OSError
 ]
 
 __all__ = [

--- a/st2common/st2common/metrics/drivers/statsd_driver.py
+++ b/st2common/st2common/metrics/drivers/statsd_driver.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import socket
 import logging as stdlib_logging
 from numbers import Number
 
@@ -28,6 +29,11 @@ from st2common.util.misc import ignore_and_log_exception
 
 LOG = logging.getLogger(__name__)
 
+# Which exceptions thrown by statsd library should be considered as non-fatal
+NON_FATAL_EXC_CLASSES = [
+    socket.error,
+]
+
 __all__ = [
     'StatsdDriver'
 ]
@@ -38,18 +44,20 @@ class StatsdDriver(BaseMetricsDriver):
     StatsD Implementation of the metrics driver
 
     NOTE: Statsd uses UDP which is "fire and forget" and any kind of send error is not fatal. There
-    is an issue with python-statsd library though which doesn't ignore DNS resolution related error
+    is an issue with python-statsd library though which doesn't ignore DNS resolution related errors
     and bubbles them all the way up.
 
     This of course breaks the application. Any kind of metric related errors should be considered
-    as non-fatal and not degrade application in any way if an error occurs and that's why we wrap
-    all the statsd library calls here to ignore the errors and just log them.
+    as non-fatal and not degrade application in any way if an error occurs. That's why we wrap all
+    the statsd library calls here to ignore the errors and just log them.
     """
+
     def __init__(self):
         statsd.Connection.set_defaults(host=cfg.CONF.metrics.host, port=cfg.CONF.metrics.port,
                                        sample_rate=cfg.CONF.metrics.sample_rate)
 
-    @ignore_and_log_exception(logger=LOG, level=stdlib_logging.WARNING)
+    @ignore_and_log_exception(exc_classes=NON_FATAL_EXC_CLASSES, logger=LOG,
+                              level=stdlib_logging.WARNING)
     def time(self, key, time):
         """
         Timer metric
@@ -61,7 +69,8 @@ class StatsdDriver(BaseMetricsDriver):
         timer = statsd.Timer('')
         timer.send(key, time)
 
-    @ignore_and_log_exception(logger=LOG, level=stdlib_logging.WARNING)
+    @ignore_and_log_exception(exc_classes=NON_FATAL_EXC_CLASSES, logger=LOG,
+                              level=stdlib_logging.WARNING)
     def inc_counter(self, key, amount=1):
         """
         Increment counter
@@ -73,7 +82,8 @@ class StatsdDriver(BaseMetricsDriver):
         counter = statsd.Counter(key)
         counter.increment(delta=amount)
 
-    @ignore_and_log_exception(logger=LOG, level=stdlib_logging.WARNING)
+    @ignore_and_log_exception(exc_classes=NON_FATAL_EXC_CLASSES, logger=LOG,
+                              level=stdlib_logging.WARNING)
     def dec_counter(self, key, amount=1):
         """
         Decrement metric
@@ -85,7 +95,8 @@ class StatsdDriver(BaseMetricsDriver):
         counter = statsd.Counter(key)
         counter.decrement(delta=amount)
 
-    @ignore_and_log_exception(logger=LOG, level=stdlib_logging.WARNING)
+    @ignore_and_log_exception(exc_classes=NON_FATAL_EXC_CLASSES, logger=LOG,
+                              level=stdlib_logging.WARNING)
     def set_gauge(self, key, value):
         """
         Set gauge value.
@@ -97,7 +108,8 @@ class StatsdDriver(BaseMetricsDriver):
         gauge = statsd.Gauge(key)
         gauge.send(None, value)
 
-    @ignore_and_log_exception(logger=LOG, level=stdlib_logging.WARNING)
+    @ignore_and_log_exception(exc_classes=NON_FATAL_EXC_CLASSES, logger=LOG,
+                              level=stdlib_logging.WARNING)
     def inc_gauge(self, key, amount=1):
         """
         Increment gauge value.
@@ -109,7 +121,8 @@ class StatsdDriver(BaseMetricsDriver):
         gauge = statsd.Gauge(key)
         gauge.increment(None, amount)
 
-    @ignore_and_log_exception(logger=LOG, level=stdlib_logging.WARNING)
+    @ignore_and_log_exception(exc_classes=NON_FATAL_EXC_CLASSES, logger=LOG,
+                              level=stdlib_logging.WARNING)
     def dec_gauge(self, key, amount=1):
         """
         Decrement gauge value.

--- a/st2common/st2common/metrics/drivers/statsd_driver.py
+++ b/st2common/st2common/metrics/drivers/statsd_driver.py
@@ -13,14 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging as stdlib_logging
 from numbers import Number
 
 import statsd
 from oslo_config import cfg
 
+from st2common import log as logging
 from st2common.metrics.base import BaseMetricsDriver
 from st2common.metrics.utils import check_key
 from st2common.metrics.utils import get_full_key_name
+from st2common.util.misc import ignore_and_log_exception
+
+
+LOG = logging.getLogger(__name__)
 
 __all__ = [
     'StatsdDriver'
@@ -30,11 +36,20 @@ __all__ = [
 class StatsdDriver(BaseMetricsDriver):
     """
     StatsD Implementation of the metrics driver
+
+    NOTE: Statsd uses UDP which is "fire and forget" and any kind of send error is not fatal. There
+    is an issue with python-statsd library though which doesn't ignore DNS resolution related error
+    and bubbles them all the way up.
+
+    This of course breaks the application. Any kind of metric related errors should be considered
+    as non-fatal and not degrade application in any way if an error occurs and that's why we wrap
+    all the statsd library calls here to ignore the errors and just log them.
     """
     def __init__(self):
         statsd.Connection.set_defaults(host=cfg.CONF.metrics.host, port=cfg.CONF.metrics.port,
                                        sample_rate=cfg.CONF.metrics.sample_rate)
 
+    @ignore_and_log_exception(logger=LOG, level=stdlib_logging.WARNING)
     def time(self, key, time):
         """
         Timer metric
@@ -46,6 +61,7 @@ class StatsdDriver(BaseMetricsDriver):
         timer = statsd.Timer('')
         timer.send(key, time)
 
+    @ignore_and_log_exception(logger=LOG, level=stdlib_logging.WARNING)
     def inc_counter(self, key, amount=1):
         """
         Increment counter
@@ -57,6 +73,7 @@ class StatsdDriver(BaseMetricsDriver):
         counter = statsd.Counter(key)
         counter.increment(delta=amount)
 
+    @ignore_and_log_exception(logger=LOG, level=stdlib_logging.WARNING)
     def dec_counter(self, key, amount=1):
         """
         Decrement metric
@@ -68,6 +85,7 @@ class StatsdDriver(BaseMetricsDriver):
         counter = statsd.Counter(key)
         counter.decrement(delta=amount)
 
+    @ignore_and_log_exception(logger=LOG, level=stdlib_logging.WARNING)
     def set_gauge(self, key, value):
         """
         Set gauge value.
@@ -79,6 +97,7 @@ class StatsdDriver(BaseMetricsDriver):
         gauge = statsd.Gauge(key)
         gauge.send(None, value)
 
+    @ignore_and_log_exception(logger=LOG, level=stdlib_logging.WARNING)
     def inc_gauge(self, key, amount=1):
         """
         Increment gauge value.
@@ -90,6 +109,7 @@ class StatsdDriver(BaseMetricsDriver):
         gauge = statsd.Gauge(key)
         gauge.increment(None, amount)
 
+    @ignore_and_log_exception(logger=LOG, level=stdlib_logging.WARNING)
     def dec_gauge(self, key, amount=1):
         """
         Decrement gauge value.

--- a/st2common/st2common/util/misc.py
+++ b/st2common/st2common/util/misc.py
@@ -187,7 +187,12 @@ def ignore_and_log_exception(exc_classes=(Exception,), logger=None, level=loggin
             try:
                 return func(*args, **kwargs)
             except exc_classes as e:
-                message = ('Exception in fuction "%s": %s' % (func.__name__, str(e)))
+                if len(args) >= 1 and getattr(args[0], '__class__', None):
+                    func_name = '%s.%s' % (args[0].__class__.__name__, func.__name__)
+                else:
+                    func_name = func.__name__
+
+                message = ('Exception in fuction "%s": %s' % (func_name, str(e)))
                 logger.log(level, message)
 
         return wrapper

--- a/st2common/st2common/util/misc.py
+++ b/st2common/st2common/util/misc.py
@@ -179,6 +179,8 @@ def ignore_and_log_exception(exc_classes=(Exception,), logger=None, level=loggin
     Decorator which catches the provided exception classes and logs them instead of letting them
     bubble all the way up.
     """
+    exc_classes = tuple(exc_classes)
+
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):

--- a/st2common/st2common/util/misc.py
+++ b/st2common/st2common/util/misc.py
@@ -15,10 +15,13 @@
 
 from __future__ import absolute_import
 
+import logging
+
 import os
 import re
 import sys
 import collections
+import functools
 
 import six
 
@@ -26,7 +29,8 @@ __all__ = [
     'prefix_dict_keys',
     'compare_path_file_name',
     'lowercase_value',
-    'get_field_name_from_mongoengine_error'
+    'get_field_name_from_mongoengine_error',
+
 ]
 
 
@@ -168,3 +172,21 @@ def get_field_name_from_mongoengine_error(exc):
         return match.groups()[0]
 
     return msg
+
+
+def ignore_and_log_exception(exc_classes=(Exception,), logger=None, level=logging.WARNING):
+    """
+    Decorator which catches the provided exception classes and logs them instead of letting them
+    bubble all the way up.
+    """
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except exc_classes as e:
+                message = ('Exception in fuction "%s": %s' % (func.__name__, str(e)))
+                logger.log(level, message)
+
+        return wrapper
+    return decorator


### PR DESCRIPTION
This pull request updates our statsd driver to treat any exception which may be thrown by the driver as non-fatal.

Metrics driver related error should never break or degrade application performance and this pull request ensures that is indeed the case.

### Background / Context

One of our users reported an issue with statd driving breaking / hanging the application when a metric backend server goes down. Initially I wasn't able to replicate it (statsd uses UDP so it should be fire and forget and there should be no exceptions).

Today the user provided log files. It turns out the problem lies in DNS resolution errors which can happen when establishing a connection to the backend server.

If a hostname and not IP address is used for metric backend and DNS resolution fails, statsd will propagate this exception all the way up and this will break the application since we don't catch and ignore / log those exceptions.

I wasn't able to reproduce the error because we use IP and not the hostname everywhere and even if backend server goes down, UDP send won't result in any exception due to the nature of the protocol.

### Proposed Solution

In this solution I simply use a decorator which just logs any exception thrown by the driver and doesn't propagate it.

Eventually we could perhaps move that logic to the statsd client library, but it's still safer to have such safe guard in our code. As mentioned above, we don't want any such error / exception to break or degrade application performance.

## TODO

- [x] Tests
- [x] Changelog entry