### PR TITLE
Fix copy/paste typo

### DIFF
--- a/contrib/core/actions/local_sudo.yaml
+++ b/contrib/core/actions/local_sudo.yaml
@@ -5,7 +5,7 @@ entry_point: ''
 name: local_sudo
 parameters:
   cmd:
-    description: Arbitrary Linux command to be executed on the remote host(s).
+    description: Arbitrary Linux command to be executed on the local host.
     required: true
     type: string
   sudo:


### PR DESCRIPTION
Presumably, `core.local_sudo` only runs commands on `localhost`, and _not_ any remote host(s). The `cmd` parameter description should reflect that.