### PR TITLE
Throw a more user-friendly error on permission denied when trying to to write a pack data file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -134,6 +134,10 @@ Fixed
   (bug fix) #4601 #4599
 
   Reported by Carlos Santana (@kknyxkk) and Rafael Martins (@rsmartins78).
+* Fix ``st2-self-check`` so it sets correct permissions on pack directories which it copies over
+  to ``/opt/stackstorm/packs``. (bug fix) #4645
+* Fix ``POST /v1/actions`` API endpoint to throw a more user-friendly error when writing data file
+  to disk fails because of incorrect permissions. (bug fix) #4645
 
 2.10.4 - March 15, 2019
 -----------------------

--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -297,7 +297,10 @@ class ActionsController(resource.ContentPackResourceController):
         directory = os.path.dirname(file_path)
 
         if not os.path.isdir(directory):
-            os.makedirs(directory)
+            # NOTE: We apply same permission bits as we do on pack install. If we don't do that,
+            # st2api won't be able to write to pack sub-directory
+            mode = stat.S_IRWXU | stat.S_IRWXG | stat.S_IROTH | stat.S_IXOTH
+            os.makedirs(directory, mode)
 
         try:
             with open(file_path, 'w') as fp:

--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -15,6 +15,7 @@
 
 import os
 import os.path
+import stat
 import errno
 
 import six
@@ -262,7 +263,18 @@ class ActionsController(resource.ContentPackResourceController):
                                                         file_path=file_path)
 
             LOG.debug('Writing data file "%s" to "%s"' % (str(data_file), file_path))
-            self._write_data_file(pack_ref=pack_ref, file_path=file_path, content=content)
+
+            try:
+                self._write_data_file(pack_ref=pack_ref, file_path=file_path, content=content)
+            except (OSError, IOError) as e:
+                # Throw a more user-friendly exception on Permission denied error
+                if e.errno == errno.EACCES:
+                    msg = ('Unable to write data to "%s" (permission denied). Make sure '
+                           'permissions for that pack directory are configured correctly so '
+                           'st2api can write to it.' % (file_path))
+                    raise ValueError(msg)
+                raise e
+
             written_file_paths.append(file_path)
 
         return written_file_paths
@@ -302,18 +314,8 @@ class ActionsController(resource.ContentPackResourceController):
             mode = stat.S_IRWXU | stat.S_IRWXG | stat.S_IROTH | stat.S_IXOTH
             os.makedirs(directory, mode)
 
-        try:
-            with open(file_path, 'w') as fp:
-                fp.write(content)
-        except IOError as e:
-            # Throw a more user-friendly exception on Permission denied error
-            if e.errno == errno.EACCES:
-                msg = ('Unable to write to pack directory "%s" (permission denied). Make sure '
-                       'permissions for that directory are configured correctly so st2api can '
-                       'write to it.' % (directory))
-                raise ValueError(msg)
-
-            raise e
+        with open(file_path, 'w') as fp:
+            fp.write(content)
 
     def _dispatch_trigger_for_written_data_files(self, action_db, written_data_files):
         trigger = ACTION_FILE_WRITTEN_TRIGGER['name']

--- a/st2common/bin/st2-self-check
+++ b/st2common/bin/st2-self-check
@@ -107,6 +107,7 @@ fi
 
 echo "Copying asserts, fixtures, tests and examples packs."
 chown -R root:st2packs st2tests/packs/
+chmod -R 775 st2tests/packs/*
 cp -R --preserve st2tests/packs/* /opt/stackstorm/packs/
 cp -Rf --preserve /usr/share/doc/st2/examples /opt/stackstorm/packs/
 

--- a/st2common/st2common/util/pack_management.py
+++ b/st2common/st2common/util/pack_management.py
@@ -290,7 +290,7 @@ def apply_pack_owner_group(pack_path):
 
 def apply_pack_permissions(pack_path):
     """
-    Recursively apply permission 770 to pack and its contents.
+    Recursively apply permission 775 to pack and its contents.
     """
     # These mask is same as mode = 775
     mode = stat.S_IRWXU | stat.S_IRWXG | stat.S_IROTH | stat.S_IXOTH


### PR DESCRIPTION
This pull request fixes a small issue I identified while testing latest st2flow packages.

Right now if pack permissions are not configured correctly and st2api doesn't have permission to write to the pack directory / sub-directory, Internal Server Error bubbles up all the way to st2flow.

This pull request fixes so we now throw a more user-friendly (non internal server error) error message.

![Screenshot from 2019-04-24 12-30-25](https://user-images.githubusercontent.com/125088/56658984-50521a00-669c-11e9-99b0-6c7ec7a8fc38.png)

From st2api.log:

```bash
...
IOError: [Errno 13] Permission denied: u'/opt/stackstorm/packs/fixtures/actions/aaa' (_exception_data={},_exception_class='IOError',_exception_message=u"[Errno 13] Permission denied: u'/opt/stackstorm/packs/fixtures/actions/aaa'")
...
````