### PR TITLE
Fix decrypting pack config keys under additionalProperties

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -471,6 +471,8 @@ jobs:
           # There is a race in some orequesta integration tests so they tend to fail quite often.
           # To avoid needed to re-run whole workflow in such case, we should try to retry this
           # specific step. This saves us a bunch of time manually re-running the whole workflow.
+          # TODO: Try to identify problematic tests (iirc mostly orquesta ones) and only retry /
+          # re-run those.
           set +e
           for i in $(seq 1 ${MAX_ATTEMPTS}); do
             echo "Attempt: ${i}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -465,8 +465,22 @@ jobs:
           ./scripts/ci/print-versions.sh
       - name: make
         # use: script -e -c to print colors
+        env:
+          MAX_ATTEMPTS: 3
         run: |
-          script -e -c "make ${TASK}"
+          # There is a race in some orequesta integration tests so they tend to fail quite often.
+          # To avoid needed to re-run whole workflow in such case, we should try to retry this
+          # specific step. This saves us a bunch of time manually re-running the whole workflow.
+          set +e
+          for i in $(seq 1 ${MAX_ATTEMPTS}); do
+            echo "Attempt: ${i}"
+            script -e -c "make ${TASK}" && exit 0
+            sleep 5
+          done
+
+          set -e
+          echo "Failed after ${MAX_ATTEMPTS} attempts"
+          exit 1
       - name: Codecov
         # NOTE: We only generate and submit coverage report for master and version branches and only when the build succeeds (default on GitHub Actions, this was not the case on Travis so we had to explicitly check success)
         if: "${{ success() && env.ENABLE_COVERAGE == 'yes' && env.TASK == 'ci-integration' }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -464,9 +464,11 @@ jobs:
         run: |
           ./scripts/ci/print-versions.sh
       - name: make
-        # use: script -e -c to print colors
+        timeout-minutes: 25  # may die if rabbitmq fails to start
         env:
           MAX_ATTEMPTS: 3
+          RETRY_DELAY: 5
+        # use: script -e -c to print colors
         run: |
           # There is a race in some orequesta integration tests so they tend to fail quite often.
           # To avoid needed to re-run whole workflow in such case, we should try to retry this
@@ -475,13 +477,16 @@ jobs:
           # re-run those.
           set +e
           for i in $(seq 1 ${MAX_ATTEMPTS}); do
-            echo "Attempt: ${i}"
+            echo "Attempt: ${i}/${MAX_ATTEMPTS}"
+
             script -e -c "make ${TASK}" && exit 0
-            sleep 5
+
+            echo "Command failed, will retry in ${RETRY_DELAY} seconds..."
+            sleep ${RETRY_DELAY}
           done
 
           set -e
-          echo "Failed after ${MAX_ATTEMPTS} attempts"
+          echo "Failed after ${MAX_ATTEMPTS} attempts, failing the job."
           exit 1
       - name: Codecov
         # NOTE: We only generate and submit coverage report for master and version branches and only when the build succeeds (default on GitHub Actions, this was not the case on Travis so we had to explicitly check success)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,11 @@ Added
 
   Contributed by @Kami.
 
+* Fix a bug in the pack config loader so that objects covered by an additionalProperties schema
+  can use encrypted datastore keys and have their default values applied correctly.
+
+  Contributed by @cognifloyd.
+
 Changed
 ~~~~~~~
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,7 +43,7 @@ Added
   Contributed by @Kami.
 
 * Fix a bug in the pack config loader so that objects covered by an additionalProperties schema
-  can use encrypted datastore keys and have their default values applied correctly.
+  can use encrypted datastore keys and have their default values applied correctly. #5225
 
   Contributed by @cognifloyd.
 

--- a/st2common/st2common/util/config_loader.py
+++ b/st2common/st2common/util/config_loader.py
@@ -145,7 +145,7 @@ class ContentPackConfigLoader(object):
             is_list = isinstance(config_item_value, list)
 
             # pass a copy of parent_keys so the loop doesn't add sibling keys
