### PR TITLE
Streaming and tailing workflow/action execution output

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -79,6 +79,8 @@ Fixed
   throw the exception which would propagate all the way up and break the application. (bug fix) #4597
 
   Reported by Chris McKenzie.
+* Add support of streaming and tailing output for a workflow/action execution command progress entries.
+  (improvement) #4602
 
 2.10.3 - March 06, 2019
 -----------------------

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -38,6 +38,7 @@ from st2common.models.api.action import LiveActionAPI
 from st2common.models.api.action import LiveActionCreateAPI
 from st2common.models.api.base import cast_argument_value
 from st2common.models.api.execution import ActionExecutionAPI
+from st2common.models.api.execution import ActionExecutionOutputAPI
 from st2common.models.db.auth import UserDB
 from st2common.persistence.liveaction import LiveAction
 from st2common.persistence.execution import ActionExecution
@@ -337,13 +338,13 @@ class ActionExecutionOutputController(ActionExecutionsControllerMixin, ResourceC
             # pylint: disable=no-member
             output_dbs = ActionExecutionOutput.query(execution_id=execution_id, **query_filters)
 
-            output = ''.join([output_db.data for output_db in output_dbs])
-            yield six.binary_type(output.encode('utf-8'))
+            output = [ActionExecutionOutputAPI.from_model(output_db) for output_db in output_dbs]
+            return output
 
         def make_response():
             app_iter = existing_output_iter()
-            res = Response(content_type='text/plain', app_iter=app_iter)
-            return res
+            response_value = Response(json=app_iter, status=http_client.OK)
+            return response_value
 
         res = make_response()
         return res

--- a/st2api/st2api/controllers/v1/workflow.py
+++ b/st2api/st2api/controllers/v1/workflow.py
@@ -1,0 +1,44 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+from six.moves import http_client
+
+from st2common import log as logging
+from st2common.models.api.workflow import TaskExecutionAPI
+from st2common.persistence.workflow import TaskExecution
+from st2common.router import Response
+
+LOG = logging.getLogger(__name__)
+
+
+class WorkflowExecutionController(object):
+    """
+    Workflow execution controller.
+    """
+
+    model = TaskExecutionAPI
+    access = TaskExecution
+
+    def get_all(self, task_id):
+        task_ex_dbs = self.access.query(workflow_execution=str(task_id))
+
+        db_iter = [self.model.from_model(task) for task in task_ex_dbs]
+        res = Response(json=db_iter, status=http_client.OK)
+        return res
+
+
+workflow_execution_controller = WorkflowExecutionController()

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -1593,10 +1593,10 @@ class ActionExecutionTailCommand(resource.ResourceCommand):
                 if include_metadata:
                     sys.stdout.write('[%s][%s] %s' % (event['timestamp'], event['output_type'],
                                                       event['data']))
-                    print ''
+                    print ('')
                 else:
                     sys.stdout.write(event['data'])
-                    print ''
+                    print ('')
 
     @classmethod
     def tail_task_execution_event(cls, event):

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -1672,7 +1672,7 @@ class ActionExecutionTailCommand(resource.ResourceCommand):
 
         sorted_output_messages = sorted(output_messages, key=lambda k: k['timestamp'])
         for log in sorted_output_messages:
-            print log['msg']
+            print (log['msg'])
 
         print('%s Workflow execution "%s" is "%s".' % (
             cls.convert_time(wf_end_timestamp), wf_execution_id, wf_status))

--- a/st2client/st2client/commands/resource.py
+++ b/st2client/st2client/commands/resource.py
@@ -142,6 +142,9 @@ class ResourceCommand(commands.Command):
         resource_name = self.resource.get_display_name().lower()
         return '%s-id' % resource_name.replace(' ', '-')
 
+    def get_workflow_manager(self):
+        return self.app.client.managers['Workflow']
+
     def print_not_found(self, name):
         print('%s "%s" is not found.\n' %
               (self.resource.get_display_name(), name))

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -195,14 +195,18 @@ class ResourceManager(object):
                 for item in response.json()]
 
     @add_auth_token_to_kwargs_from_env
