### PR TITLE
HA: comment out Action Runner config virtualenv_opts = --always-copy

### DIFF
--- a/conf/HA/st2.conf.sample
+++ b/conf/HA/st2.conf.sample
@@ -20,7 +20,8 @@ logging = /etc/st2/logging.rulesengine.conf
 
 [actionrunner]
 logging = /etc/st2/logging.actionrunner.conf
-virtualenv_opts = --always-copy
+# Leave until EL6 is removed. Causes problems with EL7 and user64
+# virtualenv_opts = --always-copy
 
 [resultstracker]
 logging = /etc/st2/logging.resultstracker.conf

--- a/conf/HA/st2.conf.sample
+++ b/conf/HA/st2.conf.sample
@@ -20,8 +20,8 @@ logging = /etc/st2/logging.rulesengine.conf
 
 [actionrunner]
 logging = /etc/st2/logging.actionrunner.conf
-# Leave until EL6 is removed. Causes problems with EL7 and user64
-# virtualenv_opts = --always-copy
+# The line should be commented and 'always-copy' removed when using EL7 or EL8 as it causes virtualenv issues on pack install
+virtualenv_opts = --always-copy
 
 [resultstracker]
 logging = /etc/st2/logging.resultstracker.conf


### PR DESCRIPTION
The problematic sample here is: `virtualenv_opts = --always-copy` from the st2-ha sample config. 

This caused considerable frustration while following the [ST2-HA setup guide](https://docs.stackstorm.com/reference/ha.html).
```
[actionrunner]
logging = /etc/st2/logging.actionrunner.conf
**virtualenv_opts = --always-copy**
```

`virtualenv_opts` should be set in EL6, but from what I can tell, not in Ubuntu or EL >=7

There's a possibility that this should be comments out here also:

https://github.com/StackStorm/st2/blob/baada1854255ad9b89ab2cba33c5f6205ff4db48/conf/st2.package.conf#L21-L23

but I suspect it may be used in testing. 