### PR TITLE
[WIP] Rescue Python path code

### DIFF
--- a/st2common/st2common/models/db/execution.py
+++ b/st2common/st2common/models/db/execution.py
@@ -97,8 +97,8 @@ class ActionExecutionDB(stormbase.StormFoundationDB):
     }
 
     def get_uid(self):
-        # TODO Construct od from non id field:
-        uid = [self.RESOURCE_TYPE, str(self.id)]
+        # TODO Construct id from non id field:
+        uid = [self.RESOURCE_TYPE, str(self.id)]  # pylint: disable=no-member
         return ':'.join(uid)
 
     def mask_secrets(self, value):

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -150,53 +150,25 @@ def get_sandbox_python_path_for_python_action(pack, inherit_from_parent=True,
     virtualenv_directories = [dir_name for dir_name in virtualenv_directories if
                               fnmatch.fnmatch(dir_name, 'python*')]
 
-    # Add Python 3 lib directory (lib/python3.x) in front of the PYTHONPATH. This way we avoid
-    # issues with scripts trying to use packages / modules from Python 2.7 site-packages
-    # directory instead of the versions from Python 3 stdlib.
-    pack_actions_lib_paths = os.path.join(pack_base_path, 'actions/lib/')
+    # Add the pack's lib directory (lib/python3.x) in front of the PYTHONPATH.
+    pack_actions_lib_paths = os.path.join(pack_base_path, 'actions', 'lib')
     pack_virtualenv_lib_path = os.path.join(virtualenv_path, 'lib')
-    python3_lib_directory = os.path.join(pack_virtualenv_lib_path, virtualenv_directories[0])
+    pack_venv_lib_directory = os.path.join(pack_virtualenv_lib_path, virtualenv_directories[0])
 
-    # Add Python 3 site-packages directory (lib/python3.x/site-packages) in front of the Python
-    # 2.7 system site-packages This is important because we want Python 3 compatible libraries
+    # Add the pack's site-packages directory (lib/python3.x/site-packages) in front of the Python
+    # system site-packages This is important because we want Python 3 compatible libraries
     # to be used from the pack virtual environment and not system ones.
-    python3_site_packages_directory = os.path.join(pack_virtualenv_lib_path,
-                                                   virtualenv_directories[0],
-                                                   'site-packages')
+    pack_venv_site_packages_directory = os.path.join(pack_virtualenv_lib_path,
+                                                     virtualenv_directories[0],
+                                                     'site-packages')
 
-    # Work around to make sure we also add system lib dir to PYTHONPATH and not just virtualenv
-    # one (e.g. /usr/lib/python3.6)
-    # NOTE: We can't simply use sys.prefix dir since it will be set to /opt/stackstorm/st2
-
-    system_prefix_dirs = []
-    # Take custom prefix into account (if specified)
-    if cfg.CONF.actionrunner.python3_prefix:
-        system_prefix_dirs.append(cfg.CONF.actionrunner.python3_prefix)
-
-    # By default, Python libs are installed either in /usr/lib/python3.x or
-    # /usr/local/lib/python3.x
-    system_prefix_dirs.extend(['/usr/lib', '/usr/local/lib'])
-
-    for system_prefix_dir in system_prefix_dirs:
-        python3_system_lib_directory = os.path.join(system_prefix_dir,
-                                                    virtualenv_directories[0])
-
-        if os.path.exists(python3_system_lib_directory):
-            break
-
-    if not python3_system_lib_directory or not os.path.exists(python3_system_lib_directory):
-        python3_system_lib_directory = None
-
-    full_sandbox_python_path = []
-
-    # NOTE: Order here is very important for imports to function correctly
-    if python3_system_lib_directory:
-        full_sandbox_python_path.append(python3_system_lib_directory)
-
-    full_sandbox_python_path.append(python3_lib_directory)
-    full_sandbox_python_path.append(python3_site_packages_directory)
-    full_sandbox_python_path.append(pack_actions_lib_paths)
-    full_sandbox_python_path.append(sandbox_python_path)
+    full_sandbox_python_path = [
+        # NOTE: Order here is very important for imports to function correctly
+        pack_venv_lib_directory,
+        pack_venv_site_packages_directory,
+        pack_actions_lib_paths,
+        sandbox_python_path,
+    ]
 
     sandbox_python_path = ':'.join(full_sandbox_python_path)
 

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -153,9 +153,10 @@ def get_sandbox_python_path_for_python_action(pack, inherit_from_parent=True,
         pack_virtualenv_lib_path = os.path.join(virtualenv_path, 'lib')
         pack_venv_lib_directory = os.path.join(pack_virtualenv_lib_path, virtualenv_directories[0])
 
-        # Add the pack's site-packages directory (lib/python3.x/site-packages) in front of the Python
-        # system site-packages This is important because we want Python 3 compatible libraries
-        # to be used from the pack virtual environment and not system ones.
+        # Add the pack's site-packages directory (lib/python3.x/site-packages)
+        # in front of the Python system site-packages This is important because
+        # we want Python 3 compatible libraries to be used from the pack virtual
+        # environment and not system ones.
         pack_venv_site_packages_directory = os.path.join(pack_virtualenv_lib_path,
                                                          virtualenv_directories[0],
                                                          'site-packages')

--- a/st2common/tests/unit/test_util_sandboxing.py
+++ b/st2common/tests/unit/test_util_sandboxing.py
@@ -38,6 +38,8 @@ __all__ = [
 
 
 class SandboxingUtilsTestCase(unittest.TestCase):
+    maxDiff = None
+
     def setUp(self):
         super(SandboxingUtilsTestCase, self).setUp()
 

--- a/st2common/tests/unit/test_util_sandboxing.py
+++ b/st2common/tests/unit/test_util_sandboxing.py
@@ -132,15 +132,15 @@ class SandboxingUtilsTestCase(unittest.TestCase):
                                                                 inherit_from_parent=False,
                                                                 inherit_parent_virtualenv=False)
 
-        actual = python_path.strip(':').split(':')
-        self.assertEqual(len(actual), 3)
+        actual_path = python_path.strip(':').split(':')
+        self.assertEqual(len(actual_path), 3)
 
         # First entry should be lib/python3 dir from venv
-        self.assertEndsWith(actual[0], 'virtualenvs/dummy_pack/lib/python3.6')
+        self.assertEndsWith(actual_path[0], 'virtualenvs/dummy_pack/lib/python3.6')
         # Second entry should be python3 site-packages dir from venv
-        self.assertEndsWith(actual[1], 'virtualenvs/dummy_pack/lib/python3.6/site-packages')
+        self.assertEndsWith(actual_path[1], 'virtualenvs/dummy_pack/lib/python3.6/site-packages')
         # Third entry should be actions/lib dir from pack root directory
-        self.assertEndsWith(actual[2], 'packs/dummy_pack/actions/lib')
+        self.assertEndsWith(actual_path[2], 'packs/dummy_pack/actions/lib')
 
         # Inherit python path from current process
         # Mock the current process python path
@@ -154,19 +154,19 @@ class SandboxingUtilsTestCase(unittest.TestCase):
                                                                 inherit_from_parent=True,
                                                                 inherit_parent_virtualenv=False)
 
-        actual = python_path.strip(':').split(':')
-        self.assertEqual(len(actual), 6)
+        actual_path = python_path.strip(':').split(':')
+        self.assertEqual(len(actual_path), 6)
 
         # First entry should be lib/python3 dir from venv
-        self.assertEndsWith(actual[0], 'virtualenvs/dummy_pack/lib/python3.6')
+        self.assertEndsWith(actual_path[0], 'virtualenvs/dummy_pack/lib/python3.6')
         # Second entry should be python3 site-packages dir from venv
-        self.assertEndsWith(actual[1], 'virtualenvs/dummy_pack/lib/python3.6/site-packages')
+        self.assertEndsWith(actual_path[1], 'virtualenvs/dummy_pack/lib/python3.6/site-packages')
         # Third entry should be actions/lib dir from pack root directory
-        self.assertEndsWith(actual[2], 'packs/dummy_pack/actions/lib')
+        self.assertEndsWith(actual_path[2], 'packs/dummy_pack/actions/lib')
         # And the rest of the paths from get_sandbox_python_path
-        self.assertEqual(actual[3], '')
-        self.assertEqual(actual[4], '/data/test1')
-        self.assertEqual(actual[5], '/data/test2')
+        self.assertEqual(actual_path[3], '')
+        self.assertEqual(actual_path[4], '/data/test1')
+        self.assertEqual(actual_path[5], '/data/test2')
 
         # Inherit from current process and from virtualenv (not running inside virtualenv)
         clear_virtualenv_prefix()
@@ -175,27 +175,43 @@ class SandboxingUtilsTestCase(unittest.TestCase):
                                               inherit_parent_virtualenv=False)
         self.assertEqual(python_path, ':/data/test1:/data/test2')
 
