### PR TITLE
Update the LF Charter to the Correct One

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -3,7 +3,7 @@ With the new Neutral Home we invite everyone: organizations, teams and individua
 
 # StackStorm Governance
 This document defines governance policies for the StackStorm project.
-It extends [Technical Charter](https://stackstorm.com/wp/wp-content/uploads/2019/10/StackStorm-Technical-Charter-20191004.pdf) for StackStorm within the Linux Foundation.
+It extends [Technical Charter](https://stackstorm.com/wp/wp-content/uploads/2020/06/2019-09-03-StackStorm-Project-Technical-Charter.pdf) for StackStorm within the Linux Foundation.
 
 ## Technical Steering Committee (TSC)
 The Technical Steering Committee is a group of Maintainers (Committers) who have earned the ability to modify (“commit”) sourcecode, documentation or other artifacts.


### PR DESCRIPTION
@armab and I realized with guidance from the Linux Foundation that the wrong version of the Charter had been posted and approved. As a formality we wish to get approval for the new charter that is now linked in GOVERNANCE.md. 

Please approve at your earliest conveinance. 

The new Technical Charter version doesn't change anything significantly, just several wording fixes and links. Please find the diff file attached as [Stackstorm Charter Redlined_DIFF.docx](https://github.com/StackStorm/st2/files/4725666/Stackstorm.Charter.Redlined_DIFF.docx)

New version: [2019-09-03-StackStorm-Project-Technical-Charter.pdf](https://github.com/StackStorm/st2/files/4725742/2019-09-03-StackStorm-Project-Technical-Charter.pdf)