### PR TITLE
Issue 4908 datetime not json serializable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,15 @@ Changed
 
 Fixed
 ~~~~~
+* Fixed two bugs when running st2 from sources. ujson>=2.0.0 instead of 1.3.5 addresses
+  ``ImportError: /home/marcel/Sources/gitlab.winem/st2/virtualenv/lib/python2.7/site-packages/ujson.so:
+  undefined symbol: Buffer_AppendShortHexUnchecked`` when starting st2 with launchdev.sh start
+  or startclean. The iso formatted datetime addresses the error ``ERROR: 500 Server Error: Internal
+  Server Error; MESSAGE: datetime.datetime(2020, 4, 15, 0, 2, 54, 70199, tzinfo=tzutc()) is not JSON
+  serializable for url: http://127.0.0.1:9101/v1/executions`` when running commands like ``st2 action
+  execute core.local uname``. (bug fix) #4908
+
+  Reported and contributed by @winem.
 * Fixed a bug where `type` attribute was missing for netstat action in linux pack. Fixes #4946
 
   Reported by @scguoi and contributed by Sheshagiri (@sheshagiri)

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -59,5 +59,5 @@ psutil==5.6.6
 python-dateutil==2.8.0
 python-statsd==2.1.0
 prometheus_client==0.1.1
-ujson==1.35
+ujson>=2.0.0 
 zipp>=0.5,<=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ six==1.13.0
 sseclient-py==1.7
 stevedore==1.30.1
 tooz==1.66.1
-ujson==1.35
+ujson>=2.0.0
 unittest2
 webob==1.8.5
 webtest

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -34,6 +34,6 @@ routes==2.4.1
 semver==2.9.0
 six==1.13.0
 tooz==1.66.1
-ujson==1.35
+ujson>=2.0.0
 webob==1.8.5
 zake==0.2.2

--- a/st2common/st2common/services/executions.py
+++ b/st2common/st2common/services/executions.py
@@ -94,7 +94,7 @@ def _create_execution_log_entry(status):
     Create execution log entry object for the provided execution status.
     """
     return {
-        'timestamp': date_utils.get_datetime_utc_now(),
+        'timestamp': date_utils.get_datetime_utc_now().isoformat(),
         'status': status
     }
 


### PR DESCRIPTION
This PR addresses actually 2 issues when running st2 from source. 

1st: Stackstorm failed to start with `ImportError: /home/marcel/Sources/gitlab.winem/st2/virtualenv/lib/python2.7/site-packages/ujson.so: undefined symbol: Buffer_AppendShortHexUnchecked`
Fix was to bump ujson from 1.3.5 to 2.0.0

2nd: Some API calls failed with `MESSAGE: datetime.datetime(2020, 4, 15, 0, 2, 54, 70199, tzinfo=tzutc()) is not JSON serializable for url: http://127.0.0.1:9101/v1/executions` 

More details can be found in #4908 

I'd be more than all ears and happy if anyone can explain why this is an issue when running st2 from sources but not when I install the packages.

closes #4908 