### PR TITLE
Allow user to retrieve more than one resource using "st2 resource get" CLI command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -257,6 +257,22 @@ Improvements
 
   Contributed by @cognifloyd.
 
+* Update majority of the "resource get" CLI commands (e.g. ``st2 execution get``,
+  ``st2 action get``, ``st2 rule get``, ``st2 pack get``, ``st2 apikey get``, ``st2 trace get``,
+  ``st2 key get``, ``st2 webhook get``, ``st2  timer get``, etc.) so they allow for retrieval
+  and printing of information for multiple resources using the following notation:
+  ``st2 <resource> get <id 1> <id 2> <id n>``, e.g. ``st2 action.get pack.show packs.get
+  packs.delete``
+
+  This change is fully backward compatible when retrieving only a single resource (aka single
+  id is passed to the command).
+
+  When retrieving a single source the command will throw and exit with non-zero if a resource is
+  not found, but when retrieving multiple resources, command will just print an error and
+  continue with printing the details of any other found resources. (new feature) #4912
+
+  Contributed by @Kami.
+
 Fixed
 ~~~~~
 

--- a/st2actions/st2actions/notifier/config.py
+++ b/st2actions/st2actions/notifier/config.py
@@ -21,8 +21,6 @@ import st2common.config as common_config
 from st2common.constants.system import VERSION_STRING
 from st2common.constants.system import DEFAULT_CONFIG_FILE_PATH
 
-common_config.register_opts()
-
 CONF = cfg.CONF
 
 
@@ -44,7 +42,7 @@ def get_logging_config_path():
 
 
 def _register_common_opts(ignore_errors=False):
-    common_config.register_opts()
+    common_config.register_opts(ignore_errors=ignore_errors)
 
 
 def _register_notifier_opts(ignore_errors=False):

--- a/st2client/st2client/commands/inquiry.py
+++ b/st2client/st2client/commands/inquiry.py
@@ -127,11 +127,6 @@ class InquiryGetCommand(resource.ResourceGetCommand):
     def __init__(self, kv_resource, *args, **kwargs):
         super(InquiryGetCommand, self).__init__(kv_resource, *args, **kwargs)
 
-    @resource.add_auth_token_to_kwargs_from_cli
-    def run(self, args, **kwargs):
-        resource_name = getattr(args, self.pk_argument_name, None)
-        return self.get_resource_by_id(id=resource_name, **kwargs)
-
 
 class InquiryRespondCommand(resource.ResourceCommand):
     display_attributes = ["id", "response"]

--- a/st2client/st2client/commands/keyvalue.py
+++ b/st2client/st2client/commands/keyvalue.py
@@ -208,12 +208,16 @@ class KeyValuePairGetCommand(resource.ResourceGetCommand):
 
     @resource.add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
-        resource_name = getattr(args, self.pk_argument_name, None)
         decrypt = getattr(args, "decrypt", False)
         scope = getattr(args, "scope", DEFAULT_GET_SCOPE)
         kwargs["params"] = {"decrypt": str(decrypt).lower()}
         kwargs["params"]["scope"] = scope
-        return self.get_resource_by_id(id=resource_name, **kwargs)
+
+        resource_ids = getattr(args, self.pk_argument_name, None)
+        resources = self._get_multiple_resources(
+            resource_ids=resource_ids, kwargs=kwargs
+        )
+        return resources
 
 
 class KeyValuePairSetCommand(resource.ResourceCommand):

--- a/st2client/st2client/commands/rule_enforcement.py
+++ b/st2client/st2client/commands/rule_enforcement.py
@@ -56,11 +56,6 @@ class RuleEnforcementGetCommand(resource.ResourceGetCommand):
 
     pk_argument_name = "id"
 
