### PR TITLE
Workaround modified GitHub Actions PATH var

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,6 +102,9 @@ jobs:
 
       # Name of the user who is running the CI (on GitHub Actions this is 'runner')
       ST2_CI_USER: 'runner'
+
+      # GitHub is juggling how to set vars for multiple shells. Protect our PATH assumptions.
+      PATH: /home/runner/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
       - name: Custom Environment Setup
         # built-in GitHub Actions environment variables


### PR DESCRIPTION
We relied on ~/.local/bin being in PATH, which was added in:
actions/virtual-environments#2982

But, then they reverted that because it wasn't cross-shell consistent:
actions/virtual-environments#2982

So, vars were getting loaded from /etc/profile.d, then they moved it
back into ~/.bashrc. But, by default GHA workflows do not source
~/.bashrc.

Who knows how else they are going to mess with the PATH, so just write
our own.