### PR TITLE
Fix a bug in invalid action alias array parameter casting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,6 +56,13 @@ Fixed
 
 * StackStorm now explicitly decodes pack files as utf-8 instead of implicitly as ascii (bug fix) #5106, #5107
 
+* Fix incorrect array parameter value casting when executing action via chatops or using
+  ``POST /aliasexecution/match_and_execute`` API endpoint. The code would incorrectly assume the
+  value is always a string, but that may not be the cast - they value could already be a list and
+  in this case we don't want any casting to be performed. (bug fix) #5141
+
+  Contributed by @Kami.
+
 Removed
 ~~~~~~~
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,7 +54,8 @@ Fixed
 
   Contributed by @guzzijones
 
-* StackStorm now explicitly decodes pack files as utf-8 instead of implicitly as ascii (bug fix) #5106, #5107
+* StackStorm now explicitly decodes pack files as utf-8 instead of implicitly as ascii (bug fix)
+  #5106, #5107
 
 * Fix incorrect array parameter value casting when executing action via chatops or using
   ``POST /aliasexecution/match_and_execute`` API endpoint. The code would incorrectly assume the

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -62,7 +62,7 @@ Fixed
   in this case we don't want any casting to be performed. (bug fix) #5141
 
   Contributed by @Kami.
-  
+
 * Fix ``@parameter_name=/path/to/file/foo.json`` notation in the ``st2 run`` command which didn't
   work correctly because it didn't convert read bytes to string / unicode type. (bug fix) #5140
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,14 +12,15 @@ Added
 
 * Added st2-rbac-backend pip requirements for RBAC integration. (new feature) #5086
   Contributed by @hnanchahal
-  
+
 * Added notification support for err-stackstorm. (new feature) #5051
 
 * Added st2-auth-ldap pip requirements for LDAP auth integartion. (new feature) #5082
   Contributed by @hnanchahal
 
 Changed
-~~~~~~~~~
+~~~~~~~
+
 * Updated deprecation warning for python 2 pack installs, following python 2 support removal. #5099
   Contributed by @amanda11
 
@@ -38,14 +39,16 @@ Changed
   Contributed by @nmaludy, @winem, and @blag
 
 Fixed
-~~~~~~~~~
+~~~~~
+
 * Pin chardet version as newest version was incompatible with pinned requests version #5101
   Contributed by @amanda11
 
 * Fixed issue were st2tests was not getting installed using pip because no version was specified.
   Contributed by @anirudhbagri
-  
+
 * Added monkey patch fix to st2stream to enable it to work with mongodb via SSL. (bug fix) #5078 #5091
+
 * Fix nginx buffering long polling stream to client.  Instead of waiting for closed connection
   wait for final event to be sent to client. (bug fix) #4842  #5042
 
@@ -54,7 +57,8 @@ Fixed
 * StackStorm now explicitly decodes pack files as utf-8 instead of implicitly as ascii (bug fix) #5106, #5107
 
 Removed
-~~~~~~~~
+~~~~~~~
+
 * Removed --python3 pack install option  #5100
   Contributed by @amanda11
 
@@ -63,9 +67,11 @@ Removed
 * Removed check-licence script (cleanup) #5092
 
   Contributed by @kroustou
+
 * Updated Makefile and CI to use Python 3 only, removing Python 2 (cleanup) #5090
 
   Contributed by @blag
+
 * Remove st2resultstracker from st2ctl, the development environment and the st2actions setup.py (cleanup) #5108
 
   Contributed by @winem

--- a/st2api/st2api/controllers/v1/aliasexecution.py
+++ b/st2api/st2api/controllers/v1/aliasexecution.py
@@ -47,8 +47,16 @@ http_client = six.moves.http_client
 
 LOG = logging.getLogger(__name__)
 
+
+def cast_array(value):
+    if isinstance(value, list):
+        # Already a list, no casting needed nor wanted.
+        return value
+
+    return [v.strip() for v in value.split(',')]
+
 CAST_OVERRIDES = {
-    'array': (lambda cs_x: [v.strip() for v in cs_x.split(',')])
+    'array': cast_array,
 }
 
 

