### PR TITLE
Make redis the default coordinator backend

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,8 @@ Added
 
   Contributed by @Kami.
 
+* Make redis the default coordinator backend.
+
 Changed
 ~~~~~~~
 

--- a/conf/st2.dev.conf
+++ b/conf/st2.dev.conf
@@ -87,6 +87,7 @@ protocol = udp
 # / cross server functionality
 #url = redis://localhost
 #url = kazoo://localhost
+url = redis://127.0.0.1:6379
 
 [webui]
 # webui_base_url = https://mywebhost.domain

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -37,6 +37,7 @@ python-keyczar==0.716
 pytz==2021.1
 pywinrm==0.3.0
 pyyaml==5.4
+redis==3.5.3
 requests[security]==2.25.1
 retrying==1.3.3
 routes==2.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,6 +53,7 @@ python-statsd==2.1.0
 pytz==2021.1
 pywinrm==0.3.0
 pyyaml==5.4
+redis==3.5.3
 rednose
 requests[security]==2.25.1
 retrying==1.3.3

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -25,6 +25,8 @@ tooz
 # Required by tooz - on new versions of tooz, all the backend dependencies need
 # to be installed manually
 zake
+# default coordinator backend configured for tooz
+redis
 routes
 flex
 webob

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -30,6 +30,7 @@ pymongo==3.11.3
 python-dateutil==2.8.1
 python-statsd==2.1.0
 pyyaml==5.4
+redis==3.5.3
 requests[security]==2.25.1
 retrying==1.3.3
 routes==2.4.1


### PR DESCRIPTION
The coordinator service is required in most cases for running workflows. Install redis-server and configure redis as the default coordinator backend used by tooz. This will avoid a number of workflow issues, especially for new StackStorm users.