### PR TITLE
Rules Engine Logging error

### DIFF
--- a/.github/ISSUE_TEMPLATE/support_request.md
+++ b/.github/ISSUE_TEMPLATE/support_request.md
@@ -4,8 +4,7 @@ about: Post any support requests on our community forum - https://forum.stacksto
 
 ---
 
-**PLEASE READ**: If you are a paid Extreme Workflow (EWC) customer, please contant [Extreme
-Network GTAC](https://gtacknowledge.extremenetworks.com/articles/How_To/How-to-contact-Extreme-Networks-Global-Technical-Assistance-Center-GTAC)
-or send an email to support@stackstorm.com
+**PLEASE READ**: If you are a paid Extreme Workflow (EWC) customer, please contact [Extreme
+Network GTAC](https://gtacknowledge.extremenetworks.com/articles/How_To/How-to-contact-Extreme-Networks-Global-Technical-Assistance-Center-GTAC).
 
-For free community support, please use out forum at [https://forum.stackstorm.com](https://forum.stackstorm.com)
+For free community support, please use our forum at [https://forum.stackstorm.com](https://forum.stackstorm.com)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ Added
 
 Fixed
 ~~~~~
+* Fixed a bug where `type` attribute was missing for netstat action in linux pack. Fixes #4946
+
+  Reported by @scguoi and contributed by Sheshagiri (@sheshagiri)
+
 * Fixed a bug where persisting Orquesta to the MongoDB database returned an error
   ``message: key 'myvar.with.period' must not contain '.'``. This happened anytime an
   ``input``, ``output``, ``publish`` or context ``var`` contained a key with a ``.`` within

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,12 @@ Fixed
   their state to the MongoDB database. (bug fix) #4932
 
   Contributed by Nick Maludy (@nmaludy Encore Technologies)
+* Fixed bug where action information in RuleDB object was not being parsed properly
+  because mongoengine EmbeddedDocument objects were added to JSON_UNFRIENDLY_TYPES and skipped.
+  Removed this and added if to use to_json method so that mongoengine EmbeddedDocument
+  are parsed properly.
+
+  Contributed by Bradley Bishop (@bishopbm1 Encore Technologies)
 
 
 3.2.0 - April 27, 2020
@@ -93,8 +99,8 @@ Fixed
 * Fix the action query when filtering tags. The old implementation returned actions which have the
   provided name as action name and not as tag name. (bug fix) #4828
 
-  Reported by @AngryDeveloper and contributed by Marcel Weinberg (@winem) 
-* Fix the passing of arrays to shell scripts where the arrays where not detected as such by the 
+  Reported by @AngryDeveloper and contributed by Marcel Weinberg (@winem)
+* Fix the passing of arrays to shell scripts where the arrays where not detected as such by the
   st2 action_db utility. This caused arrays to be passed as Python lists serialized into a string.
 
   Reported by @kingsleyadam #4804 and contributed by Marcel Weinberg (@winem) #4861

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 in development
 --------------
 
+Added
+~~~~~
+* Add make command to autogen JSON schema from the models of action, rule, etc. Add check
+  to ensure update to the models require schema to be regenerated. (new feature)
+
 Fixed
 ~~~~~
 * Fixed a bug where persisting Orquesta to the MongoDB database returned an error

--- a/Makefile
+++ b/Makefile
@@ -271,6 +271,16 @@ configgen: requirements .configgen
 	echo "" >> conf/st2.conf.sample
 	. $(VIRTUALENV_DIR)/bin/activate; python ./tools/config_gen.py >> conf/st2.conf.sample;
 
+.PHONY: schemasgen
+schemasgen: requirements .schemasgen
+
+.PHONY: .schemasgen
+.schemasgen:
+	@echo
+	@echo "================== content model schemas gen ===================="
+	@echo
+	. $(VIRTUALENV_DIR)/bin/activate; python ./st2common/bin/st2-generate-schemas;
+
 .PHONY: .pylint
 .pylint:
 	@echo
@@ -1054,7 +1064,18 @@ ci-py3-integration: requirements .ci-prepare-integration .ci-py3-integration
 	cp st2common/st2common/openapi.yaml /tmp/openapi.yaml.upstream
 	make .generate-api-spec
 	diff st2common/st2common/openapi.yaml  /tmp/openapi.yaml.upstream || (echo "st2common/st2common/openapi.yaml hasn't been re-generated and committed. Please run \"make generate-api-spec\" and include and commit the generated file." && exit 1)
-
+	# 3. Schemas for the content models - st2common/bin/st2-generate-schemas
+	cp contrib/schemas/pack.json /tmp/pack.json.upstream
+	cp contrib/schemas/action.json /tmp/action.json.upstream
+	cp contrib/schemas/alias.json /tmp/alias.json.upstream
+	cp contrib/schemas/policy.json /tmp/policy.json.upstream
+	cp contrib/schemas/rule.json /tmp/rule.json.upstream
+	make .schemasgen
+	diff contrib/schemas/pack.json /tmp/pack.json.upstream || (echo "contrib/schemas/pack.json hasn't been re-generated and committed. Please run \"make schemasgen\" and include and commit the generated file." && exit 1)
+	diff contrib/schemas/action.json /tmp/action.json.upstream || (echo "contrib/schemas/pack.json hasn't been re-generated and committed. Please run \"make schemasgen\" and include and commit the generated file." && exit 1)
+	diff contrib/schemas/alias.json /tmp/alias.json.upstream || (echo "contrib/schemas/pack.json hasn't been re-generated and committed. Please run \"make schemasgen\" and include and commit the generated file." && exit 1)
+	diff contrib/schemas/policy.json /tmp/policy.json.upstream || (echo "contrib/schemas/pack.json hasn't been re-generated and committed. Please run \"make schemasgen\" and include and commit the generated file." && exit 1)
+	diff contrib/schemas/rule.json /tmp/rule.json.upstream || (echo "contrib/schemas/pack.json hasn't been re-generated and committed. Please run \"make schemasgen\" and include and commit the generated file." && exit 1)
 	@echo "All automatically generated files are up to date."
 
 .PHONY: ci-unit

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -51,6 +51,7 @@ They're not part of the TSC voting process, but appreciated for their contributi
 * Jon Middleton ([@jjm](https://github.com/jjm)) - StackStorm Exchange, Core, Discussions.
 * Shu Sugimoto ([@shusugmt](https://github.com/shusugmt)) - Docker, StackStorm Exchange packs.
 * Tristan Struthers ([@trstruth](https://github.com/trstruth)) - Docker, K8s, Orquesta, Community.
+* Marcel Weinberg ([@winem](https://github.com/winem)) - Community, Docker, Core.
 
 # Friends
 People that are currently not very active maintainers/contributors but who participated in and formed the project we have today.

--- a/contrib/linux/actions/netstat.yaml
+++ b/contrib/linux/actions/netstat.yaml
@@ -11,3 +11,4 @@
     args:
       description: "Command line arguments"
       default: " "
+      type: "string"

--- a/contrib/linux/actions/netstat_grep.yaml
+++ b/contrib/linux/actions/netstat_grep.yaml
@@ -9,5 +9,6 @@
       immutable: true
       default: "for pid in {{pids}}; do netstat -pant | grep $pid; done; exit 0"
     pids:
-      description: "List of pids"
+      description: "List of pids. ex: [1111, 2222]"
       required: true
+      type: "array"

--- a/contrib/runners/orquesta_runner/orquesta_functions/st2kv.py
+++ b/contrib/runners/orquesta_runner/orquesta_functions/st2kv.py
@@ -43,8 +43,8 @@ def st2kv_(context, key, **kwargs):
     try:
         user_db = auth_db_access.User.get(username)
     except Exception as e:
-        raise Exception('Failed to retrieve User object for user "%s" % (username)' %
-                        (six.text_type(e)))
+        raise Exception('Failed to retrieve User object for user "%s", "%s"' %
+                        (username, six.text_type(e)))
 
     has_default = 'default' in kwargs
     default_value = kwargs.get('default')

--- a/contrib/schemas/action.json
+++ b/contrib/schemas/action.json
@@ -1,0 +1,602 @@
+{
+    "additionalProperties": false, 
+    "properties": {
+        "uid": {
+            "type": "string"
+        }, 
+        "tags": {
+            "items": {
+                "type": "object"
+            }, 
+            "type": "array", 
+            "description": "User associated metadata assigned to this object."
+        }, 
+        "entry_point": {
+            "default": "", 
+            "type": "string", 
+            "description": "The entry point for the action."
+        }, 
+        "notify": {
+            "additionalProperties": false, 
+            "type": "object", 
+            "description": "Notification settings for action.", 
+            "properties": {
+                "on-failure": {
+                    "additionalProperties": false, 
+                    "type": "object", 
+                    "properties": {
+                        "routes": {
+                            "type": "array", 
+                            "description": "Channels to post notifications to."
+                        }, 
+                        "channels": {
+                            "type": "array", 
+                            "description": "Channels to post notifications to."
+                        }, 
+                        "message": {
+                            "type": "string", 
+                            "description": "Message to use for notification"
+                        }, 
+                        "data": {
+                            "type": "object", 
+                            "description": "Data to be sent as part of notification"
+                        }
+                    }
+                }, 
+                "on-complete": {
+                    "additionalProperties": false, 
+                    "type": "object", 
+                    "properties": {
+                        "routes": {
+                            "type": "array", 
+                            "description": "Channels to post notifications to."
+                        }, 
+                        "channels": {
+                            "type": "array", 
+                            "description": "Channels to post notifications to."
+                        }, 
+                        "message": {
+                            "type": "string", 
+                            "description": "Message to use for notification"
+                        }, 
+                        "data": {
+                            "type": "object", 
+                            "description": "Data to be sent as part of notification"
+                        }
+                    }
+                }, 
+                "on-success": {
+                    "additionalProperties": false, 
+                    "type": "object", 
+                    "properties": {
+                        "routes": {
+                            "type": "array", 
+                            "description": "Channels to post notifications to."
+                        }, 
+                        "channels": {
+                            "type": "array", 
+                            "description": "Channels to post notifications to."
+                        }, 
+                        "message": {
+                            "type": "string", 
+                            "description": "Message to use for notification"
+                        }, 
+                        "data": {
+                            "type": "object", 
+                            "description": "Data to be sent as part of notification"
+                        }
+                    }
+                }
+            }
+        }, 
+        "id": {
+            "type": "string", 
+            "description": "The unique identifier for the action."
+        }, 
+        "description": {
+            "type": "string", 
+            "description": "The description of the action."
+        }, 
+        "runner_type": {
+            "required": true, 
+            "type": "string", 
+            "description": "The type of runner that executes the action."
+        }, 
+        "parameters": {
+            "additionalProperties": false, 
+            "patternProperties": {
+                "^\\w+$": {
+                    "description": "Core schema meta-schema", 
+                    "default": {}, 
+                    "id": "http://json-schema.org/draft-04/schema#", 
+                    "dependencies": {
+                        "exclusiveMaximum": [
+                            "maximum"
+                        ], 
+                        "exclusiveMinimum": [
+                            "minimum"
+                        ]
+                    }, 
+                    "additionalProperties": false, 
+                    "definitions": {
+                        "simpleTypes": {
+                            "enum": [
+                                "array", 
+                                "boolean", 
+                                "integer", 
+                                "null", 
+                                "number", 
+                                "object", 
+                                "string"
+                            ]
+                        }, 
+                        "schemaArray": {
+                            "minItems": 1, 
+                            "items": {
+                                "$ref": "#"
+                            }, 
+                            "type": "array"
+                        }, 
+                        "positiveIntegerDefault0": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/positiveInteger"
+                                }, 
+                                {
+                                    "default": 0
+                                }
+                            ]
+                        }, 
+                        "positiveInteger": {
+                            "minimum": 0, 
+                            "type": "integer"
+                        }, 
+                        "stringArray": {
+                            "minItems": 1, 
+                            "items": {
+                                "type": "string"
+                            }, 
+                            "uniqueItems": true, 
+                            "type": "array"
+                        }
+                    }, 
+                    "$schema": "http://json-schema.org/draft-04/schema#", 
+                    "type": "object", 
+                    "properties": {
+                        "definitions": {
+                            "additionalProperties": {
+                                "$ref": "#"
+                            }, 
+                            "default": {}, 
+                            "type": "object"
+                        }, 
+                        "minProperties": {
+                            "$ref": "#/definitions/positiveIntegerDefault0"
+                        }, 
+                        "uniqueItems": {
+                            "default": false, 
+                            "type": "boolean"
+                        }, 
+                        "minimum": {
+                            "type": "number"
+                        }, 
+                        "maxItems": {
+                            "$ref": "#/definitions/positiveInteger"
+                        }, 
+                        "$schema": {
+                            "type": "string", 
+                            "format": "uri"
+                        }, 
+                        "exclusiveMinimum": {
+                            "default": false, 
+                            "type": "boolean"
+                        }, 
+                        "id": {
+                            "type": "string", 
+                            "format": "uri"
+                        }, 
+                        "exclusiveMaximum": {
+                            "default": false, 
+                            "type": "boolean"
+                        }, 
+                        "title": {
+                            "type": "string"
+                        }, 
+                        "pattern": {
+                            "type": "string", 
+                            "format": "regex"
+                        }, 
+                        "patternProperties": {
+                            "additionalProperties": {
+                                "$ref": "#"
+                            }, 
+                            "default": {}, 
+                            "type": "object"
+                        }, 
+                        "multipleOf": {
+                            "type": "number", 
+                            "minimum": 0, 
+                            "exclusiveMinimum": true
+                        }, 
+                        "secret": {
+                            "default": false, 
+                            "type": "boolean"
+                        }, 
+                        "maxProperties": {
+                            "$ref": "#/definitions/positiveInteger"
+                        }, 
+                        "type": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/definitions/simpleTypes"
+                                }
+                            ]
+                        }, 
+                        "immutable": {
+                            "default": false, 
+                            "type": "boolean"
+                        }, 
+                        "description": {
+                            "type": "string"
+                        }, 
+                        "allOf": {
+                            "$ref": "#/definitions/schemaArray"
+                        }, 
+                        "minLength": {
+                            "$ref": "#/definitions/positiveIntegerDefault0"
+                        }, 
+                        "enum": {
+                            "minItems": 1, 
+                            "uniqueItems": true, 
+                            "type": "array"
+                        }, 
+                        "additionalItems": {
+                            "default": {}, 
+                            "anyOf": [
+                                {
+                                    "type": "boolean"
+                                }, 
+                                {
+                                    "$ref": "#"
+                                }
+                            ]
+                        }, 
+                        "dependencies": {
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "$ref": "#"
+                                    }, 
+                                    {
+                                        "$ref": "#/definitions/stringArray"
+                                    }
+                                ]
+                            }, 
+                            "type": "object"
+                        }, 
+                        "anyOf": {
+                            "$ref": "#/definitions/schemaArray"
+                        }, 
+                        "maxLength": {
+                            "$ref": "#/definitions/positiveInteger"
+                        }, 
+                        "not": {
+                            "$ref": "#"
+                        }, 
+                        "properties": {
+                            "additionalProperties": {
+                                "$ref": "#"
+                            }, 
+                            "default": {}, 
+                            "type": "object"
+                        }, 
+                        "oneOf": {
+                            "$ref": "#/definitions/schemaArray"
+                        }, 
+                        "default": {}, 
+                        "items": {
+                            "default": {}, 
+                            "anyOf": [
+                                {
+                                    "$ref": "#"
+                                }, 
+                                {
+                                    "$ref": "#/definitions/schemaArray"
+                                }
+                            ]
+                        }, 
+                        "required": {
+                            "default": false, 
+                            "type": "boolean"
+                        }, 
+                        "maximum": {
+                            "type": "number"
+                        }, 
+                        "minItems": {
+                            "$ref": "#/definitions/positiveIntegerDefault0"
+                        }, 
+                        "additionalProperties": {
+                            "default": {}, 
+                            "anyOf": [
+                                {
+                                    "type": "boolean"
+                                }, 
+                                {
+                                    "$ref": "#"
+                                }
+                            ]
+                        }, 
+                        "position": {
+                            "minimum": 0, 
+                            "type": "number"
+                        }
+                    }
+                }
+            }, 
+            "default": {}, 
+            "type": "object", 
+            "description": "Input parameters for the action."
+        }, 
+        "enabled": {
+            "default": true, 
+            "type": "boolean", 
+            "description": "Enable or disable the action from invocation."
+        }, 
+        "name": {
+            "required": true, 
+            "type": "string", 
+            "description": "The name of the action."
+        }, 
+        "metadata_file": {
+            "default": "", 
+            "type": "string", 
+            "description": "Path to the metadata file relative to the pack directory."
+        }, 
+        "output_schema": {
+            "additionalProperties": false, 
+            "patternProperties": {
+                "^\\w+$": {
+                    "description": "Core schema meta-schema", 
+                    "default": {}, 
+                    "id": "http://json-schema.org/draft-04/schema#", 
+                    "dependencies": {
+                        "exclusiveMaximum": [
+                            "maximum"
+                        ], 
+                        "exclusiveMinimum": [
+                            "minimum"
+                        ]
+                    }, 
+                    "definitions": {
+                        "simpleTypes": {
+                            "enum": [
+                                "array", 
+                                "boolean", 
+                                "integer", 
+                                "null", 
+                                "number", 
+                                "object", 
+                                "string"
+                            ]
+                        }, 
+                        "schemaArray": {
+                            "minItems": 1, 
+                            "items": {
+                                "$ref": "#"
+                            }, 
+                            "type": "array"
+                        }, 
+                        "positiveIntegerDefault0": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/positiveInteger"
+                                }, 
+                                {
+                                    "default": 0
+                                }
+                            ]
+                        }, 
+                        "positiveInteger": {
+                            "minimum": 0, 
+                            "type": "integer"
+                        }, 
+                        "stringArray": {
+                            "minItems": 1, 
+                            "items": {
+                                "type": "string"
+                            }, 
+                            "uniqueItems": true, 
+                            "type": "array"
+                        }
+                    }, 
+                    "$schema": "http://json-schema.org/draft-04/schema#", 
+                    "type": "object", 
+                    "properties": {
+                        "definitions": {
+                            "additionalProperties": {
+                                "$ref": "#"
+                            }, 
+                            "default": {}, 
+                            "type": "object"
+                        }, 
+                        "minProperties": {
+                            "$ref": "#/definitions/positiveIntegerDefault0"
+                        }, 
+                        "uniqueItems": {
+                            "default": false, 
+                            "type": "boolean"
+                        }, 
+                        "minimum": {
+                            "type": "number"
+                        }, 
+                        "maxItems": {
+                            "$ref": "#/definitions/positiveInteger"
+                        }, 
+                        "$schema": {
+                            "type": "string", 
+                            "format": "uri"
+                        }, 
+                        "exclusiveMinimum": {
+                            "default": false, 
+                            "type": "boolean"
+                        }, 
+                        "id": {
+                            "type": "string", 
+                            "format": "uri"
+                        }, 
+                        "exclusiveMaximum": {
+                            "default": false, 
+                            "type": "boolean"
+                        }, 
+                        "title": {
+                            "type": "string"
+                        }, 
+                        "pattern": {
+                            "type": "string", 
+                            "format": "regex"
+                        }, 
+                        "patternProperties": {
+                            "additionalProperties": {
+                                "$ref": "#"
+                            }, 
+                            "default": {}, 
+                            "type": "object"
+                        }, 
+                        "multipleOf": {
+                            "type": "number", 
+                            "minimum": 0, 
+                            "exclusiveMinimum": true
+                        }, 
+                        "secret": {
+                            "default": false, 
+                            "type": "boolean"
+                        }, 
+                        "maxProperties": {
+                            "$ref": "#/definitions/positiveInteger"
+                        }, 
+                        "type": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/definitions/simpleTypes"
+                                }
+                            ]
+                        }, 
+                        "immutable": {
+                            "default": false, 
+                            "type": "boolean"
+                        }, 
+                        "description": {
+                            "type": "string"
+                        }, 
+                        "allOf": {
+                            "$ref": "#/definitions/schemaArray"
+                        }, 
+                        "minLength": {
+                            "$ref": "#/definitions/positiveIntegerDefault0"
+                        }, 
+                        "enum": {
+                            "minItems": 1, 
+                            "uniqueItems": true, 
+                            "type": "array"
+                        }, 
+                        "additionalItems": {
+                            "default": {}, 
+                            "anyOf": [
+                                {
+                                    "type": "boolean"
+                                }, 
+                                {
+                                    "$ref": "#"
+                                }
+                            ]
+                        }, 
+                        "dependencies": {
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "$ref": "#"
+                                    }, 
+                                    {
+                                        "$ref": "#/definitions/stringArray"
+                                    }
+                                ]
+                            }, 
+                            "type": "object"
+                        }, 
+                        "anyOf": {
+                            "$ref": "#/definitions/schemaArray"
+                        }, 
+                        "maxLength": {
+                            "$ref": "#/definitions/positiveInteger"
+                        }, 
+                        "not": {
+                            "$ref": "#"
+                        }, 
+                        "properties": {
+                            "additionalProperties": {
+                                "$ref": "#"
+                            }, 
+                            "default": {}, 
+                            "type": "object"
+                        }, 
+                        "oneOf": {
+                            "$ref": "#/definitions/schemaArray"
+                        }, 
+                        "default": {}, 
+                        "items": {
+                            "default": {}, 
+                            "anyOf": [
+                                {
+                                    "$ref": "#"
+                                }, 
+                                {
+                                    "$ref": "#/definitions/schemaArray"
+                                }
+                            ]
+                        }, 
+                        "required": {
+                            "default": false, 
+                            "type": "boolean"
+                        }, 
+                        "maximum": {
+                            "type": "number"
+                        }, 
+                        "minItems": {
+                            "$ref": "#/definitions/positiveIntegerDefault0"
+                        }, 
+                        "additionalProperties": {
+                            "default": {}, 
+                            "anyOf": [
+                                {
+                                    "type": "boolean"
+                                }, 
+                                {
+                                    "$ref": "#"
+                                }
+                            ]
+                        }, 
+                        "position": {
+                            "minimum": 0, 
+                            "type": "number"
+                        }
+                    }
+                }
+            }, 
+            "default": {}, 
+            "type": "object", 
+            "description": "Schema for the action's output."
+        }, 
+        "ref": {
+            "type": "string", 
+            "description": "System computed user friendly reference for the action.                                 Provided value will be overridden by computed value."
+        }, 
+        "pack": {
+            "default": "default", 
+            "type": "string", 
+            "description": "The content pack this action belongs to."
+        }
+    }, 
+    "type": "object", 
+    "description": "An activity that happens as a response to the external event.", 
+    "title": "Action"
+}

