### PR TITLE
Pack dependency management

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ Added
 * Add support for blacklisting / whitelisting hosts to the HTTP runner by adding new
   ``url_hosts_blacklist`` and ``url_hosts_whitelist`` runner attribute. (new feature)
   #4757
+* Add support for Pack dependency management to install dependency packs and find out confilct packs.
+  #4769
 
 Changed
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Added
 * Add support for blacklisting / whitelisting hosts to the HTTP runner by adding new
   ``url_hosts_blacklist`` and ``url_hosts_whitelist`` runner attribute. (new feature)
   #4757
-* Add support for Pack dependency management to install dependency packs and find out confilct packs.
+* Add support to manage dependency conflicts on pack installation.
   #4769
 
 Changed

--- a/contrib/core/actions/error.yaml
+++ b/contrib/core/actions/error.yaml
@@ -1,0 +1,24 @@
+---
+description: Action that executes the Linux echo command (to stderr) on the localhost.
+runner_type: "local-shell-cmd"
+enabled: true
+entry_point: ''
+name: error
+parameters:
+  message:
+    description: The message that the command will echo to stderr.
+    type: string
+    required: true
+  cmd:
+    description: Arbitrary Linux command to be executed on the local host.
+    required: true
+    type: string
+    default: '>&2 echo "{{message}}"'
+    immutable: true
+  kwarg_op:
+    immutable: true
+  sudo:
+    default: false
+    immutable: true
+  sudo_password:
+    immutable: true

--- a/contrib/hello_st2/pack.yaml
+++ b/contrib/hello_st2/pack.yaml
@@ -16,6 +16,12 @@ version: 0.1.0
 python_versions:
   - "2"
   - "3"
+# New in StackStorm 3.2
+# Specify a list of dependency packs to install. If the pack is in StackStorm Exchange you can use
+# the pack name, or you can specify a full Git repository URL. Optionally, you can specify the
+# exact version, tag, or branch.
+dependencies:
+  - core
 # Name of the pack author.
 author: StackStorm, Inc.
 # Email of the pack author.

--- a/contrib/packs/actions/delete.yaml
+++ b/contrib/packs/actions/delete.yaml
@@ -16,6 +16,6 @@
       immutable: true
     delete_env:
       type: "boolean"
-      description: Flag for if need to delete virtual environment.
+      description: Delete virtual environment for pack when set to True.
       default: true
       required: false

--- a/contrib/packs/actions/delete.yaml
+++ b/contrib/packs/actions/delete.yaml
@@ -14,3 +14,8 @@
       type: "string"
       default: "/opt/stackstorm/packs/"
       immutable: true
+    delete_env:
+      type: "boolean"
+      description: Flag for if need to delete virtual environment.
+      default: true
+      required: false

--- a/contrib/packs/actions/download.yaml
+++ b/contrib/packs/actions/download.yaml
@@ -27,3 +27,9 @@
       description: "True to use Python 3 binary for this pack."
       required: false
       default: false
+    dependency_list:
+      type: "array"
+      description: "Dependency list that needs to be downloaded."
+      items:
+        type: "string"
+      required: false

--- a/contrib/packs/actions/get_pack_dependencies.yaml
+++ b/contrib/packs/actions/get_pack_dependencies.yaml
@@ -1,0 +1,20 @@
+
+
+---
+  name: "get_pack_dependencies"
+  runner_type: "python-script"
+  description: "Get pack dependencies specified in pack.yaml"
+  enabled: true
+  pack: packs
+  entry_point: "pack_mgmt/get_pack_dependencies.py"
+  parameters:
+    packs_status:
+      type: object
+      description: Name of the pack in Exchange or a git repo URL and download status.
+      required: true
+      default: null
+    nested:
+      type: integer
+      description: Nested level of dependencies to prevent infinite or really long download loops.
+      required: true
+      default: 3

--- a/contrib/packs/actions/install.meta.yaml
+++ b/contrib/packs/actions/install.meta.yaml
@@ -32,7 +32,7 @@
       description: "Use Python 3 binary when creating a virtualenv for this pack."
       required: false
       default: false
-    no_deps:
+    skip_dependencies:
       type: "boolean"
       description: "Set to True to skip pack dependency installations."
       required: false

--- a/contrib/packs/actions/install.meta.yaml
+++ b/contrib/packs/actions/install.meta.yaml
@@ -1,6 +1,6 @@
 ---
   name: "install"
-  runner_type: "action-chain"
+  runner_type: "orquesta"
   description: "Installs or upgrades a pack into local content repository, either by
                 git URL or a short name matching an index entry.
                 Will download pack, load the actions, sensors and rules from the pack.
@@ -30,5 +30,10 @@
     python3:
       type: "boolean"
       description: "Use Python 3 binary when creating a virtualenv for this pack."
+      required: false
+      default: false
+    skip:
+      type: "boolean"
+      description: "Set to True to skip pack dependency installations."
       required: false
       default: false

--- a/contrib/packs/actions/install.meta.yaml
+++ b/contrib/packs/actions/install.meta.yaml
@@ -32,7 +32,7 @@
       description: "Use Python 3 binary when creating a virtualenv for this pack."
       required: false
       default: false
-    skip:
+    no_deps:
       type: "boolean"
       description: "Set to True to skip pack dependency installations."
       required: false

--- a/contrib/packs/actions/pack_mgmt/delete.py
+++ b/contrib/packs/actions/pack_mgmt/delete.py
@@ -30,7 +30,7 @@ class UninstallPackAction(Action):
         self._base_virtualenvs_path = os.path.join(cfg.CONF.system.base_path,
                                                    'virtualenvs/')
 
-    def run(self, packs, abs_repo_base):
+    def run(self, packs, abs_repo_base, delete_env=True):
         intersection = BLOCKED_PACKS & frozenset(packs)
         if len(intersection) > 0:
             names = ', '.join(list(intersection))
@@ -43,12 +43,13 @@ class UninstallPackAction(Action):
                 self.logger.debug('Deleting pack directory "%s"' % (abs_fp))
                 shutil.rmtree(abs_fp)
 
-        # 2. Delete pack virtual environment
-        for pack_name in packs:
-            pack_name = quote_unix(pack_name)
-            virtualenv_path = os.path.join(self._base_virtualenvs_path, pack_name)
+        if delete_env:
+            # 2. Delete pack virtual environment
+            for pack_name in packs:
+                pack_name = quote_unix(pack_name)
+                virtualenv_path = os.path.join(self._base_virtualenvs_path, pack_name)
 
-            if os.path.isdir(virtualenv_path):
-                self.logger.debug('Deleting virtualenv "%s" for pack "%s"' %
-                                  (virtualenv_path, pack_name))
-                shutil.rmtree(virtualenv_path)
+                if os.path.isdir(virtualenv_path):
+                    self.logger.debug('Deleting virtualenv "%s" for pack "%s"' %
+                                      (virtualenv_path, pack_name))
+                    shutil.rmtree(virtualenv_path)

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -62,18 +62,29 @@ class DownloadGitRepoAction(Action):
         if self.proxy_ca_bundle_path and not os.environ.get('proxy_ca_bundle_path', None):
             os.environ['no_proxy'] = self.no_proxy
 
