### PR TITLE
[WIP] [DONT MERGE] [EXPERIMENT] Use more efficient mongoengine fork

### DIFF
--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -18,7 +18,7 @@ requests[security]==2.22.0
 apscheduler==3.6.3
 gitpython==2.1.11
 jsonschema==2.6.0
-git+https://github.com/closeio/mongoengine.git@master#egg=mongoengine
+git+https://github.com/StackStorm/mongoengine.git@master#egg=st2_patched_mallard
 pymongo==3.10.0
 passlib==1.7.1
 lockfile==0.12.2

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -18,8 +18,8 @@ requests[security]==2.22.0
 apscheduler==3.6.3
 gitpython==2.1.11
 jsonschema==2.6.0
+git+https://github.com/closeio/mongoengine.git@master#egg=mongoengine
 pymongo==3.10.0
-mongoengine==0.18.2
 passlib==1.7.1
 lockfile==0.12.2
 python-gnupg==0.4.5

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -18,7 +18,7 @@ requests[security]==2.22.0
 apscheduler==3.6.3
 gitpython==2.1.11
 jsonschema==2.6.0
-git+https://github.com/StackStorm/mongoengine.git@master#egg=st2_patched_mallard
+git+https://github.com/closeio/mongoengine.git@master#egg=mongoengine
 pymongo==3.10.0
 passlib==1.7.1
 lockfile==0.12.2

--- a/st2actions/tests/unit/policies/test_retry_policy.py
+++ b/st2actions/tests/unit/policies/test_retry_policy.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import mock
+from bson import ObjectId
 
 import st2actions
 from st2common.constants.action import LIVEACTION_STATUS_REQUESTED
@@ -258,7 +260,7 @@ class RetryPolicyTestCase(CleanDbTestCase):
         live_action_db = LiveActionDB(
             action='wolfpack.action-1',
             parameters={'actionstr': 'foo'},
-            context={'parent': {'execution_id': 'abcde'}}
+            context={'parent': {'execution_id': ObjectId('5609e91832ed356d04a93cc0')}}
         )
 
         live_action_db, execution_db = action_service.request(live_action_db)

--- a/st2actions/tests/unit/test_executions.py
+++ b/st2actions/tests/unit/test_executions.py
@@ -100,7 +100,7 @@ class TestActionExecutionHistoryWorker(ExecutionDbTestCase):
         self.assertEqual(execution.result, liveaction.result)
         self.assertEqual(execution.status, liveaction.status)
         self.assertEqual(execution.context, liveaction.context)
-        self.assertEqual(execution.liveaction['callback'], liveaction.callback)
+        self.assertEqual(execution.liveaction.get('callback', {}), liveaction.callback)
         self.assertEqual(execution.liveaction['action'], liveaction.action)
 
     def test_basic_execution_history_create_failed(self):
@@ -127,7 +127,7 @@ class TestActionExecutionHistoryWorker(ExecutionDbTestCase):
         self.assertEqual(execution.result, liveaction.result)
         self.assertEqual(execution.status, liveaction.status)
         self.assertEqual(execution.context, liveaction.context)
-        self.assertEqual(execution.liveaction['callback'], liveaction.callback)
+        self.assertEqual(execution.liveaction.get('callback', {}), liveaction.callback)
         self.assertEqual(execution.liveaction['action'], liveaction.action)
         self.assertGreater(len(execution.children), 0)
 
@@ -184,7 +184,7 @@ class TestActionExecutionHistoryWorker(ExecutionDbTestCase):
         self.assertEqual(execution.result, liveaction.result)
         self.assertEqual(execution.status, liveaction.status)
         self.assertEqual(execution.context, liveaction.context)
-        self.assertEqual(execution.liveaction['callback'], liveaction.callback)
+        self.assertEqual(execution.liveaction.get('callback', {}), liveaction.callback)
         self.assertEqual(execution.liveaction['action'], liveaction.action)
 
     def _get_action_execution(self, **kwargs):

--- a/st2api/st2api/controllers/v1/actionalias.py
+++ b/st2api/st2api/controllers/v1/actionalias.py
@@ -166,6 +166,8 @@ class ActionAliasController(resource.ContentPackResourceController):
             old_action_alias_db = action_alias_db
             action_alias_db = ActionAliasAPI.to_model(action_alias)
             action_alias_db.id = ref_or_id
+            # mongo mallard way of saying that we are updating an existing document
+            action_alias_db._lazy = True
             action_alias_db = ActionAlias.add_or_update(action_alias_db)
         except (ValidationError, ValueError) as e:
             LOG.exception('Validation failed for action alias data=%s', action_alias)

--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -290,9 +290,12 @@ class ActionsController(resource.ContentPackResourceController):
             file_paths.append(file_path)
 
         pack_db = Pack.get_by_ref(pack_ref)
-        pack_db.files = set(pack_db.files)
-        pack_db.files.update(set(file_paths))
-        pack_db.files = list(pack_db.files)
+
+        pack_files = set(pack_db.files)
+        pack_files.update(set(file_paths))
+        pack_files = list(pack_files)
+
+        pack_db.files = pack_files
         pack_db = Pack.add_or_update(pack_db)
 
         return pack_db

