### PR TITLE
Add @shital-orchestral to the list of Contributors

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -52,6 +52,7 @@ They're not part of the TSC voting process, but appreciated for their contributi
 * Jon Middleton ([@jjm](https://github.com/jjm)) - StackStorm Exchange, Core, Discussions.
 * Marcel Weinberg ([@winem](https://github.com/winem)) - Community, Docker, Core.
 * Sheshagiri Rao Mallipedhi ([@sheshagiri](https://github.com/sheshagiri)) - Docker, Core, StackStorm Exchange.
+* Shital Raut ([@shital-orchestral](https://github.com/shital-orchestral)), Orchestral.ai - Web UI.
 * Tristan Struthers ([@trstruth](https://github.com/trstruth)) - Docker, K8s, Orquesta, Community.
 
 # Friends

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -52,7 +52,7 @@ They're not part of the TSC voting process, but appreciated for their contributi
 * Jon Middleton ([@jjm](https://github.com/jjm)) - StackStorm Exchange, Core, Discussions.
 * Marcel Weinberg ([@winem](https://github.com/winem)) - Community, Docker, Core.
 * Sheshagiri Rao Mallipedhi ([@sheshagiri](https://github.com/sheshagiri)) - Docker, Core, StackStorm Exchange.
-* Shital Raut ([@shital-orchestral](https://github.com/shital-orchestral)), Orchestral.ai - Web UI.
+* Shital Raut ([@shital-orchestral](https://github.com/shital-orchestral)), _Orchestral.ai_ - Web UI.
 * Tristan Struthers ([@trstruth](https://github.com/trstruth)) - Docker, K8s, Orquesta, Community.
 
 # Friends


### PR DESCRIPTION
I'd like to propose adding [Shital Raut](https://github.com/shital-orchestral) to the list of StackStorm Contributors for the work he did on behalf of Orchestral to integrate the Workflow Designer into StackStorm Web UI: 
* https://github.com/StackStorm/st2web/pull/759 (big PR)

This migrates the `st2flow` codebase https://github.com/stackstorm/st2flow, previously StackStorm enterprise feature into `st2web` and PR includes a lot of the changes with the integration, follow-ups and fixes. 

The `v3.4.0` release major feature was tested by the @StackStorm/maintainers and it's a great job. Hope Shital will keep contributing to [StackStorm Web UI](https://github.com/stackstorm/st2web) in the future.
