### PR TITLE
Moving myself (@jjm) to Friends from Contributors

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,4 +1,4 @@
-StackStorm was founded in 2013. After several acquisitions the project has finally joined [The Linux Foundation](https://www.linuxfoundation.org/projects/directory/) in 2019.<br>
+ StackStorm was founded in 2013. After several acquisitions the project has finally joined [The Linux Foundation](https://www.linuxfoundation.org/projects/directory/) in 2019.<br>
 
 This page lists active project maintainers and their areas of expertise. This can be used for routing PRs, discussions, questions and overall coordination.
 
@@ -51,7 +51,6 @@ They're not part of the TSC voting process, but appreciated for their contributi
 * Harsh Nanchahal ([@hnanchahal](https://github.com/hnanchahal)), _Starbucks_ - Core, Docker, Kubernetes.
 * Hiroyasu Ohyama ([@userlocalhost](https://github.com/userlocalhost)) - Orquesta, Workflows, st2 Japan Community. [Case Study](https://stackstorm.com/case-study-dmm/).
 * Jacob Floyd ([@cognifloyd](https://github.com/cognifloyd/)), _Copart_ - StackStorm Exchange, ChatOps, Core, Discussions.
-* Jon Middleton ([@jjm](https://github.com/jjm)) - StackStorm Exchange, Core, Discussions.
 * Marcel Weinberg ([@winem](https://github.com/winem)) - Community, Docker, Core.
 * Sheshagiri Rao Mallipedhi ([@sheshagiri](https://github.com/sheshagiri)) - Docker, Core, StackStorm Exchange.
 * Shital Raut ([@shital-orchestral](https://github.com/shital-orchestral)), _Orchestral.ai_ - Web UI.
@@ -76,6 +75,7 @@ Thank you, Friends!
 * Jinping Han ([@jinpingh](https://github.com/jinpingh)) - ex Stormer. Community, Core, Tests, Pack Dependencies.
 * Johan Dahlberg ([@johandahlberg](https://github.com/johandahlberg)) - Using st2 for Bioinformatics/Science project, providing feedback & contributions in Ansible, Community, Workflows. [Case Study](https://stackstorm.com/case-study-scilifelab/).
 * Johan Hermansson ([@johanherman](https://github.com/johanherman)) - Using st2 for Bioinformatics/Science project, feedback & contributions in Ansible, Community, Workflows. [Case Study](https://stackstorm.com/case-study-scilifelab/).
+* Jon Middleton ([@jjm](https://github.com/jjm)) - StackStorm Exchange, Core, Discussions.
 * Lakshmi Kannan ([@lakshmi-kannan](https://github.com/lakshmi-kannan)) - early Stormer. Initial Core platform architecture, scalability, reliability, Team Leadership during the project hard times.
 * Lindsay Hill ([@LindsayHill](https://github.com/LindsayHill)) - ex StackStorm product manager that made a significant impact building an ecosystem we see today.
 * Manas Kelshikar ([@manasdk](https://github.com/manasdk)) - ex Stormer. Developed (well) early core platform features.


### PR DESCRIPTION
It's been quite sometime since I made active use of StackStorm, and following a recent job change I've come to the realisation that I'm not sure when it'll possible to start making an active contribution to StackStorm again.

So doing the right thing and moving myself from the **Contributors** section to **Friends** in `OWNERS.md`.

- docs: Moving myself (@jjm) to Friends from Contributors.