### PR TITLE
Refactor the orquesta st2kv function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,7 @@ Fixed
 
   Reported by Guillaume Truchot (@GuiTeK)
 * Fix orquesta st2kv to return empty string and null values. (bug fix) #4678
+* Allow the orquesta st2kv function to return default for nonexistent key. (improvement) #4678
 
 3.0.0 - April 18, 2019
 ----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,7 @@ Fixed
   NOTE: AWS DocumentDB is not officially supported. Use at your own risk. (improvement) #4688 #4690
 
   Reported by Guillaume Truchot (@GuiTeK)
+* Fix orquesta st2kv to return empty string and null values. (bug fix) #4678
 
 3.0.0 - April 18, 2019
 ----------------------

--- a/contrib/examples/actions/orquesta-st2kv-default.yaml
+++ b/contrib/examples/actions/orquesta-st2kv-default.yaml
@@ -1,0 +1,17 @@
+---
+name: orquesta-st2kv-default
+description: A sample workflow that demonstrates st2kv usage
+runner_type: orquesta
+entry_point: workflows/orquesta-st2kv-default.yaml
+enabled: true
+parameters:
+  key_name:
+    required: true
+    type: string
+  decrypt:
+    required: false
+    type: boolean
+    default: false
+  default:
+    required: False
+    type: string

--- a/contrib/examples/actions/workflows/orquesta-st2kv-default.yaml
+++ b/contrib/examples/actions/workflows/orquesta-st2kv-default.yaml
@@ -1,0 +1,15 @@
+version: 1.0
+
+description: A sample workflow that demonstrates st2kv usage.
+
+input:
+  - key_name
+  - decrypt
+  - default: null
+
+output:
+  - value: <% st2kv(ctx().key_name, decrypt => ctx().decrypt, default => ctx().default) %>
+
+tasks:
+  task1:
+    action: core.noop

--- a/contrib/examples/actions/workflows/orquesta-st2kv-default.yaml
+++ b/contrib/examples/actions/workflows/orquesta-st2kv-default.yaml
@@ -8,7 +8,8 @@ input:
   - default: null
 
 output:
-  - value: <% st2kv(ctx().key_name, decrypt => ctx().decrypt, default => ctx().default) %>
+  - value_from_yaql: <% st2kv(ctx().key_name, decrypt => ctx().decrypt, default => ctx().default) %>
+  - value_from_jinja: "{{ st2kv(ctx().key_name, decrypt=ctx().decrypt, default=ctx().default) }}"
 
 tasks:
   task1:

--- a/contrib/examples/actions/workflows/orquesta-st2kv.yaml
+++ b/contrib/examples/actions/workflows/orquesta-st2kv.yaml
@@ -7,14 +7,10 @@ input:
   - decrypt
 
 output:
-  - value: <% ctx().value %>
+  - value: <% task(task1).result.stdout %>
 
 tasks:
-  create_vm:
+  task1:
     action: core.local
     input:
       cmd: "echo <% st2kv(ctx().key_name, decrypt => ctx().decrypt) %>"
-    next:
-      - when: <% succeeded() %>
-        publish:
-          - value: <% result().stdout %>

--- a/contrib/runners/orquesta_runner/orquesta_functions/st2kv.py
+++ b/contrib/runners/orquesta_runner/orquesta_functions/st2kv.py
@@ -45,9 +45,13 @@ def st2kv_(context, key, **kwargs):
         raise Exception('Failed to retrieve User object for user "%s" % (username)' %
                         (six.text_type(e)))
 
-    try:
-        kvp = kvp_util.get_key(key=key, user_db=user_db, decrypt=decrypt)
-    except Exception as e:
-        raise exc.ExpressionEvaluationException(str(e))
+    has_default = 'default' in kwargs
+    default_value = kwargs.get('default')
 
-    return kvp
+    try:
+        return kvp_util.get_key(key=key, user_db=user_db, decrypt=decrypt)
+    except Exception as e:
+        if not has_default:
+            raise exc.ExpressionEvaluationException(str(e))
+        else:
+            return default_value

