### PR TITLE
Fix the amqp connection for WorkflowExecutionHandler to pass the SSL params

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -105,6 +105,9 @@ Fixed
   NOTE: This issue only affected installations using Python 3. (bug fix) #4832 #4834
 
   Reported by @alexku7.
+* Fix the amqp connection setup for WorkflowExecutionHandler to pass SSL params. (bug fix) #4845
+
+  Contributed by Tatsuma Matsuki (@mtatsuma)
 
 3.1.0 - June 27, 2019
 ---------------------

--- a/st2actions/st2actions/workflows/workflows.py
+++ b/st2actions/st2actions/workflows/workflows.py
@@ -14,8 +14,6 @@
 
 from __future__ import absolute_import
 
-import kombu
-
 from orquesta import statuses
 
 from st2common.constants import action as ac_const
@@ -179,5 +177,5 @@ class WorkflowExecutionHandler(consumers.VariableMessageHandler):
 
 
 def get_engine():
-    with kombu.Connection(txpt_utils.get_messaging_urls()) as conn:
+    with txpt_utils.get_connection() as conn:
         return WorkflowExecutionHandler(conn, WORKFLOW_EXECUTION_QUEUES)


### PR DESCRIPTION
To pass the SSL params, get_connection() should be used instead.

Related commit: dd4465a266c11e2dfd2fcf97896562ff8a9e8605