### PR TITLE
Avoid mongodb compatibility regression by using 'ping' instead of 'hello' command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,7 +29,7 @@ Changed
 
   Contributed by @ericreeves.
 
-* update db connect mongo connection test - `isMaster` MongoDB command depreciated, switch to `hello` #5302
+* update db connect mongo connection test - `isMaster` MongoDB command depreciated, switch to `ping` #5302, #5341
 
   Contributed by @lukepatrick
 

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -199,9 +199,9 @@ def _db_connect(
     # successfully established.
     # See http://api.mongodb.com/python/current/api/pymongo/mongo_client.html for details
     try:
-        # The hello command is cheap and does not require auth
-        # https://docs.mongodb.com/v4.4/reference/command/hello/
-        connection.admin.command("hello")
+        # The ping command is cheap and does not require auth
+        # https://www.mongodb.com/community/forums/t/how-to-use-the-new-hello-interface-for-availability/116748/
+        connection.admin.command("ping")
     except (ConnectionFailure, ServerSelectionTimeoutError) as e:
         # NOTE: ServerSelectionTimeoutError can also be thrown if SSLHandShake fails in the server
         # Sadly the client doesn't include more information about the error so in such scenarios


### PR DESCRIPTION
A follow-up to https://github.com/StackStorm/st2/pull/5302 where we replaced `isMaster` with `hello` for checking Mongo connection. Instead of mongodb version-specific `hello`, use `ping` instead that works with any mongo version as a safer alternative.

See https://www.mongodb.com/community/forums/t/how-to-use-the-new-hello-interface-for-availability/116748/

Credit goes to @blag for finding a better solution.
@lukepatrick would appreciate your feedback as well if we're good here.
