### PR TITLE
Slack notification on failed Github Action executions on the master branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,8 +3,6 @@ name: ci
 on:
   push:
     branches: ['*']
-    tags:
-      - v*
   pull_request:
     type: [opened, reopened, edited]
   schedule:
@@ -183,12 +181,12 @@ jobs:
         # this step creates an environment variable WORKFLOW_CONCLUSION and is the most reliable way to check the status of previous jobs
         uses: technote-space/workflow-conclusion-action@v2
       - name: CI Run Failure Slack Notification
-        if: ${{ env.WORKFLOW_CONCLUSION == 'failure' && github.ref == 'refs/heads/master' }}
+        if: ${{ env.WORKFLOW_CONCLUSION == 'failure' && github.ref == 'refs/pull/1/merge' }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         uses: 8398a7/action-slack@v3
         with:
-          channel: development
+          channel: ghci-integration
           fields: repo,message,commit,author,action,workflow
           status: failure
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -171,7 +171,7 @@ jobs:
         if: "${{ success() && ((env.TASK == 'ci-unit') || (env.TASK == 'ci-integration')) && (env.ENABLE_COVERAGE == 'yes') }}"
         run: |
           ./scripts/travis/submit-codecov-coverage.sh
-      - name: CI Run Success Slack Notification
+      - name: CI Run Failure Slack Notification
         if: ${{ failure() && github.ref == 'refs/head/master'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,6 +70,8 @@ jobs:
 
       # Name of the user who is running the CI (on GitHub Actions this is 'runner')
       ST2_CI_USER: 'runner'
+    outputs:
+      job_status: "{{ job.status }}"
     steps:
       - name: Custom Environment Setup
         # built-in GitHub Actions environment variables
@@ -171,9 +173,14 @@ jobs:
         if: "${{ success() && ((env.TASK == 'ci-unit') || (env.TASK == 'ci-integration')) && (env.ENABLE_COVERAGE == 'yes') }}"
         run: |
           ./scripts/travis/submit-codecov-coverage.sh
+  slack-notification:
+    name: Slack notification for failed master builds
+    needs: ci
+    runs-on: ubuntu-latest
+    steps:
       - name: CI Run Failure Slack Notification
-        needs: [ 'ci-checks', 'ci-compile', 'ci-packs-tests', 'ci-unit' ]
-        if: ${{ success() && github.ref == 'refs/pull/1/merge' }}
+        #if: ${{ success() && github.ref == 'refs/pull/1/merge' }}
+        if: "needs.ci.outputs.job_status=='success'"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -188,7 +188,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
-          channel: ghci-integration
+          channel: development
           status: FAILED
           color: danger
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -179,6 +179,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Workflow conclusion
+        if: always()
         # this creates an environment variable WORKFLOW_CONCLUSION and is the most reliable way to check the status of previous jobs
         uses: technote-space/workflow-conclusion-action@v2
       - name: CI Run Failure Slack Notification

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -172,6 +172,7 @@ jobs:
         run: |
           ./scripts/travis/submit-codecov-coverage.sh
       - name: CI Run Failure Slack Notification
+        needs: [ 'ci-checks', 'ci-compile', 'ci-packs-tests', 'ci-unit' ]
         if: ${{ success() && github.ref == 'refs/pull/1/merge' }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -183,12 +183,12 @@ jobs:
       - name: CI Run Failure Slack Notification
         if: ${{ env.WORKFLOW_CONCLUSION == 'failure' && github.ref == 'refs/pull/1/merge' }}
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        uses: 8398a7/action-slack@v3
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v1
         with:
           channel: ghci-integration
-          fields: repo,message,commit,author,action,workflow
-          status: failure
+          status: FAILED
+          color: danger
 
       # HELPER FOR FUTURE DEVELOPERS:
       #  If your GitHub Actions job is failing and you need to debug it, by default there is

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -180,7 +180,7 @@ jobs:
     steps:
       - name: CI Run Failure Slack Notification
         #if: ${{ success() && github.ref == 'refs/pull/1/merge' }}
-        if: ${{ always() && needs.ci.outputs.job_status=='success' }}
+        if: ${{ always() && needs.ci.outputs.job_status=='failure' }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -172,7 +172,7 @@ jobs:
         run: |
           ./scripts/travis/submit-codecov-coverage.sh
       - name: CI Run Failure Slack Notification
-        if: ${{ failure() && github.ref == 'refs/head/master' }}
+        if: ${{ failure() && github.ref == 'refs/heads/master' }}
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,9 +26,9 @@ jobs:
           - name: 'Pack Tests'
             task: 'ci-packs-tests'
             python-version: '3.6'
-          - name: 'Unit Tests'
-            task: 'ci-unit'
-            python-version: '3.6'
+          #- name: 'Unit Tests'
+          #  task: 'ci-unit'
+          #  python-version: '3.6'
           # Integration tests are not working yet, still done in Travis
           # - name: 'Integration Tests'
           #   task: 'ci-integration'
@@ -180,14 +180,14 @@ jobs:
     steps:
       - name: CI Run Failure Slack Notification
         #if: ${{ success() && github.ref == 'refs/pull/1/merge' }}
-        if: ${{ always() && needs.ci.outputs.job_status=='failure' }}
+        if: ${{ needs.ci.outputs.job_status=='failure' }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         uses: 8398a7/action-slack@v3
         with:
           channel: ghci-integration
-          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
-          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,workflow
+          status: ${{ needs.ci.outputs.job_status }}
 
       # HELPER FOR FUTURE DEVELOPERS:
       #  If your GitHub Actions job is failing and you need to debug it, by default there is

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -181,7 +181,7 @@ jobs:
         # this step creates an environment variable WORKFLOW_CONCLUSION and is the most reliable way to check the status of previous jobs
         uses: technote-space/workflow-conclusion-action@v2
       - name: CI Run Failure Slack Notification
-        if: ${{ env.WORKFLOW_CONCLUSION == 'failure' && github.ref == 'refs/pull/1/merge' }}
+        if: ${{ env.WORKFLOW_CONCLUSION == 'failure' && github.ref == 'refs/heads/master' }}
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -175,11 +175,11 @@ jobs:
           ./scripts/travis/submit-codecov-coverage.sh
   slack-notification:
     name: Slack notification for failed master builds
+    if: always()
     needs: ci
     runs-on: ubuntu-latest
     steps:
       - name: Workflow conclusion
-        if: always()
         # this creates an environment variable WORKFLOW_CONCLUSION and is the most reliable way to check the status of previous jobs
         uses: technote-space/workflow-conclusion-action@v2
       - name: CI Run Failure Slack Notification

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -172,7 +172,7 @@ jobs:
         run: |
           ./scripts/travis/submit-codecov-coverage.sh
       - name: CI Run Failure Slack Notification
-        if: ${{ failure() && github.ref == 'refs/head/master'
+        if: ${{ failure() && github.ref == 'refs/head/master' }}
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
       # Name of the user who is running the CI (on GitHub Actions this is 'runner')
       ST2_CI_USER: 'runner'
     outputs:
-      job_status: "{{ job.status }}"
+      job_status: "${{ job.status }}"
     steps:
       - name: Custom Environment Setup
         # built-in GitHub Actions environment variables
@@ -180,7 +180,7 @@ jobs:
     steps:
       - name: CI Run Failure Slack Notification
         #if: ${{ success() && github.ref == 'refs/pull/1/merge' }}
-        if: "needs.ci.outputs.job_status=='success'"
+        if: ${{ always() && needs.ci.outputs.job_status=='success'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,9 +26,9 @@ jobs:
           - name: 'Pack Tests'
             task: 'ci-packs-tests'
             python-version: '3.6'
-          #- name: 'Unit Tests'
-          #  task: 'ci-unit'
-          #  python-version: '3.6'
+          - name: 'Unit Tests'
+            task: 'ci-unit'
+            python-version: '3.6'
           # Integration tests are not working yet, still done in Travis
           # - name: 'Integration Tests'
           #   task: 'ci-integration'
@@ -70,8 +70,6 @@ jobs:
 
       # Name of the user who is running the CI (on GitHub Actions this is 'runner')
       ST2_CI_USER: 'runner'
-    outputs:
-      job_status: "${{ job.status }}"
     steps:
       - name: Custom Environment Setup
         # built-in GitHub Actions environment variables
@@ -180,11 +178,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Workflow conclusion
-        # this creates an environment variable WORKFLOW_CONCLUSION and is the most reliable way to check the status of previous jobs
+        # this step creates an environment variable WORKFLOW_CONCLUSION and is the most reliable way to check the status of previous jobs
         uses: technote-space/workflow-conclusion-action@v2
       - name: CI Run Failure Slack Notification
-        #if: ${{ success() && github.ref == 'refs/pull/1/merge' }}
-        if: env.WORKFLOW_CONCLUSION == 'failure'
+        if: ${{ env.WORKFLOW_CONCLUSION == 'failure' && github.ref == 'refs/pull/1/merge' }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -178,6 +178,9 @@ jobs:
     needs: ci
     runs-on: ubuntu-latest
     steps:
+      - name: Print ci job status
+        run:
+          echo ${{ jobs.ci.outputs.job_status }}
       - name: CI Run Failure Slack Notification
         #if: ${{ success() && github.ref == 'refs/pull/1/merge' }}
         if: ${{ needs.ci.outputs.job_status=='failure' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,8 +3,6 @@ name: ci
 on:
   push:
     branches: ['*']
-    tags:
-      - v*
   pull_request:
     type: [opened, reopened, edited]
   schedule:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,15 +71,6 @@ jobs:
       # Name of the user who is running the CI (on GitHub Actions this is 'runner')
       ST2_CI_USER: 'runner'
     steps:
-      - name: CI Run Start Slack Notification
-        id: stackstorm_community_slack
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel: ghci-integration
-          status: STARTING
-          color: warning
       - name: Custom Environment Setup
         # built-in GitHub Actions environment variables
         # https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables
@@ -181,17 +172,7 @@ jobs:
         run: |
           ./scripts/travis/submit-codecov-coverage.sh
       - name: CI Run Success Slack Notification
-        if: success()
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel: ghci-integration
-          message_id: ${{ steps.stackstorm_community_slack.outputs.message_id }}
-          status: SUCCESS
-          color: good
-      - name: CI Run Success Slack Notification
-        if: failure()
+        if: ${{ failure() && github.ref == 'refs/head/master'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,6 +73,15 @@ jobs:
       # Name of the user who is running the CI (on GitHub Actions this is 'runner')
       ST2_CI_USER: 'runner'
     steps:
+      - name: CI Run Start Slack Notification
+        id: stackstorm_community_slack
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: ghci-integration
+          status: STARTING
+          color: warning
       - name: Custom Environment Setup
         # built-in GitHub Actions environment variables
         # https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables
@@ -173,6 +182,26 @@ jobs:
         if: "${{ success() && ((env.TASK == 'ci-unit') || (env.TASK == 'ci-integration')) && (env.ENABLE_COVERAGE == 'yes') }}"
         run: |
           ./scripts/travis/submit-codecov-coverage.sh
+      - name: CI Run Success Slack Notification
+        if: success()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: ghci-integration
+          message_id: ${{ steps.stackstorm_community_slack.outputs.message_id }}
+          status: SUCCESS
+          color: good
+      - name: CI Run Success Slack Notification
+        if: failure()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: ghci-integration
+          message_id: ${{ steps.stackstorm_community_slack.outputs.message_id }}
+          status: FAILED
+          color: danger
 
       # HELPER FOR FUTURE DEVELOPERS:
       #  If your GitHub Actions job is failing and you need to debug it, by default there is

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -172,15 +172,14 @@ jobs:
         run: |
           ./scripts/travis/submit-codecov-coverage.sh
       - name: CI Run Failure Slack Notification
-        if: ${{ failure() && github.ref == 'refs/heads/master' }}
+        if: ${{ success() && github.ref == 'refs/pull/1/merge' }}
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        uses: 8398a7/action-slack@v3
         with:
           channel: ghci-integration
-          message_id: ${{ steps.stackstorm_community_slack.outputs.message_id }}
-          status: FAILED
-          color: danger
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
+          status: ${{ job.status }}
 
       # HELPER FOR FUTURE DEVELOPERS:
       #  If your GitHub Actions job is failing and you need to debug it, by default there is

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -180,7 +180,7 @@ jobs:
     steps:
       - name: CI Run Failure Slack Notification
         #if: ${{ success() && github.ref == 'refs/pull/1/merge' }}
-        if: ${{ always() && needs.ci.outputs.job_status=='success'
+        if: ${{ always() && needs.ci.outputs.job_status=='success' }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,8 @@ name: ci
 on:
   push:
     branches: ['*']
+    tags:
+      - v*
   pull_request:
     type: [opened, reopened, edited]
   schedule:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,8 @@ name: ci
 on:
   push:
     branches: ['*']
+    tags:
+      - v*
   pull_request:
     type: [opened, reopened, edited]
   schedule:
@@ -181,12 +183,12 @@ jobs:
         # this step creates an environment variable WORKFLOW_CONCLUSION and is the most reliable way to check the status of previous jobs
         uses: technote-space/workflow-conclusion-action@v2
       - name: CI Run Failure Slack Notification
-        if: ${{ env.WORKFLOW_CONCLUSION == 'failure' && github.ref == 'refs/pull/1/merge' }}
+        if: ${{ env.WORKFLOW_CONCLUSION == 'failure' && github.ref == 'refs/heads/master' }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         uses: 8398a7/action-slack@v3
         with:
-          channel: ghci-integration
+          channel: development
           fields: repo,message,commit,author,action,workflow
           status: failure
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -178,19 +178,19 @@ jobs:
     needs: ci
     runs-on: ubuntu-latest
     steps:
-      - name: Print ci job status
-        run:
-          echo ${{ jobs.ci.outputs.job_status }}
+      - name: Workflow conclusion
+        # this creates an environment variable WORKFLOW_CONCLUSION and is the most reliable way to check the status of previous jobs
+        uses: technote-space/workflow-conclusion-action@v2
       - name: CI Run Failure Slack Notification
         #if: ${{ success() && github.ref == 'refs/pull/1/merge' }}
-        if: ${{ needs.ci.outputs.job_status=='failure' }}
+        if: env.WORKFLOW_CONCLUSION == 'failure'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         uses: 8398a7/action-slack@v3
         with:
           channel: ghci-integration
           fields: repo,message,commit,author,action,workflow
-          status: ${{ needs.ci.outputs.job_status }}
+          status: failure
 
       # HELPER FOR FUTURE DEVELOPERS:
       #  If your GitHub Actions job is failing and you need to debug it, by default there is

--- a/st2common/tests/unit/test_action_db_utils.py
+++ b/st2common/tests/unit/test_action_db_utils.py
@@ -42,7 +42,7 @@ class ActionDBUtilsTestCase(DbTestCase):
     liveaction_db = None
 
     @classmethod
-    def setUpClass(cls) :
+    def setUpClass(cls):
         super(ActionDBUtilsTestCase, cls).setUpClass()
         ActionDBUtilsTestCase._setup_test_models()
 

--- a/st2common/tests/unit/test_action_db_utils.py
+++ b/st2common/tests/unit/test_action_db_utils.py
@@ -42,7 +42,7 @@ class ActionDBUtilsTestCase(DbTestCase):
     liveaction_db = None
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) :
         super(ActionDBUtilsTestCase, cls).setUpClass()
         ActionDBUtilsTestCase._setup_test_models()
 


### PR DESCRIPTION
Happy new year everyone, 

this PR sends a Slack notification if a GH Action run on the master branch fails. It uses the new Slack Bot API which is the currently recommended way to integrate your apps into Slack (incoming webhooks are "legacy" now).

It relies on 2 GitHub Action services: 
1st) https://github.com/technote-space/workflow-conclusion-action - this one is needed to provide a single status for all the workflows executed so far (otherwise we would get a slack notification for `ci-checks`, `ci-compile`, `ci-packs-tests` and `ci-unit` which is unneeded noise). The workflow conclusion action creates an environment variable `WORKFLOW_CONCLUSION` which is `success` if all the jobs were successful or failure if any of them failed
2nd) https://github.com/voxmedia/github-action-slack-notify-build - this is the container that actually passes the message to slack

The notification is **only** triggered for master builds that failed and it will look like this: 
![Selection_199](https://user-images.githubusercontent.com/1457899/103492709-050a7b80-4e2d-11eb-8310-8d4ab940afcd.png)

The link `ci` leads directly to the failed execution of the Github Actions.
This PR has 2 external dependencies:
1st: A Slack Bot: 
- Create the Slack App as described here: https://api.slack.com/apps and select the stackstorm-development workspace. 
- Grant the following scopes to the bot: `channels:read`, `chat:write` and `groups:read`
- Install the bot to the workspace and confirm with `Allow`
- Go to `OAuth & Permissions` and copy the `OAuth Tokens for Your Team` token

2nd: Create a Github repository secret called `SLACK_BOT_TOKEN`:
Go to the Stackstorm/st2 repository -> Settings -> Secrets -> New Repository Secret -> Set the name to `SLACK_BOT_TOKEN` and the value to the bot token created in the step above
The token must start with `xoxb-`



