### PR TITLE
Update cryptography to 3.3.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,8 @@ Changed
 
   Contributed by @nmaludy, @winem, and @blag
 
+* Updated cryptography dependency to version 3.3.2 to avoid CVE-2020-36242 (security) #5151
+
 Fixed
 ~~~~~
 

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -6,7 +6,7 @@ apscheduler==3.6.3
 chardet<3.1.0
 # NOTE: 2.0 version breaks pymongo work with hosts
 dnspython>=1.16.0,<2.0.0
-cryptography==3.2
+cryptography==3.3.2
 # Note: 0.20.0 removed select.poll() on which some of our code and libraries we
 # depend on rely
 eventlet==0.25.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ apscheduler==3.6.3
 argcomplete
 bcrypt==3.1.7
 chardet<3.1.0
-cryptography==3.2
+cryptography==3.3.2
 dnspython<2.0.0,>=1.16.0
 eventlet==0.25.1
 flex==6.14.0

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -7,7 +7,7 @@
 # update the component requirements.txt
 argcomplete
 chardet<3.1.0
-cryptography==3.2
+cryptography==3.3.2
 jsonpath-rw==1.4.0
 jsonschema==2.6.0
 more-itertools==5.0.0

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -8,7 +8,7 @@
 amqp==2.5.2
 apscheduler==3.6.3
 chardet<3.1.0
-cryptography==3.2
+cryptography==3.3.2
 dnspython<2.0.0,>=1.16.0
 eventlet==0.25.1
 flex==6.14.0


### PR DESCRIPTION
This PR updates cryptography to 3.3.2.

Closes #5147, #5148,  #5149