### PR TITLE
Fix subprocess handling when killed on timeout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,20 @@ Added
 * Added the command line utility `st2-validate-pack` that can be used by pack developers to
   validate pack contents. (improvement)
 
+* Fix a bug in the API and CLI code which would prevent users from being able to retrieve resources
+  which contain non-ascii (utf-8) characters in the names / references. (bug fix) #5189
+
+  Contributed by @Kami.
+
+* Fix a bug in the API router code and make sure we return correct and user-friendly error to the
+  user in case we fail to parse the request URL / path because it contains invalid or incorrectly
+  URL encoded data.
+
+  Previously such errors weren't handled correctly which meant original exception with a stack
+  trace got propagated to the user. (bug fix) #5189
+
+  Contributed by @Kami.
+
 Changed
 ~~~~~~~
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -271,6 +271,11 @@ Fixed
 
   Contributed by @Kami.
 
+* Make sure ``st2common.util.green.shell.run_command()`` doesn't leave stray / zombie processes
+  laying around in some command timeout scenarios. #5220
+
+  Contributed by @r0m4n-z.
+
 3.4.1 - March 14, 2021
 ----------------------
 

--- a/st2client/st2client/utils/misc.py
+++ b/st2client/st2client/utils/misc.py
@@ -14,11 +14,14 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
+from typing import List
+
 import copy
 
 import six
 
-__all__ = ["merge_dicts"]
+__all__ = ["merge_dicts", "reencode_list_with_surrogate_escape_sequences"]
 
 
 def merge_dicts(d1, d2):
@@ -37,5 +40,24 @@ def merge_dicts(d1, d2):
             result[key] = merge_dicts(result[key], value)
         elif key not in result or value is not None:
             result[key] = value
+
+    return result
+
+
+def reencode_list_with_surrogate_escape_sequences(value: List[str]) -> List[str]:
+    """
+    Function which reencodes each item in the provided list replacing unicode surrogate escape
+    sequences using actual unicode values.
+    """
+    result = []
+
+    for item in value:
+        try:
+            item = item.encode("ascii", "surrogateescape").decode("utf-8")
+        except UnicodeEncodeError:
+            # Already a unicode string, nothing to do
+            pass
+
+        result.append(item)
 
     return result

--- a/st2client/tests/unit/test_commands.py
+++ b/st2client/tests/unit/test_commands.py
@@ -295,6 +295,21 @@ class TestResourceCommand(unittest2.TestCase):
         args = self.parser.parse_args(["fakeresource", "delete", "cba"])
         self.assertRaises(Exception, self.branch.commands["delete"].run, args)
 
+    @mock.patch.object(
+        models.ResourceManager,
+        "get_by_id",
+        mock.MagicMock(return_value=base.FakeResource(**base.RESOURCES[0])),
+    )
+    def test_command_get_unicode_primary_key(self):
+        args = self.parser.parse_args(
+            ["fakeresource", "get", "examples.test_rule_utf8_náme"]
+        )
+        self.assertEqual(args.func, self.branch.commands["get"].run_and_print)
+        instance = self.branch.commands["get"].run(args)
+        actual = instance.serialize()
+        expected = json.loads(json.dumps(base.RESOURCES[0]))
+        self.assertEqual(actual, expected)
+
 
 class ResourceViewCommandTestCase(unittest2.TestCase):
     def setUp(self):

