### PR TITLE
Add try block to handle get config errors in render_final_params

### DIFF
--- a/st2common/st2common/util/param.py
+++ b/st2common/st2common/util/param.py
@@ -320,7 +320,15 @@ def render_final_params(runner_parameters, action_parameters, params, action_con
     plain values instead of trying to render them again. Returns dicts for action and runner
     parameters.
     '''
-    config = get_config(action_context.get('pack'), action_context.get('user'))
+    pack = action_context.get('pack')
+    user = action_context.get('user')
+
+    try:
+        config = get_config(pack, user)
+    except Exception as e:
+        LOG.info('Failed to retrieve config for pack %s and user %s: %s' % (pack, user,
+                 six.text_type(e)))
+        config = {}
 
     G = _create_graph(action_context, config)
 


### PR DESCRIPTION
Add try-catch block to handle unknown errors when getting pack config in render_final_params. Copy the try-catch block from render_live_params.