### PR TITLE
Revert "Add status changed by user info to context"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,10 +11,6 @@ Added
 
   Contributed by @khushboobhatia01
 
-* Added cancel/pause/resume requester information to execution context. #5459
-
-  Contributed by @khushboobhatia01
-
 Fixed
 ~~~~~
 

--- a/contrib/runners/orquesta_runner/tests/unit/test_cancel.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_cancel.py
@@ -118,7 +118,6 @@ class OrquestaRunnerCancelTest(st2tests.ExecutionDbTestCase):
         lv_ac_db, ac_ex_db = ac_svc.request_cancellation(lv_ac_db, requester)
         lv_ac_db = lv_db_access.LiveAction.get_by_id(str(lv_ac_db.id))
         self.assertEqual(lv_ac_db.status, ac_const.LIVEACTION_STATUS_CANCELING)
-        self.assertEqual(lv_ac_db.context["cancelled_by"], requester)
 
     def test_cancel_workflow_cascade_down_to_subworkflow(self):
         wf_meta = base.get_wf_fixture_meta_data(TEST_PACK_PATH, "subworkflow.yaml")

--- a/contrib/runners/orquesta_runner/tests/unit/test_pause_and_resume.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_pause_and_resume.py
@@ -118,7 +118,6 @@ class OrquestaRunnerPauseResumeTest(st2tests.ExecutionDbTestCase):
         lv_ac_db, ac_ex_db = ac_svc.request_pause(lv_ac_db, cfg.CONF.system_user.user)
         lv_ac_db = lv_db_access.LiveAction.get_by_id(str(lv_ac_db.id))
         self.assertEqual(lv_ac_db.status, ac_const.LIVEACTION_STATUS_PAUSING)
-        self.assertEqual(lv_ac_db.context["paused_by"], cfg.CONF.system_user.user)
 
     @mock.patch.object(ac_svc, "is_children_active", mock.MagicMock(return_value=True))
     def test_pause_with_active_children(self):
@@ -526,7 +525,6 @@ class OrquestaRunnerPauseResumeTest(st2tests.ExecutionDbTestCase):
             workflow_execution=str(wf_ex_dbs[0].id)
         )
         self.assertEqual(len(tk_ex_dbs), 2)
-        self.assertEqual(lv_ac_db.context["resumed_by"], cfg.CONF.system_user.user)
 
     def test_resume_cascade_to_subworkflow(self):
         wf_meta = base.get_wf_fixture_meta_data(TEST_PACK_PATH, "subworkflow.yaml")

--- a/st2common/st2common/services/action.py
+++ b/st2common/st2common/services/action.py
@@ -214,12 +214,7 @@ def request(liveaction):
 
 
 def update_status(
-    liveaction,
-    new_status,
-    result=None,
-    publish=True,
-    set_result_size=False,
-    context=None,
+    liveaction, new_status, result=None, publish=True, set_result_size=False
 ):
     if liveaction.status == new_status:
         return liveaction
@@ -231,7 +226,6 @@ def update_status(
         "status": new_status,
         "result": result,
         "publish": False,
-        "context": context,
     }
 
     if new_status in action_constants.LIVEACTION_COMPLETED_STATES:
@@ -310,10 +304,7 @@ def request_cancellation(liveaction, requester):
     else:
         status = action_constants.LIVEACTION_STATUS_CANCELED
 
-    liveaction.context["cancelled_by"] = requester
-    liveaction = update_status(
-        liveaction, status, result=result, context=liveaction.context
-    )
+    liveaction = update_status(liveaction, status, result=result)
 
     execution = ActionExecution.get(liveaction__id=str(liveaction.id))
 
@@ -355,12 +346,7 @@ def request_pause(liveaction, requester):
             % liveaction.id
         )
 
-    liveaction.context["paused_by"] = requester
-    liveaction = update_status(
-        liveaction,
-        action_constants.LIVEACTION_STATUS_PAUSING,
-        context=liveaction.context,
-    )
+    liveaction = update_status(liveaction, action_constants.LIVEACTION_STATUS_PAUSING)
 
     execution = ActionExecution.get(liveaction__id=str(liveaction.id))
 
@@ -404,12 +390,7 @@ def request_resume(liveaction, requester):
             'not in "paused" state.' % (liveaction.id, liveaction.status)
         )
 