-        actual_path = get_sandbox_python_path_for_python_action(pack='dummy_pack',
-                                                                inherit_from_parent=True,
-                                                                inherit_parent_virtualenv=True)
-
-        self.assertEndsWith(actual_path, ':/data/test1:/data/test2')
-
-        # Inherit from current process and from virtualenv (running inside virtualenv)
-        sys.real_prefix = '/usr'
-        mock_get_python_lib.return_value = f'{sys.prefix}virtualenvtest'
         python_path = get_sandbox_python_path_for_python_action(pack='dummy_pack',
                                                                 inherit_from_parent=True,
                                                                 inherit_parent_virtualenv=True)
 
         actual_path = python_path.strip(':').split(':')
+        self.assertEqual(len(actual_path), 6)
 
-        self.assertEqual(actual_path, [
-            '/tmp/virtualenvs/dummy_pack/lib/python3.6',
-            '/tmp/virtualenvs/dummy_pack/lib/python3.6/site-packages',
-            '/tmp/packs/dummy_pack/actions/lib',
-            '',
-            '/data/test1',
-            '/data/test2',
-            f'{sys.prefix}/virtualenvtest',
-        ])
+        # First entry should be lib/python3 dir from venv
+        self.assertEndsWith(actual_path[0], 'virtualenvs/dummy_pack/lib/python3.6')
+        # Second entry should be python3 site-packages dir from venv
+        self.assertEndsWith(actual_path[1], 'virtualenvs/dummy_pack/lib/python3.6/site-packages')
+        # Third entry should be actions/lib dir from pack root directory
+        self.assertEndsWith(actual_path[2], 'packs/dummy_pack/actions/lib')
+        # And the rest of the paths from get_sandbox_python_path
+        self.assertEqual(actual_path[3], '')
+        self.assertEqual(actual_path[4], '/data/test1')
+        self.assertEqual(actual_path[5], '/data/test2')
+
+        # Inherit from current process and from virtualenv (running inside virtualenv)
+        sys.real_prefix = '/usr'
+        mock_get_python_lib.return_value = f'{sys.prefix}/virtualenvtest'
+        python_path = get_sandbox_python_path_for_python_action(pack='dummy_pack',
+                                                                inherit_from_parent=True,
+                                                                inherit_parent_virtualenv=True)
+
+        actual_path = python_path.strip(':').split(':')
+        self.assertEqual(len(actual_path), 7)
+
+        # First entry should be lib/python3 dir from venv
+        self.assertEndsWith(actual_path[0], 'virtualenvs/dummy_pack/lib/python3.6')
+        # Second entry should be python3 site-packages dir from venv
+        self.assertEndsWith(actual_path[1], 'virtualenvs/dummy_pack/lib/python3.6/site-packages')
+        # Third entry should be actions/lib dir from pack root directory
+        self.assertEndsWith(actual_path[2], 'packs/dummy_pack/actions/lib')
+        # The paths from get_sandbox_python_path
+        self.assertEqual(actual_path[3], '')
+        self.assertEqual(actual_path[4], '/data/test1')
+        self.assertEqual(actual_path[5], '/data/test2')
+        # And the parent virtualenv
+        self.assertEqual(actual_path[6], f'{sys.prefix}/virtualenvtest')

