### PR TITLE
Update versions of st2tests and isort

### DIFF
--- a/st2tests/st2tests/__init__.py
+++ b/st2tests/st2tests/__init__.py
@@ -30,4 +30,4 @@ __all__ = [
     'WorkflowTestCase'
 ]
 
-__version__ = '3.3dev'
+__version__ = '3.4dev'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,7 +7,7 @@ pylint==2.6.0
 pylint-plugin-utils>=0.4
 bandit==1.5.1
 ipython<6.0.0
-isort<=4.0.0
+isort>=4.2.5
 mock==3.0.5
 nose>=1.3.7
 tabulate


### PR DESCRIPTION
Update version of isort to be compatible with pylint.
Also update st2tests to be version 3.4dev