### PR TITLE
Add StackStorm Copyright headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2020 The StackStorm Authors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ For more information, please refer to https://docs.stackstorm.com/latest/securit
 
 ## Copyright, License, and Contributors Agreement
 
+Copyright 2020 The StackStorm Authors.
 Copyright 2014-2018 StackStorm, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License. You may obtain a copy of the License in the [LICENSE](LICENSE) file, or at:

--- a/contrib/chatops/actions/format_execution_result.py
+++ b/contrib/chatops/actions/format_execution_result.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/chatops/actions/match.py
+++ b/contrib/chatops/actions/match.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/chatops/actions/match_and_execute.py
+++ b/contrib/chatops/actions/match_and_execute.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/chatops/tests/test_format_result.py
+++ b/contrib/chatops/tests/test_format_result.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/core/actions/generate_uuid.py
+++ b/contrib/core/actions/generate_uuid.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/core/actions/inject_trigger.py
+++ b/contrib/core/actions/inject_trigger.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/core/actions/pause.py
+++ b/contrib/core/actions/pause.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/core/tests/test_action_inject_trigger.py
+++ b/contrib/core/tests/test_action_inject_trigger.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/core/tests/test_action_sendmail.py
+++ b/contrib/core/tests/test_action_sendmail.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/core/tests/test_action_uuid.py
+++ b/contrib/core/tests/test_action_uuid.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/examples/actions/print_to_stdout_and_stderr.py
+++ b/contrib/examples/actions/print_to_stdout_and_stderr.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/linux/actions/checks/check_loadavg.py
+++ b/contrib/linux/actions/checks/check_loadavg.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/linux/actions/checks/check_processes.py
+++ b/contrib/linux/actions/checks/check_processes.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/linux/actions/dig.py
+++ b/contrib/linux/actions/dig.py
@@ -1,5 +1,6 @@
 #! /usr/bin/python
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/linux/actions/service.py
+++ b/contrib/linux/actions/service.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/linux/actions/wait_for_ssh.py
+++ b/contrib/linux/actions/wait_for_ssh.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/linux/sensors/file_watch_sensor.py
+++ b/contrib/linux/sensors/file_watch_sensor.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/packs/actions/get_config.py
+++ b/contrib/packs/actions/get_config.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/packs/actions/pack_mgmt/delete.py
+++ b/contrib/packs/actions/pack_mgmt/delete.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/packs/actions/pack_mgmt/download.py
+++ b/contrib/packs/actions/pack_mgmt/download.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/packs/actions/pack_mgmt/get_installed.py
+++ b/contrib/packs/actions/pack_mgmt/get_installed.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/packs/actions/pack_mgmt/get_pack_dependencies.py
+++ b/contrib/packs/actions/pack_mgmt/get_pack_dependencies.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/packs/actions/pack_mgmt/register.py
+++ b/contrib/packs/actions/pack_mgmt/register.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/packs/actions/pack_mgmt/search.py
+++ b/contrib/packs/actions/pack_mgmt/search.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/packs/actions/pack_mgmt/setup_virtualenv.py
+++ b/contrib/packs/actions/pack_mgmt/setup_virtualenv.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/packs/actions/pack_mgmt/show_remote.py
+++ b/contrib/packs/actions/pack_mgmt/show_remote.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/packs/actions/pack_mgmt/unload.py
+++ b/contrib/packs/actions/pack_mgmt/unload.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/packs/actions/pack_mgmt/virtualenv_setup_prerun.py
+++ b/contrib/packs/actions/pack_mgmt/virtualenv_setup_prerun.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/packs/tests/test_action_download.py
+++ b/contrib/packs/tests/test_action_download.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/packs/tests/test_action_unload.py
+++ b/contrib/packs/tests/test_action_unload.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/packs/tests/test_get_pack_dependencies.py
+++ b/contrib/packs/tests/test_get_pack_dependencies.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/packs/tests/test_virtualenv_setup_prerun.py
+++ b/contrib/packs/tests/test_virtualenv_setup_prerun.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/action_chain_runner/action_chain_runner/__init__.py
+++ b/contrib/runners/action_chain_runner/action_chain_runner/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/action_chain_runner/action_chain_runner/action_chain_runner.py
+++ b/contrib/runners/action_chain_runner/action_chain_runner/action_chain_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/action_chain_runner/dist_utils.py
+++ b/contrib/runners/action_chain_runner/dist_utils.py
@@ -3,6 +3,7 @@
 #       Instead modify scripts/dist_utils.py and run 'make .sdist-requirements' to
 #       update dist_utils.py files for all components
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/action_chain_runner/setup.py
+++ b/contrib/runners/action_chain_runner/setup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/action_chain_runner/tests/unit/test_actionchain.py
+++ b/contrib/runners/action_chain_runner/tests/unit/test_actionchain.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/action_chain_runner/tests/unit/test_actionchain_cancel.py
+++ b/contrib/runners/action_chain_runner/tests/unit/test_actionchain_cancel.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/action_chain_runner/tests/unit/test_actionchain_notifications.py
+++ b/contrib/runners/action_chain_runner/tests/unit/test_actionchain_notifications.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/action_chain_runner/tests/unit/test_actionchain_params_rendering.py
+++ b/contrib/runners/action_chain_runner/tests/unit/test_actionchain_params_rendering.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/action_chain_runner/tests/unit/test_actionchain_pause_resume.py
+++ b/contrib/runners/action_chain_runner/tests/unit/test_actionchain_pause_resume.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/announcement_runner/announcement_runner/__init__.py
+++ b/contrib/runners/announcement_runner/announcement_runner/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/announcement_runner/announcement_runner/announcement_runner.py
+++ b/contrib/runners/announcement_runner/announcement_runner/announcement_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/announcement_runner/dist_utils.py
+++ b/contrib/runners/announcement_runner/dist_utils.py
@@ -3,6 +3,7 @@
 #       Instead modify scripts/dist_utils.py and run 'make .sdist-requirements' to
 #       update dist_utils.py files for all components
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/announcement_runner/setup.py
+++ b/contrib/runners/announcement_runner/setup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/announcement_runner/tests/unit/test_announcementrunner.py
+++ b/contrib/runners/announcement_runner/tests/unit/test_announcementrunner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/http_runner/dist_utils.py
+++ b/contrib/runners/http_runner/dist_utils.py
@@ -3,6 +3,7 @@
 #       Instead modify scripts/dist_utils.py and run 'make .sdist-requirements' to
 #       update dist_utils.py files for all components
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/http_runner/http_runner/__init__.py
+++ b/contrib/runners/http_runner/http_runner/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/http_runner/http_runner/http_runner.py
+++ b/contrib/runners/http_runner/http_runner/http_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/http_runner/setup.py
+++ b/contrib/runners/http_runner/setup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/http_runner/tests/unit/test_http_runner.py
+++ b/contrib/runners/http_runner/tests/unit/test_http_runner.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/inquirer_runner/dist_utils.py
+++ b/contrib/runners/inquirer_runner/dist_utils.py
@@ -3,6 +3,7 @@
 #       Instead modify scripts/dist_utils.py and run 'make .sdist-requirements' to
 #       update dist_utils.py files for all components
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/inquirer_runner/inquirer_runner/__init__.py
+++ b/contrib/runners/inquirer_runner/inquirer_runner/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/inquirer_runner/inquirer_runner/inquirer_runner.py
+++ b/contrib/runners/inquirer_runner/inquirer_runner/inquirer_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/inquirer_runner/setup.py
+++ b/contrib/runners/inquirer_runner/setup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/inquirer_runner/tests/unit/test_inquirer_runner.py
+++ b/contrib/runners/inquirer_runner/tests/unit/test_inquirer_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/local_runner/dist_utils.py
+++ b/contrib/runners/local_runner/dist_utils.py
@@ -3,6 +3,7 @@
 #       Instead modify scripts/dist_utils.py and run 'make .sdist-requirements' to
 #       update dist_utils.py files for all components
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/local_runner/local_runner/__init__.py
+++ b/contrib/runners/local_runner/local_runner/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/local_runner/local_runner/base.py
+++ b/contrib/runners/local_runner/local_runner/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/local_runner/local_runner/local_shell_command_runner.py
+++ b/contrib/runners/local_runner/local_runner/local_shell_command_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/local_runner/local_runner/local_shell_script_runner.py
+++ b/contrib/runners/local_runner/local_runner/local_shell_script_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/local_runner/setup.py
+++ b/contrib/runners/local_runner/setup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/local_runner/tests/integration/test_localrunner.py
+++ b/contrib/runners/local_runner/tests/integration/test_localrunner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/mistral_v2/dist_utils.py
+++ b/contrib/runners/mistral_v2/dist_utils.py
@@ -3,6 +3,7 @@
 #       Instead modify scripts/dist_utils.py and run 'make .sdist-requirements' to
 #       update dist_utils.py files for all components
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/mistral_v2/mistral_v2/__init__.py
+++ b/contrib/runners/mistral_v2/mistral_v2/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/mistral_v2/mistral_v2/callback.py
+++ b/contrib/runners/mistral_v2/mistral_v2/callback.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/mistral_v2/mistral_v2/mistral_v2.py
+++ b/contrib/runners/mistral_v2/mistral_v2/mistral_v2.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/mistral_v2/mistral_v2/query.py
+++ b/contrib/runners/mistral_v2/mistral_v2/query.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/mistral_v2/setup.py
+++ b/contrib/runners/mistral_v2/setup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_utils.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_utils.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_auth.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_auth.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_callback.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_callback.py
@@ -1,4 +1,5 @@
 # -*- coding: UTF-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_cancel.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_cancel.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_pause_and_resume.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_pause_and_resume.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_policy.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_policy.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_querier.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_querier.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_rerun.py
