### PR TITLE
Speed up service start up time by reducing runner registration / extension loading time

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -156,6 +156,13 @@ Improvements
 
   Contributed by @Kami.
 
+* Speed up service start up time by speeding up runners registration on service start up by
+  re-using existing stevedore ``ExtensionManager`` instance instead of instantiating new
+  ``DriverManager`` instance per extension which is not necessary and it's slow since it requires
+  disk / pkg resources scan for each extension. (improvement) #5198
+
+  Contributed by @Kami.
+
 Fixed
 ~~~~~
 

--- a/st2common/st2common/bootstrap/runnersregistrar.py
+++ b/st2common/st2common/bootstrap/runnersregistrar.py
@@ -42,7 +42,7 @@ def register_runners(experimental=False, fail_on_failure=True):
     manager = ExtensionManager(namespace=RUNNERS_NAMESPACE, invoke_on_load=False)
 
     # NOTE: We use ExtensionManager directly instead of DriverManager per extension since that is
-    # much faster and allows us to reduce stevedore loading overead for each runner
+    # much faster and allows us to reduce stevedore loading overhead for each runner
     for extension in manager.extensions:
         name = extension.name
         LOG.debug('Found runner "%s"' % (name))
@@ -96,7 +96,6 @@ def register_runner(runner_type, experimental):
             runner_type_model.id = runner_type_db.id
 
         try:
-
             runner_type_db = RunnerType.add_or_update(runner_type_model)
 
             extra = {"runner_type_db": runner_type_db}

--- a/st2common/st2common/bootstrap/runnersregistrar.py
+++ b/st2common/st2common/bootstrap/runnersregistrar.py
@@ -15,7 +15,6 @@
 
 from __future__ import absolute_import
 
-from stevedore.driver import DriverManager
 from stevedore.extension import ExtensionManager
 
 from st2common import log as logging
@@ -41,15 +40,13 @@ def register_runners(experimental=False, fail_on_failure=True):
     runner_count = 0
 
     manager = ExtensionManager(namespace=RUNNERS_NAMESPACE, invoke_on_load=False)
-    extension_names = manager.names()
 
-    for name in extension_names:
+    # NOTE: We use ExtensionManager directly instead of DriverManager per extension since that is
+    # much faster and allows us to reduce stevedore loading overead for each runner
+    for extension in manager.extensions:
+        name = extension.name
         LOG.debug('Found runner "%s"' % (name))
-
-        manager = DriverManager(
-            namespace=RUNNERS_NAMESPACE, invoke_on_load=False, name=name
-        )
-        runner_metadata = manager.driver.get_metadata()
+        runner_metadata = extension.plugin.get_metadata()
         runner_count += register_runner(runner_metadata, experimental)
 
     LOG.debug("End : register runners")


### PR DESCRIPTION
I was looking at st2api profiling data some more and noticed we spend more time in stevedore code then we should.

It turns on that we were not loading all the extensions just once, but X + 1 times where X is number of runners (stevedore extensions).

This is obviously not the fastest thing since loading extensions requires pkg resources scan for available extensions.

This pull request fixes that. It should now also result in much less DEBUG level noise on service start up time.