### PR TITLE
Add changelog entries for 3.6 Release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,12 @@ Added
 
 * Added possibility to add new values to the KV store via CLI without leaking them to the shell history. #5164
 
+* Replaced the static ``.socket`` sytemd units in deb and rpm packages with a python-based generator for the
+  ``st2api``, ``st2auth``, and ``st2stream`` services. The generators will get ``<ip>:<port>`` from ``st2.conf``
+  to create the ``.socket`` files dynamically. #5286 and st2-packages#706
+
+  Contributed by @nzlosh
+
 Changed
 ~~~~~~~
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -78,10 +78,10 @@ Changed
 
   This functionality should never be used in production, but only in development environments or
   similar when debugging code. #5199
-  
+
 * Updated Bash installer to install latest RabbitMQ version rather than out-dated version available
   in OS distributions.
-  
+
   Contributed by @amanda11, Ammeon Solutions
 
 Fixed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,9 @@ Added
 
 * Added possibility to add new values to the KV store via CLI without leaking them to the shell history. #5164
 
-* Replaced the static ``.socket`` sytemd units in deb and rpm packages with a python-based generator for the
+* ``st2.conf`` is now the only place to configure ports for ``st2api``, ``st2auth``, and ``st2stream``.
+
+  We replaced the static ``.socket`` sytemd units in deb and rpm packages with a python-based generator for the
   ``st2api``, ``st2auth``, and ``st2stream`` services. The generators will get ``<ip>:<port>`` from ``st2.conf``
   to create the ``.socket`` files dynamically. #5286 and st2-packages#706
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -78,6 +78,11 @@ Changed
 
   This functionality should never be used in production, but only in development environments or
   similar when debugging code. #5199
+  
+* Updated Bash installer to install latest RabbitMQ version rather than out-dated version available
+  in OS distributions.
+  
+  Contributed by @amanda11, Ammeon Solutions
 
 Fixed
 ~~~~~


### PR DESCRIPTION
Let's use this PR to do add any final entries to the changelog for the 3.6 release.

- [x] StackStorm/st2-packages#706
   StackStorm/st2#5286
- [x] StackStorm/st2-packages#709