### PR TITLE
Add status changed by user info to context

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,10 @@ Added
 Changed
 ~~~~~~~
 
+* Added cancel/pause/resume requester information to execution context. #5459
+
+  Contributed by @khushboobhatia01
+
 * Modified action delete API to delete action files from disk along with backward compatibility.
 
   From CLI ``st2 action delete <pack>.<action>`` will delete only action database entry.

--- a/contrib/runners/orquesta_runner/tests/unit/test_cancel.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_cancel.py
@@ -118,6 +118,7 @@ class OrquestaRunnerCancelTest(st2tests.ExecutionDbTestCase):
         lv_ac_db, ac_ex_db = ac_svc.request_cancellation(lv_ac_db, requester)
         lv_ac_db = lv_db_access.LiveAction.get_by_id(str(lv_ac_db.id))
         self.assertEqual(lv_ac_db.status, ac_const.LIVEACTION_STATUS_CANCELING)
+        self.assertEqual(lv_ac_db.context["cancelled_by"], requester)
 
     def test_cancel_workflow_cascade_down_to_subworkflow(self):
         wf_meta = base.get_wf_fixture_meta_data(TEST_PACK_PATH, "subworkflow.yaml")

--- a/contrib/runners/orquesta_runner/tests/unit/test_pause_and_resume.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_pause_and_resume.py
@@ -118,6 +118,7 @@ class OrquestaRunnerPauseResumeTest(st2tests.ExecutionDbTestCase):
         lv_ac_db, ac_ex_db = ac_svc.request_pause(lv_ac_db, cfg.CONF.system_user.user)
         lv_ac_db = lv_db_access.LiveAction.get_by_id(str(lv_ac_db.id))
         self.assertEqual(lv_ac_db.status, ac_const.LIVEACTION_STATUS_PAUSING)
+        self.assertEqual(lv_ac_db.context["paused_by"], cfg.CONF.system_user.user)
 
     @mock.patch.object(ac_svc, "is_children_active", mock.MagicMock(return_value=True))
     def test_pause_with_active_children(self):
@@ -525,6 +526,7 @@ class OrquestaRunnerPauseResumeTest(st2tests.ExecutionDbTestCase):
             workflow_execution=str(wf_ex_dbs[0].id)
         )
         self.assertEqual(len(tk_ex_dbs), 2)
+        self.assertEqual(lv_ac_db.context["resumed_by"], cfg.CONF.system_user.user)
 
     def test_resume_cascade_to_subworkflow(self):
         wf_meta = base.get_wf_fixture_meta_data(TEST_PACK_PATH, "subworkflow.yaml")

--- a/st2common/st2common/services/action.py
+++ b/st2common/st2common/services/action.py
@@ -214,7 +214,12 @@ def request(liveaction):
 
 
 def update_status(
-    liveaction, new_status, result=None, publish=True, set_result_size=False
+    liveaction,
+    new_status,
+    result=None,
+    publish=True,
+    set_result_size=False,
+    context=None,
 ):
     if liveaction.status == new_status:
         return liveaction
@@ -226,6 +231,7 @@ def update_status(
         "status": new_status,
         "result": result,
         "publish": False,
+        "context": context,
     }
 
     if new_status in action_constants.LIVEACTION_COMPLETED_STATES:
@@ -304,7 +310,10 @@ def request_cancellation(liveaction, requester):
     else:
         status = action_constants.LIVEACTION_STATUS_CANCELED
 
-    liveaction = update_status(liveaction, status, result=result)
+    liveaction.context["cancelled_by"] = requester
+    liveaction = update_status(
+        liveaction, status, result=result, context=liveaction.context
+    )
 
     execution = ActionExecution.get(liveaction__id=str(liveaction.id))
 
@@ -346,7 +355,12 @@ def request_pause(liveaction, requester):
             % liveaction.id
         )
 
-    liveaction = update_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSING)
+    liveaction.context["paused_by"] = requester
+    liveaction = update_status(
+        liveaction,
+        action_constants.LIVEACTION_STATUS_PAUSING,
+        context=liveaction.context,
+    )
 
     execution = ActionExecution.get(liveaction__id=str(liveaction.id))
 
@@ -390,7 +404,12 @@ def request_resume(liveaction, requester):
             'not in "paused" state.' % (liveaction.id, liveaction.status)
         )
 
-    liveaction = update_status(liveaction, action_constants.LIVEACTION_STATUS_RESUMING)
+    liveaction.context["resumed_by"] = requester
+    liveaction = update_status(
+        liveaction,
+        action_constants.LIVEACTION_STATUS_RESUMING,
+        context=liveaction.context,
+    )
 
     execution = ActionExecution.get(liveaction__id=str(liveaction.id))
 


### PR DESCRIPTION
This is required to track who cancelled/paused/resumed any execution. 

`"context" : { "user" : "stanley", "pack" : "examples", "workflow_execution" : "61a0887aac2049b57fed57de", "paused_by" : "stanley", "resumed_by" : "stanley" }`
