### PR TITLE
Add python warning if install a pack that only supports python 2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,7 @@ Added
 
   Contributed by @punkrokk
 * Added deprecation warning if attempt to install or download a pack that only supports
-  Python 2.
+  Python 2. (new feature) #5037
 
   Contributed by @amanda11
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,10 @@ Added
   default pass to screen when the script completes. (improvement) #5013
 
   Contributed by @punkrokk
+* Added deprecation warning if attempt to install or download a pack that only supports
+  Python 2.
+
+  Contributed by @amanda11
 
 Changed
 ~~~~~~~

--- a/contrib/packs/actions/get_pack_warnings.yaml
+++ b/contrib/packs/actions/get_pack_warnings.yaml
@@ -1,7 +1,7 @@
 ---
   name: "get_pack_warnings"
   runner_type: "python-script"
-  description: "Get pack warnings specified in pack.yaml"
+  description: "Get pack warnings from analysing pack.yaml"
   enabled: true
   pack: packs
   entry_point: "pack_mgmt/get_pack_warnings.py"

--- a/contrib/packs/actions/get_pack_warnings.yaml
+++ b/contrib/packs/actions/get_pack_warnings.yaml
@@ -1,0 +1,15 @@
+
+
+---
+  name: "get_pack_warnings"
+  runner_type: "python-script"
+  description: "Get pack warnings specified in pack.yaml"
+  enabled: true
+  pack: packs
+  entry_point: "pack_mgmt/get_pack_warnings.py"
+  parameters:
+    packs_status:
+      type: object
+      description: Name of the pack in Exchange or a git repo URL and download status.
+      required: true
+      default: null

--- a/contrib/packs/actions/get_pack_warnings.yaml
+++ b/contrib/packs/actions/get_pack_warnings.yaml
@@ -1,5 +1,3 @@
-
-
 ---
   name: "get_pack_warnings"
   runner_type: "python-script"

--- a/contrib/packs/actions/get_pack_warnings.yaml
+++ b/contrib/packs/actions/get_pack_warnings.yaml
@@ -10,6 +10,6 @@
   parameters:
     packs_status:
       type: object
-      description: Name of the pack in Exchange or a git repo URL and download status.
+      description: Dictionary of pack name to download status.
       required: true
       default: null

--- a/contrib/packs/actions/pack_mgmt/get_pack_warnings.py
+++ b/contrib/packs/actions/pack_mgmt/get_pack_warnings.py
@@ -1,5 +1,4 @@
 # Copyright 2020 The StackStorm Authors.
-# Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/contrib/packs/actions/pack_mgmt/get_pack_warnings.py
+++ b/contrib/packs/actions/pack_mgmt/get_pack_warnings.py
@@ -1,0 +1,65 @@
+# Copyright 2020 The StackStorm Authors.
+# Copyright 2019 Extreme Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import print_function
+
+import six
+
+from st2common.constants.pack import PACK_VERSION_SEPARATOR
+from st2common.content.utils import get_pack_base_path
+from st2common.runners.base_action import Action
+from st2common.util.pack import get_pack_metadata
+
+
+class GetPackWarnings(Action):
+    def run(self, packs_status):
+        """
+        :param packs_status: Name of the pack in Exchange or a git repo URL and download status.
+        :type: packs_status: ``dict``
+        """
+        result = {}
+        warning_list = []
+
+        if not packs_status:
+            return result
+
+        for pack, status in six.iteritems(packs_status):
+            if 'success' not in status.lower():
+                continue
+
+            warning = get_warnings(pack)
+
+            if warning:
+                warning_list.append(warning)
+
+        result['warning_list'] = warning_list
+
+        return result
+
+
+def get_warnings(pack=None):
+    result = None
+    pack_path = get_pack_base_path(pack)
+    try:
+        pack_metadata = get_pack_metadata(pack_dir=pack_path)
+        pack_name = pack_metadata.get('name', None)
+        versions = pack_metadata.get('python_versions', None)
+        if set(versions) == set(['2']):
+            result = "DEPRECATION WARNING: Pack %s only supports Python 2.x. " \
+                     "ST2 will remove support for Python 2.x in a future release." \
+                     % pack_name
+    except Exception:
+        print('Could not open pack.yaml at location %s' % pack_path)
+    finally:
+        return result

