### PR TITLE
Add error handler or log error instead of using "pass" on exception in st2

### DIFF
--- a/contrib/linux/actions/checks/check_processes.py
+++ b/contrib/linux/actions/checks/check_processes.py
@@ -52,8 +52,8 @@ class CheckProcs(object):
                 cmdfh = open(self.procDir + "/" + p + "/cmdline")
                 cmd = cmdfh.readline()
                 pInfo[1] = cmd
-            except:
-                continue
+            except IOError:
+                print("Error: can't find file or read data.")
             finally:
                 cmdfh.close()
                 fh.close()

--- a/contrib/linux/sensors/file_watch_sensor.py
+++ b/contrib/linux/sensors/file_watch_sensor.py
@@ -44,8 +44,8 @@ class FileWatchSensor(Sensor):
 
             try:
                 self._tail.notifier.stop()
-            except Exception:
-                pass
+            except Exception as e:
+                print("Error: tail notifier is still running.", e)
 
     def add_trigger(self, trigger):
         file_path = trigger['parameters'].get('file_path', None)

--- a/contrib/runners/action_chain_runner/action_chain_runner/action_chain_runner.py
+++ b/contrib/runners/action_chain_runner/action_chain_runner/action_chain_runner.py
@@ -825,9 +825,9 @@ class ActionChainRunner(ActionRunner):
         :rtype: ``dict``
         """
         if not isinstance(created_at, datetime.datetime):
-            raise TypeError("created_at is not a datetime object")
+            raise TypeError('The created_at is not a datetime object.')
         if not isinstance(updated_at, datetime.datetime):
-            raise TypeError("updated_at is not a datetime object")
+            raise TypeError('The updated_at is not a datetime object.')
 
         result = {}
 

--- a/contrib/runners/action_chain_runner/action_chain_runner/action_chain_runner.py
+++ b/contrib/runners/action_chain_runner/action_chain_runner/action_chain_runner.py
@@ -824,8 +824,10 @@ class ActionChainRunner(ActionRunner):
 
         :rtype: ``dict``
         """
-        assert isinstance(created_at, datetime.datetime)
-        assert isinstance(updated_at, datetime.datetime)
+        if not isinstance(created_at, datetime.datetime):
+            raise TypeError("created_at is not a datetime object")
+        if not isinstance(updated_at, datetime.datetime):
+            raise TypeError("updated_at is not a datetime object")
 
         result = {}
 

--- a/contrib/runners/python_runner/python_runner/python_action_wrapper.py
+++ b/contrib/runners/python_runner/python_runner/python_action_wrapper.py
@@ -323,7 +323,7 @@ if __name__ == '__main__':
     LOG.debug('Received parameters: %s', parameters)
 
     if not isinstance(parent_args, list):
