### PR TITLE
Add Github "Sponsor" Button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,3 @@
+# FAQ: https://stackstorm.com/donate/
 # Expenses: https://github.com/StackStorm/discussions/issues/36
 community_bridge: stackstorm

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,4 @@
+# https://stackstorm.com/2020/06/12/sponsoring-stackstorm/
 # FAQ: https://stackstorm.com/donate/
 # Expenses: https://github.com/StackStorm/discussions/issues/36
 community_bridge: stackstorm

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# Expenses: https://github.com/StackStorm/discussions/issues/36
+community_bridge: stackstorm


### PR DESCRIPTION
Add Github Sponsor button, linked to StackStrom profile in Linux Foundation's Community Bridge platform https://funding.communitybridge.org/projects/stackstorm
