### PR TITLE
Fix expression function to_yaml_string to handle mongodb base types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Fixed
 * Fix orquesta st2kv to return empty string and null values. (bug fix) #4678
 * Allow tasks defined in the same task transition with ``fail`` to run for orquesta. (bug fix)
 * Fix workflow service to handle unexpected coordinator and database errors. (bug fix) #4704 #4705
+* Fix filter ``to_yaml_string`` to handle mongoengine base types for dict and list. (bug fix) #4700
 
 3.0.1 - May 24, 2019
 --------------------

--- a/contrib/examples/actions/workflows/tests/orquesta-test-jinja-data-functions.yaml
+++ b/contrib/examples/actions/workflows/tests/orquesta-test-jinja-data-functions.yaml
@@ -5,6 +5,11 @@ description: A basic workflow testing data related functions.
 vars:
   - data_json_str_1: '{"foo": {"bar": "foobar"}}'
   - none: null
+  - data_list:
+    - a: 1
+      b: 2
+    - x: 3
+      y: 4
 
 tasks:
   task1:
@@ -30,3 +35,4 @@ output:
   - data_json_str_3: '{{ json_dump(ctx("data_json_obj_4")) }}'
   - data_none_str: '{{ use_none(ctx("none")) }}'
   - data_str: '{{ use_none("foobar") }}'
+  - data_list_str: '{{ to_yaml_string(ctx("data_list")) }}'

--- a/contrib/runners/orquesta_runner/tests/unit/test_functions_common.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_functions_common.py
@@ -163,7 +163,8 @@ class OrquestaFunctionTest(st2tests.ExecutionDbTestCase):
             'data_query_1': ['foobar'],
             'data_pipe_str_1': '{"foo": {"bar": "foobar"}}',
             'data_none_str': data_funcs.NONE_MAGIC_VALUE,
-            'data_str': 'foobar'
+            'data_str': 'foobar',
+            'data_list_str': '- a: 1\n  b: 2\n- x: 3\n  y: 4\n'
         }
 
         self._execute_workflow(wf_name, expected_output)

--- a/st2common/st2common/expressions/functions/data.py
+++ b/st2common/st2common/expressions/functions/data.py
@@ -16,9 +16,10 @@ from __future__ import absolute_import
 
 import json
 import jsonpath_rw
-import mongoengine
 import six
 import yaml
