### PR TITLE
Remove automatic rendering of workflow output when updating task state

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,9 @@ Changed
 * Refactor how orquesta handles individual item result for with items task. Before the fix,
   when there are a lot of items and/or result size for each item is huge, there is a negative
   performance impact on write to the database when recording the conductor state. (improvement)
+* Remove automatic rendering of workflow output when updating task state for orquesta workflows.
+  This caused workflow output to render incorrectly in certain use case. The render_workflow_output
+  function must be called separately. (improvement)
 
 Fixed
 ~~~~~

--- a/contrib/runners/orquesta_runner/in-requirements.txt
+++ b/contrib/runners/orquesta_runner/in-requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/StackStorm/orquesta.git@5567763fd4ae10c307470d8957211bd11b6acfd4#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@c80b139d8bbd7d59ccdc0461564e6a754066adaa#egg=orquesta

--- a/contrib/runners/orquesta_runner/requirements.txt
+++ b/contrib/runners/orquesta_runner/requirements.txt
@@ -5,4 +5,4 @@
 # If you want to update depdencies for a single component, modify the
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
-git+https://github.com/StackStorm/orquesta.git@5567763fd4ae10c307470d8957211bd11b6acfd4#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@c80b139d8bbd7d59ccdc0461564e6a754066adaa#egg=orquesta

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ cryptography==2.7
 eventlet==0.25.0
 flex==6.14.0
 git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper
-git+https://github.com/StackStorm/orquesta.git@5567763fd4ae10c307470d8957211bd11b6acfd4#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@c80b139d8bbd7d59ccdc0461564e6a754066adaa#egg=orquesta
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
 gitpython==2.1.11

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -9,7 +9,7 @@ jsonschema
 kombu
 mongoengine
 networkx
-git+https://github.com/StackStorm/orquesta.git@5567763fd4ae10c307470d8957211bd11b6acfd4#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@c80b139d8bbd7d59ccdc0461564e6a754066adaa#egg=orquesta
 oslo.config
 paramiko
 pyyaml

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -10,7 +10,7 @@ apscheduler==3.6.1
 cryptography==2.7
 eventlet==0.25.0
 flex==6.14.0
-git+https://github.com/StackStorm/orquesta.git@5567763fd4ae10c307470d8957211bd11b6acfd4#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@c80b139d8bbd7d59ccdc0461564e6a754066adaa#egg=orquesta
 gitpython==2.1.11
 greenlet==0.4.15
 ipaddr

--- a/st2common/st2common/services/workflows.py
+++ b/st2common/st2common/services/workflows.py
@@ -1154,6 +1154,10 @@ def update_execution_records(wf_ex_db, conductor, update_lv_ac_on_statuses=None,
 
     wf_ac_ex_id = wf_ex_db.action_execution
 
+    # If the workflow execution is completed, then render the workflow output.
+    if conductor.get_workflow_status() in statuses.COMPLETED_STATUSES:
+        conductor.render_workflow_output()
+
     # Determine if workflow status has changed.
     wf_old_status = wf_ex_db.status
     wf_ex_db.status = conductor.get_workflow_status()

--- a/st2tests/integration/orquesta/test_wiring_error_handling.py
+++ b/st2tests/integration/orquesta/test_wiring_error_handling.py
@@ -103,6 +103,8 @@ class ErrorHandlingTest(base.TestWorkflowExecution):
         self.assertDictEqual(ex.result, {'errors': expected_errors, 'output': None})
 
     def test_start_task_error(self):
+        self.maxDiff = None
+
         expected_errors = [
             {
                 'type': 'error',
@@ -113,6 +115,13 @@ class ErrorHandlingTest(base.TestWorkflowExecution):
                 ),
                 'task_id': 'task1',
                 'route': 0
+            },
+            {
+                'type': 'error',
+                'message': (
+                    'YaqlEvaluationException: Unable to resolve key \'greeting\' '
+                    'in expression \'<% ctx().greeting %>\' from context.'
+                )
             }
         ]
 


### PR DESCRIPTION
Remove rendering of workflow output automatically when updating task state for orquesta workflows. This caused workflow output to render incorrectly in certain use case, specifically the `task` function where if the workflow output calls the task function for the last task, the information returned is not accurate. The render_workflow_output function must be called separately.