### PR TITLE
Prevent duplicate tries of long running action

### DIFF
--- a/st2actions/st2actions/scheduler/handler.py
+++ b/st2actions/st2actions/scheduler/handler.py
@@ -232,7 +232,7 @@ class ActionExecutionSchedulingQueueHandler(object):
         execution_queue_item_db.handling = True
 
         try:
-            ActionExecutionSchedulingQueue.add_or_update(execution_queue_item_db, publish=False)
+            #ActionExecutionSchedulingQueue.add_or_update(execution_queue_item_db, publish=False)
             return execution_queue_item_db
         except db_exc.StackStormDBObjectWriteConflictError:
             LOG.info(


### PR DESCRIPTION
Commenting this line out fixed my long running actions being run 2 times.
Is there a configuration setting for how often this cleanup runs?

As a side note there are retries everywhere in the code base so I am not convinced this is needed.