### PR TITLE
Update pip dependencies, fix conflicting dependency version, ensure there are no conflicting dependencies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,7 +46,7 @@ Changed
   This caused workflow output to render incorrectly in certain use case. The render_workflow_output
   function must be called separately. (improvement)
 * Update various internal dependencies to latest stable versions (cryptography, jinja2, requests,
-  apscheduler, eventlet, amqp, kombu, semver, pymongo) #4819 (improvement)
+  apscheduler, eventlet, amqp, kombu, semver, six) #4819 (improvement)
 
 Fixed
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,8 @@ Changed
 * Remove automatic rendering of workflow output when updating task state for orquesta workflows.
   This caused workflow output to render incorrectly in certain use case. The render_workflow_output
   function must be called separately. (improvement)
+* Update various internal dependencies to latest stable versions (cryptography, jinja2, requests,
+  apscheduler, eventlet, amqp, kombu, semver, pymongo) #4819 (improvement)
 
 Fixed
 ~~~~~

--- a/Makefile
+++ b/Makefile
@@ -441,7 +441,7 @@ requirements: virtualenv .sdist-requirements install-runners
 	$(VIRTUALENV_DIR)/bin/pip --version
 	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pip==19.3.1"
 	$(VIRTUALENV_DIR)/bin/pip install --upgrade "setuptools==41.0.1"  # Required for packs.install in dev envs
