### PR TITLE
Fix SSL support for MongoDB and RabbitMQ under Python 3.x

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,10 @@ Changed
   function must be called separately. (improvement)
 * Update various internal dependencies to latest stable versions (cryptography, jinja2, requests,
   apscheduler, eventlet, amqp, kombu, semver, six) #4819 (improvement)
+* Improve MongoDB connection timeout related code. Connection and server selection timeout is now
+  set to 3 seconds. Previously a default value of 30 seconds was used which means that for many
+  connection related errors, our code would first wait for this timeout to be reached (30 seconds)
+  before returning error to the end user. #4384
 
 Fixed
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,7 +50,7 @@ Changed
 * Improve MongoDB connection timeout related code. Connection and server selection timeout is now
   set to 3 seconds. Previously a default value of 30 seconds was used which means that for many
   connection related errors, our code would first wait for this timeout to be reached (30 seconds)
-  before returning error to the end user. #4384
+  before returning error to the end user. #4834
 
 Fixed
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -99,7 +99,7 @@ Fixed
   result in cryptic "maximum recursion depth exceeded while calling a Python object" error on
   connection failure.
 
-  NOTE: This issue only affected installations using Python 3. (bug fix) #4382 #4384
+  NOTE: This issue only affected installations using Python 3. (bug fix) #4832 #4834
 
   Reported by @alexku7.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -97,7 +97,9 @@ Fixed
   of a type bytes and the other is of a type unicode / string. (bug fix) #4831
 * Fix SSL connection support for MongoDB and RabbitMQ which wouldn't work under Python 3 and would
   result in cryptic "maximum recursion depth exceeded while calling a Python object" error on
-  connection failure. (bug fix) #4382 #4384
+  connection failure.
+
+  NOTE: This issue only affected installations using Python 3. (bug fix) #4382 #4384
 
   Reported by @alexku7.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -91,6 +91,11 @@ Fixed
 * Update all the various rule criteria comparison operators which also work with strings (equals,
   icontains, nequals, etc.) to work correctly on Python 3 deployments if one of the operators is
   of a type bytes and the other is of a type unicode / string. (bug fix) #4831
+* Fix SSL connection support for MongoDB and RabbitMQ which wouldn't work under Python 3 and would
+  result in cryptic "maximum recursion depth exceeded while calling a Python object" error on
+  connection failure. (bug fix) #4382 #4384
+
+  Reported by @alexku7.
 
 3.1.0 - June 27, 2019
 ---------------------

--- a/conf/st2.conf.sample
+++ b/conf/st2.conf.sample
@@ -119,6 +119,8 @@ ssl_ca_certs = None
 ssl_certfile = None
 # Connection retry backoff max (seconds).
 connection_retry_backoff_max_s = 10
+# If True and `ssl_cert_reqs` is not None, enables hostname verification
+ssl_match_hostname = True
 # Specifies whether a certificate is required from the other side of the connection, and whether it will be validated if provided
 ssl_cert_reqs = None
 # Create the connection to mongodb using SSL
@@ -133,8 +135,8 @@ connection_retry_backoff_mul = 1
 authentication_mechanism = None
 # Private keyfile used to identify the local connection against MongoDB.
 ssl_keyfile = None
-# If True and `ssl_cert_reqs` is not None, enables hostname verification
-ssl_match_hostname = True
+# Connection and server selection timeout (in ms).
+connection_timeout = 3000
 # password for db login
 password = None
 # port of db server

--- a/st2api/st2api/app.py
+++ b/st2api/st2api/app.py
@@ -24,7 +24,6 @@ from st2common.middleware.logging import LoggingMiddleware
 from st2common.middleware.instrumentation import RequestInstrumentationMiddleware
 from st2common.middleware.instrumentation import ResponseInstrumentationMiddleware
 from st2common.router import Router
-from st2common.util.monkey_patch import monkey_patch
 from st2common.constants.system import VERSION_STRING
 from st2common.service_setup import setup as common_setup
 from st2common.util import spec_loader
