### PR TITLE
Limit database index field names to 65 characters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,6 @@ Changelog
 in development
 --------------
 
-
 Fixed
 ~~~~~
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 in development
 --------------
 
+
 Fixed
 ~~~~~
 
@@ -35,6 +36,12 @@ Fixed
   ``service`` or ``action`` parameter. (bug fix) #4675
 
   Reported by James Robinson (Netskope and Veracode).
+* Truncate some database index names so they are less than 65 characters long in total. This way it
+  also works with AWS DocumentDB which doesn't support longer index name at the moment.
+
+  NOTE: AWS DocumentDB is not officially supported. Use at your own risk. (improvement) #4688 #4690
+
+  Reported by Guillaume Truchot (@GuiTeK)
 
 3.0.0 - April 18, 2019
 ----------------------

--- a/st2common/st2common/models/db/execution_queue.py
+++ b/st2common/st2common/models/db/execution_queue.py
@@ -61,10 +61,12 @@ class ActionExecutionSchedulingQueueItemDB(stormbase.StormFoundationDB,
 
     meta = {
         'indexes': [
-            {'fields': ['action_execution_id']},
-            {'fields': ['liveaction_id']},
-            {'fields': ['original_start_timestamp']},
-            {'fields': ['scheduled_start_timestamp']},
+            # NOTE: We limit index names to 65 characters total for compatibility with AWS
+            # DocumentDB
+            {'fields': ['action_execution_id'], 'name': 'ac_exc_id'},
+            {'fields': ['liveaction_id'], 'name': 'lv_ac_id'},
+            {'fields': ['original_start_timestamp'], 'name': 'orig_s_ts'},
+            {'fields': ['scheduled_start_timestamp'], 'name': 'schd_s_ts'},
         ]
     }
 

--- a/st2common/st2common/models/db/execution_queue.py
+++ b/st2common/st2common/models/db/execution_queue.py
@@ -62,7 +62,8 @@ class ActionExecutionSchedulingQueueItemDB(stormbase.StormFoundationDB,
     meta = {
         'indexes': [
             # NOTE: We limit index names to 65 characters total for compatibility with AWS
-            # DocumentDB
+            # DocumentDB.
+            # See https://github.com/StackStorm/st2/pull/4690 for details.
             {'fields': ['action_execution_id'], 'name': 'ac_exc_id'},
             {'fields': ['liveaction_id'], 'name': 'lv_ac_id'},
             {'fields': ['original_start_timestamp'], 'name': 'orig_s_ts'},

--- a/st2common/tests/unit/test_db.py
+++ b/st2common/tests/unit/test_db.py
@@ -38,6 +38,9 @@ from st2common.persistence.rule import Rule
 from st2common.persistence.trigger import TriggerType, Trigger, TriggerInstance
 from st2tests import DbTestCase
 
+from unittest2 import TestCase
+from st2tests.base import ALL_MODELS
+
 
 __all__ = [
     'DbConnectionTestCase',
@@ -49,6 +52,40 @@ __all__ = [
 
 SKIP_DELETE = False
 DUMMY_DESCRIPTION = 'Sample Description.'
+
+
+class DbIndexNameTestCase(TestCase):
+    """
+    Test which verifies that model index name are not longer than the specified limit.
+    """
+    LIMIT = 70
+
+    def test_index_name_length(self):
+        db_name = 'st2'
+
+        for model in ALL_MODELS:
+            collection_name = model._get_collection_name()
+            model_indexes = model._meta['index_specs']
+
+            for index_specs in model_indexes:
+                index_name = index_specs.get('name', None)
+                if index_name:
+                    # Custom index name defined by the developer
+                    index_field_name = index_name
+                else:
+                    # No explicit index name specified, one is auto-generated using
+                    # <db name>.<collection name>.<index field names> schema
+                    index_fields = dict(index_specs['fields']).keys()
+                    index_field_name = '.'.join(index_fields)
+
+                index_name = '%s.%s.%s' % (db_name, collection_name, index_field_name)
+                print index_name
+                continue
+
+                if len(index_name) > self.LIMIT:
+                    self.fail('Index name "%s" for model "%s" is longer than %s characters. '
+                              'Please manually define name for this index so it\'s shorter than '
+                              'that' % (index_name, model.__name__, self.LIMIT))
 
 
 class DbConnectionTestCase(DbTestCase):

--- a/st2common/tests/unit/test_db.py
+++ b/st2common/tests/unit/test_db.py
@@ -58,7 +58,7 @@ class DbIndexNameTestCase(TestCase):
     """
     Test which verifies that model index name are not longer than the specified limit.
     """
-    LIMIT = 70
+    LIMIT = 65
 
     def test_index_name_length(self):
         db_name = 'st2'
@@ -79,8 +79,6 @@ class DbIndexNameTestCase(TestCase):
                     index_field_name = '.'.join(index_fields)
 
                 index_name = '%s.%s.%s' % (db_name, collection_name, index_field_name)
-                print index_name
-                continue
 
                 if len(index_name) > self.LIMIT:
                     self.fail('Index name "%s" for model "%s" is longer than %s characters. '

--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -66,6 +66,7 @@ import st2common.models.db.keyvalue as keyvalue_model
 import st2common.models.db.runner as runner_model
 import st2common.models.db.execution as execution_model
 import st2common.models.db.executionstate as executionstate_model
+import st2common.models.db.execution_queue as execution_queue_model
 import st2common.models.db.liveaction as liveaction_model
 import st2common.models.db.actionalias as actionalias_model
 import st2common.models.db.policy as policy_model
@@ -111,6 +112,7 @@ ALL_MODELS.extend(keyvalue_model.MODELS)
 ALL_MODELS.extend(runner_model.MODELS)
 ALL_MODELS.extend(execution_model.MODELS)
 ALL_MODELS.extend(executionstate_model.MODELS)
+ALL_MODELS.extend(execution_queue_model.MODELS)
 ALL_MODELS.extend(liveaction_model.MODELS)
 ALL_MODELS.extend(actionalias_model.MODELS)
 ALL_MODELS.extend(policy_model.MODELS)


### PR DESCRIPTION
This pull request limits full database index names to 65 characters.

### Background, Context

For the most part we don't explicitly specify index name when we define index in the code. This means MongoDB automatically infer the name from db, collection and field name. For example ``st2.action_execution_d_b.status.action.ref.start_timestamp`` (``<db name>.<collection name>.<all the indexed field names>``.

This pull request explicitly specifies shorter index names for some indexes which don't work with AWS DocumentDB due to the limit (MongoDB itself claims it supports index names up to 128 characters, but that doesn't work with DocumentDB).

We don't officially support AWS DocumentDB, but it's a relatively easy change so it doesn't hurt us to include it.

In addition to that, there is a bigger long term question about MongoDB 3.6 compatibility once we switch to MongoDB 4.0 by default (which is not supported by AWS due to the MongoDB licensing change). Right now our code works with 3.6 and 4.0 and we don't really on any specific 4.0 features, but this could change in the future.

Here is an example of the offending index name - ``st2.action_execution_scheduling_queue_item_d_b.original_start_timestamp``.

As you can see, the collection name itself is also very long, but that's very hard / impossible to change that at the moment, because we don't have a migration framework in place for changing collection names. So only option we are left with, is shortening index names (which is fine).

I've added a test case so we will find out about such issues earlier in the future (during the development process).

Resolves #4688.