--- a/contrib/packs/actions/pack_mgmt/get_pack_warnings.py
+++ b/contrib/packs/actions/pack_mgmt/get_pack_warnings.py
@@ -53,8 +53,7 @@ def get_warnings(pack=None):
     pack_path = get_pack_base_path(pack)
     try:
         pack_metadata = get_pack_metadata(pack_dir=pack_path)
-        pack_name = pack_metadata.get('name', None)
-        result = get_pack_warnings(pack_metadata, pack_name)
+        result = get_pack_warnings(pack_metadata)
     except Exception:
         print('Could not open pack.yaml at location %s' % pack_path)
     finally:

--- a/contrib/packs/actions/pack_mgmt/get_pack_warnings.py
+++ b/contrib/packs/actions/pack_mgmt/get_pack_warnings.py
@@ -16,16 +16,16 @@ from __future__ import print_function
 
 import six
 
-from st2common.constants.pack import PACK_VERSION_SEPARATOR
 from st2common.content.utils import get_pack_base_path
 from st2common.runners.base_action import Action
 from st2common.util.pack import get_pack_metadata
+from st2common.util.pack import get_pack_warnings
 
 
 class GetPackWarnings(Action):
     def run(self, packs_status):
         """
-        :param packs_status: Name of the pack in Exchange or a git repo URL and download status.
+        :param packs_status: Name of the pack and download status.
         :type: packs_status: ``dict``
         """
         result = {}
@@ -54,11 +54,7 @@ def get_warnings(pack=None):
     try:
         pack_metadata = get_pack_metadata(pack_dir=pack_path)
         pack_name = pack_metadata.get('name', None)
-        versions = pack_metadata.get('python_versions', None)
-        if set(versions) == set(['2']):
-            result = "DEPRECATION WARNING: Pack %s only supports Python 2.x. " \
-                     "ST2 will remove support for Python 2.x in a future release." \
-                     % pack_name
+        result = get_pack_warnings(pack_metadata, pack_name)
     except Exception:
         print('Could not open pack.yaml at location %s' % pack_path)
     finally:

--- a/contrib/packs/actions/workflows/install.yaml
+++ b/contrib/packs/actions/workflows/install.yaml
@@ -14,6 +14,7 @@ vars:
   - packs_list: null
   - dependency_list: null
   - conflict_list: null
+  - warning_list: null
   - nested: 10
   - message: ""
 
@@ -99,6 +100,16 @@ tasks:
       python3: <% ctx().python3 %>
     next:
       - when: <% succeeded() %>
+        do: get_pack_warnings
+
+  get_pack_warnings:
+    action: packs.get_pack_warnings
+    input:
+      packs_status: <% task(download_pack).result.result %>
+    next:
+      - when: <% succeeded() %>
+        publish:
+          - warning_list: <% result().result.warning_list %>
         do: register_pack
 
   register_pack:
@@ -114,3 +125,4 @@ output:
   - packs_list: <% ctx().packs_list %>
   - message: <% ctx().message %>
   - conflict_list: <% ctx().conflict_list %>
+  - warning_list: <% ctx().warning_list %>

