### PR TITLE
remove py3-unit-nightly from Travis runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -979,13 +979,6 @@ ci-py3-packs-tests:
 	@echo
 	NOSE_WITH_TIMER=$(NOSE_WITH_TIMER) tox -e py36-packs -vv
 
-.PHONY: ci-py3-unit-nightly
-ci-py3-unit-nightly:
-	@echo
-	@echo "==================== ci-py3-unit ===================="
-	@echo
-	NOSE_WITH_TIMER=$(NOSE_WITH_TIMER) tox -e py36-unit-nightly -vv
-
 .PHONY: ci-py3-integration
 ci-py3-integration: requirements .ci-prepare-integration .ci-py3-integration
 

--- a/scripts/travis/install-requirements.sh
+++ b/scripts/travis/install-requirements.sh
@@ -46,10 +46,6 @@ if [[ " ${TASK}" = *' ci-py3-'* ]]; then
         tox -e py36-unit --notest
     fi
 
-    if [[ " ${TASK} " = *' ci-py3-unit-nightly '* ]]; then
-        tox -e py36-unit-nightly --notest
-    fi
-
     if [[ " ${TASK} " = *' ci-py3-packs-tests '* ]]; then
         tox -e py36-packs --notest
     fi


### PR DESCRIPTION
py3-unit-nightly was removed as part of mistral deprecation, as it just ran the mistral UTs, but Travis run still called it. Remove call to it from travis runs to stop error on overnight runs.