### PR TITLE
Adjust GitHub Actions config to avoid double testing on PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,11 @@ name: ci
 
 on:
   push:
-    branches: ['*']
+    branches:
+      - master  # <-- only on merges to master branch
+      - v*      #     and version branches, which only include minor versions (eg: v3.4)
     tags:
-      - v*
+      - v*      # <-- also version tags, which include bugfix releases (eg: v3.4.0)
   pull_request:
     type: [opened, reopened, edited]
   schedule:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,10 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+
   pull_request:
     type: [opened, reopened, edited]
+    branches:
+      # Only for PRs targeting those branches
+      - master
+      - v[0-9]+.[0-9]+
   schedule:
     # run every night at midnight
     - cron:  '0 0 * * *'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,10 +3,10 @@ name: ci
 on:
   push:
     branches:
-      - master  # <-- only on merges to master branch
-      - v*      #     and version branches, which only include minor versions (eg: v3.4)
+      - master          # <-- only on merges to master branch
+      - v[0-9]+.[0-9]+  #     and version branches, which only include minor versions (eg: v3.4)
     tags:
-      - v*      # <-- also version tags, which include bugfix releases (eg: v3.4.0)
+      - v[0-9]+.[0-9]+.[0-9]+  # <-- also version tags, which include bugfix releases (eg: v3.4.0)
   pull_request:
     type: [opened, reopened, edited]
   schedule:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,10 +3,13 @@ name: ci
 on:
   push:
     branches:
-      - master          # <-- only on merges to master branch
-      - v[0-9]+.[0-9]+  #     and version branches, which only include minor versions (eg: v3.4)
+      # only on merges to master branch
+      - master
+      # and version branches, which only include minor versions (eg: v3.4)
+      - v[0-9]+.[0-9]+
     tags:
-      - v[0-9]+.[0-9]+.[0-9]+  # <-- also version tags, which include bugfix releases (eg: v3.4.0)
+      # also version tags, which include bugfix releases (eg: v3.4.0)
+      - v[0-9]+.[0-9]+.[0-9]+
   pull_request:
     type: [opened, reopened, edited]
   schedule:

--- a/st2common/st2common/models/db/execution.py
+++ b/st2common/st2common/models/db/execution.py
@@ -98,7 +98,7 @@ class ActionExecutionDB(stormbase.StormFoundationDB):
 
     def get_uid(self):
         # TODO Construct od from non id field:
-        uid = [self.RESOURCE_TYPE, str(self.id)]
+        uid = [self.RESOURCE_TYPE, str(self.id)]  # pylint: disable=no-member
         return ':'.join(uid)
 
     def mask_secrets(self, value):


### PR DESCRIPTION
Our current GitHub Actions configuration runs tests twice for each push - once when the branch is pushed, and once more when a pull request is opened, reopened, or edited.

This is inefficient and slows down development since people have to wait for more tests to finish.

This PR slightly tweaks the GHA config to only run tests on pushes to:

* `master` - ensure post-merge code is good
* `v*` branches - version branches that track minor versions (eg: `v3.4`)
* `v*` tags - version tags that track bugfix releases (eg: `v3.4.0`), typically are tagged on commits to version branches

I have included comments on the configuration to ensure that everybody who isn't familiar with GHA understands what the intent is.