### PR TITLE
Pin orquesta to v1.1.0 for the st2 v3.2 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -62,7 +62,10 @@ Changed
 * Use ``pip-compile`` from ``pip-tools`` instead of ``pip-conflict-checker`` (improvement) #4896
 * Refactor how inbound criteria for join task in orquesta workflow is evaluated to count by
   task completion instead of task transition. (improvement)
-
+* The workflow engine orquesta is updated to v1.1.0 for the st2 v3.2 release. The version upgrade
+  contains various new features and bug fixes. Please review the release notes for the full list of
+  changes at https://github.com/StackStorm/orquesta/releases/tag/v1.1.0 and the st2 upgrade notes
+  for potential impact. (improvement)
 
 Fixed
 ~~~~~

--- a/contrib/runners/orquesta_runner/in-requirements.txt
+++ b/contrib/runners/orquesta_runner/in-requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/StackStorm/orquesta.git@9854f91e4de16f89eac3e689b44dc2a43269b124#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@v1.1.0#egg=orquesta

--- a/contrib/runners/orquesta_runner/requirements.txt
+++ b/contrib/runners/orquesta_runner/requirements.txt
@@ -5,4 +5,4 @@
 # If you want to update depdencies for a single component, modify the
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
-git+https://github.com/StackStorm/orquesta.git@9854f91e4de16f89eac3e689b44dc2a43269b124#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@v1.1.0#egg=orquesta

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ cryptography==2.8
 eventlet==0.25.1
 flex==6.14.0
 git+https://github.com/StackStorm/logshipper.git@stackstorm_patched#egg=logshipper
-git+https://github.com/StackStorm/orquesta.git@9854f91e4de16f89eac3e689b44dc2a43269b124#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@v1.1.0#egg=orquesta
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
 gitpython==2.1.15

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -9,7 +9,7 @@ jsonschema
 kombu
 mongoengine
 networkx
-git+https://github.com/StackStorm/orquesta.git@9854f91e4de16f89eac3e689b44dc2a43269b124#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@v1.1.0#egg=orquesta
 oslo.config
 paramiko
 pyyaml

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -10,7 +10,7 @@ apscheduler==3.6.3
 cryptography==2.8
 eventlet==0.25.1
 flex==6.14.0
-git+https://github.com/StackStorm/orquesta.git@9854f91e4de16f89eac3e689b44dc2a43269b124#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@v1.1.0#egg=orquesta
 gitpython==2.1.15
 greenlet==0.4.15
 ipaddr


### PR DESCRIPTION
Pin orquesta to release v1.1.0 for the st2 v3.2 release. Add changelog entry of the change and notify users to review release notes and upgrade notes for potential impact.