-    def run(self, packs, abs_repo_base, verifyssl=True, force=False, python3=False):
+    def run(self, packs, abs_repo_base, verifyssl=True, force=False, python3=False,
+            dependency_list=None):
         result = {}
+        pack_url = None
 
-        for pack in packs:
-            pack_result = download_pack(pack=pack, abs_repo_base=abs_repo_base,
-                                        verify_ssl=verifyssl, force=force,
-                                        proxy_config=self.proxy_config,
-                                        force_permissions=True,
-                                        use_python3=python3,
-                                        logger=self.logger)
-            pack_url, pack_ref, pack_result = pack_result
-            result[pack_ref] = pack_result
+        if dependency_list:
+            for pack_dependency in dependency_list:
+                pack_result = download_pack(pack=pack_dependency, abs_repo_base=abs_repo_base,
+                                            verify_ssl=verifyssl, force=force,
+                                            proxy_config=self.proxy_config, force_permissions=True,
+                                            use_python3=python3, logger=self.logger)
+                pack_url, pack_ref, pack_result = pack_result
+                result[pack_ref] = pack_result
+        else:
+            for pack in packs:
+                pack_result = download_pack(pack=pack, abs_repo_base=abs_repo_base,
+                                            verify_ssl=verifyssl, force=force,
+                                            proxy_config=self.proxy_config,
+                                            force_permissions=True,
+                                            use_python3=python3,
+                                            logger=self.logger)
+                pack_url, pack_ref, pack_result = pack_result
+                result[pack_ref] = pack_result
 
         return self._validate_result(result=result, repo_url=pack_url)
 

--- a/contrib/packs/actions/pack_mgmt/get_pack_dependencies.py
+++ b/contrib/packs/actions/pack_mgmt/get_pack_dependencies.py
@@ -108,9 +108,11 @@ def get_pack_version(pack=None):
     pack_path = get_pack_base_path(pack)
     try:
         pack_metadata = get_pack_metadata(pack_dir=pack_path)
-        return pack_metadata.get('version', None)
+        result = pack_metadata.get('version', None)
     except Exception:
-        return None
+        result = None
+    finally:
+        return result
 
 
 def get_dependency_list(pack=None):
@@ -118,7 +120,9 @@ def get_dependency_list(pack=None):
 
     try:
         pack_metadata = get_pack_metadata(pack_dir=pack_path)
-        return pack_metadata.get('dependencies', None)
+        result = pack_metadata.get('dependencies', None)
     except Exception:
         print('Could not open pack.yaml at location %s' % pack_path)
-        return None
+        result = None
+    finally:
+        return result

--- a/contrib/packs/actions/pack_mgmt/get_pack_dependencies.py
+++ b/contrib/packs/actions/pack_mgmt/get_pack_dependencies.py
@@ -1,0 +1,133 @@
+# Copyright 2019 Extreme Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import six
+
+from st2common.constants.pack import PACK_VERSION_SEPARATOR
+from st2common.content.utils import get_pack_base_path
+from st2common.runners.base_action import Action
+from st2common.util.pack import get_pack_metadata
+
+STACKSTORM_EXCHANGE_PACK = 'StackStorm-Exchange/stackstorm-'
+LOCAL_FILE_PREFIX = 'file://'
+
+
+class GetPackDependencies(Action):
+    def __init__(self, config=None, action_service=None):
+        self.dependency_list = []
+        self.conflict_list = []
+
+    def run(self, packs_status, nested):
+        """
+        :param packs_status: Name of the pack in Exchange or a git repo URL and download status.
+        :type: packs_status: ``dict``
+
+        :param nested: Nested level of dependencies to prevent infinite or really
+        long download loops.
+        :type nested: ``integer``
+        """
+        result = {}
+
+        if not packs_status or nested == 0:
+            return result
+
+        for pack, status in six.iteritems(packs_status):
+            if 'success' not in status.lower():
+                continue
+
+            dependency_packs = get_dependency_list(pack)
+            if not dependency_packs:
+                continue
+
+            for dependency_pack in dependency_packs:
+                pack_and_version = dependency_pack.split(PACK_VERSION_SEPARATOR)
+                name_or_url = pack_and_version[0]
+                pack_version = pack_and_version[1] if len(pack_and_version) > 1 else None
+
+                if name_or_url.startswith(LOCAL_FILE_PREFIX):
+                    self.get_local_pack_dependencies(name_or_url, pack_version, dependency_pack)
+                elif (len(name_or_url.split('/')) == 1 and STACKSTORM_EXCHANGE_PACK not in
+                      name_or_url) or STACKSTORM_EXCHANGE_PACK in name_or_url:
+                    self.get_exchange_pack_dependencies(name_or_url, pack_version, dependency_pack)
+                else:
+                    self.get_none_exchange_pack_dependencies(name_or_url, pack_version,
+                                                             dependency_pack)
+
+        result['dependency_list'] = self.dependency_list
+        result['conflict_list'] = self.conflict_list
+        result['nested'] = nested - 1
+
+        return result
+
+    # For StackStorm Exchange packs. E.g.
+    # email
+    # https://github.com/StackStorm-Exchange/stackstorm-email
+    # https://github.com/StackStorm-Exchange/stackstorm-email.git
+    def get_exchange_pack_dependencies(self, name_or_url, pack_version, dependency_pack):
+        if len(name_or_url.split('/')) == 1:
+            pack_name = name_or_url
+        else:
+            name_or_git = name_or_url.split(STACKSTORM_EXCHANGE_PACK)[-1]
+            pack_name = name_or_git if '.git' not in name_or_git else name_or_git.split('.')[0]
+
+        existing_pack_version = get_pack_version(pack_name)
+        self.check_conflict(dependency_pack, pack_version, existing_pack_version)
+
+    # For None StackStorm Exchange packs. E.g.
+    # https://github.com/EncoreTechnologies/stackstorm-freeipa.git
+    # https://github.com/EncoreTechnologies/stackstorm-freeipa
+    # https://github.com/EncoreTechnologies/pack.git
+    def get_none_exchange_pack_dependencies(self, name_or_url, pack_version, dependency_pack):
+        name_or_git = name_or_url.split('/')[-1]
+        name = name_or_git if '.git' not in name_or_git else name_or_git.split('.')[0]
+        pack_name = name.split('-')[-1] if "stackstorm-" in name else name
+
+        existing_pack_version = get_pack_version(pack_name)
+        self.check_conflict(dependency_pack, pack_version, existing_pack_version)
+
+    # For local file. E.g
+    # file:///opt/stackstorm/st2/lib/python3.6/site-packages/st2tests/fixtures/packs/dummy_pack_3
+    def get_local_pack_dependencies(self, name_or_url, pack_version, dependency_pack):
+        pack_name = name_or_url.split("/")[-1]
+
+        existing_pack_version = get_pack_version(pack_name)
+        self.check_conflict(dependency_pack, pack_version, existing_pack_version)
+
+    def check_conflict(self, pack, version, existing_version):
+        if existing_version:
+            existing_version = 'v' + existing_version
+            if version and existing_version != version and pack not in self.conflict_list:
+                self.conflict_list.append(pack)
+        elif pack not in self.dependency_list:
+            self.dependency_list.append(pack)
+
+
+def get_pack_version(pack=None):
+    pack_path = get_pack_base_path(pack)
+    try:
+        pack_metadata = get_pack_metadata(pack_dir=pack_path)
+        return pack_metadata.get('version', None)
+    except Exception:
+        return None
+
+
+def get_dependency_list(pack=None):
+    pack_path = get_pack_base_path(pack)
+
+    try:
+        pack_metadata = get_pack_metadata(pack_dir=pack_path)
+        return pack_metadata.get('dependencies', None)
+    except Exception:
+        print ('Could not open pack.yaml at location %s' % pack_path)
+        return None

