### PR TITLE
Remove EL6 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
 
   # Build & Test st2 packages
   packages:
-    parallelism: 5
+    parallelism: 4
     # 4CPUs & 8GB RAM CircleCI machine
     # sadly, it doesn't work with 'setup_remote_docker'
     resource_class: large
@@ -116,7 +116,7 @@ jobs:
       - image: circleci/python:2.7
     working_directory: ~/st2
     environment:
-      - DISTROS: "xenial bionic el6 el7 el8"
+      - DISTROS: "xenial bionic el7 el8"
       - ST2_PACKAGES_REPO: https://github.com/StackStorm/st2-packages
       - ST2_PACKAGES: "st2"
       - ST2_CHECKOUT: 0
@@ -232,7 +232,7 @@ jobs:
       - image: circleci/ruby:2.4
     working_directory: /tmp/deploy
     environment:
-      - DISTROS: "xenial bionic el6 el7 el8"
+      - DISTROS: "xenial bionic el7 el8"
     steps:
       - attach_workspace:
           at: .

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,7 +37,7 @@ Fixed
 Removed
 ~~~~~~~
 
-* Removed EL6 #4984
+* Removed ``CentOS 6``/``RHEL 6`` support #4984
 
   Contributed by Amanda McGuinness (@amanda11 Ammeon Solutions)
   

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ in development
 
 Added
 ~~~~~
+* Removed EL6 support
 * Add make command to autogen JSON schema from the models of action, rule, etc. Add check
   to ensure update to the models require schema to be regenerated. (new feature)
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,6 @@ in development
 
 Added
 ~~~~~
-* EL6 deprecation. Removed building of EL6 RPMs and associated jobs
-  Contributed by Amanda McGuinness (@amanda11 Ammeon Solutions)
 * Add make command to autogen JSON schema from the models of action, rule, etc. Add check
   to ensure update to the models require schema to be regenerated. (new feature)
 
@@ -35,8 +33,14 @@ Fixed
   up correctly, specifically when specifying a bastion host / jump box. (bug fix) #4973
 
   Contributed by Nick Maludy (@nmaludy Encore Technologies)
-  
 
+Removed
+~~~~~~~
+
+* Removed EL6 #4984
+
+  Contributed by Amanda McGuinness (@amanda11 Ammeon Solutions)
+  
 3.2.0 - April 27, 2020
 ----------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,8 @@ in development
 
 Added
 ~~~~~
-* Removed EL6 support
+* EL6 deprecation. Removed building of EL6 RPMs and associated jobs
+  Contributed by Amanda McGuinness (@amanda11 Ammeon Solutions)
 * Add make command to autogen JSON schema from the models of action, rule, etc. Add check
   to ensure update to the models require schema to be regenerated. (new feature)
 

--- a/Makefile
+++ b/Makefile
@@ -981,14 +981,6 @@ rpms:
 	$(foreach COM,$(COMPONENTS), pushd $(COM); make rpm; popd;)
 	pushd st2client && make rpm && popd
 
-rhel-rpms:
-	@echo
-	@echo "==================== rpm ===================="
-	@echo
-	rm -Rf ~/rpmbuild
-	$(foreach COM,$(COMPONENTS), pushd $(COM); make rhel-rpm; popd;)
-	pushd st2client && make rhel-rpm && popd
-
 .PHONY: debs
 debs:
 	@echo

--- a/st2actions/Makefile
+++ b/st2actions/Makefile
@@ -27,13 +27,6 @@ rpm:
 	cp packaging/rpm/$(COMPONENTS).spec $(RPM_SPECS_DIR)/
 	cd $(RPM_SPECS_DIR) && rpmbuild --clean --rmsource -ba $(COMPONENTS).spec
 
-.PHONY: rhel-rpm
-rhel-rpm:
-	pushd ~ && rpmdev-setuptree && popd
-	tar --transform=s~^~$(COMPONENTS)-$(VER)/~ -czf $(RPM_SOURCES_DIR)/$(COMPONENTS).tar.gz bin conf $(COMPONENTS)
-	cp packaging/rpm/$(COMPONENTS)-rhel6.spec $(RPM_SPECS_DIR)/
-	cd $(RPM_SPECS_DIR) && rpmbuild --clean --rmsource -ba $(COMPONENTS)-rhel6.spec
-
 .PHONY: deb
 deb:
 	mkdir -p ~/debbuild

--- a/st2actions/bin/runners.sh
+++ b/st2actions/bin/runners.sh
@@ -28,7 +28,7 @@ elif [ -z "$sv" ] && ( /sbin/start 2>&1 | grep -q "missing job name" ); then
   sv=upstart
   svbin=$UPSTARTCTL
 else
-  # Old debians, redhats and centos, amazon etc
+  # Old debians, amazon etc
   sv=sysv
   svbin=/etc/init.d/$WORKERSVC
   if [ ! -x $svbin ]; then

