### PR TITLE
Add Carlos (@nzlosh) to TSC maintainers

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -33,6 +33,8 @@ Have deep platform knowledge & experience and demonstrate technical leadership a
 Being part of Technical Steering Committee (TSC) [@StackStorm/maintainers](https://github.com/orgs/StackStorm/teams/maintainers) provide significant and reliable value to the project helping it grow and improve through development and maintenance. See [Maintainer Responsibilities](https://github.com/StackStorm/st2/blob/master/GOVERNANCE.md#maintainer-responsibilities) for more info.
 * Amanda McGuinness ([@amanda11](https://github.com/amanda11)) <<amanda.mcguinness@ammeonsolutions.com>>
   - Ansible, Core, deb/rpm packages, CI/CD, Deployments, StackStorm Exchange, Documentation.
+* Carlos ([@nzlosh](https://github.com/nzlosh)) <<nzlosh@yahoo.com>>
+  - Packaging, Systems, Chatops, Errbot, Community, Discussions, StackStorm Exchange.
 * JP Bourget ([@punkrokk](https://github.com/punkrokk)) <<jp.bourget@gmail.com>>
   - Systems, deb/rpm, Deployments, Community, StackStorm Exchange, SecOps, CircleCI.
 * Marcel Weinberg ([@winem](https://github.com/winem)), _CoreMedia_ <<mweinberg-os@email.de>>
@@ -48,7 +50,6 @@ They're not part of the TSC voting process, but appreciated for their contributi
 [@StackStorm/contributors](https://github.com/orgs/StackStorm/teams/contributors) are invited to StackStorm Github organization and have permissions to help triage the Issues and review PRs.
 * Anand Patel ([@arms11](https://github.com/arms11)), _VMware_ - Docker, Kubernetes.
 * AJ Jonen ([@guzzijones](https://github.com/guzzijones)) - ST2 Web UI, Orquesta, Core.
-* Carlos ([@nzlosh](https://github.com/nzlosh)) - Chatops, Errbot, Community, Discussions, StackStorm Exchange.
 * Harsh Nanchahal ([@hnanchahal](https://github.com/hnanchahal)), _Starbucks_ - Core, Docker, Kubernetes.
 * Hiroyasu Ohyama ([@userlocalhost](https://github.com/userlocalhost)) - Orquesta, Workflows, st2 Japan Community. [Case Study](https://stackstorm.com/case-study-dmm/).
 * Jacob Floyd ([@cognifloyd](https://github.com/cognifloyd/)), _Copart_ - StackStorm Exchange, ChatOps, Core, Discussions.


### PR DESCRIPTION
Carlos is one of the earliest community members and is known as someone who deeply cares about the StackStorm ChatOps and Open Source future.

He's a creator behind the Python-based [err-stackstorm](https://github.com/nzlosh/err-stackstorm) project as an alternative to the Javascript-based st2chatops.
Contributed to the numerous StackStorm-Exchange packs: `Consul`, `PowerDNS`, `syslog`, `icinga2`, `opsgenie`, `salt`, `prometheus`.

For the past half-year he became highly active in his StackStorm core contributions with significant efforts around the most recent `v3.5.0` release where he worked in a team with other TSC Members (@amanda11 @winem @Kami @blag) to ship the big [Plan: Python 3.8 support for Ubuntu 20.04 #68](https://github.com/StackStorm/discussions/issues/68). All these critical changes successfully landed the most recent v3.5 release and are working flawlessly.

For the upcoming `v3.6` he's working on the feature to make the st2 service ports to be easily configurable:
- https://github.com/StackStorm/st2-packages/pull/706
- https://github.com/StackStorm/st2/pull/5286

Carlos is active on Forums (https://forum.stackstorm.com/u/carlos/activity), in Slack, `#development`, and taking part in the ongoing StackStorm Pull Request reviews, as well as a regular visitor in the TSC Meetings.

With all of that, he's already a fully involved project Maintainer and it's a pleasure to propose adding Carlos (@nzlosh) to the official StackStorm TSC!