### PR TITLE
Refactor workflow service to handle tasks that run on fail

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,12 +4,17 @@ Changelog
 in development
 --------------
 
+Changed
+~~~~~~~
+
+* Allow the orquesta st2kv function to return default for nonexistent key. (improvement) #4678
+* Update requests library to latest version (2.22.0) in requirements. (improvement) #4680
+
 Fixed
 ~~~~~
 
 * Fix orquesta st2kv to return empty string and null values. (bug fix) #4678
-* Allow the orquesta st2kv function to return default for nonexistent key. (improvement) #4678
-* Update requests library to latest version (2.22.0) in requirements. (improvement) #4680
+* Allow tasks defined in the same task transition with ``fail`` to run for orquesta. (bug fix)
 
 3.0.1 - May 24, 2019
 --------------------

--- a/contrib/examples/actions/orquesta-fail-manually.yaml
+++ b/contrib/examples/actions/orquesta-fail-manually.yaml
@@ -1,0 +1,6 @@
+---
+name: orquesta-fail-manually
+description: A workflow that demonstrates how to fail manually.
+runner_type: orquesta
+entry_point: workflows/orquesta-fail-manually.yaml
+enabled: true

--- a/contrib/examples/actions/workflows/orquesta-fail-manually.yaml
+++ b/contrib/examples/actions/workflows/orquesta-fail-manually.yaml
@@ -1,0 +1,22 @@
+version: 1.0
+
+description: A workflow that demonstrates how to fail manually.
+
+tasks:
+  # On task failure, we want to run a task that
+  # logs the error before failing the workflow.
+  task1:
+    action: core.local cmd="exit 1"
+    next:
+      - when: <% failed() %>
+        publish:
+          - task_name: <% task().task_name %>
+          - task_exit_code: <% task().result.stdout %> 
+        do:
+          - log
+          - fail
+
+  log:
+    action: core.echo
+    input:
+      message: "<% ctx().task_name %> failed with exit code: <% ctx().task_exit_code %>"

--- a/contrib/runners/orquesta_runner/in-requirements.txt
+++ b/contrib/runners/orquesta_runner/in-requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/StackStorm/orquesta.git@v0.5#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@67fb92fb652073b37fe9678f9a9b9934ba8ac739#egg=orquesta

--- a/contrib/runners/orquesta_runner/requirements.txt
+++ b/contrib/runners/orquesta_runner/requirements.txt
@@ -1,2 +1,2 @@
 # Don't edit this file. It's generated automatically!
-git+https://github.com/StackStorm/orquesta.git@v0.5#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@67fb92fb652073b37fe9678f9a9b9934ba8ac739#egg=orquesta

--- a/contrib/runners/orquesta_runner/tests/unit/test_error_handling.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_error_handling.py
@@ -722,3 +722,52 @@ class OrquestaErrorHandlingTest(st2tests.ExecutionDbTestCase):
         ac_ex_db = ex_db_access.ActionExecution.get_by_id(str(ac_ex_db.id))
         self.assertEqual(ac_ex_db.status, ac_const.LIVEACTION_STATUS_FAILED)
         self.assertDictEqual(ac_ex_db.result, expected_result)
