### PR TITLE
Rename prefix of KEY_VALUE permission types to KEY_VALUE_PAIR

### DIFF
--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -1530,7 +1530,7 @@ paths:
   /api/v1/keys:
     get:
       operationId: st2api.controllers.v1.keyvalue:key_value_pair_controller.get_all
-      x-permissions: 
+      x-permissions: key_value_pair_list
       description: Returns a list of all key value pairs.
       parameters:
         - name: prefix

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -105,11 +105,11 @@ class PermissionType(Enum):
     RULE_ENFORCEMENT_VIEW = "rule_enforcement_view"
 
     # TODO - Maybe "datastore_item" / key_value_item ?
-    KEY_VALUE_LIST = "key_value_pair_list"
-    KEY_VALUE_VIEW = "key_value_pair_view"
-    KEY_VALUE_SET = "key_value_pair_set"
-    KEY_VALUE_DELETE = "key_value_pair_delete"
-    KEY_VALUE_ALL = "key_value_pair_all"
+    KEY_VALUE_PAIR_LIST = "key_value_pair_list"
+    KEY_VALUE_PAIR_VIEW = "key_value_pair_view"
+    KEY_VALUE_PAIR_SET = "key_value_pair_set"
+    KEY_VALUE_PAIR_DELETE = "key_value_pair_delete"
+    KEY_VALUE_PAIR_ALL = "key_value_pair_all"
 
     WEBHOOK_LIST = "webhook_list"
     WEBHOOK_VIEW = "webhook_view"
