### PR TITLE
Add auth token to st2 workflow inspect

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -95,6 +95,7 @@ Fixed
   is acquired before write operations to avoid write conflicts. (bug fix) Stackstorm/orquesta#125
 * Fix a bug with some API endpoints returning 500 internal server error when an exception contained
   unicode data. (bug fix) #4598
+* Fix the ``st2 workflow inspect`` command so it correctly passes authentication token. (bug fix) #4615
 
 2.10.4 - March 15, 2019
 -----------------------

--- a/st2client/st2client/commands/workflow.py
+++ b/st2client/st2client/commands/workflow.py
@@ -21,6 +21,7 @@ import os
 import yaml
 
 from st2client import commands
+from st2client.commands.resource import add_auth_token_to_kwargs_from_cli
 
 
 LOG = logging.getLogger(__name__)
@@ -79,6 +80,7 @@ class WorkflowInspectionCommand(commands.Command):
 
         return content
 
+    @add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
         wf_def_file = args.file
 
@@ -98,6 +100,7 @@ class WorkflowInspectionCommand(commands.Command):
 
         return self.manager.inspect(wf_def, **kwargs)
 
+    @add_auth_token_to_kwargs_from_cli
     def run_and_print(self, args, **kwargs):
         errors = self.run(args, **kwargs)
 

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -665,6 +665,7 @@ class WorkflowManager(object):
 
         response.raise_for_status()
 
+    @add_auth_token_to_kwargs_from_env
     def inspect(self, definition, **kwargs):
         url = '/inspect'
 


### PR DESCRIPTION
Fixes #4614 

Before:
```shell
lhill@ewcdemo:~$  st2 workflow inspect --action examples.orquesta-with-items
ERROR: 401 Client Error: Unauthorized
MESSAGE: Unauthorized - One of Token or API key required. for url: http://127.0.0.1:9101/v1/workflows/inspect

lhill@ewcdemo:~$
```

After:

```shell
lhill@ewcdemo:~$  st2 workflow inspect --action examples.orquesta-with-items
No errors found in workflow definition.
lhill@ewcdemo:~$
```