-    @resource.add_auth_token_to_kwargs_from_cli
-    def run(self, args, **kwargs):
-        resource_id = getattr(args, self.pk_argument_name, None)
-        return self.get_resource_by_id(resource_id, **kwargs)
-
 
 class RuleEnforcementListCommand(resource.ResourceCommand):
     display_attributes = [

--- a/st2client/st2client/commands/trace.py
+++ b/st2client/st2client/commands/trace.py
@@ -16,7 +16,6 @@
 from __future__ import absolute_import
 
 from st2client.models import Resource, Trace, TriggerInstance, Rule, Execution
-from st2client.exceptions.operations import OperationFailureException
 from st2client.formatters import table
 from st2client.formatters import execution as execution_formatter
 from st2client.commands import resource
@@ -327,22 +326,22 @@ class TraceGetCommand(resource.ResourceGetCommand, SingleTraceDisplayMixin):
 
     @resource.add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
-        resource_id = getattr(args, self.pk_argument_name, None)
-        return self.get_resource_by_id(resource_id, **kwargs)
+        resource_ids = getattr(args, self.pk_argument_name, None)
+        resources = self._get_multiple_resources(
+            resource_ids=resource_ids, kwargs=kwargs
+        )
+        return resources
 
     @resource.add_auth_token_to_kwargs_from_cli
     def run_and_print(self, args, **kwargs):
-        trace = None
-        try:
-            trace = self.run(args, **kwargs)
-        except resource.ResourceNotFoundError:
-            self.print_not_found(args.id)
-            raise OperationFailureException("Trace %s not found." % (args.id))
-        # First filter for causation chains
-        trace = self._filter_trace_components(trace=trace, args=args)
-        # next filter for display purposes
-        trace = self._apply_display_filters(trace=trace, args=args)
-        return self.print_trace_details(trace=trace, args=args)
+        traces = self.run(args, **kwargs)
+
+        for trace in traces:
+            # First filter for causation chains
+            trace = self._filter_trace_components(trace=trace, args=args)
+            # next filter for display purposes
+            trace = self._apply_display_filters(trace=trace, args=args)
+            self.print_trace_details(trace=trace, args=args)
 
     @staticmethod
     def _filter_trace_components(trace, args):

--- a/st2client/st2client/commands/triggerinstance.py
+++ b/st2client/st2client/commands/triggerinstance.py
@@ -212,8 +212,3 @@ class TriggerInstanceGetCommand(resource.ResourceGetCommand):
     attribute_display_order = ["id", "trigger", "occurrence_time", "payload"]
 
     pk_argument_name = "id"
-
-    @resource.add_auth_token_to_kwargs_from_cli
-    def run(self, args, **kwargs):
-        resource_id = getattr(args, self.pk_argument_name, None)
-        return self.get_resource_by_id(resource_id, **kwargs)

--- a/st2client/st2client/models/reactor.py
+++ b/st2client/st2client/models/reactor.py
@@ -38,7 +38,7 @@ class TriggerType(core.Resource):
 
 class TriggerInstance(core.Resource):
     _alias = "Trigger-Instance"
-    _display_name = "TriggerInstance"
+    _display_name = "Trigger Instance"
     _plural = "Triggerinstances"
     _plural_display_name = "TriggerInstances"
     _repr_attributes = ["id", "trigger", "occurrence_time", "payload", "status"]

--- a/st2client/tests/base.py
+++ b/st2client/tests/base.py
@@ -125,7 +125,7 @@ class BaseCLITestCase(unittest2.TestCase):
 
             print("")
             print("Captured stdout: %s" % (stdout))
-            print("Captured stdoerr: %s" % (stderr))
+            print("Captured stderr: %s" % (stderr))
             print("")
 
     def _reset_output_streams(self):

--- a/st2client/tests/unit/test_inquiry.py
+++ b/st2client/tests/unit/test_inquiry.py
@@ -151,9 +151,11 @@ class TestInquirySubcommands(TestInquiryBase):
         args = ["inquiry", "get", inquiry_id]
         retcode = self.shell.run(args)
         self.assertEqual(
-            'Inquiry "%s" is not found.\n\n' % inquiry_id, self.stdout.getvalue()
+            'Inquiry "%s" is not found.\n\nERROR: Resource asdbv not found.\n\n'
+            % inquiry_id,
+            self.stdout.getvalue(),
         )
-        self.assertEqual(retcode, 2)
+        self.assertEqual(retcode, 1)
 
     @mock.patch.object(
         requests,

--- a/st2client/tests/unit/test_shell.py
+++ b/st2client/tests/unit/test_shell.py
@@ -841,7 +841,7 @@ class CLITokenCachingTestCase(unittest2.TestCase):
         argv = ["action", "get", "examples.test_rule_utf8_náme"]
         args = shell.parser.parse_args(args=argv)
         shell.get_client(args=args)
-        self.assertEqual(args.ref_or_id, "examples.test_rule_utf8_náme")
+        self.assertEqual(args.ref_or_id, ["examples.test_rule_utf8_náme"])
 
     def test_reencode_list_replace_surrogate_escape(self):
         value = ["a", "b", "c", "d"]

--- a/st2exporter/st2exporter/config.py
+++ b/st2exporter/st2exporter/config.py
@@ -25,8 +25,6 @@ import st2common.config as common_config
 from st2common.constants.system import VERSION_STRING
 from st2common.constants.system import DEFAULT_CONFIG_FILE_PATH
 
-common_config.register_opts()
-
 CONF = cfg.CONF
 
 

--- a/st2reactor/st2reactor/garbage_collector/config.py
+++ b/st2reactor/st2reactor/garbage_collector/config.py
@@ -23,8 +23,6 @@ from st2common.constants.system import DEFAULT_CONFIG_FILE_PATH
 from st2common.constants.garbage_collection import DEFAULT_COLLECTION_INTERVAL
 from st2common.constants.garbage_collection import DEFAULT_SLEEP_DELAY
 
-common_config.register_opts()
-
 CONF = cfg.CONF
 
 

--- a/st2reactor/st2reactor/rules/config.py
+++ b/st2reactor/st2reactor/rules/config.py
@@ -21,8 +21,6 @@ import st2common.config as common_config
 from st2common.constants.system import VERSION_STRING
 from st2common.constants.system import DEFAULT_CONFIG_FILE_PATH
 
-common_config.register_opts()
-
 CONF = cfg.CONF
 
 


### PR DESCRIPTION
This pull request addresses one of my biggest minor annoyances with StackStorm CLI.

A lot of times when I'm debugging / troubleshooting things, I need to view multiple resources at once to see what is going on.

This means that currently I need to run more than one command to achieve that.

For example:

```bash
st2 execution get id1
st2 execution get id2
st2 execution get id3
```

This slows things down and means more typing (yes, I can use a bash alias or function, but that's not ideal and it's not available out of the box).

With this change, user can now view more than one resource using the get command.

The same pattern is already available with ``st2 execution cancel`` command (I added it a while ago).

For example:

```bash
st2 execution get id1 id2 id3
```

Example output:

```bash
st2 action get packs.unload packs.show
+---------------+--------------------------------------+
| Property      | Value                                |
+---------------+--------------------------------------+
| id            | 5e9ae3535550f016857e19f9             |
| uid           | action:packs:unload                  |
| ref           | packs.unload                         |
| pack          | packs                                |
| name          | unload                               |
| description   | Unregisters all content from a pack. |
| enabled       | True                                 |
| entry_point   | pack_mgmt/unload.py                  |
| runner_type   | python-script                        |
| parameters    | {                                    |
|               |     "packs": {                       |
|               |         "items": {                   |
|               |             "type": "string"         |
|               |         },                           |
|               |         "required": true,            |
|               |         "type": "array"              |
|               |     }                                |
|               | }                                    |
| metadata_file | actions/unload.yaml                  |
| notify        |                                      |
| output_schema |                                      |
| tags          |                                      |
+---------------+--------------------------------------+
+---------------+--------------------------------------------------------------+
| Property      | Value                                                        |
+---------------+--------------------------------------------------------------+
| id            | 5e9ae3535550f016857e19f7                                     |
| uid           | action:packs:show                                            |
| ref           | packs.show                                                   |
| pack          | packs                                                        |
| name          | show                                                         |
| description   | Get detailed information about pack from the remote          |
|               | StackStorm exchange index.                                   |
| enabled       | True                                                         |
| entry_point   | pack_mgmt/show_remote.py                                     |
| runner_type   | python-script                                                |
| parameters    | {                                                            |
|               |     "pack": {                                                |
|               |         "required": true,                                    |
|               |         "type": "string",                                    |
|               |         "description": "Name of pack to lookup"              |
|               |     }                                                        |
|               | }                                                            |
| metadata_file | actions/show.yaml                                            |
| notify        |                                                              |
| output_schema |                                                              |
| tags          |                                                              |
+---------------+--------------------------------------------------------------+
```

## Open Questions / To Decide

Currently when a single source id is provided, the command behaves exactly in the same manner as it did before - it's fully backward compatible.

When retrieving multiple resources, if one of the provided resources is not found, we simply print that, but we don't immediately exit with non-zero status code and print other resources which were found.

As far as using the existing command name goes - I think that's better than adding yet another command (e.g. ``st2 <resource> get-more`` or similar) - the whole idea is that it's simple and it works out of the box so any other change which would make it less simple (e.g. new argument or filter to list command, etc.) is a no go.

## TODO

- [x] (Once agreed on the approach) Implement it for other non-resource "get" commands
- [x] (Once agreed on the approach) Add tests