### PR TITLE
Fix implicit relative imports in pack actions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,6 +53,10 @@ Fixed
 
 * StackStorm now explicitly decodes pack files as utf-8 instead of implicitly as ascii (bug fix) #5106, #5107
 
+* Kept functionality for implicit relative imports in Python actions (regression, bug fix) #5127
+
+  Identified by @amanda11
+
 Removed
 ~~~~~~~~
 * Removed --python3 pack install option  #5100

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -140,15 +140,19 @@ def get_sandbox_python_path_for_python_action(pack, inherit_from_parent=True,
 
     virtualenv_path = get_sandbox_virtualenv_path(pack=pack)
 
-    if virtualenv_path:
+    # Get the pack's virtualenv site-packages directory
+    # There should only be one, but we don't know what version of Python it
+    # will be using, so we use a glob and ensure it exists
+    virtualenv_lib_path = os.path.join(virtualenv_path, 'lib', 'python*', 'site-packages')
+    virtualenv_lib_directories = glob.glob(virtualenv_lib_path)
+
+    if virtualenv_path and virtualenv_lib_directories:
         pack_base_path = get_pack_base_path(pack_name=pack)
 
         # Get the pack's actions/lib directory
         pack_actions_lib_paths = os.path.join(pack_base_path, 'actions', 'lib')
-
-        # Get the pack's virtualenv site-packages directory
-        virtualenv_lib_path = os.path.join(virtualenv_path, 'lib', 'python*', 'site-packages')
-        virtualenv_lib_directory = glob.glob(virtualenv_lib_path)[0]
+        # Get the pack's virtualenv's site-packages directory
+        virtualenv_lib_directory = virtualenv_lib_directories[0]
 
         # Work around to make sure we also add system lib dir to PYTHONPATH and not just virtualenv
         # one (e.g. /usr/lib/python3.6)

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -20,6 +20,7 @@ virtual environments.
 
 from __future__ import absolute_import
 
+import glob
 import os
 import sys
 from distutils.sysconfig import get_python_lib
@@ -27,6 +28,7 @@ from distutils.sysconfig import get_python_lib
 from oslo_config import cfg
 
 from st2common.constants.pack import SYSTEM_PACK_NAMES
+from st2common.content.utils import get_pack_base_path
 
 __all__ = [
     'get_sandbox_python_binary_path',
@@ -132,9 +134,58 @@ def get_sandbox_python_path_for_python_action(pack, inherit_from_parent=True,
     Same as get_sandbox_python_path() function, but it's intended to be used for Python runner
     actions.
     """
-    return get_sandbox_python_path(
+    sandbox_python_path = get_sandbox_python_path(
         inherit_from_parent=inherit_from_parent,
         inherit_parent_virtualenv=inherit_parent_virtualenv)
+
+    virtualenv_path = get_sandbox_virtualenv_path(pack=pack)
+
+    if virtualenv_path:
+        pack_base_path = get_pack_base_path(pack_name=pack)
+
+        # Get the pack's actions/lib directory
+        pack_actions_lib_paths = os.path.join(pack_base_path, 'actions', 'lib')
+
+        # Get the pack's virtualenv site-packages directory
+        virtualenv_lib_path = os.path.join(virtualenv_path, 'lib', 'python*', 'site-packages')
+        virtualenv_lib_directory = glob.glob(virtualenv_lib_path)[0]
+
+        # Work around to make sure we also add system lib dir to PYTHONPATH and not just virtualenv
+        # one (e.g. /usr/lib/python3.6)
+        # NOTE: We can't simply use sys.prefix dir since it will be set to /opt/stackstorm/st2
+
+        system_prefix_dirs = []
+        # Take custom prefix into account (if specified)
+        if cfg.CONF.actionrunner.python3_prefix:
+            system_prefix_dirs.append(cfg.CONF.actionrunner.python3_prefix)
+
+        # By default, Python libs are installed either in /usr/lib/python3.x or
+        # /usr/local/lib/python3.x
+        system_prefix_dirs.extend(['/usr/lib', '/usr/local/lib'])
+
+        for system_prefix_dir in system_prefix_dirs:
+            python3_system_lib_directory = os.path.join(system_prefix_dir,
+                                                        virtualenv_directories[0])
+
+            if os.path.exists(python3_system_lib_directory):
+                break
+        else:
+            # If no Python 3 system library is found
+            python3_system_lib_directory = None
+
+        full_sandbox_python_path = []
+
+        # NOTE: Order here is very important for imports to function correctly
+        if python3_system_lib_directory:
+            full_sandbox_python_path.append(python3_system_lib_directory)
+
+        full_sandbox_python_path.append(virtualenv_lib_directory)
+        full_sandbox_python_path.append(pack_actions_lib_paths)
+        full_sandbox_python_path.append(sandbox_python_path)
+
+        sandbox_python_path = ':'.join(full_sandbox_python_path)
+
+    return sandbox_python_path
 
 
 def get_sandbox_virtualenv_path(pack):

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -184,7 +184,7 @@ def get_sandbox_python_path_for_python_action(pack, inherit_from_parent=True,
             full_sandbox_python_path = []
 
             # NOTE: Order here is very important for imports to function correctly
-            if python3_system_lib_directory:
+            if system_lib_directory:
                 full_sandbox_python_path.append(system_lib_directory)
 
             full_sandbox_python_path.append(virtualenv_lib_directory)

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -158,16 +158,9 @@ def get_sandbox_python_path_for_python_action(pack, inherit_from_parent=True,
         # one (e.g. /usr/lib/python3.6)
         # NOTE: We can't simply use sys.prefix dir since it will be set to /opt/stackstorm/st2
 
-        system_prefix_dirs = []
-        # Take custom prefix into account (if specified)
-        if cfg.CONF.actionrunner.python3_prefix:
-            system_prefix_dirs.append(cfg.CONF.actionrunner.python3_prefix)
-
         # By default, Python libs are installed either in /usr/lib/python3.x or
         # /usr/local/lib/python3.x
-        system_prefix_dirs.extend(['/usr/lib', '/usr/local/lib'])
-
-        for system_prefix_dir in system_prefix_dirs:
+        for system_prefix_dir in ['/usr/lib', '/usr/local/lib']:
             python3_system_lib_directory = os.path.join(system_prefix_dir,
                                                         virtualenv_lib_directory)
 

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -165,7 +165,7 @@ def get_sandbox_python_path_for_python_action(pack, inherit_from_parent=True,
 
         for system_prefix_dir in system_prefix_dirs:
             python3_system_lib_directory = os.path.join(system_prefix_dir,
-                                                        virtualenv_directories[0])
+                                                        virtualenv_lib_directory)
 
             if os.path.exists(python3_system_lib_directory):
                 break

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -160,8 +160,8 @@ def get_sandbox_python_path_for_python_action(pack, inherit_from_parent=True,
             # Get the pack's virtualenv's site-packages directory
             virtualenv_lib_directory = os.path.join(virtualenv_lib_path, virtualenv_lib_directory)
 
-            # Work around to make sure we also add system lib dir to PYTHONPATH and not just virtualenv
-            # one (e.g. /usr/lib/python3.6)
+            # Work around to make sure we also add system lib dir to PYTHONPATH
+            # and not just virtualenv one (e.g. /usr/lib/python3.6)
             # This code will pick the same sytem Python version as exists in
             # the virtualenv, since virtualenv_lib_directory identifies that
             # directory within the virtualenv and it should have the same name

--- a/st2common/tests/unit/test_util_sandboxing.py
+++ b/st2common/tests/unit/test_util_sandboxing.py
@@ -111,6 +111,8 @@ class SandboxingUtilsTestCase(unittest.TestCase):
 
     @mock.patch('os.path.isdir', mock.Mock(return_value=True))
     @mock.patch('os.listdir', mock.Mock(return_value=['python2.7']))
+    @mock.patch('st2common.util.sandboxing.get_sandbox_virtualenv_path',
+                mock.Mock(return_value=None))
     @mock.patch('st2common.util.sandboxing.get_python_lib')
     def test_get_sandbox_python_path_for_python_action_python2_used_for_venv(self,
             mock_get_python_lib):


### PR DESCRIPTION
We were a little overzealous when [ripping out Python 2 support code](https://github.com/StackStorm/st2/pull/5100/files#diff-041d344e361a387d4bd68f89ef5d017f72ee91e765ac196be5de8cf0573ad3dfL154), and removed some Python 3 support as well. This PR adds that feature back in.

This PR re-enables pack authors to use implicit relative import paths when importing from `actions/lib` (eg: from lib.mymodule import myfunction`).

Python 3 has removed support for implicit relative imports for legitimate reasons, so we should try to push pack authors to use explicit relative imports (eg: `from .lib.mymodule import myfunction` - note the preceding `.` before `lib.mymodule`). But we should both document this quirk and take steps to remove it in a future ST2 release (tracking issue incoming).

Closes #5126.