### PR TITLE
Fix travis jobs after making python3 as default for development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,15 +38,15 @@ jobs:
     # scripts/travis/run-nightly-make-task-if-exists.sh
     - name: "Unit Tests (Python 2.7 MongoDB 4.0)"
       python: 2.7
-      env: TASK=ci-unit CACHE_NAME=py2 COMMAND_THRESHOLD=700
+      env: TASK=ci-unit CACHE_NAME=py2 PYTHON_VERSION=python2.7 COMMAND_THRESHOLD=700
 
     - name: "Integration Tests (Python 2.7)"
       python: 2.7
-      env: TASK=ci-integration CACHE_NAME=py2 COMMAND_THRESHOLD=700
+      env: TASK=ci-integration CACHE_NAME=py2 PYTHON_VERSION=python2.7 COMMAND_THRESHOLD=700
 
     - name: "Lint Checks, Packs Tests (Python 3.6)"
       python: 3.6
-      env: TASK="ci-checks ci-packs-tests" CACHE_NAME=py3 COMMAND_THRESHOLD=430
+      env: TASK="ci-checks ci-packs-tests" CACHE_NAME=py3 PYTHON_VERSION=python3.6 COMMAND_THRESHOLD=430
 
     - name: "Unit Tests, Pack Tests (Python 3.6)"
       python: 3.6

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ else
 	VIRTUALENV_COMPONENTS_DIR ?= virtualenv-components
 endif
 
-PYTHON_VERSION ?= $(shell if [ -z "`which python3.6`" ]; then which python2.7; else which python3.6; fi)
+PYTHON_VERSION ?= $(shell if [ -z "`which python3.6`" ]; then echo "python2.7"; else echo "python3.6"; fi)
 
 BINARIES := bin
 
@@ -50,7 +50,12 @@ COMPONENTS_TEST_MODULES_COMMA := $(subst $(space_char),$(comma),$(COMPONENTS_TES
 COVERAGE_GLOBS := .coverage.unit.* .coverage.integration.*
 COVERAGE_GLOBS_QUOTED := $(foreach glob,$(COVERAGE_GLOBS),'$(glob)')
 
-REQUIREMENTS := test-requirements.txt requirements.txt
+ifeq ($(PYTHON_VERSION),python2.7)
+	REQUIREMENTS := test-requirements-py27.txt requirements.txt
+else
+	REQUIREMENTS := test-requirements.txt requirements.txt
+endif
+
 # Pin common pip version here across all the targets
 # Note! Periodic maintenance pip upgrades are required to be up-to-date with the latest pip security fixes and updates
 PIP_VERSION ?= 20.0.2
@@ -543,10 +548,9 @@ requirements: virtualenv .requirements .sdist-requirements install-runners insta
 	fi
 
 	# Install requirements
-	#
 	for req in $(REQUIREMENTS); do \
-			echo "Installing $$req..." ; \
-			$(VIRTUALENV_DIR)/bin/pip install $(PIP_OPTIONS) -r $$req ; \
+		echo "Installing $$req..." ; \
+		$(VIRTUALENV_DIR)/bin/pip install $(PIP_OPTIONS) -r $$req ; \
 	done
 
 	# Install st2common package to load drivers defined in st2common setup.py

--- a/test-requirements-py27.txt
+++ b/test-requirements-py27.txt
@@ -1,0 +1,35 @@
+# NOTE: codecov only supports coverage==4.5.2
+coverage==4.5.2
+pep8==1.7.1
+st2flake8==0.1.0
+astroid==1.6.5
+pylint==1.9.4
+pylint-plugin-utils>=0.4
+bandit==1.5.1
+ipython<6.0.0
+mock==3.0.5
+nose>=1.3.7
+tabulate
+unittest2
+sphinx==1.7.9
+sphinx-autobuild
+# nosetests enhancements
+rednose
+nose-timer==0.7.5
+# splitting tests run on a separate CI machines
+nose-parallel==0.3.1
+# Required by st2client tests
+pyyaml==5.1.2
+RandomWords
+gunicorn==19.9.0
+psutil==5.6.6
+webtest==2.0.25
+rstcheck>=3.3.1,<3.4
+tox==3.14.1
+pyrabbit
+# Since StackStorm v2.8.0 we now use cryptography instead of keyczar, but we still have some tests
+# which utilize keyczar and ensure new cryptography code is fully compatible with keyczar code
+# (those tests only run under Python 2.7 since keyczar doesn't support Python 3.x).
+# See https://github.com/StackStorm/st2/pull/4165
+python-keyczar
+pip-tools  # For pip-compile, to check for version conflicts

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -28,9 +28,4 @@ webtest==2.0.25
 rstcheck>=3.3.1,<3.4
 tox==3.14.1
 pyrabbit
-# Since StackStorm v2.8.0 we now use cryptography instead of keyczar, but we still have some tests
-# which utilize keyczar and ensure new cryptography code is fully compatible with keyczar code
-# (those tests only run under Python 2.7 since keyczar doesn't support Python 3.x).
-# See https://github.com/StackStorm/st2/pull/4165
-python-keyczar
 pip-tools  # For pip-compile, to check for version conflicts


### PR DESCRIPTION
The image that travis uses contain both python 2.7 and python 3.6. Explicitly add the PYTHON_VERSION environment variable to instruct which python executable to use. Fix python 2.7 jobs in travis that are failing.