### PR TITLE
Implement SSO plugin for user authentication in StackStorm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -567,6 +567,12 @@ requirements: virtualenv .requirements .sdist-requirements install-runners
 	# make targets. This speeds up the build
 	(cd ${ROOT_DIR}/st2common; ${ROOT_DIR}/$(VIRTUALENV_DIR)/bin/python setup.py develop --no-deps)
 
+	# Install st2auth to register SSO drivers
+	# NOTE: We pass --no-deps to the script so we don't install all the
+	# package dependencies which are already installed as part of "requirements"
+	# make targets. This speeds up the build
+	(cd ${ROOT_DIR}/st2auth; ${ROOT_DIR}/$(VIRTUALENV_DIR)/bin/python setup.py develop --no-deps)
+
 	# Some of the tests rely on submodule so we need to make sure submodules are check out
 	git submodule update --recursive --remote
 

--- a/conf/st2.conf.sample
+++ b/conf/st2.conf.sample
@@ -71,7 +71,7 @@ sso = False
 mode = standalone
 # Specify to enable debug mode.
 debug = False
-# Single Sign On backend to use when SSO is enabled. Available backends: noop, saml2.
+# Single Sign On backend to use when SSO is enabled. Available backends: noop.
 sso_backend = noop
 
 # Standalone mode options - options below only apply when auth service is running in the standalone

--- a/conf/st2.conf.sample
+++ b/conf/st2.conf.sample
@@ -53,6 +53,8 @@ port = 9101
 # Common option - options below apply in both scenarios - when auth service is running as a WSGI
 # service (e.g. under Apache or Nginx) and when it's running in the standalone mode.
 
+# JSON serialized arguments which are passed to the SSO backend.
+sso_backend_kwargs = None
 # Enable authentication middleware.
 enable = True
 # Path to the logging config.
@@ -63,10 +65,14 @@ api_url = None
 service_token_ttl = 86400
 # Access token ttl in seconds.
 token_ttl = 86400
+# Enable Single Sign On for GUI if true.
+sso = False
 # Authentication mode (proxy,standalone)
 mode = standalone
 # Specify to enable debug mode.
 debug = False
+# Single Sign On backend to use when SSO is enabled. Available backends: noop, saml2.
+sso_backend = noop
 
 # Standalone mode options - options below only apply when auth service is running in the standalone
 # mode.

--- a/conf/st2.conf.sample
+++ b/conf/st2.conf.sample
@@ -71,7 +71,7 @@ sso = False
 mode = standalone
 # Specify to enable debug mode.
 debug = False
-# Single Sign On backend to use when SSO is enabled. Available backends: noop.
+# Single Sign On backend to use when SSO is enabled. Available backends: noop, saml2.
 sso_backend = noop
 
 # Standalone mode options - options below only apply when auth service is running in the standalone

--- a/st2auth/setup.py
+++ b/st2auth/setup.py
@@ -46,5 +46,10 @@ setup(
     packages=find_packages(exclude=['setuptools', 'tests']),
     scripts=[
         'bin/st2auth'
-    ]
+    ],
+    entry_points={
+        'st2auth.sso.backends': [
+            'noop = st2auth.sso.noop:NoOpSingleSignOnBackend'
+        ]
+    }
 )

--- a/st2auth/st2auth/app.py
+++ b/st2auth/st2auth/app.py
@@ -26,6 +26,8 @@ from st2common.router import Router
 from st2common.constants.system import VERSION_STRING
 from st2common.service_setup import setup as common_setup
 from st2common.util import spec_loader
+from st2common.util.monkey_patch import monkey_patch
+from st2common.util.monkey_patch import use_select_poll_workaround
 from st2auth import config as st2auth_config
 from st2auth.validation import validate_auth_backend_is_correctly_configured
 
@@ -60,6 +62,10 @@ def setup_app(config=None):
                      service_registry=True,
                      capabilities=capabilities,
                      config_args=config.get('config_args', None))
+
+        # pysaml2 uses subprocess communicate which calls communicate_with_poll
+        if cfg.CONF.auth.sso and cfg.CONF.auth.sso_backend == 'saml2':
+            use_select_poll_workaround(nose_only=False)
 
     # Additional pre-run time checks
     validate_auth_backend_is_correctly_configured()