-            current_keys = parent_keys + [str(config_item_keys)]
+            current_keys = parent_keys + [str(config_item_key)]
 
             # Inspect nested object properties
             if is_dictionary:

--- a/st2common/st2common/util/config_loader.py
+++ b/st2common/st2common/util/config_loader.py
@@ -135,7 +135,11 @@ class ContentPackConfigLoader(object):
         for config_item_key, config_item_value in iterator:
             if config_is_dict:
                 # different schema for each key/value pair
-                schema_item = schema.get(config_item_key, {})
+                try:
+                    # do not use schema.get() as schema might be a defaultdict
+                    schema_item = schema[config_item_key]
+                except KeyError:
+                    schema_item = {}
             if config_is_list:
                 # same schema is shared between every item in the list
                 schema_item = schema

--- a/st2common/st2common/util/config_loader.py
+++ b/st2common/st2common/util/config_loader.py
@@ -209,7 +209,7 @@ class ContentPackConfigLoader(object):
                 property_schema = self._get_object_property_schema(schema_item)
 
                 self._assign_default_values(
-                    schema=propety_schema, config=config[schema_item_key]
+                    schema=property_schema, config=config[schema_item_key]
                 )
 
         return config

--- a/st2common/st2common/util/config_loader.py
+++ b/st2common/st2common/util/config_loader.py
@@ -134,7 +134,7 @@ class ContentPackConfigLoader(object):
                 parent_keys += [str(config_item_key)]
                 additional_properties = schema_item.get("additionalProperties", {})
                 if isinstance(additional_properties, dict):
-                    property_schema = defaultdict(additional_properties)
+                    property_schema = defaultdict(lambda: additional_properties)
                 else:
                     property_schema = {}
                 property_schema.update(schema_item.get("properties", {}))

--- a/st2common/st2common/util/config_loader.py
+++ b/st2common/st2common/util/config_loader.py
@@ -16,6 +16,8 @@
 from __future__ import absolute_import
 import copy
 
+from collections import defaultdict
+
 import six
 
 from oslo_config import cfg
@@ -130,8 +132,14 @@ class ContentPackConfigLoader(object):
             # Inspect nested object properties
             if is_dictionary:
                 parent_keys += [str(config_item_key)]
+                additional_properties = schema_item.get("additionalProperties", {})
+                if isinstance(additional_properties, dict):
+                    property_schema = defaultdict(additional_properties)
+                else:
+                    property_schema = {}
+                property_schema.update(schema_item.get("properties", {}))
                 self._assign_dynamic_config_values(
-                    schema=schema_item.get("properties", {}),
+                    schema=property_schema,
                     config=config[config_item_key],
                     parent_keys=parent_keys,
                 )

