### PR TITLE
Upgrade various deps to latest versions

### DIFF
--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -11,7 +11,9 @@ cryptography==3.4.7
 # depend on rely
 eventlet==0.30.2
 flex==6.14.1
-gitpython==2.1.15
+gitpython==3.1.15
+# Needed by gitpython, old versions used to bundle it
+gitdb==4.0.2
 # Note: greenlet is used by eventlet
 greenlet==1.0.0
 gunicorn==20.1.0
@@ -41,7 +43,7 @@ redis==3.5.3
 requests[security]==2.25.1
 retrying==1.3.3
 routes==2.4.1
-semver==2.9.0
+semver==2.13.0
 six==1.13.0
 argparse==1.12.2
 argcomplete==1.12.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,8 @@ git+https://github.com/StackStorm/orquesta.git@v1.3.0#egg=orquesta
 git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master#egg=st2-auth-backend-flat-file
 git+https://github.com/StackStorm/st2-auth-ldap.git@master#egg=st2-auth-ldap
 git+https://github.com/StackStorm/st2-rbac-backend.git@master#egg=st2-rbac-backend
-gitpython==2.1.15
+gitdb==4.0.2
+gitpython==3.1.15
 greenlet==1.0.0
 gunicorn==20.1.0
 importlib-metadata==3.10.1
@@ -58,7 +59,7 @@ rednose
 requests[security]==2.25.1
 retrying==1.3.3
 routes==2.4.1
-semver==2.9.0
+semver==2.13.0
 simplejson
 six==1.13.0
 sseclient-py==1.7

--- a/st2actions/requirements.txt
+++ b/st2actions/requirements.txt
@@ -9,7 +9,7 @@ apscheduler==3.7.0
 chardet<3.1.0
 eventlet==0.30.2
 git+https://github.com/StackStorm/logshipper.git@stackstorm_patched#egg=logshipper
-gitpython==2.1.15
+gitpython==3.1.15
 jinja2==2.11.3
 kombu==5.0.2
 lockfile==0.12.2

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -41,6 +41,7 @@ orjson
 amqp
 # Used by st2-pack-* commands
 gitpython
+gitdb
 lockfile
 # needed by requests
 chardet

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -14,7 +14,8 @@ eventlet==0.30.2
 flex==6.14.1
 git+https://github.com/StackStorm/orquesta.git@v1.3.0#egg=orquesta
 git+https://github.com/StackStorm/st2-rbac-backend.git@master#egg=st2-rbac-backend
-gitpython==2.1.15
+gitdb==4.0.2
+gitpython==3.1.15
 greenlet==1.0.0
 jinja2==2.11.3
 jsonpath-rw==1.4.0
@@ -34,7 +35,7 @@ redis==3.5.3
 requests[security]==2.25.1
 retrying==1.3.3
 routes==2.4.1
-semver==2.9.0
+semver==2.13.0
 six==1.13.0
 tooz==2.8.0
 udatetime==0.0.16

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,8 +2,8 @@
 coverage==4.5.2
 pep8==1.7.1
 st2flake8==0.1.0
-astroid==2.5.3
-pylint==2.7.4
+astroid==2.5.6
+pylint==2.8.2
 pylint-plugin-utils>=0.4
 black==20.8b1
 pre-commit==2.1.0
@@ -36,12 +36,12 @@ prance==0.15.0
 # pip-tools 5.4 needs pip>=20.1
 # pip-tools 6.0 needs pip>=20.3
 pip-tools>=5.4,<6.1
-pytest==5.4.3
-pytest-benchmark==3.2.3
-pytest-benchmark[histogram]==3.2.3
+pytest==6.2.3
+pytest-benchmark==3.4.1
+pytest-benchmark[histogram]==3.4.1
 # zstandard is used for micro benchmarks
 zstandard==0.15.2
 # ujson is used for micro benchmarks
-ujson==1.35
+ujson==4.0.2
 # needed by integration tests for coordination
 redis==3.5.3


### PR DESCRIPTION
This PR upgrades more dependencies to the latest stable versions (gitpython, semver + dev / testing deps).

gitpython one was very outdated. I verified that installing packs from git still works correctly.