### PR TITLE
Promote carlos (@nzlosh) from contributor to maintainer

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -39,6 +39,8 @@ Being part of Technical Steering Committee (TSC) [@StackStorm/maintainers](https
   - Systems, ST2 Exchange. [Case Study](https://stackstorm.com/case-study-bitovi/).
 * Nick Maludy ([@nmaludy](https://github.com/nmaludy)) <<nmaludy@gmail.com>>
   - Community, Core, Systems, StackStorm Exchange, Puppet deployment. [Case Study](https://stackstorm.com/case-study-dmm/).
+* Carlos ([@nzlosh](https://github.com/nzlosh))
+  - Chatops, Errbot, Community, Discussions, StackStorm Exchange
 
 --------
 
@@ -46,7 +48,6 @@ Being part of Technical Steering Committee (TSC) [@StackStorm/maintainers](https
 Contributors are using and occasionally contributing back to the project, might be active in conversations or express their opinion on the project’s direction.
 They're not part of the TSC voting process, but appreciated for their contribution, involvement and may become Maintainers in future.
 <!-- [@StackStorm/contributors](https://github.com/orgs/StackStorm/teams/contributors) are invited to StackStorm Github organization and we appreciate their contribution and involvement. -->
-* Carlos ([@nzlosh](https://github.com/nzlosh)) - Chatops, Errbot, Community, Discussions, StackStorm Exchange.
 * Hiroyasu Ohyama ([@userlocalhost](https://github.com/userlocalhost)) - Orquesta, Workflows, st2 Japan Community. [Case Study](https://stackstorm.com/case-study-dmm/).
 * Jon Middleton ([@jjm](https://github.com/jjm)) - StackStorm Exchange, Core, Discussions.
 * Shu Sugimoto ([@shusugmt](https://github.com/shusugmt)) - Docker, StackStorm Exchange packs.


### PR DESCRIPTION
@nzlosh has regularly made contributions to the StackStorm project for over two years, but in just the last six months:

* He created and singlehandedly maintains the Python-based [err-stackstorm](https://github.com/nzlosh/err-stackstorm), an alternative to Node.js-based st2chatops with hubot-stackstorm. His project is so successful that it was given its own #err-stackstorm channel in our Slack community.
* He [created](https://github.com/StackStorm-Exchange/stackstorm-powerdns/pull/1) and [regularly](https://github.com/StackStorm-Exchange/stackstorm-powerdns/pull/5) [maintains](https://github.com/StackStorm-Exchange/stackstorm-powerdns/pull/6) the [PowerDNS pack](https://github.com/StackStorm-Exchange/stackstorm-powerdns)
* [Contributed documentation and examples](https://github.com/StackStorm-Exchange/stackstorm-syslog_client/pull/4) to the [syslog client pack](https://github.com/StackStorm-Exchange/stackstorm-syslog_client)
* Helps [develop](https://github.com/StackStorm-Exchange/stackstorm-consul/pulls?q=author%3Anzlosh) the [Consul pack](https://github.com/StackStorm-Exchange/stackstorm-consul)
* Has made a few contributions to other packs
  - [stackstorm-icinga2](https://github.com/StackStorm-Exchange/stackstorm-icinga2/pull/12)
  - [stackstorm-salt](https://github.com/StackStorm-Exchange/stackstorm-salt/issues/15)
* Contributes patches to (his) upstream projects:
  - [Errbot](https://github.com/errbotio/errbot/pulls?q=author%3Anzlosh)
  - [err-backend-discord](https://github.com/gbin/err-backend-discord)
* And is involved in spreading StackStorm support to Debian systems (this is greatly complicated by Debian Buster lacking Python 3.6 and MongoDB 4.0 packages):
  - StackStorm/st2#4844
  - StackStorm/st2#4855
  - StackStorm/st2packaging-dockerfiles#75
  - https://forum.stackstorm.com/t/is-python3-7-officially-supported-by-stackstorm/938/10
* Has [reported and investigated](https://github.com/StackStorm/orquesta/issues/186) issues with Orquesta and ActionChain
* He has posted in the StackStorm forums:
  - https://forum.stackstorm.com/t/test-stackstorm-alias-output/1129
  - https://forum.stackstorm.com/t/slack-extra-feature-to-get-different-colours/413
  - https://forum.stackstorm.com/t/dynamic-action-workflows-pattern/515
  - https://forum.stackstorm.com/t/support-for-bigpanda/1069
  - https://forum.stackstorm.com/t/orquesta-workflow-json-actions-items/1090
As well as helped numerous people in #community.

Additionally, he has created two personal packs:
* https://github.com/nzlosh/stackstorm_ldap
* https://github.com/nzlosh/stackstorm_livestatus

And he has also weighed in on the [discussion to transition st2chatops to something Python based](https://github.com/StackStorm/discussions/issues/8). In fact, he did the majority of the homework for that proposal to begin with.

> Being part of Technical Steering Committee (TSC) @StackStorm/maintainers provide significant and reliable value to the project helping it grow and improve through development and maintenance.

In recognition of his contributions and efforts to improve StackStorm as a product and as a community, I would like to propose that he be officially promoted from Contributor to Maintainer status and be given a seat/vote on the TSC.