### PR TITLE
Disable pylint import checking for keyczar lines (only used for tests)

### DIFF
--- a/st2common/st2common/util/crypto.py
+++ b/st2common/st2common/util/crypto.py
@@ -325,9 +325,9 @@ def keyczar_symmetric_encrypt(encrypt_key, plaintext):
 
     :rtype: ``str``
     """
-    from keyczar.keys import AesKey as KeyczarAesKey
-    from keyczar.keys import HmacKey as KeyczarHmacKey
-    from keyczar.keyinfo import GetMode
+    from keyczar.keys import AesKey as KeyczarAesKey  # pylint: disable=import-error
+    from keyczar.keys import HmacKey as KeyczarHmacKey  # pylint: disable=import-error
+    from keyczar.keyinfo import GetMode  # pylint: disable=import-error
 
     encrypt_key = KeyczarAesKey(encrypt_key.aes_key_string,
                                 KeyczarHmacKey(encrypt_key.hmac_key_string,
@@ -352,9 +352,9 @@ def keyczar_symmetric_decrypt(decrypt_key, ciphertext):
 
     :rtype: ``str``
     """
-    from keyczar.keys import AesKey as KeyczarAesKey
-    from keyczar.keys import HmacKey as KeyczarHmacKey
-    from keyczar.keyinfo import GetMode
+    from keyczar.keys import AesKey as KeyczarAesKey  # pylint: disable=import-error
+    from keyczar.keys import HmacKey as KeyczarHmacKey  # pylint: disable=import-error
+    from keyczar.keyinfo import GetMode  # pylint: disable=import-error
 
     decrypt_key = KeyczarAesKey(decrypt_key.aes_key_string,
                                 KeyczarHmacKey(decrypt_key.hmac_key_string,


### PR DESCRIPTION
The Travis CI tests are [failing](https://travis-ci.org/github/StackStorm/st2/jobs/739147683#L1572) the lint tests because pylint can't import keyzar.

Luckily, keyczar was phased out in StackStorm 2.8, and support for that was dropped once 2.10 was released (December 2018), so no keyczar code is in production - it is only code for tests.

This PR simply disables pylint import checks for those lines so Travis CI tests can successfully complete.