### PR TITLE
fixing enterprise ldap issue with execution view

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,7 +135,7 @@ script:
   # as long as PR builds
   - if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${IS_NIGHTLY_BUILD}" = "no" ]; then COMMAND_THRESHOLD=$(expr ${COMMAND_THRESHOLD} \* 2); fi; ./scripts/travis/time-command.sh "make ${TASK}" ${COMMAND_THRESHOLD}
   # Run any additional nightly checks only as part of a nightly (cron) build
-  - if [ "${IS_NIGHTLY_BUILD}" = "yes" ] && [ "${TASK}" = "ci-checks ci-packs-tests" ]; then make ci-checks-nightly; fi
+  - if [ "${IS_NIGHTLY_BUILD}" = "yes" ]; then ./scripts/travis/run-nightly-make-task-if-exists.sh "${TASK}"; fi
   # NOTE: We only generate and submit coverage report for master and version branches
   # NOTE: We put this here and not after_success so build is marked as failed if this step fails
   # See https://docs.travis-ci.com/user/customizing-the-build/#breaking-the-build
@@ -147,3 +147,13 @@ script:
 # Alternative: use strict pip pinning, including git-based pip packages
 before_cache:
   - if [ ${TRAVIS_PULL_REQUEST} = 'false' ] && [ "${IS_NIGHTLY_BUILD}" = "no" ]; then rm -rf virtualenv/; fi
+
+# We want to be notified when a master or nightly build fails
+notifications:
+  # Post build failures to '#stackstorm' channel in 'stackstorm' Slack
+  slack:
+    rooms:
+      - secure: "rPA22aDgvNe0/S/2e+cp1rSDdDUPufLXnCbfnRzMPVDSQ2UPdLmEl9IeOoEHZmq92AZtzY8UnQaPFuoM0HAPrYDgKopn4n4KpOo+xUlJ92qdNj5qk3Z1TmQHwUYFvCkMvaR/CpX2liRr/YB3qM+1vFAMsYgmqrBX8vcEqNJQy/M="
+    on_pull_requests: false
+    on_success: change # default: always
+    on_failure: always # default: always

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,10 @@ Changed
 
 Fixed
 ~~~~~
-
+* Fix rbac with execution view where the rbac is unable to verify the pack or uid of the execution
+  because it was not returned from the action execution db. This would result in an internal server
+  error when trying to view the results of a single execution.
+  Contributed by Joshua Meyer (@jdmeyer3) #4758
 * Fixed logging middleware to output a ``content_length`` of ``0`` instead of ``Infinity``
   when the type of data being returned is not supported. Previously, when the value was
   set to ``Infinity`` this would result in invalid JSON being output into structured

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Changelog
 in development
 --------------
 
+Added
+~~~~~
+
+* Add support for blacklisting / whitelisting hosts to the HTTP runner by adding new
+  ``url_hosts_blacklist`` and ``url_hosts_whitelist`` runner attribute. (new feature)
+  #4757
+
 Changed
 ~~~~~~~
 

--- a/contrib/runners/http_runner/http_runner/runner.yaml
+++ b/contrib/runners/http_runner/http_runner/runner.yaml
@@ -36,6 +36,22 @@
         CA bundle which comes from Mozilla. Verification using a custom CA bundle
         is not yet supported. Set to False to skip verification.
       type: boolean
+    url_hosts_blacklist:
+      description: Optional list of hosts (network locations) to blacklist (e.g. example.com,
+        127.0.0.1, ::1, etc.). If action will try to access that endpoint, an exception will be
+        thrown and action will be marked as failed.
+      required: false
+      type: array
+      items:
+        type: string
+    url_hosts_whitelist:
+      description: Optional list of hosts (network locations) to whitelist (e.g. example.com,
+        127.0.0.1, ::1, etc.). If specified, actions will only be able to hit hosts on this
+        whitelist.
+      required: false
+      type: array
+      items:
+        type: string
   output_key: body
   output_schema:
     status_code:

