### PR TITLE
lower CircleCI parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     # 'machine' executor runs Unit tests ~x1.5 faster, comparing to 'docker' executor
     # but the fastest is still ~x1.5-2 slower, comparing to Travis
     machine: true
-    parallelism: 4
+    parallelism: 2
     working_directory: ~/st2
     steps:
       - checkout
@@ -107,7 +107,7 @@ jobs:
 
   # Build & Test st2 packages
   packages:
-    parallelism: 4
+    parallelism: 2
     # 4CPUs & 8GB RAM CircleCI machine
     # sadly, it doesn't work with 'setup_remote_docker'
     resource_class: large


### PR DESCRIPTION
CircleCI is refusing to run our jobs now giving this error message:
```
Uh oh! When we created this build, your project was configured to use 4x parallelism but you only had 2 containers. If you haven't already, please add more containers or lower your parallelism.
Sorry! Your build didn't run because it needs more containers than your plan allows. Please decrease this project's build parallelism or add more containers to your plan.
```
Apparently they tweaked our plan so that we have 2 concurrent containers instead of 2 concurrent jobs.
Aargh.