-        raise ValueError("Parent_args needs a list of values")
+        raise ValueError('The parent_args needs to be a list.')
     obj = PythonActionWrapper(pack=args.pack,
                               file_path=args.file_path,
                               config=config,

--- a/contrib/runners/python_runner/python_runner/python_action_wrapper.py
+++ b/contrib/runners/python_runner/python_runner/python_action_wrapper.py
@@ -322,7 +322,8 @@ if __name__ == '__main__':
 
     LOG.debug('Received parameters: %s', parameters)
 
-    assert isinstance(parent_args, list)
+    if not isinstance(parent_args, list):
+        raise ValueError("Parent_args needs a list of values")
     obj = PythonActionWrapper(pack=args.pack,
                               file_path=args.file_path,
                               config=config,

--- a/contrib/runners/python_runner/python_runner/python_runner.py
+++ b/contrib/runners/python_runner/python_runner/python_runner.py
@@ -322,7 +322,8 @@ class PythonRunner(GitWorktreeActionRunner):
 
         if ACTION_OUTPUT_RESULT_DELIMITER in stdout:
             split = stdout.split(ACTION_OUTPUT_RESULT_DELIMITER)
-            assert len(split) == 3
+            if not len(split) == 3:
+                raise ValueError("Length should be 3")
             action_result = split[1].strip()
             stdout = split[0] + split[2]
         else:

--- a/contrib/runners/python_runner/python_runner/python_runner.py
+++ b/contrib/runners/python_runner/python_runner/python_runner.py
@@ -323,7 +323,7 @@ class PythonRunner(GitWorktreeActionRunner):
         if ACTION_OUTPUT_RESULT_DELIMITER in stdout:
             split = stdout.split(ACTION_OUTPUT_RESULT_DELIMITER)
             if not len(split) == 3:
-                raise ValueError("Length should be 3")
+                raise ValueError('The result length should be 3.')
             action_result = split[1].strip()
             stdout = split[0] + split[2]
         else:

--- a/st2actions/st2actions/cmd/scheduler.py
+++ b/st2actions/st2actions/cmd/scheduler.py
@@ -109,7 +109,7 @@ def _run_scheduler():
             handler.shutdown()
             entrypoint.shutdown()
         except:
-            pass
+            LOG.exception('Unable to shutdown scheduler.')
 
         return 1
 

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -378,13 +378,16 @@ class ActionExecutionReRunController(ActionExecutionsControllerMixin, ResourceCo
                                  're-running task(s) for a workflow.')
 
             if self.parameters:
-                assert isinstance(self.parameters, dict)
+                if not isinstance(self.parameters, dict):
+                    raise ValueError("Parameters needs to be a dictionary")
 
             if self.tasks:
-                assert isinstance(self.tasks, list)
+                if not isinstance(self.tasks, list):
+                    raise ValueError("Tasks needs to be a list")
 
             if self.reset:
-                assert isinstance(self.reset, list)
+                if not isinstance(self.reset, list):
+                    raise ValueError("Reset needs to be a list")
 
             if list(set(self.reset) - set(self.tasks)):
                 raise ValueError('List of tasks to reset does not match the tasks to rerun.')
@@ -405,13 +408,16 @@ class ActionExecutionReRunController(ActionExecutionsControllerMixin, ResourceCo
                              're-running task(s) for a workflow.')
 
         if spec_api.parameters:
-            assert isinstance(spec_api.parameters, dict)
+            if not isinstance(spec_api.parameters, dict):
+                raise ValueError("Parameters needs to be a list")
 
         if spec_api.tasks:
-            assert isinstance(spec_api.tasks, list)
+            if not isinstance(spec_api.tasks, list):
+                raise ValueError("Tasks needs to be a list")
 
         if spec_api.reset:
-            assert isinstance(spec_api.reset, list)
+            if not isinstance(spec_api.reset, list):
+                raise ValueError("reset needs to be a list")
 
         if list(set(spec_api.reset) - set(spec_api.tasks)):
             raise ValueError('List of tasks to reset does not match the tasks to rerun.')

--- a/st2api/st2api/controllers/v1/actionexecutions.py
+++ b/st2api/st2api/controllers/v1/actionexecutions.py
@@ -379,15 +379,15 @@ class ActionExecutionReRunController(ActionExecutionsControllerMixin, ResourceCo
 
             if self.parameters:
                 if not isinstance(self.parameters, dict):
-                    raise ValueError("Parameters needs to be a dictionary")
+                    raise ValueError('The parameters needs to be a dictionary.')
 
             if self.tasks:
                 if not isinstance(self.tasks, list):
-                    raise ValueError("Tasks needs to be a list")
+                    raise ValueError('The tasks needs to be a list.')
 
             if self.reset:
                 if not isinstance(self.reset, list):
-                    raise ValueError("Reset needs to be a list")
+                    raise ValueError('The reset needs to be a list.')
 
             if list(set(self.reset) - set(self.tasks)):
                 raise ValueError('List of tasks to reset does not match the tasks to rerun.')
@@ -409,15 +409,15 @@ class ActionExecutionReRunController(ActionExecutionsControllerMixin, ResourceCo
 
         if spec_api.parameters:
             if not isinstance(spec_api.parameters, dict):
-                raise ValueError("Parameters needs to be a list")
+                raise ValueError('The parameters needs to be a dictionary.')
 
         if spec_api.tasks:
             if not isinstance(spec_api.tasks, list):
-                raise ValueError("Tasks needs to be a list")
+                raise ValueError('The tasks needs to be a list.')
 
         if spec_api.reset:
             if not isinstance(spec_api.reset, list):
-                raise ValueError("reset needs to be a list")
+                raise ValueError('The reset needs to be a list.')
 
         if list(set(spec_api.reset) - set(spec_api.tasks)):
             raise ValueError('List of tasks to reset does not match the tasks to rerun.')

--- a/st2api/st2api/controllers/v1/keyvalue.py
+++ b/st2api/st2api/controllers/v1/keyvalue.py
@@ -193,7 +193,8 @@ class KeyValuePairController(ResourceController):
             raw_filters['scope'] = FULL_SYSTEM_SCOPE
             raw_filters['prefix'] = prefix
 
-            assert 'scope' in raw_filters
+            if 'scope'not in raw_filters:
+                raise KeyError("The key scope is not in raw_filters")
             kvp_apis_system = super(KeyValuePairController, self)._get_all(
                 from_model_kwargs=from_model_kwargs,
                 sort=sort,
@@ -212,8 +213,10 @@ class KeyValuePairController(ResourceController):
             else:
                 raw_filters['prefix'] = user_scope_prefix
 
-            assert 'scope' in raw_filters
-            assert 'prefix' in raw_filters
+            if 'scope'not in raw_filters:
+                raise KeyError("The key scope is not found in raw_filters")
+            if 'prefix'not in raw_filters:
+                raise KeyError("The key prefix is not in raw_filters")
             kvp_apis_user = super(KeyValuePairController, self)._get_all(
                 from_model_kwargs=from_model_kwargs,
                 sort=sort,
@@ -231,8 +234,10 @@ class KeyValuePairController(ResourceController):
             prefix = get_key_reference(name=prefix or '', scope=scope, user=user)
             raw_filters['prefix'] = user_scope_prefix
 
-            assert 'scope' in raw_filters
-            assert 'prefix' in raw_filters
+            if 'scope' not in raw_filters:
+                raise KeyError("The key scope is not found in raw_filters")
+            if 'prefix' not in raw_filters:
+                raise KeyError("The key prefix is not in raw_filters")
             kvp_apis = super(KeyValuePairController, self)._get_all(
                 from_model_kwargs=from_model_kwargs,
                 sort=sort,
@@ -243,7 +248,8 @@ class KeyValuePairController(ResourceController):
         elif scope in [SYSTEM_SCOPE, FULL_SYSTEM_SCOPE]:
             raw_filters['prefix'] = prefix
 
-            assert 'scope' in raw_filters
+            if 'scope' not in raw_filters:
+                raise KeyError("The key scope is not found in raw_filters")
             kvp_apis = super(KeyValuePairController, self)._get_all(
                 from_model_kwargs=from_model_kwargs,
                 sort=sort,

--- a/st2api/st2api/controllers/v1/keyvalue.py
+++ b/st2api/st2api/controllers/v1/keyvalue.py
@@ -194,7 +194,7 @@ class KeyValuePairController(ResourceController):
             raw_filters['prefix'] = prefix
 
             if 'scope'not in raw_filters:
-                raise KeyError("The key scope is not in raw_filters")
+                raise KeyError('The scope is not found in raw filters.')
             kvp_apis_system = super(KeyValuePairController, self)._get_all(
                 from_model_kwargs=from_model_kwargs,
                 sort=sort,
@@ -214,9 +214,9 @@ class KeyValuePairController(ResourceController):
                 raw_filters['prefix'] = user_scope_prefix
 
             if 'scope'not in raw_filters:
-                raise KeyError("The key scope is not found in raw_filters")
+                raise KeyError('The scope is not found in raw filters.')
             if 'prefix'not in raw_filters:
-                raise KeyError("The key prefix is not in raw_filters")
+                raise KeyError('The prefix is not found in raw filters.')
             kvp_apis_user = super(KeyValuePairController, self)._get_all(
                 from_model_kwargs=from_model_kwargs,
                 sort=sort,
@@ -235,9 +235,9 @@ class KeyValuePairController(ResourceController):
             raw_filters['prefix'] = user_scope_prefix
 
             if 'scope' not in raw_filters:
-                raise KeyError("The key scope is not found in raw_filters")
+                raise KeyError('The scope is not found in raw filters.')
             if 'prefix' not in raw_filters:
-                raise KeyError("The key prefix is not in raw_filters")
+                raise KeyError('The prefix is not found in raw filters.')
             kvp_apis = super(KeyValuePairController, self)._get_all(
                 from_model_kwargs=from_model_kwargs,
                 sort=sort,
@@ -249,7 +249,7 @@ class KeyValuePairController(ResourceController):
             raw_filters['prefix'] = prefix
 
             if 'scope' not in raw_filters:
-                raise KeyError("The key scope is not found in raw_filters")
+                raise KeyError('The scope is not found in raw filters.')
             kvp_apis = super(KeyValuePairController, self)._get_all(
                 from_model_kwargs=from_model_kwargs,
                 sort=sort,

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -325,7 +325,7 @@ class TriggerInstanceResendController(TriggerInstanceControllerMixin, resource.R
         def validate(self):
             if self.payload:
                 if not isinstance(self.payload, dict):
-                    raise TypeError("The object is not a dict type")
+                    raise TypeError('The payload has a value that is not a dictionary.')
 
             return True
 

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -324,7 +324,8 @@ class TriggerInstanceResendController(TriggerInstanceControllerMixin, resource.R
 
         def validate(self):
             if self.payload:
-                assert isinstance(self.payload, dict)
+                if not isinstance(self.payload, dict):
+                    raise TypeError("The object is not a dict type")
 
             return True
 

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -344,8 +344,11 @@ class ResourceManager(object):
             resp_json = response.json()
             if resp_json:
                 return resp_json
-        except:
-            pass
+        except Exception as e:
+            response.reason += (
+                '\nUnable to retrieve detailed message '
+                'from the HTTP response. %s\n' % six.text_type(e)
+            )
         return True
 
 

--- a/st2client/st2client/utils/terminal.py
+++ b/st2client/st2client/utils/terminal.py
@@ -63,8 +63,8 @@ def get_terminal_size_columns(default=DEFAULT_TERMINAL_SIZE_COLUMNS):
     for fd in (0, 1, 2):
         try:
             return ioctl_GWINSZ(fd)[1]
-        except Exception:
-            pass
+        except Exception as e:
+            print(e)
 
     # 3. try os.ctermid()
     try:
@@ -73,8 +73,8 @@ def get_terminal_size_columns(default=DEFAULT_TERMINAL_SIZE_COLUMNS):
             return ioctl_GWINSZ(fd)[1]
         finally:
             os.close(fd)
-    except Exception:
-        pass
+    except Exception as e:
+        print(e)
 
     # 4. try `stty size`
     try:
@@ -85,8 +85,8 @@ def get_terminal_size_columns(default=DEFAULT_TERMINAL_SIZE_COLUMNS):
         result = process.communicate()
         if process.returncode == 0:
             return tuple(int(x) for x in result[0].split())[1]
-    except Exception:
-        pass
+    except Exception as e:
+        print(e)
 
     # 5. return default fallback value
     return default

--- a/st2common/st2common/bootstrap/actionsregistrar.py
+++ b/st2common/st2common/bootstrap/actionsregistrar.py
@@ -211,7 +211,7 @@ def register_actions(packs_base_paths=None, pack_dir=None, use_pack_cache=True,
                      fail_on_failure=False):
     if packs_base_paths:
         if not isinstance(packs_base_paths, list):
-            raise ValueError("Pack base paths needs to be a list")
+            raise ValueError('The pack base paths has a value that is not a list.')
 
     if not packs_base_paths:
         packs_base_paths = content_utils.get_packs_base_paths()

--- a/st2common/st2common/bootstrap/actionsregistrar.py
+++ b/st2common/st2common/bootstrap/actionsregistrar.py
@@ -210,7 +210,8 @@ class ActionsRegistrar(ResourceRegistrar):
 def register_actions(packs_base_paths=None, pack_dir=None, use_pack_cache=True,
                      fail_on_failure=False):
     if packs_base_paths:
-        assert isinstance(packs_base_paths, list)
+        if not isinstance(packs_base_paths, list):
+            raise ValueError("Pack base paths needs to be a list")
 
     if not packs_base_paths:
         packs_base_paths = content_utils.get_packs_base_paths()

--- a/st2common/st2common/bootstrap/aliasesregistrar.py
+++ b/st2common/st2common/bootstrap/aliasesregistrar.py
@@ -192,7 +192,7 @@ def register_aliases(packs_base_paths=None, pack_dir=None, use_pack_cache=True,
 
     if packs_base_paths:
         if not isinstance(packs_base_paths, list):
-            raise TypeError("The object is not a List type")
+            raise TypeError('The pack base paths has a value that is not a list.')
 
     if not packs_base_paths:
         packs_base_paths = content_utils.get_packs_base_paths()

--- a/st2common/st2common/bootstrap/aliasesregistrar.py
+++ b/st2common/st2common/bootstrap/aliasesregistrar.py
@@ -191,7 +191,8 @@ def register_aliases(packs_base_paths=None, pack_dir=None, use_pack_cache=True,
                      fail_on_failure=False):
 
     if packs_base_paths:
-        assert isinstance(packs_base_paths, list)
+        if not isinstance(packs_base_paths, list):
+            raise TypeError("The object is not a List type")
 
     if not packs_base_paths:
         packs_base_paths = content_utils.get_packs_base_paths()

--- a/st2common/st2common/bootstrap/configsregistrar.py
+++ b/st2common/st2common/bootstrap/configsregistrar.py
@@ -149,7 +149,8 @@ def register_configs(packs_base_paths=None, pack_dir=None, use_pack_cache=True,
                      fail_on_failure=False, validate_configs=True):
 
     if packs_base_paths:
-        assert isinstance(packs_base_paths, list)
+        if not isinstance(packs_base_paths, list):
+            raise ValueError("Pack Base paths needs to be a list")
 
     if not packs_base_paths:
         packs_base_paths = content_utils.get_packs_base_paths()

--- a/st2common/st2common/bootstrap/configsregistrar.py
+++ b/st2common/st2common/bootstrap/configsregistrar.py
@@ -150,7 +150,7 @@ def register_configs(packs_base_paths=None, pack_dir=None, use_pack_cache=True,
 
     if packs_base_paths:
         if not isinstance(packs_base_paths, list):
-            raise ValueError("Pack Base paths needs to be a list")
+            raise ValueError('The pack base paths has a value that is not a list.')
 
     if not packs_base_paths:
         packs_base_paths = content_utils.get_packs_base_paths()

--- a/st2common/st2common/bootstrap/policiesregistrar.py
+++ b/st2common/st2common/bootstrap/policiesregistrar.py
@@ -206,7 +206,8 @@ def register_policy_types(module):
 def register_policies(packs_base_paths=None, pack_dir=None, use_pack_cache=True,
                      fail_on_failure=False):
     if packs_base_paths:
-        assert isinstance(packs_base_paths, list)
+        if not isinstance(packs_base_paths, list):
+            raise TypeError("The object is not a list type")
 
     if not packs_base_paths:
         packs_base_paths = content_utils.get_packs_base_paths()

--- a/st2common/st2common/bootstrap/policiesregistrar.py
+++ b/st2common/st2common/bootstrap/policiesregistrar.py
@@ -207,7 +207,7 @@ def register_policies(packs_base_paths=None, pack_dir=None, use_pack_cache=True,
                      fail_on_failure=False):
     if packs_base_paths:
         if not isinstance(packs_base_paths, list):
-            raise TypeError("The object is not a list type")
+            raise TypeError('The pack base paths has a value that is not a list.')
 
     if not packs_base_paths:
         packs_base_paths = content_utils.get_packs_base_paths()

--- a/st2common/st2common/bootstrap/rulesregistrar.py
+++ b/st2common/st2common/bootstrap/rulesregistrar.py
@@ -185,7 +185,8 @@ class RulesRegistrar(ResourceRegistrar):
 def register_rules(packs_base_paths=None, pack_dir=None, use_pack_cache=True,
                    fail_on_failure=False):
     if packs_base_paths:
-        assert isinstance(packs_base_paths, list)
+        if not isinstance(packs_base_paths, list):
+            raise ValueError("Pack base paths needs to be a list")
 
     if not packs_base_paths:
         packs_base_paths = content_utils.get_packs_base_paths()

--- a/st2common/st2common/bootstrap/rulesregistrar.py
+++ b/st2common/st2common/bootstrap/rulesregistrar.py
@@ -186,7 +186,7 @@ def register_rules(packs_base_paths=None, pack_dir=None, use_pack_cache=True,
                    fail_on_failure=False):
     if packs_base_paths:
         if not isinstance(packs_base_paths, list):
-            raise ValueError("Pack base paths needs to be a list")
+            raise ValueError('The pack base paths has a value that is not a list.')
 
     if not packs_base_paths:
         packs_base_paths = content_utils.get_packs_base_paths()

--- a/st2common/st2common/bootstrap/sensorsregistrar.py
+++ b/st2common/st2common/bootstrap/sensorsregistrar.py
@@ -178,7 +178,8 @@ class SensorsRegistrar(ResourceRegistrar):
 def register_sensors(packs_base_paths=None, pack_dir=None, use_pack_cache=True,
                      fail_on_failure=False):
     if packs_base_paths:
-        assert isinstance(packs_base_paths, list)
+        if not isinstance(packs_base_paths, list):
+            raise TypeError("The object is not a list type")
 
     if not packs_base_paths:
         packs_base_paths = content_utils.get_packs_base_paths()

--- a/st2common/st2common/bootstrap/sensorsregistrar.py
+++ b/st2common/st2common/bootstrap/sensorsregistrar.py
@@ -179,7 +179,7 @@ def register_sensors(packs_base_paths=None, pack_dir=None, use_pack_cache=True,
                      fail_on_failure=False):
     if packs_base_paths:
         if not isinstance(packs_base_paths, list):
-            raise TypeError("The object is not a list type")
+            raise TypeError('The pack base paths has a value that is not a list.')
 
     if not packs_base_paths:
         packs_base_paths = content_utils.get_packs_base_paths()

--- a/st2common/st2common/bootstrap/triggersregistrar.py
+++ b/st2common/st2common/bootstrap/triggersregistrar.py
@@ -155,7 +155,7 @@ def register_triggers(packs_base_paths=None, pack_dir=None, use_pack_cache=True,
                       fail_on_failure=False):
     if packs_base_paths:
         if not isinstance(packs_base_paths, list):
-            raise ValueError("Pack base paths needs to be a list")
+            raise ValueError('The pack base paths has a value that is not a list.')
 
     if not packs_base_paths:
         packs_base_paths = content_utils.get_packs_base_paths()

--- a/st2common/st2common/bootstrap/triggersregistrar.py
+++ b/st2common/st2common/bootstrap/triggersregistrar.py
@@ -154,7 +154,8 @@ class TriggersRegistrar(ResourceRegistrar):
 def register_triggers(packs_base_paths=None, pack_dir=None, use_pack_cache=True,
                       fail_on_failure=False):
     if packs_base_paths:
-        assert isinstance(packs_base_paths, list)
+        if not isinstance(packs_base_paths, list):
+            raise ValueError("Pack base paths needs to be a list")
 
     if not packs_base_paths:
         packs_base_paths = content_utils.get_packs_base_paths()

--- a/st2common/st2common/content/loader.py
+++ b/st2common/st2common/content/loader.py
@@ -61,7 +61,8 @@ class ContentPackLoader(object):
                  directory.
         :rtype: ``dict``
         """
-        assert isinstance(base_dirs, list)
+        if not isinstance(base_dirs, list):
+            raise TypeError("Base dirs needs to be a list")
 
         result = {}
         for base_dir in base_dirs:
@@ -88,7 +89,8 @@ class ContentPackLoader(object):
 
         :rtype: ``dict``
         """
-        assert isinstance(base_dirs, list)
+        if not isinstance(base_dirs, list):
+            raise TypeError("Base dirs needs to be a list")
 
         if content_type not in self.ALLOWED_CONTENT_TYPES:
             raise ValueError('Unsupported content_type: %s' % (content_type))

--- a/st2common/st2common/content/loader.py
+++ b/st2common/st2common/content/loader.py
@@ -62,7 +62,7 @@ class ContentPackLoader(object):
         :rtype: ``dict``
         """
         if not isinstance(base_dirs, list):
-            raise TypeError("Base dirs needs to be a list")
+            raise TypeError('The base dirs has a value that is not a list.')
 
         result = {}
         for base_dir in base_dirs:
@@ -90,7 +90,7 @@ class ContentPackLoader(object):
         :rtype: ``dict``
         """
         if not isinstance(base_dirs, list):
-            raise TypeError("Base dirs needs to be a list")
+            raise TypeError('The base dirs has a value that is not a list.')
 
         if content_type not in self.ALLOWED_CONTENT_TYPES:
             raise ValueError('Unsupported content_type: %s' % (content_type))

--- a/st2common/st2common/content/utils.py
+++ b/st2common/st2common/content/utils.py
@@ -282,7 +282,7 @@ def get_pack_file_abs_path(pack_ref, file_path, resource_type=None, use_pack_cac
     result = os.path.join(*path_components)     # pylint: disable=E1120
 
     if normalized_file_path not in result:
-        raise ValueError("This is not normalized path to prevent directory traversal")
+        raise ValueError('This is not a normalized path to prevent directory traversal.')
 
     # Final safety check for common prefix to avoid traversal attack
     common_prefix = os.path.commonprefix([pack_base_path, result])

--- a/st2common/st2common/content/utils.py
+++ b/st2common/st2common/content/utils.py
@@ -281,7 +281,8 @@ def get_pack_file_abs_path(pack_ref, file_path, resource_type=None, use_pack_cac
     path_components.append(normalized_file_path)
     result = os.path.join(*path_components)     # pylint: disable=E1120
 
-    assert normalized_file_path in result
+    if normalized_file_path not in result:
+        raise ValueError("This is not normalized path to prevent directory traversal")
 
     # Final safety check for common prefix to avoid traversal attack
     common_prefix = os.path.commonprefix([pack_base_path, result])

--- a/st2common/st2common/log.py
+++ b/st2common/st2common/log.py
@@ -129,8 +129,8 @@ def find_caller(stack_info=False, stacklevel=1):
                     sio.close()
                 rv = (filename, f.f_lineno, co.co_name, sinfo)
             break
-    except Exception:
-        pass
+    except Exception as e:
+        print('Unable to find caller.', e)
 
     return rv
 

--- a/st2common/st2common/models/api/keyvalue.py
+++ b/st2common/st2common/models/api/keyvalue.py
@@ -189,7 +189,7 @@ class KeyValuePairAPI(BaseAPI):
 
             # Additional safety check to ensure that the value hasn't been decrypted
             if not value == original_value:
-                raise ValueError("Value doesn't match with original value")
+                raise ValueError("The value doesn't match with original value.")
         elif secret:
             cls._verif_key_is_set_up(name=name)
 

--- a/st2common/st2common/models/api/keyvalue.py
+++ b/st2common/st2common/models/api/keyvalue.py
@@ -188,7 +188,8 @@ class KeyValuePairAPI(BaseAPI):
                 raise ValueError(msg)
 
             # Additional safety check to ensure that the value hasn't been decrypted
-            assert value == original_value
+            if not value == original_value:
+                raise ValueError("Value doesn't match with original value")
         elif secret:
             cls._verif_key_is_set_up(name=name)
 

--- a/st2common/st2common/models/system/action.py
+++ b/st2common/st2common/models/system/action.py
@@ -177,7 +177,8 @@ class ShellCommandAction(object):
 
         :rtype: ``str``
         """
-        assert isinstance(args, (list, tuple))
+        if not isinstance(args, (list, tuple)):
+            raise ValueError("Args needs to be a list and tuple")
 
         args = [quote_unix(arg) for arg in args]
         args = ' '.join(args)

--- a/st2common/st2common/models/system/action.py
+++ b/st2common/st2common/models/system/action.py
@@ -178,7 +178,7 @@ class ShellCommandAction(object):
         :rtype: ``str``
         """
         if not isinstance(args, (list, tuple)):
-            raise ValueError("Args needs to be a list and tuple")
+            raise ValueError('The args has a value that is not a list and tuple.')
 
         args = [quote_unix(arg) for arg in args]
         args = ' '.join(args)

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -185,7 +185,7 @@ class PermissionType(Enum):
 
         split = permission_type.split('_')
         if not len(split) >= 2:
-            raise ValueError("Length should be greater than or equal to 2")
+            raise ValueError('The length should be greater than or equal to 2.')
 
         return '_'.join(split[:-1])
 
@@ -198,7 +198,7 @@ class PermissionType(Enum):
         """
         split = permission_type.split('_')
         if not len(split) >= 2:
-            raise ValueError("Length should be greater than or equal to 2")
+            raise ValueError('The length should be greater than or equal to 2.')
 
         # Special case for PACK_VIEWS_INDEX_HEALTH
         if permission_type == PermissionType.PACK_VIEWS_INDEX_HEALTH:

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -184,7 +184,8 @@ class PermissionType(Enum):
             return ResourceType.EXECUTION
 
         split = permission_type.split('_')
-        assert len(split) >= 2
+        if not len(split) >= 2:
+            raise ValueError("Length should be greater than or equal to 2")
 
         return '_'.join(split[:-1])
 
@@ -196,7 +197,8 @@ class PermissionType(Enum):
         :rtype: ``str``
         """
         split = permission_type.split('_')
-        assert len(split) >= 2
+        if not len(split) >= 2:
+            raise ValueError("Length should be greater than or equal to 2")
 
         # Special case for PACK_VIEWS_INDEX_HEALTH
         if permission_type == PermissionType.PACK_VIEWS_INDEX_HEALTH:

--- a/st2common/st2common/runners/base.py
+++ b/st2common/st2common/runners/base.py
@@ -289,7 +289,7 @@ class GitWorktreeActionRunner(ActionRunner):
                                                   worktree_path=self.git_worktree_path)
 
             if not (entry_point.startswith(self.git_worktree_path)):
-                raise ValueError("Value not matching")
+                raise ValueError("The entry point value does not match with git worktree path.")
 
             self.entry_point = entry_point
 
@@ -377,9 +377,10 @@ class GitWorktreeActionRunner(ActionRunner):
         """
         # Safety check to make sure we don't remove something outside /tmp
         if not (worktree_path.startswith('/tmp')):
-            raise ValueError("Value not matching")
+            raise ValueError('The worktree path does not match with /tmp.')
         if not (worktree_path.startswith('/tmp/%s' % (self.WORKTREE_DIRECTORY_PREFIX))):
-            raise ValueError("Value not matching")
+            raise ValueError('The worktree path does not match with /tmp/"%s".' %
+                            (self.WORKTREE_DIRECTORY_PREFIX))
 
         if self._debug:
             LOG.debug('Not removing git worktree "%s" because debug mode is enabled' %

--- a/st2common/st2common/runners/base.py
+++ b/st2common/st2common/runners/base.py
@@ -391,8 +391,9 @@ class GitWorktreeActionRunner(ActionRunner):
 
             try:
                 shutil.rmtree(worktree_path, ignore_errors=True)
-            except:
-                pass
+            except Exception:
+                msg = ('Unable to remove / cleanup the provided git worktree directory.')
+                LOG.exception(msg)
 
         return True
 

--- a/st2common/st2common/runners/base.py
+++ b/st2common/st2common/runners/base.py
@@ -288,7 +288,8 @@ class GitWorktreeActionRunner(ActionRunner):
                                                   entry_point=self.entry_point,
                                                   worktree_path=self.git_worktree_path)
 
-            assert(entry_point.startswith(self.git_worktree_path))
+            if not (entry_point.startswith(self.git_worktree_path)):
+                raise ValueError("Value not matching")
 
             self.entry_point = entry_point
 
@@ -375,8 +376,10 @@ class GitWorktreeActionRunner(ActionRunner):
         :rtype: ``bool``
         """
         # Safety check to make sure we don't remove something outside /tmp
-        assert(worktree_path.startswith('/tmp'))
-        assert(worktree_path.startswith('/tmp/%s' % (self.WORKTREE_DIRECTORY_PREFIX)))
+        if not (worktree_path.startswith('/tmp')):
+            raise ValueError("Value not matching")
+        if not (worktree_path.startswith('/tmp/%s' % (self.WORKTREE_DIRECTORY_PREFIX))):
+            raise ValueError("Value not matching")
 
         if self._debug:
             LOG.debug('Not removing git worktree "%s" because debug mode is enabled' %

--- a/st2common/st2common/services/trace.py
+++ b/st2common/st2common/services/trace.py
@@ -54,7 +54,8 @@ def _get_valid_trace_context(trace_context):
     """
     Check if tarce_context is a valid type and returns a TraceContext object.
     """
-    assert isinstance(trace_context, (TraceContext, dict))
+    if not isinstance(trace_context, (TraceContext, dict)):
+        raise TypeError("Not a valid trace_context type")
 
     # Pretty much abuse the dynamic nature of python to make it possible to support
     # both dict and TraceContext types.

--- a/st2common/st2common/services/trace.py
+++ b/st2common/st2common/services/trace.py
@@ -55,7 +55,7 @@ def _get_valid_trace_context(trace_context):
     Check if tarce_context is a valid type and returns a TraceContext object.
     """
     if not isinstance(trace_context, (TraceContext, dict)):
-        raise TypeError("Not a valid trace_context type")
+        raise TypeError("The trace context has a value that is not a dictionary.")
 
     # Pretty much abuse the dynamic nature of python to make it possible to support
     # both dict and TraceContext types.

--- a/st2common/st2common/services/triggers.py
+++ b/st2common/st2common/services/triggers.py
@@ -253,7 +253,8 @@ def create_or_update_trigger_db(trigger, log_not_unique_error_as_debug=False):
     :param trigger: Trigger info.
     :type trigger: ``dict``
     """
-    assert isinstance(trigger, dict)
+    if not isinstance(trigger, dict):
+        raise ValueError("Trigger needs to be a dict object")
 
     existing_trigger_db = _get_trigger_db(trigger)
 
@@ -406,7 +407,8 @@ def create_or_update_trigger_type_db(trigger_type, log_not_unique_error_as_debug
 
     :rtype: ``object``
     """
-    assert isinstance(trigger_type, dict)
+    if not isinstance(trigger_type, dict):
+        raise ValueError("trigger needs to be a dict object")
 
     trigger_type_api = TriggerTypeAPI(**trigger_type)
     trigger_type_api.validate()

--- a/st2common/st2common/services/triggers.py
+++ b/st2common/st2common/services/triggers.py
@@ -254,7 +254,7 @@ def create_or_update_trigger_db(trigger, log_not_unique_error_as_debug=False):
     :type trigger: ``dict``
     """
     if not isinstance(trigger, dict):
-        raise ValueError("Trigger needs to be a dict object")
+        raise ValueError('The trigger has a value that is not a dictionary.')
 
     existing_trigger_db = _get_trigger_db(trigger)
 
@@ -408,7 +408,7 @@ def create_or_update_trigger_type_db(trigger_type, log_not_unique_error_as_debug
     :rtype: ``object``
     """
     if not isinstance(trigger_type, dict):
-        raise ValueError("trigger needs to be a dict object")
+        raise ValueError('The trigger has a value that is not a dictionary.')
 
     trigger_type_api = TriggerTypeAPI(**trigger_type)
     trigger_type_api.validate()

--- a/st2common/st2common/transport/announcement.py
+++ b/st2common/st2common/transport/announcement.py
@@ -66,9 +66,9 @@ class AnnouncementDispatcher(object):
         :type trace_context: ``TraceContext``
         """
         if not isinstance(payload, (type(None), dict)):
-            raise TypeError("Object is not a dict type")
+            raise TypeError('The payload has a value that is not a dictionary.')
         if not isinstance(trace_context, (type(None), dict, TraceContext)):
-            raise TypeError("Object is not a TraceContext type")
+            raise TypeError('The trace context has a value that is not a dictionary.')
 
         payload = {
             'payload': payload,

--- a/st2common/st2common/transport/announcement.py
+++ b/st2common/st2common/transport/announcement.py
@@ -65,8 +65,10 @@ class AnnouncementDispatcher(object):
         :param trace_context: Trace context to associate with Announcement.
         :type trace_context: ``TraceContext``
         """
-        assert isinstance(payload, (type(None), dict))
-        assert isinstance(trace_context, (type(None), dict, TraceContext))
+        if not isinstance(payload, (type(None), dict)):
+            raise TypeError("Object is not a dict type")
+        if not isinstance(trace_context, (type(None), dict, TraceContext)):
+            raise TypeError("Object is not a TraceContext type")
 
         payload = {
             'payload': payload,

--- a/st2common/st2common/transport/reactor.py
+++ b/st2common/st2common/transport/reactor.py
@@ -93,8 +93,10 @@ class TriggerDispatcher(object):
         :param trace_context: Trace context to associate with Trigger.
         :type trace_context: ``TraceContext``
         """
-        assert isinstance(payload, (type(None), dict))
-        assert isinstance(trace_context, (type(None), TraceContext))
+        if not isinstance(payload, (type(None), dict)):
+            raise TypeError("Object is not a dict type")
+        if not isinstance(trace_context, (type(None), TraceContext)):
+            raise TypeError("Object is not a TraceContext type")
 
         payload = {
             'trigger': trigger,

--- a/st2common/st2common/transport/reactor.py
+++ b/st2common/st2common/transport/reactor.py
@@ -94,9 +94,9 @@ class TriggerDispatcher(object):
         :type trace_context: ``TraceContext``
         """
         if not isinstance(payload, (type(None), dict)):
-            raise TypeError("Object is not a dict type")
+            raise TypeError('The payload has a value that is not a dictionary.')
         if not isinstance(trace_context, (type(None), TraceContext)):
-            raise TypeError("Object is not a TraceContext type")
+            raise TypeError('The trace context has a value that is not of type TraceContext.')
 
         payload = {
             'trigger': trigger,

--- a/st2common/st2common/util/crypto.py
+++ b/st2common/st2common/util/crypto.py
@@ -80,7 +80,8 @@ MINIMUM_AES_KEY_SIZE = 128
 
 DEFAULT_AES_KEY_SIZE = 256
 
-assert DEFAULT_AES_KEY_SIZE >= MINIMUM_AES_KEY_SIZE
+if not DEFAULT_AES_KEY_SIZE >= MINIMUM_AES_KEY_SIZE:
+    raise ValueError('Verify the key size :%s' % (DEFAULT_AES_KEY_SIZE))
 
 
 class AESKey(object):
@@ -206,15 +207,18 @@ def cryptography_symmetric_encrypt(encrypt_key, plaintext):
     NOTE: Header itself is unused, but it's added so the format is compatible with keyczar format.
 
     """
-    assert isinstance(encrypt_key, AESKey), 'encrypt_key needs to be AESKey class instance'
-    assert isinstance(plaintext, (six.text_type, six.string_types, six.binary_type)), \
-        'plaintext needs to either be a string/unicode or bytes'
+    if not isinstance(encrypt_key, AESKey):
+        raise ValueError("Encrypt key needs to be an AESkey class instance")
+    if not isinstance(plaintext, (six.text_type, six.string_types, six.binary_type)):
+        raise TypeError("Plaintext needs to either be a string/unicode or bytes")
 
     aes_key_bytes = encrypt_key.aes_key_bytes
     hmac_key_bytes = encrypt_key.hmac_key_bytes
 
-    assert isinstance(aes_key_bytes, six.binary_type)
-    assert isinstance(hmac_key_bytes, six.binary_type)
+    if not isinstance(aes_key_bytes, six.binary_type):
+        raise TypeError("AESKey bytes matching with binary type")
+    if not isinstance(hmac_key_bytes, six.binary_type):
+        raise TypeError("HMACKey bytes matching with binary type")
 
     if isinstance(plaintext, (six.text_type, six.string_types)):
         # Convert data to bytes
@@ -263,15 +267,18 @@ def cryptography_symmetric_decrypt(decrypt_key, ciphertext):
 
     NOTE 2: This function is loosely based on keyczar AESKey.Decrypt() (Apache 2.0 license).
     """
-    assert isinstance(decrypt_key, AESKey), 'decrypt_key needs to be AESKey class instance'
-    assert isinstance(ciphertext, (six.text_type, six.string_types, six.binary_type)), \
-        'ciphertext needs to either be a string/unicode or bytes'
+    if not isinstance(decrypt_key, AESKey):
+        raise ValueError("Decrypt key needs to be an AESKey class instance")
+    if not isinstance(ciphertext, (six.text_type, six.string_types, six.binary_type)):
+        raise TypeError("Ciphertext needs to either be a string/unicode or bytes")
 
     aes_key_bytes = decrypt_key.aes_key_bytes
     hmac_key_bytes = decrypt_key.hmac_key_bytes
 
-    assert isinstance(aes_key_bytes, six.binary_type)
-    assert isinstance(hmac_key_bytes, six.binary_type)
+    if not isinstance(aes_key_bytes, six.binary_type):
+        raise TypeError("Key Bytes type not matching")
+    if not isinstance(hmac_key_bytes, six.binary_type):
+        raise TypeError("Value Type not matching")
 
     # Convert from hex notation ASCII string to bytes
     ciphertext = binascii.unhexlify(ciphertext)

--- a/st2common/st2common/util/crypto.py
+++ b/st2common/st2common/util/crypto.py
@@ -81,7 +81,7 @@ MINIMUM_AES_KEY_SIZE = 128
 DEFAULT_AES_KEY_SIZE = 256
 
 if not DEFAULT_AES_KEY_SIZE >= MINIMUM_AES_KEY_SIZE:
-    raise ValueError('Verify the key size :%s' % (DEFAULT_AES_KEY_SIZE))
+    raise ValueError('Verify the key size :"%s".' % (DEFAULT_AES_KEY_SIZE))
 
 
 class AESKey(object):
@@ -208,17 +208,17 @@ def cryptography_symmetric_encrypt(encrypt_key, plaintext):
 
     """
     if not isinstance(encrypt_key, AESKey):
-        raise ValueError("Encrypt key needs to be an AESkey class instance")
+        raise ValueError('Encrypted key needs to be an AESkey class instance.')
     if not isinstance(plaintext, (six.text_type, six.string_types, six.binary_type)):
-        raise TypeError("Plaintext needs to either be a string/unicode or bytes")
+        raise TypeError('Plaintext needs to either be a string/unicode or bytes.')
 
     aes_key_bytes = encrypt_key.aes_key_bytes
     hmac_key_bytes = encrypt_key.hmac_key_bytes
 
     if not isinstance(aes_key_bytes, six.binary_type):
-        raise TypeError("AESKey bytes matching with binary type")
+        raise TypeError('AESKey bytes does not match with binary type.')
     if not isinstance(hmac_key_bytes, six.binary_type):
-        raise TypeError("HMACKey bytes matching with binary type")
+        raise TypeError('HMACKey bytes does not match with binary type.')
 
     if isinstance(plaintext, (six.text_type, six.string_types)):
         # Convert data to bytes
@@ -268,17 +268,17 @@ def cryptography_symmetric_decrypt(decrypt_key, ciphertext):
     NOTE 2: This function is loosely based on keyczar AESKey.Decrypt() (Apache 2.0 license).
     """
     if not isinstance(decrypt_key, AESKey):
-        raise ValueError("Decrypt key needs to be an AESKey class instance")
+        raise ValueError('Decrypted key needs to be an AESKey class instance.')
     if not isinstance(ciphertext, (six.text_type, six.string_types, six.binary_type)):
-        raise TypeError("Ciphertext needs to either be a string/unicode or bytes")
+        raise TypeError('Ciphertext needs to either be a string/unicode or bytes.')
 
     aes_key_bytes = decrypt_key.aes_key_bytes
     hmac_key_bytes = decrypt_key.hmac_key_bytes
 
     if not isinstance(aes_key_bytes, six.binary_type):
-        raise TypeError("Key Bytes type not matching")
+        raise TypeError('The aes key bytes does not match with binary type.')
     if not isinstance(hmac_key_bytes, six.binary_type):
-        raise TypeError("Value Type not matching")
+        raise TypeError('The hmac key bytes does not match with binary type.')
 
     # Convert from hex notation ASCII string to bytes
     ciphertext = binascii.unhexlify(ciphertext)

--- a/st2common/st2common/util/green/shell.py
+++ b/st2common/st2common/util/green/shell.py
@@ -91,7 +91,8 @@ def run_command(cmd, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
     """
     LOG.debug('Entering st2common.util.green.run_command.')
 
-    assert isinstance(cmd, (list, tuple) + six.string_types)
+    if not isinstance(cmd, (list, tuple) + six.string_types):
+        raise TypeError("cmd must be a type of (list, tuple) string ")
 
     if (read_stdout_func and not read_stderr_func) or (read_stderr_func and not read_stdout_func):
         raise ValueError('Both read_stdout_func and read_stderr_func arguments need '

--- a/st2common/st2common/util/green/shell.py
+++ b/st2common/st2common/util/green/shell.py
@@ -92,7 +92,7 @@ def run_command(cmd, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
     LOG.debug('Entering st2common.util.green.run_command.')
 
     if not isinstance(cmd, (list, tuple) + six.string_types):
-        raise TypeError("cmd must be a type of (list, tuple) string ")
+        raise TypeError('Command must be a type of list, tuple and string.')
 
     if (read_stdout_func and not read_stderr_func) or (read_stderr_func and not read_stdout_func):
         raise ValueError('Both read_stdout_func and read_stderr_func arguments need '

--- a/st2common/st2common/util/jsonify.py
+++ b/st2common/st2common/util/jsonify.py
@@ -73,8 +73,8 @@ def json_loads(obj, keys=None):
     for key in keys:
         try:
             obj[key] = json.loads(obj[key])
-        except:
-            pass
+        except Exception as error:
+            print('Criteria pattern not valid JSON: "%s".', error)
     return obj
 
 

--- a/st2common/st2common/util/shell.py
+++ b/st2common/st2common/util/shell.py
@@ -74,7 +74,8 @@ def run_command(cmd, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
 
     :rtype: ``tuple`` (exit_code, stdout, stderr)
     """
-    assert isinstance(cmd, (list, tuple) + six.string_types)
+    if not isinstance(cmd, (list, tuple) + six.string_types):
+        raise TypeError("cmd must be a type of (list, tuple) string ")
 
     if not env:
         env = os.environ.copy()

--- a/st2common/st2common/util/shell.py
+++ b/st2common/st2common/util/shell.py
@@ -75,7 +75,7 @@ def run_command(cmd, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
     :rtype: ``tuple`` (exit_code, stdout, stderr)
     """
     if not isinstance(cmd, (list, tuple) + six.string_types):
-        raise TypeError("cmd must be a type of (list, tuple) string ")
+        raise TypeError('Command must be a type of list, tuple and string.')
 
     if not env:
         env = os.environ.copy()

--- a/st2common/st2common/util/templating.py
+++ b/st2common/st2common/util/templating.py
@@ -40,7 +40,8 @@ def render_template(value, context=None):
     :param context: Template context.
     :type context: ``dict``
     """
-    assert isinstance(value, six.string_types)
+    if not isinstance(value, six.string_types):
+        raise TypeError("Value type does not match with string")
     context = context or {}
 
     env = get_jinja_environment(allow_undefined=False)  # nosec

--- a/st2common/st2common/util/templating.py
+++ b/st2common/st2common/util/templating.py
@@ -41,7 +41,7 @@ def render_template(value, context=None):
     :type context: ``dict``
     """
     if not isinstance(value, six.string_types):
-        raise TypeError("Value type does not match with string")
+        raise TypeError('The template value needs to be of type string.')
     context = context or {}
 
     env = get_jinja_environment(allow_undefined=False)  # nosec

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -181,8 +181,9 @@ class SensorWrapper(object):
         # 1. Parse the config with inherited parent args
         try:
             config.parse_args(args=self._parent_args)
-        except Exception:
-            pass
+        except Exception as e:
+            print('Failed to parse config using parent args (parent_args=%s): "%s".' %
+                  (str(self._parent_args), six.text_type(e)))
 
         # 2. Establish DB connection
         username = cfg.CONF.database.username if hasattr(cfg.CONF.database, 'username') else None

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -362,7 +362,7 @@ if __name__ == '__main__':
     trigger_types = trigger_types.split(',') if trigger_types else []
     parent_args = json.loads(args.parent_args) if args.parent_args else []
     if not isinstance(parent_args, list):
-        raise TypeError("Command line arguments passed to the parent process")
+        raise TypeError('Command line arguments passed to the parent process must be a list.')
 
     obj = SensorWrapper(pack=args.pack,
                         file_path=args.file_path,

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -361,7 +361,8 @@ if __name__ == '__main__':
     trigger_types = args.trigger_type_refs
     trigger_types = trigger_types.split(',') if trigger_types else []
     parent_args = json.loads(args.parent_args) if args.parent_args else []
-    assert isinstance(parent_args, list)
+    if not isinstance(parent_args, list):
+        raise TypeError("Command line arguments passed to the parent process")
 
     obj = SensorWrapper(pack=args.pack,
                         file_path=args.file_path,

--- a/st2reactor/st2reactor/garbage_collector/base.py
+++ b/st2reactor/st2reactor/garbage_collector/base.py
@@ -196,7 +196,8 @@ class GarbageCollectorService(object):
         timestamp_str = isotime.format(dt=timestamp)
         LOG.info('Deleting action executions older than: %s' % (timestamp_str))
 
-        assert timestamp < utc_now
+        if not timestamp < utc_now:
+            raise ValueError("utc_now violates the minimum time stamp")
 
         try:
             purge_executions(logger=LOG, timestamp=timestamp)
@@ -216,7 +217,8 @@ class GarbageCollectorService(object):
         timestamp_str = isotime.format(dt=timestamp)
         LOG.info('Deleting action executions output objects older than: %s' % (timestamp_str))
 
-        assert timestamp < utc_now
+        if timestamp < utc_now:
+            raise ValueError("utc_now violates the minimum time stamp")
 
         try:
             purge_execution_output_objects(logger=LOG, timestamp=timestamp)
@@ -239,7 +241,8 @@ class GarbageCollectorService(object):
         timestamp_str = isotime.format(dt=timestamp)
         LOG.info('Deleting trigger instances older than: %s' % (timestamp_str))
 
-        assert timestamp < utc_now
+        if timestamp < utc_now:
+            raise ValueError("utc_now violates the minimum time stamp")
 
         try:
             purge_trigger_instances(logger=LOG, timestamp=timestamp)

--- a/st2reactor/st2reactor/garbage_collector/base.py
+++ b/st2reactor/st2reactor/garbage_collector/base.py
@@ -197,7 +197,7 @@ class GarbageCollectorService(object):
         LOG.info('Deleting action executions older than: %s' % (timestamp_str))
 
         if not timestamp < utc_now:
-            raise ValueError("utc_now violates the minimum time stamp")
+            raise ValueError('Calculated timestamp violates the utc now.')
 
         try:
             purge_executions(logger=LOG, timestamp=timestamp)
@@ -218,7 +218,7 @@ class GarbageCollectorService(object):
         LOG.info('Deleting action executions output objects older than: %s' % (timestamp_str))
 
         if timestamp < utc_now:
-            raise ValueError("utc_now violates the minimum time stamp")
+            raise ValueError('Calculated timestamp violates the utc now.')
 
         try:
             purge_execution_output_objects(logger=LOG, timestamp=timestamp)
@@ -242,7 +242,7 @@ class GarbageCollectorService(object):
         LOG.info('Deleting trigger instances older than: %s' % (timestamp_str))
 
         if timestamp < utc_now:
-            raise ValueError("utc_now violates the minimum time stamp")
+            raise ValueError('Calculated timestamp violates the utc now.')
 
         try:
             purge_trigger_instances(logger=LOG, timestamp=timestamp)

--- a/st2reactor/st2reactor/rules/enforcer.py
+++ b/st2reactor/st2reactor/rules/enforcer.py
@@ -160,7 +160,8 @@ class RuleEnforcer(object):
             return None
 
         # This would signify some sort of coding error so assert.
-        assert trace_db
+        if not trace_db:
+            raise ValueError("tarcedb not found")
 
         trace_db = trace_service.add_or_update_given_trace_db(
             trace_db=trace_db,

--- a/st2reactor/st2reactor/rules/enforcer.py
+++ b/st2reactor/st2reactor/rules/enforcer.py
@@ -159,9 +159,9 @@ class RuleEnforcer(object):
             LOG.exception('No Trace found for TriggerInstance %s.', self.trigger_instance.id)
             return None
 
-        # This would signify some sort of coding error so assert.
+        # This would signify some sort of coding error so raise ValueError.
         if not trace_db:
-            raise ValueError("tarcedb not found")
+            raise ValueError('Trace database not found.')
 
         trace_db = trace_service.add_or_update_given_trace_db(
             trace_db=trace_db,


### PR DESCRIPTION
Replace pass statement with explicit error logs. The pass/continue statement when run in production (non-debug) code will skip the error. We want to practice safe coding so exception handling is necessary.