### PR TITLE
Add AJ (@guzzijones) to the TSC Maintainers

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -33,7 +33,7 @@ Have deep platform knowledge & experience and demonstrate technical leadership a
 Being part of Technical Steering Committee (TSC) [@StackStorm/maintainers](https://github.com/orgs/StackStorm/teams/maintainers) provide significant and reliable value to the project helping it grow and improve through development and maintenance. See [Maintainer Responsibilities](https://github.com/StackStorm/st2/blob/master/GOVERNANCE.md#maintainer-responsibilities) for more info.
 * Amanda McGuinness ([@amanda11](https://github.com/amanda11)) <<amanda.mcguinness@ammeonsolutions.com>>
   - Ansible, Core, deb/rpm packages, CI/CD, Deployments, StackStorm Exchange, Documentation.
-* AJ Jonen ([@guzzijones](https://github.com/guzzijones)) <<>>
+* AJ Jonen ([@guzzijones](https://github.com/guzzijones)), _Cypherint_ <<aaron.jonen@cypherint.com>>
   - Workflows, st2 Core Performance, Releases.
 * JP Bourget ([@punkrokk](https://github.com/punkrokk)) <<jp.bourget@gmail.com>>
   - Systems, deb/rpm, Deployments, Community, StackStorm Exchange, SecOps, CircleCI.

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -33,6 +33,8 @@ Have deep platform knowledge & experience and demonstrate technical leadership a
 Being part of Technical Steering Committee (TSC) [@StackStorm/maintainers](https://github.com/orgs/StackStorm/teams/maintainers) provide significant and reliable value to the project helping it grow and improve through development and maintenance. See [Maintainer Responsibilities](https://github.com/StackStorm/st2/blob/master/GOVERNANCE.md#maintainer-responsibilities) for more info.
 * Amanda McGuinness ([@amanda11](https://github.com/amanda11)) <<amanda.mcguinness@ammeonsolutions.com>>
   - Ansible, Core, deb/rpm packages, CI/CD, Deployments, StackStorm Exchange, Documentation.
+* AJ Jonen ([@guzzijones](https://github.com/guzzijones)) <<>>
+  - Workflows, st2 Core Performance, Releases.
 * JP Bourget ([@punkrokk](https://github.com/punkrokk)) <<jp.bourget@gmail.com>>
   - Systems, deb/rpm, Deployments, Community, StackStorm Exchange, SecOps, CircleCI.
 * Marcel Weinberg ([@winem](https://github.com/winem)), _CoreMedia_ <<mweinberg-os@email.de>>
@@ -47,7 +49,6 @@ Contributors are using and occasionally contributing back to the project, might 
 They're not part of the TSC voting process, but appreciated for their contribution, involvement and may become Maintainers in the future depending on their effort and involvement. See [How to become a Maintainer?](https://github.com/StackStorm/st2/blob/master/GOVERNANCE.md#how-to-become-a-maintainer)
 [@StackStorm/contributors](https://github.com/orgs/StackStorm/teams/contributors) are invited to StackStorm Github organization and have permissions to help triage the Issues and review PRs.
 * Anand Patel ([@arms11](https://github.com/arms11)), _VMware_ - Docker, Kubernetes.
-* AJ Jonen ([@guzzijones](https://github.com/guzzijones)) - ST2 Web UI, Orquesta, Core.
 * Carlos ([@nzlosh](https://github.com/nzlosh)) - Chatops, Errbot, Community, Discussions, StackStorm Exchange.
 * Harsh Nanchahal ([@hnanchahal](https://github.com/hnanchahal)), _Starbucks_ - Core, Docker, Kubernetes.
 * Hiroyasu Ohyama ([@userlocalhost](https://github.com/userlocalhost)) - Orquesta, Workflows, st2 Japan Community. [Case Study](https://stackstorm.com/case-study-dmm/).


### PR DESCRIPTION
AJ (@guzzijones) joined our community a while ago and became an active member of the open-source project.

He was a tester for several releases, participated in trying functionality and giving feedback for the `v3.5.0` performance improvements https://github.com/StackStorm/st2/pull/4846 working closely with @kami, provided fixes to st2: https://github.com/StackStorm/st2/pull/5267, https://github.com/StackStorm/st2/pull/5042, and also contributed to the Orquesta before: https://github.com/StackStorm/orquesta/pull/209, implementing `orquesta-rehearse` command to allow users run unit tests for workflow definition.

He is an active community member in Slack, TSC Meetings and also wrote blog posts about StackStorm:
* [StackStorm Dynamic Checkbox Inquiry](https://www.cypherint.com/post/stackstorm-dynamic-checkbox-inquiry)
* [Monitor StackStorm Polling Sensors](https://www.cypherint.com/post/monitor-stackstorm-polling-sensors)
* [StackStorm faster with-items](https://www.cypherint.com/post/stackstorm-faster-with-items)

AJ decided to jump in and help with the upcoming StackStorm releases (https://github.com/StackStorm/discussions/wiki/Release-Management-Rotation) when we had a shortage of folks willing to help with the release responsibilities. This is a hard work that should be rewarded and I'd like to propose adding AJ (@guzzijones) to the list of StackStorm Maintainers.

As https://github.com/StackStorm/st2/pull/5329 opened the door for the new Maintainers, I hope to see him participating even more in the future project development and sure he will be a great addition to the team that deeply cares about the project's future!
