### PR TITLE
Correctly handle exception instances with non-ascii (unicode) error messages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -52,6 +52,13 @@ Fixed
 * Fix orquesta with items task performance issue. Workflow runtime increase significantly when a
   with items task has many items and result in many retries on write conflicts. A distributed lock
   is acquired before write operations to avoid write conflicts. (bug fix) Stackstorm/orquesta#125
+
+2.10.4 - March 15, 2019
+-----------------------
+
+Fixed
+~~~~~
+
 * Fix inadvertent regression in notifier service which would cause generic action trigger to only
   be dispatched for completed states even if custom states were specified using
   ``action_sensor.emit_when`` config option. (bug fix)
@@ -59,8 +66,8 @@ Fixed
 * Make sure we don't log auth token and api key inside st2api log file if those values are provided
   via query parameter and not header (``?x-auth-token=foo``, ``?st2-api-key=bar``). (bug fix) #4592
   #4589
-* Fix rendering of config_context in orquesta task that references action in different pack.
-  (bug fix) #4570
+* Fix rendering of ``{{ config_context. }}`` in orquesta task that references action from a
+  different pack (bug fix) #4570 #4567
 * Add missing default config location (``/etc/st2/st2.conf``) to the following services:
   ``st2actionrunner``, ``st2scheduler``, ``st2workflowengine``. (bug fix) #4596
 * Update statsd metrics driver so any exception thrown by statsd library is treated as non fatal.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -52,6 +52,8 @@ Fixed
 * Fix orquesta with items task performance issue. Workflow runtime increase significantly when a
   with items task has many items and result in many retries on write conflicts. A distributed lock
   is acquired before write operations to avoid write conflicts. (bug fix) Stackstorm/orquesta#125
+* Fix a bug with some API endpoints returning 500 internal server error when an exception contained
+  unicode data. (bug fix) #4598
 
 2.10.4 - March 15, 2019
 -----------------------

--- a/contrib/examples/actions/pythonactions/fibonacci.py
+++ b/contrib/examples/actions/pythonactions/fibonacci.py
@@ -21,4 +21,4 @@ if __name__ == '__main__':
         print(results)
     except Exception as e:
         traceback.print_exc(file=sys.stderr)
-        sys.exit(str(e))
+        sys.exit(six.text_type(e))

--- a/contrib/examples/actions/pythonactions/forloop_parse_github_repos.py
+++ b/contrib/examples/actions/pythonactions/forloop_parse_github_repos.py
@@ -16,6 +16,6 @@ class ParseGithubRepos(Action):
                 repo_url = "https://github.com" + repo_half_url
                 output[repo_name] = repo_url
         except Exception as e:
-            raise Exception("Could not parse data: {}".format(str(e)))
+            raise Exception("Could not parse data: {}".format(six.text_type(e)))
 
         return (True, output)

--- a/contrib/examples/actions/pythonactions/forloop_push_github_repos.py
+++ b/contrib/examples/actions/pythonactions/forloop_push_github_repos.py
@@ -9,6 +9,6 @@ class PushGithubRepos(Action):
                 # Push data to a service here
                 print(str(each_item))
         except Exception as e:
-            raise Exception("Process failed: {}".format(str(e)))
+            raise Exception("Process failed: {}".format(six.text_type(e)))
 
         return (True, "Data pushed successfully")

--- a/contrib/examples/actions/ubuntu_pkg_info/ubuntu_pkg_info.py
+++ b/contrib/examples/actions/ubuntu_pkg_info/ubuntu_pkg_info.py
@@ -14,7 +14,7 @@ def main(args):
     try:
         payload = transformer.to_json(command_stdout, command_stderr, command_exitcode)
     except Exception as e:
-        sys.stderr.write('JSON conversion failed. %s' % str(e))
+        sys.stderr.write('JSON conversion failed. %s' % six.text_type(e))
         sys.exit(1)
 
     sys.stdout.write(payload)

--- a/contrib/linux/actions/wait_for_ssh.py
+++ b/contrib/linux/actions/wait_for_ssh.py
@@ -2,6 +2,7 @@
 
 import time
 
+import six
 from oslo_config import cfg
 
 from st2common.runners.base_action import Action
@@ -31,7 +32,7 @@ class BaseAction(Action):
                 return True
             except Exception as e:
                 self.logger.info('Attempt %s failed (%s), sleeping for %s seconds...' %
-                                 (attempt, str(e), sleep_delay))
+                                 (attempt, six.text_type(e), sleep_delay))
                 time.sleep(sleep_delay)
 
         raise Exception('Exceeded max retries (%s)' % (retries))

--- a/contrib/packs/actions/pack_mgmt/get_installed.py
+++ b/contrib/packs/actions/pack_mgmt/get_installed.py
@@ -16,6 +16,8 @@
 import os
 import yaml
 
+import six
+
 from git.repo import Repo
 from git.exc import InvalidGitRepositoryError
 
@@ -57,7 +59,8 @@ class GetInstalled(Action):
         try:
             details = self._parse_yaml_file(metadata_file)
         except Exception as e:
-            error = ('Pack "%s" doesn\'t contain a valid pack.yaml file: %s' % (pack, str(e)))
+            error = ('Pack "%s" doesn\'t contain a valid pack.yaml file: %s' % (pack,
+                                                                                six.text_type(e)))
             raise Exception(error)
 
         try:

--- a/contrib/runners/action_chain_runner/action_chain_runner/action_chain_runner.py
+++ b/contrib/runners/action_chain_runner/action_chain_runner/action_chain_runner.py
@@ -14,11 +14,13 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import eventlet
 import traceback
 import uuid
 import datetime
 
+import six
 from jsonschema import exceptions as json_schema_exc
 
 from st2common.runners.base import ActionRunner
@@ -259,7 +261,7 @@ class ActionChainRunner(ActionRunner):
                                                expected_type=dict)
         except Exception as e:
             message = ('Failed to parse action chain definition from "%s": %s' %
-                       (chainspec_file, str(e)))
+                       (chainspec_file, six.text_type(e)))
             LOG.exception('Failed to load action chain definition.')
             raise runner_exc.ActionRunnerPreRunError(message)
 
@@ -268,11 +270,11 @@ class ActionChainRunner(ActionRunner):
         except json_schema_exc.ValidationError as e:
             # preserve the whole nasty jsonschema message as that is better to get to the
             # root cause
-            message = str(e)
+            message = six.text_type(e)
             LOG.exception('Failed to instantiate ActionChain.')
             raise runner_exc.ActionRunnerPreRunError(message)
         except Exception as e:
-            message = str(e)
+            message = six.text_type(e)
             LOG.exception('Failed to instantiate ActionChain.')
             raise runner_exc.ActionRunnerPreRunError(message)
 
@@ -288,7 +290,7 @@ class ActionChainRunner(ActionRunner):
         try:
             self.chain_holder.validate()
         except Exception as e:
-            raise runner_exc.ActionRunnerPreRunError(str(e))
+            raise runner_exc.ActionRunnerPreRunError(six.text_type(e))
 
     def run(self, action_parameters):
         # Run the action chain.
@@ -610,7 +612,7 @@ class ActionChainRunner(ActionRunner):
 
     def _format_error(self, e, msg):
         return {
-            'error': '%s. %s' % (msg, str(e)),
+            'error': '%s. %s' % (msg, six.text_type(e)),
             'traceback': traceback.format_exc(10)
         }
 
@@ -657,7 +659,7 @@ class ActionChainRunner(ActionRunner):
             key = getattr(e, 'key', None)
             value = getattr(e, 'value', None)
             msg = ('Failed rendering value for publish parameter "%s" in task "%s" '
-                   '(template string=%s): %s' % (key, action_node.name, value, str(e)))
+                   '(template string=%s): %s' % (key, action_node.name, value, six.text_type(e)))
             raise action_exc.ParameterRenderingFailedException(msg)
 
         return rendered_result
@@ -699,7 +701,7 @@ class ActionChainRunner(ActionRunner):
             key = getattr(e, 'key', None)
             value = getattr(e, 'value', None)
             msg = ('Failed rendering value for action parameter "%s" in task "%s" '
-                   '(template string=%s): %s') % (key, action_node.name, value, str(e))
+                   '(template string=%s): %s') % (key, action_node.name, value, six.text_type(e))
             raise action_exc.ParameterRenderingFailedException(msg)
         LOG.debug('Rendered params: %s: Type: %s', rendered_params, type(rendered_params))
         return rendered_params

--- a/contrib/runners/action_chain_runner/dist_utils.py
+++ b/contrib/runners/action_chain_runner/dist_utils.py
@@ -23,7 +23,6 @@ import sys
 from distutils.version import StrictVersion
 
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
-PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 if PY3:

--- a/contrib/runners/action_chain_runner/dist_utils.py
+++ b/contrib/runners/action_chain_runner/dist_utils.py
@@ -15,9 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import re
 import sys
+
+import six
 
 from distutils.version import StrictVersion
 
