### PR TITLE
Router fix to handle url encoded form payload

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ in development
 Fixed
 ~~~~~
 
+* Fix deserialization bug for url encoded payloads. #5513
+
+  Contributed by @sravs-dev
+
 * Fix Type error for ``time_diff`` critera comparison. convert the timediff value as float to match
   ``timedelta.total_seconds()`` return. #5462
 

--- a/st2api/tests/unit/controllers/v1/test_webhooks.py
+++ b/st2api/tests/unit/controllers/v1/test_webhooks.py
@@ -269,10 +269,11 @@ class TestWebhooksController(FunctionalTest):
             "St2-Trace-Tag": "tag1",
         }
 
-        self.app.post("/v1/webhooks/git", data, headers=headers)
+        post_resp = self.app.post("/v1/webhooks/git", data, headers=headers)
+        self.assertEqual(post_resp.status_int, http_client.ACCEPTED)
         self.assertEqual(
             dispatch_mock.call_args[1]["payload"]["headers"]["Content-Type"],
-            "application/x-www-form-urlencoded",
+            "application/x-www-form-urlencoded; charset=UTF-8",
         )
         self.assertEqual(dispatch_mock.call_args[1]["payload"]["body"], data)
         self.assertEqual(dispatch_mock.call_args[1]["trace_context"].trace_tag, "tag1")

--- a/st2api/tests/unit/controllers/v1/test_webhooks.py
+++ b/st2api/tests/unit/controllers/v1/test_webhooks.py
@@ -262,11 +262,6 @@ class TestWebhooksController(FunctionalTest):
     )
     @mock.patch("st2common.transport.reactor.TriggerDispatcher.dispatch")
     def test_form_encoded_request_body(self, dispatch_mock):
-        return
-        # TODO: Fix on deserialization on API side, body dict values being decoded as bytes
-        # instead of unicode which breakgs things. Likely issue / bug with form urlencoding
-        # parsing or perhaps in the test client when sending data
-        # Send request body as form urlencoded data
         data = {"form": ["test"]}
 
         headers = {

--- a/st2auth/tests/unit/controllers/v1/test_sso.py
+++ b/st2auth/tests/unit/controllers/v1/test_sso.py
@@ -144,9 +144,7 @@ class TestIdentityProviderCallbackController(FunctionalTest):
     )
     def test_callback_url_encoded_payload(self):
         data = {"foo": ["bar"]}
-        headers = {
-            "Content-Type": "application/x-www-form-urlencoded",
-        }
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
         response = self.app.post(SSO_CALLBACK_V1_PATH, data, headers=headers)
         self.assertTrue(response.status_code, http_client.OK)
 
@@ -164,5 +162,3 @@ class TestIdentityProviderCallbackController(FunctionalTest):
         )
         self.assertTrue(response.status_code, http_client.UNAUTHORIZED)
         self.assertDictEqual(response.json, expected_error)
-
-

--- a/st2auth/tests/unit/controllers/v1/test_sso.py
+++ b/st2auth/tests/unit/controllers/v1/test_sso.py
@@ -140,6 +140,19 @@ class TestIdentityProviderCallbackController(FunctionalTest):
     @mock.patch.object(
         sso_api_controller.SSO_BACKEND,
         "verify_response",
+        mock.MagicMock(return_value={"referer": MOCK_REFERER, "username": MOCK_USER}),
+    )
+    def test_callback_url_encoded_payload(self):
+        data = {"foo": ["bar"]}
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        response = self.app.post(SSO_CALLBACK_V1_PATH, data, headers=headers)
+        self.assertTrue(response.status_code, http_client.OK)
+
+    @mock.patch.object(
+        sso_api_controller.SSO_BACKEND,
+        "verify_response",
         mock.MagicMock(
             side_effect=auth_exc.SSOVerificationError("Verification Failed")
         ),
@@ -151,3 +164,5 @@ class TestIdentityProviderCallbackController(FunctionalTest):
         )
         self.assertTrue(response.status_code, http_client.UNAUTHORIZED)
         self.assertDictEqual(response.json, expected_error)
+
+

--- a/st2common/st2common/router.py
+++ b/st2common/st2common/router.py
@@ -494,7 +494,7 @@ class Router(object):
                         "application/x-www-form-urlencoded",
                         "multipart/form-data",
                     ]:
-                        data = urlparse.parse_qs(req.body)
+                        data = urlparse.parse_qs(six.ensure_str(req.body))
                     else:
                         raise ValueError(
                             'Unsupported Content-Type: "%s"' % (content_type)


### PR DESCRIPTION
Fix for the issue https://github.com/StackStorm/st2/issues/5512

When there is a POST request with payload type "application/x-www-form-urlencoded" , Input body is of type bytes. We need to convert it to string before processing