--- a/contrib/packs/actions/pack_mgmt/get_pack_dependencies.py
+++ b/contrib/packs/actions/pack_mgmt/get_pack_dependencies.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import print_function
 
 import six
 
@@ -119,5 +120,5 @@ def get_dependency_list(pack=None):
         pack_metadata = get_pack_metadata(pack_dir=pack_path)
         return pack_metadata.get('dependencies', None)
     except Exception:
-        print ('Could not open pack.yaml at location %s' % pack_path)
+        print('Could not open pack.yaml at location %s' % pack_path)
         return None

--- a/contrib/packs/actions/pack_mgmt/get_pack_dependencies.py
+++ b/contrib/packs/actions/pack_mgmt/get_pack_dependencies.py
@@ -65,7 +65,10 @@ class GetPackDependencies(Action):
                     existing_pack_version = get_pack_version(pack_name.split('stackstorm-')[-1])
 
                 if existing_pack_version:
-                    existing_pack_version = 'v' + existing_pack_version
+                    if not existing_pack_version.startswith('v'):
+                        existing_pack_version = 'v' + existing_pack_version
+                    if not pack_version.startswith('v'):
+                        pack_version = 'v' + pack_version
                     if pack_version and existing_pack_version != pack_version \
                             and dep_pack not in conflict_list:
                         conflict_list.append(dep_pack)

--- a/contrib/packs/actions/pack_mgmt/get_pack_dependencies.py
+++ b/contrib/packs/actions/pack_mgmt/get_pack_dependencies.py
@@ -65,9 +65,9 @@ class GetPackDependencies(Action):
                     existing_pack_version = get_pack_version(pack_name.split('stackstorm-')[-1])
 
                 if existing_pack_version:
-                    if not existing_pack_version.startswith('v'):
+                    if existing_pack_version and not existing_pack_version.startswith('v'):
                         existing_pack_version = 'v' + existing_pack_version
-                    if not pack_version.startswith('v'):
+                    if pack_version and not pack_version.startswith('v'):
                         pack_version = 'v' + pack_version
                     if pack_version and existing_pack_version != pack_version \
                             and dep_pack not in conflict_list:

--- a/contrib/packs/actions/pack_mgmt/register.py
+++ b/contrib/packs/actions/pack_mgmt/register.py
@@ -72,6 +72,7 @@ class St2RegisterAction(Action):
             'types': types
         }
 
+        packs.reverse()
         if packs:
             method_kwargs['packs'] = packs
 

--- a/contrib/packs/actions/pack_mgmt/virtualenv_setup_prerun.py
+++ b/contrib/packs/actions/pack_mgmt/virtualenv_setup_prerun.py
@@ -18,13 +18,22 @@ from st2common.runners.base_action import Action
 
 
 class PacksTransformationAction(Action):
-    def run(self, packs_status):
+    def run(self, packs_status, packs_list=None):
         """
         :param packs_status: Result from packs.download action.
         :type: packs_status: ``dict``
+
+        :param packs_list: Names of the pack in Exchange, a git repo URL or local file system.
+        :type: packs_list: ``list``
         """
+        if not packs_list:
+            packs_list = []
+
         packs = []
         for pack_name, status in six.iteritems(packs_status):
             if 'success' in status.lower():
                 packs.append(pack_name)
-        return packs
+
+        packs_list.extend(packs)
+
+        return packs_list

--- a/contrib/packs/actions/virtualenv_prerun.yaml
+++ b/contrib/packs/actions/virtualenv_prerun.yaml
@@ -7,3 +7,10 @@
   parameters:
     packs_status:
       type: "object"
+    packs_list:
+      type: array
+      items:
+        type: string
+      required: false
+      default: null
+      description: Names of the pack in Exchange, a git repo URL or local file system.

--- a/contrib/packs/actions/workflows/install.yaml
+++ b/contrib/packs/actions/workflows/install.yaml
@@ -8,7 +8,7 @@ input:
   - env
   - force
   - python3
-  - no_deps
+  - skip_dependencies
 
 vars:
   - packs_list: null
@@ -47,9 +47,9 @@ tasks:
   find_next_action:
     action: core.noop
     next:
-      - when: <% ctx().no_deps or ctx().nested = 0 %>
+      - when: <% ctx().skip_dependencies or ctx().nested = 0 %>
         do: install_pack_requirements
-      - when: <% ctx().nested > 0 and not ctx().no_deps %>
+      - when: <% ctx().nested > 0 and not ctx().skip_dependencies %>
         do: get_pack_dependencies
 
   get_pack_dependencies:

--- a/contrib/packs/actions/workflows/install.yaml
+++ b/contrib/packs/actions/workflows/install.yaml
@@ -47,9 +47,7 @@ tasks:
   find_next_action:
     action: core.noop
     next:
-      - when: <% ctx().skip %>
-        do: install_pack_requirements
-      - when: <% ctx().nested = 0 and not ctx().skip %>
+      - when: <% ctx().skip or ctx().nested = 0 %>
         do: install_pack_requirements
       - when: <% ctx().nested > 0 and not ctx().skip %>
         do: get_pack_dependencies

--- a/contrib/packs/actions/workflows/install.yaml
+++ b/contrib/packs/actions/workflows/install.yaml
@@ -75,7 +75,9 @@ tasks:
     action: packs.delete
     input:
       packs: <% ctx().packs_list %>
-      delete_env: <% false %>
+      delete_env: false
+    next:
+      - do: fail
 
   install_pack_requirements:
     action: packs.setup_virtualenv

--- a/contrib/packs/actions/workflows/install.yaml
+++ b/contrib/packs/actions/workflows/install.yaml
@@ -8,13 +8,13 @@ input:
   - env
   - force
   - python3
-  - skip
+  - no_deps
 
 vars:
   - packs_list: null
   - dependency_list: null
   - conflict_list: null
-  - nested: 3
+  - nested: 10
 
 tasks:
   init_task:
@@ -47,9 +47,9 @@ tasks:
   find_next_action:
     action: core.noop
     next:
