### PR TITLE
Fix st2-self-check script reporting success on failed runs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ Fixed
 
   Contributed by @khushboobhatia01
 
+* Fix ``st2-self-check`` script reporting falsey success when the nested workflows runs failed. #5487
+
 3.6.0 - October 29, 2021
 ------------------------
 

--- a/st2common/bin/st2-self-check
+++ b/st2common/bin/st2-self-check
@@ -140,7 +140,7 @@ do
 
     START_TS=$(date +%s)
     OUTPUT=$(st2 run ${TEST} protocol=${PROTOCOL} token=${ST2_AUTH_TOKEN})
-    echo ${OUTPUT} | grep "status" | grep -q "succeeded"
+    echo ${OUTPUT} | grep -q "status: succeeded"
     EXIT_CODE=$?
     END_TS=$(date +%s)
     DURATION=$(expr ${END_TS} - ${START_TS})
@@ -159,7 +159,7 @@ if [ ${RUN_ORQUESTA_TESTS} = "true" ]; then
 
     START_TS=$(date +%s)
     OUTPUT=$(st2 run examples.orquesta-examples)
-    echo ${OUTPUT} | grep "status" | grep -q "succeeded"
+    echo ${OUTPUT} | grep -q "status: succeeded"
     EXIT_CODE=$?
     END_TS=$(date +%s)
     DURATION=$(expr ${END_TS} - ${START_TS})

--- a/st2common/bin/st2-self-check
+++ b/st2common/bin/st2-self-check
@@ -140,7 +140,7 @@ do
 
     START_TS=$(date +%s)
     OUTPUT=$(st2 run ${TEST} protocol=${PROTOCOL} token=${ST2_AUTH_TOKEN})
-    echo ${OUTPUT} | grep -q "status: succeeded"
+    echo "${OUTPUT}" | grep "status" | grep -q "succeeded"
     EXIT_CODE=$?
     END_TS=$(date +%s)
     DURATION=$(expr ${END_TS} - ${START_TS})
@@ -159,7 +159,7 @@ if [ ${RUN_ORQUESTA_TESTS} = "true" ]; then
 
     START_TS=$(date +%s)
     OUTPUT=$(st2 run examples.orquesta-examples)
-    echo ${OUTPUT} | grep -q "status: succeeded"
+    echo "${OUTPUT}" | grep "status" | grep -q "succeeded"
     EXIT_CODE=$?
     END_TS=$(date +%s)
     DURATION=$(expr ${END_TS} - ${START_TS})


### PR DESCRIPTION
When the test run contains several nested workflows the script assumes it's succeeded if at least a single sub-workflow was successful. Instead of that, the check should refer to the parent workflow with "status: succeeded".

Example
```bash
id: 61b105a82f44ed586b2d24d0
action.ref: tests.test_inquiry_chain
parameters: 
  protocol: http
  token: bbeb3f7d29e240ac83ce3d53fff90745
status: failed 
result_task: get_workflow_details_1
result: 
  failed: true
  return_code: 2
  stderr: ""
  stdout: ''
  succeeded: false 
error: ""
traceback: None
failed_on: get_workflow_details_1
start_timestamp: Wed, 08 Dec 2021 19:21:12 UTC
end_timestamp: Wed, 08 Dec 2021 19:21:23 UTC
log: 
  - status: requested
    timestamp: '2021-12-08T19:21:12.277000Z'
  - status: scheduled
    timestamp: '2021-12-08T19:21:12.434000Z'
  - status: running
    timestamp: '2021-12-08T19:21:12.697000Z'
  - status: failed
    timestamp: '2021-12-08T19:21:23.334000Z'
+--------------------------+------------------------+--------------------------+------------+-------------------------------+
| id                       | status                 | task                     | action     | start_timestamp               |
+--------------------------+------------------------+--------------------------+------------+-------------------------------+
| 61b105a8b1a7886ef90b7b15 | succeeded (4s elapsed) | execute_inquiry_workflow | core.local | Wed, 08 Dec 2021 19:21:12 UTC |
| 61b105acb1a7886ef90b7b17 | succeeded (2s elapsed) | get_inquiry_trigger      | core.local | Wed, 08 Dec 2021 19:21:16 UTC |
| 61b105afb1a7886ef90b7b19 | succeeded (0s elapsed) | get_inquiry_id           | core.local | Wed, 08 Dec 2021 19:21:19 UTC |
| 61b105b0b1a7886ef90b7b1b | succeeded (1s elapsed) | get_workflow_id          | core.local | Wed, 08 Dec 2021 19:21:20 UTC |
| 61b105b2b1a7886ef90b7b1d | failed (1s elapsed)    | get_workflow_details_1   | core.local | Wed, 08 Dec 2021 19:21:22 UTC |
+--------------------------+------------------------+--------------------------+------------+-------------------------------+

```