--- a/contrib/packs/tests/test_get_pack_warnings.py
+++ b/contrib/packs/tests/test_get_pack_warnings.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+
+# Copyright 2020 The StackStorm Authors.
+# Copyright 2019 Extreme Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+
+from st2tests.base import BaseActionTestCase
+
+from pack_mgmt.get_pack_warnings import GetPackWarnings
+
+PACK_METADATA = {
+    # Python 2 & 3
+    "py23": {
+        "version": "0.4.0",
+        "name": "py23",
+        "repo_url": "https://github.com/StackStorm-Exchange/stackstorm-no_warnings",
+        "author": "st2-dev",
+        "keywords": ["some", "search", "another", "terms"],
+        "email": "info@stackstorm.com",
+        "description": "st2 pack to test package management pipeline",
+        "python_versions": ["2","3"],
+    },
+    # Python 3
+    "py3": {
+        "version": "0.4.0",
+        "name": "py3",
+        "repo_url": "https://github.com/StackStorm-Exchange/stackstorm-no_warnings",
+        "author": "st2-dev",
+        "keywords": ["some", "search", "another", "terms"],
+        "email": "info@stackstorm.com",
+        "description": "st2 pack to test package management pipeline",
+        "python_versions": ["3"],
+    },
+    # Python missing
+    "pynone": {
+        "version": "0.4.0",
+        "name": "pynone",
+        "repo_url": "https://github.com/StackStorm-Exchange/stackstorm-no_warnings",
+        "author": "st2-dev",
+        "keywords": ["some", "search", "another", "terms"],
+        "email": "info@stackstorm.com",
+        "description": "st2 pack to test package management pipeline",
+    },
+    # Python 2 only
+    "py2": {
+        "version": "0.5.0",
+        "name": "py2",
+        "repo_url": "https://github.com/StackStorm-Exchange/stackstorm-test2",
+        "author": "stanley",
+        "keywords": ["some", "special", "terms"],
+        "email": "info@stackstorm.com",
+        "description": "another st2 pack to test package management pipeline",
+        "python_versions": ["2"],
+    },
+    # Python 2 only
+    "py22": {
+        "version": "0.5.0",
+        "name": "py22",
+        "repo_url": "https://github.com/StackStorm-Exchange/stackstorm-test2",
+        "author": "stanley",
+        "keywords": ["some", "special", "terms"],
+        "email": "info@stackstorm.com",
+        "description": "another st2 pack to test package management pipeline",
+        "python_versions": ["2"]
+    }
+}
+
+def mock_get_pack_basepath(pack):
+    """
+    Mock get_pack_basepath function which just returns pack n ame
+    """
+    return pack
+
+
+def mock_get_pack_metadata(pack_dir):
+    """
+    Mock get_pack_version function which return mocked pack version
+    """
+    metadata = {}
+
+    if pack_dir in PACK_METADATA:
+        metadata = PACK_METADATA[pack_dir]
+    return metadata
+
+
+@mock.patch('pack_mgmt.get_pack_warnings.get_pack_base_path', mock_get_pack_basepath)
+@mock.patch('pack_mgmt.get_pack_warnings.get_pack_metadata', mock_get_pack_metadata)
+class GetPackWarningsTestCase(BaseActionTestCase):
+    action_cls = GetPackWarnings
+
+    def setUp(self):
+        super(GetPackWarningsTestCase, self).setUp()
+
+    def test_run_get_pack_warnings_py3_pack(self):
+        action = self.get_action_instance()
+        packs_status = {"py3": "Success."}
+
+        result = action.run(packs_status=packs_status)
+        self.assertEqual(result['warning_list'], [])
+
+    def test_run_get_pack_warnings_py2_pack(self):
+        action = self.get_action_instance()
+        packs_status = {"py2": "Success."}
+
+        result = action.run(packs_status=packs_status)
+        self.assertEqual(len(result['warning_list']), 1)
+        warning = result['warning_list'][0]
+        self.assertTrue("DEPRECATION WARNING" in warning)
+        self.assertTrue("Pack py2 only supports Python 2" in warning)
+
+    def test_run_get_pack_warnings_py23_pack(self):
+        action = self.get_action_instance()
+        packs_status = {"py23": "Success."}
+
+        result = action.run(packs_status=packs_status)
+        self.assertEqual(result['warning_list'], [])
+
+    def test_run_get_pack_warnings_pynone_pack(self):
+        action = self.get_action_instance()
+        packs_status = {"pynone": "Success."}
+
+        result = action.run(packs_status=packs_status)
+        self.assertEqual(result['warning_list'], [])
+
+    def test_run_get_pack_warnings_multiple_pack(self):
+        action = self.get_action_instance()
+        packs_status = {"py2": "Success.",
+                        "py23": "Success.",
+                        "py22": "Success."}
+
+        result = action.run(packs_status=packs_status)
+        self.assertEqual(len(result['warning_list']), 2)
+        warning0 = result['warning_list'][0]
+        warning1 = result['warning_list'][1]
+        self.assertTrue("DEPRECATION WARNING" in warning0)
+        self.assertTrue("DEPRECATION WARNING" in warning1)
+        self.assertTrue(("Pack py2 only supports Python 2" in warning0 and
+                         "Pack py22 only supports Python 2" in warning1) or 
+                         ("Pack py22 only supports Python 2" in warning0 and
+                         "Pack py2 only supports Python 2" in warning1))
+                        

--- a/contrib/packs/tests/test_get_pack_warnings.py
+++ b/contrib/packs/tests/test_get_pack_warnings.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 # Copyright 2020 The StackStorm Authors.
-# Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/contrib/packs/tests/test_get_pack_warnings.py
+++ b/contrib/packs/tests/test_get_pack_warnings.py
@@ -17,7 +17,6 @@
 import mock
 
 from st2tests.base import BaseActionTestCase