-      - when: <% ctx().skip or ctx().nested = 0 %>
+      - when: <% ctx().no_deps or ctx().nested = 0 %>
         do: install_pack_requirements
-      - when: <% ctx().nested > 0 and not ctx().skip %>
+      - when: <% ctx().nested > 0 and not ctx().no_deps %>
         do: get_pack_dependencies
 
   get_pack_dependencies:
@@ -69,13 +69,13 @@ tasks:
     action: core.noop
     next:
       - when: <% ctx().conflict_list %>
-        do: stop_installation_and_cleanup
+        do: stop_installation_and_cleanup_because_conflict
       - when:  <% not ctx().conflict_list and ctx().dependency_list %>
         do: download_pack
       - when: <% not ctx().conflict_list and not ctx().dependency_list %>
         do: install_pack_requirements
 
-  stop_installation_and_cleanup:
+  stop_installation_and_cleanup_because_conflict:
     action: packs.delete
     input:
       packs: <% ctx().packs_list %>

--- a/contrib/packs/actions/workflows/install.yaml
+++ b/contrib/packs/actions/workflows/install.yaml
@@ -39,17 +39,13 @@ tasks:
       packs_status: <% task(download_pack).result.result %>
       packs_list: <% ctx().packs_list %>
     next:
-      - when: <% succeeded() %>
+      - when: <% succeeded() and (ctx().skip_dependencies or ctx().nested = 0) %>
         publish:
           - packs_list: <% task(make_a_prerun).result.result %>
-        do: find_next_action
-
-  find_next_action:
-    action: core.noop
-    next:
-      - when: <% ctx().skip_dependencies or ctx().nested = 0 %>
         do: install_pack_requirements
-      - when: <% ctx().nested > 0 and not ctx().skip_dependencies %>
+      - when: <% succeeded() and (ctx().nested > 0 and not ctx().skip_dependencies) %>
+        publish:
+          - packs_list: <% task(make_a_prerun).result.result %>
         do: get_pack_dependencies
 
   get_pack_dependencies:

--- a/contrib/packs/actions/workflows/install.yaml
+++ b/contrib/packs/actions/workflows/install.yaml
@@ -54,23 +54,21 @@ tasks:
       packs_status: <% task(download_pack).result.result %>
       nested: <% ctx().nested%>
     next:
-      - when: <% succeeded() and result().result.conflict_list %>
+      - when: <% succeeded() %>
         publish:
           - dependency_list: <% result().result.dependency_list %>
           - conflict_list: <% result().result.conflict_list %>
           - nested: <% result().result.nested %>
+        do: check_dependency_and_conflict_list
+
+  check_dependency_and_conflict_list:
+    action: core.noop
+    next:
+      - when: <% ctx().conflict_list %>
         do: stop_installation_and_cleanup_because_conflict
-      - when: <% succeeded() and ctx().dependency_list and not ctx().conflict_list %>
-        publish:
-          - dependency_list: <% result().result.dependency_list %>
-          - conflict_list: <% result().result.conflict_list %>
-          - nested: <% result().result.nested %>
+      - when: <% not ctx().conflict_list and ctx().dependency_list %>
         do: download_pack
-      - when: <% succeeded() and not ctx().conflict_list and not ctx().dependency_list %>
-        publish:
-          - dependency_list: <% result().result.dependency_list %>
-          - conflict_list: <% result().result.conflict_list %>
-          - nested: <% result().result.nested %>
+      - when: <% not ctx().conflict_list and not ctx().dependency_list %>
         do: install_pack_requirements
 
   stop_installation_and_cleanup_because_conflict:

--- a/contrib/packs/actions/workflows/install.yaml
+++ b/contrib/packs/actions/workflows/install.yaml
@@ -54,21 +54,23 @@ tasks:
       packs_status: <% task(download_pack).result.result %>
       nested: <% ctx().nested%>
     next:
-      - when: <% succeeded() %>
+      - when: <% succeeded() and result().result.conflict_list %>
         publish:
-          - dependency_list: <% task(get_pack_dependencies).result.result.dependency_list %>
-          - conflict_list: <% task(get_pack_dependencies).result.result.conflict_list %>
-          - nested: <% task(get_pack_dependencies).result.result.nested %>
-        do: check_dependency_and_conflict_list
-
-  check_dependency_and_conflict_list:
-    action: core.noop
-    next:
-      - when: <% ctx().conflict_list %>
+          - dependency_list: <% result().result.dependency_list %>
+          - conflict_list: <% result().result.conflict_list %>
+          - nested: <% result().result.nested %>
         do: stop_installation_and_cleanup_because_conflict
-      - when:  <% not ctx().conflict_list and ctx().dependency_list %>
+      - when: <% succeeded() and ctx().dependency_list and not ctx().conflict_list %>
+        publish:
+          - dependency_list: <% result().result.dependency_list %>
+          - conflict_list: <% result().result.conflict_list %>
+          - nested: <% result().result.nested %>
         do: download_pack
-      - when: <% not ctx().conflict_list and not ctx().dependency_list %>
+      - when: <% succeeded() and not ctx().conflict_list and not ctx().dependency_list %>
+        publish:
+          - dependency_list: <% result().result.dependency_list %>
+          - conflict_list: <% result().result.conflict_list %>
+          - nested: <% result().result.nested %>
         do: install_pack_requirements
 
   stop_installation_and_cleanup_because_conflict:

--- a/contrib/packs/actions/workflows/install.yaml
+++ b/contrib/packs/actions/workflows/install.yaml
@@ -15,6 +15,7 @@ vars:
   - dependency_list: null
   - conflict_list: null
   - nested: 10
+  - message: ""
 
 tasks:
   init_task:
@@ -77,7 +78,18 @@ tasks:
       packs: <% ctx().packs_list %>
       delete_env: false
     next:
-      - do: fail
+      - do: echo_pack_conflicts
+
+  echo_pack_conflicts:
+    action: core.noop
+    next:
+      - publish:
+          - message: >-
+              Unable to install packs due to conflicts. Review the
+              conflict_list and check the versions of corresponding installed
+              packs. You can also run the `st2 pack install` command with the
+              `--skip-dependencies` flag to skip installing dependent packs.
+        do: fail
 
   install_pack_requirements:
     action: packs.setup_virtualenv
@@ -94,6 +106,11 @@ tasks:
     input:
         register: <% ctx().register %>
         packs: <% ctx().packs_list %>
+    next:
+      - publish:
+          - message: Successfully installed packs
 
 output:
   - packs_list: <% ctx().packs_list %>
+  - message: <% ctx().message %>
+  - conflict_list: <% ctx().conflict_list %>

