### PR TITLE
Drop unused dependencies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -238,6 +238,10 @@ Improvements
 
   Contributed by @ashwini-orchestral
 
+* Drop unused python dependencies: prometheus_client, python-gnupg, more-itertools, zipp. #5228
+
+  Contributed by @cognifloyd.
+
 Fixed
 ~~~~~
 

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -32,7 +32,6 @@ prompt-toolkit==1.0.15
 pyinotify==0.9.6; platform_system=="Linux"
 pymongo==3.11.3
 python-editor==1.0.4
-python-gnupg==0.4.5
 python-keyczar==0.716
 pytz==2021.1
 pywinrm==0.3.0
@@ -55,14 +54,11 @@ zake==0.2.2
 bcrypt==3.2.0
 jinja2==2.11.3
 mock==4.0.3
-more-itertools==5.0.0
 nose-timer==0.7.5
 nose-parallel==0.3.1
 psutil==5.8.0
 python-dateutil==2.8.1
 python-statsd==2.1.0
-prometheus_client==0.1.1
 ujson==1.35
 orjson==3.5.1
 udatetime==0.0.16
-zipp>=0.5,<=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,6 @@ kombu==4.6.6
 lockfile==0.12.2
 mock==4.0.3
 mongoengine==0.23.0
-more-itertools==5.0.0
 networkx==1.11
 nose
 nose-parallel==0.3.1
@@ -68,4 +67,3 @@ unittest2
 webob==1.8.7
 webtest
 zake==0.2.2
-zipp>=0.5,<=1.0.0

--- a/st2client/in-requirements.txt
+++ b/st2client/in-requirements.txt
@@ -13,7 +13,5 @@ python-editor
 prompt-toolkit
 cryptography
 orjson
-more-itertools==5.0.0
-zipp>=0.5,<=1.0.0
 # needed by requests
 chardet

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -10,7 +10,6 @@ chardet<3.1.0
 cryptography==3.4.7
 jsonpath-rw==1.4.0
 jsonschema==2.6.0
-more-itertools==5.0.0
 orjson==3.5.1
 prettytable
 prompt-toolkit==1.0.15
@@ -21,4 +20,3 @@ pyyaml==5.4
 requests[security]==2.25.1
 six==1.13.0
 sseclient-py==1.7
-zipp>=0.5,<=1.0.0


### PR DESCRIPTION
`prometheus_client` was part of a metrics driver that was dropped. #4310 (https://github.com/StackStorm/st2/pull/4310/commits/82772cc64026b83792a344561844c4dcb09946e7) #4504 (https://github.com/StackStorm/st2/pull/4504/commits/873c57f8331e29832e17904fd9dbb9494d53c53b) _unused since v2.9.0_

`zipp` and `more-itertools` were py2-only transitive deps. #4843 #4847 (afaict these were transitive deps via `wheel`) _added in v3.2.0; unused since v3.4.0 when we dropped python 2_

`python-gnupg` was dropped with the removal of st2debug. #5103 _unused since v3.4.0_

background: _I discovered this as part of an experiment using [pants](https://pantsbuild.org) in [st2sandbox/st2@pants](https://github.com/st2sandbox/st2/tree/pants) to replace the Makefile and related scripts._