@@ -33,16 +32,14 @@ from st2api.validation import validate_rbac_is_correctly_configured
 LOG = logging.getLogger(__name__)
 
 
-def setup_app(config={}):
+def setup_app(config=None):
+    config = config or {}
+
     LOG.info('Creating st2api: %s as OpenAPI app.', VERSION_STRING)
 
     is_gunicorn = config.get('is_gunicorn', False)
     if is_gunicorn:
-        # Note: We need to perform monkey patching in the worker. If we do it in
-        # the master process (gunicorn_config.py), it breaks tons of things
-        # including shutdown
-        monkey_patch()
-
+        # NOTE: We only want to perform this logic in the WSGI worker
         st2api_config.register_opts()
         capabilities = {
             'name': 'api',

--- a/st2api/st2api/cmd/api.py
+++ b/st2api/st2api/cmd/api.py
@@ -15,6 +15,13 @@
 import os
 import sys
 
+# NOTE: It's important that we perform monkey patch as early as possible before any other modules
+# are important, otherwise SSL support for MongoDB won't work.
+# See https://github.com/StackStorm/st2/issues/4832 and https://github.com/gevent/gevent/issues/1016
+# for details.
+from st2common.util.monkey_patch import monkey_patch
+monkey_patch()
+
 import eventlet
 from oslo_config import cfg
 from eventlet import wsgi
@@ -22,7 +29,6 @@ from eventlet import wsgi
 from st2common import log as logging
 from st2common.service_setup import setup as common_setup
 from st2common.service_setup import teardown as common_teardown
-from st2common.util.monkey_patch import monkey_patch
 from st2api import config
 config.register_opts()
 from st2api import app
@@ -32,8 +38,6 @@ from st2api.validation import validate_rbac_is_correctly_configured
 __all__ = [
     'main'
 ]
-
-monkey_patch()
 
 LOG = logging.getLogger(__name__)
 

--- a/st2api/st2api/wsgi.py
+++ b/st2api/st2api/wsgi.py
@@ -12,7 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+WSGI entry point used by gunicorn.
+"""
+
 import os
+
+from st2common.util.monkey_patch import monkey_patch
+# Note: We need to perform monkey patching in the worker. If we do it in
+# the master process (gunicorn_config.py), it breaks tons of things
+# including shutdown
+# NOTE: It's important that we perform monkey patch as early as possible before any other modules
+# are important, otherwise SSL support for MongoDB won't work.
+# See https://github.com/StackStorm/st2/issues/4832 and https://github.com/gevent/gevent/issues/1016
+# for details.
+monkey_patch()
 
 from st2api import app
 

--- a/st2auth/st2auth/app.py
+++ b/st2auth/st2auth/app.py
@@ -22,7 +22,6 @@ from st2common.middleware.logging import LoggingMiddleware
 from st2common.middleware.instrumentation import RequestInstrumentationMiddleware
 from st2common.middleware.instrumentation import ResponseInstrumentationMiddleware
 from st2common.router import Router
-from st2common.util.monkey_patch import monkey_patch
 from st2common.constants.system import VERSION_STRING
 from st2common.service_setup import setup as common_setup
 from st2common.util import spec_loader
@@ -32,16 +31,14 @@ from st2auth.validation import validate_auth_backend_is_correctly_configured
 LOG = logging.getLogger(__name__)
 
 
-def setup_app(config={}):
+def setup_app(config=None):
+    config = config or {}
+
     LOG.info('Creating st2auth: %s as OpenAPI app.', VERSION_STRING)
 
     is_gunicorn = config.get('is_gunicorn', False)
     if is_gunicorn:
-        # Note: We need to perform monkey patching in the worker. If we do it in
-        # the master process (gunicorn_config.py), it breaks tons of things
-        # including shutdown
-        monkey_patch()
-
+        # NOTE: We only want to perform this logic in the WSGI worker
         st2auth_config.register_opts()
         capabilities = {
             'name': 'auth',

--- a/st2auth/st2auth/wsgi.py
+++ b/st2auth/st2auth/wsgi.py
@@ -14,6 +14,16 @@
 
 import os
 
+from st2common.util.monkey_patch import monkey_patch
+# Note: We need to perform monkey patching in the worker. If we do it in
+# the master process (gunicorn_config.py), it breaks tons of things
+# including shutdown
+# NOTE: It's important that we perform monkey patch as early as possible before any other modules
+# are important, otherwise SSL support for MongoDB won't work.
+# See https://github.com/StackStorm/st2/issues/4832 and https://github.com/gevent/gevent/issues/1016
+# for details.
+monkey_patch()
+
 from st2auth import app
 
 config = {

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -177,6 +177,9 @@ def register_opts(ignore_errors=False):
             'password',
             help='password for db login'),
         cfg.IntOpt(
+            'connection_timeout', default=3 * 1000,
+            help='Connection and server selection timeout (in ms).'),
+        cfg.IntOpt(
             'connection_retry_max_delay_m', default=3,
             help='Connection retry total time (minutes).'),
         cfg.IntOpt(

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -25,6 +25,7 @@ from mongoengine.queryset import visitor
 from pymongo import uri_parser
 from pymongo.errors import OperationFailure
 from pymongo.errors import ConnectionFailure
+from pymongo.errors import ServerSelectionTimeoutError
 
 from st2common import log as logging
 from st2common.util import isotime
@@ -122,9 +123,13 @@ def _db_connect(db_name, db_host, db_port, username=None, password=None,
                                  authentication_mechanism=authentication_mechanism,
                                  ssl_match_hostname=ssl_match_hostname)
 
+    # NOTE: We intentionally set "serverSelectionTimeoutMS" to 5 seconds. By default it's set to
+    # 30 seconds, which means it will block up to 30 seconds and fail if there are any SSL related
+    # errors
     connection = mongoengine.connection.connect(db_name, host=db_host,
                                                 port=db_port, tz_aware=True,
                                                 username=username, password=password,
+                                                serverSelectionTimeoutMS=5000,
                                                 **ssl_kwargs)
 
     # NOTE: Since pymongo 3.0, connect() method is lazy and not blocking (always returns success)
@@ -134,7 +139,10 @@ def _db_connect(db_name, db_host, db_port, username=None, password=None,
     try:
         # The ismaster command is cheap and does not require auth
         connection.admin.command('ismaster')
-    except ConnectionFailure as e:
+    except (ConnectionFailure, ServerSelectionTimeoutError) as e:
+        # NOTE: ServerSelectionTimeoutError can also be thrown if SSLHandShake fails in the server
+        # Sadly the client doesn't include more information about the error so in such scenarios
+        # user needs to check MongoDB server log
         LOG.error('Failed to connect to database "%s" @ "%s" as user "%s": %s' %
                   (db_name, host_string, str(username_string), six.text_type(e)))
         raise e

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -20,6 +20,7 @@ import traceback
 import ssl as ssl_lib
 
 import six
+from oslo_config import cfg
 import mongoengine
 from mongoengine.queryset import visitor
 from pymongo import uri_parser
@@ -123,13 +124,14 @@ def _db_connect(db_name, db_host, db_port, username=None, password=None,
                                  authentication_mechanism=authentication_mechanism,
                                  ssl_match_hostname=ssl_match_hostname)
 
-    # NOTE: We intentionally set "serverSelectionTimeoutMS" to 5 seconds. By default it's set to
+    # NOTE: We intentionally set "serverSelectionTimeoutMS" to 3 seconds. By default it's set to
     # 30 seconds, which means it will block up to 30 seconds and fail if there are any SSL related
-    # errors
+    # or other errors
+    connection_timeout = cfg.CONF.database.connection_timeout
     connection = mongoengine.connection.connect(db_name, host=db_host,
                                                 port=db_port, tz_aware=True,
                                                 username=username, password=password,
-                                                serverSelectionTimeoutMS=5000,
+                                                serverSelectionTimeoutMS=connection_timeout,
                                                 **ssl_kwargs)
 
     # NOTE: Since pymongo 3.0, connect() method is lazy and not blocking (always returns success)

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -131,6 +131,7 @@ def _db_connect(db_name, db_host, db_port, username=None, password=None,
     connection = mongoengine.connection.connect(db_name, host=db_host,
                                                 port=db_port, tz_aware=True,
                                                 username=username, password=password,
+                                                connectTimeoutMS=connection_timeout,
                                                 serverSelectionTimeoutMS=connection_timeout,
                                                 **ssl_kwargs)
 

--- a/st2common/tests/unit/test_db.py
+++ b/st2common/tests/unit/test_db.py
@@ -14,6 +14,11 @@
 
 from __future__ import absolute_import
 
+# NOTE: We need to perform monkeypatch before importing ssl module otherwise tests will fail.
+# See https://github.com/StackStorm/st2/pull/4834 for details
+from st2common.util.monkey_patch import monkey_patch
+monkey_patch()
+
 import ssl
 import time
 

--- a/st2common/tests/unit/test_db.py
+++ b/st2common/tests/unit/test_db.py
@@ -192,6 +192,7 @@ class DbConnectionTestCase(DbTestCase):
             'authentication_mechanism': 'MONGODB-X509',
             'ssl': True,
             'ssl_match_hostname': True,
+            'connectTimeoutMS': 3000,
             'serverSelectionTimeoutMS': 3000
         })
 

--- a/st2common/tests/unit/test_db.py
+++ b/st2common/tests/unit/test_db.py
@@ -15,12 +15,16 @@
 from __future__ import absolute_import
 
 import ssl
+import time
 
 import jsonschema
 import mock
 import mongoengine.connection
+from mongoengine.connection import disconnect
 from oslo_config import cfg
 from pymongo.errors import ConnectionFailure
+from pymongo.errors import ServerSelectionTimeoutError
+
 from st2common.constants.triggers import TRIGGER_INSTANCE_PROCESSED
 from st2common.models.system.common import ResourceReference
 from st2common.transport.publishers import PoolPublisher
@@ -86,6 +90,13 @@ class DbIndexNameTestCase(TestCase):
 
 
 class DbConnectionTestCase(DbTestCase):
+    def setUp(self):
+        # NOTE: It's important we re-establish a connection on each setUp
+        self.setUpClass()
+
+    def tearDown(self):
+        # NOTE: It's important we disconnect here otherwise tests will fail
+        disconnect()
 
     def test_check_connect(self):
         """
@@ -180,7 +191,8 @@ class DbConnectionTestCase(DbTestCase):
             'tz_aware': True,
             'authentication_mechanism': 'MONGODB-X509',
             'ssl': True,
-            'ssl_match_hostname': True
+            'ssl_match_hostname': True,
+            'serverSelectionTimeoutMS': 3000
         })
 
     @mock.patch('st2common.models.db.mongoengine')
