### PR TITLE
[WIP] Add script for running on tests in parallel locally

### DIFF
--- a/scripts/run-tests-in-parallel.sh
+++ b/scripts/run-tests-in-parallel.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Copyright 2021 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script allows users to easily run unit tests in parallel on multi-core systems. Compared
+# to just running single-threaded make .unit-tests, this offers much faster run time.
+
+NUM_WORKERS=${NUM_WORKERS:-$(nproc)}
+
+# TODO: Add support for FAIL_ON_FAILURE (aka fail and exit immediately + kill other running
+# processes on first failure)
+
+# Needed, otherwise some CLI tests will fail
+export COLUMNS=120
+
+echo ""
+echo "Running unit tests in parallel"
+echo "Using ${NUM_WORKERS} worker(s)"
+echo ""
+
+mkdir -p test_logs/
+rm test_logs/*
+
+START_TS=$(date +%s)
+
+for (( i=0; i < ${NUM_WORKERS}; i++ ));
+do
+    WORKER_LOG_PATH="test_logs/worker_${i}_tests.log"
+    echo "Spawning worker ${i}, output will be saved to ${WORKER_LOG_PATH}"
+
+    # Spawn worker process in background
+    TEMP_DIR=$(mktemp -d -t worker-${i}-XXXXXXXXXX)
+    mkdir -p ${TEMP_DIR}/home
+    DB_PER_WORKER=1 NODE_TOTAL=${NUM_WORKERS} NODE_INDEX=${i} HOME=${TEMP_DIR}/home make play .unit-tests &> ${WORKER_LOG_PATH} &
+    WORKER_PID=$!
+
+    sleep 0.3
+
+    # Tail logs and wait for pid
+    tail --pid=${WORKER_PID} -f ${WORKER_LOG_PATH} &
+done
+
+FAILURE_COUNTER=0
+
+for job_pid in $(jobs -p); do
+    wait ${job_pid} || let "FAILURE_COUNTER+=1"
+done
+
+END_TS=$(date +%s)
+
+DURATION=$((END_TS - START_TS))
+
+echo ""
+echo "Total duration: ${DURATION} seconds"
+echo ""
+
+if [ "${FAILURE_COUNTER}" -gt 0 ]; then
+    grep -ri "\\[error\']" test_logs/*.log
+    printf "\u274c "
+    echo "One or more tests failed, please inspect the output above or logs in test_logs/"
+    exit 1
+fi
+
+printf '\033[0;32m\u2714 \033[0m'
+echo "All tests successfuly passed!"
+
+exit 0

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -77,7 +77,16 @@ def _register_config_opts():
 
 
 def _override_db_opts():
-    CONF.set_override(name="db_name", override="st2-test", group="database")
+    node_index = os.environ.get("NODE_INDEX", None)
+    db_per_worker = os.environ.get("DB_PER_WORKER", "")
+    if node_index and db_per_worker:
+        # When running multiple unit tests in parallel at the same time we need to use different
+        # db per worker to ensure DB isolation.
+        CONF.set_override(
+            name="db_name", override="st2-test-%s" % (node_index), group="database"
+        )
+    else:
+        CONF.set_override(name="db_name", override="st2-test", group="database")
     CONF.set_override(name="host", override="127.0.0.1", group="database")
 
 


### PR DESCRIPTION
This pull request adds a script which allows user to easily run unit tests in parallel locally.

This results in large speed improvements in multi-core environments (which are a de facto today - I have a 8 core machine with 4 cores dedicated to StackStorm VirtualBox VM and makes me sad seeing most of the cores idle when running unit tests).

To put things into perspective, locally ``make .unit-tests`` (which is of course single threaded) takes ~6 minutes and this script with 4 workers takes ~2.5.

## Proposed Implementation

This pull request utilizes a simple bash script and db-level + "$HOME" isolation to achieve that.

Yes there are many ways to achieve that (isolation) including docker, etc. but the whole idea behind this script is that it should more or less work out of the box on all environment and our st2vagrantdev VM and be very simple (which would not be the case for docker based setup which would also add much more complexity).

And the whole idea behind unit tests should usually be that they can easily be run concurrency since they shouldn't have (many) external dependencies (which is not 100% true for out "unit" tests).

And yes, I know Make supports concurrent job runs natively, but not in a way we currently use it. And I'm against very large Make refactoring which would add much more complexity (I still occasionally have nightmares from our overly complex coverage targets :P).

## TODO

There are a couple of failing st2client tests which need "treatment" so they respect "$HOME" not starting with "/home" (which is a good idea regardless).