### PR TITLE
Improve test failure directions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -437,6 +437,21 @@ distclean: clean
 	@echo
 	rm -rf $(VIRTUALENV_DIR)
 
+.PHONY: .sdist-requirements
+.sdist-requirements:
+	# Copy over shared dist utils module which is needed by setup.py
+	@for component in $(COMPONENTS_WITH_RUNNERS); do\
+		cp -f ./scripts/dist_utils.py $$component/dist_utils.py;\
+		scripts/write-headers.sh $$component/dist_utils.py || break;\
+	done
+
+	# Copy over CHANGELOG.RST, CONTRIBUTING.RST and LICENSE file to each component directory
+	#@for component in $(COMPONENTS_TEST); do\
+	#	test -s $$component/README.rst || cp -f README.rst $$component/; \
+	#	cp -f CONTRIBUTING.rst $$component/; \
+	#	cp -f LICENSE $$component/; \
+	#done
+
 .PHONY: requirements
 requirements: virtualenv .sdist-requirements install-runners
 	@echo
@@ -933,22 +948,6 @@ debs:
 	rm -Rf ~/debbuild
 	$(foreach COM,$(COMPONENTS), pushd $(COM); make deb; popd;)
 	pushd st2client && make deb && popd
-
-# >>>>
-.PHONY: .sdist-requirements
-.sdist-requirements:
-	# Copy over shared dist utils module which is needed by setup.py
-	@for component in $(COMPONENTS_WITH_RUNNERS); do\
-		cp -f ./scripts/dist_utils.py $$component/dist_utils.py;\
-		scripts/write-headers.sh $$component/dist_utils.py || break;\
-	done
-
-	# Copy over CHANGELOG.RST, CONTRIBUTING.RST and LICENSE file to each component directory
-	#@for component in $(COMPONENTS_TEST); do\
-	#	test -s $$component/README.rst || cp -f README.rst $$component/; \
-	#	cp -f CONTRIBUTING.rst $$component/; \
-	#	cp -f LICENSE $$component/; \
-	#done
 
 
 .PHONY: ci

--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,31 @@ install-runners:
 .PHONY: check-requirements
 check-requirements: .requirements .check-requirements
 
+.PHONY: .check-sdist-requirements
+.check-sdist-requirements:
+	@echo
+	@echo "============== CHECKING SDIST REQUIREMENTS =============="
+	@echo
+	# Update requirements and then make sure no files were changed
+	git status -- */dist_utils.py contrib/runners/*/dist_utils.py | grep -q "nothing to commit" || { \
+		echo "It looks like you directly modified a dist_utils.py, or the source "; \
+		echo "scripts/dist_utils.py file without running:"; \
+		echo ""; \
+		echo "    make .sdist-requirements"; \
+		echo ""; \
+		echo "Please update all of the dist_utils.py files by running that command"; \
+		echo "and committing all of the changed files. You can quickly check the results"; \
+		echo "with:"; \
+		echo ""; \
+		echo "    make .check-sdist-requirements"; \
+		echo ""; \
+		exit 1; \
+	}
+	@echo "All dist_utils.py files are up-to-date!"
+
+.PHONY: check-sdist-requirements
+check-sdist-requirements: .sdist-requirements .check-sdist-requirements
+
 .PHONY: check-python-packages
 check-python-packages:
 	# Make target which verifies all the components Python packages are valid

--- a/Makefile
+++ b/Makefile
@@ -161,13 +161,16 @@ install-runners:
 	done
 
 .PHONY: check-requirements
-check-requirements: requirements
+.check-requirements:
 	@echo
 	@echo "============== CHECKING REQUIREMENTS =============="
 	@echo
 	# Update requirements and then make sure no files were changed
 	git status -- *requirements.txt */*requirements.txt | grep -q "nothing to commit"
 	@echo "All requirements files up-to-date!"
+
+.PHONY: check-requirements
+check-requirements: .requirements .check-requirements
 
 .PHONY: check-python-packages
 check-python-packages:

--- a/Makefile
+++ b/Makefile
@@ -166,8 +166,21 @@ install-runners:
 	@echo "============== CHECKING REQUIREMENTS =============="
 	@echo
 	# Update requirements and then make sure no files were changed
