### PR TITLE
Bug fix in modified action delete API

### DIFF
--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -258,9 +258,17 @@ class ActionsController(resource.ContentPackResourceController):
                 entry_point=entry_point,
                 metadata_file=metadata_file,
             )
+
+        except PermissionError as e:
+            LOG.error("No permission to delete resource files from disk.")
+            action_db.id = None
+            Action.add_or_update(action_db)
+            abort(http_client.FORBIDDEN, six.text_type(e))
+            return
+
         except Exception as e:
             LOG.error(
-                "Exception encountered during deleting resource files from disk."
+                "Exception encountered during deleting resource files from disk. "
                 "Exception was %s",
                 e,
             )

--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -264,6 +264,9 @@ class ActionsController(resource.ContentPackResourceController):
                 "Exception was %s",
                 e,
             )
+            action = ActionAPI.from_model(action_db)
+            action_db = ActionAPI.to_model(action)
+            Action.add_or_update(action_db)
             abort(http_client.INTERNAL_SERVER_ERROR, six.text_type(e))
             return
 

--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -264,8 +264,7 @@ class ActionsController(resource.ContentPackResourceController):
                 "Exception was %s",
                 e,
             )
-            action = ActionAPI.from_model(action_db)
-            action_db = ActionAPI.to_model(action)
+            action_db.id = None
             Action.add_or_update(action_db)
             abort(http_client.INTERNAL_SERVER_ERROR, six.text_type(e))
             return

--- a/st2api/tests/unit/controllers/v1/test_actions.py
+++ b/st2api/tests/unit/controllers/v1/test_actions.py
@@ -626,6 +626,23 @@ class ActionsControllerTestCase(
         del_resp = self.__do_delete(self.__get_action_id(post_resp))
         self.assertEqual(del_resp.status_int, 204)
 
+    @mock.patch("st2api.controllers.v1.actions.delete_action_files_from_pack")
+    @mock.patch.object(
+        action_validator, "validate_action", mock.MagicMock(return_value=True)
+    )
+    def test_delete_exception_to_remove_action_files(
+        self, mock_delete_action_files_from_pack
+    ):
+        msg = "No permission to delete action files from disk"
+        mock_delete_action_files_from_pack.side_effect = PermissionError(msg)
+        post_resp = self.__do_post(ACTION_1)
+        with mock.patch("st2api.controllers.v1.actions.Action.add_or_update"):
+            del_resp = self.__do_delete(
+                self.__get_action_id(post_resp), expect_errors=True
+            )
+            self.assertEqual(del_resp.status_int, 500)
+            self.assertEqual(del_resp.json["faultstring"], msg)
+
     @mock.patch.object(
         action_validator, "validate_action", mock.MagicMock(return_value=True)
     )


### PR DESCRIPTION
Currently if PermissionError (or any other exception) occurs during removing files from disk, action delete operation deregisters the action from database but action files remains in filesystem i.e. this operation leaving st2 in an inconsistent state. So, it is required to rollback the operation and register action to database again if such case occurs.