--- a/st2common/tests/unit/test_util_sandboxing.py
+++ b/st2common/tests/unit/test_util_sandboxing.py
@@ -120,17 +120,17 @@ class SandboxingUtilsTestCase(unittest.TestCase):
                                                                 inherit_from_parent=False,
                                                                 inherit_parent_virtualenv=False)
 
-        split = python_path.strip(':').split(':')
-        self.assertEqual(len(split), 3)
+        actual = python_path.strip(':').split(':')
+        self.assertEqual(len(actual), 3)
 
-        # First entry should be lib/python3 dir from venv
-        self.assertTrue('virtualenvs/dummy_pack/lib/python3.6' in split[1])
-
-        # Second entry should be python3 site-packages dir from venv
-        self.assertTrue('virtualenvs/dummy_pack/lib/python3.6/site-packages' in split[2])
-
-        # Third entry should be actions/lib dir from pack root directory
-        self.assertTrue('packs/dummy_pack/actions/lib/' in split[3])
+        self.assertEqual(actual, [
+            # First entry should be lib/python3 dir from venv
+            'virtualenvs/dummy_pack/lib/python3.6',
+            # Second entry should be python3 site-packages dir from venv
+            'virtualenvs/dummy_pack/lib/python3.6/site-packages',
+            # Third entry should be actions/lib dir from pack root directory
+            'packs/dummy_pack/actions/lib',
+        ])
 
         # Inherit python path from current process
         # Mock the current process python path
