### PR TITLE
Added end-to-end tests to coverage the past correction of decrypt_kv filter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -52,8 +52,7 @@ Added
   StackStorm instance to another which uses the same crypto key.
 
   Contributed by Nick Maludy (Encore Technologies) #4547
-
-* Added ``source_channel`` to Orquesta ``st2()`` context for workflows called via ChatOps. (#4600)
+* Add ``source_channel`` to Orquesta ``st2()`` context for workflows called via ChatOps. #4600
 
 Changed
 ~~~~~~~

--- a/contrib/examples/actions/orquesta-streaming-demo.meta.yaml
+++ b/contrib/examples/actions/orquesta-streaming-demo.meta.yaml
@@ -1,0 +1,15 @@
+---
+name: "orquesta-streaming-demo"
+description: "Action output streaming functionality demo for Orquesta workflows."
+runner_type: "orquesta"
+entry_point: "workflows/orquesta-streaming-demo.yaml"
+enabled: true
+parameters:
+  count:
+    type: "integer"
+    required: true
+    default: 5
+  sleep_delay:
+    type: "number"
+    required: true
+    default: 0.2

--- a/contrib/examples/actions/workflows/orquesta-streaming-demo.yaml
+++ b/contrib/examples/actions/workflows/orquesta-streaming-demo.yaml
@@ -1,0 +1,80 @@
+version: 1.0
+description: A workflow which demonstrates action output streaming functionality.
+
+input:
+  - count
+  - sleep_delay
+
+tasks:
+  task1:
+    action: core.local
+    input:
+      cmd: "echo 'Task 1'"
+    next:
+      - when: <% succeeded() %>
+        do: task2
+  task2:
+    action: examples.local_command_runner_print_to_stdout_and_stderr
+    input:
+      count: <% ctx(count) %>
+      sleep_delay: <% ctx(sleep_delay) %>
+    next:
+      - when: <% succeeded() %>
+        do: task3
+  task3:
+    action: core.local
+    input:
+      cmd: "echo 'Task 3'"
+    next:
+      - when: <% succeeded() %>
+        do: task4
+  task4:
+    action: examples.local_script_runner_print_to_stdout_and_stderr
+    input:
+      count: <% ctx(count) %>
+      sleep_delay: <% ctx(sleep_delay) %>
+    next:
+      - when: <% succeeded() %>
+        do: task5
+  task5:
+    action: core.local
+    input:
+      cmd: "echo 'Task 5'"
+    next:
+      - when: <% succeeded() %>
+        do: task6
+  task6:
+    action: examples.python_runner_print_to_stdout_and_stderr
+    input:
+      count: <% ctx(count) %>
+      sleep_delay: <% ctx(sleep_delay) %>
+    next:
+      - when: <% succeeded() %>
+        do: task7
+  task7:
+    action: core.local
+    input:
+      cmd: "echo 'Task 7'"
+    next:
+      - when: <% succeeded() %>
+        do: task8
+  task8:
+    action: examples.remote_command_runner_print_to_stdout_and_stderr
+    input:
+      count: <% ctx(count) %>
+      sleep_delay: <% ctx(sleep_delay) %>
+    next:
+      - when: <% succeeded() %>
+        do: task9
+  task9:
+    action: core.local
+    input:
+      cmd: "echo 'Task 9'"
+    next:
+      - when: <% succeeded() %>
+        do: task10
+  task10:
+    action: examples.remote_script_runner_print_to_stdout_and_stderr
+    input:
+      count: <% ctx(count) %>
+      sleep_delay: <% ctx(sleep_delay) %>

--- a/st2api/tests/unit/controllers/v1/test_executions_auth.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_auth.py
@@ -25,12 +25,19 @@ except ImportError:
     import json
 
 import st2common.validators.api.action as action_validator
-from st2common.util import date as date_utils
+from st2common.constants.keyvalue import FULL_USER_SCOPE
+from st2common.models.api.keyvalue import KeyValuePairAPI
 from st2common.models.db.auth import TokenDB
 from st2common.models.db.auth import UserDB
+from st2common.models.db.auth import ApiKeyDB
+from st2common.models.db.keyvalue import KeyValuePairDB
 from st2common.persistence.auth import Token
 from st2common.persistence.auth import User
+from st2common.persistence.auth import ApiKey
+from st2common.persistence.keyvalue import KeyValuePair
 from st2common.transport.publishers import PoolPublisher
+from st2common.util import crypto as crypto_utils
+from st2common.util import date as date_utils
 from st2tests.api import SUPER_SECRET_PARAMETER
 from st2tests.fixturesloader import FixturesLoader
 from st2tests.api import FunctionalTest
@@ -63,6 +70,24 @@ ACTION_1 = {
         }
     }
 }
+ACTION_DEFAULT_ENCRYPT = {
+    'name': 'st2.dummy.default_encrypted_value',
+    'description': 'An action that uses a jinja template with decrypt_kv filter '
+                   'in default parameter',
+    'enabled': True,
+    'pack': 'starterpack',
+    'runner_type': 'local-shell-cmd',
+    'parameters': {
+        'encrypted_param': {
+            'type': 'string',
+            'default': '{{ st2kv.system.secret | decrypt_kv }}'
+        },
+        'encrypted_user_param': {
+            'type': 'string',
+            'default': '{{ st2kv.user.secret | decrypt_kv }}'
+        }
+    }
+}
 
 LIVE_ACTION_1 = {
     'action': 'sixpack.st2.dummy.action1',
@@ -71,6 +96,9 @@ LIVE_ACTION_1 = {
         'cmd': 'uname -a',
         'd': SUPER_SECRET_PARAMETER
     }
+}
+LIVE_ACTION_DEFAULT_ENCRYPT = {
+    'action': 'starterpack.st2.dummy.default_encrypted_value',
 }
 
 # NOTE: We use a longer expiry time because this variable is initialized on module import (aka
