### PR TITLE
Fix & Update nginx example confings for HA setup

### DIFF
--- a/conf/HA/nginx/st2.conf.blueprint.sample
+++ b/conf/HA/nginx/st2.conf.blueprint.sample
@@ -13,10 +13,10 @@ server {
   add_header X-Content-Type-Options nosniff;
 
   if ($ssl_protocol = "") {
-       return 301 https://$host$request_uri;
+       return 308 https://$host$request_uri;
   }
 
-  index  index.html index.htm index.php;
+  index  index.html;
 
   access_log /var/log/nginx/st2webui.access.log combined;
   error_log /var/log/nginx/st2webui.error.log;
@@ -32,10 +32,10 @@ server {
   ssl_session_cache         shared:SSL:10m;
   ssl_session_timeout       5m;
   ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
-  ssl_ciphers               EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:ECDHE-RSA-AES128-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA128:DHE-RSA-AES128-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES128-GCM-SHA128:ECDHE-RSA-AES128-SHA384:ECDHE-RSA-AES128-SHA128:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES128-SHA128:DHE-RSA-AES128-SHA128:DHE-RSA-AES128-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA384:AES128-GCM-SHA128:AES128-SHA128:AES128-SHA128:AES128-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4;
+  ssl_ciphers               EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:ECDHE-RSA-AES128-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA128:DHE-RSA-AES128-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES128-GCM-SHA128:ECDHE-RSA-AES128-SHA384:ECDHE-RSA-AES128-SHA128:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES128-SHA128:DHE-RSA-AES128-SHA128:DHE-RSA-AES128-SHA:DHE-RSA-AES128-SHA:AES128-GCM-SHA384:AES128-GCM-SHA128:AES128-SHA128:AES128-SHA128:AES128-SHA:AES128-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4;
   ssl_prefer_server_ciphers on;
 
-  index  index.html index.htm index.php;
+  index  index.html;
 
   access_log            /var/log/nginx/ssl-st2webui.access.log combined;
   error_log             /var/log/nginx/ssl-st2webui.error.log;
@@ -62,58 +62,14 @@ server {
     proxy_set_header Host $host;
   }
 
+  # For backward compatibility reasons, rewrite requests from "/api/stream"
+  # to "/stream/v1/stream" and "/api/v1/stream" to "/stream/v1/stream"
+  rewrite ^/api/stream/?$ /stream/v1/stream break;
+  rewrite ^/api/(v\d)/stream/?$ /stream/$1/stream break;
   location /stream/ {
     rewrite ^/stream/(.*)  /$1 break;
 
-    proxy_pass            http://127.0.0.1:9102/;
-    proxy_read_timeout    90;
-    proxy_connect_timeout 90;
-    proxy_redirect        off;
-
-    proxy_set_header      Host $host;
-    proxy_set_header      X-Real-IP $remote_addr;
-    proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_pass_header     Authorization;
-
-    sendfile on;
-    tcp_nopush on;
-    tcp_nodelay on;
-
-    # Disable buffering and chunked encoding.
-    # In the stream case we want to receive the whole payload at once, we don't
-    # want multiple chunks.
-    proxy_set_header Connection '';
-    chunked_transfer_encoding off;
-    proxy_buffering off;
-    proxy_cache off;
-    proxy_set_header Host $host;
-  }
-
-  # For backward compatibility reasons, rewrite requests from "/api/stream"
-  # to "/stream/v1/stream" and "/api/v1/stream" to "/stream/v1/stream"
-  location /api/stream/ {
-    rewrite ^/api/stream/?(.*)$ /v1/stream/$1 break;
-    proxy_pass  http://127.0.0.1:9102;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
-    sendfile on;
-    tcp_nopush on;
-    tcp_nodelay on;
-
-    # Disable buffering and chunked encoding.
-    # In the stream case we want to receive the whole payload at once, we don't
-    # want multiple chunks.
-    proxy_set_header Connection '';
-    chunked_transfer_encoding off;
-    proxy_buffering off;
-    proxy_cache off;
-  }
-
-  location /api/v1/stream/ {
-    rewrite ^/api/v1/stream/?(.*)$ /v1/stream/$1 break;
-    proxy_pass  http://127.0.0.1:9102;
+    proxy_pass  http://127.0.0.1:9102/;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -170,5 +126,4 @@ server {
     proxy_cache off;
     proxy_set_header Host $host;
   }
-
 }

--- a/conf/HA/nginx/st2.conf.controller.sample
+++ b/conf/HA/nginx/st2.conf.controller.sample
@@ -48,8 +48,16 @@ server {
   add_header              Front-End-Https on;
   add_header              X-Content-Type-Options nosniff;
 
+  location @apiError {
+    add_header Content-Type application/json always;
+    return 503 '{ "faultstring": "Nginx is unable to reach st2api. Make sure service is running." }';
+  }
+
   location /api/ {
+    error_page 502 = @apiError;
+
     proxy_pass            https://st2/api/;
+    proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
     proxy_read_timeout    90;
     proxy_connect_timeout 90;
     proxy_redirect        off;
@@ -78,6 +86,7 @@ server {
     error_page 502 = @streamError;
 
     proxy_pass            https://st2/stream/;
+    proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -95,8 +104,16 @@ server {
     proxy_cache off;
   }
 
+  location @authError {
+    add_header Content-Type application/json always;
+    return 503 '{ "faultstring": "Nginx is unable to reach st2auth. Make sure service is running." }';
+  }
+
   location /auth/ {
+    error_page 502 = @authError;
+
     proxy_pass            https://st2/auth/;
+    proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
     proxy_read_timeout    90;
     proxy_connect_timeout 90;
     proxy_redirect        off;
@@ -115,6 +132,7 @@ server {
 
   location /mistral/ {
     proxy_pass            https://st2/mistral/;
+    proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
     proxy_read_timeout    90;
     proxy_connect_timeout 90;
     proxy_redirect        off;

--- a/conf/HA/nginx/st2.conf.controller.sample
+++ b/conf/HA/nginx/st2.conf.controller.sample
@@ -18,10 +18,10 @@ server {
   add_header X-Content-Type-Options nosniff;
 
   if ($ssl_protocol = "") {
-       return 301 https://$host$request_uri;
+       return 308 https://$host$request_uri;
   }
 
-  index  index.html index.htm index.php;
+  index  index.html;
 
   access_log /var/log/nginx/st2webui.access.log combined;
   error_log /var/log/nginx/st2webui.error.log;
@@ -37,10 +37,10 @@ server {
   ssl_session_cache         shared:SSL:10m;
   ssl_session_timeout       5m;
   ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
-  ssl_ciphers               EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:ECDHE-RSA-AES128-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA128:DHE-RSA-AES128-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES128-GCM-SHA128:ECDHE-RSA-AES128-SHA384:ECDHE-RSA-AES128-SHA128:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES128-SHA128:DHE-RSA-AES128-SHA128:DHE-RSA-AES128-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA384:AES128-GCM-SHA128:AES128-SHA128:AES128-SHA128:AES128-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4;
+  ssl_ciphers               EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:ECDHE-RSA-AES128-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA128:DHE-RSA-AES128-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES128-GCM-SHA128:ECDHE-RSA-AES128-SHA384:ECDHE-RSA-AES128-SHA128:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES128-SHA128:DHE-RSA-AES128-SHA128:DHE-RSA-AES128-SHA:DHE-RSA-AES128-SHA:AES128-GCM-SHA384:AES128-GCM-SHA128:AES128-SHA128:AES128-SHA128:AES128-SHA:AES128-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4;
   ssl_prefer_server_ciphers on;
 
-  index  index.html index.htm index.php;
+  index  index.html;
 
   access_log            /var/log/nginx/ssl-st2webui.access.log combined;
   error_log             /var/log/nginx/ssl-st2webui.error.log;
@@ -49,8 +49,6 @@ server {
   add_header              X-Content-Type-Options nosniff;
 
   location /api/ {
-    rewrite ^/api/(.*)  /api/$1 break;
-
     proxy_pass            https://st2/api/;
     proxy_read_timeout    90;
     proxy_connect_timeout 90;
@@ -67,7 +65,7 @@ server {
     proxy_set_header Host $host;
   }
 
-    location @streamError {
+  location @streamError {
     add_header Content-Type text/event-stream;
     return 200 "retry: 1000\n\n";
   }
@@ -98,8 +96,6 @@ server {
   }
 
   location /auth/ {
-    rewrite ^/auth/(.*)  /auth/$1 break;
-
     proxy_pass            https://st2/auth/;
     proxy_read_timeout    90;
     proxy_connect_timeout 90;
@@ -116,10 +112,8 @@ server {
     proxy_cache off;
     proxy_set_header Host $host;
   }
-  
-  location /mistral/ {
-    rewrite ^/mistral/(.*)  /mistral/$1 break;
 
+  location /mistral/ {
     proxy_pass            https://st2/mistral/;
     proxy_read_timeout    90;
     proxy_connect_timeout 90;
@@ -139,6 +133,10 @@ server {
 
   location / {
     root      /opt/stackstorm/static/webui/;
-    index     index.html index.htm index.php;
+    index     index.html;
+
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
   }
 }

--- a/conf/HA/nginx/st2.conf.controller.sample
+++ b/conf/HA/nginx/st2.conf.controller.sample
@@ -79,8 +79,6 @@ server {
   location /stream/ {
     error_page 502 = @streamError;
 
-    rewrite ^/stream/(.*)  /$1 break;
-
     proxy_pass            https://st2/stream/;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
- Fixes #4665 where incorrect rewrite rule was present resulting in non-working `/stream` endpoint.
- Cleans up `rewrite ^/auth/(.*) /auth/$1 break;` nginx rewrite rules that made no sense.
- Updates nginx configs with most recent fixes and additions made to https://github.com/StackStorm/st2/blob/master/conf/nginx/st2.conf
- Improve st2 nginx config for HA controller to better handle switching between upstream backends via [`proxy_next_upstream`](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream)

~TODO: st2docs update: https://docs.stackstorm.com/reference/ha.html~ (auto-updated based on `st2` files)