### PR TITLE
Action delete API rework - support for action file deletion

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,12 +7,16 @@ in development
 Changed
 ~~~~~~~
 
-* Modified action delete api. Action delete api removes related action/workflow files on disk
-  along with de-registering them from database. Prompts on CLI for user permission before
-  removing disk files.
+* Modified action delete API to delete action files from disk along with backward compatibility.
 
-  ``-f`` and ``--force`` arguments added for action delete CLI command as auto yes flag and
-  will delete related files on disk without prompting for user permission. #5304
+  From CLI ``st2 action delete <pack>.<action>`` will delete only action database entry.
+  From CLI ``st2 action delete --remove-files <pack>.<action>`` or ``st2 action delete -r <pack>.<action>``
+  will delete action database entry along with files from disk.
+
+  API action DELETE method with ``{"remove_files": true}`` argument in json body will remove database
+  entry of action along with files from disk.
+  API action DELETE method with ``{"remove_files": false}`` or no additional argument in json body will remove
+  only action database entry. #5304, #5351, #5360
 
   Contributed by @mahesh-orch.
 

--- a/st2api/st2api/controllers/v1/actions.py
+++ b/st2api/st2api/controllers/v1/actions.py
@@ -206,7 +206,7 @@ class ActionsController(resource.ContentPackResourceController):
 
         return action_api
 
