### PR TITLE
Add coordination section to the HA conf sample

### DIFF
--- a/conf/HA/st2.conf.sample
+++ b/conf/HA/st2.conf.sample
@@ -79,3 +79,7 @@ use_paramiko_ssh_runner = True
 
 [database]
 host = st2-multi-node-controller
+
+[coordination]
+# url = kazoo://st2-multi-node-controller
+url = redis://st2-multi-node-controller


### PR DESCRIPTION
Add coordination section to the HA conf sample for the st2docs update to include the Redis/Zookeeper requirement.