--- a/st2auth/st2auth/app.py
+++ b/st2auth/st2auth/app.py
@@ -26,7 +26,6 @@ from st2common.router import Router
 from st2common.constants.system import VERSION_STRING
 from st2common.service_setup import setup as common_setup
 from st2common.util import spec_loader
-from st2common.util.monkey_patch import monkey_patch
 from st2common.util.monkey_patch import use_select_poll_workaround
 from st2auth import config as st2auth_config
 from st2auth.validation import validate_auth_backend_is_correctly_configured

--- a/st2auth/st2auth/config.py
+++ b/st2auth/st2auth/config.py
@@ -22,8 +22,10 @@ from st2common.constants.system import VERSION_STRING
 from st2common.constants.system import DEFAULT_CONFIG_FILE_PATH
 from st2common.constants.auth import DEFAULT_MODE
 from st2common.constants.auth import DEFAULT_BACKEND
+from st2common.constants.auth import DEFAULT_SSO_BACKEND
 from st2common.constants.auth import VALID_MODES
-from st2auth.backends import get_available_backends
+from st2auth import backends as auth_backends
+from st2auth import sso as sso_backends
 
 
 def parse_args(args=None):
@@ -45,7 +47,9 @@ def _register_common_opts():
 
 
 def _register_app_opts():
-    available_backends = get_available_backends()
+    available_backends = auth_backends.get_available_backends()
+    available_sso_backends = sso_backends.get_available_backends()
+
     auth_opts = [
         cfg.StrOpt(
             'host', default='127.0.0.1',
@@ -78,7 +82,17 @@ def _register_app_opts():
         cfg.StrOpt(
             'backend_kwargs', default=None,
             help='JSON serialized arguments which are passed to the authentication '
-                 'backend in a standalone mode.')
+                 'backend in a standalone mode.'),
+        cfg.BoolOpt(
+            'sso', default=False,
+            help='Enable Single Sign On for GUI if true.'),
+        cfg.StrOpt(
+            'sso_backend', default=DEFAULT_SSO_BACKEND,
+            help='Single Sign On backend to use when SSO is enabled. Available '
+                 'backends: %s.' % (', '.join(available_sso_backends))),
+        cfg.StrOpt(
+            'sso_backend_kwargs', default=None,
+            help='JSON serialized arguments which are passed to the SSO backend.')
     ]
 
     cfg.CONF.register_cli_opts(auth_opts, group='auth')

--- a/st2auth/st2auth/config.py
+++ b/st2auth/st2auth/config.py
@@ -25,7 +25,6 @@ from st2common.constants.auth import DEFAULT_BACKEND
 from st2common.constants.auth import DEFAULT_SSO_BACKEND
 from st2common.constants.auth import VALID_MODES
 from st2auth import backends as auth_backends
-from st2auth import sso as sso_backends
 
 
 def parse_args(args=None):
@@ -48,7 +47,6 @@ def _register_common_opts():
 
 def _register_app_opts():
     available_backends = auth_backends.get_available_backends()
