### PR TITLE
Added 'multiple' operator to allow complex criteria matching on payload items

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -60,6 +60,10 @@ Added
 
   Contributed by @khushboobhatia01
 
+* Enhanced 'search' operator to allow complex criteria matching on payload items. #5482
+
+  Contributed by @erceth
+
 Fixed
 ~~~~~
 

--- a/st2common/tests/unit/test_operators.py
+++ b/st2common/tests/unit/test_operators.py
@@ -565,6 +565,618 @@ class SearchOperatorTest(unittest2.TestCase):
         )
 
 
+class MultipleOperatorTest(unittest2.TestCase):
+    # First few tests are the same as search to show it can do everything search can do.
+    # The later tests show the extra stuff the multiple operator can do.
+    def test_multiple_with_weird_condition(self):
+        op = operators.get_operator("multiple")
+
+        with self.assertRaises(operators.UnrecognizedConditionError):
+            op([], [], "weird", None)
+
+    def test_multiple_any_true(self):
+        op = operators.get_operator("multiple")
+
+        called_function_args = []
+
+        def record_function_args(criterion_k, criterion_v, payload_lookup):
+            called_function_args.append(
+                {
+                    "criterion_k": criterion_k,
+                    "criterion_v": criterion_v,
+                    "payload_lookup": {
+                        "field_name": payload_lookup.get_value("item.field_name")[0],
+                        "to_value": payload_lookup.get_value("item.to_value")[0],
+                    },
+                }
+            )
+            return len(called_function_args) < 3
+
+        payload = [
+            {
+                "field_name": "Status",
+                "to_value": "Approved",
+            },
+            {
+                "field_name": "Assigned to",
+                "to_value": "Stanley",
+            },
+        ]
+
+        criteria_pattern = {
+            "item.field_name": {
+                "type": "equals",
+                "pattern": "Status",
+            },
+            "item.to_value": {
+                "type": "equals",
+                "pattern": "Approved",
+            },
+        }
+
+        result = op(payload, criteria_pattern, "any", record_function_args)
+
+        self.assertTrue(result)
+        self.assertTrue(
+            list_of_dicts_strict_equal(
+                called_function_args,
+                [
+                    # Outer loop: payload -> {'field_name': "Status", 'to_value': "Approved"}
+                    {
+                        # Inner loop: criterion -> item.field_name: {'type': "equals", 'pattern': "Status"}
+                        "criterion_k": "item.field_name",
+                        "criterion_v": {
+                            "type": "equals",
+                            "pattern": "Status",
+                        },
+                        "payload_lookup": {
+                            "field_name": "Status",
+                            "to_value": "Approved",
+                        },
+                    },
+                    {
+                        # Inner loop: criterion -> item.to_value: {'type': "equals", 'pattern': "Approved"}
+                        "criterion_k": "item.to_value",
+                        "criterion_v": {
+                            "type": "equals",
+                            "pattern": "Approved",
+                        },
+                        "payload_lookup": {
+                            "field_name": "Status",
+                            "to_value": "Approved",
+                        },
+                    },
+                    # Outer loop: payload -> {'field_name': "Assigned to", 'to_value': "Stanley"}
+                    {
+                        # Inner loop: criterion -> item.field_name: {'type': "equals", 'pattern': "Status"}
+                        "criterion_k": "item.field_name",
+                        "criterion_v": {
+                            "type": "equals",
+                            "pattern": "Status",
+                        },
+                        "payload_lookup": {
+                            "field_name": "Assigned to",
+                            "to_value": "Stanley",
+                        },
+                    },
+                    {
+                        # Inner loop: criterion -> item.to_value: {'type': "equals", 'pattern': "Approved"}
+                        "criterion_k": "item.to_value",
+                        "criterion_v": {
+                            "type": "equals",
+                            "pattern": "Approved",
+                        },
+                        "payload_lookup": {
+                            "field_name": "Assigned to",
+                            "to_value": "Stanley",
+                        },
+                    },
+                ],
+            )
+        )
+
+    def test_multiple_any_false(self):
+        op = operators.get_operator("multiple")
+
+        called_function_args = []
+
+        def record_function_args(criterion_k, criterion_v, payload_lookup):
+            called_function_args.append(
+                {
+                    "criterion_k": criterion_k,
+                    "criterion_v": criterion_v,
+                    "payload_lookup": {
+                        "field_name": payload_lookup.get_value("item.field_name")[0],
+                        "to_value": payload_lookup.get_value("item.to_value")[0],
+                    },
+                }
+            )
+            return (len(called_function_args) % 2) == 0
+
+        payload = [
+            {
+                "field_name": "Status",
+                "to_value": "Denied",
+            },
+            {
+                "field_name": "Assigned to",
+                "to_value": "Stanley",
+            },
+        ]
+
+        criteria_pattern = {
+            "item.field_name": {
+                "type": "equals",
+                "pattern": "Status",
+            },
+            "item.to_value": {
+                "type": "equals",
+                "pattern": "Approved",
+            },
+        }
+
+        result = op(payload, criteria_pattern, "any", record_function_args)
+
+        self.assertFalse(result)
+        self.assertEqual(
+            called_function_args,
+            [
+                # Outer loop: payload -> {'field_name': "Status", 'to_value': "Denied"}
+                {
+                    # Inner loop: criterion -> item.field_name: {'type': "equals", 'pattern': "Status"}
+                    "criterion_k": "item.field_name",
+                    "criterion_v": {
+                        "type": "equals",
+                        "pattern": "Status",
+                    },
+                    "payload_lookup": {
+                        "field_name": "Status",
+                        "to_value": "Denied",
+                    },
+                },
+                {
+                    # Inner loop: criterion -> item.to_value: {'type': "equals", 'pattern': "Approved"}
+                    "criterion_k": "item.to_value",
+                    "criterion_v": {
+                        "type": "equals",
+                        "pattern": "Approved",
+                    },
+                    "payload_lookup": {
+                        "field_name": "Status",
+                        "to_value": "Denied",
+                    },
+                },
+                # Outer loop: payload -> {'field_name': "Assigned to", 'to_value': "Stanley"}
+                {
+                    # Inner loop: criterion -> item.to_value: {'type': "equals", 'pattern': "Approved"}
+                    "criterion_k": "item.field_name",
+                    "criterion_v": {
+                        "type": "equals",
+                        "pattern": "Status",
+                    },
+                    "payload_lookup": {
+                        "field_name": "Assigned to",
+                        "to_value": "Stanley",
+                    },
+                },
+                {
+                    # Inner loop: criterion -> item.to_value: {'type': "equals", 'pattern': "Approved"}
+                    "criterion_k": "item.to_value",
+                    "criterion_v": {
+                        "type": "equals",
+                        "pattern": "Approved",
+                    },
+                    "payload_lookup": {
+                        "field_name": "Assigned to",
+                        "to_value": "Stanley",
+                    },
+                },
+            ],
+        )
+
+    def test_multiple_all_false(self):
+        op = operators.get_operator("multiple")
+
+        called_function_args = []
+
+        def record_function_args(criterion_k, criterion_v, payload_lookup):
+            called_function_args.append(
+                {
+                    "criterion_k": criterion_k,
+                    "criterion_v": criterion_v,
+                    "payload_lookup": {
+                        "field_name": payload_lookup.get_value("item.field_name")[0],
+                        "to_value": payload_lookup.get_value("item.to_value")[0],
+                    },
+                }
+            )
+            return (len(called_function_args) % 2) == 0
+
+        payload = [
+            {
+                "field_name": "Status",
+                "to_value": "Approved",
+            },
+            {
+                "field_name": "Assigned to",
+                "to_value": "Stanley",
+            },
+        ]
+
+        criteria_pattern = {
+            "item.field_name": {
+                "type": "equals",
+                "pattern": "Status",
+            },
+            "item.to_value": {
+                "type": "equals",
+                "pattern": "Approved",
+            },
+        }
+
+        result = op(payload, criteria_pattern, "all", record_function_args)
+
+        self.assertFalse(result)
+        self.assertEqual(
+            called_function_args,
+            [
+                # Outer loop: payload -> {'field_name': "Status", 'to_value': "Approved"}
+                {
+                    # Inner loop: item.field_name -> {'type': "equals", 'pattern': "Status"}
+                    "criterion_k": "item.field_name",
+                    "criterion_v": {
+                        "type": "equals",
+                        "pattern": "Status",
+                    },
+                    "payload_lookup": {
+                        "field_name": "Status",
+                        "to_value": "Approved",
+                    },
+                },
+                {
+                    # Inner loop: item.to_value -> {'type': "equals", 'pattern': "Approved"}
+                    "criterion_k": "item.to_value",
+                    "criterion_v": {
+                        "type": "equals",
+                        "pattern": "Approved",
+                    },
+                    "payload_lookup": {
+                        "field_name": "Status",
+                        "to_value": "Approved",
+                    },
+                },
+                # Outer loop: payload -> {'field_name': "Assigned to", 'to_value': "Stanley"}
+                {
+                    # Inner loop: item.field_name -> {'type': "equals", 'pattern': "Status"}
+                    "criterion_k": "item.field_name",
+                    "criterion_v": {
+                        "type": "equals",
+                        "pattern": "Status",
+                    },
+                    "payload_lookup": {
+                        "field_name": "Assigned to",
+                        "to_value": "Stanley",
+                    },
+                },
+                {
+                    # Inner loop: item.to_value -> {'type': "equals", 'pattern': "Approved"}
+                    "criterion_k": "item.to_value",
+                    "criterion_v": {
+                        "type": "equals",
+                        "pattern": "Approved",
+                    },
+                    "payload_lookup": {
+                        "field_name": "Assigned to",
+                        "to_value": "Stanley",
+                    },
+                },
+            ],
+        )
+
+
+    def test_multiple_all_true(self):
+        op = operators.get_operator("multiple")
+
+        called_function_args = []
+
+        def record_function_args(criterion_k, criterion_v, payload_lookup):
+            called_function_args.append(
+                {
+                    "criterion_k": criterion_k,
+                    "criterion_v": criterion_v,
+                    "payload_lookup": {
+                        "field_name": payload_lookup.get_value("item.field_name")[0],
+                        "to_value": payload_lookup.get_value("item.to_value")[0],
+                    },
+                }
+            )
+            return True
+
+        payload = [
+            {
+                "field_name": "Status",
+                "to_value": "Approved",
+            },
+            {
+                "field_name": "Signed off by",
+                "to_value": "Approved",
+            },
+        ]
+
+        criteria_pattern = {
+            "item.field_name": {
+                "type": "startswith",
+                "pattern": "S",
+            },
+            "item.to_value": {
+                "type": "equals",
+                "pattern": "Approved",
+            },
+        }
+
+        result = op(payload, criteria_pattern, "all", record_function_args)
+
+        self.assertTrue(result)
+        self.assertEqual(
+            called_function_args,
+            [
+                # Outer loop: payload -> {'field_name': "Status", 'to_value': "Approved"}
+                {
+                    # Inner loop: item.field_name -> {'type': "startswith", 'pattern': "S"}
+                    "criterion_k": "item.field_name",
+                    "criterion_v": {
+                        "type": "startswith",
+                        "pattern": "S",
+                    },
+                    "payload_lookup": {
+                        "field_name": "Status",
+                        "to_value": "Approved",
+                    },
+                },
+                {
+                    # Inner loop: item.to_value -> {'type': "equals", 'pattern': "Approved"}
+                    "criterion_k": "item.to_value",
+                    "criterion_v": {
+                        "type": "equals",
+                        "pattern": "Approved",
+                    },
+                    "payload_lookup": {
+                        "field_name": "Status",
+                        "to_value": "Approved",
+                    },
+                },
+                # Outer loop: payload -> {'field_name': "Signed off by", 'to_value': "Approved"}
+                {
+                    # Inner loop: item.field_name -> {'type': "startswith", 'pattern': "S"}
+                    "criterion_k": "item.field_name",
+                    "criterion_v": {
+                        "type": "startswith",
+                        "pattern": "S",
+                    },
+                    "payload_lookup": {
+                        "field_name": "Signed off by",
+                        "to_value": "Approved",
+                    },
+                },
+                {
+                    # Inner loop: item.to_value -> {'type': "equals", 'pattern': "Approved"}
+                    "criterion_k": "item.to_value",
+                    "criterion_v": {
+                        "type": "equals",
+                        "pattern": "Approved",
+                    },
+                    "payload_lookup": {
+                        "field_name": "Signed off by",
+                        "to_value": "Approved",
+                    },
+                },
+            ],
+        )
+
+
+    def _test_function(self, criterion_k, criterion_v, payload_lookup):
+        op = operators.get_operator(criterion_v['type'])
+        return op(payload_lookup.get_value("item.to_value")[0], criterion_v["pattern"])
+
+
+    def test_multiple_any2any(self):
+        # true if any payload items match any criteria
+        op = operators.get_operator('multiple')
+
+        payload = [
+            {
+                "field_name": "waterLevel",
+                "to_value": 30,
+            },
+            {
+                "field_name": "waterLevel",
+                "to_value": 45,
+            }
+        ]
+
+        criteria_pattern = {
+            "item.waterLevel#1": {
+                "type": "lessthan",
+                "pattern": 40,
+            },
+            "item.waterLevel#2": {
+                "type": "greaterthan",
+                "pattern": 50,
+            },
+        }
+
+        result = op(payload, criteria_pattern, "any2any", self._test_function)
+        self.assertTrue(result)
+
+        payload[0]['to_value'] = 44
+
+        result = op(payload, criteria_pattern, "any2any", self._test_function)
+        self.assertFalse(result)
+
+
+    def test_multiple_any2all(self):
+        # true if any payload items match all criteria
+        op = operators.get_operator("multiple")
+        payload = [
+            {
+                "field_name": "waterLevel",
+                "to_value": 45,
+            },
+            {
+                "field_name": "waterLevel",
+                "to_value": 20,
+            },
+        ]
+
+        criteria_pattern = {
+            "item.waterLevel#1": {
+                "type": "greaterthan",
+                "pattern": 40,
+            },
+            "item.waterLevel#2": {
+                "type": "lessthan",
+                "pattern": 50,
+            },
+            "item.waterLevel#3": {
+                "type": "equals",
+                "pattern": 46,
+            }
+        }
+
+        result = op(payload, criteria_pattern, "any2all", self._test_function)
+        self.assertFalse(result)
+
+        payload[0]['to_value'] = 46
+
+        result = op(payload, criteria_pattern, "any2all", self._test_function)
+        self.assertTrue(result)
+
+        payload[0]['to_value'] = 45
+        del criteria_pattern['item.waterLevel#3']
+
+        result = op(payload, criteria_pattern, "any2all", self._test_function)
+        self.assertTrue(result)
+    
+
+    def test_multiple_all2any(self):
+        # true if all payload items match any criteria
+        op = operators.get_operator("multiple")
+        payload = [
+            {
+                "field_name": "waterLevel",
+                "to_value": 45,
+            },
+            {
+                "field_name": "waterLevel",
+                "to_value": 20,
+            },
+        ]
+
+        criteria_pattern = {
+            "item.waterLevel#1": {
+                "type": "greaterthan",
+                "pattern": 40,
+            },
+            "item.waterLevel#2": {
+                "type": "lessthan",
+                "pattern": 50,
+            },
+            "item.waterLevel#3": {
+                "type": "equals",
+                "pattern": 46,
+            }
+        }
+
+        result = op(payload, criteria_pattern, "all2any", self._test_function)
+        self.assertTrue(result)
+
+        criteria_pattern['item.waterLevel#2']['type'] = 'greaterthan'
+
+        result = op(payload, criteria_pattern, "all2any", self._test_function)
+        self.assertFalse(result)
+
+
+    def test_multiple_all2all(self):
+        # true if all payload items match all criteria items
+        op = operators.get_operator("multiple")
+        payload = [
+            {
+                "field_name": "waterLevel",
+                "to_value": 45,
+            },
+            {
+                "field_name": "waterLevel",
+                "to_value": 46,
+            }
+        ]
+
+        criteria_pattern = {
+            "item.waterLevel#1": {
+                "type": "greaterthan",
+                "pattern": 40,
+            },
+            "item.waterLevel#2": {
+                "type": "lessthan",
+                "pattern": 50,
+            }
+        }
+
+        result = op(payload, criteria_pattern, "all2all", self._test_function)
+        self.assertTrue(result)
+
+        payload[0]['to_value'] = 30
+
+        result = op(payload, criteria_pattern, "all2all", self._test_function)
+        self.assertFalse(result)
+
+        payload[0]['to_value'] = 45
+
+        criteria_pattern['item.waterLevel#3'] = {
+            "type": "equals",
+            "pattern": 46,
+        }
+
+        result = op(payload, criteria_pattern, "all2all", self._test_function)
+        self.assertFalse(result)
+
+
+    def test_multiple_payload_dict(self):
+        op = operators.get_operator("multiple")
+        payload = {
+            "field_name": "waterLevel",
+            "to_value": 45,
+        }
+
+        criteria_pattern = {
+            "item.waterLevel#1": {
+                "type": "greaterthan",
+                "pattern": 40,
+            },
+            "item.waterLevel#2": {
+                "type": "lessthan",
+                "pattern": 50,
+            }
+        }
+
+        result = op(payload, criteria_pattern, "all2all", self._test_function)
+        self.assertTrue(result)
+
+        payload['to_value'] = 30
+
+        result = op(payload, criteria_pattern, "all2all", self._test_function)
+        self.assertFalse(result)
+
+        payload['to_value'] = 45
+
+        criteria_pattern['item.waterLevel#3'] = {
+            "type": "equals",
+            "pattern": 46,
+        }
+
+        result = op(payload, criteria_pattern, "all2all", self._test_function)
+        self.assertFalse(result)
+
+
 class OperatorTest(unittest2.TestCase):
     def test_matchwildcard(self):
         op = operators.get_operator("matchwildcard")