--- a/scripts/travis/run-nightly-make-task-if-exists.sh
+++ b/scripts/travis/run-nightly-make-task-if-exists.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Script which runs a corresponding make nightly tasks if it exists. If a task corresponding
+# nightly task doesn't exist, it's ignored.
+#
+# For example, let's say we have TASK="ci-checks ci-unit ci-pack-tests" and only
+# "ci-checks-nightly" make task exists.
+# In this scenario, only "ci-check-nightly" tasks would run and other would be ignored.
+
+TASK=$1
+
+if [ ! "${TASK}" ]; then
+    echo "Missing TASK argument"
+    echo "Usage: $0 <make task>"
+    exit 2
+fi
+
+# Note: TASK could contain a list of multiple tasks
+TASKS=($TASK)
+
+EXISTING_TASKS=()
+for TASK_NAME in ${TASKS[@]}; do
+    $(make -n ${TASK_NAME}-nightly &> /dev/null)
+
+    if [ $? -eq 0 ]; then
+        # Task {TASK}-nightly exists
+        EXISTING_TASKS+=("$TASK_NAME-nightly")
+    fi
+done
+
+# Run only tasks which exist
+if [ ${#EXISTING_TASKS[@]} -eq 0 ]; then
+    echo "No existing nightly tasks found..."
+    exit 0
+fi
+
+echo "Running the following nightly tasks: ${EXISTING_TASKS[@]}"
+exec make ${EXISTING_TASKS[@]}

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -84,6 +84,9 @@ class ActionExecutionsControllerMixin(BaseRestControllerMixin):
         'action.parameters',
         'runner.runner_parameters',
         'parameters'
+        # necessary for ActionExecutionDB to determine permissions in enterprise ldap
+        'action.pack'
+        'action.uid'
     ]
 
     # A list of attributes which can be specified using ?exclude_attributes filter

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -84,9 +84,13 @@ class ActionExecutionsControllerMixin(BaseRestControllerMixin):
         'action.parameters',
         'runner.runner_parameters',
         'parameters',
-        # necessary for ActionExecutionDB to determine permissions in enterprise ldap
+
+        # Attributes below are mandatory for RBAC installations
         'action.pack',
-        'action.uid'
+        'action.uid',
+
+        # Required when rbac.permission_isolation is enabled
+        'context'
     ]
 
     # A list of attributes which can be specified using ?exclude_attributes filter

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -83,9 +83,9 @@ class ActionExecutionsControllerMixin(BaseRestControllerMixin):
     mandatory_include_fields_retrieve = [
         'action.parameters',
         'runner.runner_parameters',
-        'parameters'
+        'parameters',
         # necessary for ActionExecutionDB to determine permissions in enterprise ldap
-        'action.pack'
+        'action.pack',
         'action.uid'
     ]
 

--- a/st2tests/st2tests/api.py
+++ b/st2tests/st2tests/api.py
@@ -180,7 +180,13 @@ class APIControllerWithIncludeAndExcludeFilterTestCase(object):
     # _get_model_instance method method
     test_exact_object_count = True
 
+    # True if those tests are running with rbac enabled
+    rbac_enabled = False
+
     def test_get_all_exclude_attributes_and_include_attributes_are_mutually_exclusive(self):
+        if self.rbac_enabled:
+            self.use_user(self.users['admin'])
+
         url = self.get_all_path + '?include_attributes=id&exclude_attributes=id'
         resp = self.app.get(url, expect_errors=True)
         self.assertEqual(resp.status_int, 400)
@@ -189,6 +195,9 @@ class APIControllerWithIncludeAndExcludeFilterTestCase(object):
         self.assertRegexpMatches(resp.json['faultstring'], expected_msg)
 
     def test_get_all_invalid_exclude_and_include_parameter(self):
+        if self.rbac_enabled:
+            self.use_user(self.users['admin'])
+
         # 1. Invalid exclude_attributes field
         url = self.get_all_path + '?exclude_attributes=invalid_field'
         resp = self.app.get(url, expect_errors=True)
@@ -206,6 +215,9 @@ class APIControllerWithIncludeAndExcludeFilterTestCase(object):
         self.assertRegexpMatches(resp.json['faultstring'], expected_msg)
 
     def test_get_all_include_attributes_filter(self):
+        if self.rbac_enabled:
+            self.use_user(self.users['admin'])
+
         mandatory_include_fields = self.controller_cls.mandatory_include_fields_response
 
         # Create any resources needed by those tests (if not already created inside setUp /
@@ -249,6 +261,9 @@ class APIControllerWithIncludeAndExcludeFilterTestCase(object):
         self._delete_mock_models(object_ids)
 
     def test_get_all_exclude_attributes_filter(self):
+        if self.rbac_enabled:
+            self.use_user(self.users['admin'])
+
         # Create any resources needed by those tests (if not already created inside setUp /
         # setUpClass)
         object_ids = self._insert_mock_models()

--- a/tox.ini
+++ b/tox.ini
@@ -46,12 +46,23 @@ commands =
     nosetests --rednose --immediate -sv contrib/runners/http_runner/tests/unit/
     nosetests --rednose --immediate -sv contrib/runners/noop_runner/tests/unit/
     nosetests --rednose --immediate -sv contrib/runners/local_runner/tests/unit/
-    nosetests --rednose --immediate -sv contrib/runners/mistral_v2/tests/unit/
     nosetests --rednose --immediate -sv contrib/runners/orquesta_runner/tests/unit/
     nosetests --rednose --immediate -sv contrib/runners/python_runner/tests/unit/
     nosetests --rednose --immediate -sv contrib/runners/winrm_runner/tests/unit/
 
