### PR TITLE
Switch travis to use Bionic, Mongo 4.0, and RabbitMQ 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,11 +70,10 @@ addons:
       #- mongodb-upstart
       - sourceline: 'deb [arch=amd64] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse'
         key_url: 'https://www.mongodb.org/static/pgp/server-3.4.asc'
-      # NOTE: Precise repo doesn't contain Erlang 20.x, latest version is 19.x so we need to use RabbitMQ 3.7.6
-      #- sourceline: 'deb [arch=amd64] http://packages.erlang-solutions.com/ubuntu precise contrib'
-      #  key_url: 'https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc'
-      #- sourceline: 'deb [arch=amd64] https://dl.bintray.com/rabbitmq/debian precise rabbitmq-server-v3.6.x'
-      #  key_url: 'https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc'
+      - sourceline: 'deb [arch=amd64] http://packages.erlang-solutions.com/ubuntu xenial contrib'
+        key_url: 'https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc'
+      - sourceline: 'deb [arch=amd64] https://dl.bintray.com/rabbitmq/debian xenial rabbitmq-server-v3.6.x'
+        key_url: 'https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc'
       #git is v2.21.0 in xenial
       #- sourceline: 'ppa:git-core/ppa'
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ install:
   - cp conf/st2.dev.conf "${ST2_CONF}" ; sed -i -e "s/stanley/travis/" "${ST2_CONF}"
   - sudo scripts/travis/add-itest-user-key.sh
   - if [ "${TASK}" = 'ci-unit' ] || [ "${TASK}" = 'ci-integration' ] || [ "${TASK}" = 'ci-checks ci-packs-tests' ] || [ "${TASK}" = 'compilepy3 ci-py3-unit' ] || [ "${TASK}" = 'ci-py3-integration' ]; then sudo .circle/add-itest-user.sh; fi
-  - if [[ "${TASK}" = *'ci-packs-tests'* ]]; then sudo scripts/travis/permissions-workaround.sh; fi
+  - if [[ "${TASK}" = *'ci-packs-tests'* ]] || [[ "${TASK}" = *'-integration'* ]]; then sudo scripts/travis/permissions-workaround.sh; fi
 
 # Let's enable rabbitmqadmin
 # See https://github.com/messagebus/lapine/wiki/Testing-on-Travis.

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,19 +31,19 @@ jobs:
     # job which also includes "make requirements" and other steps
     # "make requirements" can take substantially lower if the cache is purged
     # and this would cause too many intermediate failures / false positives
-    - env: TASK=ci-unit CACHE_NAME=py2 COMMAND_THRESHOLD=700
+    - env: TASK=ci-unit CACHE_NAME=py2 COMMAND_THRESHOLD=740
       python: 2.7
       name: "Unit Tests (Python 2.7 MongoDB 3.4)"
-    - env: TASK=ci-integration CACHE_NAME=py2 COMMAND_THRESHOLD=700
+    - env: TASK=ci-integration CACHE_NAME=py2 COMMAND_THRESHOLD=740
       python: 2.7
       name: "Integration Tests (Python 2.7)"
-    - env: TASK="ci-checks ci-packs-tests" CACHE_NAME=py2 COMMAND_THRESHOLD=280
+    - env: TASK="ci-checks ci-packs-tests" CACHE_NAME=py2 COMMAND_THRESHOLD=440
       python: 2.7
       name: "Lint Checks, Packs Tests (Python 2.7)"
-    - env: TASK="compilepy3 ci-py3-unit ci-py3-packs-tests" CACHE_NAME=py3 PYTHON_VERSION=python3.6 COMMAND_THRESHOLD=680
+    - env: TASK="compilepy3 ci-py3-unit ci-py3-packs-tests" CACHE_NAME=py3 PYTHON_VERSION=python3.6 COMMAND_THRESHOLD=740
       python: 3.6
       name: "Unit Tests, Pack Tests (Python 3.6)"
