### PR TITLE
Switch Travis from Xenial to Bionic with Mongo 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: xenial
+dist: bionic
 language: python
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,8 @@ jobs:
     # scripts/travis/run-nightly-make-task-if-exists.sh
     - env: TASK=ci-unit CACHE_NAME=py2 COMMAND_THRESHOLD=700
       python: 2.7
-      name: "Unit Tests (Python 2.7 MongoDB 3.4)"
+      # bionic comes with MongoDB 4.0 and 3.4 is not available on bionic
+      name: "Unit Tests (Python 2.7 MongoDB 4.0)"
     - env: TASK=ci-integration CACHE_NAME=py2 COMMAND_THRESHOLD=700
       python: 2.7
       name: "Integration Tests (Python 2.7)"
@@ -54,12 +55,7 @@ jobs:
 
 addons:
   apt:
-    sources:
-      - sourceline: 'deb [arch=amd64] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse'
-        key_url: 'https://www.mongodb.org/static/pgp/server-3.4.asc'
     packages:
-      - mongodb-org-server=3.4.*
-      - mongodb-org-shell=3.4.*
       - rabbitmq-server
       - libffi-dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,20 +36,20 @@ jobs:
     # If you rename or reorder make targets in TASK, you may need to adjust:
     # scripts/travis/install-requirements.sh
     # scripts/travis/run-nightly-make-task-if-exists.sh
-    - env: TASK=ci-unit CACHE_NAME=py2 COMMAND_THRESHOLD=700
+    - env: TASK=ci-unit CACHE_NAME=py2 COMMAND_THRESHOLD=870
       python: 2.7
       # bionic comes with MongoDB 4.0 and 3.4 is not available on bionic
       name: "Unit Tests (Python 2.7 MongoDB 4.0)"
-    - env: TASK=ci-integration CACHE_NAME=py2 COMMAND_THRESHOLD=700
+    - env: TASK=ci-integration CACHE_NAME=py2 COMMAND_THRESHOLD=960
       python: 2.7
       name: "Integration Tests (Python 2.7)"
-    - env: TASK="ci-checks ci-packs-tests" CACHE_NAME=py2 COMMAND_THRESHOLD=430
+    - env: TASK="ci-checks ci-packs-tests" CACHE_NAME=py2 COMMAND_THRESHOLD=550
       python: 2.7
       name: "Lint Checks, Packs Tests (Python 2.7)"
-    - env: TASK="compilepy3 ci-py3-unit ci-py3-packs-tests" CACHE_NAME=py3 PYTHON_VERSION=python3.6 COMMAND_THRESHOLD=750
+    - env: TASK="compilepy3 ci-py3-unit ci-py3-packs-tests" CACHE_NAME=py3 PYTHON_VERSION=python3.6 COMMAND_THRESHOLD=1160
       python: 3.6
       name: "Unit Tests, Pack Tests (Python 3.6)"
-    - env: TASK="ci-py3-integration" CACHE_NAME=py3 PYTHON_VERSION=python3.6 COMMAND_THRESHOLD=770
+    - env: TASK="ci-py3-integration" CACHE_NAME=py3 PYTHON_VERSION=python3.6 COMMAND_THRESHOLD=1090
       python: 3.6
       name: "Integration Tests (Python 3.6)"
 


### PR DESCRIPTION
This is a rebased version of #4863. It is here for future reference (to show how minimal the update is) when we want to consider moving to bionic. I will immediately close it.

Switches travis to use Bionic with Mongo 4.0

Mongo 3.4 is not available in Bionic, so 4.0 is required.
Also, the test thresholds were increased to account for increased test times due to the mongo update.