--- a/st2common/st2common/util/green/shell.py
+++ b/st2common/st2common/util/green/shell.py
@@ -165,6 +165,8 @@ def run_command(
     # Special attribute we use to determine if the process timed out or not
     process._timed_out = False
 
+    # TODO: Now that we support Python >= 3.6 we should utilize timeout argument for the
+    # communicate() method and handle killing the process + read threads there.
     def on_timeout_expired(timeout):
         global timed_out
 

--- a/st2common/st2common/util/green/shell.py
+++ b/st2common/st2common/util/green/shell.py
@@ -85,6 +85,14 @@ def run_command(
 
     :param kill_func: Optional function which will be called on timeout to kill the process.
                       If not provided, it defaults to `process.kill`
+
+                      NOTE: If you are utilizing shell=True, you shoulf always specify a custom
+                      kill function which correctly kills shell process + the shell children
+                      process.
+
+                      If you don't do that, timeout handler won't work correctly / as expected -
+                      only the shell process will be killed, but not also the child processs
+                      spawned by the shell.
     :type kill_func: ``callable``
 
     :param read_stdout_func: Function which is responsible for reading process stdout when

--- a/st2common/st2common/util/green/shell.py
+++ b/st2common/st2common/util/green/shell.py
@@ -165,10 +165,6 @@ def run_command(
             # Note: We explicitly set the returncode to indicate the timeout.
             LOG.debug("Command execution timeout reached.")
 
-            # NOTE: It's important we set returncode twice - here and below to avoid race in this
-            # function because "kill_func()" is async and "process.kill()" is not.
-            process.returncode = TIMEOUT_EXIT_CODE
-
             if kill_func:
                 LOG.debug("Calling kill_func.")
                 kill_func(process=process)
@@ -176,6 +172,7 @@ def run_command(
                 LOG.debug("Killing process.")
                 process.kill()
 
+            process.wait()
             # NOTE: It's imporant to set returncode here as well, since call to process.kill() sets
             # it and overwrites it if we set it earlier.
             process.returncode = TIMEOUT_EXIT_CODE

--- a/st2common/tests/integration/test_util_green.py
+++ b/st2common/tests/integration/test_util_green.py
@@ -1,0 +1,106 @@
+# Copyright 2020 The StackStorm Authors.
+# Copyright 2019 Extreme Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()
+
+from st2tests.base import IntegrationTestCase
+
+from st2common.util.green.shell import run_command
+from st2common.util.green.shell import TIMEOUT_EXIT_CODE
+from st2common.util.shell import kill_process
+from st2common.util.shell import quote_unix
+
+_all__ = ["GreenShellUtilsTestCase"]
+
+
+class GreenShellUtilsTestCase(IntegrationTestCase):
+    def test_run_command_success(self):
+        # 0 exit code
+        exit_code, stdout, stderr, timed_out = run_command(
+            cmd='echo "test stdout" ; >&2 echo "test stderr"', shell=True
+        )
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stdout.strip(), b"test stdout")
+        self.assertEqual(stderr.strip(), b"test stderr")
+        self.assertFalse(timed_out)
+
+        # non-zero exit code
+        exit_code, stdout, stderr, timed_out = run_command(
+            cmd='echo "test stdout" ; >&2 echo "test stderr" ; exit 5', shell=True
+        )
+        self.assertEqual(exit_code, 5)
+        self.assertEqual(stdout.strip(), b"test stdout")
+        self.assertEqual(stderr.strip(), b"test stderr")
+        self.assertFalse(timed_out)
+
+        # implicit non zero code (invalid command)
+        exit_code, stdout, stderr, timed_out = run_command(
+            cmd="foobarbarbazrbar", shell=True
+        )
+        self.assertEqual(exit_code, 127)
+        self.assertEqual(stdout.strip(), b"")
+        self.assertTrue(b"foobarbarbazrbar: not found" in stderr.strip())
+        self.assertFalse(timed_out)
+
+    def test_run_command_timeout_shell_and_custom_kill_func(self):
+        # This test represents our local runner setup where we use a preexec_func + custom kill_func
+        # NOTE: When using shell=True. we should alaways use custom kill_func to ensure child shell
+        # processses are in fact killed as well.
+        exit_code, stdout, stderr, timed_out = run_command(
+            cmd='echo "pre sleep";  sleep 1589; echo "post sleep"',
+            preexec_func=os.setsid,
+            timeout=1,
+            kill_func=kill_process,
+            shell=True,
+        )
+        self.assertEqual(exit_code, TIMEOUT_EXIT_CODE)
+        self.assertEqual(stdout.strip(), b"pre sleep")
+        self.assertEqual(stderr.strip(), b"")
+        self.assertTrue(timed_out)
+
+        # Verify there is no zombie process left laying around
+        self.assertNoStrayProcessesLeft("sleep 1589")
+
+    def test_run_command_timeout_no_shell_no_custom_kill_func(self):
+        exit_code, stdout, stderr, timed_out = run_command(
+            cmd=["sleep", "1599"], preexec_func=os.setsid, timeout=1
+        )
+        self.assertEqual(exit_code, TIMEOUT_EXIT_CODE)
+        self.assertEqual(stdout.strip(), b"")
+        self.assertEqual(stderr.strip(), b"")
+        self.assertTrue(timed_out)
+
+        # Verify there is no zombie process left laying around
+        self.assertNoStrayProcessesLeft("sleep 1599")
+
+    def assertNoStrayProcessesLeft(self, grep_string: str) -> None:
+        """
+        Assert that there are no stray / zombie processes left with the provided command line
+        string.
+        """
+        exit_code, stdout, stderr, timed_out = run_command(
+            cmd="ps aux | grep %s | grep -v grep" % (quote_unix(grep_string)),
+            shell=True,
+        )
+
+        if stdout.strip() != b"" and stderr.strip() != b"":
+            raise AssertionError(
+                "Expected no stray processes, but found Some. stdout: %s, stderr: %s"
+                % (stdout, stderr)
+            )


### PR DESCRIPTION
**Problem:**
Running ST2 actions as subprocesses (`eventlet.green`) spawns zombies on timeout.

**Reproduce:**
1. Spawn process which execution is going to take more than command's timeout.
2. `process.kill()` will be called.
3. Spawned process becomes zombie.

Method `process.kill()` is never handled as well as `process.communicate()`, which calls `process.wait()` - all those methods check `process.returncode` against None and if `returncode` already set, it just will be returned.

Why do I suggest to remove line 170: it doesn't seem to be necessary to set returncode here to avoid race condition for some `kill_func`. Probably additional custom attribute could be used here on `process` to provide that information if it's really necessary, but I don't think ST2 should do that.