### PR TITLE
Deprecate mistral - remove mistral from the HA config and st2.*.conf samples

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -87,6 +87,10 @@ Removed
 
   Contributed by Amanda McGuinness (@amanda11 Ammeon Solutions)
 * Removed our fork of ``codecov-python`` for CI and have switched back to the upstream version (improvement) #5002
+
+* Removed mistral from the HA configuration samples as well as the st2.*.conf samples. #4762
+
+  Contributed by Marcel Weinberg (@winem)
   
 3.2.0 - April 27, 2020
 ----------------------

--- a/conf/HA/nginx/st2.conf.blueprint.sample
+++ b/conf/HA/nginx/st2.conf.blueprint.sample
@@ -104,24 +104,4 @@ server {
     proxy_cache off;
     proxy_set_header Host $host;
   }
-
-  location /mistral/ {
-    rewrite ^/mistral/(.*)  /$1 break;
-
-    proxy_pass            http://127.0.0.1:8989/;
-    proxy_read_timeout    90;
-    proxy_connect_timeout 90;
-    proxy_redirect        off;
-
-    proxy_set_header      Host $host;
-    proxy_set_header      X-Real-IP $remote_addr;
-    proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_pass_header     Authorization;
-
-    proxy_set_header Connection '';
-    chunked_transfer_encoding off;
-    proxy_buffering off;
-    proxy_cache off;
-    proxy_set_header Host $host;
-  }
 }

--- a/conf/HA/nginx/st2.conf.controller.sample
+++ b/conf/HA/nginx/st2.conf.controller.sample
@@ -125,31 +125,4 @@ server {
     proxy_buffering off;
     proxy_cache off;
   }
-
-  location /mistral/ {
-    proxy_pass            https://st2/mistral/;
-    proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
-    proxy_read_timeout    90;
-    proxy_connect_timeout 90;
-    proxy_redirect        off;
-
-    proxy_set_header      Host $host;
-    proxy_set_header      X-Real-IP $remote_addr;
-    proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_pass_header     Authorization;
-
-    proxy_set_header Connection '';
-    chunked_transfer_encoding off;
-    proxy_buffering off;
-    proxy_cache off;
-  }
-
-  location / {
-    root      /opt/stackstorm/static/webui/;
-    index     index.html;
-
-    sendfile on;
-    tcp_nopush on;
-    tcp_nodelay on;
-  }
 }

--- a/conf/HA/st2.conf.sample
+++ b/conf/HA/st2.conf.sample
@@ -82,7 +82,3 @@ use_paramiko_ssh_runner = True
 
 [database]
 host = st2-multi-node-controller
-
-[mistral]
-v2_base_url = https://st2-multi-node-controller/mistral/v2
-api_url = https://st2-multi-node-controller/api

--- a/conf/st2.conf.sample
+++ b/conf/st2.conf.sample
@@ -214,34 +214,6 @@ driver = noop
 # Destination port to connect to if driver requires connection.
 port = 8125
 
-[mistral]
-# URL Mistral uses to talk back to the API.If not provided it defaults to public API URL. Note: This needs to be a base URL without API version (e.g. http://127.0.0.1:9101)
-api_url = None
-# Multiplier for the exponential backoff.
-retry_exp_msec = 1000
-# Jitter interval to smooth out HTTP requests to mistral tasks and executions API.
-jitter_interval = 0.1
-# Allow insecure communication with Mistral.
-insecure = False
-# Username for authentication.
-keystone_username = None
-# Enable results tracking and disable callbacks.
-enable_polling = False
-# OpenStack project scope.
-keystone_project_name = None
-# Password for authentication.
-keystone_password = None
-# Auth endpoint for Keystone.
-keystone_auth_url = None
-# Optional certificate to validate endpoint.
-cacert = None
-# v2 API root endpoint.
-v2_base_url = http://127.0.0.1:8989/v2
-# Max time to stop retrying.
-retry_stop_max_msec = 600000
-# Max time for each set of backoff.
-retry_exp_max_msec = 300000
-
 [notifier]
 # Location of the logging configuration file.
 logging = /etc/st2/logging.notifier.conf

--- a/conf/st2.dev.conf
+++ b/conf/st2.dev.conf
@@ -133,10 +133,6 @@ logging = st2actions/conf/logging.workflowengine.conf
 [content]
 pack_group = stanley
 
-[mistral]
-v2_base_url = http://127.0.0.1:8989/v2
-jitter_interval = 0
-
 [packs]
 enable_common_libs = True
 

--- a/conf/st2.tests.conf
+++ b/conf/st2.tests.conf
@@ -93,6 +93,3 @@ logging = st2actions/conf/logging.notifier.conf
 
 [exporter]
 logging = st2exporter/conf/logging.exporter.conf
-
-[mistral]
-jitter_interval = 0

--- a/conf/st2.tests2.conf
+++ b/conf/st2.tests2.conf
@@ -98,6 +98,3 @@ logging = st2actions/conf/logging.notifier.conf
 
 [exporter]
 logging = st2exporter/conf/logging.exporter.conf
-
-[mistral]
-jitter_interval = 0


### PR DESCRIPTION
This PR goes along with https://github.com/StackStorm/st2docs/pull/1010/ which references some of the HA samples. 

I removed mistral relevant content from the HA samples as well as the st2.*.conf samples. 

Removing the mistral.dev folder requires updates on the launchdev.sh and db_cleanup.sh and I saw that there is another PR #5011 addressing this topic.