### PR TITLE
#5460 - Include pysocks in st2client

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,10 @@ Added
 
   Contributed by @khushboobhatia01
 
+* Added pysocks python package for SOCKS proxy support. #5460
+
+  Contributed by @kingsleyadam
+
 Fixed
 ~~~~~
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,6 +50,7 @@ pyinotify==0.9.6; platform_system=="Linux"
 pymongo==3.11.3
 pyparsing<3
 pyrabbit
+pysocks
 python-dateutil==2.8.1
 python-editor==1.0.4
 python-json-logger

--- a/st2client/in-requirements.txt
+++ b/st2client/in-requirements.txt
@@ -18,3 +18,5 @@ cryptography
 orjson
 # needed by requests
 chardet
+# required for SOCKS proxy support (HTTP_PROXY, HTTPS_PROXY, NO_PROXY)
+pysocks

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -15,6 +15,7 @@ jsonschema==2.6.0
 orjson==3.5.2
 prettytable==2.1.0
 prompt-toolkit==1.0.15
+pysocks
 python-dateutil==2.8.1
 python-editor==1.0.4
 pytz==2021.1


### PR DESCRIPTION
Without pysocks PyPi package SOCKS proxies won't work with the following errors.

```
ERROR: Missing dependencies for SOCKS support.
```