### PR TITLE
Utilize st2common.util.concurrency wrapper in st2common

### DIFF
--- a/contrib/runners/python_runner/python_runner/python_runner.py
+++ b/contrib/runners/python_runner/python_runner/python_runner.py
@@ -23,13 +23,14 @@ import functools
 from subprocess import list2cmdline
 
 import six
-from eventlet.green import subprocess
+
 from oslo_config import cfg
 from six.moves import StringIO
 
 from st2common import log as logging
 from st2common.runners.base import GitWorktreeActionRunner
 from st2common.runners.base import get_metadata as get_runner_metadata
+from st2common.util import concurrency
 from st2common.util.green.shell import run_command
 from st2common.constants.action import ACTION_OUTPUT_RESULT_DELIMITER
 from st2common.constants.action import LIVEACTION_STATUS_SUCCEEDED
@@ -173,6 +174,7 @@ class PythonRunner(GitWorktreeActionRunner):
         stdin = None
         stdin_params = None
         if len(serialized_parameters) >= MAX_PARAM_LENGTH:
+            subprocess = concurrency.get_subprocess_module()
             stdin = subprocess.PIPE
             LOG.debug('Parameters are too big...changing to stdin')
             stdin_params = '{"parameters": %s}\n' % (serialized_parameters)

--- a/contrib/runners/python_runner/python_runner/python_runner.py
+++ b/contrib/runners/python_runner/python_runner/python_runner.py
@@ -168,13 +168,14 @@ class PythonRunner(GitWorktreeActionRunner):
             '--parent-args=%s' % (parent_args),
         ]
 
+        subprocess = concurrency.get_subprocess_module()
+
         # If parameter size is larger than the maximum allowed by Linux kernel
         # we need to swap to stdin to communicate parameters. This avoids a
         # failure to fork the wrapper process when using large parameters.
         stdin = None
         stdin_params = None
         if len(serialized_parameters) >= MAX_PARAM_LENGTH:
-            subprocess = concurrency.get_subprocess_module()
             stdin = subprocess.PIPE
             LOG.debug('Parameters are too big...changing to stdin')
             stdin_params = '{"parameters": %s}\n' % (serialized_parameters)

--- a/st2common/st2common/runners/base.py
+++ b/st2common/st2common/runners/base.py
@@ -23,7 +23,6 @@ from subprocess import list2cmdline
 import six
 import yaml
 from oslo_config import cfg
-from eventlet.green import subprocess
 
 from st2common import log as logging
 from st2common.constants import action as action_constants
@@ -39,6 +38,9 @@ from st2common.util.loader import get_available_plugins
 from st2common.util.api import get_full_public_api_url
 from st2common.util.deprecation import deprecated
 from st2common.util.green.shell import run_command