-    available_sso_backends = sso_backends.get_available_backends()
 
     auth_opts = [
         cfg.StrOpt(
@@ -89,7 +87,7 @@ def _register_app_opts():
         cfg.StrOpt(
             'sso_backend', default=DEFAULT_SSO_BACKEND,
             help='Single Sign On backend to use when SSO is enabled. Available '
-                 'backends: %s.' % (', '.join(available_sso_backends))),
+                 'backends: noop, saml2.'),
         cfg.StrOpt(
             'sso_backend_kwargs', default=None,
             help='JSON serialized arguments which are passed to the SSO backend.')

--- a/st2auth/st2auth/controllers/v1/root.py
+++ b/st2auth/st2auth/controllers/v1/root.py
@@ -14,7 +14,9 @@
 # limitations under the License.
 
 from st2auth.controllers.v1 import auth
+from st2auth.controllers.v1 import sso as sso_auth
 
 
 class RootController(object):
     tokens = auth.TokenController()
+    sso = sso_auth.SingleSignOnController()

--- a/st2auth/st2auth/controllers/v1/sso.py
+++ b/st2auth/st2auth/controllers/v1/sso.py
@@ -65,9 +65,8 @@ class IdentityProviderCallbackController(object):
 class SingleSignOnController(object):
     callback = IdentityProviderCallbackController()
 
-    def get(self, **kwargs):
+    def get(self, referer):
         try:
-            referer = kwargs.get('referer')
             response = router.Response(status=http_client.TEMPORARY_REDIRECT)
             response.location = SSO_BACKEND.get_request_redirect_url(referer)
             return response

--- a/st2auth/st2auth/controllers/v1/sso.py
+++ b/st2auth/st2auth/controllers/v1/sso.py
@@ -101,7 +101,6 @@ CALLBACK_SUCCESS_RESPONSE_BODY = """
         window.localStorage.setItem('st2Session', JSON.stringify(data));
         window.location.replace("%s");
     </script>
-    <body/>
 </html>
 """
 

--- a/st2auth/st2auth/controllers/v1/sso.py
+++ b/st2auth/st2auth/controllers/v1/sso.py
@@ -14,7 +14,12 @@
 
 import datetime
 import json
-import urllib
+import six
+
+if six.PY2:
+    from urllib import quote
+else:
+    from urllib.parse import quote
 
 from six.moves import http_client
 
@@ -106,7 +111,7 @@ def process_successful_response(referer, token):
 
     resp.set_cookie(
         'st2-auth-token',
-        value=urllib.quote(json.dumps(token_json)),
+        value=quote(json.dumps(token_json)),
         expires=datetime.timedelta(seconds=60),
         overwrite=True
     )

--- a/st2auth/st2auth/controllers/v1/sso.py
+++ b/st2auth/st2auth/controllers/v1/sso.py
@@ -14,14 +14,9 @@
 
 import datetime
 import json
-import six
-
-if six.PY2:
-    from urllib import quote
-else:
-    from urllib.parse import quote
 
 from six.moves import http_client
+from six.moves import urllib
 
 import st2auth.handlers as handlers
 
@@ -110,7 +105,7 @@ def process_successful_response(referer, token):
 
     resp.set_cookie(
         'st2-auth-token',
-        value=quote(json.dumps(token_json)),
+        value=urllib.parse.quote(json.dumps(token_json)),
         expires=datetime.timedelta(seconds=60),
         overwrite=True
     )

--- a/st2auth/st2auth/controllers/v1/sso.py
+++ b/st2auth/st2auth/controllers/v1/sso.py
@@ -1,0 +1,124 @@
+# Copyright 2019 Extreme Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import json
+import urllib
+
+from six.moves import http_client
+
+import st2auth.handlers as handlers
+
+from st2auth import sso as st2auth_sso
+from st2common.exceptions import auth as auth_exc
+from st2common import log as logging
+from st2common import router
+
+
+LOG = logging.getLogger(__name__)
+SSO_BACKEND = st2auth_sso.get_sso_backend()
+
+
+class IdentityProviderCallbackController(object):
+
+    def __init__(self):
+        self.st2_auth_handler = handlers.ProxyAuthHandler()
+
+    def post(self, response, **kwargs):
+        try:
+            verified_user = SSO_BACKEND.verify_response(response)
+
+            st2_auth_token_create_request = {'user': verified_user['username'], 'ttl': None}
+
+            st2_auth_token = self.st2_auth_handler.handle_auth(
+                request=st2_auth_token_create_request,
+                remote_addr=verified_user['referer'],
+                remote_user=verified_user['username'],
+                headers={}
+            )
+
+            return process_successful_response(verified_user['referer'], st2_auth_token)
+        except NotImplementedError as e:
+            return process_failure_response(http_client.INTERNAL_SERVER_ERROR, e)
+        except auth_exc.SSOVerificationError as e:
+            return process_failure_response(http_client.UNAUTHORIZED, e)
+        except Exception as e:
+            raise e
+
+
+class SingleSignOnController(object):
+    callback = IdentityProviderCallbackController()
+
+    def get(self, **kwargs):
+        try:
+            referer = kwargs.get('referer')
+            response = router.Response(status=http_client.TEMPORARY_REDIRECT)
+            response.location = SSO_BACKEND.get_request_redirect_url(referer)
+            return response
+        except NotImplementedError as e:
+            return process_failure_response(http_client.INTERNAL_SERVER_ERROR, e)
+        except Exception as e:
+            raise e
+
+
+CALLBACK_SUCCESS_RESPONSE_BODY = """
+<html>
+    <script>
+        function getCookie(name) {
+            var v = document.cookie.match('(^|;) ?' + name + '=([^;]*)(;|$)');
+            return v ? v[2] : null;
+        }
+
+        data = JSON.parse(window.localStorage.getItem('st2Session'));
+        data['token'] = JSON.parse(decodeURIComponent(getCookie('st2-auth-token')));
+        window.localStorage.setItem('st2Session', JSON.stringify(data));
+        window.location.replace("%s");
+    </script>
+    <body/>
+</html>
+"""
+
+
+def process_successful_response(referer, token):
+    token_json = {
+        'id': str(token.id),
+        'user': token.user,
+        'token': token.token,
+        'expiry': str(token.expiry),
+        'service': False,
+        'metadata': {}
+    }
+
+    body = CALLBACK_SUCCESS_RESPONSE_BODY % referer
+    resp = router.Response(body=body)
+    resp.headers['Content-Type'] = 'text/html'
+
+    resp.set_cookie(
+        'st2-auth-token',
+        value=urllib.quote(json.dumps(token_json)),
+        expires=datetime.timedelta(seconds=60),
+        overwrite=True
+    )
+
+    return resp
+
+
+def process_failure_response(status_code, exception):
+    LOG.error(str(exception))
+    json_body = {'faultstring': str(exception)}
+    return router.Response(status_code=status_code, json_body=json_body)
+
+
+sso_controller = SingleSignOnController()
+idp_callback_controller = IdentityProviderCallbackController()

--- a/st2auth/st2auth/sso/__init__.py
+++ b/st2auth/st2auth/sso/__init__.py
@@ -1,0 +1,76 @@
+# Copyright 2019 Extreme Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import json
+import six
+import traceback
+
+from oslo_config import cfg
+
+from st2common import log as logging
+
+from st2common.util import driver_loader
+
+
+__all__ = [
+    'get_available_backends',
+    'get_backend_instance',
+    'get_sso_backend'
+]
+
+LOG = logging.getLogger(__name__)
+
+BACKENDS_NAMESPACE = 'st2auth.sso.backends'
+
+
+def get_available_backends():
+    return driver_loader.get_available_backends(namespace=BACKENDS_NAMESPACE)
+
+
+def get_backend_instance(name):
+    sso_backend_cls = driver_loader.get_backend_driver(namespace=BACKENDS_NAMESPACE, name=name)
+
+    kwargs = {}
+    sso_backend_kwargs = cfg.CONF.auth.sso_backend_kwargs
+
+    if sso_backend_kwargs:
+        try:
+            kwargs = json.loads(sso_backend_kwargs)
+        except ValueError as e:
+            raise ValueError(
+                'Failed to JSON parse backend settings for backend "%s": %s' %
+                (name, six.text_type(e))
+            )
+
+    try:
+        sso_backend = sso_backend_cls(**kwargs)
+    except Exception as e:
+        tb_msg = traceback.format_exc()
+        class_name = sso_backend_cls.__name__
+        msg = ('Failed to instantiate SSO backend "%s" (class %s) with backend settings '
+               '"%s": %s' % (name, class_name, str(kwargs), six.text_type(e)))
+        msg += '\n\n' + tb_msg
+        exc_cls = type(e)
+        raise exc_cls(msg)
+
+    return sso_backend
+
+
+def get_sso_backend():
+    """
+    Return SingleSignOnBackend class instance.
+    """
+    return get_backend_instance(cfg.CONF.auth.sso_backend)

--- a/st2auth/st2auth/sso/base.py
+++ b/st2auth/st2auth/sso/base.py
@@ -1,0 +1,36 @@
+# Copyright 2019 Extreme Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import abc
+import six
+
+
+__all__ = [
+    'BaseSingleSignOnBackend'
+]
+
+
+@six.add_metaclass(abc.ABCMeta)
+class BaseSingleSignOnBackend(object):
+    """
+    Base single sign on authentication class.
+    """
+
+    def get_request_redirect_url(self, referer):
+        msg = 'The function "get_request_redirect_url" is not implemented in the base SSO backend.'
+        raise NotImplementedError(msg)
+
+    def verify_response(self, response):
+        msg = 'The function "verify_response" is not implemented in the base SSO backend.'
+        raise NotImplementedError(msg)

--- a/st2auth/st2auth/sso/noop.py
+++ b/st2auth/st2auth/sso/noop.py
@@ -1,0 +1,39 @@
+# Copyright 2019 Extreme Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+from st2auth.sso.base import BaseSingleSignOnBackend
+
+
+__all__ = [
+    'NoOpSingleSignOnBackend'
+]
+
+NOT_IMPLEMENTED_MESSAGE = (
+    'The default "noop" SSO backend is not a proper implementation. '
+    'Please refer to the enterprise version for configuring SSO.'
+)
+
+
+class NoOpSingleSignOnBackend(BaseSingleSignOnBackend):
+    """
+    NoOp SSO authentication backend.
+    """
+
+    def get_request_redirect_url(self, referer):
+        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+
+    def verify_response(self, response):
+        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)

