### PR TITLE
Fix path for pip dir which is used for CI cache to speed up the build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: |
-            .cache/pip
+            ~/.cache/pip
             virtualenv
           key: ${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'test-requirements.txt') }}
           restore-keys: |


### PR DESCRIPTION
I noticed "requirements" step takes ~80-90 seconds on CI.

After inspecting the output, I noticed it's not using cached pip dependencies, but downloading all of them from the internet. It turns out, we were not using a correct path for the pip cache directory (``~/.cache/pip``).

This pull request fixes this.

With this change the step now takes ~36 seconds (if cache is populated / unchanged).

Before:

![Screenshot from 2021-02-27 22-26-23](https://user-images.githubusercontent.com/125088/109400779-f206ba00-794a-11eb-9ff4-c994433302fd.png)

After:

![Screenshot from 2021-02-27 22-26-10](https://user-images.githubusercontent.com/125088/109400783-f6cb6e00-794a-11eb-9903-0cd8ae738988.png)