### PR TITLE
Add Rick Kauffman (@xod442) as a Contributor

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -53,6 +53,7 @@ They're not part of the TSC voting process, but appreciated for their contributi
 * Anand Patel ([@arms11](https://github.com/arms11)), _VMware_ - Docker, Kubernetes.
 * Harsh Nanchahal ([@hnanchahal](https://github.com/hnanchahal)), _Starbucks_ - Core, Docker, Kubernetes.
 * Hiroyasu Ohyama ([@userlocalhost](https://github.com/userlocalhost)) - Orquesta, Workflows, st2 Japan Community. [Case Study](https://stackstorm.com/case-study-dmm/).
+* Rick Kauffman ([@xod442](https://github.com/xod442)), _HPE_ - Community, HOWTOs, Blogs, Publications, Docker.
 * Sheshagiri Rao Mallipedhi ([@sheshagiri](https://github.com/sheshagiri)) - Docker, Core, StackStorm Exchange.
 * Shital Raut ([@shital-orchestral](https://github.com/shital-orchestral)), _Orchestral.ai_ - Web UI.
 * Tristan Struthers ([@trstruth](https://github.com/trstruth)) - Docker, K8s, Orquesta, Community.


### PR DESCRIPTION
Rick (@xod442) was StackStorm supporter and champion for a long time.

During the last couple of years we observed many blogs, tutorials, talks, and HOWTOs by Rick dedicated to st2:
- Tutorial: https://github.com/xod442/stackstorm-tutorial
- HOWTO: [Master the automation universe the easy way! Part 1: Introduction to StackStorm](https://developer.hpe.com/blog/master-the-automation-universe-the-easy-way-part-1-introduction-to-stack/)
- HOWTO: [Master the automation universe the easy way! Part 2: The Art of Packing! ](https://developer.hpe.com/blog/master-the-automation-universe-the-easy-way-part-2-the-art-of-packing/)
- [HPE OneView and ServiceNow integration with StackStorm](https://developer.hpe.com/blog/hpe-oneview-and-servicenow-integration-with-stackstorm/)
- [StackStorm in a docker container…the easy way!](https://www.techworldwookie.com/stackstorm-in-a-docker-container-the-easy-way/)
- [HPE OneView & StackStorm](https://www.techworldwookie.com/hpe-oneview-stackstorm/)
- [Cats Dancing With Dogs? HPE Primera talking to HPE Nimble?](https://www.techworldwookie.com/cats-dancing-with-dogs-hpe-primera-talking-to-hpe-nimble/)
- [Nimble stackstorm integration pack](https://www.techworldwookie.com/nimble-stackstrorm-integration-pack/)
- [StackStorm & Jupyter on a Virtual Machine](https://www.techworldwookie.com/stackstorm-jupyter-on-a-virtual-machine/)

Other work and code contributions: 
- https://github.com/StackStorm-Exchange/stackstorm-rabbitmq/pull/15
- https://github.com/HewlettPackard/stackstorm-hpe-cfm/pull/13
- https://github.com/HewlettPackard/stackstorm-hpe-cfm/pull/4
- [HPE Oneview StackStorm integration pack](https://github.com/HewlettPackard/stackstorm-hpe-oneview)
- [StackStorm ARISTA Integration Pack](https://github.com/HewlettPackard/stackstorm-aruba-fc)
  - https://www.techworldwookie.com/arista-cvp-stackstorm-integration-pack/
- [Stackstorm integration pack for Data Center Warning Review (DWR)](https://github.com/xod442/stackstorm-dwr)
- [StackStorm pack for tektalk](https://github.com/xod442/stackstorm-talk)

Project contributions are not just about the code, but also community, growth, advocacy, use cases, howtos, talks. With all the effort Rick did for StackStorm Open Source Community I'd like us to highlight this huge work and believe listing him between the project contributors is the minimum we could do.
I hope it's just a start and can't wait to see Rick more in the TSC Meetings, community, and project future.

