### PR TITLE
Improve st2client homepage

### DIFF
--- a/st2client/setup.py
+++ b/st2client/setup.py
@@ -40,7 +40,6 @@ setup(
                  'automation platform.'),
     author='StackStorm',
     author_email='info@stackstorm.com',
-    license='Apache License (2.0)',
     url='https://stackstorm.com/',
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/st2client/setup.py
+++ b/st2client/setup.py
@@ -29,15 +29,20 @@ check_pip_version()
 ST2_COMPONENT = 'st2client'
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 REQUIREMENTS_FILE = os.path.join(BASE_DIR, 'requirements.txt')
+README_FILE = os.path.join(BASE_DIR, 'README.rst')
 
 install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
 apply_vagrant_workaround()
+
+with open(README_FILE) as f:
+    readme = f.read()
 
 setup(
     name=ST2_COMPONENT,
     version=__version__,
     description=('Python client library and CLI for the StackStorm (st2) event-driven '
                  'automation platform.'),
+    long_description=readme,
     author='StackStorm',
     author_email='info@stackstorm.com',
     url='https://stackstorm.com/',

--- a/st2client/setup.py
+++ b/st2client/setup.py
@@ -67,5 +67,16 @@ setup(
         'console_scripts': [
             'st2 = st2client.shell:main'
         ]
+    },
+    project_urls={
+        'Pack Exchange': 'https://exchange.stackstorm.org',
+        'Repository': 'https://github.com/StackStorm/st2',
+        'Documentation': 'https://docs.stackstorm.com',
+        'Community': 'https://stackstorm.com/community-signup',
+        'Questions': 'https://forum.stackstorm.com/',
+        'Donate': 'https://funding.communitybridge.org/projects/stackstorm',
+        'News/Blog': 'https://stackstorm.com/blog',
+        'Security': 'https://docs.stackstorm.com/latest/security.html',
+        'Bug Reports': 'https://github.com/StackStorm/st2/issues',
     }
 )


### PR DESCRIPTION
This PR improves the PyPI description of st2client by doing the following:

* Removes the redundant `license` specifier argument to `setup()` (see the official documentation on it [here](https://packaging.python.org/specifications/core-metadata/#license), and why this is a problem [here](https://github.com/diyan/pywinrm/pull/284))
* Adds the content of `README.rst` as the long description for the st2client package on PyPI
* Adds additional URLs to the project, which I think will be rendered in the sidebar of the PyPI project page, giving the links more visibility for users looking at the st2client package on PyPI