### PR TITLE
Update progress of workflow execution to the output stream

### DIFF
--- a/contrib/runners/orquesta_runner/orquesta_runner/orquesta_runner.py
+++ b/contrib/runners/orquesta_runner/orquesta_runner/orquesta_runner.py
@@ -72,7 +72,9 @@ class OrquestaRunner(runners.AsyncActionRunner):
                 'action_execution_id': str(self.execution.id),
                 'api_url': api_util.get_full_public_api_url(),
                 'user': self.execution.context.get('user', cfg.CONF.system_user.user),
-                'pack': self.execution.context.get('pack', None)
+                'pack': self.execution.context.get('pack', None),
+                'action': self.execution.action.get('ref', None),
+                'runner': self.execution.action.get('runner_type', None)
             }
         }
 
@@ -96,8 +98,9 @@ class OrquestaRunner(runners.AsyncActionRunner):
                 result['errors'] = wf_ex_db.errors
 
             for wf_ex_error in wf_ex_db.errors:
-                msg = '[%s] Workflow execution completed with errors.'
-                LOG.error(msg, str(self.execution.id), extra=wf_ex_error)
+                msg = 'Workflow execution completed with errors.'
+                wf_svc.update_progress(wf_ex_db, '%s %s' % (msg, str(wf_ex_error)), log=False)
+                LOG.error('[%s] %s', str(self.execution.id), msg, extra=wf_ex_error)
 
             return (status, result, self.context)
 
@@ -230,10 +233,11 @@ class OrquestaRunner(runners.AsyncActionRunner):
 
     def cancel(self):
         result = None
+        wf_ex_db = None
 
         # Try to cancel the target workflow execution.
         try:
-            wf_svc.request_cancellation(self.execution)
+            wf_ex_db = wf_svc.request_cancellation(self.execution)
         # If workflow execution is not found because the action execution is cancelled
         # before the workflow execution is created or if the workflow execution is
         # already completed, then ignore the exception and proceed with cancellation.
@@ -248,10 +252,11 @@ class OrquestaRunner(runners.AsyncActionRunner):
         # execution will be in an unknown state.
         except Exception:
             _, ex, tb = sys.exc_info()
+            msg = 'Error encountered when canceling workflow execution.'
+            LOG.exception('[%s] %s', str(self.execution.id), msg)
             msg = 'Error encountered when canceling workflow execution. %s'
+            wf_svc.update_progress(wf_ex_db, msg % str(ex), log=False)
             result = {'error': msg % str(ex), 'traceback': ''.join(traceback.format_tb(tb, 20))}
-            msg = '[%s] Error encountered when canceling workflow execution.'
-            LOG.exception(msg, str(self.execution.id))
 
         # Request cancellation of tasks that are workflows and still running.
         for child_ex_id in self.execution.children:

--- a/contrib/runners/orquesta_runner/tests/unit/test_basic.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_basic.py
@@ -138,7 +138,9 @@ class OrquestaRunnerTest(st2tests.ExecutionDbTestCase):
                 'action_execution_id': str(ac_ex_db.id),
                 'api_url': 'http://127.0.0.1/v1',
                 'user': username,
-                'pack': 'orquesta_tests'
+                'pack': 'orquesta_tests',
+                'action': 'orquesta_tests.sequential',
+                'runner': 'orquesta'
             },
             'parent': {
                 'pack': 'orquesta_tests'

--- a/contrib/runners/orquesta_runner/tests/unit/test_context.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_context.py
@@ -115,7 +115,9 @@ class OrquestaContextTest(st2tests.ExecutionDbTestCase):
             'action_execution_id': str(ac_ex_db.id),
             'api_url': 'http://127.0.0.1/v1',
             'user': 'stanley',
-            'pack': 'orquesta_tests'
+            'pack': 'orquesta_tests',
+            'action': 'orquesta_tests.runtime-context',
+            'runner': 'orquesta'
         }
 
         expected_st2_ctx_with_wf_ex_id = copy.deepcopy(expected_st2_ctx)

--- a/st2actions/st2actions/workflows/workflows.py
+++ b/st2actions/st2actions/workflows/workflows.py
@@ -103,30 +103,29 @@ class WorkflowExecutionHandler(consumers.VariableMessageHandler):
             task = {'id': task_ex_db.task_id, 'route': task_ex_db.task_route}
 
         # Log the error.