-    - env: TASK="ci-py3-integration" CACHE_NAME=py3 PYTHON_VERSION=python3.6 COMMAND_THRESHOLD=310
+    - env: TASK="ci-py3-integration" CACHE_NAME=py3 PYTHON_VERSION=python3.6 COMMAND_THRESHOLD=720
       python: 3.6
       name: "Integration Tests (Python 3.6)"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,20 +34,6 @@ jobs:
     - env: TASK=ci-unit CACHE_NAME=py2 COMMAND_THRESHOLD=700
       python: 2.7
       name: "Unit Tests (Python 2.7 MongoDB 3.4)"
-    #- env: TASK=ci-unit CACHE_NAME=py2 COMMAND_THRESHOLD=700
-      #python: 2.7
-      #name: "Unit Tests (Python 2.7 MongoDB 3.6)"
-      #addons:
-      #  apt:
-      #    sources:
-      #      - mongodb-upstart
-      #      - sourceline: 'deb [arch=amd64] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse'
-      #        key_url: 'https://www.mongodb.org/static/pgp/server-3.6.asc'
-      #      - sourceline: 'ppa:git-core/ppa'
-      #    packages:
-      #      - mongodb-org-server
-      #      - mongodb-org-shell
-      #      - git
     - env: TASK=ci-integration CACHE_NAME=py2 COMMAND_THRESHOLD=700
       python: 2.7
       name: "Integration Tests (Python 2.7)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,10 +56,10 @@ matrix:
     - env: TASK="ci-checks ci-packs-tests" CACHE_NAME=py2 COMMAND_THRESHOLD=280
       python: 2.7
       name: "Lint Checks, Packs Tests (Python 2.7)"
-    - env: TASK="compilepy3 ci-py3-unit" CACHE_NAME=py3 COMMAND_THRESHOLD=680
+    - env: TASK="compilepy3 ci-py3-unit" CACHE_NAME=py3 PYTHON_VERSION=python3.6 COMMAND_THRESHOLD=680
       python: 3.6
       name: "Unit Tests, Pack Tests (Python 3.6)"
-    - env: TASK="ci-py3-integration" CACHE_NAME=py3 COMMAND_THRESHOLD=310
+    - env: TASK="ci-py3-integration" CACHE_NAME=py3 PYTHON_VERSION=python3.6 COMMAND_THRESHOLD=310
       python: 3.6
       name: "Integration Tests (Python 3.6)"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: xenial
+dist: bionic
 language: python
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,9 +54,9 @@ addons:
       #- mongodb-upstart
       - sourceline: 'deb [arch=amd64] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse'
         key_url: 'https://www.mongodb.org/static/pgp/server-3.4.asc'
-      - sourceline: 'deb [arch=amd64] http://packages.erlang-solutions.com/ubuntu xenial contrib'
+      - sourceline: 'deb [arch=amd64] http://packages.erlang-solutions.com/ubuntu bionic contrib'
         key_url: 'https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc'
-      - sourceline: 'deb [arch=amd64] https://dl.bintray.com/rabbitmq/debian xenial rabbitmq-server-v3.8.x'
+      - sourceline: 'deb [arch=amd64] https://dl.bintray.com/rabbitmq/debian bionic rabbitmq-server-v3.8.x'
         key_url: 'https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc'
       #git is v2.21.0 in xenial
       #- sourceline: 'ppa:git-core/ppa'

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,20 +31,20 @@ jobs:
     # job which also includes "make requirements" and other steps
     # "make requirements" can take substantially lower if the cache is purged
     # and this would cause too many intermediate failures / false positives
-    - env: TASK=ci-unit CACHE_NAME=py2 COMMAND_THRESHOLD=740
+    - env: TASK=ci-unit CACHE_NAME=py2 COMMAND_THRESHOLD=870
       python: 2.7
       # bionic and xenial come with 4.0 and 3.4 is not available on bionic
       name: "Unit Tests (Python 2.7 MongoDB 4.0)"
-    - env: TASK=ci-integration CACHE_NAME=py2 COMMAND_THRESHOLD=740
+    - env: TASK=ci-integration CACHE_NAME=py2 COMMAND_THRESHOLD=960
       python: 2.7
       name: "Integration Tests (Python 2.7)"
