### PR TITLE
Deregister services from service registry on shutdown

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Added
 ~~~~~
 
 * Added service degerestration on shutdown of a service. #5396
- 
+
   Contributed by @khushboobhatia01
 
 * Added possibility to add new values to the KV store via CLI without leaking them to the shell history. #5164

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ in development
 ------------------------
 
 Added
-~~~~
+~~~~~
 
 * Added service degerestration on shutdown of a service. #5396
  

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,11 @@ in development
 ------------------------
 
 Added
-~~~~~
+~~~~
+
+* Added service degerestration on shutdown of a service. #5396
+ 
+  Contributed by @khushboobhatia01
 
 * Added possibility to add new values to the KV store via CLI without leaking them to the shell history. #5164
 

--- a/st2actions/st2actions/cmd/actionrunner.py
+++ b/st2actions/st2actions/cmd/actionrunner.py
@@ -35,6 +35,7 @@ from st2common.service_setup import deregister_service
 __all__ = ["main"]
 
 LOG = logging.getLogger(__name__)
+ACTIONRUNNER = "actionrunner"
 
 
 def _setup_sigterm_handler():
@@ -50,7 +51,7 @@ def _setup_sigterm_handler():
 def _setup():
     capabilities = {"name": "actionrunner", "type": "passive"}
     common_setup(
-        service="actionrunner",
+        service=ACTIONRUNNER,
         config=config,
         setup_db=True,
         register_mq_exchanges=True,
@@ -76,7 +77,7 @@ def _run_worker():
         errors = False
 
         try:
-            deregister_service(service="actionrunner")
+            deregister_service(service=ACTIONRUNNER)
             action_worker.shutdown()
         except:
             LOG.exception("Unable to shutdown worker.")

--- a/st2actions/st2actions/cmd/actionrunner.py
+++ b/st2actions/st2actions/cmd/actionrunner.py
@@ -30,6 +30,7 @@ from st2actions import worker
 from st2common import log as logging
 from st2common.service_setup import setup as common_setup
 from st2common.service_setup import teardown as common_teardown
+from st2common.service_setup import deregister_service
 
 __all__ = ["main"]
 
@@ -75,6 +76,7 @@ def _run_worker():
         errors = False
 
         try:
+            deregister_service(service="actionrunner")
             action_worker.shutdown()
         except:
             LOG.exception("Unable to shutdown worker.")

--- a/st2actions/st2actions/cmd/scheduler.py
+++ b/st2actions/st2actions/cmd/scheduler.py
@@ -28,6 +28,7 @@ from st2actions.scheduler import config
 from st2common import log as logging
 from st2common.service_setup import teardown as common_teardown
 from st2common.service_setup import setup as common_setup
+from st2common.service_setup import deregister_service
 
 __all__ = ["main"]
 
@@ -101,6 +102,7 @@ def _run_scheduler():
         errors = False
 
         try:
+            deregister_service(service="scheduler")
             handler.shutdown()
             entrypoint.shutdown()
         except:

--- a/st2actions/st2actions/cmd/scheduler.py
+++ b/st2actions/st2actions/cmd/scheduler.py
@@ -33,6 +33,7 @@ from st2common.service_setup import deregister_service
 __all__ = ["main"]
 
 LOG = logging.getLogger(__name__)
+SCHEDULER = "scheduler"
 
 
 def _setup_sigterm_handler():
@@ -48,7 +49,7 @@ def _setup_sigterm_handler():
 def _setup():
     capabilities = {"name": "scheduler", "type": "passive"}
     common_setup(
-        service="scheduler",
+        service=SCHEDULER,
         config=config,
         setup_db=True,
         register_mq_exchanges=True,
@@ -102,7 +103,7 @@ def _run_scheduler():
         errors = False
 
         try:
-            deregister_service(service="scheduler")
+            deregister_service(service=SCHEDULER)
             handler.shutdown()
             entrypoint.shutdown()
         except:

--- a/st2actions/st2actions/cmd/st2notifier.py
+++ b/st2actions/st2actions/cmd/st2notifier.py
@@ -32,12 +32,13 @@ from st2actions.notifier import notifier
 __all__ = ["main"]
 
 LOG = logging.getLogger(__name__)
+NOTIFIER = "notifier"
 
 
 def _setup():
     capabilities = {"name": "notifier", "type": "passive"}
     common_setup(
-        service="notifier",
+        service=NOTIFIER,
         config=config,
         setup_db=True,
         register_mq_exchanges=True,
@@ -54,7 +55,7 @@ def _run_worker():
         actions_notifier.start(wait=True)
     except (KeyboardInterrupt, SystemExit):
         LOG.info("(PID=%s) Actions notifier stopped.", os.getpid())
-        deregister_service(service="notifier")
+        deregister_service(service=NOTIFIER)
         actions_notifier.shutdown()
     return 0
 

--- a/st2actions/st2actions/cmd/st2notifier.py
+++ b/st2actions/st2actions/cmd/st2notifier.py
@@ -25,6 +25,7 @@ import sys
 from st2common import log as logging
 from st2common.service_setup import setup as common_setup
 from st2common.service_setup import teardown as common_teardown
+from st2common.service_setup import deregister_service
 from st2actions.notifier import config
 from st2actions.notifier import notifier
 
@@ -53,6 +54,7 @@ def _run_worker():
         actions_notifier.start(wait=True)
     except (KeyboardInterrupt, SystemExit):
         LOG.info("(PID=%s) Actions notifier stopped.", os.getpid())
+        deregister_service(service="notifier")
         actions_notifier.shutdown()
     return 0
 

--- a/st2actions/st2actions/cmd/workflow_engine.py
+++ b/st2actions/st2actions/cmd/workflow_engine.py
@@ -32,11 +32,12 @@ from st2actions.workflows import workflows
 from st2common import log as logging
 from st2common.service_setup import setup as common_setup
 from st2common.service_setup import teardown as common_teardown
-from st2common.service_setup import deregister_service as deregister
+from st2common.service_setup import deregister_service
 
 __all__ = ["main"]
 
 LOG = logging.getLogger(__name__)
+WORKFLOW_ENGINE = "workflow_engine"
 
 
 def setup_sigterm_handler():
@@ -52,7 +53,7 @@ def setup_sigterm_handler():
 def setup():
     capabilities = {"name": "workflowengine", "type": "passive"}
     common_setup(
-        service="workflow_engine",
+        service=WORKFLOW_ENGINE,
         config=config,
         setup_db=True,
         register_mq_exchanges=True,
@@ -73,7 +74,7 @@ def run_server():
         engine.start(wait=True)
     except (KeyboardInterrupt, SystemExit):
         LOG.info("(PID=%s) Workflow engine stopped.", os.getpid())
-        deregister(service="workflow_engine")
+        deregister_service(service=WORKFLOW_ENGINE)
         engine.shutdown()
     except:
         LOG.exception("(PID=%s) Workflow engine unexpectedly stopped.", os.getpid())

--- a/st2actions/st2actions/cmd/workflow_engine.py
+++ b/st2actions/st2actions/cmd/workflow_engine.py
@@ -32,6 +32,7 @@ from st2actions.workflows import workflows
 from st2common import log as logging
 from st2common.service_setup import setup as common_setup
 from st2common.service_setup import teardown as common_teardown
+from st2common.service_setup import deregister_service as deregister
 
 __all__ = ["main"]
 
@@ -72,6 +73,7 @@ def run_server():
         engine.start(wait=True)
     except (KeyboardInterrupt, SystemExit):
         LOG.info("(PID=%s) Workflow engine stopped.", os.getpid())
+        deregister(service="workflow_engine")
         engine.shutdown()
     except:
         LOG.exception("(PID=%s) Workflow engine unexpectedly stopped.", os.getpid())

--- a/st2api/st2api/cmd/api.py
+++ b/st2api/st2api/cmd/api.py
@@ -31,6 +31,7 @@ from eventlet import wsgi
 from st2common import log as logging
 from st2common.service_setup import setup as common_setup
 from st2common.service_setup import teardown as common_teardown
+from st2common.service_setup import deregister_service
 from st2api import config
 
 config.register_opts(ignore_errors=True)
@@ -41,6 +42,7 @@ from st2api.validation import validate_rbac_is_correctly_configured
 __all__ = ["main"]
 
 LOG = logging.getLogger(__name__)
+API = "api"
 
 # How much time to give to the request in progress to finish in seconds before killing them
 WSGI_SERVER_REQUEST_SHUTDOWN_TIME = 2
@@ -55,7 +57,7 @@ def _setup():
     }
 
     common_setup(
-        service="api",
+        service=API,
         config=config,
         setup_db=True,
         register_mq_exchanges=True,
@@ -94,6 +96,7 @@ def main():
         _setup()
         return _run_server()
     except SystemExit as exit_code:
+        deregister_service(API)
         sys.exit(exit_code)
     except Exception:
         LOG.exception("(PID=%s) ST2 API quit due to exception.", os.getpid())

--- a/st2auth/st2auth/cmd/api.py
+++ b/st2auth/st2auth/cmd/api.py
@@ -27,6 +27,7 @@ from eventlet import wsgi
 from st2common import log as logging
 from st2common.service_setup import setup as common_setup
 from st2common.service_setup import teardown as common_teardown
+from st2common.service_setup import deregister_service
 from st2auth import config
 
 config.register_opts(ignore_errors=True)
@@ -39,6 +40,7 @@ __all__ = ["main"]
 
 
 LOG = logging.getLogger(__name__)
+AUTH = "auth"
 
 
 def _setup():
@@ -50,7 +52,7 @@ def _setup():
         "type": "active",
     }
     common_setup(
-        service="auth",
+        service=AUTH,
         config=config,
         setup_db=True,
         register_mq_exchanges=False,
@@ -108,6 +110,7 @@ def main():
         _setup()
         return _run_server()
     except SystemExit as exit_code:
+        deregister_service(AUTH)
         sys.exit(exit_code)
     except Exception:
         LOG.exception("(PID=%s) ST2 Auth API quit due to exception.", os.getpid())

--- a/st2common/st2common/services/coordination.py
+++ b/st2common/st2common/services/coordination.py
@@ -21,6 +21,7 @@ from oslo_config import cfg
 from tooz import coordination
 from tooz import locking
 from tooz.coordination import GroupNotCreated
+from tooz.coordination import MemberNotJoined
 
 from st2common import log as logging
 from st2common.util import system_info
@@ -124,8 +125,15 @@ class NoOpDriver(coordination.CoordinationDriver):
     @classmethod
     def leave_group(cls, group_id):
         member_id = get_member_id()
+        try:
+            members = cls.groups[group_id]["members"]
+        except KeyError:
+            raise GroupNotCreated(group_id)
 
-        del cls.groups[group_id]["members"][member_id]
+        try:
+            del members[member_id]
+        except KeyError:
+            raise MemberNotJoined(group_id, member_id)
         return NoOpAsyncResult()
 
     @classmethod

--- a/st2reactor/st2reactor/cmd/garbagecollector.py
+++ b/st2reactor/st2reactor/cmd/garbagecollector.py
@@ -28,6 +28,7 @@ from st2common import log as logging
 from st2common.logging.misc import get_logger_name_for_module
 from st2common.service_setup import setup as common_setup
 from st2common.service_setup import teardown as common_teardown
+from st2common.service_setup import deregister_service
 from st2common.constants.exit_codes import FAILURE_EXIT_CODE
 from st2reactor.garbage_collector import config
 from st2reactor.garbage_collector.base import GarbageCollectorService
@@ -37,12 +38,13 @@ __all__ = ["main"]
 
 LOGGER_NAME = get_logger_name_for_module(sys.modules[__name__])
 LOG = logging.getLogger(LOGGER_NAME)
+GARBAGE_COLLECTOR = "garbagecollector"
 
 
 def _setup():
     capabilities = {"name": "garbagecollector", "type": "passive"}
     common_setup(
-        service="garbagecollector",
+        service=GARBAGE_COLLECTOR,
         config=config,
         setup_db=True,
         register_mq_exchanges=True,
@@ -68,6 +70,7 @@ def main():
         )
         exit_code = garbage_collector.run()
     except SystemExit as exit_code:
+        deregister_service(GARBAGE_COLLECTOR)
         return exit_code
     except:
         LOG.exception("(PID:%s) GarbageCollector quit due to exception.", os.getpid())

--- a/st2reactor/st2reactor/cmd/rulesengine.py
+++ b/st2reactor/st2reactor/cmd/rulesengine.py
@@ -26,18 +26,20 @@ from st2common import log as logging
 from st2common.logging.misc import get_logger_name_for_module
 from st2common.service_setup import setup as common_setup
 from st2common.service_setup import teardown as common_teardown
+from st2common.service_setup import deregister_service
 from st2reactor.rules import config
 from st2reactor.rules import worker
 
 
 LOGGER_NAME = get_logger_name_for_module(sys.modules[__name__])
 LOG = logging.getLogger(LOGGER_NAME)
+RULESENGINE = "rulesengine"
 
 
 def _setup():
     capabilities = {"name": "rulesengine", "type": "passive"}
     common_setup(
-        service="rulesengine",
+        service=RULESENGINE,
         config=config,
         setup_db=True,
         register_mq_exchanges=True,
@@ -63,6 +65,7 @@ def _run_worker():
         return rules_engine_worker.wait()
     except (KeyboardInterrupt, SystemExit):
         LOG.info("(PID=%s) RulesEngine stopped.", os.getpid())
+        deregister_service(RULESENGINE)
         rules_engine_worker.shutdown()
     except:
         LOG.exception("(PID:%s) RulesEngine quit due to exception.", os.getpid())

--- a/st2reactor/st2reactor/cmd/sensormanager.py
+++ b/st2reactor/st2reactor/cmd/sensormanager.py
@@ -28,6 +28,7 @@ from st2common import log as logging
 from st2common.logging.misc import get_logger_name_for_module
 from st2common.service_setup import setup as common_setup
 from st2common.service_setup import teardown as common_teardown
+from st2common.service_setup import deregister_service
 from st2common.exceptions.sensors import SensorNotFoundException
 from st2common.constants.exit_codes import FAILURE_EXIT_CODE
 from st2reactor.sensor import config
@@ -39,12 +40,13 @@ __all__ = ["main"]
 
 LOGGER_NAME = get_logger_name_for_module(sys.modules[__name__])
 LOG = logging.getLogger(LOGGER_NAME)
+SENSOR_CONTAINER = "sensorcontainer"
 
 
 def _setup():
     capabilities = {"name": "sensorcontainer", "type": "passive"}
     common_setup(
-        service="sensorcontainer",
+        service=SENSOR_CONTAINER,
         config=config,
         setup_db=True,
         register_mq_exchanges=True,
@@ -80,6 +82,7 @@ def main():
         )
         return container_manager.run_sensors()
     except SystemExit as exit_code:
+        deregister_service(SENSOR_CONTAINER)
         return exit_code
     except SensorNotFoundException as e:
         LOG.exception(e)

--- a/st2reactor/st2reactor/cmd/timersengine.py
+++ b/st2reactor/st2reactor/cmd/timersengine.py
@@ -30,18 +30,20 @@ from st2common.constants.timer import TIMER_ENABLED_LOG_LINE, TIMER_DISABLED_LOG
 from st2common.logging.misc import get_logger_name_for_module
 from st2common.service_setup import setup as common_setup
 from st2common.service_setup import teardown as common_teardown
+from st2common.service_setup import deregister_service
 from st2reactor.timer import config
 from st2reactor.timer.base import St2Timer
 
 
 LOGGER_NAME = get_logger_name_for_module(sys.modules[__name__])
 LOG = logging.getLogger(LOGGER_NAME)
+TIMER_ENGINE = "timer_engine"
 
 
 def _setup():
     capabilities = {"name": "timerengine", "type": "passive"}
     common_setup(
-        service="timer_engine",
+        service=TIMER_ENGINE,
         config=config,
         setup_db=True,
         register_mq_exchanges=True,
@@ -78,6 +80,7 @@ def _run_worker():
             LOG.info(TIMER_DISABLED_LOG_LINE)
     except (KeyboardInterrupt, SystemExit):
         LOG.info("(PID=%s) TimerEngine stopped.", os.getpid())
+        deregister_service(TIMER_ENGINE)
     except:
         LOG.exception("(PID:%s) TimerEngine quit due to exception.", os.getpid())
         return 1


### PR DESCRIPTION
Few services like worker, workflow engine, scheduler and notifier perform a shutdown sequence before exiting the process. This PR will ensure that the services deregister themselves from service registry on shutdown and then continue with shutdown sequence. 

(PR based on https://github.com/StackStorm/st2/discussions/5373 step 1)