### PR TITLE
Fix rbac execution_view unable to verify the pack or uid (v3.1)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,16 @@ Changelog
 in development
 --------------
 
+3.1.1 - August 14, 2019
+-----------------------
+
+Fixed
+~~~~~
+
+* Fix rbac with execution view where the rbac is unable to verify the pack or uid of the execution
+  because it was not returned from the action execution db. This would result in an internal server
+  error when trying to view the results of a single execution.
+  Contributed by Joshua Meyer (@jdmeyer3) #4758
 
 3.1.0 - June 27, 2019
 ---------------------

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -84,6 +84,9 @@ class ActionExecutionsControllerMixin(BaseRestControllerMixin):
         'action.parameters',
         'runner.runner_parameters',
         'parameters'
+        # necessary for ActionExecutionDB to determine permissions in enterprise ldap
+        'action.pack'
+        'action.uid'
     ]
 
     # A list of attributes which can be specified using ?exclude_attributes filter

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -84,9 +84,13 @@ class ActionExecutionsControllerMixin(BaseRestControllerMixin):
         'action.parameters',
         'runner.runner_parameters',
         'parameters',
-        # necessary for ActionExecutionDB to determine permissions in enterprise ldap
+
+        # Attributes below are mandatory for RBAC installations
         'action.pack',
-        'action.uid'
+        'action.uid',
+
+        # Required when rbac.permission_isolation is enabled
+        'context'
     ]
 
     # A list of attributes which can be specified using ?exclude_attributes filter

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -83,9 +83,9 @@ class ActionExecutionsControllerMixin(BaseRestControllerMixin):
     mandatory_include_fields_retrieve = [
         'action.parameters',
         'runner.runner_parameters',
-        'parameters'
+        'parameters',
         # necessary for ActionExecutionDB to determine permissions in enterprise ldap
-        'action.pack'
+        'action.pack',
         'action.uid'
     ]
 

--- a/st2tests/st2tests/api.py
+++ b/st2tests/st2tests/api.py
@@ -180,7 +180,13 @@ class APIControllerWithIncludeAndExcludeFilterTestCase(object):
     # _get_model_instance method method
     test_exact_object_count = True
 
+    # True if those tests are running with rbac enabled
+    rbac_enabled = False
+
     def test_get_all_exclude_attributes_and_include_attributes_are_mutually_exclusive(self):
+        if self.rbac_enabled:
+            self.use_user(self.users['admin'])
+
         url = self.get_all_path + '?include_attributes=id&exclude_attributes=id'
         resp = self.app.get(url, expect_errors=True)
         self.assertEqual(resp.status_int, 400)
@@ -189,6 +195,9 @@ class APIControllerWithIncludeAndExcludeFilterTestCase(object):
         self.assertRegexpMatches(resp.json['faultstring'], expected_msg)
 
     def test_get_all_invalid_exclude_and_include_parameter(self):
+        if self.rbac_enabled:
+            self.use_user(self.users['admin'])
+
         # 1. Invalid exclude_attributes field
         url = self.get_all_path + '?exclude_attributes=invalid_field'
         resp = self.app.get(url, expect_errors=True)
@@ -206,6 +215,9 @@ class APIControllerWithIncludeAndExcludeFilterTestCase(object):
         self.assertRegexpMatches(resp.json['faultstring'], expected_msg)
 
     def test_get_all_include_attributes_filter(self):
+        if self.rbac_enabled:
+            self.use_user(self.users['admin'])
+
         mandatory_include_fields = self.controller_cls.mandatory_include_fields_response
 
         # Create any resources needed by those tests (if not already created inside setUp /
@@ -249,6 +261,9 @@ class APIControllerWithIncludeAndExcludeFilterTestCase(object):
         self._delete_mock_models(object_ids)
 
     def test_get_all_exclude_attributes_filter(self):
+        if self.rbac_enabled:
+            self.use_user(self.users['admin'])
+
         # Create any resources needed by those tests (if not already created inside setUp /
         # setUpClass)
         object_ids = self._insert_mock_models()


### PR DESCRIPTION
Fix rbac with execution view where the rbac is unable to verify the pack or uid of the execution because it was not returned from the action execution db. This would result in an internal server error when trying to view the results of a single execution. This fix is cherry picked from selected commits at PR https://github.com/StackStorm/st2/pull/4759.