+++ b/contrib/runners/mistral_v2/tests/unit/test_mistral_v2_rerun.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/noop_runner/dist_utils.py
+++ b/contrib/runners/noop_runner/dist_utils.py
@@ -3,6 +3,7 @@
 #       Instead modify scripts/dist_utils.py and run 'make .sdist-requirements' to
 #       update dist_utils.py files for all components
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/noop_runner/noop_runner/__init__.py
+++ b/contrib/runners/noop_runner/noop_runner/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/noop_runner/noop_runner/noop_runner.py
+++ b/contrib/runners/noop_runner/noop_runner/noop_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/noop_runner/setup.py
+++ b/contrib/runners/noop_runner/setup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/noop_runner/tests/unit/test_nooprunner.py
+++ b/contrib/runners/noop_runner/tests/unit/test_nooprunner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/orquesta_runner/dist_utils.py
+++ b/contrib/runners/orquesta_runner/dist_utils.py
@@ -3,6 +3,7 @@
 #       Instead modify scripts/dist_utils.py and run 'make .sdist-requirements' to
 #       update dist_utils.py files for all components
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/orquesta_runner/orquesta_functions/runtime.py
+++ b/contrib/runners/orquesta_runner/orquesta_functions/runtime.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/orquesta_runner/orquesta_functions/st2kv.py
+++ b/contrib/runners/orquesta_runner/orquesta_functions/st2kv.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/orquesta_runner/orquesta_runner/__init__.py
+++ b/contrib/runners/orquesta_runner/orquesta_runner/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/orquesta_runner/orquesta_runner/orquesta_runner.py
+++ b/contrib/runners/orquesta_runner/orquesta_runner/orquesta_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/orquesta_runner/setup.py
+++ b/contrib/runners/orquesta_runner/setup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/orquesta_runner/tests/integration/test_wiring_functions_st2kv.py
+++ b/contrib/runners/orquesta_runner/tests/integration/test_wiring_functions_st2kv.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/orquesta_runner/tests/unit/base.py
+++ b/contrib/runners/orquesta_runner/tests/unit/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/orquesta_runner/tests/unit/test_basic.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_basic.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/orquesta_runner/tests/unit/test_cancel.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_cancel.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/orquesta_runner/tests/unit/test_context.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_context.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/orquesta_runner/tests/unit/test_data_flow.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_data_flow.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/orquesta_runner/tests/unit/test_delay.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_delay.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/orquesta_runner/tests/unit/test_error_handling.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_error_handling.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/orquesta_runner/tests/unit/test_functions_common.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_functions_common.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/orquesta_runner/tests/unit/test_functions_st2kv.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_functions_st2kv.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/orquesta_runner/tests/unit/test_functions_task.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_functions_task.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/orquesta_runner/tests/unit/test_inquiries.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_inquiries.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/orquesta_runner/tests/unit/test_notify.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_notify.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/orquesta_runner/tests/unit/test_output_schema.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_output_schema.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/orquesta_runner/tests/unit/test_pause_and_resume.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_pause_and_resume.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/orquesta_runner/tests/unit/test_policies.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_policies.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/orquesta_runner/tests/unit/test_rerun.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_rerun.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/orquesta_runner/tests/unit/test_with_items.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_with_items.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/python_runner/dist_utils.py
+++ b/contrib/runners/python_runner/dist_utils.py
@@ -3,6 +3,7 @@
 #       Instead modify scripts/dist_utils.py and run 'make .sdist-requirements' to
 #       update dist_utils.py files for all components
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/python_runner/python_runner/__init__.py
+++ b/contrib/runners/python_runner/python_runner/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/python_runner/python_runner/python_action_wrapper.py
+++ b/contrib/runners/python_runner/python_runner/python_action_wrapper.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/python_runner/python_runner/python_runner.py
+++ b/contrib/runners/python_runner/python_runner/python_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/python_runner/setup.py
+++ b/contrib/runners/python_runner/setup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/python_runner/tests/integration/test_python_action_process_wrapper.py
+++ b/contrib/runners/python_runner/tests/integration/test_python_action_process_wrapper.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/python_runner/tests/integration/test_pythonrunner_behavior.py
+++ b/contrib/runners/python_runner/tests/integration/test_pythonrunner_behavior.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/python_runner/tests/unit/test_output_schema.py
+++ b/contrib/runners/python_runner/tests/unit/test_output_schema.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
+++ b/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/remote_runner/dist_utils.py
+++ b/contrib/runners/remote_runner/dist_utils.py
@@ -3,6 +3,7 @@
 #       Instead modify scripts/dist_utils.py and run 'make .sdist-requirements' to
 #       update dist_utils.py files for all components
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/remote_runner/remote_runner/__init__.py
+++ b/contrib/runners/remote_runner/remote_runner/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/remote_runner/remote_runner/remote_command_runner.py
+++ b/contrib/runners/remote_runner/remote_runner/remote_command_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/remote_runner/remote_runner/remote_script_runner.py
+++ b/contrib/runners/remote_runner/remote_runner/remote_script_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/remote_runner/setup.py
+++ b/contrib/runners/remote_runner/setup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/winrm_runner/dist_utils.py
+++ b/contrib/runners/winrm_runner/dist_utils.py
@@ -3,6 +3,7 @@
 #       Instead modify scripts/dist_utils.py and run 'make .sdist-requirements' to
 #       update dist_utils.py files for all components
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/winrm_runner/setup.py
+++ b/contrib/runners/winrm_runner/setup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/winrm_runner/tests/unit/test_winrm_base.py
+++ b/contrib/runners/winrm_runner/tests/unit/test_winrm_base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/winrm_runner/tests/unit/test_winrm_command_runner.py
+++ b/contrib/runners/winrm_runner/tests/unit/test_winrm_command_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/winrm_runner/tests/unit/test_winrm_ps_command_runner.py
+++ b/contrib/runners/winrm_runner/tests/unit/test_winrm_ps_command_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/winrm_runner/tests/unit/test_winrm_ps_script_runner.py
+++ b/contrib/runners/winrm_runner/tests/unit/test_winrm_ps_script_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/winrm_runner/winrm_runner/__init__.py
+++ b/contrib/runners/winrm_runner/winrm_runner/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/winrm_runner/winrm_runner/winrm_base.py
+++ b/contrib/runners/winrm_runner/winrm_runner/winrm_base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/winrm_runner/winrm_runner/winrm_command_runner.py
+++ b/contrib/runners/winrm_runner/winrm_runner/winrm_command_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/winrm_runner/winrm_runner/winrm_ps_command_runner.py
+++ b/contrib/runners/winrm_runner/winrm_runner/winrm_ps_command_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/runners/winrm_runner/winrm_runner/winrm_ps_script_runner.py
+++ b/contrib/runners/winrm_runner/winrm_runner/winrm_ps_script_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pylint_plugins/api_models.py
+++ b/pylint_plugins/api_models.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pylint_plugins/db_models.py
+++ b/pylint_plugins/db_models.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/dist_utils.py
+++ b/scripts/dist_utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/dist_utils_old.py
+++ b/scripts/dist_utils_old.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/fixate-requirements.py
+++ b/scripts/fixate-requirements.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/dist_utils.py
+++ b/st2actions/dist_utils.py
@@ -3,6 +3,7 @@
 #       Instead modify scripts/dist_utils.py and run 'make .sdist-requirements' to
 #       update dist_utils.py files for all components
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/setup.py
+++ b/st2actions/setup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/st2actions/__init__.py
+++ b/st2actions/st2actions/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/st2actions/cmd/actionrunner.py
+++ b/st2actions/st2actions/cmd/actionrunner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/st2actions/cmd/scheduler.py
+++ b/st2actions/st2actions/cmd/scheduler.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/st2actions/cmd/st2notifier.py
+++ b/st2actions/st2actions/cmd/st2notifier.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/st2actions/cmd/st2resultstracker.py
+++ b/st2actions/st2actions/cmd/st2resultstracker.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/st2actions/cmd/workflow_engine.py
+++ b/st2actions/st2actions/cmd/workflow_engine.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/st2actions/config.py
+++ b/st2actions/st2actions/config.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/st2actions/container/base.py
+++ b/st2actions/st2actions/container/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/st2actions/notifier/config.py
+++ b/st2actions/st2actions/notifier/config.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/st2actions/notifier/notifier.py
+++ b/st2actions/st2actions/notifier/notifier.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/st2actions/policies/concurrency.py
+++ b/st2actions/st2actions/policies/concurrency.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/st2actions/policies/concurrency_by_attr.py
+++ b/st2actions/st2actions/policies/concurrency_by_attr.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/st2actions/policies/retry.py
+++ b/st2actions/st2actions/policies/retry.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/st2actions/resultstracker/config.py
+++ b/st2actions/st2actions/resultstracker/config.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/st2actions/resultstracker/resultstracker.py
+++ b/st2actions/st2actions/resultstracker/resultstracker.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/st2actions/runners/pythonrunner.py
+++ b/st2actions/st2actions/runners/pythonrunner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/st2actions/scheduler/config.py
+++ b/st2actions/st2actions/scheduler/config.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/st2actions/scheduler/entrypoint.py
+++ b/st2actions/st2actions/scheduler/entrypoint.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/st2actions/scheduler/handler.py
+++ b/st2actions/st2actions/scheduler/handler.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/st2actions/worker.py
+++ b/st2actions/st2actions/worker.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/st2actions/workflows/config.py
+++ b/st2actions/st2actions/workflows/config.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/st2actions/workflows/workflows.py
+++ b/st2actions/st2actions/workflows/workflows.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/tests/integration/test_action_state_consumer.py
+++ b/st2actions/tests/integration/test_action_state_consumer.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/tests/integration/test_resultstracker.py
+++ b/st2actions/tests/integration/test_resultstracker.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/tests/unit/policies/test_base.py
+++ b/st2actions/tests/unit/policies/test_base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/tests/unit/policies/test_concurrency.py
+++ b/st2actions/tests/unit/policies/test_concurrency.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/tests/unit/policies/test_concurrency_by_attr.py
+++ b/st2actions/tests/unit/policies/test_concurrency_by_attr.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/tests/unit/policies/test_retry_policy.py
+++ b/st2actions/tests/unit/policies/test_retry_policy.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/tests/unit/test_action_runner_worker.py
+++ b/st2actions/tests/unit/test_action_runner_worker.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/tests/unit/test_actions_registrar.py
+++ b/st2actions/tests/unit/test_actions_registrar.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/tests/unit/test_async_runner.py
+++ b/st2actions/tests/unit/test_async_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/tests/unit/test_execution_cancellation.py
+++ b/st2actions/tests/unit/test_execution_cancellation.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/tests/unit/test_executions.py
+++ b/st2actions/tests/unit/test_executions.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/tests/unit/test_notifier.py
+++ b/st2actions/tests/unit/test_notifier.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/tests/unit/test_parallel_ssh.py
+++ b/st2actions/tests/unit/test_parallel_ssh.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/tests/unit/test_paramiko_remote_script_runner.py
+++ b/st2actions/tests/unit/test_paramiko_remote_script_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/tests/unit/test_paramiko_ssh.py
+++ b/st2actions/tests/unit/test_paramiko_ssh.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/tests/unit/test_paramiko_ssh_runner.py
+++ b/st2actions/tests/unit/test_paramiko_ssh_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/tests/unit/test_policies.py
+++ b/st2actions/tests/unit/test_policies.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/tests/unit/test_polling_async_runner.py
+++ b/st2actions/tests/unit/test_polling_async_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/tests/unit/test_queue_consumers.py
+++ b/st2actions/tests/unit/test_queue_consumers.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/tests/unit/test_remote_runners.py
+++ b/st2actions/tests/unit/test_remote_runners.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/tests/unit/test_runner_container.py
+++ b/st2actions/tests/unit/test_runner_container.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/tests/unit/test_scheduler.py
+++ b/st2actions/tests/unit/test_scheduler.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/tests/unit/test_scheduler_entrypoint.py
+++ b/st2actions/tests/unit/test_scheduler_entrypoint.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/tests/unit/test_scheduler_retry.py
+++ b/st2actions/tests/unit/test_scheduler_retry.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/tests/unit/test_worker.py
+++ b/st2actions/tests/unit/test_worker.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2actions/tests/unit/test_workflow_engine.py
+++ b/st2actions/tests/unit/test_workflow_engine.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/dist_utils.py
+++ b/st2api/dist_utils.py
@@ -3,6 +3,7 @@
 #       Instead modify scripts/dist_utils.py and run 'make .sdist-requirements' to
 #       update dist_utils.py files for all components
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/setup.py
+++ b/st2api/setup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/__init__.py
+++ b/st2api/st2api/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/app.py
+++ b/st2api/st2api/app.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/cmd/__init__.py
+++ b/st2api/st2api/cmd/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/cmd/api.py
+++ b/st2api/st2api/cmd/api.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/config.py
+++ b/st2api/st2api/config.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/base.py
+++ b/st2api/st2api/controllers/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/controller_transforms.py
+++ b/st2api/st2api/controllers/controller_transforms.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/exp/validation.py
+++ b/st2api/st2api/controllers/exp/validation.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/root.py
+++ b/st2api/st2api/controllers/root.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/action_views.py
+++ b/st2api/st2api/controllers/v1/action_views.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/actionalias.py
+++ b/st2api/st2api/controllers/v1/actionalias.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/aliasexecution.py
+++ b/st2api/st2api/controllers/v1/aliasexecution.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/auth.py
+++ b/st2api/st2api/controllers/v1/auth.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/execution_views.py
+++ b/st2api/st2api/controllers/v1/execution_views.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/inquiries.py
+++ b/st2api/st2api/controllers/v1/inquiries.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/keyvalue.py
+++ b/st2api/st2api/controllers/v1/keyvalue.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/pack_config_schemas.py
+++ b/st2api/st2api/controllers/v1/pack_config_schemas.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/pack_configs.py
+++ b/st2api/st2api/controllers/v1/pack_configs.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/pack_views.py
+++ b/st2api/st2api/controllers/v1/pack_views.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/packs.py
+++ b/st2api/st2api/controllers/v1/packs.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/policies.py
+++ b/st2api/st2api/controllers/v1/policies.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/rbac.py
+++ b/st2api/st2api/controllers/v1/rbac.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/rule_enforcement_views.py
+++ b/st2api/st2api/controllers/v1/rule_enforcement_views.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/rule_enforcements.py
+++ b/st2api/st2api/controllers/v1/rule_enforcements.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/rule_views.py
+++ b/st2api/st2api/controllers/v1/rule_views.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/rules.py
+++ b/st2api/st2api/controllers/v1/rules.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/ruletypes.py
+++ b/st2api/st2api/controllers/v1/ruletypes.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/runnertypes.py
+++ b/st2api/st2api/controllers/v1/runnertypes.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/sensors.py
+++ b/st2api/st2api/controllers/v1/sensors.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/service_registry.py
+++ b/st2api/st2api/controllers/v1/service_registry.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/timers.py
+++ b/st2api/st2api/controllers/v1/timers.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/traces.py
+++ b/st2api/st2api/controllers/v1/traces.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/user.py
+++ b/st2api/st2api/controllers/v1/user.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/webhooks.py
+++ b/st2api/st2api/controllers/v1/webhooks.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/controllers/v1/workflow_inspection.py
+++ b/st2api/st2api/controllers/v1/workflow_inspection.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/validation.py
+++ b/st2api/st2api/validation.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/st2api/wsgi.py
+++ b/st2api/st2api/wsgi.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/__init__.py
+++ b/st2api/tests/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/integration/test_gunicorn_configs.py
+++ b/st2api/tests/integration/test_gunicorn_configs.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/exp/test_validator_mistral.py
+++ b/st2api/tests/unit/controllers/exp/test_validator_mistral.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/test_root.py
+++ b/st2api/tests/unit/controllers/test_root.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_action_alias.py
+++ b/st2api/tests/unit/controllers/v1/test_action_alias.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_action_views.py
+++ b/st2api/tests/unit/controllers/v1/test_action_views.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_actions.py
+++ b/st2api/tests/unit/controllers/v1/test_actions.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_alias_execution.py
+++ b/st2api/tests/unit/controllers/v1/test_alias_execution.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_auth.py
+++ b/st2api/tests/unit/controllers/v1/test_auth.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_auth_api_keys.py
+++ b/st2api/tests/unit/controllers/v1/test_auth_api_keys.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_base.py
+++ b/st2api/tests/unit/controllers/v1/test_base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_executions.py
+++ b/st2api/tests/unit/controllers/v1/test_executions.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_executions_auth.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_auth.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_executions_descendants.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_descendants.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_executions_filters.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_filters.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_inquiries.py
+++ b/st2api/tests/unit/controllers/v1/test_inquiries.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_kvps.py
+++ b/st2api/tests/unit/controllers/v1/test_kvps.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_pack_config_schema.py
+++ b/st2api/tests/unit/controllers/v1/test_pack_config_schema.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_pack_configs.py
+++ b/st2api/tests/unit/controllers/v1/test_pack_configs.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_packs.py
+++ b/st2api/tests/unit/controllers/v1/test_packs.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_packs_views.py
+++ b/st2api/tests/unit/controllers/v1/test_packs_views.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_policies.py
+++ b/st2api/tests/unit/controllers/v1/test_policies.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_rule_enforcement_views.py
+++ b/st2api/tests/unit/controllers/v1/test_rule_enforcement_views.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_rule_enforcements.py
+++ b/st2api/tests/unit/controllers/v1/test_rule_enforcements.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_rule_views.py
+++ b/st2api/tests/unit/controllers/v1/test_rule_views.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_rules.py
+++ b/st2api/tests/unit/controllers/v1/test_rules.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_ruletypes.py
+++ b/st2api/tests/unit/controllers/v1/test_ruletypes.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_runnertypes.py
+++ b/st2api/tests/unit/controllers/v1/test_runnertypes.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_sensortypes.py
+++ b/st2api/tests/unit/controllers/v1/test_sensortypes.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_service_registry.py
+++ b/st2api/tests/unit/controllers/v1/test_service_registry.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_timers.py
+++ b/st2api/tests/unit/controllers/v1/test_timers.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_traces.py
+++ b/st2api/tests/unit/controllers/v1/test_traces.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_triggerinstances.py
+++ b/st2api/tests/unit/controllers/v1/test_triggerinstances.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_triggers.py
+++ b/st2api/tests/unit/controllers/v1/test_triggers.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_triggertypes.py
+++ b/st2api/tests/unit/controllers/v1/test_triggertypes.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_webhooks.py
+++ b/st2api/tests/unit/controllers/v1/test_webhooks.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/controllers/v1/test_workflow_inspection.py
+++ b/st2api/tests/unit/controllers/v1/test_workflow_inspection.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2api/tests/unit/test_validation_utils.py
+++ b/st2api/tests/unit/test_validation_utils.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2auth/dist_utils.py
+++ b/st2auth/dist_utils.py
@@ -3,6 +3,7 @@
 #       Instead modify scripts/dist_utils.py and run 'make .sdist-requirements' to
 #       update dist_utils.py files for all components
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2auth/setup.py
+++ b/st2auth/setup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2auth/st2auth/__init__.py
+++ b/st2auth/st2auth/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2auth/st2auth/app.py
+++ b/st2auth/st2auth/app.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2auth/st2auth/backends/__init__.py
+++ b/st2auth/st2auth/backends/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2auth/st2auth/backends/base.py
+++ b/st2auth/st2auth/backends/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2auth/st2auth/backends/constants.py
+++ b/st2auth/st2auth/backends/constants.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2auth/st2auth/cmd/api.py
+++ b/st2auth/st2auth/cmd/api.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2auth/st2auth/config.py
+++ b/st2auth/st2auth/config.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2auth/st2auth/controllers/v1/auth.py
+++ b/st2auth/st2auth/controllers/v1/auth.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2auth/st2auth/controllers/v1/root.py
+++ b/st2auth/st2auth/controllers/v1/root.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2auth/st2auth/handlers.py
+++ b/st2auth/st2auth/handlers.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2auth/st2auth/validation.py
+++ b/st2auth/st2auth/validation.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2auth/st2auth/wsgi.py
+++ b/st2auth/st2auth/wsgi.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2auth/tests/base.py
+++ b/st2auth/tests/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2auth/tests/unit/controllers/v1/test_token.py
+++ b/st2auth/tests/unit/controllers/v1/test_token.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2auth/tests/unit/test_auth_backends.py
+++ b/st2auth/tests/unit/test_auth_backends.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2auth/tests/unit/test_handlers.py
+++ b/st2auth/tests/unit/test_handlers.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2auth/tests/unit/test_validation_utils.py
+++ b/st2auth/tests/unit/test_validation_utils.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/LICENSE
+++ b/st2client/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2020 The StackStorm Authors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/st2client/dist_utils.py
+++ b/st2client/dist_utils.py
@@ -3,6 +3,7 @@
 #       Instead modify scripts/dist_utils.py and run 'make .sdist-requirements' to
 #       update dist_utils.py files for all components
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/setup.py
+++ b/st2client/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python2.7
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/__init__.py
+++ b/st2client/st2client/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/base.py
+++ b/st2client/st2client/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/client.py
+++ b/st2client/st2client/client.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/commands/__init__.py
+++ b/st2client/st2client/commands/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/commands/action_alias.py
+++ b/st2client/st2client/commands/action_alias.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/commands/auth.py
+++ b/st2client/st2client/commands/auth.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/commands/inquiry.py
+++ b/st2client/st2client/commands/inquiry.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/commands/keyvalue.py
+++ b/st2client/st2client/commands/keyvalue.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/commands/noop.py
+++ b/st2client/st2client/commands/noop.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/commands/policy.py
+++ b/st2client/st2client/commands/policy.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/commands/rbac.py
+++ b/st2client/st2client/commands/rbac.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/commands/resource.py
+++ b/st2client/st2client/commands/resource.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/commands/rule.py
+++ b/st2client/st2client/commands/rule.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/commands/rule_enforcement.py
+++ b/st2client/st2client/commands/rule_enforcement.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/commands/sensor.py
+++ b/st2client/st2client/commands/sensor.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/commands/service_registry.py
+++ b/st2client/st2client/commands/service_registry.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/commands/timer.py
+++ b/st2client/st2client/commands/timer.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/commands/trace.py
+++ b/st2client/st2client/commands/trace.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/commands/trigger.py
+++ b/st2client/st2client/commands/trigger.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/commands/triggerinstance.py
+++ b/st2client/st2client/commands/triggerinstance.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/commands/webhook.py
+++ b/st2client/st2client/commands/webhook.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/commands/workflow.py
+++ b/st2client/st2client/commands/workflow.py
@@ -1,4 +1,5 @@
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/config.py
+++ b/st2client/st2client/config.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/config_parser.py
+++ b/st2client/st2client/config_parser.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/exceptions/base.py
+++ b/st2client/st2client/exceptions/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/exceptions/operations.py
+++ b/st2client/st2client/exceptions/operations.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/formatters/__init__.py
+++ b/st2client/st2client/formatters/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/formatters/doc.py
+++ b/st2client/st2client/formatters/doc.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/formatters/execution.py
+++ b/st2client/st2client/formatters/execution.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/formatters/table.py
+++ b/st2client/st2client/formatters/table.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/models/__init__.py
+++ b/st2client/st2client/models/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/models/action.py
+++ b/st2client/st2client/models/action.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/models/action_alias.py
+++ b/st2client/st2client/models/action_alias.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/models/aliasexecution.py
+++ b/st2client/st2client/models/aliasexecution.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/models/auth.py
+++ b/st2client/st2client/models/auth.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/models/config.py
+++ b/st2client/st2client/models/config.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/models/inquiry.py
+++ b/st2client/st2client/models/inquiry.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/models/keyvalue.py
+++ b/st2client/st2client/models/keyvalue.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/models/pack.py
+++ b/st2client/st2client/models/pack.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/models/policy.py
+++ b/st2client/st2client/models/policy.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/models/rbac.py
+++ b/st2client/st2client/models/rbac.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/models/reactor.py
+++ b/st2client/st2client/models/reactor.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/models/service_registry.py
+++ b/st2client/st2client/models/service_registry.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/models/timer.py
+++ b/st2client/st2client/models/timer.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/models/trace.py
+++ b/st2client/st2client/models/trace.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/models/webhook.py
+++ b/st2client/st2client/models/webhook.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/utils/color.py
+++ b/st2client/st2client/utils/color.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/utils/date.py
+++ b/st2client/st2client/utils/date.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/utils/httpclient.py
+++ b/st2client/st2client/utils/httpclient.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/utils/interactive.py
+++ b/st2client/st2client/utils/interactive.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/utils/jsutil.py
+++ b/st2client/st2client/utils/jsutil.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/utils/logging.py
+++ b/st2client/st2client/utils/logging.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/utils/misc.py
+++ b/st2client/st2client/utils/misc.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/utils/schema.py
+++ b/st2client/st2client/utils/schema.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/utils/strutil.py
+++ b/st2client/st2client/utils/strutil.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/utils/terminal.py
+++ b/st2client/st2client/utils/terminal.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/st2client/utils/types.py
+++ b/st2client/st2client/utils/types.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/tests/base.py
+++ b/st2client/tests/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/tests/fixtures/loader.py
+++ b/st2client/tests/fixtures/loader.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/tests/unit/test_action.py
+++ b/st2client/tests/unit/test_action.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/tests/unit/test_app.py
+++ b/st2client/tests/unit/test_app.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/tests/unit/test_auth.py
+++ b/st2client/tests/unit/test_auth.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/tests/unit/test_client.py
+++ b/st2client/tests/unit/test_client.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/tests/unit/test_client_actions.py
+++ b/st2client/tests/unit/test_client_actions.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/tests/unit/test_client_executions.py
+++ b/st2client/tests/unit/test_client_executions.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/tests/unit/test_command_actionrun.py
+++ b/st2client/tests/unit/test_command_actionrun.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/tests/unit/test_commands.py
+++ b/st2client/tests/unit/test_commands.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/tests/unit/test_config_parser.py
+++ b/st2client/tests/unit/test_config_parser.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/tests/unit/test_execution_tail_command.py
+++ b/st2client/tests/unit/test_execution_tail_command.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/tests/unit/test_formatters.py
+++ b/st2client/tests/unit/test_formatters.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/tests/unit/test_inquiry.py
+++ b/st2client/tests/unit/test_inquiry.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/tests/unit/test_interactive.py
+++ b/st2client/tests/unit/test_interactive.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/tests/unit/test_keyvalue.py
+++ b/st2client/tests/unit/test_keyvalue.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/tests/unit/test_models.py
+++ b/st2client/tests/unit/test_models.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/tests/unit/test_shell.py
+++ b/st2client/tests/unit/test_shell.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/tests/unit/test_ssl.py
+++ b/st2client/tests/unit/test_ssl.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/tests/unit/test_trace_commands.py
+++ b/st2client/tests/unit/test_trace_commands.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/tests/unit/test_util_date.py
+++ b/st2client/tests/unit/test_util_date.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/tests/unit/test_util_json.py
+++ b/st2client/tests/unit/test_util_json.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/tests/unit/test_util_misc.py
+++ b/st2client/tests/unit/test_util_misc.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/tests/unit/test_util_strutil.py
+++ b/st2client/tests/unit/test_util_strutil.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/tests/unit/test_util_terminal.py
+++ b/st2client/tests/unit/test_util_terminal.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2client/tests/unit/test_workflow.py
+++ b/st2client/tests/unit/test_workflow.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/bin/migrations/v1.5/st2-migrate-datastore-to-include-scope-secret.py
+++ b/st2common/bin/migrations/v1.5/st2-migrate-datastore-to-include-scope-secret.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/bin/migrations/v2.1/st2-migrate-datastore-scopes.py
+++ b/st2common/bin/migrations/v2.1/st2-migrate-datastore-scopes.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/bin/migrations/v3.1/st2-cleanup-policy-delayed.py
+++ b/st2common/bin/migrations/v3.1/st2-cleanup-policy-delayed.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/bin/paramiko_ssh_evenlets_tester.py
+++ b/st2common/bin/paramiko_ssh_evenlets_tester.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python2.7
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/dist_utils.py
+++ b/st2common/dist_utils.py
@@ -3,6 +3,7 @@
 #       Instead modify scripts/dist_utils.py and run 'make .sdist-requirements' to
 #       update dist_utils.py files for all components
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/setup.py
+++ b/st2common/setup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/__init__.py
+++ b/st2common/st2common/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/__init__.py
+++ b/st2common/st2common/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 StackStorm Authors.
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/bootstrap/actionsregistrar.py
+++ b/st2common/st2common/bootstrap/actionsregistrar.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/bootstrap/aliasesregistrar.py
+++ b/st2common/st2common/bootstrap/aliasesregistrar.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/bootstrap/base.py
+++ b/st2common/st2common/bootstrap/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/bootstrap/configsregistrar.py
+++ b/st2common/st2common/bootstrap/configsregistrar.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/bootstrap/policiesregistrar.py
+++ b/st2common/st2common/bootstrap/policiesregistrar.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/bootstrap/rulesregistrar.py
+++ b/st2common/st2common/bootstrap/rulesregistrar.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/bootstrap/ruletypesregistrar.py
+++ b/st2common/st2common/bootstrap/ruletypesregistrar.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/bootstrap/runnersregistrar.py
+++ b/st2common/st2common/bootstrap/runnersregistrar.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/bootstrap/sensorsregistrar.py
+++ b/st2common/st2common/bootstrap/sensorsregistrar.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/bootstrap/triggersregistrar.py
+++ b/st2common/st2common/bootstrap/triggersregistrar.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/callback/base.py
+++ b/st2common/st2common/callback/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/cmd/download_pack.py
+++ b/st2common/st2common/cmd/download_pack.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/cmd/generate_api_spec.py
+++ b/st2common/st2common/cmd/generate_api_spec.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/cmd/install_pack.py
+++ b/st2common/st2common/cmd/install_pack.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/cmd/purge_executions.py
+++ b/st2common/st2common/cmd/purge_executions.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/cmd/purge_trigger_instances.py
+++ b/st2common/st2common/cmd/purge_trigger_instances.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/cmd/setup_pack_virtualenv.py
+++ b/st2common/st2common/cmd/setup_pack_virtualenv.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/cmd/validate_api_spec.py
+++ b/st2common/st2common/cmd/validate_api_spec.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/cmd/validate_config.py
+++ b/st2common/st2common/cmd/validate_config.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/constants/action.py
+++ b/st2common/st2common/constants/action.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/constants/api.py
+++ b/st2common/st2common/constants/api.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/constants/auth.py
+++ b/st2common/st2common/constants/auth.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/constants/error_messages.py
+++ b/st2common/st2common/constants/error_messages.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/constants/exit_codes.py
+++ b/st2common/st2common/constants/exit_codes.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/constants/garbage_collection.py
+++ b/st2common/st2common/constants/garbage_collection.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/constants/keyvalue.py
+++ b/st2common/st2common/constants/keyvalue.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/constants/logging.py
+++ b/st2common/st2common/constants/logging.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/constants/meta.py
+++ b/st2common/st2common/constants/meta.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/constants/pack.py
+++ b/st2common/st2common/constants/pack.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/constants/policy.py
+++ b/st2common/st2common/constants/policy.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/constants/rule_enforcement.py
+++ b/st2common/st2common/constants/rule_enforcement.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/constants/rules.py
+++ b/st2common/st2common/constants/rules.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/constants/runners.py
+++ b/st2common/st2common/constants/runners.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/constants/scheduler.py
+++ b/st2common/st2common/constants/scheduler.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/constants/secrets.py
+++ b/st2common/st2common/constants/secrets.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/constants/sensors.py
+++ b/st2common/st2common/constants/sensors.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/constants/system.py
+++ b/st2common/st2common/constants/system.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/constants/timer.py
+++ b/st2common/st2common/constants/timer.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/constants/trace.py
+++ b/st2common/st2common/constants/trace.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/constants/triggers.py
+++ b/st2common/st2common/constants/triggers.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/constants/types.py
+++ b/st2common/st2common/constants/types.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/content/loader.py
+++ b/st2common/st2common/content/loader.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/content/utils.py
+++ b/st2common/st2common/content/utils.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/content/validators.py
+++ b/st2common/st2common/content/validators.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/database_setup.py
+++ b/st2common/st2common/database_setup.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/exceptions/__init__.py
+++ b/st2common/st2common/exceptions/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/exceptions/action.py
+++ b/st2common/st2common/exceptions/action.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/exceptions/actionalias.py
+++ b/st2common/st2common/exceptions/actionalias.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/exceptions/actionrunner.py
+++ b/st2common/st2common/exceptions/actionrunner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/exceptions/api.py
+++ b/st2common/st2common/exceptions/api.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/exceptions/apivalidation.py
+++ b/st2common/st2common/exceptions/apivalidation.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/exceptions/auth.py
+++ b/st2common/st2common/exceptions/auth.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/exceptions/connection.py
+++ b/st2common/st2common/exceptions/connection.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/exceptions/content.py
+++ b/st2common/st2common/exceptions/content.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/exceptions/db.py
+++ b/st2common/st2common/exceptions/db.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/exceptions/inquiry.py
+++ b/st2common/st2common/exceptions/inquiry.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/exceptions/keyvalue.py
+++ b/st2common/st2common/exceptions/keyvalue.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/exceptions/param.py
+++ b/st2common/st2common/exceptions/param.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/exceptions/plugins.py
+++ b/st2common/st2common/exceptions/plugins.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/exceptions/rbac.py
+++ b/st2common/st2common/exceptions/rbac.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/exceptions/resultstracker.py
+++ b/st2common/st2common/exceptions/resultstracker.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/exceptions/sensors.py
+++ b/st2common/st2common/exceptions/sensors.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/exceptions/ssh.py
+++ b/st2common/st2common/exceptions/ssh.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/exceptions/trace.py
+++ b/st2common/st2common/exceptions/trace.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/exceptions/triggers.py
+++ b/st2common/st2common/exceptions/triggers.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/exceptions/workflow.py
+++ b/st2common/st2common/exceptions/workflow.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/expressions/functions/data.py
+++ b/st2common/st2common/expressions/functions/data.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/expressions/functions/datastore.py
+++ b/st2common/st2common/expressions/functions/datastore.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/expressions/functions/path.py
+++ b/st2common/st2common/expressions/functions/path.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/expressions/functions/regex.py
+++ b/st2common/st2common/expressions/functions/regex.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/expressions/functions/time.py
+++ b/st2common/st2common/expressions/functions/time.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/expressions/functions/version.py
+++ b/st2common/st2common/expressions/functions/version.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/fields.py
+++ b/st2common/st2common/fields.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/garbage_collection/executions.py
+++ b/st2common/st2common/garbage_collection/executions.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/garbage_collection/inquiries.py
+++ b/st2common/st2common/garbage_collection/inquiries.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/garbage_collection/trigger_instances.py
+++ b/st2common/st2common/garbage_collection/trigger_instances.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/log.py
+++ b/st2common/st2common/log.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/logging/filters.py
+++ b/st2common/st2common/logging/filters.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/logging/formatters.py
+++ b/st2common/st2common/logging/formatters.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/logging/handlers.py
+++ b/st2common/st2common/logging/handlers.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/logging/misc.py
+++ b/st2common/st2common/logging/misc.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/metrics/__init__.py
+++ b/st2common/st2common/metrics/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/metrics/base.py
+++ b/st2common/st2common/metrics/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/metrics/drivers/__init__.py
+++ b/st2common/st2common/metrics/drivers/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/metrics/drivers/echo_driver.py
+++ b/st2common/st2common/metrics/drivers/echo_driver.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/metrics/drivers/noop_driver.py
+++ b/st2common/st2common/metrics/drivers/noop_driver.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/metrics/drivers/statsd_driver.py
+++ b/st2common/st2common/metrics/drivers/statsd_driver.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/metrics/utils.py
+++ b/st2common/st2common/metrics/utils.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/middleware/cors.py
+++ b/st2common/st2common/middleware/cors.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/middleware/error_handling.py
+++ b/st2common/st2common/middleware/error_handling.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/middleware/instrumentation.py
+++ b/st2common/st2common/middleware/instrumentation.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/middleware/logging.py
+++ b/st2common/st2common/middleware/logging.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/middleware/request_id.py
+++ b/st2common/st2common/middleware/request_id.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/middleware/streaming.py
+++ b/st2common/st2common/middleware/streaming.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/api/actionrunner.py
+++ b/st2common/st2common/models/api/actionrunner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/api/auth.py
+++ b/st2common/st2common/models/api/auth.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/api/base.py
+++ b/st2common/st2common/models/api/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/api/execution.py
+++ b/st2common/st2common/models/api/execution.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/api/inquiry.py
+++ b/st2common/st2common/models/api/inquiry.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/api/keyvalue.py
+++ b/st2common/st2common/models/api/keyvalue.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/api/notification.py
+++ b/st2common/st2common/models/api/notification.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/api/policy.py
+++ b/st2common/st2common/models/api/policy.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/api/rbac.py
+++ b/st2common/st2common/models/api/rbac.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/api/rule.py
+++ b/st2common/st2common/models/api/rule.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/api/rule_enforcement.py
+++ b/st2common/st2common/models/api/rule_enforcement.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/api/sensor.py
+++ b/st2common/st2common/models/api/sensor.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/api/tag.py
+++ b/st2common/st2common/models/api/tag.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/api/trace.py
+++ b/st2common/st2common/models/api/trace.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/api/trigger.py
+++ b/st2common/st2common/models/api/trigger.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/api/webhook.py
+++ b/st2common/st2common/models/api/webhook.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/base.py
+++ b/st2common/st2common/models/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/db/action.py
+++ b/st2common/st2common/models/db/action.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/db/actionalias.py
+++ b/st2common/st2common/models/db/actionalias.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/db/auth.py
+++ b/st2common/st2common/models/db/auth.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/db/execution.py
+++ b/st2common/st2common/models/db/execution.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/db/execution_queue.py
+++ b/st2common/st2common/models/db/execution_queue.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/db/executionstate.py
+++ b/st2common/st2common/models/db/executionstate.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/db/keyvalue.py
+++ b/st2common/st2common/models/db/keyvalue.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/db/liveaction.py
+++ b/st2common/st2common/models/db/liveaction.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/db/marker.py
+++ b/st2common/st2common/models/db/marker.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/db/notification.py
+++ b/st2common/st2common/models/db/notification.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/db/pack.py
+++ b/st2common/st2common/models/db/pack.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/db/policy.py
+++ b/st2common/st2common/models/db/policy.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/db/rbac.py
+++ b/st2common/st2common/models/db/rbac.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/db/reactor.py
+++ b/st2common/st2common/models/db/reactor.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/db/rule.py
+++ b/st2common/st2common/models/db/rule.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/db/rule_enforcement.py
+++ b/st2common/st2common/models/db/rule_enforcement.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/db/runner.py
+++ b/st2common/st2common/models/db/runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/db/sensor.py
+++ b/st2common/st2common/models/db/sensor.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/db/stormbase.py
+++ b/st2common/st2common/models/db/stormbase.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/db/timer.py
+++ b/st2common/st2common/models/db/timer.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/db/trace.py
+++ b/st2common/st2common/models/db/trace.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/db/trigger.py
+++ b/st2common/st2common/models/db/trigger.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/db/webhook.py
+++ b/st2common/st2common/models/db/webhook.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/db/workflow.py
+++ b/st2common/st2common/models/db/workflow.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/system/action.py
+++ b/st2common/st2common/models/system/action.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/system/actionchain.py
+++ b/st2common/st2common/models/system/actionchain.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/system/common.py
+++ b/st2common/st2common/models/system/common.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/system/keyvalue.py
+++ b/st2common/st2common/models/system/keyvalue.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/system/paramiko_command_action.py
+++ b/st2common/st2common/models/system/paramiko_command_action.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/system/paramiko_script_action.py
+++ b/st2common/st2common/models/system/paramiko_script_action.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/utils/action_alias_utils.py
+++ b/st2common/st2common/models/utils/action_alias_utils.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/utils/action_param_utils.py
+++ b/st2common/st2common/models/utils/action_param_utils.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/utils/profiling.py
+++ b/st2common/st2common/models/utils/profiling.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/models/utils/sensor_type_utils.py
+++ b/st2common/st2common/models/utils/sensor_type_utils.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/operators.py
+++ b/st2common/st2common/operators.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/persistence/action.py
+++ b/st2common/st2common/persistence/action.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/persistence/actionalias.py
+++ b/st2common/st2common/persistence/actionalias.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/persistence/auth.py
+++ b/st2common/st2common/persistence/auth.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/persistence/base.py
+++ b/st2common/st2common/persistence/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/persistence/cleanup.py
+++ b/st2common/st2common/persistence/cleanup.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/persistence/db_init.py
+++ b/st2common/st2common/persistence/db_init.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/persistence/execution.py
+++ b/st2common/st2common/persistence/execution.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/persistence/execution_queue.py
+++ b/st2common/st2common/persistence/execution_queue.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/persistence/executionstate.py
+++ b/st2common/st2common/persistence/executionstate.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/persistence/keyvalue.py
+++ b/st2common/st2common/persistence/keyvalue.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/persistence/liveaction.py
+++ b/st2common/st2common/persistence/liveaction.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/persistence/marker.py
+++ b/st2common/st2common/persistence/marker.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/persistence/pack.py
+++ b/st2common/st2common/persistence/pack.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/persistence/policy.py
+++ b/st2common/st2common/persistence/policy.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/persistence/rbac.py
+++ b/st2common/st2common/persistence/rbac.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/persistence/reactor.py
+++ b/st2common/st2common/persistence/reactor.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/persistence/rule.py
+++ b/st2common/st2common/persistence/rule.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/persistence/rule_enforcement.py
+++ b/st2common/st2common/persistence/rule_enforcement.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/persistence/runner.py
+++ b/st2common/st2common/persistence/runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/persistence/sensor.py
+++ b/st2common/st2common/persistence/sensor.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/persistence/trace.py
+++ b/st2common/st2common/persistence/trace.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/persistence/trigger.py
+++ b/st2common/st2common/persistence/trigger.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/persistence/workflow.py
+++ b/st2common/st2common/persistence/workflow.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/policies/__init__.py
+++ b/st2common/st2common/policies/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/policies/base.py
+++ b/st2common/st2common/policies/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/policies/concurrency.py
+++ b/st2common/st2common/policies/concurrency.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/query/base.py
+++ b/st2common/st2common/query/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/rbac/backends/__init__.py
+++ b/st2common/st2common/rbac/backends/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/rbac/backends/base.py
+++ b/st2common/st2common/rbac/backends/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/rbac/backends/noop.py
+++ b/st2common/st2common/rbac/backends/noop.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/rbac/migrations.py
+++ b/st2common/st2common/rbac/migrations.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/router.py
+++ b/st2common/st2common/router.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/runners/__init__.py
+++ b/st2common/st2common/runners/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/runners/base.py
+++ b/st2common/st2common/runners/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/runners/base_action.py
+++ b/st2common/st2common/runners/base_action.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/runners/parallel_ssh.py
+++ b/st2common/st2common/runners/parallel_ssh.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/runners/paramiko_ssh.py
+++ b/st2common/st2common/runners/paramiko_ssh.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/runners/paramiko_ssh_runner.py
+++ b/st2common/st2common/runners/paramiko_ssh_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/runners/utils.py
+++ b/st2common/st2common/runners/utils.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/script_setup.py
+++ b/st2common/st2common/script_setup.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/service_setup.py
+++ b/st2common/st2common/service_setup.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/services/access.py
+++ b/st2common/st2common/services/access.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/services/action.py
+++ b/st2common/st2common/services/action.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/services/config.py
+++ b/st2common/st2common/services/config.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/services/coordination.py
+++ b/st2common/st2common/services/coordination.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/services/datastore.py
+++ b/st2common/st2common/services/datastore.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/services/executions.py
+++ b/st2common/st2common/services/executions.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/services/inquiry.py
+++ b/st2common/st2common/services/inquiry.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/services/keyvalues.py
+++ b/st2common/st2common/services/keyvalues.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/services/packs.py
+++ b/st2common/st2common/services/packs.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/services/policies.py
+++ b/st2common/st2common/services/policies.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/services/queries.py
+++ b/st2common/st2common/services/queries.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/services/rules.py
+++ b/st2common/st2common/services/rules.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/services/sensor_watcher.py
+++ b/st2common/st2common/services/sensor_watcher.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/services/trace.py
+++ b/st2common/st2common/services/trace.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/services/trigger_dispatcher.py
+++ b/st2common/st2common/services/trigger_dispatcher.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/services/triggers.py
+++ b/st2common/st2common/services/triggers.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/services/triggerwatcher.py
+++ b/st2common/st2common/services/triggerwatcher.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/services/workflows.py
+++ b/st2common/st2common/services/workflows.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/signal_handlers.py
+++ b/st2common/st2common/signal_handlers.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/stream/listener.py
+++ b/st2common/st2common/stream/listener.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/transport/__init__.py
+++ b/st2common/st2common/transport/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/transport/actionexecutionstate.py
+++ b/st2common/st2common/transport/actionexecutionstate.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/transport/announcement.py
+++ b/st2common/st2common/transport/announcement.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/transport/bootstrap.py
+++ b/st2common/st2common/transport/bootstrap.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/transport/bootstrap_utils.py
+++ b/st2common/st2common/transport/bootstrap_utils.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/transport/connection_retry_wrapper.py
+++ b/st2common/st2common/transport/connection_retry_wrapper.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/transport/consumers.py
+++ b/st2common/st2common/transport/consumers.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/transport/execution.py
+++ b/st2common/st2common/transport/execution.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/transport/liveaction.py
+++ b/st2common/st2common/transport/liveaction.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/transport/publishers.py
+++ b/st2common/st2common/transport/publishers.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/transport/queues.py
+++ b/st2common/st2common/transport/queues.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/transport/reactor.py
+++ b/st2common/st2common/transport/reactor.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/transport/utils.py
+++ b/st2common/st2common/transport/utils.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/transport/workflow.py
+++ b/st2common/st2common/transport/workflow.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/triggers.py
+++ b/st2common/st2common/triggers.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/action_db.py
+++ b/st2common/st2common/util/action_db.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/actionalias_helpstring.py
+++ b/st2common/st2common/util/actionalias_helpstring.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/actionalias_matching.py
+++ b/st2common/st2common/util/actionalias_matching.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/api.py
+++ b/st2common/st2common/util/api.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/argument_parser.py
+++ b/st2common/st2common/util/argument_parser.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/auth.py
+++ b/st2common/st2common/util/auth.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/casts.py
+++ b/st2common/st2common/util/casts.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/compat.py
+++ b/st2common/st2common/util/compat.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/concurrency.py
+++ b/st2common/st2common/util/concurrency.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/config_loader.py
+++ b/st2common/st2common/util/config_loader.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/config_parser.py
+++ b/st2common/st2common/util/config_parser.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/crypto.py
+++ b/st2common/st2common/util/crypto.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/date.py
+++ b/st2common/st2common/util/date.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/db.py
+++ b/st2common/st2common/util/db.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/debugging.py
+++ b/st2common/st2common/util/debugging.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/deprecation.py
+++ b/st2common/st2common/util/deprecation.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/driver_loader.py
+++ b/st2common/st2common/util/driver_loader.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/enum.py
+++ b/st2common/st2common/util/enum.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/file_system.py
+++ b/st2common/st2common/util/file_system.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/green/shell.py
+++ b/st2common/st2common/util/green/shell.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/greenpooldispatch.py
+++ b/st2common/st2common/util/greenpooldispatch.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/gunicorn_workers.py
+++ b/st2common/st2common/util/gunicorn_workers.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/hash.py
+++ b/st2common/st2common/util/hash.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/http.py
+++ b/st2common/st2common/util/http.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/ip_utils.py
+++ b/st2common/st2common/util/ip_utils.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/isotime.py
+++ b/st2common/st2common/util/isotime.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/jinja.py
+++ b/st2common/st2common/util/jinja.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/jsonify.py
+++ b/st2common/st2common/util/jsonify.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/keyvalue.py
+++ b/st2common/st2common/util/keyvalue.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/loader.py
+++ b/st2common/st2common/util/loader.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/misc.py
+++ b/st2common/st2common/util/misc.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/mongoescape.py
+++ b/st2common/st2common/util/mongoescape.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/monkey_patch.py
+++ b/st2common/st2common/util/monkey_patch.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/output_schema.py
+++ b/st2common/st2common/util/output_schema.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/pack.py
+++ b/st2common/st2common/util/pack.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/pack_management.py
+++ b/st2common/st2common/util/pack_management.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/param.py
+++ b/st2common/st2common/util/param.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/payload.py
+++ b/st2common/st2common/util/payload.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/queues.py
+++ b/st2common/st2common/util/queues.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/reference.py
+++ b/st2common/st2common/util/reference.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/schema/__init__.py
+++ b/st2common/st2common/util/schema/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/secrets.py
+++ b/st2common/st2common/util/secrets.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/service.py
+++ b/st2common/st2common/util/service.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/shell.py
+++ b/st2common/st2common/util/shell.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/spec_loader.py
+++ b/st2common/st2common/util/spec_loader.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/system_info.py
+++ b/st2common/st2common/util/system_info.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/templating.py
+++ b/st2common/st2common/util/templating.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/types.py
+++ b/st2common/st2common/util/types.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/uid.py
+++ b/st2common/st2common/util/uid.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/ujson.py
+++ b/st2common/st2common/util/ujson.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/url.py
+++ b/st2common/st2common/util/url.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/versioning.py
+++ b/st2common/st2common/util/versioning.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/virtualenvs.py
+++ b/st2common/st2common/util/virtualenvs.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/workflow/mistral.py
+++ b/st2common/st2common/util/workflow/mistral.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/util/wsgi.py
+++ b/st2common/st2common/util/wsgi.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/validators/api/action.py
+++ b/st2common/st2common/validators/api/action.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/validators/api/misc.py
+++ b/st2common/st2common/validators/api/misc.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/validators/api/reactor.py
+++ b/st2common/st2common/validators/api/reactor.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/validators/workflow/base.py
+++ b/st2common/st2common/validators/workflow/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/st2common/validators/workflow/mistral/v2.py
+++ b/st2common/st2common/validators/workflow/mistral/v2.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/fixtures/mock_runner/mock_runner.py
+++ b/st2common/tests/fixtures/mock_runner/mock_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/fixtures/version_file.py
+++ b/st2common/tests/fixtures/version_file.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/integration/test_rabbitmq_ssl_listener.py
+++ b/st2common/tests/integration/test_rabbitmq_ssl_listener.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/integration/test_register_content_script.py
+++ b/st2common/tests/integration/test_register_content_script.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/integration/test_service_setup_log_level_filtering.py
+++ b/st2common/tests/integration/test_service_setup_log_level_filtering.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/resources/loadableplugin/plugin/sampleplugin.py
+++ b/st2common/tests/resources/loadableplugin/plugin/sampleplugin.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/resources/loadableplugin/plugin/sampleplugin2.py
+++ b/st2common/tests/resources/loadableplugin/plugin/sampleplugin2.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/resources/loadableplugin/plugin/sampleplugin3.py
+++ b/st2common/tests/resources/loadableplugin/plugin/sampleplugin3.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/resources/loadableplugin/plugin/standaloneplugin.py
+++ b/st2common/tests/resources/loadableplugin/plugin/standaloneplugin.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/resources/loadableplugin/plugin/util/randomutil.py
+++ b/st2common/tests/resources/loadableplugin/plugin/util/randomutil.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/base.py
+++ b/st2common/tests/unit/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/services/test_access.py
+++ b/st2common/tests/unit/services/test_access.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/services/test_action.py
+++ b/st2common/tests/unit/services/test_action.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/services/test_keyvalue.py
+++ b/st2common/tests/unit/services/test_keyvalue.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/services/test_policy.py
+++ b/st2common/tests/unit/services/test_policy.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/services/test_synchronization.py
+++ b/st2common/tests/unit/services/test_synchronization.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/services/test_trace.py
+++ b/st2common/tests/unit/services/test_trace.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/services/test_trace_injection_action_services.py
+++ b/st2common/tests/unit/services/test_trace_injection_action_services.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/services/test_workflow.py
+++ b/st2common/tests/unit/services/test_workflow.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/services/test_workflow_cancellation.py
+++ b/st2common/tests/unit/services/test_workflow_cancellation.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/services/test_workflow_identify_orphans.py
+++ b/st2common/tests/unit/services/test_workflow_identify_orphans.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/services/test_workflow_rerun.py
+++ b/st2common/tests/unit/services/test_workflow_rerun.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/services/test_workflow_service_retries.py
+++ b/st2common/tests/unit/services/test_workflow_service_retries.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_action_alias_utils.py
+++ b/st2common/tests/unit/test_action_alias_utils.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_action_api_validator.py
+++ b/st2common/tests/unit/test_action_api_validator.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_action_db_utils.py
+++ b/st2common/tests/unit/test_action_db_utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_action_param_utils.py
+++ b/st2common/tests/unit/test_action_param_utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_action_system_models.py
+++ b/st2common/tests/unit/test_action_system_models.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_actionchain_schema.py
+++ b/st2common/tests/unit/test_actionchain_schema.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_aliasesregistrar.py
+++ b/st2common/tests/unit/test_aliasesregistrar.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_api_model_validation.py
+++ b/st2common/tests/unit/test_api_model_validation.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_casts.py
+++ b/st2common/tests/unit/test_casts.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_config_loader.py
+++ b/st2common/tests/unit/test_config_loader.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_config_parser.py
+++ b/st2common/tests/unit/test_config_parser.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_configs_registrar.py
+++ b/st2common/tests/unit/test_configs_registrar.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_connection_retry_wrapper.py
+++ b/st2common/tests/unit/test_connection_retry_wrapper.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_content_loader.py
+++ b/st2common/tests/unit/test_content_loader.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_content_utils.py
+++ b/st2common/tests/unit/test_content_utils.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_crypto_utils.py
+++ b/st2common/tests/unit/test_crypto_utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_datastore.py
+++ b/st2common/tests/unit/test_datastore.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_date_utils.py
+++ b/st2common/tests/unit/test_date_utils.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_db.py
+++ b/st2common/tests/unit/test_db.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_db_action_state.py
+++ b/st2common/tests/unit/test_db_action_state.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_db_auth.py
+++ b/st2common/tests/unit/test_db_auth.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_db_base.py
+++ b/st2common/tests/unit/test_db_base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_db_execution.py
+++ b/st2common/tests/unit/test_db_execution.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_db_fields.py
+++ b/st2common/tests/unit/test_db_fields.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_db_liveaction.py
+++ b/st2common/tests/unit/test_db_liveaction.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_db_marker.py
+++ b/st2common/tests/unit/test_db_marker.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_db_model_uids.py
+++ b/st2common/tests/unit/test_db_model_uids.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_db_pack.py
+++ b/st2common/tests/unit/test_db_pack.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_db_policy.py
+++ b/st2common/tests/unit/test_db_policy.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_db_rbac.py
+++ b/st2common/tests/unit/test_db_rbac.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_db_rule_enforcement.py
+++ b/st2common/tests/unit/test_db_rule_enforcement.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_db_task.py
+++ b/st2common/tests/unit/test_db_task.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_db_trace.py
+++ b/st2common/tests/unit/test_db_trace.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_db_uid_mixin.py
+++ b/st2common/tests/unit/test_db_uid_mixin.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_db_workflow.py
+++ b/st2common/tests/unit/test_db_workflow.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_dist_utils.py
+++ b/st2common/tests/unit/test_dist_utils.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_exceptions_workflow.py
+++ b/st2common/tests/unit/test_exceptions_workflow.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_executions.py
+++ b/st2common/tests/unit/test_executions.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_executions_util.py
+++ b/st2common/tests/unit/test_executions_util.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_greenpooldispatch.py
+++ b/st2common/tests/unit/test_greenpooldispatch.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_hash.py
+++ b/st2common/tests/unit/test_hash.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_ip_utils.py
+++ b/st2common/tests/unit/test_ip_utils.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_isotime_utils.py
+++ b/st2common/tests/unit/test_isotime_utils.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_jinja_render_crypto_filters.py
+++ b/st2common/tests/unit/test_jinja_render_crypto_filters.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_jinja_render_data_filters.py
+++ b/st2common/tests/unit/test_jinja_render_data_filters.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_jinja_render_json_escape_filters.py
+++ b/st2common/tests/unit/test_jinja_render_json_escape_filters.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_jinja_render_jsonpath_query_filters.py
+++ b/st2common/tests/unit/test_jinja_render_jsonpath_query_filters.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_jinja_render_path_filters.py
+++ b/st2common/tests/unit/test_jinja_render_path_filters.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_jinja_render_regex_filters.py
+++ b/st2common/tests/unit/test_jinja_render_regex_filters.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_jinja_render_time_filters.py
+++ b/st2common/tests/unit/test_jinja_render_time_filters.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_jinja_render_version_filters.py
+++ b/st2common/tests/unit/test_jinja_render_version_filters.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_json_schema.py
+++ b/st2common/tests/unit/test_json_schema.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_jsonify.py
+++ b/st2common/tests/unit/test_jsonify.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_keyvalue_lookup.py
+++ b/st2common/tests/unit/test_keyvalue_lookup.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_keyvalue_system_model.py
+++ b/st2common/tests/unit/test_keyvalue_system_model.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_logger.py
+++ b/st2common/tests/unit/test_logger.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_logging.py
+++ b/st2common/tests/unit/test_logging.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_logging_middleware.py
+++ b/st2common/tests/unit/test_logging_middleware.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_metrics.py
+++ b/st2common/tests/unit/test_metrics.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_misc_utils.py
+++ b/st2common/tests/unit/test_misc_utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_model_utils_profiling.py
+++ b/st2common/tests/unit/test_model_utils_profiling.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_mongoescape.py
+++ b/st2common/tests/unit/test_mongoescape.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_notification_helper.py
+++ b/st2common/tests/unit/test_notification_helper.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_operators.py
+++ b/st2common/tests/unit/test_operators.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_pack_action_alias_unit_testing_utils.py
+++ b/st2common/tests/unit/test_pack_action_alias_unit_testing_utils.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_pack_management.py
+++ b/st2common/tests/unit/test_pack_management.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_param_utils.py
+++ b/st2common/tests/unit/test_param_utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_paramiko_command_action_model.py
+++ b/st2common/tests/unit/test_paramiko_command_action_model.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_paramiko_script_action_model.py
+++ b/st2common/tests/unit/test_paramiko_script_action_model.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_persistence.py
+++ b/st2common/tests/unit/test_persistence.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_persistence_change_revision.py
+++ b/st2common/tests/unit/test_persistence_change_revision.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_plugin_loader.py
+++ b/st2common/tests/unit/test_plugin_loader.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_policies.py
+++ b/st2common/tests/unit/test_policies.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_policies_registrar.py
+++ b/st2common/tests/unit/test_policies_registrar.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_purge_executions.py
+++ b/st2common/tests/unit/test_purge_executions.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_purge_trigger_instances.py
+++ b/st2common/tests/unit/test_purge_trigger_instances.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_query_base.py
+++ b/st2common/tests/unit/test_query_base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_queue_consumer.py
+++ b/st2common/tests/unit/test_queue_consumer.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_queue_utils.py
+++ b/st2common/tests/unit/test_queue_utils.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_rbac_types.py
+++ b/st2common/tests/unit/test_rbac_types.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_reference.py
+++ b/st2common/tests/unit/test_reference.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_register_internal_trigger.py
+++ b/st2common/tests/unit/test_register_internal_trigger.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_resource_reference.py
+++ b/st2common/tests/unit/test_resource_reference.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_resource_registrar.py
+++ b/st2common/tests/unit/test_resource_registrar.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_runners_base.py
+++ b/st2common/tests/unit/test_runners_base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_runners_utils.py
+++ b/st2common/tests/unit/test_runners_utils.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_sensor_type_utils.py
+++ b/st2common/tests/unit/test_sensor_type_utils.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_sensor_watcher.py
+++ b/st2common/tests/unit/test_sensor_watcher.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_service_setup.py
+++ b/st2common/tests/unit/test_service_setup.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_shell_action_system_model.py
+++ b/st2common/tests/unit/test_shell_action_system_model.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_state_publisher.py
+++ b/st2common/tests/unit/test_state_publisher.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_system_info.py
+++ b/st2common/tests/unit/test_system_info.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_tags.py
+++ b/st2common/tests/unit/test_tags.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_time_jinja_filters.py
+++ b/st2common/tests/unit/test_time_jinja_filters.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_transport.py
+++ b/st2common/tests/unit/test_transport.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_trigger_services.py
+++ b/st2common/tests/unit/test_trigger_services.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_triggers_registrar.py
+++ b/st2common/tests/unit/test_triggers_registrar.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_unit_testing_mocks.py
+++ b/st2common/tests/unit/test_unit_testing_mocks.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_util_actionalias_helpstrings.py
+++ b/st2common/tests/unit/test_util_actionalias_helpstrings.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_util_actionalias_matching.py
+++ b/st2common/tests/unit/test_util_actionalias_matching.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_util_api.py
+++ b/st2common/tests/unit/test_util_api.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_util_compat.py
+++ b/st2common/tests/unit/test_util_compat.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_util_db.py
+++ b/st2common/tests/unit/test_util_db.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_util_file_system.py
+++ b/st2common/tests/unit/test_util_file_system.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_util_http.py
+++ b/st2common/tests/unit/test_util_http.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_util_jinja.py
+++ b/st2common/tests/unit/test_util_jinja.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_util_keyvalue.py
+++ b/st2common/tests/unit/test_util_keyvalue.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_util_mistral_dsl_transform.py
+++ b/st2common/tests/unit/test_util_mistral_dsl_transform.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_util_output_schema.py
+++ b/st2common/tests/unit/test_util_output_schema.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_util_pack.py
+++ b/st2common/tests/unit/test_util_pack.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_util_payload.py
+++ b/st2common/tests/unit/test_util_payload.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_util_sandboxing.py
+++ b/st2common/tests/unit/test_util_sandboxing.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_util_secrets.py
+++ b/st2common/tests/unit/test_util_secrets.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_util_shell.py
+++ b/st2common/tests/unit/test_util_shell.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_util_templating.py
+++ b/st2common/tests/unit/test_util_templating.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_util_types.py
+++ b/st2common/tests/unit/test_util_types.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_util_url.py
+++ b/st2common/tests/unit/test_util_url.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_validator_mistral.py
+++ b/st2common/tests/unit/test_validator_mistral.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_versioning_utils.py
+++ b/st2common/tests/unit/test_versioning_utils.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2common/tests/unit/test_virtualenvs.py
+++ b/st2common/tests/unit/test_virtualenvs.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2debug/dist_utils.py
+++ b/st2debug/dist_utils.py
@@ -3,6 +3,7 @@
 #       Instead modify scripts/dist_utils.py and run 'make .sdist-requirements' to
 #       update dist_utils.py files for all components
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2debug/setup.py
+++ b/st2debug/setup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2debug/st2debug/__init__.py
+++ b/st2debug/st2debug/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2debug/st2debug/cmd/submit_debug_info.py
+++ b/st2debug/st2debug/cmd/submit_debug_info.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2debug/st2debug/constants.py
+++ b/st2debug/st2debug/constants.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2debug/st2debug/processors.py
+++ b/st2debug/st2debug/processors.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2debug/st2debug/utils/fs.py
+++ b/st2debug/st2debug/utils/fs.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2debug/st2debug/utils/git_utils.py
+++ b/st2debug/st2debug/utils/git_utils.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2debug/st2debug/utils/system_info.py
+++ b/st2debug/st2debug/utils/system_info.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2debug/tests/integration/fixtures/content/twilio/actions/send_sms.py
+++ b/st2debug/tests/integration/fixtures/content/twilio/actions/send_sms.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2debug/tests/integration/test_submit_debug_info.py
+++ b/st2debug/tests/integration/test_submit_debug_info.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2debug/tests/unit/test_system_info.py
+++ b/st2debug/tests/unit/test_system_info.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2exporter/dist_utils.py
+++ b/st2exporter/dist_utils.py
@@ -3,6 +3,7 @@
 #       Instead modify scripts/dist_utils.py and run 'make .sdist-requirements' to
 #       update dist_utils.py files for all components
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2exporter/setup.py
+++ b/st2exporter/setup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2exporter/st2exporter/cmd/st2exporter_starter.py
+++ b/st2exporter/st2exporter/cmd/st2exporter_starter.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2exporter/st2exporter/config.py
+++ b/st2exporter/st2exporter/config.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2exporter/st2exporter/exporter/dumper.py
+++ b/st2exporter/st2exporter/exporter/dumper.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2exporter/st2exporter/exporter/file_writer.py
+++ b/st2exporter/st2exporter/exporter/file_writer.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2exporter/st2exporter/exporter/json_converter.py
+++ b/st2exporter/st2exporter/exporter/json_converter.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2exporter/st2exporter/worker.py
+++ b/st2exporter/st2exporter/worker.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2exporter/tests/integration/test_dumper_integration.py
+++ b/st2exporter/tests/integration/test_dumper_integration.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2exporter/tests/integration/test_export_worker.py
+++ b/st2exporter/tests/integration/test_export_worker.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2exporter/tests/unit/test_dumper.py
+++ b/st2exporter/tests/unit/test_dumper.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2exporter/tests/unit/test_json_converter.py
+++ b/st2exporter/tests/unit/test_json_converter.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/dist_utils.py
+++ b/st2reactor/dist_utils.py
@@ -3,6 +3,7 @@
 #       Instead modify scripts/dist_utils.py and run 'make .sdist-requirements' to
 #       update dist_utils.py files for all components
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/setup.py
+++ b/st2reactor/setup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/__init__.py
+++ b/st2reactor/st2reactor/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/cmd/garbagecollector.py
+++ b/st2reactor/st2reactor/cmd/garbagecollector.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/cmd/rule_tester.py
+++ b/st2reactor/st2reactor/cmd/rule_tester.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/cmd/rulesengine.py
+++ b/st2reactor/st2reactor/cmd/rulesengine.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/cmd/sensormanager.py
+++ b/st2reactor/st2reactor/cmd/sensormanager.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/cmd/timersengine.py
+++ b/st2reactor/st2reactor/cmd/timersengine.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/cmd/trigger_re_fire.py
+++ b/st2reactor/st2reactor/cmd/trigger_re_fire.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/container/__init__.py
+++ b/st2reactor/st2reactor/container/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/container/hash_partitioner.py
+++ b/st2reactor/st2reactor/container/hash_partitioner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/container/manager.py
+++ b/st2reactor/st2reactor/container/manager.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/container/partitioner_lookup.py
+++ b/st2reactor/st2reactor/container/partitioner_lookup.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/container/partitioners.py
+++ b/st2reactor/st2reactor/container/partitioners.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/container/process_container.py
+++ b/st2reactor/st2reactor/container/process_container.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/container/utils.py
+++ b/st2reactor/st2reactor/container/utils.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/garbage_collector/base.py
+++ b/st2reactor/st2reactor/garbage_collector/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/garbage_collector/config.py
+++ b/st2reactor/st2reactor/garbage_collector/config.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/rules/config.py
+++ b/st2reactor/st2reactor/rules/config.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/rules/enforcer.py
+++ b/st2reactor/st2reactor/rules/enforcer.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/rules/engine.py
+++ b/st2reactor/st2reactor/rules/engine.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/rules/filter.py
+++ b/st2reactor/st2reactor/rules/filter.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/rules/matcher.py
+++ b/st2reactor/st2reactor/rules/matcher.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/rules/tester.py
+++ b/st2reactor/st2reactor/rules/tester.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/rules/worker.py
+++ b/st2reactor/st2reactor/rules/worker.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/sensor/__init__.py
+++ b/st2reactor/st2reactor/sensor/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/sensor/base.py
+++ b/st2reactor/st2reactor/sensor/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/sensor/config.py
+++ b/st2reactor/st2reactor/sensor/config.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/timer/base.py
+++ b/st2reactor/st2reactor/timer/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/st2reactor/timer/config.py
+++ b/st2reactor/st2reactor/timer/config.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/tests/integration/test_garbage_collector.py
+++ b/st2reactor/tests/integration/test_garbage_collector.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/tests/integration/test_rules_engine.py
+++ b/st2reactor/tests/integration/test_rules_engine.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/tests/integration/test_sensor_container.py
+++ b/st2reactor/tests/integration/test_sensor_container.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/tests/integration/test_sensor_watcher.py
+++ b/st2reactor/tests/integration/test_sensor_watcher.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/tests/resources/test_sensor.py
+++ b/st2reactor/tests/resources/test_sensor.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/tests/resources/test_sensor_with_typo.py
+++ b/st2reactor/tests/resources/test_sensor_with_typo.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/tests/unit/test_container_utils.py
+++ b/st2reactor/tests/unit/test_container_utils.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/tests/unit/test_enforce.py
+++ b/st2reactor/tests/unit/test_enforce.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/tests/unit/test_filter.py
+++ b/st2reactor/tests/unit/test_filter.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/tests/unit/test_garbage_collector.py
+++ b/st2reactor/tests/unit/test_garbage_collector.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/tests/unit/test_hash_partitioner.py
+++ b/st2reactor/tests/unit/test_hash_partitioner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/tests/unit/test_partitioners.py
+++ b/st2reactor/tests/unit/test_partitioners.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/tests/unit/test_process_container.py
+++ b/st2reactor/tests/unit/test_process_container.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/tests/unit/test_rule_engine.py
+++ b/st2reactor/tests/unit/test_rule_engine.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/tests/unit/test_rule_matcher.py
+++ b/st2reactor/tests/unit/test_rule_matcher.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/tests/unit/test_sensor_and_rule_registration.py
+++ b/st2reactor/tests/unit/test_sensor_and_rule_registration.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/tests/unit/test_sensor_service.py
+++ b/st2reactor/tests/unit/test_sensor_service.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/tests/unit/test_sensor_wrapper.py
+++ b/st2reactor/tests/unit/test_sensor_wrapper.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/tests/unit/test_sensor_wrapper.py
+++ b/st2reactor/tests/unit/test_sensor_wrapper.py
@@ -155,7 +155,7 @@ class SensorWrapperTestCase(unittest2.TestCase):
                           trigger_types=trigger_types, parent_args=parent_args)
         except NameError as e:
             self.assertIn('Traceback (most recent call last)', six.text_type(e))