-    def delete(self, files_remove_request, ref_or_id, requester_user):
+    def delete(self, options, ref_or_id, requester_user):
         """
         Delete an action.
 
@@ -240,7 +240,6 @@ class ActionsController(resource.ContentPackResourceController):
         pack_name = action_db["pack"]
         entry_point = action_db["entry_point"]
         metadata_file = action_db["metadata_file"]
-        remove_files = files_remove_request.remove_files
 
         try:
             Action.delete(action_db)
@@ -254,7 +253,7 @@ class ActionsController(resource.ContentPackResourceController):
             abort(http_client.INTERNAL_SERVER_ERROR, six.text_type(e))
             return
 
-        if remove_files:
+        if options.remove_files:
             try:
                 delete_action_files_from_pack(
                     pack_name=pack_name,

--- a/st2api/tests/unit/controllers/v1/test_actions.py
+++ b/st2api/tests/unit/controllers/v1/test_actions.py
@@ -618,13 +618,52 @@ class ActionsControllerTestCase(
         post_resp = self.__do_post(ACTION_15)
         self.assertEqual(post_resp.status_int, 201)
 
+    @mock.patch("st2api.controllers.v1.actions.delete_action_files_from_pack")
     @mock.patch.object(
         action_validator, "validate_action", mock.MagicMock(return_value=True)
     )
-    def test_delete(self):
+    def test_delete(self, mock_remove_files):
         post_resp = self.__do_post(ACTION_1)
-        del_resp = self.__do_delete(self.__get_action_id(post_resp))
+        action_id = self.__get_action_id(post_resp)
+        del_resp = self.__do_delete(action_id)
         self.assertEqual(del_resp.status_int, 204)
+        mock_remove_files.assert_not_called()
+        get_resp = self.__do_get_one(action_id, expect_errors=True)
+        expected_msg = 'Resource with a reference or id "%s" not found' % action_id
+        actual_msg = get_resp.json["faultstring"]
+        self.assertEqual(actual_msg, expected_msg)
+
+    @mock.patch("st2api.controllers.v1.actions.delete_action_files_from_pack")
+    @mock.patch.object(
+        action_validator, "validate_action", mock.MagicMock(return_value=True)
+    )
+    def test_delete_remove_files_false(self, mock_remove_files):
+        post_resp = self.__do_post(ACTION_1)
+        action_id = self.__get_action_id(post_resp)
+        payload = {"remove_files": False}
+        del_resp = self.__do_delete_action_with_files(payload, action_id)
+        self.assertEqual(del_resp.status_int, 204)
+        mock_remove_files.assert_not_called()
+        get_resp = self.__do_get_one(action_id, expect_errors=True)
+        expected_msg = 'Resource with a reference or id "%s" not found' % action_id
+        actual_msg = get_resp.json["faultstring"]
+        self.assertEqual(actual_msg, expected_msg)
+
+    @mock.patch("st2api.controllers.v1.actions.delete_action_files_from_pack")
+    @mock.patch.object(
+        action_validator, "validate_action", mock.MagicMock(return_value=True)
+    )
+    def test_delete_remove_files_true(self, mock_remove_files):
+        post_resp = self.__do_post(ACTION_1)
+        action_id = self.__get_action_id(post_resp)
+        payload = {"remove_files": True}
+        del_resp = self.__do_delete_action_with_files(payload, action_id)
+        self.assertEqual(del_resp.status_int, 204)
+        self.assertTrue(mock_remove_files.called)
+        get_resp = self.__do_get_one(action_id, expect_errors=True)
+        expected_msg = 'Resource with a reference or id "%s" not found' % action_id
+        actual_msg = get_resp.json["faultstring"]
+        self.assertEqual(actual_msg, expected_msg)
 
     @mock.patch.object(
         action_validator, "validate_action", mock.MagicMock(return_value=True)
@@ -857,11 +896,9 @@ class ActionsControllerTestCase(
             "/v1/actions/%s" % action_id, expect_errors=expect_errors
         )
 
-    def __do_delete_action_with_files(
-        self, files_remove_request, action_id, expect_errors=False
-    ):
+    def __do_delete_action_with_files(self, options, action_id, expect_errors=False):
         return self.app.delete_json(
             "/v1/actions/%s" % action_id,
-            files_remove_request,
+            options,
             expect_errors=expect_errors,
         )

--- a/st2api/tests/unit/controllers/v1/test_actions.py
+++ b/st2api/tests/unit/controllers/v1/test_actions.py
@@ -629,6 +629,60 @@ class ActionsControllerTestCase(
     @mock.patch.object(
         action_validator, "validate_action", mock.MagicMock(return_value=True)
     )
+    def test_delete_permission_error_and_action_reregistered_to_database(self):
+        post_resp = self.__do_post(ACTION_1)
+
+        with mock.patch(
+            "st2api.controllers.v1.actions.delete_action_files_from_pack"
+        ) as mock_remove_files:
+            msg = "No permission to delete action files from disk"
+            mock_remove_files.side_effect = PermissionError(msg)
+            payload = {"remove_files": True}
+            del_resp = self.__do_delete_action_with_files(
+                payload, self.__get_action_id(post_resp), expect_errors=True
+            )
+            self.assertEqual(del_resp.status_int, 403)
+            self.assertEqual(del_resp.json["faultstring"], msg)
+
+        # retrieving reregistered action
+        get_resp = self.__do_get_actions_by_url_parameter("name", ACTION_1["name"])
+        expected_uid = post_resp.json["uid"]
+        actual_uid = get_resp.json[0]["uid"]
+        self.assertEqual(actual_uid, expected_uid)
+        action_id = get_resp.json[0]["id"]
+        del_resp = self.__do_delete(action_id)
+        self.assertEqual(del_resp.status_int, 204)
+
+    @mock.patch.object(
+        action_validator, "validate_action", mock.MagicMock(return_value=True)
+    )
+    def test_delete_exception_and_action_reregistered_to_database(self):
+        post_resp = self.__do_post(ACTION_1)
+
+        with mock.patch(
+            "st2api.controllers.v1.actions.delete_action_files_from_pack"
+        ) as mock_remove_files:
+            msg = "Exception encountered during removing files from disk"
+            mock_remove_files.side_effect = Exception(msg)
+            payload = {"remove_files": True}
+            del_resp = self.__do_delete_action_with_files(
+                payload, self.__get_action_id(post_resp), expect_errors=True
+            )
+            self.assertEqual(del_resp.status_int, 500)
+            self.assertEqual(del_resp.json["faultstring"], msg)
+
+        # retrieving reregistered action
+        get_resp = self.__do_get_actions_by_url_parameter("name", ACTION_1["name"])
+        expected_uid = post_resp.json["uid"]
+        actual_uid = get_resp.json[0]["uid"]
+        self.assertEqual(actual_uid, expected_uid)
+        action_id = get_resp.json[0]["id"]
+        del_resp = self.__do_delete(action_id)
+        self.assertEqual(del_resp.status_int, 204)
+
+    @mock.patch.object(
+        action_validator, "validate_action", mock.MagicMock(return_value=True)
+    )
     def test_action_with_tags(self):
         post_resp = self.__do_post(ACTION_1)
         action_id = self.__get_action_id(post_resp)
@@ -801,4 +855,13 @@ class ActionsControllerTestCase(
     def __do_delete(self, action_id, expect_errors=False):
         return self.app.delete(
             "/v1/actions/%s" % action_id, expect_errors=expect_errors
+        )
+
+    def __do_delete_action_with_files(
+        self, files_remove_request, action_id, expect_errors=False
+    ):
+        return self.app.delete_json(
+            "/v1/actions/%s" % action_id,
+            files_remove_request,
+            expect_errors=expect_errors,
         )

--- a/st2api/tests/unit/controllers/v1/test_actions.py
+++ b/st2api/tests/unit/controllers/v1/test_actions.py
@@ -628,6 +628,7 @@ class ActionsControllerTestCase(
         del_resp = self.__do_delete(action_id)
         self.assertEqual(del_resp.status_int, 204)
         mock_remove_files.assert_not_called()
+        # asserting ACTION_1 database entry has removed
         get_resp = self.__do_get_one(action_id, expect_errors=True)
         expected_msg = 'Resource with a reference or id "%s" not found' % action_id
         actual_msg = get_resp.json["faultstring"]

--- a/st2api/tests/unit/controllers/v1/test_actions.py
+++ b/st2api/tests/unit/controllers/v1/test_actions.py
@@ -628,6 +628,7 @@ class ActionsControllerTestCase(
         del_resp = self.__do_delete(action_id)
         self.assertEqual(del_resp.status_int, 204)
         mock_remove_files.assert_not_called()
+
         # asserting ACTION_1 database entry has removed
         get_resp = self.__do_get_one(action_id, expect_errors=True)
         expected_msg = 'Resource with a reference or id "%s" not found' % action_id

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -282,7 +282,7 @@ class ActionDeleteCommand(resource.ContentPackResourceDeleteCommand):
         super(ActionDeleteCommand, self).__init__(resource, *args, **kwargs)
 
         self.parser.add_argument(
-            "-rf",
+            "-r",
             "--remove-files",
             action="store_true",
             dest="remove_files",

--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -286,6 +286,7 @@ class ActionDeleteCommand(resource.ContentPackResourceDeleteCommand):
             "--remove-files",
             action="store_true",
             dest="remove_files",
+            default=False,
             help="Remove action files from disk.",
         )
 
@@ -293,11 +294,7 @@ class ActionDeleteCommand(resource.ContentPackResourceDeleteCommand):
     def run(self, args, **kwargs):
         resource_id = getattr(args, self.pk_argument_name, None)
         instance = self.get_resource(resource_id, **kwargs)
-        if args.remove_files:
-            remove_files = True
-        else:
-            remove_files = False
-
+        remove_files = args.remove_files
         self.manager.delete_action(instance, remove_files, **kwargs)
         print('Resource with id "%s" has been successfully deleted.' % (resource_id))
 

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -377,6 +377,21 @@ class ResourceManager(object):
         return True
 
     @add_auth_token_to_kwargs_from_env
+    def delete_action(self, instance, remove_files, **kwargs):
+        url = "/%s/%s" % (self.resource.get_url_path_name(), instance.id)
+        payload = {"remove_files": remove_files}
+        response = self.client.delete(url, data=orjson.dumps(payload), **kwargs)
+        if response.status_code not in [
+            http_client.OK,
+            http_client.NO_CONTENT,
+            http_client.NOT_FOUND,
+        ]:
+            self.handle_error(response)
+            return False
+
+        return True
+
+    @add_auth_token_to_kwargs_from_env
     def delete_by_id(self, instance_id, **kwargs):
         url = "/%s/%s" % (self.resource.get_url_path_name(), instance_id)
         response = self.client.delete(url, **kwargs)

--- a/st2client/tests/unit/test_models.py
+++ b/st2client/tests/unit/test_models.py
@@ -355,6 +355,56 @@ class TestResourceManager(unittest2.TestCase):
         instance = mgr.get_by_name("abc")
         self.assertRaises(Exception, mgr.delete, instance)
 
+    @mock.patch.object(
+        httpclient.HTTPClient,
+        "get",
+        mock.MagicMock(
+            return_value=base.FakeResponse(
+                json.dumps([base.RESOURCES[0]]), 200, "OK", {}
+            )
+        ),
+    )
+    @mock.patch.object(
+        httpclient.HTTPClient,
+        "delete",
+        mock.MagicMock(return_value=base.FakeResponse("", 204, "NO CONTENT")),
+    )
+    def test_resource_delete_action(self):
+        mgr = models.ResourceManager(base.FakeResource, base.FAKE_ENDPOINT)
+        instance = mgr.get_by_name("abc")
+        mgr.delete_action(instance, True)
+
+    @mock.patch.object(
+        httpclient.HTTPClient,
+        "delete",
+        mock.MagicMock(return_value=base.FakeResponse("", 404, "NOT FOUND")),
+    )
+    def test_resource_delete_action_404(self):
+        mgr = models.ResourceManager(base.FakeResource, base.FAKE_ENDPOINT)
+        instance = base.FakeResource.deserialize(base.RESOURCES[0])
+        mgr.delete_action(instance, False)
+
+    @mock.patch.object(
+        httpclient.HTTPClient,
+        "get",
+        mock.MagicMock(
+            return_value=base.FakeResponse(
+                json.dumps([base.RESOURCES[0]]), 200, "OK", {}
+            )
+        ),
+    )
+    @mock.patch.object(
+        httpclient.HTTPClient,
+        "delete",
+        mock.MagicMock(
+            return_value=base.FakeResponse("", 500, "INTERNAL SERVER ERROR")
+        ),
+    )
+    def test_resource_delete_action_failed(self):
+        mgr = models.ResourceManager(base.FakeResource, base.FAKE_ENDPOINT)
+        instance = mgr.get_by_name("abc")
+        self.assertRaises(Exception, mgr.delete_action, instance, True)
+
     @mock.patch("requests.get")
     @mock.patch("sseclient.SSEClient")
     def test_stream_resource_listen(self, mock_sseclient, mock_requests):

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -413,6 +413,11 @@ paths:
           description: Entity reference or id
           type: string
           required: true
+        - name: files_remove_request
+          in: body
+          description: Flag to remove action files from disk
+          schema:
+            $ref: '#/definitions/ActionDeleteRequest'
       x-parameters:
         - name: user
           in: context
@@ -4684,6 +4689,9 @@ definitions:
     allOf:
       - $ref: '#/definitions/Action'
       - $ref: '#/definitions/DataFilesSubSchema'
+  ActionDeleteRequest:
+    allOf:
+      - $ref: '#/definitions/ActionDeleteSchema'
   ActionParameters:
     type: object
     properties:
@@ -5383,6 +5391,14 @@ definitions:
         description: Channels to post notifications to.
         items:
           type: string
+    additionalProperties: false
+  ActionDeleteSchema:
+    type: object
+    properties:
+      remove_files:
+        type: boolean
+        description: Force delete action files from disk
+        default: false
     additionalProperties: false
   TokenRequest:
     type: object

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -5397,7 +5397,7 @@ definitions:
     properties:
       remove_files:
         type: boolean
-        description: Force delete action files from disk
+        description: Flag to delete action files from disk
         default: false
     additionalProperties: false
   TokenRequest:

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -413,7 +413,7 @@ paths:
           description: Entity reference or id
           type: string
           required: true
-        - name: files_remove_request
+        - name: options
           in: body
           description: Flag to remove action files from disk
           schema:

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -409,7 +409,7 @@ paths:
           description: Entity reference or id
           type: string
           required: true
-        - name: files_remove_request
+        - name: options
           in: body
           description: Flag to remove action files from disk
           schema:

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -409,6 +409,11 @@ paths:
           description: Entity reference or id
           type: string
           required: true
+        - name: files_remove_request
+          in: body
+          description: Flag to remove action files from disk
+          schema:
+            $ref: '#/definitions/ActionDeleteRequest'
       x-parameters:
         - name: user
           in: context
@@ -4680,6 +4685,9 @@ definitions:
     allOf:
       - $ref: '#/definitions/Action'
       - $ref: '#/definitions/DataFilesSubSchema'
+  ActionDeleteRequest:
+    allOf:
+      - $ref: '#/definitions/ActionDeleteSchema'
   ActionParameters:
     type: object
     properties:
@@ -5379,6 +5387,14 @@ definitions:
         description: Channels to post notifications to.
         items:
           type: string
+    additionalProperties: false
+  ActionDeleteSchema:
+    type: object
+    properties:
+      remove_files:
+        type: boolean
+        description: Force delete action files from disk
+        default: false
     additionalProperties: false
   TokenRequest:
     type: object

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -5393,7 +5393,7 @@ definitions:
     properties:
       remove_files:
         type: boolean
-        description: Force delete action files from disk
+        description: Flag to delete action files from disk
         default: false
     additionalProperties: false
   TokenRequest:


### PR DESCRIPTION
* Action delete API modification to have option to delete action database entry without removing files from disk
* From CLI `st2 action delete <pack>.<action>` will delete database entry only
* From CLI `st2 action delete --remove-files <pack>.<action>` will delete database entry and files.
* If action DELETE method has additional argument as `{"remove_files": true}` in the body then it will remove related action files from disk along with database entry.
* `{"remove_files": false}` or no additional argument in action DELETE method body will remove only database entry.