### PR TITLE
Use byte type lock name which is supported by all tooz drivers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,6 +39,10 @@ Fixed
 
 * Fix ``st2-self-check`` script reporting falsey success when the nested workflows runs failed. #5487
 
+* Use byte type lock name which is supported by all tooz drivers. #5529
+
+  Contributed by @khushboobhatia01
+
 3.6.0 - October 29, 2021
 ------------------------
 

--- a/st2common/st2common/services/executions.py
+++ b/st2common/st2common/services/executions.py
@@ -196,7 +196,7 @@ def update_execution(liveaction_db, publish=True, set_result_size=False):
     """
     execution = ActionExecution.get(liveaction__id=str(liveaction_db.id))
 
-    with coordination.get_coordinator().get_lock(str(liveaction_db.id)):
+    with coordination.get_coordinator().get_lock(str(liveaction_db.id).encode()):
         # Skip execution object update when action is already in completed state.
         if execution.status in action_constants.LIVEACTION_COMPLETED_STATES:
             LOG.debug(

--- a/st2common/st2common/services/workflows.py
+++ b/st2common/st2common/services/workflows.py
@@ -938,7 +938,7 @@ def handle_action_execution_completion(ac_ex_db):
     task_ex_id = ac_ex_db.context["orquesta"]["task_execution_id"]
 
     # Acquire lock before write operations.
-    with coord_svc.get_coordinator(start_heart=True).get_lock(wf_ex_id):
+    with coord_svc.get_coordinator(start_heart=True).get_lock(str(wf_ex_id).encode()):
         # Get execution records for logging purposes.
         wf_ex_db = wf_db_access.WorkflowExecution.get_by_id(wf_ex_id)
         task_ex_db = wf_db_access.TaskExecution.get_by_id(task_ex_id)


### PR DESCRIPTION
String lock names are not supported by all the tooz drivers because of unsafe encode/decode and concatenation which results in error with string types.

Example:
- etcd3gw => https://opendev.org/openstack/tooz/src/branch/master/tooz/drivers/etcd3gw.py#L72 `TypeError: can't concat bytes to str`

- memcached => https://opendev.org/openstack/tooz/src/branch/master/tooz/drivers/memcached.py#L79 `TypeError: can't concat bytes to str`

- etcd3 => https://opendev.org/openstack/tooz/src/branch/master/tooz/drivers/etcd3.py#L70 `AttributeError: 'str' object has no attribute 'decode'`

Remaining drivers support both str and byte type
- consul => https://opendev.org/openstack/tooz/src/branch/master/tooz/drivers/consul.py#L295 `Safe decode`

- etcd => https://opendev.org/openstack/tooz/src/branch/master/tooz/drivers/etcd.py#L255 `Safe encode`

- redis => https://opendev.org/openstack/tooz/src/branch/master/tooz/drivers/redis.py#L81 `Converts to string`

- zookeeper => https://opendev.org/openstack/tooz/src/branch/master/tooz/drivers/zookeeper.py#L447 `Safe decode`