### PR TITLE
Switch Travis from Precise to Xenial infra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,8 @@ addons:
       #- sourceline: 'deb [arch=amd64] https://dl.bintray.com/rabbitmq/debian precise rabbitmq-server-v3.6.x'
       #  key_url: 'https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc'
     packages:
-      - mongodb-org-server
-      - mongodb-org-shell
+      - mongodb-org-server=3.4.*
+      - mongodb-org-shell=3.4.*
       - erlang
       - rabbitmq-server
       - libffi-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,20 +35,6 @@ jobs:
     - env: TASK=ci-unit CACHE_NAME=py2 COMMAND_THRESHOLD=700
       python: 2.7
       name: "Unit Tests (Python 2.7 MongoDB 3.4)"
-    #- env: TASK=ci-unit CACHE_NAME=py2 COMMAND_THRESHOLD=700
-      #python: 2.7
-      #name: "Unit Tests (Python 2.7 MongoDB 3.6)"
-      #addons:
-      #  apt:
-      #    sources:
-      #      - mongodb-upstart
-      #      - sourceline: 'deb [arch=amd64] http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.6 multiverse'
-      #        key_url: 'https://www.mongodb.org/static/pgp/server-3.6.asc'
-      #      - sourceline: 'ppa:git-core/ppa'
-      #    packages:
-      #      - mongodb-org-server
-      #      - mongodb-org-shell
-      #      - git
     - env: TASK=ci-integration CACHE_NAME=py2 COMMAND_THRESHOLD=700
       python: 2.7
       name: "Integration Tests (Python 2.7)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,7 @@ install:
   - cp conf/st2.dev.conf "${ST2_CONF}" ; sed -i -e "s/stanley/travis/" "${ST2_CONF}"
   - sudo scripts/travis/add-itest-user-key.sh
   - sudo .circle/add-itest-user.sh
+  - if [[ "${TASK}" = *'-packs-tests'* ]] || [[ "${TASK}" = *'-integration'* ]]; then sudo scripts/travis/permissions-workaround.sh; fi
 
 # Let's enable rabbitmqadmin
 # See https://github.com/messagebus/lapine/wiki/Testing-on-Travis.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 os: linux
-# NOTE: We use precise because tests finish faster than on Xenial
-dist: precise
+dist: xenial
 language: python
 
 branches:
@@ -51,21 +50,18 @@ jobs:
 addons:
   apt:
     sources:
-      - mongodb-upstart
-      - sourceline: 'deb [arch=amd64] http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.4 multiverse'
+      - sourceline: 'deb [arch=amd64] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse'
         key_url: 'https://www.mongodb.org/static/pgp/server-3.4.asc'
       # NOTE: Precise repo doesn't contain Erlang 20.x, latest version is 19.x so we need to use RabbitMQ 3.7.6
       #- sourceline: 'deb [arch=amd64] http://packages.erlang-solutions.com/ubuntu precise contrib'
       #  key_url: 'https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc'
       #- sourceline: 'deb [arch=amd64] https://dl.bintray.com/rabbitmq/debian precise rabbitmq-server-v3.6.x'
       #  key_url: 'https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc'
-      - sourceline: 'ppa:git-core/ppa'
     packages:
       - mongodb-org-server
       - mongodb-org-shell
       - erlang
       - rabbitmq-server
-      - git
       - libffi-dev
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,13 +42,13 @@ jobs:
     - env: TASK=ci-integration CACHE_NAME=py2 COMMAND_THRESHOLD=700
       python: 2.7
       name: "Integration Tests (Python 2.7)"
-    - env: TASK="ci-checks ci-packs-tests" CACHE_NAME=py2 COMMAND_THRESHOLD=280
+    - env: TASK="ci-checks ci-packs-tests" CACHE_NAME=py2 COMMAND_THRESHOLD=430
       python: 2.7
       name: "Lint Checks, Packs Tests (Python 2.7)"
-    - env: TASK="compilepy3 ci-py3-unit ci-py3-packs-tests" CACHE_NAME=py3 PYTHON_VERSION=python3.6 COMMAND_THRESHOLD=680
+    - env: TASK="compilepy3 ci-py3-unit ci-py3-packs-tests" CACHE_NAME=py3 PYTHON_VERSION=python3.6 COMMAND_THRESHOLD=750
       python: 3.6
       name: "Unit Tests, Pack Tests (Python 3.6)"
