### PR TITLE
Fix issue with pack option not working when running policy list cli

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,10 @@ Fixed
 
   Contributed by @blackstrip
 
+* Fix issue with pack option not working when running policy list cli #5534
+
+  Contributed by @momokuri-3
+
 Added
 ~~~~~
 

--- a/st2client/st2client/commands/policy.py
+++ b/st2client/st2client/commands/policy.py
@@ -109,20 +109,19 @@ class PolicyListCommand(resource.ContentPackResourceListCommand):
 
     @resource.add_auth_token_to_kwargs_from_cli
     def run(self, args, **kwargs):
-        if args.resource_ref or args.policy_type:
-            filters = {}
-
-            if args.resource_ref:
-                filters["resource_ref"] = args.resource_ref
-
-            if args.policy_type:
-                filters["policy_type"] = args.policy_type
-
-            filters.update(**kwargs)
-
-            return self.manager.query(**filters)
-        else:
-            return self.manager.get_all(**kwargs)
+        filters = {}
+        if args.pack:
+            filters["pack"] = args.pack
+        if args.resource_ref:
+            filters["resource_ref"] = args.resource_ref
+        if args.policy_type:
+            filters["policy_type"] = args.policy_type
+        filters.update(**kwargs)
+        include_attributes = self._get_include_attributes(args=args)
+        if include_attributes:
+            include_attributes = ",".join(include_attributes)
+            filters["params"] = {"include_attributes": include_attributes}
+        return self.manager.query(**filters)
 
 
 class PolicyGetCommand(resource.ContentPackResourceGetCommand):

--- a/st2client/tests/unit/test_shell.py
+++ b/st2client/tests/unit/test_shell.py
@@ -562,6 +562,21 @@ class ShellTestCase(base.BaseCLITestCase):
             shell.LOG.info.call_args_list[1][0][0], "Skipping parsing CLI config"
         )
 
+    def test_policy_list_with_pack_option(self):
+        argv = ["policy", "list", "-p", "test"]
+        mock_obj = mock.MagicMock(
+            return_value=base.FakeResponse(json.dumps(base.RESOURCES), 200, "OK")
+        )
+        with mock.patch.object(httpclient.HTTPClient, "get", mock_obj):
+            self.shell.run(argv)
+            self.assertEqual(
+                mock_obj.mock_calls[0],
+                mock.call(
+                    "/policies/?include_attributes=ref%2Cresource_ref%2C"
+                    "policy_type%2Cenabled&pack=test"
+                ),
+            )
+
 
 class CLITokenCachingTestCase(unittest2.TestCase):
     def setUp(self):


### PR DESCRIPTION
This error occurs when run ```policy list``` with st2-client.
If the ```--pack``` option is given, it should return only the resources belonging to the provided pack.
However, there was no change in the output when the ```--pack``` option was specified or not.

Don't specify the pack option
```
st2 policy list

+---------------------------------+---------------------+-------------------------+---------+
| ref                             | resource_ref        | policy_type             | enabled |
+---------------------------------+---------------------+-------------------------+---------+
| testpack1.test.concurrency      | testpack1.test      | action.concurrency      | True    |
| testpack2.test.concurrency      | testpack2.test      | action.concurrency      | True    |
+---------------------------------+---------------------+-------------------------+---------+
```

Specify the pack option
```
st2 policy list --pack testpack1

+---------------------------------+---------------------+-------------------------+---------+
| ref                             | resource_ref        | policy_type             | enabled |
+---------------------------------+---------------------+-------------------------+---------+
| testpack1.test.concurrency      | testpack1.test      | action.concurrency      | True    |
| testpack2.test.concurrency      | testpack2.test      | action.concurrency      | True    |
+---------------------------------+---------------------+-------------------------+---------+
```

The code for the case where the pack option was specified was missing, so it will be corrected.
