### PR TITLE
Add workflow system info in Workflow Execution context

### DIFF
--- a/contrib/runners/orquesta_runner/tests/unit/test_basic.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_basic.py
@@ -48,6 +48,7 @@ from st2common.services import workflows as wf_svc
 from st2common.transport import liveaction as lv_ac_xport
 from st2common.transport import workflow as wf_ex_xport
 from st2common.transport import publishers
+from st2common.util import system_info
 from st2tests.mocks import liveaction as mock_lv_ac_xport
 from st2tests.mocks import workflow as mock_wf_ex_xport
 
@@ -165,6 +166,7 @@ class OrquestaRunnerTest(st2tests.ExecutionDbTestCase):
         expected_lv_ac_ctx = {
             "workflow_execution": str(wf_ex_db.id),
             "pack": "orquesta_tests",
+            "engine_info": system_info.get_process_info(),
         }
 
         self.assertDictEqual(lv_ac_db.context, expected_lv_ac_ctx)

--- a/st2actions/st2actions/workflows/workflows.py
+++ b/st2actions/st2actions/workflows/workflows.py
@@ -125,11 +125,13 @@ class WorkflowExecutionHandler(consumers.VariableMessageHandler):
         wf_svc.update_progress(wf_ex_db, msg % (msg_type, wf_ex_id), severity="error")
         wf_svc.fail_workflow_execution(wf_ex_id, exception, task=task)
 
+    @wf_svc.add_system_info_to_action_context
     def handle_workflow_execution(self, wf_ex_db):
         # Request the next set of tasks to execute.
         wf_svc.update_progress(wf_ex_db, "Processing request for workflow execution.")
         wf_svc.request_next_tasks(wf_ex_db)
 
+    @wf_svc.add_system_info_to_action_context
     def handle_action_execution(self, ac_ex_db):
         # Exit if action execution is not executed under an orquesta workflow.
         if not wf_svc.is_action_execution_under_workflow_context(ac_ex_db):


### PR DESCRIPTION
This PR adds workflow engine system information to WorkflowExecution context.
Ref https://github.com/StackStorm/st2/discussions/5373

```
{
    "engine_info": {
        "hostname": "st2", 
        "pid": 1085262
    }, 
    "parent": {
        "user": "stanley", 
        "pack": "examples"
    }, 
    "st2": {
        "action_execution_id": "6174ce479195da5bbddf5443", 
        "api_url": "http://127.0.0.1:9101/v1", 
        "runner": "orquesta", 
        "workflow_execution_id": "6174ce48f3b5fca8fa795f97", 
        "user": "stanley", 
        "action": "examples.orquesta-sequential", 
        "pack": "examples"
    }
}
```

This information will be used to identify orphaned workflow execution.

