### PR TITLE
remove deprecated ssl and duplicate proxy host header

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,8 @@ Fixed
 * Fix a bug where passing an empty list to a with items task in a subworkflow causes
   the parent workflow to be stuck in running status. (bug fix) #4954
 
+* Fixed a bug in the example nginx HA template declared headers twice (bug fix) #4966
+  Contributed by @punkrokk
 
 3.2.0 - April 27, 2020
 ----------------------

--- a/conf/HA/nginx/st2.conf.blueprint.sample
+++ b/conf/HA/nginx/st2.conf.blueprint.sample
@@ -25,8 +25,6 @@ server {
 server {
   listen       *:443 ssl;
 
-  ssl on;
-
   ssl_certificate           /etc/ssl/st2/st2.crt;
   ssl_certificate_key       /etc/ssl/st2/st2.key;
   ssl_session_cache         shared:SSL:10m;

--- a/conf/HA/nginx/st2.conf.controller.sample
+++ b/conf/HA/nginx/st2.conf.controller.sample
@@ -30,8 +30,6 @@ server {
 server {
   listen       *:443 ssl;
 
-  ssl on;
-
   ssl_certificate           /etc/ssl/st2/st2.crt;
   ssl_certificate_key       /etc/ssl/st2/st2.key;
   ssl_session_cache         shared:SSL:10m;
@@ -70,7 +68,6 @@ server {
     chunked_transfer_encoding off;
     proxy_buffering off;
     proxy_cache off;
-    proxy_set_header Host $host;
   }
 
   location @streamError {
@@ -127,7 +124,6 @@ server {
     chunked_transfer_encoding off;
     proxy_buffering off;
     proxy_cache off;
-    proxy_set_header Host $host;
   }
 
   location /mistral/ {
@@ -146,7 +142,6 @@ server {
     chunked_transfer_encoding off;
     proxy_buffering off;
     proxy_cache off;
-    proxy_set_header Host $host;
   }
 
   location / {


### PR DESCRIPTION
This PR removes:

- the duplicate host header in the Load balancer configs for each API endpoint
- the `ssl on` directive with is deprecated and redundant with ` listen       *:443 ssl;` directive

Tested