### PR TITLE
Fixed Apache range header DOS and proxy disclosure issue

### DIFF
--- a/conf/nginx/st2.conf
+++ b/conf/nginx/st2.conf
@@ -15,7 +15,7 @@ server {
   if ($ssl_protocol = "") {
        return 308 https://$host$request_uri;
   }
-  if ($request_method !~ ^(GET|HEAD|POST|PUT|DELETE)$ ) {
+  if ($request_method !~ ^(GET|HEAD|POST|PUT|DELETE|OPTIONS)$ ) {
        return 405;
   }
   index  index.html;
@@ -28,7 +28,7 @@ server {
   listen       *:443 ssl;
   server_tokens off;
 
-  if ($request_method !~ ^(GET|HEAD|POST|PUT|DELETE)$ ) {
+  if ($request_method !~ ^(GET|HEAD|POST|PUT|DELETE|OPTIONS)$ ) {
        return 405;
   }
 

--- a/conf/nginx/st2.conf
+++ b/conf/nginx/st2.conf
@@ -15,7 +15,9 @@ server {
   if ($ssl_protocol = "") {
        return 308 https://$host$request_uri;
   }
-
+  if ($request_method !~ ^(GET|HEAD|POST)$ ) {
+       return 405;
+  }
   index  index.html;
 
   access_log /var/log/nginx/st2webui.access.log combined;
@@ -134,6 +136,8 @@ server {
   location / {
     root      /opt/stackstorm/static/webui/;
     index     index.html;
+
+    proxy_set_header Range "";
 
     sendfile on;
     tcp_nopush on;

--- a/conf/nginx/st2.conf
+++ b/conf/nginx/st2.conf
@@ -15,7 +15,7 @@ server {
   if ($ssl_protocol = "") {
        return 308 https://$host$request_uri;
   }
-  if ($request_method !~ ^(GET|HEAD|POST)$ ) {
+  if ($request_method !~ ^(GET|HEAD|POST|PUT|DELETE)$ ) {
        return 405;
   }
   index  index.html;
@@ -27,6 +27,11 @@ server {
 server {
   listen       *:443 ssl;
   server_tokens off;
+
+  if ($request_method !~ ^(GET|HEAD|POST|PUT|DELETE)$ ) {
+       return 405;
+  }
+
   ssl_certificate           /etc/ssl/st2/st2.crt;
   ssl_certificate_key       /etc/ssl/st2/st2.key;
   ssl_session_cache         shared:SSL:10m;
@@ -70,6 +75,7 @@ server {
     proxy_buffering off;
     proxy_cache off;
     proxy_set_header Host $host;
+    max_ranges 0;
   }
 
   location @streamError {
@@ -104,6 +110,7 @@ server {
     chunked_transfer_encoding off;
     proxy_buffering off;
     proxy_cache off;
+    max_ranges 0;
   }
 
   location @authError {
@@ -131,13 +138,13 @@ server {
     proxy_buffering off;
     proxy_cache off;
     proxy_set_header Host $host;
+    max_ranges 0;
   }
 
   location / {
+    max_ranges 0;
     root      /opt/stackstorm/static/webui/;
     index     index.html;
-
-    proxy_set_header Range "";
 
     sendfile on;
     tcp_nopush on;


### PR DESCRIPTION
The default Nginx configuration can have many vulnerabilities, a fix for a few of them.
1. Disable unwanted HTTP methods - Allowing TRACE or DELETE is risky as it can allow a Cross-Site Tracking attack and potentially allow a hacker to steal the cookie information.
2. HTTP requests with a large byte range in the range header can trigger the crash so have to handle this by using this proxy_set_header Range "";