-    - env: TASK="ci-checks ci-packs-tests" CACHE_NAME=py2 COMMAND_THRESHOLD=440
+    - env: TASK="ci-checks ci-packs-tests" CACHE_NAME=py2 COMMAND_THRESHOLD=550
       python: 2.7
       name: "Lint Checks, Packs Tests (Python 2.7)"
-    - env: TASK="compilepy3 ci-py3-unit ci-py3-packs-tests" CACHE_NAME=py3 PYTHON_VERSION=python3.6 COMMAND_THRESHOLD=740
+    - env: TASK="compilepy3 ci-py3-unit ci-py3-packs-tests" CACHE_NAME=py3 PYTHON_VERSION=python3.6 COMMAND_THRESHOLD=1160
       python: 3.6
       name: "Unit Tests, Pack Tests (Python 3.6)"
-    - env: TASK="ci-py3-integration" CACHE_NAME=py3 PYTHON_VERSION=python3.6 COMMAND_THRESHOLD=720
+    - env: TASK="ci-py3-integration" CACHE_NAME=py3 PYTHON_VERSION=python3.6 COMMAND_THRESHOLD=1090
       python: 3.6
       name: "Integration Tests (Python 3.6)"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,6 +106,7 @@ install:
   - cp conf/st2.dev.conf "${ST2_CONF}" ; sed -i -e "s/stanley/travis/" "${ST2_CONF}"
   - sudo scripts/travis/add-itest-user-key.sh
   - if [ "${TASK}" = 'ci-unit' ] || [ "${TASK}" = 'ci-integration' ] || [ "${TASK}" = 'ci-checks ci-packs-tests' ] || [ "${TASK}" = 'compilepy3 ci-py3-unit' ] || [ "${TASK}" = 'ci-py3-integration' ]; then sudo .circle/add-itest-user.sh; fi
+  - if [[ "${TASK}" = *'ci-packs-tests'* ]]; then sudo scripts/travis/permissions-workaround.sh; fi
 
 # Let's enable rabbitmqadmin
 # See https://github.com/messagebus/lapine/wiki/Testing-on-Travis.

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ jobs:
     # and this would cause too many intermediate failures / false positives
     - env: TASK=ci-unit CACHE_NAME=py2 COMMAND_THRESHOLD=740
       python: 2.7
-      name: "Unit Tests (Python 2.7 MongoDB 3.4)"
+      # bionic and xenial come with 4.0 and 3.4 is not available on bionic
+      name: "Unit Tests (Python 2.7 MongoDB 4.0)"
     - env: TASK=ci-integration CACHE_NAME=py2 COMMAND_THRESHOLD=740
       python: 2.7
       name: "Integration Tests (Python 2.7)"
@@ -50,19 +51,21 @@ jobs:
 addons:
   apt:
     sources:
-      # xenial has systemd not upstart
+      # xenial and bionic have systemd not upstart
       #- mongodb-upstart
-      - sourceline: 'deb [arch=amd64] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse'
-        key_url: 'https://www.mongodb.org/static/pgp/server-3.4.asc'
+      # mongodb 3.4 is available on precise, trusty, and xenial, but not bionic.
+      #- sourceline: 'deb [arch=amd64] http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.4 multiverse'
+      #  key_url: 'https://www.mongodb.org/static/pgp/server-3.4.asc'
       - sourceline: 'deb [arch=amd64] http://packages.erlang-solutions.com/ubuntu bionic contrib'
         key_url: 'https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc'
       - sourceline: 'deb [arch=amd64] https://dl.bintray.com/rabbitmq/debian bionic rabbitmq-server-v3.8.x'
         key_url: 'https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc'
-      #git is v2.21.0 in xenial
+      #git is v2.21.0 in xenial, v2.24.1 in bionic
       #- sourceline: 'ppa:git-core/ppa'
     packages:
-      - mongodb-org-server=3.4.24
-      - mongodb-org-shell=3.4.24
+      # bionic has mongodb 4.0.14 by default
+      #- mongodb-org-server=3.4.24
+      #- mongodb-org-shell=3.4.24
       - erlang
       - rabbitmq-server
       #- git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