--- a/contrib/runners/orquesta_runner/orquesta_functions/st2kv.py
+++ b/contrib/runners/orquesta_runner/orquesta_functions/st2kv.py
@@ -43,11 +43,9 @@ def st2kv_(context, key, decrypt=False):
         raise Exception('Failed to retrieve User object for user "%s" % (username)' %
                         (six.text_type(e)))
 
-    kvp = kvp_util.get_key(key=key, user_db=user_db, decrypt=decrypt)
-
-    if not kvp:
-        raise exc.ExpressionEvaluationException(
-            'Key %s does not exist in StackStorm datastore.' % key
-        )
+    try:
+        kvp = kvp_util.get_key(key=key, user_db=user_db, decrypt=decrypt)
+    except Exception as e:
+        raise exc.ExpressionEvaluationException(str(e))
 
     return kvp

--- a/contrib/runners/orquesta_runner/orquesta_functions/st2kv.py
+++ b/contrib/runners/orquesta_runner/orquesta_functions/st2kv.py
@@ -25,9 +25,11 @@ from st2common.util import keyvalue as kvp_util
 LOG = logging.getLogger(__name__)
 
 
-def st2kv_(context, key, decrypt=False):
+def st2kv_(context, key, **kwargs):
     if not isinstance(key, six.string_types):
         raise TypeError('Given key is not typeof string.')
+
+    decrypt = kwargs.get('decrypt', False)
 
     if not isinstance(decrypt, bool):
         raise TypeError('Decrypt parameter is not typeof bool.')

--- a/contrib/runners/orquesta_runner/orquesta_functions/st2kv.py
+++ b/contrib/runners/orquesta_runner/orquesta_functions/st2kv.py
@@ -18,6 +18,7 @@ import six
 
 from orquesta import exceptions as exc
 
+from st2common.exceptions import db as db_exc
 from st2common.persistence import auth as auth_db_access
 from st2common.util import keyvalue as kvp_util
 
@@ -50,8 +51,10 @@ def st2kv_(context, key, **kwargs):
 
     try:
         return kvp_util.get_key(key=key, user_db=user_db, decrypt=decrypt)
-    except Exception as e:
+    except db_exc.StackStormDBObjectNotFoundError as e:
         if not has_default:
             raise exc.ExpressionEvaluationException(str(e))
         else:
             return default_value
+    except Exception as e:
+        raise exc.ExpressionEvaluationException(str(e))

--- a/contrib/runners/orquesta_runner/tests/unit/test_functions_st2kv.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_functions_st2kv.py
@@ -105,7 +105,11 @@ class UserScopeDatastoreFunctionTest(st2tests.ExecutionDbTestCase):
         )
 
     def test_key_decrypt(self):
+        self.assertNotEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'fu'), 'bar')
+        self.assertNotEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'fu', decrypt=False), 'bar')
         self.assertEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'fu', decrypt=True), 'bar')
+        self.assertNotEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'fu_empty'), '')
+        self.assertNotEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'fu_empty', decrypt=False), '')
         self.assertEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'fu_empty', decrypt=True), '')
 
 
@@ -163,5 +167,9 @@ class SystemScopeDatastoreFunctionTest(st2tests.ExecutionDbTestCase):
         )
 
     def test_key_decrypt(self):
+        self.assertNotEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'system.fu'), 'bar')
+        self.assertNotEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'system.fu', decrypt=False), 'bar')
         self.assertEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'system.fu', decrypt=True), 'bar')
+        self.assertNotEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'system.fu_empty'), '')
+        self.assertNotEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'system.fu_empty', decrypt=False), '')
         self.assertEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'system.fu_empty', decrypt=True), '')

--- a/contrib/runners/orquesta_runner/tests/unit/test_functions_st2kv.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_functions_st2kv.py
@@ -14,6 +14,7 @@
 
 from __future__ import absolute_import
 
+import mock
 import six
 import unittest2
 
