### PR TITLE
Decode pack files as utf-8 instead of ascii

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,8 @@ Fixed
 
   Contributed by @guzzijones
 
+* StackStorm now explicitly decodes pack files as utf-8 instead of implicitly as ascii (bug fix) #5106
+
 Removed
 ~~~~~~~~
 * Removed check-licence script (cleanup) #5092

--- a/st2common/st2common/content/loader.py
+++ b/st2common/st2common/content/loader.py
@@ -243,7 +243,7 @@ class MetaLoader(object):
         return result
 
     def _load(self, parser_func, file_path):
-        with open(file_path, 'r') as fd:
+        with open(file_path, 'r', encoding='utf-8') as fd:
             try:
                 return parser_func(fd)
             except ValueError:


### PR DESCRIPTION
This PR fixes the current issue plaguing the end-to-end tests on Ubuntu 16 when the bootstrap script attempts to install the stackstorm-st2 pack from StackStorm Exchange:

```
20201216T075024+0000 For the \"st2\" pack, the following content will be registered:
20201216T075024+0000 
20201216T075024+0000 actions   |  24
20201216T075024+0000 rules     |  0
20201216T075024+0000 sensors   |  0
20201216T075024+0000 aliases   |  12
20201216T075024+0000 triggers  |  0
20201216T075024+0000 
20201216T075024+0000 Installation may take a while for packs with many items.
20201216T075024+0000 
20201216T075025+0000 \t[ \u001b[93mscheduled\u001b[0m ] init_task
\t[  \u001b[93mrunning\u001b[0m  ] init_task
\t[ \u001b[92msucceeded\u001b[0m ] init_task
20201216T075027+0000 \t[ \u001b[93mscheduled\u001b[0m ] download_pack
\t[  \u001b[93mrunning\u001b[0m  ] download_pack
\t[ \u001b[92msucceeded\u001b[0m ] download_pack
20201216T075027+0000 \t[ \u001b[93mscheduled\u001b[0m ] make_a_prerun
\t[  \u001b[93mrunning\u001b[0m  ] make_a_prerun
\t[ \u001b[92msucceeded\u001b[0m ] make_a_prerun
20201216T075028+0000 \t[ \u001b[93mscheduled\u001b[0m ] get_pack_dependencies
\t[  \u001b[93mrunning\u001b[0m  ] get_pack_dependencies
\t[ \u001b[92msucceeded\u001b[0m ] get_pack_dependencies
20201216T075029+0000 \t[ \u001b[93mscheduled\u001b[0m ] check_dependency_and_conflict_list
\t[  \u001b[93mrunning\u001b[0m  ] check_dependency_and_conflict_list
\t[ \u001b[92msucceeded\u001b[0m ] check_dependency_and_conflict_list
20201216T075034+0000 \t[ \u001b[93mscheduled\u001b[0m ] install_pack_requirements
\t[  \u001b[93mrunning\u001b[0m  ] install_pack_requirements
\t[ \u001b[92msucceeded\u001b[0m ] install_pack_requirements
20201216T075035+0000 \t[ \u001b[93mscheduled\u001b[0m ] get_pack_warnings
\t[  \u001b[93mrunning\u001b[0m  ] get_pack_warnings
\t[ \u001b[92msucceeded\u001b[0m ] get_pack_warnings
20201216T075036+0000 \t[ \u001b[93mscheduled\u001b[0m ] register_pack
\t[  \u001b[93mrunning\u001b[0m  ] register_pack
\t[  \u001b[91mfailed\u001b[0m   ] register_pack
20201216T075036+0000 
20201216T075037+0000 \u001b[94mid\u001b[0m: 5fd9bc3f1431f79d4902d0e8
20201216T075037+0000 \u001b[94maction.ref\u001b[0m: packs.install
20201216T075037+0000 \u001b[94mparameters\u001b[0m: 
20201216T075037+0000   packs:
20201216T075037+0000   - st2
20201216T075037+0000   python3: false
20201216T075037+0000 \u001b[94mstatus\u001b[0m: \u001b[91mfailed\u001b[0m
20201216T075037+0000 \u001b[94mstart_timestamp\u001b[0m: Wed, 16 Dec 2020 07:50:23 UTC
20201216T075037+0000 \u001b[94mend_timestamp\u001b[0m: Wed, 16 Dec 2020 07:50:36 UTC
20201216T075037+0000 \u001b[94mresult\u001b[0m: 
20201216T075037+0000   errors:
20201216T075037+0000   - message: Execution failed. See result for details.
20201216T075037+0000     result:
20201216T075037+0000       exit_code: 1
20201216T075037+0000       result: None
20201216T075037+0000       stderr: \"st2.actions.python.St2RegisterAction: DEBUG    Calling client method \"register\" with kwargs \"{'types': ['all'], 'packs': ['st2']}\"
20201216T075037+0000 Traceback (most recent call last):
20201216T075037+0000   File \"/opt/stackstorm/st2/lib/python3.6/site-packages/python_runner/python_action_wrapper.py\", line 334, in <module>
20201216T075037+0000     obj.run()
20201216T075037+0000   File \"/opt/stackstorm/st2/lib/python3.6/site-packages/python_runner/python_action_wrapper.py\", line 193, in run
20201216T075037+0000     output = action.run(**self._parameters)
20201216T075037+0000   File \"/opt/stackstorm/packs/packs/actions/pack_mgmt/register.py\", line 82, in run
20201216T075037+0000     format_func=format_result)
20201216T075037+0000   File \"/opt/stackstorm/packs/packs/actions/pack_mgmt/register.py\", line 150, in _run_client_method
20201216T075037+0000     result = method(**method_kwargs)
20201216T075037+0000   File \"/opt/stackstorm/st2/lib/python3.6/site-packages/st2client/models/core.py\", line 42, in decorate
20201216T075037+0000     return func(*args, **kwargs)
20201216T075037+0000   File \"/opt/stackstorm/st2/lib/python3.6/site-packages/st2client/models/core.py\", line 564, in register
20201216T075037+0000     self.handle_error(response)
20201216T075037+0000   File \"/opt/stackstorm/st2/lib/python3.6/site-packages/st2client/models/core.py\", line 168, in handle_error
20201216T075037+0000     response.raise_for_status()
20201216T075037+0000   File \"/opt/stackstorm/st2/lib/python3.6/site-packages/requests/models.py\", line 941, in raise_for_status
20201216T075037+0000     raise HTTPError(http_error_msg, response=self)
20201216T075037+0000 requests.exceptions.HTTPError: 400 Client Error: Bad Request
20201216T075037+0000 MESSAGE: Failed to register alias \"/opt/stackstorm/packs/st2/aliases/actions_list.yaml\" from pack \"st2\": 'ascii' codec can't decode byte 0xe2 in position 439: ordinal not in range(128) for url: http://127.0.0.1:9101/v1/packs/register
20201216T075037+0000 \"
20201216T075037+0000       stdout: ''
20201216T075037+0000     task_id: register_pack
20201216T075037+0000     type: error
20201216T075037+0000   output:
20201216T075037+0000     conflict_list: []"
```