### PR TITLE
Use io.open() when running on Python 2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,7 +44,7 @@ Fixed
 
   Contributed by @guzzijones
 
-* StackStorm now explicitly decodes pack files as utf-8 instead of implicitly as ascii (bug fix) #5106
+* StackStorm now explicitly decodes pack files as utf-8 instead of implicitly as ascii (bug fix) #5106, #5107
 
 Removed
 ~~~~~~~~

--- a/st2common/st2common/content/loader.py
+++ b/st2common/st2common/content/loader.py
@@ -25,6 +25,9 @@ from st2common.constants.meta import ALLOWED_EXTS
 from st2common.constants.meta import PARSER_FUNCS
 from st2common.constants.pack import MANIFEST_FILE_NAME
 
+if six.PY2:
+    from io import open
+
 __all__ = [
     'ContentPackLoader',
     'MetaLoader'


### PR DESCRIPTION
This PR fixes a regression introduced by #5106. That code runs within a pack's virtualenv, and because we are still supporting Python 2 in StackStorm Exchange packs, we also need to support Python 2 in `st2common/content/loader.py`.

Using the `encoding` keyword argument to `open()` works on Python 3, but the native `open()` on Python 2 does not accept the `encoding` argument.

Instead, this PR imports `io.open` when running on Python 2, which should resolve the issue.

Thanks to @nmaludy for tracking down the issue and @armab for pointing [this Stack Overflow post](https://stackoverflow.com/questions/10971033/backporting-python-3-openencoding-utf-8-to-python-2/56520670#56520670) out [on Slack](https://stackstorm-community.slack.com/archives/CSBELJ78A/p1608318231282400).