### PR TITLE
Remove inactive Contributors

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -49,8 +49,6 @@ They're not part of the TSC voting process, but appreciated for their contributi
 * Amanda McGuinness ([@amanda11](https://github.com/amanda11)) - StackStorm Exchange, Ansible, ChatOps, Documentation, core.
 * Carlos ([@nzlosh](https://github.com/nzlosh)) - Chatops, Errbot, Community, Discussions, StackStorm Exchange.
 * Hiroyasu Ohyama ([@userlocalhost](https://github.com/userlocalhost)) - Orquesta, Workflows, st2 Japan Community. [Case Study](https://stackstorm.com/case-study-dmm/).
-* Jon Middleton ([@jjm](https://github.com/jjm)) - StackStorm Exchange, Core, Discussions.
-* Shu Sugimoto ([@shusugmt](https://github.com/shusugmt)) - Docker, StackStorm Exchange packs.
 * Tristan Struthers ([@trstruth](https://github.com/trstruth)) - Docker, K8s, Orquesta, Community.
 * Marcel Weinberg ([@winem](https://github.com/winem)) - Community, Docker, Core.
 

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -49,6 +49,7 @@ They're not part of the TSC voting process, but appreciated for their contributi
 * Amanda McGuinness ([@amanda11](https://github.com/amanda11)) - StackStorm Exchange, Ansible, ChatOps, Documentation, core.
 * Carlos ([@nzlosh](https://github.com/nzlosh)) - Chatops, Errbot, Community, Discussions, StackStorm Exchange.
 * Hiroyasu Ohyama ([@userlocalhost](https://github.com/userlocalhost)) - Orquesta, Workflows, st2 Japan Community. [Case Study](https://stackstorm.com/case-study-dmm/).
+* Jon Middleton ([@jjm](https://github.com/jjm)) - StackStorm Exchange, Core, Discussions.
 * Tristan Struthers ([@trstruth](https://github.com/trstruth)) - Docker, K8s, Orquesta, Community.
 * Marcel Weinberg ([@winem](https://github.com/winem)) - Community, Docker, Core.
 


### PR DESCRIPTION
Remove Contributors from the list who weren't active in StackStorm Community this year.

We should keep the list up to date according to the LF Analytics data https://lfanalytics.io/projects/stackstorm/dashboard including Slack, Forums, Github and Contributing Activities we expect to be valuable for the project: https://github.com/StackStorm/st2/blob/master/GOVERNANCE.md#how-to-start-contributing
