### PR TITLE
Update orquesta to version with array of dicts fix for YAQL functions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -131,6 +131,10 @@ Fixed
   PR StackStorm/orquesta#195.
 * Fix orquesta yaql/jinja vars extraction to ignore methods of base ctx() dict. (bug fix)
   PR StackStorm/orquesta#196. Fixes #4866.
+* Fix parsing of array of dicts in YAQL functions. Fix regression in YAQL/Jinja conversion
+  functions as a result of the change. (bug fix) PR StackStorm/orquesta#191.
+
+  Contributed by Hiroyasu Ohyama (@userlocalhost)
 
 Removed
 ~~~~~~~

--- a/contrib/runners/orquesta_runner/in-requirements.txt
+++ b/contrib/runners/orquesta_runner/in-requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/StackStorm/orquesta.git@dc85df7a4690fce8dc7fdbe9df34bd8541fa7185#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@9854f91e4de16f89eac3e689b44dc2a43269b124#egg=orquesta

--- a/contrib/runners/orquesta_runner/requirements.txt
+++ b/contrib/runners/orquesta_runner/requirements.txt
@@ -5,4 +5,4 @@
 # If you want to update depdencies for a single component, modify the
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
-git+https://github.com/StackStorm/orquesta.git@dc85df7a4690fce8dc7fdbe9df34bd8541fa7185#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@9854f91e4de16f89eac3e689b44dc2a43269b124#egg=orquesta

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ cryptography==2.8
 eventlet==0.25.1
 flex==6.14.0
 git+https://github.com/StackStorm/logshipper.git@stackstorm_patched#egg=logshipper
-git+https://github.com/StackStorm/orquesta.git@dc85df7a4690fce8dc7fdbe9df34bd8541fa7185#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@9854f91e4de16f89eac3e689b44dc2a43269b124#egg=orquesta
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
 gitpython==2.1.15

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -9,7 +9,7 @@ jsonschema
 kombu
 mongoengine
 networkx
-git+https://github.com/StackStorm/orquesta.git@dc85df7a4690fce8dc7fdbe9df34bd8541fa7185#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@9854f91e4de16f89eac3e689b44dc2a43269b124#egg=orquesta
 oslo.config
 paramiko
 pyyaml

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -10,7 +10,7 @@ apscheduler==3.6.3
 cryptography==2.8
 eventlet==0.25.1
 flex==6.14.0
-git+https://github.com/StackStorm/orquesta.git@dc85df7a4690fce8dc7fdbe9df34bd8541fa7185#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@9854f91e4de16f89eac3e689b44dc2a43269b124#egg=orquesta
 gitpython==2.1.15
 greenlet==0.4.15
 ipaddr

--- a/st2common/st2common/expressions/functions/data.py
+++ b/st2common/st2common/expressions/functions/data.py
@@ -42,6 +42,8 @@ def from_yaml_string(value):
 
 
 def to_json_string(value, indent=None, sort_keys=False, separators=(',', ': ')):
+    value = db_util.mongodb_to_python_types(value)
+
     options = {}
 
     if indent is not None:

--- a/st2common/st2common/util/db.py
+++ b/st2common/st2common/util/db.py
@@ -14,6 +14,7 @@
 
 from __future__ import absolute_import
 
+import collections
 import mongoengine
 import six
 
@@ -24,6 +25,12 @@ def mongodb_to_python_types(value):
         value = dict(value)
     elif isinstance(value, mongoengine.base.datastructures.BaseList):
         value = list(value)
+    # Convert collections.Mapping types to python dict otherwise YAQL/Jinja related
+    # functions used to convert JSON/YAML objects/strings will errored. This is caused
+    # by the PR StackStorm/orquesta#191 which converts dict to collections.Mapping
+    # in YAQL related functions.
+    elif isinstance(value, collections.Mapping):
+        value = dict(value)
 
     # Recursively traverse the dict and list to convert values.
     if isinstance(value, dict):


### PR DESCRIPTION
Update orquesta to version with array of dicts fix for YAQL functions. The change also fix regression in JSON/YAML related conversion functions as a result of the orquesta change.