### PR TITLE
Promote Amanda McGuinness (@amanda11) to the StackStorm TSC Maintainers

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -33,8 +33,10 @@ Have deep platform knowledge & experience and demonstrate technical leadership a
 # Maintainers *
 ###### 1 vote points
 Being part of Technical Steering Committee (TSC) [@StackStorm/maintainers](https://github.com/orgs/StackStorm/teams/maintainers) provide significant and reliable value to the project helping it grow and improve through development and maintenance.
+* Amanda McGuinness ([@amanda11](https://github.com/amanda11)) <<amanda.mcguinness@ammeonsolutions.com>>
+  - Ansible, Core, deb/rpm packages, CI/CD, Deployments, StackStorm Exchange, Documentation.
 * JP Bourget ([@punkrokk](https://github.com/punkrokk)) <<jp.bourget@gmail.com>>
-  - Systems, deb/rpm, Deployments, Community, StackStorm Exchange, SecOps, CircleCi
+  - Systems, deb/rpm, Deployments, Community, StackStorm Exchange, SecOps, CircleCI.
 * Mick McGrath ([@mickmcgrath13](https://github.com/mickmcgrath13)) <<mick@bitovi.com>>
   - Systems, ST2 Exchange. [Case Study](https://stackstorm.com/case-study-bitovi/).
 * Nick Maludy ([@nmaludy](https://github.com/nmaludy)) <<nmaludy@gmail.com>>
@@ -46,7 +48,6 @@ Being part of Technical Steering Committee (TSC) [@StackStorm/maintainers](https
 Contributors are using and occasionally contributing back to the project, might be active in conversations or express their opinion on the project’s direction.
 They're not part of the TSC voting process, but appreciated for their contribution, involvement and may become Maintainers in future.
 <!-- [@StackStorm/contributors](https://github.com/orgs/StackStorm/teams/contributors) are invited to StackStorm Github organization and we appreciate their contribution and involvement. -->
-* Amanda McGuinness ([@amanda11](https://github.com/amanda11)) - StackStorm Exchange, Ansible, ChatOps, Documentation, core.
 * Carlos ([@nzlosh](https://github.com/nzlosh)) - Chatops, Errbot, Community, Discussions, StackStorm Exchange.
 * Hiroyasu Ohyama ([@userlocalhost](https://github.com/userlocalhost)) - Orquesta, Workflows, st2 Japan Community. [Case Study](https://stackstorm.com/case-study-dmm/).
 * Jon Middleton ([@jjm](https://github.com/jjm)) - StackStorm Exchange, Core, Discussions.


### PR DESCRIPTION
Looking at the Linux Foundation Contribution Analytics (https://lfanalytics.io/projects/stackstorm/), @amanda11 already outperformed many TSC members showing exceptional dedication to the StackStorm project.

She's active Contributor of StackStorm Community for the past half of year, starting helping with the `v3.2.0` release testing and being a great assistance where it's needed most for StackStorm.

Looking at [Maintainer Responsibilities](https://github.com/StackStorm/st2/blob/master/GOVERNANCE.md#maintainer-responsibilities) Amanda touched almost every part of the system, starting from the documentation, pre-release testing, good first issues, community help (Slack, Forum, Github) ending with very insightful PR Reviews, contributions to StackStorm core and code fixes, even looked deeper into CI/CD, release workflows as well as recently led big roadmap items that are important for the project upcoming release `v3.3.0`. That's an attitude of the project Maintainer!

Between the most recent major items:
* Closing the significant tasks in [Ansible-st2](https://github.com/stackstorm/ansible-st2) backlog:
  - [Adding MongoDB 4.0 support](https://github.com/StackStorm/ansible-st2/pull/266)
  - [postgresql and st2mistral roles removal](https://github.com/StackStorm/ansible-st2/pull/272)
  - [Drop Ubuntu Trusty support](https://github.com/StackStorm/ansible-st2/pull/265)
  - [Dropping the EL6 support](https://github.com/StackStorm/ansible-st2/pull/268)
  - [Add EL8 support](https://github.com/StackStorm/ansible-st2/pull/261) 
  - Wrote a StackStorm Blog post: [Ansible StackStorm role v2.0.0 released](https://stackstorm.com/2020/08/05/ansible-st2-v2-0-0/)
* EL6 Removal Roadmap: https://github.com/orgs/StackStorm/projects/17 (part of the `v3.3.0` release)
  - big project with `11` PRs contributed, https://github.com/StackStorm/discussions/issues/39
* Mistral Deprecation Roadmap (WIP): https://github.com/orgs/StackStorm/projects/16 (part of the `v3.3.0` release)
  - see game plan: https://github.com/StackStorm/st2/issues/4762
  - project affecting many repositories with tens of thousands lines of code (!) diff
  - biggest PRs in [st2-packages](https://github.com/StackStorm/st2-packages/pull/656), [st2](https://github.com/StackStorm/st2/pull/5011/files), [st2ci](https://github.com/StackStorm/st2ci/pull/189) and [st2cd](https://github.com/StackStorm/st2cd/pull/440)


Amanda has exceptional senior engineering skill, dedication helping the project with its priorities and she's also a great team player easy to work with. She would be a strong addition to the official TSC Maintainers team helping driving the StackStorm project forward!