@@ -140,13 +140,21 @@ class SandboxingUtilsTestCase(unittest.TestCase):
                                               inherit_parent_virtualenv=False)
         self.assertEqual(python_path, ':/data/test1:/data/test2')
 
-        python_path = get_sandbox_python_path_for_python_action(pack='dummy_pack',
+        actual_path = get_sandbox_python_path_for_python_action(pack='dummy_pack',
                                                                 inherit_from_parent=True,
                                                                 inherit_parent_virtualenv=False)
-        expected = ('/tmp/virtualenvs/dummy_pack/lib/python3.6:'
-                    '/tmp/virtualenvs/dummy_pack/lib/python3.6/site-packages:'
-                    '/tmp/packs/dummy_pack/actions/lib/::/data/test1:/data/test2')
-        self.assertEqual(python_path, expected)
+        self.assertEqual(actual_path, [
+            # First entry should be lib/python3 dir from venv
+            '/tmp/virtualenvs/dummy_pack/lib/python3.6',
+            # Second entry should be python3 site-packages dir from venv
+            '/tmp/virtualenvs/dummy_pack/lib/python3.6/site-packages',
+            # Third entry should be actions/lib dir from pack root directory
+            '/tmp/packs/dummy_pack/actions/lib',
+            # And the rest of the paths from get_sandbox_python_path
+            '',
+            '/data/test1',
+            '/data/test2',
+        ])
 
         # Inherit from current process and from virtualenv (not running inside virtualenv)
         clear_virtualenv_prefix()
@@ -155,15 +163,25 @@ class SandboxingUtilsTestCase(unittest.TestCase):
                                               inherit_parent_virtualenv=False)
         self.assertEqual(python_path, ':/data/test1:/data/test2')
 
-        # Inherit from current process and from virtualenv (running inside virtualenv)
-        sys.real_prefix = '/usr'
-        mock_get_python_lib.return_value = sys.prefix + '/virtualenvtest'
-        python_path = get_sandbox_python_path_for_python_action(pack='dummy_pack',
+        actual_path = get_sandbox_python_path_for_python_action(pack='dummy_pack',
                                                                 inherit_from_parent=True,
                                                                 inherit_parent_virtualenv=True)
 
-        expected = ('/tmp/virtualenvs/dummy_pack/lib/python3.6:'
-                    '/tmp/virtualenvs/dummy_pack/lib/python3.6/site-packages:'
-                    '/tmp/packs/dummy_pack/actions/lib/::/data/test1:/data/test2:'
-                    '%s/virtualenvtest' % (sys.prefix))
-        self.assertEqual(python_path, expected)
+        self.assertEqual(actual_path, ':/data/test1:/data/test2')
+
+        # Inherit from current process and from virtualenv (running inside virtualenv)
+        sys.real_prefix = '/usr'
+        mock_get_python_lib.return_value = f'{sys.prefix}virtualenvtest'
+        actual_path = get_sandbox_python_path_for_python_action(pack='dummy_pack',
+                                                                inherit_from_parent=True,
+                                                                inherit_parent_virtualenv=True)
+
+        self.assertEqual(actual_path, [
+            '/tmp/virtualenvs/dummy_pack/lib/python3.6',
+            '/tmp/virtualenvs/dummy_pack/lib/python3.6/site-packages',
+            '/tmp/packs/dummy_pack/actions/lib',
+            '',
+            '/data/test1',
+            '/data/test2',
+            f'{sys.prefix}/virtualenvtest',
+        ])

--- a/st2common/tests/unit/test_util_sandboxing.py
+++ b/st2common/tests/unit/test_util_sandboxing.py
@@ -110,9 +110,9 @@ class SandboxingUtilsTestCase(unittest.TestCase):
                          (sys.prefix))
 
     @mock.patch('os.path.isdir', mock.Mock(return_value=True))
