### PR TITLE
fix netstat action in linux pack

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ Added
 
 Fixed
 ~~~~~
+* Fixed a bug where `type` attribute was missing for netstat action in linux pack. Fixes #4946
+
+  Reported by @scguoi and contributed by Sheshagiri (@sheshagiri)
+
 * Fixed a bug where persisting Orquesta to the MongoDB database returned an error
   ``message: key 'myvar.with.period' must not contain '.'``. This happened anytime an
   ``input``, ``output``, ``publish`` or context ``var`` contained a key with a ``.`` within

--- a/contrib/linux/actions/netstat.yaml
+++ b/contrib/linux/actions/netstat.yaml
@@ -11,3 +11,4 @@
     args:
       description: "Command line arguments"
       default: " "
+      type: "string"

--- a/contrib/linux/actions/netstat_grep.yaml
+++ b/contrib/linux/actions/netstat_grep.yaml
@@ -9,5 +9,6 @@
       immutable: true
       default: "for pid in {{pids}}; do netstat -pant | grep $pid; done; exit 0"
     pids:
-      description: "List of pids"
+      description: "List of pids. ex: [1111, 2222]"
       required: true
+      type: "array"

--- a/contrib/runners/orquesta_runner/orquesta_functions/st2kv.py
+++ b/contrib/runners/orquesta_runner/orquesta_functions/st2kv.py
@@ -43,8 +43,8 @@ def st2kv_(context, key, **kwargs):
     try:
         user_db = auth_db_access.User.get(username)
     except Exception as e:
-        raise Exception('Failed to retrieve User object for user "%s" % (username)' %
-                        (six.text_type(e)))
+        raise Exception('Failed to retrieve User object for user "%s", "%s"' %
+                        (username, six.text_type(e)))
 
     has_default = 'default' in kwargs
     default_value = kwargs.get('default')

--- a/st2common/st2common/util/monkey_patch.py
+++ b/st2common/st2common/util/monkey_patch.py
@@ -79,7 +79,7 @@ def use_select_poll_workaround(nose_only=True):
     import eventlet
 
     # Work around to get tests to pass with eventlet >= 0.20.0
-    if not nose_only or (nose_only and'nose' in sys.modules.keys()):
+    if not nose_only or (nose_only and 'nose' in sys.modules.keys()):
         # Add back blocking poll() to eventlet monkeypatched select
         original_poll = eventlet.patcher.original('select').poll
         select.poll = original_poll

--- a/st2common/tests/unit/test_dist_utils.py
+++ b/st2common/tests/unit/test_dist_utils.py
@@ -44,7 +44,7 @@ class DistUtilsTestCase(unittest2.TestCase):
     def setUp(self):
         super(DistUtilsTestCase, self).setUp()
 
-        if 'pip'in sys.modules:
+        if 'pip' in sys.modules:
             del sys.modules['pip']
 
     def tearDown(self):


### PR DESCRIPTION
looks like the `type` attribute is missing for `netstat` action in Linux pack because of which the action in not usable.

```
$ st2 run linux.netstat hosts=172.31.114.68 args="-antp"
ERROR: 'type'
```

closes: #4946 