--- a/st2common/tests/unit/test_config_loader.py
+++ b/st2common/tests/unit/test_config_loader.py
@@ -557,7 +557,7 @@ class ContentPackConfigLoaderTestCase(CleanDbTestCase):
         self.assertEqual(
             config_rendered,
             {
-                "regions": "us-east-1",
+                "regions": ["us-east-1"],
                 "profiles": {
                     "dev": {
                         "host": "127.0.0.3",

--- a/st2common/tests/unit/test_config_loader.py
+++ b/st2common/tests/unit/test_config_loader.py
@@ -19,8 +19,10 @@ from st2common.models.db.pack import ConfigDB
 from st2common.models.db.keyvalue import KeyValuePairDB
 from st2common.exceptions.db import StackStormDBObjectNotFoundError
 from st2common.persistence.keyvalue import KeyValuePair
+from st2common.models.api.keyvalue import KeyValuePairAPI
 from st2common.services.config import set_datastore_value_for_config_key
 from st2common.util.config_loader import ContentPackConfigLoader
+from st2common.util import crypto
 
 from st2tests.base import CleanDbTestCase
 
@@ -522,8 +524,11 @@ class ContentPackConfigLoaderTestCase(CleanDbTestCase):
         pack_name = "dummy_pack_schema_with_additional_properties_1"
         loader = ContentPackConfigLoader(pack_name=pack_name)
 
+        encrypted_value = crypto.symmetric_encrypt(
+            KeyValuePairAPI.crypto_key, "v1_encrypted"
+        )
         KeyValuePair.add_or_update(
-            KeyValuePairDB(name="k1_encrypted", value="v1_encrypted", secret=True)
+            KeyValuePairDB(name="k1_encrypted", value=encrypted_value, secret=True)
         )
 
         ####################

--- a/st2common/tests/unit/test_config_loader.py
+++ b/st2common/tests/unit/test_config_loader.py
@@ -523,7 +523,9 @@ class ContentPackConfigLoaderTestCase(CleanDbTestCase):
         loader = ContentPackConfigLoader(pack_name=pack_name)
 
         KeyValuePair.add_or_update(KeyValuePairDB(name="k0", value="v0"))
-        KeyValuePair.add_or_update(KeyValuePairDB(name="k1_encrypted", value="v1_encrypted", secret=True))
+        KeyValuePair.add_or_update(
+            KeyValuePairDB(name="k1_encrypted", value="v1_encrypted", secret=True)
+        )
 
         ####################
         # values in objects under an object with additionalProperties

--- a/st2common/tests/unit/test_config_loader.py
+++ b/st2common/tests/unit/test_config_loader.py
@@ -557,7 +557,7 @@ class ContentPackConfigLoaderTestCase(CleanDbTestCase):
         self.assertEqual(
             config_rendered,
             {
-                "regions": "us-east-1",
+                "region": "us-east-1",
                 "profiles": {
                     "dev": {
                         "host": "127.0.0.3",

--- a/st2common/tests/unit/test_config_loader.py
+++ b/st2common/tests/unit/test_config_loader.py
@@ -557,7 +557,7 @@ class ContentPackConfigLoaderTestCase(CleanDbTestCase):
         self.assertEqual(
             config_rendered,
             {
-                "regions": ["us-east-1"],
+                "regions": "us-east-1",
                 "profiles": {
                     "dev": {
                         "host": "127.0.0.3",

--- a/st2common/tests/unit/test_config_loader.py
+++ b/st2common/tests/unit/test_config_loader.py
@@ -532,11 +532,11 @@ class ContentPackConfigLoaderTestCase(CleanDbTestCase):
         values = {
             "profiles": {
                 "dev": {
-                    "host": "127.0.0.1",
+                    # no host or port to test default value
                     "token": "hard-coded-secret",
                 },
                 "stage": {
-                    "host": "127.0.0.2",
+                    "host": "127.0.0.1",
                     "port": 8181,
                     # unencrypted in datastore
                     "token": "{{st2kv.system.k0}}",
@@ -560,12 +560,12 @@ class ContentPackConfigLoaderTestCase(CleanDbTestCase):
                 "regions": "us-east-1",
                 "profiles": {
                     "dev": {
-                        "host": "127.0.0.1",
+                        "host": "127.0.0.3",
                         "port": 8080,
                         "token": "hard-coded-secret",
                     },
                     "stage": {
-                        "host": "127.0.0.2",
+                        "host": "127.0.0.1",
                         "port": 8181,
                         "token": "v0",
                     },

--- a/st2common/tests/unit/test_config_loader.py
+++ b/st2common/tests/unit/test_config_loader.py
@@ -545,6 +545,7 @@ class ContentPackConfigLoaderTestCase(CleanDbTestCase):
                     "host": "127.1.2.7",
                     "port": 8282,
                     # encrypted in datastore
+                    # (schema declares `secret: true` which triggers auto-decryption)
                     "token": "{{st2kv.system.k1_encrypted}}",
                 },
             }

--- a/st2common/tests/unit/test_config_loader.py
+++ b/st2common/tests/unit/test_config_loader.py
@@ -522,7 +522,6 @@ class ContentPackConfigLoaderTestCase(CleanDbTestCase):
         pack_name = "dummy_pack_schema_with_additional_properties_1"
         loader = ContentPackConfigLoader(pack_name=pack_name)
 
-        KeyValuePair.add_or_update(KeyValuePairDB(name="k0", value="v0"))
         KeyValuePair.add_or_update(
             KeyValuePairDB(name="k1_encrypted", value="v1_encrypted", secret=True)
         )
@@ -535,18 +534,13 @@ class ContentPackConfigLoaderTestCase(CleanDbTestCase):
                     # no host or port to test default value
                     "token": "hard-coded-secret",
                 },
-                "stage": {
-                    "host": "127.0.0.1",
-                    "port": 8181,
-                    # unencrypted in datastore
-                    "token": "{{st2kv.system.k0}}",
-                },
                 "prod": {
                     "host": "127.1.2.7",
                     "port": 8282,
                     # encrypted in datastore
-                    # (schema declares `secret: true` which triggers auto-decryption)
                     "token": "{{st2kv.system.k1_encrypted}}",
+                    # schema declares `secret: true` which triggers auto-decryption.
+                    # If this were not encrypted, it would try to decrypt it and fail.
                 },
             }
         }
@@ -564,11 +558,6 @@ class ContentPackConfigLoaderTestCase(CleanDbTestCase):
                         "host": "127.0.0.3",
                         "port": 8080,
                         "token": "hard-coded-secret",
-                    },
-                    "stage": {
-                        "host": "127.0.0.1",
-                        "port": 8181,
-                        "token": "v0",
                     },
                     "prod": {
                         "host": "127.1.2.7",

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_additional_properties_1/config.schema.yaml
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_additional_properties_1/config.schema.yaml
@@ -1,7 +1,7 @@
 ---
   regions:
     type: "array"
-    required: true
+    required: false
     default: "us-east-1"
   profiles:
     type: "object"
@@ -12,11 +12,11 @@
       properties:
         host:
           type: "string"
-          required: true
+          required: false
           default: "127.0.0.3"
         port:
           type: "integer"
-          required: true
+          required: false
           default: 8080
         token:
           type: "string"

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_additional_properties_1/config.schema.yaml
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_additional_properties_1/config.schema.yaml
@@ -1,0 +1,24 @@
+---
+  regions:
+    type: "array"
+    required: true
+    default: "us-east-1"
+  profiles:
+    type: "object"
+    required: false
+    additionalProperties:
+      type: object
+      additionalProperties: false
+      properties:
+        host:
+          type: "string"
+          required: true
+          default: "127.0.0.3"
+        port:
+          type: "integer"
+          required: true
+          default: 8080
+        token:
+          type: "string"
+          required: true
+          secret: true

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_additional_properties_1/config.schema.yaml
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_additional_properties_1/config.schema.yaml
@@ -1,6 +1,6 @@
 ---
-  regions:
-    type: "array"
+  region:
+    type: "string"
     required: false
     default: "us-east-1"
   profiles:

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_additional_properties_1/pack.yaml
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_additional_properties_1/pack.yaml
@@ -1,0 +1,6 @@
+---
+name : dummy_pack_schema_with_additional_properties_1
+description : dummy pack with nested objects under additionalProperties
+version : 0.1.0
+author : st2-dev
+email : info@stackstorm.com


### PR DESCRIPTION
The pack config loader uses "secret: true" in a schema to trigger decrypting a key from the datastore. However, it does not look at the schema under additionalProperties, so those properties can't use encrypted keys.

This issue was first documented in https://github.com/StackStorm-Exchange/stackstorm-jira/pull/19#discussion_r242319464

This PR fixes that so that the pack config loader handles additionalProperties when defined.