### PR TITLE
try to support tooz in EL8/py3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -60,7 +60,7 @@ Changed
 * Use ``pip-compile`` from ``pip-tools`` instead of ``pip-conflict-checker`` (improvement) #4896
 * Refactor how inbound criteria for join task in orquesta workflow is evaluated to count by
   task completion instead of task transition. (improvement)
-* Update tooz to v2.3.0 to apply fix for consul coordination session timeout (@punkrokk)
+* Updated and tested tooz to v2.3.0 to apply fix for consul coordination heartbeat (@punkrokk)
 
 Fixed
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -60,6 +60,7 @@ Changed
 * Use ``pip-compile`` from ``pip-tools`` instead of ``pip-conflict-checker`` (improvement) #4896
 * Refactor how inbound criteria for join task in orquesta workflow is evaluated to count by
   task completion instead of task transition. (improvement)
+* Update tooz to v2.3.0 to apply fix for consul coordination session timeout (@punkrokk)
 
 Fixed
 ~~~~~

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -41,7 +41,8 @@ six==1.13.0
 # NOTE: sseclient has various issues which sometimes hang the connection for a long time, etc.
 sseclient-py==1.7
 stevedore==1.30.1
-tooz==1.66.1
+tooz==1.66.1; python_version <= '2.7'
+tooz==2.3.0; python_version >= '3.6'
 # Note: We use latest version of virtualenv which uses pip 19
 virtualenv==16.6.0
 webob==1.8.5


### PR DESCRIPTION
Problem: Tooz < 2.2.0 doesn't support consul heartbeat. @nmaludy Got it committed to tooz: https://github.com/openstack/tooz/commit/6e750b6921c42f3c2ffed2e135be4d9c65e96f36#diff-ac4db250c2e1f5b2d95e610996274b96.

I have tested this and updated fixed-requirements.txt as follows: 

```
tooz==1.66.1; python_version <= '2.7'
tooz==2.3.0; python_version >= '3.6'
```

The question is - will this build correctly? It seems to me (@blag ) that the make requirements script doesn't put both lines in the generated requirements files. 

Proof that it works: 
![image](https://user-images.githubusercontent.com/1099386/78748293-a6fe4580-7939-11ea-84a9-23f7a2904ed2.png)
