### PR TITLE
Fix a bug with authentication API endpoint returning internal server error under gunicorn if auth.api_url config option was not set

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -65,6 +65,11 @@ Fixed
   ``GET /v1/rules`` and ``GET /v1/rules/<ref>`` API endpoint. (bug fix) #4788 #4807
 
   Contributed by @Nicodemos305 and @jeansfelix
+* Fix a bug with authentication API endpoint (``POST /auth/v1/tokens``) returning internal
+  server error when running under gunicorn and when``auth.api_url`` config option was not set.
+  (bug fix) #4809
+
+  Reported by @guzzijones
 
 3.1.0 - June 27, 2019
 ---------------------

--- a/st2auth/st2auth/controllers/v1/auth.py
+++ b/st2auth/st2auth/controllers/v1/auth.py
@@ -22,6 +22,7 @@ from st2common.exceptions.param import ParamException
 from st2common.router import exc
 from st2common.router import Response
 from st2common.util import auth as auth_utils
+from st2common.util import api as api_utils
 from st2common import log as logging
 import st2auth.handlers as handlers
 
@@ -80,7 +81,8 @@ class TokenController(object):
 
 def process_successful_response(token):
     resp = Response(json=token, status=http_client.CREATED)
-    resp.headers['X-API-URL'] = cfg.CONF.auth.api_url
+    # NOTE: gunicon fails and throws an error if header value is not a string (e.g. if it's None)
+    resp.headers['X-API-URL'] = api_utils.get_base_public_api_url()
     return resp
 
 


### PR DESCRIPTION
This pull request fixes a bug with ``POST /auth/v1/tokens``API endpoint returning internal server error when running under gunicorn without ``auth.api_url`` config option being set.

NOTE: First I couldn't reproduce the issue, but it turns out it only happens when using gunicorn deployment.

When running st2auh directly, the WSGI implementation simply casts all the "None" header values to empty strings, but that's not the case for gunicorn.

Originally reported here - https://forum.stackstorm.com/t/ldap-error-handling-api-call-failed-expected-string-or-buffer/893.