### PR TITLE
[WIP] Automatically (re)format code using "black" library

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,31 @@ deps = -r{toxinidir}/requirements.txt
        -e{toxinidir}/st2reactor
 
 # Python 3 tasks
+[testenv:py36-black]
+basepython = python3.6
+setenv = PYTHONPATH = {toxinidir}/external:{toxinidir}/st2common:{toxinidir}/st2api:{toxinidir}/st2actions:{toxinidir}/st2exporter:{toxinidir}/st2reactor:{toxinidir}/st2tests:{toxinidir}/contrib/runners/action_chain_runner:{toxinidir}/contrib/runners/local_runner:{toxinidir}/contrib/runners/python_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/noop_runner:{toxinidir}/contrib/runners/announcement_runner:{toxinidir}/contrib/runners/remote_runner:{toxinidir}/contrib/runners/remote_runner:{toxinidir}/contrib/runners/mistral_v2:{toxinidir}/contrib/runners/orquesta_runner:{toxinidir}/contrib/runners/inquirer_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/winrm_runner
+         VIRTUALENV_DIR = {envdir}
+passenv = NOSE_WITH_TIMER TRAVIS
+install_command = pip install -U --force-reinstall {opts} {packages}
+deps = virtualenv
+       -r{toxinidir}/requirements.txt
+       -e{toxinidir}/st2client
+       -e{toxinidir}/st2common
+       black
+commands =
+    black --config lint-configs/python/pyproject.toml st2api/
+    black --config lint-configs/python/pyproject.toml st2auth/
+    black --config lint-configs/python/pyproject.toml st2client/
+    black --config lint-configs/python/pyproject.toml st2common/
+    black --config lint-configs/python/pyproject.toml st2debug/
+    black --config lint-configs/python/pyproject.toml st2exporter/
+    black --config lint-configs/python/pyproject.toml st2reactor/
+    black --config lint-configs/python/pyproject.toml st2stream/
+    black --config lint-configs/python/pyproject.toml st2tests/
+    black --config lint-configs/python/pyproject.toml contrib/
+    black --config lint-configs/python/pyproject.toml tools/
+    black --config lint-configs/python/pyproject.toml scripts
+
 [testenv:py36-unit]
 basepython = python3.6
 setenv = PYTHONPATH = {toxinidir}/external:{toxinidir}/st2common:{toxinidir}/st2api:{toxinidir}/st2actions:{toxinidir}/st2exporter:{toxinidir}/st2reactor:{toxinidir}/st2tests:{toxinidir}/contrib/runners/action_chain_runner:{toxinidir}/contrib/runners/local_runner:{toxinidir}/contrib/runners/python_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/noop_runner:{toxinidir}/contrib/runners/announcement_runner:{toxinidir}/contrib/runners/remote_runner:{toxinidir}/contrib/runners/remote_runner:{toxinidir}/contrib/runners/mistral_v2:{toxinidir}/contrib/runners/orquesta_runner:{toxinidir}/contrib/runners/inquirer_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/winrm_runner


### PR DESCRIPTION
We've talked about this for a while now and it's time to finally make some concrete steps to consistent code style and automatic code formatting.

## Background / Context

We, the developers, have various opinions on code styling which are by nature, subjective. Some of the more "objectively" defined style rules (defined in thing such as pep8, etc.) are already enforced in our code base using tools like pep8, flake8 and pylint, but those tools only go so far.

Besides that it's a bit of "wild west" - we all have our own preferences and those tend to end up in the code base one way or another.

This means inconsistent styling in the code which makes the code harder to follow, read and understand, etc. It also means unnecessary "arguing" about style choices.

To solve for that and have a single consistent style in the code (think ``gofmt``), we should introduce a tool which automatically and deterministically formats the code so it follows a single consistent style,

After doing some research, I think the best tool for our use case probably is black - https://github.com/ambv/black.

There are other tools out there, but the good thing about black is that it's opinionated. If we select a tool which has 100 different options and flag to tweak styling to our linking (think yapf - https://github.com/google/yapf), then we will probably never all agree on how those options should be configured.

And personally, I'm also not a fan of some of the styling choices black makes, but at least it's consistent.

Once we agree on the approach and library to use, we should make the following changes:

1. [ ] Reformat all of the existing code - initial diff will be large, but there is no way around that
2. [ ] Document this in our developer documentation, contribution guidelines, etc.
3. [ ] Automatically enforce reformatting as part of:
    - [ ] Pre-commit hook
    - [ ] Travis CI build process - fail the build if code hasn't been formatted using black style
    - [ ] Document how people can integrate and do this automatically inside their editor / IDE
4. [ ] Eventually enforce the same styling rules on StackStorm-Exchange repos