-
 from pack_mgmt.get_pack_warnings import GetPackWarnings
 
 PACK_METADATA = {

--- a/contrib/packs/tests/test_get_pack_warnings.py
+++ b/contrib/packs/tests/test_get_pack_warnings.py
@@ -150,4 +150,3 @@ class GetPackWarningsTestCase(BaseActionTestCase):
                          "Pack py22 only supports Python 2" in warning1) or 
                          ("Pack py22 only supports Python 2" in warning0 and
                          "Pack py2 only supports Python 2" in warning1))
-                        

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -284,6 +284,10 @@ class PackInstallCommand(PackAsyncCommand):
                               attributes=args.attr, widths=args.width,
                               json=args.json, yaml=args.yaml)
 
+        warnings = instance.result['output']['warning_list']
+        for warning in warnings:
+            print(warning)
+
 
 class PackRemoveCommand(PackAsyncCommand):
     def __init__(self, resource, *args, **kwargs):

--- a/st2common/st2common/util/pack.py
+++ b/st2common/st2common/util/pack.py
@@ -44,7 +44,8 @@ __all__ = [
 
 # Common format for python 2.7 warning
 PACK_PYTHON2_WARNING = "DEPRECATION WARNING: Pack %s only supports Python 2.x. " \
-                       "ST2 will remove support for Python 2.x in a future release."
+                       "Python 2 support will be dropped in future releases. " \
+                       "Please consider updating your packs to work with Python 3.x"
 
 
 def get_pack_ref_from_metadata(metadata, pack_directory_name=None):
@@ -99,7 +100,7 @@ def get_pack_metadata(pack_dir):
     return content
 
 
-def get_pack_warnings(pack_metadata, pack_name):
+def get_pack_warnings(pack_metadata):
     """
     Return warning string if pack metadata indicates only python 2 is supported
 
@@ -107,6 +108,7 @@ def get_pack_warnings(pack_metadata, pack_name):
     """
     warning = None
     versions = pack_metadata.get('python_versions', None)
+    pack_name = pack_metadata.get('name', None)
     if set(versions) == set(['2']):
         warning = PACK_PYTHON2_WARNING % pack_name
     return warning

--- a/st2common/st2common/util/pack.py
+++ b/st2common/st2common/util/pack.py
@@ -109,7 +109,7 @@ def get_pack_warnings(pack_metadata):
     warning = None
     versions = pack_metadata.get('python_versions', None)
     pack_name = pack_metadata.get('name', None)
-    if set(versions) == set(['2']):
+    if versions and set(versions) == set(['2']):
         warning = PACK_PYTHON2_WARNING % pack_name
     return warning
 

--- a/st2common/st2common/util/pack.py
+++ b/st2common/st2common/util/pack.py
@@ -32,6 +32,7 @@ from st2common.util import jinja as jinja_utils
 __all__ = [
     'get_pack_ref_from_metadata',
     'get_pack_metadata',
+    'get_pack_warnings',
 
     'get_pack_common_libs_path_for_pack_ref',
     'get_pack_common_libs_path_for_pack_db',
@@ -40,6 +41,10 @@ __all__ = [
 
     'normalize_pack_version'
 ]
+
+# Common format for python 2.7 warning
+PACK_PYTHON2_WARNING = "DEPRECATION WARNING: Pack %s only supports Python 2.x. " \
+                       "ST2 will remove support for Python 2.x in a future release."
 
 
 def get_pack_ref_from_metadata(metadata, pack_directory_name=None):
@@ -92,6 +97,19 @@ def get_pack_metadata(pack_dir):
         raise ValueError('Pack "%s" metadata file is empty' % (pack_dir))
 
     return content
+
+
+def get_pack_warnings(pack_metadata, pack_name):
+    """
+    Return warning string if pack metadata indicates only python 2 is supported
+
+    :rtype: ``str``
+    """
+    warning = None
+    versions = pack_metadata.get('python_versions', None)
+    if set(versions) == set(['2']):
+        warning = PACK_PYTHON2_WARNING % pack_name
+    return warning
 
 
 def validate_config_against_schema(config_schema, config_object, config_path,

--- a/st2common/st2common/util/pack_management.py
+++ b/st2common/st2common/util/pack_management.py
@@ -310,7 +310,7 @@ def move_pack(abs_repo_base, pack_name, abs_local_path, pack_metadata, force_own
         if warning:
             logger.warning(warning)
 
-        message = "Success."
+        message = 'Success.'
     elif message:
         message = 'Failure : %s' % message
 

--- a/st2common/st2common/util/pack_management.py
+++ b/st2common/st2common/util/pack_management.py
@@ -306,7 +306,7 @@ def move_pack(abs_repo_base, pack_name, abs_local_path, pack_metadata, force_own
             apply_pack_permissions(pack_path=dest_pack_path)
 
         # Log warning if python2 only supported
-        warning = get_pack_warnings(pack_metadata, pack_name)
+        warning = get_pack_warnings(pack_metadata)
         if warning:
             logger.warning(warning)
 

--- a/st2common/st2common/util/pack_management.py
+++ b/st2common/st2common/util/pack_management.py
@@ -42,6 +42,7 @@ from st2common.constants.pack import PACK_VERSION_REGEX
 from st2common.services.packs import get_pack_from_index
 from st2common.util.pack import get_pack_metadata
 from st2common.util.pack import get_pack_ref_from_metadata
+from st2common.util.pack import get_pack_warnings
 from st2common.util.green import shell
 from st2common.util.versioning import complex_semver_match
 from st2common.util.versioning import get_stackstorm_version
@@ -304,14 +305,12 @@ def move_pack(abs_repo_base, pack_name, abs_local_path, pack_metadata, force_own
             # 2. Setup the right permissions and group ownership
             apply_pack_permissions(pack_path=dest_pack_path)
 
-        # Raise warning if python2 only supported
-        supported_python_versions = pack_metadata.get('python_versions', None)
+        # Log warning if python2 only supported
+        warning = get_pack_warnings(pack_metadata, pack_name)
+        if warning:
+            logger.warning(warning)
+
         message = "Success."
-        if set(supported_python_versions) == set(['2']):
-           warning = "DEPRECATION WARNING: Pack %s only supports Python 2.x. " \
-                     "ST2 will remove support for Python 2.x in a future release." \
-                     % pack_name
-           logger.warning(warning)
     elif message:
         message = 'Failure : %s' % message
 

--- a/st2common/st2common/util/pack_management.py
+++ b/st2common/st2common/util/pack_management.py
@@ -155,16 +155,18 @@ def download_pack(pack, abs_repo_base='/opt/stackstorm/packs', verify_ssl=True, 
                 clone_repo(temp_dir=abs_local_path, repo_url=pack_url, verify_ssl=verify_ssl,
                            ref=pack_version)
 
+            pack_metadata = get_pack_metadata(pack_dir=abs_local_path)
             pack_ref = get_pack_ref(pack_dir=abs_local_path)
             result[1] = pack_ref
 
             # 2. Verify that the pack version if compatible with current StackStorm version
             if not force:
-                verify_pack_version(pack_dir=abs_local_path, use_python3=use_python3)
+                verify_pack_version(pack_metadata=pack_metadata, use_python3=use_python3)
 
             # 3. Move pack to the final location
             move_result = move_pack(abs_repo_base=abs_repo_base, pack_name=pack_ref,
                                     abs_local_path=abs_local_path,
+                                    pack_metadata=pack_metadata,
                                     force_owner_group=force_owner_group,
                                     force_permissions=force_permissions,
                                     logger=logger)
@@ -267,7 +269,7 @@ def clone_repo(temp_dir, repo_url, verify_ssl=True, ref='master'):
     return temp_dir
 
 
-def move_pack(abs_repo_base, pack_name, abs_local_path, force_owner_group=True,
+def move_pack(abs_repo_base, pack_name, abs_local_path, pack_metadata, force_owner_group=True,
               force_permissions=True, logger=LOG):
     """
     Move pack directory into the final location.
@@ -302,7 +304,14 @@ def move_pack(abs_repo_base, pack_name, abs_local_path, force_owner_group=True,
             # 2. Setup the right permissions and group ownership
             apply_pack_permissions(pack_path=dest_pack_path)
 
-        message = 'Success.'
+        # Raise warning if python2 only supported
+        supported_python_versions = pack_metadata.get('python_versions', None)
+        message = "Success."
+        if set(supported_python_versions) == set(['2']):
+           warning = "DEPRECATION WARNING: Pack %s only supports Python 2.x. " \
+                     "ST2 will remove support for Python 2.x in a future release." \
+                     % pack_name
+           logger.warning(warning)
     elif message:
         message = 'Failure : %s' % message
 
@@ -420,11 +429,10 @@ def is_desired_pack(abs_pack_path, pack_name):
     return (True, '')
 
 
-def verify_pack_version(pack_dir, use_python3=False):
+def verify_pack_version(pack_metadata, use_python3=False):
     """
     Verify that the pack works with the currently running StackStorm version.
     """
-    pack_metadata = get_pack_metadata(pack_dir=pack_dir)
     pack_name = pack_metadata.get('name', None)
     required_stackstorm_version = pack_metadata.get('stackstorm_version', None)
     supported_python_versions = pack_metadata.get('python_versions', None)
@@ -456,7 +464,8 @@ def verify_pack_version(pack_dir, use_python3=False):
                    'the pack is not guaranteed to work.' % (pack_name, CURRENT_PYTHON_VERSION))
             raise ValueError(msg)
         else:
-            # Pack support Python 2.x and 3.x so no check is needed
+            # Pack support Python 2.x and 3.x so no check is needed, or
+            # supported version matches ST2 version
             pass
 
     return True

--- a/st2common/tests/unit/test_util_pack.py
+++ b/st2common/tests/unit/test_util_pack.py
@@ -66,7 +66,7 @@ class PackUtilsTestCase(unittest2.TestCase):
 
     def test_get_pack_warnings_python2_and_3(self):
         pack_metadata = {
-            'python_versions': ['2','3'],
+            'python_versions': ['2', '3'],
             'name': 'Pack23'
         }
         warning = get_pack_warnings(pack_metadata)

--- a/st2common/tests/unit/test_util_pack.py
+++ b/st2common/tests/unit/test_util_pack.py
@@ -71,3 +71,10 @@ class PackUtilsTestCase(unittest2.TestCase):
         }
         warning = get_pack_warnings(pack_metadata)
         self.assertEqual(None, warning)
+
+    def test_get_pack_warnings_no_python(self):
+        pack_metadata = {
+            'name': 'PackNone'
+        }
+        warning = get_pack_warnings(pack_metadata)
+        self.assertEqual(None, warning)

--- a/st2common/tests/unit/test_util_pack.py
+++ b/st2common/tests/unit/test_util_pack.py
@@ -18,6 +18,7 @@ import unittest2
 
 from st2common.models.db.pack import PackDB
 from st2common.util.pack import get_pack_common_libs_path_for_pack_db
+from st2common.util.pack import get_pack_warnings
 
 
 class PackUtilsTestCase(unittest2.TestCase):
@@ -46,3 +47,27 @@ class PackUtilsTestCase(unittest2.TestCase):
         pack_db = PackDB(**pack_model_args)
         lib_path = get_pack_common_libs_path_for_pack_db(pack_db)
         self.assertEqual(None, lib_path)
+
+    def test_get_pack_warnings_python2_only(self):
+        pack_metadata = {
+            'python_versions': ['2'],
+            'name': 'Pack2'
+        }
+        warning = get_pack_warnings(pack_metadata)
+        self.assertTrue("DEPRECATION WARNING" in warning)
+
+    def test_get_pack_warnings_python3_only(self):
+        pack_metadata = {
+            'python_versions': ['3'],
+            'name': 'Pack3'
+        }
+        warning = get_pack_warnings(pack_metadata)
+        self.assertEqual(None, warning)
+
+    def test_get_pack_warnings_python2_and_3(self):
+        pack_metadata = {
+            'python_versions': ['2','3'],
+            'name': 'Pack23'
+        }
+        warning = get_pack_warnings(pack_metadata)
+        self.assertEqual(None, warning)


### PR DESCRIPTION
packs.download action will log a warning if attempt to install a pack that only supports python 2

packs.install workflow will include an extra step to check if the metadata indicates warnings (and will return a warning_list of any of the packs that had a warning - whereby warnings will only be raised if the pack supports python 2). The warning_list will also be an output of the workflow (similar to conflict_list)

st2 client, when running "pack install" will output to screen any warnings reported in the warning_list from the workflow execution. 

Part of #4938