+from st2common.util import concurrency
+
+subprocess = concurrency.get_subprocess_module()
 
 __all__ = [
     'ActionRunner',

--- a/st2common/st2common/runners/paramiko_ssh.py
+++ b/st2common/st2common/runners/paramiko_ssh.py
@@ -13,13 +13,15 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import posixpath
 import time
 
-import eventlet
 from oslo_config import cfg
 from six.moves import StringIO
+
+import six
 
 import paramiko
 from paramiko.ssh_exception import SSHException
@@ -33,7 +35,7 @@ from st2common.util.misc import strip_shell_chars
 from st2common.util.misc import sanitize_output
 from st2common.util.shell import quote_unix
 from st2common.constants.runners import DEFAULT_SSH_PORT, REMOTE_RUNNER_PRIVATE_KEY_HEADER
-import six
+from st2common.util import concurrency
 
 __all__ = [
     'ParamikoSSHClient',
@@ -434,7 +436,7 @@ class ParamikoSSHClient(object):
                 break
 
             # Short sleep to prevent busy waiting
-            eventlet.sleep(self.SLEEP_DELAY)
+            concurrency.sleep(self.SLEEP_DELAY)
         # print('Wait over. Channel must be ready for host: %s' % self.hostname)
 
         # Receive the exit status code of the command we ran.

--- a/st2common/st2common/runners/utils.py
+++ b/st2common/st2common/runners/utils.py
@@ -153,7 +153,9 @@ def make_read_and_store_stream_func(execution_db, action_db, store_data_func):
     """
     # NOTE: This import has intentionally been moved here to avoid massive performance overhead
     # (1+ second) for other functions inside this module which don't need to use those imports.
-    import eventlet
+    from st2common.util import concurrency
+
+    greenlet_exit_exc_cls = concurrency.get_greenlet_exit_exception_class()
 
     def read_and_store_stream(stream, buff):
         try:
@@ -176,7 +178,7 @@ def make_read_and_store_stream_func(execution_db, action_db, store_data_func):
         except RuntimeError:
             # process was terminated abruptly
             pass
-        except eventlet.support.greenlets.GreenletExit:
+        except greenlet_exit_exc_cls:
             # Green thread exited / was killed
             pass
 

--- a/st2common/st2common/services/sensor_watcher.py
+++ b/st2common/st2common/services/sensor_watcher.py
@@ -19,12 +19,12 @@
 from __future__ import absolute_import
 
 import six
-import eventlet
 from kombu.mixins import ConsumerMixin
 
 from st2common import log as logging
 from st2common.transport import reactor, publishers
 from st2common.transport import utils as transport_utils
+from st2common.util import concurrency
 import st2common.util.queues as queue_utils
 
 LOG = logging.getLogger(__name__)
@@ -90,7 +90,7 @@ class SensorWatcher(ConsumerMixin):
     def start(self):
         try:
             self.connection = transport_utils.get_connection()
-            self._updates_thread = eventlet.spawn(self.run)
+            self._updates_thread = concurrency.spawn(self.run)
         except:
             LOG.exception('Failed to start sensor_watcher.')
             self.connection.release()
@@ -99,7 +99,7 @@ class SensorWatcher(ConsumerMixin):
         LOG.debug('Shutting down sensor watcher.')
         try:
             if self._updates_thread:
-                self._updates_thread = eventlet.kill(self._updates_thread)
+                self._updates_thread = concurrency.kill(self._updates_thread)
 
             if self.connection:
                 channel = self.connection.channel()

--- a/st2common/st2common/transport/connection_retry_wrapper.py
+++ b/st2common/st2common/transport/connection_retry_wrapper.py
@@ -15,7 +15,8 @@
 from __future__ import absolute_import
 
 import six
-import eventlet
+
+from st2common.util import concurrency
 
 __all__ = ['ConnectionRetryWrapper', 'ClusterRetryContext']
 
@@ -141,7 +142,7 @@ class ConnectionRetryWrapper(object):
                 # -1, 0 and 1+ are handled properly by eventlet.sleep
                 self._logger.debug('Received RabbitMQ server error, sleeping for %s seconds '
                                    'before retrying: %s' % (wait, six.text_type(e)))
-                eventlet.sleep(wait)
+                concurrency.sleep(wait)
 
                 connection.close()
                 # ensure_connection will automatically switch to an alternate. Other connections

--- a/st2common/st2common/transport/consumers.py
+++ b/st2common/st2common/transport/consumers.py
@@ -14,7 +14,6 @@
 
 from __future__ import absolute_import
 import abc
-import eventlet
 import six
 
 from kombu.mixins import ConsumerMixin
@@ -22,6 +21,7 @@ from oslo_config import cfg
 
 from st2common import log as logging
 from st2common.util.greenpooldispatch import BufferedDispatcher
+from st2common.util import concurrency
 
 __all__ = [
     'QueueConsumer',
@@ -169,7 +169,7 @@ class MessageHandler(object):
 
     def start(self, wait=False):
         LOG.info('Starting %s...', self.__class__.__name__)
-        self._consumer_thread = eventlet.spawn(self._queue_consumer.run)
+        self._consumer_thread = concurrency.spawn(self._queue_consumer.run)
 
         if wait:
             self.wait()

--- a/st2common/st2common/util/shell.py
+++ b/st2common/st2common/util/shell.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import shlex
 import signal
@@ -20,11 +21,13 @@ from subprocess import list2cmdline
 from ctypes import cdll
 
 import six
-# NOTE: eventlet 0.19.0 removed support for sellect.poll() so we not only provide green version of
-# subprocess functionality and run_command
-from eventlet.green import subprocess
 
 from st2common import log as logging
+from st2common.util import concurrency
+
+# NOTE: eventlet 0.19.0 removed support for sellect.poll() so we not only provide green version of
+# subprocess functionality and run_command
+subprocess = concurrency.get_subprocess_module()
 
 __all__ = [
     'run_command',
@@ -75,8 +78,8 @@ def run_command(cmd, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
     if not env:
         env = os.environ.copy()
 
-    process = subprocess.Popen(cmd, stdin=stdin, stdout=stdout, stderr=stderr,
-                               env=env, cwd=cwd, shell=shell)
+    process = concurrency.subprocess_popen(args=cmd, stdin=stdin, stdout=stdout, stderr=stderr,
+                                           env=env, cwd=cwd, shell=shell)
     stdout, stderr = process.communicate()
     exit_code = process.returncode
 


### PR DESCRIPTION
This pull request updates more code in st2common to utilize ``st2common.util.concurrency`` wrapper instead of calling ``eventlet`` directly.

Some of those changes were already introduced in #4792 and this pull request just builds on that and updates more code in st2common to use that wrapper.

Now 90% of the code in st2common, uses this wrapper and there are only a few places left which call eventlet directly (outside tests).