-    liveaction.context["resumed_by"] = requester
-    liveaction = update_status(
-        liveaction,
-        action_constants.LIVEACTION_STATUS_RESUMING,
-        context=liveaction.context,
-    )
+    liveaction = update_status(liveaction, action_constants.LIVEACTION_STATUS_RESUMING)
 
     execution = ActionExecution.get(liveaction__id=str(liveaction.id))
 


### PR DESCRIPTION
Reverts StackStorm/st2#5459

Looks like there is a regression from the previous PR which failed in e2e st2-self-check tests.

@khushboobhatia01 We can wait for the patch on top of the previous PR from you.
Alternatively, to unblock the builds, we can revert the PR until another iteration on this feature from your side.

-----

### Steps to reproduce
After running the st2-self-check which does some pause/resume workflows:
```
vagrant@stackstorm:~$  sudo ST2_AUTH_TOKEN=$(st2 auth st2admin -p 'Ch@ngeMe' -t) st2-self-check
```
Things will fail with `500` from API:
```
vagrant@stackstorm:~$ st2 execution list
ERROR: 500 Server Error: Internal Server Error
MESSAGE: Internal Server Error for url: http://127.0.0.1:9101/v1/executions/?limit=50&parent=null&sort_desc=True&include_attributes=id%2Caction.ref%2Ccontext.user%2Cstatus%2Cstart_timestamp%2Cend_timestamp
```

`st2api.log`:
```
2021-12-08 21:07:08,022 139904180972432 INFO logging [-] 9cbe8e6a-3736-4f3d-b98e-9d758d211a4e - GET /v1/executions/ with query={'limit': ['50'], 'parent': ['null'], 'sort_desc': ['True'], 'include_attributes': ['id,action.ref,context.user,status,start_timestamp,end_timestamp']} (method='GET',path='/v1/executions/',remote_addr='127.0.0.1',query={'limit': ['50'], 'parent': ['null'], 'sort_desc': ['True'], 'include_attributes': ['id,action.ref,context.user,status,start_timestamp,end_timestamp']},request_id='9cbe8e6a-3736-4f3d-b98e-9d758d211a4e')
2021-12-08 21:07:08,072 139904180972432 ERROR router [-] Failed to call controller function "get_all" for operation "st2api.controllers.v1.actionexecutions:action_executions_controller.get_all": Type is not JSON serializable: DBRef
Traceback (most recent call last):
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/router.py", line 621, in __call__
    resp = func(**kw)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2api/controllers/v1/actionexecutions.py", line 749, in get_all
    requester_user=requester_user,
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2api/controllers/v1/actionexecutions.py", line 1145, in _get_action_executions
    requester_user=requester_user,
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2api/controllers/resource.py", line 253, in _get_all
    resp = Response(json=result)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/router.py", line 192, in __init__
    body = json_encode(json_body).encode("utf-8")
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/util/jsonify.py", line 116, in json_encode
    return json_encode_orjson(obj=obj, indent=indent, sort_keys=sort_keys)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/util/jsonify.py", line 92, in json_encode_orjson
    return orjson.dumps(obj, default=default).decode("utf-8")
TypeError: Type is not JSON serializable: DBRef
2021-12-08 21:07:08,072 139904180972432 ERROR error_handling [-] API call failed: Type is not JSON serializable: DBRef
Traceback (most recent call last):
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/middleware/error_handling.py", line 49, in __call__
    return self.app(environ, start_response)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/middleware/streaming.py", line 46, in __call__
    return self.app(environ, start_response)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/router.py", line 735, in as_wsgi
    resp = self(req)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/router.py", line 633, in __call__
    raise e
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/router.py", line 621, in __call__
    resp = func(**kw)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2api/controllers/v1/actionexecutions.py", line 749, in get_all
    requester_user=requester_user,
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2api/controllers/v1/actionexecutions.py", line 1145, in _get_action_executions
    requester_user=requester_user,
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2api/controllers/resource.py", line 253, in _get_all
    resp = Response(json=result)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/router.py", line 192, in __init__
    body = json_encode(json_body).encode("utf-8")
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/util/jsonify.py", line 116, in json_encode
    return json_encode_orjson(obj=obj, indent=indent, sort_keys=sort_keys)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/util/jsonify.py", line 92, in json_encode_orjson
    return orjson.dumps(obj, default=default).decode("utf-8")
TypeError: Type is not JSON serializable: DBRef (_exception_class='TypeError',_exception_message='Type is not JSON serializable: DBRef',_exception_data={})

```