@@ -298,6 +310,37 @@ class DbConnectionTestCase(DbTestCase):
                             '"user_st2": Failed to connect')
         actual_message = mock_log.error.call_args_list[0][0][0]
         self.assertEqual(expected_message, actual_message)
+
+    def test_db_connect_server_selection_timeout_ssl_on_non_ssl_listener(self):
+        # Verify that the we wait connection_timeout ms (server selection timeout ms) before failing
+        # and propagating the error
+        disconnect()
+
+        db_name = 'st2'
+        db_host = 'localhost'
+        db_port = 27017
+
+        cfg.CONF.set_override(name='connection_timeout', group='database', override=1000)
+
+        start = time.time()
+        self.assertRaises(ServerSelectionTimeoutError, db_setup, db_name=db_name, db_host=db_host,
+                          db_port=db_port, ssl=True)
+        end = time.time()
+        diff = (end - start)
+
+        self.assertTrue(diff >= 1)
+
+        disconnect()
+
+        cfg.CONF.set_override(name='connection_timeout', group='database', override=400)
+
+        start = time.time()
+        self.assertRaises(ServerSelectionTimeoutError, db_setup, db_name=db_name, db_host=db_host,
+                          db_port=db_port, ssl=True)
+        end = time.time()
+        diff = (end - start)
+
+        self.assertTrue(diff >= 0.4)
 
 
 class DbCleanupTestCase(DbTestCase):

