### PR TITLE
Allow cancel to proceed if workflow execution is not found or completed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 in development
 --------------
 
+Fixed
+~~~~~
+
+* Fix the workflow execution cancelation to proceed even if the workflow execution is not found or
+  completed. (bug fix) #4735
+
 
 3.1.0 - June 27, 2019
 ---------------------


### PR DESCRIPTION
Allow the workflow execution cancelation to proceed even if the workflow execution is not found or completed otherwise the method will raise an exception and the workflow execution will be stuck with a canceling status. Fixes #4735