### PR TITLE
Fix chardet as fix requests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ Added
 
 Changed
 ~~~~~~~~~
+* Pin chardet requirement #5101
+  Contributed by @amanda11
+
 * Improve the st2-self-check script to echo to stderr and exit if it isn't run with a
   ST2_AUTH_TOKEN or ST2_API_KEY environment variable. (improvement) #5068
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,9 +17,6 @@ Added
 
 Changed
 ~~~~~~~~~
-* Pin chardet requirement #5101
-  Contributed by @amanda11
-
 * Improve the st2-self-check script to echo to stderr and exit if it isn't run with a
   ST2_AUTH_TOKEN or ST2_API_KEY environment variable. (improvement) #5068
 
@@ -32,6 +29,9 @@ Changed
 
 Fixed
 ~~~~~~~~~
+* Pin chardet version as newest version was incompatible with pinned requests version #5101
+  Contributed by @amanda11
+
 * Fixed issue were st2tests was not getting installed using pip because no version was specified.
   Contributed by @anirudhbagri
   

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -2,6 +2,8 @@
 # Note: amqp is used by kombu
 amqp==2.5.2
 apscheduler==3.6.3
+# requests 2.23 requires chardet < 3.1.0
+chardet<3.1.0
 # NOTE: 2.0 version breaks pymongo work with hosts
 dnspython>=1.16.0,<2.0.0
 cryptography==3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ amqp==2.5.2
 apscheduler==3.6.3
 argcomplete
 bcrypt==3.1.7
+chardet<3.1.0
 cryptography==3.2
 dnspython<2.0.0,>=1.16.0
 eventlet==0.25.1

--- a/st2actions/in-requirements.txt
+++ b/st2actions/in-requirements.txt
@@ -1,4 +1,4 @@
-# Remeber to list implicit packages here, otherwise version won't be fixated!
+# Remember to list implicit packages here, otherwise version won't be fixated!
 apscheduler
 python-dateutil
 eventlet
@@ -18,3 +18,5 @@ pyinotify
 git+https://github.com/StackStorm/logshipper.git@stackstorm_patched#egg=logshipper
 # required by pack_mgmt/setup_virtualenv.py#L135
 virtualenv
+# needed by requests
+chardet

--- a/st2actions/requirements.txt
+++ b/st2actions/requirements.txt
@@ -6,6 +6,7 @@
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
 apscheduler==3.6.3
+chardet<3.1.0
 eventlet==0.25.1
 git+https://github.com/StackStorm/logshipper.git@stackstorm_patched#egg=logshipper
 gitpython==2.1.15

--- a/st2api/in-requirements.txt
+++ b/st2api/in-requirements.txt
@@ -1,4 +1,4 @@
-# Remeber to list implicit packages here, otherwise version won't be fixated!
+# Remember to list implicit packages here, otherwise version won't be fixated!
 eventlet
 jsonschema
 kombu

--- a/st2auth/in-requirements.txt
+++ b/st2auth/in-requirements.txt
@@ -1,4 +1,4 @@
-# Remeber to list implicit packages here, otherwise version won't be fixated!
+# Remember to list implicit packages here, otherwise version won't be fixated!
 bcrypt
 eventlet
 oslo.config

--- a/st2client/in-requirements.txt
+++ b/st2client/in-requirements.txt
@@ -1,4 +1,4 @@
-# Remeber to list implicit packages here, otherwise version won't be fixated!
+# Remember to list implicit packages here, otherwise version won't be fixated!
 argcomplete
 prettytable
 pytz
@@ -14,3 +14,5 @@ prompt-toolkit
 cryptography
 more-itertools==5.0.0
 zipp>=0.5,<=1.0.0
+# needed by requests
+chardet

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -6,6 +6,7 @@
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
 argcomplete
+chardet<3.1.0
 cryptography==3.2
 jsonpath-rw==1.4.0
 jsonschema==2.6.0

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -1,4 +1,4 @@
-# Remeber to list implicit packages here, otherwise version won't be fixated!
+# Remember to list implicit packages here, otherwise version won't be fixated!
 apscheduler
 dnspython
 python-dateutil
@@ -38,3 +38,5 @@ amqp
 # Used by st2-pack-* commands
 gitpython
 lockfile
+# needed by requests
+chardet

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -7,6 +7,7 @@
 # update the component requirements.txt
 amqp==2.5.2
 apscheduler==3.6.3
+chardet<3.1.0
 cryptography==3.2
 dnspython<2.0.0,>=1.16.0
 eventlet==0.25.1

--- a/st2debug/in-requirements.txt
+++ b/st2debug/in-requirements.txt
@@ -1,6 +1,8 @@
-# Remeber to list implicit packages here, otherwise version won't be fixated!
+# Remember to list implicit packages here, otherwise version won't be fixated!
 six
 eventlet
 pyyaml
 python-gnupg
 requests
+# needed by requests
+chardet

--- a/st2debug/requirements.txt
+++ b/st2debug/requirements.txt
@@ -5,6 +5,7 @@
 # If you want to update depdencies for a single component, modify the
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
+chardet<3.1.0
 eventlet==0.25.1
 python-gnupg==0.4.5
 pyyaml==5.1.2

--- a/st2exporter/in-requirements.txt
+++ b/st2exporter/in-requirements.txt
@@ -1,4 +1,4 @@
-# Remeber to list implicit packages here, otherwise version won't be fixated!
+# Remember to list implicit packages here, otherwise version won't be fixated!
 six
 eventlet
 kombu

--- a/st2reactor/in-requirements.txt
+++ b/st2reactor/in-requirements.txt
@@ -1,4 +1,4 @@
-# Remeber to list implicit packages here, otherwise version won't be fixated!
+# Remember to list implicit packages here, otherwise version won't be fixated!
 apscheduler
 python-dateutil
 eventlet

--- a/st2stream/in-requirements.txt
+++ b/st2stream/in-requirements.txt
@@ -1,4 +1,4 @@
-# Remeber to list implicit packages here, otherwise version won't be fixated!
+# Remember to list implicit packages here, otherwise version won't be fixated!
 eventlet
 jsonschema
 kombu

--- a/st2tests/in-requirements.txt
+++ b/st2tests/in-requirements.txt
@@ -1,4 +1,4 @@
-# Remeber to list implicit packages here, otherwise version won't be fixated!
+# Remember to list implicit packages here, otherwise version won't be fixated!
 mock
 unittest2
 nose


### PR DESCRIPTION
We pin requests[security] but that has a check when running that chardet is < 3.1.0, but chardet is not listed as requirement with a pinned requirement.
Also fix typo in in-requirements.txt comments