-    - env: TASK="ci-py3-integration" CACHE_NAME=py3 PYTHON_VERSION=python3.6 COMMAND_THRESHOLD=310
+    - env: TASK="ci-py3-integration" CACHE_NAME=py3 PYTHON_VERSION=python3.6 COMMAND_THRESHOLD=770
       python: 3.6
       name: "Integration Tests (Python 3.6)"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,15 +52,9 @@ addons:
     sources:
       - sourceline: 'deb [arch=amd64] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse'
         key_url: 'https://www.mongodb.org/static/pgp/server-3.4.asc'
-      # NOTE: Precise repo doesn't contain Erlang 20.x, latest version is 19.x so we need to use RabbitMQ 3.7.6
-      #- sourceline: 'deb [arch=amd64] http://packages.erlang-solutions.com/ubuntu precise contrib'
-      #  key_url: 'https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc'
-      #- sourceline: 'deb [arch=amd64] https://dl.bintray.com/rabbitmq/debian precise rabbitmq-server-v3.6.x'
-      #  key_url: 'https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc'
     packages:
       - mongodb-org-server=3.4.*
       - mongodb-org-shell=3.4.*
-      - erlang
       - rabbitmq-server
       - libffi-dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,11 @@ jobs:
     # job which also includes "make requirements" and other steps
     # "make requirements" can take substantially lower if the cache is purged
     # and this would cause too many intermediate failures / false positives
+    # NOTE: TASK is inspected in commands below and other travis scripts.
+    # For example, ci-py3* targets trigger an alternate virtualenv build method.
+    # If you rename or reorder make targets in TASK, you may need to adjust:
+    # scripts/travis/install-requirements.sh
+    # scripts/travis/run-nightly-make-task-if-exists.sh
     - env: TASK=ci-unit CACHE_NAME=py2 COMMAND_THRESHOLD=700
       python: 2.7
       name: "Unit Tests (Python 2.7 MongoDB 3.4)"
@@ -40,10 +45,10 @@ jobs:
     - env: TASK="ci-checks ci-packs-tests" CACHE_NAME=py2 COMMAND_THRESHOLD=280
       python: 2.7
       name: "Lint Checks, Packs Tests (Python 2.7)"
-    - env: TASK="compilepy3 ci-py3-unit" CACHE_NAME=py3 COMMAND_THRESHOLD=680
+    - env: TASK="compilepy3 ci-py3-unit ci-py3-packs-tests" CACHE_NAME=py3 PYTHON_VERSION=python3.6 COMMAND_THRESHOLD=680
       python: 3.6
       name: "Unit Tests, Pack Tests (Python 3.6)"
-    - env: TASK="ci-py3-integration" CACHE_NAME=py3 COMMAND_THRESHOLD=310
+    - env: TASK="ci-py3-integration" CACHE_NAME=py3 PYTHON_VERSION=python3.6 COMMAND_THRESHOLD=310
       python: 3.6
       name: "Integration Tests (Python 3.6)"
 
@@ -79,7 +84,7 @@ install:
   # prep a travis-specific dev conf file that uses travis instead of stanley
   - cp conf/st2.dev.conf "${ST2_CONF}" ; sed -i -e "s/stanley/travis/" "${ST2_CONF}"
   - sudo scripts/travis/add-itest-user-key.sh
-  - if [ "${TASK}" = 'ci-unit' ] || [ "${TASK}" = 'ci-integration' ] || [ "${TASK}" = 'ci-checks ci-packs-tests' ] || [ "${TASK}" = 'compilepy3 ci-py3-unit' ] || [ "${TASK}" = 'ci-py3-integration' ]; then sudo .circle/add-itest-user.sh; fi
+  - sudo .circle/add-itest-user.sh
 
 # Let's enable rabbitmqadmin
 # See https://github.com/messagebus/lapine/wiki/Testing-on-Travis.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
-# Used old infrastructure, needed for integration tests:
-# http://docs.travis-ci.com/user/workers/standard-infrastructure/
-sudo: required
+os: linux
 # NOTE: We use precise because tests finish faster than on Xenial
 dist: precise
 language: python
