### PR TITLE
Add st2-generate-schemas to autogen schemas for the content models

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 in development
 --------------
 
+Added
+~~~~~
+* Add make command to autogen JSON schema from the models of action, rule, etc. Add check
+  to ensure update to the models require schema to be regenerated. (new feature)
+
 Fixed
 ~~~~~
 * Fixed a bug where persisting Orquesta to the MongoDB database returned an error

--- a/Makefile
+++ b/Makefile
@@ -271,6 +271,16 @@ configgen: requirements .configgen
 	echo "" >> conf/st2.conf.sample
 	. $(VIRTUALENV_DIR)/bin/activate; python ./tools/config_gen.py >> conf/st2.conf.sample;
 
+.PHONY: schemasgen
+schemasgen: requirements .schemasgen
+
+.PHONY: .schemasgen
+.schemasgen:
+	@echo
+	@echo "================== content model schemas gen ===================="
+	@echo
+	. $(VIRTUALENV_DIR)/bin/activate; python ./st2common/bin/st2-generate-schemas;
+
 .PHONY: .pylint
 .pylint:
 	@echo
@@ -1054,7 +1064,18 @@ ci-py3-integration: requirements .ci-prepare-integration .ci-py3-integration
 	cp st2common/st2common/openapi.yaml /tmp/openapi.yaml.upstream
 	make .generate-api-spec
 	diff st2common/st2common/openapi.yaml  /tmp/openapi.yaml.upstream || (echo "st2common/st2common/openapi.yaml hasn't been re-generated and committed. Please run \"make generate-api-spec\" and include and commit the generated file." && exit 1)
-
+	# 3. Schemas for the content models - st2common/bin/st2-generate-schemas
+	cp contrib/schemas/pack.json /tmp/pack.json.upstream
+	cp contrib/schemas/action.json /tmp/action.json.upstream
+	cp contrib/schemas/alias.json /tmp/alias.json.upstream
+	cp contrib/schemas/policy.json /tmp/policy.json.upstream
+	cp contrib/schemas/rule.json /tmp/rule.json.upstream
+	make .schemasgen
+	diff contrib/schemas/pack.json /tmp/pack.json.upstream || (echo "contrib/schemas/pack.json hasn't been re-generated and committed. Please run \"make schemasgen\" and include and commit the generated file." && exit 1)
+	diff contrib/schemas/action.json /tmp/action.json.upstream || (echo "contrib/schemas/pack.json hasn't been re-generated and committed. Please run \"make schemasgen\" and include and commit the generated file." && exit 1)
+	diff contrib/schemas/alias.json /tmp/alias.json.upstream || (echo "contrib/schemas/pack.json hasn't been re-generated and committed. Please run \"make schemasgen\" and include and commit the generated file." && exit 1)
+	diff contrib/schemas/policy.json /tmp/policy.json.upstream || (echo "contrib/schemas/pack.json hasn't been re-generated and committed. Please run \"make schemasgen\" and include and commit the generated file." && exit 1)
+	diff contrib/schemas/rule.json /tmp/rule.json.upstream || (echo "contrib/schemas/pack.json hasn't been re-generated and committed. Please run \"make schemasgen\" and include and commit the generated file." && exit 1)
 	@echo "All automatically generated files are up to date."
 
 .PHONY: ci-unit