-# Python 3 tasks
+[testenv:py36-unit-nightly]
+basepython = python3.6
+setenv = PYTHONPATH = {toxinidir}/external:{toxinidir}/st2common:{toxinidir}/st2api:{toxinidir}/st2actions:{toxinidir}/st2exporter:{toxinidir}/st2reactor:{toxinidir}/st2tests:{toxinidir}/contrib/runners/action_chain_runner:{toxinidir}/contrib/runners/local_runner:{toxinidir}/contrib/runners/python_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/noop_runner:{toxinidir}/contrib/runners/announcement_runner:{toxinidir}/contrib/runners/remote_runner:{toxinidir}/contrib/runners/remote_runner:{toxinidir}/contrib/runners/mistral_v2:{toxinidir}/contrib/runners/orquesta_runner:{toxinidir}/contrib/runners/inquirer_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/winrm_runner
+         VIRTUALENV_DIR = {envdir}
+passenv = NOSE_WITH_TIMER TRAVIS
+install_command = pip install -U --force-reinstall {opts} {packages}
+deps = virtualenv
+       -r{toxinidir}/requirements.txt
+       -e{toxinidir}/st2client
+       -e{toxinidir}/st2common
+commands =
+    nosetests --rednose --immediate -sv contrib/runners/mistral_v2/tests/unit/
+
 [testenv:py36-packs]
 basepython = python3.6
 setenv = PYTHONPATH = {toxinidir}/external:{toxinidir}/st2common:{toxinidir}/st2api:{toxinidir}/st2actions:{toxinidir}/st2exporter:{toxinidir}/st2reactor:{toxinidir}/st2tests:{toxinidir}/contrib/runners/action_chain_runner:{toxinidir}/contrib/runners/local_runner:{toxinidir}/contrib/runners/python_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/noop_runner:{toxinidir}/contrib/runners/announcement_runner:{toxinidir}/contrib/runners/remote_runner:{toxinidir}/contrib/runners/remote_runner:{toxinidir}/contrib/runners/mistral_v2:{toxinidir}/contrib/runners/orquesta_runner:{toxinidir}/contrib/runners/inquirer_runner:{toxinidir}/contrib/runners/http_runner:{toxinidir}/contrib/runners/winrm_runner


### PR DESCRIPTION
Closes #4758

The error caused in #4758 is because the ldap rbac is expecting the document returned from the ActionExecutionDB to contain action.pack and action.uid, but they are currently not being returned. 

Here is the traceback I got from the rbac
```
Traceback (most recent call last):
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2rbac_enterprise_backend/utils.py", line 120, in assert_user_has_resource_db_permission
    permission_type=permission_type)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2rbac_enterprise_backend/utils.py", line 287, in user_has_resource_db_permission
    permission_type=permission_type)
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2rbac_enterprise_backend/resolvers.py", line 673, in user_has_resource_db_permission
    pack_db = PackDB(ref=action['pack'])
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/mongoengine/base/datastructures.py", line 54, in __getitem__
    value = super(BaseDict, self).__getitem__(key)
KeyError: 'pack'
```
 
and here is the action object that is returned when it gets the key error
```
<ActionExecutionDB: ActionExecutionDB(action={u'parameters': {u'pack': {u'required': True, u'type': u'string', u'description': u'Name of pack to lookup'}}}, children=[], context={}, delay=None, end_timestamp=None, id=5d49d6ddf55f7d00f89a00e7, liveaction={}, log=[], parameters={u'log_level': u'DEBUG', u'pack': u'packs'}, parent=None, result={u'result': {u'git_status': None, u'pack': {u'description': u'Pack management functionality.', u'author': u'StackStorm, Inc.', u'python_versions': [u'2', u'3'], u'version': u'3.1.0', u'email': u'info@stackstorm.com', u'name': u'packs'}}, u'exit_code': 0, u'stderr': u'', u'stdout': u''}, rule={}, runner={u'runner_parameters': {u'debug': {u'default': False, u'required': False, u'type': u'boolean', u'description': u'Enable runner debug mode.'}, u'content_version': {u'required': False, u'type': u'string', u'description': u'Git revision of the pack content to use for this action execution (git commit sha / tag / branch). Only applies to packs which are git repositories.'}, u'log_level': {u'default': u'DEBUG', u'enum': [u'AUDIT', u'CRITICAL', u'ERROR', u'WARNING', u'INFO', u'DEBUG'], u'type': u'string', u'description': u'Default log level for Python runner actions.'}, u'env': {u'type': u'object', u'description': u'Environment variables which will be available to the script.'}, u'timeout': {u'default': 600, u'type': u'integer', u'description': u"Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds."}}}, start_timestamp="2019-08-06 19:58:10.371616+00:00", status=None, task_execution=None, trigger={}, trigger_instance={}, trigger_type={}, web_url=None, workflow_execution=None)>
```

By having mongo return the action.pack, and the action.uid, it should satisfy the st2rbac requirements
![image](https://user-images.githubusercontent.com/25443446/62573141-8fbf0380-b852-11e9-877a-e02b42111e13.png)