@@ -86,6 +114,12 @@ FIXTURES_PACK = 'generic'
 FIXTURES = {
     'users': ['system_user.yaml', 'token_user.yaml']
 }
+
+# These parameters are used for the tests of getting value from datastore and decrypting it at
+# Jinja expression in a action metadata definition.
+TEST_USER = UserDB(name='user1')
+TEST_TOKEN = TokenDB(id=bson.ObjectId(), user=TEST_USER, token=uuid.uuid4().hex, expiry=EXPIRY)
+TEST_APIKEY = ApiKeyDB(user=TEST_USER, key_hash='secret_key', enabled=True)
 
 
 def mock_get_token(*args, **kwargs):
@@ -113,8 +147,22 @@ class ActionExecutionControllerTestCaseAuthEnabled(FunctionalTest):
         post_resp = cls.app.post_json('/v1/actions', cls.action, headers=headers)
         cls.action['id'] = post_resp.json['id']
 
+        cls.action_encrypt = copy.deepcopy(ACTION_DEFAULT_ENCRYPT)
+        post_resp = cls.app.post_json('/v1/actions', cls.action_encrypt, headers=headers)
+        cls.action_encrypt['id'] = post_resp.json['id']
+
         FixturesLoader().save_fixtures_to_db(fixtures_pack=FIXTURES_PACK,
                                              fixtures_dict=FIXTURES)
+
+        # register datastore values which are used in this tests
+        KeyValuePairAPI._setup_crypto()
+        register_items = [
+            {'name': 'secret', 'secret': True,
+             'value': crypto_utils.symmetric_encrypt(KeyValuePairAPI.crypto_key, 'foo')},
+            {'name': 'user1:secret', 'secret': True, 'scope': FULL_USER_SCOPE,
+             'value': crypto_utils.symmetric_encrypt(KeyValuePairAPI.crypto_key, 'bar')},
+        ]
+        cls.kvps = [KeyValuePair.add_or_update(KeyValuePairDB(**x)) for x in register_items]
 
     @classmethod
     @mock.patch.object(
@@ -123,6 +171,11 @@ class ActionExecutionControllerTestCaseAuthEnabled(FunctionalTest):
     def tearDownClass(cls):
         headers = {'content-type': 'application/json', 'X-Auth-Token': str(SYS_TOKEN.token)}
         cls.app.delete('/v1/actions/%s' % cls.action['id'], headers=headers)
+        cls.app.delete('/v1/actions/%s' % cls.action_encrypt['id'], headers=headers)
+
+        # unregister key-value pairs for tests
+        [KeyValuePair.delete(x) for x in cls.kvps]
+
         super(ActionExecutionControllerTestCaseAuthEnabled, cls).tearDownClass()
 
     def _do_post(self, liveaction, *args, **kwargs):
@@ -145,3 +198,30 @@ class ActionExecutionControllerTestCaseAuthEnabled(FunctionalTest):
         self.assertEqual(resp.status_int, 201)
         self.assertEqual(resp.json['context']['user'], 'tokenuser')
         self.assertEqual(resp.json['context']['parent'], context['parent'])
+
+    @mock.patch.object(ApiKey, 'get', mock.Mock(return_value=TEST_APIKEY))
+    @mock.patch.object(User, 'get_by_name', mock.Mock(return_value=TEST_USER))
+    def test_template_encrypted_params_with_apikey(self):
+        resp = self._do_post(LIVE_ACTION_DEFAULT_ENCRYPT, headers={
+            'St2-Api-key': 'secret_key'
+        })
+        self.assertEqual(resp.status_int, 201)
+        self.assertEqual(resp.json['parameters']['encrypted_param'], 'foo')
+        self.assertEqual(resp.json['parameters']['encrypted_user_param'], 'bar')
+
+    @mock.patch.object(Token, 'get', mock.Mock(return_value=TEST_TOKEN))
+    @mock.patch.object(User, 'get_by_name', mock.Mock(return_value=TEST_USER))
+    def test_template_encrypted_params_with_access_token(self):
+        resp = self._do_post(LIVE_ACTION_DEFAULT_ENCRYPT, headers={
+            'X-Auth-Token': str(TEST_TOKEN.token)
+        })
+        self.assertEqual(resp.status_int, 201)
+        self.assertEqual(resp.json['parameters']['encrypted_param'], 'foo')
+        self.assertEqual(resp.json['parameters']['encrypted_user_param'], 'bar')
+
+    def test_template_encrypted_params_without_auth(self):
+        resp = self._do_post(LIVE_ACTION_DEFAULT_ENCRYPT, expect_errors=True)
+
+        self.assertEqual(resp.status_int, 401)
+        self.assertEqual(resp.json['faultstring'],
+                         'Unauthorized - One of Token or API key required.')


### PR DESCRIPTION
This is a remaining work of #4634. This adds end-to-end tests for it.

The tests in this patch call `/v1/executions` endpoint in the following conditions.

* without user specification (auth.enable = False)
* with specific user (via X-Auth-Token and St2-Api-Key)
* with specific user, but the user-scope value corresponding to the specified key is not registered