--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -15,6 +15,11 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+# NOTE: We need to perform monkeypatch before importing ssl module otherwise tests will fail.
+# See https://github.com/StackStorm/st2/pull/4834 for details
+from st2common.util.monkey_patch import monkey_patch
+monkey_patch()
+
 try:
     import simplejson as json
 except ImportError:


### PR DESCRIPTION
This pull request fixes #4832  SSL support for MongoD and RabbitMQ when running under Python 3.6.

## Background / Details

When running under Python 3 and enabling SSL support for MongoDB, st2api and st2auth would fail with a cryptic error:

```bash
2019-12-15 08:08:45,891 140651884441824 INFO (unknown file) [-] Connecting to database "somedatabase" @ "mongodb-host:27017" as user "someuser".
2019-12-15 08:08:45,892 140651884441824 WARNING (unknown file) [-] Retry on ConnectionError - Cannot connect to database default :
maximum recursion depth exceeded while calling a Python object
```

After some more digging in and manual instrumentation, I managed to track down the original exception / root cause - https://gist.github.com/Kami/ea8e63cdc539fd879fff41271969d650.

The root cause was an SSL error which happened because ``st2api`` and ``st2auth`` didn't perform eventlet monkey patching early enough. They performed monkey patching after some other module (likely mongoengine or pymongo) already imported ``ssl`` which has undefined behavior and won't work.