@@ -25,7 +23,7 @@ env:
     - NOSE_TIME=$([ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${IS_NIGHTLY_BUILD}" = "no" ] && echo "yes" || echo "no")
     # Travis-specific st2.conf (with travis user instead of stanley)
     - ST2_CONF=conf/st2.travis.conf
-matrix:
+jobs:
   include:
     # NOTE: We combine builds because Travis offers a maximum of 5 concurrent
     # builds and having 6 tasks / builds means 1 tasks will need to wait for one

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,8 @@ before_script:
   - sudo wget http://guest:guest@localhost:15672/cli/rabbitmqadmin -O /usr/local/bin/rabbitmqadmin
   - sudo chmod +x /usr/local/bin/rabbitmqadmin
   - sudo service rabbitmq-server restart
-  - sudo tail -n 30 /var/log/rabbitmq/*
+  # chmod to make glob work (*.log to avoid log dir)
+  - sudo chmod a+rx /var/log/rabbitmq ; sudo tail -n 30 /var/log/rabbitmq/*.log
   # Print various binary versions
   - mongod --version
   - git --version

--- a/Makefile
+++ b/Makefile
@@ -951,6 +951,12 @@ ci-py3-unit:
 	@echo "==================== ci-py3-unit ===================="
 	@echo
 	NOSE_WITH_TIMER=$(NOSE_WITH_TIMER) tox -e py36-unit -vv
+
+.PHONY: ci-py3-packs-tests
+ci-py3-packs-tests:
+	@echo
+	@echo "==================== ci-py3-packs-tests ===================="
+	@echo
 	NOSE_WITH_TIMER=$(NOSE_WITH_TIMER) tox -e py36-packs -vv
 
 .PHONY: ci-py3-unit-nightly

--- a/Makefile
+++ b/Makefile
@@ -672,7 +672,7 @@ endif
 		echo "-----------------------------------------------------------"; \
 		. $(VIRTUALENV_DIR)/bin/activate; \
 		    COVERAGE_FILE=.coverage.integration.$$(echo $$component | tr '/' '.') \
-		    nosetests $(NOSE_OPTS) -s -v --exe $(NOSE_COVERAGE_FLAGS) \
+		    nosetests $(NOSE_OPTS) -s -v $(NOSE_COVERAGE_FLAGS) \
 		    $(NOSE_COVERAGE_PACKAGES) \
 		    $$component/tests/integration || exit 1; \
 		echo "-----------------------------------------------------------"; \

--- a/scripts/travis/permissions-workaround.sh
+++ b/scripts/travis/permissions-workaround.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+if [ "$(whoami)" != 'root' ]; then
+    echo 'Please run with sudo'
+    exit 2
+fi
+
+# rabbitmq user needs access to the ssl_certs fixtures during integration tests
+# stanley needs to work with packs fixtures during the packs tests
+# this can't be the travis user because 'stanley' is the hardcoded user in the tests
+# o=other; X=only set execute bit if user execute bit is set (eg on dirs)
+chmod -R o+rX ${TRAVIS_BUILD_DIR}/st2tests/st2tests/fixtures ${TRAVIS_BUILD_DIR}/contrib
+
+# make sure parent directories are traversable
+d=${TRAVIS_BUILD_DIR}/st2tests/st2tests
+while [[ "${d}" != "/" ]]; do
+    chmod o+rx "${d}"
+    d=$(dirname "${d}")
+done

--- a/scripts/travis/rabbitmq.config
+++ b/scripts/travis/rabbitmq.config
@@ -1,7 +1,6 @@
 [
   {rabbit, [
      {ssl_listeners, [5671]},
-     {ssl_allow_poodle_attack, true},
      {ssl_options, [{cacertfile, "/home/travis/build/StackStorm/st2/st2tests/st2tests/fixtures/ssl_certs/ca/ca_certificate_bundle.pem"},
                     {certfile,   "/home/travis/build/StackStorm/st2/st2tests/st2tests/fixtures/ssl_certs/server/server_certificate.pem"},
                     {keyfile,    "/home/travis/build/StackStorm/st2/st2tests/st2tests/fixtures/ssl_certs/server/private_key.pem"},

--- a/st2common/tests/integration/test_rabbitmq_ssl_listener.py
+++ b/st2common/tests/integration/test_rabbitmq_ssl_listener.py
@@ -39,10 +39,7 @@ SSL_LISTENER_PORT = 5671
 
 # NOTE: We only run those tests on Travis because at the moment, local vagrant dev VM doesn't
 # expose RabbitMQ SSL listener by default
-# TODO: Re-enable once we upgrade Travis from Precise to Xenial where latest version of RabbitMQ
-# and OpenSSL is available
-@unittest2.skip('Skipping until we upgrade to Xenial on Travis')
-# @unittest2.skipIf(not ON_TRAVIS, 'Skipping tests because not running on Travis')
+@unittest2.skipIf(not ON_TRAVIS, 'Skipping tests because not running on Travis')
 class RabbitMQTLSListenerTestCase(unittest2.TestCase):
 
     def setUp(self):
@@ -56,16 +53,18 @@ class RabbitMQTLSListenerTestCase(unittest2.TestCase):
     def test_non_ssl_connection_on_ssl_listener_port_failure(self):
         connection = transport_utils.get_connection(urls='amqp://guest:guest@127.0.0.1:5671/')
 
-        expected_msg_1 = '[Errno 104] Connection reset by peer'
+        expected_msg_1 = '[Errno 104]'  # followed by: ' Connection reset by peer' or ' ECONNRESET'
         expected_msg_2 = 'Socket closed'
+        expected_msg_3 = 'Server unexpectedly closed connection'
 
         try:
             connection.connect()
         except Exception as e:
             self.assertFalse(connection.connected)
             self.assertIsInstance(e, (IOError, socket.error))
-            self.assertTrue(expected_msg_1 in six.text_type(e) or expected_msg_2 in
-                            six.text_type(e))
+            self.assertTrue(expected_msg_1 in six.text_type(e) or
+                            expected_msg_2 in six.text_type(e) or
+                            expected_msg_3 in six.text_type(e))
         else:
             self.fail('Exception was not thrown')
 

--- a/tox.ini
+++ b/tox.ini
@@ -93,15 +93,15 @@ deps = virtualenv
        -e{toxinidir}/st2client
        -e{toxinidir}/st2common
 commands =
-    nosetests --rednose --immediate -sv --exe st2actions/tests/integration/
-    nosetests --rednose --immediate -sv --exe st2api/tests/integration/
-    nosetests --rednose --immediate -sv --exe st2common/tests/integration/
-    nosetests --rednose --immediate -sv --exe st2debug/tests/integration/
-    nosetests --rednose --immediate -sv --exe st2exporter/tests/integration/
-    nosetests --rednose --immediate -sv --exe st2reactor/tests/integration/
-    nosetests --rednose --immediate -sv --exe contrib/runners/action_chain_runner/tests/integration/
-    nosetests --rednose --immediate -sv --exe contrib/runners/local_runner/tests/integration/
-    nosetests --rednose --immediate -sv --exe contrib/runners/mistral_v2/tests/integration/
-    nosetests --rednose --immediate -sv --exe contrib/runners/orquesta_runner/tests/integration/
-    nosetests --rednose --immediate -sv --exe st2tests/integration/orquesta/
-    nosetests --rednose --immediate -sv --exe contrib/runners/python_runner/tests/integration/
+    nosetests --rednose --immediate -sv st2actions/tests/integration/
+    nosetests --rednose --immediate -sv st2api/tests/integration/
+    nosetests --rednose --immediate -sv st2common/tests/integration/
+    nosetests --rednose --immediate -sv st2debug/tests/integration/
+    nosetests --rednose --immediate -sv st2exporter/tests/integration/
+    nosetests --rednose --immediate -sv st2reactor/tests/integration/
+    nosetests --rednose --immediate -sv contrib/runners/action_chain_runner/tests/integration/
+    nosetests --rednose --immediate -sv contrib/runners/local_runner/tests/integration/
+    nosetests --rednose --immediate -sv contrib/runners/mistral_v2/tests/integration/
+    nosetests --rednose --immediate -sv contrib/runners/orquesta_runner/tests/integration/
+    nosetests --rednose --immediate -sv st2tests/integration/orquesta/
+    nosetests --rednose --immediate -sv contrib/runners/python_runner/tests/integration/


### PR DESCRIPTION
Try to upgrade travis to xenial from precise.
Ensures that mongo is 3.4 not 4.0. mongo 3.4 is not available in bionic so #4862 probably won't work until dependence on 3.4 is gone.
#4772 tried to update and ran into a many issues esp slowness. It also missed downgrading mongodb.

closes #4772
closes #4862