--- a/st2api/st2api/controllers/v1/aliasexecution.py
+++ b/st2api/st2api/controllers/v1/aliasexecution.py
@@ -55,6 +55,7 @@ def cast_array(value):
 
     return [v.strip() for v in value.split(',')]
 
+
 CAST_OVERRIDES = {
     'array': cast_array,
 }

--- a/st2api/tests/unit/controllers/v1/test_action_alias.py
+++ b/st2api/tests/unit/controllers/v1/test_action_alias.py
@@ -76,7 +76,6 @@ class ActionAliasControllerTestCase(FunctionalTest,
 
         loaded_models = FixturesLoader().load_models(fixtures_pack=GENERIC_FIXTURES_PACK,
                                                      fixtures_dict=TEST_LOAD_MODELS_GENERIC)
-        print(loaded_models)
         cls.alias3_generic = loaded_models['aliases']['alias3.yaml']
 
     def test_get_all(self):
@@ -203,15 +202,19 @@ class ActionAliasControllerTestCase(FunctionalTest,
         # I assume that was done to make specifying complex params in chat easier.
         # NOTE: This function only handles casting list, but not casting nested list items (e.g.
         # list of objects)
-
-        # immutable_param is already a list - verify no casting is performed
         self.assertEqual(resp.status_int, 201)
-        self.assertTrue(isinstance(resp.json["results"][0]["execution"]["liveaction"]["parameters"]["array_param"], list))
-        self.assertEqual(resp.json["results"][0]["execution"]["liveaction"]["parameters"]["array_param"][0], "one")
-        self.assertEqual(resp.json["results"][0]["execution"]["liveaction"]["parameters"]["array_param"][1], "two")
-        self.assertEqual(resp.json["results"][0]["execution"]["liveaction"]["parameters"]["array_param"][2], "three")
-        self.assertEqual(resp.json["results"][0]["execution"]["liveaction"]["parameters"]["array_param"][3], "four")
-        self.assertTrue(isinstance(resp.json["results"][0]["actionalias"]["immutable_parameters"]["array_param"], str))
+
+        result = resp.json["results"][0]
+        live_action = result["execution"]["liveaction"]
+        action_alias = result["actionalias"]
+
+        self.assertEqual(resp.status_int, 201)
+        self.assertTrue(isinstance(live_action["parameters"]["array_param"], list))
+        self.assertEqual(live_action["parameters"]["array_param"][0], "one")
+        self.assertEqual(live_action["parameters"]["array_param"][1], "two")
+        self.assertEqual(live_action["parameters"]["array_param"][2], "three")
+        self.assertEqual(live_action["parameters"]["array_param"][3], "four")
+        self.assertTrue(isinstance(action_alias["immutable_parameters"]["array_param"], str))
 
     def test_match_and_execute_list_action_param_already_a_list(self):
         data = {
@@ -223,12 +226,18 @@ class ActionAliasControllerTestCase(FunctionalTest,
 
         # immutable_param is already a list - verify no casting is performed
         self.assertEqual(resp.status_int, 201)
-        self.assertTrue(isinstance(resp.json["results"][0]["execution"]["liveaction"]["parameters"]["array_param"], list))
-        self.assertEqual(resp.json["results"][0]["execution"]["liveaction"]["parameters"]["array_param"][0]["key1"], "one")
-        self.assertEqual(resp.json["results"][0]["execution"]["liveaction"]["parameters"]["array_param"][0]["key2"], "two")
-        self.assertEqual(resp.json["results"][0]["execution"]["liveaction"]["parameters"]["array_param"][1]["key3"], "three")
-        self.assertEqual(resp.json["results"][0]["execution"]["liveaction"]["parameters"]["array_param"][1]["key4"], "four")
-        self.assertTrue(isinstance(resp.json["results"][0]["actionalias"]["immutable_parameters"]["array_param"], list))
+
+        result = resp.json["results"][0]
+        live_action = result["execution"]["liveaction"]
+        action_alias = result["actionalias"]
+
+        self.assertEqual(resp.status_int, 201)
+        self.assertTrue(isinstance(live_action["parameters"]["array_param"], list))
+        self.assertEqual(live_action["parameters"]["array_param"][0]["key1"], "one")
+        self.assertEqual(live_action["parameters"]["array_param"][0]["key2"], "two")
+        self.assertEqual(live_action["parameters"]["array_param"][1]["key3"], "three")
+        self.assertEqual(live_action["parameters"]["array_param"][1]["key4"], "four")
+        self.assertTrue(isinstance(action_alias["immutable_parameters"]["array_param"], list))
 
     def test_help(self):
         resp = self.app.get("/v1/actionalias/help")

--- a/st2api/tests/unit/controllers/v1/test_action_alias.py
+++ b/st2api/tests/unit/controllers/v1/test_action_alias.py
@@ -24,17 +24,21 @@ from st2tests.api import APIControllerWithIncludeAndExcludeFilterTestCase
 FIXTURES_PACK = 'aliases'
 
 TEST_MODELS = {
-    'aliases': ['alias1.yaml', 'alias2.yaml', 'alias_with_undefined_jinja_in_ack_format.yaml']
+    'aliases': ['alias1.yaml', 'alias2.yaml', 'alias_with_undefined_jinja_in_ack_format.yaml',
+                'alias_with_immutable_list_param.yaml',
+                'alias_with_immutable_list_param_str_cast.yaml'],
+    'actions': ['action3.yaml', 'action4.yaml']
 }
 
 TEST_LOAD_MODELS = {
-    'aliases': ['alias3.yaml']
+    'aliases': ['alias3.yaml'],
 }
 
 GENERIC_FIXTURES_PACK = 'generic'
 
 TEST_LOAD_MODELS_GENERIC = {
-    'aliases': ['alias3.yaml']
+    'aliases': ['alias3.yaml'],
+    'runners': ['testrunner1.yaml']
 }
 
 
@@ -49,6 +53,8 @@ class ActionAliasControllerTestCase(FunctionalTest,
     alias1 = None
     alias2 = None
     alias3 = None
+    alias4 = None
+    alias5 = None
     alias3_generic = None
 
     @classmethod
@@ -58,6 +64,8 @@ class ActionAliasControllerTestCase(FunctionalTest,
                                                           fixtures_dict=TEST_MODELS)
         cls.alias1 = cls.models['aliases']['alias1.yaml']
         cls.alias2 = cls.models['aliases']['alias2.yaml']
+        cls.alias4 = cls.models['aliases']['alias_with_immutable_list_param.yaml']
+        cls.alias5 = cls.models['aliases']['alias_with_immutable_list_param_str_cast.yaml']
 
         loaded_models = FixturesLoader().load_models(fixtures_pack=FIXTURES_PACK,
                                                      fixtures_dict=TEST_LOAD_MODELS)
@@ -68,16 +76,19 @@ class ActionAliasControllerTestCase(FunctionalTest,
 
         loaded_models = FixturesLoader().load_models(fixtures_pack=GENERIC_FIXTURES_PACK,
                                                      fixtures_dict=TEST_LOAD_MODELS_GENERIC)
+        print(loaded_models)
         cls.alias3_generic = loaded_models['aliases']['alias3.yaml']
 
     def test_get_all(self):
         resp = self.app.get('/v1/actionalias')
         self.assertEqual(resp.status_int, 200)
-        self.assertEqual(len(resp.json), 4, '/v1/actionalias did not return all aliases.')
+        self.assertEqual(len(resp.json), 6, '/v1/actionalias did not return all aliases.')
 
         retrieved_names = [alias['name'] for alias in resp.json]
 
         self.assertEqual(retrieved_names, [self.alias1.name, self.alias2.name,
+                                           self.alias4.name,
+                                           self.alias5.name,
                                            'alias_with_undefined_jinja_in_ack_format',
                                            'alias7'],
                          'Incorrect aliases retrieved.')
@@ -89,7 +100,7 @@ class ActionAliasControllerTestCase(FunctionalTest,
 
         resp = self.app.get('/v1/actionalias?pack=aliases')
         self.assertEqual(resp.status_int, 200)
-        self.assertEqual(len(resp.json), 3)
+        self.assertEqual(len(resp.json), 5)
 
         for alias_api in resp.json:
             self.assertEqual(alias_api['pack'], 'aliases')
@@ -180,20 +191,61 @@ class ActionAliasControllerTestCase(FunctionalTest,
         self.assertEqual(resp.json['actionalias']['name'],
                          'alias_with_undefined_jinja_in_ack_format')
 
+    def test_match_and_execute_list_action_param_str_cast_to_list(self):
+        data = {
+            'command': 'test alias list param str cast',
+            'source_channel': 'hubot',
+            'user': 'foo',
+        }
+        resp = self.app.post_json("/v1/aliasexecution/match_and_execute", data, expect_errors=True)
+
+        # Param is a comma delimited string - our custom cast function should cast it to a list.
+        # I assume that was done to make specifying complex params in chat easier.
+        # NOTE: This function only handles casting list, but not casting nested list items (e.g.
+        # list of objects)
+
+        # immutable_param is already a list - verify no casting is performed
+        self.assertEqual(resp.status_int, 201)
+        self.assertTrue(isinstance(resp.json["results"][0]["execution"]["liveaction"]["parameters"]["array_param"], list))
+        self.assertEqual(resp.json["results"][0]["execution"]["liveaction"]["parameters"]["array_param"][0], "one")
+        self.assertEqual(resp.json["results"][0]["execution"]["liveaction"]["parameters"]["array_param"][1], "two")
+        self.assertEqual(resp.json["results"][0]["execution"]["liveaction"]["parameters"]["array_param"][2], "three")
+        self.assertEqual(resp.json["results"][0]["execution"]["liveaction"]["parameters"]["array_param"][3], "four")
+        self.assertTrue(isinstance(resp.json["results"][0]["actionalias"]["immutable_parameters"]["array_param"], str))
+
+    def test_match_and_execute_list_action_param_already_a_list(self):
+        data = {
+            'command': 'test alias foo',
+            'source_channel': 'hubot',
+            'user': 'foo',
+        }
+        resp = self.app.post_json("/v1/aliasexecution/match_and_execute", data, expect_errors=True)
+
+        # immutable_param is already a list - verify no casting is performed
+        self.assertEqual(resp.status_int, 201)
+        self.assertTrue(isinstance(resp.json["results"][0]["execution"]["liveaction"]["parameters"]["array_param"], list))
+        self.assertEqual(resp.json["results"][0]["execution"]["liveaction"]["parameters"]["array_param"][0]["key1"], "one")
+        self.assertEqual(resp.json["results"][0]["execution"]["liveaction"]["parameters"]["array_param"][0]["key2"], "two")
+        self.assertEqual(resp.json["results"][0]["execution"]["liveaction"]["parameters"]["array_param"][1]["key3"], "three")
+        self.assertEqual(resp.json["results"][0]["execution"]["liveaction"]["parameters"]["array_param"][1]["key4"], "four")
+        self.assertTrue(isinstance(resp.json["results"][0]["actionalias"]["immutable_parameters"]["array_param"], list))
+
     def test_help(self):
         resp = self.app.get("/v1/actionalias/help")
         self.assertEqual(resp.status_int, 200)
-        self.assertEqual(resp.json.get('available'), 5)
+        self.assertEqual(resp.json.get('available'), 7)
 
     def test_help_args(self):
         resp = self.app.get("/v1/actionalias/help?filter=.*&pack=aliases&limit=1&offset=0")
         self.assertEqual(resp.status_int, 200)
-        self.assertEqual(resp.json.get('available'), 3)
+        self.assertEqual(resp.json.get('available'), 5)
         self.assertEqual(len(resp.json.get('helpstrings')), 1)
 
     def _insert_mock_models(self):
         alias_ids = [self.alias1['id'], self.alias2['id'], self.alias3['id'],
-                     self.alias3_generic['id']]
+                     self.alias3_generic['id'],
+                     self.alias4['id'],
+                     self.alias5['id']]
         return alias_ids
 
     def _delete_mock_models(self, object_ids):

--- a/st2api/tests/unit/controllers/v1/test_alias_execution.py
+++ b/st2api/tests/unit/controllers/v1/test_alias_execution.py
@@ -28,9 +28,11 @@ FIXTURES_PACK = 'aliases'
 
 TEST_MODELS = {
     'aliases': ['alias1.yaml', 'alias2.yaml', 'alias_with_undefined_jinja_in_ack_format.yaml',
+                'alias_with_immutable_list_param.yaml',
+                'alias_with_immutable_list_param_str_cast.yaml',
                 'alias4.yaml', 'alias5.yaml', 'alias_fixes1.yaml', 'alias_fixes2.yaml',
                 'alias_match_multiple.yaml'],
-    'actions': ['action1.yaml', 'action2.yaml'],
+    'actions': ['action1.yaml', 'action2.yaml', 'action3.yaml', 'action4.yaml'],
     'runners': ['runner1.yaml']
 }
 
@@ -273,6 +275,67 @@ class AliasExecutionTestCase(FunctionalTest):
         self.assertEqual(str(resp.json['faultstring']),
                          "Command '{command}' "
                          "matched more than 1 (multi) pattern".format(command=data['command']))
+
+    def test_match_and_execute_list_action_param_str_cast_to_list(self):
+        data = {
+            'command': 'test alias list param str cast',
+            'source_channel': 'hubot',
+            'user': 'foo',
+        }
+        resp = self.app.post_json("/v1/aliasexecution/match_and_execute", data, expect_errors=True)
+
+        # Param is a comma delimited string - our custom cast function should cast it to a list.
+        # I assume that was done to make specifying complex params in chat easier.
+        # NOTE: This function only handles casting list, but not casting nested list items (e.g.
+        # list of objects)
+        self.assertEqual(resp.status_int, 201)
+
+        result = resp.json["results"][0]
+        live_action = result["execution"]["liveaction"]
+        action_alias = result["actionalias"]
+
+        self.assertEqual(resp.status_int, 201)
+        self.assertTrue(isinstance(live_action["parameters"]["array_param"], list))
+        self.assertEqual(live_action["parameters"]["array_param"][0], "one")
+        self.assertEqual(live_action["parameters"]["array_param"][1], "two")
+        self.assertEqual(live_action["parameters"]["array_param"][2], "three")
+        self.assertEqual(live_action["parameters"]["array_param"][3], "four")
+        self.assertTrue(isinstance(action_alias["immutable_parameters"]["array_param"], str))
+
+    def test_match_and_execute_list_action_param_already_a_list(self):
+        data = {
+            'command': 'test alias foo',
+            'source_channel': 'hubot',
+            'user': 'foo',
+        }
+        resp = self.app.post_json("/v1/aliasexecution/match_and_execute", data, expect_errors=True)
+
+        # immutable_param is already a list - verify no casting is performed
+        self.assertEqual(resp.status_int, 201)
+
+        result = resp.json["results"][0]
+        live_action = result["execution"]["liveaction"]
+        action_alias = result["actionalias"]
+
+        self.assertEqual(resp.status_int, 201)
+        self.assertTrue(isinstance(live_action["parameters"]["array_param"], list))
+        self.assertEqual(live_action["parameters"]["array_param"][0]["key1"], "one")
+        self.assertEqual(live_action["parameters"]["array_param"][0]["key2"], "two")
+        self.assertEqual(live_action["parameters"]["array_param"][1]["key3"], "three")
+        self.assertEqual(live_action["parameters"]["array_param"][1]["key4"], "four")
+        self.assertTrue(isinstance(action_alias["immutable_parameters"]["array_param"], list))
+
+    def test_match_and_execute_success(self):
+        data = {
+            'command': 'run whoami on localhost1',
+            'source_channel': 'hubot',
+            'user': "user",
+        }
+        resp = self.app.post_json("/v1/aliasexecution/match_and_execute", data)
+        self.assertEqual(resp.status_int, 201)
+        self.assertEqual(len(resp.json["results"]), 1)
+        self.assertTrue(resp.json["results"][0]["actionalias"]["ref"],
+                        "aliases.alias_with_undefined_jinja_in_ack_format")
 
     def _do_post(self, alias_execution, command, format_str=None, expect_errors=False,
                  show_secrets=False):

--- a/st2tests/st2tests/fixtures/aliases/actions/action3.yaml
+++ b/st2tests/st2tests/fixtures/aliases/actions/action3.yaml
@@ -1,0 +1,12 @@
+---
+  name: "action3"
+  description: ""
+  runner_type: "noop"
+  pack: "wolfpack"
+  entry_point: "/tmp/test/action2.sh"
+  enabled: true
+  parameters:
+    array_param:
+      type: "array"
+      items:
+        type: "object"

--- a/st2tests/st2tests/fixtures/aliases/actions/action4.yaml
+++ b/st2tests/st2tests/fixtures/aliases/actions/action4.yaml
@@ -1,0 +1,12 @@
+---
+  name: "action4"
+  description: ""
+  runner_type: "noop"
+  pack: "wolfpack"
+  entry_point: "/tmp/test/action2.sh"
+  enabled: true
+  parameters:
+    array_param:
+      type: "array"
+      items:
+        type: "string"

--- a/st2tests/st2tests/fixtures/aliases/aliases/alias_with_immutable_list_param.yaml
+++ b/st2tests/st2tests/fixtures/aliases/aliases/alias_with_immutable_list_param.yaml
@@ -1,0 +1,15 @@
+---
+  name: "alias_with_immutable_list_param"
+  pack: "aliases"
+  description: "DON'T CARE"
+  action_ref: "wolfpack.action3"
+  formats:
+    - "test alias foo"
+  immutable_parameters:
+    array_param:
+      -
+        key1: "one"
+        key2: "two"
+      -
+        key3: "three"
+        key4: "four"

--- a/st2tests/st2tests/fixtures/aliases/aliases/alias_with_immutable_list_param_str_cast.yaml
+++ b/st2tests/st2tests/fixtures/aliases/aliases/alias_with_immutable_list_param_str_cast.yaml
@@ -1,0 +1,9 @@
+---
+  name: "alias_with_immutable_list_param_str_cast"
+  pack: "aliases"
+  description: "DON'T CARE"
+  action_ref: "wolfpack.action4"
+  formats:
+    - "test alias list param str cast"
+  immutable_parameters:
+    array_param: "one,two,three,four,give"

--- a/st2tests/st2tests/fixturesloader.py
+++ b/st2tests/st2tests/fixturesloader.py
@@ -370,7 +370,8 @@ class FixturesLoader(object):
         fixture_types = list(fixtures_dict.keys())
         for fixture_type in fixture_types:
             if fixture_type not in allowed:
-                raise Exception('Disallowed fixture type: %s' % fixture_type)
+                raise Exception('Disallowed fixture type: %s. Valid fixture types are: %s' % (
+                    fixture_type, ", ".join(allowed)))
 
     def _is_fixture_pack_exists(self, fixtures_pack_path):
         return os.path.exists(fixtures_pack_path)


### PR DESCRIPTION
This pull request fixes a bug in action alias array parameter value casting when executing an alias.

The code would incorrectly assume value is always a string and try to cast it to an array (the value may very well be a string when executing command from chat, but even then is not always true).

This would not work if value is already a list (e.g. if parameter contains a default value or a default value is specified using ``immutable_parameters`` in action alias definition).

## Background, Context

I encountered this bug when trying to define a default value for a parameter in action alias which is a list.


Here is action alias definition in question:

```yaml
---
name: "test"
pack: "scalyr"
action_ref: "scalyr.timeseries_queries"
description: "Get server temps."
formats:
    - "temps"
result:
  format: |
    CPUs: 

    Core 0: {{ execution.result.result.results[0]["values"][0]|int }} C
    Core 1: {{ execution.result.result.results[1]["values"][0]|int }} C 
immutable_parameters:
  queries:
    -
      filter: "$source='tsdb' $serverHost='foo' metric = 'output' and instance = 'core_0_temp_celsius'"
      function: "mean(value)"
      startTime: "10 minutes"
      buckets: 1
    -
      filter: "$source='tsdb' $serverHost='foo' metric = 'output' and instance = 'core_1_temp_celsius'"
      function: "mean(value)"
      startTime: "10 minutes"
      buckets: 1
 ...
```

## TODO

- [x] Tests