### PR TITLE
Fix typo in the supported API filters when filtering packs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -65,6 +65,10 @@ Changed
 
 Fixed
 ~~~~~
+* Fix a typo that caused an internal server error when filtering actions by tags. Fixes #4918
+
+  Reported by @mweinberg-cm and contributed by Marcel Weinberg (@winem)
+
 * Fix the action query when filtering tags. The old implementation returned actions which have the
   provided name as action name and not as tag name. (bug fix) #4828
 

--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -62,7 +62,7 @@ class ActionsController(resource.ContentPackResourceController):
     supported_filters = {
         'name': 'name',
         'pack': 'pack',
-        'tags': 'tag.name'
+        'tags': 'tags.name'
     }
 
     query_options = {

--- a/st2api/tests/unit/controllers/v1/test_actions.py
+++ b/st2api/tests/unit/controllers/v1/test_actions.py
@@ -607,7 +607,7 @@ class ActionsControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclu
         get_resp = self.__do_get_actions_by_url_parameter('name', action_name)
         self.assertEqual(get_resp.status_int, 200)
         self.assertEqual(self.__get_action_id_and_name(get_resp)[0], action_id)
-        self.assertEqual(get_resp.json['ref'], ref)
+        self.assertEqual(self.__get_action_id_and_name(get_resp)[1], action_name)
         self.__do_delete(action_id)
 
     @mock.patch.object(action_validator, 'validate_action', mock.MagicMock(
@@ -616,8 +616,8 @@ class ActionsControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclu
         action_id, action_tags = self.__get_action_id_and_tags(self.__do_post(ACTION_1))
         get_resp = self.__do_get_actions_by_url_parameter('tags', action_tags[0]['value'])
         self.assertEqual(get_resp.status_int, 200)
+        self.assertEqual(self.__get_action_id_and_tags(get_resp)[0], action_id)
         self.assertEqual(self.__get_action_id_and_tags(get_resp)[1], action_tags)
-        self.assertEqual(get_resp.json['ref'], ref)
         self.__do_delete(action_id)
 
     # TODO: Re-enable those tests after we ensure DB is flushed in setUp
@@ -656,11 +656,11 @@ class ActionsControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclu
 
     @staticmethod
     def __get_action_id_and_name(resp):
-        return resp.json['id'],resp.json['name']
+        return resp.json['id'], resp.json['name']
 
     @staticmethod
     def __get_action_id_and_tags(resp):
-        return resp.json['id'],resp.json['tags']
+        return resp.json['id'], resp.json['tags']
 
     def __do_get_one(self, action_id, expect_errors=False):
         return self.app.get('/v1/actions/%s' % action_id, expect_errors=expect_errors)

--- a/st2api/tests/unit/controllers/v1/test_actions.py
+++ b/st2api/tests/unit/controllers/v1/test_actions.py
@@ -606,8 +606,8 @@ class ActionsControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclu
         action_id, action_name = self.__get_action_id_and_name(self.__do_post(ACTION_1))
         get_resp = self.__do_get_actions_by_url_parameter('name', action_name)
         self.assertEqual(get_resp.status_int, 200)
-        self.assertEqual(self.__get_action_id_and_name(get_resp)[0], action_id)
-        self.assertEqual(self.__get_action_id_and_name(get_resp)[1], action_name)
+        self.assertEqual(self.__get_action_id(get_resp), action_id)
+        self.assertEqual(self.__get_action_name(get_resp), action_name)
         self.__do_delete(action_id)
 
     @mock.patch.object(action_validator, 'validate_action', mock.MagicMock(
@@ -616,8 +616,8 @@ class ActionsControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclu
         action_id, action_tags = self.__get_action_id_and_tags(self.__do_post(ACTION_1))
         get_resp = self.__do_get_actions_by_url_parameter('tags', action_tags[0]['value'])
         self.assertEqual(get_resp.status_int, 200)
-        self.assertEqual(self.__get_action_id_and_tags(get_resp)[0], action_id)
-        self.assertEqual(self.__get_action_id_and_tags(get_resp)[1], action_tags)
+        self.assertEqual(self.__get_action_id(get_resp), action_id)
+        self.assertEqual(self.__get_action_tags(get_resp), action_tags)
         self.__do_delete(action_id)
 
     # TODO: Re-enable those tests after we ensure DB is flushed in setUp
@@ -655,12 +655,16 @@ class ActionsControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclu
         return resp.json['name']
 
     @staticmethod
+    def __get_action_tags(resp):
+        return resp.json['tags']
+
+    @staticmethod
     def __get_action_id_and_name(resp):
         return resp.json['id'], resp.json['name']
 
     @staticmethod
     def __get_action_id_and_tags(resp):
-        return resp.json['id'], resp.json['tags']
+        return [resp.json['id'], resp.json['tags']]
 
     def __do_get_one(self, action_id, expect_errors=False):
         return self.app.get('/v1/actions/%s' % action_id, expect_errors=expect_errors)

--- a/st2api/tests/unit/controllers/v1/test_actions.py
+++ b/st2api/tests/unit/controllers/v1/test_actions.py
@@ -605,7 +605,8 @@ class ActionsControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclu
     @mock.patch.object(action_validator, 'validate_action', mock.MagicMock(
         return_value=True))
     def test_get_one_using_name_parameter(self):
-        action_id, action_name = self.__get_action_id_and_additional_attribute(self.__do_post(ACTION_1), 'name')
+        action_id, action_name = self.__get_action_id_and_additional_attribute(
+            self.__do_post(ACTION_1), 'name')
         get_resp = self.__do_get_actions_by_url_parameter('name', action_name)
         self.assertEqual(get_resp.status_int, 200)
         self.assertEqual(get_resp.json[0]['id'], action_id)
@@ -615,7 +616,8 @@ class ActionsControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclu
     @mock.patch.object(action_validator, 'validate_action', mock.MagicMock(
         return_value=True))
     def test_get_one_using_pack_parameter(self):
-        action_id, action_pack = self.__get_action_id_and_additional_attribute(self.__do_post(ACTION_10), 'pack')
+        action_id, action_pack = self.__get_action_id_and_additional_attribute(
+            self.__do_post(ACTION_10), 'pack')
         get_resp = self.__do_get_actions_by_url_parameter('pack', action_pack)
         self.assertEqual(get_resp.status_int, 200)
         self.assertEqual(get_resp.json[0]['id'], action_id)
@@ -625,7 +627,8 @@ class ActionsControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclu
     @mock.patch.object(action_validator, 'validate_action', mock.MagicMock(
         return_value=True))
     def test_get_one_using_tag_parameter(self):
-        action_id, action_tags = self.__get_action_id_and_additional_attribute(self.__do_post(ACTION_1), 'tags')
+        action_id, action_tags = self.__get_action_id_and_additional_attribute(
+            self.__do_post(ACTION_1), 'tags')
         get_resp = self.__do_get_actions_by_url_parameter('tags', action_tags[0]['name'])
         self.assertEqual(get_resp.status_int, 200)
         self.assertEqual(get_resp.json[0]['id'], action_id)

--- a/st2api/tests/unit/controllers/v1/test_actions.py
+++ b/st2api/tests/unit/controllers/v1/test_actions.py
@@ -666,7 +666,7 @@ class ActionsControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclu
         return self.app.get('/v1/actions/%s' % action_id, expect_errors=expect_errors)
 
     def __do_get_actions_by_url_parameter(self, filter, value, expect_errors=False):
-        return self.app.get('/v1/actions?%s=%s' % filter, value, expect_errors=expect_errors)
+        return self.app.get('/v1/actions?%s=%s' % (filter, value), expect_errors=expect_errors)
 
     def __do_post(self, action, expect_errors=False):
         return self.app.post_json('/v1/actions', action, expect_errors=expect_errors)

--- a/st2api/tests/unit/controllers/v1/test_actions.py
+++ b/st2api/tests/unit/controllers/v1/test_actions.py
@@ -606,18 +606,19 @@ class ActionsControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclu
         action_id, action_name = self.__get_action_id_and_name(self.__do_post(ACTION_1))
         get_resp = self.__do_get_actions_by_url_parameter('name', action_name)
         self.assertEqual(get_resp.status_int, 200)
-        self.assertEqual(self.__get_action_id(get_resp), action_id)
-        self.assertEqual(self.__get_action_name(get_resp), action_name)
+        self.assertEqual(get_resp.json[0]['id'], action_id)
+        self.assertEqual(get_resp.json[0]['name'], action_name)
         self.__do_delete(action_id)
 
     @mock.patch.object(action_validator, 'validate_action', mock.MagicMock(
         return_value=True))
     def test_get_one_using_tag_parameter(self):
         action_id, action_tags = self.__get_action_id_and_tags(self.__do_post(ACTION_1))
-        get_resp = self.__do_get_actions_by_url_parameter('tags', action_tags[0]['value'])
+        #get_resp = self.__do_get_one(action_id)
+        get_resp = self.__do_get_actions_by_url_parameter('tags', action_tags[0]['name'])
         self.assertEqual(get_resp.status_int, 200)
-        self.assertEqual(self.__get_action_id(get_resp), action_id)
-        self.assertEqual(self.__get_action_tags(get_resp), action_tags)
+        self.assertEqual(get_resp.json[0]['id'], action_id)
+        self.assertEqual(get_resp.json[0]['tags'], action_tags)
         self.__do_delete(action_id)
 
     # TODO: Re-enable those tests after we ensure DB is flushed in setUp
@@ -664,7 +665,7 @@ class ActionsControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclu
 
     @staticmethod
     def __get_action_id_and_tags(resp):
-        return [resp.json['id'], resp.json['tags']]
+        return resp.json['id'], resp.json['tags']
 
     def __do_get_one(self, action_id, expect_errors=False):
         return self.app.get('/v1/actions/%s' % action_id, expect_errors=expect_errors)

--- a/st2api/tests/unit/controllers/v1/test_actions.py
+++ b/st2api/tests/unit/controllers/v1/test_actions.py
@@ -626,7 +626,6 @@ class ActionsControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclu
         return_value=True))
     def test_get_one_using_tag_parameter(self):
         action_id, action_tags = self.__get_action_id_and_additional_attribute(self.__do_post(ACTION_1), 'tags')
-        #get_resp = self.__do_get_one(action_id)
         get_resp = self.__do_get_actions_by_url_parameter('tags', action_tags[0]['name'])
         self.assertEqual(get_resp.status_int, 200)
         self.assertEqual(get_resp.json[0]['id'], action_id)

--- a/st2api/tests/unit/controllers/v1/test_actions.py
+++ b/st2api/tests/unit/controllers/v1/test_actions.py
@@ -666,7 +666,7 @@ class ActionsControllerTestCase(FunctionalTest, APIControllerWithIncludeAndExclu
         return self.app.get('/v1/actions/%s' % action_id, expect_errors=expect_errors)
 
     def __do_get_actions_by_url_parameter(self, filter, value, expect_errors=False):
-        return self.app.post_json('/v1/actions?%s=%s', filter, value, expect_errors=expect_errors)
+        return self.app.get('/v1/actions?%s=%s' % filter, value, expect_errors=expect_errors)
 
     def __do_post(self, action, expect_errors=False):
         return self.app.post_json('/v1/actions', action, expect_errors=expect_errors)


### PR DESCRIPTION
This PR fixes the issue I found tonight when testing the tag filter as reported in #4918 and adds unit tests to test the API with actions filtered by the name or tag. 