-    def get_by_id(self, id, **kwargs):
+    def get_by_id(self, id, self_deserialize=True, **kwargs):
         url = '/%s/%s' % (self.resource.get_url_path_name(), id)
         response = self.client.get(url, **kwargs)
         if response.status_code == http_client.NOT_FOUND:
             return None
         if response.status_code != http_client.OK:
             self.handle_error(response)
-        return self.resource.deserialize(response.json())
+
+        if self_deserialize:
+            return self.resource.deserialize(response.json())
+        else:
+            return response.json()
 
     @add_auth_token_to_kwargs_from_env
     def get_property(self, id_, property_name, self_deserialize=True, **kwargs):
@@ -411,7 +415,7 @@ class ExecutionResourceManager(ResourceManager):
         if response.status_code != http_client.OK:
             self.handle_error(response)
 
-        return response.text
+        return response.json()
 
     @add_auth_token_to_kwargs_from_env
     def pause(self, execution_id, **kwargs):
@@ -678,6 +682,18 @@ class WorkflowManager(object):
 
         response = self.client.post_raw(url, definition, **kwargs)
 
+        if response.status_code != http_client.OK:
+            self.handle_error(response)
+
+        return response.json()
+
+    @add_auth_token_to_kwargs_from_env
+    def get_tasks_executions(self, id, self_deserialize=True, **kwargs):
+        url = '/taskexecutions/{0}'.format(str(id))
+
+        response = self.client.get(url, **kwargs)
+        if response.status_code == http_client.NOT_FOUND:
+            return None
         if response.status_code != http_client.OK:
             self.handle_error(response)
 

--- a/st2common/st2common/models/api/workflow.py
+++ b/st2common/st2common/models/api/workflow.py
@@ -1,0 +1,164 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import six
+
+from orquesta import statuses
+
+from st2common.models.api.base import BaseAPI
+from st2common.models.db.workflow import TaskExecutionDB
+from st2common.util import isotime
+
+__all__ = [
+    'TaskExecutionAPI'
+]
+
+
+class TaskExecutionAPI(BaseAPI):
+    """The system entity that represents the task execution in the system.
+    """
+
+    model = TaskExecutionDB
+    schema = {
+        "title": "taskexecution",
+        "description": "A task execution of an action.",
+        "type": "object",
+        "properties": {
+            "id": {
+                "type": "string",
+                "required": True
+            },
+            "workflow_execution": {
+                "description": "The unique identifier for the workflow execution.",
+                "type": "string"
+            },
+            "task_name": {
+                "description": "The current task name of the task execution.",
+                "type": "string"
+            },
+            "task_id": {
+                "description": "The current task id of the task execution.",
+                "type": "string"
+            },
+            "task_route": {
+                "description": "The current task routing value.",
+                "type": "integer"
+            },
+            'task_spec': {
+                "description": "The current task specification.",
+                'type': 'object',
+                'default': {}
+            },
+            "delay": {
+                "description": ("How long (in milliseconds) to delay the execution before"
+                                "scheduling."),
+                "type": "integer"
+            },
+            "itemized": {
+                "type": "boolean",
+                "default": False
+            },
+            "items_count": {
+                "description": "The current task items count value.",
+                "type": "integer"
+            },
+            "items_concurrency": {
+                "description": "The current task items concurrency.",
+                "type": "integer"
+            },
+            "context": {
+                "description": "The current task context.",
+                "type": "object",
+                "default": False
+            },
+            "status": {
+                "description": "The current status of the task execution.",
+                "type": "string"
+            },
+            "result": {
+                "description": "The current task execution result.",
+                'type': 'object',
+                'default': {}
+            },
+            "start_timestamp": {
+                "description": "The start time when the task is executed.",
+                "type": "string",
+                "pattern": isotime.ISO8601_UTC_REGEX
+            },
+            "end_timestamp": {
+                "description": "The timestamp when the task has finished.",
+                "type": "string",
+                "pattern": isotime.ISO8601_UTC_REGEX
+            },
+            "log": {
+                "description": "Contains information about execution state transitions.",
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "timestamp": {
+                            "type": "string",
+                            "pattern": isotime.ISO8601_UTC_REGEX},
+                        "status": {
+                            "type": "string",
+                            "enum": statuses
+                        }
+                    }
+                }
+            },
+            "additionalProperties": False
+        }
+    }
+
+    @classmethod
+    def from_model(cls, model, mask_secrets=True):
+        doc = cls._from_model(model, mask_secrets=mask_secrets)
+        if model.start_timestamp:
+            doc['start_timestamp'] = isotime.format(model.start_timestamp, offset=False)
+        if model.end_timestamp:
+            doc['end_timestamp'] = isotime.format(model.end_timestamp, offset=False)
+
+        for entry in doc.get('log', []):
+            entry['timestamp'] = isotime.format(entry['timestamp'], offset=False)
+
+        attrs = {attr: value for attr, value in six.iteritems(doc) if value is not None}
+        return cls(**attrs)
+
+    @classmethod
+    def to_model(cls, task_execution):
+        if getattr(task_execution, 'start_timestamp', None):
+            start_timestamp = isotime.parse(task_execution.start_timestamp)
+        else:
+            start_timestamp = None
+
+        if getattr(task_execution, 'end_timestamp', None):
+            end_timestamp = isotime.parse(task_execution.end_timestamp)
+        else:
+            end_timestamp = None
+
+        workflow_execution = getattr(task_execution, 'workflow_execution', None)
+        task_name = getattr(task_execution, 'task_name', None)
+        task_id = getattr(task_execution, 'task_id', None)
+        status = getattr(task_execution, 'status', None)
+        result = getattr(task_execution, 'result', None)
+        log = getattr(task_execution, 'log', [])
+
+        model = cls.model(workflow_execution=workflow_execution, task_name=task_name,
+                          task_id=task_id, status=status, result=result,
+                          start_timestamp=start_timestamp, end_timestamp=end_timestamp, log=log)
+
+        return model