--- a/contrib/packs/actions/workflows/install.yaml
+++ b/contrib/packs/actions/workflows/install.yaml
@@ -1,32 +1,103 @@
----
-  chain:
-    -
-      name: "download pack"
-      ref: "packs.download"
-      parameters:
-        packs: "{{packs}}"
-        force: "{{force}}"
-        python3: "{{python3}}"
-      on-success: "make a prerun"
-    -
-      name: "make a prerun"
-      ref: "packs.virtualenv_prerun"
-      parameters:
-        packs_status: "{{ __results['download pack'].result }}"
-      on-success: "install pack dependencies"
-    -
-      name: "install pack dependencies"
-      ref: "packs.setup_virtualenv"
-      parameters:
-        packs: "{{ __results['make a prerun'].result }}"
-        env: "{{env}}"
-        python3: "{{python3}}"
-      on-success: "register pack"
-    -
-      name: "register pack"
-      ref: "packs.load"
-      parameters:
-        register: "{{register}}"
-        packs: "{{ __results['make a prerun'].result }}"
+version: 1.0
 
-  default: "download pack"
+description: A orquesta workflow to install packs.
+
+input:
+  - packs
+  - register
+  - env
+  - force
+  - python3
+  - skip
+
+vars:
+  - packs_list: null
+  - dependency_list: null
+  - conflict_list: null
+  - nested: 3
+
+tasks:
+  init_task:
+    action: core.noop
+    next:
+      - do: download_pack
+
+  download_pack:
+    action: packs.download
+    input:
+      packs: <% ctx().packs %>
+      force: <% ctx().force %>
+      python3: <% ctx().python3 %>
+      dependency_list: <% ctx().dependency_list %>
+    next:
+      - when: <% succeeded() %>
+        do: make_a_prerun
+
+  make_a_prerun:
+    action: packs.virtualenv_prerun
+    input:
+      packs_status: <% task(download_pack).result.result %>
+      packs_list: <% ctx().packs_list %>
+    next:
+      - when: <% succeeded() %>
+        publish:
+          - packs_list: <% task(make_a_prerun).result.result %>
+        do: find_next_action
+
+  find_next_action:
+    action: core.noop
+    next:
+      - when: <% ctx().skip %>
+        do: install_pack_requirements
+      - when: <% ctx().nested = 0 and not ctx().skip %>
+        do: install_pack_requirements
+      - when: <% ctx().nested > 0 and not ctx().skip %>
+        do: get_pack_dependencies
+
+  get_pack_dependencies:
+    action: packs.get_pack_dependencies
+    input:
+      packs_status: <% task(download_pack).result.result %>
+      nested: <% ctx().nested%>
+    next:
+      - when: <% succeeded() %>
+        publish:
+          - dependency_list: <% task(get_pack_dependencies).result.result.dependency_list %>
+          - conflict_list: <% task(get_pack_dependencies).result.result.conflict_list %>
+          - nested: <% task(get_pack_dependencies).result.result.nested %>
+        do: check_dependency_and_conflict_list
+
+  check_dependency_and_conflict_list:
+    action: core.noop
+    next:
+      - when: <% ctx().conflict_list %>
+        do: stop_installation_and_cleanup
+      - when:  <% not ctx().conflict_list and ctx().dependency_list %>
+        do: download_pack
+      - when: <% not ctx().conflict_list and not ctx().dependency_list %>
+        do: install_pack_requirements
+
+  stop_installation_and_cleanup:
+    action: packs.delete
+    input:
+      packs: <% ctx().packs_list %>
+      delete_env: <% false %>
+
+  install_pack_requirements:
+    action: packs.setup_virtualenv
+    input:
+      packs: <% ctx().packs_list %>
+      env: <% ctx().env %>
+      python3: <% ctx().python3 %>
+    next:
+      - when: <% succeeded() %>
+        do: register_pack
+
+  register_pack:
+    action: packs.load
+    input:
+        register: <% ctx().register %>
+        packs: <% ctx().packs_list %>
+
+output:
+  - packs_list: <% ctx().packs_list %>

--- a/contrib/packs/pack.yaml
+++ b/contrib/packs/pack.yaml
@@ -1,7 +1,7 @@
 ---
 name : packs
 description : Pack management functionality.
-version : 1.0.1
+version : 2.0.0
 python_versions:
   - "2"
   - "3"