--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -171,6 +171,8 @@ class ActionsController(resource.ContentPackResourceController):
             action_db = ActionAPI.to_model(action)
             LOG.debug('/actions/ PUT incoming action: %s', action_db)
             action_db.id = action_id
+            # mongo mallard way of saying that we are updating an existing document
+            action_db._lazy = True
             action_db = Action.add_or_update(action_db)
             LOG.debug('/actions/ PUT after add_or_update: %s', action_db)
         except (ValidationError, ValueError) as e:

--- a/st2api/st2api/controllers/v1/auth.py
+++ b/st2api/st2api/controllers/v1/auth.py
@@ -205,6 +205,8 @@ class ApiKeyController(BaseRestControllerMixin):
             raise ValueError('Update of key_hash is not allowed.')
 
         api_key_db.id = old_api_key_db.id
+        # mongo mallard way of saying that we are updating an existing document
+        api_key_db._lazy = True
         api_key_db = ApiKey.add_or_update(api_key_db)
 
         extra = {'old_api_key_db': old_api_key_db, 'new_api_key_db': api_key_db}

--- a/st2api/st2api/controllers/v1/keyvalue.py
+++ b/st2api/st2api/controllers/v1/keyvalue.py
@@ -310,6 +310,8 @@ class KeyValuePairController(ResourceController):
 
                 if existing_kvp_api:
                     kvp_db.id = existing_kvp_api.id
+                    # mongo mallard way of saying that we are updating an existing document
+                    kvp_db._lazy = True
 
                 kvp_db = KeyValuePair.add_or_update(kvp_db)
             except (ValidationError, ValueError) as e:

--- a/st2api/st2api/controllers/v1/policies.py
+++ b/st2api/st2api/controllers/v1/policies.py
@@ -198,6 +198,8 @@ class PolicyController(resource.ContentPackResourceController):
         try:
             db_model = self.model.to_model(instance)
             db_model.id = db_model_id
+            # mongo mallard way of saying that we are updating an existing document
+            db_model._lazy = True
             db_model = self.access.add_or_update(db_model)
         except (ValidationError, ValueError) as e:
             LOG.exception('%s unable to update object: %s', op, db_model)

--- a/st2api/st2api/controllers/v1/rules.py
+++ b/st2api/st2api/controllers/v1/rules.py
@@ -196,6 +196,8 @@ class RuleController(BaseRestControllerMixin, BaseResourceIsolationControllerMix
                                                                           rule_api=rule)
 
             rule_db.id = rule_ref_or_id
+            # mongo mallard way of saying that we are updating an existing document
+            rule_db._lazy = True
             rule_db = Rule.add_or_update(rule_db)
             # After the rule has been added modify the ref_count. This way a failure to add
             # the rule due to violated constraints will have no impact on ref_count.

--- a/st2api/st2api/controllers/v1/sensors.py
+++ b/st2api/st2api/controllers/v1/sensors.py
@@ -92,6 +92,8 @@ class SensorTypeController(resource.ContentPackResourceController):
         try:
             old_sensor_type_db = sensor_type_db
             sensor_type_db.id = sensor_type_id
+            # mongo mallard way of saying that we are updating an existing document
+            sensor_type_db._lazy = True
             sensor_type_db.enabled = getattr(sensor_type, 'enabled', False)
             sensor_type_db = SensorType.add_or_update(sensor_type_db)
         except (ValidationError, ValueError) as e:

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -110,6 +110,8 @@ class TriggerTypeController(resource.ContentPackResourceController):
                 LOG.warning('Discarding mismatched id=%s found in payload and using uri_id=%s.',
                             triggertype.id, triggertype_id)
             triggertype_db.id = triggertype_id
+            # mongo mallard way of saying that we are updating an existing document
+            triggertype_db._lazy = True
             old_triggertype_db = triggertype_db
             triggertype_db = TriggerType.add_or_update(triggertype_db)
         except (ValidationError, ValueError) as e:
@@ -254,6 +256,8 @@ class TriggerController(object):
                             trigger.id, trigger_id)
             trigger_db = TriggerAPI.to_model(trigger)
             trigger_db.id = trigger_id
+            # mongo mallard way of saying that we are updating an existing document
+            trigger_db._lazy = True
             trigger_db = Trigger.add_or_update(trigger_db)
         except (ValidationError, ValueError) as e:
             LOG.exception('Validation failed for trigger data=%s', trigger)

--- a/st2common/st2common/bootstrap/actionsregistrar.py
+++ b/st2common/st2common/bootstrap/actionsregistrar.py
@@ -176,7 +176,10 @@ class ActionsRegistrar(ResourceRegistrar):
         else:
             LOG.debug('Action %s found. Will be updated from: %s to: %s',
                       action_ref, existing, model)
+            # NOTE: _lazy is needed because of mongo mallard changes to amke sure we update an
+            # existing object which doesn't have _db_data attribute populated
             model.id = existing.id
+            model._lazy = True
 
         try:
             model = Action.add_or_update(model)

