### PR TITLE
Add chat context to chatops

### DIFF
--- a/contrib/chatops/actions/post_message.yaml
+++ b/contrib/chatops/actions/post_message.yaml
@@ -25,6 +25,10 @@ parameters:
     type: "string"
     description: "Channel to post to"
     required: true
+  context:
+    type: "object"
+    description: "Context for channel (includes type of channel, user, etc.)"
+    required: false
   extra:
     type: "object"
     description: "Extra adapter-specific parameters."

--- a/contrib/chatops/actions/post_result.yaml
+++ b/contrib/chatops/actions/post_result.yaml
@@ -21,3 +21,7 @@ parameters:
     type: "string"
     description: "Channel to post to"
     required: true
+  context:
+    type: "object"
+    description: "Context for channel (includes type of channel, user, etc.)"
+    required: false

--- a/contrib/chatops/actions/workflows/post_result.yaml
+++ b/contrib/chatops/actions/workflows/post_result.yaml
@@ -9,39 +9,39 @@ input:
   - channel
 
 tasks:
-    format_execution_result:
-      action: chatops.format_execution_result
-      input:
-        execution_id: "{{ ctx('execution_id') }}"
-      next:
-        -
-          when: "{{ result().result.enabled == true }}"
-          publish:
-            - message: "{{ result().result.message }}"
-            - extra: "{% if 'extra' in result().result %}{{ result().result.extra }}{% else %}{}{% endif %}"
-          do:
-            - post_message
-        -
-          when: "{{ result().result.enabled == false }}"
-          do:
-            - result_disabled
+  format_execution_result:
+    action: chatops.format_execution_result
+    input:
+      execution_id: "{{ ctx('execution_id') }}"
+    next:
+      -
+        when: "{{ result().result.enabled == true }}"
+        publish:
+          - message: "{{ result().result.message }}"
+          - extra: "{% if 'extra' in result().result %}{{ result().result.extra }}{% else %}{}{% endif %}"
+        do:
+          - post_message
+      -
+        when: "{{ result().result.enabled == false }}"
+        do:
+          - result_disabled
 
-    post_message:
-      action: chatops.post_message
-      input:
-        user: "{{ ctx('user') }}"
-        channel: "{{ ctx('channel') }}"
-        whisper: "{{ ctx('whisper') }}"
-        message: "{{ ctx('message') }}"
-        extra: "{{ ctx('extra') }}"
-      next:
-        - publish:
-            - msg: "Execution result has been posted."
+  post_message:
+    action: chatops.post_message
+    input:
+      user: "{{ ctx('user') }}"
+      channel: "{{ ctx('channel') }}"
+      whisper: "{{ ctx('whisper') }}"
+      message: "{{ ctx('message') }}"
+      extra: "{{ ctx('extra') }}"
+    next:
+      - publish:
+          - msg: "Execution result has been posted."
 
-    result_disabled:
-      action: core.noop
-      next:
-        - publish:
-            - msg: "Execution result is disabled."
+  result_disabled:
+    action: core.noop
+    next:
+      - publish:
+          - msg: "Execution result is disabled."
 output:
   - note: "{{ ctx('msg') }}"

--- a/contrib/chatops/actions/workflows/post_result.yaml
+++ b/contrib/chatops/actions/workflows/post_result.yaml
@@ -7,6 +7,7 @@ input:
   - whisper
   - execution_id
   - channel
+  - context
 
 tasks:
   format_execution_result:
@@ -33,6 +34,7 @@ tasks:
       channel: "{{ ctx('channel') }}"
       whisper: "{{ ctx('whisper') }}"
       message: "{{ ctx('message') }}"
+      context: "{{ ctx('context') }}"
       extra: "{{ ctx('extra') }}"
     next:
       - publish:

--- a/contrib/chatops/rules/notify_hubot.yaml
+++ b/contrib/chatops/rules/notify_hubot.yaml
@@ -15,3 +15,4 @@ action:
     channel: "{{trigger.data.source_channel}}"
     user: "{{trigger.data.user}}"
     execution_id: "{{trigger.execution_id}}"
+    context: "{{trigger.data.source_context}}"

--- a/st2api/st2api/controllers/v1/aliasexecution.py
+++ b/st2api/st2api/controllers/v1/aliasexecution.py
@@ -78,7 +78,7 @@ class ActionAliasExecutionController(BaseRestControllerMixin):
             'format': representation,
             'command': command,
             'user': input_api.user,
-            'source_channel': input_api.source_channel
+            'source_channel': input_api.source_channel,
         }
 
         # Add in any additional parameters provided by the user
@@ -145,7 +145,7 @@ class ActionAliasExecutionController(BaseRestControllerMixin):
             'action_alias_ref': reference.get_ref_from_model(action_alias_db),
             'api_user': payload.user,
             'user': requester_user.name,
-            'source_channel': payload.source_channel
+            'source_channel': payload.source_channel,
         }
 
         results = []
@@ -206,7 +206,7 @@ class ActionAliasExecutionController(BaseRestControllerMixin):
         on_complete.routes = [route]
         on_complete.data = {
             'user': payload.user,
-            'source_channel': payload.source_channel
+            'source_channel': payload.source_channel,
         }
         notify = NotificationSchema()
         notify.on_complete = on_complete

--- a/st2api/st2api/controllers/v1/aliasexecution.py
+++ b/st2api/st2api/controllers/v1/aliasexecution.py
@@ -145,7 +145,6 @@ class ActionAliasExecutionController(BaseRestControllerMixin):
             'action_alias_ref': reference.get_ref_from_model(action_alias_db),
             'api_user': payload.user,
             'user': requester_user.name,
-            'source_channel': payload.source_channel,
         }
 
         results = []
@@ -207,6 +206,7 @@ class ActionAliasExecutionController(BaseRestControllerMixin):
         on_complete.data = {
             'user': payload.user,
             'source_channel': payload.source_channel,
+            'source_context': getattr(payload, 'source_context', None),
         }
         notify = NotificationSchema()
         notify.on_complete = on_complete

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -687,8 +687,8 @@ class AliasExecutionAPI(BaseAPI):
             },
             "source_channel": {
                 "type": "string",
-                "description": "Channel from which the execution was requested. This is not the \
-                                channel as defined by the notification system.",
+                "description": "Channel from which the execution was requested. This is not the "
+                               "channel as defined by the notification system.",
                 "required": True
             },
             "notification_channel": {

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -691,6 +691,13 @@ class AliasExecutionAPI(BaseAPI):
                                "channel as defined by the notification system.",
                 "required": True
             },
+            "source_context": {
+                "type": "object",
+                "description": "ALL data included with the message (also called the message "
+                               "envelope). This is currently only used by the Microsoft Teams "
+                               "adapter.",
+                "required": False
+            },
             "notification_channel": {
                 "type": "string",
                 "description": "StackStorm notification channel to use to respond.",


### PR DESCRIPTION
This is part of the work to add a Microsoft Teams (via BotFramework) adapter.

Microsoft Teams needs a bit more context other than the requesting user and the channel name.

Instead of adding the minimum amount of context, this PR adds a `context` parameter to the `post_` actions in the chatops pack and adds it to the notify `on_complete` dictionary. The `context` parameter maximizes the amount of information available to the notification mechanism, in the hopes that it can be reused by other adapters.

* st2chatops in StackStorm/st2chatops#121
* hubot-stackstorm changes in StackStorm/hubot-stackstorm#164
* Documentation for configuring Microsoft Teams with BotFramework in StackStorm/st2docs#872