### PR TITLE
Add @cognifloyd as a StackStorm Contributor

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -48,7 +48,7 @@ They're not part of the TSC voting process, but appreciated for their contributi
 * Carlos ([@nzlosh](https://github.com/nzlosh)) - Chatops, Errbot, Community, Discussions, StackStorm Exchange.
 * Harsh Nanchahal ([@hnanchahal](https://github.com/hnanchahal)), _Starbucks_ - Core, Docker, Kubernetes.
 * Hiroyasu Ohyama ([@userlocalhost](https://github.com/userlocalhost)) - Orquesta, Workflows, st2 Japan Community. [Case Study](https://stackstorm.com/case-study-dmm/).
-* Jacob Floyd ([@cognifloyd](https://github.com/cognifloyd/)), _Copart_ - StackStorm Exchange, Core, Community.
+* Jacob Floyd ([@cognifloyd](https://github.com/cognifloyd/)), _Copart_ - StackStorm Exchange, ChatOps, Core, Discussions.
 * Jon Middleton ([@jjm](https://github.com/jjm)) - StackStorm Exchange, Core, Discussions.
 * Marcel Weinberg ([@winem](https://github.com/winem)) - Community, Docker, Core.
 * Sheshagiri Rao Mallipedhi ([@sheshagiri](https://github.com/sheshagiri)) - Docker, Core, StackStorm Exchange.

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -48,6 +48,7 @@ They're not part of the TSC voting process, but appreciated for their contributi
 * Carlos ([@nzlosh](https://github.com/nzlosh)) - Chatops, Errbot, Community, Discussions, StackStorm Exchange.
 * Harsh Nanchahal ([@hnanchahal](https://github.com/hnanchahal)), _Starbucks_ - Core, Docker, Kubernetes.
 * Hiroyasu Ohyama ([@userlocalhost](https://github.com/userlocalhost)) - Orquesta, Workflows, st2 Japan Community. [Case Study](https://stackstorm.com/case-study-dmm/).
+* Jacob Floyd ([@cognifloyd](https://github.com/cognifloyd/)), _Copart_ - StackStorm Exchange, Core, Community.
 * Jon Middleton ([@jjm](https://github.com/jjm)) - StackStorm Exchange, Core, Discussions.
 * Marcel Weinberg ([@winem](https://github.com/winem)) - Community, Docker, Core.
 * Sheshagiri Rao Mallipedhi ([@sheshagiri](https://github.com/sheshagiri)) - Docker, Core, StackStorm Exchange.


### PR DESCRIPTION
Jacob (@cognifloyd) is a long time member of the StackStorm Community. He's giving feedback and participating in the discussions, contributing improvements to the Ansible, packs, StackStorm-Exchange and is getting involved around the st2 core enhancements recently.

His recent participation in the developments behind the [OpsDroid](https://github.com/opsdroid/opsdroid/) project as one of the possible StackStorm ChatOps future solutions (https://github.com/StackStorm/discussions/issues/8) and bridging OpsDroid <> StackStorm teams is impressive!
Besides of that, he provided assistance around the StackStorm-Exchange maintenance:
  - Updating the [StackStorm-Exchange](https://github.com/stackstorm-exchange/) and move all the `150+` packs from `python 2` to `python 3` support, including releasing version for each pack. A lot of dedication and work.
  -  Improved Exchange CI/CD pipelines and tooling overhaul along the way: https://github.com/StackStorm-Exchange/ci/pull/108 https://github.com/StackStorm-Exchange/ci/pull/104 https://github.com/StackStorm-Exchange/ci/pull/105 https://github.com/StackStorm-Exchange/ci/pull/106 https://github.com/StackStorm-Exchange/ci/pull/107 https://github.com/StackStorm-Exchange/ci/pull/111 and many more.
  - [Discussion: Proposal: Use Github Actions for StackStorm-Exchange CI and Maintenance #63 ](https://github.com/StackStorm/discussions/issues/63)
- Reviewing PRs and providing feedback in the StackStorm org repositories.


As a recognition for his efforts, contribution activity and energy, I'd like to propose adding Jacob to the list of StackStorm Contributors and hoping to see even more teamwork and core platform development/maintenance help in the future! :+1: 