### PR TITLE
Add Ankur Singh (@rush-skills) as a StackStorm Contributor

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -51,6 +51,7 @@ Contributors are using and occasionally contributing back to the project, might 
 They're not part of the TSC voting process, but appreciated for their contribution, involvement and may become Maintainers in the future depending on their effort and involvement. See [How to become a Maintainer?](https://github.com/StackStorm/st2/blob/master/GOVERNANCE.md#how-to-become-a-maintainer)
 [@StackStorm/contributors](https://github.com/orgs/StackStorm/teams/contributors) are invited to StackStorm Github organization and have permissions to help triage the Issues and review PRs.
 * Anand Patel ([@arms11](https://github.com/arms11)), _VMware_ - Docker, Kubernetes.
+* Ankur Singh ([@rush-skills](https://github.com/rush-skills)), _CERN_ - Puppet, Core, Docker, K8s.
 * Harsh Nanchahal ([@hnanchahal](https://github.com/hnanchahal)), _Starbucks_ - Core, Docker, Kubernetes.
 * Hiroyasu Ohyama ([@userlocalhost](https://github.com/userlocalhost)) - Orquesta, Workflows, st2 Japan Community. [Case Study](https://stackstorm.com/case-study-dmm/).
 * Sheshagiri Rao Mallipedhi ([@sheshagiri](https://github.com/sheshagiri)) - Docker, Core, StackStorm Exchange.


### PR DESCRIPTION
Ankur (@rush-skills) was active in StackStorm community for the past several months, he also joined us in several TSC meetings and helped with the development, ideas and improvements around the project.

PRs:
- https://github.com/StackStorm/puppet-st2/pull/335
- https://github.com/StackStorm/puppet-st2/pull/337
- https://github.com/StackStorm/puppet-st2/pull/329
- https://github.com/StackStorm/puppet-st2/pull/330
- https://github.com/StackStorm/puppet-st2/pull/331

Taking part in the Discussions, Reviews, Slack and `#development` channels, asking questions, st2 Q/A topics, trying to discuss the tech ideas, - all this makes him a good teamplayer:
- https://github.com/StackStorm/st2/discussions/5278
- https://github.com/StackStorm/ansible-st2/pull/298
- https://github.com/StackStorm/puppet-st2/issues/338
- https://github.com/StackStorm/discussions/issues/68
- https://github.com/StackStorm/discussions/issues/69


I also personally like the different perspective to the problems he brings in and would like to highlight his contributions by adding him to the official **stackstorm/Contributors** list.
I hope it's just a start and we'll see much more in the future: PRs, TSC meetings participation, help around development and features by Ankur.
