### PR TITLE
update db connect mongo connection test

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Changed
 
   Contributed by @ericreeves.
 
+* update db connect mongo connection test - `isMaster` MongoDB command depreciated, switch to `hello` #5302
+
+  Contributed by @lukepatrick
+
 3.5.0 - June 23, 2021
 ---------------------
 

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -199,8 +199,9 @@ def _db_connect(
     # successfully established.
     # See http://api.mongodb.com/python/current/api/pymongo/mongo_client.html for details
     try:
-        # The ismaster command is cheap and does not require auth
-        connection.admin.command("ismaster")
+        # The hello command is cheap and does not require auth
+        # https://docs.mongodb.com/v4.4/reference/command/hello/
+        connection.admin.command("hello")
     except (ConnectionFailure, ServerSelectionTimeoutError) as e:
         # NOTE: ServerSelectionTimeoutError can also be thrown if SSLHandShake fails in the server
         # Sadly the client doesn't include more information about the error so in such scenarios


### PR DESCRIPTION
the `isMaster` MongoDB command is depreciated in future versions of mongo. `hello` is in the updated patch versions across a few major versions: `4.4.2: (and 4.2.10, 4.0.21, and 3.6.21)`

https://docs.mongodb.com/v4.4/reference/command/hello/#mongodb-dbcommand-dbcmd.hello

This minor update supports future MongoDB development