--- a/contrib/schemas/action.json
+++ b/contrib/schemas/action.json
@@ -1,0 +1,602 @@
+{
+    "additionalProperties": false, 
+    "properties": {
+        "uid": {
+            "type": "string"
+        }, 
+        "tags": {
+            "items": {
+                "type": "object"
+            }, 
+            "type": "array", 
+            "description": "User associated metadata assigned to this object."
+        }, 
+        "entry_point": {
+            "default": "", 
+            "type": "string", 
+            "description": "The entry point for the action."
+        }, 
+        "notify": {
+            "additionalProperties": false, 
+            "type": "object", 
+            "description": "Notification settings for action.", 
+            "properties": {
+                "on-failure": {
+                    "additionalProperties": false, 
+                    "type": "object", 
+                    "properties": {
+                        "routes": {
+                            "type": "array", 
+                            "description": "Channels to post notifications to."
+                        }, 
+                        "channels": {
+                            "type": "array", 
+                            "description": "Channels to post notifications to."
+                        }, 
+                        "message": {
+                            "type": "string", 
+                            "description": "Message to use for notification"
+                        }, 
+                        "data": {
+                            "type": "object", 
+                            "description": "Data to be sent as part of notification"
+                        }
+                    }
+                }, 
+                "on-complete": {
+                    "additionalProperties": false, 
+                    "type": "object", 
+                    "properties": {
+                        "routes": {
+                            "type": "array", 
+                            "description": "Channels to post notifications to."
+                        }, 
+                        "channels": {
+                            "type": "array", 
+                            "description": "Channels to post notifications to."
+                        }, 
+                        "message": {
+                            "type": "string", 
+                            "description": "Message to use for notification"
+                        }, 
+                        "data": {
+                            "type": "object", 
+                            "description": "Data to be sent as part of notification"
+                        }
+                    }
+                }, 
+                "on-success": {
+                    "additionalProperties": false, 
+                    "type": "object", 
+                    "properties": {
+                        "routes": {
+                            "type": "array", 
+                            "description": "Channels to post notifications to."
+                        }, 
+                        "channels": {
+                            "type": "array", 
+                            "description": "Channels to post notifications to."
+                        }, 
+                        "message": {
+                            "type": "string", 
+                            "description": "Message to use for notification"
+                        }, 
+                        "data": {
+                            "type": "object", 
+                            "description": "Data to be sent as part of notification"
+                        }
+                    }
+                }
+            }
+        }, 
+        "id": {
+            "type": "string", 
+            "description": "The unique identifier for the action."
+        }, 
+        "description": {
+            "type": "string", 
+            "description": "The description of the action."
+        }, 
+        "runner_type": {
+            "required": true, 
+            "type": "string", 
+            "description": "The type of runner that executes the action."
+        }, 
+        "parameters": {
+            "additionalProperties": false, 
+            "patternProperties": {
+                "^\\w+$": {
+                    "description": "Core schema meta-schema", 
+                    "default": {}, 
+                    "id": "http://json-schema.org/draft-04/schema#", 
+                    "dependencies": {
+                        "exclusiveMaximum": [
+                            "maximum"
+                        ], 
+                        "exclusiveMinimum": [
+                            "minimum"
+                        ]
+                    }, 
+                    "additionalProperties": false, 
+                    "definitions": {
+                        "simpleTypes": {
+                            "enum": [
+                                "array", 
+                                "boolean", 
+                                "integer", 
+                                "null", 
+                                "number", 
+                                "object", 
+                                "string"
+                            ]
+                        }, 
+                        "schemaArray": {
+                            "minItems": 1, 
+                            "items": {
+                                "$ref": "#"
+                            }, 
+                            "type": "array"
+                        }, 
+                        "positiveIntegerDefault0": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/positiveInteger"
+                                }, 
+                                {
+                                    "default": 0
+                                }
+                            ]
+                        }, 
+                        "positiveInteger": {
+                            "minimum": 0, 
+                            "type": "integer"
+                        }, 
+                        "stringArray": {
+                            "minItems": 1, 
+                            "items": {
+                                "type": "string"
+                            }, 
+                            "uniqueItems": true, 
+                            "type": "array"
+                        }
+                    }, 
+                    "$schema": "http://json-schema.org/draft-04/schema#", 
+                    "type": "object", 
+                    "properties": {
+                        "definitions": {
+                            "additionalProperties": {
+                                "$ref": "#"
+                            }, 
+                            "default": {}, 
+                            "type": "object"
+                        }, 
+                        "minProperties": {
+                            "$ref": "#/definitions/positiveIntegerDefault0"
+                        }, 
+                        "uniqueItems": {
+                            "default": false, 
+                            "type": "boolean"
+                        }, 
+                        "minimum": {
+                            "type": "number"
+                        }, 
+                        "maxItems": {
+                            "$ref": "#/definitions/positiveInteger"
+                        }, 
+                        "$schema": {
+                            "type": "string", 
+                            "format": "uri"
+                        }, 
+                        "exclusiveMinimum": {
+                            "default": false, 
+                            "type": "boolean"
+                        }, 
+                        "id": {
+                            "type": "string", 
+                            "format": "uri"
+                        }, 
+                        "exclusiveMaximum": {
+                            "default": false, 
+                            "type": "boolean"
+                        }, 
+                        "title": {
+                            "type": "string"
+                        }, 
+                        "pattern": {
+                            "type": "string", 
+                            "format": "regex"
+                        }, 
+                        "patternProperties": {
+                            "additionalProperties": {
+                                "$ref": "#"
+                            }, 
+                            "default": {}, 
+                            "type": "object"
+                        }, 
+                        "multipleOf": {
+                            "type": "number", 
+                            "minimum": 0, 
+                            "exclusiveMinimum": true
+                        }, 
+                        "secret": {
+                            "default": false, 
+                            "type": "boolean"
+                        }, 
+                        "maxProperties": {
+                            "$ref": "#/definitions/positiveInteger"
+                        }, 
+                        "type": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/definitions/simpleTypes"
+                                }
+                            ]
+                        }, 
+                        "immutable": {
+                            "default": false, 
+                            "type": "boolean"
+                        }, 
+                        "description": {
+                            "type": "string"
+                        }, 
+                        "allOf": {
+                            "$ref": "#/definitions/schemaArray"
+                        }, 
+                        "minLength": {
+                            "$ref": "#/definitions/positiveIntegerDefault0"
+                        }, 
+                        "enum": {
+                            "minItems": 1, 
+                            "uniqueItems": true, 
+                            "type": "array"
+                        }, 
+                        "additionalItems": {
+                            "default": {}, 
+                            "anyOf": [
+                                {
+                                    "type": "boolean"
+                                }, 
+                                {
+                                    "$ref": "#"
+                                }
+                            ]
+                        }, 
+                        "dependencies": {
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "$ref": "#"
+                                    }, 
+                                    {
+                                        "$ref": "#/definitions/stringArray"
+                                    }
+                                ]
+                            }, 
+                            "type": "object"
+                        }, 
+                        "anyOf": {
+                            "$ref": "#/definitions/schemaArray"
+                        }, 
+                        "maxLength": {
+                            "$ref": "#/definitions/positiveInteger"
+                        }, 
+                        "not": {
+                            "$ref": "#"
+                        }, 
+                        "properties": {
+                            "additionalProperties": {
+                                "$ref": "#"
+                            }, 
+                            "default": {}, 
+                            "type": "object"
+                        }, 
+                        "oneOf": {
+                            "$ref": "#/definitions/schemaArray"
+                        }, 
+                        "default": {}, 
+                        "items": {
+                            "default": {}, 
+                            "anyOf": [
+                                {
+                                    "$ref": "#"
+                                }, 
+                                {
+                                    "$ref": "#/definitions/schemaArray"
+                                }
+                            ]
+                        }, 
+                        "required": {
+                            "default": false, 
+                            "type": "boolean"
+                        }, 
+                        "maximum": {
+                            "type": "number"
+                        }, 
+                        "minItems": {
+                            "$ref": "#/definitions/positiveIntegerDefault0"
+                        }, 
+                        "additionalProperties": {
+                            "default": {}, 
+                            "anyOf": [
+                                {
+                                    "type": "boolean"
+                                }, 
+                                {
+                                    "$ref": "#"
+                                }
+                            ]
+                        }, 
+                        "position": {
+                            "minimum": 0, 
+                            "type": "number"
+                        }
+                    }
+                }
+            }, 
+            "default": {}, 
+            "type": "object", 
+            "description": "Input parameters for the action."
+        }, 
+        "enabled": {
+            "default": true, 
+            "type": "boolean", 
+            "description": "Enable or disable the action from invocation."
+        }, 
+        "name": {
+            "required": true, 
+            "type": "string", 
+            "description": "The name of the action."
+        }, 
+        "metadata_file": {
+            "default": "", 
+            "type": "string", 
+            "description": "Path to the metadata file relative to the pack directory."
+        }, 
+        "output_schema": {
+            "additionalProperties": false, 
+            "patternProperties": {
+                "^\\w+$": {
+                    "description": "Core schema meta-schema", 
+                    "default": {}, 
+                    "id": "http://json-schema.org/draft-04/schema#", 
+                    "dependencies": {
+                        "exclusiveMaximum": [
+                            "maximum"
+                        ], 
+                        "exclusiveMinimum": [
+                            "minimum"
+                        ]
+                    }, 
+                    "definitions": {
+                        "simpleTypes": {
+                            "enum": [
+                                "array", 
+                                "boolean", 
+                                "integer", 
+                                "null", 
+                                "number", 
+                                "object", 
+                                "string"
+                            ]
+                        }, 
+                        "schemaArray": {
+                            "minItems": 1, 
+                            "items": {
+                                "$ref": "#"
+                            }, 
+                            "type": "array"
+                        }, 
+                        "positiveIntegerDefault0": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/positiveInteger"
+                                }, 
+                                {
+                                    "default": 0
+                                }
+                            ]
+                        }, 
+                        "positiveInteger": {
+                            "minimum": 0, 
+                            "type": "integer"
+                        }, 
+                        "stringArray": {
+                            "minItems": 1, 
+                            "items": {
+                                "type": "string"
+                            }, 
+                            "uniqueItems": true, 
+                            "type": "array"
+                        }
+                    }, 
+                    "$schema": "http://json-schema.org/draft-04/schema#", 
+                    "type": "object", 
+                    "properties": {
+                        "definitions": {
+                            "additionalProperties": {
+                                "$ref": "#"
+                            }, 
+                            "default": {}, 
+                            "type": "object"
+                        }, 
+                        "minProperties": {
+                            "$ref": "#/definitions/positiveIntegerDefault0"
+                        }, 
+                        "uniqueItems": {
+                            "default": false, 
+                            "type": "boolean"
+                        }, 
+                        "minimum": {
+                            "type": "number"
+                        }, 
+                        "maxItems": {
+                            "$ref": "#/definitions/positiveInteger"
+                        }, 
+                        "$schema": {
+                            "type": "string", 
+                            "format": "uri"
+                        }, 
+                        "exclusiveMinimum": {
+                            "default": false, 
+                            "type": "boolean"
+                        }, 
+                        "id": {
+                            "type": "string", 
+                            "format": "uri"
+                        }, 
+                        "exclusiveMaximum": {
+                            "default": false, 
+                            "type": "boolean"
+                        }, 
+                        "title": {
+                            "type": "string"
+                        }, 
+                        "pattern": {
+                            "type": "string", 
+                            "format": "regex"
+                        }, 
+                        "patternProperties": {
+                            "additionalProperties": {
+                                "$ref": "#"
+                            }, 
+                            "default": {}, 
+                            "type": "object"
+                        }, 
+                        "multipleOf": {
+                            "type": "number", 
+                            "minimum": 0, 
+                            "exclusiveMinimum": true
+                        }, 
+                        "secret": {
+                            "default": false, 
+                            "type": "boolean"
+                        }, 
+                        "maxProperties": {
+                            "$ref": "#/definitions/positiveInteger"
+                        }, 
+                        "type": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/definitions/simpleTypes"
+                                }
+                            ]
+                        }, 
+                        "immutable": {
+                            "default": false, 
+                            "type": "boolean"
+                        }, 
+                        "description": {
+                            "type": "string"
+                        }, 
+                        "allOf": {
+                            "$ref": "#/definitions/schemaArray"
+                        }, 
+                        "minLength": {
+                            "$ref": "#/definitions/positiveIntegerDefault0"
+                        }, 
+                        "enum": {
+                            "minItems": 1, 
+                            "uniqueItems": true, 
+                            "type": "array"
+                        }, 
+                        "additionalItems": {
+                            "default": {}, 
+                            "anyOf": [
+                                {
+                                    "type": "boolean"
+                                }, 
+                                {
+                                    "$ref": "#"
+                                }
+                            ]
+                        }, 
+                        "dependencies": {
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "$ref": "#"
+                                    }, 
+                                    {
+                                        "$ref": "#/definitions/stringArray"
+                                    }
+                                ]
+                            }, 
+                            "type": "object"
+                        }, 
+                        "anyOf": {
+                            "$ref": "#/definitions/schemaArray"
+                        }, 
+                        "maxLength": {
+                            "$ref": "#/definitions/positiveInteger"
+                        }, 
+                        "not": {
+                            "$ref": "#"
+                        }, 
+                        "properties": {
+                            "additionalProperties": {
+                                "$ref": "#"
+                            }, 
+                            "default": {}, 
+                            "type": "object"
+                        }, 
+                        "oneOf": {
+                            "$ref": "#/definitions/schemaArray"
+                        }, 
+                        "default": {}, 
+                        "items": {
+                            "default": {}, 
+                            "anyOf": [
+                                {
+                                    "$ref": "#"
+                                }, 
+                                {
+                                    "$ref": "#/definitions/schemaArray"
+                                }
+                            ]
+                        }, 
+                        "required": {
+                            "default": false, 
+                            "type": "boolean"
+                        }, 
+                        "maximum": {
+                            "type": "number"
+                        }, 
+                        "minItems": {
+                            "$ref": "#/definitions/positiveIntegerDefault0"
+                        }, 
+                        "additionalProperties": {
+                            "default": {}, 
+                            "anyOf": [
+                                {
+                                    "type": "boolean"
+                                }, 
+                                {
+                                    "$ref": "#"
+                                }
+                            ]
+                        }, 
+                        "position": {
+                            "minimum": 0, 
+                            "type": "number"
+                        }
+                    }
+                }
+            }, 
+            "default": {}, 
+            "type": "object", 
+            "description": "Schema for the action's output."
+        }, 
+        "ref": {
+            "type": "string", 
+            "description": "System computed user friendly reference for the action.                                 Provided value will be overridden by computed value."
+        }, 
+        "pack": {
+            "default": "default", 
+            "type": "string", 
+            "description": "The content pack this action belongs to."
+        }
+    }, 
+    "type": "object", 
+    "description": "An activity that happens as a response to the external event.", 
+    "title": "Action"
+}

