### PR TITLE
[v3.4] Backport sudo -E CI fix

### DIFF
--- a/.circle/add-itest-user.sh
+++ b/.circle/add-itest-user.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -ex
 
 if [ "$(whoami)" != 'root' ]; then
     echo 'Please run with sudo'

--- a/scripts/travis/add-itest-user-key.sh
+++ b/scripts/travis/add-itest-user-key.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-set -e
+set -ex
 mkdir -p ~/.ssh
 
 # Generate ssh keys on StackStorm box and copy over public key into remote box.
 ssh-keygen -f ~/.ssh/st2_id_rsa -P ""
 
 # Authorize key-base acces
-sudo bash -c "cat ~/.ssh/st2_id_rsa.pub >> ~/.ssh/authorized_keys"
+sudo bash -xc "cat ~/.ssh/st2_id_rsa.pub >> ~/.ssh/authorized_keys"
 sudo chmod 0600 ~/.ssh/authorized_keys
 sudo chmod 0700 ~/.ssh
 sudo chown -R "${ST2_CI_USER}:${ST2_CI_USER}" ~/.ssh

--- a/scripts/travis/add-itest-user-key.sh
+++ b/scripts/travis/add-itest-user-key.sh
@@ -6,8 +6,9 @@ mkdir -p ~/.ssh
 # Generate ssh keys on StackStorm box and copy over public key into remote box.
 ssh-keygen -f ~/.ssh/st2_id_rsa -P ""
 
+# sudo -E = preserve HOME var
 # Authorize key-base acces
-sudo bash -xc "cat ~/.ssh/st2_id_rsa.pub >> ~/.ssh/authorized_keys"
-sudo chmod 0600 ~/.ssh/authorized_keys
-sudo chmod 0700 ~/.ssh
-sudo chown -R "${ST2_CI_USER}:${ST2_CI_USER}" ~/.ssh
+sudo -E bash -xc "cat ~/.ssh/st2_id_rsa.pub >> ~/.ssh/authorized_keys"
+sudo -E chmod 0600 ~/.ssh/authorized_keys
+sudo -E chmod 0700 ~/.ssh
+sudo -E chown -R "${ST2_CI_USER}:${ST2_CI_USER}" ~/.ssh


### PR DESCRIPTION
Backport of #5186

- make add-itest-user scripts more verbose
- use `sudo -E` to preserve env vars

Github Actions has this in their Default: env_reset in their sudoers config file. This means that HOME and other vars are set to match the sudo target user. Using sudo -E preserves the environment allowing ~ to resolve correctly.

I'm not sure why we didn't hit this earlier. Maybe Github changed their sudoers config? In any case, this should fix it.