+
+from st2common.util import db as db_util
 
 
 __all__ = [
@@ -56,8 +57,7 @@ def to_json_string(value, indent=None, sort_keys=False, separators=(',', ': ')):
 
 
 def to_yaml_string(value, indent=None, allow_unicode=True):
-    if isinstance(value, mongoengine.base.datastructures.BaseDict):
-        value = dict(value)
+    value = db_util.mongodb_to_python_types(value)
 
     options = {'default_flow_style': False}
 

--- a/st2common/st2common/util/db.py
+++ b/st2common/st2common/util/db.py
@@ -19,16 +19,16 @@ import six
 
 
 def mongodb_to_python_types(value):
+    # Convert MongoDB BaseDict and BaseList types to python dict and list types.
     if isinstance(value, mongoengine.base.datastructures.BaseDict):
         value = dict(value)
-
-    if isinstance(value, mongoengine.base.datastructures.BaseList):
+    elif isinstance(value, mongoengine.base.datastructures.BaseList):
         value = list(value)
 
+    # Recursively traverse the dict and list to convert values.
     if isinstance(value, dict):
         value = {k: mongodb_to_python_types(v) for k, v in six.iteritems(value)}
-
-    if isinstance(value, list):
+    elif isinstance(value, list):
         value = [mongodb_to_python_types(v) for v in value]
 
     return value

--- a/st2common/st2common/util/db.py
+++ b/st2common/st2common/util/db.py
@@ -1,0 +1,34 @@
+# Copyright 2019 Extreme Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import mongoengine
+import six
+
+
+def mongodb_to_python_types(value):
+    if isinstance(value, mongoengine.base.datastructures.BaseDict):
+        value = dict(value)
+
+    if isinstance(value, mongoengine.base.datastructures.BaseList):
+        value = list(value)
+
+    if isinstance(value, dict):
+        value = {k: mongodb_to_python_types(v) for k, v in six.iteritems(value)}
+
+    if isinstance(value, list):
+        value = [mongodb_to_python_types(v) for v in value]
+
+    return value

--- a/st2common/tests/unit/test_util_db.py
+++ b/st2common/tests/unit/test_util_db.py
@@ -1,0 +1,108 @@
+# Copyright 2019 Extreme Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import mongoengine
+import unittest2
+
+from st2common.util import db as db_util
+
+
+class DatabaseUtilTestCase(unittest2.TestCase):
+
+    def test_noop_mongodb_to_python_types(self):
+        data = [
+            123,
+            999.99,
+            True,
+            [10, 20, 30],
+            {'a': 1, 'b': 2},
+            None
+        ]
+
+        for item in data:
+            self.assertEqual(db_util.mongodb_to_python_types(item), item)
+
+    def test_mongodb_basedict_to_dict(self):
+        data = {'a': 1, 'b': 2}
+
+        obj = mongoengine.base.datastructures.BaseDict(data, None, 'foobar')
+
+        self.assertDictEqual(db_util.mongodb_to_python_types(obj), data)
+
+    def test_mongodb_baselist_to_list(self):
+        data = [2, 4, 6]
+
+        obj = mongoengine.base.datastructures.BaseList(data, None, 'foobar')
+
+        self.assertListEqual(db_util.mongodb_to_python_types(obj), data)
+
+    def test_nested_mongdb_to_python_types(self):
+        data = {
+            'a': mongoengine.base.datastructures.BaseList([1, 2, 3], None, 'a'),
+            'b': mongoengine.base.datastructures.BaseDict({'a': 1, 'b': 2}, None, 'b'),
+            'c': {
+                'd': mongoengine.base.datastructures.BaseList([4, 5, 6], None, 'd'),
+                'e': mongoengine.base.datastructures.BaseDict({'c': 3, 'd': 4}, None, 'e')
+            },
+            'f': mongoengine.base.datastructures.BaseList(
+                [
+                    mongoengine.base.datastructures.BaseDict({'e': 5}, None, 'f1'),
+                    mongoengine.base.datastructures.BaseDict({'f': 6}, None, 'f2')
+                ],
+                None,
+                'f'
+            ),
+            'g': mongoengine.base.datastructures.BaseDict(
+                {
+                    'h': mongoengine.base.datastructures.BaseList(
+                        [
+                            mongoengine.base.datastructures.BaseDict({'g': 7}, None, 'h1'),
+                            mongoengine.base.datastructures.BaseDict({'h': 8}, None, 'h2')
+                        ],
+                        None,
+                        'h'
+                    ),
+                    'i': mongoengine.base.datastructures.BaseDict({'j': 9, 'k': 10}, None, 'i')
+                },
+                None,
+                'g'
+            ),
+        }
+
+        expected = {
+            'a': [1, 2, 3],
+            'b': {'a': 1, 'b': 2},
+            'c': {
+                'd': [4, 5, 6],
+                'e': {'c': 3, 'd': 4}
+            },
+            'f': [
+                {'e': 5},
+                {'f': 6}
+            ],
+            'g': {
+                'h': [
+                    {'g': 7},
+                    {'h': 8}
+                ],
+                'i': {
+                    'j': 9,
+                    'k': 10
+                }
+            }
+        }
+
+        self.assertDictEqual(db_util.mongodb_to_python_types(data), expected)

--- a/st2tests/integration/orquesta/test_wiring_functions.py
+++ b/st2tests/integration/orquesta/test_wiring_functions.py
@@ -57,7 +57,8 @@ class FunctionsWiringTest(base.TestWorkflowExecution):
             'data_query_1': ['foobar'],
             'data_pipe_str_1': '{"foo": {"bar": "foobar"}}',
             'data_none_str': '%*****__%NONE%__*****%',
-            'data_str': 'foobar'
+            'data_str': 'foobar',
+            'data_list_str': '- a: 1\n  b: 2\n- x: 3\n  y: 4\n'
         }
 
         expected_result = {'output': expected_output}

--- a/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/jinja-data-functions.yaml
+++ b/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/workflows/jinja-data-functions.yaml
@@ -5,6 +5,11 @@ description: A basic workflow testing data related functions.
 vars:
   - data_json_str_1: '{"foo": {"bar": "foobar"}}'
   - none: null
+  - data_list:
+    - a: 1
+      b: 2
+    - x: 3
+      y: 4
 
 tasks:
   task1:
@@ -30,3 +35,4 @@ output:
   - data_json_str_3: '{{ json_dump(ctx("data_json_obj_4")) }}'
   - data_none_str: '{{ use_none(ctx("none")) }}'
   - data_str: '{{ use_none("foobar") }}'
+  - data_list_str: '{{ to_yaml_string(ctx("data_list")) }}'


### PR DESCRIPTION
Refactor the filter to_yaml_string used in YAQL/Jinja expressions to be able to handle mongodb base types such as BaseDict and BaseList. The filter will call a helper function to recursively convert BaseDict and BaseList to python dict and list respectively. Fixes #4700.