-	git status -- *requirements.txt */*requirements.txt | grep -q "nothing to commit"
-	@echo "All requirements files up-to-date!"
+	git status -- *requirements.txt */*requirements.txt | grep -q "nothing to commit" || { \
+		echo "It looks like you directly modified a requirements.txt file, an"; \
+		echo "in-requirements.txt file, or fixed-requirements.txt without running:"; \
+		echo ""; \
+		echo "    make .requirements"; \
+		echo ""; \
+		echo "Please update all of the requirements.txt files by running that command"; \
+		echo "and committing all of the changed files. You can quickly check the results"; \
+		echo "with:"; \
+		echo ""; \
+		echo "    make .check-requirements"; \
+		echo ""; \
+		exit 1; \
+	}
+	@echo "All requirements files are up-to-date!"
 
 .PHONY: check-requirements
 check-requirements: .requirements .check-requirements

--- a/Makefile
+++ b/Makefile
@@ -452,21 +452,8 @@ distclean: clean
 	#	cp -f LICENSE $$component/; \
 	#done
 
-.PHONY: requirements
-requirements: virtualenv .sdist-requirements install-runners
-	@echo
-	@echo "==================== requirements ===================="
-	@echo
-	# If you update these versions, make sure you also update the versions in the
-	# .st2client-install-check target and .travis.yml to match
-	# Make sure we use latest version of pip
-	$(VIRTUALENV_DIR)/bin/pip --version
-	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pip==20.0.2"
-	# setuptools >= 41.0.1 is required for packs.install in dev envs
-	# setuptools >= 42     is required so setup.py install respects dependencies' python_requires
-	$(VIRTUALENV_DIR)/bin/pip install --upgrade "setuptools==44.1.0"
-	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pbr==5.4.3"  # workaround for pbr issue
-
+.PHONY: .requirements
+.requirements: virtualenv
 	# Generate all requirements to support current CI pipeline.
 	$(VIRTUALENV_DIR)/bin/python scripts/fixate-requirements.py --skip=virtualenv,virtualenv-osx -s st2*/in-requirements.txt contrib/runners/*/in-requirements.txt -f fixed-requirements.txt -o requirements.txt
 
@@ -481,6 +468,21 @@ requirements: virtualenv .sdist-requirements install-runners
 	done
 
 	@echo "==========================================================="
+
+.PHONY: requirements
+requirements: virtualenv .requirements .sdist-requirements install-runners
+	@echo
+	@echo "==================== requirements ===================="
+	@echo
+	# If you update these versions, make sure you also update the versions in the
+	# .st2client-install-check target and .travis.yml to match
+	# Make sure we use latest version of pip
+	$(VIRTUALENV_DIR)/bin/pip --version
+	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pip>=19.3.1"
+	# setuptools >= 41.0.1 is required for packs.install in dev envs
+	# setuptools >= 42     is required so setup.py install respects dependencies' python_requires
+	$(VIRTUALENV_DIR)/bin/pip install --upgrade "setuptools>=42"
+	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pbr==5.4.3"  # workaround for pbr issue
 
 	# Fix for Travis CI race
 	$(VIRTUALENV_DIR)/bin/pip install "six==1.12.0"

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ play:
 	@echo
 
 .PHONY: check
-check: check-requirements flake8 checklogs
+check: check-requirements check-sdist-requirements flake8 checklogs
 
 # NOTE: We pass --no-deps to the script so we don't install all the
 # package dependencies which are already installed as part of "requirements"
@@ -997,7 +997,7 @@ debs:
 ci: ci-checks ci-unit ci-integration ci-mistral ci-packs-tests
 
 .PHONY: ci-checks
-ci-checks: compile .generated-files-check .pylint .flake8 check-requirements .st2client-dependencies-check .st2common-circular-dependencies-check circle-lint-api-spec .rst-check .st2client-install-check check-python-packages
+ci-checks: compile .generated-files-check .pylint .flake8 check-requirements check-sdist-requirements .st2client-dependencies-check .st2common-circular-dependencies-check circle-lint-api-spec .rst-check .st2client-install-check check-python-packages
 
 .PHONY: ci-py3-unit
 ci-py3-unit:


### PR DESCRIPTION
Updating dependencies is not an obvious, straightforward, or documented process, so many people have tried to simply update the root `requirements.txt` files, or the `requirements.txt` in one of our subpackages (eg: runners and st2* packages). While we do have headers on all of those files instructing people how to do it properly, it's very easy to miss them.

To combat this, I have previously added a step in the `ci-checks` that runs the `make requirements` target and uses git to check if there were any changes.

However, when this causes test failures in Travis CI, the error output isn't very helpful. Furthermore, running `make requirements` takes a long time to complete.

This PR splits the `requirements` target into `requirements` and `.requirements` and uses targets to maintain reverse compatibility. Additionally, it gives very obvious directions for how to update versions properly, and how to check again before pushing additional changes.

```bash
$ make .requirements .check-requirements

============== CHECKING REQUIREMENTS ==============

# Update requirements and then make sure no files were changed
git status -- *requirements.txt */*requirements.txt | grep -q "nothing to commit" || { \
	echo "It looks like you directly modified a requirements.txt file, an"; \
	echo "in-requirements.txt file, or fixed-requirements.txt without running:"; \
	echo ""; \
	echo "    make .requirements"; \
	echo ""; \
	echo "Please update all of the requirements.txt files by running that command"; \
	echo "and committing all of the changed files. You can quickly check the results"; \
	echo "with:"; \
	echo ""; \
	echo "    make .check-requirements"; \
	echo ""; \
	exit 1; \
}
It looks like you directly modified a requirements.txt file, an
in-requirements.txt file, or fixed-requirements.txt without running:

    make .requirements