--- a/contrib/packs/tests/test_get_pack_dependencies.py
+++ b/contrib/packs/tests/test_get_pack_dependencies.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python
+
+# Copyright 2019 Extreme Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+
+from st2tests.base import BaseActionTestCase
+
+from pack_mgmt.get_pack_dependencies import GetPackDependencies
+
+UNINSTALLED_PACK = 'uninstalled_pack'
+UNINSTALLED_PACK_URL = 'https://github.com/StackStorm-Exchange/stackstorm-' + UNINSTALLED_PACK\
+                       + '.git'
+UNINSTALLED_PRIVATE_PACK_URL = 'https://github.com/privaterepo/' + UNINSTALLED_PACK + '.git=v4.5.0'
+UNINSTALLED_LOCAL_PACK = 'file:///opt/pack_dir/' + UNINSTALLED_PACK + '=v4.5.0'
+
+DOWNLOADED_OR_INSTALLED_PACK_METAdATA = {
+    # No dependencies.
+    "no_dependencies": {
+        "version": "0.4.0",
+        "name": "no_dependencies",
+        "repo_url": "https://github.com/StackStorm-Exchange/stackstorm-no_dependencies",
+        "author": "st2-dev",
+        "keywords": ["some", "search", "another", "terms"],
+        "email": "info@stackstorm.com",
+        "description": "st2 pack to test package management pipeline",
+    },
+    # One uninstalled and one installed dependency packs.
+    "test2": {
+        "version": "0.5.0",
+        "name": "test2",
+        "repo_url": "https://github.com/StackStorm-Exchange/stackstorm-test2",
+        "author": "stanley",
+        "keywords": ["some", "special", "terms"],
+        "email": "info@stackstorm.com",
+        "description": "another st2 pack to test package management pipeline",
+        "dependencies": [
+            UNINSTALLED_PACK, "test3"
+        ]
+    },
+    # One uninstalled, one installed and one conflict dependency packs.
+    "test3": {
+        "version": "0.6.0",
+        "stackstorm_version": ">=1.6.0, <2.2.0",
+        "name": "test3",
+        "repo_url": "https://github.com/StackStorm-Exchange/stackstorm-test3",
+        "author": "stanley",
+        "keywords": ["some", "special", "terms"],
+        "email": "info@stackstorm.com",
+        "description": "another st2 pack to test package management pipeline",
+        "dependencies": [
+            UNINSTALLED_PACK, "test2=v0.4.0", "test4=v0.7.0"
+        ]
+    },
+    # One uninstalled, one installed and one conflict with StackStorm Exchange urls.
+    "test4": {
+        "version": "0.7.0",
+        "stackstorm_version": ">=1.6.0, <2.2.0",
+        "name": "test4",
+        "repo_url": "https://github.com/StackStorm-Exchange/stackstorm-test4",
+        "author": "stanley",
+        "keywords": ["some", "special", "terms"],
+        "email": "info@stackstorm.com",
+        "description": "another st2 pack to test package management pipeline",
+        "dependencies": [
+            UNINSTALLED_PACK_URL,
+            "https://github.com/StackStorm-Exchange/stackstorm-test2=v0.4.0",
+            "https://github.com/StackStorm-Exchange/stackstorm-test5.git"
+        ]
+    },
+    # One uninstalled, one installed and one conflict private urls.
+    "test5": {
+        "version": "0.8.0",
+        "stackstorm_version": ">=1.6.0, <2.2.0",
+        "name": "test3",
+        "repo_url": "https://github.com/StackStorm-Exchange/stackstorm-test5",
+        "author": "stanley",
+        "keywords": ["some", "special", "terms"],
+        "email": "info@stackstorm.com",
+        "description": "another st2 pack to test package management pipeline",
+        "dependencies": [
+            UNINSTALLED_PRIVATE_PACK_URL,
+            "https://github.com/privaterepo/test4.git=v0.5.0",
+            "https://github.com/privaterepo/test6.git"
+        ]
+    },
+    # One uninstalled, one installed and one conflict local files.
+    "test6": {
+        "version": "0.9.0",
+        "stackstorm_version": ">=1.6.0, <2.2.0",
+        "name": "test3",
+        "repo_url": "https://github.com/StackStorm-Exchange/stackstorm-test6",
+        "author": "stanley",
+        "keywords": ["some", "special", "terms"],
+        "email": "info@stackstorm.com",
+        "description": "another st2 pack to test package management pipeline",
+        "dependencies": [
+            UNINSTALLED_LOCAL_PACK,
+            "file:///opt/pack_dir/test2=v0.7.0",
+            "file:///opt/some_dir/test5=v0.8.0"
+        ]
+    }
+}
+
+
+def mock_get_dependency_list(pack):
+    """
+    Mock get_dependency_list function which return dependencies list
+    """
+    dependencies = None
+
+    if pack in DOWNLOADED_OR_INSTALLED_PACK_METAdATA:
+        metadata = DOWNLOADED_OR_INSTALLED_PACK_METAdATA[pack]
+        dependencies = metadata.get('dependencies', None)
+
+    return dependencies
+
+
+def mock_get_pack_version(pack):
+    """
+    Mock get_pack_version function which return mocked pack version
+    """
+    version = None
+
+    if pack in DOWNLOADED_OR_INSTALLED_PACK_METAdATA:
+        metadata = DOWNLOADED_OR_INSTALLED_PACK_METAdATA[pack]
+        version = metadata.get('version', None)
+
+    return version
+
+
+@mock.patch('pack_mgmt.get_pack_dependencies.get_dependency_list', mock_get_dependency_list)
+@mock.patch('pack_mgmt.get_pack_dependencies.get_pack_version', mock_get_pack_version)
+class GetPackDependenciesTestCase(BaseActionTestCase):
+    action_cls = GetPackDependencies
+
+    def setUp(self):
+        super(GetPackDependenciesTestCase, self).setUp()
+
+    def test_run_get_pack_dependencies_with_nested_zero_value(self):
+        action = self.get_action_instance()
+        packs_status = {"test": "Success."}
+        nested = 0
+
+        result = action.run(packs_status=packs_status, nested=nested)
+        self.assertEqual(result, {})
+
+    def test_run_get_pack_dependencies_with_empty_packs_status(self):
+        action = self.get_action_instance()
+        packs_status = None
+        nested = 3
+
+        result = action.run(packs_status=packs_status, nested=nested)
+        self.assertEqual(result, {})
+
+    def test_run_get_pack_dependencies_with_failed_packs_status(self):
+        action = self.get_action_instance()
+        packs_status = {"test3": "Failed."}
+        nested = 2
+
+        result = action.run(packs_status=packs_status, nested=nested)
+        self.assertEqual(result['dependency_list'], [])
+        self.assertEqual(result['conflict_list'], [])
+        self.assertEqual(result['nested'], nested - 1)
+
+    def test_run_get_pack_dependencies_with_failed_and_succeeded_packs_status(self):
+        action = self.get_action_instance()
+        packs_status = {"test3": "Failed.", "test2": "Success."}
+        nested = 2
+
+        result = action.run(packs_status=packs_status, nested=nested)
+        self.assertEqual(result['dependency_list'], [UNINSTALLED_PACK])
+        self.assertEqual(result['conflict_list'], [])
+        self.assertEqual(result['nested'], nested - 1)
+
+    def test_run_get_pack_dependencies_with_no_dependency(self):
+        action = self.get_action_instance()
+        packs_status = {"no_dependencies": "Success."}
+        nested = 3
+
+        result = action.run(packs_status=packs_status, nested=nested)
+        self.assertEqual(result['dependency_list'], [])
+        self.assertEqual(result['conflict_list'], [])
+        self.assertEqual(result['nested'], nested - 1)
+
+    def test_run_get_pack_dependencies(self):
+        action = self.get_action_instance()
+        packs_status = {"test3": "Success.", "test2": "Success."}
+        nested = 1
+
+        result = action.run(packs_status=packs_status, nested=nested)
+        self.assertEqual(result['dependency_list'], [UNINSTALLED_PACK])
+        self.assertEqual(result['conflict_list'], ['test2=v0.4.0'])
+        self.assertEqual(result['nested'], nested - 1)
+
+    def test_run_get_pack_dependencies_with_stackstorm_exchange_url(self):
+        action = self.get_action_instance()
+        packs_status = {"test4": "Success."}
+        nested = 3
+
+        result = action.run(packs_status=packs_status, nested=nested)
+        self.assertEqual(result['dependency_list'], [UNINSTALLED_PACK_URL])
+        self.assertEqual(result['conflict_list'],
+                         ['https://github.com/StackStorm-Exchange/stackstorm-test2=v0.4.0'])
+        self.assertEqual(result['nested'], nested - 1)
+
+    def test_run_get_pack_dependencies_with_private_url(self):
+        action = self.get_action_instance()
+        packs_status = {"test5": "Success."}
+        nested = 3
+
+        result = action.run(packs_status=packs_status, nested=nested)
+        self.assertEqual(result['dependency_list'], [UNINSTALLED_PRIVATE_PACK_URL])
+        self.assertEqual(result['conflict_list'],
+                         ['https://github.com/privaterepo/test4.git=v0.5.0'])
+        self.assertEqual(result['nested'], nested - 1)
+
+    def test_run_get_pack_dependencies_with_local_file(self):
+        action = self.get_action_instance()
+        packs_status = {"test6": "Success."}
+        nested = 3
+
+        result = action.run(packs_status=packs_status, nested=nested)
+        self.assertEqual(result['dependency_list'], [UNINSTALLED_LOCAL_PACK])
+        self.assertEqual(result['conflict_list'], ["file:///opt/pack_dir/test2=v0.7.0"])
+        self.assertEqual(result['nested'], nested - 1)

