### PR TITLE
Enable setting ttl for MockDatastoreService

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Added
 ~~~~~
 
 * Enable setting ttl for MockDatastoreService. #5468
- 
+
   Contributed by @ytjohn
 
 * Added st2 API and CLI command for actions clone operation.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ in development
 Added
 ~~~~~
 
+* Enable setting ttl for MockDatastoreServic
+ 
+  Contributed by @ytjohn
+
 * Added service degerestration on shutdown of a service. #5396
 
   Contributed by @khushboobhatia01

--- a/st2tests/st2tests/mocks/datastore.py
+++ b/st2tests/st2tests/mocks/datastore.py
@@ -35,7 +35,7 @@ class MockDatastoreService(BaseDatastoreService):
         self._class_name = class_name
         self._username = api_username or "admin"
         self._logger = logger
- 
+
         # Holds mock KeyValuePair objects
         # Key is a KeyValuePair name and value is the KeyValuePair object
         self._datastore_items = {}
@@ -105,7 +105,9 @@ class MockDatastoreService(BaseDatastoreService):
         instance.name = name
         instance.value = value
         if ttl:
-            self._logger.warning("MockDatastoreService is not able to expire keys based on ttl.")
+            self._logger.warning(
+                "MockDatastoreService is not able to expire keys based on ttl."
+            )
             instance.ttl = ttl
 
         self._datastore_items[name] = instance

--- a/st2tests/st2tests/mocks/datastore.py
+++ b/st2tests/st2tests/mocks/datastore.py
@@ -34,7 +34,8 @@ class MockDatastoreService(BaseDatastoreService):
         self._pack_name = pack_name
         self._class_name = class_name
         self._username = api_username or "admin"
-
+        self._logger = logger
+ 
         # Holds mock KeyValuePair objects
         # Key is a KeyValuePair name and value is the KeyValuePair object
         self._datastore_items = {}
@@ -96,10 +97,6 @@ class MockDatastoreService(BaseDatastoreService):
         """
         Store a value in a dictionary which is local to this class.
         """
-        if ttl:
-            raise ValueError(
-                'MockDatastoreService.set_value doesn\'t support "ttl" argument'
-            )
 
         name = self._get_full_key_name(name=name, local=local)
 
@@ -107,6 +104,9 @@ class MockDatastoreService(BaseDatastoreService):
         instance.id = name
         instance.name = name
         instance.value = value
+        if ttl:
+            self._logger.warning("MockDatastoreService is not able to expire keys based on ttl.")
+            instance.ttl = ttl
 
         self._datastore_items[name] = instance
         return True


### PR DESCRIPTION
This allows people to test their code if they are already setting a ttl. This resolves #4880

I think we would also be fine with not issuing a log warning, but put that in for completeness.