### PR TITLE
Persist StackStorm service logs on integration tests failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -491,7 +491,7 @@ jobs:
         with:
           name: logs
           path: logs.tar.gz
-        retention-days: 3
+          retention-days: 7
       - name: Stop Redis Service Container
         if: "${{ always() }}"
         run: docker rm --force redis || true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -481,6 +481,10 @@ jobs:
         if: "${{ success() && env.ENABLE_COVERAGE == 'yes' && env.TASK == 'ci-integration' }}"
         run: |
           ./scripts/ci/submit-codecov-coverage.sh
+      - name: Compress Service Logs Before upload
+        if: ${{ failure() && env.TASK == 'ci-integration' }}
+        run: |
+          tar cvzpf logs.tar.gz logs/*
       - name: Upload StackStorm services Logs
         if: ${{ failure() && env.TASK == 'ci-integration' }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -487,6 +487,7 @@ jobs:
         with:
           name: logs
           path: logs/
+        retention-days: 3
       - name: Stop Redis Service Container
         if: "${{ always() }}"
         run: docker rm --force redis || true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -490,7 +490,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: logs
-          path: logs/
+          path: logs.tar.gz
         retention-days: 3
       - name: Stop Redis Service Container
         if: "${{ always() }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -481,6 +481,12 @@ jobs:
         if: "${{ success() && env.ENABLE_COVERAGE == 'yes' && env.TASK == 'ci-integration' }}"
         run: |
           ./scripts/ci/submit-codecov-coverage.sh
+      - name: Upload StackStorm services Logs
+        if: ${{ failure() && env.TASK == 'ci-integration' }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs
+          path: logs/
       - name: Stop Redis Service Container
         if: "${{ always() }}"
         run: docker rm --force redis || true

--- a/.github/workflows/orquesta-integration-tests.yaml
+++ b/.github/workflows/orquesta-integration-tests.yaml
@@ -219,7 +219,6 @@ jobs:
           set +e
           for i in $(seq 1 ${MAX_ATTEMPTS}); do
             echo "Attempt: ${i}/${MAX_ATTEMPTS}"
-            # TODO: Add timeout and retry on timeout
             script -e -c "timeout 10m make ${TASK}" && exit 0
             exit_code=$?
             echo "Command failed / timed out (exit_code=${exit_code}), will retry in ${RETRY_DELAY} seconds..."

--- a/.github/workflows/orquesta-integration-tests.yaml
+++ b/.github/workflows/orquesta-integration-tests.yaml
@@ -2,7 +2,7 @@
 # Orquesta tests have a lot of race conditions which result in intermediate failures and timeouts.
 # Utilizing separate workflow allows us to re-run just this workflow / job on failure instead of
 # wasting time and resources by needing to re-run all the jobs.
-name: CI
+name: Orquesta CI
 
 on:
   push:
@@ -232,6 +232,7 @@ jobs:
         with:
           name: logs
           path: logs/
+        retention-days: 3
       - name: Codecov
         # NOTE: We only generate and submit coverage report for master and version branches and only when the build succeeds (default on GitHub Actions, this was not the case on Travis so we had to explicitly check success)
         if: "${{ success() && env.ENABLE_COVERAGE == 'yes' }}"

--- a/.github/workflows/orquesta-integration-tests.yaml
+++ b/.github/workflows/orquesta-integration-tests.yaml
@@ -232,11 +232,11 @@ jobs:
         run: |
           ./scripts/ci/submit-codecov-coverage.sh
       - name: Compress Service Logs Before upload
-        if: ${{ failure() }}
+        if: ${{ failure()  || true }}
         run: |
           tar cvzpf logs.tar.gz logs/*
       - name: Upload StackStorm services Logs
-        if: ${{ failure() }}
+        if: ${{ failure() || true }}
         uses: actions/upload-artifact@v2
         with:
           name: logs

--- a/.github/workflows/orquesta-integration-tests.yaml
+++ b/.github/workflows/orquesta-integration-tests.yaml
@@ -241,7 +241,7 @@ jobs:
         with:
           name: logs
           path: logs.tar.gz
-        retention-days: 3
+          retention-days: 7
       - name: Stop Redis Service Container
         if: "${{ always() }}"
         run: docker rm --force redis || true

--- a/.github/workflows/orquesta-integration-tests.yaml
+++ b/.github/workflows/orquesta-integration-tests.yaml
@@ -226,9 +226,15 @@ jobs:
           set -e
           echo "Failed after ${MAX_ATTEMPTS} attempts, failing the job."
           exit 1
+      - name: Upload StackStorm services Logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs
+          path: logs/
       - name: Codecov
         # NOTE: We only generate and submit coverage report for master and version branches and only when the build succeeds (default on GitHub Actions, this was not the case on Travis so we had to explicitly check success)
-        if: "${{ success() && env.ENABLE_COVERAGE == 'yes' && env.TASK == 'ci-integration' }}"
+        if: "${{ success() && env.ENABLE_COVERAGE == 'yes' }}"
         run: |
           ./scripts/ci/submit-codecov-coverage.sh
       - name: Stop Redis Service Container

--- a/.github/workflows/orquesta-integration-tests.yaml
+++ b/.github/workflows/orquesta-integration-tests.yaml
@@ -226,18 +226,22 @@ jobs:
           set -e
           echo "Failed after ${MAX_ATTEMPTS} attempts, failing the job."
           exit 1
-      - name: Upload StackStorm services Logs
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: logs
-          path: logs/
-        retention-days: 3
       - name: Codecov
         # NOTE: We only generate and submit coverage report for master and version branches and only when the build succeeds (default on GitHub Actions, this was not the case on Travis so we had to explicitly check success)
         if: "${{ success() && env.ENABLE_COVERAGE == 'yes' }}"
         run: |
           ./scripts/ci/submit-codecov-coverage.sh
+      - name: Compress Service Logs Before upload
+        if: ${{ failure() }}
+        run: |
+          tar cvzpf logs.tar.gz logs/*
+      - name: Upload StackStorm services Logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs
+          path: logs.tar.gz
+        retention-days: 3
       - name: Stop Redis Service Container
         if: "${{ always() }}"
         run: docker rm --force redis || true

--- a/.github/workflows/orquesta-integration-tests.yaml
+++ b/.github/workflows/orquesta-integration-tests.yaml
@@ -205,9 +205,9 @@ jobs:
         run: |
           ./scripts/ci/print-versions.sh
       - name: make
-        timeout-minutes: 20
+        timeout-minutes: 31
         env:
-          MAX_ATTEMPTS: 2
+          MAX_ATTEMPTS: 3
           RETRY_DELAY: 5
         # use: script -e -c to print colors
         run: |
@@ -219,8 +219,10 @@ jobs:
           set +e
           for i in $(seq 1 ${MAX_ATTEMPTS}); do
             echo "Attempt: ${i}/${MAX_ATTEMPTS}"
-            script -e -c "make ${TASK}" && exit 0
-            echo "Command failed, will retry in ${RETRY_DELAY} seconds..."
+            # TODO: Add timeout and retry on timeout
+            script -e -c "timeout 10m make ${TASK}" && exit 0
+            exit_code=$?
+            echo "Command failed / timed out (exit_code=${exit_code}), will retry in ${RETRY_DELAY} seconds..."
             sleep ${RETRY_DELAY}
           done
           set -e

--- a/.github/workflows/orquesta-integration-tests.yaml
+++ b/.github/workflows/orquesta-integration-tests.yaml
@@ -232,11 +232,11 @@ jobs:
         run: |
           ./scripts/ci/submit-codecov-coverage.sh
       - name: Compress Service Logs Before upload
-        if: ${{ failure()  || true }}
+        if: ${{ failure() }}
         run: |
           tar cvzpf logs.tar.gz logs/*
       - name: Upload StackStorm services Logs
-        if: ${{ failure() || true }}
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v2
         with:
           name: logs


### PR DESCRIPTION
This PR updates integration tests CI jobs so we preserve service logs on test failure.

This may help us troubleshoot various integration tests related failures.

Since service logs are quite large uncompressed (~300 MB) I added a step which compresses them and set a shorter retention policy.