### PR TITLE
Update the requests library version to latest (2.22.0) in requirements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,6 +46,7 @@ Fixed
   Reported by Guillaume Truchot (@GuiTeK)
 * Fix orquesta st2kv to return empty string and null values. (bug fix) #4678
 * Allow the orquesta st2kv function to return default for nonexistent key. (improvement) #4678
+* Update requests library to latest version (2.22.0) in requirements. (improvement) #4680
 
 3.0.0 - April 18, 2019
 ----------------------

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -14,7 +14,7 @@ oslo.config>=1.12.1,<1.13
 oslo.utils>=3.36.2,<=3.37.0
 six==1.12.0
 pyyaml==5.1
-requests[security]<2.15,>=2.14.1
+requests[security]>=2.22.0,<2.23.0
 apscheduler==3.6.0
 gitpython==2.1.11
 jsonschema==2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ pytz==2019.1
 pywinrm==0.3.0
 pyyaml==5.1
 rednose
-requests[security]<2.15,>=2.14.1
+requests[security]<2.23.0,>=2.22.0
 retrying==1.3.3
 routes==2.4.1
 semver==2.8.1

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -9,6 +9,6 @@ python-dateutil==2.8.0
 python-editor==1.0.4
 pytz==2019.1
 pyyaml==5.1
-requests[security]<2.15,>=2.14.1
+requests[security]<2.23.0,>=2.22.0
 six==1.12.0
 sseclient-py==1.7

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -19,7 +19,7 @@ pymongo==3.7.2
 python-dateutil==2.8.0
 python-statsd==2.1.0
 pyyaml==5.1
-requests[security]<2.15,>=2.14.1
+requests[security]<2.23.0,>=2.22.0
 retrying==1.3.3
 routes==2.4.1
 semver==2.8.1


### PR DESCRIPTION
This PR updates the `requests` package version to the latest (2.22.0) - Closes #4680 