@@ -367,11 +367,11 @@ RESOURCE_TYPE_TO_PERMISSION_TYPES_MAP = {
         PermissionType.EXECUTION_VIEWS_FILTERS_LIST,
     ],
     ResourceType.KEY_VALUE_PAIR: [
-        PermissionType.KEY_VALUE_LIST,
-        PermissionType.KEY_VALUE_VIEW,
-        PermissionType.KEY_VALUE_SET,
-        PermissionType.KEY_VALUE_DELETE,
-        PermissionType.KEY_VALUE_ALL,
+        PermissionType.KEY_VALUE_PAIR_LIST,
+        PermissionType.KEY_VALUE_PAIR_VIEW,
+        PermissionType.KEY_VALUE_PAIR_SET,
+        PermissionType.KEY_VALUE_PAIR_DELETE,
+        PermissionType.KEY_VALUE_PAIR_ALL,
     ],
     ResourceType.WEBHOOK: [
         PermissionType.WEBHOOK_LIST,
@@ -597,11 +597,11 @@ PERMISION_TYPE_TO_DESCRIPTION_MAP = {
     PermissionType.API_KEY_ALL: (
         "Ability to perform all the supported operations on an API Key."
     ),
-    PermissionType.KEY_VALUE_LIST: ("Ability to list (view all) Key-Value Pairs."),
-    PermissionType.KEY_VALUE_VIEW: ("Ability to view Key-Value Pairs."),
-    PermissionType.KEY_VALUE_SET: ("Ability to set a Key-Value Pair."),
-    PermissionType.KEY_VALUE_DELETE: ("Ability to delete an existing Key-Value Pair."),
-    PermissionType.KEY_VALUE_ALL: (
+    PermissionType.KEY_VALUE_PAIR_LIST: ("Ability to list (view all) Key-Value Pairs."),
+    PermissionType.KEY_VALUE_PAIR_VIEW: ("Ability to view Key-Value Pairs."),
+    PermissionType.KEY_VALUE_PAIR_SET: ("Ability to set a Key-Value Pair."),
+    PermissionType.KEY_VALUE_PAIR_DELETE: ("Ability to delete an existing Key-Value Pair."),
+    PermissionType.KEY_VALUE_PAIR_ALL: (
         "Ability to perform all the supported operations on a Key-Value Pair."
     ),
     PermissionType.TRACE_LIST: ("Ability to list (view all) traces."),

--- a/st2common/st2common/rbac/types.py
+++ b/st2common/st2common/rbac/types.py
@@ -600,7 +600,9 @@ PERMISION_TYPE_TO_DESCRIPTION_MAP = {
     PermissionType.KEY_VALUE_PAIR_LIST: ("Ability to list (view all) Key-Value Pairs."),
     PermissionType.KEY_VALUE_PAIR_VIEW: ("Ability to view Key-Value Pairs."),
     PermissionType.KEY_VALUE_PAIR_SET: ("Ability to set a Key-Value Pair."),
-    PermissionType.KEY_VALUE_PAIR_DELETE: ("Ability to delete an existing Key-Value Pair."),
+    PermissionType.KEY_VALUE_PAIR_DELETE: (
+        "Ability to delete an existing Key-Value Pair."
+    ),
     PermissionType.KEY_VALUE_PAIR_ALL: (
         "Ability to perform all the supported operations on a Key-Value Pair."
     ),

--- a/st2common/tests/unit/test_rbac_types.py
+++ b/st2common/tests/unit/test_rbac_types.py
@@ -289,7 +289,9 @@ class RBACPermissionTypeTestCase(TestCase):
             PermissionType.KEY_VALUE_PAIR_SET,
         )
         self.assertEqual(
-            PermissionType.get_permission_type(resource_type=t, permission_name="delete"),
+            PermissionType.get_permission_type(
+                resource_type=t, permission_name="delete"
+            ),
             PermissionType.KEY_VALUE_PAIR_DELETE,
         )
         self.assertEqual(
@@ -325,16 +327,19 @@ class RBACPermissionTypeTestCase(TestCase):
         )
 
         self.assertEqual(
-            PermissionType.get_permission_name(PermissionType.KEY_VALUE_PAIR_LIST), "list"
+            PermissionType.get_permission_name(PermissionType.KEY_VALUE_PAIR_LIST),
+            "list",
         )
         self.assertEqual(
-            PermissionType.get_permission_name(PermissionType.KEY_VALUE_PAIR_VIEW), "view"
+            PermissionType.get_permission_name(PermissionType.KEY_VALUE_PAIR_VIEW),
+            "view",
         )
         self.assertEqual(
             PermissionType.get_permission_name(PermissionType.KEY_VALUE_PAIR_SET), "set"
         )
         self.assertEqual(
-            PermissionType.get_permission_name(PermissionType.KEY_VALUE_PAIR_DELETE), "delete"
+            PermissionType.get_permission_name(PermissionType.KEY_VALUE_PAIR_DELETE),
+            "delete",
         )
         self.assertEqual(
             PermissionType.get_permission_name(PermissionType.KEY_VALUE_PAIR_ALL), "all"

--- a/st2common/tests/unit/test_rbac_types.py
+++ b/st2common/tests/unit/test_rbac_types.py
@@ -161,15 +161,23 @@ class RBACPermissionTypeTestCase(TestCase):
         )
 
         self.assertEqual(
-            PermissionType.get_resource_type(PermissionType.KEY_VALUE_VIEW),
+            PermissionType.get_resource_type(PermissionType.KEY_VALUE_PAIR_LIST),
             SystemType.KEY_VALUE_PAIR,
         )
         self.assertEqual(
-            PermissionType.get_resource_type(PermissionType.KEY_VALUE_SET),
+            PermissionType.get_resource_type(PermissionType.KEY_VALUE_PAIR_VIEW),
             SystemType.KEY_VALUE_PAIR,
         )
         self.assertEqual(
-            PermissionType.get_resource_type(PermissionType.KEY_VALUE_DELETE),
+            PermissionType.get_resource_type(PermissionType.KEY_VALUE_PAIR_SET),
+            SystemType.KEY_VALUE_PAIR,
+        )
+        self.assertEqual(
+            PermissionType.get_resource_type(PermissionType.KEY_VALUE_PAIR_DELETE),
+            SystemType.KEY_VALUE_PAIR,
+        )
+        self.assertEqual(
+            PermissionType.get_resource_type(PermissionType.KEY_VALUE_PAIR_ALL),
             SystemType.KEY_VALUE_PAIR,
         )
 
@@ -267,6 +275,28 @@ class RBACPermissionTypeTestCase(TestCase):
             PermissionType.RULE_ENFORCEMENT_VIEW,
         )
 
+        t = ResourceType.KEY_VALUE_PAIR
+        self.assertEqual(
+            PermissionType.get_permission_type(resource_type=t, permission_name="list"),
+            PermissionType.KEY_VALUE_PAIR_LIST,
+        )
+        self.assertEqual(
+            PermissionType.get_permission_type(resource_type=t, permission_name="view"),
+            PermissionType.KEY_VALUE_PAIR_VIEW,
+        )
+        self.assertEqual(
+            PermissionType.get_permission_type(resource_type=t, permission_name="set"),
+            PermissionType.KEY_VALUE_PAIR_SET,
+        )
+        self.assertEqual(
+            PermissionType.get_permission_type(resource_type=t, permission_name="delete"),
+            PermissionType.KEY_VALUE_PAIR_DELETE,
+        )
+        self.assertEqual(
+            PermissionType.get_permission_type(resource_type=t, permission_name="all"),
+            PermissionType.KEY_VALUE_PAIR_ALL,
+        )
+
     def test_get_permission_name(self):
         self.assertEqual(
             PermissionType.get_permission_name(PermissionType.ACTION_LIST), "list"
@@ -292,4 +322,20 @@ class RBACPermissionTypeTestCase(TestCase):
         self.assertEqual(
             PermissionType.get_permission_name(PermissionType.RULE_ENFORCEMENT_LIST),
             "list",
+        )
+
+        self.assertEqual(
+            PermissionType.get_permission_name(PermissionType.KEY_VALUE_PAIR_LIST), "list"
+        )
+        self.assertEqual(
+            PermissionType.get_permission_name(PermissionType.KEY_VALUE_PAIR_VIEW), "view"
+        )
+        self.assertEqual(
+            PermissionType.get_permission_name(PermissionType.KEY_VALUE_PAIR_SET), "set"
+        )
+        self.assertEqual(
+            PermissionType.get_permission_name(PermissionType.KEY_VALUE_PAIR_DELETE), "delete"
+        )
+        self.assertEqual(
+            PermissionType.get_permission_name(PermissionType.KEY_VALUE_PAIR_ALL), "all"
         )


### PR DESCRIPTION
The function get_permission_type uses the string value of ResourceType.KEY_VALUE_PAIR which is key_value_pair to return the enum for the permission type. Since the permissions are prefixed with KEY_VALUE and not KEY_VALUE_PAIR, get_permission_types return not found error.