### PR TITLE
Pin PyOpenSSL<20 and prettytable<2 due to python2.7 conflicts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ jobs:
             set -x
             git clone ${ST2_PACKAGES_REPO} ~/st2-packages
             cd ~/st2-packages
-            git checkout ${CIRCLE_BRANCH} || true
+            git checkout ${CIRCLE_BRANCH} || git checkout v3.3 || true
       - run:
           name: Initialize packages Build Environment
           command: |

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -5,9 +5,6 @@ apscheduler==3.6.3
 # NOTE: 2.0 version breaks pymongo work with hosts
 dnspython>=1.16.0,<2.0.0
 cryptography==2.8
-# requests==2.23 (below) needs pyOpenSSL>=0.14, but pyOpenSSL 20 (Nov 2020)
-# requires cryptography>=3.2 which conflicts with our 2.8 requirement.
-pyOpenSSL<20
 # Note: 0.20.0 removed select.poll() on which some of our code and libraries we
 # depend on rely
 eventlet==0.25.1
@@ -29,9 +26,14 @@ oslo.utils>=3.36.2,<=3.37.0
 paramiko==2.7.1
 passlib==1.7.1
 prance==0.9.0
+# prettytable 2.0 does not support python 2.7
+prettytable<2.0
 prompt-toolkit==1.0.15
 pyinotify==0.9.6; platform_system=="Linux"
 pymongo==3.10.0
+# requests==2.23 needs pyOpenSSL>=0.14, but pyOpenSSL 20 (Nov 2020)
+# requires cryptography>=3.2 which conflicts with our 2.8 requirement.
+pyOpenSSL<20
 python-editor==1.0.4
 python-gnupg==0.4.5
 python-keyczar==0.716

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -5,6 +5,9 @@ apscheduler==3.6.3
 # NOTE: 2.0 version breaks pymongo work with hosts
 dnspython>=1.16.0,<2.0.0
 cryptography==2.8
+# requests==2.23 (below) needs pyOpenSSL>=0.14, but pyOpenSSL 20 (Nov 2020)
+# requires cryptography>=3.2 which conflicts with our 2.8 requirement.
+pyOpenSSL<20
 # Note: 0.20.0 removed select.poll() on which some of our code and libraries we
 # depend on rely
 eventlet==0.25.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,7 @@ passlib==1.7.1
 prettytable
 prompt-toolkit==1.0.15
 psutil==5.6.6
+pyOpenSSL<20
 pyinotify==0.9.6 ; platform_system == "Linux"
 pymongo==3.10.0
 pyrabbit

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ oslo.config<1.13,>=1.12.1
 oslo.utils<=3.37.0,>=3.36.2
 paramiko==2.7.1
 passlib==1.7.1
-prettytable
+prettytable<2.0
 prompt-toolkit==1.0.15
 psutil==5.6.6
 pyOpenSSL<20

--- a/st2client/in-requirements.txt
+++ b/st2client/in-requirements.txt
@@ -12,5 +12,6 @@ sseclient-py
 python-editor
 prompt-toolkit
 cryptography
+pyOpenSSL
 more-itertools==5.0.0
 zipp>=0.5,<=1.0.0

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -12,6 +12,7 @@ jsonschema==2.6.0
 more-itertools==5.0.0
 prettytable
 prompt-toolkit==1.0.15
+pyOpenSSL<20
 python-dateutil==2.8.0
 python-editor==1.0.4
 pytz==2019.1

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -10,7 +10,7 @@ cryptography==2.8
 jsonpath-rw==1.4.0
 jsonschema==2.6.0
 more-itertools==5.0.0
-prettytable
+prettytable<2.0
 prompt-toolkit==1.0.15
 pyOpenSSL<20
 python-dateutil==2.8.0

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -16,6 +16,7 @@ paramiko
 pyyaml
 pymongo
 cryptography
+pyOpenSSL
 requests
 retrying
 semver

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -24,6 +24,7 @@ mongoengine==0.18.2
 networkx==1.11
 oslo.config<1.13,>=1.12.1
 paramiko==2.7.1
+pyOpenSSL<20
 pymongo==3.10.0
 python-dateutil==2.8.0
 python-statsd==2.1.0


### PR DESCRIPTION
In order to install st2 v3.3 requirements on python 2.7, we need to pin `PyOpenSSL<20` and `prettytable<2`.

We require `requests==2.23.0` which needs `pyOpenSSL >= 0.14`.
https://github.com/psf/requests/blob/v2.23.0/setup.py#L105

We also pin `cryptography==2.8`, but `pyOpenSSL==20.0.0` was released Nov 27, 2020 and that requires `cryptography>=3.2`.
https://github.com/pyca/pyopenssl/blob/20.0.0/setup.py#L98

st2client requires prettytable. prettytable 2.0 was released in November as well, and it does not support python2. pip is still trying to install it though, so we need to prevent that.