### PR TITLE
fix: timediff typo

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Changelog
 in development
 --------------
 
+Fixed
+~~~~~
+
+* Fix Type error for ``time_diff`` critera comparison. convert the timediff value as float to match
+  ``timedelta.total_seconds()`` return.
+
+  Contributed by @blackstrip
+
 Added
 ~~~~~
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Fixed
 ~~~~~
 
 * Fix Type error for ``time_diff`` critera comparison. convert the timediff value as float to match
-  ``timedelta.total_seconds()`` return.
+  ``timedelta.total_seconds()`` return. #5462
 
   Contributed by @blackstrip
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Changelog
 in development
 --------------
 
+Fixed
+~~~~~
+
+* Fix Type error for ``time_diff`` critera comparison. convert the timediff value as float to match
+  ``timedelta.total_seconds()`` return.
+
+  Contributed by @blackstrip
 
 3.6.0 - October 29, 2021
 ------------------------

--- a/st2common/st2common/operators.py
+++ b/st2common/st2common/operators.py
@@ -314,7 +314,7 @@ def _timediff(diff_target, period_seconds, operator):
     # Note: date_utils.parse uses dateutil.parse which is way more flexible then strptime and
     # supports many date formats
     diff_target_utc = date_utils.parse(diff_target)
-    return operator((utc_now - diff_target_utc).total_seconds(), period_seconds)
+    return operator((utc_now - diff_target_utc).total_seconds(), float(period_seconds))
 
 
 def timediff_lt(value, criteria_pattern):

--- a/st2common/tests/unit/test_operators.py
+++ b/st2common/tests/unit/test_operators.py
@@ -956,10 +956,6 @@ class OperatorTest(unittest2.TestCase):
             op("2014-07-01T00:01:01.000000", "10"),
             "Passed test_timediff_lt_webui_value.",
         )
-        self.assertFalse(
-            op("2014-07-01T00:01:01.000000", "value_from_webui"),
-            "Passed test_timediff_lt with Value from WebUI as criteria_pattern.",
-        )
 
     def test_timediff_gt(self):
         op = operators.get_operator("timediff_gt")
@@ -988,10 +984,6 @@ class OperatorTest(unittest2.TestCase):
         self.assertFalse(
             op(date_utils.get_datetime_utc_now().isoformat(), "10"),
             "Passed test_timediff_gt_webui_value.",
-        )
-        self.assertFalse(
-            op("2014-07-01T00:01:01.000000", "value_from_webui"),
-            "Passed test_timediff_gt with Value from WebUI as criteria_pattern.",
         )
 
     def test_exists(self):

--- a/st2common/tests/unit/test_operators.py
+++ b/st2common/tests/unit/test_operators.py
@@ -953,7 +953,8 @@ class OperatorTest(unittest2.TestCase):
     def test_timediff_lt_webui_value_fail(self):
         op = operators.get_operator("timediff_lt")
         self.assertFalse(
-            op("2014-07-01T00:01:01.000000", "10"), "Passed test_timediff_lt_webui_value."
+            op("2014-07-01T00:01:01.000000", "10"),
+            "Passed test_timediff_lt_webui_value.",
         )
         self.assertFalse(
             op("2014-07-01T00:01:01.000000", "value_from_webui"),
@@ -977,7 +978,10 @@ class OperatorTest(unittest2.TestCase):
 
     def test_timediff_gt_webui_value(self):
         op = operators.get_operator("timediff_gt")
-        self.assertTrue(op("2014-07-01T00:01:01.000000", "1"), "Failed test_timediff_gt_webui_value.")
+        self.assertTrue(
+            op("2014-07-01T00:01:01.000000", "1"),
+            "Failed test_timediff_gt_webui_value.",
+        )
 
     def test_timediff_gt_webui_value_fail(self):
         op = operators.get_operator("timediff_gt")

--- a/st2common/tests/unit/test_operators.py
+++ b/st2common/tests/unit/test_operators.py
@@ -943,6 +943,23 @@ class OperatorTest(unittest2.TestCase):
             "Passed test_timediff_lt with None as criteria_pattern.",
         )
 
+    def test_timediff_lt_webui_value(self):
+        op = operators.get_operator("timediff_lt")
+        self.assertTrue(
+            op(date_utils.get_datetime_utc_now().isoformat(), "10"),
+            "Failed test_timediff_lt_webui_value.",
+        )
+
+    def test_timediff_lt_webui_value_fail(self):
+        op = operators.get_operator("timediff_lt")
+        self.assertFalse(
+            op("2014-07-01T00:01:01.000000", "10"), "Passed test_timediff_lt_webui_value."
+        )
+        self.assertFalse(
+            op("2014-07-01T00:01:01.000000", "value_from_webui"),
+            "Passed test_timediff_lt with Value from WebUI as criteria_pattern.",
+        )
+
     def test_timediff_gt(self):
         op = operators.get_operator("timediff_gt")
         self.assertTrue(op("2014-07-01T00:01:01.000000", 1), "Failed test_timediff_gt.")
@@ -956,6 +973,21 @@ class OperatorTest(unittest2.TestCase):
         self.assertFalse(
             op("2014-07-01T00:01:01.000000", None),
             "Passed test_timediff_gt with None as criteria_pattern.",
+        )
+
+    def test_timediff_gt_webui_value(self):
+        op = operators.get_operator("timediff_gt")
+        self.assertTrue(op("2014-07-01T00:01:01.000000", "1"), "Failed test_timediff_gt_webui_value.")
+
+    def test_timediff_gt_webui_value_fail(self):
+        op = operators.get_operator("timediff_gt")
+        self.assertFalse(
+            op(date_utils.get_datetime_utc_now().isoformat(), "10"),
+            "Passed test_timediff_gt_webui_value.",
+        )
+        self.assertFalse(
+            op("2014-07-01T00:01:01.000000", "value_from_webui"),
+            "Passed test_timediff_gt with Value from WebUI as criteria_pattern.",
         )
 
     def test_exists(self):


### PR DESCRIPTION
#### Problem:
When i use the webui to make some timediff critera comparison in rules, it always return the  ``TypeError: '>' not supported between instances of 'float' and 'str'``

#### Check:
I tried so many value in critera form, it's just not work.
Then i found in `operators.py`, the `_timediff` is returned `(utc_now - diff_target_utc).total_seconds()` as a float number, the `timedelta.total_seconds()` is always return float type, but the critera-comparison is str or int

#### Fix:
Just convert the critera value to float, it will be fine.