### PR TITLE
update sensor partitioner error message

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Added
 ~~~~~
 * Add make command to autogen JSON schema from the models of action, rule, etc. Add check
   to ensure update to the models require schema to be regenerated. (new feature)
+* Improved st2sensor service logging message when a sensor will not be loaded when assigned to a
+  different partition (@punkrokk)
 
 Fixed
 ~~~~~

--- a/st2reactor/st2reactor/container/manager.py
+++ b/st2reactor/st2reactor/container/manager.py
@@ -139,7 +139,8 @@ class SensorContainerManager(object):
 
     def _handle_update_sensor(self, sensor):
         if not self._sensors_partitioner.is_sensor_owner(sensor):
-            LOG.info('sensor %s is not supported. Ignoring update.', self._get_sensor_ref(sensor))
+            LOG.info('sensor %s is not assigned to this partition. Ignoring update. ',
+                     self._get_sensor_ref(sensor))
             return
         sensor_ref = self._get_sensor_ref(sensor)
         sensor_obj = self._to_sensor_object(sensor)


### PR DESCRIPTION
Updates the sensor error message when a sensor won't be ran if it's assigned to a different partition. 