### PR TITLE
WinRM parameter passing fails for larger scripts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Fixed
 * Fix issue of WinRM parameter passing fails for larger scripts.#5538
 
   Contributed by @ashwini-orchestral
-  
+
 * Fix Type error for ``time_diff`` critera comparison. convert the timediff value as float to match
   ``timedelta.total_seconds()`` return. #5462
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ in development
 Fixed
 ~~~~~
 
+* Fix issue of WinRM parameter passing fails for larger scripts.#5538
+
+  Contributed by @ashwini-orchestral
+  
 * Fix Type error for ``time_diff`` critera comparison. convert the timediff value as float to match
   ``timedelta.total_seconds()`` return. #5462
 

--- a/contrib/runners/winrm_runner/tests/unit/test_winrm_base.py
+++ b/contrib/runners/winrm_runner/tests/unit/test_winrm_base.py
@@ -909,7 +909,7 @@ Add-Content -value $data -encoding byte -path $filePath
         mock_tmp_script.assert_called_with(
             "[System.IO.Path]::GetTempPath()", "$PSVersionTable"
         )
-        mock_run_ps.assert_called_with("& {C:\\tmpscript.ps1}")
+        mock_run_ps.assert_called_with("C:\\tmpscript.ps1")
 
     @mock.patch("winrm_runner.winrm_base.WinRmBaseRunner._run_ps")
     @mock.patch("winrm_runner.winrm_base.WinRmBaseRunner._tmp_script")
@@ -923,7 +923,7 @@ Add-Content -value $data -encoding byte -path $filePath
         mock_tmp_script.assert_called_with(
             "[System.IO.Path]::GetTempPath()", "Get-ChildItem"
         )
-        mock_run_ps.assert_called_with("& {C:\\tmpscript.ps1} -param1 value1 arg1")
+        mock_run_ps.assert_called_with("C:\\tmpscript.ps1 -param1 value1 arg1")
 
     @mock.patch("winrm_runner.winrm_base.WinRmBaseRunner._run_ps")
     def test__run_ps_or_raise(self, mock_run_ps):

--- a/contrib/runners/winrm_runner/winrm_runner/winrm_base.py
+++ b/contrib/runners/winrm_runner/winrm_runner/winrm_base.py
@@ -403,7 +403,7 @@ Add-Content -value $data -encoding byte -path $filePath
             # the following wraps the script (from the file) in a script block ( {} )
             # executes it, passing in the parameters built above
             # https://docs.microsoft.com/en-us/powershell/scripting/core-powershell/console/powershell.exe-command-line-help
-            ps = "& {%s}" % (tmp_script)
+            ps = tmp_script
             if params:
                 ps += " " + params
             return self._run_ps(ps)

--- a/contrib/runners/winrm_runner/winrm_runner/winrm_base.py
+++ b/contrib/runners/winrm_runner/winrm_runner/winrm_base.py
@@ -401,7 +401,7 @@ Add-Content -value $data -encoding byte -path $filePath
         # handle deletion of the temporary file on exit of the with block
         with self._tmp_script(tmp_dir, script) as tmp_script:
             # the following wraps the script (from the file) in a script block ( {} )
-            # executes it, passing in the parameters built above
+            # executes it, passing in the parameters built above.
             # https://docs.microsoft.com/en-us/powershell/scripting/core-powershell/console/powershell.exe-command-line-help
             ps = tmp_script
             if params:


### PR DESCRIPTION
When winrm-ps-script runner type was used, found that we were unable to pass parameters successfully from Stackstorm to the PowerShell script. We noticed inconsistent parameter passing to the PowerShell scripts, seemingly being able to pass inputs to smaller scripts but not to larger ones.