--- a/st2auth/tests/unit/controllers/v1/test_sso.py
+++ b/st2auth/tests/unit/controllers/v1/test_sso.py
@@ -18,14 +18,8 @@ tests_config.parse_args()
 import json
 import mock
 
-import six
-
-if six.PY2:
-    from urllib import unquote
-else:
-    from urllib.parse import unquote
-
 from six.moves import http_client
+from six.moves import urllib
 
 from st2auth.controllers.v1 import sso as sso_api_controller
 from st2auth.sso import noop
@@ -99,7 +93,7 @@ class TestIdentityProviderCallbackController(FunctionalTest):
         self.assertEqual(len(set_cookies_list), 1)
         self.assertIn('st2-auth-token', set_cookies_list[0][1])
 
-        cookie = unquote(set_cookies_list[0][1]).split('=')
+        cookie = urllib.parse.unquote(set_cookies_list[0][1]).split('=')
         st2_auth_token = json.loads(cookie[1].split(';')[0])
         self.assertIn('token', st2_auth_token)
         self.assertEqual(st2_auth_token['user'], MOCK_USER)

--- a/st2auth/tests/unit/controllers/v1/test_sso.py
+++ b/st2auth/tests/unit/controllers/v1/test_sso.py
@@ -1,0 +1,109 @@
+# Copyright 2019 Extreme Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import st2tests.config as tests_config
+tests_config.parse_args()
+
+import json
+import mock
+import urllib
+
+from six.moves import http_client
+
+from st2auth.controllers.v1 import sso as sso_api_controller
+from st2auth.sso import noop
+from st2common.exceptions import auth as auth_exc
+from tests.base import FunctionalTest
+
+
+SSO_V1_PATH = '/v1/sso'
+SSO_CALLBACK_V1_PATH = SSO_V1_PATH + '/callback'
+MOCK_REFERER = 'https://127.0.0.1'
+MOCK_USER = 'stanley'
+
+
+class TestSingleSignOnController(FunctionalTest):
+
+    @mock.patch.object(
+        sso_api_controller.SSO_BACKEND,
+        'get_request_redirect_url',
+        mock.MagicMock(side_effect=Exception('fooobar')))
+    def test_default_backend_unknown_exception(self):
+        expected_error = {'faultstring': 'Internal Server Error'}
+        response = self.app.get(SSO_V1_PATH, expect_errors=True)
+        self.assertTrue(response.status_code, http_client.INTERNAL_SERVER_ERROR)
+        self.assertDictEqual(response.json, expected_error)
+
+    def test_default_backend_not_implemented(self):
+        expected_error = {'faultstring': noop.NOT_IMPLEMENTED_MESSAGE}
+        response = self.app.get(SSO_V1_PATH, expect_errors=True)
+        self.assertTrue(response.status_code, http_client.INTERNAL_SERVER_ERROR)
+        self.assertDictEqual(response.json, expected_error)
+
+    @mock.patch.object(
+        sso_api_controller.SSO_BACKEND,
+        'get_request_redirect_url',
+        mock.MagicMock(return_value='https://127.0.0.1'))
+    def test_idp_redirect(self):
+        response = self.app.get(SSO_V1_PATH, expect_errors=False)
+        self.assertTrue(response.status_code, http_client.TEMPORARY_REDIRECT)
+        self.assertEqual(response.location, 'https://127.0.0.1')
+
+
+class TestIdentityProviderCallbackController(FunctionalTest):
+
+    @mock.patch.object(
+        sso_api_controller.SSO_BACKEND,
+        'verify_response',
+        mock.MagicMock(side_effect=Exception('fooobar')))
+    def test_default_backend_unknown_exception(self):
+        expected_error = {'faultstring': 'Internal Server Error'}
+        response = self.app.post_json(SSO_CALLBACK_V1_PATH, {'foo': 'bar'}, expect_errors=True)
+        self.assertTrue(response.status_code, http_client.INTERNAL_SERVER_ERROR)
+        self.assertDictEqual(response.json, expected_error)
+
+    def test_default_backend_not_implemented(self):
+        expected_error = {'faultstring': noop.NOT_IMPLEMENTED_MESSAGE}
+        response = self.app.post_json(SSO_CALLBACK_V1_PATH, {'foo': 'bar'}, expect_errors=True)
+        self.assertTrue(response.status_code, http_client.INTERNAL_SERVER_ERROR)
+        self.assertDictEqual(response.json, expected_error)
+
+    @mock.patch.object(
+        sso_api_controller.SSO_BACKEND,
+        'verify_response',
+        mock.MagicMock(return_value={'referer': MOCK_REFERER, 'username': MOCK_USER}))
+    def test_idp_callback(self):
+        expected_body = sso_api_controller.CALLBACK_SUCCESS_RESPONSE_BODY % MOCK_REFERER
+        response = self.app.post_json(SSO_CALLBACK_V1_PATH, {'foo': 'bar'}, expect_errors=False)
+        self.assertTrue(response.status_code, http_client.OK)
+        self.assertEqual(expected_body, response.body)
+
+        set_cookies_list = [h for h in response.headerlist if h[0] == 'Set-Cookie']
+        self.assertEqual(len(set_cookies_list), 1)
+        self.assertIn('st2-auth-token', set_cookies_list[0][1])
+
+        cookie = urllib.unquote(set_cookies_list[0][1]).split('=')
+        st2_auth_token = json.loads(cookie[1].split(';')[0])
+        self.assertIn('token', st2_auth_token)
+        self.assertEqual(st2_auth_token['user'], MOCK_USER)
+
+    @mock.patch.object(
+        sso_api_controller.SSO_BACKEND,
+        'verify_response',
+        mock.MagicMock(side_effect=auth_exc.SSOVerificationError('Verification Failed')))
+    def test_idp_callback_verification_failed(self):
+        expected_error = {'faultstring': 'Verification Failed'}
+        response = self.app.post_json(SSO_CALLBACK_V1_PATH, {'foo': 'bar'}, expect_errors=True)
+        self.assertTrue(response.status_code, http_client.UNAUTHORIZED)
+        self.assertDictEqual(response.json, expected_error)