--- a/contrib/schemas/alias.json
+++ b/contrib/schemas/alias.json
@@ -1,0 +1,115 @@
+{
+    "additionalProperties": false, 
+    "properties": {
+        "uid": {
+            "type": "string"
+        }, 
+        "extra": {
+            "type": "object", 
+            "description": "Extra parameters, usually adapter-specific."
+        }, 
+        "immutable_parameters": {
+            "type": "object", 
+            "description": "Parameters to be passed to the action on every execution."
+        }, 
+        "result": {
+            "type": "object", 
+            "properties": {
+                "extra": {
+                    "type": "object"
+                }, 
+                "enabled": {
+                    "type": "boolean"
+                }, 
+                "format": {
+                    "type": "string"
+                }
+            }, 
+            "description": "Execution message format."
+        }, 
+        "id": {
+            "type": "string", 
+            "description": "The unique identifier for the action alias."
+        }, 
+        "description": {
+            "default": null, 
+            "type": "string", 
+            "description": "Description of the action alias."
+        }, 
+        "name": {
+            "required": true, 
+            "type": "string", 
+            "description": "Name of the action alias."
+        }, 
+        "ack": {
+            "type": "object", 
+            "properties": {
+                "append_url": {
+                    "type": "boolean"
+                }, 
+                "extra": {
+                    "type": "object"
+                }, 
+                "enabled": {
+                    "type": "boolean"
+                }, 
+                "format": {
+                    "type": "string"
+                }
+            }, 
+            "description": "Acknowledgement message format."
+        }, 
+        "enabled": {
+            "default": true, 
+            "type": "boolean", 
+            "description": "Flag indicating of action alias is enabled."
+        }, 
+        "metadata_file": {
+            "default": "", 
+            "type": "string", 
+            "description": "Path to the metadata file relative to the pack directory."
+        }, 
+        "formats": {
+            "items": {
+                "anyOf": [
+                    {
+                        "type": "string"
+                    }, 
+                    {
+                        "type": "object", 
+                        "properties": {
+                            "representation": {
+                                "items": {
+                                    "type": "string"
+                                }, 
+                                "type": "array"
+                            }, 
+                            "display": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ]
+            }, 
+            "type": "array", 
+            "description": "Possible parameter format."
+        }, 
+        "action_ref": {
+            "required": true, 
+            "type": "string", 
+            "description": "Reference to the aliased action."
+        }, 
+        "ref": {
+            "type": "string", 
+            "description": "System computed user friendly reference for the alias.                                 Provided value will be overridden by computed value."
+        }, 
+        "pack": {
+            "required": true, 
+            "type": "string", 
+            "description": "The content pack this actionalias belongs to."
+        }
+    }, 
+    "type": "object", 
+    "description": "Alias for an action.", 
+    "title": "ActionAlias"
+}

--- a/contrib/schemas/alias.json
+++ b/contrib/schemas/alias.json
@@ -101,7 +101,7 @@
         }, 
         "ref": {
             "type": "string", 
-            "description": "System computed user friendly reference for the alias.                                 Provided value will be overridden by computed value."
+            "description": "System computed user friendly reference for the alias. Provided value will be overridden by computed value."
         }, 
         "pack": {
             "required": true, 

--- a/contrib/schemas/pack.json
+++ b/contrib/schemas/pack.json
@@ -1,0 +1,109 @@
+{
+    "additionalProperties": true, 
+    "type": "object", 
+    "description": "Content pack schema.", 
+    "properties": {
+        "files": {
+            "default": [], 
+            "items": {
+                "type": "string"
+            }, 
+            "type": "array", 
+            "description": "A list of files inside the pack."
+        }, 
+        "name": {
+            "required": true, 
+            "type": "string", 
+            "description": "Display name of the pack. If the name only contains lowercaseletters, digits and underscores, the \"ref\" field is not required."
+        }, 
+        "contributors": {
+            "items": {
+                "type": "string", 
+                "maxLength": 100
+            }, 
+            "type": "array", 
+            "description": "A list of people who have contributed to the pack. Format is: Name <email address> e.g. Tomaz Muraus <tomaz@stackstorm.com>."
+        }, 
+        "author": {
+            "required": true, 
+            "type": "string", 
+            "description": "Pack author or authors."
+        }, 
+        "description": {
+            "required": true, 
+            "type": "string", 
+            "description": "Brief description of the pack and the service it integrates with."
+        }, 
+        "system": {
+            "default": {}, 
+            "type": "object", 
+            "description": "Specification for the system components and packages required for the pack."
+        }, 
+        "python_versions": {
+            "additionalItems": true, 
+            "description": "Major Python versions supported by this pack. E.g. \"2\" for Python 2.7.x and \"3\" for Python 3.6.x", 
+            "minItems": 1, 
+            "items": {
+                "enum": [
+                    "2", 
+                    "3"
+                ], 
+                "type": "string"
+            }, 
+            "maxItems": 2, 
+            "uniqueItems": true, 
+            "type": "array"
+        }, 
+        "stackstorm_version": {
+            "pattern": "^((>?>|>=|=|<=|<?<)\\s*[0-9]+\\.[0-9]+\\.[0-9]+?(\\s*,)?\\s*)+$", 
+            "type": "string", 
+            "description": "Required StackStorm version. Examples: \">1.6.0\", \">=1.8.0, <2.2.0\""
+        }, 
+        "email": {
+            "type": "string", 
+            "description": "E-mail of the pack author.", 
+            "format": "email"
+        }, 
+        "version": {
+            "pattern": "^(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)(?:-[\\da-z\\-]+(?:\\.[\\da-z\\-]+)*)?(?:\\+[\\da-z\\-]+(?:\\.[\\da-z\\-]+)*)?$", 
+            "required": true, 
+            "type": "string", 
+            "description": "Pack version. Must follow the semver format (for instance, \"0.1.0\")."
+        }, 
+        "dependencies": {
+            "default": [], 
+            "items": {
+                "type": "string"
+            }, 
+            "type": "array", 
+            "description": "A list of other StackStorm packs this pack depends upon. The same format as in \"st2 pack install\" is used: \"<name or full URL>[=<version or git ref>]\"."
+        }, 
+        "keywords": {
+            "default": [], 
+            "items": {
+                "type": "string"
+            }, 
+            "type": "array", 
+            "description": "Keywords describing the pack."
+        }, 
+        "path": {
+            "required": false, 
+            "type": "string", 
+            "description": "Location of the pack on disk in st2 system."
+        }, 
+        "ref": {
+            "default": null, 
+            "pattern": "^[a-z0-9_]+$", 
+            "type": "string", 
+            "description": "Reference for the pack, used as an internal id."
+        }, 
+        "id": {
+            "default": null, 
+            "type": "string", 
+            "description": "Unique identifier for the pack."
+        }, 
+        "uid": {
+            "type": "string"
+        }
+    }
+}

--- a/contrib/schemas/policy.json
+++ b/contrib/schemas/policy.json
@@ -1,0 +1,72 @@
+{
+    "additionalProperties": false, 
+    "type": "object", 
+    "properties": {
+        "uid": {
+            "type": "string"
+        }, 
+        "resource_ref": {
+            "required": true, 
+            "type": "string"
+        }, 
+        "metadata_file": {
+            "default": "", 
+            "type": "string", 
+            "description": "Path to the metadata file relative to the pack directory."
+        }, 
+        "id": {
+            "default": null, 
+            "type": "string"
+        }, 
+        "description": {
+            "type": "string"
+        }, 
+        "name": {
+            "required": true, 
+            "type": "string"
+        }, 
+        "parameters": {
+            "additionalProperties": false, 
+            "patternProperties": {
+                "^\\w+$": {
+                    "anyOf": [
+                        {
+                            "type": "array"
+                        }, 
+                        {
+                            "type": "boolean"
+                        }, 
+                        {
+                            "type": "integer"
+                        }, 
+                        {
+                            "type": "number"
+                        }, 
+                        {
+                            "type": "object"
+                        }, 
+                        {
+                            "type": "string"
+                        }
+                    ]
+                }
+            }, 
+            "type": "object"
+        }, 
+        "enabled": {
+            "default": true, 
+            "type": "boolean"
+        }, 
+        "policy_type": {
+            "required": true, 
+            "type": "string"
+        }, 
+        "ref": {
+            "type": "string"
+        }, 
+        "pack": {
+            "type": "string"
+        }
+    }, 
+    "title": "Policy"
+}

--- a/contrib/schemas/rule.json
+++ b/contrib/schemas/rule.json
@@ -1,0 +1,105 @@
+{
+    "additionalProperties": false, 
+    "type": "object", 
+    "properties": {
+        "uid": {
+            "type": "string"
+        }, 
+        "tags": {
+            "items": {
+                "type": "object"
+            }, 
+            "type": "array", 
+            "description": "User associated metadata assigned to this object."
+        }, 
+        "metadata_file": {
+            "default": "", 
+            "type": "string", 
+            "description": "Path to the metadata file relative to the pack directory."
+        }, 
+        "id": {
+            "default": null, 
+            "type": "string"
+        }, 
+        "description": {
+            "type": "string"
+        }, 
+        "name": {
+            "required": true, 
+            "type": "string"
+        }, 
+        "ref": {
+            "type": "string", 
+            "description": "System computed user friendly reference for the action.                                 Provided value will be overridden by computed value."
+        }, 
+        "enabled": {
+            "default": false, 
+            "type": "boolean"
+        }, 
+        "trigger": {
+            "additionalProperties": true, 
+            "required": true, 
+            "type": "object", 
+            "properties": {
+                "ref": {
+                    "required": false, 
+                    "type": "string"
+                }, 
+                "type": {
+                    "required": true, 
+                    "type": "string"
+                }, 
+                "description": {
+                    "require": false, 
+                    "type": "string"
+                }, 
+                "parameters": {
+                    "default": {}, 
+                    "type": "object"
+                }
+            }
+        }, 
+        "context": {
+            "type": "object"
+        }, 
+        "criteria": {
+            "default": {}, 
+            "type": "object"
+        }, 
+        "action": {
+            "additionalProperties": false, 
+            "required": true, 
+            "type": "object", 
+            "properties": {
+                "ref": {
+                    "required": true, 
+                    "type": "string"
+                }, 
+                "description": {
+                    "require": false, 
+                    "type": "string"
+                }, 
+                "parameters": {
+                    "type": "object"
+                }
+            }
+        }, 
+        "type": {
+            "additionalProperties": false, 
+            "type": "object", 
+            "properties": {
+                "ref": {
+                    "required": true, 
+                    "type": "string"
+                }, 
+                "parameters": {
+                    "type": "object"
+                }
+            }
+        }, 
+        "pack": {
+            "default": "default", 
+            "type": "string"
+        }
+    }
+}

--- a/contrib/schemas/rule.json
+++ b/contrib/schemas/rule.json
@@ -30,7 +30,7 @@
         }, 
         "ref": {
             "type": "string", 
-            "description": "System computed user friendly reference for the action.                                 Provided value will be overridden by computed value."
+            "description": "System computed user friendly reference for the rule. Provided value will be overridden by computed value."
         }, 
         "enabled": {
             "default": false, 

--- a/st2common/bin/st2-generate-schemas
+++ b/st2common/bin/st2-generate-schemas
@@ -28,11 +28,11 @@ from st2common.models.api import policy as policy_models
 from st2common.models.api import rule as rule_models
 
 content_models = {
-        'pack': pack_models.PackAPI,
-	'action': action_models.ActionAPI,
-        'alias': action_models.ActionAliasAPI,
-        'policy': policy_models.PolicyAPI,
-        'rule': rule_models.RuleAPI,
+    'pack': pack_models.PackAPI,
+    'action': action_models.ActionAPI,
+    'alias': action_models.ActionAliasAPI,
+    'policy': policy_models.PolicyAPI,
+    'rule': rule_models.RuleAPI,
 }
 
 def main():

--- a/st2common/bin/st2-generate-schemas
+++ b/st2common/bin/st2-generate-schemas
@@ -1,0 +1,55 @@
+#!/usr/bin/env python2.7
+#
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import inspect
+import json
+import os
+import six
+
+from st2common.models.api import action as action_models
+from st2common.models.api import pack as pack_models
+from st2common.models.api import policy as policy_models
+from st2common.models.api import rule as rule_models
+
+content_models = {
+        'pack': pack_models.PackAPI,
+	'action': action_models.ActionAPI,
+        'alias': action_models.ActionAliasAPI,
+        'policy': policy_models.PolicyAPI,
+        'rule': rule_models.RuleAPI,
+}
+
+def main():
+    scripts_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+    schemas_dir = scripts_dir + '/../../contrib/schemas'
+
+    for name, model in six.iteritems(content_models):
+        schema_text = json.dumps(model.schema, indent=4)
+        print('Generated schema for the "%s" model.' % name)
+
+        schema_file = os.path.abspath(schemas_dir + '/' + name + '.json')
+        print('Schema will be written to "%s".' % schema_file)
+
+        with open(schema_file, 'w') as f:
+            f.write(schema_text)
+            f.write('\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -550,8 +550,10 @@ class ActionAliasAPI(BaseAPI, APIUIDMixin):
                 "type": "string"
             },
             "ref": {
-                "description": "System computed user friendly reference for the alias. \
-                                Provided value will be overridden by computed value.",
+                "description": (
+                    "System computed user friendly reference for the alias. "
+                    "Provided value will be overridden by computed value."
+                ),
                 "type": "string"
             },
             "uid": {

--- a/st2common/st2common/models/api/rule.py
+++ b/st2common/st2common/models/api/rule.py
@@ -51,17 +51,17 @@ class RuleTypeAPI(BaseAPI):
         'type': 'object',
         'properties': {
             'id': {
-                'description': 'The unique identifier for the action runner.',
+                'description': 'The unique identifier for the rule type.',
                 'type': 'string',
                 'default': None
             },
             'name': {
-                'description': 'The name of the action runner.',
+                'description': 'The name for the rule type.',
                 'type': 'string',
                 'required': True
             },
             'description': {
-                'description': 'The description of the action runner.',
+                'description': 'The description of the rule type.',
                 'type': 'string'
             },
             'enabled': {
@@ -121,8 +121,10 @@ class RuleAPI(BaseAPI, APIUIDMixin):
                 'default': None
             },
             "ref": {
-                "description": "System computed user friendly reference for the action. \
-                                Provided value will be overridden by computed value.",
+                "description": (
+                    "System computed user friendly reference for the rule. "
+                    "Provided value will be overridden by computed value."
+                ),
                 "type": "string"
             },
             'uid': {


### PR DESCRIPTION
Add the script st2-generate-schemas to autogen schemas for the content models such as pack, action, alias, policy, and rule. The schemas will be used in developer workflow to help with user generated contents.