### PR TITLE
Fix overlapping include field values for compatibility with Mongo DB 4.4

### DIFF
--- a/.github/workflows/microbenchmarks.yaml
+++ b/.github/workflows/microbenchmarks.yaml
@@ -3,12 +3,6 @@
 name: Micro Benchmarks
 
 on:
-  pull_request:
-    type: [opened, reopened, edited]
-    branches:
-      # Only for PRs targeting those branches
-      - master
-      - v[0-9]+.[0-9]+
   schedule:
     - cron:  '30 3 * * *'
 
@@ -43,6 +37,11 @@ jobs:
             nosetests_node_total: 1
             nosetests_node_index: 0
             python-version: '3.6'
+          - name: 'Microbenchmarks'
+            task: 'micro-benchmarks'
+            nosetests_node_total: 1
+            nosetests_node_index: 0
+            python-version: '3.8'
     services:
       mongo:
         image: mongo:4.4

--- a/st2api/tests/unit/controllers/v1/test_executions.py
+++ b/st2api/tests/unit/controllers/v1/test_executions.py
@@ -1580,6 +1580,14 @@ class ActionExecutionControllerTestCase(
         )
         self.assertEqual(get_resp.body, expected_result)
 
+    def test_get_include_attributes_overlapping_values(self):
+        resp = self.app.get(
+            "/v1/actionexecutions?include_attributes=context,context.user,action"
+        )
+        self.assertIn("context", resp.json[0])
+        self.assertIn("action", resp.json[0])
+        self.assertNotIn("parameters", resp.json[0])
+
     def test_get_include_attributes_and_secret_parameters(self):
         # Verify that secret parameters are correctly masked when using ?include_attributes filter
         self._do_post(LIVE_ACTION_WITH_SECRET_PARAM)


### PR DESCRIPTION
This pull request includes a small fix needed for MongoDB 4.4 compatibility issue previously reported here - #5247.

Versions of MongoDB prior to 4.4 automatically and transparently handled overlapping values for projection queries (e.g. ``foo, bar, baz, bar.foo`` would get "translated" to ``foo, bar, baz``), but 4.4 throws if such values are provided for a projection query.

This pull request includes a small change which acts as a compatibility layer. We now perform "sanitization" of the include fields in the API side (aka if we see foo,bar,foo.a, we translate it to foo,bar).

In ideal world, we would throw a validation exception in such scenario, but this would change previous behavior and could break custom scripts or similar if someone is using overlapping values for ``?include_attributes`` query parameter value.