### PR TITLE
Change minimum garbage_collection TTL to 1 day from 7

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -263,7 +263,7 @@ Changed
 
 * Update orquesta to v1.4.0.
 
-* Reduced minimum TTL on garbage collection for action executions and trigger instances from 7 days to 1 day.
+* Reduced minimum TTL on garbage collection for action executions and trigger instances from 7 days to 1 day. #5287
 
   Contributed by @ericreeves.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 in development
 --------------
 
+Improvements
+~~~~~~~~~~~~
+* Reduced minimum TTL on garbage collection for action executions and trigger instances from 7 days to 1 day. #5287
+
+  Contributed by @ericreeves.
+
 
 3.5.0 - June 23, 2021
 ---------------------
@@ -267,9 +273,6 @@ Changed
 
 * Update orquesta to v1.4.0.
 
-* Reduced minimum TTL on garbage collection for action executions and trigger instances from 7 days to 1 day. #5287
-
-  Contributed by @ericreeves.
 
 Improvements
 ~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -263,6 +263,10 @@ Changed
 
 * Update orquesta to v1.4.0.
 
+* Reduced minimum TTL on garbage collection for action executions and trigger instances from 7 days to 1 day.
+
+  Contributed by @ericreeves.
+
 Improvements
 ~~~~~~~~~~~~
 

--- a/st2common/st2common/constants/garbage_collection.py
+++ b/st2common/st2common/constants/garbage_collection.py
@@ -28,7 +28,7 @@ DEFAULT_COLLECTION_INTERVAL = 600
 DEFAULT_SLEEP_DELAY = 2
 
 # Minimum value for the TTL. If user supplies value lower than this, we will throw.
-MINIMUM_TTL_DAYS = 7
+MINIMUM_TTL_DAYS = 1
 
 # Minimum TTL in days for action execution output objects.
 MINIMUM_TTL_DAYS_EXECUTION_OUTPUT = 1

--- a/st2common/st2common/constants/garbage_collection.py
+++ b/st2common/st2common/constants/garbage_collection.py
@@ -27,7 +27,7 @@ DEFAULT_COLLECTION_INTERVAL = 600
 # How to long to wait / sleep between collection of different object types (in seconds)
 DEFAULT_SLEEP_DELAY = 2
 
-# Minimum value for the TTL. If user supplies value lower than this, we will throw.
+# Minimum TTL in days for action executions and trigger instances.
 MINIMUM_TTL_DAYS = 1
 
 # Minimum TTL in days for action execution output objects.


### PR DESCRIPTION
A very simple change to modify the minimum TTL on the garbage collector, pulling it back to 1 day from 7.

It still seems quite reasonable to ensure the user doesn't specify "0".