### PR TITLE
[BUGFIX] Use pip 20.0.2 to build virtualenvs

### DIFF
--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -46,8 +46,9 @@ six==1.13.0
 sseclient-py==1.7
 stevedore==1.30.1
 tooz==2.8.0
-# Note: We use latest version of virtualenv which uses pip 19
-virtualenv==16.6.0
+# Note: virtualenv embeds the pip wheel, so pinning virtualenv also pins pip
+# virtualenv==20.0.18 has pip==20.0.2
+virtualenv==20.0.18
 webob==1.8.5
 zake==0.2.2
 # test requirements below

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -30,4 +30,6 @@ webtest==2.0.25
 rstcheck>=3.3.1,<3.4
 tox==3.14.1
 pyrabbit
-pip-tools  # For pip-compile, to check for version conflicts
+# pip-tools provides pip-compile: to check for version conflicts
+# pip-tools 5.4 needs pip>=20.1, but we use 20.0.2
+pip-tools<5.4


### PR DESCRIPTION
We have already been using `pip==20.0.2` for testing since st2 v3.2.0. `virtualenv` embeds the wheel for `pip`, so we need to adjust the pinned version of virtualenv to update which version of pip is used to create virtualenvs (eg for packs).

This also clarifies the comment about why we're pinning virtualenv instead of pip directly.
