### PR TITLE
Update orquesta to version that has the vars eval fix for ctx() dict methods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -126,8 +126,10 @@ Fixed
   Contributed by Tatsuma Matsuki (@mtatsuma)
 
 * Fix dependency conflicts by updating ``requests`` (2.23.0) and ``gitpython`` (2.1.15). #4869
-* Fix orquesta syntax error for with items task where action is misindented or missing.
-  StackStorm/orquesta#195 (bug fix)
+* Fix orquesta syntax error for with items task where action is misindented or missing. (bug fix)
+  PR StackStorm/orquesta#195.
+* Fix orquesta yaql/jinja vars extraction to ignore methods of base ctx() dict. (bug fix)
+  PR StackStorm/orquesta#196. Fixes #4866.
 
 Removed
 ~~~~~~~

--- a/contrib/runners/orquesta_runner/in-requirements.txt
+++ b/contrib/runners/orquesta_runner/in-requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/StackStorm/orquesta.git@419a4a94fc387a274b7873e04de0cc3e00d6cc5d#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@dc85df7a4690fce8dc7fdbe9df34bd8541fa7185#egg=orquesta

--- a/contrib/runners/orquesta_runner/requirements.txt
+++ b/contrib/runners/orquesta_runner/requirements.txt
@@ -5,4 +5,4 @@
 # If you want to update depdencies for a single component, modify the
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
-git+https://github.com/StackStorm/orquesta.git@419a4a94fc387a274b7873e04de0cc3e00d6cc5d#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@dc85df7a4690fce8dc7fdbe9df34bd8541fa7185#egg=orquesta

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ cryptography==2.8
 eventlet==0.25.1
 flex==6.14.0
 git+https://github.com/StackStorm/logshipper.git@stackstorm_patched#egg=logshipper
-git+https://github.com/StackStorm/orquesta.git@419a4a94fc387a274b7873e04de0cc3e00d6cc5d#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@dc85df7a4690fce8dc7fdbe9df34bd8541fa7185#egg=orquesta
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
 gitpython==2.1.15

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -9,7 +9,7 @@ jsonschema
 kombu
 mongoengine
 networkx
-git+https://github.com/StackStorm/orquesta.git@419a4a94fc387a274b7873e04de0cc3e00d6cc5d#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@dc85df7a4690fce8dc7fdbe9df34bd8541fa7185#egg=orquesta
 oslo.config
 paramiko
 pyyaml

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -10,7 +10,7 @@ apscheduler==3.6.3
 cryptography==2.8
 eventlet==0.25.1
 flex==6.14.0
-git+https://github.com/StackStorm/orquesta.git@419a4a94fc387a274b7873e04de0cc3e00d6cc5d#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@dc85df7a4690fce8dc7fdbe9df34bd8541fa7185#egg=orquesta
 gitpython==2.1.15
 greenlet==0.4.15
 ipaddr


### PR DESCRIPTION
Update orquesta to the commit version with the fix that will not return false positives on variables evaluation for dict method calls on ctx().