### PR TITLE
Update pymongo to the latest version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,7 @@ Changed
   function must be called separately. (improvement)
 * Update various internal dependencies to latest stable versions (cryptography, jinja2, requests,
   apscheduler, eventlet, amqp, kombu, semver, six) #4819 (improvement)
+* Upgrade ``pymongo`` to the latest stable version (``3.10.0.``). #4835 (improvement)
 
 Fixed
 ~~~~~

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -18,7 +18,7 @@ requests[security]==2.22.0
 apscheduler==3.6.3
 gitpython==2.1.11
 jsonschema==2.6.0
-pymongo==3.7.2
+pymongo==3.10.0
 mongoengine==0.18.2
 passlib==1.7.1
 lockfile==0.12.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ prettytable
 prompt-toolkit==1.0.15
 psutil==5.6.3
 pyinotify==0.9.6
-pymongo==3.7.2
+pymongo==3.10.0
 pyrabbit
 python-dateutil==2.8.0
 python-editor==1.0.4

--- a/st2api/requirements.txt
+++ b/st2api/requirements.txt
@@ -13,5 +13,5 @@ kombu==4.6.6
 mongoengine==0.18.2
 oslo.config<1.13,>=1.12.1
 oslo.utils<=3.37.0,>=3.36.2
-pymongo==3.7.2
+pymongo==3.10.0
 six==1.13.0

--- a/st2auth/requirements.txt
+++ b/st2auth/requirements.txt
@@ -11,6 +11,6 @@ git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-
 gunicorn==19.9.0
 oslo.config<1.13,>=1.12.1
 passlib==1.7.1
-pymongo==3.7.2
+pymongo==3.10.0
 six==1.13.0
 stevedore==1.30.1

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -23,7 +23,7 @@ mongoengine==0.18.2
 networkx==1.11
 oslo.config<1.13,>=1.12.1
 paramiko==2.6.0
-pymongo==3.7.2
+pymongo==3.10.0
 python-dateutil==2.8.0
 python-statsd==2.1.0
 pyyaml==5.1.2

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -295,6 +295,9 @@ def db_cleanup(db_name, db_host, db_port, username=None, password=None,
 
 def _get_ssl_kwargs(ssl=False, ssl_keyfile=None, ssl_certfile=None, ssl_cert_reqs=None,
                     ssl_ca_certs=None, authentication_mechanism=None, ssl_match_hostname=True):
+    # NOTE: In pymongo 3.9.0 some of the ssl related arguments have been renamed -
+    # https://api.mongodb.com/python/current/changelog.html#changes-in-version-3-9-0
+    # Old names still work, but we should eventually update to new argument names.
     ssl_kwargs = {
         'ssl': ssl,
     }

--- a/st2stream/requirements.txt
+++ b/st2stream/requirements.txt
@@ -12,5 +12,5 @@ kombu==4.6.6
 mongoengine==0.18.2
 oslo.config<1.13,>=1.12.1
 oslo.utils<=3.37.0,>=3.36.2
-pymongo==3.7.2
+pymongo==3.10.0
 six==1.13.0


### PR DESCRIPTION
This pull request updates pymongo to the latest version.

Issue which has prevent us from upgrading in the past (https://jira.mongodb.org/browse/PYTHON-1966) has been resolved in the latest release.

NOTE: Some of the SSL / TLS related constructor arguments have been renamed, but the old names still work so I skipped renaming those arguments for now - https://api.mongodb.com/python/current/changelog.html#changes-in-version-3-9-0.