--- a/contrib/packs/tests/test_virtualenv_setup_prerun.py
+++ b/contrib/packs/tests/test_virtualenv_setup_prerun.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+# Copyright 2019 Extreme Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from st2tests.base import BaseActionTestCase
+
+from pack_mgmt.virtualenv_setup_prerun import PacksTransformationAction
+
+
+class VirtualenvSetUpPreRunTestCase(BaseActionTestCase):
+    action_cls = PacksTransformationAction
+
+    def setUp(self):
+        super(VirtualenvSetUpPreRunTestCase, self).setUp()
+
+    def test_run_with_pack_list(self):
+        action = self.get_action_instance()
+        result = action.run(packs_status={'test1': 'Success.', 'test2': 'Success.'},
+                            packs_list=['test3', 'test4'])
+
+        self.assertEqual(result, ['test3', 'test4', 'test1', 'test2'])
+
+    def test_run_with_none_pack_list(self):
+        action = self.get_action_instance()
+        result = action.run(packs_status={'test1': 'Success.', 'test2': 'Success.'},
+                            packs_list=None)
+
+        self.assertEqual(result, ['test1', 'test2'])
+
+    def test_run_with_failed_status(self):
+        action = self.get_action_instance()
+        result = action.run(packs_status={'test1': 'Failed.', 'test2': 'Success.'},
+                            packs_list=['test3', 'test4'])
+
+        self.assertEqual(result, ['test3', 'test4', 'test2'])

--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -103,6 +103,9 @@ class PackInstallController(ActionExecutionsControllerMixin):
         if pack_install_request.force:
             parameters['force'] = True
 
+        if pack_install_request.skip:
+            parameters['skip'] = True
+
         if not requester_user:
             requester_user = UserDB(cfg.CONF.system_user.user)
 

--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -103,8 +103,8 @@ class PackInstallController(ActionExecutionsControllerMixin):
         if pack_install_request.force:
             parameters['force'] = True
 
-        if pack_install_request.no_deps:
-            parameters['no_deps'] = True
+        if pack_install_request.skip_dependencies:
+            parameters['skip_dependencies'] = True
 
         if not requester_user:
             requester_user = UserDB(cfg.CONF.system_user.user)

--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -103,8 +103,8 @@ class PackInstallController(ActionExecutionsControllerMixin):
         if pack_install_request.force:
             parameters['force'] = True
 
-        if pack_install_request.skip:
-            parameters['skip'] = True
+        if pack_install_request.no_deps:
+            parameters['no_deps'] = True
 
         if not requester_user:
             requester_user = UserDB(cfg.CONF.system_user.user)

