### PR TITLE
Ignore more vim temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.py[cod]
 *.sqlite
-*.swp
 *.log
 .stamp*
 
@@ -62,3 +61,5 @@ benchmark_histograms/
 # Editor Saves
 *~
 \#*\#
+[._]*.sw[a-p]
+[._]sw[a-p]


### PR DESCRIPTION
I use vim quite a bit, so I end up with a variety of vim temporary files.
I could use my user gitignore, but this could be helpful for other vim users as well, so I'm submitting a quick PR.