### PR TITLE
Upgrade pip to latest 19.x version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,10 +94,8 @@ cache:
     #- .tox/
 
 before_install:
-  # Work around for apt Travis timeout issues, see https://github.com/travis-ci/travis-ci/issues/9112
-  #- sudo apt-get update --option Acquire::Retries=100 --option Acquire::http::Timeout="60"
-  - pip install --upgrade "pip>=9.0,<9.1"
-  - sudo pip install --upgrade "virtualenv==15.1.0"
+  - pip install --upgrade "pip>=19.0,<20.0"
+  - sudo pip install --upgrade "virtualenv==16.6.0"
 
 install:
   - ./scripts/travis/install-requirements.sh

--- a/Makefile
+++ b/Makefile
@@ -389,10 +389,10 @@ requirements: virtualenv .sdist-requirements install-runners
 	@echo
 	@echo "==================== requirements ===================="
 	@echo
-	# Make sure we use latest version of pip which is < 10.0.0
+	# Make sure we use latest version of pip which is 19
 	$(VIRTUALENV_DIR)/bin/pip --version
-	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pip>=9.0,<9.1"
-	$(VIRTUALENV_DIR)/bin/pip install --upgrade "virtualenv==15.1.0" # Required for packs.install in dev envs.
+	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pip>=19.0,<20.0"
+	$(VIRTUALENV_DIR)/bin/pip install --upgrade "virtualenv==16.6.0" # Required for packs.install in dev envs.
 
 	# Generate all requirements to support current CI pipeline.
 	$(VIRTUALENV_DIR)/bin/python scripts/fixate-requirements.py --skip=virtualenv,virtualenv-osx -s st2*/in-requirements.txt contrib/runners/*/in-requirements.txt -f fixed-requirements.txt -o requirements.txt

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -33,8 +33,8 @@ networkx==1.11
 python-keyczar==0.716
 cryptography==2.6.1
 retrying==1.3.3
-# Note: We use latest version of virtualenv which uses pip 9.0
-virtualenv==15.1.0
+# Note: We use latest version of virtualenv which uses pip 19
+virtualenv==16.6.0
 # NOTE: sseclient has various issues which sometimes hang the connection for a long time, etc.
 sseclient-py==1.7
 python-editor==1.0.4


### PR DESCRIPTION
This PR upgrades pip from previously strictly pinned `9.x` to currently latest one which is `19.x`.

Part of StackStorm/st2#4681 and https://github.com/StackStorm/st2-packages/pull/614 and https://github.com/StackStorm/st2packaging-dockerfiles/pull/70