### PR TITLE
Trstruth/st2client user filter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -90,6 +90,9 @@ Changed
   level is set to ``DEBUG`` or ``system.debug`` config option is set to ``True``.
 
   Reported by Nick Maludy. (improvement) #4538 #4502 #4621
+* Add missing ``--user`` argument to ``st2 execution list`` CLI command. (improvement) #4632
+
+  Contributed by Tristan Struthers (@trstruth).
 
 Fixed
 ~~~~~

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -1086,7 +1086,7 @@ class ActionExecutionListCommand(ResourceViewCommand):
                                                   \'%s\', \'%s\', \'%s\', \'%s\' or \'%s\''
                                                   '.' % POSSIBLE_ACTION_STATUS_VALUES))
         self.group.add_argument('--user',
-                                help='Only return executions created by provided the user.')
+                                help='Only return executions created by the provided user.')
         self.group.add_argument('--trigger_instance',
                                 help='Trigger instance id to filter the list.')
         self.parser.add_argument('-tg', '--timestamp-gt', type=str, dest='timestamp_gt',

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -1085,6 +1085,8 @@ class ActionExecutionListCommand(ResourceViewCommand):
                                                   status. Possible values are \'%s\', \'%s\', \
                                                   \'%s\', \'%s\', \'%s\', \'%s\' or \'%s\''
                                                   '.' % POSSIBLE_ACTION_STATUS_VALUES))
+        self.group.add_argument('--user',
+                                help='Only return executions created by provided the user.')
         self.group.add_argument('--trigger_instance',
                                 help='Trigger instance id to filter the list.')
         self.parser.add_argument('-tg', '--timestamp-gt', type=str, dest='timestamp_gt',
@@ -1117,6 +1119,8 @@ class ActionExecutionListCommand(ResourceViewCommand):
             kwargs['action'] = args.action
         if args.status:
             kwargs['status'] = args.status
+        if args.user:
+            kwargs['user'] = args.user
         if args.trigger_instance:
             kwargs['trigger_instance'] = args.trigger_instance
         if not args.showall:


### PR DESCRIPTION
the `st2 execution list` cli command doesn't expose a `--user` filter, despite the fact that st2client accepts a `user` kwarg for `st2client.client.executions.get_all()`.  This changes that.

![image](https://user-images.githubusercontent.com/9982381/56008115-ef841400-5c8f-11e9-8eb4-5234f1a9502d.png)
![image](https://user-images.githubusercontent.com/9982381/56008252-79cc7800-5c90-11e9-9178-b4c63df79441.png)
