### PR TITLE
Add missing setup.py entry for the new migration script

### DIFF
--- a/st2common/setup.py
+++ b/st2common/setup.py
@@ -63,6 +63,7 @@ setup(
         "bin/st2-pack-install",
         "bin/st2-pack-download",
         "bin/st2-pack-setup-virtualenv",
+        "bin/migrations/v3.5/st2-migrate-db-dict-field-values",
     ],
     entry_points={
         "st2common.metrics.driver": [


### PR DESCRIPTION
This PR adds missing setup.py scripts entry so the new migration script gets installed into virtualenv ``bin/`` directory.

https://github.com/StackStorm/discussions/issues/81#issuecomment-863227036