### PR TITLE
Fix nightly build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ branches:
 
 env:
   global:
-    - IS_NIGHTLY_BUILD=$([ "${TRAVIS_EVENT_TYPE}" = "cron" ] && echo "yes" || echo "no")
+    - IS_NIGHTLY_BUILD=yes
+      #- IS_NIGHTLY_BUILD=$([ "${TRAVIS_EVENT_TYPE}" = "cron" ] && echo "yes" || echo "no")
     # NOTE: We only enable coverage for master builds and not pull requests
     # since it has huge performance overhead (tests are 50% or so slower)
     - ENABLE_COVERAGE=$([ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${IS_NIGHTLY_BUILD}" = "no" ] && echo "yes" || echo "no")

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ branches:
 
 env:
   global:
-    - IS_NIGHTLY_BUILD=yes
-      #- IS_NIGHTLY_BUILD=$([ "${TRAVIS_EVENT_TYPE}" = "cron" ] && echo "yes" || echo "no")
+    - IS_NIGHTLY_BUILD=$([ "${TRAVIS_EVENT_TYPE}" = "cron" ] && echo "yes" || echo "no")
     # NOTE: We only enable coverage for master builds and not pull requests
     # since it has huge performance overhead (tests are 50% or so slower)
     - ENABLE_COVERAGE=$([ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${IS_NIGHTLY_BUILD}" = "no" ] && echo "yes" || echo "no")

--- a/Makefile
+++ b/Makefile
@@ -997,7 +997,7 @@ ci-unit-nightly:
 	@echo
 	@echo "============== ci-unit-nightly =============="
 	@echo
-	nosetests $(NOSE_OPTS) -s -v  contrib/runners/mistral_v2/tests/unit
+	$(VIRTUALENV_DIR)/bin/nosetests $(NOSE_OPTS) -s -v  contrib/runners/mistral_v2/tests/unit
 
 .PHONY: .ci-prepare-integration
 .ci-prepare-integration:

--- a/Makefile
+++ b/Makefile
@@ -997,7 +997,7 @@ ci-unit-nightly:
 	@echo
 	@echo "============== ci-unit-nightly =============="
 	@echo
-	$(VIRTUALENV_DIR)/bin/nosetests $(NOSE_OPTS) -s -v  contrib/runners/mistral_v2/tests/unit
+	. $(VIRTUALENV_DIR)/bin/activate; nosetests $(NOSE_OPTS) -s -v  contrib/runners/mistral_v2/tests/unit
 
 .PHONY: .ci-prepare-integration
 .ci-prepare-integration:


### PR DESCRIPTION
This pull request fixes nightly build failure in https://travis-ci.org/StackStorm/st2/jobs/569901661.

We didn't correctly use ``nosetests`` binary from the virtualenv.

```bash
...
0.35s$ if [ "${IS_NIGHTLY_BUILD}" = "yes" ]; then ./scripts/travis/run-nightly-make-task-if-exists.sh "${TASK}"; fi
Running the following nightly tasks: ci-unit-nightly
# NOTE: We run mistral runner checks only as part of a nightly build to speed up
# non nightly builds (Mistral will be deprecated in the future)
============== ci-unit-nightly ==============
nosetests --rednose --immediate --with-parallel -s -v  contrib/runners/mistral_v2/tests/unit
Usage: nosetests [options]
nosetests: error: no such option: --rednose
make: *** [ci-unit-nightly] Error 2
....
```