### PR TITLE
Fix the garbage collection for orquesta workflow executions (v3.1)

### DIFF
--- a/conf/st2.conf.sample
+++ b/conf/st2.conf.sample
@@ -371,6 +371,6 @@ retry_stop_max_msec = 60000
 retry_max_jitter_msec = 1000
 # Interval inbetween retries.
 retry_wait_fixed_msec = 1000
-# Max seconds to allow workflow execution be idled before it is identified as orphaned and cancelled by the garbage collector.
-gc_max_idle_sec = 900
+# Max seconds to allow workflow execution be idled before it is identified as orphaned and cancelled by the garbage collector. A value of zero means the feature is disabled. This is disabled by default.
+gc_max_idle_sec = 0
 

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -643,9 +643,10 @@ def register_opts(ignore_errors=False):
             'retry_max_jitter_msec', default=1000,
             help='Max jitter interval to smooth out retries.'),
         cfg.IntOpt(
-            'gc_max_idle_sec', default=900,
+            'gc_max_idle_sec', default=0,
             help='Max seconds to allow workflow execution be idled before it is identified as '
-                 'orphaned and cancelled by the garbage collector.')
+                 'orphaned and cancelled by the garbage collector. A value of zero means the '
+                 'feature is disabled. This is disabled by default.')
     ]
 
     do_register_opts(workflow_engine_opts, group='workflow_engine', ignore_errors=ignore_errors)

--- a/st2common/st2common/services/workflows.py
+++ b/st2common/st2common/services/workflows.py
@@ -1237,8 +1237,9 @@ def identify_orphaned_workflows():
         runtime = (utc_now_dt - status_change_logs[0]['timestamp']).total_seconds()
 
         # Fetch the task executions for the workflow execution.
+        # Ensure that the root action execution is not being selected.
         wf_ex_id = ac_ex_db.context['workflow_execution']
-        query_filters = {'workflow_execution': wf_ex_id}
+        query_filters = {'workflow_execution': wf_ex_id, 'id__ne': ac_ex_db.id}
         tk_ac_ex_dbs = ex_db_access.ActionExecution.query(**query_filters)
 
         # The workflow execution is orphaned if there are
@@ -1265,9 +1266,7 @@ def identify_orphaned_workflows():
             if len(completed_tasks) > 0 else False
         )
 
-        if (len(tk_ac_ex_dbs) > 0 and (
-                has_active_tasks or (
-                not has_active_tasks and most_recent_completed_task_expired))):
+        if len(tk_ac_ex_dbs) > 0 and not has_active_tasks and most_recent_completed_task_expired:
             msg = '[%s] Workflow action execution will be canceled by garbage collector.'
             LOG.info(msg, str(ac_ex_db.id))
             orphaned.append(ac_ex_db)

--- a/st2reactor/tests/unit/test_garbage_collector.py
+++ b/st2reactor/tests/unit/test_garbage_collector.py
@@ -1,0 +1,103 @@
+# Copyright 2019 Extreme Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import mock
+import unittest
+
+from oslo_config import cfg
+
+import st2tests.config as tests_config
+tests_config.parse_args()
+
+from st2reactor.garbage_collector import base as garbage_collector
+
+
+class GarbageCollectorServiceTest(unittest.TestCase):
+
+    def tearDown(self):
+        # Reset gc_max_idle_sec with a value of 1 to reenable for other tests.
+        cfg.CONF.set_override('gc_max_idle_sec', 1, group='workflow_engine')
+        super(GarbageCollectorServiceTest, self).tearDown()
+
+    @mock.patch.object(
+        garbage_collector.GarbageCollectorService,
+        '_purge_action_executions',
+        mock.MagicMock(return_value=None))
+    @mock.patch.object(
+        garbage_collector.GarbageCollectorService,
+        '_purge_action_executions_output',
+        mock.MagicMock(return_value=None))
+    @mock.patch.object(
+        garbage_collector.GarbageCollectorService,
+        '_purge_trigger_instances',
+        mock.MagicMock(return_value=None))
+    @mock.patch.object(
+        garbage_collector.GarbageCollectorService,
+        '_timeout_inquiries',
+        mock.MagicMock(return_value=None))
+    @mock.patch.object(
+        garbage_collector.GarbageCollectorService,
+        '_purge_orphaned_workflow_executions',
+        mock.MagicMock(return_value=None))
+    def test_orphaned_workflow_executions_gc_enabled(self):
+        # Mock the default value of gc_max_idle_sec with a value >= 1 to enable. The config
+        # gc_max_idle_sec is assigned to _workflow_execution_max_idle which gc checks to see
+        # whether to run the routine.
+        cfg.CONF.set_override('gc_max_idle_sec', 1, group='workflow_engine')
+
+        # Run the garbage collection.
+        gc = garbage_collector.GarbageCollectorService(sleep_delay=0)
+        gc._perform_garbage_collection()
+
+        # Make sure _purge_orphaned_workflow_executions is called.
+        self.assertTrue(
+            garbage_collector.GarbageCollectorService._purge_orphaned_workflow_executions.called
+        )
+
+    @mock.patch.object(
+        garbage_collector.GarbageCollectorService,
+        '_purge_action_executions',
+        mock.MagicMock(return_value=None))
+    @mock.patch.object(
+        garbage_collector.GarbageCollectorService,
+        '_purge_action_executions_output',
+        mock.MagicMock(return_value=None))
+    @mock.patch.object(
+        garbage_collector.GarbageCollectorService,
+        '_purge_trigger_instances',
+        mock.MagicMock(return_value=None))
+    @mock.patch.object(
+        garbage_collector.GarbageCollectorService,
+        '_timeout_inquiries',
+        mock.MagicMock(return_value=None))
+    @mock.patch.object(
+        garbage_collector.GarbageCollectorService,
+        '_purge_orphaned_workflow_executions',
+        mock.MagicMock(return_value=None))
+    def test_orphaned_workflow_executions_gc_disabled(self):
+        # Mock the default value of gc_max_idle_sec with a value of 0 to disable. The config
+        # gc_max_idle_sec is assigned to _workflow_execution_max_idle which gc checks to see
+        # whether to run the routine.
+        cfg.CONF.set_override('gc_max_idle_sec', 0, group='workflow_engine')
+
+        # Run the garbage collection.
+        gc = garbage_collector.GarbageCollectorService(sleep_delay=0)
+        gc._perform_garbage_collection()
+
+        # Make sure _purge_orphaned_workflow_executions is not called.
+        self.assertFalse(
+            garbage_collector.GarbageCollectorService._purge_orphaned_workflow_executions.called
+        )


### PR DESCRIPTION
Cherry pick from https://github.com/StackStorm/st2/pull/4733

Fix logic in identifying orphaned workflow executions which causes long running workflow executions to be canceled. Disable this garbage collection feature for orphaned workflow executions by default.