### PR TITLE
Action has been moved from tests to fixtures pack, update affected code

### DIFF
--- a/contrib/examples/actions/workflows/render_config_context.yaml
+++ b/contrib/examples/actions/workflows/render_config_context.yaml
@@ -2,6 +2,6 @@ version: 1.0
 description: Testing config context render".
 tasks:
   task1:
-    action: tests.render_config_context
+    action: fixtures.render_config_context
 output:
   - context_value: <% task(task1).result.result.context_value %>

--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -220,7 +220,7 @@ function st2start(){
         git clone https://github.com/StackStorm/st2tests.git
         ret=$?
         if [ ${ret} -eq 0 ]; then
-            cp -Rp ./st2tests/packs/tests $PACKS_BASE_DIR
+            cp -Rp ./st2tests/packs/fixtures $PACKS_BASE_DIR
             rm -R st2tests/
         else
             echo "Failed to clone st2tests repo"
@@ -428,7 +428,7 @@ function st2start(){
     fi
 
     if [ "$copy_test_packs" = true ]; then
-        st2 run packs.setup_virtualenv packs=tests
+        st2 run packs.setup_virtualenv packs=fixtures
         if [ $? != 0 ]; then
             echo "Warning: Unable to setup virtualenv for the \"tests\" pack. Please setup virtualenv for the \"tests\" pack before running integration tests"
         fi

--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -213,7 +213,7 @@ function st2start(){
     cp -Rp ./contrib/packs/ $PACKS_BASE_DIR
 
     if [ "$copy_test_packs" = true ]; then
-        echo "Copying test packs examples and tests to $PACKS_BASE_DIR"
+        echo "Copying test packs examples and fixtures to $PACKS_BASE_DIR"
         cp -Rp ./contrib/examples $PACKS_BASE_DIR
         # Clone st2tests in /tmp directory.
         pushd /tmp


### PR DESCRIPTION
``render_config_context`` action has been moved from ``tests`` to ``fixture`` pack to fix ``st2-self-check`` and to follow the existing layout for end to end tests in ``st2tests/tests`` pack - https://github.com/StackStorm/st2tests/pull/153.

This pull request updates affected code to use ``fixtures`` instead of ``tests`` pack.