### PR TITLE
Remove deprecated 'ssl on' nginx config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -66,6 +66,7 @@ Changed
   contains various new features and bug fixes. Please review the release notes for the full list of
   changes at https://github.com/StackStorm/orquesta/releases/tag/v1.1.0 and the st2 upgrade notes
   for potential impact. (improvement)
+* Update st2 nginx config to remove deprecated ``ssl on`` option. #4917 (improvement)
 
 Fixed
 ~~~~~

--- a/conf/nginx/st2.conf
+++ b/conf/nginx/st2.conf
@@ -25,8 +25,6 @@ server {
 server {
   listen       *:443 ssl;
 
-  ssl on;
-
   ssl_certificate           /etc/ssl/st2/st2.crt;
   ssl_certificate_key       /etc/ssl/st2/st2.key;
   ssl_session_cache         shared:SSL:10m;


### PR DESCRIPTION
> Spot during the https://github.com/StackStorm/discussions/issues/6

```
Starting nginx: nginx: [warn] the "ssl" directive is deprecated, use the "listen ... ssl" directive instead in /etc/nginx/conf.d/st2.conf:28
```
Looks like we're already using `listen ssl` and so `ssl on;` was there just for compatibility with the ancient nginx versions.

The `ssl` directive is deprecated in nginx `0.7.14` and is safe to remove, considering its release date in 2008.