### PR TITLE
[WIP] [DONT MERGE] Upgrade tooz, re-enable service registry registration by default

### DIFF
--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -38,7 +38,7 @@ virtualenv==15.1.0
 sseclient==0.0.19
 python-editor==1.0.3
 prompt-toolkit==1.0.15
-tooz==1.63.1
+tooz==1.64.2
 zake==0.2.2
 routes==2.4.1
 webob==1.8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ semver==2.8.1
 six==1.12.0
 sseclient==0.0.19
 stevedore==1.30.0
-tooz==1.63.1
+tooz==1.64.2
 ujson==1.35
 unittest2
 webob==1.8.4

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -19,6 +19,8 @@ requests
 retrying
 semver
 six
+# Need our fork with various bug fixes in etcd drivers
+git+https://github.com/StackStorm/tooz.git@etcd3_driver_fixes#egg=tooz
 tooz
 # Required by tooz - on new versions of tooz, all the backend dependencies need
 # to be installed manually

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -24,7 +24,7 @@ retrying==1.3.3
 routes==2.4.1
 semver==2.8.1
 six==1.12.0
-tooz==1.63.1
+tooz==1.64.2
 ujson==1.35
 webob==1.8.4
 zake==0.2.2


### PR DESCRIPTION
This pull request updates tooz dependency to our fork - https://github.com/openstack/tooz/compare/master...StackStorm:etcd3_driver_fixes?expand=1.

Latest version does contain some group related functionality in ``etcd3`` and ``etcd3+http`` driver, but it's partial and broken.

I've fixed various issues in our fork and I also plan to submit changes upstream (but it might take a while to get them merged and new version releases) so we need to use our fork for now.

There are some more issues I need to fix there.

NOTE: For this to work in stackstorm-ha, we need to ensure etcd >= 3.0.0 is installed and used. In addition to that, we need to use ``etcd+http://localhost`` driver there.