### PR TITLE
Betterize test assertions

### DIFF
--- a/contrib/chatops/tests/test_format_result.py
+++ b/contrib/chatops/tests/test_format_result.py
@@ -38,8 +38,8 @@ class FormatResultActionTestCase(BaseActionTestCase):
         )
         result = action.run(execution_id='57967f9355fc8c19a96d9e4f')
         self.assertTrue(result)
-        self.assertTrue('web_url' in result['message'], result['message'])
-        self.assertTrue('Took 2s to complete' in result['message'], result['message'])
+        self.assertIn('web_url', result['message'])
+        self.assertIn('Took 2s to complete', result['message'])
 
     def test_rendering_local_shell_cmd(self):
         local_shell_cmd_execution_model = json.loads(

--- a/contrib/core/tests/test_action_sendmail.py
+++ b/contrib/core/tests/test_action_sendmail.py
@@ -67,7 +67,7 @@ class SendmailActionTestCase(RunnerTestCase, CleanDbTestCase, CleanFilesTestCase
                          'send_mail running on %s' % (HOSTNAME))
 
         status, _, email_data, message = self._run_action(action_parameters=action_parameters)
-        self.assertEquals(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
 
         # Verify subject contains utf-8 charset and is base64 encoded
         self.assertIn('SUBJECT: =?UTF-8?B?', email_data)
@@ -96,7 +96,7 @@ class SendmailActionTestCase(RunnerTestCase, CleanDbTestCase, CleanFilesTestCase
                          'send_mail running on %s' % (HOSTNAME))
 
         status, _, email_data, message = self._run_action(action_parameters=action_parameters)
-        self.assertEquals(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
 
         # Verify subject contains utf-8 charset and is base64 encoded
         self.assertIn('SUBJECT: =?UTF-8?B?', email_data)
@@ -133,7 +133,7 @@ class SendmailActionTestCase(RunnerTestCase, CleanDbTestCase, CleanFilesTestCase
                              u'send_mail running on %s' % (HOSTNAME))
 
         status, _, email_data, message = self._run_action(action_parameters=action_parameters)
-        self.assertEquals(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
 
         # Verify subject contains utf-8 charset and is base64 encoded
         self.assertIn('SUBJECT: =?UTF-8?B?', email_data)
@@ -167,7 +167,7 @@ class SendmailActionTestCase(RunnerTestCase, CleanDbTestCase, CleanFilesTestCase
                              u'send_mail running on %s' % (HOSTNAME))
 
         status, _, email_data, message = self._run_action(action_parameters=action_parameters)
-        self.assertEquals(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
 
         self.assertEqual(message.to[0][1], action_parameters['to'])
         self.assertEqual(message.from_[0][1], action_parameters['from'])
@@ -207,7 +207,7 @@ class SendmailActionTestCase(RunnerTestCase, CleanDbTestCase, CleanFilesTestCase
                          'send_mail running on %s' % (HOSTNAME))
 
         status, _, email_data, message = self._run_action(action_parameters=action_parameters)
-        self.assertEquals(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
 
         # Verify subject contains utf-8 charset and is base64 encoded
         self.assertIn('SUBJECT: =?UTF-8?B?', email_data)

--- a/contrib/core/tests/test_action_sendmail.py
+++ b/contrib/core/tests/test_action_sendmail.py
@@ -70,7 +70,7 @@ class SendmailActionTestCase(RunnerTestCase, CleanDbTestCase, CleanFilesTestCase
         self.assertEquals(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
 
         # Verify subject contains utf-8 charset and is base64 encoded
-        self.assertTrue('SUBJECT: =?UTF-8?B?' in email_data)
+        self.assertIn('SUBJECT: =?UTF-8?B?', email_data)
 
         self.assertEqual(message.to[0][1], action_parameters['to'])
         self.assertEqual(message.from_[0][1], action_parameters['from'])
@@ -99,7 +99,7 @@ class SendmailActionTestCase(RunnerTestCase, CleanDbTestCase, CleanFilesTestCase
         self.assertEquals(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
 
         # Verify subject contains utf-8 charset and is base64 encoded
-        self.assertTrue('SUBJECT: =?UTF-8?B?' in email_data)
+        self.assertIn('SUBJECT: =?UTF-8?B?', email_data)
 
         self.assertEqual(message.to[0][1], action_parameters['to'])
         self.assertEqual(message.from_[0][1], action_parameters['from'])
@@ -136,7 +136,7 @@ class SendmailActionTestCase(RunnerTestCase, CleanDbTestCase, CleanFilesTestCase
         self.assertEquals(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
 
         # Verify subject contains utf-8 charset and is base64 encoded
-        self.assertTrue('SUBJECT: =?UTF-8?B?' in email_data)
+        self.assertIn('SUBJECT: =?UTF-8?B?', email_data)
 
         self.assertEqual(message.to[0][1], action_parameters['to'])
         self.assertEqual(message.from_[0][1], action_parameters['from'])
@@ -210,7 +210,7 @@ class SendmailActionTestCase(RunnerTestCase, CleanDbTestCase, CleanFilesTestCase
         self.assertEquals(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
 
         # Verify subject contains utf-8 charset and is base64 encoded
-        self.assertTrue('SUBJECT: =?UTF-8?B?' in email_data)
+        self.assertIn('SUBJECT: =?UTF-8?B?', email_data)
 
         self.assertEqual(message.to[0][1], action_parameters['to'])
         self.assertEqual(message.from_[0][1], action_parameters['from'])
@@ -224,8 +224,8 @@ class SendmailActionTestCase(RunnerTestCase, CleanDbTestCase, CleanFilesTestCase
 
         # There should be 2 attachments
         self.assertEqual(email_data.count('Content-Transfer-Encoding: base64'), 2)
-        self.assertTrue(base64.b64encode(b'content 1').decode('utf-8') in email_data)
-        self.assertTrue(base64.b64encode(b'content 2').decode('utf-8') in email_data)
+        self.assertIn(base64.b64encode(b'content 1').decode('utf-8'), email_data)
+        self.assertIn(base64.b64encode(b'content 2').decode('utf-8'), email_data)
 
     def _run_action(self, action_parameters):
         """

--- a/contrib/runners/action_chain_runner/tests/unit/test_actionchain.py
+++ b/contrib/runners/action_chain_runner/tests/unit/test_actionchain.py
@@ -448,7 +448,7 @@ class TestActionChainRunner(ExecutionDbTestCase):
                            {u'p2': u'1', u'p3': u'1', u'p1': u'1'}]
         # Each of the call_args must be one of
         for call_args in request.call_args_list:
-            self.assertTrue(call_args[0][0].parameters in expected_values)
+            self.assertIn(call_args[0][0].parameters, expected_values)
             expected_values.remove(call_args[0][0].parameters)
         self.assertEqual(len(expected_values), 0, 'Not all expected values received.')
 
@@ -478,7 +478,7 @@ class TestActionChainRunner(ExecutionDbTestCase):
         # Each of the call_args must be one of
         self.assertEqual(request.call_count, 3)
         for call_args in request.call_args_list:
-            self.assertTrue(call_args[0][0].parameters in expected_values)
+            self.assertIn(call_args[0][0].parameters, expected_values)
             expected_values.remove(call_args[0][0].parameters)
 
         self.assertEqual(len(expected_values), 0, 'Not all expected values received.')
@@ -515,10 +515,10 @@ class TestActionChainRunner(ExecutionDbTestCase):
         # No tasks ran because rendering of parameters for the first task failed
         self.assertEqual(status, LIVEACTION_STATUS_FAILED)
         self.assertEqual(result['tasks'], [])
-        self.assertTrue('error' in result)
-        self.assertTrue('traceback' in result)
-        self.assertTrue('Failed to run task "c1". Parameter rendering failed' in result['error'])
-        self.assertTrue('Traceback' in result['traceback'])
+        self.assertIn('error', result)
+        self.assertIn('traceback', result)
+        self.assertIn('Failed to run task "c1". Parameter rendering failed', result['error'])
+        self.assertIn('Traceback', result['traceback'])
 
     @mock.patch.object(action_db_util, 'get_action_by_ref',
                        mock.MagicMock(return_value=ACTION_1))
@@ -542,11 +542,11 @@ class TestActionChainRunner(ExecutionDbTestCase):
         expected_error = ('Failed rendering value for action parameter "p1" in '
                           'task "c2" (template string={{s1}}):')
 
-        self.assertTrue('error' in result)
-        self.assertTrue('traceback' in result)
-        self.assertTrue('Failed to run task "c2". Parameter rendering failed' in result['error'])
-        self.assertTrue(expected_error in result['error'])
-        self.assertTrue('Traceback' in result['traceback'])
+        self.assertIn('error', result)
+        self.assertIn('traceback', result)
+        self.assertIn('Failed to run task "c2". Parameter rendering failed', result['error'])
+        self.assertIn(expected_error, result['error'])
+        self.assertIn('Traceback', result['traceback'])
 
     @mock.patch.object(action_db_util, 'get_action_by_ref',
                        mock.MagicMock(return_value=ACTION_2))
@@ -686,7 +686,7 @@ class TestActionChainRunner(ExecutionDbTestCase):
             # rendering failure
             expected_error = ('Failed rendering value for publish parameter "p1" in '
                               'task "c2" (template string={{ not_defined }}):')
-            self.assertTrue(expected_error in six.text_type(e))
+            self.assertIn(expected_error, six.text_type(e))
             pass
         else:
             self.fail('Exception was not thrown')
@@ -725,8 +725,8 @@ class TestActionChainRunner(ExecutionDbTestCase):
         expected_error = ('Failed to run task "c1". Action with reference "wolfpack.a2" '
                           'doesn\'t exist.')
         self.assertEqual(status, LIVEACTION_STATUS_FAILED)
-        self.assertTrue(expected_error in output['error'])
-        self.assertTrue('Traceback' in output['traceback'], output['traceback'])
+        self.assertIn(expected_error, output['error'])
+        self.assertIn('Traceback', output['traceback'])
 
     def test_exception_is_thrown_if_both_params_and_parameters_attributes_are_provided(self):
         chain_runner = acr.get_runner()

--- a/contrib/runners/action_chain_runner/tests/unit/test_actionchain.py
+++ b/contrib/runners/action_chain_runner/tests/unit/test_actionchain.py
@@ -842,7 +842,7 @@ class TestActionChainRunner(ExecutionDbTestCase):
         action_parameters = {}
         _, result, _ = chain_runner.run(action_parameters=action_parameters)
 
-        self.assertTrue('published' not in result)
+        self.assertNotIn('published', result)
         self.assertEqual(result.get('published', {}), {})
 
     @classmethod

--- a/contrib/runners/announcement_runner/tests/unit/test_announcementrunner.py
+++ b/contrib/runners/announcement_runner/tests/unit/test_announcementrunner.py
@@ -34,7 +34,7 @@ class AnnouncementRunnerTestCase(RunnerTestCase):
 
     def test_runner_creation(self, dispatch):
         runner = announcement_runner.get_runner()
-        self.assertTrue(runner is not None, 'Creation failed. No instance.')
+        self.assertIsNotNone(runner, 'Creation failed. No instance.')
         self.assertEqual(type(runner), announcement_runner.AnnouncementRunner,
                          'Creation failed. No instance.')
         self.assertEqual(runner._dispatcher.dispatch, dispatch)
@@ -51,7 +51,7 @@ class AnnouncementRunnerTestCase(RunnerTestCase):
         (status, result, _) = runner.run({'test': 'passed'})
 
         self.assertEqual(status, LIVEACTION_STATUS_SUCCEEDED)
-        self.assertTrue(result is not None)
+        self.assertIsNotNone(result)
         self.assertEqual(result['test'], 'passed')
         dispatch.assert_called_once_with('general', payload={'test': 'passed'},
                                          trace_context=None)
@@ -85,7 +85,7 @@ class AnnouncementRunnerTestCase(RunnerTestCase):
         (status, result, _) = runner.run({'test': 'passed'})
 
         self.assertEqual(status, LIVEACTION_STATUS_SUCCEEDED)
-        self.assertTrue(result is not None)
+        self.assertIsNotNone(result)
         self.assertEqual(result['test'], 'passed')
         context.assert_called_once_with(TraceContext,
                                         **runner.liveaction.context['trace_context'])

--- a/contrib/runners/http_runner/tests/unit/test_http_runner.py
+++ b/contrib/runners/http_runner/tests/unit/test_http_runner.py
@@ -81,7 +81,7 @@ class HTTPClientTestCase(unittest2.TestCase):
         mock_requests.request.return_value = mock_result
         result = client.run()
 
-        self.assertTrue(isinstance(result['body'], dict))
+        self.assertIsInstance(result['body'], dict)
         self.assertEqual(result['body'], {'test1': 'val1'})
 
         # JSON content-type with charset and JSON body
@@ -91,7 +91,7 @@ class HTTPClientTestCase(unittest2.TestCase):
         mock_requests.request.return_value = mock_result
         result = client.run()
 
-        self.assertTrue(isinstance(result['body'], dict))
+        self.assertIsInstance(result['body'], dict)
         self.assertEqual(result['body'], {'test1': 'val1'})
 
         # JSON content-type and invalid json body

--- a/contrib/runners/http_runner/tests/unit/test_http_runner.py
+++ b/contrib/runners/http_runner/tests/unit/test_http_runner.py
@@ -101,7 +101,7 @@ class HTTPClientTestCase(unittest2.TestCase):
         mock_requests.request.return_value = mock_result
         result = client.run()
 
-        self.assertFalse(isinstance(result['body'], dict))
+        self.assertNotIsInstance(result['body'], dict)
         self.assertEqual(result['body'], mock_result.text)
 
     @mock.patch('http_runner.http_runner.requests')

--- a/contrib/runners/inquirer_runner/tests/unit/test_inquirer_runner.py
+++ b/contrib/runners/inquirer_runner/tests/unit/test_inquirer_runner.py
@@ -84,7 +84,7 @@ class InquiryTestCase(st2tests.RunnerTestCase):
 
     def test_runner_creation(self):
         runner = inquirer_runner.get_runner()
-        self.assertTrue(runner is not None, 'Creation failed. No instance.')
+        self.assertIsNotNone(runner, 'Creation failed. No instance.')
         self.assertEqual(type(runner), inquirer_runner.Inquirer, 'Creation failed. No instance.')
 
     def test_simple_inquiry(self):

--- a/contrib/runners/local_runner/tests/integration/test_localrunner.py
+++ b/contrib/runners/local_runner/tests/integration/test_localrunner.py
@@ -67,8 +67,8 @@ class LocalShellCommandRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         status, result, _ = runner.run({})
         runner.post_run(status, result)
 
-        self.assertEquals(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
-        self.assertEquals(result['stdout'], 10)
+        self.assertEqual(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(result['stdout'], 10)
 
         # End result should be the same when streaming is enabled
         cfg.CONF.set_override(name='stream_output', group='actionrunner', override=True)
@@ -82,8 +82,8 @@ class LocalShellCommandRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         status, result, _ = runner.run({})
         runner.post_run(status, result)
 
-        self.assertEquals(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
-        self.assertEquals(result['stdout'], 10)
+        self.assertEqual(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(result['stdout'], 10)
 
         output_dbs = ActionExecutionOutput.get_all()
         self.assertEqual(len(output_dbs), 1)
@@ -99,7 +99,7 @@ class LocalShellCommandRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         runner.pre_run()
         status, result, _ = runner.run({})
         runner.post_run(status, result)
-        self.assertEquals(status, action_constants.LIVEACTION_STATUS_TIMED_OUT)
+        self.assertEqual(status, action_constants.LIVEACTION_STATUS_TIMED_OUT)
 
     @mock.patch.object(
         shell, 'run_command',
@@ -111,7 +111,7 @@ class LocalShellCommandRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         runner = self._get_runner(action_db, cmd='sleep 0.1')
         runner.pre_run()
         status, result, _ = runner.run({})
-        self.assertEquals(status, action_constants.LIVEACTION_STATUS_ABANDONED)
+        self.assertEqual(status, action_constants.LIVEACTION_STATUS_ABANDONED)
 
     def test_common_st2_env_vars_are_available_to_the_action(self):
         models = self.fixtures_loader.load_models(
@@ -123,7 +123,7 @@ class LocalShellCommandRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         status, result, _ = runner.run({})
         runner.post_run(status, result)
 
-        self.assertEquals(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
         self.assertEqual(result['stdout'].strip(), get_full_public_api_url())
 
         runner = self._get_runner(action_db, cmd='echo $ST2_ACTION_AUTH_TOKEN')
@@ -131,7 +131,7 @@ class LocalShellCommandRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         status, result, _ = runner.run({})
         runner.post_run(status, result)
 
-        self.assertEquals(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
         self.assertEqual(result['stdout'].strip(), 'mock-token')
 
     def test_sudo_and_env_variable_preservation(self):
@@ -149,7 +149,7 @@ class LocalShellCommandRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         status, result, _ = runner.run({})
         runner.post_run(status, result)
 
-        self.assertEquals(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
         self.assertEqual(result['stdout'].strip(), 'root\nponiesponies')
 
     @mock.patch('st2common.util.concurrency.subprocess_popen')
@@ -192,7 +192,7 @@ class LocalShellCommandRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         status, result, _ = runner.run({})
         runner.post_run(status, result)
 
-        self.assertEquals(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
 
         self.assertEqual(result['stdout'], 'stdout line 1\nstdout line 2')
         self.assertEqual(result['stderr'], 'stderr line 1\nstderr line 2\nstderr line 3')
@@ -260,7 +260,7 @@ class LocalShellCommandRunnerTestCase(RunnerTestCase, CleanDbTestCase):
             runner.pre_run()
             status, result, _ = runner.run({})
 
-            self.assertEquals(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+            self.assertEqual(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
 
             self.assertEqual(result['stdout'], 'stdout line 1\nstdout line 2')
             self.assertEqual(result['stderr'], 'stderr line 1\nstderr line 2')
@@ -313,9 +313,9 @@ class LocalShellCommandRunnerTestCase(RunnerTestCase, CleanDbTestCase):
             status, result, _ = runner.run({})
             runner.post_run(status, result)
 
-            self.assertEquals(status,
+            self.assertEqual(status,
                     action_constants.LIVEACTION_STATUS_SUCCEEDED)
-            self.assertEquals(result['stdout'], sudo_password)
+            self.assertEqual(result['stdout'], sudo_password)
 
         # with sudo
         for sudo_password in sudo_passwords:
@@ -326,9 +326,9 @@ class LocalShellCommandRunnerTestCase(RunnerTestCase, CleanDbTestCase):
             status, result, _ = runner.run({})
             runner.post_run(status, result)
 
-            self.assertEquals(status,
+            self.assertEqual(status,
                     action_constants.LIVEACTION_STATUS_SUCCEEDED)
-            self.assertEquals(result['stdout'], sudo_password)
+            self.assertEqual(result['stdout'], sudo_password)
 
         # Verify new process which provides password via stdin to the command is created
         with mock.patch('st2common.util.concurrency.subprocess_popen') as mock_subproc_popen:
@@ -369,9 +369,9 @@ class LocalShellCommandRunnerTestCase(RunnerTestCase, CleanDbTestCase):
 
         expected_error = ('Invalid sudo password provided or sudo is not configured for this '
                           'user (bar)')
-        self.assertEquals(status, action_constants.LIVEACTION_STATUS_FAILED)
+        self.assertEqual(status, action_constants.LIVEACTION_STATUS_FAILED)
         self.assertEqual(result['error'], expected_error)
-        self.assertEquals(result['stdout'], '')
+        self.assertEqual(result['stdout'], '')
 
     @staticmethod
     def _get_runner(action_db,
@@ -592,8 +592,8 @@ class LocalShellScriptRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         runner.pre_run()
         status, result, _ = runner.run({'chars': 1000})
         runner.post_run(status, result)
-        self.assertEquals(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
-        self.assertEquals(len(result['stdout']), 1000)
+        self.assertEqual(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(len(result['stdout']), 1000)
 
     def test_large_stdout(self):
         models = self.fixtures_loader.load_models(
@@ -606,8 +606,8 @@ class LocalShellScriptRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         char_count = 10 ** 6  # Note 10^7 succeeds but ends up being slow.
         status, result, _ = runner.run({'chars': char_count})
         runner.post_run(status, result)
-        self.assertEquals(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
-        self.assertEquals(len(result['stdout']), char_count)
+        self.assertEqual(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(len(result['stdout']), char_count)
 
     def _get_runner(self, action_db, entry_point):
         runner = LocalShellScriptRunner(uuid.uuid4().hex)

--- a/contrib/runners/local_runner/tests/integration/test_localrunner.py
+++ b/contrib/runners/local_runner/tests/integration/test_localrunner.py
@@ -433,12 +433,12 @@ class LocalShellScriptRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         status, result, _ = runner.run(action_parameters=action_parameters)
         runner.post_run(status, result)
         self.assertEqual(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
-        self.assertTrue('PARAM_STRING=test string' in result['stdout'])
-        self.assertTrue('PARAM_INTEGER=1' in result['stdout'])
-        self.assertTrue('PARAM_FLOAT=2.55' in result['stdout'])
-        self.assertTrue('PARAM_BOOLEAN=1' in result['stdout'])
-        self.assertTrue('PARAM_LIST=a,b,c' in result['stdout'])
-        self.assertTrue('PARAM_OBJECT={"foo": "bar"}' in result['stdout'])
+        self.assertIn('PARAM_STRING=test string', result['stdout'])
+        self.assertIn('PARAM_INTEGER=1', result['stdout'])
+        self.assertIn('PARAM_FLOAT=2.55', result['stdout'])
+        self.assertIn('PARAM_BOOLEAN=1', result['stdout'])
+        self.assertIn('PARAM_LIST=a,b,c', result['stdout'])
+        self.assertIn('PARAM_OBJECT={"foo": "bar"}', result['stdout'])
 
         action_parameters = {
             'param_string': 'test string',
@@ -455,7 +455,7 @@ class LocalShellScriptRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         runner.post_run(status, result)
 
         self.assertEqual(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
-        self.assertTrue('PARAM_BOOLEAN=0' in result['stdout'])
+        self.assertIn('PARAM_BOOLEAN=0', result['stdout'])
 
         action_parameters = {
             'param_string': '',
@@ -469,9 +469,9 @@ class LocalShellScriptRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         runner.post_run(status, result)
 
         self.assertEqual(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
-        self.assertTrue('PARAM_STRING=\n' in result['stdout'])
-        self.assertTrue('PARAM_INTEGER=\n' in result['stdout'])
-        self.assertTrue('PARAM_FLOAT=\n' in result['stdout'])
+        self.assertIn('PARAM_STRING=\n', result['stdout'])
+        self.assertIn('PARAM_INTEGER=\n', result['stdout'])
+        self.assertIn('PARAM_FLOAT=\n', result['stdout'])
 
         # End result should be the same when streaming is enabled
         cfg.CONF.set_override(name='stream_output', group='actionrunner', override=True)
@@ -495,12 +495,12 @@ class LocalShellScriptRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         runner.post_run(status, result)
 
         self.assertEqual(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
-        self.assertTrue('PARAM_STRING=test string' in result['stdout'])
-        self.assertTrue('PARAM_INTEGER=1' in result['stdout'])
-        self.assertTrue('PARAM_FLOAT=2.55' in result['stdout'])
-        self.assertTrue('PARAM_BOOLEAN=1' in result['stdout'])
-        self.assertTrue('PARAM_LIST=a,b,c' in result['stdout'])
-        self.assertTrue('PARAM_OBJECT={"foo": "bar"}' in result['stdout'])
+        self.assertIn('PARAM_STRING=test string', result['stdout'])
+        self.assertIn('PARAM_INTEGER=1', result['stdout'])
+        self.assertIn('PARAM_FLOAT=2.55', result['stdout'])
+        self.assertIn('PARAM_BOOLEAN=1', result['stdout'])
+        self.assertIn('PARAM_LIST=a,b,c', result['stdout'])
+        self.assertIn('PARAM_OBJECT={"foo": "bar"}', result['stdout'])
 
         output_dbs = ActionExecutionOutput.query(output_type='stdout')
         self.assertEqual(len(output_dbs), 6)

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2.py
@@ -225,7 +225,7 @@ class MistralRunnerTest(ExecutionDbTestCase):
         }
 
         context = MistralRunner._build_mistral_context(parent, current)
-        self.assertTrue(context is not None)
+        self.assertIsNotNone(context)
         self.assertIn('parent', list(context['mistral'].keys()))
 
         parent_dict = {

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2.py
@@ -226,7 +226,7 @@ class MistralRunnerTest(ExecutionDbTestCase):
 
         context = MistralRunner._build_mistral_context(parent, current)
         self.assertTrue(context is not None)
-        self.assertTrue('parent' in list(context['mistral'].keys()))
+        self.assertIn('parent', list(context['mistral'].keys()))
 
         parent_dict = {
             'workflow_name': parent['mistral']['workflow_name'],

--- a/contrib/runners/noop_runner/tests/unit/test_nooprunner.py
+++ b/contrib/runners/noop_runner/tests/unit/test_nooprunner.py
@@ -38,10 +38,10 @@ class TestNoopRunner(TestCase):
         runner = TestNoopRunner._get_runner(action_db)
         status, result, _ = runner.run({})
 
-        self.assertEquals(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
-        self.assertEquals(result['failed'], False)
-        self.assertEquals(result['succeeded'], True)
-        self.assertEquals(result['return_code'], 0)
+        self.assertEqual(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertEqual(result['failed'], False)
+        self.assertEqual(result['succeeded'], True)
+        self.assertEqual(result['return_code'], 0)
 
     @staticmethod
     def _get_runner(action_db):

--- a/contrib/runners/orquesta_runner/tests/unit/test_basic.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_basic.py
@@ -157,13 +157,13 @@ class OrquestaRunnerTest(st2tests.ExecutionDbTestCase):
 
         # Check graph.
         self.assertIsNotNone(wf_ex_db.graph)
-        self.assertTrue(isinstance(wf_ex_db.graph, dict))
+        self.assertIsInstance(wf_ex_db.graph, dict)
         self.assertIn('nodes', wf_ex_db.graph)
         self.assertIn('adjacency', wf_ex_db.graph)
 
         # Check task states.
         self.assertIsNotNone(wf_ex_db.state)
-        self.assertTrue(isinstance(wf_ex_db.state, dict))
+        self.assertIsInstance(wf_ex_db.state, dict)
         self.assertIn('tasks', wf_ex_db.state)
         self.assertIn('sequence', wf_ex_db.state)
 

--- a/contrib/runners/python_runner/tests/integration/test_python_action_process_wrapper.py
+++ b/contrib/runners/python_runner/tests/integration/test_python_action_process_wrapper.py
@@ -74,7 +74,7 @@ class PythonRunnerActionWrapperProcessTestCase(unittest2.TestCase):
         # 2. First run it without time to verify path is valid
         command_string = 'python %s --file-path=foo.py' % (WRAPPER_SCRIPT_PATH)
         _, _, stderr = run_command(command_string, shell=True)
-        self.assertTrue('usage: python_action_wrapper.py' in stderr)
+        self.assertIn('usage: python_action_wrapper.py', stderr)
 
         expected_msg_1 = 'python_action_wrapper.py: error: argument --pack is required'
         expected_msg_2 = ('python_action_wrapper.py: error: the following arguments are '
@@ -121,7 +121,7 @@ class PythonRunnerActionWrapperProcessTestCase(unittest2.TestCase):
                          (WRAPPER_SCRIPT_PATH, file_path, config, parameters))
         exit_code, stdout, stderr = run_command(command_string, shell=True)
         self.assertEqual(exit_code, 0)
-        self.assertTrue('"status"' in stdout)
+        self.assertIn('"status"', stdout)
 
     def test_stdin_params_timeout_no_stdin_data_provided(self):
         config = {}
@@ -135,7 +135,7 @@ class PythonRunnerActionWrapperProcessTestCase(unittest2.TestCase):
         expected_msg = ('ValueError: No input received and timed out while waiting for parameters '
                         'from stdin')
         self.assertEqual(exit_code, 1)
-        self.assertTrue(expected_msg in stderr)
+        self.assertIn(expected_msg, stderr)
 
     def test_stdin_params_invalid_format_friendly_error(self):
         config = {}
@@ -150,4 +150,4 @@ class PythonRunnerActionWrapperProcessTestCase(unittest2.TestCase):
         expected_msg = ('ValueError: Failed to parse parameters from stdin. Expected a JSON '
                         'object with "parameters" attribute:')
         self.assertEqual(exit_code, 1)
-        self.assertTrue(expected_msg in stderr)
+        self.assertIn(expected_msg, stderr)

--- a/contrib/runners/python_runner/tests/unit/test_output_schema.py
+++ b/contrib/runners/python_runner/tests/unit/test_output_schema.py
@@ -70,7 +70,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
             output
         )
         self.assertEqual(status, LIVEACTION_STATUS_SUCCEEDED)
-        self.assertTrue(output is not None)
+        self.assertIsNotNone(output)
         self.assertEqual(output['result'], [1, 5, 10, 10, 5, 1])
 
     def test_fail_incorrect_output_schema(self):

--- a/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
+++ b/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
@@ -173,7 +173,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
 
         self.assertEqual(status, LIVEACTION_STATUS_FAILED)
         self.assertTrue(output is not None)
-        self.assertTrue('<pascal_row.PascalRowAction object at' in output['result'])
+        self.assertIn('<pascal_row.PascalRowAction object at', output['result'])
 
     def test_simple_action_with_status_failed_result_none(self):
         runner = self._get_mock_runner_obj()
@@ -539,8 +539,8 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         _, call_kwargs = mock_popen.call_args
         actual_env = call_kwargs['env']
         pack_common_lib_path = 'fixtures/packs/core/lib'
-        self.assertTrue('PYTHONPATH' in actual_env)
-        self.assertTrue(pack_common_lib_path in actual_env['PYTHONPATH'])
+        self.assertIn('PYTHONPATH', actual_env)
+        self.assertIn(pack_common_lib_path, actual_env['PYTHONPATH'])
 
     @mock.patch('st2common.util.concurrency.subprocess_popen')
     def test_pythonpath_env_var_not_contains_common_libs_config_disabled(self, mock_popen):
@@ -559,7 +559,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         _, call_kwargs = mock_popen.call_args
         actual_env = call_kwargs['env']
         pack_common_lib_path = '/mnt/src/storm/st2/st2tests/st2tests/fixtures/packs/core/lib'
-        self.assertTrue('PYTHONPATH' in actual_env)
+        self.assertIn('PYTHONPATH', actual_env)
         self.assertTrue(pack_common_lib_path not in actual_env['PYTHONPATH'])
 
     def test_action_class_instantiation_action_service_argument(self):
@@ -679,11 +679,11 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         self.assertTrue(output is not None)
         self.assertEqual(output['result'], [1, 2])
 
-        self.assertTrue(expected_msg_1 in output['stderr'])
-        self.assertTrue(expected_msg_2 in output['stderr'])
-        self.assertTrue(expected_msg_3 in output['stderr'])
-        self.assertTrue(expected_msg_4 in output['stderr'])
-        self.assertTrue(expected_msg_5 in output['stderr'])
+        self.assertIn(expected_msg_1, output['stderr'])
+        self.assertIn(expected_msg_2, output['stderr'])
+        self.assertIn(expected_msg_3, output['stderr'])
+        self.assertIn(expected_msg_4, output['stderr'])
+        self.assertIn(expected_msg_5, output['stderr'])
 
         stderr = output['stderr'].strip().split('\n')
         expected_count = 5
@@ -714,9 +714,9 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         self.assertTrue(output is not None)
         self.assertEqual(output['result'], [1, 2])
 
-        self.assertTrue(expected_msg_3 in output['stderr'])
+        self.assertIn(expected_msg_3, output['stderr'])
         self.assertTrue(expected_msg_4 not in output['stderr'])
-        self.assertTrue(expected_msg_5 in output['stderr'])
+        self.assertIn(expected_msg_5, output['stderr'])
 
         # Only log messages with level error and above should be displayed
         runner = self._get_mock_runner_obj()
@@ -732,7 +732,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
 
         self.assertTrue(expected_msg_3 not in output['stderr'])
         self.assertTrue(expected_msg_4 not in output['stderr'])
-        self.assertTrue(expected_msg_5 in output['stderr'])
+        self.assertIn(expected_msg_5, output['stderr'])
 
         # Default log level is changed in st2.config
         cfg.CONF.set_override(name='python_runner_log_level', override='INFO',
@@ -747,9 +747,9 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         self.assertTrue(output is not None)
         self.assertEqual(output['result'], [1, 2])
 
-        self.assertTrue(expected_msg_3 in output['stderr'])
+        self.assertIn(expected_msg_3, output['stderr'])
         self.assertTrue(expected_msg_4 not in output['stderr'])
-        self.assertTrue(expected_msg_5 in output['stderr'])
+        self.assertIn(expected_msg_5, output['stderr'])
 
     def test_traceback_messages_are_not_duplicated_in_stderr(self):
         # Verify tracebacks are not duplicated
@@ -763,8 +763,8 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         expected_msg_1 = 'Traceback (most recent'
         expected_msg_2 = 'ValueError: Duplicate traceback test'
 
-        self.assertTrue(expected_msg_1 in output['stderr'])
-        self.assertTrue(expected_msg_2 in output['stderr'])
+        self.assertIn(expected_msg_1, output['stderr'])
+        self.assertIn(expected_msg_2, output['stderr'])
 
         self.assertEqual(output['stderr'].count(expected_msg_1), 1)
         self.assertEqual(output['stderr'].count(expected_msg_2), 1)
@@ -855,8 +855,8 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         _, call_kwargs = mock_popen.call_args
         actual_env = call_kwargs['env']
         pack_common_lib_path = os.path.join(runner.git_worktree_path, 'lib')
-        self.assertTrue('PYTHONPATH' in actual_env)
-        self.assertTrue(pack_common_lib_path in actual_env['PYTHONPATH'])
+        self.assertIn('PYTHONPATH', actual_env)
+        self.assertIn(pack_common_lib_path, actual_env['PYTHONPATH'])
 
     @mock.patch('python_runner.python_runner.get_sandbox_virtualenv_path')
     def test_content_version_success_local_modules_work_fine(self,
@@ -943,10 +943,10 @@ fatal: invalid reference: vinvalid
 
         self.assertEqual(status, LIVEACTION_STATUS_FAILED)
         self.assertTrue(output is not None)
-        self.assertTrue('{}' in output['stdout'])
-        self.assertTrue('default_value' in output['stdout'])
-        self.assertTrue('Config for pack "core" is missing key "key"' in output['stderr'])
-        self.assertTrue('make sure you run "st2ctl reload --register-configs"' in output['stderr'])
+        self.assertIn('{}', output['stdout'])
+        self.assertIn('default_value', output['stdout'])
+        self.assertIn('Config for pack "core" is missing key "key"', output['stderr'])
+        self.assertIn('make sure you run "st2ctl reload --register-configs"', output['stderr'])
 
     def _get_mock_runner_obj(self, pack=None, sandbox=None):
         runner = python_runner.get_runner()

--- a/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
+++ b/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
@@ -89,7 +89,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
 
     def test_runner_creation(self):
         runner = python_runner.get_runner()
-        self.assertTrue(runner is not None, 'Creation failed. No instance.')
+        self.assertIsNotNone(runner, 'Creation failed. No instance.')
         self.assertEqual(type(runner), python_runner.PythonRunner, 'Creation failed. No instance.')
 
     def test_action_returns_non_serializable_result(self):
@@ -101,7 +101,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         (status, output, _) = runner.run({})
 
         self.assertEqual(status, LIVEACTION_STATUS_SUCCEEDED)
-        self.assertTrue(output is not None)
+        self.assertIsNotNone(output)
 
         if six.PY2:
             expected_result_re = (r"\[{'a': '1'}, {'h': 3, 'c': 2}, {'e': "
@@ -119,7 +119,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         runner.pre_run()
         (status, output, _) = runner.run({'row_index': 5})
         self.assertEqual(status, LIVEACTION_STATUS_SUCCEEDED)
-        self.assertTrue(output is not None)
+        self.assertIsNotNone(output)
         self.assertEqual(output['result'], [1, 5, 10, 10, 5, 1])
 
     def test_simple_action_with_result_as_None_no_status(self):
@@ -128,7 +128,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         runner.pre_run()
         (status, output, _) = runner.run({'row_index': 'b'})
         self.assertEqual(status, LIVEACTION_STATUS_SUCCEEDED)
-        self.assertTrue(output is not None)
+        self.assertIsNotNone(output)
         self.assertEqual(output['exit_code'], 0)
         self.assertEqual(output['result'], None)
 
@@ -140,7 +140,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         runner.pre_run()
         (status, output, _) = runner.run({'row_index': 4})
         self.assertEqual(status, LIVEACTION_STATUS_TIMED_OUT)
-        self.assertTrue(output is not None)
+        self.assertIsNotNone(output)
         self.assertEqual(output['result'], 'None')
         self.assertEqual(output['error'], 'Action failed to complete in 0 seconds')
         self.assertEqual(output['exit_code'], -9)
@@ -151,7 +151,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         runner.pre_run()
         (status, output, _) = runner.run({'row_index': 4})
         self.assertEqual(status, LIVEACTION_STATUS_SUCCEEDED)
-        self.assertTrue(output is not None)
+        self.assertIsNotNone(output)
         self.assertEqual(output['result'], [1, 4, 6, 4, 1])
 
     def test_simple_action_with_status_failed(self):
@@ -160,7 +160,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         runner.pre_run()
         (status, output, _) = runner.run({'row_index': 'a'})
         self.assertEqual(status, LIVEACTION_STATUS_FAILED)
-        self.assertTrue(output is not None)
+        self.assertIsNotNone(output)
         self.assertEqual(output['result'], "This is suppose to fail don't worry!!")
 
     def test_simple_action_with_status_complex_type_returned_for_result(self):
@@ -172,7 +172,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         (status, output, _) = runner.run({'row_index': 'complex_type'})
 
         self.assertEqual(status, LIVEACTION_STATUS_FAILED)
-        self.assertTrue(output is not None)
+        self.assertIsNotNone(output)
         self.assertIn('<pascal_row.PascalRowAction object at', output['result'])
 
     def test_simple_action_with_status_failed_result_none(self):
@@ -181,7 +181,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         runner.pre_run()
         (status, output, _) = runner.run({'row_index': 'c'})
         self.assertEqual(status, LIVEACTION_STATUS_FAILED)
-        self.assertTrue(output is not None)
+        self.assertIsNotNone(output)
         self.assertEqual(output['result'], None)
 
     def test_exception_in_simple_action_with_invalid_status(self):
@@ -197,7 +197,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         runner.pre_run()
         (status, output, _) = runner.run({'row_index': 'e'})
         self.assertEqual(status, LIVEACTION_STATUS_SUCCEEDED)
-        self.assertTrue(output is not None)
+        self.assertIsNotNone(output)
         self.assertEqual(output['result'], [1, 2])
 
     def test_simple_action_config_value_provided_overriden_in_datastore(self):
@@ -235,7 +235,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         runner.entry_point = PASCAL_ROW_ACTION_PATH
         runner.pre_run()
         (status, result, _) = runner.run({'row_index': '4'})
-        self.assertTrue(result is not None)
+        self.assertIsNotNone(result)
         self.assertEqual(status, LIVEACTION_STATUS_FAILED)
 
     def test_simple_action_no_file(self):
@@ -243,7 +243,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         runner.entry_point = 'foo.py'
         runner.pre_run()
         (status, result, _) = runner.run({})
-        self.assertTrue(result is not None)
+        self.assertIsNotNone(result)
         self.assertEqual(status, LIVEACTION_STATUS_FAILED)
 
     def test_simple_action_no_entry_point(self):
@@ -611,7 +611,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         runner.pre_run()
         (status, output, _) = runner.run({})
         self.assertEqual(status, LIVEACTION_STATUS_SUCCEEDED)
-        self.assertTrue(output is not None)
+        self.assertIsNotNone(output)
         self.assertEqual(output['result'], 'test action')
 
     def test_python_action_wrapper_script_doesnt_get_added_to_sys_path(self):
@@ -623,7 +623,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         (status, output, _) = runner.run({})
 
         self.assertEqual(status, LIVEACTION_STATUS_SUCCEEDED)
-        self.assertTrue(output is not None)
+        self.assertIsNotNone(output)
 
         lines = output['stdout'].split('\n')
         process_sys_path = lines[0]
@@ -676,7 +676,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         runner.pre_run()
         (status, output, _) = runner.run({'row_index': 'e'})
         self.assertEqual(status, LIVEACTION_STATUS_SUCCEEDED)
-        self.assertTrue(output is not None)
+        self.assertIsNotNone(output)
         self.assertEqual(output['result'], [1, 2])
 
         self.assertIn(expected_msg_1, output['stderr'])
@@ -711,7 +711,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         runner.pre_run()
         (status, output, _) = runner.run({'row_index': 'e'})
         self.assertEqual(status, LIVEACTION_STATUS_SUCCEEDED)
-        self.assertTrue(output is not None)
+        self.assertIsNotNone(output)
         self.assertEqual(output['result'], [1, 2])
 
         self.assertIn(expected_msg_3, output['stderr'])
@@ -727,7 +727,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         runner.pre_run()
         (status, output, _) = runner.run({'row_index': 'e'})
         self.assertEqual(status, LIVEACTION_STATUS_SUCCEEDED)
-        self.assertTrue(output is not None)
+        self.assertIsNotNone(output)
         self.assertEqual(output['result'], [1, 2])
 
         self.assertNotIn(expected_msg_3, output['stderr'])
@@ -744,7 +744,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         runner.pre_run()
         (status, output, _) = runner.run({'row_index': 'e'})
         self.assertEqual(status, LIVEACTION_STATUS_SUCCEEDED)
-        self.assertTrue(output is not None)
+        self.assertIsNotNone(output)
         self.assertEqual(output['result'], [1, 2])
 
         self.assertIn(expected_msg_3, output['stderr'])
@@ -758,7 +758,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         runner.pre_run()
         (status, output, _) = runner.run({'row_index': 'f'})
         self.assertEqual(status, LIVEACTION_STATUS_FAILED)
-        self.assertTrue(output is not None)
+        self.assertIsNotNone(output)
 
         expected_msg_1 = 'Traceback (most recent'
         expected_msg_2 = 'ValueError: Duplicate traceback test'
@@ -776,7 +776,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         large_value = ''.join(['1' for _ in range(MAX_PARAM_LENGTH)])
         (status, output, _) = runner.run({'action_input': large_value})
         self.assertEqual(status, LIVEACTION_STATUS_SUCCEEDED)
-        self.assertTrue(output is not None)
+        self.assertIsNotNone(output)
         self.assertEqual(output['result']['action_input'], large_value)
 
     def test_execution_with_close_to_very_large_parameter(self):
@@ -790,7 +790,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         large_value = ''.join(['1' for _ in range(MAX_PARAM_LENGTH - 21)])
         (status, output, _) = runner.run({'action_input': large_value})
         self.assertEqual(status, LIVEACTION_STATUS_SUCCEEDED)
-        self.assertTrue(output is not None)
+        self.assertIsNotNone(output)
         self.assertEqual(output['result']['action_input'], large_value)
 
     @mock.patch('python_runner.python_runner.get_sandbox_virtualenv_path')
@@ -942,7 +942,7 @@ fatal: invalid reference: vinvalid
         (status, output, _) = runner.run({})
 
         self.assertEqual(status, LIVEACTION_STATUS_FAILED)
-        self.assertTrue(output is not None)
+        self.assertIsNotNone(output)
         self.assertIn('{}', output['stdout'])
         self.assertIn('default_value', output['stdout'])
         self.assertIn('Config for pack "core" is missing key "key"', output['stderr'])

--- a/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
+++ b/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
@@ -560,7 +560,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         actual_env = call_kwargs['env']
         pack_common_lib_path = '/mnt/src/storm/st2/st2tests/st2tests/fixtures/packs/core/lib'
         self.assertIn('PYTHONPATH', actual_env)
-        self.assertTrue(pack_common_lib_path not in actual_env['PYTHONPATH'])
+        self.assertNotIn(pack_common_lib_path, actual_env['PYTHONPATH'])
 
     def test_action_class_instantiation_action_service_argument(self):
         class Action1(Action):
@@ -635,8 +635,8 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         wrapper_script_path = 'st2common/runners'
 
         assertion_msg = 'Found python wrapper script path in subprocess path'
-        self.assertTrue(wrapper_script_path not in process_sys_path, assertion_msg)
-        self.assertTrue(wrapper_script_path not in process_pythonpath, assertion_msg)
+        self.assertNotIn(wrapper_script_path, process_sys_path, assertion_msg)
+        self.assertNotIn(wrapper_script_path, process_pythonpath, assertion_msg)
 
     def test_python_action_wrapper_action_script_file_doesnt_exist_friendly_error(self):
         # File in a directory which is not a Python package
@@ -715,7 +715,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         self.assertEqual(output['result'], [1, 2])
 
         self.assertIn(expected_msg_3, output['stderr'])
-        self.assertTrue(expected_msg_4 not in output['stderr'])
+        self.assertNotIn(expected_msg_4, output['stderr'])
         self.assertIn(expected_msg_5, output['stderr'])
 
         # Only log messages with level error and above should be displayed
@@ -730,8 +730,8 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         self.assertTrue(output is not None)
         self.assertEqual(output['result'], [1, 2])
 
-        self.assertTrue(expected_msg_3 not in output['stderr'])
-        self.assertTrue(expected_msg_4 not in output['stderr'])
+        self.assertNotIn(expected_msg_3, output['stderr'])
+        self.assertNotIn(expected_msg_4, output['stderr'])
         self.assertIn(expected_msg_5, output['stderr'])
 
         # Default log level is changed in st2.config
@@ -748,7 +748,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         self.assertEqual(output['result'], [1, 2])
 
         self.assertIn(expected_msg_3, output['stderr'])
-        self.assertTrue(expected_msg_4 not in output['stderr'])
+        self.assertNotIn(expected_msg_4, output['stderr'])
         self.assertIn(expected_msg_5, output['stderr'])
 
     def test_traceback_messages_are_not_duplicated_in_stderr(self):

--- a/contrib/runners/winrm_runner/tests/unit/test_winrm_base.py
+++ b/contrib/runners/winrm_runner/tests/unit/test_winrm_base.py
@@ -46,7 +46,7 @@ class WinRmBaseTestCase(RunnerTestCase):
     def test_win_rm_runner_timout_error(self):
         error = WinRmRunnerTimoutError('test_response')
         self.assertIsInstance(error, Exception)
-        self.assertEquals(error.response, 'test_response')
+        self.assertEqual(error.response, 'test_response')
         with self.assertRaises(WinRmRunnerTimoutError):
             raise WinRmRunnerTimoutError('test raising')
 
@@ -54,7 +54,7 @@ class WinRmBaseTestCase(RunnerTestCase):
         runner = winrm_ps_command_runner.WinRmPsCommandRunner('abcdef')
         self.assertIsInstance(runner, WinRmBaseRunner)
         self.assertIsInstance(runner, ActionRunner)
-        self.assertEquals(runner.runner_id, "abcdef")
+        self.assertEqual(runner.runner_id, "abcdef")
 
     @mock.patch('winrm_runner.winrm_base.ActionRunner.pre_run')
     def test_pre_run(self, mock_pre_run):
@@ -72,21 +72,21 @@ class WinRmBaseTestCase(RunnerTestCase):
         self._runner.runner_parameters = runner_parameters
         self._runner.pre_run()
         mock_pre_run.assert_called_with()
-        self.assertEquals(self._runner._session, None)
-        self.assertEquals(self._runner._host, 'host@domain.tld')
-        self.assertEquals(self._runner._username, 'user@domain.tld')
-        self.assertEquals(self._runner._password, 'abc123')
-        self.assertEquals(self._runner._timeout, 99)
-        self.assertEquals(self._runner._read_timeout, 100)
-        self.assertEquals(self._runner._port, 1234)
-        self.assertEquals(self._runner._scheme, 'http')
-        self.assertEquals(self._runner._transport, 'ntlm')
-        self.assertEquals(self._runner._winrm_url, 'http://host@domain.tld:1234/wsman')
-        self.assertEquals(self._runner._verify_ssl, False)
-        self.assertEquals(self._runner._server_cert_validation, 'ignore')
-        self.assertEquals(self._runner._cwd, 'C:\\Test')
-        self.assertEquals(self._runner._env, {'TEST_VAR': 'TEST_VALUE'})
-        self.assertEquals(self._runner._kwarg_op, '/')
+        self.assertEqual(self._runner._session, None)
+        self.assertEqual(self._runner._host, 'host@domain.tld')
+        self.assertEqual(self._runner._username, 'user@domain.tld')
+        self.assertEqual(self._runner._password, 'abc123')
+        self.assertEqual(self._runner._timeout, 99)
+        self.assertEqual(self._runner._read_timeout, 100)
+        self.assertEqual(self._runner._port, 1234)
+        self.assertEqual(self._runner._scheme, 'http')
+        self.assertEqual(self._runner._transport, 'ntlm')
+        self.assertEqual(self._runner._winrm_url, 'http://host@domain.tld:1234/wsman')
+        self.assertEqual(self._runner._verify_ssl, False)
+        self.assertEqual(self._runner._server_cert_validation, 'ignore')
+        self.assertEqual(self._runner._cwd, 'C:\\Test')
+        self.assertEqual(self._runner._env, {'TEST_VAR': 'TEST_VALUE'})
+        self.assertEqual(self._runner._kwarg_op, '/')
 
     @mock.patch('winrm_runner.winrm_base.ActionRunner.pre_run')
     def test_pre_run_defaults(self, mock_pre_run):
@@ -96,20 +96,20 @@ class WinRmBaseTestCase(RunnerTestCase):
         self._runner.runner_parameters = runner_parameters
         self._runner.pre_run()
         mock_pre_run.assert_called_with()
-        self.assertEquals(self._runner._host, 'host@domain.tld')
-        self.assertEquals(self._runner._username, 'user@domain.tld')
-        self.assertEquals(self._runner._password, 'abc123')
-        self.assertEquals(self._runner._timeout, 60)
-        self.assertEquals(self._runner._read_timeout, 61)
-        self.assertEquals(self._runner._port, 5986)
-        self.assertEquals(self._runner._scheme, 'https')
-        self.assertEquals(self._runner._transport, 'ntlm')
-        self.assertEquals(self._runner._winrm_url, 'https://host@domain.tld:5986/wsman')
-        self.assertEquals(self._runner._verify_ssl, True)
-        self.assertEquals(self._runner._server_cert_validation, 'validate')
-        self.assertEquals(self._runner._cwd, None)
-        self.assertEquals(self._runner._env, {})
-        self.assertEquals(self._runner._kwarg_op, '-')
+        self.assertEqual(self._runner._host, 'host@domain.tld')
+        self.assertEqual(self._runner._username, 'user@domain.tld')
+        self.assertEqual(self._runner._password, 'abc123')
+        self.assertEqual(self._runner._timeout, 60)
+        self.assertEqual(self._runner._read_timeout, 61)
+        self.assertEqual(self._runner._port, 5986)
+        self.assertEqual(self._runner._scheme, 'https')
+        self.assertEqual(self._runner._transport, 'ntlm')
+        self.assertEqual(self._runner._winrm_url, 'https://host@domain.tld:5986/wsman')
+        self.assertEqual(self._runner._verify_ssl, True)
+        self.assertEqual(self._runner._server_cert_validation, 'validate')
+        self.assertEqual(self._runner._cwd, None)
+        self.assertEqual(self._runner._env, {})
+        self.assertEqual(self._runner._kwarg_op, '-')
 
     @mock.patch('winrm_runner.winrm_base.ActionRunner.pre_run')
     def test_pre_run_5985_force_http(self, mock_pre_run):
@@ -121,22 +121,22 @@ class WinRmBaseTestCase(RunnerTestCase):
         self._runner.runner_parameters = runner_parameters
         self._runner.pre_run()
         mock_pre_run.assert_called_with()
-        self.assertEquals(self._runner._host, 'host@domain.tld')
-        self.assertEquals(self._runner._username, 'user@domain.tld')
-        self.assertEquals(self._runner._password, 'abc123')
-        self.assertEquals(self._runner._timeout, 60)
-        self.assertEquals(self._runner._read_timeout, 61)
+        self.assertEqual(self._runner._host, 'host@domain.tld')
+        self.assertEqual(self._runner._username, 'user@domain.tld')
+        self.assertEqual(self._runner._password, 'abc123')
+        self.assertEqual(self._runner._timeout, 60)
+        self.assertEqual(self._runner._read_timeout, 61)
         # ensure port is still 5985
-        self.assertEquals(self._runner._port, 5985)
+        self.assertEqual(self._runner._port, 5985)
         # ensure scheme is set back to http
-        self.assertEquals(self._runner._scheme, 'http')
-        self.assertEquals(self._runner._transport, 'ntlm')
-        self.assertEquals(self._runner._winrm_url, 'http://host@domain.tld:5985/wsman')
-        self.assertEquals(self._runner._verify_ssl, True)
-        self.assertEquals(self._runner._server_cert_validation, 'validate')
-        self.assertEquals(self._runner._cwd, None)
-        self.assertEquals(self._runner._env, {})
-        self.assertEquals(self._runner._kwarg_op, '-')
+        self.assertEqual(self._runner._scheme, 'http')
+        self.assertEqual(self._runner._transport, 'ntlm')
+        self.assertEqual(self._runner._winrm_url, 'http://host@domain.tld:5985/wsman')
+        self.assertEqual(self._runner._verify_ssl, True)
+        self.assertEqual(self._runner._server_cert_validation, 'validate')
+        self.assertEqual(self._runner._cwd, None)
+        self.assertEqual(self._runner._env, {})
+        self.assertEqual(self._runner._kwarg_op, '-')
 
     @mock.patch('winrm_runner.winrm_base.ActionRunner.pre_run')
     def test_pre_run_none_env(self, mock_pre_run):
@@ -148,7 +148,7 @@ class WinRmBaseTestCase(RunnerTestCase):
         self._runner.pre_run()
         mock_pre_run.assert_called_with()
         # ensure that env is set to {} even though we passed in None
-        self.assertEquals(self._runner._env, {})
+        self.assertEqual(self._runner._env, {})
 
     @mock.patch('winrm_runner.winrm_base.ActionRunner.pre_run')
     def test_pre_run_ssl_verify_true(self, mock_pre_run):
@@ -159,8 +159,8 @@ class WinRmBaseTestCase(RunnerTestCase):
         self._runner.runner_parameters = runner_parameters
         self._runner.pre_run()
         mock_pre_run.assert_called_with()
-        self.assertEquals(self._runner._verify_ssl, True)
-        self.assertEquals(self._runner._server_cert_validation, 'validate')
+        self.assertEqual(self._runner._verify_ssl, True)
+        self.assertEqual(self._runner._server_cert_validation, 'validate')
 
     @mock.patch('winrm_runner.winrm_base.ActionRunner.pre_run')
     def test_pre_run_ssl_verify_false(self, mock_pre_run):
@@ -171,8 +171,8 @@ class WinRmBaseTestCase(RunnerTestCase):
         self._runner.runner_parameters = runner_parameters
         self._runner.pre_run()
         mock_pre_run.assert_called_with()
-        self.assertEquals(self._runner._verify_ssl, False)
-        self.assertEquals(self._runner._server_cert_validation, 'ignore')
+        self.assertEqual(self._runner._verify_ssl, False)
+        self.assertEqual(self._runner._server_cert_validation, 'ignore')
 
     @mock.patch('winrm_runner.winrm_base.Session')
     def test_get_session(self, mock_session):
@@ -187,8 +187,8 @@ class WinRmBaseTestCase(RunnerTestCase):
         mock_session.return_value = "session"
 
         result = self._runner._get_session()
-        self.assertEquals(result, "session")
-        self.assertEquals(result, self._runner._session)
+        self.assertEqual(result, "session")
+        self.assertEqual(result, self._runner._session)
         mock_session.assert_called_with('https://host@domain.tld:5986/wsman',
                                         auth=('user@domain.tld', 'abc123'),
                                         transport='ntlm',
@@ -199,7 +199,7 @@ class WinRmBaseTestCase(RunnerTestCase):
         # ensure calling _get_session again doesn't create a new one, it reuses the existing
         old_session = self._runner._session
         result = self._runner._get_session()
-        self.assertEquals(result, old_session)
+        self.assertEqual(result, old_session)
 
     def test_winrm_get_command_output(self):
         self._runner._timeout = 0
@@ -212,7 +212,7 @@ class WinRmBaseTestCase(RunnerTestCase):
 
         result = self._runner._winrm_get_command_output(mock_protocol, 567, 890)
 
-        self.assertEquals(result, (b'output1output2output3', b'error1error2error3', 789))
+        self.assertEqual(result, (b'output1output2output3', b'error1error2error3', 789))
         mock_protocol._raw_get_command_output.assert_has_calls = [
             mock.call(567, 890),
             mock.call(567, 890),
@@ -274,7 +274,7 @@ class WinRmBaseTestCase(RunnerTestCase):
         expected_response = Response((b'output', b'error', 9))
         expected_response.timeout = False
 
-        self.assertEquals(result.__dict__, expected_response.__dict__)
+        self.assertEqual(result.__dict__, expected_response.__dict__)
         mock_protocol.open_shell.assert_called_with(env_vars={'PATH': 'C:\\st2\\bin'},
                                                     working_directory='C:\\st2')
         mock_protocol.run_command.assert_called_with(123, 'fake-command', ['arg1', 'arg2'])
@@ -298,7 +298,7 @@ class WinRmBaseTestCase(RunnerTestCase):
         expected_response = Response(('', '', 5))
         expected_response.timeout = True
 
-        self.assertEquals(result.__dict__, expected_response.__dict__)
+        self.assertEqual(result.__dict__, expected_response.__dict__)
         mock_protocol.open_shell.assert_called_with(env_vars={'PATH': 'C:\\st2\\bin'},
                                                     working_directory='C:\\st2')
         mock_protocol.run_command.assert_called_with(123, 'fake-command', ['arg1', 'arg2'])
@@ -308,11 +308,11 @@ class WinRmBaseTestCase(RunnerTestCase):
     def test_winrm_encode(self):
         result = self._runner._winrm_encode('hello world')
         # result translated into UTF-16 little-endian
-        self.assertEquals(result, 'aABlAGwAbABvACAAdwBvAHIAbABkAA==')
+        self.assertEqual(result, 'aABlAGwAbABvACAAdwBvAHIAbABkAA==')
 
     def test_winrm_ps_cmd(self):
         result = self._runner._winrm_ps_cmd('abc123==')
-        self.assertEquals(result, 'powershell -encodedcommand abc123==')
+        self.assertEqual(result, 'powershell -encodedcommand abc123==')
 
     @mock.patch('winrm_runner.winrm_base.WinRmBaseRunner._winrm_run_cmd')
     def test_winrm_run_ps(self, mock_run_cmd):
@@ -323,8 +323,8 @@ class WinRmBaseTestCase(RunnerTestCase):
                                             env={'PATH': 'C:\\st2\\bin'},
                                             cwd='C:\\st2')
 
-        self.assertEquals(result.__dict__,
-                          Response(('output', '', 3)).__dict__)
+        self.assertEqual(result.__dict__,
+                         Response(('output', '', 3)).__dict__)
         expected_ps = ('powershell -encodedcommand ' +
                        b64encode("Get-ADUser stanley".encode('utf_16_le')).decode('ascii'))
         mock_run_cmd.assert_called_with("session",
@@ -343,8 +343,8 @@ class WinRmBaseTestCase(RunnerTestCase):
                                             env={'PATH': 'C:\\st2\\bin'},
                                             cwd='C:\\st2')
 
-        self.assertEquals(result.__dict__,
-                          Response(('output', 'e', 3)).__dict__)
+        self.assertEqual(result.__dict__,
+                         Response(('output', 'e', 3)).__dict__)
         expected_ps = ('powershell -encodedcommand ' +
                        b64encode("Get-ADUser stanley".encode('utf_16_le')).decode('ascii'))
         mock_run_cmd.assert_called_with(mock_session,
@@ -358,47 +358,46 @@ class WinRmBaseTestCase(RunnerTestCase):
         response.timeout = False
 
         result = self._runner._translate_response(response)
-        self.assertEquals(result, ('succeeded',
-                                   {'failed': False,
-                                    'succeeded': True,
-                                    'return_code': 0,
-                                    'stdout': 'output1',
-                                    'stderr': 'error1'},
-                                   None))
+        self.assertEqual(result, ('succeeded',
+                                  {'failed': False,
+                                   'succeeded': True,
+                                   'return_code': 0,
+                                   'stdout': 'output1',
+                                   'stderr': 'error1'},
+                                  None))
 
     def test_translate_response_failure(self):
         response = Response(('output1', 'error1', 123))
         response.timeout = False
 
         result = self._runner._translate_response(response)
-        self.assertEquals(result, ('failed',
-                                   {'failed': True,
-                                    'succeeded': False,
-                                    'return_code': 123,
-                                    'stdout': 'output1',
-                                    'stderr': 'error1'},
-
-                                   None))
+        self.assertEqual(result, ('failed',
+                                  {'failed': True,
+                                   'succeeded': False,
+                                   'return_code': 123,
+                                   'stdout': 'output1',
+                                   'stderr': 'error1'},
+                                  None))
 
     def test_translate_response_timeout(self):
         response = Response(('output1', 'error1', 123))
         response.timeout = True
 
         result = self._runner._translate_response(response)
-        self.assertEquals(result, ('timeout',
-                                   {'failed': True,
-                                    'succeeded': False,
-                                    'return_code': -1,
-                                    'stdout': 'output1',
-                                    'stderr': 'error1'},
-                                   None))
+        self.assertEqual(result, ('timeout',
+                                  {'failed': True,
+                                   'succeeded': False,
+                                   'return_code': -1,
+                                   'stdout': 'output1',
+                                   'stderr': 'error1'},
+                                  None))
 
     @mock.patch('winrm_runner.winrm_base.WinRmBaseRunner._run_ps_or_raise')
     def test_make_tmp_dir(self, mock_run_ps_or_raise):
         mock_run_ps_or_raise.return_value = {'stdout': ' expected \n'}
 
         result = self._runner._make_tmp_dir('C:\\Windows\\Temp')
-        self.assertEquals(result, 'expected')
+        self.assertEqual(result, 'expected')
         mock_run_ps_or_raise.assert_called_with('''$parent = C:\\Windows\\Temp
 $name = [System.IO.Path]::GetRandomFileName()
 $path = Join-Path $parent $name
@@ -478,7 +477,7 @@ Add-Content -value $data -encoding byte -path $filePath
         mock_make_tmp_dir.return_value = 'C:\\Windows\\Temp\\abc123'
 
         with self._runner._tmp_script('C:\\Windows\\Temp', 'Get-ChildItem') as tmp:
-            self.assertEquals(tmp, 'C:\\Windows\\Temp\\abc123\\script.ps1')
+            self.assertEqual(tmp, 'C:\\Windows\\Temp\\abc123\\script.ps1')
         mock_make_tmp_dir.assert_called_with('C:\\Windows\\Temp')
         mock_upload.assert_called_with('Get-ChildItem',
                                        'C:\\Windows\\Temp\\abc123\\script.ps1')
@@ -494,7 +493,7 @@ Add-Content -value $data -encoding byte -path $filePath
 
         with self.assertRaises(RuntimeError):
             with self._runner._tmp_script('C:\\Windows\\Temp', 'Get-ChildItem') as tmp:
-                self.assertEquals(tmp, "can never get here")
+                self.assertEqual(tmp, "can never get here")
         mock_make_tmp_dir.assert_called_with('C:\\Windows\\Temp')
         mock_upload.assert_called_with('Get-ChildItem',
                                        'C:\\Windows\\Temp\\abc123\\script.ps1')
@@ -512,13 +511,13 @@ Add-Content -value $data -encoding byte -path $filePath
 
         self._init_runner()
         result = self._runner.run_cmd("ipconfig /all")
-        self.assertEquals(result, ('succeeded',
-                                   {'failed': False,
-                                    'succeeded': True,
-                                    'return_code': 0,
-                                    'stdout': 'output1output2output3',
-                                    'stderr': 'error1error2error3'},
-                                   None))
+        self.assertEqual(result, ('succeeded',
+                                  {'failed': False,
+                                   'succeeded': True,
+                                   'return_code': 0,
+                                   'stdout': 'output1output2output3',
+                                   'stderr': 'error1error2error3'},
+                                  None))
 
     @mock.patch('winrm.Protocol')
     def test_run_cmd_failed(self, mock_protocol_init):
@@ -532,13 +531,13 @@ Add-Content -value $data -encoding byte -path $filePath
 
         self._init_runner()
         result = self._runner.run_cmd("ipconfig /all")
-        self.assertEquals(result, ('failed',
-                                   {'failed': True,
-                                    'succeeded': False,
-                                    'return_code': 1,
-                                    'stdout': 'output1output2output3',
-                                    'stderr': 'error1error2error3'},
-                                   None))
+        self.assertEqual(result, ('failed',
+                                  {'failed': True,
+                                   'succeeded': False,
+                                   'return_code': 1,
+                                   'stdout': 'output1output2output3',
+                                   'stderr': 'error1error2error3'},
+                                  None))
 
     @mock.patch('winrm.Protocol')
     def test_run_cmd_timeout(self, mock_protocol_init):
@@ -554,13 +553,13 @@ Add-Content -value $data -encoding byte -path $filePath
         mock_protocol_init.return_value = mock_protocol
 
         result = self._runner.run_cmd("ipconfig /all")
-        self.assertEquals(result, ('timeout',
-                                   {'failed': True,
-                                    'succeeded': False,
-                                    'return_code': -1,
-                                    'stdout': 'output1',
-                                    'stderr': 'error1'},
-                                   None))
+        self.assertEqual(result, ('timeout',
+                                  {'failed': True,
+                                   'succeeded': False,
+                                   'return_code': -1,
+                                   'stdout': 'output1',
+                                   'stderr': 'error1'},
+                                  None))
 
     @mock.patch('winrm.Protocol')
     def test_run_ps(self, mock_protocol_init):
@@ -574,13 +573,13 @@ Add-Content -value $data -encoding byte -path $filePath
 
         self._init_runner()
         result = self._runner.run_ps("Get-Location")
-        self.assertEquals(result, ('succeeded',
-                                   {'failed': False,
-                                    'succeeded': True,
-                                    'return_code': 0,
-                                    'stdout': 'output1output2output3',
-                                    'stderr': 'error1error2error3'},
-                                   None))
+        self.assertEqual(result, ('succeeded',
+                                  {'failed': False,
+                                   'succeeded': True,
+                                   'return_code': 0,
+                                   'stdout': 'output1output2output3',
+                                   'stderr': 'error1error2error3'},
+                                  None))
 
     @mock.patch('winrm.Protocol')
     def test_run_ps_failed(self, mock_protocol_init):
@@ -594,13 +593,13 @@ Add-Content -value $data -encoding byte -path $filePath
 
         self._init_runner()
         result = self._runner.run_ps("Get-Location")
-        self.assertEquals(result, ('failed',
-                                   {'failed': True,
-                                    'succeeded': False,
-                                    'return_code': 1,
-                                    'stdout': 'output1output2output3',
-                                    'stderr': 'error1error2error3'},
-                                   None))
+        self.assertEqual(result, ('failed',
+                                  {'failed': True,
+                                   'succeeded': False,
+                                   'return_code': 1,
+                                   'stdout': 'output1output2output3',
+                                   'stderr': 'error1error2error3'},
+                                  None))
 
     @mock.patch('winrm.Protocol')
     def test_run_ps_timeout(self, mock_protocol_init):
@@ -616,13 +615,13 @@ Add-Content -value $data -encoding byte -path $filePath
         mock_protocol_init.return_value = mock_protocol
 
         result = self._runner.run_ps("Get-Location")
-        self.assertEquals(result, ('timeout',
-                                   {'failed': True,
-                                    'succeeded': False,
-                                    'return_code': -1,
-                                    'stdout': 'output1',
-                                    'stderr': 'error1'},
-                                   None))
+        self.assertEqual(result, ('timeout',
+                                  {'failed': True,
+                                   'succeeded': False,
+                                   'return_code': -1,
+                                   'stdout': 'output1',
+                                   'stderr': 'error1'},
+                                  None))
 
     @mock.patch('winrm_runner.winrm_base.WinRmBaseRunner._run_ps')
     @mock.patch('winrm_runner.winrm_base.WinRmBaseRunner._winrm_encode')
@@ -633,7 +632,7 @@ Add-Content -value $data -encoding byte -path $filePath
         self._init_runner()
         result = self._runner.run_ps("Get-Location", '-param1 value1 arg1')
 
-        self.assertEquals(result, "expected")
+        self.assertEqual(result, "expected")
         mock_winrm_encode.assert_called_with('& {Get-Location} -param1 value1 arg1')
         mock_run_ps.assert_called_with('xyz123==', is_b64=True)
 
@@ -651,7 +650,7 @@ Add-Content -value $data -encoding byte -path $filePath
         self._init_runner()
         result = self._runner.run_ps('$PSVersionTable')
 
-        self.assertEquals(result, "expected")
+        self.assertEqual(result, "expected")
         mock_run_ps_script.assert_called_with('$PSVersionTable', None)
 
     @mock.patch('winrm.Protocol')
@@ -666,13 +665,13 @@ Add-Content -value $data -encoding byte -path $filePath
 
         self._init_runner()
         result = self._runner._run_ps("Get-Location")
-        self.assertEquals(result, ('succeeded',
-                                   {'failed': False,
-                                    'succeeded': True,
-                                    'return_code': 0,
-                                    'stdout': 'output1output2output3',
-                                    'stderr': 'error1error2error3'},
-                                   None))
+        self.assertEqual(result, ('succeeded',
+                                  {'failed': False,
+                                   'succeeded': True,
+                                   'return_code': 0,
+                                   'stdout': 'output1output2output3',
+                                   'stderr': 'error1error2error3'},
+                                  None))
 
     @mock.patch('winrm.Protocol')
     def test__run_ps_failed(self, mock_protocol_init):
@@ -686,13 +685,13 @@ Add-Content -value $data -encoding byte -path $filePath
 
         self._init_runner()
         result = self._runner._run_ps("Get-Location")
-        self.assertEquals(result, ('failed',
-                                   {'failed': True,
-                                    'succeeded': False,
-                                    'return_code': 1,
-                                    'stdout': 'output1output2output3',
-                                    'stderr': 'error1error2error3'},
-                                   None))
+        self.assertEqual(result, ('failed',
+                                  {'failed': True,
+                                   'succeeded': False,
+                                   'return_code': 1,
+                                   'stdout': 'output1output2output3',
+                                   'stderr': 'error1error2error3'},
+                                  None))
 
     @mock.patch('winrm.Protocol')
     def test__run_ps_timeout(self, mock_protocol_init):
@@ -708,13 +707,13 @@ Add-Content -value $data -encoding byte -path $filePath
         mock_protocol_init.return_value = mock_protocol
 
         result = self._runner._run_ps("Get-Location")
-        self.assertEquals(result, ('timeout',
-                                   {'failed': True,
-                                    'succeeded': False,
-                                    'return_code': -1,
-                                    'stdout': 'output1',
-                                    'stderr': 'error1'},
-                                   None))
+        self.assertEqual(result, ('timeout',
+                                  {'failed': True,
+                                   'succeeded': False,
+                                   'return_code': -1,
+                                   'stdout': 'output1',
+                                   'stderr': 'error1'},
+                                  None))
 
     @mock.patch('winrm_runner.winrm_base.WinRmBaseRunner._winrm_run_ps')
     def test__run_ps_b64_default(self, mock_winrm_run_ps):
@@ -725,13 +724,13 @@ Add-Content -value $data -encoding byte -path $filePath
 
         self._init_runner()
         result = self._runner._run_ps("$PSVersionTable")
-        self.assertEquals(result, ('succeeded',
-                                   {'failed': False,
-                                    'succeeded': True,
-                                    'return_code': 0,
-                                    'stdout': 'output1',
-                                    'stderr': 'error1'},
-                                   None))
+        self.assertEqual(result, ('succeeded',
+                                  {'failed': False,
+                                   'succeeded': True,
+                                   'return_code': 0,
+                                   'stdout': 'output1',
+                                   'stderr': 'error1'},
+                                  None))
         mock_winrm_run_ps.assert_called_with(self._runner._session,
                                              '$PSVersionTable',
                                              env={},
@@ -747,13 +746,13 @@ Add-Content -value $data -encoding byte -path $filePath
 
         self._init_runner()
         result = self._runner._run_ps("xyz123", is_b64=True)
-        self.assertEquals(result, ('succeeded',
-                                   {'failed': False,
-                                    'succeeded': True,
-                                    'return_code': 0,
-                                    'stdout': 'output1',
-                                    'stderr': 'error1'},
-                                   None))
+        self.assertEqual(result, ('succeeded',
+                                  {'failed': False,
+                                   'succeeded': True,
+                                   'return_code': 0,
+                                   'stdout': 'output1',
+                                   'stderr': 'error1'},
+                                  None))
         mock_winrm_run_ps.assert_called_with(self._runner._session,
                                              'xyz123',
                                              env={},
@@ -768,7 +767,7 @@ Add-Content -value $data -encoding byte -path $filePath
 
         self._init_runner()
         result = self._runner._run_ps_script("$PSVersionTable")
-        self.assertEquals(result, 'expected')
+        self.assertEqual(result, 'expected')
         mock_tmp_script.assert_called_with('[System.IO.Path]::GetTempPath()',
                                            '$PSVersionTable')
         mock_run_ps.assert_called_with('& {C:\\tmpscript.ps1}')
@@ -781,7 +780,7 @@ Add-Content -value $data -encoding byte -path $filePath
 
         self._init_runner()
         result = self._runner._run_ps_script("Get-ChildItem", '-param1 value1 arg1')
-        self.assertEquals(result, 'expected')
+        self.assertEqual(result, 'expected')
         mock_tmp_script.assert_called_with('[System.IO.Path]::GetTempPath()',
                                            'Get-ChildItem')
         mock_run_ps.assert_called_with('& {C:\\tmpscript.ps1} -param1 value1 arg1')
@@ -799,7 +798,7 @@ Add-Content -value $data -encoding byte -path $filePath
                                     None)
         self._init_runner()
         result = self._runner._run_ps_or_raise('Get-ChildItem', 'my error message')
-        self.assertEquals(result, {
+        self.assertEqual(result, {
             'failed': False,
             'succeeded': True,
             'return_code': 0,
@@ -827,7 +826,7 @@ Add-Content -value $data -encoding byte -path $filePath
                             'c': 'y',
                             'aaa': 'z'}
         result = self._runner._multireplace('aaaccaa', multireplace_map)
-        self.assertEquals(result, 'zyyxx')
+        self.assertEqual(result, 'zyyxx')
 
     def test_multireplace_powershell(self):
         param_str = (
@@ -845,7 +844,7 @@ Add-Content -value $data -encoding byte -path $filePath
             '$'
         )
         result = self._runner._multireplace(param_str, PS_ESCAPE_SEQUENCES)
-        self.assertEquals(result, (
+        self.assertEqual(result, (
             '`n'
             '`r'
             '`t'
@@ -864,41 +863,41 @@ Add-Content -value $data -encoding byte -path $filePath
         # test None/null
         param = None
         result = self._runner._param_to_ps(param)
-        self.assertEquals(result, '$null')
+        self.assertEqual(result, '$null')
 
     def test_param_to_ps_string(self):
         # test ascii
         param_str = 'StackStorm 1234'
         result = self._runner._param_to_ps(param_str)
-        self.assertEquals(result, '"StackStorm 1234"')
+        self.assertEqual(result, '"StackStorm 1234"')
 
         # test escaped
         param_str = '\n\r\t'
         result = self._runner._param_to_ps(param_str)
-        self.assertEquals(result, '"`n`r`t"')
+        self.assertEqual(result, '"`n`r`t"')
 
     def test_param_to_ps_bool(self):
         # test True
         result = self._runner._param_to_ps(True)
-        self.assertEquals(result, '$true')
+        self.assertEqual(result, '$true')
 
         # test False
         result = self._runner._param_to_ps(False)
-        self.assertEquals(result, '$false')
+        self.assertEqual(result, '$false')
 
     def test_param_to_ps_integer(self):
         result = self._runner._param_to_ps(9876)
-        self.assertEquals(result, '9876')
+        self.assertEqual(result, '9876')
 
         result = self._runner._param_to_ps(-765)
-        self.assertEquals(result, '-765')
+        self.assertEqual(result, '-765')
 
     def test_param_to_ps_float(self):
         result = self._runner._param_to_ps(98.76)
-        self.assertEquals(result, '98.76')
+        self.assertEqual(result, '98.76')
 
         result = self._runner._param_to_ps(-76.5)
-        self.assertEquals(result, '-76.5')
+        self.assertEqual(result, '-76.5')
 
     def test_param_to_ps_list(self):
         input_list = ['StackStorm Test String',
@@ -906,12 +905,12 @@ Add-Content -value $data -encoding byte -path $filePath
                       True,
                       99]
         result = self._runner._param_to_ps(input_list)
-        self.assertEquals(result, '@("StackStorm Test String", "```0`$", $true, 99)')
+        self.assertEqual(result, '@("StackStorm Test String", "```0`$", $true, 99)')
 
     def test_param_to_ps_list_nested(self):
         input_list = [['a'], ['b'], [['c']]]
         result = self._runner._param_to_ps(input_list)
-        self.assertEquals(result, '@(@("a"), @("b"), @(@("c")))')
+        self.assertEqual(result, '@(@("a"), @("b"), @(@("c")))')
 
     def test_param_to_ps_dict(self):
         input_list = collections.OrderedDict(
@@ -928,7 +927,7 @@ Add-Content -value $data -encoding byte -path $filePath
             '11 = 99; '
             '18.3 = 12.34}'
         )
-        self.assertEquals(result, expected_str)
+        self.assertEqual(result, expected_str)
 
     def test_param_to_ps_dict_nexted(self):
         input_list = collections.OrderedDict(
@@ -939,7 +938,7 @@ Add-Content -value $data -encoding byte -path $filePath
             '@{"a" = @{"deep_a" = "value"}; '
             '"b" = @{"deep_b" = @{"deep_deep_b" = "value"}}}'
         )
-        self.assertEquals(result, expected_str)
+        self.assertEqual(result, expected_str)
 
     def test_param_to_ps_deep_nested_dict_outer(self):
         ####
@@ -952,7 +951,7 @@ Add-Content -value $data -encoding byte -path $filePath
             '@{"a" = @(@{"deep_a" = "value"}, '
             '@{"deep_b" = @("a", "b", "c")})}'
         )
-        self.assertEquals(result, expected_str)
+        self.assertEqual(result, expected_str)
 
     def test_param_to_ps_deep_nested_list_outer(self):
         ####
@@ -966,7 +965,7 @@ Add-Content -value $data -encoding byte -path $filePath
             '@{"deep_b" = @("a", "b", "c")}, '
             '@{"deep_c" = @(@{"x" = "y"})})'
         )
-        self.assertEquals(result, expected_str)
+        self.assertEqual(result, expected_str)
 
     def test_transform_params_to_ps(self):
         positional_args = [1, 'a', '\n']
@@ -979,8 +978,8 @@ Add-Content -value $data -encoding byte -path $filePath
 
         result_pos, result_named = self._runner._transform_params_to_ps(positional_args,
                                                                         named_args)
-        self.assertEquals(result_pos, ['1', '"a"', '"`n"'])
-        self.assertEquals(result_named, collections.OrderedDict([
+        self.assertEqual(result_pos, ['1', '"a"', '"`n"'])
+        self.assertEqual(result_named, collections.OrderedDict([
             ('a', '"value1"'),
             ('b', '$true'),
             ('c', '@("x", "y")'),
@@ -992,8 +991,8 @@ Add-Content -value $data -encoding byte -path $filePath
 
         result_pos, result_named = self._runner._transform_params_to_ps(positional_args,
                                                                         named_args)
-        self.assertEquals(result_pos, None)
-        self.assertEquals(result_named, None)
+        self.assertEqual(result_pos, None)
+        self.assertEqual(result_named, None)
 
     def test_create_ps_params_string(self):
         positional_args = [1, 'a', '\n']
@@ -1006,12 +1005,12 @@ Add-Content -value $data -encoding byte -path $filePath
 
         result = self._runner.create_ps_params_string(positional_args, named_args)
 
-        self.assertEquals(result,
-                          '-a "value1" -b $true -c @("x", "y") -d @{"z" = "w"} 1 "a" "`n"')
+        self.assertEqual(result,
+                         '-a "value1" -b $true -c @("x", "y") -d @{"z" = "w"} 1 "a" "`n"')
 
     def test_create_ps_params_string_none(self):
         positional_args = None
         named_args = None
 
         result = self._runner.create_ps_params_string(positional_args, named_args)
-        self.assertEquals(result, "")
+        self.assertEqual(result, "")

--- a/contrib/runners/winrm_runner/tests/unit/test_winrm_command_runner.py
+++ b/contrib/runners/winrm_runner/tests/unit/test_winrm_command_runner.py
@@ -31,7 +31,7 @@ class WinRmCommandRunnerTestCase(RunnerTestCase):
         runner = winrm_command_runner.WinRmCommandRunner('abcdef')
         self.assertIsInstance(runner, WinRmBaseRunner)
         self.assertIsInstance(runner, ActionRunner)
-        self.assertEquals(runner.runner_id, 'abcdef')
+        self.assertEqual(runner.runner_id, 'abcdef')
 
     @mock.patch('winrm_runner.winrm_command_runner.WinRmCommandRunner.run_cmd')
     def test_run(self, mock_run_cmd):
@@ -40,5 +40,5 @@ class WinRmCommandRunnerTestCase(RunnerTestCase):
         self._runner.runner_parameters = {'cmd': 'ipconfig /all'}
         result = self._runner.run({})
 
-        self.assertEquals(result, 'expected')
+        self.assertEqual(result, 'expected')
         mock_run_cmd.assert_called_with('ipconfig /all')

--- a/contrib/runners/winrm_runner/tests/unit/test_winrm_ps_command_runner.py
+++ b/contrib/runners/winrm_runner/tests/unit/test_winrm_ps_command_runner.py
@@ -31,7 +31,7 @@ class WinRmPsCommandRunnerTestCase(RunnerTestCase):
         runner = winrm_ps_command_runner.WinRmPsCommandRunner('abcdef')
         self.assertIsInstance(runner, WinRmBaseRunner)
         self.assertIsInstance(runner, ActionRunner)
-        self.assertEquals(runner.runner_id, 'abcdef')
+        self.assertEqual(runner.runner_id, 'abcdef')
 
     @mock.patch('winrm_runner.winrm_ps_command_runner.WinRmPsCommandRunner.run_ps')
     def test_run(self, mock_run_ps):
@@ -40,5 +40,5 @@ class WinRmPsCommandRunnerTestCase(RunnerTestCase):
         self._runner.runner_parameters = {'cmd': 'Get-ADUser stanley'}
         result = self._runner.run({})
 
-        self.assertEquals(result, 'expected')
+        self.assertEqual(result, 'expected')
         mock_run_ps.assert_called_with('Get-ADUser stanley')

--- a/contrib/runners/winrm_runner/tests/unit/test_winrm_ps_script_runner.py
+++ b/contrib/runners/winrm_runner/tests/unit/test_winrm_ps_script_runner.py
@@ -36,7 +36,7 @@ class WinRmPsScriptRunnerTestCase(RunnerTestCase):
         runner = winrm_ps_script_runner.WinRmPsScriptRunner('abcdef')
         self.assertIsInstance(runner, WinRmBaseRunner)
         self.assertIsInstance(runner, ActionRunner)
-        self.assertEquals(runner.runner_id, 'abcdef')
+        self.assertEqual(runner.runner_id, 'abcdef')
 
     @mock.patch('winrm_runner.winrm_ps_script_runner.WinRmPsScriptRunner._get_script_args')
     @mock.patch('winrm_runner.winrm_ps_script_runner.WinRmPsScriptRunner.run_ps')
@@ -52,7 +52,7 @@ class WinRmPsScriptRunnerTestCase(RunnerTestCase):
 
         result = self._runner.run({})
 
-        self.assertEquals(result, 'expected')
+        self.assertEqual(result, 'expected')
         mock_run_ps.assert_called_with('''[CmdletBinding()]
 Param(
   [bool]$p_bool,

--- a/st2actions/tests/integration/test_resultstracker.py
+++ b/st2actions/tests/integration/test_resultstracker.py
@@ -115,13 +115,11 @@ class ResultsTrackerTests(EventletTestCase, DbTestCase):
 
         exec_id = str(ResultsTrackerTests.states['state1.yaml'].execution_id)
         exec_db = LiveAction.get_by_id(exec_id)
-        self.assertTrue(exec_db.result['called_with'][exec_id] is not None,
-                        exec_db.result)
+        self.assertIsNotNone(exec_db.result['called_with'][exec_id], exec_db.result)
 
         exec_id = str(ResultsTrackerTests.states['state2.yaml'].execution_id)
         exec_db = LiveAction.get_by_id(exec_id)
-        self.assertTrue(exec_db.result['called_with'][exec_id] is not None,
-                        exec_db.result)
+        self.assertIsNotNone(exec_db.result['called_with'][exec_id], exec_db.result)
 
         tracker.shutdown()
 
@@ -149,7 +147,7 @@ class ResultsTrackerTests(EventletTestCase, DbTestCase):
 
     def test_get_querier_success(self):
         tracker = self._get_tracker()
-        self.assertTrue(tracker.get_querier('test_querymodule') is not None)
+        self.assertIsNotNone(tracker.get_querier('test_querymodule'))
 
     def test_get_querier_not_found(self):
         with mock.patch('st2actions.resultstracker.resultstracker.get_query_module',
@@ -339,13 +337,11 @@ class ResultsTrackerTests(EventletTestCase, DbTestCase):
 
         exec_id = str(ResultsTrackerTests.states['state1.yaml'].execution_id)
         exec_db = LiveAction.get_by_id(exec_id)
-        self.assertTrue(exec_db.result['called_with'][exec_id] is not None,
-                        exec_db.result)
+        self.assertIsNotNone(exec_db.result['called_with'][exec_id], exec_db.result)
 
         exec_id = str(ResultsTrackerTests.states['state2.yaml'].execution_id)
         exec_db = LiveAction.get_by_id(exec_id)
-        self.assertTrue(exec_db.result['called_with'][exec_id] is not None,
-                        exec_db.result)
+        self.assertIsNotNone(exec_db.result['called_with'][exec_id], exec_db.result)
 
         tracker.shutdown()
 

--- a/st2actions/tests/unit/policies/test_retry_policy.py
+++ b/st2actions/tests/unit/policies/test_retry_policy.py
@@ -132,7 +132,7 @@ class RetryPolicyTestCase(CleanDbTestCase):
         original_liveaction_id = action_execution_dbs[0].liveaction['id']
 
         context = action_execution_dbs[1].context
-        self.assertTrue('policies' in context)
+        self.assertIn('policies', context)
         self.assertEqual(context['policies']['retry']['retry_count'], 1)
         self.assertEqual(context['policies']['retry']['applied_policy'], 'test_policy')
         self.assertEqual(context['policies']['retry']['retried_liveaction_id'],
@@ -183,7 +183,7 @@ class RetryPolicyTestCase(CleanDbTestCase):
         original_liveaction_id = action_execution_dbs[0].liveaction['id']
 
         context = action_execution_dbs[1].context
-        self.assertTrue('policies' in context)
+        self.assertIn('policies', context)
         self.assertEqual(context['policies']['retry']['retry_count'], 1)
         self.assertEqual(context['policies']['retry']['applied_policy'], 'test_policy')
         self.assertEqual(context['policies']['retry']['retried_liveaction_id'],
@@ -214,7 +214,7 @@ class RetryPolicyTestCase(CleanDbTestCase):
         original_liveaction_id = action_execution_dbs[1].liveaction['id']
 
         context = action_execution_dbs[2].context
-        self.assertTrue('policies' in context)
+        self.assertIn('policies', context)
         self.assertEqual(context['policies']['retry']['retry_count'], 2)
         self.assertEqual(context['policies']['retry']['applied_policy'], 'test_policy')
         self.assertEqual(context['policies']['retry']['retried_liveaction_id'],

--- a/st2actions/tests/unit/test_parallel_ssh.py
+++ b/st2actions/tests/unit/test_parallel_ssh.py
@@ -255,7 +255,7 @@ class ParallelSSHTests(unittest2.TestCase):
                                    pkey_file='~/.ssh/id_rsa',
                                    connect=True)
         results = client.run('stuff', timeout=60)
-        self.assertTrue('127.0.0.1' in results)
+        self.assertIn('127.0.0.1', results)
         self.assertDictEqual(results['127.0.0.1']['stdout'], {'foo': 'bar'})
 
     @patch('paramiko.SSHClient', Mock)
@@ -277,7 +277,7 @@ class ParallelSSHTests(unittest2.TestCase):
                           'Invalid sudo password provided or sudo is not configured for '
                           'this user (bar)')
 
-        self.assertTrue('127.0.0.1' in results)
+        self.assertIn('127.0.0.1', results)
         self.assertEqual(results['127.0.0.1']['succeeded'], False)
         self.assertEqual(results['127.0.0.1']['failed'], True)
-        self.assertTrue(expected_error in results['127.0.0.1']['error'])
+        self.assertIn(expected_error, results['127.0.0.1']['error'])

--- a/st2actions/tests/unit/test_paramiko_remote_script_runner.py
+++ b/st2actions/tests/unit/test_paramiko_remote_script_runner.py
@@ -104,7 +104,7 @@ class ParamikoScriptRunnerTestCase(unittest2.TestCase):
         self.assertEqual(status, LIVEACTION_STATUS_FAILED)
         self.assertEqual(result['failed'], True)
         self.assertEqual(result['succeeded'], False)
-        self.assertTrue('Failed copying content to remote boxes' in result['error'])
+        self.assertIn('Failed copying content to remote boxes', result['error'])
 
     def test_command_construction_correct_default_parameter_values_are_used(self):
         runner_parameters = {}

--- a/st2actions/tests/unit/test_paramiko_ssh.py
+++ b/st2actions/tests/unit/test_paramiko_ssh.py
@@ -570,14 +570,14 @@ class ParamikoSSHClientTestCase(unittest2.TestCase):
         client = ParamikoSSHClient(**conn_params)
         client.connect()
 
-        self.assertTrue(client.sftp_client is None)
+        self.assertIsNone(client.sftp_client)
 
         # run method doesn't require sftp access so it shouldn't establish connection
         client = ParamikoSSHClient(**conn_params)
         client.connect()
         client.run(cmd='whoami')
 
-        self.assertTrue(client.sftp_client is None)
+        self.assertIsNone(client.sftp_client)
 
         # Methods below require SFTP access so they should cause SFTP connection to be established
         # put
@@ -606,7 +606,7 @@ class ParamikoSSHClientTestCase(unittest2.TestCase):
         client = ParamikoSSHClient(**conn_params)
         client.connect()
 
-        self.assertTrue(client.sftp_client is None)
+        self.assertIsNone(client.sftp_client)
         client.close()
 
         # Verify SFTP connection is closed if it's opened

--- a/st2actions/tests/unit/test_paramiko_ssh.py
+++ b/st2actions/tests/unit/test_paramiko_ssh.py
@@ -586,21 +586,21 @@ class ParamikoSSHClientTestCase(unittest2.TestCase):
         path = '/root/random_script.sh'
         client.put(path, path, mirror_local_mode=False)
 
-        self.assertTrue(client.sftp_client is not None)
+        self.assertIsNotNone(client.sftp_client)
 
         # exists
         client = ParamikoSSHClient(**conn_params)
         client.connect()
         client.exists('/root/somepath.txt')
 
-        self.assertTrue(client.sftp_client is not None)
+        self.assertIsNotNone(client.sftp_client)
 
         # mkdir
         client = ParamikoSSHClient(**conn_params)
         client.connect()
         client.mkdir('/root/somedirfoo')
 
-        self.assertTrue(client.sftp_client is not None)
+        self.assertIsNotNone(client.sftp_client)
 
         # Verify close doesn't throw if SFTP connection is not established
         client = ParamikoSSHClient(**conn_params)
@@ -614,7 +614,7 @@ class ParamikoSSHClientTestCase(unittest2.TestCase):
         client.connect()
         client.mkdir('/root/somedirfoo')
 
-        self.assertTrue(client.sftp_client is not None)
+        self.assertIsNotNone(client.sftp_client)
         client.close()
 
         self.assertEqual(client.sftp_client.close.call_count, 1)

--- a/st2actions/tests/unit/test_runner_container.py
+++ b/st2actions/tests/unit/test_runner_container.py
@@ -106,7 +106,7 @@ class RunnerContainerTest(DbTestCase):
 
     def test_get_runner_module(self):
         runner = get_runner(name='local-shell-script')
-        self.assertTrue(runner is not None, 'TestRunner must be valid.')
+        self.assertIsNotNone(runner, 'TestRunner must be valid.')
 
     def test_pre_run_runner_is_disabled(self):
         runnertype_db = RunnerContainerTest.runnertype_db
@@ -355,8 +355,8 @@ class RunnerContainerTest(DbTestCase):
 
         self.assertTrue(len(found) > 0, 'There should be a state db object.')
         self.assertTrue(len(found) == 1, 'There should only be one state db object.')
-        self.assertTrue(found[0].query_context is not None)
-        self.assertTrue(found[0].query_module is not None)
+        self.assertIsNotNone(found[0].query_context)
+        self.assertIsNotNone(found[0].query_module)
 
     @mock.patch.object(
         PollingAsyncActionRunner,

--- a/st2actions/tests/unit/test_runner_container.py
+++ b/st2actions/tests/unit/test_runner_container.py
@@ -310,8 +310,8 @@ class RunnerContainerTest(DbTestCase):
         runner_container.dispatch(liveaction_db)
         # pickup updated liveaction_db
         liveaction_db = LiveAction.get_by_id(liveaction_db.id)
-        self.assertTrue('error' in liveaction_db.result)
-        self.assertTrue('traceback' in liveaction_db.result)
+        self.assertIn('error', liveaction_db.result)
+        self.assertIn('traceback', liveaction_db.result)
 
     def test_dispatch_override_default_action_params(self):
         runner_container = get_runner_container()

--- a/st2actions/tests/unit/test_scheduler.py
+++ b/st2actions/tests/unit/test_scheduler.py
@@ -174,7 +174,7 @@ class ActionExecutionSchedulingQueueItemDBTest(ExecutionDbTestCase):
 
         schedule_q_db = self.scheduling_queue._get_next_execution()
 
-        self.assertEquals(schedule_q_db, None)
+        self.assertEqual(schedule_q_db, None)
 
     def test_no_double_entries(self):
         self.reset()

--- a/st2actions/tests/unit/test_scheduler_entrypoint.py
+++ b/st2actions/tests/unit/test_scheduler_entrypoint.py
@@ -57,7 +57,7 @@ class SchedulerServiceEntryPointTestCase(CleanDbTestCase):
         self.assertEqual(result, 1)
 
         mock_log_exception_call = mock_log.exception.call_args_list[0][0][0]
-        self.assertTrue('Scheduler unexpectedly stopped' in mock_log_exception_call)
+        self.assertIn('Scheduler unexpectedly stopped', mock_log_exception_call)
 
     @mock.patch.object(ActionExecutionSchedulingQueueHandler, 'cleanup', mock_handler_cleanup)
     @mock.patch('st2actions.cmd.scheduler.LOG')
@@ -68,7 +68,7 @@ class SchedulerServiceEntryPointTestCase(CleanDbTestCase):
         self.assertEqual(result, 1)
 
         mock_log_exception_call = mock_log.exception.call_args_list[0][0][0]
-        self.assertTrue('Scheduler unexpectedly stopped' in mock_log_exception_call)
+        self.assertIn('Scheduler unexpectedly stopped', mock_log_exception_call)
 
     @mock.patch.object(SchedulerEntrypoint, 'start', mock_entrypoint_start)
     @mock.patch('st2actions.cmd.scheduler.LOG')
@@ -79,4 +79,4 @@ class SchedulerServiceEntryPointTestCase(CleanDbTestCase):
         self.assertEqual(result, 1)
 
         mock_log_exception_call = mock_log.exception.call_args_list[0][0][0]
-        self.assertTrue('Scheduler unexpectedly stopped' in mock_log_exception_call)
+        self.assertIn('Scheduler unexpectedly stopped', mock_log_exception_call)

--- a/st2actions/tests/unit/test_worker.py
+++ b/st2actions/tests/unit/test_worker.py
@@ -87,8 +87,8 @@ class WorkerTestCase(DbTestCase):
         except InvalidStringData:
             liveaction_db = LiveAction.get_by_id(liveaction_db.id)
             self.assertEqual(liveaction_db.status, action_constants.LIVEACTION_STATUS_FAILED)
-            self.assertTrue('error' in liveaction_db.result)
-            self.assertTrue('traceback' in liveaction_db.result)
+            self.assertIn('error', liveaction_db.result)
+            self.assertIn('traceback', liveaction_db.result)
             execution_db = ActionExecution.get_by_id(execution_db.id)
             self.assertEqual(liveaction_db.status, action_constants.LIVEACTION_STATUS_FAILED)
 

--- a/st2api/tests/unit/controllers/test_root.py
+++ b/st2api/tests/unit/controllers/test_root.py
@@ -24,5 +24,5 @@ class RootControllerTestCase(FunctionalTest):
         paths = ['/', '/v1/', '/v1']
         for path in paths:
             resp = self.app.get(path)
-            self.assertTrue('version' in resp.json)
-            self.assertTrue('docs_url' in resp.json)
+            self.assertIn('version', resp.json)
+            self.assertIn('docs_url', resp.json)

--- a/st2api/tests/unit/controllers/v1/test_action_views.py
+++ b/st2api/tests/unit/controllers/v1/test_action_views.py
@@ -240,8 +240,8 @@ class ActionEntryPointViewControllerTestCase(FunctionalTest):
         try:
             get_resp = self.app.get('/v1/actions/views/entry_point/%s' % action_ref)
             self.assertEqual(get_resp.status_int, 200)
-            self.assertTrue(get_resp.headers['Content-Type'] in ['application/x-python',
-                                                                 'text/x-python'])
+            self.assertIn(get_resp.headers['Content-Type'], ['application/x-python',
+                                                             'text/x-python'])
         finally:
             self.app.delete('/v1/actions/%s' % action_id)
 

--- a/st2api/tests/unit/controllers/v1/test_actions.py
+++ b/st2api/tests/unit/controllers/v1/test_actions.py
@@ -486,7 +486,7 @@ class ActionsControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclu
         post_resp = self.__do_post(ACTION_1)
         self.assertEqual(post_resp.status_int, 201)
         action_in_db = Action.get_by_name(ACTION_1.get('name'))
-        self.assertTrue(action_in_db is not None, 'Action must be in db.')
+        self.assertIsNotNone(action_in_db, 'Action must be in db.')
         action_ids.append(self.__get_action_id(post_resp))
 
         post_resp = self.__do_post(ACTION_1, expect_errors=True)
@@ -590,7 +590,7 @@ class ActionsControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclu
         get_resp = self.__do_get_one(action_id)
         self.assertEqual(get_resp.status_int, 200)
         self.assertEqual(self.__get_action_id(get_resp), action_id)
-        self.assertTrue(get_resp.json['notify']['on-complete'] is not None)
+        self.assertIsNotNone(get_resp.json['notify']['on-complete'])
         # Now post the same action with no notify
         ACTION_WITHOUT_NOTIFY = copy.copy(ACTION_WITH_NOTIFY)
         del ACTION_WITHOUT_NOTIFY['notify']

--- a/st2api/tests/unit/controllers/v1/test_actions.py
+++ b/st2api/tests/unit/controllers/v1/test_actions.py
@@ -445,13 +445,13 @@ class ActionsControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclu
         # 2. Action already exists
         post_resp = self.__do_post(action, expect_errors=True)
         self.assertEqual(post_resp.status_int, 409)
-        self.assertTrue('Tried to save duplicate unique keys' in post_resp.json['faultstring'])
+        self.assertIn('Tried to save duplicate unique keys', post_resp.json['faultstring'])
 
         # 3. Action already exists (this time with unicode type)
         action['name'] = u'žactionćšžži💩'
         post_resp = self.__do_post(action, expect_errors=True)
         self.assertEqual(post_resp.status_int, 409)
-        self.assertTrue('Tried to save duplicate unique keys' in post_resp.json['faultstring'])
+        self.assertIn('Tried to save duplicate unique keys', post_resp.json['faultstring'])
 
     @mock.patch.object(action_validator, 'validate_action', mock.MagicMock(
         return_value=True))
@@ -465,7 +465,7 @@ class ActionsControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclu
             expected_error = \
                 b'[u\'string\', u\'object\'] is not valid under any of the given schemas'
 
-        self.assertTrue(expected_error in post_resp.body)
+        self.assertIn(expected_error, post_resp.body)
 
     @mock.patch.object(action_validator, 'validate_action', mock.MagicMock(
         return_value=True))
@@ -524,7 +524,7 @@ class ActionsControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclu
 
         # Verify PackDB.files has been updated
         pack_db = Pack.get_by_ref(ACTION_12['pack'])
-        self.assertTrue('actions/filea.txt' in pack_db.files)
+        self.assertIn('actions/filea.txt', pack_db.files)
         self.__do_delete(self.__get_action_id(post_resp))
 
     @mock.patch.object(action_validator, 'validate_action', mock.MagicMock(

--- a/st2api/tests/unit/controllers/v1/test_actions.py
+++ b/st2api/tests/unit/controllers/v1/test_actions.py
@@ -507,7 +507,7 @@ class ActionsControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclu
     def test_post_include_files(self):
         # Verify initial state
         pack_db = Pack.get_by_ref(ACTION_12['pack'])
-        self.assertTrue('actions/filea.txt' not in pack_db.files)
+        self.assertNotIn('actions/filea.txt', pack_db.files)
 
         action = copy.deepcopy(ACTION_12)
         action['data_files'] = [

--- a/st2api/tests/unit/controllers/v1/test_alias_execution.py
+++ b/st2api/tests/unit/controllers/v1/test_alias_execution.py
@@ -96,7 +96,7 @@ class AliasExecutionTestCase(FunctionalTest):
         self.assertEqual(post_resp.status_int, 400)
         expected_msg = ('Format string "some invalid not supported string" is '
                         'not available on the alias "alias1"')
-        self.assertTrue(expected_msg in post_resp.json['faultstring'])
+        self.assertIn(expected_msg, post_resp.json['faultstring'])
 
     @mock.patch.object(action_service, 'request',
                        return_value=(None, EXECUTION))
@@ -218,7 +218,7 @@ class AliasExecutionTestCase(FunctionalTest):
         # https://github.com/StackStorm/st2/issues/4650
         actual_context = mock_request.call_args[0][0].context
 
-        self.assertTrue('source_channel' in mock_request.call_args[0][0].context.keys())
+        self.assertIn('source_channel', mock_request.call_args[0][0].context.keys())
         self.assertEquals(actual_context['source_channel'], 'chat-channel')
         self.assertEquals(actual_context['api_user'], 'chat-user')
         self.assertEquals(actual_context['user'], 'stanley')

--- a/st2api/tests/unit/controllers/v1/test_alias_execution.py
+++ b/st2api/tests/unit/controllers/v1/test_alias_execution.py
@@ -75,7 +75,7 @@ class AliasExecutionTestCase(FunctionalTest):
         post_resp = self._do_post(alias_execution=self.alias1, command=command)
         self.assertEqual(post_resp.status_int, 201)
         expected_parameters = {'param1': 'value1', 'param2': 'value2 value3'}
-        self.assertEquals(request.call_args[0][0].parameters, expected_parameters)
+        self.assertEqual(request.call_args[0][0].parameters, expected_parameters)
 
     @mock.patch.object(action_service, 'request',
                        return_value=(None, EXECUTION))
@@ -84,7 +84,7 @@ class AliasExecutionTestCase(FunctionalTest):
         post_resp = self._do_post(alias_execution=self.alias5, command=command)
         self.assertEqual(post_resp.status_int, 201)
         expected_parameters = {'param1': 'value1', 'param2': 'value2'}
-        self.assertEquals(request.call_args[0][0].parameters, expected_parameters)
+        self.assertEqual(request.call_args[0][0].parameters, expected_parameters)
 
     @mock.patch.object(action_service, 'request',
                        return_value=(None, EXECUTION))
@@ -104,7 +104,7 @@ class AliasExecutionTestCase(FunctionalTest):
         command = 'Lorem ipsum value1 dolor sit value2 amet.'
         self._do_post(alias_execution=self.alias2, command=command)
         expected_parameters = {'param1': 'value1', 'param3': ['value2']}
-        self.assertEquals(request.call_args[0][0].parameters, expected_parameters)
+        self.assertEqual(request.call_args[0][0].parameters, expected_parameters)
 
     @mock.patch.object(action_service, 'request',
                        return_value=(None, EXECUTION))
@@ -113,7 +113,7 @@ class AliasExecutionTestCase(FunctionalTest):
         post_resp = self._do_post(alias_execution=self.alias2, command=command)
         self.assertEqual(post_resp.status_int, 201)
         expected_parameters = {'param1': 'value1', 'param3': ['value2', 'value3']}
-        self.assertEquals(request.call_args[0][0].parameters, expected_parameters)
+        self.assertEqual(request.call_args[0][0].parameters, expected_parameters)
 
     @mock.patch.object(action_service, 'request',
                        return_value=(None, EXECUTION))
@@ -127,7 +127,7 @@ class AliasExecutionTestCase(FunctionalTest):
         )
         self.assertEqual(post_resp.status_int, 201)
         expected_parameters = {'cmd': 'date', 'hosts': 'localhost'}
-        self.assertEquals(request.call_args[0][0].parameters, expected_parameters)
+        self.assertEqual(request.call_args[0][0].parameters, expected_parameters)
         self.assertEqual(
             post_resp.json['message'],
             'Cannot render "format" in field "ack" for alias. \'cmd\' is undefined'
@@ -151,7 +151,7 @@ class AliasExecutionTestCase(FunctionalTest):
         post_resp = self._do_post(alias_execution=self.alias4, command=command)
         self.assertEqual(post_resp.status_int, 201)
         expected_parameters = {'param1': 'value1', 'param4': SUPER_SECRET_PARAMETER}
-        self.assertEquals(request.call_args[0][0].parameters, expected_parameters)
+        self.assertEqual(request.call_args[0][0].parameters, expected_parameters)
         post_resp = self._do_post(alias_execution=self.alias4, command=command, show_secrets=True,
                                   expect_errors=True)
         self.assertEqual(post_resp.status_int, 201)
@@ -212,16 +212,16 @@ class AliasExecutionTestCase(FunctionalTest):
         self.assertEqual(resp.json['results'][0]['execution']['status'], EXECUTION['status'])
 
         expected_parameters = {'cmd': 'date', 'hosts': 'localhost'}
-        self.assertEquals(mock_request.call_args[0][0].parameters, expected_parameters)
+        self.assertEqual(mock_request.call_args[0][0].parameters, expected_parameters)
 
         # Also check for source_channel - see
         # https://github.com/StackStorm/st2/issues/4650
         actual_context = mock_request.call_args[0][0].context
 
         self.assertIn('source_channel', mock_request.call_args[0][0].context.keys())
-        self.assertEquals(actual_context['source_channel'], 'chat-channel')
-        self.assertEquals(actual_context['api_user'], 'chat-user')
-        self.assertEquals(actual_context['user'], 'stanley')
+        self.assertEqual(actual_context['source_channel'], 'chat-channel')
+        self.assertEqual(actual_context['api_user'], 'chat-user')
+        self.assertEqual(actual_context['user'], 'stanley')
 
     @mock.patch.object(action_service, 'request',
                        return_value=(None, EXECUTION))
@@ -253,7 +253,7 @@ class AliasExecutionTestCase(FunctionalTest):
         # We've also already checked the results array
         #
         expected_parameters = {'issue_key': 'DRSEUSS-12'}
-        self.assertEquals(mock_request.call_args[0][0].parameters, expected_parameters)
+        self.assertEqual(mock_request.call_args[0][0].parameters, expected_parameters)
 
     @mock.patch.object(action_service, 'request',
                        return_value=(None, EXECUTION))

--- a/st2api/tests/unit/controllers/v1/test_auth.py
+++ b/st2api/tests/unit/controllers/v1/test_auth.py
@@ -45,7 +45,7 @@ class TestTokenBasedAuth(FunctionalTest):
     def test_token_validation_token_in_headers(self):
         response = self.app.get('/v1/actions', headers={'X-Auth-Token': TOKEN},
                                 expect_errors=False)
-        self.assertTrue('application/json' in response.headers['content-type'])
+        self.assertIn('application/json', response.headers['content-type'])
         self.assertEqual(response.status_int, 200)
 
     @mock.patch.object(
@@ -54,7 +54,7 @@ class TestTokenBasedAuth(FunctionalTest):
     @mock.patch.object(User, 'get_by_name', mock.Mock(return_value=USER_DB))
     def test_token_validation_token_in_query_params(self):
         response = self.app.get('/v1/actions?x-auth-token=%s' % (TOKEN), expect_errors=False)
-        self.assertTrue('application/json' in response.headers['content-type'])
+        self.assertIn('application/json', response.headers['content-type'])
         self.assertEqual(response.status_int, 200)
 
     @mock.patch.object(
@@ -64,12 +64,12 @@ class TestTokenBasedAuth(FunctionalTest):
     def test_token_validation_token_in_cookies(self):
         response = self.app.get('/v1/actions', headers={'X-Auth-Token': TOKEN},
                                 expect_errors=False)
-        self.assertTrue('application/json' in response.headers['content-type'])
+        self.assertIn('application/json', response.headers['content-type'])
         self.assertEqual(response.status_int, 200)
 
         with mock.patch.object(self.app.cookiejar, 'clear', return_value=None):
             response = self.app.get('/v1/actions', expect_errors=False)
-        self.assertTrue('application/json' in response.headers['content-type'])
+        self.assertIn('application/json', response.headers['content-type'])
         self.assertEqual(response.status_int, 200)
 
     @mock.patch.object(
@@ -78,7 +78,7 @@ class TestTokenBasedAuth(FunctionalTest):
     def test_token_expired(self):
         response = self.app.get('/v1/actions', headers={'X-Auth-Token': TOKEN},
                                 expect_errors=True)
-        self.assertTrue('application/json' in response.headers['content-type'])
+        self.assertIn('application/json', response.headers['content-type'])
         self.assertEqual(response.status_int, 401)
 
     @mock.patch.object(
@@ -86,12 +86,12 @@ class TestTokenBasedAuth(FunctionalTest):
     def test_token_not_found(self):
         response = self.app.get('/v1/actions', headers={'X-Auth-Token': TOKEN},
                                 expect_errors=True)
-        self.assertTrue('application/json' in response.headers['content-type'])
+        self.assertIn('application/json', response.headers['content-type'])
         self.assertEqual(response.status_int, 401)
 
     def test_token_not_provided(self):
         response = self.app.get('/v1/actions', expect_errors=True)
-        self.assertTrue('application/json' in response.headers['content-type'])
+        self.assertIn('application/json', response.headers['content-type'])
         self.assertEqual(response.status_int, 401)
 
 
@@ -125,20 +125,20 @@ class TestApiKeyBasedAuth(FunctionalTest):
     def test_apikey_validation_apikey_in_headers(self):
         response = self.app.get('/v1/actions', headers={'St2-Api-key': KEY1_KEY},
                                 expect_errors=False)
-        self.assertTrue('application/json' in response.headers['content-type'])
+        self.assertIn('application/json', response.headers['content-type'])
         self.assertEqual(response.status_int, 200)
 
     @mock.patch.object(User, 'get_by_name', mock.Mock(return_value=UserDB(name='bill')))
     def test_apikey_validation_apikey_in_query_params(self):
         response = self.app.get('/v1/actions?st2-api-key=%s' % (KEY1_KEY), expect_errors=False)
-        self.assertTrue('application/json' in response.headers['content-type'])
+        self.assertIn('application/json', response.headers['content-type'])
         self.assertEqual(response.status_int, 200)
 
     @mock.patch.object(User, 'get_by_name', mock.Mock(return_value=UserDB(name='bill')))
     def test_apikey_validation_apikey_in_cookies(self):
         response = self.app.get('/v1/actions', headers={'St2-Api-key': KEY1_KEY},
                                 expect_errors=False)
-        self.assertTrue('application/json' in response.headers['content-type'])
+        self.assertIn('application/json', response.headers['content-type'])
         self.assertEqual(response.status_int, 200)
 
         with mock.patch.object(self.app.cookiejar, 'clear', return_value=None):
@@ -150,14 +150,14 @@ class TestApiKeyBasedAuth(FunctionalTest):
     def test_apikey_disabled(self):
         response = self.app.get('/v1/actions', headers={'St2-Api-key': DISABLED_KEY},
                                 expect_errors=True)
-        self.assertTrue('application/json' in response.headers['content-type'])
+        self.assertIn('application/json', response.headers['content-type'])
         self.assertEqual(response.status_int, 401)
         self.assertEqual(response.json_body['faultstring'], 'Unauthorized - API key is disabled.')
 
     def test_apikey_not_found(self):
         response = self.app.get('/v1/actions', headers={'St2-Api-key': 'UNKNOWN'},
                                 expect_errors=True)
-        self.assertTrue('application/json' in response.headers['content-type'])
+        self.assertIn('application/json', response.headers['content-type'])
         self.assertEqual(response.status_int, 401)
         self.assertRegexpMatches(response.json_body['faultstring'],
                                  '^Unauthorized - ApiKey with key_hash=([a-zA-Z0-9]+) not found.$')
@@ -173,5 +173,5 @@ class TestApiKeyBasedAuth(FunctionalTest):
         response = self.app.get('/v1/actions',
                                 headers={'X-Auth-Token': TOKEN, 'St2-Api-key': KEY1_KEY},
                                 expect_errors=True)
-        self.assertTrue('application/json' in response.headers['content-type'])
+        self.assertIn('application/json', response.headers['content-type'])
         self.assertEqual(response.status_int, 200)

--- a/st2api/tests/unit/controllers/v1/test_executions.py
+++ b/st2api/tests/unit/controllers/v1/test_executions.py
@@ -380,9 +380,9 @@ class ActionExecutionControllerTestCase(BaseActionExecutionControllerTestCase, F
         get_resp = self._do_get_one(actionexecution_id)
         self.assertEqual(get_resp.status_int, 200)
         self.assertEqual(self._get_actionexecution_id(get_resp), actionexecution_id)
-        self.assertTrue('web_url' in get_resp)
+        self.assertIn('web_url', get_resp)
         if 'end_timestamp' in get_resp:
-            self.assertTrue('elapsed_seconds' in get_resp)
+            self.assertIn('elapsed_seconds', get_resp)
 
         get_resp = self._do_get_one('last')
         self.assertEqual(get_resp.status_int, 200)
@@ -401,7 +401,7 @@ class ActionExecutionControllerTestCase(BaseActionExecutionControllerTestCase, F
     def test_get_all_id_query_param_filtering_invalid_id(self):
         resp = self.app.get('/v1/executions?id=invalidid', expect_errors=True)
         self.assertEqual(resp.status_int, 400)
-        self.assertTrue('not a valid ObjectId' in resp.json['faultstring'])
+        self.assertIn('not a valid ObjectId', resp.json['faultstring'])
 
     def test_get_all_id_query_param_filtering_multiple_ids_provided(self):
         post_resp = self._do_post(LIVE_ACTION_1)
@@ -430,9 +430,9 @@ class ActionExecutionControllerTestCase(BaseActionExecutionControllerTestCase, F
         for i in range(len(body) - 1):
             self.assertTrue(isotime.parse(body[i]['start_timestamp']) >=
                             isotime.parse(body[i + 1]['start_timestamp']))
-            self.assertTrue('web_url' in body[i])
+            self.assertIn('web_url', body[i])
             if 'end_timestamp' in body[i]:
-                self.assertTrue('elapsed_seconds' in body[i])
+                self.assertIn('elapsed_seconds', body[i])
 
     def test_get_all_invalid_offset_too_large(self):
         offset = '2141564789454123457895412237483648'
@@ -1350,7 +1350,7 @@ class ActionExecutionControllerTestCase(BaseActionExecutionControllerTestCase, F
         for url in urls:
             resp = self.app.get(url + '&limit=1')
 
-            self.assertTrue('parameters' in resp.json[0])
+            self.assertIn('parameters', resp.json[0])
             self.assertEqual(resp.json[0]['parameters']['a'], 'param a')
             self.assertEqual(resp.json[0]['parameters']['d'], MASKED_ATTRIBUTE_VALUE)
             self.assertEqual(resp.json[0]['parameters']['password'], MASKED_ATTRIBUTE_VALUE)
@@ -1367,7 +1367,7 @@ class ActionExecutionControllerTestCase(BaseActionExecutionControllerTestCase, F
         for url in urls:
             resp = self.app.get(url + '&limit=1&show_secrets=True')
 
-            self.assertTrue('parameters' in resp.json[0])
+            self.assertIn('parameters', resp.json[0])
             self.assertEqual(resp.json[0]['parameters']['a'], 'param a')
             self.assertEqual(resp.json[0]['parameters']['d'], 'secretpassword1')
             self.assertEqual(resp.json[0]['parameters']['password'], 'secretpassword2')
@@ -1452,7 +1452,7 @@ class ActionExecutionControllerTestCase(BaseActionExecutionControllerTestCase, F
             url = item['url']
             resp = self.app.get(url)
 
-            self.assertTrue('parameters' in resp.json)
+            self.assertIn('parameters', resp.json)
             self.assertEqual(resp.json['parameters']['a'], 'param a')
             self.assertEqual(resp.json['parameters']['d'], MASKED_ATTRIBUTE_VALUE)
             self.assertEqual(resp.json['parameters']['password'], MASKED_ATTRIBUTE_VALUE)
@@ -1488,7 +1488,7 @@ class ActionExecutionControllerTestCase(BaseActionExecutionControllerTestCase, F
             url = item['url']
             resp = self.app.get(url + '&show_secrets=True')
 
-            self.assertTrue('parameters' in resp.json)
+            self.assertIn('parameters', resp.json)
             self.assertEqual(resp.json['parameters']['a'], 'param a')
             self.assertEqual(resp.json['parameters']['d'], 'secretpassword1')
             self.assertEqual(resp.json['parameters']['password'], 'secretpassword2')

--- a/st2api/tests/unit/controllers/v1/test_executions_filters.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_filters.py
@@ -116,7 +116,7 @@ class TestActionExecutionFilters(FunctionalTest):
         response = self.app.get(path)
 
         self.assertEqual(response.status_int, 200)
-        self.assertFalse('result' in response.json[0])
+        self.assertNotIn('result', response.json[0])
 
     def test_get_one(self):
         obj_id = random.choice(list(self.refs.keys()))

--- a/st2api/tests/unit/controllers/v1/test_executions_filters.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_filters.py
@@ -389,7 +389,7 @@ class TestActionExecutionFilters(FunctionalTest):
 
             # Verify empty (None / null) filters are excluded
             if key not in FILTERS_WITH_VALID_NULL_VALUES:
-                self.assertTrue(None not in filter_values)
+                self.assertNotIn(None, filter_values)
 
             if None in value or None in filter_values:
                 filter_values = [item for item in filter_values if item is not None]

--- a/st2api/tests/unit/controllers/v1/test_executions_filters.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_filters.py
@@ -109,7 +109,7 @@ class TestActionExecutionFilters(FunctionalTest):
         response = self.app.get('/v1/executions?action=executions.local&limit=1')
 
         self.assertEqual(response.status_int, 200)
-        self.assertTrue('result' in response.json[0])
+        self.assertIn('result', response.json[0])
 
         # Exclude "result" attribute
         path = '/v1/executions?action=executions.local&limit=1&exclude_attributes=result'

--- a/st2api/tests/unit/controllers/v1/test_inquiries.py
+++ b/st2api/tests/unit/controllers/v1/test_inquiries.py
@@ -193,7 +193,7 @@ class InquiryControllerTestCase(BaseInquiryControllerTestCase,
         get_all_resp = self._do_get_all()
         inquiries = get_all_resp.json
         self.assertEqual(get_all_resp.headers['X-Total-Count'], str(len(inquiries)))
-        self.assertTrue(isinstance(inquiries, list))
+        self.assertIsInstance(inquiries, list)
         self.assertEqual(len(inquiries), inquiry_count)
 
     def test_get_all_empty(self):
@@ -202,7 +202,7 @@ class InquiryControllerTestCase(BaseInquiryControllerTestCase,
         inquiry_count = 0
         get_all_resp = self._do_get_all()
         inquiries = get_all_resp.json
-        self.assertTrue(isinstance(inquiries, list))
+        self.assertIsInstance(inquiries, list)
         self.assertEqual(len(inquiries), inquiry_count)
 
     def test_get_all_decrease_after_respond(self):
@@ -215,7 +215,7 @@ class InquiryControllerTestCase(BaseInquiryControllerTestCase,
             self._do_create_inquiry(INQUIRY_2, RESULT_DEFAULT)
         get_all_resp = self._do_get_all()
         inquiries = get_all_resp.json
-        self.assertTrue(isinstance(inquiries, list))
+        self.assertIsInstance(inquiries, list)
         self.assertEqual(len(inquiries), inquiry_count)
 
         # Respond to one of them
@@ -225,7 +225,7 @@ class InquiryControllerTestCase(BaseInquiryControllerTestCase,
         # Ensure the list is one smaller
         get_all_resp = self._do_get_all()
         inquiries = get_all_resp.json
-        self.assertTrue(isinstance(inquiries, list))
+        self.assertIsInstance(inquiries, list)
         self.assertEqual(len(inquiries), inquiry_count - 1)
 
     def test_get_all_limit(self):
@@ -239,7 +239,7 @@ class InquiryControllerTestCase(BaseInquiryControllerTestCase,
             self._do_create_inquiry(INQUIRY_1, RESULT_DEFAULT)
         get_all_resp = self._do_get_all(limit=limit)
         inquiries = get_all_resp.json
-        self.assertTrue(isinstance(inquiries, list))
+        self.assertIsInstance(inquiries, list)
         self.assertEqual(inquiry_count, int(get_all_resp.headers['X-Total-Count']))
         self.assertEqual(len(inquiries), limit)
 

--- a/st2api/tests/unit/controllers/v1/test_kvps.py
+++ b/st2api/tests/unit/controllers/v1/test_kvps.py
@@ -481,7 +481,7 @@ class KeyValuePairControllerTestCase(FunctionalTest):
         for stored_kvp in stored_kvps:
             self.assertFalse(stored_kvp['encrypted'])
             exp_kvp = kvps.get(stored_kvp['name'])
-            self.assertTrue(exp_kvp is not None)
+            self.assertIsNotNone(exp_kvp)
             self.assertEqual(exp_kvp['value'], stored_kvp['value'])
         self.__do_delete(kvp_id_1)
         self.__do_delete(kvp_id_2)

--- a/st2api/tests/unit/controllers/v1/test_kvps.py
+++ b/st2api/tests/unit/controllers/v1/test_kvps.py
@@ -550,7 +550,7 @@ class KeyValuePairControllerTestCase(FunctionalTest):
 
         expected_error = ('Failed to verify the integrity of the provided value for key '
                           '"secret_key1".')
-        self.assertTrue(expected_error in put_resp.json['faultstring'])
+        self.assertIn(expected_error, put_resp.json['faultstring'])
 
         data = copy.deepcopy(ENCRYPTED_KVP)
         data['value'] = str(data['value'][:-2])
@@ -559,7 +559,7 @@ class KeyValuePairControllerTestCase(FunctionalTest):
 
         expected_error = ('Failed to verify the integrity of the provided value for key '
                           '"secret_key1".')
-        self.assertTrue(expected_error in put_resp.json['faultstring'])
+        self.assertIn(expected_error, put_resp.json['faultstring'])
 
     def test_put_delete(self):
         put_resp = self.__do_put('key1', KVP)

--- a/st2api/tests/unit/controllers/v1/test_pack_config_schema.py
+++ b/st2api/tests/unit/controllers/v1/test_pack_config_schema.py
@@ -40,14 +40,14 @@ class PackConfigSchemasControllerTestCase(FunctionalTest):
         resp = self.app.get('/v1/config_schemas/dummy_pack_1')
         self.assertEqual(resp.status_int, 200)
         self.assertEqual(resp.json['pack'], 'dummy_pack_1')
-        self.assertTrue('api_key' in resp.json['attributes'])
+        self.assertIn('api_key', resp.json['attributes'])
 
     def test_get_one_doesnt_exist(self):
         # Pack exists, schema doesnt
         resp = self.app.get('/v1/config_schemas/dummy_pack_2',
                             expect_errors=True)
         self.assertEqual(resp.status_int, 404)
-        self.assertTrue('Unable to identify resource with pack_ref ' in resp.json['faultstring'])
+        self.assertIn('Unable to identify resource with pack_ref ', resp.json['faultstring'])
 
         # Pack doesn't exist
         ref_or_id = 'pack_doesnt_exist'

--- a/st2api/tests/unit/controllers/v1/test_pack_configs.py
+++ b/st2api/tests/unit/controllers/v1/test_pack_configs.py
@@ -56,14 +56,14 @@ class PackConfigsControllerTestCase(FunctionalTest):
         resp = self.app.get('/v1/configs/dummy_pack_2',
                             expect_errors=True)
         self.assertEqual(resp.status_int, 404)
-        self.assertTrue('Unable to identify resource with pack_ref ' in resp.json['faultstring'])
+        self.assertIn('Unable to identify resource with pack_ref ', resp.json['faultstring'])
 
         # Pack doesn't exist
         resp = self.app.get('/v1/configs/pack_doesnt_exist',
                             expect_errors=True)
         self.assertEqual(resp.status_int, 404)
         # Changed from : 'Unable to find the PackDB instance.'
-        self.assertTrue('Unable to identify resource with pack_ref' in resp.json['faultstring'])
+        self.assertIn('Unable to identify resource with pack_ref', resp.json['faultstring'])
 
     @mock.patch.object(PackConfigsController, '_dump_config_to_disk', mock.MagicMock())
     def test_put_pack_config(self):
@@ -90,4 +90,4 @@ class PackConfigsControllerTestCase(FunctionalTest):
                         'decrypted by default. Use of "decrypt_kv" jinja filter is not allowed '
                         'for such values. Please check the specified values in the config or '
                         'the default values in the schema.')
-        self.assertTrue(expected_msg in put_resp.json['faultstring'])
+        self.assertIn(expected_msg, put_resp.json['faultstring'])

--- a/st2api/tests/unit/controllers/v1/test_packs.py
+++ b/st2api/tests/unit/controllers/v1/test_packs.py
@@ -449,16 +449,16 @@ class PacksControllerTestCase(FunctionalTest,
         resp = self.app.post_json('/v1/packs/register', {'fail_on_failure': False})
 
         self.assertEqual(resp.status_int, 200)
-        self.assertTrue('runners' in resp.json)
-        self.assertTrue('actions' in resp.json)
-        self.assertTrue('triggers' in resp.json)
-        self.assertTrue('sensors' in resp.json)
-        self.assertTrue('rules' in resp.json)
-        self.assertTrue('rule_types' in resp.json)
-        self.assertTrue('aliases' in resp.json)
-        self.assertTrue('policy_types' in resp.json)
-        self.assertTrue('policies' in resp.json)
-        self.assertTrue('configs' in resp.json)
+        self.assertIn('runners', resp.json)
+        self.assertIn('actions', resp.json)
+        self.assertIn('triggers', resp.json)
+        self.assertIn('sensors', resp.json)
+        self.assertIn('rules', resp.json)
+        self.assertIn('rule_types', resp.json)
+        self.assertIn('aliases', resp.json)
+        self.assertIn('policy_types', resp.json)
+        self.assertIn('policies', resp.json)
+        self.assertIn('configs', resp.json)
 
         self.assertTrue(resp.json['actions'] >= 3)
         self.assertTrue(resp.json['configs'] >= 1)
@@ -482,16 +482,16 @@ class PacksControllerTestCase(FunctionalTest,
                                                          'types': ['all']})
 
         self.assertEqual(resp.status_int, 200)
-        self.assertTrue('runners' in resp.json)
-        self.assertTrue('actions' in resp.json)
-        self.assertTrue('triggers' in resp.json)
-        self.assertTrue('sensors' in resp.json)
-        self.assertTrue('rules' in resp.json)
-        self.assertTrue('rule_types' in resp.json)
-        self.assertTrue('aliases' in resp.json)
-        self.assertTrue('policy_types' in resp.json)
-        self.assertTrue('policies' in resp.json)
-        self.assertTrue('configs' in resp.json)
+        self.assertIn('runners', resp.json)
+        self.assertIn('actions', resp.json)
+        self.assertIn('triggers', resp.json)
+        self.assertIn('sensors', resp.json)
+        self.assertIn('rules', resp.json)
+        self.assertIn('rule_types', resp.json)
+        self.assertIn('aliases', resp.json)
+        self.assertIn('policy_types', resp.json)
+        self.assertIn('policies', resp.json)
+        self.assertIn('configs', resp.json)
 
         # Registering single resource type should also cause dependent resources
         # to be registered
@@ -563,14 +563,14 @@ class PacksControllerTestCase(FunctionalTest,
                                   expect_errors=True)
 
         self.assertEqual(resp.status_int, 400)
-        self.assertTrue('Pack "doesntexist" not found on disk:' in resp.json['faultstring'])
+        self.assertIn('Pack "doesntexist" not found on disk:', resp.json['faultstring'])
 
         # Fail on failure is enabled by default
         resp = self.app.post_json('/v1/packs/register', expect_errors=True)
 
         expected_msg = 'Failed to register pack "dummy_pack_10":'
         self.assertEqual(resp.status_int, 400)
-        self.assertTrue(expected_msg in resp.json['faultstring'])
+        self.assertIn(expected_msg, resp.json['faultstring'])
 
         # Fail on failure (broken pack metadata)
         resp = self.app.post_json('/v1/packs/register', {'packs': ['dummy_pack_1']},
@@ -578,7 +578,7 @@ class PacksControllerTestCase(FunctionalTest,
 
         expected_msg = 'Referenced policy_type "action.mock_policy_error" doesnt exist'
         self.assertEqual(resp.status_int, 400)
-        self.assertTrue(expected_msg in resp.json['faultstring'])
+        self.assertIn(expected_msg, resp.json['faultstring'])
 
         # Fail on failure (broken action metadata)
         resp = self.app.post_json('/v1/packs/register', {'packs': ['dummy_pack_15']},
@@ -586,11 +586,11 @@ class PacksControllerTestCase(FunctionalTest,
 
         expected_msg = 'Failed to register action'
         self.assertEqual(resp.status_int, 400)
-        self.assertTrue(expected_msg in resp.json['faultstring'])
+        self.assertIn(expected_msg, resp.json['faultstring'])
 
         expected_msg = '\'stringa\' is not valid under any of the given schemas'
         self.assertEqual(resp.status_int, 400)
-        self.assertTrue(expected_msg in resp.json['faultstring'])
+        self.assertIn(expected_msg, resp.json['faultstring'])
 
     def test_get_all_invalid_exclude_and_include_parameter(self):
         pass

--- a/st2api/tests/unit/controllers/v1/test_packs_views.py
+++ b/st2api/tests/unit/controllers/v1/test_packs_views.py
@@ -60,7 +60,7 @@ class PacksViewsControllerTestCase(FunctionalTest):
         self.assertEqual(len(resp.json), non_binary_files_count)
 
         for file_path in binary_files:
-            self.assertTrue(file_path in pack_db.files)
+            self.assertIn(file_path, pack_db.files)
 
         # But not in files controller response
         for file_path in binary_files:
@@ -70,7 +70,7 @@ class PacksViewsControllerTestCase(FunctionalTest):
     def test_get_pack_file_success(self):
         resp = self.app.get('/v1/packs/views/file/dummy_pack_1/pack.yaml')
         self.assertEqual(resp.status_int, http_client.OK)
-        self.assertTrue(b'name : dummy_pack_1' in resp.body)
+        self.assertIn(b'name : dummy_pack_1', resp.body)
 
     def test_get_pack_file_pack_doesnt_exist(self):
         resp = self.app.get('/v1/packs/views/files/doesntexist/pack.yaml', expect_errors=True)
@@ -80,19 +80,19 @@ class PacksViewsControllerTestCase(FunctionalTest):
     def test_pack_file_file_larger_then_maximum_size(self):
         resp = self.app.get('/v1/packs/views/file/dummy_pack_1/pack.yaml', expect_errors=True)
         self.assertEqual(resp.status_int, http_client.BAD_REQUEST)
-        self.assertTrue('File pack.yaml exceeds maximum allowed file size' in resp)
+        self.assertIn('File pack.yaml exceeds maximum allowed file size', resp)
 
     def test_headers_get_pack_file(self):
         resp = self.app.get('/v1/packs/views/file/dummy_pack_1/pack.yaml')
         self.assertEqual(resp.status_int, http_client.OK)
-        self.assertTrue(b'name : dummy_pack_1' in resp.body)
+        self.assertIn(b'name : dummy_pack_1', resp.body)
         self.assertIsNotNone(resp.headers['ETag'])
         self.assertIsNotNone(resp.headers['Last-Modified'])
 
     def test_no_change_get_pack_file(self):
         resp = self.app.get('/v1/packs/views/file/dummy_pack_1/pack.yaml')
         self.assertEqual(resp.status_int, http_client.OK)
-        self.assertTrue(b'name : dummy_pack_1' in resp.body)
+        self.assertIn(b'name : dummy_pack_1', resp.body)
 
         # Confirm NOT_MODIFIED
         resp = self.app.get('/v1/packs/views/file/dummy_pack_1/pack.yaml',
@@ -107,12 +107,12 @@ class PacksViewsControllerTestCase(FunctionalTest):
         resp = self.app.get('/v1/packs/views/file/dummy_pack_1/pack.yaml',
                             headers={'If-None-Match': 'ETAG'})
         self.assertEqual(resp.status_code, http_client.OK)
-        self.assertTrue(b'name : dummy_pack_1' in resp.body)
+        self.assertIn(b'name : dummy_pack_1', resp.body)
 
         resp = self.app.get('/v1/packs/views/file/dummy_pack_1/pack.yaml',
                             headers={'If-Modified-Since': 'Last-Modified'})
         self.assertEqual(resp.status_code, http_client.OK)
-        self.assertTrue(b'name : dummy_pack_1' in resp.body)
+        self.assertIn(b'name : dummy_pack_1', resp.body)
 
     def test_get_pack_files_and_pack_file_ref_doesnt_equal_pack_name(self):
         # Ref is not equal to the name, controller should still work
@@ -123,4 +123,4 @@ class PacksViewsControllerTestCase(FunctionalTest):
 
         resp = self.app.get('/v1/packs/views/file/dummy_pack_16/pack.yaml')
         self.assertEqual(resp.status_int, http_client.OK)
-        self.assertTrue(b'ref: dummy_pack_16' in resp.body)
+        self.assertIn(b'ref: dummy_pack_16', resp.body)

--- a/st2api/tests/unit/controllers/v1/test_rules.py
+++ b/st2api/tests/unit/controllers/v1/test_rules.py
@@ -391,7 +391,7 @@ class RulesControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclude
         test_rule = post_resp.json
         if 'pack' in test_rule:
             del test_rule['pack']
-        self.assertTrue('pack' not in test_rule)
+        self.assertNotIn('pack', test_rule)
         put_resp = self.__do_put(self.__get_rule_id(post_resp), test_rule)
         self.assertEqual(put_resp.json['pack'], DEFAULT_PACK_NAME)
         self.assertEqual(put_resp.status_int, http_client.OK)

--- a/st2api/tests/unit/controllers/v1/test_rules.py
+++ b/st2api/tests/unit/controllers/v1/test_rules.py
@@ -300,33 +300,33 @@ class RulesControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclude
         else:
             expected_msg = b'Additional properties are not allowed (u\'minutex\' was unexpected)'
 
-        self.assertTrue(expected_msg in post_resp.body)
+        self.assertIn(expected_msg, post_resp.body)
 
     def test_post_trigger_parameter_schema_validation_fails_missing_required_param(self):
         post_resp = self.__do_post(RulesControllerTestCase.RULE_5)
         self.assertEqual(post_resp.status_int, http_client.BAD_REQUEST)
 
         expected_msg = b'\'date\' is a required property'
-        self.assertTrue(expected_msg in post_resp.body)
+        self.assertIn(expected_msg, post_resp.body)
 
     def test_post_invalid_crontimer_trigger_parameters(self):
         post_resp = self.__do_post(RulesControllerTestCase.RULE_6)
         self.assertEqual(post_resp.status_int, http_client.BAD_REQUEST)
 
         expected_msg = b'1000 is greater than the maximum of 6'
-        self.assertTrue(expected_msg in post_resp.body)
+        self.assertIn(expected_msg, post_resp.body)
 
         post_resp = self.__do_post(RulesControllerTestCase.RULE_7)
         self.assertEqual(post_resp.status_int, http_client.BAD_REQUEST)
 
         expected_msg = b'Invalid weekday name \\"abcdef\\"'
-        self.assertTrue(expected_msg in post_resp.body)
+        self.assertIn(expected_msg, post_resp.body)
 
         post_resp = self.__do_post(RulesControllerTestCase.RULE_8)
         self.assertEqual(post_resp.status_int, http_client.BAD_REQUEST)
 
         expected_msg = b'Invalid weekday name \\"a\\"'
-        self.assertTrue(expected_msg in post_resp.body)
+        self.assertIn(expected_msg, post_resp.body)
 
     def test_post_invalid_custom_trigger_parameter_trigger_param_validation_enabled(self):
         # Invalid custom trigger parameter (invalid type) and non-system trigger parameter
@@ -343,8 +343,8 @@ class RulesControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclude
             expected_msg_1 = "Failed validating u'type' in schema[u'properties'][u'param1']:"
             expected_msg_2 = '12345 is not of type u\'string\''
 
-        self.assertTrue(expected_msg_1 in post_resp.json['faultstring'])
-        self.assertTrue(expected_msg_2 in post_resp.json['faultstring'])
+        self.assertIn(expected_msg_1, post_resp.json['faultstring'])
+        self.assertIn(expected_msg_2, post_resp.json['faultstring'])
 
     def test_post_invalid_custom_trigger_parameter_trigger_param_validation_disabled(self):
         # Invalid custom trigger parameter (invalid type) and non-system trigger parameter

--- a/st2api/tests/unit/controllers/v1/test_timers.py
+++ b/st2api/tests/unit/controllers/v1/test_timers.py
@@ -57,7 +57,7 @@ class TestTimersHolder(DbTestCase):
     def test_remove_trigger(self):
         holder = TimersHolder()
         model = TestTimersHolder.MODELS.get('cron1.yaml', None)
-        self.assertTrue(model is not None)
+        self.assertIsNotNone(model)
         ref = ResourceReference.to_string_reference(pack=model['pack'], name=model['name'])
         holder.add_trigger(ref, model)
         self.assertEqual(len(holder._timers), 1)

--- a/st2api/tests/unit/controllers/v1/test_triggerinstances.py
+++ b/st2api/tests/unit/controllers/v1/test_triggerinstances.py
@@ -111,8 +111,8 @@ class TriggerInstanceTestCase(FunctionalTest,
         self.assertEqual(resp.status_int, http_client.OK)
         resent_message = resp.json['message']
         resent_payload = resp.json['payload']
-        self.assertTrue(instance_id in resent_message)
-        self.assertTrue('__context' in resent_payload)
+        self.assertIn(instance_id, resent_message)
+        self.assertIn('__context', resent_payload)
         self.assertEqual(resent_payload['__context']['original_id'], instance_id)
 
     def test_get_one(self):

--- a/st2api/tests/unit/controllers/v1/test_webhooks.py
+++ b/st2api/tests/unit/controllers/v1/test_webhooks.py
@@ -170,10 +170,10 @@ class TestWebhooksController(FunctionalTest):
         self.assertEqual(post_resp.status_int, http_client.BAD_REQUEST)
 
         expected_msg = 'Trigger payload validation failed'
-        self.assertTrue(expected_msg in post_resp.json['faultstring'])
+        self.assertIn(expected_msg, post_resp.json['faultstring'])
 
         expected_msg = "'invalid' is not of type 'object'"
-        self.assertTrue(expected_msg in post_resp.json['faultstring'])
+        self.assertIn(expected_msg, post_resp.json['faultstring'])
 
     @mock.patch.object(TriggerInstancePublisher, 'publish_trigger', mock.MagicMock(
         return_value=True))
@@ -189,7 +189,7 @@ class TestWebhooksController(FunctionalTest):
         return_value=True))
     def test_st2_webhook_body_missing_trigger(self):
         post_resp = self.__do_post('st2', {'payload': {}}, expect_errors=True)
-        self.assertTrue('Trigger not specified.' in post_resp)
+        self.assertIn('Trigger not specified.', post_resp)
         self.assertEqual(post_resp.status_int, http_client.BAD_REQUEST)
 
     @mock.patch.object(TriggerInstancePublisher, 'publish_trigger', mock.MagicMock(
@@ -227,7 +227,7 @@ class TestWebhooksController(FunctionalTest):
         post_resp = self.app.post('/v1/webhooks/git', data, headers=headers,
                       expect_errors=True)
         self.assertEqual(post_resp.status_int, http_client.BAD_REQUEST)
-        self.assertTrue('Failed to parse request body' in post_resp)
+        self.assertIn('Failed to parse request body', post_resp)
 
     @mock.patch.object(TriggerInstancePublisher, 'publish_trigger', mock.MagicMock(
         return_value=True))
@@ -261,8 +261,8 @@ class TestWebhooksController(FunctionalTest):
         post_resp = self.app.post('/v1/webhooks/git', json.dumps(data), headers=headers,
                                   expect_errors=True)
         self.assertEqual(post_resp.status_int, http_client.BAD_REQUEST)
-        self.assertTrue('Failed to parse request body' in post_resp)
-        self.assertTrue('Unsupported Content-Type' in post_resp)
+        self.assertIn('Failed to parse request body', post_resp)
+        self.assertIn('Unsupported Content-Type', post_resp)
 
     @mock.patch.object(TriggerInstancePublisher, 'publish_trigger', mock.MagicMock(
         return_value=True))

--- a/st2auth/tests/unit/test_auth_backends.py
+++ b/st2auth/tests/unit/test_auth_backends.py
@@ -24,4 +24,4 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 class AuthenticationBackendsTestCase(unittest2.TestCase):
     def test_flat_file_backend_is_available_by_default(self):
         available_backends = get_available_backends()
-        self.assertTrue('flat_file' in available_backends)
+        self.assertIn('flat_file', available_backends)

--- a/st2client/tests/unit/test_auth.py
+++ b/st2client/tests/unit/test_auth.py
@@ -288,7 +288,7 @@ class TestLoginUncaughtException(TestLoginBase):
         self.shell.run(args)
         retcode = self.shell.run(args)
 
-        self.assertTrue('Failed to log in as %s' % expected_username in self.stdout.getvalue())
+        self.assertIn('Failed to log in as %s' % expected_username, self.stdout.getvalue())
         self.assertTrue('Logged in as' not in self.stdout.getvalue())
         self.assertEqual(retcode, 1)
 

--- a/st2client/tests/unit/test_auth.py
+++ b/st2client/tests/unit/test_auth.py
@@ -141,8 +141,8 @@ class TestLoginPasswordAndConfig(TestLoginBase):
         with open(self.CONFIG_FILE, 'r') as config_file:
             for line in config_file.readlines():
                 # Make sure certain values are not present
-                self.assertFalse('password' in line)
-                self.assertFalse('olduser' in line)
+                self.assertNotIn('password', line)
+                self.assertNotIn('olduser', line)
 
                 # Make sure configured username is what we expect
                 if 'username' in line:
@@ -194,8 +194,8 @@ class TestLoginIntPwdAndConfig(TestLoginBase):
         with open(self.CONFIG_FILE, 'r') as config_file:
             for line in config_file.readlines():
                 # Make sure certain values are not present
-                self.assertFalse('password' in line)
-                self.assertFalse('olduser' in line)
+                self.assertNotIn('password', line)
+                self.assertNotIn('olduser', line)
 
                 # Make sure configured username is what we expect
                 if 'username' in line:
@@ -250,7 +250,7 @@ class TestLoginWritePwdOkay(TestLoginBase):
             for line in config_file.readlines():
 
                 # Make sure certain values are not present
-                self.assertFalse('olduser' in line)
+                self.assertNotIn('olduser', line)
 
                 # Make sure configured username is what we expect
                 if 'username' in line:

--- a/st2client/tests/unit/test_auth.py
+++ b/st2client/tests/unit/test_auth.py
@@ -146,7 +146,7 @@ class TestLoginPasswordAndConfig(TestLoginBase):
 
                 # Make sure configured username is what we expect
                 if 'username' in line:
-                    self.assertEquals(line.split(' ')[2][:-1], expected_username)
+                    self.assertEqual(line.split(' ')[2][:-1], expected_username)
 
             # validate token was created
             self.assertTrue(os.path.isfile('%stoken-%s' % (self.DOTST2_PATH, expected_username)))
@@ -199,7 +199,7 @@ class TestLoginIntPwdAndConfig(TestLoginBase):
 
                 # Make sure configured username is what we expect
                 if 'username' in line:
-                    self.assertEquals(line.split(' ')[2][:-1], expected_username)
+                    self.assertEqual(line.split(' ')[2][:-1], expected_username)
 
             # validate token was created
             self.assertTrue(os.path.isfile('%stoken-%s' % (self.DOTST2_PATH, expected_username)))
@@ -254,7 +254,7 @@ class TestLoginWritePwdOkay(TestLoginBase):
 
                 # Make sure configured username is what we expect
                 if 'username' in line:
-                    self.assertEquals(line.split(' ')[2][:-1], expected_username)
+                    self.assertEqual(line.split(' ')[2][:-1], expected_username)
 
             # validate token was created
             self.assertTrue(os.path.isfile('%stoken-%s' % (self.DOTST2_PATH, expected_username)))

--- a/st2client/tests/unit/test_auth.py
+++ b/st2client/tests/unit/test_auth.py
@@ -289,7 +289,7 @@ class TestLoginUncaughtException(TestLoginBase):
         retcode = self.shell.run(args)
 
         self.assertIn('Failed to log in as %s' % expected_username, self.stdout.getvalue())
-        self.assertTrue('Logged in as' not in self.stdout.getvalue())
+        self.assertNotIn('Logged in as', self.stdout.getvalue())
         self.assertEqual(retcode, 1)
 
 

--- a/st2client/tests/unit/test_client_executions.py
+++ b/st2client/tests/unit/test_client_executions.py
@@ -225,5 +225,5 @@ class TestExecutionResourceManager(unittest2.TestCase):
 
         expected_msg = 'st2client.liveactions has been renamed'
         self.assertTrue(len(mock_warn.call_args_list) >= 1)
-        self.assertTrue(expected_msg in mock_warn.call_args_list[0][0][0])
+        self.assertIn(expected_msg, mock_warn.call_args_list[0][0][0])
         self.assertEqual(mock_warn.call_args_list[0][0][1], DeprecationWarning)

--- a/st2client/tests/unit/test_command_actionrun.py
+++ b/st2client/tests/unit/test_command_actionrun.py
@@ -44,16 +44,16 @@ class ActionRunCommandTest(unittest2.TestCase):
         self.assertEqual(len(list(params.keys())), 3)
 
         self.assertIn('foo', imm, '"foo" param should be in immutable set.')
-        self.assertTrue('foo' not in rqd, '"foo" param should not be in required set.')
-        self.assertTrue('foo' not in opt, '"foo" param should not be in optional set.')
+        self.assertNotIn('foo', rqd, '"foo" param should not be in required set.')
+        self.assertNotIn('foo', opt, '"foo" param should not be in optional set.')
 
         self.assertIn('bar', opt, '"bar" param should be in optional set.')
-        self.assertTrue('bar' not in rqd, '"bar" param should not be in required set.')
-        self.assertTrue('bar' not in imm, '"bar" param should not be in immutable set.')
+        self.assertNotIn('bar', rqd, '"bar" param should not be in required set.')
+        self.assertNotIn('bar', imm, '"bar" param should not be in immutable set.')
 
         self.assertIn('stuff', rqd, '"stuff" param should be in required set.')
-        self.assertTrue('stuff' not in opt, '"stuff" param should be in optional set.')
-        self.assertTrue('stuff' not in imm, '"stuff" param should be in immutable set.')
+        self.assertNotIn('stuff', opt, '"stuff" param should not be in optional set.')
+        self.assertNotIn('stuff', imm, '"stuff" param should not be in immutable set.')
         self.assertEqual(runner.runner_parameters, orig_runner_params, 'Runner params modified.')
         self.assertEqual(action.parameters, orig_action_params, 'Action params modified.')
 

--- a/st2client/tests/unit/test_command_actionrun.py
+++ b/st2client/tests/unit/test_command_actionrun.py
@@ -138,7 +138,7 @@ class ActionRunCommandTest(unittest2.TestCase):
 
         param = command._get_action_parameters_from_args(action=action, runner=runner, args=mockarg)
 
-        self.assertTrue(isinstance(param, dict))
+        self.assertIsInstance(param, dict)
         self.assertEqual(param['param_string'], 'hoge')
         self.assertEqual(param['param_integer'], 123)
         self.assertEqual(param['param_number'], 1.23)
@@ -147,15 +147,15 @@ class ActionRunCommandTest(unittest2.TestCase):
         self.assertEqual(param['param_array'], ['foo', 'bar', 'baz'])
 
         # checking the result of parsing for array of objects
-        self.assertTrue(isinstance(param['param_array_of_dicts'], list))
+        self.assertIsInstance(param['param_array_of_dicts'], list)
         self.assertEqual(len(param['param_array_of_dicts']), 2)
         for param in param['param_array_of_dicts']:
-            self.assertTrue(isinstance(param, dict))
-            self.assertTrue(isinstance(param['foo'], str))
-            self.assertTrue(isinstance(param['bar'], int))
-            self.assertTrue(isinstance(param['baz'], float))
-            self.assertTrue(isinstance(param['qux'], dict))
-            self.assertTrue(isinstance(param['quux'], bool))
+            self.assertIsInstance(param, dict)
+            self.assertIsInstance(param['foo'], str)
+            self.assertIsInstance(param['bar'], int)
+            self.assertIsInstance(param['baz'], float)
+            self.assertIsInstance(param['qux'], dict)
+            self.assertIsInstance(param['quux'], bool)
 
         # set auto_dict back to default
         mockarg.auto_dict = False

--- a/st2client/tests/unit/test_command_actionrun.py
+++ b/st2client/tests/unit/test_command_actionrun.py
@@ -43,15 +43,15 @@ class ActionRunCommandTest(unittest2.TestCase):
         params, rqd, opt, imm = ActionRunCommand._get_params_types(runner, action)
         self.assertEqual(len(list(params.keys())), 3)
 
-        self.assertTrue('foo' in imm, '"foo" param should be in immutable set.')
+        self.assertIn('foo', imm, '"foo" param should be in immutable set.')
         self.assertTrue('foo' not in rqd, '"foo" param should not be in required set.')
         self.assertTrue('foo' not in opt, '"foo" param should not be in optional set.')
 
-        self.assertTrue('bar' in opt, '"bar" param should be in optional set.')
+        self.assertIn('bar', opt, '"bar" param should be in optional set.')
         self.assertTrue('bar' not in rqd, '"bar" param should not be in required set.')
         self.assertTrue('bar' not in imm, '"bar" param should not be in immutable set.')
 
-        self.assertTrue('stuff' in rqd, '"stuff" param should be in required set.')
+        self.assertIn('stuff', rqd, '"stuff" param should be in required set.')
         self.assertTrue('stuff' not in opt, '"stuff" param should be in optional set.')
         self.assertTrue('stuff' not in imm, '"stuff" param should be in immutable set.')
         self.assertEqual(runner.runner_parameters, orig_runner_params, 'Runner params modified.')

--- a/st2client/tests/unit/test_commands.py
+++ b/st2client/tests/unit/test_commands.py
@@ -362,6 +362,6 @@ class CommandsHelpStringTestCase(BaseCLITestCase):
             # Verify that the actual help usage string was triggered and not the invalid
             # "too few arguments" which would indicate command doesn't actually correctly handle
             # --help flag
-            self.assertTrue('too few arguments' not in stdout)
+            self.assertNotIn('too few arguments', stdout)
 
             self._reset_output_streams()

--- a/st2client/tests/unit/test_commands.py
+++ b/st2client/tests/unit/test_commands.py
@@ -334,10 +334,10 @@ class CommandsHelpStringTestCase(BaseCLITestCase):
 
             stdout = self.stdout.getvalue()
 
-            self.assertTrue('usage:' in stdout)
-            self.assertTrue(' '.join(command) in stdout)
-            # self.assertTrue('positional arguments:' in stdout)
-            self.assertTrue('optional arguments:' in stdout)
+            self.assertIn('usage:', stdout)
+            self.assertIn(' '.join(command), stdout)
+            # self.assertIn('positional arguments:', stdout)
+            self.assertIn('optional arguments:', stdout)
 
             # Reset stdout and stderr after each iteration
             self._reset_output_streams()
@@ -354,10 +354,10 @@ class CommandsHelpStringTestCase(BaseCLITestCase):
 
             stdout = self.stdout.getvalue()
 
-            self.assertTrue('usage:' in stdout)
-            self.assertTrue(' '.join(command) in stdout)
-            # self.assertTrue('positional arguments:' in stdout)
-            self.assertTrue('optional arguments:' in stdout)
+            self.assertIn('usage:', stdout)
+            self.assertIn(' '.join(command), stdout)
+            # self.assertIn('positional arguments:', stdout)
+            self.assertIn('optional arguments:', stdout)
 
             # Verify that the actual help usage string was triggered and not the invalid
             # "too few arguments" which would indicate command doesn't actually correctly handle

--- a/st2client/tests/unit/test_execution_tail_command.py
+++ b/st2client/tests/unit/test_execution_tail_command.py
@@ -287,7 +287,7 @@ class ActionExecutionTailCommandTestCase(BaseCLITestCase):
         self.assertEqual(self.shell.run(argv), 0)
         stdout = self.stdout.getvalue()
         stderr = self.stderr.getvalue()
-        self.assertTrue('Execution idfoo1 has completed (status=succeeded)' in stdout)
+        self.assertIn('Execution idfoo1 has completed (status=succeeded)', stdout)
         self.assertEqual(stderr, '')
 
     @mock.patch.object(
@@ -300,7 +300,7 @@ class ActionExecutionTailCommandTestCase(BaseCLITestCase):
         self.assertEqual(self.shell.run(argv), 0)
         stdout = self.stdout.getvalue()
         stderr = self.stderr.getvalue()
-        self.assertTrue('Execution idfoo2 has completed (status=failed)' in stdout)
+        self.assertIn('Execution idfoo2 has completed (status=failed)', stdout)
         self.assertEqual(stderr, '')
 
     @mock.patch.object(

--- a/st2client/tests/unit/test_formatters.py
+++ b/st2client/tests/unit/test_formatters.py
@@ -276,12 +276,12 @@ class TestExecutionResultFormatter(unittest2.TestCase):
                 "more results."
             print(self.table.note_box("action executions", 1))
             content = (fackety_fake.getvalue().split("|")[1].strip())
-            self.assertEquals(content, expected)
+            self.assertEqual(content, expected)
 
     def test_SinlgeRowTable_notebox_zero(self):
         with mock.patch('sys.stderr', new=BytesIO()) as fackety_fake:
             contents = (fackety_fake.getvalue())
-            self.assertEquals(contents, b'')
+            self.assertEqual(contents, b'')
 
     def test_SinlgeRowTable_notebox_default(self):
         with mock.patch('sys.stderr', new=StringIO()) as fackety_fake:
@@ -289,10 +289,10 @@ class TestExecutionResultFormatter(unittest2.TestCase):
                 "for more results."
             print(self.table.note_box("action executions", 50))
             content = (fackety_fake.getvalue().split("|")[1].strip())
-            self.assertEquals(content, expected)
+            self.assertEqual(content, expected)
         with mock.patch('sys.stderr', new=StringIO()) as fackety_fake:
             expected = "Note: Only first 15 action executions are displayed. Use -n/--last flag " \
                 "for more results."
             print(self.table.note_box("action executions", 15))
             content = (fackety_fake.getvalue().split("|")[1].strip())
-            self.assertEquals(content, expected)
+            self.assertEqual(content, expected)

--- a/st2client/tests/unit/test_inquiry.py
+++ b/st2client/tests/unit/test_inquiry.py
@@ -181,7 +181,7 @@ class TestInquirySubcommands(TestInquiryBase):
         retcode = self.shell.run(args)
         self.assertEqual(retcode, 0)
         self.assertEqual(self.stdout.getvalue().count('1440'), 50)
-        self.assertTrue('Note: Only first 50 inquiries are displayed.' in self.stderr.getvalue())
+        self.assertIn('Note: Only first 50 inquiries are displayed.', self.stderr.getvalue())
 
     @mock.patch.object(
         requests, 'get',

--- a/st2client/tests/unit/test_interactive.py
+++ b/st2client/tests/unit/test_interactive.py
@@ -96,7 +96,7 @@ class TestInteractive(unittest2.TestCase):
         with mock.patch.object(interactive.InteractiveForm, 'readers', [Reader]):
             interactive.InteractiveForm(schema).initiate_dialog()
 
-        self.assertEquals(stdout_mock.getvalue(), 'Dialog interrupted.\n')
+        self.assertEqual(stdout_mock.getvalue(), 'Dialog interrupted.\n')
 
     def test_interactive_form_interrupted_reraised(self):
         reader = mock.MagicMock()

--- a/st2client/tests/unit/test_keyvalue.py
+++ b/st2client/tests/unit/test_keyvalue.py
@@ -139,7 +139,7 @@ class TestKeyValueSet(TestKeyValueBase):
         stderr = self.stderr.read()
 
         expected_msg = ('error: argument --encrypted: not allowed with argument -e/--encrypt')
-        self.assertTrue(expected_msg in stderr)
+        self.assertIn(expected_msg, stderr)
 
 
 class TestKeyValueLoad(TestKeyValueBase):

--- a/st2client/tests/unit/test_shell.py
+++ b/st2client/tests/unit/test_shell.py
@@ -76,10 +76,10 @@ class ShellTestCase(base.BaseCLITestCase):
 
         self.stderr.seek(0)
         stderr = self.stderr.read()
-        self.assertTrue('Usage: ' in stderr)
-        self.assertTrue('For example:' in stderr)
-        self.assertTrue('CLI for StackStorm' in stderr)
-        self.assertTrue('positional arguments:' in stderr)
+        self.assertIn('Usage: ', stderr)
+        self.assertIn('For example:', stderr)
+        self.assertIn('CLI for StackStorm', stderr)
+        self.assertIn('positional arguments:', stderr)
 
         self.stdout.truncate()
         self.stderr.truncate()
@@ -92,10 +92,10 @@ class ShellTestCase(base.BaseCLITestCase):
 
         self.stdout.seek(0)
         stdout = self.stdout.read()
-        self.assertTrue('Usage: ' in stdout)
-        self.assertTrue('For example:' in stdout)
-        self.assertTrue('CLI for StackStorm' in stdout)
-        self.assertTrue('positional arguments:' in stdout)
+        self.assertIn('Usage: ', stdout)
+        self.assertIn('For example:', stdout)
+        self.assertIn('CLI for StackStorm', stdout)
+        self.assertIn('positional arguments:', stdout)
 
         self.stdout.truncate()
         self.stderr.truncate()
@@ -109,11 +109,11 @@ class ShellTestCase(base.BaseCLITestCase):
         self.stderr.seek(0)
         stderr = self.stderr.read()
 
-        self.assertTrue('usage' in stderr)
+        self.assertIn('usage', stderr)
 
         if six.PY2:
-            self.assertTrue('{list,get,create,update' in stderr)
-            self.assertTrue('error: too few arguments' in stderr)
+            self.assertIn('{list,get,create,update', stderr)
+            self.assertIn('error: too few arguments', stderr)
 
     def test_endpoints_default(self):
         base_url = 'http://127.0.0.1'
@@ -312,8 +312,8 @@ class ShellTestCase(base.BaseCLITestCase):
         self.stdout.seek(0)
         stdout = self.stdout.read()
 
-        self.assertTrue('username = None' in stdout)
-        self.assertTrue('cache_token = True' in stdout)
+        self.assertIn('username = None', stdout)
+        self.assertIn('cache_token = True', stdout)
 
     def test_print_config_custom_config_as_env_variable(self):
         os.environ['ST2_CONFIG_FILE'] = CONFIG_FILE_PATH_FULL
@@ -323,8 +323,8 @@ class ShellTestCase(base.BaseCLITestCase):
         self.stdout.seek(0)
         stdout = self.stdout.read()
 
-        self.assertTrue('username = test1' in stdout)
-        self.assertTrue('cache_token = False' in stdout)
+        self.assertIn('username = test1', stdout)
+        self.assertIn('cache_token = False', stdout)
 
     def test_print_config_custom_config_as_command_line_argument(self):
         argv = ['--print-config', '--config-file=%s' % (CONFIG_FILE_PATH_FULL)]
@@ -333,8 +333,8 @@ class ShellTestCase(base.BaseCLITestCase):
         self.stdout.seek(0)
         stdout = self.stdout.read()
 
-        self.assertTrue('username = test1' in stdout)
-        self.assertTrue('cache_token = False' in stdout)
+        self.assertIn('username = test1', stdout)
+        self.assertIn('cache_token = False', stdout)
 
     def test_run(self):
         args_list = [
@@ -391,7 +391,7 @@ class ShellTestCase(base.BaseCLITestCase):
 
         self.version_output.seek(0)
         stderr = self.version_output.read()
-        self.assertTrue('v2.8.0, on Python' in stderr)
+        self.assertIn('v2.8.0, on Python', stderr)
 
     @mock.patch('sys.exit', mock.Mock())
     @mock.patch('st2client.shell.__version__', 'v2.8.0')
@@ -405,7 +405,7 @@ class ShellTestCase(base.BaseCLITestCase):
 
         self.version_output.seek(0)
         stderr = self.version_output.read()
-        self.assertTrue('v2.8.0, on Python' in stderr)
+        self.assertIn('v2.8.0, on Python', stderr)
 
     @mock.patch('sys.exit', mock.Mock())
     @mock.patch('st2client.shell.__version__', 'v2.9dev')
@@ -418,7 +418,7 @@ class ShellTestCase(base.BaseCLITestCase):
 
         self.version_output.seek(0)
         stderr = self.version_output.read()
-        self.assertTrue('v2.9dev, on Python' in stderr)
+        self.assertIn('v2.9dev, on Python', stderr)
 
     @mock.patch('sys.exit', mock.Mock())
     @mock.patch('st2client.shell.__version__', 'v2.9dev')
@@ -433,7 +433,7 @@ class ShellTestCase(base.BaseCLITestCase):
 
         self.version_output.seek(0)
         stderr = self.version_output.read()
-        self.assertTrue('v2.9dev (abcdefg), on Python' in stderr)
+        self.assertIn('v2.9dev (abcdefg), on Python', stderr)
 
     @mock.patch('locale.getdefaultlocale', mock.Mock(return_value=['en_US']))
     @mock.patch('locale.getpreferredencoding', mock.Mock(return_value='iso'))
@@ -446,7 +446,7 @@ class ShellTestCase(base.BaseCLITestCase):
         shell.run(argv=['trigger', 'list'])
 
         call_args = mock_logger.warn.call_args[0][0]
-        self.assertTrue('Locale en_US with encoding iso which is not UTF-8 is used.' in call_args)
+        self.assertIn('Locale en_US with encoding iso which is not UTF-8 is used.', call_args)
 
     @mock.patch('locale.getdefaultlocale', mock.Mock(side_effect=ValueError('bar')))
     @mock.patch('locale.getpreferredencoding', mock.Mock(side_effect=ValueError('bar')))

--- a/st2client/tests/unit/test_trace_commands.py
+++ b/st2client/tests/unit/test_trace_commands.py
@@ -41,9 +41,9 @@ class TraceCommandTestCase(base.BaseCLITestCase):
         setattr(args, 'hide_noop_triggers', False)
 
         trace = trace_commands.TraceGetCommand._filter_trace_components(trace, args)
-        self.assertEquals(len(trace.action_executions), 1)
-        self.assertEquals(len(trace.rules), 1)
-        self.assertEquals(len(trace.trigger_instances), 1)
+        self.assertEqual(len(trace.action_executions), 1)
+        self.assertEqual(len(trace.rules), 1)
+        self.assertEqual(len(trace.trigger_instances), 1)
 
     def test_trace_get_filter_trace_components_rules(self):
         trace = trace_models.Trace()
@@ -65,9 +65,9 @@ class TraceCommandTestCase(base.BaseCLITestCase):
         setattr(args, 'hide_noop_triggers', False)
 
         trace = trace_commands.TraceGetCommand._filter_trace_components(trace, args)
-        self.assertEquals(len(trace.action_executions), 0)
-        self.assertEquals(len(trace.rules), 1)
-        self.assertEquals(len(trace.trigger_instances), 1)
+        self.assertEqual(len(trace.action_executions), 0)
+        self.assertEqual(len(trace.rules), 1)
+        self.assertEqual(len(trace.trigger_instances), 1)
 
     def test_trace_get_filter_trace_components_trigger_instances(self):
         trace = trace_models.Trace()
@@ -89,9 +89,9 @@ class TraceCommandTestCase(base.BaseCLITestCase):
         setattr(args, 'hide_noop_triggers', False)
 
         trace = trace_commands.TraceGetCommand._filter_trace_components(trace, args)
-        self.assertEquals(len(trace.action_executions), 0)
-        self.assertEquals(len(trace.rules), 0)
-        self.assertEquals(len(trace.trigger_instances), 1)
+        self.assertEqual(len(trace.action_executions), 0)
+        self.assertEqual(len(trace.rules), 0)
+        self.assertEqual(len(trace.trigger_instances), 1)
 
     def test_trace_get_apply_display_filters_show_executions(self):
         trace = trace_models.Trace()
@@ -174,9 +174,9 @@ class TraceCommandTestCase(base.BaseCLITestCase):
         setattr(args, 'hide_noop_triggers', False)
 
         trace = trace_commands.TraceGetCommand._apply_display_filters(trace, args)
-        self.assertEquals(len(trace.action_executions), 1)
-        self.assertEquals(len(trace.rules), 1)
-        self.assertEquals(len(trace.trigger_instances), 1)
+        self.assertEqual(len(trace.action_executions), 1)
+        self.assertEqual(len(trace.rules), 1)
+        self.assertEqual(len(trace.trigger_instances), 1)
 
     def test_trace_get_apply_display_filters_hide_noop(self):
         trace = trace_models.Trace()
@@ -195,6 +195,6 @@ class TraceCommandTestCase(base.BaseCLITestCase):
         setattr(args, 'hide_noop_triggers', True)
 
         trace = trace_commands.TraceGetCommand._apply_display_filters(trace, args)
-        self.assertEquals(len(trace.action_executions), 1)
-        self.assertEquals(len(trace.rules), 1)
-        self.assertEquals(len(trace.trigger_instances), 1)
+        self.assertEqual(len(trace.action_executions), 1)
+        self.assertEqual(len(trace.rules), 1)
+        self.assertEqual(len(trace.trigger_instances), 1)

--- a/st2common/tests/integration/test_rabbitmq_ssl_listener.py
+++ b/st2common/tests/integration/test_rabbitmq_ssl_listener.py
@@ -63,7 +63,7 @@ class RabbitMQTLSListenerTestCase(unittest2.TestCase):
             connection.connect()
         except Exception as e:
             self.assertFalse(connection.connected)
-            self.assertTrue(isinstance(e, (IOError, socket.error)))
+            self.assertIsInstance(e, (IOError, socket.error))
             self.assertTrue(expected_msg_1 in six.text_type(e) or expected_msg_2 in
                             six.text_type(e))
         else:

--- a/st2common/tests/integration/test_register_content_script.py
+++ b/st2common/tests/integration/test_register_content_script.py
@@ -51,7 +51,7 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
         ]
         cmd = BASE_REGISTER_ACTIONS_CMD_ARGS + opts
         exit_code, _, stderr = run_command(cmd=cmd)
-        self.assertTrue('Registered 1 actions.' in stderr)
+        self.assertIn('Registered 1 actions.', stderr)
         self.assertEqual(exit_code, 0)
 
     def test_register_from_pack_fail_on_failure_pack_dir_doesnt_exist(self):
@@ -76,7 +76,7 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
         ]
         cmd = BASE_REGISTER_ACTIONS_CMD_ARGS + opts
         exit_code, _, stderr = run_command(cmd=cmd)
-        self.assertTrue('Directory "doesntexistblah" doesn\'t exist' in stderr)
+        self.assertIn('Directory "doesntexistblah" doesn\'t exist', stderr)
         self.assertEqual(exit_code, 1)
 
     def test_register_from_pack_action_metadata_fails_validation(self):
@@ -92,7 +92,7 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
 
         cmd = BASE_REGISTER_ACTIONS_CMD_ARGS + opts
         exit_code, _, stderr = run_command(cmd=cmd)
-        self.assertTrue('Registered 0 actions.' in stderr)
+        self.assertIn('Registered 0 actions.', stderr)
         self.assertEqual(exit_code, 0)
 
         # Fail on failure, should fail
@@ -104,7 +104,7 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
         ]
         cmd = BASE_REGISTER_ACTIONS_CMD_ARGS + opts
         exit_code, _, stderr = run_command(cmd=cmd)
-        self.assertTrue('object has no attribute \'get\'' in stderr)
+        self.assertIn('object has no attribute \'get\'', stderr)
         self.assertEqual(exit_code, 1)
 
     def test_register_from_packs_doesnt_throw_on_missing_pack_resource_folder(self):
@@ -116,15 +116,15 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
         cmd = [sys.executable, SCRIPT_PATH, '--config-file=conf/st2.tests1.conf', '-v',
                '--register-sensors']
         exit_code, _, stderr = run_command(cmd=cmd)
-        self.assertTrue('Registered 0 sensors.' in stderr, 'Actual stderr: %s' % (stderr))
+        self.assertIn('Registered 0 sensors.', stderr, 'Actual stderr: %s' % (stderr))
         self.assertEqual(exit_code, 0)
 
         cmd = [sys.executable, SCRIPT_PATH, '--config-file=conf/st2.tests1.conf', '-v',
                '--register-all', '--register-no-fail-on-failure']
         exit_code, _, stderr = run_command(cmd=cmd)
-        self.assertTrue('Registered 0 actions.' in stderr)
-        self.assertTrue('Registered 0 sensors.' in stderr)
-        self.assertTrue('Registered 0 rules.' in stderr)
+        self.assertIn('Registered 0 actions.', stderr)
+        self.assertIn('Registered 0 sensors.', stderr)
+        self.assertIn('Registered 0 rules.', stderr)
         self.assertEqual(exit_code, 0)
 
     def test_register_all_and_register_setup_virtualenvs(self):
@@ -138,9 +138,9 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
             '--register-no-fail-on-failure'
         ]
         exit_code, stdout, stderr = run_command(cmd=cmd)
-        self.assertTrue('Registering actions' in stderr, 'Actual stderr: %s' % (stderr))
-        self.assertTrue('Registering rules' in stderr)
-        self.assertTrue('Setup virtualenv for %s pack(s)' % ('1') in stderr)
+        self.assertIn('Registering actions', stderr, 'Actual stderr: %s' % (stderr))
+        self.assertIn('Registering rules', stderr)
+        self.assertIn('Setup virtualenv for %s pack(s)' % ('1'), stderr)
         self.assertEqual(exit_code, 0)
 
     def test_register_setup_virtualenvs(self):
@@ -151,6 +151,6 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
                                '--register-no-fail-on-failure']
         exit_code, stdout, stderr = run_command(cmd=cmd)
 
-        self.assertTrue('Setting up virtualenv for pack "dummy_pack_1"' in stderr)
-        self.assertTrue('Setup virtualenv for 1 pack(s)' in stderr)
+        self.assertIn('Setting up virtualenv for pack "dummy_pack_1"', stderr)
+        self.assertIn('Setup virtualenv for 1 pack(s)', stderr)
         self.assertEqual(exit_code, 0)

--- a/st2common/tests/integration/test_service_setup_log_level_filtering.py
+++ b/st2common/tests/integration/test_service_setup_log_level_filtering.py
@@ -69,7 +69,7 @@ class ServiceSetupLogLevelFilteringTestCase(IntegrationTestCase):
         # First 3 log lines are debug messages about the environment which are always logged
         stdout = '\n'.join(process.stdout.read().decode('utf-8').split('\n')[3:])
 
-        self.assertTrue('INFO [-]' in stdout)
+        self.assertIn('INFO [-]', stdout)
         self.assertTrue('DEBUG [-]' not in stdout)
         self.assertTrue('AUDIT [-]' not in stdout)
 
@@ -84,9 +84,9 @@ class ServiceSetupLogLevelFilteringTestCase(IntegrationTestCase):
         # First 3 log lines are debug messages about the environment which are always logged
         stdout = '\n'.join(process.stdout.read().decode('utf-8').split('\n')[3:])
 
-        self.assertTrue('INFO [-]' in stdout)
-        self.assertTrue('DEBUG [-]' in stdout)
-        self.assertTrue('AUDIT [-]' in stdout)
+        self.assertIn('INFO [-]', stdout)
+        self.assertIn('DEBUG [-]', stdout)
+        self.assertIn('AUDIT [-]', stdout)
 
         # 3. AUDIT log level - audit messages should be included
         process = self._start_process(config_path=ST2_CONFIG_AUDIT_LL_PATH)
@@ -101,7 +101,7 @@ class ServiceSetupLogLevelFilteringTestCase(IntegrationTestCase):
 
         self.assertTrue('INFO [-]' not in stdout)
         self.assertTrue('DEBUG [-]' not in stdout)
-        self.assertTrue('AUDIT [-]' in stdout)
+        self.assertIn('AUDIT [-]', stdout)
 
         # 2. INFO log level but system.debug set to True
         process = self._start_process(config_path=ST2_CONFIG_SYSTEM_DEBUG_PATH)
@@ -114,9 +114,9 @@ class ServiceSetupLogLevelFilteringTestCase(IntegrationTestCase):
         # First 3 log lines are debug messages about the environment which are always logged
         stdout = '\n'.join(process.stdout.read().decode('utf-8').split('\n')[3:])
 
-        self.assertTrue('INFO [-]' in stdout)
-        self.assertTrue('DEBUG [-]' in stdout)
-        self.assertTrue('AUDIT [-]' in stdout)
+        self.assertIn('INFO [-]', stdout)
+        self.assertIn('DEBUG [-]', stdout)
+        self.assertIn('AUDIT [-]', stdout)
 
     def test_kombu_heartbeat_tick_log_messages_are_excluded(self):
         # 1. system.debug = True config option is set, verify heartbeat_tick message is not logged

--- a/st2common/tests/integration/test_service_setup_log_level_filtering.py
+++ b/st2common/tests/integration/test_service_setup_log_level_filtering.py
@@ -70,8 +70,8 @@ class ServiceSetupLogLevelFilteringTestCase(IntegrationTestCase):
         stdout = '\n'.join(process.stdout.read().decode('utf-8').split('\n')[3:])
 
         self.assertIn('INFO [-]', stdout)
-        self.assertTrue('DEBUG [-]' not in stdout)
-        self.assertTrue('AUDIT [-]' not in stdout)
+        self.assertNotIn('DEBUG [-]', stdout)
+        self.assertNotIn('AUDIT [-]', stdout)
 
         # 2. DEBUG log level - audit messages should be included
         process = self._start_process(config_path=ST2_CONFIG_DEBUG_LL_PATH)
@@ -99,8 +99,8 @@ class ServiceSetupLogLevelFilteringTestCase(IntegrationTestCase):
         # First 3 log lines are debug messages about the environment which are always logged
         stdout = '\n'.join(process.stdout.read().decode('utf-8').split('\n')[3:])
 
-        self.assertTrue('INFO [-]' not in stdout)
-        self.assertTrue('DEBUG [-]' not in stdout)
+        self.assertNotIn('INFO [-]', stdout)
+        self.assertNotIn('DEBUG [-]', stdout)
         self.assertIn('AUDIT [-]', stdout)
 
         # 2. INFO log level but system.debug set to True
@@ -128,7 +128,7 @@ class ServiceSetupLogLevelFilteringTestCase(IntegrationTestCase):
         process.send_signal(signal.SIGKILL)
 
         stdout = '\n'.join(process.stdout.read().decode('utf-8').split('\n'))
-        self.assertTrue('heartbeat_tick' not in stdout)
+        self.assertNotIn('heartbeat_tick', stdout)
 
         # 2. system.debug = False, log level is set to debug
         process = self._start_process(config_path=ST2_CONFIG_DEBUG_LL_PATH)
@@ -139,7 +139,7 @@ class ServiceSetupLogLevelFilteringTestCase(IntegrationTestCase):
         process.send_signal(signal.SIGKILL)
 
         stdout = '\n'.join(process.stdout.read().decode('utf-8').split('\n'))
-        self.assertTrue('heartbeat_tick' not in stdout)
+        self.assertNotIn('heartbeat_tick', stdout)
 
     def _start_process(self, config_path):
         cmd = CMD + [config_path]

--- a/st2common/tests/unit/services/test_access.py
+++ b/st2common/tests/unit/services/test_access.py
@@ -39,8 +39,8 @@ class AccessServiceTest(DbTestCase):
 
     def test_create_token(self):
         token = access.create_token(USERNAME)
-        self.assertTrue(token is not None)
-        self.assertTrue(token.token is not None)
+        self.assertIsNotNone(token)
+        self.assertIsNotNone(token.token)
         self.assertEqual(token.user, USERNAME)
 
     def test_create_token_fail(self):
@@ -67,8 +67,8 @@ class AccessServiceTest(DbTestCase):
     def test_create_token_ttl_ok(self):
         ttl = 10
         token = access.create_token(USERNAME, 10)
-        self.assertTrue(token is not None)
-        self.assertTrue(token.token is not None)
+        self.assertIsNotNone(token)
+        self.assertIsNotNone(token.token)
         self.assertEqual(token.user, USERNAME)
         expected_expiry = date_utils.get_datetime_utc_now() + datetime.timedelta(seconds=ttl)
         expected_expiry = date_utils.add_utc_tz(expected_expiry)
@@ -79,8 +79,8 @@ class AccessServiceTest(DbTestCase):
         expected_expiry = date_utils.get_datetime_utc_now() + datetime.timedelta(seconds=ttl)
         expected_expiry = date_utils.add_utc_tz(expected_expiry)
         token = access.create_token(USERNAME, 10)
-        self.assertTrue(token is not None)
-        self.assertTrue(token.token is not None)
+        self.assertIsNotNone(token)
+        self.assertIsNotNone(token.token)
         self.assertEqual(token.user, USERNAME)
         self.assertLess(isotime.parse(token.expiry), expected_expiry)
 
@@ -92,7 +92,7 @@ class AccessServiceTest(DbTestCase):
         expected_expiry = date_utils.get_datetime_utc_now() + datetime.timedelta(seconds=ttl)
         expected_expiry = date_utils.add_utc_tz(expected_expiry)
 
-        self.assertTrue(token is not None)
+        self.assertIsNotNone(token)
         self.assertEqual(token.user, USERNAME)
         self.assertLess(isotime.parse(token.expiry), expected_expiry)
 

--- a/st2common/tests/unit/services/test_action.py
+++ b/st2common/tests/unit/services/test_action.py
@@ -286,7 +286,7 @@ class TestActionExecutionService(DbTestCase):
         self.assertEqual(ex.context['user'], req.context['user'])
         self.assertDictEqual(ex.parameters, req.parameters)
         self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_REQUESTED)
-        self.assertTrue(ex.notify is not None)
+        self.assertIsNotNone(ex.notify)
         # mongoengine DateTimeField stores datetime only up to milliseconds
         self.assertEqual(isotime.format(ex.start_timestamp, usec=False),
                          isotime.format(req.start_timestamp, usec=False))

--- a/st2common/tests/unit/test_action_api_validator.py
+++ b/st2common/tests/unit/test_action_api_validator.py
@@ -71,7 +71,7 @@ class TestActionAPIValidator(DbTestCase):
             action_validator.validate_action(action_api)
             self.fail('Action validation should not have passed. %s' % json.dumps(action_api_dict))
         except ValueValidationException as e:
-            self.assertTrue('Cannot override in action.' in six.text_type(e))
+            self.assertIn('Cannot override in action.', six.text_type(e))
 
     @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(
         return_value=True))
@@ -82,7 +82,7 @@ class TestActionAPIValidator(DbTestCase):
             action_validator.validate_action(action_api)
             self.fail('Action validation should not have passed. %s' % json.dumps(action_api_dict))
         except ValueValidationException as e:
-            self.assertTrue('requires a default value.' in six.text_type(e))
+            self.assertIn('requires a default value.', six.text_type(e))
 
     @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(
         return_value=True))
@@ -109,7 +109,7 @@ class TestActionAPIValidator(DbTestCase):
             self.fail('Action validation should have failed ' +
                       'because position values are not unique.' % json.dumps(action_api_dict))
         except ValueValidationException as e:
-            self.assertTrue('have same position' in six.text_type(e))
+            self.assertIn('have same position', six.text_type(e))
 
     @mock.patch.object(action_validator, '_is_valid_pack', mock.MagicMock(
         return_value=True))
@@ -122,4 +122,4 @@ class TestActionAPIValidator(DbTestCase):
             self.fail('Action validation should have failed ' +
                       'because position values are not contiguous.' % json.dumps(action_api_dict))
         except ValueValidationException as e:
-            self.assertTrue('are not contiguous' in six.text_type(e))
+            self.assertIn('are not contiguous', six.text_type(e))

--- a/st2common/tests/unit/test_action_db_utils.py
+++ b/st2common/tests/unit/test_action_db_utils.py
@@ -329,8 +329,8 @@ class ActionDBUtilsTestCase(DbTestCase):
         pos_args, named_args = action_db_utils.get_args(params, ActionDBUtilsTestCase.action_db)
         self.assertListEqual(pos_args, ['20', '', 'foo', '', '', '', ''],
                             'Positional args not parsed correctly.')
-        self.assertTrue('actionint' not in named_args)
-        self.assertTrue('actionstr' not in named_args)
+        self.assertNotIn('actionint', named_args)
+        self.assertNotIn('actionstr', named_args)
         self.assertEqual(named_args.get('runnerint'), 555)
 
         # Test serialization for different positional argument types and values
@@ -416,8 +416,8 @@ class ActionDBUtilsTestCase(DbTestCase):
         ]
         pos_args, named_args = action_db_utils.get_args(params, ActionDBUtilsTestCase.action_db)
         self.assertListEqual(pos_args, expected_pos_args, 'Positional args not parsed correctly.')
-        self.assertTrue('actionint' not in named_args)
-        self.assertTrue('actionstr' not in named_args)
+        self.assertNotIn('actionint', named_args)
+        self.assertNotIn('actionstr', named_args)
         self.assertEqual(named_args.get('runnerint'), 555)
 
     @classmethod

--- a/st2common/tests/unit/test_action_db_utils.py
+++ b/st2common/tests/unit/test_action_db_utils.py
@@ -67,7 +67,7 @@ class ActionDBUtilsTestCase(DbTestCase):
                           'somedummyactionid')
         # By ref.
         action = action_db_utils.get_action_by_ref('packaintexist.somedummyactionname')
-        self.assertTrue(action is None)
+        self.assertIsNone(action)
 
     def test_get_action_existing(self):
         # Lookup by id and verify name equals

--- a/st2common/tests/unit/test_action_param_utils.py
+++ b/st2common/tests/unit/test_action_param_utils.py
@@ -83,8 +83,9 @@ class ActionParamsUtilsTest(DbTestCase):
         # Validate required params.
         self.assertEqual(len(required), 1, 'Required should contain only one param.')
         self.assertIn('actionstr', required, 'actionstr param is a required param.')
-        self.assertTrue('actionstr' not in optional and 'actionstr' not in immutable and
-                        'actionstr' in merged)
+        self.assertNotIn('actionstr', optional, 'actionstr should not be in optional parameters')
+        self.assertNotIn('actionstr', immutable, 'actionstr should not be in immutable parameters')
+        self.assertIn('actionstr', merged, 'actionstr should be in action parameters')
 
         # Validate immutable params.
         self.assertIn('runnerimmutable', immutable, 'runnerimmutable should be in immutable.')
@@ -92,8 +93,9 @@ class ActionParamsUtilsTest(DbTestCase):
 
         # Validate optional params.
         for opt in optional:
-            self.assertTrue(opt not in required and opt not in immutable and opt in merged,
-                            'Optional parameter %s failed validation.' % opt)
+            self.assertIn(opt, merged, 'Optional %s should be in action parameters' % opt)
+            self.assertNotIn(opt, required, 'Optional %s should not be in required params' % opt)
+            self.assertNotIn(opt, immutable, 'Optional %s should not be in immutable params' % opt)
 
     def test_merge_param_meta_values(self):
         runner_meta = copy.deepcopy(

--- a/st2common/tests/unit/test_action_param_utils.py
+++ b/st2common/tests/unit/test_action_param_utils.py
@@ -82,13 +82,13 @@ class ActionParamsUtilsTest(DbTestCase):
 
         # Validate required params.
         self.assertEqual(len(required), 1, 'Required should contain only one param.')
-        self.assertTrue('actionstr' in required, 'actionstr param is a required param.')
+        self.assertIn('actionstr', required, 'actionstr param is a required param.')
         self.assertTrue('actionstr' not in optional and 'actionstr' not in immutable and
                         'actionstr' in merged)
 
         # Validate immutable params.
-        self.assertTrue('runnerimmutable' in immutable, 'runnerimmutable should be in immutable.')
-        self.assertTrue('actionimmutable' in immutable, 'actionimmutable should be in immutable.')
+        self.assertIn('runnerimmutable', immutable, 'runnerimmutable should be in immutable.')
+        self.assertIn('actionimmutable', immutable, 'actionimmutable should be in immutable.')
 
         # Validate optional params.
         for opt in optional:

--- a/st2common/tests/unit/test_actionchain_schema.py
+++ b/st2common/tests/unit/test_actionchain_schema.py
@@ -37,24 +37,24 @@ class ActionChainSchemaTest(unittest2.TestCase):
 
     def test_actionchain_schema_valid(self):
         chain = actionchain.ActionChain(**CHAIN_1)
-        self.assertEquals(len(chain.chain), len(CHAIN_1['chain']))
-        self.assertEquals(chain.default, CHAIN_1['default'])
+        self.assertEqual(len(chain.chain), len(CHAIN_1['chain']))
+        self.assertEqual(chain.default, CHAIN_1['default'])
 
     def test_actionchain_no_default(self):
         chain = actionchain.ActionChain(**NO_DEFAULT_CHAIN)
-        self.assertEquals(len(chain.chain), len(NO_DEFAULT_CHAIN['chain']))
-        self.assertEquals(chain.default, None)
+        self.assertEqual(len(chain.chain), len(NO_DEFAULT_CHAIN['chain']))
+        self.assertEqual(chain.default, None)
 
     def test_actionchain_with_vars(self):
         chain = actionchain.ActionChain(**CHAIN_WITH_VARS)
-        self.assertEquals(len(chain.chain), len(CHAIN_WITH_VARS['chain']))
-        self.assertEquals(len(chain.vars), len(CHAIN_WITH_VARS['vars']))
+        self.assertEqual(len(chain.chain), len(CHAIN_WITH_VARS['chain']))
+        self.assertEqual(len(chain.vars), len(CHAIN_WITH_VARS['vars']))
 
     def test_actionchain_with_publish(self):
         chain = actionchain.ActionChain(**CHAIN_WITH_PUBLISH)
-        self.assertEquals(len(chain.chain), len(CHAIN_WITH_PUBLISH['chain']))
-        self.assertEquals(len(chain.chain[0].publish),
-                          len(CHAIN_WITH_PUBLISH['chain'][0]['publish']))
+        self.assertEqual(len(chain.chain), len(CHAIN_WITH_PUBLISH['chain']))
+        self.assertEqual(len(chain.chain[0].publish),
+                         len(CHAIN_WITH_PUBLISH['chain'][0]['publish']))
 
     def test_actionchain_schema_invalid(self):
         with self.assertRaises(ValidationError):

--- a/st2common/tests/unit/test_config_loader.py
+++ b/st2common/tests/unit/test_config_loader.py
@@ -398,7 +398,7 @@ class ContentPackConfigLoaderTestCase(CleanDbTestCase):
 
         config_rendered = loader.get_config()
 
-        self.assertEquals(config_rendered, {'level0_key': 'v1'})
+        self.assertEqual(config_rendered, {'level0_key': 'v1'})
 
         config_db.delete()
 
@@ -426,16 +426,16 @@ class ContentPackConfigLoaderTestCase(CleanDbTestCase):
 
         config_rendered = loader.get_config()
 
-        self.assertEquals(config_rendered,
-                          {
-                              'level0_key': 'v0',
-                              'level0_object': {
-                                  'level1_key': 'v1',
-                                  'level1_object': {
-                                      'level2_key': 'v2'
-                                  }
-                              }
-                          })
+        self.assertEqual(config_rendered,
+                         {
+                             'level0_key': 'v0',
+                             'level0_object': {
+                                 'level1_key': 'v1',
+                                 'level1_object': {
+                                     'level2_key': 'v2'
+                                 }
+                             }
+                         })
 
         config_db.delete()
 
@@ -461,15 +461,15 @@ class ContentPackConfigLoaderTestCase(CleanDbTestCase):
 
         config_rendered = loader.get_config()
 
-        self.assertEquals(config_rendered,
-                          {
-                              'level0_key': [
-                                  'a',
-                                  'v0',
-                                  'b',
-                                  'v1'
-                              ]
-                          })
+        self.assertEqual(config_rendered,
+                         {
+                             'level0_key': [
+                                 'a',
+                                 'v0',
+                                 'b',
+                                 'v1'
+                             ]
+                         })
 
         config_db.delete()
 
@@ -506,25 +506,25 @@ class ContentPackConfigLoaderTestCase(CleanDbTestCase):
 
         config_rendered = loader.get_config()
 
-        self.assertEquals(config_rendered,
-                          {
-                              'level0_key': [
-                                  {
-                                      'level1_key0': 'v0'
-                                  },
-                                  'v1',
-                                  [
-                                      'v0',
-                                      'v1',
-                                      'v2',
-                                  ],
-                                  {
-                                      'level1_key2': [
-                                          'v2',
-                                      ]
-                                  }
-                              ]
-                          })
+        self.assertEqual(config_rendered,
+                         {
+                             'level0_key': [
+                                 {
+                                     'level1_key0': 'v0'
+                                 },
+                                 'v1',
+                                 [
+                                     'v0',
+                                     'v1',
+                                     'v2',
+                                 ],
+                                 {
+                                     'level1_key2': [
+                                         'v2',
+                                     ]
+                                 }
+                             ]
+                         })
 
         config_db.delete()
 

--- a/st2common/tests/unit/test_content_loader.py
+++ b/st2common/tests/unit/test_content_loader.py
@@ -53,8 +53,8 @@ class ContentLoaderTest(unittest2.TestCase):
 
         loader = ContentPackLoader()
         sensors = loader.get_content(base_dirs=base_dirs, content_type='sensors')
-        self.assertTrue('pack1' in sensors)  # from packs/
-        self.assertTrue('pack3' in sensors)  # from packs2/
+        self.assertIn('pack1', sensors)  # from packs/
+        self.assertIn('pack3', sensors)  # from packs2/
 
         # Assert that a warning is emitted when a duplicated pack is found
         expected_msg = ('Pack "pack1" already found in '

--- a/st2common/tests/unit/test_content_loader.py
+++ b/st2common/tests/unit/test_content_loader.py
@@ -30,7 +30,7 @@ class ContentLoaderTest(unittest2.TestCase):
         packs_base_path = os.path.join(RESOURCES_DIR, 'packs/')
         loader = ContentPackLoader()
         pack_sensors = loader.get_content(base_dirs=[packs_base_path], content_type='sensors')
-        self.assertTrue(pack_sensors.get('pack1', None) is not None)
+        self.assertIsNotNone(pack_sensors.get('pack1', None))
 
     def test_get_sensors_pack_missing_sensors(self):
         loader = ContentPackLoader()

--- a/st2common/tests/unit/test_crypto_utils.py
+++ b/st2common/tests/unit/test_crypto_utils.py
@@ -91,7 +91,7 @@ class CryptoUtilsTestCase(TestCase):
 
         for _ in range(0, 10000):
             crypto = symmetric_encrypt(CryptoUtilsTestCase.test_crypto_key, original)
-            self.assertTrue(crypto not in cryptos)
+            self.assertNotIn(crypto, cryptos)
             cryptos.add(crypto)
 
     def test_decrypt_ciphertext_is_too_short(self):

--- a/st2common/tests/unit/test_datastore.py
+++ b/st2common/tests/unit/test_datastore.py
@@ -105,8 +105,8 @@ class DatastoreServiceTestCase(DbTestCase):
         value = self._datastore_service.set_value(name='test1', value='foo', local=False)
         self.assertTrue(value)
         kvp = mock_api_client.keys.update.call_args[1]['instance']
-        self.assertEquals(kvp.value, 'foo')
-        self.assertEquals(kvp.scope, SYSTEM_SCOPE)
+        self.assertEqual(kvp.value, 'foo')
+        self.assertEqual(kvp.scope, SYSTEM_SCOPE)
 
     def test_datastore_operations_delete_value(self):
         mock_api_client = mock.Mock()
@@ -124,9 +124,9 @@ class DatastoreServiceTestCase(DbTestCase):
             encrypt=True)
         self.assertTrue(value)
         kvp = mock_api_client.keys.update.call_args[1]['instance']
-        self.assertEquals(kvp.value, 'foo')
+        self.assertEqual(kvp.value, 'foo')
         self.assertTrue(kvp.secret)
-        self.assertEquals(kvp.scope, SYSTEM_SCOPE)
+        self.assertEqual(kvp.scope, SYSTEM_SCOPE)
 
     def test_datastore_unsupported_scope(self):
         self.assertRaises(ValueError, self._datastore_service.get_value, name='test1',
@@ -141,14 +141,14 @@ class DatastoreServiceTestCase(DbTestCase):
         mock_api_client.keys.get_by_id.side_effect = ValueError("Exception test")
         self._set_mock_api_client(mock_api_client)
         value = self._datastore_service.get_value(name='test1')
-        self.assertEquals(value, None)
+        self.assertEqual(value, None)
 
     def test_datastore_delete_exception(self):
         mock_api_client = mock.Mock()
         mock_api_client.keys.delete.side_effect = ValueError("Exception test")
         self._set_mock_api_client(mock_api_client)
         delete_success = self._datastore_service.delete_value(name='test1')
-        self.assertEquals(delete_success, False)
+        self.assertEqual(delete_success, False)
 
     def test_datastore_token_timeout(self):
         datastore_service = SensorDatastoreService(logger=mock.Mock(),

--- a/st2common/tests/unit/test_db.py
+++ b/st2common/tests/unit/test_db.py
@@ -111,7 +111,7 @@ class DbConnectionTestCase(DbTestCase):
         client = mongoengine.connection.get_connection()
 
         expected_str = "host=['%s:%s']" % (cfg.CONF.database.host, cfg.CONF.database.port)
-        self.assertTrue(expected_str in str(client), 'Not connected to desired host.')
+        self.assertIn(expected_str, str(client), 'Not connected to desired host.')
 
     def test_get_ssl_kwargs(self):
         # 1. No SSL kwargs provided

--- a/st2common/tests/unit/test_db_execution.py
+++ b/st2common/tests/unit/test_db_execution.py
@@ -132,7 +132,7 @@ class ActionExecutionModelTest(DbTestCase):
     def test_update_execution(self):
         """Test ActionExecutionDb update
         """
-        self.assertTrue(self.executions['execution_1'].end_timestamp is None)
+        self.assertIsNone(self.executions['execution_1'].end_timestamp)
         self.executions['execution_1'].end_timestamp = date_utils.get_datetime_utc_now()
         updated = ActionExecution.add_or_update(self.executions['execution_1'])
         self.assertTrue(updated.end_timestamp == self.executions['execution_1'].end_timestamp)

--- a/st2common/tests/unit/test_db_liveaction.py
+++ b/st2common/tests/unit/test_db_liveaction.py
@@ -41,7 +41,7 @@ class LiveActionModelTest(DbTestCase):
         self.assertEqual(retrieved.notify, None)
 
         # Test update
-        self.assertTrue(retrieved.end_timestamp is None)
+        self.assertIsNone(retrieved.end_timestamp)
         retrieved.end_timestamp = date_utils.get_datetime_utc_now()
         updated = LiveAction.add_or_update(retrieved)
         self.assertTrue(updated.end_timestamp == retrieved.end_timestamp)

--- a/st2common/tests/unit/test_db_rule_enforcement.py
+++ b/st2common/tests/unit/test_db_rule_enforcement.py
@@ -40,7 +40,7 @@ class RuleEnforcementModelTest(DbTestCase):
         retrieved = RuleEnforcement.get_by_id(saved.id)
         self.assertEqual(saved.rule.ref, retrieved.rule.ref,
                          'Same rule enforcement was not returned.')
-        self.assertTrue(retrieved.enforced_at is not None)
+        self.assertIsNotNone(retrieved.enforced_at)
         # test update
         RULE_ID = str(bson.ObjectId())
         self.assertEqual(retrieved.rule.id, None)

--- a/st2common/tests/unit/test_db_trace.py
+++ b/st2common/tests/unit/test_db_trace.py
@@ -31,7 +31,7 @@ class TraceDBTest(CleanDbTestCase):
             rules=[str(bson.ObjectId()) for _ in range(4)],
             trigger_instances=[str(bson.ObjectId()) for _ in range(5)])
         retrieved = Trace.get(id=saved.id)
-        self.assertEquals(retrieved.id, saved.id, 'Incorrect trace retrieved.')
+        self.assertEqual(retrieved.id, saved.id, 'Incorrect trace retrieved.')
 
     def test_query(self):
         saved = TraceDBTest._create_save_trace(
@@ -40,8 +40,8 @@ class TraceDBTest(CleanDbTestCase):
             rules=[str(bson.ObjectId()) for _ in range(4)],
             trigger_instances=[str(bson.ObjectId()) for _ in range(5)])
         retrieved = Trace.query(trace_tag=saved.trace_tag)
-        self.assertEquals(len(retrieved), 1, 'Should have 1 trace.')
-        self.assertEquals(retrieved[0].id, saved.id, 'Incorrect trace retrieved.')
+        self.assertEqual(len(retrieved), 1, 'Should have 1 trace.')
+        self.assertEqual(retrieved[0].id, saved.id, 'Incorrect trace retrieved.')
 
         # Add another trace with same trace_tag and confirm that we support.
         # This is most likley an anti-pattern for the trace_tag but it is an unknown.
@@ -51,7 +51,7 @@ class TraceDBTest(CleanDbTestCase):
             rules=[str(bson.ObjectId()) for _ in range(4)],
             trigger_instances=[str(bson.ObjectId()) for _ in range(3)])
         retrieved = Trace.query(trace_tag=saved.trace_tag)
-        self.assertEquals(len(retrieved), 2, 'Should have 2 traces.')
+        self.assertEqual(len(retrieved), 2, 'Should have 2 traces.')
 
     def test_update(self):
         saved = TraceDBTest._create_save_trace(
@@ -60,8 +60,8 @@ class TraceDBTest(CleanDbTestCase):
             rules=[],
             trigger_instances=[])
         retrieved = Trace.query(trace_tag=saved.trace_tag)
-        self.assertEquals(len(retrieved), 1, 'Should have 1 trace.')
-        self.assertEquals(retrieved[0].id, saved.id, 'Incorrect trace retrieved.')
+        self.assertEqual(len(retrieved), 1, 'Should have 1 trace.')
+        self.assertEqual(retrieved[0].id, saved.id, 'Incorrect trace retrieved.')
 
         no_action_executions = 4
         no_rules = 4
@@ -74,14 +74,14 @@ class TraceDBTest(CleanDbTestCase):
             trigger_instances=[str(bson.ObjectId()) for _ in range(no_trigger_instances)])
         retrieved = Trace.query(trace_tag=saved.trace_tag)
 
-        self.assertEquals(len(retrieved), 1, 'Should have 1 trace.')
-        self.assertEquals(retrieved[0].id, saved.id, 'Incorrect trace retrieved.')
+        self.assertEqual(len(retrieved), 1, 'Should have 1 trace.')
+        self.assertEqual(retrieved[0].id, saved.id, 'Incorrect trace retrieved.')
         # validate update
-        self.assertEquals(len(retrieved[0].action_executions), no_action_executions,
-                          'Failed to update action_executions.')
-        self.assertEquals(len(retrieved[0].rules), no_rules, 'Failed to update rules.')
-        self.assertEquals(len(retrieved[0].trigger_instances), no_trigger_instances,
-                          'Failed to update trigger_instances.')
+        self.assertEqual(len(retrieved[0].action_executions), no_action_executions,
+                         'Failed to update action_executions.')
+        self.assertEqual(len(retrieved[0].rules), no_rules, 'Failed to update rules.')
+        self.assertEqual(len(retrieved[0].trigger_instances), no_trigger_instances,
+                         'Failed to update trigger_instances.')
 
     def test_update_via_list_push(self):
         no_action_executions = 4
@@ -101,10 +101,10 @@ class TraceDBTest(CleanDbTestCase):
             saved, trigger_instance=TraceComponentDB(object_id=str(bson.ObjectId())))
 
         retrieved = Trace.get(id=saved.id)
-        self.assertEquals(retrieved.id, saved.id, 'Incorrect trace retrieved.')
-        self.assertEquals(len(retrieved.action_executions), no_action_executions + 1)
-        self.assertEquals(len(retrieved.rules), no_rules + 1)
-        self.assertEquals(len(retrieved.trigger_instances), no_trigger_instances + 1)
+        self.assertEqual(retrieved.id, saved.id, 'Incorrect trace retrieved.')
+        self.assertEqual(len(retrieved.action_executions), no_action_executions + 1)
+        self.assertEqual(len(retrieved.rules), no_rules + 1)
+        self.assertEqual(len(retrieved.trigger_instances), no_trigger_instances + 1)
 
     def test_update_via_list_push_components(self):
         no_action_executions = 4
@@ -125,10 +125,10 @@ class TraceDBTest(CleanDbTestCase):
             trigger_instances=[TraceComponentDB(object_id=str(bson.ObjectId()))
                                for _ in range(no_trigger_instances)])
 
-        self.assertEquals(retrieved.id, saved.id, 'Incorrect trace retrieved.')
-        self.assertEquals(len(retrieved.action_executions), no_action_executions * 2)
-        self.assertEquals(len(retrieved.rules), no_rules * 2)
-        self.assertEquals(len(retrieved.trigger_instances), no_trigger_instances * 2)
+        self.assertEqual(retrieved.id, saved.id, 'Incorrect trace retrieved.')
+        self.assertEqual(len(retrieved.action_executions), no_action_executions * 2)
+        self.assertEqual(len(retrieved.rules), no_rules * 2)
+        self.assertEqual(len(retrieved.trigger_instances), no_trigger_instances * 2)
 
     @staticmethod
     def _create_save_trace(trace_tag, id_=None, action_executions=None, rules=None,

--- a/st2common/tests/unit/test_executions.py
+++ b/st2common/tests/unit/test_executions.py
@@ -84,7 +84,7 @@ class TestActionExecutionHistoryModel(DbTestCase):
         self.assertDictEqual(obj.rule, self.fake_history_workflow['rule'])
         self.assertDictEqual(obj.action, self.fake_history_workflow['action'])
         self.assertDictEqual(obj.runner, self.fake_history_workflow['runner'])
-        self.assertEquals(obj.liveaction, self.fake_history_workflow['liveaction'])
+        self.assertEqual(obj.liveaction, self.fake_history_workflow['liveaction'])
         self.assertIsNone(getattr(obj, 'parent', None))
         self.assertListEqual(obj.children, self.fake_history_workflow['children'])
 

--- a/st2common/tests/unit/test_executions_util.py
+++ b/st2common/tests/unit/test_executions_util.py
@@ -127,7 +127,7 @@ class ExecutionsUtilTestCase(CleanDbTestCase):
                                                raise_exception=True)
         self.assertTrue(execution.web_url is not None)
         execution_id = str(execution.id)
-        self.assertTrue(('history/%s/general' % execution_id) in execution.web_url)
+        self.assertIn(('history/%s/general' % execution_id), execution.web_url)
 
     def test_execution_creation_chains(self):
         childliveaction = self.MODELS['liveactions']['childliveaction.yaml']
@@ -135,7 +135,7 @@ class ExecutionsUtilTestCase(CleanDbTestCase):
         parent_execution_id = childliveaction.context['parent']['execution_id']
         parent_execution = ActionExecution.get_by_id(parent_execution_id)
         child_execs = parent_execution.children
-        self.assertTrue(str(child_exec.id) in child_execs)
+        self.assertIn(str(child_exec.id), child_execs)
 
     def test_execution_update(self):
         liveaction = self.MODELS['liveactions']['liveaction1.yaml']

--- a/st2common/tests/unit/test_executions_util.py
+++ b/st2common/tests/unit/test_executions_util.py
@@ -125,7 +125,7 @@ class ExecutionsUtilTestCase(CleanDbTestCase):
         executions_util.create_execution_object(liveaction)
         execution = self._get_action_execution(liveaction__id=str(liveaction.id),
                                                raise_exception=True)
-        self.assertTrue(execution.web_url is not None)
+        self.assertIsNotNone(execution.web_url)
         execution_id = str(execution.id)
         self.assertIn(('history/%s/general' % execution_id), execution.web_url)
 

--- a/st2common/tests/unit/test_executions_util.py
+++ b/st2common/tests/unit/test_executions_util.py
@@ -83,9 +83,9 @@ class ExecutionsUtilTestCase(CleanDbTestCase):
         runner = RunnerType.get_by_name(action.runner_type['name'])
         self.assertDictEqual(execution.runner, vars(RunnerTypeAPI.from_model(runner)))
         liveaction = LiveAction.get_by_id(str(liveaction.id))
-        self.assertEquals(execution.liveaction['id'], str(liveaction.id))
-        self.assertEquals(len(execution.log), 1)
-        self.assertEquals(execution.log[0]['status'], liveaction.status)
+        self.assertEqual(execution.liveaction['id'], str(liveaction.id))
+        self.assertEqual(len(execution.log), 1)
+        self.assertEqual(execution.log[0]['status'], liveaction.status)
         self.assertGreater(execution.log[0]['timestamp'], pre_creation_timestamp)
         self.assertLess(execution.log[0]['timestamp'], post_creation_timestamp)
 
@@ -118,7 +118,7 @@ class ExecutionsUtilTestCase(CleanDbTestCase):
         runner = RunnerType.get_by_name(action.runner_type['name'])
         self.assertDictEqual(execution.runner, vars(RunnerTypeAPI.from_model(runner)))
         liveaction = LiveAction.get_by_id(str(liveaction.id))
-        self.assertEquals(execution.liveaction['id'], str(liveaction.id))
+        self.assertEqual(execution.liveaction['id'], str(liveaction.id))
 
     def test_execution_creation_with_web_url(self):
         liveaction = self.MODELS['liveactions']['liveaction1.yaml']
@@ -146,8 +146,8 @@ class ExecutionsUtilTestCase(CleanDbTestCase):
         post_update_timestamp = date_utils.get_datetime_utc_now()
         execution = self._get_action_execution(liveaction__id=str(liveaction.id),
                                                raise_exception=True)
-        self.assertEquals(len(execution.log), 2)
-        self.assertEquals(execution.log[1]['status'], liveaction.status)
+        self.assertEqual(len(execution.log), 2)
+        self.assertEqual(execution.log[1]['status'], liveaction.status)
         self.assertGreater(execution.log[1]['timestamp'], pre_update_timestamp)
         self.assertLess(execution.log[1]['timestamp'], post_update_timestamp)
 
@@ -159,7 +159,7 @@ class ExecutionsUtilTestCase(CleanDbTestCase):
         execution_db = executions_util.abandon_execution_if_incomplete(
             liveaction_id=str(liveaction_db.id))
 
-        self.assertEquals(execution_db.status, 'abandoned')
+        self.assertEqual(execution_db.status, 'abandoned')
 
         runners_utils.invoke_post_run.assert_called_once()
 

--- a/st2common/tests/unit/test_jsonify.py
+++ b/st2common/tests/unit/test_jsonify.py
@@ -22,7 +22,7 @@ class JsonifyTests(unittest2.TestCase):
 
     def test_none_object(self):
         obj = None
-        self.assertTrue(jsonify.json_loads(obj) is None)
+        self.assertIsNone(jsonify.json_loads(obj))
 
     def test_no_keys(self):
         obj = {'foo': '{"bar": "baz"}'}

--- a/st2common/tests/unit/test_keyvalue_lookup.py
+++ b/st2common/tests/unit/test_keyvalue_lookup.py
@@ -42,15 +42,15 @@ class TestKeyValueLookup(CleanDbTestCase):
                                                        scope=FULL_USER_SCOPE))
 
         lookup = KeyValueLookup()
-        self.assertEquals(str(lookup.k1), k1.value)
-        self.assertEquals(str(lookup.k2), k2.value)
-        self.assertEquals(str(lookup.k3), k3.value)
+        self.assertEqual(str(lookup.k1), k1.value)
+        self.assertEqual(str(lookup.k2), k2.value)
+        self.assertEqual(str(lookup.k3), k3.value)
 
         # Scoped lookup
         lookup = KeyValueLookup(scope=FULL_SYSTEM_SCOPE)
-        self.assertEquals(str(lookup.k4), '')
+        self.assertEqual(str(lookup.k4), '')
         user_lookup = UserKeyValueLookup(scope=FULL_USER_SCOPE, user='stanley')
-        self.assertEquals(str(user_lookup.k4), k4.value)
+        self.assertEqual(str(user_lookup.k4), k4.value)
 
     def test_hierarchical_lookup_dotted(self):
         k1 = KeyValuePair.add_or_update(KeyValuePairDB(name='a.b', value='v1'))
@@ -60,16 +60,16 @@ class TestKeyValueLookup(CleanDbTestCase):
                                                        scope=FULL_USER_SCOPE))
 
         lookup = KeyValueLookup()
-        self.assertEquals(str(lookup.a.b), k1.value)
-        self.assertEquals(str(lookup.a.b.c), k2.value)
-        self.assertEquals(str(lookup.b.c), k3.value)
-        self.assertEquals(str(lookup.a), '')
+        self.assertEqual(str(lookup.a.b), k1.value)
+        self.assertEqual(str(lookup.a.b.c), k2.value)
+        self.assertEqual(str(lookup.b.c), k3.value)
+        self.assertEqual(str(lookup.a), '')
 
         # Scoped lookup
         lookup = KeyValueLookup(scope=FULL_SYSTEM_SCOPE)
-        self.assertEquals(str(lookup.r.i.p), '')
+        self.assertEqual(str(lookup.r.i.p), '')
         user_lookup = UserKeyValueLookup(scope=FULL_USER_SCOPE, user='stanley')
-        self.assertEquals(str(user_lookup.r.i.p), k4.value)
+        self.assertEqual(str(user_lookup.r.i.p), k4.value)
 
     def test_hierarchical_lookup_dict(self):
         k1 = KeyValuePair.add_or_update(KeyValuePairDB(name='a.b', value='v1'))
@@ -79,34 +79,34 @@ class TestKeyValueLookup(CleanDbTestCase):
                                                        scope=FULL_USER_SCOPE))
 
         lookup = KeyValueLookup()
-        self.assertEquals(str(lookup['a']['b']), k1.value)
-        self.assertEquals(str(lookup['a']['b']['c']), k2.value)
-        self.assertEquals(str(lookup['b']['c']), k3.value)
-        self.assertEquals(str(lookup['a']), '')
+        self.assertEqual(str(lookup['a']['b']), k1.value)
+        self.assertEqual(str(lookup['a']['b']['c']), k2.value)
+        self.assertEqual(str(lookup['b']['c']), k3.value)
+        self.assertEqual(str(lookup['a']), '')
 
         # Scoped lookup
         lookup = KeyValueLookup(scope=FULL_SYSTEM_SCOPE)
-        self.assertEquals(str(lookup['r']['i']['p']), '')
+        self.assertEqual(str(lookup['r']['i']['p']), '')
         user_lookup = UserKeyValueLookup(scope=FULL_USER_SCOPE, user='stanley')
-        self.assertEquals(str(user_lookup['r']['i']['p']), k4.value)
+        self.assertEqual(str(user_lookup['r']['i']['p']), k4.value)
 
     def test_lookups_older_scope_names_backward_compatibility(self):
         k1 = KeyValuePair.add_or_update(KeyValuePairDB(name='a.b', value='v1',
                                                        scope=FULL_SYSTEM_SCOPE))
         lookup = KeyValueLookup(scope=SYSTEM_SCOPE)
-        self.assertEquals(str(lookup['a']['b']), k1.value)
+        self.assertEqual(str(lookup['a']['b']), k1.value)
 
         k2 = KeyValuePair.add_or_update(KeyValuePairDB(name='stanley:r.i.p', value='v4',
                                                        scope=FULL_USER_SCOPE))
         user_lookup = UserKeyValueLookup(scope=USER_SCOPE, user='stanley')
-        self.assertEquals(str(user_lookup['r']['i']['p']), k2.value)
+        self.assertEqual(str(user_lookup['r']['i']['p']), k2.value)
 
     def test_user_scope_lookups_dot_in_user(self):
         KeyValuePair.add_or_update(KeyValuePairDB(name='first.last:r.i.p', value='v4',
                                                   scope=FULL_USER_SCOPE))
         lookup = UserKeyValueLookup(scope=FULL_USER_SCOPE, user='first.last')
-        self.assertEquals(str(lookup.r.i.p), 'v4')
-        self.assertEquals(str(lookup['r']['i']['p']), 'v4')
+        self.assertEqual(str(lookup.r.i.p), 'v4')
+        self.assertEqual(str(lookup['r']['i']['p']), 'v4')
 
     def test_user_scope_lookups_user_sep_in_name(self):
         KeyValuePair.add_or_update(KeyValuePairDB(name='stanley:r:i:p', value='v4',
@@ -114,15 +114,15 @@ class TestKeyValueLookup(CleanDbTestCase):
         lookup = UserKeyValueLookup(scope=FULL_USER_SCOPE, user='stanley')
         # This is the only way to lookup because USER_SEPARATOR (':') cannot be a part of
         # variable name in Python.
-        self.assertEquals(str(lookup['r:i:p']), 'v4')
+        self.assertEqual(str(lookup['r:i:p']), 'v4')
 
     def test_missing_key_lookup(self):
         lookup = KeyValueLookup(scope=FULL_SYSTEM_SCOPE)
-        self.assertEquals(str(lookup.missing_key), '')
+        self.assertEqual(str(lookup.missing_key), '')
         self.assertTrue(lookup.missing_key, 'Should be not none.')
 
         user_lookup = UserKeyValueLookup(scope=FULL_USER_SCOPE, user='stanley')
-        self.assertEquals(str(user_lookup.missing_key), '')
+        self.assertEqual(str(user_lookup.missing_key), '')
         self.assertTrue(user_lookup.missing_key, 'Should be not none.')
 
     def test_secret_lookup(self):
@@ -139,12 +139,12 @@ class TestKeyValueLookup(CleanDbTestCase):
         )
 
         lookup = KeyValueLookup()
-        self.assertEquals(str(lookup.k1), k1.value)
-        self.assertEquals(str(lookup.k2), k2.value)
-        self.assertEquals(str(lookup.k3), '')
+        self.assertEqual(str(lookup.k1), k1.value)
+        self.assertEqual(str(lookup.k2), k2.value)
+        self.assertEqual(str(lookup.k3), '')
 
         user_lookup = UserKeyValueLookup(scope=FULL_USER_SCOPE, user='stanley')
-        self.assertEquals(str(user_lookup.k3), k3.value)
+        self.assertEqual(str(user_lookup.k3), k3.value)
 
     def test_lookup_cast(self):
         KeyValuePair.add_or_update(KeyValuePairDB(name='count', value='5.5'))

--- a/st2common/tests/unit/test_logger.py
+++ b/st2common/tests/unit/test_logger.py
@@ -252,7 +252,7 @@ class ConsoleLogFormatterTestCase(unittest.TestCase):
                              r"u?'parameter2': u?'\*\*\*\*\*\*\*\*'}")
 
         message = formatter.format(record=record)
-        self.assertTrue('test message 1' in message)
+        self.assertIn('test message 1', message)
         self.assertRegexpMatches(message, expected_msg_part)
 
 
@@ -277,7 +277,7 @@ class GelfLogFormatterTestCase(unittest.TestCase):
         parsed = json.loads(message)
 
         for key in expected_keys:
-            self.assertTrue(key in parsed)
+            self.assertIn(key, parsed)
 
         self.assertEqual(parsed['short_message'], mock_message)
         self.assertEqual(parsed['full_message'], mock_message)
@@ -298,7 +298,7 @@ class GelfLogFormatterTestCase(unittest.TestCase):
         parsed = json.loads(message)
 
         for key in expected_keys:
-            self.assertTrue(key in parsed)
+            self.assertIn(key, parsed)
 
         self.assertEqual(parsed['short_message'], mock_message)
         self.assertEqual(parsed['full_message'], mock_message)
@@ -327,13 +327,13 @@ class GelfLogFormatterTestCase(unittest.TestCase):
         parsed = json.loads(message)
 
         for key in expected_keys:
-            self.assertTrue(key in parsed)
+            self.assertIn(key, parsed)
 
         self.assertEqual(parsed['short_message'], mock_message)
-        self.assertTrue(mock_message in parsed['full_message'])
-        self.assertTrue('Traceback' in parsed['full_message'])
-        self.assertTrue('_exception' in parsed)
-        self.assertTrue('_traceback' in parsed)
+        self.assertIn(mock_message, parsed['full_message'])
+        self.assertIn('Traceback', parsed['full_message'])
+        self.assertIn('_exception', parsed)
+        self.assertIn('_traceback', parsed)
 
     def test_extra_object_serialization(self):
         class MyClass1(object):

--- a/st2common/tests/unit/test_logger.py
+++ b/st2common/tests/unit/test_logger.py
@@ -306,7 +306,7 @@ class GelfLogFormatterTestCase(unittest.TestCase):
         self.assertEqual(parsed['_value'], 'bar')
         self.assertEqual(parsed['timestamp'], 1234)
         self.assertEqual(parsed['timestamp_f'], 1234.5678)
-        self.assertTrue('ignored' not in parsed)
+        self.assertNotIn('ignored', parsed)
 
         # Record with an exception
         mock_exception = Exception('mock exception bar')

--- a/st2common/tests/unit/test_metrics.py
+++ b/st2common/tests/unit/test_metrics.py
@@ -289,7 +289,7 @@ class TestTimerContextManager(unittest2.TestCase):
                 (end_time - middle_time).total_seconds()
             )
             time_delta = timer.get_time_delta()
-            self.assertEquals(
+            self.assertEqual(
                 time_delta.total_seconds(),
                 (end_time - middle_time).total_seconds()
             )
@@ -330,7 +330,7 @@ class TestCounterWithTimerContextManager(unittest2.TestCase):
                 (self.end_time - self.middle_time).total_seconds()
             )
             time_delta = timer.get_time_delta()
-            self.assertEquals(
+            self.assertEqual(
                 time_delta.total_seconds(),
                 (self.end_time - self.middle_time).total_seconds()
             )
@@ -373,7 +373,7 @@ class TestCounterWithTimerDecorator(unittest2.TestCase):
                 (end_time - middle_time).total_seconds()
             )
             time_delta = metrics_counter_with_timer.get_time_delta()
-            self.assertEquals(
+            self.assertEqual(
                 time_delta.total_seconds(),
                 (end_time - middle_time).total_seconds()
             )
@@ -431,7 +431,7 @@ class TestTimerDecorator(unittest2.TestCase):
                 (end_time - middle_time).total_seconds()
             )
             time_delta = metrics_timer.get_time_delta()
-            self.assertEquals(
+            self.assertEqual(
                 time_delta.total_seconds(),
                 (end_time - middle_time).total_seconds()
             )

--- a/st2common/tests/unit/test_metrics.py
+++ b/st2common/tests/unit/test_metrics.py
@@ -275,7 +275,7 @@ class TestTimerContextManager(unittest2.TestCase):
         ]
         test_key = "test_key"
         with base.Timer(test_key) as timer:
-            self.assertTrue(isinstance(timer._start_time, datetime))
+            self.assertIsInstance(timer._start_time, datetime)
             metrics_patch.time.assert_not_called()
             timer.send_time()
             metrics_patch.time.assert_called_with(
@@ -317,7 +317,7 @@ class TestCounterWithTimerContextManager(unittest2.TestCase):
         ]
         test_key = "test_key"
         with base.CounterWithTimer(test_key) as timer:
-            self.assertTrue(isinstance(timer._start_time, datetime))
+            self.assertIsInstance(timer._start_time, datetime)
             metrics_patch.time.assert_not_called()
             timer.send_time()
             metrics_patch.time.assert_called_with(test_key,
@@ -360,7 +360,7 @@ class TestCounterWithTimerDecorator(unittest2.TestCase):
 
         @base.CounterWithTimer(test_key, include_parameter=True)
         def _get_tested(metrics_counter_with_timer=None):
-            self.assertTrue(isinstance(metrics_counter_with_timer._start_time, datetime))
+            self.assertIsInstance(metrics_counter_with_timer._start_time, datetime)
             metrics_patch.time.assert_not_called()
             metrics_counter_with_timer.send_time()
             metrics_patch.time.assert_called_with(test_key,
@@ -417,7 +417,7 @@ class TestTimerDecorator(unittest2.TestCase):
 
         @base.Timer(test_key, include_parameter=True)
         def _get_tested(metrics_timer=None):
-            self.assertTrue(isinstance(metrics_timer._start_time, datetime))
+            self.assertIsInstance(metrics_timer._start_time, datetime)
             metrics_patch.time.assert_not_called()
             metrics_timer.send_time()
             metrics_patch.time.assert_called_with(

--- a/st2common/tests/unit/test_model_utils_profiling.py
+++ b/st2common/tests/unit/test_model_utils_profiling.py
@@ -49,9 +49,9 @@ class MongoDBProfilingTestCase(DbTestCase):
         expected_result = ("db.user_d_b.find({'name': {'$in': ['test1', 'test2']}})"
                            ".sort({aa: 1, bb: -1}).limit(1);")
         self.assertEqual(queryset, result)
-        self.assertTrue(expected_result in call_args[0])
-        self.assertTrue('mongo_query' in call_kwargs['extra'])
-        self.assertTrue('mongo_shell_query' in call_kwargs['extra'])
+        self.assertIn(expected_result, call_args[0])
+        self.assertIn('mongo_query', call_kwargs['extra'])
+        self.assertIn('mongo_shell_query', call_kwargs['extra'])
 
     def test_logging_profiling_is_enabled_non_queryset_object(self):
         enable_profiling()

--- a/st2common/tests/unit/test_operators.py
+++ b/st2common/tests/unit/test_operators.py
@@ -874,8 +874,8 @@ class OperatorTest(unittest2.TestCase):
 
 class GetOperatorsTest(unittest2.TestCase):
     def test_get_operator(self):
-        self.assertTrue(bool(operators.get_operator('equals')))
-        self.assertTrue(bool(operators.get_operator('EQUALS')))
+        self.assertTrue(operators.get_operator('equals'))
+        self.assertTrue(operators.get_operator('EQUALS'))
 
     def test_get_operator_returns_same_operator_with_different_cases(self):
         equals = operators.get_operator('equals')

--- a/st2common/tests/unit/test_param_utils.py
+++ b/st2common/tests/unit/test_param_utils.py
@@ -308,7 +308,7 @@ class ParamsUtilsTest(DbTestCase):
         except ParamException as e:
             error_msg = 'Failed to render parameter "a2": \'dict object\' ' + \
                         'has no attribute \'lorem_ipsum\''
-            self.assertTrue(error_msg in six.text_type(e))
+            self.assertIn(error_msg, six.text_type(e))
             pass
 
     def test_unicode_value_casting(self):

--- a/st2common/tests/unit/test_param_utils.py
+++ b/st2common/tests/unit/test_param_utils.py
@@ -789,7 +789,7 @@ class ParamsUtilsTest(DbTestCase):
             'templateparam': '3'
         }
         result = param_utils._cast_params_from({}, context, schemas)
-        self.assertEquals(result, {})
+        self.assertEqual(result, {})
 
         # Test with no live params, and two parameters - one should make it through because
         # it was a template, and the other shouldn't because its default wasn't a template
@@ -805,7 +805,7 @@ class ParamsUtilsTest(DbTestCase):
             'templateparam': '3'
         }
         result = param_utils._cast_params_from({}, context, schemas)
-        self.assertEquals(result, {'templateparam': 3})
+        self.assertEqual(result, {'templateparam': 3})
 
         # Ensure parameter is skipped if the value in context is identical to default
         schemas = [
@@ -820,7 +820,7 @@ class ParamsUtilsTest(DbTestCase):
             'nottemplateparam': '4',
         }
         result = param_utils._cast_params_from({}, context, schemas)
-        self.assertEquals(result, {})
+        self.assertEqual(result, {})
 
         # Ensure parameter is skipped if the parameter doesn't have a default
         schemas = [
@@ -834,7 +834,7 @@ class ParamsUtilsTest(DbTestCase):
             'nottemplateparam': '4',
         }
         result = param_utils._cast_params_from({}, context, schemas)
-        self.assertEquals(result, {})
+        self.assertEqual(result, {})
 
         # Skip if the default value isn't a Jinja expression
         schemas = [
@@ -849,7 +849,7 @@ class ParamsUtilsTest(DbTestCase):
             'nottemplateparam': '4',
         }
         result = param_utils._cast_params_from({}, context, schemas)
-        self.assertEquals(result, {})
+        self.assertEqual(result, {})
 
         # Ensure parameter is skipped if the parameter is being overridden
         schemas = [
@@ -864,7 +864,7 @@ class ParamsUtilsTest(DbTestCase):
             'templateparam': '4',
         }
         result = param_utils._cast_params_from({'templateparam': '4'}, context, schemas)
-        self.assertEquals(result, {'templateparam': 4})
+        self.assertEqual(result, {'templateparam': 4})
 
     def test_render_final_params_and_shell_script_action_command_strings(self):
         runner_parameters = {}

--- a/st2common/tests/unit/test_param_utils.py
+++ b/st2common/tests/unit/test_param_utils.py
@@ -92,7 +92,7 @@ class ParamsUtilsTest(DbTestCase):
         self.assertEqual(action_params.get('action_api_user'), 'noob')
         # Assert that none of runner params are present in action_params.
         for k in action_params:
-            self.assertTrue(k not in runner_params, 'Param ' + k + ' is a runner param.')
+            self.assertNotIn(k, runner_params, 'Param ' + k + ' is a runner param.')
 
     def test_get_finalized_params_system_values(self):
         KeyValuePair.add_or_update(KeyValuePairDB(name='actionstr', value='foo'))

--- a/st2common/tests/unit/test_plugin_loader.py
+++ b/st2common/tests/unit/test_plugin_loader.py
@@ -57,7 +57,7 @@ class LoaderTest(unittest2.TestCase):
         # matches the specs of DummyPlugin class.
         self.assertEqual(1, len(plugin_classes))
         # Validate sys.path now contains the plugin directory.
-        self.assertTrue(os.path.abspath(os.path.join(SRC_ROOT, 'plugin')) in sys.path)
+        self.assertIn(os.path.abspath(os.path.join(SRC_ROOT, 'plugin')), sys.path)
         # Validate the individual plugins
         for plugin_class in plugin_classes:
             try:

--- a/st2common/tests/unit/test_queue_utils.py
+++ b/st2common/tests/unit/test_queue_utils.py
@@ -29,12 +29,12 @@ class TestQueueUtils(TestCase):
         self.assertRaises(ValueError,
                           queue_utils.get_queue_name,
                           queue_name_base='', queue_name_suffix=None)
-        self.assertEquals(queue_utils.get_queue_name(queue_name_base='st2.test.watch',
-                          queue_name_suffix=None),
-                          'st2.test.watch')
-        self.assertEquals(queue_utils.get_queue_name(queue_name_base='st2.test.watch',
-                          queue_name_suffix=''),
-                          'st2.test.watch')
+        self.assertEqual(queue_utils.get_queue_name(queue_name_base='st2.test.watch',
+                         queue_name_suffix=None),
+                         'st2.test.watch')
+        self.assertEqual(queue_utils.get_queue_name(queue_name_base='st2.test.watch',
+                         queue_name_suffix=''),
+                         'st2.test.watch')
         queue_name = queue_utils.get_queue_name(
             queue_name_base='st2.test.watch',
             queue_name_suffix='foo',

--- a/st2common/tests/unit/test_resource_registrar.py
+++ b/st2common/tests/unit/test_resource_registrar.py
@@ -77,8 +77,8 @@ class ResourceRegistrarTestCase(CleanDbTestCase):
         self.assertEqual(len(pack_db.contributors), 2)
         self.assertEqual(pack_db.contributors[0], 'John Doe1 <john.doe1@gmail.com>')
         self.assertEqual(pack_db.contributors[1], 'John Doe2 <john.doe2@gmail.com>')
-        self.assertTrue('api_key' in config_schema_db.attributes)
-        self.assertTrue('api_secret' in config_schema_db.attributes)
+        self.assertIn('api_key', config_schema_db.attributes)
+        self.assertIn('api_secret', config_schema_db.attributes)
 
         # Verify pack_db.files is correct and doesn't contain excluded files (*.pyc, .git/*, etc.)
         # Note: We can't test that .git/* files are excluded since git doesn't allow you to add
@@ -156,7 +156,7 @@ class ResourceRegistrarTestCase(CleanDbTestCase):
         try:
             registrar._register_pack_db(pack_name=None, pack_dir=PACK_PATH_13)
         except ValidationError as e:
-            self.assertTrue("'invalid-has-dash' does not match '^[a-z0-9_]+$'" in six.text_type(e))
+            self.assertIn("'invalid-has-dash' does not match '^[a-z0-9_]+$'", six.text_type(e))
         else:
             self.fail('Exception not thrown')
 

--- a/st2common/tests/unit/test_resource_registrar.py
+++ b/st2common/tests/unit/test_resource_registrar.py
@@ -90,7 +90,7 @@ class ResourceRegistrarTestCase(CleanDbTestCase):
         ]
 
         for excluded_file in excluded_files:
-            self.assertTrue(excluded_file not in pack_db.files)
+            self.assertNotIn(excluded_file, pack_db.files)
 
     def test_register_pack_arbitrary_properties_are_allowed(self):
         # Test registering a pack which has "arbitrary" properties in pack.yaml

--- a/st2common/tests/unit/test_tags.py
+++ b/st2common/tests/unit/test_tags.py
@@ -34,18 +34,18 @@ class TestTags(DbTestCase):
                          stormbase.TagField(name='tag2', value='v2')]
         saved = instance.save()
         retrieved = TaggedModel.objects(id=instance.id).first()
-        self.assertEquals(len(saved.tags), len(retrieved.tags), 'Failed to retrieve tags.')
+        self.assertEqual(len(saved.tags), len(retrieved.tags), 'Failed to retrieve tags.')
 
     def test_simple_value(self):
         instance = TaggedModel()
         instance.tags = [stormbase.TagField(name='tag1', value='v1')]
         saved = instance.save()
         retrieved = TaggedModel.objects(id=instance.id).first()
-        self.assertEquals(len(saved.tags), len(retrieved.tags), 'Failed to retrieve tags.')
+        self.assertEqual(len(saved.tags), len(retrieved.tags), 'Failed to retrieve tags.')
         saved_tag = saved.tags[0]
         retrieved_tag = retrieved.tags[0]
-        self.assertEquals(saved_tag.name, retrieved_tag.name, 'Failed to retrieve tag.')
-        self.assertEquals(saved_tag.value, retrieved_tag.value, 'Failed to retrieve tag.')
+        self.assertEqual(saved_tag.name, retrieved_tag.name, 'Failed to retrieve tag.')
+        self.assertEqual(saved_tag.value, retrieved_tag.value, 'Failed to retrieve tag.')
 
     def test_tag_max_size_restriction(self):
         instance = TaggedModel()
@@ -53,7 +53,7 @@ class TestTags(DbTestCase):
                                             value=self._gen_random_string())]
         saved = instance.save()
         retrieved = TaggedModel.objects(id=instance.id).first()
-        self.assertEquals(len(saved.tags), len(retrieved.tags), 'Failed to retrieve tags.')
+        self.assertEqual(len(saved.tags), len(retrieved.tags), 'Failed to retrieve tags.')
 
     def test_name_exceeds_max_size(self):
         instance = TaggedModel()

--- a/st2common/tests/unit/test_trigger_services.py
+++ b/st2common/tests/unit/test_trigger_services.py
@@ -39,14 +39,14 @@ class TriggerServiceTests(CleanDbTestCase):
 
         trigger_db_ret_1 = trigger_service.create_trigger_db_from_rule(
             RuleAPI(**rules['cron_timer_rule_1.yaml']))
-        self.assertTrue(trigger_db_ret_1 is not None)
+        self.assertIsNotNone(trigger_db_ret_1)
         trigger_db = Trigger.get_by_id(trigger_db_ret_1.id)
         self.assertDictEqual(trigger_db.parameters,
                              rules['cron_timer_rule_1.yaml']['trigger']['parameters'])
 
         trigger_db_ret_2 = trigger_service.create_trigger_db_from_rule(
             RuleAPI(**rules['cron_timer_rule_3.yaml']))
-        self.assertTrue(trigger_db_ret_2 is not None)
+        self.assertIsNotNone(trigger_db_ret_2)
         self.assertTrue(trigger_db_ret_2.id != trigger_db_ret_1.id)
 
     def test_create_trigger_db_from_rule_duplicate(self):
@@ -59,10 +59,10 @@ class TriggerServiceTests(CleanDbTestCase):
 
         trigger_db_ret_1 = trigger_service.create_trigger_db_from_rule(
             RuleAPI(**rules['cron_timer_rule_1.yaml']))
-        self.assertTrue(trigger_db_ret_1 is not None)
+        self.assertIsNotNone(trigger_db_ret_1)
         trigger_db_ret_2 = trigger_service.create_trigger_db_from_rule(
             RuleAPI(**rules['cron_timer_rule_2.yaml']))
-        self.assertTrue(trigger_db_ret_2 is not None)
+        self.assertIsNotNone(trigger_db_ret_2)
         self.assertEqual(trigger_db_ret_1, trigger_db_ret_2, 'Should reuse same trigger.')
         trigger_db = Trigger.get_by_id(trigger_db_ret_1.id)
         self.assertDictEqual(trigger_db.parameters,
@@ -200,7 +200,7 @@ class TriggerServiceTests(CleanDbTestCase):
         trigtype_db = TriggerType.get_by_id(trigger_type.id)
         self.assertEqual(trigtype_db.pack, 'dummy_pack_1')
         self.assertEqual(trigtype_db.name, trig_type.get('name'))
-        self.assertTrue(trigger is not None)
+        self.assertIsNotNone(trigger)
         self.assertEqual(trigger.name, trigtype_db.name)
 
         # Add duplicate

--- a/st2common/tests/unit/test_util_keyvalue.py
+++ b/st2common/tests/unit/test_util_keyvalue.py
@@ -85,19 +85,19 @@ class TestKeyValueUtil(unittest2.TestCase):
             self.assertRaises(*assert_params)
 
     def test_get_datastore_full_scope(self):
-        self.assertEquals(
+        self.assertEqual(
             kv_utl.get_datastore_full_scope(USER_SCOPE),
             DATASTORE_SCOPE_SEPARATOR.join([DATASTORE_PARENT_SCOPE, USER_SCOPE])
         )
 
     def test_get_datastore_full_scope_all_scope(self):
-        self.assertEquals(
+        self.assertEqual(
             kv_utl.get_datastore_full_scope(ALL_SCOPE),
             ALL_SCOPE
         )
 
     def test_get_datastore_full_scope_datastore_parent_scope(self):
-        self.assertEquals(
+        self.assertEqual(
             kv_utl.get_datastore_full_scope(DATASTORE_PARENT_SCOPE),
             DATASTORE_PARENT_SCOPE
         )
@@ -107,7 +107,7 @@ class TestKeyValueUtil(unittest2.TestCase):
         scope = USER_SCOPE
         result = kv_utl._derive_scope_and_key(key, scope)
 
-        self.assertEquals(
+        self.assertEqual(
             (FULL_USER_SCOPE, 'user:%s' % key),
             result
         )
@@ -117,7 +117,7 @@ class TestKeyValueUtil(unittest2.TestCase):
         scope = None
         result = kv_utl._derive_scope_and_key(key, scope)
 
-        self.assertEquals(
+        self.assertEqual(
             (FULL_USER_SCOPE, 'None:%s' % key),
             result
         )
@@ -127,7 +127,7 @@ class TestKeyValueUtil(unittest2.TestCase):
         scope = None
         result = kv_utl._derive_scope_and_key(key, scope)
 
-        self.assertEquals(
+        self.assertEqual(
             (FULL_SYSTEM_SCOPE, key.split('.')[1]),
             result
         )

--- a/st2common/tests/unit/test_util_sandboxing.py
+++ b/st2common/tests/unit/test_util_sandboxing.py
@@ -164,16 +164,16 @@ class SandboxingUtilsTestCase(unittest.TestCase):
         self.assertEqual(len(split), 4)
 
         # First entry should be system lib/python3 dir
-        self.assertTrue('/usr/lib/python3.6' in split[0])
+        self.assertIn('/usr/lib/python3.6', split[0])
 
         # Second entry should be lib/python3 dir from venv
-        self.assertTrue('virtualenvs/dummy_pack/lib/python3.6' in split[1])
+        self.assertIn('virtualenvs/dummy_pack/lib/python3.6', split[1])
 
         # Third entry should be python3 site-packages dir from venv
-        self.assertTrue('virtualenvs/dummy_pack/lib/python3.6/site-packages' in split[2])
+        self.assertIn('virtualenvs/dummy_pack/lib/python3.6/site-packages', split[2])
 
         # Fourth entry should be actions/lib dir from pack root directory
-        self.assertTrue('packs/dummy_pack/actions/lib/' in split[3])
+        self.assertIn('packs/dummy_pack/actions/lib/', split[3])
 
         # Inherit python path from current process
         # Mock the current process python path
@@ -222,13 +222,13 @@ class SandboxingUtilsTestCase(unittest.TestCase):
         self.assertEqual(len(split), 4)
 
         # First entry should be system lib/python3 dir
-        self.assertTrue('/opt/lib/python3.6' in split[0])
+        self.assertIn('/opt/lib/python3.6', split[0])
 
         # Second entry should be lib/python3 dir from venv
-        self.assertTrue('virtualenvs/dummy_pack/lib/python3.6' in split[1])
+        self.assertIn('virtualenvs/dummy_pack/lib/python3.6', split[1])
 
         # Third entry should be python3 site-packages dir from venv
-        self.assertTrue('virtualenvs/dummy_pack/lib/python3.6/site-packages' in split[2])
+        self.assertIn('virtualenvs/dummy_pack/lib/python3.6/site-packages', split[2])
 
         # Fourth entry should be actions/lib dir from pack root directory
-        self.assertTrue('packs/dummy_pack/actions/lib/' in split[3])
+        self.assertIn('packs/dummy_pack/actions/lib/', split[3])

--- a/st2common/tests/unit/test_virtualenvs.py
+++ b/st2common/tests/unit/test_virtualenvs.py
@@ -122,7 +122,7 @@ class VirtualenvUtilsTestCase(CleanFilesTestCase):
             setup_pack_virtualenv(pack_name=pack_name, update=False,
                                   include_setuptools=False, include_wheel=False)
         except Exception as e:
-            self.assertTrue('Failed to install requirements from' in six.text_type(e))
+            self.assertIn('Failed to install requirements from', six.text_type(e))
             self.assertTrue('No matching distribution found for someinvalidname' in
                             six.text_type(e))
         else:
@@ -312,7 +312,7 @@ class VirtualenvUtilsTestCase(CleanFilesTestCase):
         actual_cmd = ' '.join(actual_cmd)
 
         self.assertEqual(mock_run_command.call_count, 2)
-        self.assertTrue('-p /usr/bin/python2.7' in actual_cmd)
+        self.assertIn('-p /usr/bin/python2.7', actual_cmd)
 
         mock_run_command.reset_mock()
 
@@ -325,15 +325,15 @@ class VirtualenvUtilsTestCase(CleanFilesTestCase):
 
         actual_cmd = mock_run_command.call_args_list[0][1]['cmd']
         actual_cmd = ' '.join(actual_cmd)
-        self.assertTrue('-p /usr/bin/python3' in actual_cmd)
+        self.assertIn('-p /usr/bin/python3', actual_cmd)
 
         actual_cmd = mock_run_command.call_args_list[1][1]['cmd']
         actual_cmd = ' '.join(actual_cmd)
-        self.assertTrue('pip install pyyaml' in actual_cmd)
+        self.assertIn('pip install pyyaml', actual_cmd)
 
         actual_cmd = mock_run_command.call_args_list[2][1]['cmd']
         actual_cmd = ' '.join(actual_cmd)
-        self.assertTrue('pip install' in actual_cmd)
+        self.assertIn('pip install', actual_cmd)
 
     def assertVirtualenvExists(self, virtualenv_dir):
         self.assertTrue(os.path.exists(virtualenv_dir))

--- a/st2debug/tests/integration/test_submit_debug_info.py
+++ b/st2debug/tests/integration/test_submit_debug_info.py
@@ -251,12 +251,12 @@ class SubmitDebugInfoTestCase(CleanFilesTestCase):
         with open(mistral_config_path, 'r') as fp:
             mistral_config_content = fp.read()
 
-        self.assertTrue('ponies' not in st2_config_content)
+        self.assertNotIn('ponies', st2_config_content)
         self.assertIn('username = **removed**', st2_config_content)
         self.assertIn('password = **removed**', st2_config_content)
         self.assertIn('url = **removed**', st2_config_content)
 
-        self.assertTrue('StackStorm' not in mistral_config_content)
+        self.assertNotIn('StackStorm', mistral_config_content)
         self.assertIn('connection = **removed**', mistral_config_content)
 
         # Very config.yaml has been removed from the content pack directories

--- a/st2debug/tests/integration/test_submit_debug_info.py
+++ b/st2debug/tests/integration/test_submit_debug_info.py
@@ -126,9 +126,9 @@ class SubmitDebugInfoTestCase(CleanFilesTestCase):
         self.assertEqual(len(command_files), 3)
 
         # Verify command output file names
-        self.assertTrue('echofoo.txt' in command_files)
-        self.assertTrue('echobar12.txt' in command_files)
-        self.assertTrue('pwd.txt' in command_files)
+        self.assertIn('echofoo.txt', command_files)
+        self.assertIn('echobar12.txt', command_files)
+        self.assertIn('pwd.txt', command_files)
 
         # Verify "cwd" is set correctly for the shells where commands run
         file_path = os.path.join(commands_path, 'pwd.txt')
@@ -138,7 +138,7 @@ class SubmitDebugInfoTestCase(CleanFilesTestCase):
         # cwd for the process where commands run should be set to temporary directory where
         # commands output is stored
         expected_cwd_path = os.path.join(debug_collector._temp_dir_path, 'commands')
-        self.assertTrue(expected_cwd_path in content)
+        self.assertIn(expected_cwd_path, content)
 
         # Verify file contents
         with open(os.path.join(commands_path, 'echofoo.txt')) as f:
@@ -252,12 +252,12 @@ class SubmitDebugInfoTestCase(CleanFilesTestCase):
             mistral_config_content = fp.read()
 
         self.assertTrue('ponies' not in st2_config_content)
-        self.assertTrue('username = **removed**' in st2_config_content)
-        self.assertTrue('password = **removed**' in st2_config_content)
-        self.assertTrue('url = **removed**' in st2_config_content)
+        self.assertIn('username = **removed**', st2_config_content)
+        self.assertIn('password = **removed**', st2_config_content)
+        self.assertIn('url = **removed**', st2_config_content)
 
         self.assertTrue('StackStorm' not in mistral_config_content)
-        self.assertTrue('connection = **removed**' in mistral_config_content)
+        self.assertIn('connection = **removed**', mistral_config_content)
 
         # Very config.yaml has been removed from the content pack directories
         pack_dir = os.path.join(content_path, 'twilio')

--- a/st2exporter/tests/integration/test_dumper_integration.py
+++ b/st2exporter/tests/integration/test_dumper_integration.py
@@ -64,7 +64,7 @@ class TestDumper(DbTestCase):
         max_timestamp = max(timestamps)
         marker_db = dumper._write_marker_to_db(max_timestamp)
         persisted_marker = marker_db.marker
-        self.assertTrue(isinstance(persisted_marker, six.string_types))
+        self.assertIsInstance(persisted_marker, six.string_types)
         self.assertEqual(isotime.parse(persisted_marker), max_timestamp)
 
     @mock.patch.object(os.path, 'exists', mock.MagicMock(return_value=True))

--- a/st2exporter/tests/integration/test_export_worker.py
+++ b/st2exporter/tests/integration/test_export_worker.py
@@ -84,7 +84,7 @@ class TestExportWorker(DbTestCase):
 
         count = 0
         while count < exec_exporter.pending_executions.qsize():
-            self.assertTrue(isinstance(exec_exporter.pending_executions.get(), ActionExecutionAPI))
+            self.assertIsInstance(exec_exporter.pending_executions.get(), ActionExecutionAPI)
             count += 1
 
     @mock.patch.object(os.path, 'exists', mock.MagicMock(return_value=True))

--- a/st2exporter/tests/unit/test_dumper.py
+++ b/st2exporter/tests/unit/test_dumper.py
@@ -131,7 +131,7 @@ class TestDumper(EventletTestCase):
         # Batch 1
         batch = self.execution_apis[0:5]
         new_marker = dumper._update_marker(batch)
-        self.assertTrue(new_marker is not None)
+        self.assertIsNotNone(new_marker)
         timestamps = [isotime.parse(execution.end_timestamp) for execution in batch]
         max_timestamp = max(timestamps)
         self.assertEqual(new_marker, max_timestamp)

--- a/st2reactor/tests/unit/test_container_utils.py
+++ b/st2reactor/tests/unit/test_container_utils.py
@@ -36,7 +36,7 @@ class ContainerUtilsTest(CleanDbTestCase):
         trigger_instance = 'dummy_pack.footrigger'
         instance = create_trigger_instance(trigger=trigger_instance, payload={},
                                            occurrence_time=None)
-        self.assertTrue(instance is None)
+        self.assertIsNone(instance)
 
     def test_create_trigger_instance_success(self):
         # Here we test trigger instance creation using various ways to look up corresponding

--- a/st2reactor/tests/unit/test_enforce.py
+++ b/st2reactor/tests/unit/test_enforce.py
@@ -138,8 +138,7 @@ class RuleEnforcerTestCase(BaseRuleEnforcerTestCase):
         execution_db = enforcer.enforce()
         self.assertIsNotNone(execution_db)
         self.assertTrue(action_service.request.called)
-        self.assertTrue(isinstance(action_service.request.call_args[0][0].parameters['objtype'],
-                                   dict))
+        self.assertIsInstance(action_service.request.call_args[0][0].parameters['objtype'], dict)
 
     @mock.patch.object(action_service, 'request', mock.MagicMock(
         return_value=(MOCK_LIVEACTION, MOCK_EXECUTION)))

--- a/st2reactor/tests/unit/test_enforce.py
+++ b/st2reactor/tests/unit/test_enforce.py
@@ -129,14 +129,14 @@ class RuleEnforcerTestCase(BaseRuleEnforcerTestCase):
     def test_ruleenforcement_occurs(self):
         enforcer = RuleEnforcer(MOCK_TRIGGER_INSTANCE, self.models['rules']['rule1.yaml'])
         execution_db = enforcer.enforce()
-        self.assertTrue(execution_db is not None)
+        self.assertIsNotNone(execution_db)
 
     @mock.patch.object(action_service, 'request', mock.MagicMock(
         return_value=(MOCK_LIVEACTION, MOCK_EXECUTION)))
     def test_ruleenforcement_casts(self):
         enforcer = RuleEnforcer(MOCK_TRIGGER_INSTANCE, self.models['rules']['rule2.yaml'])
         execution_db = enforcer.enforce()
-        self.assertTrue(execution_db is not None)
+        self.assertIsNotNone(execution_db)
         self.assertTrue(action_service.request.called)
         self.assertTrue(isinstance(action_service.request.call_args[0][0].parameters['objtype'],
                                    dict))
@@ -147,7 +147,7 @@ class RuleEnforcerTestCase(BaseRuleEnforcerTestCase):
     def test_ruleenforcement_create_on_success(self):
         enforcer = RuleEnforcer(MOCK_TRIGGER_INSTANCE, self.models['rules']['rule2.yaml'])
         execution_db = enforcer.enforce()
-        self.assertTrue(execution_db is not None)
+        self.assertIsNotNone(execution_db)
         self.assertTrue(RuleEnforcement.add_or_update.called)
         self.assertEqual(RuleEnforcement.add_or_update.call_args[0][0].rule.ref,
                          self.models['rules']['rule2.yaml'].ref)
@@ -176,7 +176,7 @@ class RuleEnforcerTestCase(BaseRuleEnforcerTestCase):
         call_args = action_service.request.call_args[0]
         live_action_db = call_args[0]
         self.assertEqual(live_action_db.parameters['actionstr'], 'somevalue')
-        self.assertTrue(execution_db is not None)
+        self.assertIsNotNone(execution_db)
         self.assertTrue(RuleEnforcement.add_or_update.called)
         self.assertEqual(RuleEnforcement.add_or_update.call_args[0][0].rule.ref,
                          self.models['rules']['rule_use_none_filter.yaml'].ref)
@@ -200,7 +200,7 @@ class RuleEnforcerTestCase(BaseRuleEnforcerTestCase):
         call_args = action_service.request.call_args[0]
         live_action_db = call_args[0]
         self.assertEqual(live_action_db.parameters['actionstr'], None)
-        self.assertTrue(execution_db is not None)
+        self.assertIsNotNone(execution_db)
         self.assertTrue(RuleEnforcement.add_or_update.called)
         self.assertEqual(RuleEnforcement.add_or_update.call_args[0][0].rule.ref,
                          self.models['rules']['rule_use_none_filter.yaml'].ref)
@@ -222,7 +222,7 @@ class RuleEnforcerTestCase(BaseRuleEnforcerTestCase):
         call_args = action_service.request.call_args[0]
         live_action_db = call_args[0]
         self.assertEqual(live_action_db.parameters['actionstr'], 'None-value2')
-        self.assertTrue(execution_db is not None)
+        self.assertIsNotNone(execution_db)
         self.assertTrue(RuleEnforcement.add_or_update.called)
         self.assertEqual(RuleEnforcement.add_or_update.call_args[0][0].rule.ref,
                          self.models['rules']['rule_none_no_use_none_filter.yaml'].ref)
@@ -256,7 +256,7 @@ class RuleEnforcerTestCase(BaseRuleEnforcerTestCase):
         enforcer = RuleEnforcer(MOCK_TRIGGER_INSTANCE, rule)
         execution_db = enforcer.enforce()
 
-        self.assertTrue(execution_db is not None)
+        self.assertIsNotNone(execution_db)
         self.assertTrue(RuleEnforcement.add_or_update.called)
         self.assertEqual(RuleEnforcement.add_or_update.call_args[0][0].rule.ref, rule.ref)
         self.assertEqual(RuleEnforcement.add_or_update.call_args[0][0].status,
@@ -278,7 +278,7 @@ class RuleEnforcerTestCase(BaseRuleEnforcerTestCase):
         enforcer = RuleEnforcer(MOCK_TRIGGER_INSTANCE, rule)
         execution_db = enforcer.enforce()
 
-        self.assertTrue(execution_db is not None)
+        self.assertIsNotNone(execution_db)
         self.assertTrue(RuleEnforcement.add_or_update.called)
         self.assertEqual(RuleEnforcement.add_or_update.call_args[0][0].rule.ref, rule.ref)
         self.assertEqual(RuleEnforcement.add_or_update.call_args[0][0].status,

--- a/st2reactor/tests/unit/test_enforce.py
+++ b/st2reactor/tests/unit/test_enforce.py
@@ -237,7 +237,7 @@ class RuleEnforcerTestCase(BaseRuleEnforcerTestCase):
     def test_ruleenforcement_create_on_fail(self):
         enforcer = RuleEnforcer(MOCK_TRIGGER_INSTANCE, self.models['rules']['rule1.yaml'])
         execution_db = enforcer.enforce()
-        self.assertTrue(execution_db is None)
+        self.assertIsNone(execution_db)
         self.assertTrue(RuleEnforcement.add_or_update.called)
         self.assertEqual(RuleEnforcement.add_or_update.call_args[0][0].failure_reason,
                          FAILURE_REASON)
@@ -304,7 +304,7 @@ class RuleEnforcerTestCase(BaseRuleEnforcerTestCase):
         enforcer = RuleEnforcer(MOCK_TRIGGER_INSTANCE, rule)
         execution_db = enforcer.enforce()
 
-        self.assertTrue(execution_db is None)
+        self.assertIsNone(execution_db)
         self.assertTrue(RuleEnforcement.add_or_update.called)
         self.assertEqual(RuleEnforcement.add_or_update.call_args[0][0].rule.ref, rule.ref)
         self.assertEqual(RuleEnforcement.add_or_update.call_args[0][0].status,

--- a/st2reactor/tests/unit/test_process_container.py
+++ b/st2reactor/tests/unit/test_process_container.py
@@ -120,7 +120,7 @@ class ProcessContainerTests(unittest2.TestCase):
         actual_env = call_kwargs['env']
         self.assertIn('PYTHONPATH', actual_env)
         pack_common_lib_path = '/opt/stackstorm/packs/wolfpack/lib'
-        self.assertTrue(pack_common_lib_path not in actual_env['PYTHONPATH'])
+        self.assertNotIn(pack_common_lib_path, actual_env['PYTHONPATH'])
 
     @patch.object(time, 'time', MagicMock(return_value=1439441533))
     def test_dispatch_triggers_on_spawn_exit(self):

--- a/st2reactor/tests/unit/test_process_container.py
+++ b/st2reactor/tests/unit/test_process_container.py
@@ -78,9 +78,9 @@ class ProcessContainerTests(unittest2.TestCase):
 
         _, call_kwargs = mock_subproc_popen.call_args
         actual_env = call_kwargs['env']
-        self.assertTrue('PYTHONPATH' in actual_env)
+        self.assertIn('PYTHONPATH', actual_env)
         pack_common_lib_path = '/opt/stackstorm/packs/wolfpack/lib'
-        self.assertTrue(pack_common_lib_path in actual_env['PYTHONPATH'])
+        self.assertIn(pack_common_lib_path, actual_env['PYTHONPATH'])
 
     @patch.object(ProcessSensorContainer, '_get_sensor_id',
                   MagicMock(return_value='wolfpack.StupidSensor'))
@@ -118,7 +118,7 @@ class ProcessContainerTests(unittest2.TestCase):
 
         _, call_kwargs = mock_subproc_popen.call_args
         actual_env = call_kwargs['env']
-        self.assertTrue('PYTHONPATH' in actual_env)
+        self.assertIn('PYTHONPATH', actual_env)
         pack_common_lib_path = '/opt/stackstorm/packs/wolfpack/lib'
         self.assertTrue(pack_common_lib_path not in actual_env['PYTHONPATH'])
 

--- a/st2reactor/tests/unit/test_rule_engine.py
+++ b/st2reactor/tests/unit/test_rule_engine.py
@@ -78,7 +78,7 @@ class RuleEngineTest(DbTestCase):
         matching_rules = rules_engine.get_matching_rules_for_trigger(trigger_instance)
         expected_rules = ['st2.test.rule2']
         for rule in matching_rules:
-            self.assertTrue(rule.name in expected_rules)
+            self.assertIn(rule.name, expected_rules)
 
     def test_handle_trigger_instance_no_rules(self):
         trigger_instance = container_utils.create_trigger_instance(

--- a/st2reactor/tests/unit/test_rule_matcher.py
+++ b/st2reactor/tests/unit/test_rule_matcher.py
@@ -153,7 +153,7 @@ class RuleMatcherTestCase(CleanDbTestCase):
         trigger = get_trigger_db_by_ref(trigger_instance.trigger)
         rules_matcher = RulesMatcher(trigger_instance, trigger, rules)
         matching_rules = rules_matcher.get_matching_rules()
-        self.assertTrue(matching_rules is not None)
+        self.assertIsNotNone(matching_rules)
         self.assertEqual(len(matching_rules), 1)
 
     def test_trigger_instance_payload_with_special_values(self):
@@ -174,7 +174,7 @@ class RuleMatcherTestCase(CleanDbTestCase):
         trigger = get_trigger_db_by_ref(trigger_instance.trigger)
         rules_matcher = RulesMatcher(trigger_instance, trigger, rules)
         matching_rules = rules_matcher.get_matching_rules()
-        self.assertTrue(matching_rules is not None)
+        self.assertIsNotNone(matching_rules)
         self.assertEqual(len(matching_rules), 1)
 
     @mock.patch('st2reactor.rules.matcher.RuleFilter._render_criteria_pattern',

--- a/st2reactor/tests/unit/test_sensor_and_rule_registration.py
+++ b/st2reactor/tests/unit/test_sensor_and_rule_registration.py
@@ -155,7 +155,7 @@ class RuleRegistrationTestCase(DbTestCase):
 
         self.assertEqual(rule_dbs[0].name, 'sample.with_the_same_timer')
         self.assertEqual(rule_dbs[1].name, 'sample.with_timer')
-        self.assertTrue(trigger_dbs[0].name is not None)
+        self.assertIsNotNone(trigger_dbs[0].name)
 
         # Verify second register call updates existing models
         registrar.register_from_packs(base_dirs=[PACKS_DIR])

--- a/st2reactor/tests/unit/test_sensor_wrapper.py
+++ b/st2reactor/tests/unit/test_sensor_wrapper.py
@@ -121,7 +121,7 @@ class SensorWrapperTestCase(unittest2.TestCase):
                                 poll_interval=poll_interval)
         self.assertIsNotNone(wrapper._sensor_instance)
         self.assertIsInstance(wrapper._sensor_instance, PollingSensor)
-        self.assertEquals(wrapper._sensor_instance._poll_interval, poll_interval)
+        self.assertEqual(wrapper._sensor_instance._poll_interval, poll_interval)
 
     def test_sensor_init_fails_file_doesnt_exist(self):
         file_path = os.path.join(RESOURCES_DIR, 'test_sensor_doesnt_exist.py')

--- a/st2reactor/tests/unit/test_sensor_wrapper.py
+++ b/st2reactor/tests/unit/test_sensor_wrapper.py
@@ -152,8 +152,8 @@ class SensorWrapperTestCase(unittest2.TestCase):
             SensorWrapper(pack='core', file_path=file_path, class_name='TestSensor',
                           trigger_types=trigger_types, parent_args=parent_args)
         except NameError as e:
-            self.assertTrue('Traceback (most recent call last)' in six.text_type(e))
-            self.assertTrue('line 19, in <module>' in six.text_type(e))
+            self.assertIn('Traceback (most recent call last)', six.text_type(e))
+            self.assertIn('line 19, in <module>', six.text_type(e))
         else:
             self.fail('NameError not thrown')
 

--- a/st2reactor/tests/unit/test_sensor_wrapper.py
+++ b/st2reactor/tests/unit/test_sensor_wrapper.py
@@ -53,8 +53,8 @@ class SensorWrapperTestCase(unittest2.TestCase):
                                 class_name='TestSensor',
                                 trigger_types=trigger_types,
                                 parent_args=parent_args)
-        self.assertTrue(getattr(wrapper._sensor_instance, 'sensor_service', None) is not None)
-        self.assertTrue(getattr(wrapper._sensor_instance, 'config', None) is not None)
+        self.assertIsNotNone(getattr(wrapper._sensor_instance, 'sensor_service', None))
+        self.assertIsNotNone(getattr(wrapper._sensor_instance, 'config', None))
 
     def test_trigger_cud_event_handlers(self):
         trigger_id = '57861fcb0640fd1524e577c0'

--- a/st2reactor/tests/unit/test_timer.py
+++ b/st2reactor/tests/unit/test_timer.py
@@ -43,7 +43,7 @@ class St2TimerTestCase(CleanDbTestCase):
 
         for trigger_type in trigger_type_dbs:
             ref = ResourceReference(pack=trigger_type.pack, name=trigger_type.name).ref
-            self.assertTrue(ref in timer_trigger_type_refs)
+            self.assertIn(ref, timer_trigger_type_refs)
 
     def test_existing_rules_are_loaded_on_start(self):
         # Assert that we dispatch message for every existing Trigger object

--- a/st2stream/tests/unit/controllers/v1/test_stream.py
+++ b/st2stream/tests/unit/controllers/v1/test_stream.py
@@ -216,10 +216,10 @@ class TestStreamController(FunctionalTest):
 
         received_messages = dispatch_and_handle_mock_data(resp)
         self.assertEqual(len(received_messages), 9)
-        self.assertTrue('st2.execution__create' in received_messages[0])
-        self.assertTrue('st2.liveaction__delete' in received_messages[5])
-        self.assertTrue('st2.announcement__chatops' in received_messages[7])
-        self.assertTrue('st2.announcement__errbot' in received_messages[8])
+        self.assertIn('st2.execution__create', received_messages[0])
+        self.assertIn('st2.liveaction__delete', received_messages[5])
+        self.assertIn('st2.announcement__chatops', received_messages[7])
+        self.assertIn('st2.announcement__errbot', received_messages[8])
 
         # 1. ?events= filter
         # No filter provided - all messages should be received
@@ -228,11 +228,11 @@ class TestStreamController(FunctionalTest):
 
         received_messages = dispatch_and_handle_mock_data(resp)
         self.assertEqual(len(received_messages), 11)
-        self.assertTrue('st2.execution__create' in received_messages[0])
-        self.assertTrue('st2.announcement__chatops' in received_messages[7])
-        self.assertTrue('st2.execution.output__create' in received_messages[8])
-        self.assertTrue('st2.execution.output__create' in received_messages[9])
-        self.assertTrue('st2.announcement__errbot' in received_messages[10])
+        self.assertIn('st2.execution__create', received_messages[0])
+        self.assertIn('st2.announcement__chatops', received_messages[7])
+        self.assertIn('st2.execution.output__create', received_messages[8])
+        self.assertIn('st2.execution.output__create', received_messages[9])
+        self.assertIn('st2.announcement__errbot', received_messages[10])
 
         # Filter provided, only three messages should be received
         events = ['st2.execution__create', 'st2.liveaction__delete']
@@ -240,9 +240,9 @@ class TestStreamController(FunctionalTest):
 
         received_messages = dispatch_and_handle_mock_data(resp)
         self.assertEqual(len(received_messages), 3)
-        self.assertTrue('st2.execution__create' in received_messages[0])
-        self.assertTrue('st2.liveaction__delete' in received_messages[1])
-        self.assertTrue('st2.liveaction__delete' in received_messages[2])
+        self.assertIn('st2.execution__create', received_messages[0])
+        self.assertIn('st2.liveaction__delete', received_messages[1])
+        self.assertIn('st2.liveaction__delete', received_messages[2])
 
         # Filter provided, only three messages should be received
         events = ['st2.liveaction__create', 'st2.liveaction__delete']
@@ -250,10 +250,10 @@ class TestStreamController(FunctionalTest):
 
         received_messages = dispatch_and_handle_mock_data(resp)
         self.assertEqual(len(received_messages), 4)
-        self.assertTrue('st2.liveaction__create' in received_messages[0])
-        self.assertTrue('st2.liveaction__create' in received_messages[1])
-        self.assertTrue('st2.liveaction__delete' in received_messages[2])
-        self.assertTrue('st2.liveaction__delete' in received_messages[3])
+        self.assertIn('st2.liveaction__create', received_messages[0])
+        self.assertIn('st2.liveaction__create', received_messages[1])
+        self.assertIn('st2.liveaction__delete', received_messages[2])
+        self.assertIn('st2.liveaction__delete', received_messages[3])
 
         # Glob filter
         events = ['st2.announcement__*']
@@ -261,8 +261,8 @@ class TestStreamController(FunctionalTest):
 
         received_messages = dispatch_and_handle_mock_data(resp)
         self.assertEqual(len(received_messages), 2)
-        self.assertTrue('st2.announcement__chatops' in received_messages[0])
-        self.assertTrue('st2.announcement__errbot' in received_messages[1])
+        self.assertIn('st2.announcement__chatops', received_messages[0])
+        self.assertIn('st2.announcement__errbot', received_messages[1])
 
         # Filter provided
         events = ['st2.execution.output__create']
@@ -270,8 +270,8 @@ class TestStreamController(FunctionalTest):
 
         received_messages = dispatch_and_handle_mock_data(resp)
         self.assertEqual(len(received_messages), 2)
-        self.assertTrue('st2.execution.output__create' in received_messages[0])
-        self.assertTrue('st2.execution.output__create' in received_messages[1])
+        self.assertIn('st2.execution.output__create', received_messages[0])
+        self.assertIn('st2.execution.output__create', received_messages[1])
 
         # Filter provided, invalid , no message should be received
         events = ['invalid1', 'invalid2']

--- a/st2tests/integration/mistral/test_filters.py
+++ b/st2tests/integration/mistral/test_filters.py
@@ -44,9 +44,9 @@ class FromJsonStringFiltersTest(base.TestWorkflowExecution):
         self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
         jinja_dict = ex.result['result_jinja']
         yaql_dict = ex.result['result_yaql']
-        self.assertTrue(isinstance(jinja_dict, dict))
+        self.assertIsInstance(jinja_dict, dict)
         self.assertEqual(jinja_dict["a"], "b")
-        self.assertTrue(isinstance(yaql_dict, dict))
+        self.assertIsInstance(yaql_dict, dict)
         self.assertEqual(yaql_dict["a"], "b")
 
 
@@ -64,9 +64,9 @@ class FromYamlStringFiltersTest(base.TestWorkflowExecution):
         self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
         jinja_dict = ex.result['result_jinja']
         yaql_dict = ex.result['result_yaql']
-        self.assertTrue(isinstance(jinja_dict, dict))
+        self.assertIsInstance(jinja_dict, dict)
         self.assertEqual(jinja_dict["a"], "b")
-        self.assertTrue(isinstance(yaql_dict, dict))
+        self.assertIsInstance(yaql_dict, dict)
         self.assertEqual(yaql_dict["a"], "b")
 
 
@@ -80,9 +80,9 @@ class JsonEscapeFiltersTest(base.TestWorkflowExecution):
         self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
         jinja_dict = json.loads(ex.result['result_jinja'])[0]
         yaql_dict = json.loads(ex.result['result_yaql'])[0]
-        self.assertTrue(isinstance(jinja_dict, dict))
+        self.assertIsInstance(jinja_dict, dict)
         self.assertEqual(jinja_dict['title'], breaking_str)
-        self.assertTrue(isinstance(yaql_dict, dict))
+        self.assertIsInstance(yaql_dict, dict)
         self.assertEqual(yaql_dict['title'], breaking_str)
 
 
@@ -106,9 +106,9 @@ class JsonpathQueryFiltersTest(base.TestWorkflowExecution):
         self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
         jinja_result = ex.result['result_jinja']
         yaql_result = ex.result['result_yaql']
-        self.assertTrue(isinstance(jinja_result, list))
+        self.assertIsInstance(jinja_result, list)
         self.assertEqual(jinja_result, expected_result)
-        self.assertTrue(isinstance(yaql_result, list))
+        self.assertIsInstance(yaql_result, list)
         self.assertEqual(yaql_result, expected_result)
 
 
@@ -214,9 +214,9 @@ class ToComplexFiltersTest(base.TestWorkflowExecution):
         self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
         jinja_dict = json.loads(ex.result['result_jinja'])
         yaql_dict = json.loads(ex.result['result_yaql'])
-        self.assertTrue(isinstance(jinja_dict, dict))
+        self.assertIsInstance(jinja_dict, dict)
         self.assertEqual(jinja_dict['a'], 'b')
-        self.assertTrue(isinstance(yaql_dict, dict))
+        self.assertIsInstance(yaql_dict, dict)
         self.assertEqual(yaql_dict['a'], 'b')
 
 
@@ -229,9 +229,9 @@ class ToJsonStringFiltersTest(base.TestWorkflowExecution):
         self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
         jinja_dict = json.loads(ex.result['result_jinja'])
         yaql_dict = json.loads(ex.result['result_yaql'])
-        self.assertTrue(isinstance(jinja_dict, dict))
+        self.assertIsInstance(jinja_dict, dict)
         self.assertEqual(jinja_dict['a'], 'b')
-        self.assertTrue(isinstance(yaql_dict, dict))
+        self.assertIsInstance(yaql_dict, dict)
         self.assertEqual(yaql_dict['a'], 'b')
 
 
@@ -244,9 +244,9 @@ class ToYamlStringFiltersTest(base.TestWorkflowExecution):
         self.assertEqual(ex.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
         jinja_dict = yaml.safe_load(ex.result['result_jinja'])
         yaql_dict = yaml.safe_load(ex.result['result_yaql'])
-        self.assertTrue(isinstance(jinja_dict, dict))
+        self.assertIsInstance(jinja_dict, dict)
         self.assertEqual(jinja_dict['a'], 'b')
-        self.assertTrue(isinstance(yaql_dict, dict))
+        self.assertIsInstance(yaql_dict, dict)
         self.assertEqual(yaql_dict['a'], 'b')
 
 

--- a/st2tests/st2tests/api.py
+++ b/st2tests/st2tests/api.py
@@ -293,7 +293,7 @@ class APIControllerWithIncludeAndExcludeFilterTestCase(object):
         if self.test_exact_object_count:
             self.assertEqual(len(resp.json), len(object_ids))
 
-        self.assertFalse(exclude_attribute in resp.json[0])
+        self.assertNotIn(exclude_attribute, resp.json[0])
 
         self._delete_mock_models(object_ids)
 

--- a/st2tests/st2tests/api.py
+++ b/st2tests/st2tests/api.py
@@ -280,7 +280,7 @@ class APIControllerWithIncludeAndExcludeFilterTestCase(object):
         if self.test_exact_object_count:
             self.assertEqual(len(resp.json), len(object_ids))
 
-        self.assertTrue(exclude_attribute in resp.json[0])
+        self.assertIn(exclude_attribute, resp.json[0])
 
         # 2. Verify attribute is excluded when filter is provided
         exclude_attribute = self.exclude_attribute_field_name
@@ -303,13 +303,13 @@ class APIControllerWithIncludeAndExcludeFilterTestCase(object):
             split = field.split('.')
 
             for index, field_part in enumerate(split):
-                self.assertTrue(field_part in resp_item)
+                self.assertIn(field_part, resp_item)
                 resp_item = resp_item[field_part]
 
             # Additional safety check
             self.assertEqual(index, len(split) - 1)
         else:
-            self.assertTrue(field in resp_item)
+            self.assertIn(field, resp_item)
 
     def _insert_mock_models(self):
         """

--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -148,7 +148,7 @@ class RunnerTestCase(unittest2.TestCase):
         for var_name in COMMON_ACTION_ENV_VARIABLES:
             self.assertIn(var_name, env)
         self.assertEqual(env['ST2_ACTION_API_URL'], get_full_public_api_url())
-        self.assertTrue(env[AUTH_TOKEN_ENV_VARIABLE_NAME] is not None)
+        self.assertIsNotNone(env[AUTH_TOKEN_ENV_VARIABLE_NAME])
 
     def loader(self, path):
         """ Load the runner config

--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -146,7 +146,7 @@ class RunnerTestCase(unittest2.TestCase):
         environment.
         """
         for var_name in COMMON_ACTION_ENV_VARIABLES:
-            self.assertTrue(var_name in env)
+            self.assertIn(var_name, env)
         self.assertEqual(env['ST2_ACTION_API_URL'], get_full_public_api_url())
         self.assertTrue(env[AUTH_TOKEN_ENV_VARIABLE_NAME] is not None)
 


### PR DESCRIPTION
| Previously | Converted to | Assertion doc |
| ------- | ----- | ------------- |
| `assertTrue(a)` | `assertTrue(bool(a))` | [`unittest.TestCase.assertTrue`](https://docs.python.org/2/library/unittest.html#deprecated-aliases) |
| `assertTrue(a in b)` | `assertIn(a, b)` | [`unittest.TestCase.assertIn`](https://docs.python.org/2/library/unittest.html#unittest.TestCase.assertIn) |
| `assertTrue(a not in b)` | `assertNotIn(a, b)` | [`unittest.TestCase.assertNotIn`](https://docs.python.org/2/library/unittest.html#unittest.TestCase.assertNotIn) |
| `assertFalse(a in b)` | `assertNotIn(a, b)` | [`unittest.TestCase.assertNotIn`](https://docs.python.org/2/library/unittest.html#unittest.TestCase.assertNotIn) |
| `assertTrue(a is None)` | `assertIsNone(a)` | [`unittest.TestCase.assertIsNone`](https://docs.python.org/2/library/unittest.html#unittest.TestCase.assertIsNone) |
| `assertTrue(a is not None)` | `assertIsNotNone(a)` | [`unittest.TestCase.assertIsNotNone`](https://docs.python.org/2/library/unittest.html#unittest.TestCase.assertIsNotNone) |
| `assertTrue(isinstance(a, b))` | `assertIsInstance(a, b)` | [`unittest.TestCase.assertIsInstance`](https://docs.python.org/2/library/unittest.html#unittest.TestCase.assertIsInstance) |
| `assertFalse(isinstance(a, b))` | `assertNotIsInstance(a, b)` | [`unittest.TestCase.assertNotIsInstance`](https://docs.python.org/2/library/unittest.html#unittest.TestCase.assertIsNotInstance) |
| `assertEquals(a, b)` | `assertEqual(a, b)` | [`unittest.TestCase.assertEquals`](https://docs.python.org/2/library/unittest.html#deprecated-aliases) |
