### PR TITLE
Fix master builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ virtualenv-components
 virtualenv-components-osx
 .venv-st2devbox
 
+# generated travis conf
+conf/st2.travis.conf
+
 # Installer logs
 pip-log.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ env:
     # We only run tests with "--with-timer" flag on master and not for PRs since it adds 1-2
     # # minutes of overhead to each build.
     - NOSE_TIME=$([ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${IS_NIGHTLY_BUILD}" = "no" ] && echo "yes" || echo "no")
+    # Travis-specific st2.conf (with travis user instead of stanley)
+    - ST2_CONF=conf/st2.travis.conf
 matrix:
   include:
     # NOTE: We combine builds because Travis offers a maximum of 5 concurrent
@@ -100,6 +102,9 @@ before_install:
 
 install:
   - ./scripts/travis/install-requirements.sh
+  # prep a travis-specific dev conf file that uses travis instead of stanley
+  - cp conf/st2.dev.conf "${ST2_CONF}" ; sed -i -e "s/stanley/travis/" "${ST2_CONF}"
+  - sudo scripts/travis/add-itest-user-key.sh
   - if [ "${TASK}" = 'ci-unit' ] || [ "${TASK}" = 'ci-integration' ] || [ "${TASK}" = 'ci-checks ci-packs-tests' ] || [ "${TASK}" = 'compilepy3 ci-py3-unit' ] || [ "${TASK}" = 'ci-py3-integration' ]; then sudo .circle/add-itest-user.sh; fi
 
 # Let's enable rabbitmqadmin

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ check-python-packages:
 	@echo "================== CHECK PYTHON PACKAGES ===================="
 	@echo ""
 
-	test -f $(VIRTUALENV_COMPONENTS_DIR)/bin/activate || virtualenv --python=$(PYTHON_VERSION) --no-site-packages $(VIRTUALENV_COMPONENTS_DIR) --no-download
+	test -f $(VIRTUALENV_COMPONENTS_DIR)/bin/activate || virtualenv --python=$(PYTHON_VERSION) $(VIRTUALENV_COMPONENTS_DIR) --no-download
 	@for component in $(COMPONENTS_WITHOUT_ST2TESTS); do \
 		echo "==========================================================="; \
 		echo "Checking component:" $$component; \
@@ -192,7 +192,7 @@ check-python-packages-nightly:
 	@echo "================== CHECK PYTHON PACKAGES ===================="
 	@echo ""
 
-	test -f $(VIRTUALENV_COMPONENTS_DIR)/bin/activate || virtualenv --python=$(PYTHON_VERSION) --no-site-packages $(VIRTUALENV_COMPONENTS_DIR) --no-download
+	test -f $(VIRTUALENV_COMPONENTS_DIR)/bin/activate || virtualenv --python=$(PYTHON_VERSION) $(VIRTUALENV_COMPONENTS_DIR) --no-download
 	@for component in $(COMPONENTS_WITHOUT_ST2TESTS); do \
 		echo "==========================================================="; \
 		echo "Checking component:" $$component; \
@@ -314,7 +314,7 @@ flake8: requirements .flake8
 	@echo
 	@echo "==================== st2client install check ===================="
 	@echo
-	test -f $(VIRTUALENV_ST2CLIENT_DIR)/bin/activate || virtualenv --python=$(PYTHON_VERSION) --no-site-packages $(VIRTUALENV_ST2CLIENT_DIR) --no-download
+	test -f $(VIRTUALENV_ST2CLIENT_DIR)/bin/activate || virtualenv --python=$(PYTHON_VERSION) $(VIRTUALENV_ST2CLIENT_DIR) --no-download
 
 	# Setup PYTHONPATH in bash activate script...
 	# Delete existing entries (if any)
@@ -506,7 +506,7 @@ virtualenv:
 	@echo
 	# Note: We pass --no-download flag to make sure version of pip which we install (9.0.1) is used
 	# instead of latest version being downloaded from PyPi
-	test -f $(VIRTUALENV_DIR)/bin/activate || virtualenv --python=$(PYTHON_VERSION) --no-site-packages $(VIRTUALENV_DIR) --no-download
+	test -f $(VIRTUALENV_DIR)/bin/activate || virtualenv --python=$(PYTHON_VERSION) $(VIRTUALENV_DIR) --no-download
 
 	# Setup PYTHONPATH in bash activate script...
 	# Delete existing entries (if any)

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -16,7 +16,7 @@ six==1.13.0
 pyyaml==5.1.2
 requests[security]==2.22.0
 apscheduler==3.6.3
-gitpython==2.1.11
+gitpython==2.1.15
 jsonschema==2.6.0
 pymongo==3.10.0
 mongoengine==0.18.2

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -14,7 +14,7 @@ oslo.config>=1.12.1,<1.13
 oslo.utils>=3.36.2,<=3.37.0
 six==1.13.0
 pyyaml==5.1.2
-requests[security]==2.22.0
+requests[security]==2.23.0
 apscheduler==3.6.3
 gitpython==2.1.15
 jsonschema==2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ pytz==2019.1
 pywinrm==0.3.0
 pyyaml==5.1.2
 rednose
-requests[security]==2.22.0
+requests[security]==2.23.0
 retrying==1.3.3
 routes==2.4.1
 semver==2.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ git+https://github.com/StackStorm/logshipper.git@stackstorm_patched#egg=logshipp
 git+https://github.com/StackStorm/orquesta.git@6e2fa8052cd62b07e96e540f68e7290b324d0f01#egg=orquesta
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
-gitpython==2.1.11
+gitpython==2.1.15
 greenlet==0.4.15
 gunicorn==19.9.0
 ipaddr

--- a/scripts/travis/add-itest-user-key.sh
+++ b/scripts/travis/add-itest-user-key.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ "$(whoami)" != 'root' ]; then
+    echo 'Please run with sudo'
+    exit 2
+fi
+
+mkdir -p /home/travis/.ssh
+
+# Generate ssh keys on StackStorm box and copy over public key into remote box.
+ssh-keygen -f /home/travis/.ssh/travis_rsa -P ""
+
+# Authorize key-base acces
+sh -c 'cat /home/travis/.ssh/travis_rsa.pub >> /home/travis/.ssh/authorized_keys'
+chmod 0600 /home/travis/.ssh/authorized_keys
+chmod 0700 /home/travis/.ssh

--- a/scripts/travis/prepare-integration.sh
+++ b/scripts/travis/prepare-integration.sh
@@ -32,3 +32,7 @@ echo " === END: Catting screen process log files. ==="
 # as root can't write to logs/ directory and tests fail
 chmod 777 logs/
 chmod 777 logs/*
+
+# root needs to access write some lock files when creating virtualenvs
+# o=other; X=only set execute bit if user execute bit is set (eg on dirs)
+chmod -R o+rwX ${HOME}/.local/share/virtualenv

--- a/scripts/travis/prepare-integration.sh
+++ b/scripts/travis/prepare-integration.sh
@@ -6,8 +6,6 @@ if [ "$(whoami)" != 'root' ]; then
     exit 2
 fi
 
-UBUNTU_VERSION=`lsb_release -a 2>&1 | grep Codename | grep -v "LSB" | awk '{print $2}'`
-
 # Activate the virtualenv created during make requirements phase
 source ./virtualenv/bin/activate
 
@@ -34,12 +32,3 @@ echo " === END: Catting screen process log files. ==="
 # as root can't write to logs/ directory and tests fail
 chmod 777 logs/
 chmod 777 logs/*
-
-# Workaround for Travis on Ubuntu Xenial so local runner integration tests work
-# when executing them under user "stanley" (by default Travis checks out the
-# code and runs tests under a different system user).
-# NOTE: We need to pass "--exe" flag to nosetests when using this workaround.
-if [ "${UBUNTU_VERSION}" == "xenial" ]; then
-  echo "Applying workaround for stanley user permissions issue to /home/travis on Xenial"
-  chmod 777 -R /home/travis
-fi

--- a/scripts/travis/setup-mistral.sh
+++ b/scripts/travis/setup-mistral.sh
@@ -144,7 +144,7 @@ setup_mistral() {
 
   # Setup virtualenv for running mistral.
   cd /opt/openstack/mistral
-  virtualenv --no-site-packages .venv
+  virtualenv .venv
   . /opt/openstack/mistral/.venv/bin/activate
   pip install -q -r requirements.txt
   pip install -q psycopg2

--- a/st2actions/requirements.txt
+++ b/st2actions/requirements.txt
@@ -19,5 +19,5 @@ pyinotify==0.9.6
 python-dateutil==2.8.0
 python-json-logger
 pyyaml==5.1.2
-requests[security]==2.22.0
+requests[security]==2.23.0
 six==1.13.0

--- a/st2actions/requirements.txt
+++ b/st2actions/requirements.txt
@@ -9,7 +9,7 @@ apscheduler==3.6.3
 eventlet==0.25.1
 git+https://github.com/StackStorm/logshipper.git@stackstorm_patched#egg=logshipper
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
-gitpython==2.1.11
+gitpython==2.1.15
 jinja2==2.10.3
 kombu==4.6.6
 lockfile==0.12.2

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -16,7 +16,7 @@ python-dateutil==2.8.0
 python-editor==1.0.4
 pytz==2019.1
 pyyaml==5.1.2
-requests[security]==2.22.0
+requests[security]==2.23.0
 six==1.13.0
 sseclient-py==1.7
 zipp<=1.0.0,>=0.5

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -27,7 +27,7 @@ pymongo==3.10.0
 python-dateutil==2.8.0
 python-statsd==2.1.0
 pyyaml==5.1.2
-requests[security]==2.22.0
+requests[security]==2.23.0
 retrying==1.3.3
 routes==2.4.1
 semver==2.9.0

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -11,7 +11,7 @@ cryptography==2.8
 eventlet==0.25.1
 flex==6.14.0
 git+https://github.com/StackStorm/orquesta.git@6e2fa8052cd62b07e96e540f68e7290b324d0f01#egg=orquesta
-gitpython==2.1.11
+gitpython==2.1.15
 greenlet==0.4.15
 ipaddr
 jinja2==2.10.3

--- a/st2debug/requirements.txt
+++ b/st2debug/requirements.txt
@@ -8,5 +8,5 @@
 eventlet==0.25.1
 python-gnupg==0.4.5
 pyyaml==5.1.2
-requests[security]==2.22.0
+requests[security]==2.23.0
 six==1.13.0


### PR DESCRIPTION
Fixes includes:

Update gitpython requirement (Thanks to @blag for tracking down the bug.)

- gitpython requires gitdb2, but that has removed some things in newer
  versions, and 2.11.1 had an open ended dep. So, update gitpython to a
  newer version that has more specific version requirements for gitdb2.
- This should fix these errors:
  https://github.com/gitpython-developers/GitPython/issues/983
  https://travis-ci.org/StackStorm/st2/jobs/652088774#L9416
  https://circleci.com/gh/StackStorm-Exchange/stackstorm-sumologic/155

Drop --no-site-packages from virtualenv calls

Make travis use the travis user instead of stanley, and add a restricted permissions workaround for the root user.

Update requests which had a conflicting dep on idna (primary said `idna>=2.5,<2.9` but security extra wanted any `idna>=2.0.0`. idna 2.9 was released a couple of days ago, and requests 2.23.0 with fixed deps was released today.