### PR TITLE
#4932 - Fixes for field escaping in orquesta workflows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,18 @@ Changelog
 in development
 --------------
 
+Fixed
+~~~~~
+* Fixed a bug where persisting Orquesta to the MongoDB database returned an error
+  ``message: key 'myvar.with.period' must not contain '.'``. This happened anytime an
+  ``input``, ``output``, ``publish`` or context ``var`` contained a key with a ``.`` within
+  the name (such as with hostnames and IP addresses). This was a regression introduced by
+  trying to improve performance. Fixing this bug means we are sacrificing performance of
+  serialization/deserialization in favor of correctness for persisting workflows and
+  their state to the MongoDB database. (bug fix) #4932
+
+  Contributed by Nick Maludy (@nmaludy Encore Technologies)
+
 
 3.2.0 - April 27, 2020
 ----------------------

--- a/Makefile
+++ b/Makefile
@@ -495,8 +495,9 @@ distclean: clean
 
 .PHONY: .requirements
 .requirements: virtualenv
-	# Generate all requirements to support current CI pipeline.
+	# Print out pip version so we can see what version was restored from the Travis cache
 	$(VIRTUALENV_DIR)/bin/pip --version
+	# Generate all requirements to support current CI pipeline.
 	$(VIRTUALENV_DIR)/bin/python scripts/fixate-requirements.py --skip=virtualenv,virtualenv-osx -s st2*/in-requirements.txt contrib/runners/*/in-requirements.txt -f fixed-requirements.txt -o requirements.txt
 
 	# Remove any *.egg-info files which polute PYTHONPATH

--- a/Makefile
+++ b/Makefile
@@ -496,6 +496,7 @@ distclean: clean
 .PHONY: .requirements
 .requirements: virtualenv
 	# Generate all requirements to support current CI pipeline.
+	$(VIRTUALENV_DIR)/bin/pip --version
 	$(VIRTUALENV_DIR)/bin/python scripts/fixate-requirements.py --skip=virtualenv,virtualenv-osx -s st2*/in-requirements.txt contrib/runners/*/in-requirements.txt -f fixed-requirements.txt -o requirements.txt
 
 	# Remove any *.egg-info files which polute PYTHONPATH

--- a/contrib/examples/actions/orquesta-test-field-escaping.yaml
+++ b/contrib/examples/actions/orquesta-test-field-escaping.yaml
@@ -1,0 +1,8 @@
+---
+name: orquesta-test-field-escaping
+description: A workflow used to test escaping of things like vars, task names, results, outputs, etc.
+pack: examples
+runner_type: orquesta
+entry_point: workflows/tests/orquesta-test-field-escaping.yaml
+enabled: true
+parameters: {}

--- a/contrib/examples/actions/python-mock-core-remote.py
+++ b/contrib/examples/actions/python-mock-core-remote.py
@@ -1,0 +1,23 @@
+from st2common.runners.base_action import Action
+
+
+class MockCoreRemoteAction(Action):
+
+    def run(self, cmd, hosts, hosts_dict):
+        if hosts_dict:
+            return hosts_dict
+
+        if not hosts:
+            return None
+
+        host_list = hosts.split(',')
+        results = {}
+        for h in hosts:
+            results[h] = {
+                'failed': False,
+                'return_code': 0,
+                'stderr': '',
+                'succeeded': True,
+                'stdout': cmd,
+            }
+        return results

--- a/contrib/examples/actions/python-mock-core-remote.yaml
+++ b/contrib/examples/actions/python-mock-core-remote.yaml
@@ -1,6 +1,5 @@
 ---
 name: python-mock-core-remote
-pack: default
 runner_type: python-script
 description: Action which mocks the core.remote action. It returns results with hostnames/IPs in them to ensure we are escaping the . properly. We set the output to the value of the command passed in
 enabled: true

--- a/contrib/examples/actions/python-mock-core-remote.yaml
+++ b/contrib/examples/actions/python-mock-core-remote.yaml
@@ -1,0 +1,18 @@
+---
+name: python-mock-core-remote
+pack: default
+runner_type: python-script
+description: Action which mocks the core.remote action. It returns results with hostnames/IPs in them to ensure we are escaping the . properly. We set the output to the value of the command passed in
+enabled: true
+entry_point: python-mock-core-remote.py
+parameters:
+  cmd:
+    type: string
+    required: false
+  hosts:
+    type: string
+    required: false
+  hosts_dict:
+    type: object
+    description: "If specified, just returns this dict back out. Used for testing inputs and outputs of dicts with keys containing '.' character."
+    required: false

--- a/contrib/examples/actions/workflows/tests/orquesta-test-field-escaping.yaml
+++ b/contrib/examples/actions/workflows/tests/orquesta-test-field-escaping.yaml
@@ -1,0 +1,26 @@
+version: 1.0
+
+description: A workflow used to test escaping of things like vars, task names, results, outputs, etc.
+
+vars:
+  - vars.key.with.periods: "vars.value.with.periods"
+  - vars.nested.with.periods:
+      nested.periods: "vars.nested.value.with.periods"
+
+tasks:
+  run:
+    action: examples.python-mock-core-remote
+    input:
+      hosts_dict:
+        hostname.domain.tld: "{{ ctx()['vars.key.with.periods'] }}"
+        hostname2.domain.tld:
+          stdout: "{{ ctx()['vars.nested.with.periods']['nested.periods'] }}"
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - published.hosts: "{{ result().result }}"
+          - published.field: "{{ result().result['hostname2.domain.tld']['stdout'] }}"
+
+output:
+  - wf.hostname.with.periods: "{{ ctx()['published.hosts'] }}"
+  - wf.output.with.periods: "{{ ctx()['published.field'] }}"

--- a/scripts/fixate-requirements.py
+++ b/scripts/fixate-requirements.py
@@ -108,6 +108,14 @@ def locate_file(path, must_exist=False):
         print("Error: couldn't locate file `{0}'".format(path))
     return path
 
+def get_req_attr(req):
+    # pip >= 20.0
+    requirement = getattr(req, 'requirement', None)
+    if not requirement:
+        # pip < 20.0
+        requirement = getattr(req, 'req', None)
+    return requirement
+
 
 def merge_source_requirements(sources):
     """
@@ -119,7 +127,7 @@ def merge_source_requirements(sources):
         for req in load_requirements(infile_path):
             # Requirements starting with project name "project ..."
             print("DEBUG: type(req) = {}".format(type(req)))
-            if req.req:
+            if get_req_attr(req):
                 # Skip already added project name
                 if req.name in projects:
                     continue
@@ -150,7 +158,7 @@ def write_requirements(sources=None, fixed_requirements=None, output_file=None,
     for req in fixed:
         project_name = req.name
 
-        if not req.req:
+        if not get_req_attr(req):
             continue
 
         if project_name in fixedreq_hash:
@@ -171,11 +179,11 @@ def write_requirements(sources=None, fixed_requirements=None, output_file=None,
 
             if req.editable:
                 rline = '-e %s' % (rline)
-        elif req.req:
+        elif get_req_attr(req):
             project = req.name
             req_obj = fixedreq_hash.get(project, req)
 
-            rline = str(req_obj.req)
+            rline = str(get_req_attr(req_obj))
 
             # Also write out environment markers
             if req_obj.markers:

--- a/scripts/fixate-requirements.py
+++ b/scripts/fixate-requirements.py
@@ -69,6 +69,7 @@ except ImportError:
         print('Using pip: %s' % (str(pip_version)))
         sys.exit(1)
 
+print("DEBUG: pip version = {}".format(pip.__version__))
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Tool for requirements.txt generation.')
@@ -117,6 +118,7 @@ def merge_source_requirements(sources):
     for infile_path in (locate_file(p, must_exist=True) for p in sources):
         for req in load_requirements(infile_path):
             # Requirements starting with project name "project ..."
+            print("DEBUG: type(req) = {}".format(type(req)))
             if req.req:
                 # Skip already added project name
                 if req.name in projects:

--- a/st2common/st2common/models/db/workflow.py
+++ b/st2common/st2common/models/db/workflow.py
@@ -36,11 +36,11 @@ class WorkflowExecutionDB(stormbase.StormFoundationDB, stormbase.ChangeRevisionF
     RESOURCE_TYPE = types.ResourceType.EXECUTION
 
     action_execution = me.StringField(required=True)
-    spec = me.DictField()
+    spec = stormbase.EscapedDictField()
     graph = me.DictField()
     input = stormbase.EscapedDictField()
     notify = me.DictField()
-    context = me.DictField()
+    context = stormbase.EscapedDictField()
     state = stormbase.EscapedDictField()
     status = me.StringField(required=True)
     output = stormbase.EscapedDictField()
@@ -62,7 +62,7 @@ class TaskExecutionDB(stormbase.StormFoundationDB, stormbase.ChangeRevisionField
     task_name = me.StringField(required=True)
     task_id = me.StringField(required=True)
     task_route = me.IntField(required=True, min_value=0)
-    task_spec = me.DictField()
+    task_spec = stormbase.EscapedDictField()
     delay = me.IntField(min_value=0)
     itemized = me.BooleanField(default=False)
     items_count = me.IntField(min_value=0)

--- a/st2tests/integration/orquesta/test_wiring.py
+++ b/st2tests/integration/orquesta/test_wiring.py
@@ -156,3 +156,23 @@ class WiringTest(base.TestWorkflowExecution):
 
         self.assertEqual(ex.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
         self.assertDictEqual(ex.result, expected_result)
+
+    def test_field_escaping(self):
+        wf_name = 'examples.orquesta-test-field-escaping'
+
+        ex = self._execute_workflow(wf_name)
+        ex = self._wait_for_completion(ex)
+
+        expected_output = {
+            'wf.hostname.with.periods': {
+                'hostname.domain.tld': 'vars.value.with.periods',
+                'hostname2.domain.tld': {
+                    'stdout': 'vars.nested.value.with.periods',
+                },
+            },
+            'wf.output.with.periods': 'vars.nested.value.with.periods',
+        }
+        expected_result = {'output': expected_output}
+
+        self.assertEqual(ex.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
+        self.assertDictEqual(ex.result, expected_result)


### PR DESCRIPTION
Closes #4932 

This is a fix for the bug found in #4932 .

I had to revert 3x fields in the workflow DB model:

1. `WorkflowExecutionDB.spec` for any fields/dict keys that were statically defined in the workflow spec that include a `.` in their name:
Example:
```yaml
vars:
  - vars.key.with.periods: "vars.value.with.periods"
  - vars.nested.with.periods:
      nested.periods: "vars.nested.value.with.periods"

output:
  - wf.hostname.with.periods: "{{ ctx()['published.hosts'] }}"
  - wf.output.with.periods: "{{ ctx()['published.field'] }}"
```

2. `WorkflowExecutionDB.context` for any dicts/objects that is present in the "context", ie. from a published variable. This can occur, for example, when running `core.remote`. The resulting dictionary has hostnames/IPs as keys in the returned dict.
Example:
```yaml
  run:
    action: core.remote
    input:
      cmd: date
      hosts: "hostname.domain.tld,hostname2.domain.tld"
    next:
      - when: "{{ succeeded() }}"
        publish:
          - published.hosts: "{{ result().result }}"
          - published.field: "{{ result().result['hostname2.domain.tld']['stdout'] }}"
```

3. `TaskExecutionDB.task_spec` for any inputs passed into the task that may have a dict with a key contain a `.`.  
Example:
```

  bolt_plan_run:
    action: bolt.plan_run
    input:
      plan: "{{ ctx().plan }}"
      targets: "{{ ctx().targets }}"
      env:
        ST2KV_CONFIG:
          ssh.username: system.linux.username
          ssh.password: system.linux.password
```

I've added a single integration test case `examples.orequest-test-field-escaping` that invokes these three corner cases.