-        LOG.error(
-            '[%s] Unknown error while processing %s execution. %s: %s',
-            wf_ex_db.action_execution,
-            msg_type,
-            exception.__class__.__name__,
-            str(exception)
+        msg = 'Unknown error while processing %s execution. %s: %s'
+        wf_svc.update_progress(
+            wf_ex_db,
+            msg % (msg_type, exception.__class__.__name__, str(exception)),
+            severity='error'
         )
 
         # Fail the task execution so it's marked correctly in the
         # conductor state to allow for task rerun if needed.
         if isinstance(message, ex_db_models.ActionExecutionDB):
-            msg = '[%s] Unknown error while processing %s execution. Failing task execution "%s".'
-            LOG.error(msg, wf_ex_db.action_execution, msg_type, task_ex_id)
+            msg = 'Unknown error while processing %s execution. Failing task execution "%s".'
+            wf_svc.update_progress(wf_ex_db, msg % (msg_type, task_ex_id), severity='error')
             wf_svc.update_task_execution(task_ex_id, ac_const.LIVEACTION_STATUS_FAILED)
             wf_svc.update_task_state(task_ex_id, ac_const.LIVEACTION_STATUS_FAILED)
 
         # Fail the workflow execution.
-        msg = '[%s] Unknown error while processing %s execution. Failing workflow execution "%s".'
-        LOG.error(msg, wf_ex_db.action_execution, msg_type, wf_ex_id)
+        msg = 'Unknown error while processing %s execution. Failing workflow execution "%s".'
+        wf_svc.update_progress(wf_ex_db, msg % (msg_type, wf_ex_id), severity='error')
         wf_svc.fail_workflow_execution(wf_ex_id, exception, task=task)
 
     def handle_workflow_execution(self, wf_ex_db):
         # Request the next set of tasks to execute.
-        LOG.info('[%s] Processing request for workflow execution.', wf_ex_db.action_execution)
+        wf_svc.update_progress(wf_ex_db, 'Processing request for workflow execution.')
         wf_svc.request_next_tasks(wf_ex_db)
 
     def handle_action_execution(self, ac_ex_db):
@@ -142,16 +141,22 @@ class WorkflowExecutionHandler(consumers.VariableMessageHandler):
         wf_ex_db = wf_db_access.WorkflowExecution.get_by_id(wf_ex_id)
         task_ex_db = wf_db_access.TaskExecution.get_by_id(task_ex_id)
 
-        wf_ac_ex_id = wf_ex_db.action_execution
-        msg = '[%s] Action execution "%s" for task "%s" is updated and in "%s" state.'
-        LOG.info(msg, wf_ac_ex_id, str(ac_ex_db.id), task_ex_db.task_id, ac_ex_db.status)
+        msg = (
+            'Action execution "%s" for task "%s" is updated and in "%s" state.' %
+            (str(ac_ex_db.id), task_ex_db.task_id, ac_ex_db.status)
+        )
+        wf_svc.update_progress(wf_ex_db, msg)
 
         # Skip if task execution is already in completed state.
         if task_ex_db.status in statuses.COMPLETED_STATUSES:
-            msg = ('[%s] Action execution "%s" for task "%s", route "%s", is not processed '
-                   'because task execution "%s" is already in completed state "%s".')
-            LOG.info(msg, wf_ac_ex_id, str(ac_ex_db.id), task_ex_db.task_id,
-                     str(task_ex_db.task_route), str(task_ex_db.id), task_ex_db.status)
+            msg = (
+                'Action execution "%s" for task "%s", route "%s", is not processed '
+                'because task execution "%s" is already in completed state "%s".' % (
+                    str(ac_ex_db.id), task_ex_db.task_id, str(task_ex_db.task_route),
+                    str(task_ex_db.id), task_ex_db.status
+                )
+            )
+            wf_svc.update_progress(wf_ex_db, msg)
             return
 
         # Process pending request on the action execution.

--- a/st2common/st2common/services/action.py
+++ b/st2common/st2common/services/action.py
@@ -427,7 +427,7 @@ def get_root_execution(execution_db):
     return get_root_execution(parent_execution_db) if parent_execution_db else execution_db
 
 
-def store_execution_output_data(execution_db, data, action_db=None, output_type='output',
+def store_execution_output_data(execution_db, action_db, data, output_type='output',
                                 timestamp=None):
     """
     Store output from an execution as a new document in the collection.

--- a/st2common/st2common/services/action.py
+++ b/st2common/st2common/services/action.py
@@ -427,24 +427,38 @@ def get_root_execution(execution_db):
     return get_root_execution(parent_execution_db) if parent_execution_db else execution_db
 
 
-def store_execution_output_data(execution_db, action_db, data, output_type='output',
+def store_execution_output_data(execution_db, data, action_db=None, output_type='output',
                                 timestamp=None):
     """
     Store output from an execution as a new document in the collection.
     """
     execution_id = str(execution_db.id)
-    action_ref = action_db.ref
-    runner_ref = getattr(action_db, 'runner_type', {}).get('name', 'unknown')
+
+    if action_db is None:
+        action_ref = execution_db.action.get('ref', 'unknown')
+        runner_ref = execution_db.action.get('runner_type', 'unknown')
+    else:
+        action_ref = action_db.ref
+        runner_ref = getattr(action_db, 'runner_type', {}).get('name', 'unknown')
+
+    return store_execution_output_data_ex(
+        execution_id, action_ref, runner_ref, data,
+        output_type=output_type, timestamp=timestamp
+    )
+
+
+def store_execution_output_data_ex(execution_id, action_ref, runner_ref, data, output_type='output',
+                                   timestamp=None):
     timestamp = timestamp or date_utils.get_datetime_utc_now()
 
-    output_db = ActionExecutionOutputDB(execution_id=execution_id,
-                                        action_ref=action_ref,
-                                        runner_ref=runner_ref,
-                                        timestamp=timestamp,
-                                        output_type=output_type,
-                                        data=data)
-    output_db = ActionExecutionOutput.add_or_update(output_db, publish=True,
-                                                    dispatch_trigger=False)
+    output_db = ActionExecutionOutputDB(
+        execution_id=execution_id, action_ref=action_ref, runner_ref=runner_ref,
+        timestamp=timestamp, output_type=output_type, data=data
+    )
+
+    output_db = ActionExecutionOutput.add_or_update(
+        output_db, publish=True, dispatch_trigger=False
+    )
 
     return output_db
 

--- a/st2common/st2common/services/workflows.py
+++ b/st2common/st2common/services/workflows.py
@@ -1042,6 +1042,11 @@ def request_next_tasks(wf_ex_db, task_ex_id=None):
         update_progress(wf_ex_db, '\n', log=False)
         update_execution_records(wf_ex_db, conductor)
 
+        if conductor.get_workflow_status() in statuses.COMPLETED_STATUSES:
+            msg = 'The workflow execution is completed with status "%s".'
+            update_progress(wf_ex_db, msg % conductor.get_workflow_status())
+            update_progress(wf_ex_db, '\n', log=False)
+
     # Iterate while there are next tasks identified for processing. In the case for
     # task with no action execution defined, the task execution will complete
     # immediately with a new set of tasks available.

--- a/st2common/st2common/services/workflows.py
+++ b/st2common/st2common/services/workflows.py
@@ -38,8 +38,8 @@ from st2common.models.db import liveaction as lv_db_models
 from st2common.models.db import workflow as wf_db_models
 from st2common.models.system import common as sys_models
 from st2common.models.utils import action_param_utils
-from st2common.persistence import liveaction as lv_db_access
 from st2common.persistence import execution as ex_db_access
+from st2common.persistence import liveaction as lv_db_access
 from st2common.persistence import workflow as wf_db_access
 from st2common.runners import utils as runners_utils
 from st2common.services import action as ac_svc
@@ -51,6 +51,31 @@ from st2common.util import param as param_utils
 
 
 LOG = logging.getLogger(__name__)
+
+LOG_FUNCTIONS = {
+    'audit': LOG.audit,
+    'debug': LOG.debug,
+    'info': LOG.info,
+    'warning': LOG.warning,
+    'error': LOG.error,
+    'critical': LOG.critical,
+}
+
+
+def update_progress(wf_ex_db, message, severity='info', log=True, stream=True):
+    if not wf_ex_db:
+        return
+
+    if log and severity in LOG_FUNCTIONS:
+        LOG_FUNCTIONS[severity]('[%s] %s', wf_ex_db.context['st2']['action_execution_id'], message)
+
+    if stream:
+        ac_svc.store_execution_output_data_ex(
+            wf_ex_db.context['st2']['action_execution_id'],
+            wf_ex_db.context['st2']['action'],
+            wf_ex_db.context['st2']['runner'],
+            '%s\n' % message,
+        )
 
 
 def is_action_execution_under_workflow_context(ac_ex_db):
@@ -185,8 +210,7 @@ def inspect_task_contents(wf_spec):
 
 
 def request(wf_def, ac_ex_db, st2_ctx, notify_cfg=None):
-    wf_ac_ex_id = str(ac_ex_db.id)
-    LOG.info('[%s] Processing action execution request for workflow.', wf_ac_ex_id)
+    LOG.info('[%s] Processing action execution request for workflow.', str(ac_ex_db.id))
 
     # Load workflow definition into workflow spec model.
     spec_module = specs_loader.get_spec_module('native')
@@ -253,7 +277,7 @@ def request(wf_def, ac_ex_db, st2_ctx, notify_cfg=None):
 
     # Insert new record into the database and do not publish to the message bus yet.
     wf_ex_db = wf_db_access.WorkflowExecution.insert(wf_ex_db, publish=False)
-    LOG.info('[%s] Workflow execution "%s" is created.', wf_ac_ex_id, str(wf_ex_db.id))
+    update_progress(wf_ex_db, 'Workflow execution "%s" is created.' % str(wf_ex_db.id))
 
     # Update the context with the workflow execution id created on database insert.
     # Publish the workflow execution requested status to the message bus.
@@ -271,11 +295,11 @@ def request(wf_def, ac_ex_db, st2_ctx, notify_cfg=None):
         # Update the workflow execution record.
         wf_ex_db = wf_db_access.WorkflowExecution.update(wf_ex_db, publish=False)
         wf_db_access.WorkflowExecution.publish_status(wf_ex_db)
-        msg = '[%s] Workflow execution "%s" is published.'
-        LOG.info(msg, wf_ac_ex_id, str(wf_ex_db.id))
+        msg = 'Workflow execution "%s" is published.'
+        update_progress(wf_ex_db, msg % str(wf_ex_db.id), stream=False)
     else:
-        msg = '[%s] Unable to request workflow execution. It is already in completed status "%s".'
-        LOG.info(msg, wf_ac_ex_id, wf_ex_db.status)
+        msg = 'Unable to request workflow execution. It is already in completed status "%s".'
+        update_progress(wf_ex_db, msg % wf_ex_db.status)
 
     return wf_ex_db
 
@@ -442,8 +466,8 @@ def request_cancellation(ac_ex_db):
     wait_fixed=cfg.CONF.workflow_engine.retry_wait_fixed_msec,
     wait_jitter_max=cfg.CONF.workflow_engine.retry_max_jitter_msec)
 def request_rerun(ac_ex_db, st2_ctx, options=None):
-    ac_ex_id = str(ac_ex_db.id)
-    LOG.info('[%s] Processing rerun request for workflow.', ac_ex_id)
+    wf_ac_ex_id = str(ac_ex_db.id)
+    LOG.info('[%s] Processing rerun request for workflow.', wf_ac_ex_id)
 
     wf_ex_id = st2_ctx.get('workflow_execution_id')
 
@@ -461,7 +485,7 @@ def request_rerun(ac_ex_db, st2_ctx, options=None):
         msg = 'Unable to rerun workflow execution "%s" because it is not in a completed state.'
         raise wf_exc.WorkflowExecutionRerunException(msg % wf_ex_id)
 
-    wf_ex_db.action_execution = ac_ex_id
+    wf_ex_db.action_execution = wf_ac_ex_id
     wf_ex_db.context['st2'] = st2_ctx['st2']
     wf_ex_db.context['parent'] = st2_ctx['parent']
     conductor = deserialize_conductor(wf_ex_db)
@@ -516,7 +540,6 @@ def request_rerun(ac_ex_db, st2_ctx, options=None):
 
 
 def request_task_execution(wf_ex_db, st2_ctx, task_ex_req):
-    wf_ac_ex_id = wf_ex_db.action_execution
     task_id = task_ex_req['id']
     task_route = task_ex_req['route']
     task_spec = task_ex_req['spec']
@@ -524,8 +547,8 @@ def request_task_execution(wf_ex_db, st2_ctx, task_ex_req):
     task_actions = task_ex_req['actions']
     task_delay = task_ex_req.get('delay')
 
-    msg = '[%s] Processing task execution request for task "%s", route "%s".'
-    LOG.info(msg, wf_ac_ex_id, task_id, str(task_route))
+    msg = 'Processing task execution request for task "%s", route "%s".'
+    update_progress(wf_ex_db, msg % (task_id, str(task_route)), stream=False)
 
     # Use existing task execution when task is with items and still running.
     task_ex_dbs = wf_db_access.TaskExecution.query(
@@ -539,8 +562,8 @@ def request_task_execution(wf_ex_db, st2_ctx, task_ex_req):
             task_ex_dbs[0].status == ac_const.LIVEACTION_STATUS_RUNNING):
         task_ex_db = task_ex_dbs[0]
         task_ex_id = str(task_ex_db.id)
-        msg = '[%s] Task execution "%s" retrieved for task "%s", route "%s".'
-        LOG.info(msg, wf_ac_ex_id, task_ex_id, task_id, str(task_route))
+        msg = 'Task execution "%s" retrieved for task "%s", route "%s".'
+        update_progress(wf_ex_db, msg % (task_ex_id, task_id, str(task_route)))
     else:
         # Create a record for task execution.
         task_ex_db = wf_db_models.TaskExecutionDB(
@@ -564,14 +587,14 @@ def request_task_execution(wf_ex_db, st2_ctx, task_ex_req):
         # Insert new record into the database.
         task_ex_db = wf_db_access.TaskExecution.insert(task_ex_db, publish=False)
         task_ex_id = str(task_ex_db.id)
-        msg = '[%s] Task execution "%s" created for task "%s", route "%s".'
-        LOG.info(msg, wf_ac_ex_id, task_ex_id, task_id, str(task_route))
+        msg = 'Task execution "%s" created for task "%s", route "%s".'
+        update_progress(wf_ex_db, msg % (task_ex_id, task_id, str(task_route)))
 
     try:
         # Return here if no action is specified in task spec.
         if task_spec.action is None:
-            msg = '[%s] Task "%s", route "%s", is action less and succeed by default.'
-            LOG.info(msg, wf_ac_ex_id, task_id, str(task_route))
+            msg = 'Task "%s", route "%s", is action less and succeed by default.'
+            update_progress(wf_ex_db, msg % (task_id, str(task_route)))
 
             # Set the task execution to running.
             task_ex_db.status = statuses.RUNNING
@@ -586,8 +609,8 @@ def request_task_execution(wf_ex_db, st2_ctx, task_ex_req):
 
         # Return here for task with items but the items list is empty.
         if task_ex_db.itemized and task_ex_db.items_count == 0:
-            msg = '[%s] Task "%s", route "%s", has no items and succeed by default.'
-            LOG.info(msg, wf_ac_ex_id, task_id, str(task_route))
+            msg = 'Task "%s", route "%s", has no items and succeed by default.'
+            update_progress(wf_ex_db, msg % (task_id, str(task_route)))
 
             # Set the task execution to running.
             task_ex_db.status = statuses.RUNNING
@@ -606,10 +629,13 @@ def request_task_execution(wf_ex_db, st2_ctx, task_ex_req):
             request_action_execution(wf_ex_db, task_ex_db, st2_ctx, ac_ex_req, delay=ac_ex_delay)
             task_ex_db = wf_db_access.TaskExecution.get_by_id(str(task_ex_db.id))
     except Exception as e:
-        msg = '[%s] Failed action execution(s) for task "%s", route "%s". %s'
-        LOG.exception(msg, wf_ac_ex_id, task_id, str(task_route), six.text_type(e))
-        message = '%s: %s' % (type(e).__name__, six.text_type(e))
-        error = {'type': 'error', 'message': message, 'task_id': task_id, 'route': task_route}
+        msg = 'Failed action execution(s) for task "%s", route "%s".'
+        msg = msg % (task_id, str(task_route))
+        LOG.exception(msg)
+        msg = '%s %s: %s' % (msg, type(e).__name__, six.text_type(e))
+        update_progress(wf_ex_db, msg, severity='error', log=False)
+        msg = '%s: %s' % (type(e).__name__, six.text_type(e))
+        error = {'type': 'error', 'message': msg, 'task_id': task_id, 'route': task_route}
         update_task_execution(str(task_ex_db.id), statuses.FAILED, {'errors': [error]})
         raise e
 
@@ -646,7 +672,6 @@ def eval_action_execution_delay(task_ex_req, ac_ex_req, itemized=False):
     wait_fixed=cfg.CONF.workflow_engine.retry_wait_fixed_msec,
     wait_jitter_max=cfg.CONF.workflow_engine.retry_max_jitter_msec)
 def request_action_execution(wf_ex_db, task_ex_db, st2_ctx, ac_ex_req, delay=None):
-    wf_ac_ex_id = wf_ex_db.action_execution
     action_ref = ac_ex_req['action']
     action_input = ac_ex_req['input']
     item_id = ac_ex_req.get('item_id')
@@ -727,8 +752,9 @@ def request_action_execution(wf_ex_db, task_ex_db, st2_ctx, ac_ex_req, delay=Non
 
     # Request action execution.
     lv_ac_db, ac_ex_db = ac_svc.request(lv_ac_db)
-    msg = '[%s] Action execution "%s" requested for task "%s", route "%s".'
-    LOG.info(msg, wf_ac_ex_id, str(ac_ex_db.id), task_ex_db.task_id, str(task_ex_db.task_route))
+    msg = 'Action execution "%s" requested for task "%s", route "%s".'
+    msg = msg % (str(ac_ex_db.id), task_ex_db.task_id, str(task_ex_db.task_route))
+    update_progress(wf_ex_db, msg)
 
     return ac_ex_db
 
@@ -749,9 +775,11 @@ def handle_action_execution_pending(ac_ex_db):
     wf_ex_db = wf_db_access.WorkflowExecution.get_by_id(wf_ex_id)
     task_ex_db = wf_db_access.TaskExecution.get_by_id(task_ex_id)
 
-    msg = '[%s] Handling pending of action execution "%s" for task "%s", route "%s".'
-    LOG.info(msg, wf_ex_db.action_execution, str(ac_ex_db.id),
-             task_ex_db.task_id, str(task_ex_db.task_route))
+    msg = 'Handling pending of action execution "%s" for task "%s", route "%s".'
+    update_progress(
+        wf_ex_db,
+        msg % (str(ac_ex_db.id), task_ex_db.task_id, str(task_ex_db.task_route))
+    )
 
     # Updat task execution
     update_task_execution(task_ex_id, ac_ex_db.status, ac_ex_ctx=ac_ex_db.context)
@@ -781,9 +809,11 @@ def handle_action_execution_pause(ac_ex_db):
     if task_ex_db.status == ac_ex_db.status:
         return
 
-    msg = '[%s] Handling pause of action execution "%s" for task "%s", route "%s".'
-    LOG.info(msg, wf_ex_db.action_execution, str(ac_ex_db.id),
-             task_ex_db.task_id, str(task_ex_db.task_route))
+    msg = 'Handling pause of action execution "%s" for task "%s", route "%s".'
+    update_progress(
+        wf_ex_db,
+        msg % (str(ac_ex_db.id), task_ex_db.task_id, str(task_ex_db.task_route))
+    )
 
     # Updat task execution
     update_task_execution(task_ex_id, ac_ex_db.status, ac_ex_ctx=ac_ex_db.context)
@@ -808,9 +838,11 @@ def handle_action_execution_resume(ac_ex_db):
     wf_ex_db = wf_db_access.WorkflowExecution.get_by_id(wf_ex_id)
     task_ex_db = wf_db_access.TaskExecution.get_by_id(task_ex_id)
 
-    msg = '[%s] Handling resume of action execution "%s" for task "%s", route "%s".'
-    LOG.info(msg, wf_ex_db.action_execution, str(ac_ex_db.id),
-             task_ex_db.task_id, str(task_ex_db.task_route))
+    msg = 'Handling resume of action execution "%s" for task "%s", route "%s".'
+    update_progress(
+        wf_ex_db,
+        msg % (str(ac_ex_db.id), task_ex_db.task_id, str(task_ex_db.task_route))
+    )
 
     # Updat task execution to running.
     resume_task_execution(task_ex_id)
@@ -858,10 +890,14 @@ def handle_action_execution_completion(ac_ex_db):
         wf_ex_db = wf_db_access.WorkflowExecution.get_by_id(wf_ex_id)
         task_ex_db = wf_db_access.TaskExecution.get_by_id(task_ex_id)
 
-        msg = ('[%s] Handling completion of action execution "%s" '
-               'in status "%s" for task "%s", route "%s".')
-        LOG.info(msg, wf_ex_db.action_execution, str(ac_ex_db.id), ac_ex_db.status,
-                 task_ex_db.task_id, str(task_ex_db.task_route))
+        msg = (
+            'Handling completion of action execution "%s" '
+            'in status "%s" for task "%s", route "%s".' % (
+                str(ac_ex_db.id), ac_ex_db.status, task_ex_db.task_id,
+                str(task_ex_db.task_route)
+            )
+        )
+        update_progress(wf_ex_db, msg)
 
         # If task is currently paused and the action execution is skipped to
         # completion, then transition task status to running first.
@@ -929,11 +965,11 @@ def update_task_state(task_ex_id, ac_ex_status, ac_ex_result=None, ac_ex_ctx=Non
     # Refresh records
     task_ex_db = wf_db_access.TaskExecution.get_by_id(task_ex_id)
     conductor, wf_ex_db = refresh_conductor(task_ex_db.workflow_execution)
-    wf_ac_ex_id = wf_ex_db.action_execution
 
     # Update task flow if task execution is completed or paused.
-    msg = '[%s] Publish task "%s", route "%s", with status "%s" to conductor.'
-    LOG.info(msg, wf_ac_ex_id, task_ex_db.task_id, str(task_ex_db.task_route), task_ex_db.status)
+    msg = 'Publish task "%s", route "%s", with status "%s" to conductor.'
+    msg = msg % (task_ex_db.task_id, str(task_ex_db.task_route), task_ex_db.status)
+    update_progress(wf_ex_db, msg, stream=False)
 
     if not ac_ex_ctx or 'item_id' not in ac_ex_ctx or ac_ex_ctx['item_id'] < 0:
         ac_ex_event = events.ActionExecutionEvent(ac_ex_status, result=ac_ex_result)
@@ -950,7 +986,7 @@ def update_task_state(task_ex_id, ac_ex_status, ac_ex_result=None, ac_ex_ctx=Non
             accumulated_result=accumulated_result
         )
 
-    LOG.debug('[%s] %s', wf_ac_ex_id, conductor.serialize())
+    update_progress(wf_ex_db, conductor.serialize(), severity='debug', stream=False)
     conductor.update_task_state(task_ex_db.task_id, task_ex_db.task_route, ac_ex_event)
 
     # Update workflow execution and related liveaction and action execution.
@@ -977,45 +1013,47 @@ def request_next_tasks(wf_ex_db, task_ex_id=None):
 
     # Refresh records.
     conductor, wf_ex_db = refresh_conductor(str(wf_ex_db.id))
-    wf_ac_ex_id = wf_ex_db.action_execution
 
     # If workflow is in requested status, set it to running.
     if conductor.get_workflow_status() in [statuses.REQUESTED, statuses.SCHEDULED]:
-        LOG.info('[%s] Requesting conductor to start running workflow execution.', wf_ac_ex_id)
+        update_progress(wf_ex_db, 'Requesting conductor to start running workflow execution.')
         conductor.request_workflow_status(statuses.RUNNING)
 
     # Identify the list of next set of tasks. Don't pass the task id to the conductor
     # so it can identify any next set of tasks to run from the workflow.
     if task_ex_id:
         task_ex_db = wf_db_access.TaskExecution.get_by_id(task_ex_id)
-        msg = '[%s] Identifying next set (%s) of tasks after completion of task "%s", route "%s".'
-        LOG.info(msg, wf_ac_ex_id, str(iteration), task_ex_db.task_id, str(task_ex_db.task_route))
-        LOG.debug('[%s] %s', wf_ac_ex_id, conductor.serialize())
+        msg = 'Identifying next set (iter %s) of tasks after completion of task "%s", route "%s".'
+        msg = msg % (str(iteration), task_ex_db.task_id, str(task_ex_db.task_route))
+        update_progress(wf_ex_db, msg)
+        update_progress(wf_ex_db, conductor.serialize(), severity='debug', stream=False)
         next_tasks = conductor.get_next_tasks()
     else:
-        msg = '[%s] Identifying next set (%s) of tasks for workflow execution in status "%s".'
-        LOG.info(msg, wf_ac_ex_id, str(iteration), conductor.get_workflow_status())
-        LOG.debug('[%s] %s', wf_ac_ex_id, conductor.serialize())
+        msg = 'Identifying next set (iter %s) of tasks for workflow execution in status "%s".'
+        msg = msg % (str(iteration), conductor.get_workflow_status())
+        update_progress(wf_ex_db, msg)
+        update_progress(wf_ex_db, conductor.serialize(), severity='debug', stream=False)
         next_tasks = conductor.get_next_tasks()
 
     # If there is no new tasks, update execution records to handle possible completion.
     if not next_tasks:
         # Update workflow execution and related liveaction and action execution.
-        LOG.info('[%s] No tasks identified to execute next.', wf_ac_ex_id)
+        update_progress(wf_ex_db, 'No tasks identified to execute next.')
+        update_progress(wf_ex_db, '\n', log=False)
         update_execution_records(wf_ex_db, conductor)
 
     # Iterate while there are next tasks identified for processing. In the case for
     # task with no action execution defined, the task execution will complete
     # immediately with a new set of tasks available.
     while next_tasks:
-        msg = '[%s] Identified the following set of tasks to execute next: %s'
+        msg = 'Identified the following set of tasks to execute next: %s'
         tasks_list = ', '.join(["%s (route %s)" % (t['id'], str(t['route'])) for t in next_tasks])
-        LOG.info(msg, wf_ac_ex_id, tasks_list)
+        update_progress(wf_ex_db, msg % tasks_list)
 
         # Mark the tasks as running in the task flow before actual task execution.
         for task in next_tasks:
-            msg = '[%s] Mark task "%s", route "%s", in conductor as running.'
-            LOG.info(msg, wf_ac_ex_id, task['id'], str(task['route']))
+            msg = 'Mark task "%s", route "%s", in conductor as running.'
+            update_progress(wf_ex_db, msg % (task['id'], str(task['route'])), stream=False)
 
             # If task has items and items list is empty, then actions under the next task is empty
             # and will not be processed in the for loop below. Handle this use case separately and
@@ -1031,8 +1069,9 @@ def request_next_tasks(wf_ex_db, task_ex_id=None):
                 if 'item_id' not in action or action['item_id'] is None:
                     ac_ex_event = events.ActionExecutionEvent(statuses.RUNNING)
                 else:
-                    msg = '[%s] Mark task "%s", route "%s", item "%s" in conductor as running.'
-                    LOG.info(msg, wf_ac_ex_id, task['id'], str(task['route']), action['item_id'])
+                    msg = 'Mark task "%s", route "%s", item "%s" in conductor as running.'
+                    msg = msg % (task['id'], str(task['route']), action['item_id'])
+                    update_progress(wf_ex_db, msg)
                     ac_ex_event = events.TaskItemActionExecutionEvent(
                         action['item_id'],
                         statuses.RUNNING
@@ -1041,19 +1080,19 @@ def request_next_tasks(wf_ex_db, task_ex_id=None):
                 conductor.update_task_state(task['id'], task['route'], ac_ex_event)
 
         # Update workflow execution and related liveaction and action execution.
-        LOG.debug('[%s] %s', wf_ac_ex_id, conductor.serialize())
+        update_progress(wf_ex_db, conductor.serialize(), severity='debug', stream=False)
         update_execution_records(wf_ex_db, conductor)
 
         # Request task execution for the tasks.
         for task in next_tasks:
             try:
-                msg = '[%s] Requesting execution for task "%s", route "%s".'
-                LOG.info(msg, wf_ac_ex_id, task['id'], str(task['route']))
+                msg = 'Requesting execution for task "%s", route "%s".'
+                update_progress(wf_ex_db, msg % (task['id'], str(task['route'])))
 
                 # Pass down appropriate st2 context to the task and action execution(s).
                 root_st2_ctx = wf_ex_db.context.get('st2', {})
                 st2_ctx = {
-                    'execution_id': wf_ac_ex_id,
+                    'execution_id': wf_ex_db.action_execution,
                     'user': root_st2_ctx.get('user'),
                     'pack': root_st2_ctx.get('pack')
                 }
@@ -1066,21 +1105,25 @@ def request_next_tasks(wf_ex_db, task_ex_id=None):
                 # Request the task execution.
                 request_task_execution(wf_ex_db, st2_ctx, task)
             except Exception as e:
-                msg = '[%s] Failed task execution for task "%s", route "%s".'
-                LOG.exception(msg, wf_ac_ex_id, task['id'], str(task['route']))
+                msg = 'Failed task execution for task "%s", route "%s".'
+                msg = msg % (task['id'], str(task['route']))
+                update_progress(wf_ex_db, '%s %s' % (msg, str(e)), severity='error', log=False)
+                LOG.exception(msg)
                 fail_workflow_execution(str(wf_ex_db.id), e, task=task)
                 return
 
         # Identify the next set of tasks to execute.
         iteration += 1
         conductor, wf_ex_db = refresh_conductor(str(wf_ex_db.id))
-        msg = '[%s] Identifying next set (%s) of tasks for workflow execution in status "%s".'
-        LOG.info(msg, wf_ac_ex_id, str(iteration), conductor.get_workflow_status())
-        LOG.debug('[%s] %s', wf_ac_ex_id, conductor.serialize())
+        msg = 'Identifying next set (iter %s) of tasks for workflow execution in status "%s".'
+        msg = msg % (str(iteration), conductor.get_workflow_status())
+        update_progress(wf_ex_db, msg)
+        update_progress(wf_ex_db, conductor.serialize(), severity='debug', stream=False)
         next_tasks = conductor.get_next_tasks()
 
         if not next_tasks:
-            LOG.info('[%s] No tasks identified to execute next.', wf_ac_ex_id)
+            update_progress(wf_ex_db, 'No tasks identified to execute next.')
+            update_progress(wf_ex_db, '\n', log=False)
 
 
 @retrying.retry(
@@ -1102,20 +1145,23 @@ def update_task_execution(task_ex_id, ac_ex_status, ac_ex_result=None, ac_ex_ctx
     # Treat the update of task with items but items list is empty like a normal task execution.
     if not task_ex_db.itemized or (task_ex_db.itemized and task_ex_db.items_count == 0):
         if ac_ex_status != task_ex_db.status:
-            msg = '[%s] Updating task execution from status "%s" to "%s".'
-            LOG.debug(msg, wf_ex_db.action_execution, task_ex_db.status, ac_ex_status)
+            msg = 'Updating task execution "%s" for task "%s" from status "%s" to "%s".'
+            msg = msg % (task_ex_id, task_ex_db.task_id, task_ex_db.status, ac_ex_status)
+            update_progress(wf_ex_db, msg)
 
         task_ex_db.status = ac_ex_status
         task_ex_db.result = ac_ex_result if ac_ex_result else task_ex_db.result
     elif task_ex_db.itemized and ac_ex_ctx:
         if 'orquesta' not in ac_ex_ctx or 'item_id' not in ac_ex_ctx['orquesta']:
-            raise Exception('Context information for the item is not provided. %s' % str(ac_ex_ctx))
+            msg = 'Context information for the item is not provided. %s' % str(ac_ex_ctx)
+            update_progress(wf_ex_db, msg, severity='error', log=False)
+            raise Exception(msg)
 
         item_id = ac_ex_ctx['orquesta']['item_id']
 
-        msg = '[%s] Processing action execution for task "%s", route "%s", item "%s".'
-        LOG.debug(msg, wf_ex_db.action_execution, task_ex_db.task_id,
-                  str(task_ex_db.task_route), item_id)
+        msg = 'Processing action execution for task "%s", route "%s", item "%s".'
+        msg = msg % (task_ex_db.task_id, str(task_ex_db.task_route), item_id)
+        update_progress(wf_ex_db, msg, severity='debug')
 
         task_ex_db.result['items'][item_id] = {'status': ac_ex_status, 'result': ac_ex_result}
 
@@ -1133,12 +1179,12 @@ def update_task_execution(task_ex_id, ac_ex_status, ac_ex_result=None, ac_ex_ctx
                 else statuses.FAILED
             )
 
-            msg = '[%s] Updating task execution from status "%s" to "%s".'
-            LOG.debug(msg, wf_ex_db.action_execution, task_ex_db.status, new_task_status)
+            msg = 'Updating task execution from status "%s" to "%s".'
+            update_progress(wf_ex_db, msg % (task_ex_db.status, new_task_status), severity='debug')
             task_ex_db.status = new_task_status
         else:
-            msg = '[%s] Task execution is not complete because not all items are complete: %s'
-            LOG.debug(msg, wf_ex_db.action_execution, ', '.join(item_statuses))
+            msg = 'Task execution is not complete because not all items are complete: %s'
+            update_progress(wf_ex_db, msg % ', '.join(item_statuses), severity='debug')
 
     if task_ex_db.status in statuses.COMPLETED_STATUSES:
         task_ex_db.end_timestamp = date_utils.get_datetime_utc_now()
@@ -1160,9 +1206,8 @@ def resume_task_execution(task_ex_id):
     task_ex_db = wf_db_access.TaskExecution.get_by_id(task_ex_id)
     wf_ex_db = wf_db_access.WorkflowExecution.get_by_id(task_ex_db.workflow_execution)
 
-    msg = '[%s] Updating task execution from status "%s" to "%s".'
-    LOG.debug(msg, wf_ex_db.action_execution, task_ex_db.status, statuses.RUNNING)
-
+    msg = 'Updating task execution from status "%s" to "%s".'
+    update_progress(wf_ex_db, msg % (task_ex_db.status, statuses.RUNNING), severity='debug')
     task_ex_db.status = statuses.RUNNING
 
     # Write update to the database.
@@ -1236,9 +1281,6 @@ def fail_workflow_execution(wf_ex_id, exception, task=None):
 
 def update_execution_records(wf_ex_db, conductor, update_lv_ac_on_statuses=None,
                              pub_wf_ex=False, pub_lv_ac=True, pub_ac_ex=True):
-
-    wf_ac_ex_id = wf_ex_db.action_execution
-
     # If the workflow execution is completed, then render the workflow output.
     if conductor.get_workflow_status() in statuses.COMPLETED_STATUSES:
         conductor.render_workflow_output()
@@ -1249,8 +1291,8 @@ def update_execution_records(wf_ex_db, conductor, update_lv_ac_on_statuses=None,
     status_changed = (wf_old_status != wf_ex_db.status)
 
     if status_changed:
-        msg = '[%s] Updating workflow execution from status "%s" to "%s".'
-        LOG.info(msg, wf_ac_ex_id, wf_old_status, wf_ex_db.status)
+        msg = 'Updating workflow execution from status "%s" to "%s".'
+        update_progress(wf_ex_db, msg % (wf_old_status, wf_ex_db.status))
 
     # Update timestamp and output if workflow is completed.
     if wf_ex_db.status in statuses.COMPLETED_STATUSES:
@@ -1279,9 +1321,12 @@ def update_execution_records(wf_ex_db, conductor, update_lv_ac_on_statuses=None,
     if wf_ex_db.status in statuses.ABENDED_STATUSES:
         result['errors'] = wf_ex_db.errors
 
-        for wf_ex_error in wf_ex_db.errors:
-            msg = '[%s] Workflow execution completed with errors.'
-            LOG.error(msg, wf_ac_ex_id, extra=wf_ex_error)
+        if wf_ex_db.errors:
+            msg = 'Workflow execution completed with errors.'
+            update_progress(wf_ex_db, msg, severity='error')
+
+            for wf_ex_error in wf_ex_db.errors:
+                update_progress(wf_ex_db, wf_ex_error, severity='error')
 
     # Sync update with corresponding liveaction and action execution.
     if pub_lv_ac or pub_ac_ex:
@@ -1289,12 +1334,13 @@ def update_execution_records(wf_ex_db, conductor, update_lv_ac_on_statuses=None,
         pub_ac_ex = pub_lv_ac
 
     if wf_lv_ac_db.status != wf_ex_db.status:
-        msg = '[%s] Updating workflow liveaction from status "%s" to "%s".'
-        LOG.debug(msg, wf_ac_ex_id, wf_lv_ac_db.status, wf_ex_db.status)
-        msg = '[%s] Workflow liveaction status change %s be published.'
-        LOG.debug(msg, wf_ac_ex_id, 'will' if pub_lv_ac else 'will not')
-        msg = '[%s] Workflow action execution status change %s be published.'
-        LOG.debug(msg, wf_ac_ex_id, 'will' if pub_ac_ex else 'will not')
+        kwargs = {'severity': 'debug', 'stream': False}
+        msg = 'Updating workflow liveaction from status "%s" to "%s".'
+        update_progress(wf_ex_db, msg % (wf_lv_ac_db.status, wf_ex_db.status), **kwargs)
+        msg = 'Workflow liveaction status change %s be published.'
+        update_progress(wf_ex_db, msg % 'will' if pub_lv_ac else 'will not', **kwargs)
+        msg = 'Workflow action execution status change %s be published.'
+        update_progress(wf_ex_db, msg % 'will' if pub_ac_ex else 'will not', **kwargs)
 
     wf_lv_ac_db = action_utils.update_liveaction_status(
         status=wf_ex_db.status,
@@ -1307,7 +1353,7 @@ def update_execution_records(wf_ex_db, conductor, update_lv_ac_on_statuses=None,
 
     # Invoke post run on the liveaction for the workflow execution.
     if status_changed and wf_lv_ac_db.status in ac_const.LIVEACTION_COMPLETED_STATES:
-        LOG.info('[%s] Workflow action execution is completed and invoking post run.', wf_ac_ex_id)
+        update_progress(wf_ex_db, 'Workflow action execution is completed and invoking post run.')
         runners_utils.invoke_post_run(wf_lv_ac_db)
 
 
@@ -1345,14 +1391,15 @@ def identify_orphaned_workflows():
         # Fetch the task executions for the workflow execution.
         # Ensure that the root action execution is not being selected.
         wf_ex_id = ac_ex_db.context['workflow_execution']
+        wf_ex_db = wf_db_access.WorkflowExecution.get_by_id(wf_ex_id)
         query_filters = {'workflow_execution': wf_ex_id, 'id__ne': ac_ex_db.id}
         tk_ac_ex_dbs = ex_db_access.ActionExecution.query(**query_filters)
 
         # The workflow execution is orphaned if there are
         # no task executions and runtime passed expiry.
         if len(tk_ac_ex_dbs) <= 0 and runtime > gc_max_idle:
-            msg = '[%s] Workflow action execution will be canceled by garbage collector.'
-            LOG.info(msg, str(ac_ex_db.id))
+            msg = 'The action execution is orphaned and will be canceled by the garbage collector.'
+            update_progress(wf_ex_db, msg)
             orphaned.append(ac_ex_db)
             continue
 
@@ -1373,8 +1420,8 @@ def identify_orphaned_workflows():
         )
 
         if len(tk_ac_ex_dbs) > 0 and not has_active_tasks and most_recent_completed_task_expired:
-            msg = '[%s] Workflow action execution will be canceled by garbage collector.'
-            LOG.info(msg, str(ac_ex_db.id))
+            msg = 'The action execution is orphaned and will be canceled by the garbage collector.'
+            update_progress(wf_ex_db, msg)
             orphaned.append(ac_ex_db)
             continue
 

--- a/st2common/tests/unit/services/test_workflow.py
+++ b/st2common/tests/unit/services/test_workflow.py
@@ -142,7 +142,9 @@ class WorkflowExecutionServiceTest(st2tests.WorkflowTestCase):
         wf_meta = self.get_wf_fixture_meta_data(TEST_PACK_PATH, 'sequential.yaml')
 
         # Manually create the action execution object with the bad action.
-        ac_ex_db = ex_db_models.ActionExecutionDB(action={'ref': 'mock.foobar'})
+        ac_ex_db = ex_db_models.ActionExecutionDB(
+            action={'ref': 'mock.foobar'}, runner={'name': 'foobar'}
+        )
 
         # Request the workflow execution.
         self.assertRaises(

--- a/st2common/tests/unit/services/test_workflow_identify_orphans.py
+++ b/st2common/tests/unit/services/test_workflow_identify_orphans.py
@@ -136,7 +136,9 @@ class WorkflowServiceIdentifyOrphansTest(st2tests.WorkflowTestCase):
 
         # Create the WorkflowExecutionDB record first since the ID needs to be
         # included in the LiveActionDB and ActionExecutionDB records.
+        st2_ctx = {'st2': {'action_execution_id': '123', 'action': 'foobar', 'runner': 'orquesta'}}
         wf_ex_db = wf_db_models.WorkflowExecutionDB(
+            context=st2_ctx,
             status=status,
             start_timestamp=start_timestamp,
             end_timestamp=end_timestamp

--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -635,7 +635,9 @@ class WorkflowTestCase(ExecutionDbTestCase):
             'st2': {
                 'api_url': api_util.get_full_public_api_url(),
                 'action_execution_id': str(ac_ex_db.id),
-                'user': 'stanley'
+                'user': 'stanley',
+                'action': ac_ex_db.action['ref'],
+                'runner': ac_ex_db.runner['name']
             }
         }
 


### PR DESCRIPTION
Currently, progress of workflow execution is written to the workflow service and action runner log files. Update the logging in the orquesta runner and workflow service to write the execution progress to the action execution output table which will be available in the streaming API and when tailing execution output.