@@ -32,6 +33,7 @@ from st2common.models.db import auth as auth_db
 from st2common.models.db import keyvalue as kvp_db
 from st2common.persistence import keyvalue as kvp_db_access
 from st2common.util import crypto
+from st2common.util import keyvalue as kvp_util
 
 
 MOCK_CTX = {'__vars': {'st2': {'user': 'stanley'}}}
@@ -117,6 +119,17 @@ class UserScopeDatastoreFunctionTest(st2tests.ExecutionDbTestCase):
         self.assertNotEqual(st2kv.st2kv_(MOCK_CTX, 'fu_empty', decrypt=False), '')
         self.assertEqual(st2kv.st2kv_(MOCK_CTX, 'fu_empty', decrypt=True), '')
 
+    @mock.patch.object(
+        kvp_util, 'get_key',
+        mock.MagicMock(side_effect=Exception('Mock failure.')))
+    def test_get_key_exception(self):
+        self.assertRaisesRegexp(
+            exc.ExpressionEvaluationException,
+            'Mock failure.',
+            st2kv.st2kv_,
+            MOCK_CTX,
+            'foo'
+        )
 
 class SystemScopeDatastoreFunctionTest(st2tests.ExecutionDbTestCase):
 
@@ -183,3 +196,15 @@ class SystemScopeDatastoreFunctionTest(st2tests.ExecutionDbTestCase):
         self.assertNotEqual(st2kv.st2kv_(MOCK_CTX, 'system.fu_empty'), '')
         self.assertNotEqual(st2kv.st2kv_(MOCK_CTX, 'system.fu_empty', decrypt=False), '')
         self.assertEqual(st2kv.st2kv_(MOCK_CTX, 'system.fu_empty', decrypt=True), '')
+
+    @mock.patch.object(
+        kvp_util, 'get_key',
+        mock.MagicMock(side_effect=Exception('Mock failure.')))
+    def test_get_key_exception(self):
+        self.assertRaisesRegexp(
+            exc.ExpressionEvaluationException,
+            'Mock failure.',
+            st2kv.st2kv_,
+            MOCK_CTX,
+            'system.foo'
+        )

--- a/contrib/runners/orquesta_runner/tests/unit/test_functions_st2kv.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_functions_st2kv.py
@@ -104,6 +104,11 @@ class UserScopeDatastoreFunctionTest(st2tests.ExecutionDbTestCase):
             'foobar'
         )
 
+    def test_key_does_not_exist_but_return_default(self):
+        self.assertEqual(st2kv.st2kv_(MOCK_CTX, 'foobar', default='foosball'), 'foosball')
+        self.assertEqual(st2kv.st2kv_(MOCK_CTX, 'foobar', default=''), '')
+        self.assertIsNone(st2kv.st2kv_(MOCK_CTX, 'foobar', default=None))
+
     def test_key_decrypt(self):
         self.assertNotEqual(st2kv.st2kv_(MOCK_CTX, 'fu'), 'bar')
         self.assertNotEqual(st2kv.st2kv_(MOCK_CTX, 'fu', decrypt=False), 'bar')
@@ -165,6 +170,11 @@ class SystemScopeDatastoreFunctionTest(st2tests.ExecutionDbTestCase):
             MOCK_CTX,
             'foo'
         )
+
+    def test_key_does_not_exist_but_return_default(self):
+        self.assertEqual(st2kv.st2kv_(MOCK_CTX, 'system.foobar', default='foosball'), 'foosball')
+        self.assertEqual(st2kv.st2kv_(MOCK_CTX, 'system.foobar', default=''), '')
+        self.assertIsNone(st2kv.st2kv_(MOCK_CTX, 'system.foobar', default=None))
 
     def test_key_decrypt(self):
         self.assertNotEqual(st2kv.st2kv_(MOCK_CTX, 'system.fu'), 'bar')

--- a/contrib/runners/orquesta_runner/tests/unit/test_functions_st2kv.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_functions_st2kv.py
@@ -34,14 +34,14 @@ from st2common.persistence import keyvalue as kvp_db_access
 from st2common.util import crypto
 
 
