### PR TITLE
Fix st2client @key=file_path.json notation for specifying complex objects in a file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,6 +53,11 @@ Fixed
 
 * StackStorm now explicitly decodes pack files as utf-8 instead of implicitly as ascii (bug fix) #5106, #5107
 
+* Fix ``@parameter_name=/path/to/file/foo.json`` notation in the ``st2 run`` command which didn't
+  work correctly because it didn't convert read bytes to string / unicode type. (bug fix) #5140
+
+  Contributed by @kami.
+
 Removed
 ~~~~~~~~
 * Removed --python3 pack install option  #5100

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -541,6 +541,12 @@ class ActionRunCommandMixin(object):
         action_ref_or_id = action.ref
 
         def read_file(file_path):
+            """
+            Read file content and return content as string / unicode.
+
+            NOTE: It's only mean to be used to read non-binary files since API right now doesn't
+            support passing binary data.
+            """
             if not os.path.exists(file_path):
                 raise ValueError('File "%s" doesn\'t exist' % (file_path))
 

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -550,7 +550,7 @@ class ActionRunCommandMixin(object):
             with open(file_path, 'rb') as fp:
                 content = fp.read()
 
-            return content
+            return content.decode("utf-8")
 
         def transform_object(value):
             # Also support simple key1=val1,key2=val2 syntax

--- a/st2client/tests/unit/test_command_actionrun.py
+++ b/st2client/tests/unit/test_command_actionrun.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 import copy
 
 import unittest2
+import six
 import mock
 
 from st2client.commands.action import ActionRunCommand
@@ -160,6 +161,44 @@ class ActionRunCommandTest(unittest2.TestCase):
 
         # set auto_dict back to default
         mockarg.auto_dict = False
+
+    def test_get_params_from_args_read_content_from_file(self):
+        runner = RunnerType()
+        runner.runner_parameters = {}
+
+        action = Action()
+        action.ref = 'test.action'
+        action.parameters = {
+            'param_object': {'type': 'object'},
+        }
+
+        subparser = mock.Mock()
+        command = ActionRunCommand(action, self, subparser, name='test')
+
+        # 1. File doesn't exist
+        mockarg = mock.Mock()
+        mockarg.inherit_env = False
+        mockarg.auto_dict = True
+        mockarg.parameters = [
+            '@param_object=doesnt-exist.json'
+        ]
+
+        self.assertRaisesRegex(ValueError, "doesn't exist",
+                                 command._get_action_parameters_from_args, action=action,
+                                 runner=runner, args=mockarg)
+
+        # 2. Valid file path (we simply read this file)
+        mockarg = mock.Mock()
+        mockarg.inherit_env = False
+        mockarg.auto_dict = True
+        mockarg.parameters = [
+            '@param_string=%s' % (__file__)
+        ]
+
+        params = command._get_action_parameters_from_args(action=action,
+                                 runner=runner, args=mockarg)
+        self.assertTrue(isinstance(params["param_string"], six.text_type))
+        self.assertTrue(params["param_string"].startswith("# Copyright"))
 
     def test_get_params_from_args_with_multiple_declarations(self):
         """test_get_params_from_args_with_multiple_declarations

--- a/st2client/tests/unit/test_command_actionrun.py
+++ b/st2client/tests/unit/test_command_actionrun.py
@@ -184,8 +184,8 @@ class ActionRunCommandTest(unittest2.TestCase):
         ]
 
         self.assertRaisesRegex(ValueError, "doesn't exist",
-                                 command._get_action_parameters_from_args, action=action,
-                                 runner=runner, args=mockarg)
+                               command._get_action_parameters_from_args, action=action,
+                               runner=runner, args=mockarg)
 
         # 2. Valid file path (we simply read this file)
         mockarg = mock.Mock()


### PR DESCRIPTION
I tried to use ``st2 run @param=file_path.json`` notation to specify complex JSON parameter value in a file.

It turns out it's not working correctly. Using ``--debug`` flag it shows it's not correctly converting bytes to unicode which means JSON serialization fails (actual value has``b""`` prefix which indicates that code is incorrectly calling ``str()`` on the value somewhere instead of using ``bytes.decode()``).

```bash
st2 --debug run scalyr.timeseries_queries @queries=1.json
...
ERROR: Object of type 'bytes' is not JSON serializable
....
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2client/utils/httpclient.py", line 98, in post
    response = requests.post(self.root + url, json.dumps(data), **kwargs)
  File "/usr/lib/python3.6/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python3.6/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.6/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python3.6/json/encoder.py", line 180, in default
    o.__class__.__name__)
TypeError: Object of type 'bytes' is not JSON serializable
```

This pull request fixes that.

## TODO

- [x] Add tests
- [x] Add tests and verify it works correctly with http runner (that one may expect bytes, but unlikely since the current code doesn't handle that anyway)
