### PR TITLE
Fix running scripts/write-headers.sh on Darwin

### DIFF
--- a/scripts/write-headers.sh
+++ b/scripts/write-headers.sh
@@ -7,15 +7,16 @@
 # that are used by popular editors and formalized in PEP 263
 # https://www.python.org/dev/peps/pep-0263/
 
-HEADER="# NOTE: This file is auto-generated - DO NOT EDIT MANUALLY\\
+HEADER="\\
+# NOTE: This file is auto-generated - DO NOT EDIT MANUALLY\\
 #       Instead modify scripts/dist_utils.py and run 'make .sdist-requirements' to\\
 #       update dist_utils.py files for all components\\
 "
 
 if [[ $(uname) == "Linux" ]]; then
-	sed -i -e "s|^\(# -\*- .*\)$|\1\\n$HEADER|; /^# \/\//d" "$@" || exit 2
+	sed -i -e "s|^\(# -\*- .*\)$|\1$HEADER|; /^# \/\//d" "$@" || exit 2
 elif [[ $(uname) == "Darwin" ]]; then
-	sed -i '' -e "s|^\(# -\*- .*\)$|\1\\n$HEADER|; /^# \/\//d" "$@" || exit 2
+	sed -i '' -e "s|^\(# -\*- .*\)$|\1$HEADER|; /^# \/\//d" "$@" || exit 2
 else
 	echo >&2 "Unknown OS"
 	exit 2


### PR DESCRIPTION
I tried running scripts/write-headers.sh on Mac OSX but the sed behavior, or perhaps the escaping behavior, was slightly different, so the headers were malformed. In particular `\n` did not add a newline as expected. So, I massaged the HEADER message such that injecting that newline was no longer necessary.
