### PR TITLE
Fix to st2client install check

### DIFF
--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -57,3 +57,4 @@ ujson==1.35
 python-dateutil==2.8.0
 bcrypt==3.1.7
 jinja2==2.10.3
+more-itertools==5.0.0

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -58,3 +58,4 @@ python-dateutil==2.8.0
 bcrypt==3.1.7
 jinja2==2.10.3
 more-itertools==5.0.0
+zipp>=0.5,<=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ kombu==4.6.6
 lockfile==0.12.2
 mock==2.0.0
 mongoengine==0.18.2
+more-itertools==5.0.0
 networkx==1.11
 nose
 nose-parallel==0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,3 +65,4 @@ unittest2
 webob==1.8.5
 webtest
 zake==0.2.2
+zipp<=1.0.0,>=0.5

--- a/st2client/in-requirements.txt
+++ b/st2client/in-requirements.txt
@@ -12,3 +12,4 @@ sseclient-py
 python-editor
 prompt-toolkit
 cryptography
+more-itertools==5.0.0

--- a/st2client/in-requirements.txt
+++ b/st2client/in-requirements.txt
@@ -13,3 +13,4 @@ python-editor
 prompt-toolkit
 cryptography
 more-itertools==5.0.0
+zipp>=0.5,<=1.0.0

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -9,6 +9,7 @@ argcomplete
 cryptography==2.8
 jsonpath-rw==1.4.0
 jsonschema==2.6.0
+more-itertools==5.0.0
 prettytable
 prompt-toolkit==1.0.15
 python-dateutil==2.8.0

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -19,3 +19,4 @@ pyyaml==5.1.2
 requests[security]==2.22.0
 six==1.13.0
 sseclient-py==1.7
+zipp<=1.0.0,>=0.5


### PR DESCRIPTION
The make .st2client-install-check command is failing because latest more-itertools no longer supports python 2.7. To workaround, pin more-itertools to an older version.  The zipp requirement is pinned to >=0.5,<=1.0.0 because the latest 2.0.0 version is registered as 0.0.0 and causing install check to fail.

Closes #4843