### PR TITLE
Update dependencies to latest versions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -85,7 +85,7 @@ Changed
 
   Contributed by Nick Maludy (Encore Technologies)
 * Update various internal dependencies to latest stable versions (apscheduler, pyyaml, kombu,
-  mongoengine, pytz, stevedore, sseclient, python-editor). #4610
+  mongoengine, pytz, stevedore, sseclient, python-editor, Jinja2). #4610
 * Update logging code so we exclude log messages with log level ``AUDIT`` from a default service
   log file (e.g. ``st2api.log``). Log messages with level ``AUDIT`` are already logged in a
   dedicated service audit log file (e.g. ``st2api.audit.log``) so there is no need for them to also

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -85,7 +85,7 @@ Changed
 
   Contributed by Nick Maludy (Encore Technologies)
 * Update various internal dependencies to latest stable versions (apscheduler, pyyaml, kombu,
-  mongoengine, pytz, stevedore, sseclient, python-editor, Jinja2). #4610
+  mongoengine, pytz, stevedore, python-editor, jinja2). #4610
 * Update logging code so we exclude log messages with log level ``AUDIT`` from a default service
   log file (e.g. ``st2api.log``). Log messages with level ``AUDIT`` are already logged in a
   dedicated service audit log file (e.g. ``st2api.audit.log``) so there is no need for them to also

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -35,7 +35,7 @@ cryptography==2.6.1
 retrying==1.3.3
 # Note: We use latest version of virtualenv which uses pip 9.0
 virtualenv==15.1.0
-sseclient==0.0.19
+sseclient==0.0.24
 python-editor==1.0.4
 prompt-toolkit==1.0.15
 tooz==1.64.2
@@ -55,3 +55,4 @@ mock==2.0.0
 ujson==1.35
 python-dateutil==2.8.0
 bcrypt==3.1.6
+Jinja2==2.10.1

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -26,12 +26,12 @@ python-gnupg==0.4.4
 jsonpath-rw==1.4.0
 pyinotify==0.9.6
 semver==2.8.1
-pytz==2018.9
+pytz==2019.1
 stevedore==1.30.1
 paramiko==2.4.2
 networkx==1.11
 python-keyczar==0.716
-cryptography==2.4.2
+cryptography==2.6.1
 retrying==1.3.3
 # Note: We use latest version of virtualenv which uses pip 9.0
 virtualenv==15.1.0
@@ -53,4 +53,5 @@ python-statsd==2.1.0
 prometheus_client==0.1.1
 mock==2.0.0
 ujson==1.35
-python-dateutil==2.7.5
+python-dateutil==2.8.0
+bcrypt==3.1.6

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -35,7 +35,7 @@ cryptography==2.6.1
 retrying==1.3.3
 # Note: We use latest version of virtualenv which uses pip 9.0
 virtualenv==15.1.0
-sseclient==0.0.24
+sseclient==0.0.19
 python-editor==1.0.4
 prompt-toolkit==1.0.15
 tooz==1.64.2

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -55,4 +55,4 @@ mock==2.0.0
 ujson==1.35
 python-dateutil==2.8.0
 bcrypt==3.1.6
-Jinja2==2.10.1
+jinja2==2.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ RandomWords
 amqp==2.4.2
 apscheduler==3.6.0
 argcomplete
-bcrypt
-cryptography==2.4.2
+bcrypt==3.1.6
+cryptography==2.6.1
 eventlet==0.24.1
 flex==6.14.0
 git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper
@@ -36,12 +36,12 @@ psutil==5.6.1
 pyinotify==0.9.6
 pymongo==3.7.2
 pyrabbit
-python-dateutil==2.7.5
+python-dateutil==2.8.0
 python-editor==1.0.4
 python-gnupg==0.4.4
 python-json-logger
 python-statsd==2.1.0
-pytz==2018.9
+pytz==2019.1
 pywinrm==0.3.0
 pyyaml==5.1
 rednose

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ retrying==1.3.3
 routes==2.4.1
 semver==2.8.1
 six==1.12.0
-sseclient==0.0.24
+sseclient==0.0.19
 stevedore==1.30.1
 tooz==1.64.2
 ujson==1.35

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ gitpython==2.1.11
 greenlet==0.4.15
 gunicorn==19.9.0
 ipaddr
-jinja2
+jinja2==2.10.1
 jsonpath-rw==1.4.0
 jsonschema==2.6.0
 kombu==4.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ retrying==1.3.3
 routes==2.4.1
 semver==2.8.1
 six==1.12.0
-sseclient==0.0.19
+sseclient==0.0.24
 stevedore==1.30.1
 tooz==1.64.2
 ujson==1.35

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -11,4 +11,4 @@ pytz==2019.1
 pyyaml==5.1
 requests[security]<2.15,>=2.14.1
 six==1.12.0
-sseclient==0.0.19
+sseclient==0.0.24

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -11,4 +11,4 @@ pytz==2019.1
 pyyaml==5.1
 requests[security]<2.15,>=2.14.1
 six==1.12.0
-sseclient==0.0.24
+sseclient==0.0.19

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -1,13 +1,13 @@
 # Don't edit this file. It's generated automatically!
 argcomplete
-cryptography==2.4.2
+cryptography==2.6.1
 jsonpath-rw==1.4.0
 jsonschema==2.6.0
 prettytable
 prompt-toolkit==1.0.15
-python-dateutil==2.7.5
+python-dateutil==2.8.0
 python-editor==1.0.4
-pytz==2018.9
+pytz==2019.1
 pyyaml==5.1
 requests[security]<2.15,>=2.14.1
 six==1.12.0

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -1,7 +1,7 @@
 # Don't edit this file. It's generated automatically!
 amqp==2.4.2
 apscheduler==3.6.0
-cryptography==2.4.2
+cryptography==2.6.1
 eventlet==0.24.1
 flex==6.14.0
 git+https://github.com/StackStorm/orquesta.git@c9af76e25bf9163fddb4dcb0117c3bbf8d5876ef#egg=orquesta
@@ -16,7 +16,7 @@ networkx==1.11
 oslo.config<1.13,>=1.12.1
 paramiko==2.4.2
 pymongo==3.7.2
-python-dateutil==2.7.5
+python-dateutil==2.8.0
 python-statsd==2.1.0
 pyyaml==5.1
 requests[security]<2.15,>=2.14.1

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -7,7 +7,7 @@ flex==6.14.0
 git+https://github.com/StackStorm/orquesta.git@c9af76e25bf9163fddb4dcb0117c3bbf8d5876ef#egg=orquesta
 greenlet==0.4.15
 ipaddr
-jinja2
+jinja2==2.10.1
 jsonpath-rw==1.4.0
 jsonschema==2.6.0
 kombu==4.5.0


### PR DESCRIPTION
Just some house keeping before the release.

I noticed we didn't pin ``bcrypt`` dependency so I also fixed that so we have reproducible builds.