-	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pbr==5.4.0"  # workaround for pbr issue
+	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pbr==5.4.3"  # workaround for pbr issue
 
 	# Generate all requirements to support current CI pipeline.
 	$(VIRTUALENV_DIR)/bin/python scripts/fixate-requirements.py --skip=virtualenv,virtualenv-osx -s st2*/in-requirements.txt contrib/runners/*/in-requirements.txt -f fixed-requirements.txt -o requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -446,6 +446,9 @@ requirements: virtualenv .sdist-requirements install-runners
 	# Generate all requirements to support current CI pipeline.
 	$(VIRTUALENV_DIR)/bin/python scripts/fixate-requirements.py --skip=virtualenv,virtualenv-osx -s st2*/in-requirements.txt contrib/runners/*/in-requirements.txt -f fixed-requirements.txt -o requirements.txt
 
+	# Remove any *.egg-info files which polute PYTHONPATH
+	rm -rf *.egg-info*
+
 	# Generate finall requirements.txt file for each component
 	@for component in $(COMPONENTS_WITH_RUNNERS); do\
 		echo "==========================================================="; \

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,6 @@ check: check-requirements flake8 checklogs
 # make targets. This speeds up the build
 .PHONY: install-runners
 install-runners:
-
 	@echo ""
 	@echo "================== INSTALL RUNNERS ===================="
 	@echo ""
@@ -329,7 +328,7 @@ flake8: requirements .flake8
 	touch $(VIRTUALENV_ST2CLIENT_DIR)/bin/activate
 	chmod +x $(VIRTUALENV_ST2CLIENT_DIR)/bin/activate
 
-	$(VIRTUALENV_ST2CLIENT_DIR)/bin/pip install --upgrade "pip>=9.0,<9.1"
+	$(VIRTUALENV_ST2CLIENT_DIR)/bin/pip install --upgrade "pip==19.3.1"
 	# NOTE We need to upgrade setuptools to avoid bug with dependency resolving in old versions
 	$(VIRTUALENV_ST2CLIENT_DIR)/bin/pip install --upgrade "setuptools==41.0.1"
 	$(VIRTUALENV_ST2CLIENT_DIR)/bin/activate; cd st2client ; ../$(VIRTUALENV_ST2CLIENT_DIR)/bin/python setup.py install ; cd ..
@@ -440,8 +439,9 @@ requirements: virtualenv .sdist-requirements install-runners
 	@echo
 	# Make sure we use latest version of pip which is 19
 	$(VIRTUALENV_DIR)/bin/pip --version
-	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pip>=19.0,<20.0"
-	$(VIRTUALENV_DIR)/bin/pip install --upgrade "virtualenv==16.6.0" # Required for packs.install in dev envs
+	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pip==19.3.1"
+	$(VIRTUALENV_DIR)/bin/pip install --upgrade "setuptools==41.0.1"  # Required for packs.install in dev envs
+	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pbr==5.4.0"  # workaround for pbr issue
 
 	# Generate all requirements to support current CI pipeline.
 	$(VIRTUALENV_DIR)/bin/python scripts/fixate-requirements.py --skip=virtualenv,virtualenv-osx -s st2*/in-requirements.txt contrib/runners/*/in-requirements.txt -f fixed-requirements.txt -o requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -494,6 +494,9 @@ requirements: virtualenv .sdist-requirements install-runners
 	# Some of the tests rely on submodule so we need to make sure submodules are check out
 	git submodule update --recursive --remote
 
+	# Verify there are no conflicting dependencies
+	$(VIRTUALENV_DIR)/bin/pipconflictchecker
+
 .PHONY: virtualenv
 	# Note: We always want to update virtualenv/bin/activate file to make sure
 	# PYTHONPATH is up to date and to avoid caching issues on Travis

--- a/contrib/linux/requirements.txt
+++ b/contrib/linux/requirements.txt
@@ -1,3 +1,3 @@
 # used by file watcher sensor
 pyinotify>=0.9.5,<=0.10
--e git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper
+-e git+https://github.com/StackStorm/logshipper.git@stackstorm_patched#egg=logshipper

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -12,7 +12,7 @@ amqp==2.5.2
 # See https://github.com/StackStorm/st2/issues/4160#issuecomment-394386433 for details
 oslo.config>=1.12.1,<1.13
 oslo.utils>=3.36.2,<=3.37.0
-six==1.12.0
+six==1.13.0
 pyyaml==5.1.2
 requests[security]==2.22.0
 apscheduler==3.6.3

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -14,7 +14,7 @@ oslo.config>=1.12.1,<1.13
 oslo.utils>=3.36.2,<=3.37.0
 six==1.12.0
 pyyaml==5.1.2
-requests[security]>=2.21.0,<2.22.0
+requests[security]==2.22.0
 apscheduler==3.6.1
 gitpython==2.1.11
 jsonschema==2.6.0

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -31,7 +31,7 @@ stevedore==1.30.1
 paramiko==2.6.0
 networkx==1.11
 python-keyczar==0.716
-cryptography==2.7
+cryptography==2.8
 retrying==1.3.3
 # Note: We use latest version of virtualenv which uses pip 19
 virtualenv==16.6.0

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -18,7 +18,7 @@ requests[security]==2.22.0
 apscheduler==3.6.3
 gitpython==2.1.11
 jsonschema==2.6.0
-pymongo==3.9.0
+pymongo==3.7.2
 mongoengine==0.18.2
 passlib==1.7.1
 lockfile==0.12.2

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -3,29 +3,29 @@
 greenlet==0.4.15
 # Note: 0.20.0 removed select.poll() on which some of our code and libraries we
 # depend on rely
-eventlet==0.25.0
+eventlet==0.25.1
 gunicorn==19.9.0
-kombu==4.6.4
+kombu==4.6.6
 # Note: amqp is used by kombu
-amqp==2.5.1
+amqp==2.5.2
 # NOTE: Recent version substantially affect the performance and add big import time overhead
 # See https://github.com/StackStorm/st2/issues/4160#issuecomment-394386433 for details
 oslo.config>=1.12.1,<1.13
 oslo.utils>=3.36.2,<=3.37.0
-six==1.12.0
+six==1.13.0
 pyyaml==5.1.2
 requests[security]==2.22.0
-apscheduler==3.6.1
+apscheduler==3.6.3
 gitpython==2.1.11
 jsonschema==2.6.0
-pymongo==3.7.2
+pymongo==3.9.0
 mongoengine==0.18.2
 passlib==1.7.1
 lockfile==0.12.2
 python-gnupg==0.4.5
 jsonpath-rw==1.4.0
 pyinotify==0.9.6
-semver==2.8.1
+semver==2.9.0
 pytz==2019.1
 stevedore==1.30.1
 paramiko==2.6.0

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -12,7 +12,7 @@ amqp==2.5.2
 # See https://github.com/StackStorm/st2/issues/4160#issuecomment-394386433 for details
 oslo.config>=1.12.1,<1.13
 oslo.utils>=3.36.2,<=3.37.0
-six==1.13.0
+six==1.12.0
 pyyaml==5.1.2
 requests[security]==2.22.0
 apscheduler==3.6.3

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -56,4 +56,4 @@ mock==2.0.0
 ujson==1.35
 python-dateutil==2.8.0
 bcrypt==3.1.7
-jinja2==2.10.1
+jinja2==2.10.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ prettytable
 prompt-toolkit==1.0.15
 psutil==5.6.3
 pyinotify==0.9.6
-pymongo==3.9.0
+pymongo==3.7.2
 pyrabbit
 python-dateutil==2.8.0
 python-editor==1.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ bcrypt==3.1.7
 cryptography==2.8
 eventlet==0.25.1
 flex==6.14.0
-git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper
+git+https://github.com/StackStorm/logshipper.git@stackstorm_patched#egg=logshipper
 git+https://github.com/StackStorm/orquesta.git@c80b139d8bbd7d59ccdc0461564e6a754066adaa#egg=orquesta
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,7 @@ pytz==2019.1
 pywinrm==0.3.0
 pyyaml==5.1.2
 rednose
-requests[security]<2.22.0,>=2.21.0
+requests[security]==2.22.0
 retrying==1.3.3
 routes==2.4.1
 semver==2.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ requests[security]==2.22.0
 retrying==1.3.3
 routes==2.4.1
 semver==2.9.0
-six==1.12.0
+six==1.13.0
 sseclient-py==1.7
 stevedore==1.30.1
 tooz==1.66.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ gitpython==2.1.11
 greenlet==0.4.15
 gunicorn==19.9.0
 ipaddr
-jinja2==2.10.1
+jinja2==2.10.3
 jsonpath-rw==1.4.0
 jsonschema==2.6.0
 kombu==4.6.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,12 +6,12 @@
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
 RandomWords
-amqp==2.5.1
-apscheduler==3.6.1
+amqp==2.5.2
+apscheduler==3.6.3
 argcomplete
 bcrypt==3.1.7
 cryptography==2.8
-eventlet==0.25.0
+eventlet==0.25.1
 flex==6.14.0
 git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper
 git+https://github.com/StackStorm/orquesta.git@c80b139d8bbd7d59ccdc0461564e6a754066adaa#egg=orquesta
@@ -24,7 +24,7 @@ ipaddr
 jinja2==2.10.3
 jsonpath-rw==1.4.0
 jsonschema==2.6.0
-kombu==4.6.4
+kombu==4.6.6
 lockfile==0.12.2
 mock==2.0.0
 mongoengine==0.18.2
@@ -40,7 +40,7 @@ prettytable
 prompt-toolkit==1.0.15
 psutil==5.6.3
 pyinotify==0.9.6
-pymongo==3.7.2
+pymongo==3.9.0
 pyrabbit
 python-dateutil==2.8.0
 python-editor==1.0.4
@@ -54,8 +54,8 @@ rednose
 requests[security]==2.22.0
 retrying==1.3.3
 routes==2.4.1
-semver==2.8.1
-six==1.12.0
+semver==2.9.0
+six==1.13.0
 sseclient-py==1.7
 stevedore==1.30.1
 tooz==1.66.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ requests[security]==2.22.0
 retrying==1.3.3
 routes==2.4.1
 semver==2.9.0
-six==1.13.0
+six==1.12.0
 sseclient-py==1.7
 stevedore==1.30.1
 tooz==1.66.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ amqp==2.5.1
 apscheduler==3.6.1
 argcomplete
 bcrypt==3.1.7
-cryptography==2.7
+cryptography==2.8
 eventlet==0.25.0
 flex==6.14.0
 git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper

--- a/st2actions/in-requirements.txt
+++ b/st2actions/in-requirements.txt
@@ -16,6 +16,6 @@ gitpython
 lockfile
 # needed by core "linux" pack - TODO: create virtualenv for linux pack on postinst
 pyinotify
-git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper
+git+https://github.com/StackStorm/logshipper.git@stackstorm_patched#egg=logshipper
 # required by pack_mgmt/setup_virtualenv.py#L135
 virtualenv

--- a/st2actions/requirements.txt
+++ b/st2actions/requirements.txt
@@ -5,13 +5,13 @@
 # If you want to update depdencies for a single component, modify the
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
-apscheduler==3.6.1
-eventlet==0.25.0
+apscheduler==3.6.3
+eventlet==0.25.1
 git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
 gitpython==2.1.11
 jinja2==2.10.3
-kombu==4.6.4
+kombu==4.6.6
 lockfile==0.12.2
 oslo.config<1.13,>=1.12.1
 oslo.utils<=3.37.0,>=3.36.2
@@ -20,4 +20,4 @@ python-dateutil==2.8.0
 python-json-logger
 pyyaml==5.1.2
 requests[security]==2.22.0
-six==1.12.0
+six==1.13.0

--- a/st2actions/requirements.txt
+++ b/st2actions/requirements.txt
@@ -10,7 +10,7 @@ eventlet==0.25.0
 git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
 gitpython==2.1.11
-jinja2==2.10.1
+jinja2==2.10.3
 kombu==4.6.4
 lockfile==0.12.2
 oslo.config<1.13,>=1.12.1

--- a/st2actions/requirements.txt
+++ b/st2actions/requirements.txt
@@ -20,4 +20,4 @@ python-dateutil==2.8.0
 python-json-logger
 pyyaml==5.1.2
 requests[security]==2.22.0
-six==1.12.0
+six==1.13.0

--- a/st2actions/requirements.txt
+++ b/st2actions/requirements.txt
@@ -20,4 +20,4 @@ python-dateutil==2.8.0
 python-json-logger
 pyyaml==5.1.2
 requests[security]==2.22.0
-six==1.13.0
+six==1.12.0

--- a/st2actions/requirements.txt
+++ b/st2actions/requirements.txt
@@ -19,5 +19,5 @@ pyinotify==0.9.6
 python-dateutil==2.8.0
 python-json-logger
 pyyaml==5.1.2
-requests[security]<2.22.0,>=2.21.0
+requests[security]==2.22.0
 six==1.12.0

--- a/st2actions/requirements.txt
+++ b/st2actions/requirements.txt
@@ -7,7 +7,7 @@
 # update the component requirements.txt
 apscheduler==3.6.3
 eventlet==0.25.1
-git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper
+git+https://github.com/StackStorm/logshipper.git@stackstorm_patched#egg=logshipper
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
 gitpython==2.1.11
 jinja2==2.10.3

--- a/st2api/requirements.txt
+++ b/st2api/requirements.txt
@@ -14,4 +14,4 @@ mongoengine==0.18.2
 oslo.config<1.13,>=1.12.1
 oslo.utils<=3.37.0,>=3.36.2
 pymongo==3.9.0
-six==1.13.0
+six==1.12.0

--- a/st2api/requirements.txt
+++ b/st2api/requirements.txt
@@ -5,13 +5,13 @@
 # If you want to update depdencies for a single component, modify the
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
-eventlet==0.25.0
+eventlet==0.25.1
 git+https://github.com/StackStorm/python-mistralclient#egg=python-mistralclient
 gunicorn==19.9.0
 jsonschema==2.6.0
-kombu==4.6.4
+kombu==4.6.6
 mongoengine==0.18.2
 oslo.config<1.13,>=1.12.1
 oslo.utils<=3.37.0,>=3.36.2
-pymongo==3.7.2
-six==1.12.0
+pymongo==3.9.0
+six==1.13.0

--- a/st2api/requirements.txt
+++ b/st2api/requirements.txt
@@ -14,4 +14,4 @@ mongoengine==0.18.2
 oslo.config<1.13,>=1.12.1
 oslo.utils<=3.37.0,>=3.36.2
 pymongo==3.9.0
-six==1.12.0
+six==1.13.0

--- a/st2api/requirements.txt
+++ b/st2api/requirements.txt
@@ -13,5 +13,5 @@ kombu==4.6.6
 mongoengine==0.18.2
 oslo.config<1.13,>=1.12.1
 oslo.utils<=3.37.0,>=3.36.2
-pymongo==3.9.0
+pymongo==3.7.2
 six==1.13.0

--- a/st2auth/requirements.txt
+++ b/st2auth/requirements.txt
@@ -12,5 +12,5 @@ gunicorn==19.9.0
 oslo.config<1.13,>=1.12.1
 passlib==1.7.1
 pymongo==3.9.0
-six==1.12.0
+six==1.13.0
 stevedore==1.30.1

--- a/st2auth/requirements.txt
+++ b/st2auth/requirements.txt
@@ -11,6 +11,6 @@ git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-
 gunicorn==19.9.0
 oslo.config<1.13,>=1.12.1
 passlib==1.7.1
-pymongo==3.9.0
+pymongo==3.7.2
 six==1.13.0
 stevedore==1.30.1

--- a/st2auth/requirements.txt
+++ b/st2auth/requirements.txt
@@ -6,11 +6,11 @@
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
 bcrypt==3.1.7
-eventlet==0.25.0
+eventlet==0.25.1
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
 gunicorn==19.9.0
 oslo.config<1.13,>=1.12.1
 passlib==1.7.1
-pymongo==3.7.2
-six==1.12.0
+pymongo==3.9.0
+six==1.13.0
 stevedore==1.30.1

--- a/st2auth/requirements.txt
+++ b/st2auth/requirements.txt
@@ -12,5 +12,5 @@ gunicorn==19.9.0
 oslo.config<1.13,>=1.12.1
 passlib==1.7.1
 pymongo==3.9.0
-six==1.13.0
+six==1.12.0
 stevedore==1.30.1

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -16,5 +16,5 @@ python-editor==1.0.4
 pytz==2019.1
 pyyaml==5.1.2
 requests[security]==2.22.0
-six==1.12.0
+six==1.13.0
 sseclient-py==1.7

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -16,5 +16,5 @@ python-editor==1.0.4
 pytz==2019.1
 pyyaml==5.1.2
 requests[security]==2.22.0
-six==1.13.0
+six==1.12.0
 sseclient-py==1.7

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -15,6 +15,6 @@ python-dateutil==2.8.0
 python-editor==1.0.4
 pytz==2019.1
 pyyaml==5.1.2
-requests[security]<2.22.0,>=2.21.0
+requests[security]==2.22.0
 six==1.12.0
 sseclient-py==1.7

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -6,7 +6,7 @@
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
 argcomplete
-cryptography==2.7
+cryptography==2.8
 jsonpath-rw==1.4.0
 jsonschema==2.6.0
 prettytable

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -31,7 +31,7 @@ requests[security]==2.22.0
 retrying==1.3.3
 routes==2.4.1
 semver==2.9.0
-six==1.12.0
+six==1.13.0
 tooz==1.66.1
 ujson==1.35
 webob==1.8.5

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -14,7 +14,7 @@ git+https://github.com/StackStorm/orquesta.git@c80b139d8bbd7d59ccdc0461564e6a754
 gitpython==2.1.11
 greenlet==0.4.15
 ipaddr
-jinja2==2.10.1
+jinja2==2.10.3
 jsonpath-rw==1.4.0
 jsonschema==2.6.0
 kombu==4.6.4

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -27,7 +27,7 @@ pymongo==3.7.2
 python-dateutil==2.8.0
 python-statsd==2.1.0
 pyyaml==5.1.2
-requests[security]<2.22.0,>=2.21.0
+requests[security]==2.22.0
 retrying==1.3.3
 routes==2.4.1
 semver==2.8.1

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -5,10 +5,10 @@
 # If you want to update depdencies for a single component, modify the
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
-amqp==2.5.1
-apscheduler==3.6.1
+amqp==2.5.2
+apscheduler==3.6.3
 cryptography==2.8
-eventlet==0.25.0
+eventlet==0.25.1
 flex==6.14.0
 git+https://github.com/StackStorm/orquesta.git@c80b139d8bbd7d59ccdc0461564e6a754066adaa#egg=orquesta
 gitpython==2.1.11
@@ -17,21 +17,21 @@ ipaddr
 jinja2==2.10.3
 jsonpath-rw==1.4.0
 jsonschema==2.6.0
-kombu==4.6.4
+kombu==4.6.6
 lockfile==0.12.2
 mongoengine==0.18.2
 networkx==1.11
 oslo.config<1.13,>=1.12.1
 paramiko==2.6.0
-pymongo==3.7.2
+pymongo==3.9.0
 python-dateutil==2.8.0
 python-statsd==2.1.0
 pyyaml==5.1.2
 requests[security]==2.22.0
 retrying==1.3.3
 routes==2.4.1
-semver==2.8.1
-six==1.12.0
+semver==2.9.0
+six==1.13.0
 tooz==1.66.1
 ujson==1.35
 webob==1.8.5

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -7,7 +7,7 @@
 # update the component requirements.txt
 amqp==2.5.1
 apscheduler==3.6.1
-cryptography==2.7
+cryptography==2.8
 eventlet==0.25.0
 flex==6.14.0
 git+https://github.com/StackStorm/orquesta.git@c80b139d8bbd7d59ccdc0461564e6a754066adaa#egg=orquesta

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -23,7 +23,7 @@ mongoengine==0.18.2
 networkx==1.11
 oslo.config<1.13,>=1.12.1
 paramiko==2.6.0
-pymongo==3.9.0
+pymongo==3.7.2
 python-dateutil==2.8.0
 python-statsd==2.1.0
 pyyaml==5.1.2

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -31,7 +31,7 @@ requests[security]==2.22.0
 retrying==1.3.3
 routes==2.4.1
 semver==2.9.0
-six==1.13.0
+six==1.12.0
 tooz==1.66.1
 ujson==1.35
 webob==1.8.5

--- a/st2debug/requirements.txt
+++ b/st2debug/requirements.txt
@@ -9,4 +9,4 @@ eventlet==0.25.1
 python-gnupg==0.4.5
 pyyaml==5.1.2
 requests[security]==2.22.0
-six==1.13.0
+six==1.12.0

--- a/st2debug/requirements.txt
+++ b/st2debug/requirements.txt
@@ -9,4 +9,4 @@ eventlet==0.25.1
 python-gnupg==0.4.5
 pyyaml==5.1.2
 requests[security]==2.22.0
-six==1.12.0
+six==1.13.0

--- a/st2debug/requirements.txt
+++ b/st2debug/requirements.txt
@@ -8,5 +8,5 @@
 eventlet==0.25.0
 python-gnupg==0.4.5
 pyyaml==5.1.2
-requests[security]<2.22.0,>=2.21.0
+requests[security]==2.22.0
 six==1.12.0

--- a/st2debug/requirements.txt
+++ b/st2debug/requirements.txt
@@ -5,8 +5,8 @@
 # If you want to update depdencies for a single component, modify the
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
-eventlet==0.25.0
+eventlet==0.25.1
 python-gnupg==0.4.5
 pyyaml==5.1.2
 requests[security]==2.22.0
-six==1.12.0
+six==1.13.0

--- a/st2exporter/requirements.txt
+++ b/st2exporter/requirements.txt
@@ -5,7 +5,7 @@
 # If you want to update depdencies for a single component, modify the
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
-eventlet==0.25.0
-kombu==4.6.4
+eventlet==0.25.1
+kombu==4.6.6
 oslo.config<1.13,>=1.12.1
-six==1.12.0
+six==1.13.0

--- a/st2exporter/requirements.txt
+++ b/st2exporter/requirements.txt
@@ -8,4 +8,4 @@
 eventlet==0.25.1
 kombu==4.6.6
 oslo.config<1.13,>=1.12.1
-six==1.13.0
+six==1.12.0

--- a/st2exporter/requirements.txt
+++ b/st2exporter/requirements.txt
@@ -8,4 +8,4 @@
 eventlet==0.25.1
 kombu==4.6.6
 oslo.config<1.13,>=1.12.1
-six==1.12.0
+six==1.13.0

--- a/st2reactor/requirements.txt
+++ b/st2reactor/requirements.txt
@@ -5,11 +5,11 @@
 # If you want to update depdencies for a single component, modify the
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
-apscheduler==3.6.1
-eventlet==0.25.0
+apscheduler==3.6.3
+eventlet==0.25.1
 jsonpath-rw==1.4.0
 jsonschema==2.6.0
-kombu==4.6.4
+kombu==4.6.6
 oslo.config<1.13,>=1.12.1
 python-dateutil==2.8.0
-six==1.12.0
+six==1.13.0

--- a/st2reactor/requirements.txt
+++ b/st2reactor/requirements.txt
@@ -12,4 +12,4 @@ jsonschema==2.6.0
 kombu==4.6.6
 oslo.config<1.13,>=1.12.1
 python-dateutil==2.8.0
-six==1.12.0
+six==1.13.0

--- a/st2reactor/requirements.txt
+++ b/st2reactor/requirements.txt
@@ -12,4 +12,4 @@ jsonschema==2.6.0
 kombu==4.6.6
 oslo.config<1.13,>=1.12.1
 python-dateutil==2.8.0
-six==1.13.0
+six==1.12.0

--- a/st2stream/requirements.txt
+++ b/st2stream/requirements.txt
@@ -12,5 +12,5 @@ kombu==4.6.6
 mongoengine==0.18.2
 oslo.config<1.13,>=1.12.1
 oslo.utils<=3.37.0,>=3.36.2
-pymongo==3.9.0
+pymongo==3.7.2
 six==1.13.0

--- a/st2stream/requirements.txt
+++ b/st2stream/requirements.txt
@@ -13,4 +13,4 @@ mongoengine==0.18.2
 oslo.config<1.13,>=1.12.1
 oslo.utils<=3.37.0,>=3.36.2
 pymongo==3.9.0
-six==1.13.0
+six==1.12.0

--- a/st2stream/requirements.txt
+++ b/st2stream/requirements.txt
@@ -5,12 +5,12 @@
 # If you want to update depdencies for a single component, modify the
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
-eventlet==0.25.0
+eventlet==0.25.1
 gunicorn==19.9.0
 jsonschema==2.6.0
-kombu==4.6.4
+kombu==4.6.6
 mongoengine==0.18.2
 oslo.config<1.13,>=1.12.1
 oslo.utils<=3.37.0,>=3.36.2
-pymongo==3.7.2
-six==1.12.0
+pymongo==3.9.0
+six==1.13.0

--- a/st2stream/requirements.txt
+++ b/st2stream/requirements.txt
@@ -13,4 +13,4 @@ mongoengine==0.18.2
 oslo.config<1.13,>=1.12.1
 oslo.utils<=3.37.0,>=3.36.2
 pymongo==3.9.0
-six==1.12.0
+six==1.13.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -19,10 +19,10 @@ nose-timer==0.7.5
 # splitting tests run on a separate CI machines
 nose-parallel==0.3.1
 # Required by st2client tests
-pyyaml==5.1
+pyyaml==5.1.2
 RandomWords
 gunicorn==19.9.0
-psutil==5.6.1
+psutil==5.6.3
 webtest==2.0.25
 rstcheck>=3.3.1,<3.4
 tox==3.13.2

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -32,3 +32,4 @@ pyrabbit
 # (those tests only run under Python 2.7 since keyczar doesn't support Python 3.x).
 # See https://github.com/StackStorm/st2/pull/4165
 python-keyczar
+git+https://github.com/Kami/pip-conflict-checker.git@fix_pip_issue#egg=pip-conflict-checker

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -32,4 +32,4 @@ pyrabbit
 # (those tests only run under Python 2.7 since keyczar doesn't support Python 3.x).
 # See https://github.com/StackStorm/st2/pull/4165
 python-keyczar
-git+https://github.com/Kami/pip-conflict-checker.git@fix_pip_issue#egg=pip-conflict-checker
+git+https://github.com/StackStorm/pip-conflict-checker.git@fix_pip_issue#egg=pip-conflict-checker

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -25,7 +25,7 @@ gunicorn==19.9.0
 psutil==5.6.3
 webtest==2.0.25
 rstcheck>=3.3.1,<3.4
-tox==3.13.2
+tox==3.14.1
 pyrabbit
 # Since StackStorm v2.8.0 we now use cryptography instead of keyczar, but we still have some tests
 # which utilize keyczar and ensure new cryptography code is fully compatible with keyczar code


### PR DESCRIPTION
This pull request includes the following changes:

1. Update ``cryptography`` dependency to v2.8 since version of ``requests`` we use depends on that version. As per https://github.com/StackStorm/st2/issues/4818#issuecomment-555545997, that is not actually a fatal issue since pip just prints a warning and doesn't fail on install, but it's still good to get it sorted out.
2. Update various dependencies to latest versions (jinja2, requests and pip, setuptools and pbr for tests)
3. Make sure versions in ``test-requirements.txt`` are in sync with versions in ``requirements.txt``
4. Run ``pip-conflict-checker`` as part of ``make requirements`` step. This command will fail and exit with non-zero if there are any conflicting dependency versions.

## TODO

- [x] Changelog entries

Resolves #4818.