--- a/st2common/st2common/constants/auth.py
+++ b/st2common/st2common/constants/auth.py
@@ -36,3 +36,4 @@ QUERY_PARAM_API_KEY_ATTRIBUTE_NAME = 'st2-api-key'
 DEFAULT_MODE = 'standalone'
 
 DEFAULT_BACKEND = 'flat_file'
+DEFAULT_SSO_BACKEND = 'noop'

--- a/st2common/st2common/exceptions/auth.py
+++ b/st2common/st2common/exceptions/auth.py
@@ -83,3 +83,7 @@ class AmbiguousUserError(StackStormBaseException):
 
 class NotServiceUserError(StackStormBaseException):
     pass
+
+
+class SSOVerificationError(StackStormBaseException):
+    pass

--- a/st2common/st2common/exceptions/auth.py
+++ b/st2common/st2common/exceptions/auth.py
@@ -29,7 +29,8 @@ __all__ = [
     'NoNicknameOriginProvidedError',
     'UserNotFoundError',
     'AmbiguousUserError',
-    'NotServiceUserError'
+    'NotServiceUserError',
+    'SSOVerificationError'
 ]
 
 

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -4450,6 +4450,23 @@ paths:
   /auth/v1/sso:
     get:
       operationId: st2auth.controllers.v1.sso:sso_controller.get
