### PR TITLE
bug fix for `output_value[output_key]` is not iterable

### DIFF
--- a/st2common/st2common/util/output_schema.py
+++ b/st2common/st2common/util/output_schema.py
@@ -69,8 +69,9 @@ def mask_secret_output(ac_ex, output_value):
         return output_value
 
     for key, spec in output_schema.items():
-        if key in output_value[output_key] and spec.get("secret", False):
-            output_value[output_key][key] = MASKED_ATTRIBUTE_VALUE
+        if not isinstance(output_value[output_key], bool):
+            if key in output_value[output_key] and spec.get("secret", False):
+                output_value[output_key][key] = MASKED_ATTRIBUTE_VALUE
 
     return output_value
 


### PR DESCRIPTION
if output_value[output_key] is not iterable and instead a boolean I receive the following error code from the st2api.
IE:
```
output_value: {'stdout': '', 'stderr': '', 'exit_code': 0, 'result': True}
spec: {'status': 'bool'}
key: output
output_key: result
```
ERROR:
```
ERROR: 500 Server Error: Internal Server Error
MESSAGE: Internal Server Error for url: https://stackstorm-vf.ifp.lmco.com/api/executions/60f94708c3a6d1a338dc0ad7/children/?depth=-1
```