### PR TITLE
Temporary disable service registry service registration to work around issue in stackstorm-ha

### DIFF
--- a/conf/st2.conf.sample
+++ b/conf/st2.conf.sample
@@ -97,6 +97,8 @@ packs_base_paths = None
 [coordination]
 # Endpoint for the coordination server.
 url = None
+# True to register StackStorm services in a service registry.
+service_registry = False
 # TTL for the lock if backend suports it.
 lock_timeout = 60
 

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -441,7 +441,10 @@ def register_opts(ignore_errors=False):
             help='Endpoint for the coordination server.'),
         cfg.IntOpt(
             'lock_timeout', default=60,
-            help='TTL for the lock if backend suports it.')
+            help='TTL for the lock if backend suports it.'),
+        cfg.BoolOpt(
+            'service_registry', default=False,
+            help='True to register StackStorm services in a service registry.'),
     ]
 
     do_register_opts(coord_opts, 'coordination', ignore_errors)

--- a/st2common/st2common/service_setup.py
+++ b/st2common/st2common/service_setup.py
@@ -181,7 +181,7 @@ def setup(service, config, setup_db=True, register_mq_exchanges=True,
     metrics_initialize()
 
     # Register service in the service registry
-    if service_registry:
+    if cfg.CONF.coordination.service_registry and service_registry:
         # NOTE: It's important that we pass start_heart=True to start the hearbeat process
         register_service_in_service_registry(service=service, capabilities=capabilities,
                                              start_heart=True)


### PR DESCRIPTION
This pull request adds a config option which specifies if a service should be registered in a service registry (and in any case, it's a good idea to have a flag so people can opt-out, if they have a valid reason for it, once it will default to ``True``).

To work around bug / issue in - https://github.com/StackStorm/stackstorm-ha/issues/57 it defaults to ``False``.

I forgot that the etcd ``tooz`` driver we use is old and doesn't support group functionality.

I opened a PR for etcd3gw driver group functionality support in tooz quite a long time ago. I will look into updating version ``tooz`` version we use and once that's done, I will flip that config value to ``True``.