### PR TITLE
Install pack with the latest tag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 in development
 --------------
 
+Changed
+~~~~~~~
+
+* Install pack with the latest tag version if it exists when branch is not specialized.
+  (improvement) #4743
+
 Fixed
 ~~~~~
 

--- a/contrib/packs/tests/test_action_download.py
+++ b/contrib/packs/tests/test_action_download.py
@@ -505,6 +505,9 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
         ]
 
         for default_branch, ref in edge_cases:
+            if not ref:
+                ref = PACK_INDEX['test']['version']
+
             self.repo_instance.git = mock.MagicMock(
                 branch=(lambda *args: default_branch),
                 checkout=(lambda *args: True)
@@ -529,10 +532,7 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
 
             action = self.get_action_instance()
 
-            if ref:
-                packs = ['test=%s' % (ref)]
-            else:
-                packs = ['test']
+            packs = ['test=%s' % (ref)]
 
             result = action.run(packs=packs, abs_repo_base=self.repo_base)
             self.assertEqual(result, {'test': 'Success.'})

--- a/contrib/packs/tests/test_action_download.py
+++ b/contrib/packs/tests/test_action_download.py
@@ -505,9 +505,6 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
         ]
 
         for default_branch, ref in edge_cases:
-            if not ref:
-                ref = PACK_INDEX['test']['version']
-
             self.repo_instance.git = mock.MagicMock(
                 branch=(lambda *args: default_branch),
                 checkout=(lambda *args: True)
@@ -523,7 +520,7 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
 
             # Fool _get_gitref into working when its ref == our ref
             def fake_commit(arg_ref):
-                if arg_ref == ref:
+                if not ref or arg_ref == ref:
                     return gitref
                 else:
                     raise BadName()
@@ -532,7 +529,10 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
 
             action = self.get_action_instance()
 
-            packs = ['test=%s' % (ref)]
+            if ref:
+                packs = ['test=%s' % (ref)]
+            else:
+                packs = ['test']
 
             result = action.run(packs=packs, abs_repo_base=self.repo_base)
             self.assertEqual(result, {'test': 'Success.'})

--- a/contrib/packs/tests/test_action_download.py
+++ b/contrib/packs/tests/test_action_download.py
@@ -86,8 +86,13 @@ def mock_get_gitref(repo, ref):
     Mock get_gitref function which return mocked object if ref passed is
     PACK_INDEX['test']['version']
     """
-    if ref == 'v%s' % PACK_INDEX['test']['version']:
-        return mock.MagicMock(hexsha=PACK_INDEX['test']['version'])
+    if PACK_INDEX['test']['version'] in ref:
+        if ref[0] == 'v':
+            return mock.MagicMock(hexsha=PACK_INDEX['test']['version'])
+        else:
+            return None
+    elif ref:
+        return mock.MagicMock(hexsha="abcDef")
     else:
         return None
 

--- a/st2common/st2common/util/pack_management.py
+++ b/st2common/st2common/util/pack_management.py
@@ -370,7 +370,7 @@ def get_repo_url(pack, proxy_config=None):
         if not pack:
             raise Exception('No record of the "%s" pack in the index.' % (name_or_url))
 
-        return (pack['repo_url'], version)
+        return (pack['repo_url'], version or pack['version'])
     else:
         return (eval_repo_url(name_or_url), version)
 


### PR DESCRIPTION
First part of Fixes StackStorm/discussions#354.
If pack version is not specified, install the latest version from pack index.json (https://index.stackstorm.org/v1/index.json), otherwise install from master branch as today.
Note: Direct github/repo install is not considered an Exchange index hit, therefore it is not covert by this fix.

Closes #4384