### PR TITLE
Refactor evaluation of inbound criteria of join task in orquesta workflow

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,6 +56,8 @@ Changed
 * Remove `.scrutinizer.yml` config file. No longer used.
 * Convert escaped dict and dynamic fields in workflow db models to normal dict and dynamic fields.
   (performnce improvement)
+* Refactor how inbound criteria for join task in orquesta workflow is evaluated to count by
+  task completion instead of task transition. (improvement)
 
 Fixed
 ~~~~~

--- a/contrib/runners/orquesta_runner/in-requirements.txt
+++ b/contrib/runners/orquesta_runner/in-requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/StackStorm/orquesta.git@6e2fa8052cd62b07e96e540f68e7290b324d0f01#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@359a33f3d51c82f0177b175998ecd99214f992e8#egg=orquesta

--- a/contrib/runners/orquesta_runner/requirements.txt
+++ b/contrib/runners/orquesta_runner/requirements.txt
@@ -5,4 +5,4 @@
 # If you want to update depdencies for a single component, modify the
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
-git+https://github.com/StackStorm/orquesta.git@6e2fa8052cd62b07e96e540f68e7290b324d0f01#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@359a33f3d51c82f0177b175998ecd99214f992e8#egg=orquesta

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ cryptography==2.8
 eventlet==0.25.1
 flex==6.14.0
 git+https://github.com/StackStorm/logshipper.git@stackstorm_patched#egg=logshipper
-git+https://github.com/StackStorm/orquesta.git@6e2fa8052cd62b07e96e540f68e7290b324d0f01#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@359a33f3d51c82f0177b175998ecd99214f992e8#egg=orquesta
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
 gitpython==2.1.15

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -9,7 +9,7 @@ jsonschema
 kombu
 mongoengine
 networkx
-git+https://github.com/StackStorm/orquesta.git@6e2fa8052cd62b07e96e540f68e7290b324d0f01#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@359a33f3d51c82f0177b175998ecd99214f992e8#egg=orquesta
 oslo.config
 paramiko
 pyyaml

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -10,7 +10,7 @@ apscheduler==3.6.3
 cryptography==2.8
 eventlet==0.25.1
 flex==6.14.0
-git+https://github.com/StackStorm/orquesta.git@6e2fa8052cd62b07e96e540f68e7290b324d0f01#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@359a33f3d51c82f0177b175998ecd99214f992e8#egg=orquesta
 gitpython==2.1.15
 greenlet==0.4.15
 ipaddr


### PR DESCRIPTION
Update orquesta dependency to version that refactored evaluation of inbound criteria for join task on inbound task completion and not on inbound task transition. This allows for different use cases such as multiple task transition from the same inbound task, inbound task transition on completion or inbound task transition on failure. Include additional check in the state machine to detect case where there is an unreachable join task where inbound criteria is partially satisfied but all inbound tasks have already completed and it will never be satisfied.