### PR TITLE
Add user field to re_run method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Added
 * Add support for blacklisting / whitelisting hosts to the HTTP runner by adding new
   ``url_hosts_blacklist`` and ``url_hosts_whitelist`` runner attribute. (new feature)
   #4757
+* Add ``user`` parameter to ``re_run`` method of st2client. #4785
 
 Changed
 ~~~~~~~

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -378,7 +378,7 @@ class ActionAliasExecutionManager(ResourceManager):
 
 class ExecutionResourceManager(ResourceManager):
     @add_auth_token_to_kwargs_from_env
-    def re_run(self, execution_id, parameters=None, tasks=None, no_reset=None, delay=0, **kwargs):
+    def re_run(self, execution_id, parameters=None, tasks=None, no_reset=None, user=None, delay=0, **kwargs):
         url = '/%s/%s/re_run' % (self.resource.get_url_path_name(), execution_id)
 
         tasks = tasks or []
@@ -391,7 +391,8 @@ class ExecutionResourceManager(ResourceManager):
             'parameters': parameters or {},
             'tasks': tasks,
             'reset': list(set(tasks) - set(no_reset)),
-            'delay': delay
+            'delay': delay,
+            'user': user
         }
 
         response = self.client.post(url, data, **kwargs)

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -378,7 +378,8 @@ class ActionAliasExecutionManager(ResourceManager):
 
 class ExecutionResourceManager(ResourceManager):
     @add_auth_token_to_kwargs_from_env
-    def re_run(self, execution_id, parameters=None, tasks=None, no_reset=None, user=None, delay=0, **kwargs):
+    def re_run(self, execution_id, parameters=None, tasks=None, no_reset=None, user=None, delay=0,
+               **kwargs):
         url = '/%s/%s/re_run' % (self.resource.get_url_path_name(), execution_id)
 
         tasks = tasks or []

--- a/st2client/tests/unit/test_client_executions.py
+++ b/st2client/tests/unit/test_client_executions.py
@@ -86,6 +86,7 @@ class TestExecutionResourceManager(unittest2.TestCase):
             'tasks': ['foobar'],
             'reset': ['foobar'],
             'parameters': {},
+            'user': None,
             'delay': 0
         }
 
@@ -120,6 +121,7 @@ class TestExecutionResourceManager(unittest2.TestCase):
             'tasks': ['foobar'],
             'reset': ['foobar'],
             'parameters': params,
+            'user': None,
             'delay': 0
         }
 
@@ -146,7 +148,35 @@ class TestExecutionResourceManager(unittest2.TestCase):
             'tasks': ['foobar'],
             'reset': ['foobar'],
             'parameters': {},
+            'user': None,
             'delay': 100
+        }
+
+        httpclient.HTTPClient.post.assert_called_with(endpoint, data)
+
+    @mock.patch.object(
+        models.ResourceManager, 'get_by_id',
+        mock.MagicMock(return_value=models.Execution(**EXECUTION)))
+    @mock.patch.object(
+        models.ResourceManager, 'get_by_ref_or_id',
+        mock.MagicMock(return_value=models.Action(**ACTION)))
+    @mock.patch.object(
+        models.ResourceManager, 'get_by_name',
+        mock.MagicMock(return_value=models.RunnerType(**RUNNER)))
+    @mock.patch.object(
+        httpclient.HTTPClient, 'post',
+        mock.MagicMock(return_value=base.FakeResponse(json.dumps(EXECUTION), 200, 'OK')))
+    def test_rerun_with_user(self):
+        self.client.executions.re_run(EXECUTION['id'], tasks=['foobar'], user='stanley')
+
+        endpoint = '/executions/%s/re_run' % EXECUTION['id']
+
+        data = {
+            'tasks': ['foobar'],
+            'reset': ['foobar'],
+            'parameters': {},
+            'user': 'stanley',
+            'delay': 0
         }
 
         httpclient.HTTPClient.post.assert_called_with(endpoint, data)


### PR DESCRIPTION
The [executions re_run route](https://api.stackstorm.com/api/v1/executions/#/action_execution_rerun_controller.post) in st2api allows for a user to be specified in the request body.
![image](https://user-images.githubusercontent.com/9982381/64205512-07ca1a80-ce4d-11e9-86e4-7ed17a58c084.png)
This PR extends the same functionality to st2client.