--- a/st2common/st2common/models/db/workflow.py
+++ b/st2common/st2common/models/db/workflow.py
@@ -73,6 +73,7 @@ class TaskExecutionDB(stormbase.StormFoundationDB, stormbase.ChangeRevisionField
     result = stormbase.EscapedDictField()
     start_timestamp = db_field_types.ComplexDateTimeField(default=date_utils.get_datetime_utc_now)
     end_timestamp = db_field_types.ComplexDateTimeField()
+    log = me.ListField(field=me.DictField())
 
     meta = {
         'indexes': [

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -8,7 +8,7 @@ info:
   version: "1.0.0"
   title: StackStorm API
   description: |
-    
+
     ## Welcome
 
     Welcome to the StackStorm API Reference documentation! You can use the StackStorm API to integrate StackStorm with 3rd-party systems and custom applications. Example integrations include writing your own self-service user portal, or integrating with other orquestation systems.
@@ -197,7 +197,7 @@ info:
     Join our [Slack Community](https://stackstorm.com/community-signup) to get help from the engineering team and fellow users. You can also create issues against the main [StackStorm GitHub repo](https://github.com/StackStorm/st2/issues), or the [st2apidocs repo](https://github.com/StackStorm/st2apidocs) for documentation-specific issues.
 
     We also recommend reviewing the main [StackStorm documentation](https://docs.stackstorm.com/).
-    
+
 
 paths:
   /api/v1/:
@@ -1463,7 +1463,7 @@ paths:
   /api/v1/keys:
     get:
       operationId: st2api.controllers.v1.keyvalue:key_value_pair_controller.get_all
-      x-permissions: 
+      x-permissions:
       description: Returns a list of all key value pairs.
       parameters:
         - name: prefix
@@ -4269,6 +4269,30 @@ paths:
                 message: "[{'cmd': 'echo <% ctx().macro %>'}] is not of type 'object'"
                 schema_path: "properties.tasks.patternProperties.^\\w+$.properties.input.type"
                 spec_path: "tasks.task2.input"
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+
+  /api/v1/workflows/taskexecutions/{id}:
+    get:
+      operationId: st2api.controllers.v1.workflow:workflow_execution_controller.get_all
+      description: |
+        Get all Task Executions.
+      parameters:
+        - name: id
+          in: path
+          description: Workflow Execution ID
+          type: string
+          required: true
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
+      responses:
+        '200':
+          description: Task Execution requested
         default:
           description: Unexpected error
           schema:

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -4270,6 +4270,30 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
+  /api/v1/workflows/taskexecutions/{id}:
+    get:
+      operationId: st2api.controllers.v1.workflow:workflow_execution_controller.get_all
+      description: |
+        Get all Task Executions.
+      parameters:
+        - name: id
+          in: path
+          description: Workflow Execution ID
+          type: string
+          required: true
+      x-parameters:
+        - name: user
+          in: context
+          x-as: requester_user
+          description: User performing the operation.
+      responses:
+        '200':
+          description: Task Execution requested
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+
   /api/exp/validation/mistral:
     post:
       operationId: st2api.controllers.exp.validation:mistral_validation_controller.post

--- a/st2common/st2common/persistence/workflow.py
+++ b/st2common/st2common/persistence/workflow.py
@@ -50,3 +50,10 @@ class TaskExecution(persistence.StatusBasedResource):
     @classmethod
     def _get_impl(cls):
         return cls.impl
+
+    @classmethod
+    def _get_publisher(cls):
+        if not cls.publisher:
+            cls.publisher = transport.workflow.TaskExecutionPublisher()
+
+        return cls.publisher

--- a/st2common/st2common/runners/paramiko_ssh_runner.py
+++ b/st2common/st2common/runners/paramiko_ssh_runner.py
@@ -133,7 +133,7 @@ class BaseParallelSSHRunner(ActionRunner, ShellRunnerMixin):
         def make_store_stdout_line_func(execution_db, action_db):
             def store_stdout_line(line):
                 if cfg.CONF.actionrunner.stream_output:
-                    store_execution_output_data(execution_db=execution_db, action_db=action_db,
+                    store_execution_output_data(execution_db.id, action_db=action_db,
                                                 data=line, output_type='stdout')
 
             return store_stdout_line
@@ -141,7 +141,7 @@ class BaseParallelSSHRunner(ActionRunner, ShellRunnerMixin):
         def make_store_stderr_line_func(execution_db, action_db):
             def store_stderr_line(line):
                 if cfg.CONF.actionrunner.stream_output:
-                    store_execution_output_data(execution_db=execution_db, action_db=action_db,
+                    store_execution_output_data(execution_db.id, action_db=action_db,
                                                 data=line, output_type='stderr')
 
             return store_stderr_line

--- a/st2common/st2common/runners/utils.py
+++ b/st2common/st2common/runners/utils.py
@@ -173,7 +173,7 @@ def make_read_and_store_stream_func(execution_db, action_db, store_data_func):
                     continue
 
                 if cfg.CONF.actionrunner.stream_output:
-                    store_data_func(execution_db=execution_db, action_db=action_db, data=line)
+                    store_data_func(execution_db.id, action_db=action_db, data=line)
         except RuntimeError:
             # process was terminated abruptly
             pass

--- a/st2common/st2common/services/action.py
+++ b/st2common/st2common/services/action.py
@@ -428,14 +428,20 @@ def get_root_execution(execution_db):
     return get_root_execution(parent_execution_db) if parent_execution_db else execution_db
 
 
-def store_execution_output_data(execution_db, action_db, data, output_type='output',
+def store_execution_output_data(execution_db_id, action_db, data, output_type='output',
                                 timestamp=None):
     """
     Store output from an execution as a new document in the collection.
     """
-    execution_id = str(execution_db.id)
-    action_ref = action_db.ref
-    runner_ref = getattr(action_db, 'runner_type', {}).get('name', 'unknown')
+    execution_id = str(execution_db_id)
+
+    if action_db:
+        action_ref = action_db.ref
+        runner_ref = getattr(action_db, 'runner_type', {}).get('name', 'unknown')
+    else:
+        action_ref = ''
+        runner_ref = ''
+
     timestamp = timestamp or date_utils.get_datetime_utc_now()
 
     output_db = ActionExecutionOutputDB(execution_id=execution_id,

--- a/st2common/st2common/services/executions.py
+++ b/st2common/st2common/services/executions.py
@@ -36,6 +36,7 @@ from bson.objectid import ObjectId
 
 from st2common import log as logging
 from st2common.util import date as date_utils
+from st2common.util import isotime as isotime_utils
 from st2common.util import reference
 import st2common.util.action_db as action_utils
 from st2common.constants import action as action_constants
@@ -95,8 +96,9 @@ def _create_execution_log_entry(status):
     """
     Create execution log entry object for the provided execution status.
     """
+    timestamp = str(isotime_utils.parse(date_utils.get_datetime_utc_now()))
     return {
-        'timestamp': date_utils.get_datetime_utc_now(),
+        'timestamp': timestamp,
         'status': status
     }
 

--- a/st2common/st2common/stream/listener.py
+++ b/st2common/st2common/stream/listener.py
@@ -24,12 +24,14 @@ from oslo_config import cfg
 from st2common.models.api.action import LiveActionAPI
 from st2common.models.api.execution import ActionExecutionAPI
 from st2common.models.api.execution import ActionExecutionOutputAPI
+from st2common.models.api.workflow import TaskExecutionAPI
 from st2common.transport import utils as transport_utils
 from st2common.transport.queues import STREAM_ANNOUNCEMENT_WORK_QUEUE
 from st2common.transport.queues import STREAM_EXECUTION_ALL_WORK_QUEUE
 from st2common.transport.queues import STREAM_EXECUTION_UPDATE_WORK_QUEUE
 from st2common.transport.queues import STREAM_LIVEACTION_WORK_QUEUE
 from st2common.transport.queues import STREAM_EXECUTION_OUTPUT_QUEUE
+from st2common.transport.queues import STREAM_EXECUTION_TASK_UPDATE_QUEUE
 from st2common import log as logging
 
 __all__ = [
@@ -169,6 +171,8 @@ class BaseListener(ConsumerMixin):
             execution_id = None
         elif isinstance(body, (ActionExecutionOutputAPI)):
             execution_id = body.execution_id
+        elif isinstance(body, TaskExecutionAPI):
+            execution_id = str(body.id)
 
         return execution_id
 
@@ -196,7 +200,11 @@ class StreamListener(BaseListener):
 
             consumer(queues=[STREAM_EXECUTION_OUTPUT_QUEUE],
                      accept=['pickle'],
-                     callbacks=[self.processor(ActionExecutionOutputAPI)])
+                     callbacks=[self.processor(ActionExecutionOutputAPI)]),
+
+            consumer(queues=[STREAM_EXECUTION_TASK_UPDATE_QUEUE],
+                     accept=['pickle'],
+                     callbacks=[self.processor(TaskExecutionAPI)])
         ]
 
 

--- a/st2common/st2common/transport/bootstrap_utils.py
+++ b/st2common/st2common/transport/bootstrap_utils.py
@@ -49,6 +49,7 @@ from st2common.transport.queues import STREAM_LIVEACTION_WORK_QUEUE
 from st2common.transport.queues import STREAM_EXECUTION_OUTPUT_QUEUE
 from st2common.transport.queues import WORKFLOW_EXECUTION_WORK_QUEUE
 from st2common.transport.queues import WORKFLOW_EXECUTION_RESUME_QUEUE
+from st2common.transport.queues import STREAM_EXECUTION_TASK_UPDATE_QUEUE
 
 LOG = logging.getLogger('st2common.transport.bootstrap')
 
@@ -90,6 +91,7 @@ QUEUES = [
     STREAM_EXECUTION_ALL_WORK_QUEUE,
     STREAM_LIVEACTION_WORK_QUEUE,
     STREAM_EXECUTION_OUTPUT_QUEUE,
+    STREAM_EXECUTION_TASK_UPDATE_QUEUE,
 
     WORKFLOW_EXECUTION_WORK_QUEUE,
     WORKFLOW_EXECUTION_RESUME_QUEUE,

--- a/st2common/st2common/transport/queues.py
+++ b/st2common/st2common/transport/queues.py
@@ -55,7 +55,8 @@ __all__ = [
     'STREAM_LIVEACTION_WORK_QUEUE',
 
     'WORKFLOW_EXECUTION_WORK_QUEUE',
-    'WORKFLOW_EXECUTION_RESUME_QUEUE'
+    'WORKFLOW_EXECUTION_RESUME_QUEUE',
+    'STREAM_EXECUTION_TASK_UPDATE_QUEUE'
 ]
 
 
@@ -138,6 +139,10 @@ STREAM_EXECUTION_OUTPUT_QUEUE = execution.get_output_queue(
     exclusive=True,
     auto_delete=True)
 
+STREAM_EXECUTION_TASK_UPDATE_QUEUE = workflow.get_task_queue(
+    name='st2.workflow',
+    routing_key=publishers.UPDATE_RK
+)
 
 # Used by the workflow engine service
 WORKFLOW_EXECUTION_WORK_QUEUE = workflow.get_status_management_queue(

--- a/st2common/st2common/transport/workflow.py
+++ b/st2common/st2common/transport/workflow.py
@@ -23,9 +23,11 @@ from st2common.transport import publishers
 
 __all__ = [
     'WorkflowExecutionPublisher',
+    'TaskExecutionPublisher',
 
     'get_queue',
-    'get_status_management_queue'
+    'get_status_management_queue',
+    'get_task_queue'
 ]
 
 WORKFLOW_EXECUTION_XCHG = kombu.Exchange('st2.workflow', type='topic')
@@ -39,9 +41,18 @@ class WorkflowExecutionPublisher(publishers.CUDPublisher, publishers.StatePublis
         publishers.StatePublisherMixin.__init__(self, exchange=WORKFLOW_EXECUTION_STATUS_MGMT_XCHG)
 
 
+class TaskExecutionPublisher(publishers.CUDPublisher):
+    def __init__(self):
+        publishers.CUDPublisher.__init__(self, exchange=WORKFLOW_EXECUTION_XCHG)
+
+
 def get_queue(name, routing_key):
     return kombu.Queue(name, WORKFLOW_EXECUTION_XCHG, routing_key=routing_key)
 
 
 def get_status_management_queue(name, routing_key):
     return kombu.Queue(name, WORKFLOW_EXECUTION_STATUS_MGMT_XCHG, routing_key=routing_key)
+
+
+def get_task_queue(name, routing_key):
+    return kombu.Queue(name, WORKFLOW_EXECUTION_XCHG, routing_key=routing_key)


### PR DESCRIPTION
Fixes https://github.com/StackStorm/orquesta/issues/109 : Streaming and tailing workflow/action execution output

Supersedes https://github.com/StackStorm/st2/pull/4529. 
PR 4529 was closed during change branch name because old name was not followed good practice. 
Old PR had discussion about how to implement this feature. Had some code changes but they were removed after discussion with @kami. 

New PR is based on clean new branch for easy review. 
1. For tailing running Workflow:
   a. Create and publish `ActionExecutionOutput` for tailing next tasks with following:

   ```'execution_id' : [Workflow Execution ID]
   'out_type' : 'next_tasks'
   'data' : "List of next task names"```
  b. Publish `TaskExecution` alone with new element `log` for tailing task execution.
2. For tailing Completed Workflow:
  a. Call `execution_manager.get_by_id()` to mainly get Workflow execution ID and Workflow status.
  b. Call `execution_manager.get_property(execution_id, "children", False)` to get children action execution information.
  c. Call `execution_manager.get_output(execution_id=execution_id, output_type='next_tasks')` to get next_tasks information
  d. Create new `st2api` and Controller to get `TaskExecution` information for tailing task execution information

Please see CLI tailing output messages at: https://gist.github.com/jinpingh/05e32f9822514c03c9dc7771f8e64db3 