### PR TITLE
Close proxycommand socket when its not needed anymore and resolve ssh zombies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -64,6 +64,7 @@ Changed
 Fixed
 ~~~~~
 
+* Fix ssh zombies when using ProxyCommand from ssh config #4881 [Eric Edgar]
 * Fix rbac with execution view where the rbac is unable to verify the pack or uid of the execution
   because it was not returned from the action execution db. This would result in an internal server
   error when trying to view the results of a single execution.
@@ -2427,7 +2428,6 @@ Deprecated
 Fixed
 ~~~~~
 
-* Fix ssh zombies when using ProxyCommand from ssh config #4881 [Eric Edgar]
 * Bug fixes to allow Sensors to have their own log files. #2487 [Andrew Regan]
 * Make sure that the ``filename``, ``module``, ``funcName`` and ``lineno`` attributes which are
   available in the log formatter string contain the correct values. (bug-fix)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,6 @@ Added
 
 Changed
 ~~~~~~~
-* Fix ssh zombies when using ProxyCommand from ssh config #4881
 * Install pack with the latest tag version if it exists when branch is not specialized.
   (improvement) #4743
 * Implement "continue" engine command to orquesta workflow. (improvement) #4740
@@ -2428,6 +2427,7 @@ Deprecated
 Fixed
 ~~~~~
 
+* Fix ssh zombies when using ProxyCommand from ssh config #4881 [Eric Edgar]
 * Bug fixes to allow Sensors to have their own log files. #2487 [Andrew Regan]
 * Make sure that the ``filename``, ``module``, ``funcName`` and ``lineno`` attributes which are
   available in the log formatter string contain the correct values. (bug-fix)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,7 @@ Added
 
 Changed
 ~~~~~~~
-
+* Fix ssh zombies when using ProxyCommand from ssh config #4881
 * Install pack with the latest tag version if it exists when branch is not specialized.
   (improvement) #4743
 * Implement "continue" engine command to orquesta workflow. (improvement) #4740

--- a/st2actions/tests/unit/test_paramiko_ssh.py
+++ b/st2actions/tests/unit/test_paramiko_ssh.py
@@ -803,10 +803,8 @@ class ParamikoSSHClientTestCase(unittest2.TestCase):
         call_kwargs = mock_client.connect.call_args[1]
         self.assertEqual(call_kwargs['port'], 9999)
 
-    @patch('paramiko.SSHClient', Mock)
     @patch.object(ParamikoSSHClient, '_is_key_file_needs_passphrase',
                   MagicMock(return_value=False))
-
     def test_socket_closed(self):
         conn_params = {'hostname': 'dummy.host.org',
                        'username': 'ubuntu',
@@ -823,6 +821,7 @@ class ParamikoSSHClientTestCase(unittest2.TestCase):
         ssh_client.socket = Mock()
 
         # Make sure we havent called any close methods at this point
+        # TODO: Replace these with .assert_not_called() once it's Python 3.6+ only
         self.assertEqual(ssh_client.socket.process.kill.call_count, 0)
         self.assertEqual(ssh_client.socket.process.poll.call_count, 0)
 
@@ -830,7 +829,6 @@ class ParamikoSSHClientTestCase(unittest2.TestCase):
         ssh_client.close()
 
         # Make sure we have called kill and poll
+        # TODO: Replace these with .assert_called_once() once it's Python 3.6+ only
         self.assertEqual(ssh_client.socket.process.kill.call_count, 1)
         self.assertEqual(ssh_client.socket.process.poll.call_count, 1)
-
-

--- a/st2actions/tests/unit/test_paramiko_ssh.py
+++ b/st2actions/tests/unit/test_paramiko_ssh.py
@@ -811,7 +811,6 @@ class ParamikoSSHClientTestCase(unittest2.TestCase):
                        'password': 'pass',
                        'timeout': '600'}
         ssh_client = ParamikoSSHClient(**conn_params)
-        ssh_client.connect()
 
         # Make sure .close() doesn't actually call anything real
         ssh_client.client = Mock()

--- a/st2common/st2common/runners/paramiko_ssh.py
+++ b/st2common/st2common/runners/paramiko_ssh.py
@@ -458,7 +458,7 @@ class ParamikoSSHClient(object):
 
         if self.socket:
             self.logger.debug('Closing proxycommand socket connection')
-            #https://github.com/paramiko/paramiko/issues/789  Avoid zombie ssh processes
+            # https://github.com/paramiko/paramiko/issues/789  Avoid zombie ssh processes
             self.socket.process.kill()
             self.socket.process.poll()
 

--- a/st2common/st2common/runners/paramiko_ssh.py
+++ b/st2common/st2common/runners/paramiko_ssh.py
@@ -705,7 +705,7 @@ class ParamikoSSHClient(object):
                  '_username': self.username, '_timeout': self.timeout}
         self.logger.debug('Connecting to server', extra=extra)
 
-        self.socket = self.socket or ssh_config_file_info.get('sock', None)
+        self.socket = socket or ssh_config_file_info.get('sock', None)
         if self.socket:
             conninfo['sock'] = socket
 


### PR DESCRIPTION
Needs confirmation that this is written correctly from @eedgar (-- @punkrokk )
Paramiko has a bug that is not patched, that causes ssh proxy connected to not get closed. 

eg. zombie ssh processes are left from the proxycommand

If I were to modify my st2.conf file as follows:

```more modify-st2-config.sh 
#/bin/bash
crudini --set /etc/st2/st2.conf ssh_runner use_ssh_config True
crudini --set /etc/st2/st2.conf ssh_runner ssh_config_file_path /root/.ssh/config
chown -R root:root /root/.ssh/*
chmod 600 /root/.ssh/config
chmod 600 /root/.ssh/id_rsa
```
```more ssh-config
  Host 10.1.*
    ProxyCommand ssh -o StrictHostKeyChecking=no bastion nc %h %p
    IdentityFile ~/.ssh/id_rsa
    User stanley

  Host bastion
    Hostname bastion.example.com
    IdentityFile ~/.ssh/id_rsa
    User stanley
```
We end up with zombie ssh connections. Paramiko has a bug, but it is not patched: https://github.com/paramiko/paramiko/issues/789

This PR checks for sockets that are left open and closes them. 