### PR TITLE
Propose adding @winem as a Maintainer

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -33,6 +33,8 @@ Being part of Technical Steering Committee (TSC) [@StackStorm/maintainers](https
   - Ansible, Core, deb/rpm packages, CI/CD, Deployments, StackStorm Exchange, Documentation.
 * JP Bourget ([@punkrokk](https://github.com/punkrokk)) <<jp.bourget@gmail.com>>
   - Systems, deb/rpm, Deployments, Community, StackStorm Exchange, SecOps, CircleCI.
+* Marcel Weinberg ([@winem](https://github.com/winem)), _CoreMedia_ <<mweinberg-os@email.de>>
+  - Systems, Core, CI/CD, Docker, Community.
 * Mick McGrath ([@mickmcgrath13](https://github.com/mickmcgrath13)) <<mick@bitovi.com>>
   - Systems, ST2 Exchange. [Case Study](https://stackstorm.com/case-study-bitovi/).
 * Nick Maludy ([@nmaludy](https://github.com/nmaludy)) <<nmaludy@gmail.com>>


### PR DESCRIPTION
Marcel (@winem) was consistently contributing to the project for the past year and being more actively involved recently, helping delivering the roadmap release items, testing, StackStorm core improvements, community support as well as deployment methods like `curl|bash` scripted installer and Docker.

Some examples:
- `v3.2`, `v3.3` and `v3.4` pre-release testing help, finding bugs and actually helping to resolve them, assisting the team.
- 3.4 roadmap: full `st2resultstracker` removal: https://github.com/StackStorm/st2/pull/5108 https://github.com/StackStorm/st2/issues/5070 https://github.com/StackStorm/st2-packages/pull/683 https://github.com/StackStorm/st2docs/pull/1045 https://github.com/StackStorm/st2-dockerfiles/pull/40 https://github.com/StackStorm/st2-docker/pull/204
- 3.4 roadmap: Assisting in CircleCI to Github Actions migration (https://github.com/StackStorm/st2/pull/5111), participating in the bigger task #5098 for StackStorm/st2
- 3.4: Wider Docker tagging for the container releases: https://github.com/StackStorm/st2-dockerfiles/pull/41 https://github.com/StackStorm/st2-dockerfiles/pull/44
- Documentation Updates here and there: https://github.com/StackStorm/st2/pull/5027 https://github.com/StackStorm/st2docs/pull/1010 https://github.com/StackStorm/st2docs/pull/1016 https://github.com/StackStorm/st2docs/pull/1004  https://github.com/StackStorm/st2docs/pull/1057
- Other minor PRs with enhancements/bugfixes:
  - Assistance in updating `tooz` dependency for st2: https://github.com/StackStorm/st2/pull/5121
  - Add support to force recreation of packs virtualenvs: https://github.com/StackStorm/st2/pull/5167
  - Deadsnakes curl|bash installer fixes: https://github.com/StackStorm/st2-packages/pull/689
- StackStorm v3.5 Roadmap tasks commitments

He's an active team player asking and being able to help where the team needs more assistance and identifying places to fill the gaps. I'd like to propose adding Marcel to the TSC and hope he'll be a good reinforcement to StackStorm Maintainers.