### PR TITLE
Update orquesta requirement to version with fix to task rerun

### DIFF
--- a/contrib/runners/orquesta_runner/in-requirements.txt
+++ b/contrib/runners/orquesta_runner/in-requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/StackStorm/orquesta.git@fc001fe8b7dcf4974c61a120e8a428e8e4b9565e#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@6e2fa8052cd62b07e96e540f68e7290b324d0f01#egg=orquesta

--- a/contrib/runners/orquesta_runner/requirements.txt
+++ b/contrib/runners/orquesta_runner/requirements.txt
@@ -5,4 +5,4 @@
 # If you want to update depdencies for a single component, modify the
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
-git+https://github.com/StackStorm/orquesta.git@fc001fe8b7dcf4974c61a120e8a428e8e4b9565e#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@6e2fa8052cd62b07e96e540f68e7290b324d0f01#egg=orquesta

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ cryptography==2.8
 eventlet==0.25.1
 flex==6.14.0
 git+https://github.com/StackStorm/logshipper.git@stackstorm_patched#egg=logshipper
-git+https://github.com/StackStorm/orquesta.git@fc001fe8b7dcf4974c61a120e8a428e8e4b9565e#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@6e2fa8052cd62b07e96e540f68e7290b324d0f01#egg=orquesta
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
 gitpython==2.1.11

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -9,7 +9,7 @@ jsonschema
 kombu
 mongoengine
 networkx
-git+https://github.com/StackStorm/orquesta.git@fc001fe8b7dcf4974c61a120e8a428e8e4b9565e#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@6e2fa8052cd62b07e96e540f68e7290b324d0f01#egg=orquesta
 oslo.config
 paramiko
 pyyaml

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -10,7 +10,7 @@ apscheduler==3.6.3
 cryptography==2.8
 eventlet==0.25.1
 flex==6.14.0
-git+https://github.com/StackStorm/orquesta.git@fc001fe8b7dcf4974c61a120e8a428e8e4b9565e#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@6e2fa8052cd62b07e96e540f68e7290b324d0f01#egg=orquesta
 gitpython==2.1.11
 greenlet==0.4.15
 ipaddr


### PR DESCRIPTION
Update orquesta requirement to version with fix to task rerun to ignore duplicate task rerun requests and detect and ignore tasks that are along the path of executions for another task rerun requests.