### PR TITLE
better expose default creds for devs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Added
   group in st2.conf. (new feature) #4914
 
   This option was requested by Harry Lee (@tclh123) and contributed by Marcel Weinberg (@winem).
+* Added a FAQ for the default user/pass for the `tools/launch_dev.sh` script and print out the
+ default pass to screen when the script completes.
+
+Contributed by @punkrokk
 
 Changed
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Added
 
   This option was requested by Harry Lee (@tclh123) and contributed by Marcel Weinberg (@winem).
 * Added a FAQ for the default user/pass for the `tools/launch_dev.sh` script and print out the
- default pass to screen when the script completes.
+  default pass to screen when the script completes.
 
 Contributed by @punkrokk
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Added
 * Add make command to autogen JSON schema from the models of action, rule, etc. Add check
   to ensure update to the models require schema to be regenerated. (new feature)
 * Improved st2sensor service logging message when a sensor will not be loaded when assigned to a
-  different partition (@punkrokk)
+  different partition (@punkrokk) #4991
 * Add support for a configurable connect timeout for SSH connections as requested in #4715
   by adding the new configuration parameter ``ssh_connect_timeout`` to the ``ssh_runner``
   group in st2.conf. (new feature) #4914
@@ -18,13 +18,14 @@ Added
 * Added a FAQ for the default user/pass for the `tools/launch_dev.sh` script and print out the
   default pass to screen when the script completes. (improvement) #5013
 
-Contributed by @punkrokk
+  Contributed by @punkrokk
 
 Changed
 ~~~~~~~
-* Switch to MongoDB ``4.0`` as the default version starting with all supported OS's in st2 ``v3.3.0`` (improvement) #4972
+* Switch to MongoDB ``4.0`` as the default version starting with all supported OS's in st2
+  ``v3.3.0`` (improvement) #4972
 
-Contributed by @punkrokk 
+  Contributed by @punkrokk
 
 Fixed
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Added
 
   This option was requested by Harry Lee (@tclh123) and contributed by Marcel Weinberg (@winem).
 * Added a FAQ for the default user/pass for the `tools/launch_dev.sh` script and print out the
-  default pass to screen when the script completes.
+  default pass to screen when the script completes. (improvement) #5013
 
 Contributed by @punkrokk
 

--- a/dev_docs/Troubleshooting_Guide.rst
+++ b/dev_docs/Troubleshooting_Guide.rst
@@ -5,7 +5,7 @@ Troubleshooting Guide
 
 **A: The default creds are**:
   user: testu
-  pass: test p
+  pass: testp
 
 **Q: After starting st2 server using** ``tools/launchdev.sh`` **script, getting following error:**::
 

--- a/dev_docs/Troubleshooting_Guide.rst
+++ b/dev_docs/Troubleshooting_Guide.rst
@@ -1,6 +1,12 @@
 Troubleshooting Guide
 =====================
 
+**Q: What is the default username and password for the** ``tools/launchdev.sh`` **script?**
+
+**A: The default creds are**:
+  user: testu
+  pass: test p
+
 **Q: After starting st2 server using** ``tools/launchdev.sh`` **script, getting following error:**::
 
   $ st2 action list

--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -436,6 +436,9 @@ function st2start(){
         fi
     fi
 
+    # Print default creds to the screen
+    echo "The default creds are testu:testp"
+
     # List screen sessions
     screen -ls || exit 0
 }


### PR DESCRIPTION
This PR prints out the default creds right before completing the `tools/launch_dev.sh` script and adds a FAQ to the [dev docs/Troubleshooting_Guide.rst](https://github.com/StackStorm/st2/tree/master/dev_docs)