### PR TITLE
Fix decrypting pack config keys under additionalProperties

### DIFF
--- a/st2common/st2common/util/config_loader.py
+++ b/st2common/st2common/util/config_loader.py
@@ -16,6 +16,8 @@
 from __future__ import absolute_import
 import copy
 
+from collections import defaultdict
+
 import six
 
 from oslo_config import cfg
@@ -130,8 +132,14 @@ class ContentPackConfigLoader(object):
             # Inspect nested object properties
             if is_dictionary:
                 parent_keys += [str(config_item_key)]
+                additional_properties = schema_item.get("additionalProperties", {})
+                if isinstance(additional_properties, dict):
+                    property_schema = defaultdict(additional_properties)
+                else:
+                    property_schema = {}
+                property_schema.update(schema_item.get("properties", {})
                 self._assign_dynamic_config_values(
-                    schema=schema_item.get("properties", {}),
+                    schema=property_schema,
                     config=config[config_item_key],
                     parent_keys=parent_keys,
                 )


### PR DESCRIPTION
The pack config loader uses "secret: true" in a schema to trigger decrypting a key from the datastore. However, it does not look at the schema under additionalProperties, so those properties can't use encrypted keys.

This issue was first documented in https://github.com/StackStorm-Exchange/stackstorm-jira/pull/19#discussion_r242319464

This PR fixes that so that the pack config loader handles additionalProperties when defined.
