### PR TITLE
Fix README that fails pypi checking

### DIFF
--- a/st2client/README.rst
+++ b/st2client/README.rst
@@ -4,7 +4,7 @@ StackStorm CLI and Python Client
 Install stable / production version from Python Package Index (PyPi)
 --------------------------------------------------------------------
 
-.. sourcecode:: base
+.. sourcecode:: bash
 
     pip install st2client
 


### PR DESCRIPTION
Fix README as made in 3.5 release process as fails pypi validation.