+      description: Returns a flag indicating if SSO is enabled or not.
+      responses:
+        '200':
+          description: Returns a flag indicating if SSO is enabled
+          schema:
+            $ref: '#/definitions/SSOEnabledResult'
+          examples:
+            application/json:
+              enabled: false
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+      security: []
+  /auth/v1/sso/request:
+    get:
+      operationId: st2auth.controllers.v1.sso:sso_request_controller.get
       description: Redirects to the SSO Idp login page.
       parameters:
         - name: referer
@@ -5370,6 +5387,11 @@ definitions:
     type: object
     properties:
       valid:
+        type: boolean
+  SSOEnabledResult:
+    type: object
+    properties:
+      enabled:
         type: boolean
   ApiKey:
     x-api-model: st2common.models.api.auth:ApiKeyAPI

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -4447,6 +4447,45 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
+  /auth/v1/sso:
+    get:
+      operationId: st2auth.controllers.v1.sso:sso_controller.get
+      description: Redirects to the SSO Idp login page.
+      parameters:
+        - name: referer
+          in: header
+          description: set externally to indicate real source of the request
+          type: string
+      responses:
+        '307':
+          description: Temporary redirect
+      security: []
+  /auth/v1/sso/callback:
+    post:
+      operationId: st2auth.controllers.v1.sso:idp_callback_controller.post
+      description: Handle callback from the SSO Idp.
+      parameters:
+        - name: response
+          in: body
+          description: SSO response
+          schema:
+            type: object
+      responses:
+        '200':
+          description: SSO response valid
+        '401':
+          description: Invalid or missing credentials has been provided
+          schema:
+            $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              faultstring: Invalid or missing credentials
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+      security: []
+
   /stream/v1/stream:
     get:
       operationId: st2stream.controllers.v1.stream:stream_controller.get_all

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -4443,6 +4443,45 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
+  /auth/v1/sso:
+    get:
+      operationId: st2auth.controllers.v1.sso:sso_controller.get
+      description: Redirects to the SSO Idp login page.
+      parameters:
+        - name: referer
+          in: header
+          description: set externally to indicate real source of the request
+          type: string
+      responses:
+        '307':
+          description: Temporary redirect
+      security: []
+  /auth/v1/sso/callback:
+    post:
+      operationId: st2auth.controllers.v1.sso:idp_callback_controller.post
+      description: Handle callback from the SSO Idp.
+      parameters:
+        - name: response
+          in: body
+          description: SSO response
+          schema:
+            type: object
+      responses:
+        '200':
+          description: SSO response valid
+        '401':
+          description: Invalid or missing credentials has been provided
+          schema:
+            $ref: '#/definitions/Error'
+          examples:
+            application/json:
+              faultstring: Invalid or missing credentials
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+      security: []
+
   /stream/v1/stream:
     get:
       operationId: st2stream.controllers.v1.stream:stream_controller.get_all

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -4446,6 +4446,23 @@ paths:
   /auth/v1/sso:
     get:
       operationId: st2auth.controllers.v1.sso:sso_controller.get
