### PR TITLE
Update core.py

### DIFF
--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -116,7 +116,7 @@ class Resource(object):
         if cls._url_path:
             return cls._url_path
 
-        return cls.get_plural_name().lower()
+        return cls.get_plural_name()
 
     def serialize(self):
         return dict((k, v)


### PR DESCRIPTION
Remove .lower() from get_plural_name()

I am running my stackstorm engine in a docker with the name _stackstorm-{user}_ where my {user} happens to be capital. The st2client is converting it to lower case and thus unable to connect to the engine.

Is there any particular reason why the .lower() is present here?

Stacktrace:
> requests.exceptions.ConnectionError: HTTPSConnectionPool(host='stackstorm-**{user}**', port=443): Max retries exceeded with url: /api/packs (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7faee197e0b8>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution',))