### PR TITLE
Clean up unused methods in concurrency policies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -365,7 +365,7 @@ Fixed
 
   Contributed by @khushboobhatia01.
 
-* Clean up to remove unused methods in the action execution concurrency policies.
+* Clean up to remove unused methods in the action execution concurrency policies. #5268
 
 3.4.1 - March 14, 2021
 ----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -365,6 +365,8 @@ Fixed
 
   Contributed by @khushboobhatia01.
 
+* Clean up to remove unused methods in the action execution concurrency policies.
+
 3.4.1 - March 14, 2021
 ----------------------
 

--- a/st2actions/st2actions/policies/concurrency.py
+++ b/st2actions/st2actions/policies/concurrency.py
@@ -36,10 +36,6 @@ class ConcurrencyApplicator(BaseConcurrencyApplicator):
             action=action,
         )
 
-    def _get_lock_uid(self, target):
-        values = {"policy_type": self._policy_type, "action": target.action}
-        return self._get_lock_name(values=values)
-
     def _apply_before(self, target):
         # Get the count of scheduled instances of the action.
         scheduled = action_access.LiveAction.count(

--- a/st2actions/st2actions/policies/concurrency_by_attr.py
+++ b/st2actions/st2actions/policies/concurrency_by_attr.py
@@ -15,7 +15,6 @@
 
 from __future__ import absolute_import
 
-import json
 import six
 
 from st2common.constants import action as action_constants
@@ -41,15 +40,6 @@ class ConcurrencyByAttributeApplicator(BaseConcurrencyApplicator):
             action=action,
         )
         self.attributes = attributes or []
-
-    def _get_lock_uid(self, target):
-        meta = {
-            "policy_type": self._policy_type,
-            "action": target.action,
-            "attributes": self.attributes,
-        }
-
-        return json.dumps(meta)
 
     def _get_filters(self, target):
         filters = {

--- a/st2common/st2common/policies/base.py
+++ b/st2common/st2common/policies/base.py
@@ -69,5 +69,7 @@ def get_driver(policy_ref, policy_type, **parameters):
             # interested in
             continue
 
-        if issubclass(obj, ResourcePolicyApplicator) and not obj.__name__.startswith("Base"):
+        if issubclass(obj, ResourcePolicyApplicator) and not obj.__name__.startswith(
+            "Base"
+        ):
             return obj(policy_ref, policy_type, **parameters)

--- a/st2common/st2common/policies/base.py
+++ b/st2common/st2common/policies/base.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import abc
 import importlib
 import inspect
@@ -57,23 +58,6 @@ class ResourcePolicyApplicator(object):
         """
         return target
 
-    def _get_lock_name(self, values):
-        """
-        Return a safe string which can be used as a lock name.
-
-        :param values: Dictionary with values to use in the lock name.
-        :type values: ``dict``
-
-        :rtype: ``st``
-        """
-        lock_uid = []
-
-        for key, value in six.iteritems(values):
-            lock_uid.append("%s=%s" % (key, value))
-
-        lock_uid = ",".join(lock_uid)
-        return lock_uid
-
 
 def get_driver(policy_ref, policy_type, **parameters):
     policy_type_db = policy_access.PolicyType.get_by_ref(policy_type)
@@ -85,7 +69,5 @@ def get_driver(policy_ref, policy_type, **parameters):
             # interested in
             continue
 
-        if issubclass(obj, ResourcePolicyApplicator) and not obj.__name__.startswith(
-            "Base"
-        ):
+        if issubclass(obj, ResourcePolicyApplicator) and not obj.__name__.startswith("Base"):
             return obj(policy_ref, policy_type, **parameters)


### PR DESCRIPTION
The get uid method for the concurrency policies is not used. Remove related methods to avoid confusion.