### PR TITLE
Update orquesta version with fix for task retry

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -143,6 +143,8 @@ Fixed
   functions as a result of the change. (bug fix) PR StackStorm/orquesta#191.
 
   Contributed by Hiroyasu Ohyama (@userlocalhost)
+* Fix retry in orquesta when a task that has a transition on failure will also be traversed on
+  retry. (bug fix) PR StackStorm/orquesta#200
 
 Removed
 ~~~~~~~

--- a/contrib/runners/orquesta_runner/in-requirements.txt
+++ b/contrib/runners/orquesta_runner/in-requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/StackStorm/orquesta.git@v1.1.0#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@v1.1.1#egg=orquesta

--- a/contrib/runners/orquesta_runner/requirements.txt
+++ b/contrib/runners/orquesta_runner/requirements.txt
@@ -5,4 +5,4 @@
 # If you want to update depdencies for a single component, modify the
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
-git+https://github.com/StackStorm/orquesta.git@v1.1.0#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@v1.1.1#egg=orquesta

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ cryptography==2.8
 eventlet==0.25.1
 flex==6.14.0
 git+https://github.com/StackStorm/logshipper.git@stackstorm_patched#egg=logshipper
-git+https://github.com/StackStorm/orquesta.git@v1.1.0#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@v1.1.1#egg=orquesta
 git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
 gitpython==2.1.15

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -9,7 +9,7 @@ jsonschema
 kombu
 mongoengine
 networkx
-git+https://github.com/StackStorm/orquesta.git@v1.1.0#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@v1.1.1#egg=orquesta
 oslo.config
 paramiko
 pyyaml

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -10,7 +10,7 @@ apscheduler==3.6.3
 cryptography==2.8
 eventlet==0.25.1
 flex==6.14.0
-git+https://github.com/StackStorm/orquesta.git@v1.1.0#egg=orquesta
+git+https://github.com/StackStorm/orquesta.git@v1.1.1#egg=orquesta
 gitpython==2.1.15
 greenlet==0.4.15
 ipaddr


### PR DESCRIPTION
Fix issue with orquesta task retry when a task that has a transition on failure will also be traversed on retry. This patch update the orquesta version in appropriate requirements.txt that has the fix.