--- a/st2common/st2common/bootstrap/aliasesregistrar.py
+++ b/st2common/st2common/bootstrap/aliasesregistrar.py
@@ -146,6 +146,7 @@ class AliasesRegistrar(ResourceRegistrar):
 
         try:
             action_alias_db.id = ActionAlias.get_by_name(action_alias_db.name).id
+            action_alias._lazy = True
         except StackStormDBObjectNotFoundError:
             LOG.debug('ActionAlias %s not found. Creating new one.', action_alias)
 

--- a/st2common/st2common/fields.py
+++ b/st2common/st2common/fields.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 import datetime
 import calendar
 
-from mongoengine import LongField
+from mongoengine import IntField
 
 from st2common.util import date as date_utils
 
@@ -27,7 +27,7 @@ __all__ = [
 SECOND_TO_MICROSECONDS = 1000000
 
 
-class ComplexDateTimeField(LongField):
+class ComplexDateTimeField(IntField):
     """
     Date time field which handles microseconds exactly and internally stores
     the timestamp as number of microseconds since the unix epoch.
@@ -92,6 +92,9 @@ class ComplexDateTimeField(LongField):
         return self._convert_from_db(data)
 
     def __set__(self, instance, value):
+        #if isinstance(value, int):
+        #    value = self.to_python(value)
+
         value = self._convert_from_datetime(value) if value else value
         return super(ComplexDateTimeField, self).__set__(instance, value)
 
@@ -109,8 +112,12 @@ class ComplexDateTimeField(LongField):
             return original_value
 
     def to_mongo(self, value):
+        if value is None:
+            return value
         value = self.to_python(value)
         return self._convert_from_datetime(value)
 
     def prepare_query_value(self, op, value):
-        return self._convert_from_datetime(value)
+        if isinstance(value, datetime.datetime):
+            return self._convert_from_datetime(value)
+        return value

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -236,9 +236,10 @@ def cleanup_extra_indexes(model_class):
     """
     Finds any extra indexes and removes those from mongodb.
     """
-    extra_indexes = model_class.compare_indexes().get('extra', None)
-    if not extra_indexes:
-        return 0
+    return 0
+    #extra_indexes = model_class.compare_indexes().get('extra', None)
+    #if not extra_indexes:
+    #    return 0
 
     # mongoengine does not have the necessary method so we need to drop to
     # pymongo interfaces via some private methods.

--- a/st2common/st2common/models/db/execution.py
+++ b/st2common/st2common/models/db/execution.py
@@ -103,7 +103,7 @@ class ActionExecutionDB(stormbase.StormFoundationDB):
     def mask_secrets(self, value):
         result = copy.deepcopy(value)
 
-        liveaction = result['liveaction']
+        liveaction = result.get('liveaction', {})
         parameters = {}
         # pylint: disable=no-member
         parameters.update(value.get('action', {}).get('parameters', {}))

--- a/st2common/st2common/models/db/stormbase.py
+++ b/st2common/st2common/models/db/stormbase.py
@@ -123,8 +123,7 @@ class EscapedDictField(me.DictField):
 
     def to_mongo(self, value, use_db_field=True, fields=None):
         value = mongoescape.escape_chars(value)
-        return super(EscapedDictField, self).to_mongo(value=value, use_db_field=use_db_field,
-                                                      fields=fields)
+        return super(EscapedDictField, self).to_mongo(value)
 
     def to_python(self, value):
         value = super(EscapedDictField, self).to_python(value)
@@ -142,8 +141,7 @@ class EscapedDynamicField(me.DynamicField):
 
     def to_mongo(self, value, use_db_field=True, fields=None):
         value = mongoescape.escape_chars(value)
-        return super(EscapedDynamicField, self).to_mongo(value=value, use_db_field=use_db_field,
-                                                         fields=fields)
+        return super(EscapedDynamicField, self).to_mongo(value)
 
     def to_python(self, value):
         value = super(EscapedDynamicField, self).to_python(value)

--- a/st2common/tests/unit/test_db_fields.py
+++ b/st2common/tests/unit/test_db_fields.py
@@ -68,7 +68,7 @@ class ComplexDateTimeFieldTestCase(unittest2.TestCase):
             expected_value = datetime_values[index]
             self.assertEqual(actual_value, expected_value)
 
-    @mock.patch('st2common.fields.LongField.__get__')
+    @mock.patch('st2common.fields.IntField.__get__')
     def test_get_(self, mock_get):
         field = ComplexDateTimeField()
 


### PR DESCRIPTION
This is just a quick experiment to see if we could use a more efficient fork of mongoengine (https://github.com/closeio/mongoengine) which reduces a lot of conversion overhead which is involved in regular mongoengine (which results in very slow operations with large documents).

The problem is that even though a lot of similar projects claim almost full mongoengine API compatibility, that doesn't really help us much since our DB abstraction is based heavily around mongoengine and also utilizes various low level APIs and functionality.

In addition to that, this fork is also based around older version of mongoengine.

So this means there will likely be no quick and easy wins for us. If that doesn't work out, probably the most reasonable approach is to try to incrementally optimize hot code paths (especially the ones which workflow results are saved and retrieved) one by one and use pymongo directly in those code paths.