### PR TITLE
Update the st2 API validation on RBAC configuration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,9 @@ Changed
   Contributed by Justin Sostre (@saucetray)
 * The built-in ``st2.action.file_writen`` trigger has been renamed to ``st2.action.file_written``
   to fix the typo (bug fix) #4992
+* Renamed reference to the RBAC backend/plugin from ``enterprise`` to ``default``. Updated st2api
+  validation to use the new value when checking RBAC configuration. Removed other references to
+  enterprise for RBAC related contents. (improvement)
 
 Fixed
 ~~~~~

--- a/contrib/runners/inquirer_runner/inquirer_runner/runner.yaml
+++ b/contrib/runners/inquirer_runner/inquirer_runner/runner.yaml
@@ -23,7 +23,7 @@
     roles:
       default: []
       required: false
-      description: A list of roles that are permitted to respond to the action (if nothing provided, all are permitted) - REQUIRES ENTERPRISE FEATURES 
+      description: A list of roles that are permitted to respond to the action (if nothing provided, all are permitted) - REQUIRES RBAC FEATURES 
       type: array
     users:
       default: []

--- a/st2api/st2api/validation.py
+++ b/st2api/st2api/validation.py
@@ -36,16 +36,15 @@ def validate_rbac_is_correctly_configured():
                'You can either enable authentication or disable RBAC.')
         raise ValueError(msg)
 
-    # 2. Verify enterprise backend is set
-    if cfg.CONF.rbac.backend != 'enterprise':
-        msg = ('You have enabled RBAC, but RBAC backend is not set to "enterprise". '
-               'For RBAC to work, you need to install "bwc-enterprise" package, set '
-               '"rbac.backend" config option to "enterprise" and restart st2api service.')
+    # 2. Verify default backend is set
+    if cfg.CONF.rbac.backend != 'default':
+        msg = ('You have enabled RBAC, but RBAC backend is not set to "default". '
+               'For RBAC to work, you need to install "st2-rbac-backend" package, set '
+               '"rbac.backend" config option to "default" and restart st2api service.')
         raise ValueError(msg)
 
-    # 2. Verify enterprise bits are available
-    if 'enterprise' not in available_rbac_backends:
-        msg = ('"enterprise" RBAC backend is not available. Make sure '
-               '"bwc-enterprise" and "st2-rbac-backend" system packages are '
-               'installed.')
+    # 2. Verify default RBAC backend is available
+    if 'default' not in available_rbac_backends:
+        msg = ('"default" RBAC backend is not available. Make sure '
+               '"st2-rbac-backend" system packages are installed.')
         raise ValueError(msg)

--- a/st2api/tests/unit/test_validation_utils.py
+++ b/st2api/tests/unit/test_validation_utils.py
@@ -42,20 +42,20 @@ class ValidationUtilsTestCase(unittest2.TestCase):
         self.assertRaisesRegexp(ValueError, expected_msg,
                                 validate_rbac_is_correctly_configured)
 
-    def test_validate_rbac_is_correctly_configured_non_enterprise_backend_set(self):
+    def test_validate_rbac_is_correctly_configured_non_default_backend_set(self):
         cfg.CONF.set_override(group='rbac', name='enable', override=True)
         cfg.CONF.set_override(group='rbac', name='backend', override='invalid')
         cfg.CONF.set_override(group='auth', name='enable', override=True)
 
-        expected_msg = ('You have enabled RBAC, but RBAC backend is not set to "enterprise".')
+        expected_msg = ('You have enabled RBAC, but RBAC backend is not set to "default".')
         self.assertRaisesRegexp(ValueError, expected_msg,
                                 validate_rbac_is_correctly_configured)
 
-    def test_validate_rbac_is_correctly_configured_enterprise_backend_not_available(self):
+    def test_validate_rbac_is_correctly_configured_default_backend_not_available(self):
         cfg.CONF.set_override(group='rbac', name='enable', override=True)
-        cfg.CONF.set_override(group='rbac', name='backend', override='enterprise')
+        cfg.CONF.set_override(group='rbac', name='backend', override='default')
         cfg.CONF.set_override(group='auth', name='enable', override=True)
 
-        expected_msg = ('"enterprise" RBAC backend is not available. ')
+        expected_msg = ('"default" RBAC backend is not available. ')
         self.assertRaisesRegexp(ValueError, expected_msg,
                                 validate_rbac_is_correctly_configured)

--- a/st2tests/st2tests/fixtures/generic/runners/inquirer.yaml
+++ b/st2tests/st2tests/fixtures/generic/runners/inquirer.yaml
@@ -24,7 +24,7 @@ runner_parameters:
   roles:
     default: []
     required: false
-    description: A list of roles that are permitted to respond to the action (if nothing provided, all are permitted) - REQUIRES ENTERPRISE FEATURES 
+    description: A list of roles that are permitted to respond to the action (if nothing provided, all are permitted) - REQUIRES RBAC FEATURES 
     type: array
   users:
     default: []


### PR DESCRIPTION
The RBAC backend will be named "default" instead of "enterprise" after it has been open sourced. Update the API validation to look for the "default" value instead of "enterprise". Minor update to comments related to the RBAC enterprise feature.