-    @mock.patch('os.listdir', mock.Mock(return_value=['python2.7']))
+    @mock.patch('os.listdir', mock.Mock(return_value=['python3.6']))
     @mock.patch('st2common.util.sandboxing.get_python_lib')
-    def test_get_sandbox_python_path_for_python_action_python2_used_for_venv(self,
+    def test_get_sandbox_python_path_for_python_action_for_venv(self,
             mock_get_python_lib):
 
         # No inheritance

--- a/st2common/tests/unit/test_util_sandboxing.py
+++ b/st2common/tests/unit/test_util_sandboxing.py
@@ -89,7 +89,8 @@ class SandboxingUtilsTestCase(unittest.TestCase):
 
         virtualenv_path = '/home/venv/test'
         result = get_sandbox_path(virtualenv_path=virtualenv_path)
-        self.assertEqual(result, '/home/venv/test/bin/:/home/path1:/home/path2:/home/path3')
+
+        self.assertEqual(result, f'{virtualenv_path}/bin/:/home/path1:/home/path2:/home/path3')
 
     @mock.patch('st2common.util.sandboxing.get_python_lib')
     def test_get_sandbox_python_path(self, mock_get_python_lib):
@@ -115,11 +116,10 @@ class SandboxingUtilsTestCase(unittest.TestCase):
 
         # Inherit from current process and from virtualenv (running inside virtualenv)
         sys.real_prefix = '/usr'
-        mock_get_python_lib.return_value = sys.prefix + '/virtualenvtest'
+        mock_get_python_lib.return_value = f'{sys.prefix}/virtualenvtest'
         python_path = get_sandbox_python_path(inherit_from_parent=True,
                                               inherit_parent_virtualenv=True)
-        self.assertEqual(python_path, ':/data/test1:/data/test2:%s/virtualenvtest' %
-                         (sys.prefix))
+        self.assertEqual(python_path, f':/data/test1:/data/test2:{sys.prefix}/virtualenvtest')
 
     @mock.patch('os.path.isdir', mock.Mock(return_value=True))
     @mock.patch('os.listdir', mock.Mock(return_value=['python3.6']))

--- a/st2common/tests/unit/test_util_sandboxing.py
+++ b/st2common/tests/unit/test_util_sandboxing.py
@@ -124,7 +124,7 @@ class SandboxingUtilsTestCase(unittest.TestCase):
     @mock.patch('os.path.isdir', mock.Mock(return_value=True))
     @mock.patch('os.listdir', mock.Mock(return_value=['python3.6']))
     @mock.patch('st2common.util.sandboxing.get_python_lib')
-    def test_get_sandbox_python_path_for_python_action_for_venv(self,
+    def test_get_sandbox_python_path_for_python_action_no_inheritance(self,
             mock_get_python_lib):
 
         # No inheritance
@@ -141,6 +141,12 @@ class SandboxingUtilsTestCase(unittest.TestCase):
         self.assertEndsWith(actual_path[1], 'virtualenvs/dummy_pack/lib/python3.6/site-packages')
         # Third entry should be actions/lib dir from pack root directory
         self.assertEndsWith(actual_path[2], 'packs/dummy_pack/actions/lib')
+
+    @mock.patch('os.path.isdir', mock.Mock(return_value=True))
+    @mock.patch('os.listdir', mock.Mock(return_value=['python3.6']))
+    @mock.patch('st2common.util.sandboxing.get_python_lib')
+    def test_get_sandbox_python_path_for_python_action_inherit_from_parent_process_only(self,
+            mock_get_python_lib):
 
         # Inherit python path from current process
         # Mock the current process python path
@@ -167,6 +173,16 @@ class SandboxingUtilsTestCase(unittest.TestCase):
         self.assertEqual(actual_path[3], '')
         self.assertEqual(actual_path[4], '/data/test1')
         self.assertEqual(actual_path[5], '/data/test2')
+
+    @mock.patch('os.path.isdir', mock.Mock(return_value=True))
+    @mock.patch('os.listdir', mock.Mock(return_value=['python3.6']))
+    @mock.patch('st2common.util.sandboxing.get_python_lib')
+    def test_get_sandbox_python_path_for_python_action_inherit_from_parent_process_and_venv(self,
+            mock_get_python_lib):
+
+        # Inherit python path from current process
+        # Mock the current process python path
+        os.environ['PYTHONPATH'] = ':/data/test1:/data/test2'
 
         # Inherit from current process and from virtualenv (not running inside virtualenv)
         clear_virtualenv_prefix()

--- a/st2common/tests/unit/test_util_sandboxing.py
+++ b/st2common/tests/unit/test_util_sandboxing.py
@@ -184,9 +184,11 @@ class SandboxingUtilsTestCase(unittest.TestCase):
         # Inherit from current process and from virtualenv (running inside virtualenv)
         sys.real_prefix = '/usr'
         mock_get_python_lib.return_value = f'{sys.prefix}virtualenvtest'
-        actual_path = get_sandbox_python_path_for_python_action(pack='dummy_pack',
+        python_path = get_sandbox_python_path_for_python_action(pack='dummy_pack',
                                                                 inherit_from_parent=True,
                                                                 inherit_parent_virtualenv=True)
+
+        actual_path = python_path.strip(':').split(':')
 
         self.assertEqual(actual_path, [
             '/tmp/virtualenvs/dummy_pack/lib/python3.6',


### PR DESCRIPTION
This PR partially reverts the code removed in #5100 and refactors it a bit since we no longer need to deal with Python 2.7 at all.

In StackStorm <= v3.3, when the sandboxing code was generating a `PYTHONPATH` for Python actions, it would prepend the operating system's Python directory (eg: `/usr/lib/python3.5`) in an attempt to provide modules and packages from the Python 3 stdlib _before_ the third party packages (usually backports of the same name) for Python 2.7 (eg: `<st2root>/st2/lib/python2.7/site-packages`).

All of that was over-enthusiastically ripped out when we removed Python 2.7 support, however some of the `PYTHONPATH` handling for Python actions is still necessary.

With this PR, the code once again generates an appropriate `PYTHONPATH` for Python actions:

1. The pack's virtualenv `lib` directory (eg: `<st2root>/virtualenvs/<pack>/lib/python3.x`)
2. The pack's virtualenv `site-packages` directory (eg: `<st2root>/virtualenvs/<pack>/lib/python3.x/site-packages`)
3. The pack action `lib` directory (eg: `<st2root>/packs/<pack>/actions/lib`)
4. The Python path (optionally) inherited from the parent process' `PYTHONPATH`, or from the parent virtualenv (the code is only ever [called with both set to `True`](https://github.com/StackStorm/st2/blob/2ae7548b5259394edbb1227d5ca9b56b80908383/contrib/runners/python_runner/python_runner/python_runner.py#L200)), so StackStorm's system `site-packages` directory will always be appended (eg: `<st2root>/st2/lib/python3.x/site-packages`)

As we no longer support Python 2.7, we do not need to prepend the `PYTHONPATH` with the operating system's Python 3 path.

I have also resurrected the tests for this function and refactored them as well.

This might also fix the Windows end-to-end tests that started to fail a few weeks ago.

Related PRs:

* #4297
* #4666
* #4674

Fixes #5126. Special thanks for @amanda11 for catching that before the v3.4 release!

This is currently a WIP. I still need to tweak the tests a bit.