### PR TITLE
Use the v3.4 for the LDAP and RBAC plugins

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,8 +18,8 @@ flex==6.14.0
 git+https://github.com/StackStorm/logshipper.git@stackstorm_patched#egg=logshipper
 git+https://github.com/StackStorm/orquesta.git@v1.3.0#egg=orquesta
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
-git+https://github.com/StackStorm/st2-auth-ldap.git@master#egg=st2-auth-ldap
-git+https://github.com/StackStorm/st2-rbac-backend.git@master#egg=st2-rbac-backend
+git+https://github.com/StackStorm/st2-auth-ldap.git@v3.4#egg=st2-auth-ldap
+git+https://github.com/StackStorm/st2-rbac-backend.git@v3.4#egg=st2-rbac-backend
 gitpython==2.1.15
 greenlet==0.4.15
 gunicorn==19.9.0

--- a/st2auth/in-requirements.txt
+++ b/st2auth/in-requirements.txt
@@ -8,5 +8,5 @@ six
 stevedore
 # For backward compatibility reasons, flat file backend is installed by default
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
-git+https://github.com/StackStorm/st2-auth-ldap.git@master#egg=st2-auth-ldap
+git+https://github.com/StackStorm/st2-auth-ldap.git@v3.4#egg=st2-auth-ldap
 gunicorn

--- a/st2auth/requirements.txt
+++ b/st2auth/requirements.txt
@@ -8,7 +8,7 @@
 bcrypt==3.1.7
 eventlet==0.25.1
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
-git+https://github.com/StackStorm/st2-auth-ldap.git@master#egg=st2-auth-ldap
+git+https://github.com/StackStorm/st2-auth-ldap.git@v3.4#egg=st2-auth-ldap
 gunicorn==19.9.0
 oslo.config<1.13,>=1.12.1
 passlib==1.7.1

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -11,7 +11,7 @@ kombu
 mongoengine
 networkx
 git+https://github.com/StackStorm/orquesta.git@v1.3.0#egg=orquesta
-git+https://github.com/StackStorm/st2-rbac-backend.git@master#egg=st2-rbac-backend
+git+https://github.com/StackStorm/st2-rbac-backend.git@v3.4#egg=st2-rbac-backend
 oslo.config
 paramiko
 pyyaml

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -13,7 +13,7 @@ dnspython<2.0.0,>=1.16.0
 eventlet==0.25.1
 flex==6.14.0
 git+https://github.com/StackStorm/orquesta.git@v1.3.0#egg=orquesta
-git+https://github.com/StackStorm/st2-rbac-backend.git@master#egg=st2-rbac-backend
+git+https://github.com/StackStorm/st2-rbac-backend.git@v3.4#egg=st2-rbac-backend
 gitpython==2.1.15
 greenlet==0.4.15
 ipaddr


### PR DESCRIPTION
I'm trying to avoid painting ourselves into a corner here.

The st2-auth-ldap and st2-rbac-backend plugins are currently installed from `master`, even for the v3.4 release.

This PR fixes that - only for the `v3.4` branch here - to make sure that we don't break existing installations as we develop the plugins on their `master` branches.