### PR TITLE
Add example action for testing "st2 execution tail" functionality with Orquesta workflows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -52,8 +52,7 @@ Added
   StackStorm instance to another which uses the same crypto key.
 
   Contributed by Nick Maludy (Encore Technologies) #4547
-
-* Added ``source_channel`` to Orquesta ``st2()`` context for workflows called via ChatOps. (#4600)
+* Add ``source_channel`` to Orquesta ``st2()`` context for workflows called via ChatOps. #4600
 
 Changed
 ~~~~~~~

--- a/contrib/examples/actions/orquesta-streaming-demo.meta.yaml
+++ b/contrib/examples/actions/orquesta-streaming-demo.meta.yaml
@@ -1,0 +1,15 @@
+---
+name: "orquesta-streaming-demo"
+description: "Action output streaming functionality demo for Orquesta workflows."
+runner_type: "orquesta"
+entry_point: "workflows/orquesta-streaming-demo.yaml"
+enabled: true
+parameters:
+  count:
+    type: "integer"
+    required: true
+    default: 5
+  sleep_delay:
+    type: "number"
+    required: true
+    default: 0.2

--- a/contrib/examples/actions/workflows/orquesta-streaming-demo.yaml
+++ b/contrib/examples/actions/workflows/orquesta-streaming-demo.yaml
@@ -1,0 +1,80 @@
+version: 1.0
+description: A workflow which demonstrates action output streaming functionality.
+
+input:
+  - count
+  - sleep_delay
+
+tasks:
+  task1:
+    action: core.local
+    input:
+      cmd: "echo 'Task 1'"
+    next:
+      - when: <% succeeded() %>
+        do: task2
+  task2:
+    action: examples.local_command_runner_print_to_stdout_and_stderr
+    input:
+      count: <% ctx(count) %>
+      sleep_delay: <% ctx(sleep_delay) %>
+    next:
+      - when: <% succeeded() %>
+        do: task3
+  task3:
+    action: core.local
+    input:
+      cmd: "echo 'Task 3'"
+    next:
+      - when: <% succeeded() %>
+        do: task4
+  task4:
+    action: examples.local_script_runner_print_to_stdout_and_stderr
+    input:
+      count: <% ctx(count) %>
+      sleep_delay: <% ctx(sleep_delay) %>
+    next:
+      - when: <% succeeded() %>
+        do: task5
+  task5:
+    action: core.local
+    input:
+      cmd: "echo 'Task 5'"
+    next:
+      - when: <% succeeded() %>
+        do: task6
+  task6:
+    action: examples.python_runner_print_to_stdout_and_stderr
+    input:
+      count: <% ctx(count) %>
+      sleep_delay: <% ctx(sleep_delay) %>
+    next:
+      - when: <% succeeded() %>
+        do: task7
+  task7:
+    action: core.local
+    input:
+      cmd: "echo 'Task 7'"
+    next:
+      - when: <% succeeded() %>
+        do: task8
+  task8:
+    action: examples.remote_command_runner_print_to_stdout_and_stderr
+    input:
+      count: <% ctx(count) %>
+      sleep_delay: <% ctx(sleep_delay) %>
+    next:
+      - when: <% succeeded() %>
+        do: task9
+  task9:
+    action: core.local
+    input:
+      cmd: "echo 'Task 9'"
+    next:
+      - when: <% succeeded() %>
+        do: task10
+  task10:
+    action: examples.remote_script_runner_print_to_stdout_and_stderr
+    input:
+      count: <% ctx(count) %>
+      sleep_delay: <% ctx(sleep_delay) %>


### PR DESCRIPTION
This pull request adds new example action for testing ``st2 execution tail`` command with Orquesta workflows (it's a clone of the existing action we already have for action-chain and Mistral workflows).

### Background, Context

Here (https://github.com/StackStorm/st2tests/pull/152) I noticed we don't have any integration tests for ``st2 execution tail`` command for Orquesta workflows so I'm fixing that (we do have unit ones though).