+
+    def test_fail_manually(self):
+        wf_meta = base.get_wf_fixture_meta_data(TEST_PACK_PATH, 'fail-manually.yaml')
+        lv_ac_db = lv_db_models.LiveActionDB(action=wf_meta['name'])
+        lv_ac_db, ac_ex_db = ac_svc.request(lv_ac_db)
+        wf_ex_db = wf_db_access.WorkflowExecution.query(action_execution=str(ac_ex_db.id))[0]
+
+        # Assert task1 and workflow execution failed due to fail in the task transition.
+        query_filters = {'workflow_execution': str(wf_ex_db.id), 'task_id': 'task1'}
+        tk1_ex_db = wf_db_access.TaskExecution.query(**query_filters)[0]
+        tk1_ac_ex_db = ex_db_access.ActionExecution.query(task_execution=str(tk1_ex_db.id))[0]
+        tk1_lv_ac_db = lv_db_access.LiveAction.get_by_id(tk1_ac_ex_db.liveaction['id'])
+        self.assertEqual(tk1_lv_ac_db.status, ac_const.LIVEACTION_STATUS_FAILED)
+        wf_svc.handle_action_execution_completion(tk1_ac_ex_db)
+        wf_ex_db = wf_db_access.WorkflowExecution.get_by_id(wf_ex_db.id)
+        self.assertEqual(wf_ex_db.status, wf_statuses.FAILED)
+
+        # Assert log task is scheduled even though the workflow execution failed manually.
+        query_filters = {'workflow_execution': str(wf_ex_db.id), 'task_id': 'log'}
+        tk2_ex_db = wf_db_access.TaskExecution.query(**query_filters)[0]
+        tk2_ac_ex_db = ex_db_access.ActionExecution.query(task_execution=str(tk2_ex_db.id))[0]
+        tk2_lv_ac_db = lv_db_access.LiveAction.get_by_id(tk2_ac_ex_db.liveaction['id'])
+        self.assertEqual(tk2_lv_ac_db.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
+        wf_svc.handle_action_execution_completion(tk2_ac_ex_db)
+        wf_ex_db = wf_db_access.WorkflowExecution.get_by_id(wf_ex_db.id)
+        self.assertEqual(wf_ex_db.status, wf_statuses.FAILED)
+
+        # Check errors and output.
+        expected_errors = [
+            {
+                'task_id': 'fail',
+                'type': 'error',
+                'message': 'Execution failed. See result for details.'
+            },
+            {
+                'task_id': 'task1',
+                'type': 'error',
+                'message': 'Execution failed. See result for details.',
+                'result': {
+                    'failed': True,
+                    'return_code': 1,
+                    'stderr': '',
+                    'stdout': '',
+                    'succeeded': False
+                }
+            }
+        ]
+
+        self.assertListEqual(self.sort_wf_runtime_errors(wf_ex_db.errors), expected_errors)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cryptography==2.6.1
 eventlet==0.24.1
 flex==6.14.0
 git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper
-git+https://github.com/StackStorm/orquesta.git@v0.5#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@67fb92fb652073b37fe9678f9a9b9934ba8ac739#egg=orquesta
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
 gitpython==2.1.11

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -9,7 +9,7 @@ jsonschema
 kombu
 mongoengine
 networkx
-git+https://github.com/StackStorm/orquesta.git@v0.5#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@67fb92fb652073b37fe9678f9a9b9934ba8ac739#egg=orquesta
 oslo.config
 paramiko
 pyyaml

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -4,7 +4,7 @@ apscheduler==3.6.0
 cryptography==2.6.1
 eventlet==0.24.1
 flex==6.14.0
-git+https://github.com/StackStorm/orquesta.git@v0.5#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@67fb92fb652073b37fe9678f9a9b9934ba8ac739#egg=orquesta
 greenlet==0.4.15
 ipaddr
 jinja2==2.10.1

--- a/st2common/st2common/services/workflows.py
+++ b/st2common/st2common/services/workflows.py
@@ -849,12 +849,6 @@ def request_next_tasks(wf_ex_db, task_ex_id=None):
         LOG.info('[%s] No tasks identified to execute next.', wf_ac_ex_id)
         update_execution_records(wf_ex_db, conductor)
 
-    # If workflow execution is no longer active, then stop processing here.
-    if wf_ex_db.status in statuses.COMPLETED_STATUSES:
-        msg = '[%s] Workflow execution is in completed status "%s".'
-        LOG.info(msg, wf_ac_ex_id, wf_ex_db.status)
-        return
-
     # Iterate while there are next tasks identified for processing. In the case for
     # task with no action execution defined, the task execution will complete
     # immediately with a new set of tasks available.
@@ -892,12 +886,6 @@ def request_next_tasks(wf_ex_db, task_ex_id=None):
         # Update workflow execution and related liveaction and action execution.
         LOG.debug('[%s] %s', wf_ac_ex_id, conductor.serialize())
         update_execution_records(wf_ex_db, conductor)
-
-        # If workflow execution is no longer active, then stop processing here.
-        if wf_ex_db.status in statuses.COMPLETED_STATUSES:
-            msg = '[%s] Workflow execution is in completed status "%s".'
-            LOG.info(msg, wf_ac_ex_id, wf_ex_db.status)
-            break
 
         # Request task execution for the tasks.
         for task in next_tasks:

--- a/st2tests/integration/orquesta/test_wiring_error_handling.py
+++ b/st2tests/integration/orquesta/test_wiring_error_handling.py
@@ -218,3 +218,35 @@ class ErrorHandlingTest(base.TestWorkflowExecution):
         ex = self._wait_for_completion(ex)
         self.assertEqual(ex.status, ac_const.LIVEACTION_STATUS_FAILED)
         self.assertDictEqual(ex.result, {'errors': expected_errors, 'output': None})
+
+    def test_fail_manually(self):
+        expected_errors = [
+            {
+                'task_id': 'task1',
+                'type': 'error',
+                'message': 'Execution failed. See result for details.',
+                'result': {
+                    'failed': True,
+                    'return_code': 1,
+                    'stderr': '',
+                    'stdout': '',
+                    'succeeded': False
+                }
+            },
+            {
+                'task_id': 'fail',
+                'type': 'error',
+                'message': 'Execution failed. See result for details.'
+            }
+        ]
+
+        ex = self._execute_workflow('examples.orquesta-fail-manually')
+        ex = self._wait_for_completion(ex)
+
+        # Assert that the log task is executed.
+        self._wait_for_task(ex, 'task1', ac_const.LIVEACTION_STATUS_FAILED)
+        self._wait_for_task(ex, 'log', ac_const.LIVEACTION_STATUS_SUCCEEDED)
+
+        # Assert workflow status and result.
+        self.assertEqual(ex.status, ac_const.LIVEACTION_STATUS_FAILED)
+        self.assertDictEqual(ex.result, {'errors': expected_errors, 'output': None})

--- a/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/fail-manually-with-recovery-failure.yaml
+++ b/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/fail-manually-with-recovery-failure.yaml
@@ -1,0 +1,7 @@
+---
+name: fail-manually-with-recovery-failure
+description: A workflow to test task failure after workflow already failed manually.
+pack: orquesta_tests
+runner_type: orquesta
+entry_point: workflows/fail-manually-with-recovery-failure.yaml
+enabled: true

--- a/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/fail-manually.yaml
+++ b/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/fail-manually.yaml
@@ -1,0 +1,7 @@
+---
+name: fail-manually
+description: A workflow that demonstrates how to fail manually.
+pack: orquesta_tests
+runner_type: orquesta
+entry_point: workflows/fail-manually.yaml
+enabled: true

--- a/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/fail-manually-with-recovery-failure.yaml
+++ b/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/fail-manually-with-recovery-failure.yaml
@@ -1,0 +1,18 @@
+version: 1.0
+
+description: A workflow to test task failure after workflow already failed manually.
+
+tasks:
+  task1:
+    action: core.local cmd="exit 1"
+    next:
+      - when: <% failed() %>
+        publish:
+          - task_name: <% task().task_name %>
+          - task_exit_code: <% task().result.stdout %>
+        do:
+          - recover
+          - fail
+
+  recover:
+    action: core.local cmd="exit 1"

--- a/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/fail-manually.yaml
+++ b/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/fail-manually.yaml
@@ -1,0 +1,22 @@
+version: 1.0
+
+description: A workflow that demonstrates how to fail manually.
+
+tasks:
+  # On task failure, we want to run a task that
+  # logs the error before failing the workflow.
+  task1:
+    action: core.local cmd="exit 1"
+    next:
+      - when: <% failed() %>
+        publish:
+          - task_name: <% task().task_name %>
+          - task_exit_code: <% task().result.stdout %>
+        do:
+          - log
+          - fail
+
+  log:
+    action: core.echo
+    input:
+      message: "<% ctx().task_name %> failed with exit code: <% ctx().task_exit_code %>"


### PR DESCRIPTION
The workflow conductor already directs which next tasks to run next, taking into account of workflow status. Remove check for workflow completion status in the workflow service that restricts any more tasks to be executed. Add unit tests to cover use cases where there is a fail in task transition and other recovery/remediation tasks. These other tasks should be allowed to run on failure.