--- a/contrib/schemas/alias.json
+++ b/contrib/schemas/alias.json
@@ -1,0 +1,115 @@
+{
+    "additionalProperties": false, 
+    "properties": {
+        "uid": {
+            "type": "string"
+        }, 
+        "extra": {
+            "type": "object", 
+            "description": "Extra parameters, usually adapter-specific."
+        }, 
+        "immutable_parameters": {
+            "type": "object", 
+            "description": "Parameters to be passed to the action on every execution."
+        }, 
+        "result": {
+            "type": "object", 
+            "properties": {
+                "extra": {
+                    "type": "object"
+                }, 
+                "enabled": {
+                    "type": "boolean"
+                }, 
+                "format": {
+                    "type": "string"
+                }
+            }, 
+            "description": "Execution message format."
+        }, 
+        "id": {
+            "type": "string", 
+            "description": "The unique identifier for the action alias."
+        }, 
+        "description": {
+            "default": null, 
+            "type": "string", 
+            "description": "Description of the action alias."
+        }, 
+        "name": {
+            "required": true, 
+            "type": "string", 
+            "description": "Name of the action alias."
+        }, 
+        "ack": {
+            "type": "object", 
+            "properties": {
+                "append_url": {
+                    "type": "boolean"
+                }, 
+                "extra": {
+                    "type": "object"
+                }, 
+                "enabled": {
+                    "type": "boolean"
+                }, 
+                "format": {
+                    "type": "string"
+                }
+            }, 
+            "description": "Acknowledgement message format."
+        }, 
+        "enabled": {
+            "default": true, 
+            "type": "boolean", 
+            "description": "Flag indicating of action alias is enabled."
+        }, 
+        "metadata_file": {
+            "default": "", 
+            "type": "string", 
+            "description": "Path to the metadata file relative to the pack directory."
+        }, 
+        "formats": {
+            "items": {
+                "anyOf": [
+                    {
+                        "type": "string"
+                    }, 
+                    {
+                        "type": "object", 
+                        "properties": {
+                            "representation": {
+                                "items": {
+                                    "type": "string"
+                                }, 
+                                "type": "array"
+                            }, 
+                            "display": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ]
+            }, 
+            "type": "array", 
+            "description": "Possible parameter format."
+        }, 
+        "action_ref": {
+            "required": true, 
+            "type": "string", 
+            "description": "Reference to the aliased action."
+        }, 
+        "ref": {
+            "type": "string", 
+            "description": "System computed user friendly reference for the alias.                                 Provided value will be overridden by computed value."
+        }, 
+        "pack": {
+            "required": true, 
+            "type": "string", 
+            "description": "The content pack this actionalias belongs to."
+        }
+    }, 
+    "type": "object", 
+    "description": "Alias for an action.", 
+    "title": "ActionAlias"
+}

--- a/contrib/schemas/alias.json
+++ b/contrib/schemas/alias.json
@@ -101,7 +101,7 @@
         }, 
         "ref": {
             "type": "string", 
-            "description": "System computed user friendly reference for the alias.                                 Provided value will be overridden by computed value."
+            "description": "System computed user friendly reference for the alias. Provided value will be overridden by computed value."
         }, 
         "pack": {
             "required": true, 

--- a/contrib/schemas/pack.json
+++ b/contrib/schemas/pack.json
@@ -1,0 +1,109 @@
+{
+    "additionalProperties": true, 
+    "type": "object", 
+    "description": "Content pack schema.", 
+    "properties": {
+        "files": {
+            "default": [], 
+            "items": {
+                "type": "string"
+            }, 
+            "type": "array", 
+            "description": "A list of files inside the pack."
+        }, 
+        "name": {
+            "required": true, 
+            "type": "string", 
+            "description": "Display name of the pack. If the name only contains lowercaseletters, digits and underscores, the \"ref\" field is not required."
+        }, 
+        "contributors": {
+            "items": {
+                "type": "string", 
+                "maxLength": 100
+            }, 
+            "type": "array", 
+            "description": "A list of people who have contributed to the pack. Format is: Name <email address> e.g. Tomaz Muraus <tomaz@stackstorm.com>."
+        }, 
+        "author": {
+            "required": true, 
+            "type": "string", 
+            "description": "Pack author or authors."
+        }, 
+        "description": {
+            "required": true, 
+            "type": "string", 
+            "description": "Brief description of the pack and the service it integrates with."
+        }, 
+        "system": {
+            "default": {}, 
+            "type": "object", 
+            "description": "Specification for the system components and packages required for the pack."
+        }, 
+        "python_versions": {
+            "additionalItems": true, 
+            "description": "Major Python versions supported by this pack. E.g. \"2\" for Python 2.7.x and \"3\" for Python 3.6.x", 
+            "minItems": 1, 
+            "items": {
+                "enum": [
+                    "2", 
+                    "3"
+                ], 
+                "type": "string"
+            }, 
+            "maxItems": 2, 
+            "uniqueItems": true, 
+            "type": "array"
+        }, 
+        "stackstorm_version": {
+            "pattern": "^((>?>|>=|=|<=|<?<)\\s*[0-9]+\\.[0-9]+\\.[0-9]+?(\\s*,)?\\s*)+$", 
+            "type": "string", 
+            "description": "Required StackStorm version. Examples: \">1.6.0\", \">=1.8.0, <2.2.0\""
+        }, 
+        "email": {
+            "type": "string", 
+            "description": "E-mail of the pack author.", 
+            "format": "email"
+        }, 
+        "version": {
+            "pattern": "^(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)(?:-[\\da-z\\-]+(?:\\.[\\da-z\\-]+)*)?(?:\\+[\\da-z\\-]+(?:\\.[\\da-z\\-]+)*)?$", 
+            "required": true, 
+            "type": "string", 
+            "description": "Pack version. Must follow the semver format (for instance, \"0.1.0\")."
+        }, 
+        "dependencies": {
+            "default": [], 
+            "items": {
+                "type": "string"
+            }, 
+            "type": "array", 
+            "description": "A list of other StackStorm packs this pack depends upon. The same format as in \"st2 pack install\" is used: \"<name or full URL>[=<version or git ref>]\"."
+        }, 
+        "keywords": {
+            "default": [], 
+            "items": {
+                "type": "string"
+            }, 
+            "type": "array", 
+            "description": "Keywords describing the pack."
+        }, 
+        "path": {
+            "required": false, 
+            "type": "string", 
+            "description": "Location of the pack on disk in st2 system."
+        }, 
+        "ref": {
+            "default": null, 
+            "pattern": "^[a-z0-9_]+$", 
+            "type": "string", 
+            "description": "Reference for the pack, used as an internal id."
+        }, 
+        "id": {
+            "default": null, 
+            "type": "string", 
+            "description": "Unique identifier for the pack."
+        }, 
+        "uid": {
+            "type": "string"
+        }
+    }
+}

--- a/contrib/schemas/policy.json
+++ b/contrib/schemas/policy.json
@@ -1,0 +1,72 @@
+{
+    "additionalProperties": false, 
+    "type": "object", 
+    "properties": {
+        "uid": {
+            "type": "string"
+        }, 
+        "resource_ref": {
+            "required": true, 
+            "type": "string"
+        }, 
+        "metadata_file": {
+            "default": "", 
+            "type": "string", 
+            "description": "Path to the metadata file relative to the pack directory."
+        }, 
+        "id": {
+            "default": null, 
+            "type": "string"
+        }, 
+        "description": {
+            "type": "string"
+        }, 
+        "name": {
+            "required": true, 
+            "type": "string"
+        }, 
+        "parameters": {
+            "additionalProperties": false, 
+            "patternProperties": {
+                "^\\w+$": {
+                    "anyOf": [
+                        {
+                            "type": "array"
+                        }, 
+                        {
+                            "type": "boolean"
+                        }, 
+                        {
+                            "type": "integer"
+                        }, 
+                        {
+                            "type": "number"
+                        }, 
+                        {
+                            "type": "object"
+                        }, 
+                        {
+                            "type": "string"
+                        }
+                    ]
+                }
+            }, 
+            "type": "object"
+        }, 
+        "enabled": {
+            "default": true, 
+            "type": "boolean"
+        }, 
+        "policy_type": {
+            "required": true, 
+            "type": "string"
+        }, 
+        "ref": {
+            "type": "string"
+        }, 
+        "pack": {
+            "type": "string"
+        }
+    }, 
+    "title": "Policy"
+}

--- a/contrib/schemas/rule.json
+++ b/contrib/schemas/rule.json
@@ -1,0 +1,105 @@
+{
+    "additionalProperties": false, 
+    "type": "object", 
+    "properties": {
+        "uid": {
+            "type": "string"
+        }, 
+        "tags": {
+            "items": {
+                "type": "object"
+            }, 
+            "type": "array", 
+            "description": "User associated metadata assigned to this object."
+        }, 
+        "metadata_file": {
+            "default": "", 
+            "type": "string", 
+            "description": "Path to the metadata file relative to the pack directory."
+        }, 
+        "id": {
+            "default": null, 
+            "type": "string"
+        }, 
+        "description": {
+            "type": "string"
+        }, 
+        "name": {
+            "required": true, 
+            "type": "string"
+        }, 
+        "ref": {
+            "type": "string", 
+            "description": "System computed user friendly reference for the action.                                 Provided value will be overridden by computed value."
+        }, 
+        "enabled": {
+            "default": false, 
+            "type": "boolean"
+        }, 
+        "trigger": {
+            "additionalProperties": true, 
+            "required": true, 
+            "type": "object", 
+            "properties": {
+                "ref": {
+                    "required": false, 
+                    "type": "string"
+                }, 
+                "type": {
+                    "required": true, 
+                    "type": "string"
+                }, 
+                "description": {
+                    "require": false, 
+                    "type": "string"
+                }, 
+                "parameters": {
+                    "default": {}, 
+                    "type": "object"
+                }
+            }
+        }, 
+        "context": {
+            "type": "object"
+        }, 
+        "criteria": {
+            "default": {}, 
+            "type": "object"
+        }, 
+        "action": {
+            "additionalProperties": false, 
+            "required": true, 
+            "type": "object", 
+            "properties": {
+                "ref": {
+                    "required": true, 
+                    "type": "string"
+                }, 
+                "description": {
+                    "require": false, 
+                    "type": "string"
+                }, 
+                "parameters": {
+                    "type": "object"
+                }
+            }
+        }, 
+        "type": {
+            "additionalProperties": false, 
+            "type": "object", 
+            "properties": {
+                "ref": {
+                    "required": true, 
+                    "type": "string"
+                }, 
+                "parameters": {
+                    "type": "object"
+                }
+            }
+        }, 
+        "pack": {
+            "default": "default", 
+            "type": "string"
+        }
+    }
+}

--- a/contrib/schemas/rule.json
+++ b/contrib/schemas/rule.json
@@ -30,7 +30,7 @@
         }, 
         "ref": {
             "type": "string", 
-            "description": "System computed user friendly reference for the action.                                 Provided value will be overridden by computed value."
+            "description": "System computed user friendly reference for the rule. Provided value will be overridden by computed value."
         }, 
         "enabled": {
             "default": false, 

--- a/st2common/bin/st2-generate-schemas
+++ b/st2common/bin/st2-generate-schemas
@@ -28,11 +28,11 @@ from st2common.models.api import policy as policy_models
 from st2common.models.api import rule as rule_models
 
 content_models = {
-        'pack': pack_models.PackAPI,
-	'action': action_models.ActionAPI,
-        'alias': action_models.ActionAliasAPI,
-        'policy': policy_models.PolicyAPI,
-        'rule': rule_models.RuleAPI,
+    'pack': pack_models.PackAPI,
+    'action': action_models.ActionAPI,
+    'alias': action_models.ActionAliasAPI,
+    'policy': policy_models.PolicyAPI,
+    'rule': rule_models.RuleAPI,
 }
 
 def main():

--- a/st2common/bin/st2-generate-schemas
+++ b/st2common/bin/st2-generate-schemas
@@ -1,0 +1,55 @@
+#!/usr/bin/env python2.7
+#
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import inspect
+import json
+import os
+import six
+
+from st2common.models.api import action as action_models
+from st2common.models.api import pack as pack_models
+from st2common.models.api import policy as policy_models
+from st2common.models.api import rule as rule_models
+
+content_models = {
+        'pack': pack_models.PackAPI,
+	'action': action_models.ActionAPI,
+        'alias': action_models.ActionAliasAPI,
+        'policy': policy_models.PolicyAPI,
+        'rule': rule_models.RuleAPI,
+}
+
+def main():
+    scripts_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+    schemas_dir = scripts_dir + '/../../contrib/schemas'
+
+    for name, model in six.iteritems(content_models):
+        schema_text = json.dumps(model.schema, indent=4)
+        print('Generated schema for the "%s" model.' % name)
+
+        schema_file = os.path.abspath(schemas_dir + '/' + name + '.json')
+        print('Schema will be written to "%s".' % schema_file)
+
+        with open(schema_file, 'w') as f:
+            f.write(schema_text)
+            f.write('\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -550,8 +550,10 @@ class ActionAliasAPI(BaseAPI, APIUIDMixin):
                 "type": "string"
             },
             "ref": {
-                "description": "System computed user friendly reference for the alias. \
-                                Provided value will be overridden by computed value.",
+                "description": (
+                    "System computed user friendly reference for the alias. "
+                    "Provided value will be overridden by computed value."
+                ),
                 "type": "string"
             },
             "uid": {

--- a/st2common/st2common/models/api/rule.py
+++ b/st2common/st2common/models/api/rule.py
@@ -51,17 +51,17 @@ class RuleTypeAPI(BaseAPI):
         'type': 'object',
         'properties': {
             'id': {
-                'description': 'The unique identifier for the action runner.',
+                'description': 'The unique identifier for the rule type.',
                 'type': 'string',
                 'default': None
             },
             'name': {
-                'description': 'The name of the action runner.',
+                'description': 'The name for the rule type.',
                 'type': 'string',
                 'required': True
             },
             'description': {
-                'description': 'The description of the action runner.',
+                'description': 'The description of the rule type.',
                 'type': 'string'
             },
             'enabled': {
@@ -121,8 +121,10 @@ class RuleAPI(BaseAPI, APIUIDMixin):
                 'default': None
             },
             "ref": {
-                "description": "System computed user friendly reference for the action. \
-                                Provided value will be overridden by computed value.",
+                "description": (
+                    "System computed user friendly reference for the rule. "
+                    "Provided value will be overridden by computed value."
+                ),
                 "type": "string"
             },
             'uid': {

--- a/st2common/st2common/models/db/stormbase.py
+++ b/st2common/st2common/models/db/stormbase.py
@@ -20,6 +20,7 @@ import bson
 import six
 import mongoengine as me
 from oslo_config import cfg
+import json
 
 from st2common.util import mongoescape
 from st2common.models.base import DictSerializableClassMixin
@@ -40,7 +41,7 @@ __all__ = [
     'ContentPackResourceMixin'
 ]
 
-JSON_UNFRIENDLY_TYPES = (datetime.datetime, bson.ObjectId, me.EmbeddedDocument)
+JSON_UNFRIENDLY_TYPES = (datetime.datetime, bson.ObjectId)
 
 
 class StormFoundationDB(me.Document, DictSerializableClassMixin):
@@ -98,7 +99,11 @@ class StormFoundationDB(me.Document, DictSerializableClassMixin):
         serializable_dict = {}
         for k in sorted(six.iterkeys(self._fields)):
             v = getattr(self, k)
-            v = str(v) if isinstance(v, JSON_UNFRIENDLY_TYPES) else v
+            if isinstance(v, JSON_UNFRIENDLY_TYPES):
+                v = str(v)
+            elif isinstance(v, me.EmbeddedDocument):
+                v = json.loads(v.to_json())
+
             serializable_dict[k] = v
 
         if mask_secrets and cfg.CONF.log.mask_secrets:

--- a/st2common/st2common/util/monkey_patch.py
+++ b/st2common/st2common/util/monkey_patch.py
@@ -79,7 +79,7 @@ def use_select_poll_workaround(nose_only=True):
     import eventlet
 
     # Work around to get tests to pass with eventlet >= 0.20.0
-    if not nose_only or (nose_only and'nose' in sys.modules.keys()):
+    if not nose_only or (nose_only and 'nose' in sys.modules.keys()):
         # Add back blocking poll() to eventlet monkeypatched select
         original_poll = eventlet.patcher.original('select').poll
         select.poll = original_poll

--- a/st2common/tests/unit/test_db_base.py
+++ b/st2common/tests/unit/test_db_base.py
@@ -20,12 +20,34 @@ from st2common.util import date as date_utils
 from st2tests import DbTestCase
 
 
+class FakeRuleSpecDB(mongoengine.EmbeddedDocument):
+    ref = mongoengine.StringField(required=True, unique=False)
+    parameters = mongoengine.DictField()
+
+    def __str__(self):
+        result = []
+        result.append('ActionExecutionSpecDB@')
+        result.append('test')
+        result.append('(ref="%s", ' % self.ref)
+        result.append('parameters="%s")' % self.parameters)
+        return ''.join(result)
+
+
 class FakeModel(stormbase.StormBaseDB):
     boolean_field = mongoengine.BooleanField()
     datetime_field = mongoengine.DateTimeField()
     dict_field = mongoengine.DictField()
     integer_field = mongoengine.IntField()
     list_field = mongoengine.ListField()
+
+
+class FakeRuleModel(stormbase.StormBaseDB):
+    boolean_field = mongoengine.BooleanField()
+    datetime_field = mongoengine.DateTimeField()
+    dict_field = mongoengine.DictField()
+    integer_field = mongoengine.IntField()
+    list_field = mongoengine.ListField()
+    embedded_doc_field = mongoengine.EmbeddedDocumentField(FakeRuleSpecDB)
 
 
 class TestBaseModel(DbTestCase):
@@ -38,6 +60,21 @@ class TestBaseModel(DbTestCase):
 
         expected = ('FakeModel(boolean_field=True, datetime_field="%s", description="fun!", '
                     'dict_field={\'a\': 1}, id=None, integer_field=68, list_field=[\'abc\'], '
+                    'name="seesaw")' % str(instance.datetime_field))
+
+        self.assertEqual(str(instance), expected)
+
+    def test_rule_print(self):
+        instance = FakeRuleModel(name='seesaw', boolean_field=True,
+                                 datetime_field=date_utils.get_datetime_utc_now(),
+                                 description=u'fun!', dict_field={'a': 1},
+                                 integer_field=68, list_field=['abc'],
+                                 embedded_doc_field={'ref': '1234', 'parameters': {'b': 2}})
+
+        expected = ('FakeRuleModel(boolean_field=True, datetime_field="%s", description="fun!", '
+                    'dict_field={\'a\': 1}, embedded_doc_field=ActionExecutionSpecDB@test('
+                    'ref="1234", parameters="{\'b\': 2}"), id=None, integer_field=68, '
+                    'list_field=[\'abc\'], '
                     'name="seesaw")' % str(instance.datetime_field))
 
         self.assertEqual(str(instance), expected)

--- a/st2common/tests/unit/test_dist_utils.py
+++ b/st2common/tests/unit/test_dist_utils.py
@@ -44,7 +44,7 @@ class DistUtilsTestCase(unittest2.TestCase):
     def setUp(self):
         super(DistUtilsTestCase, self).setUp()
 
-        if 'pip'in sys.modules:
+        if 'pip' in sys.modules:
             del sys.modules['pip']
 
     def tearDown(self):

--- a/st2common/tests/unit/test_logger.py
+++ b/st2common/tests/unit/test_logger.py
@@ -291,10 +291,7 @@ class ConsoleLogFormatterTestCase(unittest.TestCase):
     @mock.patch('st2common.logging.formatters.MASKED_ATTRIBUTES_BLACKLIST',
                 MOCK_MASKED_ATTRIBUTES_BLACKLIST)
     @mock.patch('st2common.models.db.rule.RuleDB._get_referenced_action_model')
-    # @mock.patch('st2common.models.db.stormbase.cfg')
     def test_format_secret_rule_parameters_are_masked(self, mock__get_referenced_action_model):
-        formatter = ConsoleLogFormatter()
-
         expected_result = {
             'description': 'Test description',
             'tags': [],
@@ -346,7 +343,6 @@ class ConsoleLogFormatterTestCase(unittest.TestCase):
 
         result = mock_rule_db.to_serializable_dict(True)
 
-        print result
         self.assertEqual(expected_result, result)
 
 

--- a/st2common/tests/unit/test_logger.py
+++ b/st2common/tests/unit/test_logger.py
@@ -30,6 +30,7 @@ from st2common.logging.formatters import ConsoleLogFormatter
 from st2common.logging.formatters import GelfLogFormatter
 from st2common.constants.secrets import MASKED_ATTRIBUTE_VALUE
 from st2common.models.db.action import ActionDB
+from st2common.models.db.rule import RuleDB
 from st2common.models.db.execution import ActionExecutionDB
 import st2tests.config as tests_config
 
@@ -254,6 +255,99 @@ class ConsoleLogFormatterTestCase(unittest.TestCase):
         message = formatter.format(record=record)
         self.assertIn('test message 1', message)
         self.assertRegexpMatches(message, expected_msg_part)
+
+    @mock.patch('st2common.logging.formatters.MASKED_ATTRIBUTES_BLACKLIST',
+                MOCK_MASKED_ATTRIBUTES_BLACKLIST)
+    def test_format_rule(self):
+        expected_result = {
+            'description': 'Test description',
+            'tags': [],
+            'type': {
+                'ref': 'standard',
+                'parameters': {}},
+            'enabled': True,
+            'trigger': 'test tigger',
+            'metadata_file': None,
+            'context': {},
+            'criteria': {},
+            'action': {
+                'ref': '1234',
+                'parameters': {'b': 2}},
+            'uid': 'rule:testpack:test.action',
+            'pack': 'testpack',
+            'ref': 'testpack.test.action',
+            'id': None,
+            'name': 'test.action'
+        }
+        mock_rule_db = RuleDB(pack='testpack',
+                              name='test.action',
+                              description='Test description',
+                              trigger='test tigger',
+                              action={'ref': '1234', 'parameters': {'b': 2}})
+
+        result = mock_rule_db.to_serializable_dict()
+        self.assertEqual(expected_result, result)
+
+    @mock.patch('st2common.logging.formatters.MASKED_ATTRIBUTES_BLACKLIST',
+                MOCK_MASKED_ATTRIBUTES_BLACKLIST)
+    @mock.patch('st2common.models.db.rule.RuleDB._get_referenced_action_model')
+    # @mock.patch('st2common.models.db.stormbase.cfg')
+    def test_format_secret_rule_parameters_are_masked(self, mock__get_referenced_action_model):
+        formatter = ConsoleLogFormatter()
+
+        expected_result = {
+            'description': 'Test description',
+            'tags': [],
+            'type': {
+                'ref': 'standard',
+                'parameters': {}},
+            'enabled': True,
+            'trigger': 'test tigger',
+            'metadata_file': None,
+            'context': {},
+            'criteria': {},
+            'action': {
+                'ref': '1234',
+                'parameters': {
+                    'parameter1': 'value1',
+                    'parameter2': '********'
+                }},
+            'uid': 'rule:testpack:test.action',
+            'pack': 'testpack',
+            'ref': 'testpack.test.action',
+            'id': None,
+            'name': 'test.action'
+        }
+
+        parameters = {
+            'parameter1': {
+                'type': 'string',
+                'required': False
+            },
+            'parameter2': {
+                'type': 'string',
+                'required': False,
+                'secret': True
+            }
+        }
+        mock_action_db = ActionDB(pack='testpack', name='test.action', parameters=parameters)
+        mock__get_referenced_action_model.return_value = mock_action_db
+        cfg.CONF.set_override(group='log', name='mask_secrets',
+                              override=True)
+        mock_rule_db = RuleDB(pack='testpack',
+                              name='test.action',
+                              description='Test description',
+                              trigger='test tigger',
+                              action={'ref': '1234',
+                                      'parameters': {
+                                          'parameter1': 'value1',
+                                          'parameter2': 'value2'
+                                      }})
+
+        result = mock_rule_db.to_serializable_dict(True)
+
+        print result
+        self.assertEqual(expected_result, result)
 
 
 class GelfLogFormatterTestCase(unittest.TestCase):


### PR DESCRIPTION
This is a fix for issue: https://github.com/StackStorm/st2/issues/4934

We started by adding a logging to method: https://github.com/StackStorm/st2/blob/master/st2common/st2common/models/db/rule.py#L121
That looked like:
```
LOG.debug("result: {}".format(result))
LOG.debug("type of result = {}".format(type(result)))
action = result.get('action', {})
LOG.debug("action: {}".format(action))
LOG.debug("type of action = {}".format(type(action)))
ref = action.get('ref', None)
LOG.debug("ref: {}".format(ref))
LOG.debug("type of ref = {}".format(type(ref)))
```
That produced:
```
result: {'description': u'Sample rule using an Interval Timer.', 'tags': [], 'ref': u'encore.sample_rule_with_timer', 'enabled': True, 'name': u'sample_rule_with_timer', 'trigger': u'core.38d1bbdd-a659-4038-b3f4-ce250eb79db8', 'metadata_file': u'rules/sample_rule_with_timer.yaml', 'context': {}, 'criteria': {}, 'action': 'ActionExecutionSpecDB@139730096706896(ref="core.local", parameters="{u\'cmd\': u\'echo "{{trigger.executed_at}}"\'}")', 'pack': u'encore', 'type': 'RuleTypeSpecDB@139730096707280(ref="standard", parameters="{}")', 'id': '5eb05b4e58c1e95f540e4c3b', 'uid': u'rule:encore:sample_rule_with_timer'}
type of result = <type 'dict'>
action: ActionExecutionSpecDB@139730096706896(ref="core.local", parameters="{u'cmd': u'echo "{{trigger.executed_at}}"'}")
type of action = <type 'str'>
2020-05-05 13:54:21,082 ERROR [-]     ref = action.get('ref', None)
message:     ref = action.get('ref', None)
message: AttributeError: 'str' object has no attribute 'get'
```

looking at: https://github.com/StackStorm/st2/blob/master/st2reactor/st2reactor/rules/enforcer.py#L118

added print statements:
```
print "trigger_instance = {}".format(self.trigger_instance)
print "rule = {}".format(self.rule)
print "enforcer rule action = {}".format(self.rule.action.ref)
```
which produced:
```
trigger_instance = TriggerInstanceDB(id=5eb3119e83c3a05c1db61e81, occurrence_time="2020-05-06 19:35:58.661164+00:00", payload={u'executed_at': u'2020-05-06 19:33:35.493510+00:00', u'schedule': None}, status="processing", trigger="core.94333cfe-11d1-4f98-8fd7-12837fd51c2e")
rule = RuleDB(action=ActionExecutionSpecDB@140536422173264(ref="core.local", parameters="{u'cmd': u'echo "{{trigger.executed_at}}"'}"), context={}, criteria={}, description="Sample rule using an Interval Timer.", enabled=True, id=5eb05b4e58c1e95f540e4c3b, metadata_file="rules/sample_rule_with_timer.yaml", name="sample_rule_with_timer", pack="encore", ref="encore.sample_rule_with_timer", tags=[], trigger="core.94333cfe-11d1-4f98-8fd7-12837fd51c2e", type=RuleTypeSpecDB@140536422173392(ref="standard", parameters="{}"), uid="rule:encore:sample_rule_with_timer")
enforcer rule action = core.local
```

showing that before the `LOG.audit` was called the `rule.action.ref` was a `dict` object like expected so something was happening when parsing the rule object for the logger.

This led to: https://github.com/StackStorm/st2/blob/master/st2common/st2common/models/db/stormbase.py#L89 but specifically: https://github.com/StackStorm/st2/blob/master/st2common/st2common/models/db/stormbase.py#L101

where `JSON_UNFRIENDLY_TYPES = (datetime.datetime, bson.ObjectId, me.EmbeddedDocument)` so the mongoengine `EmbeddedDocument` types were skipped during the serialization causing them to be returned as a string.

we then found that for mongoengine EmbeddedDocuments there is a to_json method: http://docs.mongoengine.org/apireference.html?highlight=json#mongoengine.EmbeddedDocument.to_json

so we added an extra is instance to handle the `EmbeddedDocuments` type and return the json to the dict and after the error went away as show below:
```
2020-05-06 17:23:52,578 139971178114736 INFO filter [-] Validating rule encore.sample_rule_with_timer for 38d1bbdd-a659-4038-b3f4-ce250eb79db8. (trigger_instance={'status': 'processing', 'occurrence_time': '2020-05-06 21:23:52.543438+00:00', 'trigger': u'core.38d1bbdd-a659-4038-b3f4-ce250eb79db8', 'id': '5eb32ae8ed687f9c4d357fd9', 'payload': {u'executed_at': u'2020-05-06 21:23:52.538257+00:00', u'schedule': None}},rule={'description': u'Sample rule using an Interval Timer.', 'tags': [], 'type': {u'ref': u'standard', u'parameters': {}}, 'enabled': True, 'trigger': u'core.38d1bbdd-a659-4038-b3f4-ce250eb79db8', 'metadata_file': u'rules/sample_rule_with_timer.yaml', 'context': {}, 'criteria': {}, 'action': {u'ref': u'core.local', u'parameters': {u'cmd': u'echo "{{trigger.executed_at}}"'}}, 'uid': u'rule:encore:sample_rule_with_timer', 'pack': u'encore', 'ref': u'encore.sample_rule_with_timer', 'id': '5eb05b4e58c1e95f540e4c3b', 'name': u'sample_rule_with_timer'},trigger={'description': None, 'parameters': {u'unit': u'seconds', u'delta': 5}, 'ref': u'core.38d1bbdd-a659-4038-b3f4-ce250eb79db8', 'ref_count': 1, 'metadata_file': None, 'uid': u'trigger:core:38d1bbdd-a659-4038-b3f4-ce250eb79db8:889c1c0b04f53100997af85f35ad3979', 'pack': u'core', 'type': u'core.st2.IntervalTimer', 'id': '5eb05b4e58c1e95f540e4c3a', 'name': u'38d1bbdd-a659-4038-b3f4-ce250eb79db8'})
2020-05-06 17:23:52,608 139971178114736 INFO matcher [-] 1 rule(s) found to enforce for 38d1bbdd-a659-4038-b3f4-ce250eb79db8.
2020-05-06 17:23:52,609 139971178114736 INFO engine [-] Matched 1 rule(s) for trigger_instance 5eb32ae8ed687f9c4d357fd9 (trigger=core.38d1bbdd-a659-4038-b3f4-ce250eb79db8)
2020-05-06 17:23:52,622 139971178114736 INFO enforcer [-] Invoking action core.local for trigger_instance 5eb32ae8ed687f9c4d357fd9 with params {"cmd": "echo \"{{trigger.executed_at}}\""}.
2020-05-06 17:23:53,460 139971178114896 INFO engine [-] Found 0 rules defined for trigger core.st2.generic.actiontrigger
2020-05-06 17:23:53,463 139971178114896 INFO engine [-] No matching rules found for trigger instance 5eb32ae9ed687f9c4d357fde.
2020-05-06 17:23:57,577 139971178114896 INFO engine [-] Found 1 rules defined for trigger core.38d1bbdd-a659-4038-b3f4-ce250eb79db8
2020-05-06 17:23:57,578 139971178114896 INFO filter [-] Validating rule encore.sample_rule_with_timer for 38d1bbdd-a659-4038-b3f4-ce250eb79db8. (trigger_instance={'status': 'processing', 'occurrence_time': '2020-05-06 21:23:57.542899+00:00', 'trigger': u'core.38d1bbdd-a659-4038-b3f4-ce250eb79db8', 'id': '5eb32aeded687f9c4d357fdf', 'payload': {u'executed_at': u'2020-05-06 21:23:57.538205+00:00', u'schedule': None}},rule={'description': u'Sample rule using an Interval Timer.', 'tags': [], 'type': {u'ref': u'standard', u'parameters': {}}, 'enabled': True, 'trigger': u'core.38d1bbdd-a659-4038-b3f4-ce250eb79db8', 'metadata_file': u'rules/sample_rule_with_timer.yaml', 'context': {}, 'criteria': {}, 'action': {u'ref': u'core.local', u'parameters': {u'cmd': u'echo "{{trigger.executed_at}}"'}}, 'uid': u'rule:encore:sample_rule_with_timer', 'pack': u'encore', 'ref': u'encore.sample_rule_with_timer', 'id': '5eb05b4e58c1e95f540e4c3b', 'name': u'sample_rule_with_timer'},trigger={'description': None, 'parameters': {u'unit': u'seconds', u'delta': 5}, 'ref': u'core.38d1bbdd-a659-4038-b3f4-ce250eb79db8', 'ref_count': 1, 'metadata_file': None, 'uid': u'trigger:core:38d1bbdd-a659-4038-b3f4-ce250eb79db8:889c1c0b04f53100997af85f35ad3979', 'pack': u'core', 'type': u'core.st2.IntervalTimer', 'id': '5eb05b4e58c1e95f540e4c3a', 'name': u'38d1bbdd-a659-4038-b3f4-ce250eb79db8'})
2020-05-06 17:23:57,610 139971178114896 INFO matcher [-] 1 rule(s) found to enforce for 38d1bbdd-a659-4038-b3f4-ce250eb79db8.
2020-05-06 17:23:57,611 139971178114896 INFO engine [-] Matched 1 rule(s) for trigger_instance 5eb32aeded687f9c4d357fdf (trigger=core.38d1bbdd-a659-4038-b3f4-ce250eb79db8)
2020-05-06 17:23:57,624 139971178114896 INFO enforcer [-] Invoking action core.local for trigger_instance 5eb32aeded687f9c4d357fdf with params {"cmd": "echo \"{{trigger.executed_at}}\""}.
2020-05-06 17:23:58,503 139971178114736 INFO engine [-] Found 0 rules defined for trigger core.st2.generic.actiontrigger
2020-05-06 17:23:58,506 139971178114736 INFO engine [-] No matching rules found for trigger instance 5eb32aeeed687f9c4d357fe4.
2020-05-06 17:24:02,578 139971178114736 INFO engine [-] Found 1 rules defined for trigger core.38d1bbdd-a659-4038-b3f4-ce250eb79db8
```

This behavior looks to have changed in this commit: https://github.com/StackStorm/st2/pull/4788/files