### PR TITLE
Pin pip consistently in one place across the targets, fix st2docs build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,6 @@ cache:
 before_install:
   # If you update these versions, make sure you update the versions in the .st2client-install-check
   # and the requirements targets in the Makefile to match
-  - pip install --upgrade "pip==20.0.2"
   - sudo pip install --upgrade "virtualenv==16.6.0"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,9 +80,8 @@ cache:
     #- .tox/
 
 before_install:
-  # If you update these versions, make sure you update the versions in the .st2client-install-check
-  # and the requirements targets in the Makefile to match
-  - sudo pip install --upgrade "virtualenv==16.6.0"
+  # Upgrade virtualenv to latest
+  - sudo pip install --upgrade "virtualenv"
 
 install:
   - ./scripts/travis/install-requirements.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,10 +79,6 @@ cache:
     # are updated so it's disabled
     #- .tox/
 
-before_install:
-  # Upgrade virtualenv to latest
-  - pip install --upgrade "virtualenv"
-
 install:
   - ./scripts/travis/install-requirements.sh
   # prep a travis-specific dev conf file that uses travis instead of stanley

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ cache:
 
 before_install:
   # Upgrade virtualenv to latest
-  - sudo pip install --upgrade "virtualenv"
+  - pip install --upgrade "virtualenv"
 
 install:
   - ./scripts/travis/install-requirements.sh

--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,8 @@ check-python-packages:
 	@echo ""
 	@echo "================== CHECK PYTHON PACKAGES ===================="
 	@echo ""
-	test -f $(VIRTUALENV_COMPONENTS_DIR)/bin/activate || virtualenv --python=$(PYTHON_VERSION) $(VIRTUALENV_COMPONENTS_DIR) --pip $(PIP_VERSION)
+
+	test -f $(VIRTUALENV_COMPONENTS_DIR)/bin/activate || virtualenv --python=$(PYTHON_VERSION) $(VIRTUALENV_COMPONENTS_DIR) --no-download
 	@for component in $(COMPONENTS_WITHOUT_ST2TESTS); do \
 		echo "==========================================================="; \
 		echo "Checking component:" $$component; \
@@ -235,7 +236,7 @@ check-python-packages-nightly:
 	@echo "================== CHECK PYTHON PACKAGES ===================="
 	@echo ""
 
-	test -f $(VIRTUALENV_COMPONENTS_DIR)/bin/activate || virtualenv --python=$(PYTHON_VERSION) $(VIRTUALENV_COMPONENTS_DIR) --pip $(PIP_VERSION)
+	test -f $(VIRTUALENV_COMPONENTS_DIR)/bin/activate || virtualenv --python=$(PYTHON_VERSION) $(VIRTUALENV_COMPONENTS_DIR) --no-download
 	@for component in $(COMPONENTS_WITHOUT_ST2TESTS); do \
 		echo "==========================================================="; \
 		echo "Checking component:" $$component; \
@@ -321,7 +322,7 @@ lint-api-spec: requirements .lint-api-spec
 	@echo
 	@echo "================== Lint API spec ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate; st2common/bin/st2-validate-api-spec --config-file conf/st2.dev.conf 
+	. $(VIRTUALENV_DIR)/bin/activate; st2common/bin/st2-validate-api-spec --config-file conf/st2.dev.conf
 
 .PHONY: generate-api-spec
 generate-api-spec: requirements .generate-api-spec
@@ -367,7 +368,7 @@ flake8: requirements .flake8
 	@echo
 	@echo "==================== st2client install check ===================="
 	@echo
-	test -f $(VIRTUALENV_ST2CLIENT_DIR)/bin/activate || virtualenv --python=$(PYTHON_VERSION) $(VIRTUALENV_ST2CLIENT_DIR) --pip $(PIP_VERSION)
+	test -f $(VIRTUALENV_ST2CLIENT_DIR)/bin/activate || virtualenv --python=$(PYTHON_VERSION) $(VIRTUALENV_ST2CLIENT_DIR) --no-download
 
 	# Setup PYTHONPATH in bash activate script...
 	# Delete existing entries (if any)
@@ -381,6 +382,7 @@ flake8: requirements .flake8
 	touch $(VIRTUALENV_ST2CLIENT_DIR)/bin/activate
 	chmod +x $(VIRTUALENV_ST2CLIENT_DIR)/bin/activate
 
