### PR TITLE
Fix orquesta example used in first section of docs

### DIFF
--- a/contrib/examples/actions/orquesta-sequential.yaml
+++ b/contrib/examples/actions/orquesta-sequential.yaml
@@ -1,5 +1,6 @@
 ---
 name: orquesta-sequential
+pack: examples
 description: A basic sequential workflow.
 runner_type: orquesta
 entry_point: workflows/orquesta-sequential.yaml


### PR DESCRIPTION
Add the pack explicitly in metadata so when the user follow the instruction to install the action, it will be registered under the examples pack and not under default pack.