--- a/st2api/tests/unit/controllers/v1/test_packs.py
+++ b/st2api/tests/unit/controllers/v1/test_packs.py
@@ -178,9 +178,9 @@ class PacksControllerTestCase(FunctionalTest,
         self.assertEqual(resp.json, {'execution_id': '123'})
 
     @mock.patch.object(ActionExecutionsControllerMixin, '_handle_schedule_execution')
-    def test_install_with_skip_parameter(self, _handle_schedule_execution):
+    def test_install_with_no_deps_parameter(self, _handle_schedule_execution):
         _handle_schedule_execution.return_value = Response(json={'id': '123'})
-        payload = {'packs': ['some'], 'skip': True}
+        payload = {'packs': ['some'], 'no_deps': True}
 
         resp = self.app.post_json('/v1/packs/install', payload)
 

--- a/st2api/tests/unit/controllers/v1/test_packs.py
+++ b/st2api/tests/unit/controllers/v1/test_packs.py
@@ -178,9 +178,9 @@ class PacksControllerTestCase(FunctionalTest,
         self.assertEqual(resp.json, {'execution_id': '123'})
 
     @mock.patch.object(ActionExecutionsControllerMixin, '_handle_schedule_execution')
-    def test_install_with_no_deps_parameter(self, _handle_schedule_execution):
+    def test_install_with_skip_dependencies_parameter(self, _handle_schedule_execution):
         _handle_schedule_execution.return_value = Response(json={'id': '123'})
-        payload = {'packs': ['some'], 'no_deps': True}
+        payload = {'packs': ['some'], 'skip_dependencies': True}
 
         resp = self.app.post_json('/v1/packs/install', payload)
 

--- a/st2api/tests/unit/controllers/v1/test_packs.py
+++ b/st2api/tests/unit/controllers/v1/test_packs.py
@@ -178,6 +178,16 @@ class PacksControllerTestCase(FunctionalTest,
         self.assertEqual(resp.json, {'execution_id': '123'})
 
     @mock.patch.object(ActionExecutionsControllerMixin, '_handle_schedule_execution')
+    def test_install_with_skip_parameter(self, _handle_schedule_execution):
+        _handle_schedule_execution.return_value = Response(json={'id': '123'})
+        payload = {'packs': ['some'], 'skip': True}
+
+        resp = self.app.post_json('/v1/packs/install', payload)
+
+        self.assertEqual(resp.status_int, 202)
+        self.assertEqual(resp.json, {'execution_id': '123'})
+
+    @mock.patch.object(ActionExecutionsControllerMixin, '_handle_schedule_execution')
     def test_uninstall(self, _handle_schedule_execution):
         _handle_schedule_execution.return_value = Response(json={'id': '123'})
         payload = {'packs': ['some']}

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -96,7 +96,7 @@ class PackAsyncCommand(ActionRunCommandMixin, resource.ResourceCommand):
 
         detail_arg_grp = self.parser.add_mutually_exclusive_group()
         detail_arg_grp.add_argument('--attr', nargs='+',
-                                    default=['name', 'description', 'version', 'author'],
+                                    default=['ref', 'name', 'description', 'version', 'author'],
                                     help=('List of attributes to include in the '
                                           'output. "all" or unspecified will '
                                           'return all attributes.'))
@@ -276,7 +276,7 @@ class PackInstallCommand(PackAsyncCommand):
             pack_instances = []
 
             for pack in all_pack_instances:
-                if pack.name in packs:
+                if pack.name in packs or pack.ref in packs:
                     pack_instances.append(pack)
 
             self.print_output(pack_instances, table.MultiColumnTable,
@@ -324,7 +324,7 @@ class PackRemoveCommand(PackAsyncCommand):
             pack_instances = []
 
             for pack in all_pack_instances:
-                if pack.name in packs:
+                if pack.name in packs or pack.ref in packs:
                     pack_instances.append(pack)
                 if pack in remaining_pack_instances:
                     raise OperationFailureException('Pack %s has not been removed properly'

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -195,7 +195,7 @@ class PackInstallCommand(PackAsyncCommand):
                                  action='store_true',
                                  default=False,
                                  help='Force pack installation.')
-        self.parser.add_argument('--no_deps',
+        self.parser.add_argument('--skip-dependencies',
                                  action='store_true',
                                  default=False,
                                  help='Skip pack dependency installation.')
@@ -209,7 +209,7 @@ class PackInstallCommand(PackAsyncCommand):
             self._get_content_counts_for_pack(args, **kwargs)
 
         return self.manager.install(args.packs, python3=args.python3, force=args.force,
-                                    no_deps=args.no_deps, **kwargs)
+                                    skip_dependencies=args.skip_dependencies, **kwargs)
 
     def _get_content_counts_for_pack(self, args, **kwargs):
         # Global content list, excluding "tests"

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -195,7 +195,7 @@ class PackInstallCommand(PackAsyncCommand):
                                  action='store_true',
                                  default=False,
                                  help='Force pack installation.')
-        self.parser.add_argument('--skip',
+        self.parser.add_argument('--no_deps',
                                  action='store_true',
                                  default=False,
                                  help='Skip pack dependency installation.')
@@ -209,7 +209,7 @@ class PackInstallCommand(PackAsyncCommand):
             self._get_content_counts_for_pack(args, **kwargs)
 
         return self.manager.install(args.packs, python3=args.python3, force=args.force,
-                                    skip=args.skip, **kwargs)
+                                    no_deps=args.no_deps, **kwargs)
 
     def _get_content_counts_for_pack(self, args, **kwargs):
         # Global content list, excluding "tests"

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -494,13 +494,13 @@ class AsyncRequest(Resource):
 
 class PackResourceManager(ResourceManager):
     @add_auth_token_to_kwargs_from_env
-    def install(self, packs, force=False, python3=False, skip=False, **kwargs):
+    def install(self, packs, force=False, python3=False, no_deps=False, **kwargs):
         url = '/%s/install' % (self.resource.get_url_path_name())
         payload = {
             'packs': packs,
             'force': force,
             'python3': python3,
-            'skip': skip
+            'no_deps': no_deps
         }
         response = self.client.post(url, payload, **kwargs)
         if response.status_code != http_client.OK:

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -494,13 +494,13 @@ class AsyncRequest(Resource):
 
 class PackResourceManager(ResourceManager):
     @add_auth_token_to_kwargs_from_env
-    def install(self, packs, force=False, python3=False, no_deps=False, **kwargs):
+    def install(self, packs, force=False, python3=False, skip_dependencies=False, **kwargs):
         url = '/%s/install' % (self.resource.get_url_path_name())
         payload = {
             'packs': packs,
             'force': force,
             'python3': python3,
-            'no_deps': no_deps
+            'skip_dependencies': skip_dependencies
         }
         response = self.client.post(url, payload, **kwargs)
         if response.status_code != http_client.OK:

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -494,12 +494,13 @@ class AsyncRequest(Resource):
 
 class PackResourceManager(ResourceManager):
     @add_auth_token_to_kwargs_from_env
-    def install(self, packs, force=False, python3=False, **kwargs):
+    def install(self, packs, force=False, python3=False, skip=False, **kwargs):
         url = '/%s/install' % (self.resource.get_url_path_name())
         payload = {
             'packs': packs,
             'force': force,
-            'python3': python3
+            'python3': python3,
+            'skip': skip
         }
         response = self.client.post(url, payload, **kwargs)
         if response.status_code != http_client.OK:

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -5028,7 +5028,7 @@ definitions:
         description: Force pack installation.
         type: boolean
         default: false
-      skip:
+      no_deps:
         type: boolean
         description: Set to True to skip pack dependency installations.
         required: false

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -5028,7 +5028,7 @@ definitions:
         description: Force pack installation.
         type: boolean
         default: false
-      no_deps:
+      skip_dependencies:
         type: boolean
         description: Set to True to skip pack dependency installations.
         required: false

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -5028,6 +5028,11 @@ definitions:
         description: Force pack installation.
         type: boolean
         default: false
+      skip:
+        type: boolean
+        description: Set to True to skip pack dependency installations.
+        required: false
+        default: false
   PacksUninstall:
     type: object
     properties:

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -5024,7 +5024,7 @@ definitions:
         description: Force pack installation.
         type: boolean
         default: false
-      skip:
+      no_deps:
         type: boolean
         description: Set to True to skip pack dependency installations.
         required: false

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -5024,6 +5024,11 @@ definitions:
         description: Force pack installation.
         type: boolean
         default: false
+      skip:
+        type: boolean
+        description: Set to True to skip pack dependency installations.
+        required: false
+        default: false
   PacksUninstall:
     type: object
     properties:

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -5024,7 +5024,7 @@ definitions:
         description: Force pack installation.
         type: boolean
         default: false
-      no_deps:
+      skip_dependencies:
         type: boolean
         description: Set to True to skip pack dependency installations.
         required: false

--- a/st2common/st2common/util/pack_management.py
+++ b/st2common/st2common/util/pack_management.py
@@ -241,19 +241,27 @@ def clone_repo(temp_dir, repo_url, verify_ssl=True, ref='master'):
     # We're trying to figure out which branch the ref is actually on,
     # since there's no direct way to check for this in git-python.
     branches = repo.git.branch('-a', '--contains', gitref.hexsha)  # pylint: disable=no-member
-    branches = branches.replace('*', '').split()
 
-    if active_branch.name not in branches or use_branch:
-        branch = 'origin/%s' % ref if use_branch else branches[0]
-        short_branch = ref if use_branch else branches[0].split('/')[-1]
-        repo.git.checkout('-b', short_branch, branch)
-        branch = repo.head.reference
+    # Git tags aren't necessarily on a branch.
+    # If this is the case, gitref will be the tag name, but branches will be
+    # empty.
+    # We also need to checkout tags slightly differently than branches.
+    if branches:
+        branches = branches.replace('*', '').split()
+
+        if active_branch.name not in branches or use_branch:
+            branch = 'origin/%s' % ref if use_branch else branches[0]
+            short_branch = ref if use_branch else branches[0].split('/')[-1]
+            repo.git.checkout('-b', short_branch, branch)
+            branch = repo.head.reference
+        else:
+            branch = repo.active_branch.name
+
+        repo.git.checkout(gitref.hexsha)  # pylint: disable=no-member
+        repo.git.branch('-f', branch, gitref.hexsha)  # pylint: disable=no-member
+        repo.git.checkout(branch)
     else:
-        branch = repo.active_branch.name
-
-    repo.git.checkout(gitref.hexsha)  # pylint: disable=no-member
-    repo.git.branch('-f', branch, gitref.hexsha)  # pylint: disable=no-member
-    repo.git.checkout(branch)
+        repo.git.checkout('v%s' % ref)  # pylint: disable=no-member
 
     return temp_dir
 


### PR DESCRIPTION
Fixes https://github.com/StackStorm/discussions/issues/354
Resolves https://github.com/StackStorm/st2/issues/3336
Closes https://github.com/StackStorm/st2/issues/3698




1. `packs.install` workflow changed from `achtion-chain` to `orquesta` for workflow complexity.
2. Download all packs and dependency packs before `install pack requirements` and `register pack`.
3. Register packs in reverse order, it means the last dependency pack will be installed first.
4. Workflow fails on any time if conflict pack is recognized,  downloaded packs will be removed.
5. New option `--skip` (default value is False) for skipping dependencies check:  `st2 install pack --skip`
6. Only case that will check conflict is that if pack was installed and dependency pack has specified pack version.
7. Nested level of dependencies to prevent infinite or long download loops is 3.
8. Support StackStorm Exchange packs, the private repository ULR and local file system for conflict pack checking.