### PR TITLE
#4795 fix 'core.sendmail' for subject line wrapping

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -85,6 +85,9 @@ Fixed
 * Update ``st2 execution get`` command to always include ``context.user``, ``start_timestamp`` and
   ``end_timestamp`` attributes. (improvement) #4739
 
+  Contributed by @stevemuskiewicz and @guzzijones
+* Fixed ``core.sendmail`` base64 encoding of longer subject lines (bug fix) #4795
+
 3.1.0 - June 27, 2019
 ---------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -85,8 +85,9 @@ Fixed
 * Update ``st2 execution get`` command to always include ``context.user``, ``start_timestamp`` and
   ``end_timestamp`` attributes. (improvement) #4739
 
-  Contributed by @stevemuskiewicz and @guzzijones
 * Fixed ``core.sendmail`` base64 encoding of longer subject lines (bug fix) #4795
+
+  Contributed by @stevemuskiewicz and @guzzijones
 
 3.1.0 - June 27, 2019
 ---------------------

--- a/contrib/core/actions/send_mail/send_mail
+++ b/contrib/core/actions/send_mail/send_mail
@@ -65,7 +65,7 @@ if [[ -z $trimmed && $SEND_EMPTY_BODY -eq 1 ]] || [[ -n $trimmed ]]; then
 cat <<EOF
 TO: ${TO}
 FROM: ${FROM}
-SUBJECT: =?UTF-8?B?$(echo ${SUBJECT} | base64)?=
+SUBJECT: =?UTF-8?B?$(echo ${SUBJECT} | base64 -w 0)?=
 EOF
 
 if [[ -n $ATTACHMENTS ]]; then

--- a/contrib/core/pack.yaml
+++ b/contrib/core/pack.yaml
@@ -1,7 +1,7 @@
 ---
 name : core
 description : Basic core actions.
-version : 1.0.0
+version : 1.0.1
 python_versions:
   - "2"
   - "3"


### PR DESCRIPTION
Fixes #4795: add `-w 0` to base64 encoding of subject line to avoid line wrapping

Credit to @guzzijones for finding the fix here https://superuser.com/questions/1225134/why-does-the-base64-of-a-string-contain-n