### PR TITLE
Use upstream codecov instead of our own fork

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,6 +55,7 @@ Removed
 * Removed ``CentOS 6``/``RHEL 6`` support #4984
 
   Contributed by Amanda McGuinness (@amanda11 Ammeon Solutions)
+* Removed our fork of ``codecov-python`` and have switched back to the upstream version
   
 3.2.0 - April 27, 2020
 ----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,7 +55,7 @@ Removed
 * Removed ``CentOS 6``/``RHEL 6`` support #4984
 
   Contributed by Amanda McGuinness (@amanda11 Ammeon Solutions)
-* Removed our fork of ``codecov-python`` and have switched back to the upstream version
+* Removed our fork of ``codecov-python`` for CI and have switched back to the upstream version (improvement) #5002
   
 3.2.0 - April 27, 2020
 ----------------------

--- a/scripts/travis/submit-codecov-coverage.sh
+++ b/scripts/travis/submit-codecov-coverage.sh
@@ -19,7 +19,9 @@ if [ ${TRAVIS_TEST_RESULT} -eq 0 ]; then
     # NOTE: We need eventlet installed so coverage can be correctly combined. This is needed because we are covering code which utilizes eventlet.
     # Without eventlet being available to the coverage command it will fail with "Couldn't trace with concurrency=eventlet, the module isn't installed."
     pip install eventlet
-    pip install -e "git+https://github.com/StackStorm/codecov-python.git@better_error_output#egg=codecov"
+    # NOTE: codecov only supports coverage==4.5.2
+    pip install coverage<5.0
+    pip install codecov
 
     # 2. Combine coverage report and submit coverage report to codecovs.io
     codecov --required


### PR DESCRIPTION
We've been seeing repeated build failures for codecov issues: https://travis-ci.org/github/StackStorm/st2/jobs/710376520#L27406

The fix is to upgrade to `codecov-python >= 2.1` per https://community.codecov.io/t/http-400-while-uploading-to-s3-with-python-codecov-from-travis/1428/6

However, we are maintaining our own fork of `codecov-python` and those changes haven't been merged into our fork.

Couple things here:

- It looks like we're maintaining our own fork so that we can get better error outputs: https://github.com/codecov/codecov-python/compare/master...StackStorm:better_error_output
- I've submitted a PR upstream to include these changes so we don't have to maintain our own fork: https://github.com/codecov/codecov-python/pull/288
- Once the PR above is merged we can merge this PR

Until we get the changes merged upstream, i've also submitted a PR against our own `codecov-python` fork to pull in the upstream changes so our tests can pass again without these errors: https://github.com/StackStorm/codecov-python/pull/2

**DECISION POINTS / OPTIONS**

1. If we don't mind having the "better error messages" shown in case of `codecov` failure, we can merge this PR and just use upstream
  - At some point in the future our "better error messages" PR will be merged and we'll take advantage of that automatically
2. We can let this PR sit until the upstream changes are merged and instead merge PR https://github.com/StackStorm/codecov-python/pull/2 so we can stop getting errors in our builds.
