### PR TITLE
Proposal: Add @winem to the StackStorm Contributors [skip ci]

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -51,6 +51,7 @@ They're not part of the TSC voting process, but appreciated for their contributi
 * Jon Middleton ([@jjm](https://github.com/jjm)) - StackStorm Exchange, Core, Discussions.
 * Shu Sugimoto ([@shusugmt](https://github.com/shusugmt)) - Docker, StackStorm Exchange packs.
 * Tristan Struthers ([@trstruth](https://github.com/trstruth)) - Docker, K8s, Orquesta, Community.
+* Marcel Weinberg ([@winem](https://github.com/winem)) - Community, Docker, Core.
 
 # Friends
 People that are currently not very active maintainers/contributors but who participated in and formed the project we have today.


### PR DESCRIPTION
I'd like to propose adding @winem to the list of StackStorm Contributors.

During the past half year he was helping StackStorm project via bug reports, PR fixes, PR reviews, release testing efforts as well as actively supporting community in Slack and Forums.


Github PRs:
- [Fix tag filter when querying actions #4874](https://github.com/StackStorm/st2/pull/4874) fixing https://github.com/StackStorm/st2/issues/4828 `good first issue`.
- [Add configurable ssh connect timeout #4914](https://github.com/StackStorm/st2/pull/4914) addressing another `good first issue` https://github.com/StackStorm/st2/issues/4715
- [Handle action parameters of type array correctly #4861](https://github.com/StackStorm/st2/pull/4861) closing bug https://github.com/StackStorm/st2/issues/4804
- [Fix bug in the supported API filters when filtering packs #4919](https://github.com/StackStorm/st2/pull/4919) fixing https://github.com/StackStorm/st2/issues/4918
- Bug report [Creating executions fails due to unserializible date (running from sources) #4908](https://github.com/StackStorm/st2/issues/4908)
- [New example for an Orquesta workflow #4841](https://github.com/StackStorm/st2/pull/4841) in `st2`
- [New example for an Orquesta workflow querying multiple parameters #954](https://github.com/StackStorm/st2docs/pull/954) in `st2docs` 
- [Fix broken link to the replicated zookeeper documentation #957](https://github.com/StackStorm/st2docs/pull/957) in `st2docs`
- [Update the stream api endpoint path #953](https://github.com/StackStorm/st2docs/pull/953) fixing https://github.com/StackStorm/st2docs/issues/952
- [Docs/correct syntax to register single packs #963](https://github.com/StackStorm/st2docs/pull/963) in `st2docs`.

> Working on fixing bugs and good first issues as well as covering them with tests in `stackstorm/st2` core is something that's highly appreciated! 

Release Testing:
- Testing the `v3.2dev` https://github.com/StackStorm/discussions/issues/6 and not just reporting bugs to st2 core and documentation, but also shipping PRs to fix them. That's the most valued attitude.

Forums:
- [Quick Install stackstorm error](https://forum.stackstorm.com/t/quick-install-stackstorm-error/1219)
- [Reg st2-docker persistancy](https://forum.stackstorm.com/t/reg-st2-docker-persistancy/1196)

Not to forget about being active in Slack Community and guiding StackStorm newcomers which is very helpful!

-----

> FYI Contributors don't have any obligations according to https://github.com/StackStorm/st2/blob/master/OWNERS.md#contributors
> However it's one step before becoming a Maintainer, if they would like to go that path in future.
> 
> Starting Contributing to StackStorm is easy.
> See the first steps & criteria: https://github.com/StackStorm/st2/blob/master/GOVERNANCE.md#how-to-start-contributing 
>
> Any work that's aligned with the current project needs like triaging issues, fixing bugs, cutting tech debt, testing features, code reviews, community help in Slack/Forums, documentation updates, working on a roadmap items and so on is something that's highly valued!