-# Used old infrastructure, needed for integration tests:
-# http://docs.travis-ci.com/user/workers/standard-infrastructure/
-sudo: required
+os: linux
 dist: xenial
 language: python
 
@@ -24,7 +22,7 @@ env:
     - NOSE_TIME=$([ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${IS_NIGHTLY_BUILD}" = "no" ] && echo "yes" || echo "no")
     # Travis-specific st2.conf (with travis user instead of stanley)
     - ST2_CONF=conf/st2.travis.conf
-matrix:
+jobs:
   include:
     # NOTE: We combine builds because Travis offers a maximum of 5 concurrent
     # builds and having 6 tasks / builds means 1 tasks will need to wait for one

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ matrix:
     - env: TASK="ci-checks ci-packs-tests" CACHE_NAME=py2 COMMAND_THRESHOLD=280
       python: 2.7
       name: "Lint Checks, Packs Tests (Python 2.7)"
-    - env: TASK="compilepy3 ci-py3-unit" CACHE_NAME=py3 PYTHON_VERSION=python3.6 COMMAND_THRESHOLD=680
+    - env: TASK="compilepy3 ci-py3-unit ci-py3-packs-tests" CACHE_NAME=py3 PYTHON_VERSION=python3.6 COMMAND_THRESHOLD=680
       python: 3.6
       name: "Unit Tests, Pack Tests (Python 3.6)"
     - env: TASK="ci-py3-integration" CACHE_NAME=py3 PYTHON_VERSION=python3.6 COMMAND_THRESHOLD=310
@@ -105,8 +105,8 @@ install:
   # prep a travis-specific dev conf file that uses travis instead of stanley
   - cp conf/st2.dev.conf "${ST2_CONF}" ; sed -i -e "s/stanley/travis/" "${ST2_CONF}"
   - sudo scripts/travis/add-itest-user-key.sh
-  - if [ "${TASK}" = 'ci-unit' ] || [ "${TASK}" = 'ci-integration' ] || [ "${TASK}" = 'ci-checks ci-packs-tests' ] || [ "${TASK}" = 'compilepy3 ci-py3-unit' ] || [ "${TASK}" = 'ci-py3-integration' ]; then sudo .circle/add-itest-user.sh; fi
-  - if [[ "${TASK}" = *'ci-packs-tests'* ]] || [[ "${TASK}" = *'-integration'* ]]; then sudo scripts/travis/permissions-workaround.sh; fi
+  - sudo .circle/add-itest-user.sh
+  - if [[ "${TASK}" = *'-packs-tests'* ]] || [[ "${TASK}" = *'-integration'* ]]; then sudo scripts/travis/permissions-workaround.sh; fi
 
 # Let's enable rabbitmqadmin
 # See https://github.com/messagebus/lapine/wiki/Testing-on-Travis.

--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,8 @@ before_script:
   - sudo wget http://guest:guest@localhost:15672/cli/rabbitmqadmin -O /usr/local/bin/rabbitmqadmin
   - sudo chmod +x /usr/local/bin/rabbitmqadmin
   - sudo service rabbitmq-server restart
-  - sudo tail -n 30 /var/log/rabbitmq/*
+  # chmod to make glob work (*.log to avoid log dir)
+  - sudo chmod a+rx /var/log/rabbitmq ; sudo tail -n 30 /var/log/rabbitmq/*.log
   # Print various binary versions
   - mongod --version
   - git --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 # Used old infrastructure, needed for integration tests:
 # http://docs.travis-ci.com/user/workers/standard-infrastructure/
 sudo: required
-# NOTE: We use precise because tests finish faster than on Xenial
-dist: precise
+dist: xenial
 language: python
 
 branches:
@@ -44,7 +43,7 @@ matrix:
       #  apt:
       #    sources:
       #      - mongodb-upstart
-      #      - sourceline: 'deb [arch=amd64] http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.6 multiverse'
+      #      - sourceline: 'deb [arch=amd64] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse'
       #        key_url: 'https://www.mongodb.org/static/pgp/server-3.6.asc'
       #      - sourceline: 'ppa:git-core/ppa'
       #    packages:
@@ -67,21 +66,23 @@ matrix:
 addons:
   apt:
     sources:
-      - mongodb-upstart
-      - sourceline: 'deb [arch=amd64] http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.4 multiverse'
+      # xenial has systemd not upstart
+      #- mongodb-upstart
+      - sourceline: 'deb [arch=amd64] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse'
         key_url: 'https://www.mongodb.org/static/pgp/server-3.4.asc'
       # NOTE: Precise repo doesn't contain Erlang 20.x, latest version is 19.x so we need to use RabbitMQ 3.7.6
       #- sourceline: 'deb [arch=amd64] http://packages.erlang-solutions.com/ubuntu precise contrib'
       #  key_url: 'https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc'
       #- sourceline: 'deb [arch=amd64] https://dl.bintray.com/rabbitmq/debian precise rabbitmq-server-v3.6.x'
       #  key_url: 'https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc'
-      - sourceline: 'ppa:git-core/ppa'
+      #git is v2.21.0 in xenial
+      #- sourceline: 'ppa:git-core/ppa'
     packages:
-      - mongodb-org-server
-      - mongodb-org-shell
+      - mongodb-org-server=3.4.24
+      - mongodb-org-shell=3.4.24
       - erlang
       - rabbitmq-server
-      - git
+      #- git
       - libffi-dev
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ addons:
         key_url: 'https://www.mongodb.org/static/pgp/server-3.4.asc'
       - sourceline: 'deb [arch=amd64] http://packages.erlang-solutions.com/ubuntu xenial contrib'
         key_url: 'https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc'
-      - sourceline: 'deb [arch=amd64] https://dl.bintray.com/rabbitmq/debian xenial rabbitmq-server-v3.6.x'
+      - sourceline: 'deb [arch=amd64] https://dl.bintray.com/rabbitmq/debian xenial rabbitmq-server-v3.8.x'
         key_url: 'https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc'
       #git is v2.21.0 in xenial
       #- sourceline: 'ppa:git-core/ppa'

--- a/Makefile
+++ b/Makefile
@@ -951,6 +951,12 @@ ci-py3-unit:
 	@echo "==================== ci-py3-unit ===================="
 	@echo
 	NOSE_WITH_TIMER=$(NOSE_WITH_TIMER) tox -e py36-unit -vv
+
+.PHONY: ci-py3-packs-tests
+ci-py3-packs-tests:
+	@echo
+	@echo "==================== ci-py3-packs-tests ===================="
+	@echo
 	NOSE_WITH_TIMER=$(NOSE_WITH_TIMER) tox -e py36-packs -vv
 
 .PHONY: ci-py3-unit-nightly

--- a/Makefile
+++ b/Makefile
@@ -672,7 +672,7 @@ endif
 		echo "-----------------------------------------------------------"; \
 		. $(VIRTUALENV_DIR)/bin/activate; \
 		    COVERAGE_FILE=.coverage.integration.$$(echo $$component | tr '/' '.') \
-		    nosetests $(NOSE_OPTS) -s -v --exe $(NOSE_COVERAGE_FLAGS) \
+		    nosetests $(NOSE_OPTS) -s -v $(NOSE_COVERAGE_FLAGS) \
 		    $(NOSE_COVERAGE_PACKAGES) \
 		    $$component/tests/integration || exit 1; \
 		echo "-----------------------------------------------------------"; \

--- a/scripts/travis/install-requirements.sh
+++ b/scripts/travis/install-requirements.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [ "${TASK}" = 'compilepy3 ci-py3-unit' ] || [ "${TASK}" = 'ci-py3-integration' ]; then
+if [[ "${TASK}" = *'ci-py3'* ]]; then
     pip install "tox==3.8.6"
 
     # cleanup any invalid python2 cache
@@ -22,15 +22,21 @@ if [ "${TASK}" = 'compilepy3 ci-py3-unit' ] || [ "${TASK}" = 'ci-py3-integration
     # NOTE: We create the environment and install the dependencies first. This
     # means that the subsequent tox build / test command has a stable run time
     # since it doesn't depend on dependencies being installed.
-    if [ "${TASK}" = 'compilepy3 ci-py3-unit' ]; then
-        TOX_TASK="py36-unit"
+    build_tox_env() {
+        tox -e $1 --notest
+    }
+
+    if [[ "${TASK}" = *'ci-py3-unit'* ]]; then
+        build_tox_env py36-unit
     fi
 
-    if [ "${TASK}" = 'ci-py3-integration' ]; then
-        TOX_TASK="py36-integration"
+    if [[ "${TASK}" = *'ci-py3-packs-tests'* ]]; then
+        build_tox_env py36-packs
     fi
 
-    tox -e ${TOX_TASK} --notest
+    if [[ "${TASK}" = *'ci-py3-integration'* ]]; then
+        build_tox_env py36-integration
+    fi
 else
     make requirements
 fi

--- a/scripts/travis/install-requirements.sh
+++ b/scripts/travis/install-requirements.sh
@@ -3,6 +3,11 @@
 if [ "${TASK}" = 'compilepy3 ci-py3-unit' ] || [ "${TASK}" = 'ci-py3-integration' ]; then
     pip install "tox==3.8.6"
 
+    # cleanup any invalid python2 cache
+    test -d virtualenv/lib/${PYTHON_VERSION} || rm -rf virtualenv/*
+    # rebuild virtualenv if necessary
+    test -f virtualenv/bin/activate || virtualenv --python=${PYTHON_VERSION} virtualenv --no-download
+
     # Install runners
     . virtualenv/bin/activate
 

--- a/scripts/travis/permissions-workaround.sh
+++ b/scripts/travis/permissions-workaround.sh
@@ -9,6 +9,6 @@ fi
 # stanley needs to work with some fixtures during the tests
 # this can't be the travis user because 'stanley' is the hardcoded user in the tests
 # o=other; X=only set execute bit if user execute bit is set (eg on dirs)
-chmod -R o+rwX ${TRAVIS_BUILD_DIR}/st2tests/st2tests/fixtures/packs
+chmod -R o+rX ${TRAVIS_BUILD_DIR}/st2tests/st2tests/fixtures/packs
 # rabbitmq user needs access to these certs
-chmod -R o+rwX ${TRAVIS_BUILD_DIR}/st2tests/st2tests/fixtures/ssl_certs
+chmod -R o+rX ${TRAVIS_BUILD_DIR}/st2tests/st2tests/fixtures/ssl_certs

--- a/scripts/travis/permissions-workaround.sh
+++ b/scripts/travis/permissions-workaround.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+if [ "$(whoami)" != 'root' ]; then
+    echo 'Please run with sudo'
+    exit 2
+fi
+
+# stanley needs to work with some fixtures during the tests
+# this can't be the travis user because 'stanley' is the hardcoded user in the tests
+# o=other; X=only set execute bit if user execute bit is set (eg on dirs)
+chmod -R o+rwX ${TRAVIS_BUILD_DIR}/StackStorm/st2/st2tests/st2tests/fixtures/packs

--- a/scripts/travis/permissions-workaround.sh
+++ b/scripts/travis/permissions-workaround.sh
@@ -9,6 +9,6 @@ fi
 # stanley needs to work with some fixtures during the tests
 # this can't be the travis user because 'stanley' is the hardcoded user in the tests
 # o=other; X=only set execute bit if user execute bit is set (eg on dirs)
-chmod -R o+rwX ${TRAVIS_BUILD_DIR}/StackStorm/st2/st2tests/st2tests/fixtures/packs
+chmod -R o+rwX ${TRAVIS_BUILD_DIR}/st2tests/st2tests/fixtures/packs
 # rabbitmq user needs access to these certs
-chmod -R o+rwX ${TRAVIS_BUILD_DIR}/StackStorm/st2/st2tests/st2tests/fixtures/ssl_certs
+chmod -R o+rwX ${TRAVIS_BUILD_DIR}/st2tests/st2tests/fixtures/ssl_certs

--- a/scripts/travis/permissions-workaround.sh
+++ b/scripts/travis/permissions-workaround.sh
@@ -6,9 +6,15 @@ if [ "$(whoami)" != 'root' ]; then
     exit 2
 fi
 
-# stanley needs to work with some fixtures during the tests
+# rabbitmq user needs access to the ssl_certs fixtures during integration tests
+# stanley needs to work with packs fixtures during the packs tests
 # this can't be the travis user because 'stanley' is the hardcoded user in the tests
 # o=other; X=only set execute bit if user execute bit is set (eg on dirs)
-chmod -R o+rX ${TRAVIS_BUILD_DIR}/st2tests/st2tests/fixtures/packs
-# rabbitmq user needs access to these certs
-chmod -R o+rX ${TRAVIS_BUILD_DIR}/st2tests/st2tests/fixtures/ssl_certs
+chmod -R o+rX ${TRAVIS_BUILD_DIR}/st2tests/st2tests/fixtures ${TRAVIS_BUILD_DIR}/contrib
+
+# make sure parent directories are traversable
+d=${TRAVIS_BUILD_DIR}/st2tests/st2tests
+while [[ "${d}" != "/" ]]; do
+    chmod o+rx "${d}"
+    d=$(dirname "${d}")
+done

--- a/scripts/travis/permissions-workaround.sh
+++ b/scripts/travis/permissions-workaround.sh
@@ -10,3 +10,5 @@ fi
 # this can't be the travis user because 'stanley' is the hardcoded user in the tests
 # o=other; X=only set execute bit if user execute bit is set (eg on dirs)
 chmod -R o+rwX ${TRAVIS_BUILD_DIR}/StackStorm/st2/st2tests/st2tests/fixtures/packs
+# rabbitmq user needs access to these certs
+chmod -R o+rwX ${TRAVIS_BUILD_DIR}/StackStorm/st2/st2tests/st2tests/fixtures/ssl_certs

--- a/scripts/travis/rabbitmq.config
+++ b/scripts/travis/rabbitmq.config
@@ -1,7 +1,6 @@
 [
   {rabbit, [
      {ssl_listeners, [5671]},
-     {ssl_allow_poodle_attack, true},
      {ssl_options, [{cacertfile, "/home/travis/build/StackStorm/st2/st2tests/st2tests/fixtures/ssl_certs/ca/ca_certificate_bundle.pem"},
                     {certfile,   "/home/travis/build/StackStorm/st2/st2tests/st2tests/fixtures/ssl_certs/server/server_certificate.pem"},
                     {keyfile,    "/home/travis/build/StackStorm/st2/st2tests/st2tests/fixtures/ssl_certs/server/private_key.pem"},

--- a/st2common/tests/integration/test_rabbitmq_ssl_listener.py
+++ b/st2common/tests/integration/test_rabbitmq_ssl_listener.py
@@ -39,10 +39,7 @@ SSL_LISTENER_PORT = 5671
 
 # NOTE: We only run those tests on Travis because at the moment, local vagrant dev VM doesn't
 # expose RabbitMQ SSL listener by default
-# TODO: Re-enable once we upgrade Travis from Precise to Xenial where latest version of RabbitMQ
-# and OpenSSL is available
-@unittest2.skip('Skipping until we upgrade to Xenial on Travis')
-# @unittest2.skipIf(not ON_TRAVIS, 'Skipping tests because not running on Travis')
+@unittest2.skipIf(not ON_TRAVIS, 'Skipping tests because not running on Travis')
 class RabbitMQTLSListenerTestCase(unittest2.TestCase):
 
     def setUp(self):

--- a/st2common/tests/integration/test_rabbitmq_ssl_listener.py
+++ b/st2common/tests/integration/test_rabbitmq_ssl_listener.py
@@ -55,14 +55,16 @@ class RabbitMQTLSListenerTestCase(unittest2.TestCase):
 
         expected_msg_1 = '[Errno 104] Connection reset by peer'
         expected_msg_2 = 'Socket closed'
+        expected_msg_3 = 'Server unexpectedly closed connection'
 
         try:
             connection.connect()
         except Exception as e:
             self.assertFalse(connection.connected)
             self.assertIsInstance(e, (IOError, socket.error))
-            self.assertTrue(expected_msg_1 in six.text_type(e) or expected_msg_2 in
-                            six.text_type(e))
+            self.assertTrue(expected_msg_1 in six.text_type(e) or
+                            expected_msg_2 in six.text_type(e) or
+                            expected_msg_3 in six.text_type(e))
         else:
             self.fail('Exception was not thrown')
 

--- a/st2common/tests/integration/test_rabbitmq_ssl_listener.py
+++ b/st2common/tests/integration/test_rabbitmq_ssl_listener.py
@@ -53,7 +53,7 @@ class RabbitMQTLSListenerTestCase(unittest2.TestCase):
     def test_non_ssl_connection_on_ssl_listener_port_failure(self):
         connection = transport_utils.get_connection(urls='amqp://guest:guest@127.0.0.1:5671/')
 
-        expected_msg_1 = '[Errno 104] Connection reset by peer'
+        expected_msg_1 = '[Errno 104]'  # followed by: ' Connection reset by peer' or ' ECONNRESET'
         expected_msg_2 = 'Socket closed'
         expected_msg_3 = 'Server unexpectedly closed connection'
 

--- a/tox.ini
+++ b/tox.ini
@@ -93,15 +93,15 @@ deps = virtualenv
        -e{toxinidir}/st2client
        -e{toxinidir}/st2common
 commands =
-    nosetests --rednose --immediate -sv --exe st2actions/tests/integration/
-    nosetests --rednose --immediate -sv --exe st2api/tests/integration/
-    nosetests --rednose --immediate -sv --exe st2common/tests/integration/
-    nosetests --rednose --immediate -sv --exe st2debug/tests/integration/
-    nosetests --rednose --immediate -sv --exe st2exporter/tests/integration/
-    nosetests --rednose --immediate -sv --exe st2reactor/tests/integration/
-    nosetests --rednose --immediate -sv --exe contrib/runners/action_chain_runner/tests/integration/
-    nosetests --rednose --immediate -sv --exe contrib/runners/local_runner/tests/integration/
-    nosetests --rednose --immediate -sv --exe contrib/runners/mistral_v2/tests/integration/
-    nosetests --rednose --immediate -sv --exe contrib/runners/orquesta_runner/tests/integration/
-    nosetests --rednose --immediate -sv --exe st2tests/integration/orquesta/
-    nosetests --rednose --immediate -sv --exe contrib/runners/python_runner/tests/integration/
+    nosetests --rednose --immediate -sv st2actions/tests/integration/
+    nosetests --rednose --immediate -sv st2api/tests/integration/
+    nosetests --rednose --immediate -sv st2common/tests/integration/
+    nosetests --rednose --immediate -sv st2debug/tests/integration/
+    nosetests --rednose --immediate -sv st2exporter/tests/integration/
+    nosetests --rednose --immediate -sv st2reactor/tests/integration/
+    nosetests --rednose --immediate -sv contrib/runners/action_chain_runner/tests/integration/
+    nosetests --rednose --immediate -sv contrib/runners/local_runner/tests/integration/
+    nosetests --rednose --immediate -sv contrib/runners/mistral_v2/tests/integration/
+    nosetests --rednose --immediate -sv contrib/runners/orquesta_runner/tests/integration/
+    nosetests --rednose --immediate -sv st2tests/integration/orquesta/
+    nosetests --rednose --immediate -sv contrib/runners/python_runner/tests/integration/


### PR DESCRIPTION
Switches travis to use Bionic, Mongo 4.0, and RabbitMQ 3.8

- The commits transition first to xenial and then to bionic.
- I enabled the rabbitmq tests that were disabled until we moved to xenial.
- Those ssl rabbitmq tests required a newer version of rabbitmq, so we use 3.8 (the latest).
- The python3.6 tests were partially using python2.7 which causes the tests to fail in bionic.
- Mongo 3.4 is not available in Bionic, so 4.0 is required.
- Also, the test thresholds were increased to account for increased test times due to the mongo update and the python 3.6 fix.

closes #4772 (replaced by and partially included in this PR)
closes #4863 (included in this PR)