--- a/st2actions/bin/runners.sh
+++ b/st2actions/bin/runners.sh
@@ -12,15 +12,7 @@ if [ -z "$WORKERS" ]; then
   WORKERS="${WORKERS:-4}"
 fi
 
-# 1. Choose init type on Debian containers use sysv
-if [ -x "$LSB_RELEASE" ]; then
-  if [ -f /.dockerenv ] && [ $($LSB_RELEASE -is) = Debian ]; then
-    sv=sysv
-    svbin=/etc/init.d/$WORKERSVC
-  fi
-fi
-
-# 2. Second criteria
+# 1. Choose init type
 if [ -z "$sv" -a -x $SYSTEMDCTL ]; then
   sv=systemd
   svbin=$SYSTEMDCTL
@@ -28,14 +20,8 @@ elif [ -z "$sv" ] && ( /sbin/start 2>&1 | grep -q "missing job name" ); then
   sv=upstart
   svbin=$UPSTARTCTL
 else
-  # Old debians, amazon etc
-  sv=sysv
-  svbin=/etc/init.d/$WORKERSVC
-  if [ ! -x $svbin ]; then
-    >&2 echo "Init file not found: $svbin"
-    >&2 echo "Unknown platform, we support ONLY debian, systemd and sysv!"
-    exit 99
-  fi
+  >&2 echo "Unknown platform, we support ONLY upstart and systemd!"
+  exit 99
 fi
 
 # 2. Spwan workers
@@ -47,8 +33,6 @@ while [ $i -le $WORKERS ]; do
     $svbin $action $SPAWNSVC@$i
   elif [ $sv = upstart ]; then
     $svbin $action $WORKERSVC WORKERID=$i
-  elif [ $sv = sysv ]; then
-    WORKERID=$i $svbin $action
   fi
   cmdrs=$?
   [ $cmdrs -gt 0 ] && rs=$cmdrs

--- a/st2api/Makefile
+++ b/st2api/Makefile
@@ -27,13 +27,6 @@ rpm:
 	cp packaging/rpm/$(COMPONENTS).spec $(RPM_SPECS_DIR)/
 	cd $(RPM_SPECS_DIR) && rpmbuild --clean --rmsource -ba $(COMPONENTS).spec
 
-.PHONY: rhel-rpm
-rhel-rpm:
-	pushd ~ && rpmdev-setuptree && popd
-	tar --transform=s~^~$(COMPONENTS)-$(VER)/~ -czf $(RPM_SOURCES_DIR)/$(COMPONENTS).tar.gz bin conf $(COMPONENTS)
-	cp packaging/rpm/$(COMPONENTS)-rhel6.spec $(RPM_SPECS_DIR)/
-	cd $(RPM_SPECS_DIR) && rpmbuild --clean --rmsource -ba $(COMPONENTS)-rhel6.spec
-
 .PHONY: deb
 deb:
 	mkdir -p ~/debbuild

--- a/st2auth/Makefile
+++ b/st2auth/Makefile
@@ -27,13 +27,6 @@ rpm:
 	cp packaging/rpm/$(COMPONENTS).spec $(RPM_SPECS_DIR)/
 	cd $(RPM_SPECS_DIR) && rpmbuild --clean --rmsource -ba $(COMPONENTS).spec
 
-.PHONY: rhel-rpm
-rhel-rpm:
-	pushd ~ && rpmdev-setuptree && popd
-	tar --transform=s~^~$(COMPONENTS)-$(VER)/~ -czf $(RPM_SOURCES_DIR)/$(COMPONENTS).tar.gz bin conf $(COMPONENTS)
-	cp packaging/rpm/$(COMPONENTS)-rhel6.spec $(RPM_SPECS_DIR)/
-	cd $(RPM_SPECS_DIR) && rpmbuild --clean --rmsource -ba $(COMPONENTS)-rhel6.spec
-
 .PHONY: deb
 deb:
 	mkdir -p ~/debbuild

