### PR TITLE
Add support for blacklisting hosts to the HTTP runner

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Changelog
 in development
 --------------
 
+Added
+~~~~~
+
+* Add support for blacklisting / whitelisting hosts to the HTTP runner by adding new
+  ``url_hosts_blacklist`` and ``url_hosts_whitelist`` runner attribute. (new feature)
+  #4757
+
 Changed
 ~~~~~~~
 

--- a/contrib/runners/http_runner/http_runner/http_runner.py
+++ b/contrib/runners/http_runner/http_runner/http_runner.py
@@ -205,6 +205,11 @@ class HTTPClient(object):
         self.url_hosts_blacklist = url_hosts_blacklist or []
         self.url_hosts_whitelist = url_hosts_whitelist or []
 
+        if self.url_hosts_blacklist and self.url_hosts_whitelist:
+            msg = ('"url_hosts_blacklist" and "url_hosts_whitelist" parameters are mutually '
+                   'exclusive. Only one should be provided.')
+            raise ValueError(msg)
+
     def run(self):
         results = {}
         resp = None

--- a/contrib/runners/http_runner/http_runner/runner.yaml
+++ b/contrib/runners/http_runner/http_runner/runner.yaml
@@ -36,9 +36,18 @@
         CA bundle which comes from Mozilla. Verification using a custom CA bundle
         is not yet supported. Set to False to skip verification.
       type: boolean
-    hosts_blacklist:
+    url_hosts_blacklist:
       description: Optional list of hosts (network locations) to blacklist (e.g. example.com,
-        127.0.0.1, etc.)
+        127.0.0.1, ::1, etc.). If action will try to access that endpoint, an exception will be
+        thrown and action will be marked as failed.
+      required: false
+      type: array
+      items:
+        type: string
+    url_hosts_whitelist:
+      description: Optional list of hosts (network locations) to whitelist (e.g. example.com,
+        127.0.0.1, ::1, etc.). If specified, actions will only be able to hit hosts on this
+        whitelist.
       required: false
       type: array
       items:

--- a/contrib/runners/http_runner/http_runner/runner.yaml
+++ b/contrib/runners/http_runner/http_runner/runner.yaml
@@ -36,6 +36,13 @@
         CA bundle which comes from Mozilla. Verification using a custom CA bundle
         is not yet supported. Set to False to skip verification.
       type: boolean
+    hosts_blacklist:
+      description: Optional list of hosts (network locations) to blacklist (e.g. example.com,
+        127.0.0.1, etc.)
+      required: false
+      type: array
+      items:
+        type: string
   output_key: body
   output_schema:
     status_code:

--- a/contrib/runners/http_runner/tests/unit/test_http_runner.py
+++ b/contrib/runners/http_runner/tests/unit/test_http_runner.py
@@ -324,3 +324,11 @@ class HTTPRunnerTestCase(unittest2.TestCase):
             client.run()
 
             self.assertEqual(mock_requests.request.call_count, 1)
+
+    def test_url_host_blacklist_and_url_host_blacklist_params_are_mutually_exclusive(self):
+        url = 'http://www.example.com'
+
+        expected_msg = (r'"url_hosts_blacklist" and "url_hosts_whitelist" parameters are mutually '
+                        'exclusive.')
+        self.assertRaisesRegexp(ValueError, expected_msg, HTTPClient, url=url, method='GET',
+                                url_hosts_blacklist=[url], url_hosts_whitelist=[url])


### PR DESCRIPTION
This pull request adds support for blacklisting hosts to the HTTP runner by adding a new ``hosts_blacklist`` attribute.

With this attribute, pack author can specify a list of hosts which will be blacklisted (aka won't work) with the HTTP runner.

For example, if an operator wants to allow StackStorm users to use HTTP runner, without being able to hit some hosts, they could define new ``mypack.http`` action which metadata could look something like this:

```yaml
---
name: http
runner_type: "http-request"
parameters:
  hosts_blacklist:
    default:
        - "localhost"
        - "127.0.0.1"
        - "::1"
    immutable: true
```

NOTE: As with any feature which could be used in a security sensitive context, it's important to know that this feature doesn't cover all scenarios and security is all about layers.

This means that runner level filtering should be just one of those layers. Where security is very important, it should be combined with additional filtering on the network layer (e.g. firewall) and potentially also in combination with a custom StackStorm action / workflow which performs more complex logic (e.g. also resolves the hostname and checks the IP, etc.).