-MOCK_ORCHESTRA_CTX = {'__vars': {'st2': {'user': 'stanley'}}}
-MOCK_ORCHESTRA_CTX_NO_USER = {'__vars': {'st2': {}}}
+MOCK_CTX = {'__vars': {'st2': {'user': 'stanley'}}}
+MOCK_CTX_NO_USER = {'__vars': {'st2': {}}}
 
 
 class DatastoreFunctionTest(unittest2.TestCase):
 
     def test_missing_user_context(self):
-        self.assertRaises(KeyError, st2kv.st2kv_, MOCK_ORCHESTRA_CTX_NO_USER, 'foo')
+        self.assertRaises(KeyError, st2kv.st2kv_, MOCK_CTX_NO_USER, 'foo')
 
     def test_invalid_input(self):
         self.assertRaises(TypeError, st2kv.st2kv_, None, 123)
@@ -91,26 +91,26 @@ class UserScopeDatastoreFunctionTest(st2tests.ExecutionDbTestCase):
         super(UserScopeDatastoreFunctionTest, cls).tearDownClass()
 
     def test_key_exists(self):
-        self.assertEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'foo'), 'bar')
-        self.assertEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'foo_empty'), '')
-        self.assertIsNone(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'foo_null'))
+        self.assertEqual(st2kv.st2kv_(MOCK_CTX, 'foo'), 'bar')
+        self.assertEqual(st2kv.st2kv_(MOCK_CTX, 'foo_empty'), '')
+        self.assertIsNone(st2kv.st2kv_(MOCK_CTX, 'foo_null'))
 
     def test_key_does_not_exist(self):
         self.assertRaisesRegexp(
             exc.ExpressionEvaluationException,
             'The key ".*" does not exist in the StackStorm datastore.',
             st2kv.st2kv_,
-            MOCK_ORCHESTRA_CTX,
+            MOCK_CTX,
             'foobar'
         )
 
     def test_key_decrypt(self):
-        self.assertNotEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'fu'), 'bar')
-        self.assertNotEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'fu', decrypt=False), 'bar')
-        self.assertEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'fu', decrypt=True), 'bar')
-        self.assertNotEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'fu_empty'), '')
-        self.assertNotEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'fu_empty', decrypt=False), '')
-        self.assertEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'fu_empty', decrypt=True), '')
+        self.assertNotEqual(st2kv.st2kv_(MOCK_CTX, 'fu'), 'bar')
+        self.assertNotEqual(st2kv.st2kv_(MOCK_CTX, 'fu', decrypt=False), 'bar')
+        self.assertEqual(st2kv.st2kv_(MOCK_CTX, 'fu', decrypt=True), 'bar')
+        self.assertNotEqual(st2kv.st2kv_(MOCK_CTX, 'fu_empty'), '')
+        self.assertNotEqual(st2kv.st2kv_(MOCK_CTX, 'fu_empty', decrypt=False), '')
+        self.assertEqual(st2kv.st2kv_(MOCK_CTX, 'fu_empty', decrypt=True), '')
 
 
 class SystemScopeDatastoreFunctionTest(st2tests.ExecutionDbTestCase):
@@ -153,23 +153,23 @@ class SystemScopeDatastoreFunctionTest(st2tests.ExecutionDbTestCase):
         super(SystemScopeDatastoreFunctionTest, cls).tearDownClass()
 
     def test_key_exists(self):
-        self.assertEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'system.foo'), 'bar')
-        self.assertEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'system.foo_empty'), '')
-        self.assertIsNone(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'system.foo_null'))
+        self.assertEqual(st2kv.st2kv_(MOCK_CTX, 'system.foo'), 'bar')
+        self.assertEqual(st2kv.st2kv_(MOCK_CTX, 'system.foo_empty'), '')
+        self.assertIsNone(st2kv.st2kv_(MOCK_CTX, 'system.foo_null'))
 
     def test_key_does_not_exist(self):
         self.assertRaisesRegexp(
             exc.ExpressionEvaluationException,
             'The key ".*" does not exist in the StackStorm datastore.',
             st2kv.st2kv_,
-            MOCK_ORCHESTRA_CTX,
+            MOCK_CTX,
             'foo'
         )
 
     def test_key_decrypt(self):