+      description: Returns a flag indicating if SSO is enabled or not.
+      responses:
+        '200':
+          description: Returns a flag indicating if SSO is enabled
+          schema:
+            $ref: '#/definitions/SSOEnabledResult'
+          examples:
+            application/json:
+              enabled: false
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+      security: []
+  /auth/v1/sso/request:
+    get:
+      operationId: st2auth.controllers.v1.sso:sso_request_controller.get
       description: Redirects to the SSO Idp login page.
       parameters:
         - name: referer
@@ -5366,6 +5383,11 @@ definitions:
     type: object
     properties:
       valid:
+        type: boolean
+  SSOEnabledResult:
+    type: object
+    properties:
+      enabled:
         type: boolean
   ApiKey:
     x-api-model: st2common.models.api.auth:ApiKeyAPI

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -234,6 +234,9 @@ def _register_auth_opts():
         cfg.StrOpt('backend_kwargs', default=None),
         cfg.StrOpt('logging', default='conf/logging.conf'),
         cfg.IntOpt('token_ttl', default=86400, help='Access token ttl in seconds.'),
+        cfg.BoolOpt('sso', default=True),
+        cfg.StrOpt('sso_backend', default='noop'),
+        cfg.StrOpt('sso_backend_kwargs', default=None),
         cfg.BoolOpt('debug', default=True)
     ]
 

--- a/tools/config_gen.py
+++ b/tools/config_gen.py
@@ -50,6 +50,9 @@ AUTH_OPTIONS = {
         'api_url',
         'token_ttl',
         'service_token_ttl',
+        'sso',
+        'sso_backend',
+        'sso_backend_kwargs',
         'debug'
     ],
     'standalone': [

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ deps = virtualenv
        -r{toxinidir}/requirements.txt
        -e{toxinidir}/st2client
        -e{toxinidir}/st2common
+       -e{toxinidir}/st2auth
 commands =
     nosetests --rednose --immediate -sv st2actions/tests/unit/
     nosetests --rednose --immediate -sv st2auth/tests/unit/


### PR DESCRIPTION
Add SSO endpoints to the st2 API spec. Add API controllers for the SSO redirect and handle Idp callback. Implement scaffolding for the SSO backends. Add unit tests to capture not implemented errors, unknown exception, and also SSO verification errors in the API controllers.