Please update all of the requirements.txt files by running that command
and committing all of the changed files. You can quickly check the results
with:

    make .check-requirements

Makefile:165: recipe for target '.check-requirements' failed
make: *** [.check-requirements] Error 1
```

Additionally, since I didn't realize that we had a similar situation with `scripts/dist_utils.py` and didn't update those for #4895, this PR adds a similar check for the sdist-requirements, with similar instructions, and a similar make target.

```bash
$ make .sdist-requirements .check-sdist-requirements
# Copy over shared dist utils module which is needed by setup.py
# Copy over CHANGELOG.RST, CONTRIBUTING.RST and LICENSE file to each component directory
#@for component in st2actions st2api st2auth st2client st2common st2debug st2exporter st2reactor st2stream contrib/runners/mistral_v2 contrib/runners/noop_runner contrib/runners/inquirer_runner contrib/runners/local_runner contrib/runners/winrm_runner contrib/runners/http_runner contrib/runners/remote_runner contrib/runners/orquesta_runner contrib/runners/python_runner contrib/runners/announcement_runner contrib/runners/action_chain_runner; do\
#	test -s $component/README.rst || cp -f README.rst $component/; \
#	cp -f CONTRIBUTING.rst $component/; \
#	cp -f LICENSE $component/; \
#done

============== CHECKING SDIST REQUIREMENTS ==============

# Update requirements and then make sure no files were changed
git status -- */dist_utils.py contrib/runners/*/dist_utils.py | grep -q "nothing to commit" || { \
	echo "It looks like you directly modified a dist_utils.py, or the source "; \
	echo "scripts/dist_utils.py file without running:"; \
	echo ""; \
	echo "    make .sdist-requirements"; \
	echo ""; \
	echo "Please update all of the dist_utils.py files by running that command"; \
	echo "and committing all of the changed files. You can quickly check the results"; \
	echo "with:"; \
	echo ""; \
	echo "    make .check-sdist-requirements"; \
	echo ""; \
	exit 1; \
}
It looks like you directly modified a dist_utils.py, or the source
scripts/dist_utils.py file without running:

    make .sdist-requirements

Please update all of the dist_utils.py files by running that command
and committing all of the changed files. You can quickly check the results
with:

    make .check-sdist-requirements

Makefile:190: recipe for target '.check-sdist-requirements' failed
make: *** [.check-sdist-requirements] Error 1
```