## Proposed Fix

This pull request fixes the issue by making sure we perform eventlet monkey patching as early as possible (before any other modules are imported) inside ``st2api`` and ``st2auth`` service.

In addition to that, I made another change by setting ``serverSelectionTimeoutMS`` MongoClient option to 5 seconds.

It defaults to 30 seconds which means if there is a SSL related connection error (e.g. handshake failed), exception won't be raised until 30 seconds has passed.

Keep in mind though that in such scenarios, only "connection closed" exception will be returned to the user and for the actual root cause, user will need to check the mongo server logs (that's the limitation of the client / server and nothing we can do).

This will also provide a better user-experience because previously in many scenarios our code would wait 30 seconds for this timeout to be reached before propagating the connection error.

## Affected Components / Services

Based on my digging it, this issue only affected ``st2api`` and ``st2auth`` because other services already performed eventlet monkey patching as early as possible.

This also explains why user reported that ``st2-register-content`` worked in #4832 (we intentionally don't perform any monkey patching there so it works fine).

Another thing worth keeping in mind is that we have two entry points for ``st2api`` and ``st2auth`` - WSGI one (for production gunicorn deployments) and the direct eventlet WSGI server one (for local testing and development).

Both entry points were affected so I needed to fix both.

## Configuration

For completeness, here is the st2.conf and mongod.conf configuration I used:

st2.conf:

```ini
...
[database]
ssl = true
host = 127.0.0.1
ssl_cert_reqs = none
username = stackstorm
password = ...
...
```

mongod.conf:

```yaml
...
net:
  port: 27017
  bindIp: 127.0.0.1
  ssl:
    mode: requireSSL
    PEMKeyFile: /home/ubuntu/mongodb.pem
    CAFile: /home/ubuntu/rootCA.pem
    allowConnectionsWithoutCertificates: true  # NOTE: If this option is not set, client also needs to specify client server otherwise connection / auth will fail
...
```
