### PR TITLE
Prefer explicit imports from st2client.models

### DIFF
--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -30,7 +30,7 @@ from os.path import join as pjoin
 
 from six.moves import range
 
-from st2client import models
+from st2client.models.action import Action, Execution
 from st2client.commands import resource
 from st2client.commands.resource import ResourceNotFoundError
 from st2client.commands.resource import ResourceViewCommand
@@ -198,7 +198,7 @@ def format_execution_status(instance):
 class ActionBranch(resource.ResourceBranch):
     def __init__(self, description, app, subparsers, parent_parser=None):
         super(ActionBranch, self).__init__(
-            models.Action,
+            Action,
             description,
             app,
             subparsers,
@@ -1082,7 +1082,7 @@ class ActionRunCommandMixin(object):
             task_name_key = "context.orquesta.task_name"
         # Use Execution as the object so that the formatter lookup does not change.
         # AKA HACK!
-        return models.action.Execution(
+        return Execution(
             **{
                 "id": task.id,
                 "status": task.status,
@@ -1240,7 +1240,7 @@ class ActionRunCommand(ActionRunCommandMixin, resource.ResourceCommand):
             action=action, runner=runner, args=args
         )
 
-        execution = models.Execution()
+        execution = Execution()
         execution.action = action_ref
         execution.parameters = action_parameters
         execution.user = args.user
@@ -1267,7 +1267,7 @@ class ActionRunCommand(ActionRunCommandMixin, resource.ResourceCommand):
 class ActionExecutionBranch(resource.ResourceBranch):
     def __init__(self, description, app, subparsers, parent_parser=None):
         super(ActionExecutionBranch, self).__init__(
-            models.Execution,
+            Execution,
             description,
             app,
             subparsers,

--- a/st2client/st2client/commands/auth.py
+++ b/st2client/st2client/commands/auth.py
@@ -27,7 +27,7 @@ from six.moves import http_client
 
 from st2client.base import BaseCLIApp
 from st2client import config_parser
-from st2client import models
+from st2client.models.auth import ApiKey
 from st2client.commands import resource
 from st2client.commands.noop import NoopCommand
 from st2client.exceptions.operations import OperationFailureException
@@ -278,7 +278,7 @@ class WhoamiCommand(resource.ResourceCommand):
 class ApiKeyBranch(resource.ResourceBranch):
     def __init__(self, description, app, subparsers, parent_parser=None):
         super(ApiKeyBranch, self).__init__(
-            models.ApiKey,
+            ApiKey,
             description,
             app,
             subparsers,

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -21,9 +21,9 @@ import six
 import editor
 import yaml
 
-from st2client.models import Config
-from st2client.models import Pack
-from st2client.models import Execution
+from st2client.models.config import Config
+from st2client.models.pack import Pack
+from st2client.models.action import Execution
 from st2client.commands import resource
 from st2client.commands.resource import add_auth_token_to_kwargs_from_cli
 from st2client.commands.action import ActionRunCommandMixin

--- a/st2client/st2client/commands/policy.py
+++ b/st2client/st2client/commands/policy.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 
 import logging
 
-from st2client import models
+from st2client.models.policy import Policy, PolicyType
 from st2client.commands import resource
 
 
@@ -27,7 +27,7 @@ LOG = logging.getLogger(__name__)
 class PolicyTypeBranch(resource.ResourceBranch):
     def __init__(self, description, app, subparsers, parent_parser=None):
         super(PolicyTypeBranch, self).__init__(
-            models.PolicyType,
+            PolicyType,
             description,
             app,
             subparsers,
@@ -72,7 +72,7 @@ class PolicyTypeGetCommand(resource.ResourceGetCommand):
 class PolicyBranch(resource.ResourceBranch):
     def __init__(self, description, app, subparsers, parent_parser=None):
         super(PolicyBranch, self).__init__(
-            models.Policy,
+            Policy,
             description,
             app,
             subparsers,

--- a/st2client/st2client/commands/rule.py
+++ b/st2client/st2client/commands/rule.py
@@ -15,7 +15,7 @@
 
 from __future__ import absolute_import
 
-from st2client import models
+from st2client.models.reactor import Rule
 from st2client.commands import resource
 from st2client.formatters import table
 
@@ -23,7 +23,7 @@ from st2client.formatters import table
 class RuleBranch(resource.ResourceBranch):
     def __init__(self, description, app, subparsers, parent_parser=None):
         super(RuleBranch, self).__init__(
-            models.Rule,
+            Rule,
             description,
             app,
             subparsers,

--- a/st2client/st2client/commands/rule_enforcement.py
+++ b/st2client/st2client/commands/rule_enforcement.py
@@ -15,7 +15,7 @@
 
 from __future__ import absolute_import
 
-from st2client import models
+from st2client.models.reactor import RuleEnforcement
 from st2client.commands import resource
 from st2client.formatters import table
 from st2client.utils.date import format_isodate_for_user_timezone
@@ -24,7 +24,7 @@ from st2client.utils.date import format_isodate_for_user_timezone
 class RuleEnforcementBranch(resource.ResourceBranch):
     def __init__(self, description, app, subparsers, parent_parser=None):
         super(RuleEnforcementBranch, self).__init__(
-            models.RuleEnforcement,
+            RuleEnforcement,
             description,
             app,
             subparsers,

--- a/st2client/st2client/commands/sensor.py
+++ b/st2client/st2client/commands/sensor.py
@@ -15,7 +15,7 @@
 
 from __future__ import absolute_import
 
-from st2client.models import Sensor
+from st2client.models.reactor import Sensor
 from st2client.commands import resource
 
 

--- a/st2client/st2client/commands/timer.py
+++ b/st2client/st2client/commands/timer.py
@@ -15,7 +15,7 @@
 
 from __future__ import absolute_import
 
-from st2client.models import Timer
+from st2client.models.timer import Timer
 from st2client.commands import resource
 
 

--- a/st2client/st2client/commands/trace.py
+++ b/st2client/st2client/commands/trace.py
@@ -15,7 +15,10 @@
 
 from __future__ import absolute_import
 
-from st2client.models import Resource, Trace, TriggerInstance, Rule, Execution
+from st2client.models.core import Resource
+from st2client.models.trace import Trace
+from st2client.models.reactor import TriggerInstance, Rule
+from st2client.models.action import Execution
 from st2client.formatters import table
 from st2client.formatters import execution as execution_formatter
 from st2client.commands import resource

--- a/st2client/st2client/commands/trigger.py
+++ b/st2client/st2client/commands/trigger.py
@@ -16,7 +16,7 @@
 from __future__ import absolute_import
 
 from st2client.commands import resource
-from st2client.models import TriggerType
+from st2client.models.reactor import TriggerType
 from st2client.formatters import table
 
 

--- a/st2client/st2client/commands/triggerinstance.py
+++ b/st2client/st2client/commands/triggerinstance.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 
 from st2client.commands import resource
 from st2client.formatters import table
-from st2client.models import TriggerInstance
+from st2client.models.reactor import TriggerInstance
 from st2client.utils.date import format_isodate_for_user_timezone
 
 

--- a/st2client/st2client/commands/webhook.py
+++ b/st2client/st2client/commands/webhook.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 
 from st2client.commands import resource
 from st2client.formatters import table
-from st2client.models import Webhook
+from st2client.models.webhook import Webhook
 
 
 class WebhookBranch(resource.ResourceBranch):

--- a/st2common/st2common/services/datastore.py
+++ b/st2common/st2common/services/datastore.py
@@ -19,7 +19,7 @@ from datetime import timedelta
 from oslo_config import cfg
 
 from st2client.client import Client
-from st2client.models import KeyValuePair
+from st2client.models.keyvalue import KeyValuePair
 from st2common.util.api import get_full_public_api_url
 from st2common.util.date import get_datetime_utc_now
 from st2common.constants.keyvalue import DATASTORE_KEY_SEPARATOR, SYSTEM_SCOPE


### PR DESCRIPTION
Before this change, some places explicitly imported models from `st2client.models.<model>` and other places imported models from `st2client.models`. These `st2client.models` imports rely on the fact that `st2client/st2client/models/__init__.py` implicitly imports all models like:

```
from st2client.models.<model> import *  # noqa
```

Note the "# noqa" which silences our linters instead of dealing with the bad `import *` practice.

For external code, relying on the `from ... import *` in `st2client.models` is fine; And, doing so allows 3rd party code to have a much nicer interface. However, in ST2 code we should prefer explicit imports.
