### PR TITLE
Replace Forum badge with GH Discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Join our community Slack](https://img.shields.io/badge/slack-stackstorm-success.svg?logo=slack)](https://stackstorm.com/community-signup)
 [![deb/rpm packages](https://img.shields.io/badge/deb/rpm-Packagecloud-%236366f1)](https://packagecloud.io/StackStorm/)
 [![Code Search](https://img.shields.io/badge/code%20search-Sourcegraph-%2300B4F2?logo=sourcegraph)](https://sourcegraph.com/stackstorm)
-[![Forum](https://img.shields.io/discourse/https/forum.stackstorm.com/posts.svg)](https://forum.stackstorm.com/)
+[![GitHub Discussions](https://img.shields.io/github/discussions/stackstorm/st2)](https://github.com/StackStorm/st2/discussions)
 [![Twitter Follow](https://img.shields.io/twitter/follow/StackStorm?style=social)](https://twitter.com/StackStorm/)
 
 ---


### PR DESCRIPTION
Per https://github.com/StackStorm/discussions/issues/89 plan we've moved from Discourse forum to native GH Discussions.

The PR replaces the badge and URL in the `README.md` to use new GH Discussions.
