### PR TITLE
Update ST2 CircleCI and Travis to use mongodb 4.0 instead of 3.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 # Setup in CircleCI account the following ENV variables:
-# PACKAGECLOUD_ORGANIZATION (default: stackstorm)
+# PACKAGECLOUD_ORGANIZATION (default: stackstorm) 
 # PACKAGECLOUD_TOKEN
 version: 2
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
   integration:
     docker:
       - image: circleci/python:2.7
-      - image: mongo:3.4
+      - image: mongo:4.0
       - image: rabbitmq:3
     working_directory: ~/st2
     steps:
@@ -57,8 +57,8 @@ jobs:
           name: Install Mongo Shell
           command: |
             set -x
-            sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6
-            echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/3.4 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list
+            sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4
+            echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/4.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.0.list
             sudo apt-get -qq -y update
             sudo apt-get -qq -y install mongodb-org-shell
       - run:
@@ -80,7 +80,7 @@ jobs:
   lint:
     docker:
       - image: circleci/python:2.7
-      - image: mongo:3.4
+      - image: mongo:4.0
       - image: rabbitmq:3
     working_directory: ~/st2
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
     # If you rename or reorder make targets in TASK, you may need to adjust:
     # scripts/travis/install-requirements.sh
     # scripts/travis/run-nightly-make-task-if-exists.sh
-    - name: "Unit Tests (Python 2.7 MongoDB 3.4)"
+    - name: "Unit Tests (Python 2.7 MongoDB 4.0)"
       python: 2.7
       env: TASK=ci-unit CACHE_NAME=py2 COMMAND_THRESHOLD=700
 
@@ -59,11 +59,11 @@ jobs:
 addons:
   apt:
     sources:
-      - sourceline: 'deb [arch=amd64] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse'
-        key_url: 'https://www.mongodb.org/static/pgp/server-3.4.asc'
+      - sourceline: 'deb [arch=amd64] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.0 multiverse'
+        key_url: 'https://www.mongodb.org/static/pgp/server-4.0.asc'
     packages:
-      - mongodb-org-server=3.4.*
-      - mongodb-org-shell=3.4.*
+      - mongodb-org-server=4.0.*
+      - mongodb-org-shell=4.0.*
       - rabbitmq-server
       - libffi-dev
 
@@ -92,7 +92,7 @@ install:
 before_script:
   # Use a custom mongod.conf which uses various speed optimizations
   - sudo cp scripts/travis/mongod.conf /etc/mongod.conf
-  # Clean up any old MongoDB 3.4 data files laying around and make sure mongodb user can write to it
+  # Clean up any old MongoDB 4.0 data files laying around and make sure mongodb user can write to it
   - sudo rm -rf /var/lib/mongodb ; sudo mkdir /var/lib/mongodb ; sudo chown -R mongodb:mongodb /var/lib/mongodb
   - sudo service mongod restart ; sleep 5
   - sudo service mongod status


### PR DESCRIPTION
Update CircleCI and Travis to use mongodb 4.0

Addresses CircleCI/Travis part of https://github.com/StackStorm/st2/issues/4972