### PR TITLE
Fix version quotes for black

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 in development
 --------------
 
+Changed
+~~~~~~~
+
+* Fixed ``__init__.py`` files to use double quotes to better align with black linting #5299
+
+  Contributed by @blag.
 
 3.5.0 - June 23, 2021
 ---------------------

--- a/contrib/runners/action_chain_runner/action_chain_runner/__init__.py
+++ b/contrib/runners/action_chain_runner/action_chain_runner/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '3.6dev'
+__version__ = "3.6dev"

--- a/contrib/runners/announcement_runner/announcement_runner/__init__.py
+++ b/contrib/runners/announcement_runner/announcement_runner/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '3.6dev'
+__version__ = "3.6dev"

--- a/contrib/runners/http_runner/http_runner/__init__.py
+++ b/contrib/runners/http_runner/http_runner/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '3.6dev'
+__version__ = "3.6dev"

--- a/contrib/runners/inquirer_runner/inquirer_runner/__init__.py
+++ b/contrib/runners/inquirer_runner/inquirer_runner/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '3.6dev'
+__version__ = "3.6dev"

--- a/contrib/runners/local_runner/local_runner/__init__.py
+++ b/contrib/runners/local_runner/local_runner/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '3.6dev'
+__version__ = "3.6dev"

--- a/contrib/runners/noop_runner/noop_runner/__init__.py
+++ b/contrib/runners/noop_runner/noop_runner/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '3.6dev'
+__version__ = "3.6dev"

--- a/contrib/runners/orquesta_runner/orquesta_runner/__init__.py
+++ b/contrib/runners/orquesta_runner/orquesta_runner/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '3.6dev'
+__version__ = "3.6dev"

--- a/contrib/runners/python_runner/python_runner/__init__.py
+++ b/contrib/runners/python_runner/python_runner/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '3.6dev'
+__version__ = "3.6dev"

--- a/contrib/runners/remote_runner/remote_runner/__init__.py
+++ b/contrib/runners/remote_runner/remote_runner/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '3.6dev'
+__version__ = "3.6dev"

--- a/contrib/runners/winrm_runner/winrm_runner/__init__.py
+++ b/contrib/runners/winrm_runner/winrm_runner/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '3.6dev'
+__version__ = "3.6dev"

--- a/st2actions/st2actions/__init__.py
+++ b/st2actions/st2actions/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '3.6dev'
+__version__ = "3.6dev"

--- a/st2api/st2api/__init__.py
+++ b/st2api/st2api/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '3.6dev'
+__version__ = "3.6dev"

--- a/st2auth/st2auth/__init__.py
+++ b/st2auth/st2auth/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '3.6dev'
+__version__ = "3.6dev"

--- a/st2client/st2client/__init__.py
+++ b/st2client/st2client/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '3.6dev'
+__version__ = "3.6dev"

--- a/st2common/st2common/__init__.py
+++ b/st2common/st2common/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '3.6dev'
+__version__ = "3.6dev"

--- a/st2reactor/st2reactor/__init__.py
+++ b/st2reactor/st2reactor/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '3.6dev'
+__version__ = "3.6dev"

--- a/st2stream/st2stream/__init__.py
+++ b/st2stream/st2stream/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '3.6dev'
+__version__ = "3.6dev"

--- a/st2tests/st2tests/__init__.py
+++ b/st2tests/st2tests/__init__.py
@@ -30,4 +30,4 @@ __all__ = [
     "WorkflowTestCase",
 ]
 
-__version__ = '3.6dev'
+__version__ = "3.6dev"


### PR DESCRIPTION
GHA [CI is failing](https://github.com/StackStorm/st2/runs/2985686600?check_suite_focus=true) because our [release scripts](https://github.com/StackStorm/st2cd/blob/da810fdfa353a976743b8a16d70f34d63c613957/actions/st2_chg_ver_for_st2.sh#L79) insert single quotes instead of double quotes:

```bash
sed -i -e "s/\(__version__ = \).*/\1'${VERSION}'/" ${INIT_FILE}
#                                   ^          ^
```

But black forces us to use double quotes:

```
================== black-check ====================

# st2 components
===========================================================
Running black on st2actions
===========================================================
would reformat /home/runner/work/st2/st2/st2actions/st2actions/__init__.py
Oh no! 💥 💔 💥
1 file would be reformatted, 59 files would be left unchanged.
make: *** [Makefile:372: .black-check] Error 1
Script done, file is typescript
Error: Process completed with exit code 2.
```

Running black manually:

```diff
diff --git a/st2actions/st2actions/__init__.py b/st2actions/st2actions/__init__.py
index 2e5ec8277..18f4135fa 100644
--- a/st2actions/st2actions/__init__.py
+++ b/st2actions/st2actions/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.

-__version__ = '3.6dev'
+__version__ = "3.6dev"
```

This PR switches to using double quotes in all of the `__init__.py` files for the various packages in the codebase.

The corresponding PR to fix our release scripts is StackStorm/st2cd#464.