-        self.assertNotEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'system.fu'), 'bar')
-        self.assertNotEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'system.fu', decrypt=False), 'bar')
-        self.assertEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'system.fu', decrypt=True), 'bar')
-        self.assertNotEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'system.fu_empty'), '')
-        self.assertNotEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'system.fu_empty', decrypt=False), '')
-        self.assertEqual(st2kv.st2kv_(MOCK_ORCHESTRA_CTX, 'system.fu_empty', decrypt=True), '')
+        self.assertNotEqual(st2kv.st2kv_(MOCK_CTX, 'system.fu'), 'bar')
+        self.assertNotEqual(st2kv.st2kv_(MOCK_CTX, 'system.fu', decrypt=False), 'bar')
+        self.assertEqual(st2kv.st2kv_(MOCK_CTX, 'system.fu', decrypt=True), 'bar')
+        self.assertNotEqual(st2kv.st2kv_(MOCK_CTX, 'system.fu_empty'), '')
+        self.assertNotEqual(st2kv.st2kv_(MOCK_CTX, 'system.fu_empty', decrypt=False), '')
+        self.assertEqual(st2kv.st2kv_(MOCK_CTX, 'system.fu_empty', decrypt=True), '')

--- a/contrib/runners/orquesta_runner/tests/unit/test_functions_st2kv.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_functions_st2kv.py
@@ -131,6 +131,7 @@ class UserScopeDatastoreFunctionTest(st2tests.ExecutionDbTestCase):
             'foo'
         )
 
+
 class SystemScopeDatastoreFunctionTest(st2tests.ExecutionDbTestCase):
 
     @classmethod

--- a/st2common/st2common/persistence/keyvalue.py
+++ b/st2common/st2common/persistence/keyvalue.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 from st2common import log as logging
 from st2common.constants.triggers import KEY_VALUE_PAIR_CREATE_TRIGGER
 from st2common.constants.triggers import KEY_VALUE_PAIR_UPDATE_TRIGGER
 from st2common.constants.triggers import KEY_VALUE_PAIR_VALUE_CHANGE_TRIGGER
 from st2common.constants.triggers import KEY_VALUE_PAIR_DELETE_TRIGGER
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2common.models.api.keyvalue import KeyValuePairAPI
 from st2common.models.db.keyvalue import keyvaluepair_access
 from st2common.models.system.common import ResourceReference
