### PR TITLE
Propose adding @Sheshagiri to the StackStorm Contributors

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -48,11 +48,11 @@ They're not part of the TSC voting process, but appreciated for their contributi
 <!-- [@StackStorm/contributors](https://github.com/orgs/StackStorm/teams/contributors) are invited to StackStorm Github organization and we appreciate their contribution and involvement. -->
 * Amanda McGuinness ([@amanda11](https://github.com/amanda11)) - StackStorm Exchange, Ansible, ChatOps, Documentation, core.
 * Carlos ([@nzlosh](https://github.com/nzlosh)) - Chatops, Errbot, Community, Discussions, StackStorm Exchange.
-* Sheshagiri Rao Mallipedhi ([@sheshagiri](https://github.com/sheshagiri)) - Docker, Core, StackStorm Exchange.
 * Hiroyasu Ohyama ([@userlocalhost](https://github.com/userlocalhost)) - Orquesta, Workflows, st2 Japan Community. [Case Study](https://stackstorm.com/case-study-dmm/).
 * Jon Middleton ([@jjm](https://github.com/jjm)) - StackStorm Exchange, Core, Discussions.
-* Tristan Struthers ([@trstruth](https://github.com/trstruth)) - Docker, K8s, Orquesta, Community.
 * Marcel Weinberg ([@winem](https://github.com/winem)) - Community, Docker, Core.
+* Sheshagiri Rao Mallipedhi ([@sheshagiri](https://github.com/sheshagiri)) - Docker, Core, StackStorm Exchange.
+* Tristan Struthers ([@trstruth](https://github.com/trstruth)) - Docker, K8s, Orquesta, Community.
 
 # Friends
 People that are currently not very active maintainers/contributors but who participated in and formed the project we have today.

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -48,6 +48,7 @@ They're not part of the TSC voting process, but appreciated for their contributi
 <!-- [@StackStorm/contributors](https://github.com/orgs/StackStorm/teams/contributors) are invited to StackStorm Github organization and we appreciate their contribution and involvement. -->
 * Amanda McGuinness ([@amanda11](https://github.com/amanda11)) - StackStorm Exchange, Ansible, ChatOps, Documentation, core.
 * Carlos ([@nzlosh](https://github.com/nzlosh)) - Chatops, Errbot, Community, Discussions, StackStorm Exchange.
+* Sheshagiri Rao Mallipedhi ([@sheshagiri](https://github.com/sheshagiri)) - Docker, Core, StackStorm Exchange.
 * Hiroyasu Ohyama ([@userlocalhost](https://github.com/userlocalhost)) - Orquesta, Workflows, st2 Japan Community. [Case Study](https://stackstorm.com/case-study-dmm/).
 * Jon Middleton ([@jjm](https://github.com/jjm)) - StackStorm Exchange, Core, Discussions.
 * Tristan Struthers ([@trstruth](https://github.com/trstruth)) - Docker, K8s, Orquesta, Community.


### PR DESCRIPTION
I'd like to propose adding @Sheshagiri to the list of [StackStorm Contributors](https://github.com/StackStorm/st2/blob/master/OWNERS.md#contributors).

During the past several months @Sheshagiri was helpful in StackStorm Community by answering Forum questions, reporting issues and actually fixing things, assisting with the roadmap items like EL6 removal, StackStorm API docsgen fixes, K8s, Docker and also PR reviews.

* :+1: Very detailed and helpful assistance on StackStorm Forums:
  - https://forum.stackstorm.com/t/how-to-define-data-type-for-action-inputs/1364
  - https://forum.stackstorm.com/t/issue-while-calling-first-task-in-workflow-in-stackstorm-v3-1-0/1325
  - https://forum.stackstorm.com/t/repeated-execution-of-an-action/1084
  - https://forum.stackstorm.com/t/specified-version-of-stackstorm-like-3-2-to-install-on-k8s/1316
  - https://forum.stackstorm.com/t/kubernetes-ha-not-working-for-me/1310
  - https://forum.stackstorm.com/t/need-to-implement-stackstorm-actions/1298/
  - https://forum.stackstorm.com/t/cant-send-mail-with-core-sendmail/1087/
  - https://forum.stackstorm.com/t/execute-command-on-a-storage-device/955/2
* StackStorm-Exchange:
  - Reported StackStorm-Terraform Issue (https://github.com/StackStorm-Exchange/stackstorm-terraform/issues/18) and also fixed it: https://github.com/StackStorm-Exchange/stackstorm-terraform/pull/19
* StackStorm/st2:
  - Feature request: [Print elapsed time in user friendly format instead of seconds on cli #4944](https://github.com/StackStorm/st2/issues/4944)
  - Fixed [netstat action in linux pack #4947](https://github.com/StackStorm/st2/pull/4947) closing a https://github.com/StackStorm/st2/issues/4946 bug from the backlog
* Docker and K8s:
  - [K8s: Support for custom st2actionrunner images via values.yaml](https://github.com/StackStorm/stackstorm-ha/pull/141)
  - Removing EL6 Dockerfiles (https://github.com/StackStorm/st2packaging-dockerfiles/pull/89) together with @amanda11, which was part of the EL6 Removal Game plan (`v3.3.0` release backlog).
* :star: Fixing https://api.stackstorm.com/ Docs:
  - With https://github.com/StackStorm/st2apidocs/pull/11 and https://github.com/StackStorm/st2apidocgen/pull/9 Javascript PRs he was able to fix StackStorm API docs generation which wasn't updated for about one year!
  - See [Broken CD build results in outdated api.stackstorm.com](https://github.com/StackStorm/st2apidocs/issues/9)
  - See [api.stackstorm.com is unsync with openapi.yaml (CD) #4051](https://github.com/StackStorm/st2/issues/4051)
  - See: https://twitter.com/Stack_Storm/status/1280163374127624192
  - Being part of the `v3.3.0` backlog this kind of help is highly appreciated!

Thanks for those timely fixes and I hope @Sheshagiri will continue contributing to StackStorm more and will be a strong support to the project in future.