@@ -27,7 +30,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (str(e)))
+    print('Failed to import pip: %s' % (six.text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -41,7 +44,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/contrib/runners/action_chain_runner/dist_utils.py
+++ b/contrib/runners/action_chain_runner/dist_utils.py
@@ -20,9 +20,16 @@ import os
 import re
 import sys
 
-import six
-
 from distutils.version import StrictVersion
+
+# NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode
 
 GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
@@ -30,7 +37,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (six.text_type(e)))
+    print('Failed to import pip: %s' % (text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -44,7 +51,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
+        print('Failed to import parse_requirements from pip: %s' % (text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/contrib/runners/action_chain_runner/tests/unit/test_actionchain.py
+++ b/contrib/runners/action_chain_runner/tests/unit/test_actionchain.py
@@ -687,7 +687,7 @@ class TestActionChainRunner(ExecutionDbTestCase):
             # rendering failure
             expected_error = ('Failed rendering value for publish parameter "p1" in '
                               'task "c2" (template string={{ not_defined }}):')
-            self.assertTrue(expected_error in str(e))
+            self.assertTrue(expected_error in six.text_type(e))
             pass
         else:
             self.fail('Exception was not thrown')

--- a/contrib/runners/announcement_runner/dist_utils.py
+++ b/contrib/runners/announcement_runner/dist_utils.py
@@ -23,7 +23,6 @@ import sys
 from distutils.version import StrictVersion
 
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
-PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 if PY3:

--- a/contrib/runners/announcement_runner/dist_utils.py
+++ b/contrib/runners/announcement_runner/dist_utils.py
@@ -15,9 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import re
 import sys
+
+import six
 
 from distutils.version import StrictVersion
 
@@ -27,7 +30,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (str(e)))
+    print('Failed to import pip: %s' % (six.text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -41,7 +44,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/contrib/runners/announcement_runner/dist_utils.py
+++ b/contrib/runners/announcement_runner/dist_utils.py
@@ -20,9 +20,16 @@ import os
 import re
 import sys
 
-import six
-
 from distutils.version import StrictVersion
+
+# NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode
 
 GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
@@ -30,7 +37,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (six.text_type(e)))
+    print('Failed to import pip: %s' % (text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -44,7 +51,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
+        print('Failed to import parse_requirements from pip: %s' % (text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/contrib/runners/http_runner/dist_utils.py
+++ b/contrib/runners/http_runner/dist_utils.py
@@ -23,7 +23,6 @@ import sys
 from distutils.version import StrictVersion
 
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
-PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 if PY3:

--- a/contrib/runners/http_runner/dist_utils.py
+++ b/contrib/runners/http_runner/dist_utils.py
@@ -15,9 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import re
 import sys
+
+import six
 
 from distutils.version import StrictVersion
 
@@ -27,7 +30,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (str(e)))
+    print('Failed to import pip: %s' % (six.text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -41,7 +44,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/contrib/runners/http_runner/dist_utils.py
+++ b/contrib/runners/http_runner/dist_utils.py
@@ -20,9 +20,16 @@ import os
 import re
 import sys
 
-import six
-
 from distutils.version import StrictVersion
+
+# NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode
 
 GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
@@ -30,7 +37,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (six.text_type(e)))
+    print('Failed to import pip: %s' % (text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -44,7 +51,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
+        print('Failed to import parse_requirements from pip: %s' % (text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/contrib/runners/http_runner/http_runner/http_runner.py
+++ b/contrib/runners/http_runner/http_runner/http_runner.py
@@ -101,7 +101,7 @@ class HttpRunner(ActionRunner):
         try:
             result = client.run()
         except requests.exceptions.Timeout as e:
-            result = {'error': str(e)}
+            result = {'error': six.text_type(e)}
             status = LIVEACTION_STATUS_TIMED_OUT
         else:
             status = HttpRunner._get_result_status(result.get('status_code', None))

--- a/contrib/runners/inquirer_runner/dist_utils.py
+++ b/contrib/runners/inquirer_runner/dist_utils.py
@@ -23,7 +23,6 @@ import sys
 from distutils.version import StrictVersion
 
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
-PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 if PY3:

--- a/contrib/runners/inquirer_runner/dist_utils.py
+++ b/contrib/runners/inquirer_runner/dist_utils.py
@@ -15,9 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import re
 import sys
+
+import six
 
 from distutils.version import StrictVersion
 
@@ -27,7 +30,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (str(e)))
+    print('Failed to import pip: %s' % (six.text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -41,7 +44,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/contrib/runners/inquirer_runner/dist_utils.py
+++ b/contrib/runners/inquirer_runner/dist_utils.py
@@ -20,9 +20,16 @@ import os
 import re
 import sys
 
-import six
-
 from distutils.version import StrictVersion
+
+# NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode
 
 GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
@@ -30,7 +37,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (six.text_type(e)))
+    print('Failed to import pip: %s' % (text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -44,7 +51,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
+        print('Failed to import parse_requirements from pip: %s' % (text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/contrib/runners/local_runner/dist_utils.py
+++ b/contrib/runners/local_runner/dist_utils.py
@@ -23,7 +23,6 @@ import sys
 from distutils.version import StrictVersion
 
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
-PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 if PY3:

--- a/contrib/runners/local_runner/dist_utils.py
+++ b/contrib/runners/local_runner/dist_utils.py
@@ -15,9 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import re
 import sys
+
+import six
 
 from distutils.version import StrictVersion
 
@@ -27,7 +30,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (str(e)))
+    print('Failed to import pip: %s' % (six.text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -41,7 +44,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/contrib/runners/local_runner/dist_utils.py
+++ b/contrib/runners/local_runner/dist_utils.py
@@ -20,9 +20,16 @@ import os
 import re
 import sys
 
-import six
-
 from distutils.version import StrictVersion
+
+# NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode
 
 GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
@@ -30,7 +37,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (six.text_type(e)))
+    print('Failed to import pip: %s' % (text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -44,7 +51,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
+        print('Failed to import parse_requirements from pip: %s' % (text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/contrib/runners/mistral_v2/dist_utils.py
+++ b/contrib/runners/mistral_v2/dist_utils.py
@@ -23,7 +23,6 @@ import sys
 from distutils.version import StrictVersion
 
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
-PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 if PY3:

--- a/contrib/runners/mistral_v2/dist_utils.py
+++ b/contrib/runners/mistral_v2/dist_utils.py
@@ -15,9 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import re
 import sys
+
+import six
 
 from distutils.version import StrictVersion
 
@@ -27,7 +30,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (str(e)))
+    print('Failed to import pip: %s' % (six.text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -41,7 +44,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/contrib/runners/mistral_v2/dist_utils.py
+++ b/contrib/runners/mistral_v2/dist_utils.py
@@ -20,9 +20,16 @@ import os
 import re
 import sys
 
-import six
-
 from distutils.version import StrictVersion
+
+# NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode
 
 GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
@@ -30,7 +37,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (six.text_type(e)))
+    print('Failed to import pip: %s' % (text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -44,7 +51,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
+        print('Failed to import parse_requirements from pip: %s' % (text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/contrib/runners/noop_runner/dist_utils.py
+++ b/contrib/runners/noop_runner/dist_utils.py
@@ -23,7 +23,6 @@ import sys
 from distutils.version import StrictVersion
 
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
-PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 if PY3:

--- a/contrib/runners/noop_runner/dist_utils.py
+++ b/contrib/runners/noop_runner/dist_utils.py
@@ -15,9 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import re
 import sys
+
+import six
 
 from distutils.version import StrictVersion
 
@@ -27,7 +30,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (str(e)))
+    print('Failed to import pip: %s' % (six.text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -41,7 +44,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/contrib/runners/noop_runner/dist_utils.py
+++ b/contrib/runners/noop_runner/dist_utils.py
@@ -20,9 +20,16 @@ import os
 import re
 import sys
 
-import six
-
 from distutils.version import StrictVersion
+
+# NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode
 
 GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
@@ -30,7 +37,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (six.text_type(e)))
+    print('Failed to import pip: %s' % (text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -44,7 +51,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
+        print('Failed to import parse_requirements from pip: %s' % (text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/contrib/runners/orquesta_runner/dist_utils.py
+++ b/contrib/runners/orquesta_runner/dist_utils.py
@@ -23,7 +23,6 @@ import sys
 from distutils.version import StrictVersion
 
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
-PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 if PY3:

--- a/contrib/runners/orquesta_runner/dist_utils.py
+++ b/contrib/runners/orquesta_runner/dist_utils.py
@@ -15,9 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import re
 import sys
+
+import six
 
 from distutils.version import StrictVersion
 
@@ -27,7 +30,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (str(e)))
+    print('Failed to import pip: %s' % (six.text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -41,7 +44,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/contrib/runners/orquesta_runner/dist_utils.py
+++ b/contrib/runners/orquesta_runner/dist_utils.py
@@ -20,9 +20,16 @@ import os
 import re
 import sys
 
-import six
-
 from distutils.version import StrictVersion
+
+# NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode
 
 GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
@@ -30,7 +37,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (six.text_type(e)))
+    print('Failed to import pip: %s' % (text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -44,7 +51,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
+        print('Failed to import parse_requirements from pip: %s' % (text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/contrib/runners/orquesta_runner/orquesta_functions/st2kv.py
+++ b/contrib/runners/orquesta_runner/orquesta_functions/st2kv.py
@@ -41,7 +41,8 @@ def st2kv_(context, key, decrypt=False):
     try:
         user_db = auth_db_access.User.get(username)
     except Exception as e:
-        raise Exception('Failed to retrieve User object for user "%s" % (username)' % (str(e)))
+        raise Exception('Failed to retrieve User object for user "%s" % (username)' %
+                        (six.text_type(e)))
 
     kvp = kvp_util.get_key(key=key, user_db=user_db, decrypt=decrypt)
 

--- a/contrib/runners/orquesta_runner/orquesta_runner/orquesta_runner.py
+++ b/contrib/runners/orquesta_runner/orquesta_runner/orquesta_runner.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 
 import uuid
 
+import six
 from oslo_config import cfg
 
 from orquesta import exceptions as wf_exc
@@ -96,7 +97,7 @@ class OrquestaRunner(runners.AsyncActionRunner):
             return (status, result, self.context)
         except Exception as e:
             status = ac_const.LIVEACTION_STATUS_FAILED
-            result = {'errors': [{'message': str(e)}], 'output': None}
+            result = {'errors': [{'message': six.text_type(e)}], 'output': None}
             return (status, result, self.context)
 
         if wf_ex_db.status in wf_statuses.COMPLETED_STATUSES:

--- a/contrib/runners/orquesta_runner/tests/unit/test_notify.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_notify.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 import jsonschema
 import mock
 
+import six
 from orquesta import statuses as wf_statuses
 
 import st2tests
@@ -214,7 +215,7 @@ class OrquestaNotifyTest(st2tests.ExecutionDbTestCase):
                     lv_ac_db
                 )
             except Exception as e:
-                raise AssertionError('%s: %s' % (str(e), notify_tasks))
+                raise AssertionError('%s: %s' % (six.text_type(e), notify_tasks))
 
     def test_notify_task_list_nonexistent_task(self):
         wf_meta = base.get_wf_fixture_meta_data(TEST_PACK_PATH, 'sequential.yaml')

--- a/contrib/runners/python_runner/dist_utils.py
+++ b/contrib/runners/python_runner/dist_utils.py
@@ -23,7 +23,6 @@ import sys
 from distutils.version import StrictVersion
 
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
-PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 if PY3:

--- a/contrib/runners/python_runner/dist_utils.py
+++ b/contrib/runners/python_runner/dist_utils.py
@@ -15,9 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import re
 import sys
+
+import six
 
 from distutils.version import StrictVersion
 
@@ -27,7 +30,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (str(e)))
+    print('Failed to import pip: %s' % (six.text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -41,7 +44,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/contrib/runners/python_runner/dist_utils.py
+++ b/contrib/runners/python_runner/dist_utils.py
@@ -20,9 +20,16 @@ import os
 import re
 import sys
 
-import six
-
 from distutils.version import StrictVersion
+
+# NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode
 
 GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
@@ -30,7 +37,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (six.text_type(e)))
+    print('Failed to import pip: %s' % (text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -44,7 +51,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
+        print('Failed to import parse_requirements from pip: %s' % (text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/contrib/runners/python_runner/python_runner/python_action_wrapper.py
+++ b/contrib/runners/python_runner/python_runner/python_action_wrapper.py
@@ -48,6 +48,8 @@ import sys
 import json
 import argparse
 
+import six
+
 from st2common import log as logging
 from st2common import config as st2common_config
 from st2common.runners.base_action import Action
@@ -177,7 +179,7 @@ class PythonActionWrapper(object):
             st2common_config.parse_args(args=self._parent_args)
         except Exception as e:
             LOG.debug('Failed to parse config using parent args (parent_args=%s): %s' %
-                      (str(self._parent_args), str(e)))
+                      (str(self._parent_args), six.text_type(e)))
 
         # Note: We can only set a default user value if one is not provided after parsing the
         # config
@@ -237,7 +239,7 @@ class PythonActionWrapper(object):
         except Exception as e:
             tb_msg = traceback.format_exc()
             msg = ('Failed to load action class from file "%s" (action file most likely doesn\'t '
-                   'exist or contains invalid syntax): %s' % (self._file_path, str(e)))
+                   'exist or contains invalid syntax): %s' % (self._file_path, six.text_type(e)))
             msg += '\n\n' + tb_msg
             exc_cls = type(e)
             raise exc_cls(msg)
@@ -313,7 +315,7 @@ if __name__ == '__main__':
             stdin_parameters = stdin_parameters.get('parameters', {})
         except Exception as e:
             msg = ('Failed to parse parameters from stdin. Expected a JSON object with '
-                   '"parameters" attribute: %s' % (str(e)))
+                   '"parameters" attribute: %s' % (six.text_type(e)))
             raise ValueError(msg)
 
         parameters.update(stdin_parameters)

--- a/contrib/runners/python_runner/python_runner/python_runner.py
+++ b/contrib/runners/python_runner/python_runner/python_runner.py
@@ -23,6 +23,7 @@ import uuid
 import functools
 from subprocess import list2cmdline
 
+import six
 from eventlet.green import subprocess
 from oslo_config import cfg
 from six.moves import StringIO
@@ -202,7 +203,7 @@ class PythonRunner(GitWorktreeActionRunner):
             try:
                 pack_common_libs_path = self._get_pack_common_libs_path(pack_ref=pack)
             except Exception as e:
-                LOG.debug('Failed to retrieve pack common lib path: %s' % (str(e)))
+                LOG.debug('Failed to retrieve pack common lib path: %s' % (six.text_type(e)))
                 # There is no MongoDB connection available in Lambda and pack common lib
                 # functionality is not also mandatory for Lambda so we simply ignore those errors.
                 # Note: We should eventually refactor this code to make runner standalone and not
@@ -325,7 +326,8 @@ class PythonRunner(GitWorktreeActionRunner):
             action_result = json.loads(action_result)
         except Exception as e:
             # Failed to de-serialize the result, probably it contains non-simple type or similar
-            LOG.warning('Failed to de-serialize result "%s": %s' % (str(action_result), str(e)))
+            LOG.warning('Failed to de-serialize result "%s": %s' % (str(action_result),
+                                                                    six.text_type(e)))
 
         if action_result:
             if isinstance(action_result, dict):

--- a/contrib/runners/remote_runner/dist_utils.py
+++ b/contrib/runners/remote_runner/dist_utils.py
@@ -23,7 +23,6 @@ import sys
 from distutils.version import StrictVersion
 
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
-PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 if PY3:

--- a/contrib/runners/remote_runner/dist_utils.py
+++ b/contrib/runners/remote_runner/dist_utils.py
@@ -15,9 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import re
 import sys
+
+import six
 
 from distutils.version import StrictVersion
 
@@ -27,7 +30,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (str(e)))
+    print('Failed to import pip: %s' % (six.text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -41,7 +44,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/contrib/runners/remote_runner/dist_utils.py
+++ b/contrib/runners/remote_runner/dist_utils.py
@@ -20,9 +20,16 @@ import os
 import re
 import sys
 
-import six
-
 from distutils.version import StrictVersion
+
+# NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode
 
 GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
@@ -30,7 +37,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (six.text_type(e)))
+    print('Failed to import pip: %s' % (text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -44,7 +51,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
+        print('Failed to import parse_requirements from pip: %s' % (text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/contrib/runners/winrm_runner/dist_utils.py
+++ b/contrib/runners/winrm_runner/dist_utils.py
@@ -23,7 +23,6 @@ import sys
 from distutils.version import StrictVersion
 
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
-PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 if PY3:

--- a/contrib/runners/winrm_runner/dist_utils.py
+++ b/contrib/runners/winrm_runner/dist_utils.py
@@ -15,9 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import re
 import sys
+
+import six
 
 from distutils.version import StrictVersion
 
@@ -27,7 +30,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (str(e)))
+    print('Failed to import pip: %s' % (six.text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -41,7 +44,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/contrib/runners/winrm_runner/dist_utils.py
+++ b/contrib/runners/winrm_runner/dist_utils.py
@@ -20,9 +20,16 @@ import os
 import re
 import sys
 
-import six
-
 from distutils.version import StrictVersion
+
+# NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode
 
 GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
@@ -30,7 +37,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (six.text_type(e)))
+    print('Failed to import pip: %s' % (text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -44,7 +51,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
+        print('Failed to import parse_requirements from pip: %s' % (text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/scripts/dist_utils.py
+++ b/scripts/dist_utils.py
@@ -23,7 +23,6 @@ import sys
 from distutils.version import StrictVersion
 
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
-PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 if PY3:

--- a/scripts/dist_utils.py
+++ b/scripts/dist_utils.py
@@ -15,9 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import re
 import sys
+
+import six
 
 from distutils.version import StrictVersion
 
@@ -27,7 +30,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (str(e)))
+    print('Failed to import pip: %s' % (six.text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -41,7 +44,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/scripts/dist_utils.py
+++ b/scripts/dist_utils.py
@@ -20,9 +20,16 @@ import os
 import re
 import sys
 
-import six
-
 from distutils.version import StrictVersion
+
+# NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode
 
 GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
@@ -30,7 +37,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (six.text_type(e)))
+    print('Failed to import pip: %s' % (text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -44,7 +51,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
+        print('Failed to import parse_requirements from pip: %s' % (text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/scripts/fixate-requirements.py
+++ b/scripts/fixate-requirements.py
@@ -33,9 +33,17 @@ import argparse
 import os
 import os.path
 import sys
+
 from distutils.version import StrictVersion
 
-import six
+# NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode
 
 OSCWD = os.path.abspath(os.curdir)
 GET_PIP = '    curl https://bootstrap.pypa.io/get-pip.py | python'
@@ -44,7 +52,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (six.text_type(e)))
+    print('Failed to import pip: %s' % (text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -58,7 +66,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
+        print('Failed to import parse_requirements from pip: %s' % (text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/scripts/fixate-requirements.py
+++ b/scripts/fixate-requirements.py
@@ -28,11 +28,14 @@ where version of packages are fixed according to fixed-requirements.txt.
 """
 
 from __future__ import absolute_import, print_function
+
 import argparse
 import os
 import os.path
 import sys
 from distutils.version import StrictVersion
+
+import six
 
 OSCWD = os.path.abspath(os.curdir)
 GET_PIP = '    curl https://bootstrap.pypa.io/get-pip.py | python'
@@ -41,7 +44,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (str(e)))
+    print('Failed to import pip: %s' % (six.text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -55,7 +58,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/st2actions/dist_utils.py
+++ b/st2actions/dist_utils.py
@@ -23,7 +23,6 @@ import sys
 from distutils.version import StrictVersion
 
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
-PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 if PY3:

--- a/st2actions/dist_utils.py
+++ b/st2actions/dist_utils.py
@@ -15,9 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import re
 import sys
+
+import six
 
 from distutils.version import StrictVersion
 
@@ -27,7 +30,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (str(e)))
+    print('Failed to import pip: %s' % (six.text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -41,7 +44,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/st2actions/dist_utils.py
+++ b/st2actions/dist_utils.py
@@ -20,9 +20,16 @@ import os
 import re
 import sys
 
-import six
-
 from distutils.version import StrictVersion
+
+# NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode
 
 GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
@@ -30,7 +37,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (six.text_type(e)))
+    print('Failed to import pip: %s' % (text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -44,7 +51,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
+        print('Failed to import parse_requirements from pip: %s' % (text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/st2actions/st2actions/container/base.py
+++ b/st2actions/st2actions/container/base.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 import sys
 import traceback
 
+import six
 from oslo_config import cfg
 
 from st2common import log as logging
@@ -107,7 +108,7 @@ class RunnerContainer(object):
 
                 runner.runner_parameters = runner_params
             except ParamException as e:
-                raise actionrunner.ActionRunnerException(str(e))
+                raise actionrunner.ActionRunnerException(six.text_type(e))
 
             LOG.debug('Performing pre-run for runner: %s', runner.runner_id)
             runner.pre_run()

--- a/st2actions/tests/unit/test_actions_registrar.py
+++ b/st2actions/tests/unit/test_actions_registrar.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 
 import os
 
+import six
 import jsonschema
 import mock
 import yaml
@@ -48,7 +49,7 @@ class ActionsRegistrarTest(tests_base.DbTestCase):
             all_actions_in_db = Action.get_all()
             actions_registrar.register_actions(packs_base_paths=[packs_base_path])
         except Exception as e:
-            print(str(e))
+            print(six.text_type(e))
             self.fail('All actions must be registered without exceptions.')
         else:
             all_actions_in_db = Action.get_all()

--- a/st2api/dist_utils.py
+++ b/st2api/dist_utils.py
@@ -23,7 +23,6 @@ import sys
 from distutils.version import StrictVersion
 
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
-PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 if PY3:

--- a/st2api/dist_utils.py
+++ b/st2api/dist_utils.py
@@ -15,9 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import re
 import sys
+
+import six
 
 from distutils.version import StrictVersion
 
@@ -27,7 +30,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (str(e)))
+    print('Failed to import pip: %s' % (six.text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -41,7 +44,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/st2api/dist_utils.py
+++ b/st2api/dist_utils.py
@@ -20,9 +20,16 @@ import os
 import re
 import sys
 
-import six
-
 from distutils.version import StrictVersion
+
+# NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode
 
 GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
@@ -30,7 +37,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (six.text_type(e)))
+    print('Failed to import pip: %s' % (text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -44,7 +51,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
+        print('Failed to import parse_requirements from pip: %s' % (text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -217,7 +217,7 @@ class ResourceController(object):
                     self.model.model._lookup_field(path)
                     filters['__'.join(path)] = v
                 except LookUpError as e:
-                    raise ValueError(str(e))
+                    raise ValueError(six.text_type(e))
 
         instances = self.access.query(exclude_fields=exclude_fields, only_fields=include_fields,
                                       **filters)
@@ -513,8 +513,8 @@ class ContentPackResourceController(ResourceController):
             instance = self._get_by_ref_or_id(ref_or_id=ref_or_id, exclude_fields=exclude_fields,
                                               include_fields=include_fields)
         except Exception as e:
-            LOG.exception(str(e))
-            abort(http_client.NOT_FOUND, str(e))
+            LOG.exception(six.text_type(e))
+            abort(http_client.NOT_FOUND, six.text_type(e))
             return
 
         if permission_type:

--- a/st2api/st2api/controllers/v1/actionalias.py
+++ b/st2api/st2api/controllers/v1/actionalias.py
@@ -85,7 +85,7 @@ class ActionAliasController(resource.ContentPackResourceController):
             format_ = get_matching_alias(command=command)
         except ActionAliasAmbiguityException as e:
             LOG.exception('Command "%s" matched (%s) patterns.', e.command, len(e.matches))
-            return abort(http_client.BAD_REQUEST, str(e))
+            return abort(http_client.BAD_REQUEST, six.text_type(e))
 
         # Convert ActionAliasDB to API
         action_alias_api = ActionAliasAPI.from_model(format_['alias'])
@@ -107,8 +107,8 @@ class ActionAliasController(resource.ContentPackResourceController):
             aliases = [ActionAliasAPI(**alias) for alias in aliases_resp.json]
             return generate_helpstring_result(aliases, filter, pack, int(limit), int(offset))
         except (TypeError) as e:
-            LOG.exception('Helpstring request contains an invalid data type: %s.', str(e))
-            return abort(http_client.BAD_REQUEST, str(e))
+            LOG.exception('Helpstring request contains an invalid data type: %s.', six.text_type(e))
+            return abort(http_client.BAD_REQUEST, six.text_type(e))
 
     def post(self, action_alias, requester_user):
         """
@@ -130,7 +130,7 @@ class ActionAliasController(resource.ContentPackResourceController):
             action_alias_db = ActionAlias.add_or_update(action_alias_db)
         except (ValidationError, ValueError, ValueValidationException) as e:
             LOG.exception('Validation failed for action alias data=%s.', action_alias)
-            abort(http_client.BAD_REQUEST, str(e))
+            abort(http_client.BAD_REQUEST, six.text_type(e))
             return
 
         extra = {'action_alias_db': action_alias_db}
@@ -169,7 +169,7 @@ class ActionAliasController(resource.ContentPackResourceController):
             action_alias_db = ActionAlias.add_or_update(action_alias_db)
         except (ValidationError, ValueError) as e:
             LOG.exception('Validation failed for action alias data=%s', action_alias)
-            abort(http_client.BAD_REQUEST, str(e))
+            abort(http_client.BAD_REQUEST, six.text_type(e))
             return
 
         extra = {'old_action_alias_db': old_action_alias_db, 'new_action_alias_db': action_alias_db}
@@ -199,7 +199,7 @@ class ActionAliasController(resource.ContentPackResourceController):
         except Exception as e:
             LOG.exception('Database delete encountered exception during delete of id="%s".',
                           ref_or_id)
-            abort(http_client.INTERNAL_SERVER_ERROR, str(e))
+            abort(http_client.INTERNAL_SERVER_ERROR, six.text_type(e))
             return
 
         extra = {'action_alias_db': action_alias_db}

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -135,18 +135,18 @@ class ActionExecutionsControllerMixin(BaseRestControllerMixin):
                                             action_db=action_db)
         except ValueError as e:
             LOG.exception('Unable to execute action.')
-            abort(http_client.BAD_REQUEST, str(e))
+            abort(http_client.BAD_REQUEST, six.text_type(e))
         except jsonschema.ValidationError as e:
             LOG.exception('Unable to execute action. Parameter validation failed.')
             abort(http_client.BAD_REQUEST, re.sub("u'([^']*)'", r"'\1'",
-                                                  getattr(e, 'message', str(e))))
+                                                  getattr(e, 'message', six.text_type(e))))
         except trace_exc.TraceNotFoundException as e:
-            abort(http_client.BAD_REQUEST, str(e))
+            abort(http_client.BAD_REQUEST, six.text_type(e))
         except validation_exc.ValueValidationException as e:
             raise e
         except Exception as e:
             LOG.exception('Unable to execute action. Unexpected error encountered.')
-            abort(http_client.INTERNAL_SERVER_ERROR, str(e))
+            abort(http_client.INTERNAL_SERVER_ERROR, six.text_type(e))
 
     def _schedule_execution(self, liveaction, requester_user, action_db, user=None,
                             context_string=None, show_secrets=False):
@@ -196,10 +196,11 @@ class ActionExecutionsControllerMixin(BaseRestControllerMixin):
             action_service.update_status(
                 liveaction=liveaction_db,
                 new_status=action_constants.LIVEACTION_STATUS_FAILED,
-                result={'error': str(e), 'traceback': ''.join(traceback.format_tb(tb, 20))})
+                result={'error': six.text_type(e),
+                        'traceback': ''.join(traceback.format_tb(tb, 20))})
             # Might be a good idea to return the actual ActionExecution rather than bubble up
             # the exception.
-            raise validation_exc.ValueValidationException(str(e))
+            raise validation_exc.ValueValidationException(six.text_type(e))
 
         # The request should be created after the above call to render_live_params
         # so any templates in live parameters have a chance to render.
@@ -620,13 +621,13 @@ class ActionExecutionsController(BaseResourceIsolationControllerMixin,
             else:
                 liveaction_db, actionexecution_db = update_status(liveaction_api, liveaction_db)
         except runner_exc.InvalidActionRunnerOperationError as e:
-            LOG.exception('Failed updating liveaction %s. %s', liveaction_db.id, str(e))
-            abort(http_client.BAD_REQUEST, 'Failed updating execution. %s' % str(e))
+            LOG.exception('Failed updating liveaction %s. %s', liveaction_db.id, six.text_type(e))
+            abort(http_client.BAD_REQUEST, 'Failed updating execution. %s' % six.text_type(e))
         except runner_exc.UnexpectedActionExecutionStatusError as e:
-            LOG.exception('Failed updating liveaction %s. %s', liveaction_db.id, str(e))
-            abort(http_client.BAD_REQUEST, 'Failed updating execution. %s' % str(e))
+            LOG.exception('Failed updating liveaction %s. %s', liveaction_db.id, six.text_type(e))
+            abort(http_client.BAD_REQUEST, 'Failed updating execution. %s' % six.text_type(e))
         except Exception as e:
-            LOG.exception('Failed updating liveaction %s. %s', liveaction_db.id, str(e))
+            LOG.exception('Failed updating liveaction %s. %s', liveaction_db.id, six.text_type(e))
             abort(
                 http_client.INTERNAL_SERVER_ERROR,
                 'Failed updating execution due to unexpected error.'

--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -111,7 +111,7 @@ class ActionsController(resource.ContentPackResourceController):
         except (ValidationError, ValueError,
                 ValueValidationException, InvalidActionParameterException) as e:
             LOG.exception('Unable to create action data=%s', action)
-            abort(http_client.BAD_REQUEST, str(e))
+            abort(http_client.BAD_REQUEST, six.text_type(e))
             return
 
         # Write pack data files to disk (if any are provided)
@@ -172,7 +172,7 @@ class ActionsController(resource.ContentPackResourceController):
             LOG.debug('/actions/ PUT after add_or_update: %s', action_db)
         except (ValidationError, ValueError) as e:
             LOG.exception('Unable to update action data=%s', action)
-            abort(http_client.BAD_REQUEST, str(e))
+            abort(http_client.BAD_REQUEST, six.text_type(e))
             return
 
         # Dispatch an internal trigger for each written data file. This way user
@@ -206,7 +206,7 @@ class ActionsController(resource.ContentPackResourceController):
         try:
             validate_not_part_of_system_pack(action_db)
         except ValueValidationException as e:
-            abort(http_client.BAD_REQUEST, str(e))
+            abort(http_client.BAD_REQUEST, six.text_type(e))
 
         LOG.debug('DELETE /actions/ lookup with ref_or_id=%s found object: %s',
                   ref_or_id, action_db)
@@ -216,7 +216,7 @@ class ActionsController(resource.ContentPackResourceController):
         except Exception as e:
             LOG.error('Database delete encountered exception during delete of id="%s". '
                       'Exception was %s', action_id, e)
-            abort(http_client.INTERNAL_SERVER_ERROR, str(e))
+            abort(http_client.INTERNAL_SERVER_ERROR, six.text_type(e))
             return
 
         extra = {'action_db': action_db}

--- a/st2api/st2api/controllers/v1/aliasexecution.py
+++ b/st2api/st2api/controllers/v1/aliasexecution.py
@@ -16,6 +16,7 @@
 import jsonschema
 from jinja2.exceptions import UndefinedError
 from oslo_config import cfg
+
 import six
 
 from st2api.controllers.base import BaseRestControllerMixin
@@ -67,7 +68,7 @@ class ActionAliasExecutionController(BaseRestControllerMixin):
             format_ = get_matching_alias(command=command)
         except ActionAliasAmbiguityException as e:
             LOG.exception('Command "%s" matched (%s) patterns.', e.command, len(e.matches))
-            return abort(http_client.BAD_REQUEST, str(e))
+            return abort(http_client.BAD_REQUEST, six.text_type(e))
 
         action_alias_db = format_['alias']
         representation = format_['representation']
@@ -171,7 +172,8 @@ class ActionAliasExecutionController(BaseRestControllerMixin):
                         })
                 except UndefinedError as e:
                     result.update({
-                        'message': 'Cannot render "format" in field "ack" for alias. ' + str(e)
+                        'message': ('Cannot render "format" in field "ack" for alias. ' +
+                                    six.text_type(e))
                     })
 
                 try:
@@ -181,7 +183,8 @@ class ActionAliasExecutionController(BaseRestControllerMixin):
                         })
                 except UndefinedError as e:
                     result.update({
-                        'extra': 'Cannot render "extra" in field "ack" for alias. ' + str(e)
+                        'extra': ('Cannot render "extra" in field "ack" for alias. ' +
+                                  six.text_type(e))
                     })
 
             results.append(result)
@@ -237,13 +240,13 @@ class ActionAliasExecutionController(BaseRestControllerMixin):
             return ActionExecutionAPI.from_model(action_execution_db, mask_secrets=mask_secrets)
         except ValueError as e:
             LOG.exception('Unable to execute action.')
-            abort(http_client.BAD_REQUEST, str(e))
+            abort(http_client.BAD_REQUEST, six.text_type(e))
         except jsonschema.ValidationError as e:
             LOG.exception('Unable to execute action. Parameter validation failed.')
-            abort(http_client.BAD_REQUEST, str(e))
+            abort(http_client.BAD_REQUEST, six.text_type(e))
         except Exception as e:
             LOG.exception('Unable to execute action. Unexpected error encountered.')
-            abort(http_client.INTERNAL_SERVER_ERROR, str(e))
+            abort(http_client.INTERNAL_SERVER_ERROR, six.text_type(e))
 
 
 action_alias_execution_controller = ActionAliasExecutionController()

--- a/st2api/st2api/controllers/v1/auth.py
+++ b/st2api/st2api/controllers/v1/auth.py
@@ -87,7 +87,7 @@ class ApiKeyController(BaseRestControllerMixin):
             return ApiKeyAPI.from_model(api_key_db, mask_secrets=mask_secrets)
         except (ValidationError, ValueError) as e:
             LOG.exception('Failed to serialize API key.')
-            abort(http_client.INTERNAL_SERVER_ERROR, str(e))
+            abort(http_client.INTERNAL_SERVER_ERROR, six.text_type(e))
 
     @property
     def max_limit(self):
@@ -158,7 +158,7 @@ class ApiKeyController(BaseRestControllerMixin):
             api_key_db = ApiKey.add_or_update(ApiKeyAPI.to_model(api_key_api))
         except (ValidationError, ValueError) as e:
             LOG.exception('Validation failed for api_key data=%s.', api_key_api)
-            abort(http_client.BAD_REQUEST, str(e))
+            abort(http_client.BAD_REQUEST, six.text_type(e))
 
         extra = {'api_key_db': api_key_db}
         LOG.audit('ApiKey created. ApiKey.id=%s' % (api_key_db.id), extra=extra)

--- a/st2api/st2api/controllers/v1/inquiries.py
+++ b/st2api/st2api/controllers/v1/inquiries.py
@@ -16,6 +16,7 @@
 import copy
 import json
 
+import six
 from oslo_config import cfg
 from six.moves import http_client
 
@@ -113,18 +114,18 @@ class InquiriesController(ResourceController):
             )
         except db_exceptions.StackStormDBObjectNotFoundError as e:
             LOG.exception('Unable to identify inquiry with id "%s".' % inquiry_id)
-            api_router.abort(http_client.NOT_FOUND, str(e))
+            api_router.abort(http_client.NOT_FOUND, six.text_type(e))
         except rbac_exceptions.ResourceAccessDeniedError as e:
             LOG.exception('User is denied access to inquiry "%s".' % inquiry_id)
-            api_router.abort(http_client.FORBIDDEN, str(e))
+            api_router.abort(http_client.FORBIDDEN, six.text_type(e))
         except Exception as e:
             LOG.exception('Unable to get record for inquiry "%s".' % inquiry_id)
-            api_router.abort(http_client.INTERNAL_SERVER_ERROR, str(e))
+            api_router.abort(http_client.INTERNAL_SERVER_ERROR, six.text_type(e))
 
         try:
             inquiry_service.check_inquiry(inquiry)
         except Exception as e:
-            api_router.abort(http_client.BAD_REQUEST, str(e))
+            api_router.abort(http_client.BAD_REQUEST, six.text_type(e))
 
         return inqy_api_models.InquiryResponseAPI.from_inquiry_api(inquiry)
 
@@ -154,41 +155,41 @@ class InquiriesController(ResourceController):
             )
         except db_exceptions.StackStormDBObjectNotFoundError as e:
             LOG.exception('Unable to identify inquiry with id "%s".' % inquiry_id)
-            api_router.abort(http_client.NOT_FOUND, str(e))
+            api_router.abort(http_client.NOT_FOUND, six.text_type(e))
         except rbac_exceptions.ResourceAccessDeniedError as e:
             LOG.exception('User is denied access to inquiry "%s".' % inquiry_id)
-            api_router.abort(http_client.FORBIDDEN, str(e))
+            api_router.abort(http_client.FORBIDDEN, six.text_type(e))
         except Exception as e:
             LOG.exception('Unable to get record for inquiry "%s".' % inquiry_id)
-            api_router.abort(http_client.INTERNAL_SERVER_ERROR, str(e))
+            api_router.abort(http_client.INTERNAL_SERVER_ERROR, six.text_type(e))
 
         # Check if inquiry can still be respond to.
         try:
             inquiry_service.check_inquiry(inquiry)
         except Exception as e:
             LOG.exception('Fail checking validity of inquiry "%s".' % inquiry_id)
-            api_router.abort(http_client.BAD_REQUEST, str(e))
+            api_router.abort(http_client.BAD_REQUEST, six.text_type(e))
 
         # Check if user has permission to respond to this inquiry.
         try:
             inquiry_service.check_permission(inquiry, requester_user)
         except Exception as e:
             LOG.exception('Fail checking permission for inquiry "%s".' % inquiry_id)
-            api_router.abort(http_client.FORBIDDEN, str(e))
+            api_router.abort(http_client.FORBIDDEN, six.text_type(e))
 
         # Validate the body of the response against the schema parameter for this inquiry.
         try:
             inquiry_service.validate_response(inquiry, response_data.response)
         except Exception as e:
             LOG.exception('Fail checking response for inquiry "%s".' % inquiry_id)
-            api_router.abort(http_client.BAD_REQUEST, str(e))
+            api_router.abort(http_client.BAD_REQUEST, six.text_type(e))
 
         # Respond to inquiry and update if there is a partial response.
         try:
             inquiry_service.respond(inquiry, response_data.response, requester=requester_user)
         except Exception as e:
             LOG.exception('Fail to update response for inquiry "%s".' % inquiry_id)
-            api_router.abort(http_client.INTERNAL_SERVER_ERROR, str(e))
+            api_router.abort(http_client.INTERNAL_SERVER_ERROR, six.text_type(e))
 
         return {
             'id': inquiry_id,

--- a/st2api/st2api/controllers/v1/keyvalue.py
+++ b/st2api/st2api/controllers/v1/keyvalue.py
@@ -306,15 +306,15 @@ class KeyValuePairController(ResourceController):
                 kvp_db = KeyValuePair.add_or_update(kvp_db)
             except (ValidationError, ValueError) as e:
                 LOG.exception('Validation failed for key value data=%s', kvp)
-                abort(http_client.BAD_REQUEST, str(e))
+                abort(http_client.BAD_REQUEST, six.text_type(e))
                 return
             except CryptoKeyNotSetupException as e:
-                LOG.exception(str(e))
-                abort(http_client.BAD_REQUEST, str(e))
+                LOG.exception(six.text_type(e))
+                abort(http_client.BAD_REQUEST, six.text_type(e))
                 return
             except InvalidScopeException as e:
-                LOG.exception(str(e))
-                abort(http_client.BAD_REQUEST, str(e))
+                LOG.exception(six.text_type(e))
+                abort(http_client.BAD_REQUEST, six.text_type(e))
                 return
         extra = {'kvp_db': kvp_db}
         LOG.audit('KeyValuePair updated. KeyValuePair.id=%s' % (kvp_db.id), extra=extra)
@@ -367,7 +367,7 @@ class KeyValuePairController(ResourceController):
             except Exception as e:
                 LOG.exception('Database delete encountered exception during '
                               'delete of name="%s". ', name)
-                abort(http_client.INTERNAL_SERVER_ERROR, str(e))
+                abort(http_client.INTERNAL_SERVER_ERROR, six.text_type(e))
                 return
 
         extra = {'kvp_db': kvp_db}

--- a/st2api/st2api/controllers/v1/pack_configs.py
+++ b/st2api/st2api/controllers/v1/pack_configs.py
@@ -106,7 +106,7 @@ class PackConfigsController(ResourceController, BaseRestControllerMixin):
             config_api = ConfigAPI(pack=pack_ref, values=vars(pack_config_content))
             config_api.validate(validate_against_schema=True)
         except jsonschema.ValidationError as e:
-            raise ValueValidationException(str(e))
+            raise ValueValidationException(six.text_type(e))
 
         self._dump_config_to_disk(config_api)
 

--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -192,8 +192,8 @@ class PackRegisterController(object):
                             result[name] += registered_count
                         except ValueError as e:
                             # Throw more user-friendly exception if requsted pack doesn't exist
-                            if re.match('Directory ".*?" doesn\'t exist', str(e)):
-                                msg = 'Pack "%s" not found on disk: %s' % (pack, str(e))
+                            if re.match('Directory ".*?" doesn\'t exist', six.text_type(e)):
+                                msg = 'Pack "%s" not found on disk: %s' % (pack, six.text_type(e))
                                 raise ValueError(msg)
 
                             raise e

--- a/st2api/st2api/controllers/v1/policies.py
+++ b/st2api/st2api/controllers/v1/policies.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import six
 from mongoengine import ValidationError
 from six.moves import http_client
 
@@ -187,7 +188,7 @@ class PolicyController(resource.ContentPackResourceController):
             validate_not_part_of_system_pack(db_model)
         except ValueValidationException as e:
             LOG.exception('%s unable to update object from system pack.', op)
-            abort(http_client.BAD_REQUEST, str(e))
+            abort(http_client.BAD_REQUEST, six.text_type(e))
 
         if not getattr(instance, 'pack', None):
             instance.pack = db_model.pack
@@ -198,7 +199,7 @@ class PolicyController(resource.ContentPackResourceController):
             db_model = self.access.add_or_update(db_model)
         except (ValidationError, ValueError) as e:
             LOG.exception('%s unable to update object: %s', op, db_model)
-            abort(http_client.BAD_REQUEST, str(e))
+            abort(http_client.BAD_REQUEST, six.text_type(e))
             return
 
         LOG.debug('%s updated object: %s', op, db_model)
@@ -230,13 +231,13 @@ class PolicyController(resource.ContentPackResourceController):
             validate_not_part_of_system_pack(db_model)
         except ValueValidationException as e:
             LOG.exception('%s unable to delete object from system pack.', op)
-            abort(http_client.BAD_REQUEST, str(e))
+            abort(http_client.BAD_REQUEST, six.text_type(e))
 
         try:
             self.access.delete(db_model)
         except Exception as e:
             LOG.exception('%s unable to delete object: %s', op, db_model)
-            abort(http_client.INTERNAL_SERVER_ERROR, str(e))
+            abort(http_client.INTERNAL_SERVER_ERROR, six.text_type(e))
             return
 
         LOG.debug('%s deleted object: %s', op, db_model)

--- a/st2api/st2api/controllers/v1/rules.py
+++ b/st2api/st2api/controllers/v1/rules.py
@@ -130,11 +130,11 @@ class RuleController(BaseResourceIsolationControllerMixin, ContentPackResourceCo
             increment_trigger_ref_count(rule_api=rule)
         except (ValidationError, ValueError) as e:
             LOG.exception('Validation failed for rule data=%s.', rule)
-            abort(http_client.BAD_REQUEST, str(e))
+            abort(http_client.BAD_REQUEST, six.text_type(e))
             return
         except (ValueValidationException, jsonschema.ValidationError) as e:
             LOG.exception('Validation failed for rule data=%s.', rule)
-            abort(http_client.BAD_REQUEST, str(e))
+            abort(http_client.BAD_REQUEST, six.text_type(e))
             return
         except TriggerDoesNotExistException as e:
             msg = ('Trigger "%s" defined in the rule does not exist in system or it\'s missing '
@@ -179,7 +179,7 @@ class RuleController(BaseResourceIsolationControllerMixin, ContentPackResourceCo
             try:
                 rule_db = RuleAPI.to_model(rule)
             except TriggerDoesNotExistException as e:
-                abort(http_client.BAD_REQUEST, str(e))
+                abort(http_client.BAD_REQUEST, six.text_type(e))
                 return
 
             # Check referenced trigger and action permissions
@@ -195,7 +195,7 @@ class RuleController(BaseResourceIsolationControllerMixin, ContentPackResourceCo
             increment_trigger_ref_count(rule_api=rule)
         except (ValueValidationException, jsonschema.ValidationError, ValueError) as e:
             LOG.exception('Validation failed for rule data=%s', rule)
-            abort(http_client.BAD_REQUEST, str(e))
+            abort(http_client.BAD_REQUEST, six.text_type(e))
             return
 
         # use old_rule_db for cleanup.
@@ -227,7 +227,7 @@ class RuleController(BaseResourceIsolationControllerMixin, ContentPackResourceCo
         except Exception as e:
             LOG.exception('Database delete encountered exception during delete of id="%s".',
                           rule_ref_or_id)
-            abort(http_client.INTERNAL_SERVER_ERROR, str(e))
+            abort(http_client.INTERNAL_SERVER_ERROR, six.text_type(e))
             return
 
         # use old_rule_db for cleanup.

--- a/st2api/st2api/controllers/v1/runnertypes.py
+++ b/st2api/st2api/controllers/v1/runnertypes.py
@@ -82,7 +82,7 @@ class RunnerTypesController(ResourceController):
             runner_type_db = RunnerType.add_or_update(runner_type_db)
         except (ValidationError, ValueError) as e:
             LOG.exception('Validation failed for runner type data=%s', runner_type_api)
-            abort(http_client.BAD_REQUEST, str(e))
+            abort(http_client.BAD_REQUEST, six.text_type(e))
             return
 
         extra = {'old_runner_type_db': old_runner_type_db, 'new_runner_type_db': runner_type_db}

--- a/st2api/st2api/controllers/v1/sensors.py
+++ b/st2api/st2api/controllers/v1/sensors.py
@@ -84,7 +84,7 @@ class SensorTypeController(resource.ContentPackResourceController):
         try:
             validate_not_part_of_system_pack(sensor_type_db)
         except ValueValidationException as e:
-            abort(http_client.BAD_REQUEST, str(e))
+            abort(http_client.BAD_REQUEST, six.text_type(e))
             return
 
         if not getattr(sensor_type, 'pack', None):
@@ -96,7 +96,7 @@ class SensorTypeController(resource.ContentPackResourceController):
             sensor_type_db = SensorType.add_or_update(sensor_type_db)
         except (ValidationError, ValueError) as e:
             LOG.exception('Unable to update sensor_type data=%s', sensor_type)
-            abort(http_client.BAD_REQUEST, str(e))
+            abort(http_client.BAD_REQUEST, six.text_type(e))
             return
 
         extra = {

--- a/st2api/st2api/controllers/v1/timers.py
+++ b/st2api/st2api/controllers/v1/timers.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import six
 from six import iteritems
 from six.moves import http_client
 
@@ -99,8 +100,8 @@ class TimersController(resource.ContentPackResourceController):
         try:
             trigger_db = self._get_by_ref_or_id(ref_or_id=ref_or_id)
         except Exception as e:
-            LOG.exception(str(e))
-            abort(http_client.NOT_FOUND, str(e))
+            LOG.exception(six.text_type(e))
+            abort(http_client.NOT_FOUND, six.text_type(e))
             return
 
         permission_type = PermissionType.TIMER_VIEW

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -83,7 +83,7 @@ class TriggerTypeController(resource.ContentPackResourceController):
             triggertype_db = TriggerType.add_or_update(triggertype_db)
         except (ValidationError, ValueError) as e:
             LOG.exception('Validation failed for triggertype data=%s.', triggertype)
-            abort(http_client.BAD_REQUEST, str(e))
+            abort(http_client.BAD_REQUEST, six.text_type(e))
             return
         else:
             extra = {'triggertype_db': triggertype_db}
@@ -102,7 +102,7 @@ class TriggerTypeController(resource.ContentPackResourceController):
         try:
             validate_not_part_of_system_pack(triggertype_db)
         except ValueValidationException as e:
-            abort(http_client.BAD_REQUEST, str(e))
+            abort(http_client.BAD_REQUEST, six.text_type(e))
 
         try:
             triggertype_db = TriggerTypeAPI.to_model(triggertype)
@@ -115,7 +115,7 @@ class TriggerTypeController(resource.ContentPackResourceController):
             triggertype_db = TriggerType.add_or_update(triggertype_db)
         except (ValidationError, ValueError) as e:
             LOG.exception('Validation failed for triggertype data=%s', triggertype)
-            abort(http_client.BAD_REQUEST, str(e))
+            abort(http_client.BAD_REQUEST, six.text_type(e))
             return
 
         extra = {'old_triggertype_db': old_triggertype_db, 'new_triggertype_db': triggertype_db}
@@ -141,14 +141,14 @@ class TriggerTypeController(resource.ContentPackResourceController):
         try:
             validate_not_part_of_system_pack(triggertype_db)
         except ValueValidationException as e:
-            abort(http_client.BAD_REQUEST, str(e))
+            abort(http_client.BAD_REQUEST, six.text_type(e))
 
         try:
             TriggerType.delete(triggertype_db)
         except Exception as e:
             LOG.exception('Database delete encountered exception during delete of id="%s". ',
                           triggertype_id)
-            abort(http_client.INTERNAL_SERVER_ERROR, str(e))
+            abort(http_client.INTERNAL_SERVER_ERROR, six.text_type(e))
             return
         else:
             extra = {'triggertype': triggertype_db}
@@ -177,7 +177,7 @@ class TriggerTypeController(resource.ContentPackResourceController):
             return
         except StackStormDBObjectConflictError as e:
             LOG.warn('Trigger creation of "%s" failed with uniqueness conflict. Exception: %s',
-                     trigger, str(e))
+                     trigger, six.text_type(e))
             # Not aborting as this is convenience.
             return
 
@@ -238,7 +238,7 @@ class TriggerController(object):
             trigger_db = TriggerService.create_trigger_db(trigger)
         except (ValidationError, ValueError) as e:
             LOG.exception('Validation failed for trigger data=%s.', trigger)
-            abort(http_client.BAD_REQUEST, str(e))
+            abort(http_client.BAD_REQUEST, six.text_type(e))
             return
 
         extra = {'trigger': trigger_db}
@@ -258,7 +258,7 @@ class TriggerController(object):
             trigger_db = Trigger.add_or_update(trigger_db)
         except (ValidationError, ValueError) as e:
             LOG.exception('Validation failed for trigger data=%s', trigger)
-            abort(http_client.BAD_REQUEST, str(e))
+            abort(http_client.BAD_REQUEST, six.text_type(e))
             return
 
         extra = {'old_trigger_db': trigger, 'new_trigger_db': trigger_db}
@@ -281,7 +281,7 @@ class TriggerController(object):
         except Exception as e:
             LOG.exception('Database delete encountered exception during delete of id="%s". ',
                           trigger_id)
-            abort(http_client.INTERNAL_SERVER_ERROR, str(e))
+            abort(http_client.INTERNAL_SERVER_ERROR, six.text_type(e))
             return
 
         extra = {'trigger_db': trigger_db}
@@ -355,7 +355,7 @@ class TriggerInstanceResendController(TriggerInstanceControllerMixin, resource.R
                 'payload': new_payload
             }
         except Exception as e:
-            abort(http_client.INTERNAL_SERVER_ERROR, str(e))
+            abort(http_client.INTERNAL_SERVER_ERROR, six.text_type(e))
 
 
 class TriggerInstanceController(TriggerInstanceControllerMixin, resource.ResourceController):

--- a/st2auth/dist_utils.py
+++ b/st2auth/dist_utils.py
@@ -23,7 +23,6 @@ import sys
 from distutils.version import StrictVersion
 
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
-PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 if PY3:

--- a/st2auth/dist_utils.py
+++ b/st2auth/dist_utils.py
@@ -15,9 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import re
 import sys
+
+import six
 
 from distutils.version import StrictVersion
 
@@ -27,7 +30,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (str(e)))
+    print('Failed to import pip: %s' % (six.text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -41,7 +44,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/st2auth/dist_utils.py
+++ b/st2auth/dist_utils.py
@@ -20,9 +20,16 @@ import os
 import re
 import sys
 
-import six
-
 from distutils.version import StrictVersion
+
+# NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode
 
 GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
@@ -30,7 +37,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (six.text_type(e)))
+    print('Failed to import pip: %s' % (text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -44,7 +51,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
+        print('Failed to import parse_requirements from pip: %s' % (text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/st2auth/st2auth/backends/__init__.py
+++ b/st2auth/st2auth/backends/__init__.py
@@ -16,6 +16,7 @@
 import traceback
 import json
 
+import six
 from oslo_config import cfg
 
 from st2common import log as logging
@@ -68,7 +69,7 @@ def get_backend_instance(name):
             kwargs = json.loads(backend_kwargs)
         except ValueError as e:
             raise ValueError('Failed to JSON parse backend settings for backend "%s": %s' %
-                             (name, str(e)))
+                             (name, six.text_type(e)))
     else:
         kwargs = {}
 
@@ -80,7 +81,7 @@ def get_backend_instance(name):
         tb_msg = traceback.format_exc()
         class_name = cls.__name__
         msg = ('Failed to instantiate auth backend "%s" (class %s) with backend settings '
-               '"%s": %s' % (name, class_name, str(kwargs), str(e)))
+               '"%s": %s' % (name, class_name, str(kwargs), six.text_type(e)))
         msg += '\n\n' + tb_msg
         exc_cls = type(e)
         raise exc_cls(msg)

--- a/st2auth/st2auth/handlers.py
+++ b/st2auth/st2auth/handlers.py
@@ -119,7 +119,7 @@ class ProxyAuthHandler(AuthHandlerBase):
                                                     ttl=ttl)
             except TTLTooLargeException as e:
                 abort_request(status_code=http_client.BAD_REQUEST,
-                              message=str(e))
+                              message=six.text_type(e))
             return token
 
         LOG.audit('Access denied to anonymous user.', extra=extra)
@@ -179,7 +179,7 @@ class StandaloneAuthHandler(AuthHandlerBase):
                 token = self._create_token_for_user(username=username, ttl=ttl)
             except TTLTooLargeException as e:
                 abort_request(status_code=http_client.BAD_REQUEST,
-                              message=str(e))
+                              message=six.text_type(e))
                 return
 
             # If remote group sync is enabled, sync the remote groups with local StackStorm roles

--- a/st2client/dist_utils.py
+++ b/st2client/dist_utils.py
@@ -23,7 +23,6 @@ import sys
 from distutils.version import StrictVersion
 
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
-PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 if PY3:

--- a/st2client/dist_utils.py
+++ b/st2client/dist_utils.py
@@ -15,9 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import re
 import sys
+
+import six
 
 from distutils.version import StrictVersion
 
@@ -27,7 +30,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (str(e)))
+    print('Failed to import pip: %s' % (six.text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -41,7 +44,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/st2client/dist_utils.py
+++ b/st2client/dist_utils.py
@@ -20,9 +20,16 @@ import os
 import re
 import sys
 
-import six
-
 from distutils.version import StrictVersion
+
+# NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode
 
 GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
@@ -30,7 +37,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (six.text_type(e)))
+    print('Failed to import pip: %s' % (text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -44,7 +51,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
+        print('Failed to import parse_requirements from pip: %s' % (text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/st2client/st2client/base.py
+++ b/st2client/st2client/base.py
@@ -277,7 +277,7 @@ class BaseCLIApp(object):
             expire_timestamp = data['expire_timestamp']
         except Exception as e:
             msg = ('File "%s" with cached token is corrupted or invalid (%s). Please delete '
-                   ' this file' % (cached_token_path, str(e)))
+                   ' this file' % (cached_token_path, six.text_type(e)))
             raise ValueError(msg)
 
         now = int(time.time())

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -706,7 +706,7 @@ class ActionRunCommandMixin(object):
                 except Exception as e:
                     # TODO: Move transformers in a separate module and handle
                     # exceptions there
-                    if 'malformed string' in str(e):
+                    if 'malformed string' in six.text_type(e):
                         message = ('Invalid value for boolean parameter. '
                                    'Valid values are: true, false')
                         raise ValueError(message)

--- a/st2client/st2client/commands/auth.py
+++ b/st2client/st2client/commands/auth.py
@@ -21,6 +21,7 @@ import logging
 import os
 
 import requests
+import six
 from six.moves.configparser import ConfigParser
 from six.moves import http_client
 
@@ -155,7 +156,7 @@ class LoginCommand(resource.ResourceCommand):
             if self.app.client.debug:
                 raise
 
-            raise Exception('Failed to log in as %s: %s' % (args.username, str(e)))
+            raise Exception('Failed to log in as %s: %s' % (args.username, six.text_type(e)))
 
         print('Logged in as %s' % (args.username))
 
@@ -315,7 +316,7 @@ class ApiKeyCreateCommand(resource.ResourceCommand):
             if not instance:
                 raise Exception('Server did not create instance.')
         except Exception as e:
-            message = str(e)
+            message = six.text_type(e)
             print('ERROR: %s' % (message))
             raise OperationFailureException(message)
         if args.only_key:

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -14,8 +14,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import sys
 
+import six
 import editor
 import yaml
 
@@ -81,7 +83,7 @@ class PackResourceCommand(resource.ResourceCommand):
         except resource.ResourceNotFoundError:
             print("No matching items found")
         except Exception as e:
-            message = str(e)
+            message = six.text_type(e)
             print('ERROR: %s' % (message))
             raise OperationFailureException(message)
 
@@ -401,7 +403,7 @@ class PackConfigCommand(resource.ResourceCommand):
                 modified = editor.edit(contents=contents)
                 config = yaml.safe_load(modified)
             except editor.EditorError as e:
-                print(str(e))
+                print(six.text_type(e))
 
         message = '---\nDo you want me to save it?'
         save_dialog = interactive.Question(message, {'default': 'y'})
@@ -426,6 +428,6 @@ class PackConfigCommand(resource.ResourceCommand):
             if self.app.client.debug:
                 raise
 
-            message = str(e)
+            message = six.text_type(e)
             print('ERROR: %s' % (message))
             raise OperationFailureException(message)

--- a/st2client/st2client/commands/resource.py
+++ b/st2client/st2client/commands/resource.py
@@ -425,7 +425,7 @@ class ResourceCreateCommand(ResourceCommand):
             self.print_output(instance, table.PropertyValueTable,
                               attributes=['all'], json=args.json, yaml=args.yaml)
         except Exception as e:
-            message = str(e)
+            message = six.text_type(e)
             print('ERROR: %s' % (message))
             raise OperationFailureException(message)
 
@@ -473,8 +473,8 @@ class ResourceUpdateCommand(ResourceCommand):
             self.print_output(instance, table.PropertyValueTable,
                               attributes=['all'], json=args.json, yaml=args.yaml)
         except Exception as e:
-            print('ERROR: %s' % (str(e)))
-            raise OperationFailureException(str(e))
+            print('ERROR: %s' % (six.text_type(e)))
+            raise OperationFailureException(six.text_type(e))
 
 
 class ContentPackResourceUpdateCommand(ResourceUpdateCommand):

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -162,7 +162,7 @@ class ResourceManager(object):
                 response.reason += '\nMESSAGE: %s' % fault
         except Exception as e:
             response.reason += ('\nUnable to retrieve detailed message '
-                                'from the HTTP response. %s\n' % str(e))
+                                'from the HTTP response. %s\n' % six.text_type(e))
         response.raise_for_status()
 
     @add_auth_token_to_kwargs_from_env
@@ -660,7 +660,7 @@ class WorkflowManager(object):
         except Exception as e:
             response.reason += (
                 '\nUnable to retrieve detailed message '
-                'from the HTTP response. %s\n' % str(e)
+                'from the HTTP response. %s\n' % six.text_type(e)
             )
 
         response.raise_for_status()

--- a/st2client/st2client/utils/interactive.py
+++ b/st2client/st2client/utils/interactive.py
@@ -14,8 +14,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import re
 
+import six
 import jsonschema
 from jsonschema import Draft3Validator
 from prompt_toolkit import prompt
@@ -76,7 +78,7 @@ class StringReader(object):
         try:
             jsonschema.validate(input, spec, Draft3Validator)
         except jsonschema.ValidationError as e:
-            raise validation.ValidationError(len(input), str(e))
+            raise validation.ValidationError(len(input), six.text_type(e))
 
     def read(self):
         message = self.template.format(self.prefix + self.name, **self.spec)
@@ -154,7 +156,7 @@ class NumberReader(StringReader):
             try:
                 input = float(input)
             except ValueError as e:
-                raise validation.ValidationError(len(input), str(e))
+                raise validation.ValidationError(len(input), six.text_type(e))
 
             super(NumberReader, NumberReader).validate(input, spec)
 
@@ -181,7 +183,7 @@ class IntegerReader(StringReader):
             try:
                 input = int(input)
             except ValueError as e:
-                raise validation.ValidationError(len(input), str(e))
+                raise validation.ValidationError(len(input), six.text_type(e))
 
             super(IntegerReader, IntegerReader).validate(input, spec)
 
@@ -287,7 +289,7 @@ class ArrayReader(StringReader):
             try:
                 StringReader.validate(item, spec.get('items', {}))
             except validation.ValidationError as e:
-                raise validation.ValidationError(index, str(e))
+                raise validation.ValidationError(index, six.text_type(e))
 
     def read(self):
         item_type = self.spec.get('items', {}).get('type', 'string')
@@ -357,7 +359,7 @@ class ArrayEnumReader(EnumReader):
             try:
                 EnumReader.validate(item, spec.get('items', {}))
             except validation.ValidationError as e:
-                raise validation.ValidationError(index, str(e))
+                raise validation.ValidationError(index, six.text_type(e))
 
     def _construct_template(self):
         self.template = u'{0}: '
@@ -417,7 +419,7 @@ class InteractiveForm(object):
                 try:
                     result[field] = self._read_field(field)
                 except ReaderNotImplemented as e:
-                    print('%s. Skipping...' % str(e))
+                    print('%s. Skipping...' % six.text_type(e))
         except DialogInterrupted:
             if self.reraise:
                 raise

--- a/st2common/dist_utils.py
+++ b/st2common/dist_utils.py
@@ -23,7 +23,6 @@ import sys
 from distutils.version import StrictVersion
 
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
-PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 if PY3:

--- a/st2common/dist_utils.py
+++ b/st2common/dist_utils.py
@@ -15,9 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import re
 import sys
+
+import six
 
 from distutils.version import StrictVersion
 
@@ -27,7 +30,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (str(e)))
+    print('Failed to import pip: %s' % (six.text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -41,7 +44,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/st2common/dist_utils.py
+++ b/st2common/dist_utils.py
@@ -20,9 +20,16 @@ import os
 import re
 import sys
 
-import six
-
 from distutils.version import StrictVersion
+
+# NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode
 
 GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
@@ -30,7 +37,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (six.text_type(e)))
+    print('Failed to import pip: %s' % (text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -44,7 +51,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
+        print('Failed to import parse_requirements from pip: %s' % (text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/st2common/st2common/bootstrap/actionsregistrar.py
+++ b/st2common/st2common/bootstrap/actionsregistrar.py
@@ -139,7 +139,7 @@ class ActionsRegistrar(ResourceRegistrar):
             action_api.validate()
         except jsonschema.ValidationError as e:
             # We throw a more user-friendly exception on invalid parameter name
-            msg = str(e)
+            msg = six.text_type(e)
 
             is_invalid_parameter_name = 'does not match any of the regexes: ' in msg
 
@@ -196,12 +196,12 @@ class ActionsRegistrar(ResourceRegistrar):
             except Exception as e:
                 # We ignore mistral-v2 runner not found errors since those represent installations
                 # without Mistral
-                if 'mistral-v2 is not found' in str(e):
+                if 'mistral-v2 is not found' in six.text_type(e):
                     continue
 
                 if self._fail_on_failure:
                     msg = ('Failed to register action "%s" from pack "%s": %s' % (action, pack,
-                                                                                  str(e)))
+                                                                                  six.text_type(e)))
                     raise ValueError(msg)
 
                 LOG.exception('Unable to register action: %s', action)

--- a/st2common/st2common/bootstrap/aliasesregistrar.py
+++ b/st2common/st2common/bootstrap/aliasesregistrar.py
@@ -176,7 +176,7 @@ class AliasesRegistrar(ResourceRegistrar):
             except Exception as e:
                 if self._fail_on_failure:
                     msg = ('Failed to register alias "%s" from pack "%s": %s' % (alias, pack,
-                                                                                 str(e)))
+                                                                                 six.text_type(e)))
                     raise ValueError(msg)
 
                 LOG.exception('Unable to register alias: %s', alias)

--- a/st2common/st2common/bootstrap/base.py
+++ b/st2common/st2common/bootstrap/base.py
@@ -128,7 +128,7 @@ class ResourceRegistrar(object):
             pack_db, _ = self._register_pack(pack_name=pack_name, pack_dir=pack_dir)
         except Exception as e:
             if self._fail_on_failure:
-                msg = 'Failed to register pack "%s": %s' % (pack_name, str(e))
+                msg = 'Failed to register pack "%s": %s' % (pack_name, six.text_type(e))
                 raise ValueError(msg)
 
             LOG.exception('Failed to register pack "%s"' % (pack_name))

--- a/st2common/st2common/bootstrap/configsregistrar.py
+++ b/st2common/st2common/bootstrap/configsregistrar.py
@@ -14,8 +14,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 
+import six
 from oslo_config import cfg
 
 from st2common import log as logging
@@ -76,10 +78,11 @@ class ConfigsRegistrar(ResourceRegistrar):
                 if self._fail_on_failure:
                     msg = ('Failed to register config "%s" for pack "%s": %s' % (config_path,
                                                                                  pack_name,
-                                                                                 str(e)))
+                                                                                 six.text_type(e)))
                     raise ValueError(msg)
 
-                LOG.exception('Failed to register config for pack "%s": %s', pack_name, str(e))
+                LOG.exception('Failed to register config for pack "%s": %s', pack_name,
+                              six.text_type(e))
             else:
                 registered_count += 1
 

--- a/st2common/st2common/bootstrap/policiesregistrar.py
+++ b/st2common/st2common/bootstrap/policiesregistrar.py
@@ -122,7 +122,7 @@ class PolicyRegistrar(ResourceRegistrar):
             except Exception as e:
                 if self._fail_on_failure:
                     msg = ('Failed to register policy "%s" from pack "%s": %s' % (policy, pack,
-                                                                                  str(e)))
+                                                                                  six.text_type(e)))
                     raise ValueError(msg)
 
                 LOG.exception('Unable to register policy: %s', policy)

--- a/st2common/st2common/bootstrap/rulesregistrar.py
+++ b/st2common/st2common/bootstrap/rulesregistrar.py
@@ -172,7 +172,7 @@ class RulesRegistrar(ResourceRegistrar):
             except Exception as e:
                 if self._fail_on_failure:
                     msg = ('Failed to register rule "%s" from pack "%s": %s' % (rule, pack,
-                                                                                str(e)))
+                                                                                six.text_type(e)))
                     raise ValueError(msg)
 
                 LOG.exception('Failed registering rule from %s.', rule)

--- a/st2common/st2common/bootstrap/sensorsregistrar.py
+++ b/st2common/st2common/bootstrap/sensorsregistrar.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 
 import six
@@ -67,7 +68,7 @@ class SensorsRegistrar(ResourceRegistrar):
                     raise e
 
                 LOG.exception('Failed registering all sensors from pack "%s": %s', sensors_dir,
-                              str(e))
+                              six.text_type(e))
 
         return registered_count
 
@@ -99,7 +100,8 @@ class SensorsRegistrar(ResourceRegistrar):
             if self._fail_on_failure:
                 raise e
 
-            LOG.exception('Failed registering all sensors from pack "%s": %s', sensors_dir, str(e))
+            LOG.exception('Failed registering all sensors from pack "%s": %s', sensors_dir,
+                          six.text_type(e))
 
         return registered_count
 
@@ -114,10 +116,10 @@ class SensorsRegistrar(ResourceRegistrar):
             except Exception as e:
                 if self._fail_on_failure:
                     msg = ('Failed to register sensor "%s" from pack "%s": %s' % (sensor, pack,
-                                                                                  str(e)))
+                                                                                  six.text_type(e)))
                     raise ValueError(msg)
 
-                LOG.debug('Failed to register sensor "%s": %s', sensor, str(e))
+                LOG.debug('Failed to register sensor "%s": %s', sensor, six.text_type(e))
             else:
                 LOG.debug('Sensor "%s" successfully registered', sensor)
                 registered_count += 1

--- a/st2common/st2common/bootstrap/triggersregistrar.py
+++ b/st2common/st2common/bootstrap/triggersregistrar.py
@@ -64,7 +64,7 @@ class TriggersRegistrar(ResourceRegistrar):
                     raise e
 
                 LOG.exception('Failed registering all triggers from pack "%s": %s', triggers_dir,
-                              str(e))
+                              six.text_type(e))
 
         return registered_count
 
@@ -97,7 +97,7 @@ class TriggersRegistrar(ResourceRegistrar):
                 raise e
 
             LOG.exception('Failed registering all triggers from pack "%s": %s', triggers_dir,
-                          str(e))
+                          six.text_type(e))
 
         return registered_count
 
@@ -117,10 +117,10 @@ class TriggersRegistrar(ResourceRegistrar):
             except Exception as e:
                 if self._fail_on_failure:
                     msg = ('Failed to register trigger "%s" from pack "%s": %s' % (trigger, pack,
-                                                                                   str(e)))
+                        six.text_type(e)))
                     raise ValueError(msg)
 
-                LOG.debug('Failed to register trigger "%s": %s', trigger, str(e))
+                LOG.debug('Failed to register trigger "%s": %s', trigger, six.text_type(e))
             else:
                 LOG.debug('Trigger "%s" successfully registered', trigger)
                 registered_count += 1

--- a/st2common/st2common/cmd/purge_executions.py
+++ b/st2common/st2common/cmd/purge_executions.py
@@ -22,9 +22,11 @@ timestamp.
 """
 
 from __future__ import absolute_import
-from datetime import datetime
-import pytz
 
+from datetime import datetime
+
+import six
+import pytz
 from oslo_config import cfg
 
 from st2common import config
@@ -79,7 +81,7 @@ def main():
         purge_executions(logger=LOG, timestamp=timestamp, action_ref=action_ref,
                          purge_incomplete=purge_incomplete)
     except Exception as e:
-        LOG.exception(str(e))
+        LOG.exception(six.text_type(e))
         return FAILURE_EXIT_CODE
     finally:
         common_teardown()

--- a/st2common/st2common/cmd/purge_trigger_instances.py
+++ b/st2common/st2common/cmd/purge_trigger_instances.py
@@ -22,9 +22,11 @@ timestamp.
 """
 
 from __future__ import absolute_import
-from datetime import datetime
-import pytz
 
+from datetime import datetime
+
+import six
+import pytz
 from oslo_config import cfg
 
 from st2common import config
@@ -71,7 +73,7 @@ def main():
     try:
         purge_trigger_instances(logger=LOG, timestamp=timestamp)
     except Exception as e:
-        LOG.exception(str(e))
+        LOG.exception(six.text_type(e))
         return FAILURE_EXIT_CODE
     finally:
         common_teardown()

--- a/st2common/st2common/cmd/validate_config.py
+++ b/st2common/st2common/cmd/validate_config.py
@@ -18,9 +18,11 @@ Script for validating a config file against a a particular config schema.
 """
 
 from __future__ import absolute_import
-import os
-import yaml
 
+import os
+
+import yaml
+import six
 from oslo_config import cfg
 
 from st2common.config import do_register_cli_opts
@@ -73,7 +75,7 @@ def main():
         validate_config_against_schema(config_schema=config_schema, config_object=config_object,
                                        config_path=config_path)
     except Exception as e:
-        print('Failed to validate pack config.\n%s' % str(e))
+        print('Failed to validate pack config.\n%s' % six.text_type(e))
         return FAILURE_EXIT_CODE
 
     print('Config "%s" successfully validated against schema in %s.' % (config_path, schema_path))

--- a/st2common/st2common/garbage_collection/executions.py
+++ b/st2common/st2common/garbage_collection/executions.py
@@ -19,8 +19,10 @@ corresponding live action objects.
 """
 
 from __future__ import absolute_import
+
 import copy
 
+import six
 from mongoengine.errors import InvalidQueryError
 
 from st2common.constants import action as action_constants
@@ -86,7 +88,7 @@ def purge_executions(logger, timestamp, action_ref=None, purge_incomplete=False)
         deleted_count = ActionExecution.delete_by_query(**exec_filters)
     except InvalidQueryError as e:
         msg = ('Bad query (%s) used to delete execution instances: %s'
-               'Please contact support.' % (exec_filters, str(e)))
+               'Please contact support.' % (exec_filters, six.text_type(e)))
         raise InvalidQueryError(msg)
     except:
         logger.exception('Deletion of execution models failed for query with filters: %s.',
@@ -99,7 +101,7 @@ def purge_executions(logger, timestamp, action_ref=None, purge_incomplete=False)
         deleted_count = LiveAction.delete_by_query(**liveaction_filters)
     except InvalidQueryError as e:
         msg = ('Bad query (%s) used to delete liveaction instances: %s'
-               'Please contact support.' % (liveaction_filters, str(e)))
+               'Please contact support.' % (liveaction_filters, six.text_type(e)))
         raise InvalidQueryError(msg)
     except:
         logger.exception('Deletion of liveaction models failed for query with filters: %s.',
@@ -116,7 +118,7 @@ def purge_executions(logger, timestamp, action_ref=None, purge_incomplete=False)
         deleted_count = ActionExecutionOutput.delete_by_query(**output_dbs_filters)
     except InvalidQueryError as e:
         msg = ('Bad query (%s) used to delete execution output instances: %s'
-               'Please contact support.' % (output_dbs_filters, str(e)))
+               'Please contact support.' % (output_dbs_filters, six.text_type(e)))
         raise InvalidQueryError(msg)
     except:
         logger.exception('Deletion of execution output models failed for query with filters: %s.',
@@ -165,7 +167,7 @@ def purge_execution_output_objects(logger, timestamp, action_ref=None):
         deleted_count = ActionExecutionOutput.delete_by_query(**filters)
     except InvalidQueryError as e:
         msg = ('Bad query (%s) used to delete execution output instances: %s'
-               'Please contact support.' % (filters, str(e)))
+               'Please contact support.' % (filters, six.text_type(e)))
         raise InvalidQueryError(msg)
     except:
         logger.exception('Deletion of execution output models failed for query with filters: %s.',

--- a/st2common/st2common/garbage_collection/trigger_instances.py
+++ b/st2common/st2common/garbage_collection/trigger_instances.py
@@ -18,6 +18,8 @@ Module with utility functions for purging old trigger instance objects.
 """
 
 from __future__ import absolute_import
+
+import six
 from mongoengine.errors import InvalidQueryError
 
 from st2common.persistence.trigger import TriggerInstance
@@ -45,7 +47,7 @@ def purge_trigger_instances(logger, timestamp):
         deleted_count = TriggerInstance.delete_by_query(**query_filters)
     except InvalidQueryError as e:
         msg = ('Bad query (%s) used to delete trigger instances: %s'
-               'Please contact support.' % (query_filters, str(e)))
+               'Please contact support.' % (query_filters, six.text_type(e)))
         raise InvalidQueryError(msg)
     except:
         logger.exception('Deleting instances using query_filters %s failed.', query_filters)

--- a/st2common/st2common/log.py
+++ b/st2common/st2common/log.py
@@ -110,7 +110,7 @@ def decorate_log_method(func):
             # See:
             # - https://docs.python.org/release/2.7.3/library/logging.html#logging.Logger.exception
             # - https://docs.python.org/release/2.7.7/library/logging.html#logging.Logger.exception
-            if 'got an unexpected keyword argument \'extra\'' in str(e):
+            if 'got an unexpected keyword argument \'extra\'' in six.text_type(e):
                 kwargs.pop('extra', None)
                 return func(*args, **kwargs)
             raise e

--- a/st2common/st2common/logging/formatters.py
+++ b/st2common/st2common/logging/formatters.py
@@ -264,7 +264,7 @@ class GelfLogFormatter(BaseExtraLogFormatter):
             # Include exception information
             exc_type, exc_value, exc_tb = exc_info
             tb_str = ''.join(traceback.format_tb(exc_tb))
-            data['_exception'] = str(exc_value)
+            data['_exception'] = six.text_type(exc_value)
             data['_traceback'] = tb_str
 
         # Include common Python log record attributes

--- a/st2common/st2common/logging/misc.py
+++ b/st2common/st2common/logging/misc.py
@@ -18,6 +18,8 @@ from __future__ import absolute_import
 import os.path
 import logging
 
+import six
+
 from st2common.logging.filters import LoggerFunctionNameExclusionFilter
 
 __all__ = [
@@ -74,7 +76,7 @@ def reopen_log_files(handlers):
             try:
                 handler.release()
             except RuntimeError as e:
-                if 'cannot release' in str(e):
+                if 'cannot release' in six.text_type(e):
                     # Release failed which most likely indicates that acquire failed
                     # and lock was never acquired
                     LOG.warn('Failed to release lock', exc_info=True)

--- a/st2common/st2common/middleware/error_handling.py
+++ b/st2common/st2common/middleware/error_handling.py
@@ -14,8 +14,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import traceback
 
+import six
 from mongoengine import ValidationError
 
 from st2common.exceptions import db as db_exceptions
@@ -60,30 +62,30 @@ class ErrorHandlingMiddleware(object):
 
             if isinstance(e, exc.HTTPException):
                 status_code = status
-                message = str(e)
+                message = six.text_type(e)
             elif isinstance(e, db_exceptions.StackStormDBObjectNotFoundError):
                 status_code = exc.HTTPNotFound.code
-                message = str(e)
+                message = six.text_type(e)
             elif isinstance(e, db_exceptions.StackStormDBObjectConflictError):
                 status_code = exc.HTTPConflict.code
-                message = str(e)
+                message = six.text_type(e)
                 body['conflict-id'] = getattr(e, 'conflict_id', None)
             elif isinstance(e, rbac_exceptions.AccessDeniedError):
                 status_code = exc.HTTPForbidden.code
-                message = str(e)
+                message = six.text_type(e)
             elif isinstance(e, (ValueValidationException, ValueError, ValidationError)):
                 status_code = exc.HTTPBadRequest.code
-                message = getattr(e, 'message', str(e))
+                message = getattr(e, 'message', six.text_type(e))
             else:
                 status_code = exc.HTTPInternalServerError.code
                 message = 'Internal Server Error'
 
             # Log the error
             is_internal_server_error = status_code == exc.HTTPInternalServerError.code
-            error_msg = getattr(e, 'comment', str(e))
+            error_msg = getattr(e, 'comment', six.text_type(e))
             extra = {
                 'exception_class': e.__class__.__name__,
-                'exception_message': str(e),
+                'exception_message': six.text_type(e),
                 'exception_data': e.__dict__
             }
 

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -14,8 +14,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 
+import six
 import jsonschema
 from oslo_config import cfg
 
@@ -180,7 +182,7 @@ class PackAPI(BaseAPI):
         try:
             super(PackAPI, self).validate()
         except jsonschema.ValidationError as e:
-            msg = str(e)
+            msg = six.text_type(e)
 
             # Invalid version
             if "Failed validating 'pattern' in schema['properties']['version']" in msg:

--- a/st2common/st2common/models/utils/action_param_utils.py
+++ b/st2common/st2common/models/utils/action_param_utils.py
@@ -132,7 +132,7 @@ def cast_params(action_ref, params, cast_overrides=None):
             v_type = type(v).__name__
             msg = ('Failed to cast value "%s" (type: %s) for parameter "%s" of type "%s": %s. '
                    'Perhaps the value is of an invalid type?' %
-                   (v, v_type, k, parameter_type, str(e)))
+                   (v, v_type, k, parameter_type, six.text_type(e)))
             raise ValueError(msg)
 
     return params

--- a/st2common/st2common/persistence/base.py
+++ b/st2common/st2common/persistence/base.py
@@ -135,14 +135,14 @@ class Access(object):
             model_object = cls._get_impl().insert(model_object)
         except NotUniqueError as e:
             if log_not_unique_error_as_debug:
-                LOG.debug('Conflict while trying to save in DB: %s.', str(e))
+                LOG.debug('Conflict while trying to save in DB: %s.', six.text_type(e))
             else:
                 LOG.exception('Conflict while trying to save in DB.')
             # On a conflict determine the conflicting object and return its id in
             # the raised exception.
             conflict_object = cls._get_by_object(model_object)
             conflict_id = str(conflict_object.id) if conflict_object else None
-            message = str(e)
+            message = six.text_type(e)
             raise StackStormDBObjectConflictError(message=message, conflict_id=conflict_id,
                                                   model_object=model_object)
 
@@ -174,14 +174,14 @@ class Access(object):
             model_object = cls._get_impl().add_or_update(model_object, validate=True)
         except NotUniqueError as e:
             if log_not_unique_error_as_debug:
-                LOG.debug('Conflict while trying to save in DB: %s.', str(e))
+                LOG.debug('Conflict while trying to save in DB: %s.', six.text_type(e))
             else:
                 LOG.exception('Conflict while trying to save in DB.')
             # On a conflict determine the conflicting object and return its id in
             # the raised exception.
             conflict_object = cls._get_by_object(model_object)
             conflict_id = str(conflict_object.id) if conflict_object else None
-            message = str(e)
+            message = six.text_type(e)
             raise StackStormDBObjectConflictError(message=message, conflict_id=conflict_id,
                                                   model_object=model_object)
 

--- a/st2common/st2common/router.py
+++ b/st2common/st2common/router.py
@@ -71,7 +71,6 @@ def op_resolver(op_id):
     method_callable = functools.reduce(getattr, func_name.split('.'), module)
 
     return controller_instance, method_callable
-    return functools.reduce(getattr, func_name.split('.'), module)
 
 
 def abort(status_code=exc.HTTPInternalServerError.code, message='Unhandled exception'):

--- a/st2common/st2common/router.py
+++ b/st2common/st2common/router.py
@@ -71,8 +71,6 @@ def op_resolver(op_id):
     method_callable = functools.reduce(getattr, func_name.split('.'), module)
 
     return controller_instance, method_callable
-    print('xxx')
-    print(controller_instance)
     return functools.reduce(getattr, func_name.split('.'), module)
 
 
@@ -316,26 +314,26 @@ class Router(object):
                     raise auth_exc.NoAuthSourceProvidedError('One of Token or API key required.')
             except (auth_exc.NoAuthSourceProvidedError,
                     auth_exc.MultipleAuthSourcesError) as e:
-                LOG.error(str(e))
-                return abort_unauthorized(str(e))
+                LOG.error(six.text_type(e))
+                return abort_unauthorized(six.text_type(e))
             except auth_exc.TokenNotProvidedError as e:
                 LOG.exception('Token is not provided.')
-                return abort_unauthorized(str(e))
+                return abort_unauthorized(six.text_type(e))
             except auth_exc.TokenNotFoundError as e:
                 LOG.exception('Token is not found.')
-                return abort_unauthorized(str(e))
+                return abort_unauthorized(six.text_type(e))
             except auth_exc.TokenExpiredError as e:
                 LOG.exception('Token has expired.')
-                return abort_unauthorized(str(e))
+                return abort_unauthorized(six.text_type(e))
             except auth_exc.ApiKeyNotProvidedError as e:
                 LOG.exception('API key is not provided.')
-                return abort_unauthorized(str(e))
+                return abort_unauthorized(six.text_type(e))
             except auth_exc.ApiKeyNotFoundError as e:
                 LOG.exception('API key is not found.')
-                return abort_unauthorized(str(e))
+                return abort_unauthorized(six.text_type(e))
             except auth_exc.ApiKeyDisabledError as e:
                 LOG.exception('API key is disabled.')
-                return abort_unauthorized(str(e))
+                return abort_unauthorized(six.text_type(e))
 
             if cfg.CONF.rbac.enable:
                 user_db = context['user']
@@ -406,7 +404,7 @@ class Router(object):
                     else:
                         raise ValueError('Unsupported Content-Type: "%s"' % (content_type))
                 except Exception as e:
-                    detail = 'Failed to parse request body: %s' % str(e)
+                    detail = 'Failed to parse request body: %s' % six.text_type(e)
                     raise exc.HTTPBadRequest(detail=detail)
 
                 # Special case for Python 3
@@ -417,7 +415,7 @@ class Router(object):
                 try:
                     CustomValidator(schema, resolver=self.spec_resolver).validate(data)
                 except (jsonschema.ValidationError, ValueError) as e:
-                    raise exc.HTTPBadRequest(detail=getattr(e, 'message', str(e)),
+                    raise exc.HTTPBadRequest(detail=getattr(e, 'message', six.text_type(e)),
                                              comment=traceback.format_exc())
 
                 if content_type == 'text/plain':
@@ -451,7 +449,7 @@ class Router(object):
                         try:
                             instance = instance.validate()
                         except (jsonschema.ValidationError, ValueError) as e:
-                            raise exc.HTTPBadRequest(detail=getattr(e, 'message', str(e)),
+                            raise exc.HTTPBadRequest(detail=getattr(e, 'message', six.text_type(e)),
                                                      comment=traceback.format_exc())
                     else:
                         LOG.debug('Missing x-api-model definition for %s, using generic Body '
@@ -509,14 +507,14 @@ class Router(object):
             controller_instance, func = op_resolver(endpoint['operationId'])
         except Exception as e:
             LOG.exception('Failed to load controller for operation "%s": %s' %
-                          (endpoint['operationId'], str(e)))
+                          (endpoint['operationId'], six.text_type(e)))
             raise e
 
         try:
             resp = func(**kw)
         except Exception as e:
             LOG.exception('Failed to call controller function "%s" for operation "%s": %s' %
-                          (func.__name__, endpoint['operationId'], str(e)))
+                          (func.__name__, endpoint['operationId'], six.text_type(e)))
             raise e
 
         # Handle response
@@ -600,7 +598,7 @@ class Router(object):
             instance = model_cls(**data)
         except TypeError as e:
             # Throw a more user-friendly exception when input data is not an object
-            if 'type object argument after ** must be a mapping, not' in str(e):
+            if 'type object argument after ** must be a mapping, not' in six.text_type(e):
                 type_string = get_json_type_for_python_value(data)
                 msg = ('Input body needs to be an object, got: %s' % (type_string))
                 raise ValueError(msg)

--- a/st2common/st2common/runners/base.py
+++ b/st2common/st2common/runners/base.py
@@ -89,7 +89,7 @@ def get_runner(name, config=None):
                    (name, available_runners))
             LOG.exception(msg)
 
-            raise exc.ActionRunnerCreateError('%s\n\n%s' % (msg, str(e)))
+            raise exc.ActionRunnerCreateError('%s\n\n%s' % (msg, six.text_type(e)))
 
     LOG.debug('Instance of runner module: %s', module)
 

--- a/st2common/st2common/runners/paramiko_ssh.py
+++ b/st2common/st2common/runners/paramiko_ssh.py
@@ -694,7 +694,7 @@ class ParamikoSSHClient(object):
         try:
             client.connect(**conninfo)
         except SSHException as e:
-            paramiko_msg = str(e)
+            paramiko_msg = six.text_type(e)
 
             if conninfo.get('password', None):
                 conninfo['password'] = '<redacted>'

--- a/st2common/st2common/runners/utils.py
+++ b/st2common/st2common/runners/utils.py
@@ -133,7 +133,7 @@ def get_action_class_instance(action_cls, config=None, action_service=None):
     try:
         action_instance = action_cls(**kwargs)
     except TypeError as e:
-        if 'unexpected keyword argument \'action_service\'' not in str(e):
+        if 'unexpected keyword argument \'action_service\'' not in six.text_type(e):
             raise e
 
         LOG.debug('Action class (%s) constructor doesn\'t take "action_service" argument, '

--- a/st2common/st2common/service_setup.py
+++ b/st2common/st2common/service_setup.py
@@ -24,6 +24,7 @@ import sys
 import traceback
 import logging as stdlib_logging
 
+import six
 from oslo_config import cfg
 
 from st2common import log as logging
@@ -110,7 +111,7 @@ def setup(service, config, setup_db=True, register_mq_exchanges=True,
         tb_msg = traceback.format_exc()
         if 'log.setLevel' in tb_msg:
             msg = 'Invalid log level selected. Log level names need to be all uppercase.'
-            msg += '\n\n' + getattr(e, 'message', str(e))
+            msg += '\n\n' + getattr(e, 'message', six.text_type(e))
             raise KeyError(msg)
         else:
             raise e

--- a/st2common/st2common/services/action.py
+++ b/st2common/st2common/services/action.py
@@ -138,7 +138,7 @@ def create_request(liveaction, action_db=None, runnertype_db=None):
         _, trace_db = trace_service.get_trace_db_by_live_action(liveaction)
     except db_exc.StackStormDBObjectNotFoundError as e:
         _cleanup_liveaction(liveaction)
-        raise trace_exc.TraceNotFoundException(str(e))
+        raise trace_exc.TraceNotFoundException(six.text_type(e))
 
     execution = executions.create_execution_object(liveaction=liveaction, action_db=action_db,
                                                    runnertype_db=runnertype_db, publish=False)

--- a/st2common/st2common/services/inquiry.py
+++ b/st2common/st2common/services/inquiry.py
@@ -110,7 +110,7 @@ def validate_response(inquiry, response):
     except Exception as e:
         msg = 'Response for inquiry "%s" did not pass schema validation.'
         LOG.exception(msg % str(inquiry.id))
-        raise inquiry_exceptions.InvalidInquiryResponse(str(inquiry.id), str(e))
+        raise inquiry_exceptions.InvalidInquiryResponse(str(inquiry.id), six.text_type(e))
 
 
 def respond(inquiry, response, requester=None):

--- a/st2common/st2common/services/sensor_watcher.py
+++ b/st2common/st2common/services/sensor_watcher.py
@@ -18,6 +18,8 @@
 # XXX: Refactor.
 
 from __future__ import absolute_import
+
+import six
 import eventlet
 from kombu.mixins import ConsumerMixin
 
@@ -82,7 +84,7 @@ class SensorWatcher(ConsumerMixin):
                 handler(body)
             except Exception as e:
                 LOG.exception('Handling failed. Message body: %s. Exception: %s',
-                              body, str(e))
+                              body, six.text_type(e))
         finally:
             message.ack()
 

--- a/st2common/st2common/services/trigger_dispatcher.py
+++ b/st2common/st2common/services/trigger_dispatcher.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 
+import six
 from oslo_config import cfg
 from jsonschema import ValidationError
 
@@ -84,13 +85,14 @@ class TriggerDispatcherService(object):
                                      throw_on_inexistent_trigger=True)
         except (ValidationError, ValueError, Exception) as e:
             self._logger.warn('Failed to validate payload (%s) for trigger "%s": %s' %
-                              (str(payload), trigger, str(e)))
+                              (str(payload), trigger, six.text_type(e)))
 
             # If validation is disabled, still dispatch a trigger even if it failed validation
             # This condition prevents unexpected restriction.
             if cfg.CONF.system.validate_trigger_payload:
                 msg = ('Trigger payload validation failed and validation is enabled, not '
-                       'dispatching a trigger "%s" (%s): %s' % (trigger, str(payload), str(e)))
+                       'dispatching a trigger "%s" (%s): %s' % (trigger, str(payload),
+                                                                six.text_type(e)))
 
                 if throw_on_validation_error:
                     raise ValueError(msg)

--- a/st2common/st2common/services/triggerwatcher.py
+++ b/st2common/st2common/services/triggerwatcher.py
@@ -16,6 +16,7 @@
 
 from __future__ import absolute_import
 
+import six
 import eventlet
 from kombu.mixins import ConsumerMixin
 
@@ -100,7 +101,7 @@ class TriggerWatcher(ConsumerMixin):
                 handler(body)
             except Exception as e:
                 LOG.exception('Handling failed. Message body: %s. Exception: %s',
-                              body, str(e))
+                              body, six.text_type(e))
         finally:
             message.ack()
 

--- a/st2common/st2common/services/workflows.py
+++ b/st2common/st2common/services/workflows.py
@@ -496,8 +496,8 @@ def request_task_execution(wf_ex_db, st2_ctx, task_ex_req):
             task_ex_db = wf_db_access.TaskExecution.get_by_id(str(task_ex_db.id))
     except Exception as e:
         msg = '[%s] Failed action execution(s) for task "%s", route "%s". %s'
-        LOG.exception(msg, wf_ac_ex_id, task_id, str(task_route), str(e))
-        message = '%s: %s' % (type(e).__name__, str(e))
+        LOG.exception(msg, wf_ac_ex_id, task_id, str(task_route), six.text_type(e))
+        message = '%s: %s' % (type(e).__name__, six.text_type(e))
         error = {'type': 'error', 'message': message, 'task_id': task_id, 'route': task_route}
         update_task_execution(str(task_ex_db.id), statuses.FAILED, {'errors': [error]})
         raise e

--- a/st2common/st2common/transport/connection_retry_wrapper.py
+++ b/st2common/st2common/transport/connection_retry_wrapper.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 
+import six
 import eventlet
 
 __all__ = ['ConnectionRetryWrapper', 'ClusterRetryContext']
@@ -41,7 +42,7 @@ class ClusterRetryContext(object):
         # during tests on Travis and block and slown down the tests
         # NOTE: This error is not fatal during tests and we can simply switch to a next connection
         # without sleeping.
-        if "second 'channel.open' seen" in str(e):
+        if "second 'channel.open' seen" in six.text_type(e):
             return False, -1
 
         should_stop = True
@@ -140,7 +141,7 @@ class ConnectionRetryWrapper(object):
 
                 # -1, 0 and 1+ are handled properly by eventlet.sleep
                 self._logger.debug('Received RabbitMQ server error, sleeping for %s seconds '
-                                   'before retrying: %s' % (wait, str(e)))
+                                   'before retrying: %s' % (wait, six.text_type(e)))
                 eventlet.sleep(wait)
 
                 connection.close()
@@ -152,7 +153,7 @@ class ConnectionRetryWrapper(object):
 
                 def log_error_on_conn_failure(exc, interval):
                     self._logger.debug('Failed to re-establish connection to RabbitMQ server, '
-                                       'retrying in %s seconds: %s' % (interval, str(e)))
+                                       'retrying in %s seconds: %s' % (interval, six.text_type(e)))
 
                 try:
                     # NOTE: This function blocks and tries to restablish a connection for
@@ -161,11 +162,11 @@ class ConnectionRetryWrapper(object):
                                                  errback=log_error_on_conn_failure)
                 except Exception:
                     self._logger.exception('Connections to RabbitMQ cannot be re-established: %s',
-                                           str(e))
+                                           six.text_type(e))
                     raise
             except Exception as e:
                 self._logger.exception('Connections to RabbitMQ cannot be re-established: %s',
-                                       str(e))
+                                       six.text_type(e))
                 # Not being able to publish a message could be a significant issue for an app.
                 raise
             finally:

--- a/st2common/st2common/util/config_loader.py
+++ b/st2common/st2common/util/config_loader.py
@@ -206,7 +206,7 @@ class ContentPackConfigLoader(object):
         except Exception as e:
             # Throw a more user-friendly exception on failed render
             exc_class = type(e)
-            original_msg = str(e)
+            original_msg = six.text_type(e)
             msg = ('Failed to render dynamic configuration value for key "%s" with value '
                    '"%s" for pack "%s" config: %s %s ' % (key, value, self.pack_name,
                                                           exc_class, original_msg))

--- a/st2common/st2common/util/crypto.py
+++ b/st2common/st2common/util/crypto.py
@@ -176,7 +176,7 @@ def read_crypto_key(key_path):
                          mode=content['mode'].upper(),
                          size=content['size'])
     except KeyError as e:
-        msg = 'Invalid or malformed key file "%s": %s' % (key_path, str(e))
+        msg = 'Invalid or malformed key file "%s": %s' % (key_path, six.text_type(e))
         raise KeyError(msg)
 
     return aes_key
@@ -442,4 +442,4 @@ def Base64WSDecode(s):
         return base64.urlsafe_b64decode(s)
     except TypeError as e:
         # Decoding raises TypeError if s contains invalid characters.
-        raise ValueError('Base64 decoding error: %s' % (str(e)))
+        raise ValueError('Base64 decoding error: %s' % (six.text_type(e)))

--- a/st2common/st2common/util/gunicorn_workers.py
+++ b/st2common/st2common/util/gunicorn_workers.py
@@ -14,8 +14,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import sys
 
+import six
 from gunicorn.workers.sync import SyncWorker
 
 __all__ = [
@@ -40,7 +42,7 @@ class EventletSyncWorker(SyncWorker):
         try:
             return super(EventletSyncWorker, self).handle_quit(sig=sig, frame=frame)
         except AssertionError as e:
-            msg = str(e)
+            msg = six.text_type(e)
 
             if 'do not call blocking functions from the mainloop' in msg:
                 # Workaround for "do not call blocking functions from the mainloop" issue

--- a/st2common/st2common/util/pack.py
+++ b/st2common/st2common/util/pack.py
@@ -19,6 +19,8 @@ import os
 import re
 import collections
 
+import six
+
 from st2common.util import schema as util_schema
 from st2common.constants.pack import MANIFEST_FILE_NAME
 from st2common.constants.pack import PACK_REF_WHITELIST_REGEX
@@ -119,7 +121,7 @@ def validate_config_against_schema(config_schema, config_object, config_path,
             attribute = str(attribute)
 
         msg = ('Failed validating attribute "%s" in config for pack "%s" (%s): %s' %
-               (attribute, pack_name, config_path, str(e)))
+               (attribute, pack_name, config_path, six.text_type(e)))
         raise jsonschema.ValidationError(msg)
 
     return cleaned

--- a/st2common/st2common/util/pack_management.py
+++ b/st2common/st2common/util/pack_management.py
@@ -94,7 +94,7 @@ def download_pack(pack, abs_repo_base='/opt/stackstorm/packs', verify_ssl=True, 
         pack_url, pack_version = get_repo_url(pack, proxy_config=proxy_config)
     except Exception as e:
         # Pack not found or similar
-        result = [None, pack, (False, str(e))]
+        result = [None, pack, (False, six.text_type(e))]
         return result
 
     result = [pack_url, None, None]

--- a/st2common/st2common/util/param.py
+++ b/st2common/st2common/util/param.py
@@ -225,7 +225,7 @@ def _resolve_dependencies(G):
 
         except Exception as e:
             LOG.debug('Failed to render %s: %s', name, e, exc_info=True)
-            msg = 'Failed to render parameter "%s": %s' % (name, str(e))
+            msg = 'Failed to render parameter "%s": %s' % (name, six.text_type(e))
             raise ParamException(msg)
 
     return context
@@ -294,7 +294,8 @@ def render_live_params(runner_parameters, action_parameters, params, action_cont
     try:
         config = get_config(pack, user)
     except Exception as e:
-        LOG.info('Failed to retrieve config for pack %s and user %s: %s' % (pack, user, str(e)))
+        LOG.info('Failed to retrieve config for pack %s and user %s: %s' % (pack, user,
+                 six.text_type(e)))
         config = {}
 
     G = _create_graph(action_context, config)

--- a/st2common/st2common/util/virtualenvs.py
+++ b/st2common/st2common/util/virtualenvs.py
@@ -18,10 +18,12 @@ Pack virtual environment related utility functions.
 """
 
 from __future__ import absolute_import
+
 import os
 import re
 import shutil
 
+import six
 from oslo_config import cfg
 
 from st2common import log as logging
@@ -201,7 +203,7 @@ def create_virtualenv(virtualenv_path, logger=None, include_pip=True, include_se
         exit_code, _, stderr = run_command(cmd=cmd)
     except OSError as e:
         raise Exception('Error executing command %s. %s.' % (' '.join(cmd),
-                                                             str(e)))
+                                                             six.text_type(e)))
 
     if exit_code != 0:
         raise Exception('Failed to create virtualenv in "%s": %s' %

--- a/st2common/st2common/validators/workflow/mistral/v2.py
+++ b/st2common/st2common/validators/workflow/mistral/v2.py
@@ -119,6 +119,6 @@ class MistralWorkflowValidator(WorkflowValidator):
             # Run custom DSL transformer to check action parameters.
             utils.transform_definition(def_dict)
         except WorkflowDefinitionException as e:
-            return [self.parse(str(e))]
+            return [self.parse(six.text_type(e))]
 
         return []

--- a/st2common/tests/integration/test_rabbitmq_ssl_listener.py
+++ b/st2common/tests/integration/test_rabbitmq_ssl_listener.py
@@ -19,6 +19,7 @@ import os
 import ssl
 import socket
 
+import six
 import unittest2
 from oslo_config import cfg
 
@@ -64,7 +65,8 @@ class RabbitMQTLSListenerTestCase(unittest2.TestCase):
         except Exception as e:
             self.assertFalse(connection.connected)
             self.assertTrue(isinstance(e, (IOError, socket.error)))
-            self.assertTrue(expected_msg_1 in str(e) or expected_msg_2 in str(e))
+            self.assertTrue(expected_msg_1 in six.text_type(e) or expected_msg_2 in
+                            six.text_type(e))
         else:
             self.fail('Exception was not thrown')
 

--- a/st2common/tests/unit/test_action_api_validator.py
+++ b/st2common/tests/unit/test_action_api_validator.py
@@ -19,6 +19,7 @@ try:
 except ImportError:
     import json
 
+import six
 import mock
 
 from st2common.exceptions.apivalidation import ValueValidationException
@@ -71,7 +72,7 @@ class TestActionAPIValidator(DbTestCase):
             action_validator.validate_action(action_api)
             self.fail('Action validation should not have passed. %s' % json.dumps(action_api_dict))
         except ValueValidationException as e:
-            self.assertTrue('Cannot override in action.' in str(e))
+            self.assertTrue('Cannot override in action.' in six.text_type(e))
 
     @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(
         return_value=True))
@@ -82,7 +83,7 @@ class TestActionAPIValidator(DbTestCase):
             action_validator.validate_action(action_api)
             self.fail('Action validation should not have passed. %s' % json.dumps(action_api_dict))
         except ValueValidationException as e:
-            self.assertTrue('requires a default value.' in str(e))
+            self.assertTrue('requires a default value.' in six.text_type(e))
 
     @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(
         return_value=True))
@@ -109,7 +110,7 @@ class TestActionAPIValidator(DbTestCase):
             self.fail('Action validation should have failed ' +
                       'because position values are not unique.' % json.dumps(action_api_dict))
         except ValueValidationException as e:
-            self.assertTrue('have same position' in str(e))
+            self.assertTrue('have same position' in six.text_type(e))
 
     @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(
         return_value=True))
@@ -122,4 +123,4 @@ class TestActionAPIValidator(DbTestCase):
             self.fail('Action validation should have failed ' +
                       'because position values are not contiguous.' % json.dumps(action_api_dict))
         except ValueValidationException as e:
-            self.assertTrue('are not contiguous' in str(e))
+            self.assertTrue('are not contiguous' in six.text_type(e))

--- a/st2common/tests/unit/test_param_utils.py
+++ b/st2common/tests/unit/test_param_utils.py
@@ -308,7 +308,7 @@ class ParamsUtilsTest(DbTestCase):
         except ParamException as e:
             error_msg = 'Failed to render parameter "a2": \'dict object\' ' + \
                         'has no attribute \'lorem_ipsum\''
-            self.assertTrue(error_msg in str(e))
+            self.assertTrue(error_msg in six.text_type(e))
             pass
 
     def test_unicode_value_casting(self):
@@ -482,7 +482,7 @@ class ParamsUtilsTest(DbTestCase):
                                              {'user': None})
             test_pass = False
         except ParamException as e:
-            test_pass = str(e).find('Cyclic') == 0
+            test_pass = six.text_type(e).find('Cyclic') == 0
         self.assertTrue(test_pass)
 
     def test_get_finalized_params_with_missing_dependency(self):
@@ -497,7 +497,7 @@ class ParamsUtilsTest(DbTestCase):
                                              {'user': None})
             test_pass = False
         except ParamException as e:
-            test_pass = str(e).find('Dependency') == 0
+            test_pass = six.text_type(e).find('Dependency') == 0
         self.assertTrue(test_pass)
 
         params = {}
@@ -511,7 +511,7 @@ class ParamsUtilsTest(DbTestCase):
                                              {'user': None})
             test_pass = False
         except ParamException as e:
-            test_pass = str(e).find('Dependency') == 0
+            test_pass = six.text_type(e).find('Dependency') == 0
         self.assertTrue(test_pass)
 
     def test_get_finalized_params_no_double_rendering(self):

--- a/st2common/tests/unit/test_resource_registrar.py
+++ b/st2common/tests/unit/test_resource_registrar.py
@@ -14,8 +14,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 
+import six
 import mock
 from jsonschema import ValidationError
 
@@ -155,7 +157,7 @@ class ResourceRegistrarTestCase(CleanDbTestCase):
         try:
             registrar._register_pack_db(pack_name=None, pack_dir=PACK_PATH_13)
         except ValidationError as e:
-            self.assertTrue("'invalid-has-dash' does not match '^[a-z0-9_]+$'" in str(e))
+            self.assertTrue("'invalid-has-dash' does not match '^[a-z0-9_]+$'" in six.text_type(e))
         else:
             self.fail('Exception not thrown')
 

--- a/st2common/tests/unit/test_virtualenvs.py
+++ b/st2common/tests/unit/test_virtualenvs.py
@@ -14,9 +14,11 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import tempfile
 
+import six
 import mock
 from oslo_config import cfg
 
@@ -121,8 +123,9 @@ class VirtualenvUtilsTestCase(CleanFilesTestCase):
             setup_pack_virtualenv(pack_name=pack_name, update=False,
                                   include_setuptools=False, include_wheel=False)
         except Exception as e:
-            self.assertTrue('Failed to install requirements from' in str(e))
-            self.assertTrue('No matching distribution found for someinvalidname' in str(e))
+            self.assertTrue('Failed to install requirements from' in six.text_type(e))
+            self.assertTrue('No matching distribution found for someinvalidname' in
+                            six.text_type(e))
         else:
             self.fail('Exception not thrown')
 

--- a/st2debug/dist_utils.py
+++ b/st2debug/dist_utils.py
@@ -23,7 +23,6 @@ import sys
 from distutils.version import StrictVersion
 
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
-PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 if PY3:

--- a/st2debug/dist_utils.py
+++ b/st2debug/dist_utils.py
@@ -15,9 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import re
 import sys
+
+import six
 
 from distutils.version import StrictVersion
 
@@ -27,7 +30,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (str(e)))
+    print('Failed to import pip: %s' % (six.text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -41,7 +44,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/st2debug/dist_utils.py
+++ b/st2debug/dist_utils.py
@@ -20,9 +20,16 @@ import os
 import re
 import sys
 
-import six
-
 from distutils.version import StrictVersion
+
+# NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode
 
 GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
@@ -30,7 +37,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (six.text_type(e)))
+    print('Failed to import pip: %s' % (text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -44,7 +51,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
+        print('Failed to import parse_requirements from pip: %s' % (text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/st2exporter/dist_utils.py
+++ b/st2exporter/dist_utils.py
@@ -23,7 +23,6 @@ import sys
 from distutils.version import StrictVersion
 
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
-PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 if PY3:

--- a/st2exporter/dist_utils.py
+++ b/st2exporter/dist_utils.py
@@ -15,9 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import re
 import sys
+
+import six
 
 from distutils.version import StrictVersion
 
@@ -27,7 +30,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (str(e)))
+    print('Failed to import pip: %s' % (six.text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -41,7 +44,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/st2exporter/dist_utils.py
+++ b/st2exporter/dist_utils.py
@@ -20,9 +20,16 @@ import os
 import re
 import sys
 
-import six
-
 from distutils.version import StrictVersion
+
+# NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode
 
 GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
@@ -30,7 +37,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (six.text_type(e)))
+    print('Failed to import pip: %s' % (text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -44,7 +51,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
+        print('Failed to import parse_requirements from pip: %s' % (text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/st2reactor/dist_utils.py
+++ b/st2reactor/dist_utils.py
@@ -23,7 +23,6 @@ import sys
 from distutils.version import StrictVersion
 
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
-PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 if PY3:

--- a/st2reactor/dist_utils.py
+++ b/st2reactor/dist_utils.py
@@ -15,9 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import re
 import sys
+
+import six
 
 from distutils.version import StrictVersion
 
@@ -27,7 +30,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (str(e)))
+    print('Failed to import pip: %s' % (six.text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -41,7 +44,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/st2reactor/dist_utils.py
+++ b/st2reactor/dist_utils.py
@@ -20,9 +20,16 @@ import os
 import re
 import sys
 
-import six
-
 from distutils.version import StrictVersion
+
+# NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode
 
 GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
@@ -30,7 +37,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (six.text_type(e)))
+    print('Failed to import pip: %s' % (text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -44,7 +51,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
+        print('Failed to import parse_requirements from pip: %s' % (text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/st2reactor/st2reactor/container/process_container.py
+++ b/st2reactor/st2reactor/container/process_container.py
@@ -261,7 +261,7 @@ class ProcessSensorContainer(object):
             try:
                 self._spawn_sensor_process(sensor=sensor_obj)
             except Exception as e:
-                LOG.warning(str(e), exc_info=True)
+                LOG.warning(six.text_type(e), exc_info=True)
 
                 # Disable sensor which we are unable to start
                 del self._sensors[sensor_id]
@@ -355,7 +355,7 @@ class ProcessSensorContainer(object):
         except Exception as e:
             cmd = ' '.join(args)
             message = ('Failed to spawn process for sensor %s ("%s"): %s' %
-                       (sensor_id, cmd, str(e)))
+                       (sensor_id, cmd, six.text_type(e)))
             raise Exception(message)
 
         self._processes[sensor_id] = process
@@ -440,7 +440,7 @@ class ProcessSensorContainer(object):
         try:
             self._spawn_sensor_process(sensor=sensor)
         except Exception as e:
-            LOG.warning(str(e), exc_info=True)
+            LOG.warning(six.text_type(e), exc_info=True)
 
             # Disable sensor which we are unable to start
             del self._sensors[sensor_id]

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -14,12 +14,14 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import json
 import atexit
 import argparse
 import traceback
 
+import six
 from oslo_config import cfg
 
 from st2common import log as logging
@@ -229,7 +231,7 @@ class SensorWrapper(object):
         except Exception as e:
             # Include traceback
             msg = ('Sensor "%s" run method raised an exception: %s.' %
-                   (self._class_name, str(e)))
+                   (self._class_name, six.text_type(e)))
             self._logger.warn(msg, exc_info=True)
             raise Exception(msg)
 
@@ -288,7 +290,7 @@ class SensorWrapper(object):
         except Exception as e:
             tb_msg = traceback.format_exc()
             msg = ('Failed to load sensor class from file "%s" (sensor file most likely doesn\'t '
-                   'exist or contains invalid syntax): %s' % (self._file_path, str(e)))
+                   'exist or contains invalid syntax): %s' % (self._file_path, six.text_type(e)))
             msg += '\n\n' + tb_msg
             exc_cls = type(e)
             raise exc_cls(msg)

--- a/st2reactor/st2reactor/garbage_collector/base.py
+++ b/st2reactor/st2reactor/garbage_collector/base.py
@@ -18,10 +18,12 @@ Garbage collection service which deletes old data from the database.
 """
 
 from __future__ import absolute_import
+
 import signal
 import datetime
 import random
 
+import six
 import eventlet
 from eventlet.support import greenlets as greenlet
 from oslo_config import cfg
@@ -86,7 +88,7 @@ class GarbageCollectorService(object):
             self._running = False
             return SUCCESS_EXIT_CODE
         except Exception as e:
-            LOG.exception('Exception in the garbage collector: %s' % (str(e)))
+            LOG.exception('Exception in the garbage collector: %s' % (six.text_type(e)))
             self._running = False
             return FAILURE_EXIT_CODE
 
@@ -183,7 +185,7 @@ class GarbageCollectorService(object):
         try:
             purge_executions(logger=LOG, timestamp=timestamp)
         except Exception as e:
-            LOG.exception('Failed to delete executions: %s' % (str(e)))
+            LOG.exception('Failed to delete executions: %s' % (six.text_type(e)))
 
         return True
 
@@ -205,7 +207,7 @@ class GarbageCollectorService(object):
         try:
             purge_execution_output_objects(logger=LOG, timestamp=timestamp)
         except Exception as e:
-            LOG.exception('Failed to delete execution output objects: %s' % (str(e)))
+            LOG.exception('Failed to delete execution output objects: %s' % (six.text_type(e)))
 
         return True
 
@@ -230,7 +232,7 @@ class GarbageCollectorService(object):
         try:
             purge_trigger_instances(logger=LOG, timestamp=timestamp)
         except Exception as e:
-            LOG.exception('Failed to trigger instances: %s' % (str(e)))
+            LOG.exception('Failed to trigger instances: %s' % (six.text_type(e)))
 
         return True
 
@@ -242,6 +244,6 @@ class GarbageCollectorService(object):
         try:
             purge_inquiries(logger=LOG)
         except Exception as e:
-            LOG.exception('Failed to purge inquiries: %s' % (str(e)))
+            LOG.exception('Failed to purge inquiries: %s' % (six.text_type(e)))
 
         return True

--- a/st2reactor/st2reactor/rules/enforcer.py
+++ b/st2reactor/st2reactor/rules/enforcer.py
@@ -19,6 +19,8 @@ import sys
 import json
 import traceback
 
+import six
+
 from st2common import log as logging
 from st2common.constants import action as action_constants
 from st2common.constants.trace import TRACE_CONTEXT
@@ -101,7 +103,7 @@ class RuleEnforcer(object):
         except Exception as e:
             # Record the failure reason in the RuleEnforcement.
             enforcement_db.status = RULE_ENFORCEMENT_STATUS_FAILED
-            enforcement_db.failure_reason = str(e)
+            enforcement_db.failure_reason = six.text_type(e)
             LOG.exception('Failed kicking off execution for rule %s.', self.rule, extra=extra)
         finally:
             self._update_enforcement(enforcement_db)
@@ -207,11 +209,12 @@ class RuleEnforcer(object):
             action_service.update_status(
                 liveaction=liveaction_db,
                 new_status=action_constants.LIVEACTION_STATUS_FAILED,
-                result={'error': str(e), 'traceback': ''.join(traceback.format_tb(tb, 20))})
+                result={'error': six.text_type(e),
+                        'traceback': ''.join(traceback.format_tb(tb, 20))})
 
             # Might be a good idea to return the actual ActionExecution rather than bubble up
             # the exception.
-            raise validation_exc.ValueValidationException(str(e))
+            raise validation_exc.ValueValidationException(six.text_type(e))
 
         liveaction_db, execution_db = action_service.request(liveaction_db)
 

--- a/st2reactor/st2reactor/rules/tester.py
+++ b/st2reactor/st2reactor/rules/tester.py
@@ -110,7 +110,7 @@ class RuleTester(object):
                 LOG.info('\t%s: %s', param[0], param[1])
             return True
         except (UndefinedError, ValueError) as e:
-            LOG.error('Failed to resolve parameters\n\tOriginal error : %s', str(e))
+            LOG.error('Failed to resolve parameters\n\tOriginal error : %s', six.text_type(e))
             return False
         except:
             LOG.exception('Failed to resolve parameters.')

--- a/st2reactor/tests/unit/test_sensor_wrapper.py
+++ b/st2reactor/tests/unit/test_sensor_wrapper.py
@@ -1,7 +1,24 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import absolute_import
+
 import os
 import unittest2
 
+import six
 import mock
 import eventlet
 
@@ -136,8 +153,8 @@ class SensorWrapperTestCase(unittest2.TestCase):
             SensorWrapper(pack='core', file_path=file_path, class_name='TestSensor',
                           trigger_types=trigger_types, parent_args=parent_args)
         except NameError as e:
-            self.assertTrue('Traceback (most recent call last)' in str(e))
-            self.assertTrue('line 5, in <module>' in str(e))
+            self.assertTrue('Traceback (most recent call last)' in six.text_type(e))
+            self.assertTrue('line 5, in <module>' in six.text_type(e))
         else:
             self.fail('NameError not thrown')
 

--- a/st2stream/dist_utils.py
+++ b/st2stream/dist_utils.py
@@ -23,7 +23,6 @@ import sys
 from distutils.version import StrictVersion
 
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
-PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 if PY3:

--- a/st2stream/dist_utils.py
+++ b/st2stream/dist_utils.py
@@ -15,9 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import re
 import sys
+
+import six
 
 from distutils.version import StrictVersion
 
@@ -27,7 +30,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (str(e)))
+    print('Failed to import pip: %s' % (six.text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -41,7 +44,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/st2stream/dist_utils.py
+++ b/st2stream/dist_utils.py
@@ -20,9 +20,16 @@ import os
 import re
 import sys
 
-import six
-
 from distutils.version import StrictVersion
+
+# NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode
 
 GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
@@ -30,7 +37,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (six.text_type(e)))
+    print('Failed to import pip: %s' % (text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -44,7 +51,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
+        print('Failed to import parse_requirements from pip: %s' % (text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/st2tests/dist_utils.py
+++ b/st2tests/dist_utils.py
@@ -23,7 +23,6 @@ import sys
 from distutils.version import StrictVersion
 
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
-PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 if PY3:

--- a/st2tests/dist_utils.py
+++ b/st2tests/dist_utils.py
@@ -15,9 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import re
 import sys
+
+import six
 
 from distutils.version import StrictVersion
 
@@ -27,7 +30,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (str(e)))
+    print('Failed to import pip: %s' % (six.text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -41,7 +44,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/st2tests/dist_utils.py
+++ b/st2tests/dist_utils.py
@@ -20,9 +20,16 @@ import os
 import re
 import sys
 
-import six
-
 from distutils.version import StrictVersion
+
+# NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode
 
 GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
@@ -30,7 +37,7 @@ try:
     import pip
     from pip import __version__ as pip_version
 except ImportError as e:
-    print('Failed to import pip: %s' % (six.text_type(e)))
+    print('Failed to import pip: %s' % (text_type(e)))
     print('')
     print('Download pip:\n%s' % (GET_PIP))
     sys.exit(1)
@@ -44,7 +51,7 @@ except ImportError:
     try:
         from pip._internal.req.req_file import parse_requirements
     except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (six.text_type(e)))
+        print('Failed to import parse_requirements from pip: %s' % (text_type(e)))
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 

--- a/st2tests/integration/orquesta/test_wiring_functions_st2kv.py
+++ b/st2tests/integration/orquesta/test_wiring_functions_st2kv.py
@@ -1,1 +1,98 @@
-../../../contrib/runners/orquesta_runner/tests/integration/test_wiring_functions_st2kv.py
+# -*- coding: utf-8 -*-
+
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from integration.orquesta import base
+from st2client import models
+from st2common.constants import action as ac_const
+
+
+class DatastoreFunctionTest(base.TestWorkflowExecution):
+    @classmethod
+    def set_kvp(cls, name, value, scope='system', secret=False):
+        kvp = models.KeyValuePair(
+            id=name,
+            name=name,
+            value=value,
+            scope=scope,
+            secret=secret
+        )
+
+        cls.st2client.keys.update(kvp)
+
+    @classmethod
+    def del_kvp(cls, name, scope='system'):
+        kvp = models.KeyValuePair(
+            id=name,
+            name=name,
+            scope=scope
+        )
+
+        cls.st2client.keys.delete(kvp)
+
+    def test_st2kv_system_scope(self):
+        key = 'lakshmi'
+        value = 'kanahansnasnasdlsajks'
+
+        self.set_kvp(key, value)
+        wf_name = 'examples.orquesta-st2kv'
+        wf_input = {'key_name': 'system.%s' % key}
+        execution = self._execute_workflow(wf_name, wf_input)
+
+        output = self._wait_for_completion(execution)
+
+        self.assertEqual(output.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertIn('output', output.result)
+        self.assertIn('value', output.result['output'])
+        self.assertEqual(value, output.result['output']['value'])
+        self.del_kvp(key)
+
+    def test_st2kv_user_scope(self):
+        key = 'winson'
+        value = 'SoDiamondEng'
+
+        self.set_kvp(key, value, 'user')
+        wf_name = 'examples.orquesta-st2kv'
+        wf_input = {'key_name': key}
+        execution = self._execute_workflow(wf_name, wf_input)
+
+        output = self._wait_for_completion(execution)
+
+        self.assertEqual(output.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertIn('output', output.result)
+        self.assertIn('value', output.result['output'])
+        self.assertEqual(value, output.result['output']['value'])
+        # self.del_kvp(key)
+
+    def test_st2kv_decrypt(self):
+        key = 'kami'
+        value = 'eggplant'
+
+        self.set_kvp(key, value, secret=True)
+        wf_name = 'examples.orquesta-st2kv'
+        wf_input = {
+            'key_name': 'system.%s' % key,
+            'decrypt': True
+        }
+
+        execution = self._execute_workflow(wf_name, wf_input)
+
+        output = self._wait_for_completion(execution)
+
+        self.assertEqual(output.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertIn('output', output.result)
+        self.assertIn('value', output.result['output'])
+        self.assertEqual(value, output.result['output']['value'])
+        self.del_kvp(key)

--- a/st2tests/st2tests/action_aliases.py
+++ b/st2tests/st2tests/action_aliases.py
@@ -14,7 +14,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
+
+import six
 
 from st2common.content.loader import ContentPackLoader
 from st2common.content.loader import MetaLoader
@@ -90,7 +93,7 @@ class BaseActionAliasTestCase(BasePackResourceTestCase):
             try:
                 self.assertEqual(extracted_params, parameters)
             except AssertionError as e:
-                msg += str(e)
+                msg += six.text_type(e)
 
             raise AssertionError(msg)
 

--- a/st2tests/st2tests/api.py
+++ b/st2tests/st2tests/api.py
@@ -74,7 +74,7 @@ class TestApp(webtest.TestApp):
             try:
                 body = res.body
             except AssertionError as e:
-                if 'Iterator read after closed' in str(e):
+                if 'Iterator read after closed' in six.text_type(e):
                     body = b''
                 else:
                     raise e

--- a/st2tests/st2tests/fixtures/packs/runners/test_async_runner/test_async_runner.py
+++ b/st2tests/st2tests/fixtures/packs/runners/test_async_runner/test_async_runner.py
@@ -1,1 +1,56 @@
-../../../../../../st2actions/tests/unit/test_async_runner.py
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+try:
+    import simplejson as json
+except:
+    import json
+
+from st2common.runners.base import AsyncActionRunner
+from st2common.constants.action import (LIVEACTION_STATUS_RUNNING)
+
+RAISE_PROPERTY = 'raise'
+
+
+def get_runner():
+    return AsyncTestRunner()
+
+
+class AsyncTestRunner(AsyncActionRunner):
+    def __init__(self):
+        super(AsyncTestRunner, self).__init__(runner_id='1')
+        self.pre_run_called = False
+        self.run_called = False
+        self.post_run_called = False
+
+    def pre_run(self):
+        self.pre_run_called = True
+
+    def run(self, action_params):
+        self.run_called = True
+        result = {}
+        if self.runner_parameters.get(RAISE_PROPERTY, False):
+            raise Exception('Raise required.')
+        else:
+            result = {
+                'ran': True,
+                'action_params': action_params
+            }
+
+        return (LIVEACTION_STATUS_RUNNING, json.dumps(result), {'id': 'foo'})
+
+    def post_run(self, status, result):
+        self.post_run_called = True

--- a/st2tests/st2tests/fixtures/packs/runners/test_polling_async_runner/test_polling_async_runner.py
+++ b/st2tests/st2tests/fixtures/packs/runners/test_polling_async_runner/test_polling_async_runner.py
@@ -1,1 +1,56 @@
-../../../../../../st2actions/tests/unit/test_polling_async_runner.py
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+try:
+    import simplejson as json
+except:
+    import json
+
+from st2common.runners.base import PollingAsyncActionRunner
+from st2common.constants.action import (LIVEACTION_STATUS_RUNNING)
+
+RAISE_PROPERTY = 'raise'
+
+
+def get_runner():
+    return PollingAsyncTestRunner()
+
+
+class PollingAsyncTestRunner(PollingAsyncActionRunner):
+    def __init__(self):
+        super(PollingAsyncTestRunner, self).__init__(runner_id='1')
+        self.pre_run_called = False
+        self.run_called = False
+        self.post_run_called = False
+
+    def pre_run(self):
+        self.pre_run_called = True
+
+    def run(self, action_params):
+        self.run_called = True
+        result = {}
+        if self.runner_parameters.get(RAISE_PROPERTY, False):
+            raise Exception('Raise required.')
+        else:
+            result = {
+                'ran': True,
+                'action_params': action_params
+            }
+
+        return (LIVEACTION_STATUS_RUNNING, json.dumps(result), {'id': 'foo'})
+
+    def post_run(self, status, result):
+        self.post_run_called = True

--- a/st2tests/st2tests/mocks/liveaction.py
+++ b/st2tests/st2tests/mocks/liveaction.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import six
 import eventlet
 import traceback
 
@@ -97,7 +98,7 @@ class MockLiveActionPublisherNonBlocking(object):
             try:
                 thread.wait()
             except Exception as e:
-                print(str(e))
+                print(six.text_type(e))
             finally:
                 cls.threads.remove(thread)
 

--- a/st2tests/st2tests/mocks/workflow.py
+++ b/st2tests/st2tests/mocks/workflow.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 
+import six
 import eventlet
 import traceback
 
@@ -77,6 +78,6 @@ class MockWorkflowExecutionPublisherNonBlocking(object):
             try:
                 thread.wait()
             except Exception as e:
-                print(str(e))
+                print(six.text_type(e))
             finally:
                 cls.threads.remove(thread)

--- a/tools/migrate_rules_to_include_pack.py
+++ b/tools/migrate_rules_to_include_pack.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
+import six
 import mongoengine as me
 
 from st2common import config
@@ -130,7 +132,7 @@ def migrate_rules():
             print('Migrating rule: %s to rule: %s' % (rule.name, rule_with_pack.ref))
             RuleWithPack.add_or_update(rule_with_pack)
     except Exception as e:
-        print('Migration failed. %s' % str(e))
+        print('Migration failed. %s' % six.text_type(e))
 
 
 def main():


### PR DESCRIPTION
While working on unrelated thing, I noticed our code doesn't correctly handle exception messages which contain non-ascii (unicode) data.

We call ``str(e)`` on exception message everywhere and this would fail with UnicodeDecodeError if exception message contains unicode data.

For example when creating an object with unicode character in the primary key field where object with such primary key already exists:

Before:

```bash
curl -X POST -H "Content-Type: application/json" "http://127.0.0.1:9101/v1/actions" -d '{"name":"ažžž", "runner_type": "local-shell-cmd"}'
{
    "faultstring": ""
}
```

API log

```bash
2019-03-14 17:34:04,559 ERROR [-] Failed to call controller function "post" for operation "st2api.controllers.v1.actions:actions_controller.post": 'ascii' codec can't encode characters in position 1-3: ordinal not in range(128)
Traceback (most recent call last):
  File "/data/stanley/st2common/st2common/router.py", line 516, in __call__
    resp = func(**kw)
  File "/data/stanley/st2api/st2api/controllers/v1/actions.py", line 127, in post
    action_db = Action.add_or_update(action_model)
  File "/data/stanley/st2common/st2common/persistence/base.py", line 182, in add_or_update
    conflict_object = cls._get_by_object(model_object)
  File "/data/stanley/st2common/st2common/persistence/base.py", line 357, in _get_by_object
    return cls.get_by_ref(ResourceReference.to_string_reference(pack=pack, name=name))
  File "/data/stanley/st2common/st2common/persistence/base.py", line 349, in get_by_ref
    pack=ref_obj.pack).first()
  File "/data/stanley/st2common/st2common/persistence/base.py", line 115, in query
    return cls._get_impl().query(*args, **kwargs)
  File "/data/stanley/st2common/st2common/models/db/__init__.py", line 409, in query
    filters = self._process_null_filters(filters=filters)
  File "/data/stanley/st2common/st2common/models/db/__init__.py", line 510, in _process_null_filters
    null_filters = {k: v for k, v in six.iteritems(filters)
  File "/data/stanley/st2common/st2common/models/db/__init__.py", line 512, in <dictcomp>
    (type(v) in [str, six.text_type] and str(v.lower()) == 'null')}
UnicodeEncodeError: 'ascii' codec can't encode characters in position 1-3: ordinal not in range(128)
2019-03-14 17:34:04,560 DEBUG [-] API call failed: 'ascii' codec can't encode characters in position 1-3: ordinal not in range(128) (exception_message="'ascii' codec can't encode characters in position 1-3: ordinal not in range(128)",exception_data={},exception_class='UnicodeEncodeError')
2019-03-14 17:34:04,562 DEBUG [-] Traceback (most recent call last):
  File "/data/stanley/st2common/st2common/middleware/error_handling.py", line 47, in __call__
    return self.app(environ, start_response)
  File "/data/stanley/st2common/st2common/middleware/streaming.py", line 48, in __call__
    return self.app(environ, start_response)
  File "/data/stanley/st2common/st2common/router.py", line 595, in as_wsgi
    resp = self(req)
  File "/data/stanley/st2common/st2common/router.py", line 520, in __call__
    raise e
UnicodeEncodeError: 'ascii' codec can't encode characters in position 1-3: ordinal not in range(128)

2019-03-14 17:34:04,563 DEBUG [-] [metrics] counter.incr(api.response.status.400, 1)
2019-03-14 17:34:04,563 DEBUG [-] Match path: /v1/actions
2019-03-14 17:34:04,564 INFO [-] 703c5cec-5bfc-4914-8389-a9d68ec33fdd - 400 25 40.859ms (content_length=25,request_id='703c5cec-5bfc-4914-8389-a9d68ec33fdd',runtime=40.859,remote_addr='127.0.0.1',status=400,method='POST',path='/v1/actions')
2019-03-14 17:34:04,565 DEBUG [-] 703c5cec-5bfc-4914-8389-a9d68ec33fdd - 400 25 40.859ms
{
    "faultstring": ""
} (result='{\n    "faultstring": ""\n}',content_length=25,request_id='703c5cec-5bfc-4914-8389-a9d68ec33fdd',runtime=40.859,remote_addr='127.0.0.1',status=400,method='POST',path='/v1/actions')
```

After:

```bash
curl -X POST -H "Content-Type: application/json" "http://127.0.0.1:9101/v1/actions" -d '{"name":"ažžž", "runner_type": "local-shell-cmd"}'
{
    "conflict-id": "5c8a85450761296eb7e72223",
    "faultstring": "Tried to save duplicate unique keys (insertDocument :: caused by :: 11000 E11000 duplicate key error index: st2.action_d_b.$uid_1  dup key: { : \"action:default:a\u017e\u017e\u017e\" })"
}
```

Good news is that we handle input correctly everywhere, it's just the way we handle field filters and exception messages.

## TODO

- [x] Changelog entry