@@ -107,6 +109,11 @@ class KeyValuePair(Access):
         :rtype: :class:`KeyValuePairDB` or ``None``
         """
         query_result = cls.impl.query(scope=scope, name=name)
+
+        if not query_result:
+            msg = 'The key "%s" does not exist in the StackStorm datastore.'
+            raise StackStormDBObjectNotFoundError(msg % name)
+
         return query_result.first() if query_result else None
 
     @classmethod

--- a/st2common/st2common/services/config.py
+++ b/st2common/st2common/services/config.py
@@ -24,6 +24,7 @@ from st2common.constants.keyvalue import FULL_SYSTEM_SCOPE
 from st2common.util.crypto import symmetric_decrypt
 from st2common.models.api.keyvalue import KeyValuePairAPI
 from st2common.persistence.keyvalue import KeyValuePair
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
 
 __all__ = [
     'set_datastore_value_for_config_key',
@@ -65,7 +66,11 @@ def set_datastore_value_for_config_key(pack_name, key_name, value, secret=False,
     kvp_db = KeyValuePairAPI.to_model(kvp_api)
 
     # TODO: Obtain a lock
-    existing_kvp_db = KeyValuePair.get_by_scope_and_name(scope=scope, name=name)
+    try:
+        existing_kvp_db = KeyValuePair.get_by_scope_and_name(scope=scope, name=name)
+    except StackStormDBObjectNotFoundError:
+        existing_kvp_db = None
+
     if existing_kvp_db:
         kvp_db.id = existing_kvp_db.id
 

--- a/st2common/st2common/services/keyvalues.py
+++ b/st2common/st2common/services/keyvalues.py
@@ -21,6 +21,7 @@ from st2common.constants.keyvalue import SYSTEM_SCOPE, FULL_SYSTEM_SCOPE
 from st2common.constants.keyvalue import USER_SCOPE, FULL_USER_SCOPE
 from st2common.constants.keyvalue import ALLOWED_SCOPES
 from st2common.constants.keyvalue import DATASTORE_KEY_SEPARATOR
+from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2common.exceptions.keyvalue import InvalidScopeException, InvalidUserException
 from st2common.models.system.keyvalue import UserKeyReference
 from st2common.persistence.keyvalue import KeyValuePair
@@ -148,7 +149,12 @@ class KeyValueLookup(BaseKeyValueLookup):
     def _get_kv(self, key):
         scope = self._scope
         LOG.debug('Lookup system kv: scope: %s and key: %s', scope, key)
-        kvp = KeyValuePair.get_by_scope_and_name(scope=scope, name=key)
+
+        try:
+            kvp = KeyValuePair.get_by_scope_and_name(scope=scope, name=key)
+        except StackStormDBObjectNotFoundError:
+            kvp = None
+
         if kvp:
             LOG.debug('Got value %s from datastore.', kvp.value)
         return kvp.value if kvp else ''
@@ -203,7 +209,12 @@ class UserKeyValueLookup(BaseKeyValueLookup):
 
     def _get_kv(self, key):
         scope = self._scope
-        kvp = KeyValuePair.get_by_scope_and_name(scope=scope, name=key)
+
+        try:
+            kvp = KeyValuePair.get_by_scope_and_name(scope=scope, name=key)
+        except StackStormDBObjectNotFoundError:
+            kvp = None
+
         return kvp.value if kvp else ''
 
 

--- a/st2common/st2common/util/keyvalue.py
+++ b/st2common/st2common/util/keyvalue.py
@@ -110,12 +110,11 @@ def get_key(key=None, user_db=None, scope=None, decrypt=False):
     _validate_decrypt_query_parameter(decrypt=decrypt, scope=scope, is_admin=is_admin,
                                       user_db=user_db)
 
-    value = KeyValuePair.get_by_scope_and_name(scope, key_id)
+    # Get the key value pair by scope and name.
+    kvp = KeyValuePair.get_by_scope_and_name(scope, key_id)
 
-    if value:
-        return deserialize_key_value(
-            value.value,
-            decrypt
-        )
+    # Decrypt in deserialize_key_value cannot handle NoneType.
+    if kvp.value is None:
+        return kvp.value
 
-    return None
+    return deserialize_key_value(kvp.value, decrypt)

--- a/st2tests/integration/orquesta/test_wiring_functions_st2kv.py
+++ b/st2tests/integration/orquesta/test_wiring_functions_st2kv.py
@@ -131,8 +131,10 @@ class DatastoreFunctionTest(base.TestWorkflowExecution):
 
         self.assertEqual(output.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
         self.assertIn('output', output.result)
-        self.assertIn('value', output.result['output'])
-        self.assertEqual(wf_input['default'], output.result['output']['value'])
+        self.assertIn('value_from_yaql', output.result['output'])
+        self.assertEqual(wf_input['default'], output.result['output']['value_from_yaql'])
+        self.assertIn('value_from_jinja', output.result['output'])
+        self.assertEqual(wf_input['default'], output.result['output']['value_from_jinja'])
 
     def test_st2kv_default_value_with_empty_string(self):
         key = 'matt'
@@ -150,8 +152,10 @@ class DatastoreFunctionTest(base.TestWorkflowExecution):
 
         self.assertEqual(output.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
         self.assertIn('output', output.result)
-        self.assertIn('value', output.result['output'])
-        self.assertEqual(wf_input['default'], output.result['output']['value'])
+        self.assertIn('value_from_yaql', output.result['output'])
+        self.assertEqual(wf_input['default'], output.result['output']['value_from_yaql'])
+        self.assertIn('value_from_jinja', output.result['output'])
+        self.assertEqual(wf_input['default'], output.result['output']['value_from_jinja'])
 
     def test_st2kv_default_value_with_null(self):
         key = 'matt'
@@ -169,5 +173,7 @@ class DatastoreFunctionTest(base.TestWorkflowExecution):
 
         self.assertEqual(output.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
         self.assertIn('output', output.result)
-        self.assertIn('value', output.result['output'])
-        self.assertEqual(wf_input['default'], output.result['output']['value'])
+        self.assertIn('value_from_yaql', output.result['output'])
+        self.assertEqual(wf_input['default'], output.result['output']['value_from_yaql'])
+        self.assertIn('value_from_jinja', output.result['output'])
+        self.assertEqual(wf_input['default'], output.result['output']['value_from_jinja'])

--- a/st2tests/integration/orquesta/test_wiring_functions_st2kv.py
+++ b/st2tests/integration/orquesta/test_wiring_functions_st2kv.py
@@ -95,3 +95,79 @@ class DatastoreFunctionTest(base.TestWorkflowExecution):
         self.assertIn('value', output.result['output'])
         self.assertEqual(value, output.result['output']['value'])
         self.del_kvp(key)
+
+    def test_st2kv_nonexistent(self):
+        key = 'matt'
+
+        wf_name = 'examples.orquesta-st2kv'
+        wf_input = {
+            'key_name': 'system.%s' % key,
+            'decrypt': True
+        }
+
+        execution = self._execute_workflow(wf_name, wf_input)
+
+        output = self._wait_for_completion(execution)
+
+        self.assertEqual(output.status, ac_const.LIVEACTION_STATUS_FAILED)
+
+        expected_error = 'The key "%s" does not exist in the StackStorm datastore.' % key
+
+        self.assertIn(expected_error, output.result['errors'][0]['message'])
+
+    def test_st2kv_default_value(self):
+        key = 'matt'
+
+        wf_name = 'examples.orquesta-st2kv-default'
+        wf_input = {
+            'key_name': 'system.%s' % key,
+            'decrypt': True,
+            'default': 'stone'
+        }
+
+        execution = self._execute_workflow(wf_name, wf_input)
+
+        output = self._wait_for_completion(execution)
+
+        self.assertEqual(output.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertIn('output', output.result)
+        self.assertIn('value', output.result['output'])
+        self.assertEqual(wf_input['default'], output.result['output']['value'])
+
+    def test_st2kv_default_value_with_empty_string(self):
+        key = 'matt'
+
+        wf_name = 'examples.orquesta-st2kv-default'
+        wf_input = {
+            'key_name': 'system.%s' % key,
+            'decrypt': True,
+            'default': ''
+        }
+
+        execution = self._execute_workflow(wf_name, wf_input)
+
+        output = self._wait_for_completion(execution)
+
+        self.assertEqual(output.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertIn('output', output.result)
+        self.assertIn('value', output.result['output'])
+        self.assertEqual(wf_input['default'], output.result['output']['value'])
+
+    def test_st2kv_default_value_with_null(self):
+        key = 'matt'
+
+        wf_name = 'examples.orquesta-st2kv-default'
+        wf_input = {
+            'key_name': 'system.%s' % key,
+            'decrypt': True,
+            'default': None
+        }
+
+        execution = self._execute_workflow(wf_name, wf_input)
+
+        output = self._wait_for_completion(execution)
+
+        self.assertEqual(output.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertIn('output', output.result)
+        self.assertIn('value', output.result['output'])
+        self.assertEqual(wf_input['default'], output.result['output']['value'])


### PR DESCRIPTION
Fix the orquesta st2kv to return empty string and null values correctly and allow st2kv function to return a supplied default value for nonexistent key. Closes #4678