### PR TITLE
Add Jacob (@cognifloyd) to the TSC Maintainers

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -33,7 +33,7 @@ Have deep platform knowledge & experience and demonstrate technical leadership a
 Being part of Technical Steering Committee (TSC) [@StackStorm/maintainers](https://github.com/orgs/StackStorm/teams/maintainers) provide significant and reliable value to the project helping it grow and improve through development and maintenance. See [Maintainer Responsibilities](https://github.com/StackStorm/st2/blob/master/GOVERNANCE.md#maintainer-responsibilities) for more info.
 * Amanda McGuinness ([@amanda11](https://github.com/amanda11)) <<amanda.mcguinness@ammeonsolutions.com>>
   - Ansible, Core, deb/rpm packages, CI/CD, Deployments, StackStorm Exchange, Documentation.
-* Jacob Floyd ([@cognifloyd](https://github.com/cognifloyd/)), _Copart_ <<>>
+* Jacob Floyd ([@cognifloyd](https://github.com/cognifloyd/)), _Copart_ <<cognifloyd@gmail.com>>
   - StackStorm Exchange, Kubernetes, ChatOps, Core, Ansible, Discussions.
 * JP Bourget ([@punkrokk](https://github.com/punkrokk)) <<jp.bourget@gmail.com>>
   - Systems, deb/rpm, Deployments, Community, StackStorm Exchange, SecOps, CircleCI.

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -33,6 +33,8 @@ Have deep platform knowledge & experience and demonstrate technical leadership a
 Being part of Technical Steering Committee (TSC) [@StackStorm/maintainers](https://github.com/orgs/StackStorm/teams/maintainers) provide significant and reliable value to the project helping it grow and improve through development and maintenance. See [Maintainer Responsibilities](https://github.com/StackStorm/st2/blob/master/GOVERNANCE.md#maintainer-responsibilities) for more info.
 * Amanda McGuinness ([@amanda11](https://github.com/amanda11)) <<amanda.mcguinness@ammeonsolutions.com>>
   - Ansible, Core, deb/rpm packages, CI/CD, Deployments, StackStorm Exchange, Documentation.
+* Jacob Floyd ([@cognifloyd](https://github.com/cognifloyd/)), _Copart_ <<>>
+  - StackStorm Exchange, Kubernetes, ChatOps, Core, Ansible, Discussions.
 * JP Bourget ([@punkrokk](https://github.com/punkrokk)) <<jp.bourget@gmail.com>>
   - Systems, deb/rpm, Deployments, Community, StackStorm Exchange, SecOps, CircleCI.
 * Marcel Weinberg ([@winem](https://github.com/winem)), _CoreMedia_ <<mweinberg-os@email.de>>
@@ -51,7 +53,6 @@ They're not part of the TSC voting process, but appreciated for their contributi
 * Carlos ([@nzlosh](https://github.com/nzlosh)) - Chatops, Errbot, Community, Discussions, StackStorm Exchange.
 * Harsh Nanchahal ([@hnanchahal](https://github.com/hnanchahal)), _Starbucks_ - Core, Docker, Kubernetes.
 * Hiroyasu Ohyama ([@userlocalhost](https://github.com/userlocalhost)) - Orquesta, Workflows, st2 Japan Community. [Case Study](https://stackstorm.com/case-study-dmm/).
-* Jacob Floyd ([@cognifloyd](https://github.com/cognifloyd/)), _Copart_ - StackStorm Exchange, ChatOps, Core, Discussions.
 * Marcel Weinberg ([@winem](https://github.com/winem)) - Community, Docker, Core.
 * Sheshagiri Rao Mallipedhi ([@sheshagiri](https://github.com/sheshagiri)) - Docker, Core, StackStorm Exchange.
 * Shital Raut ([@shital-orchestral](https://github.com/shital-orchestral)), _Orchestral.ai_ - Web UI.


### PR DESCRIPTION
Jacob (@cognifloyd) was an active StackStorm community member for many years.

Being more involved around the Ansible, deployments, and Operations in the past, he started participating in the StackStorm project life more and contributed to the StackStorm core (people loved it!), Packaging, StackStorm-HA (K8s), helping with really massive efforts for the StackStorm-Exchange maintenance and ChatOps rework (https://github.com/StackStorm/discussions/issues/8) that includes development and intra-community collaboration with OpsDroid project to draw the future of st2chatops.

I'm also glad that as a Contributor and member of StackStorm Github org he jumped in and helped to triage lots of issues, applying tags, reviewing Pull Requests, following best standards for the open-source project maintenance.
Taking part in the TSC Meetings, Github Discussions, Proposals, Slack, and Forums (https://forum.stackstorm.com/u/cognifloyd/activity) he's also one of the best idea generators!

https://github.com/StackStorm/st2/pull/5329 opened the door for the new Maintainers and I'd like to propose adding Jacob as a new StackStorm Maintainer and a full TSC Member!
