### PR TITLE
Fix stable st2docs builds (v3.2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,12 +79,6 @@ cache:
     # are updated so it's disabled
     #- .tox/
 
-before_install:
-  # If you update these versions, make sure you update the versions in the .st2client-install-check
-  # and the requirements targets in the Makefile to match
-  - pip install --upgrade "pip==20.0.2"
-  - sudo pip install --upgrade "virtualenv==16.6.0"
-
 install:
   - ./scripts/travis/install-requirements.sh
   # prep a travis-specific dev conf file that uses travis instead of stanley

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,9 @@ COVERAGE_GLOBS := .coverage.unit.* .coverage.integration.* .coverage.mistral.*
 COVERAGE_GLOBS_QUOTED := $(foreach glob,$(COVERAGE_GLOBS),'$(glob)')
 
 REQUIREMENTS := test-requirements.txt requirements.txt
+# Pin common pip version here across all the targets
+# Note! Periodic maintenance pip upgrades are required to be up-to-date with the latest pip security fixes and updates
+PIP_VERSION ?= 20.0.2
 PIP_OPTIONS := $(ST2_PIP_OPTIONS)
 
 ifndef PYLINT_CONCURRENCY
@@ -309,7 +312,7 @@ lint-api-spec: requirements .lint-api-spec
 	@echo
 	@echo "================== Lint API spec ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate; st2common/bin/st2-validate-api-spec --config-file conf/st2.dev.conf 
+	. $(VIRTUALENV_DIR)/bin/activate; st2common/bin/st2-validate-api-spec --config-file conf/st2.dev.conf
 
 .PHONY: generate-api-spec
 generate-api-spec: requirements .generate-api-spec
@@ -369,10 +372,7 @@ flake8: requirements .flake8
 	touch $(VIRTUALENV_ST2CLIENT_DIR)/bin/activate
 	chmod +x $(VIRTUALENV_ST2CLIENT_DIR)/bin/activate
 
-	# If you update these versions, make sure you also update the versions in the
-	# requirements target and .travis.yml to match
-	# Make sure we use the latest version of pip
-	$(VIRTUALENV_ST2CLIENT_DIR)/bin/pip install --upgrade "pip==20.0.2"
+	$(VIRTUALENV_ST2CLIENT_DIR)/bin/pip install --upgrade "pip==$(PIP_VERSION)"
 	# NOTE We need to upgrade setuptools to avoid bug with dependency resolving in old versions
 	# Setuptools 42 added support for python_requires, which is used by the configparser package,
 	# which is required by the importlib-metadata package
@@ -495,6 +495,9 @@ distclean: clean
 
 .PHONY: .requirements
 .requirements: virtualenv
+	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pip==$(PIP_VERSION)"
+	# Print out pip version
+	$(VIRTUALENV_DIR)/bin/pip --version
 	# Generate all requirements to support current CI pipeline.
 	$(VIRTUALENV_DIR)/bin/python scripts/fixate-requirements.py --skip=virtualenv,virtualenv-osx -s st2*/in-requirements.txt contrib/runners/*/in-requirements.txt -f fixed-requirements.txt -o requirements.txt
 
@@ -515,14 +518,9 @@ requirements: virtualenv .requirements .sdist-requirements install-runners
 	@echo
 	@echo "==================== requirements ===================="
 	@echo
-	# If you update these versions, make sure you also update the versions in the
-	# .st2client-install-check target and .travis.yml to match
-	# Make sure we use latest version of pip
-	$(VIRTUALENV_DIR)/bin/pip --version
-	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pip>=19.3.1"
 	# setuptools >= 41.0.1 is required for packs.install in dev envs
 	# setuptools >= 42     is required so setup.py install respects dependencies' python_requires
-	$(VIRTUALENV_DIR)/bin/pip install --upgrade "setuptools>=42"
+	$(VIRTUALENV_DIR)/bin/pip install --upgrade "setuptools==44.1.0"
 	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pbr==5.4.3"  # workaround for pbr issue
 
 	# Fix for Travis CI race
@@ -574,8 +572,6 @@ virtualenv:
 	@echo
 	@echo "==================== virtualenv ===================="
 	@echo
-	# Note: We pass --no-download flag to make sure version of pip which we install (9.0.1) is used
-	# instead of latest version being downloaded from PyPi
 	test -f $(VIRTUALENV_DIR)/bin/activate || virtualenv --python=$(PYTHON_VERSION) $(VIRTUALENV_DIR) --no-download
 
 	# Setup PYTHONPATH in bash activate script...

--- a/contrib/runners/orquesta_runner/orquesta_functions/st2kv.py
+++ b/contrib/runners/orquesta_runner/orquesta_functions/st2kv.py
@@ -43,8 +43,8 @@ def st2kv_(context, key, **kwargs):
     try:
         user_db = auth_db_access.User.get(username)
     except Exception as e:
-        raise Exception('Failed to retrieve User object for user "%s" % (username)' %
-                        (six.text_type(e)))
+        raise Exception('Failed to retrieve User object for user "%s", "%s"' %
+                        (username, six.text_type(e)))
 
     has_default = 'default' in kwargs
     default_value = kwargs.get('default')

--- a/st2common/st2common/util/monkey_patch.py
+++ b/st2common/st2common/util/monkey_patch.py
@@ -79,7 +79,7 @@ def use_select_poll_workaround(nose_only=True):
     import eventlet
 
     # Work around to get tests to pass with eventlet >= 0.20.0
-    if not nose_only or (nose_only and'nose' in sys.modules.keys()):
+    if not nose_only or (nose_only and 'nose' in sys.modules.keys()):
         # Add back blocking poll() to eventlet monkeypatched select
         original_poll = eventlet.patcher.original('select').poll
         select.poll = original_poll

--- a/st2common/tests/unit/test_dist_utils.py
+++ b/st2common/tests/unit/test_dist_utils.py
@@ -45,7 +45,7 @@ class DistUtilsTestCase(unittest2.TestCase):
     def setUp(self):
         super(DistUtilsTestCase, self).setUp()
 
-        if 'pip'in sys.modules:
+        if 'pip' in sys.modules:
             del sys.modules['pip']
 
     def tearDown(self):


### PR DESCRIPTION
Cherry-picking changes into `v3.2` branch from the (#4957) which should fix st2docs builds for `stable` branch.

* Pin pip to 20.0.2 consistently across the Makefile targets
* Remove virtualenv and pip installation from Travis yaml
* Fix st2docs build relying on st2 master makefiles
(cherry picked from commit 29ca930)

Also cherry-picking lint changes made by @Sheshagiri in https://github.com/StackStorm/st2/pull/4947

See https://github.com/StackStorm/st2docs/pull/1001 https://github.com/StackStorm/st2docs/pull/999 which are blocked by the CI failures in st2 `v3.2` branch.