-            self.assertIn('line 19, in <module>', six.text_type(e))
+            self.assertIn('line 20, in <module>', six.text_type(e))
         else:
             self.fail('NameError not thrown')
 

--- a/st2reactor/tests/unit/test_tester.py
+++ b/st2reactor/tests/unit/test_tester.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2reactor/tests/unit/test_timer.py
+++ b/st2reactor/tests/unit/test_timer.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2stream/dist_utils.py
+++ b/st2stream/dist_utils.py
@@ -3,6 +3,7 @@
 #       Instead modify scripts/dist_utils.py and run 'make .sdist-requirements' to
 #       update dist_utils.py files for all components
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2stream/setup.py
+++ b/st2stream/setup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2stream/st2stream/__init__.py
+++ b/st2stream/st2stream/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2stream/st2stream/app.py
+++ b/st2stream/st2stream/app.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2stream/st2stream/cmd/__init__.py
+++ b/st2stream/st2stream/cmd/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2stream/st2stream/cmd/api.py
+++ b/st2stream/st2stream/cmd/api.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2stream/st2stream/config.py
+++ b/st2stream/st2stream/config.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2stream/st2stream/controllers/v1/executions.py
+++ b/st2stream/st2stream/controllers/v1/executions.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2stream/st2stream/controllers/v1/root.py
+++ b/st2stream/st2stream/controllers/v1/root.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2stream/st2stream/controllers/v1/stream.py
+++ b/st2stream/st2stream/controllers/v1/stream.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2stream/st2stream/signal_handlers.py
+++ b/st2stream/st2stream/signal_handlers.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2stream/st2stream/wsgi.py
+++ b/st2stream/st2stream/wsgi.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2stream/tests/unit/controllers/v1/base.py
+++ b/st2stream/tests/unit/controllers/v1/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2stream/tests/unit/controllers/v1/test_stream.py
+++ b/st2stream/tests/unit/controllers/v1/test_stream.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2stream/tests/unit/controllers/v1/test_stream_execution_output.py
+++ b/st2stream/tests/unit/controllers/v1/test_stream_execution_output.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/dist_utils.py
+++ b/st2tests/dist_utils.py
@@ -3,6 +3,7 @@
 #       Instead modify scripts/dist_utils.py and run 'make .sdist-requirements' to
 #       update dist_utils.py files for all components
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/integration/mistral/base.py
+++ b/st2tests/integration/mistral/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/integration/mistral/test_errors.py
+++ b/st2tests/integration/mistral/test_errors.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/integration/mistral/test_examples.py
+++ b/st2tests/integration/mistral/test_examples.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/integration/mistral/test_filters.py
+++ b/st2tests/integration/mistral/test_filters.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/integration/mistral/test_st2kv.py
+++ b/st2tests/integration/mistral/test_st2kv.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/integration/mistral/test_wiring.py
+++ b/st2tests/integration/mistral/test_wiring.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/integration/mistral/test_wiring_cancel.py
+++ b/st2tests/integration/mistral/test_wiring_cancel.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/integration/mistral/test_wiring_pause_resume.py
+++ b/st2tests/integration/mistral/test_wiring_pause_resume.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/integration/mistral/test_wiring_rerun.py
+++ b/st2tests/integration/mistral/test_wiring_rerun.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/integration/orquesta/base.py
+++ b/st2tests/integration/orquesta/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/integration/orquesta/test_performance.py
+++ b/st2tests/integration/orquesta/test_performance.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/integration/orquesta/test_wiring.py
+++ b/st2tests/integration/orquesta/test_wiring.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/integration/orquesta/test_wiring_cancel.py
+++ b/st2tests/integration/orquesta/test_wiring_cancel.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/integration/orquesta/test_wiring_data_flow.py
+++ b/st2tests/integration/orquesta/test_wiring_data_flow.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/integration/orquesta/test_wiring_delay.py
+++ b/st2tests/integration/orquesta/test_wiring_delay.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/integration/orquesta/test_wiring_error_handling.py
+++ b/st2tests/integration/orquesta/test_wiring_error_handling.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/integration/orquesta/test_wiring_functions.py
+++ b/st2tests/integration/orquesta/test_wiring_functions.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/integration/orquesta/test_wiring_functions_st2kv.py
+++ b/st2tests/integration/orquesta/test_wiring_functions_st2kv.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/integration/orquesta/test_wiring_functions_task.py
+++ b/st2tests/integration/orquesta/test_wiring_functions_task.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/integration/orquesta/test_wiring_inquiry.py
+++ b/st2tests/integration/orquesta/test_wiring_inquiry.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/integration/orquesta/test_wiring_pause_and_resume.py
+++ b/st2tests/integration/orquesta/test_wiring_pause_and_resume.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/integration/orquesta/test_wiring_rerun.py
+++ b/st2tests/integration/orquesta/test_wiring_rerun.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/integration/orquesta/test_wiring_task_retry.py
+++ b/st2tests/integration/orquesta/test_wiring_task_retry.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/integration/orquesta/test_wiring_with_items.py
+++ b/st2tests/integration/orquesta/test_wiring_with_items.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/setup.py
+++ b/st2tests/setup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/__init__.py
+++ b/st2tests/st2tests/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/action_aliases.py
+++ b/st2tests/st2tests/action_aliases.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/actions.py
+++ b/st2tests/st2tests/actions.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/api.py
+++ b/st2tests/st2tests/api.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/fixtures/history_views/__init__.py
+++ b/st2tests/st2tests/fixtures/history_views/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/fixtures/localrunner_pack/actions/text_gen.py
+++ b/st2tests/st2tests/fixtures/localrunner_pack/actions/text_gen.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_1/actions/my_action.py
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_1/actions/my_action.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_1/sensors/my_sensor.py
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_1/sensors/my_sensor.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_2/actions/my_action.py
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_2/actions/my_action.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_2/sensors/my_sensor.py
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_2/sensors/my_sensor.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_3/actions/my_action.py
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_3/actions/my_action.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_3/sensors/my_sensor.py
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_3/sensors/my_sensor.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_7/actions/render_config_context.py
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_7/actions/render_config_context.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_9/actions/invalid_syntax.py
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_9/actions/invalid_syntax.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/fixtures/packs/executions/__init__.py
+++ b/st2tests/st2tests/fixtures/packs/executions/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/fixtures/packs/runners/test_async_runner/test_async_runner.py
+++ b/st2tests/st2tests/fixtures/packs/runners/test_async_runner/test_async_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/fixtures/packs/runners/test_polling_async_runner/test_polling_async_runner.py
+++ b/st2tests/st2tests/fixtures/packs/runners/test_polling_async_runner/test_polling_async_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/fixtures/packs/runners/test_querymodule/callback/test_querymodule.py
+++ b/st2tests/st2tests/fixtures/packs/runners/test_querymodule/callback/test_querymodule.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/fixtures/packs/runners/test_querymodule/query/test_querymodule.py
+++ b/st2tests/st2tests/fixtures/packs/runners/test_querymodule/query/test_querymodule.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/fixtures/packs/test_library_dependencies/actions/get_library_path.py
+++ b/st2tests/st2tests/fixtures/packs/test_library_dependencies/actions/get_library_path.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/fixturesloader.py
+++ b/st2tests/st2tests/fixturesloader.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/http.py
+++ b/st2tests/st2tests/http.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/mocks/action.py
+++ b/st2tests/st2tests/mocks/action.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/mocks/auth.py
+++ b/st2tests/st2tests/mocks/auth.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/mocks/datastore.py
+++ b/st2tests/st2tests/mocks/datastore.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/mocks/execution.py
+++ b/st2tests/st2tests/mocks/execution.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/mocks/liveaction.py
+++ b/st2tests/st2tests/mocks/liveaction.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/mocks/runners/async_runner.py
+++ b/st2tests/st2tests/mocks/runners/async_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/mocks/runners/polling_async_runner.py
+++ b/st2tests/st2tests/mocks/runners/polling_async_runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/mocks/runners/runner.py
+++ b/st2tests/st2tests/mocks/runners/runner.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/mocks/sensor.py
+++ b/st2tests/st2tests/mocks/sensor.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/mocks/workflow.py
+++ b/st2tests/st2tests/mocks/workflow.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/pack_resource.py
+++ b/st2tests/st2tests/pack_resource.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/policies/concurrency.py
+++ b/st2tests/st2tests/policies/concurrency.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/policies/mock_exception.py
+++ b/st2tests/st2tests/policies/mock_exception.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/resources/packs/pythonactions/actions/echoer.py
+++ b/st2tests/st2tests/resources/packs/pythonactions/actions/echoer.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/resources/packs/pythonactions/actions/non_simple_type.py
+++ b/st2tests/st2tests/resources/packs/pythonactions/actions/non_simple_type.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/resources/packs/pythonactions/actions/pascal_row.py
+++ b/st2tests/st2tests/resources/packs/pythonactions/actions/pascal_row.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/resources/packs/pythonactions/actions/print_config_item_doesnt_exist.py
+++ b/st2tests/st2tests/resources/packs/pythonactions/actions/print_config_item_doesnt_exist.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/resources/packs/pythonactions/actions/print_to_stdout_and_stderr.py
+++ b/st2tests/st2tests/resources/packs/pythonactions/actions/print_to_stdout_and_stderr.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/resources/packs/pythonactions/actions/python_paths.py
+++ b/st2tests/st2tests/resources/packs/pythonactions/actions/python_paths.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/resources/packs/pythonactions/actions/test.py
+++ b/st2tests/st2tests/resources/packs/pythonactions/actions/test.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/st2tests/sensors.py
+++ b/st2tests/st2tests/sensors.py
@@ -1,3 +1,4 @@
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/st2tests/testpacks/checks/actions/checks/check_loadavg.py
+++ b/st2tests/testpacks/checks/actions/checks/check_loadavg.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/config_gen.py
+++ b/tools/config_gen.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/diff-db-disk.py
+++ b/tools/diff-db-disk.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/direct_queue_publisher.py
+++ b/tools/direct_queue_publisher.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/enumerate-runners.py
+++ b/tools/enumerate-runners.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/json2yaml.py
+++ b/tools/json2yaml.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/list_group_members.py
+++ b/tools/list_group_members.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/log_watcher.py
+++ b/tools/log_watcher.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python2.7
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/migrate_messaging_setup.py
+++ b/tools/migrate_messaging_setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/migrate_rules_to_include_pack.py
+++ b/tools/migrate_rules_to_include_pack.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/migrate_triggers_to_include_ref_count.py
+++ b/tools/migrate_triggers_to_include_ref_count.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/queue_consumer.py
+++ b/tools/queue_consumer.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/queue_producer.py
+++ b/tools/queue_producer.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/st2-analyze-links.py
+++ b/tools/st2-analyze-links.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/st2-inject-trigger-instances.py
+++ b/tools/st2-inject-trigger-instances.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/visualize_action_chain.py
+++ b/tools/visualize_action_chain.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Copyright 2020 The StackStorm Authors.
 # Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Add new 2020 StackStorm project copyright headers which operates now under the Linux Foundation. “StackStorm Authors” accumulates all the contributions made by the new StackStorm Open Source project maintainers, contributors and community.
This new copyright string should be added on top of existing ExtremeNetworks copyright header.

References
* https://www.linuxfoundation.org/blog/2020/01/copyright-notices-in-open-source-software-projects/
* https://github.com/cncf/foundation/blob/master/copyright-notices.md#copyright-notices