--- a/st2reactor/st2reactor/rules/filter.py
+++ b/st2reactor/st2reactor/rules/filter.py
@@ -154,7 +154,8 @@ class RuleFilter(object):
 
             return (False, None, None)
 
-        criterion_k_hash_strip = criterion_k.split('#', 1)[0]
+        # Avoids the dict unique keys limitation. Allows multiple evaluations of the same payload item by a rule.
+        criterion_k_hash_strip = criterion_k.split("#", 1)[0]
         try:
             matches = payload_lookup.get_value(criterion_k_hash_strip)
             # pick value if only 1 matches else will end up being an array match.
@@ -172,7 +173,7 @@ class RuleFilter(object):
         op_func = criteria_operators.get_operator(criteria_operator)
 
         try:
-            if (criteria_operator == criteria_operators.SEARCH) or (criteria_operator == criteria_operators.MULTIPLE):
+            if criteria_operator == criteria_operators.SEARCH:
                 result = op_func(
                     value=payload_value,
                     criteria_pattern=criteria_pattern,

--- a/st2reactor/st2reactor/rules/filter.py
+++ b/st2reactor/st2reactor/rules/filter.py
@@ -154,8 +154,9 @@ class RuleFilter(object):
 
             return (False, None, None)
 
+        criterion_k_hash_strip = criterion_k.split('#', 1)[0]
         try:
-            matches = payload_lookup.get_value(criterion_k)
+            matches = payload_lookup.get_value(criterion_k_hash_strip)
             # pick value if only 1 matches else will end up being an array match.
             if matches:
                 payload_value = matches[0] if len(matches) > 0 else matches
@@ -171,7 +172,7 @@ class RuleFilter(object):
         op_func = criteria_operators.get_operator(criteria_operator)
 
         try:
-            if criteria_operator == criteria_operators.SEARCH:
+            if (criteria_operator == criteria_operators.SEARCH) or (criteria_operator == criteria_operators.MULTIPLE):
                 result = op_func(
                     value=payload_value,
                     criteria_pattern=criteria_pattern,

--- a/st2reactor/tests/unit/test_filter.py
+++ b/st2reactor/tests/unit/test_filter.py
@@ -414,3 +414,19 @@ class FilterTest(DbTestCase):
         }
         f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
         self.assertTrue(f.filter())
+
+    def test_hash_strip_int_value(self):
+        rule = MOCK_RULE_1
+        rule.criteria = {"trigger.int": {"type": "gt", "pattern": 0}, "trigger.int#2": {"type": "lt", "pattern": 2}}
+        f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
+        self.assertTrue(f.filter(), "equals check should have passed.")
+
+        rule = MOCK_RULE_1
+        rule.criteria = {"trigger.int": {"type": "gt", "pattern": 2}, "trigger.int#2": {"type": "lt", "pattern": 3}}
+        f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
+        self.assertFalse(f.filter(), "trigger value is gt than 0 but didn't match.")
+
+        rule = MOCK_RULE_1
+        rule.criteria = {"trigger.int#1": {"type": "lt", "pattern": 2}}
+        f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
+        self.assertTrue(f.filter(), "trigger value is gt than 0 but didn't match.")

--- a/st2reactor/tests/unit/test_filter.py
+++ b/st2reactor/tests/unit/test_filter.py
@@ -417,12 +417,18 @@ class FilterTest(DbTestCase):
 
     def test_hash_strip_int_value(self):
         rule = MOCK_RULE_1
-        rule.criteria = {"trigger.int": {"type": "gt", "pattern": 0}, "trigger.int#2": {"type": "lt", "pattern": 2}}
+        rule.criteria = {
+            "trigger.int": {"type": "gt", "pattern": 0},
+            "trigger.int#2": {"type": "lt", "pattern": 2},
+        }
         f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
         self.assertTrue(f.filter(), "equals check should have passed.")
 
         rule = MOCK_RULE_1
-        rule.criteria = {"trigger.int": {"type": "gt", "pattern": 2}, "trigger.int#2": {"type": "lt", "pattern": 3}}
+        rule.criteria = {
+            "trigger.int": {"type": "gt", "pattern": 2},
+            "trigger.int#2": {"type": "lt", "pattern": 3},
+        }
         f = RuleFilter(MOCK_TRIGGER_INSTANCE, MOCK_TRIGGER, rule)
         self.assertFalse(f.filter(), "trigger value is gt than 0 but didn't match.")
 


### PR DESCRIPTION
The new "multiple" operator is similar to "search" except it adds some additional features. It allows multiple evaluations of the same payload item by a rule. This solves a problem brought up in #2656 

Now evaluations such as the following are possible:
```
trigger.body.location.latitude:
  type: multiple
  condition: all2any
  pattern:
    item.value:
      type: "lessthan"
      pattern: 40
    item.value#2:
      type: "greaterthan"
      pattern: 50
trigger.body.location.longitude:
  type: multiple
  condition: all2any
  pattern:
    item.value:
      type: "greaterthan"
      pattern: -90
    item.value#2:
      type: "lessthan"
      pattern: -100
```

In this example the action for this criteria would occur when the latitude and longitude payload data falls outside the area specified, creating a simple box geo-fence.

There are four different criteria conditions:
* all2all - true if all payload items match all criteria items
* all2any - true if all payload items match any criteria items
* any2any - true if any payload items match any criteria items
* any2all - true if any payload items match all criteria items

When specifying payload data in the rule, the "#" symbol and text after it are ignored. This allows dictionary keys to be unique but refer to the same field. Any text can go after the hash.

Using the four different criteria conditions, inclusive or exclusive ranges for the same field are possible.

See tests for more examples.

The multiple operator could eventually replace the search operator.

Closes #2656