### PR TITLE
Pin dnspython pip dependency due to regression in v2.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,8 @@ Fixed
 * Fixed a bug where a python3 sensor using ssl needs to be monkey patched earlier. See also #4832, #4975 and gevent/gevent#1016 (bug fix) #4976
   
   Contributed by @punkrokk
+* Fix a regression when updated ``dnspython`` pip dependency resulted in
+  st2 services unable to connect to mongodb remote host (bug fix) #4997
 
 Removed
 ~~~~~~~

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -2,6 +2,8 @@
 # Note: amqp is used by kombu
 amqp==2.5.2
 apscheduler==3.6.3
+# NOTE: 2.0 version breaks pymongo work with hosts
+dnspython>=1.16.0,<2.0.0
 cryptography==2.8
 # Note: 0.20.0 removed select.poll() on which some of our code and libraries we
 # depend on rely

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ apscheduler==3.6.3
 argcomplete
 bcrypt==3.1.7
 cryptography==2.8
+dnspython<2.0.0,>=1.16.0
 eventlet==0.25.1
 flex==6.14.0
 git+https://github.com/StackStorm/logshipper.git@stackstorm_patched#egg=logshipper

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -1,5 +1,6 @@
 # Remeber to list implicit packages here, otherwise version won't be fixated!
 apscheduler
+dnspython
 python-dateutil
 eventlet
 # used by eventlet

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -8,6 +8,7 @@
 amqp==2.5.2
 apscheduler==3.6.3
 cryptography==2.8
+dnspython<2.0.0,>=1.16.0
 eventlet==0.25.1
 flex==6.14.0
 git+https://github.com/StackStorm/orquesta.git@v1.1.1#egg=orquesta


### PR DESCRIPTION
Recently both `st2-docker` https://circleci.com/gh/StackStorm/st2-docker/2199 and `stackstorm-ha` https://circleci.com/gh/StackStorm/stackstorm-ha/2393 nightly builds started to fail :fire:.

Fixes https://github.com/StackStorm/stackstorm-ha/issues/143
Fixes https://github.com/StackStorm/st2-docker/issues/194

The issue is that st2 services started to fail if mongodb is a host and not an IP, meaning all remote-host scenarios are broken:

```
root@86f87ce3c778:/opt/stackstorm# /opt/stackstorm/st2/bin/st2api --config-file=/etc/st2/st2.conf --config-file=/etc/st2/st2.docker.conf --config-file=/etc/st2/st2.docker.conf
2020-07-19 15:47:53,175 DEBUG [-] Using Python: 3.6.9 (/opt/stackstorm/st2/bin/python)
2020-07-19 15:47:53,176 DEBUG [-] Using config files: /etc/st2/st2.conf,/etc/st2/st2.docker.conf,/etc/st2/st2.docker.conf
2020-07-19 15:47:53,179 DEBUG [-] Using logging config: /etc/st2/logging.api.gunicorn.conf
2020-07-19 15:47:53,261 INFO [-] Connecting to database "st2" @ "mongo:27017" as user "None".
2020-07-19 15:47:56,299 ERROR [-] Failed to connect to database "st2" @ "mongo:27017" as user "None": No servers found yet
2020-07-19 15:47:56,300 ERROR [-] (PID=791) ST2 API quit due to exception.
Traceback (most recent call last):
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2api/cmd/api.py", line 84, in main
    _setup()
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2api/cmd/api.py", line 58, in _setup
    service_registry=True, capabilities=capabilities)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/service_setup.py", line 160, in setup
    db_setup()
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/database_setup.py", line 56, in db_setup
    connection = db_init.db_setup_with_retry(**db_cfg)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/persistence/db_init.py", line 75, in db_setup_with_retry
    ssl_match_hostname=ssl_match_hostname)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/persistence/db_init.py", line 58, in db_func_with_retry
    return retrying_obj.call(db_func, *args, **kwargs)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/retrying.py", line 206, in call
    return attempt.get(self._wrap_exception)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/retrying.py", line 247, in get
    six.reraise(self.value[0], self.value[1], self.value[2])
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/six.py", line 696, in reraise
    raise value
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/retrying.py", line 200, in call
    attempt = Attempt(fn(*args, **kwargs), attempt_number, False)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/models/db/__init__.py", line 169, in db_setup
    ssl_match_hostname=ssl_match_hostname)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/models/db/__init__.py", line 151, in _db_connect
    raise e
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/models/db/__init__.py", line 144, in _db_connect
    connection.admin.command('ismaster')
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/pymongo/database.py", line 730, in command
    read_preference, session) as (sock_info, slave_ok):
  File "/usr/lib/python3.6/contextlib.py", line 81, in __enter__
    return next(self.gen)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/pymongo/mongo_client.py", line 1298, in _socket_for_reads
    server = self._select_server(read_preference, session)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/pymongo/mongo_client.py", line 1253, in _select_server
    server = topology.select_server(server_selector)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/pymongo/topology.py", line 235, in select_server
    address))
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/pymongo/topology.py", line 193, in select_servers
    selector, server_timeout, address)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/pymongo/topology.py", line 209, in _select_servers_loop
    self._error_message(selector))
pymongo.errors.ServerSelectionTimeoutError: No servers found yet
```

Looking deeper, the only diff in pip dependencies between the working and broken deb packages was `dnspython` that updated from `v1.16.0` to `v2.0.0`.

This PR pins `dnspython` to a working non-breaking version before `2.0.0`.