### PR TITLE
Add RBAC permission types for key value pairs

### DIFF
--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -602,7 +602,7 @@ PERMISION_TYPE_TO_DESCRIPTION_MAP = {
     PermissionType.KEY_VALUE_SET: ("Ability to set a Key-Value Pair."),
     PermissionType.KEY_VALUE_DELETE: ("Ability to delete an existing Key-Value Pair."),
     PermissionType.KEY_VALUE_ALL: (
-        "Ability to perform all the support operations on a Key-Value Pair."
+        "Ability to perform all the supported operations on a Key-Value Pair."
     ),
     PermissionType.TRACE_LIST: ("Ability to list (view all) traces."),
     PermissionType.TRACE_VIEW: ("Ability to view a trace."),

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -367,9 +367,11 @@ RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP = {
         PermissionType.EXECUTION_VIEWS_FILTERS_LIST,
     ],
     ResourceType.KEY_VALUE_PAIR: [
+        PermissionType.KEY_VALUE_LIST,
         PermissionType.KEY_VALUE_VIEW,
         PermissionType.KEY_VALUE_SET,
         PermissionType.KEY_VALUE_DELETE,
+        PermissionType.KEY_VALUE_ALL,
     ],
     ResourceType.WEBHOOK: [
         PermissionType.WEBHOOK_LIST,
@@ -595,9 +597,13 @@ PERMISION_TYPE_TO_DESCRIPTION_MAP = {
     PermissionType.API_KEY_ALL: (
         "Ability to perform all the supported operations on an API Key."
     ),
+    PermissionType.KEY_VALUE_LIST: ("Ability to list (view all) Key-Value Pairs."),
     PermissionType.KEY_VALUE_VIEW: ("Ability to view Key-Value Pairs."),
     PermissionType.KEY_VALUE_SET: ("Ability to set a Key-Value Pair."),
     PermissionType.KEY_VALUE_DELETE: ("Ability to delete an existing Key-Value Pair."),
+    PermissionType.KEY_VALUE_ALL: (
+        "Ability to perform all the support operations on a Key-Value Pair."
+    ),
     PermissionType.TRACE_LIST: ("Ability to list (view all) traces."),
     PermissionType.TRACE_VIEW: ("Ability to view a trace."),
     PermissionType.TRACE_ALL: (

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -105,9 +105,11 @@ class PermissionType(Enum):
     RULE_ENFORCEMENT_VIEW = "rule_enforcement_view"
 
     # TODO - Maybe "datastore_item" / key_value_item ?
+    KEY_VALUE_LIST = "key_value_pair_list"
     KEY_VALUE_VIEW = "key_value_pair_view"
     KEY_VALUE_SET = "key_value_pair_set"
     KEY_VALUE_DELETE = "key_value_pair_delete"
+    KEY_VALUE_ALL = "key_value_pair_all"
 
     WEBHOOK_LIST = "webhook_list"
     WEBHOOK_VIEW = "webhook_view"


### PR DESCRIPTION
Add RBAC permission types for key value pairs so the changes at https://github.com/StackStorm/st2-rbac-backend/pull/55 to introduce RBAC to KVP can pass CI.