### PR TITLE
Make our custom pylint plugin use the AST

### DIFF
--- a/pylint_plugins/api_models.py
+++ b/pylint_plugins/api_models.py
@@ -22,7 +22,6 @@ constructor.
 """
 
 import astroid
-import six
 
 from astroid import MANAGER
 from astroid import nodes


### PR DESCRIPTION
pylint plugins are supposed to inspect code without importing it to avoid side effects like importing eventlet.
In some of my manual pylint runs, I ran into a variety of really odd errors and hangs that were ultimately caused by importing the st2 modules from within the pylint plugin.

So, this PR modifies the plugin to use the astroid AST instead of using `__import__`.

~This is a draft while I compare run times with master branch. I'm curious if this will speed things up at all.~

- Fix pylint plugin to rely on ast instead of `__import__()`
- finish pylint api_models plugin so it uses AST only
- drop unused import
