### PR TITLE
Update the StackStorm-Exchange reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ StackStorm helps automate common operational patterns. Some examples are:
 * **Automated remediation** - identifying and verifying hardware failure on OpenStack compute node, properly evacuating instances and emailing VM about potential downtime, but if anything goes wrong - freezing the workflow and calling PagerDuty to wake up a human.
 * **Continuous deployment** - build and test with Jenkins, provision a new AWS cluster, turn on some traffic with the load balancer, and roll-forth or roll-back based on NewRelic app performance data.
 
-StackStorm helps you compose these and other operational patterns as rules and workflows or actions; and these rules and workflows - the content within the StackStorm platform - are stored *as code* which means they support the same approach to collaboration that you use today for code development and can be shared with the broader open source community via [StackStorm Exchange](https://exchange.stackstorm.com).
+StackStorm helps you compose these and other operational patterns as rules and workflows or actions; and these rules and workflows - the content within the StackStorm platform - are stored *as code* which means they support the same approach to collaboration that you use today for code development and can be shared with the broader open source community via [StackStorm Exchange](https://exchange.stackstorm.org).
 
 ### Who is using StackStorm?
 


### PR DESCRIPTION
Update the StackStorm-Exchange reference from https://exchange.stackstorm.com to original https://exchange.stackstorm.org
Despite the current redirect set between the domains, there is no guarantee it'll work in the future.