--- a/st2client/Makefile
+++ b/st2client/Makefile
@@ -17,15 +17,6 @@ rpm:
 	cp dist/*src.rpm $(RPM_ROOT)/SRPMS/$(COMPONENTS)-$(VER)-$(RELEASE).src.rpm
 	rm -Rf dist $(COMPONENTS).egg-info ChangeLog AUTHORS build
 
-.PHONY: rhel-rpm
-rhel-rpm:
-	$(PY27) setup.py bdist_rpm --python=$(PY27)
-	mkdir -p $(RPM_ROOT)/RPMS/noarch
-	cp dist/$(COMPONENTS)*noarch.rpm $(RPM_ROOT)/RPMS/noarch/$(COMPONENTS)-$(VER)-$(RELEASE).noarch.rpm
-	mkdir -p $(RPM_ROOT)/SRPMS
-	cp dist/*src.rpm $(RPM_ROOT)/SRPMS/$(COMPONENTS)-$(VER)-$(RELEASE).src.rpm
-	rm -Rf dist $(COMPONENTS).egg-info ChangeLog AUTHORS build
-
 .PHONY: deb
 deb:
 	$(PY27) setup.py --command-packages=stdeb.command bdist_deb

--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -115,10 +115,8 @@ function service_manager() {
     /sbin/initctl $action $svcname
   elif command -v service > /dev/null 2>&1; then
     service $svcname $action
-  elif [ -x /etc/init.d/${1} ]; then
-    /etc/init.d/$svcname $action
   else
-    echo -e "\e[31mError: Unknown service manager, we ONLY support systemd, upstart and sysv! \e[0m\n"
+    echo -e "\e[31mError: Unknown service manager, we ONLY support systemd and upstart! \e[0m\n"
     exit 1
   fi
 }

--- a/st2debug/Makefile
+++ b/st2debug/Makefile
@@ -27,13 +27,6 @@ rpm:
 	cp packaging/rpm/$(COMPONENTS).spec $(RPM_SPECS_DIR)/
 	cd $(RPM_SPECS_DIR) && rpmbuild --clean --rmsource -ba $(COMPONENTS).spec
 
-.PHONY: rhel-rpm
-rhel-rpm:
-	pushd ~ && rpmdev-setuptree && popd
-	tar --transform=s~^~$(COMPONENTS)-$(VER)/~ -czf $(RPM_SOURCES_DIR)/$(COMPONENTS).tar.gz bin $(COMPONENTS)
-	cp packaging/rpm/$(COMPONENTS)-rhel6.spec $(RPM_SPECS_DIR)/
-	cd $(RPM_SPECS_DIR) && rpmbuild --clean --rmsource -ba $(COMPONENTS)-rhel6.spec
-
 .PHONY: deb
 deb:
 	mkdir -p ~/debbuild

--- a/st2reactor/Makefile
+++ b/st2reactor/Makefile
@@ -13,13 +13,6 @@ rpm:
 	cp packaging/rpm/$(COMPONENTS).spec $(RPM_SPECS_DIR)/
 	cd $(RPM_SPECS_DIR) && rpmbuild --clean --rmsource -ba $(COMPONENTS).spec
 
-.PHONY: rhel-rpm
-rhel-rpm:
-	pushd ~ && rpmdev-setuptree && popd
-	tar --transform=s~^~$(COMPONENTS)-$(VER)/~ -czf $(RPM_SOURCES_DIR)/$(COMPONENTS).tar.gz bin conf $(COMPONENTS)
-	cp packaging/rpm/$(COMPONENTS)-rhel6.spec $(RPM_SPECS_DIR)/
-	cd $(RPM_SPECS_DIR) && rpmbuild --clean --rmsource -ba $(COMPONENTS)-rhel6.spec
-
 .PHONY: deb
 deb:
 	mkdir -p ~/debbuild

--- a/st2stream/Makefile
+++ b/st2stream/Makefile
@@ -27,13 +27,6 @@ rpm:
 	cp packaging/rpm/$(COMPONENTS).spec $(RPM_SPECS_DIR)/
 	cd $(RPM_SPECS_DIR) && rpmbuild --clean --rmsource -ba $(COMPONENTS).spec
 
-.PHONY: rhel-rpm
-rhel-rpm:
-	pushd ~ && rpmdev-setuptree && popd
-	tar --transform=s~^~$(COMPONENTS)-$(VER)/~ -czf $(RPM_SOURCES_DIR)/$(COMPONENTS).tar.gz bin conf $(COMPONENTS)
-	cp packaging/rpm/$(COMPONENTS)-rhel6.spec $(RPM_SPECS_DIR)/
-	cd $(RPM_SPECS_DIR) && rpmbuild --clean --rmsource -ba $(COMPONENTS)-rhel6.spec
-
 .PHONY: deb
 deb:
 	mkdir -p ~/debbuild

--- a/st2tests/Makefile
+++ b/st2tests/Makefile
@@ -27,13 +27,6 @@ rpm:
 	cp packaging/rpm/$(COMPONENTS).spec $(RPM_SPECS_DIR)/
 	cd $(RPM_SPECS_DIR) && rpmbuild --clean --rmsource -ba $(COMPONENTS).spec
 
-.PHONY: rhel-rpm
-rhel-rpm:
-	pushd ~ && rpmdev-setuptree && popd
-	tar --transform=s~^~$(COMPONENTS)-$(VER)/~ -czf $(RPM_SOURCES_DIR)/$(COMPONENTS).tar.gz bin $(COMPONENTS)
-	cp packaging/rpm/$(COMPONENTS)-rhel6.spec $(RPM_SPECS_DIR)/
-	cd $(RPM_SPECS_DIR) && rpmbuild --clean --rmsource -ba $(COMPONENTS)-rhel6.spec
-
 .PHONY: deb
 deb:
 	mkdir -p ~/debbuild


### PR DESCRIPTION
EL6 is being deprecated. Remove running of builds in EL6.

Remove rhel-rpm in Makefiles, and keep the rpm for EL7 and above. I was a bit confused with the name rhel-rpm - it seemed to just use the el6 specs - and so I was presuming it was no-longer required - but would need confirmation. 