### PR TITLE
Use correct gunicorn logging config with st2 packages (don't include AUDIT log messages in non-AUDIT log file)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -81,6 +81,15 @@ Changed
   Contributed by Nick Maludy (Encore Technologies)
 * Update various internal dependencies to latest stable versions (apscheduler, pyyaml, kombu,
   mongoengine, pytz, stevedore, sseclient, python-editor). #4610
+* Update logging code so we exclude log messages with log level ``AUDIT`` from a default service
+  log file (e.g. ``st2api.log``). Log messages with level ``AUDIT`` are already logged in a
+  dedicated service audit log file (e.g. ``st2api.audit.log``) so there is no need for them to also
+  be duplicated and included in regular service log file.
+
+  NOTE: To aid with debugging, audit log messages are also included in a regular log file when log
+  level is set to ``DEBUG`` or ``system.debug`` config option is set to ``True``.
+
+  Reported by Nick Maludy. (improvement) #4538 #4502 #4621
 
 Fixed
 ~~~~~

--- a/conf/st2.package.conf
+++ b/conf/st2.package.conf
@@ -4,13 +4,13 @@
 # Host and port to bind the API server.
 host = 127.0.0.1
 port = 9101
-logging = /etc/st2/logging.api.conf
+logging = /etc/st2/logging.api.gunicorn.conf
 mask_secrets = True
 # allow_origin is required for handling CORS in st2 web UI.
 # allow_origin = http://myhost1.example.com:3000,http://myhost2.example.com:3000
 
 [stream]
-logging = /etc/st2/logging.stream.conf
+logging = /etc/st2/logging.stream.gunicorn.conf
 
 [sensorcontainer]
 logging = /etc/st2/logging.sensorcontainer.conf
@@ -43,7 +43,7 @@ port = 9100
 use_ssl = False
 debug = False
 enable = False
-logging = /etc/st2/logging.auth.conf
+logging = /etc/st2/logging.auth.gunicorn.conf
 
 mode = standalone
 


### PR DESCRIPTION
While testing some other changes, I noticed fix in #4538 doesn't appear to be working in production with packages.

It turns out we were not using correct gunicorn logging config with StackStorm packages (gunicorn config makes sure DEBUG and non-audit log messages don't end up in non-audit service log file bi default).

Related PR: https://github.com/StackStorm/st2-packages/pull/607