### PR TITLE
Propose adding @amanda11 to the StackStorm Contributors

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -46,6 +46,7 @@ Being part of Technical Steering Committee (TSC) [@StackStorm/maintainers](https
 Contributors are using and occasionally contributing back to the project, might be active in conversations or express their opinion on the project’s direction.
 They're not part of the TSC voting process, but appreciated for their contribution, involvement and may become Maintainers in future.
 <!-- [@StackStorm/contributors](https://github.com/orgs/StackStorm/teams/contributors) are invited to StackStorm Github organization and we appreciate their contribution and involvement. -->
+* Amanda McGuinness ([@amanda11](https://github.com/amanda11)) - StackStorm Exchange, Ansible, ChatOps, Documentation, core.
 * Carlos ([@nzlosh](https://github.com/nzlosh)) - Chatops, Errbot, Community, Discussions, StackStorm Exchange.
 * Hiroyasu Ohyama ([@userlocalhost](https://github.com/userlocalhost)) - Orquesta, Workflows, st2 Japan Community. [Case Study](https://stackstorm.com/case-study-dmm/).
 * Jon Middleton ([@jjm](https://github.com/jjm)) - StackStorm Exchange, Core, Discussions.


### PR DESCRIPTION
I'd like to propose adding @amanda11 to the list of StackStorm Contributors.

She was a great help to the project during the past several months starting from `v3.2.0` pre-release testing (https://github.com/StackStorm/discussions/issues/6), verifying different testing scenarios, finding the bugs (https://github.com/StackStorm/orquesta/pull/200) and regressions in the platform, reporting them and also fixing some of them. Besides of that: 

- Stackstorm-Exchange:
  - aws: https://github.com/StackStorm-Exchange/stackstorm-aws/issues/98 and fix https://github.com/StackStorm-Exchange/stackstorm-aws/issues/99, review https://github.com/StackStorm-Exchange/stackstorm-aws/pull/104, fix https://github.com/StackStorm-Exchange/stackstorm-aws/pull/107
  - servicenow: bug https://github.com/StackStorm-Exchange/stackstorm-servicenow/issues/13 and fix https://github.com/StackStorm-Exchange/stackstorm-servicenow/pull/14
- Documentation help:
  - https://github.com/StackStorm/st2docs/issues/975 and fix https://github.com/StackStorm/st2docs/pull/976
  - https://github.com/StackStorm/st2docs/issues/977 and respective fix https://github.com/StackStorm/st2docs/issues/978
  - https://github.com/StackStorm/st2docs/pull/973
- Adding CentOS 8 / RHEL 8 support in Ansible: https://github.com/StackStorm/ansible-st2/pull/261 - pretty big addition

I liked the attitude to ask questions first and help the project where it's needed most, report the bugs and do-approach to actually trying to fix them. I also was amazed by Amanda diligence, teamwork, code quality and as a way to thank her for project support, happy to propose adding @amanda11 to the StackStorm Contributors.