+	$(VIRTUALENV_ST2CLIENT_DIR)/bin/pip install --upgrade "pip==$(PIP_VERSION)"
 	# NOTE We need to upgrade setuptools to avoid bug with dependency resolving in old versions
 	# Setuptools 42 added support for python_requires, which is used by the configparser package,
 	# which is required by the importlib-metadata package
@@ -503,7 +505,8 @@ distclean: clean
 
 .PHONY: .requirements
 .requirements: virtualenv
-	# Print out pip version so we can see what version was restored from the Travis cache
+	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pip==$(PIP_VERSION)"
+	# Print out pip version
 	$(VIRTUALENV_DIR)/bin/pip --version
 	# Generate all requirements to support current CI pipeline.
 	$(VIRTUALENV_DIR)/bin/python scripts/fixate-requirements.py --skip=virtualenv,virtualenv-osx -s st2*/in-requirements.txt contrib/runners/*/in-requirements.txt -f fixed-requirements.txt -o requirements.txt
@@ -525,8 +528,6 @@ requirements: virtualenv .requirements .sdist-requirements install-runners
 	@echo
 	@echo "==================== requirements ===================="
 	@echo
-	# If you update these versions, make sure you also update the versions in the .st2client-install-check target to match
-	$(VIRTUALENV_DIR)/bin/pip --version
 	# setuptools >= 41.0.1 is required for packs.install in dev envs
 	# setuptools >= 42     is required so setup.py install respects dependencies' python_requires
 	$(VIRTUALENV_DIR)/bin/pip install --upgrade "setuptools==44.1.0"
@@ -581,9 +582,7 @@ virtualenv:
 	@echo
 	@echo "==================== virtualenv ===================="
 	@echo
-	virtualenv --version
-	virtualenv --help
-	test -f $(VIRTUALENV_DIR)/bin/activate || virtualenv --python=$(PYTHON_VERSION) $(VIRTUALENV_DIR) --pip $(PIP_VERSION)
+	test -f $(VIRTUALENV_DIR)/bin/activate || virtualenv --python=$(PYTHON_VERSION) $(VIRTUALENV_DIR) --no-download
 
 	# Setup PYTHONPATH in bash activate script...
 	# Delete existing entries (if any)

--- a/Makefile
+++ b/Makefile
@@ -581,8 +581,8 @@ virtualenv:
 	@echo
 	@echo "==================== virtualenv ===================="
 	@echo
-	virtualenv --version
-	virtualenv --help
+	sudo virtualenv --version
+	sudo virtualenv --help
 	test -f $(VIRTUALENV_DIR)/bin/activate || virtualenv --python=$(PYTHON_VERSION) $(VIRTUALENV_DIR) --pip $(PIP_VERSION)
 
 	# Setup PYTHONPATH in bash activate script...

--- a/Makefile
+++ b/Makefile
@@ -581,8 +581,8 @@ virtualenv:
 	@echo
 	@echo "==================== virtualenv ===================="
 	@echo
-	sudo virtualenv --version
-	sudo virtualenv --help
+	virtualenv --version
+	virtualenv --help
 	test -f $(VIRTUALENV_DIR)/bin/activate || virtualenv --python=$(PYTHON_VERSION) $(VIRTUALENV_DIR) --pip $(PIP_VERSION)
 
 	# Setup PYTHONPATH in bash activate script...

--- a/Makefile
+++ b/Makefile
@@ -581,6 +581,8 @@ virtualenv:
 	@echo
 	@echo "==================== virtualenv ===================="
 	@echo
+	virtualenv --version
+	virtualenv --help
 	test -f $(VIRTUALENV_DIR)/bin/activate || virtualenv --python=$(PYTHON_VERSION) $(VIRTUALENV_DIR) --pip $(PIP_VERSION)
 
 	# Setup PYTHONPATH in bash activate script...


### PR DESCRIPTION
`st2docs` build which is based on `st2` makefile started to fail (https://circleci.com/gh/StackStorm/st2docs/2529) due to upstream pip updated to latest `20.1.1`, while we failed to pin it to `20.0.2`. Thanks to @winem for the find.

We should not pin `pip` in files like `.travis.yml`, but instead use single consistent way and not hack across the many places as other systems rely on st2 makefiles for the builds.

Related: https://github.com/StackStorm/discussions/issues/2

This change sets pip version in one Makefile place and fixes st2docs builds.