### PR TITLE
Remove py2.7 from the README badges

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,4 +276,4 @@ experimental:
 
 notify:
   webhooks:
-    - url: https://ci-webhooks.stackstorm.net/webhooks/build/events
+    - url: https://ci-webhooks.stackstorm.com/webhooks/build/events

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Packages Build Status](https://circleci.com/gh/StackStorm/st2/tree/master.svg?style=shield)](https://circleci.com/gh/StackStorm/st2) 
 [![Codecov](https://codecov.io/github/StackStorm/st2/badge.svg?branch=master&service=github)](https://codecov.io/github/StackStorm/st2?branch=master) 
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1833/badge)](https://bestpractices.coreinfrastructure.org/projects/1833) 
-![Python 2.7 | 3.6](https://img.shields.io/badge/python-2.7%20%7C%203.6-blue) 
+![Python 3.6](https://img.shields.io/badge/python-3.6-blue) 
 [![Apache Licensed](https://img.shields.io/github/license/StackStorm/st2)](LICENSE) 
 [![Join our community Slack](https://img.shields.io/badge/slack-stackstorm-success.svg?logo=slack)](https://stackstorm.com/community-signup) 
 [![Forum](https://img.shields.io/discourse/https/forum.stackstorm.com/posts.svg)](https://forum.stackstorm.com/)


### PR DESCRIPTION
Remove `py 2.7` from the README, leave `py 3.6` only for the upcoming `v3.4.0` release.

_Side Note:_ PR to test if StackStorm CI webhooks work for triggering the e2e test builds.