### PR TITLE
Add status changed by user info to context

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -64,6 +64,10 @@ Added
 
   Contributed by @erceth
 
+* Added cancel/pause/resume requester information to execution context. #5554
+
+  Contributed by @khushboobhatia01
+
 Fixed
 ~~~~~
 

--- a/contrib/runners/orquesta_runner/tests/unit/test_cancel.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_cancel.py
@@ -118,6 +118,7 @@ class OrquestaRunnerCancelTest(st2tests.ExecutionDbTestCase):
         lv_ac_db, ac_ex_db = ac_svc.request_cancellation(lv_ac_db, requester)
         lv_ac_db = lv_db_access.LiveAction.get_by_id(str(lv_ac_db.id))
         self.assertEqual(lv_ac_db.status, ac_const.LIVEACTION_STATUS_CANCELING)
+        self.assertEqual(lv_ac_db.context["cancelled_by"], requester)
 
     def test_cancel_workflow_cascade_down_to_subworkflow(self):
         wf_meta = base.get_wf_fixture_meta_data(TEST_PACK_PATH, "subworkflow.yaml")

--- a/contrib/runners/orquesta_runner/tests/unit/test_pause_and_resume.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_pause_and_resume.py
@@ -118,6 +118,7 @@ class OrquestaRunnerPauseResumeTest(st2tests.ExecutionDbTestCase):
         lv_ac_db, ac_ex_db = ac_svc.request_pause(lv_ac_db, cfg.CONF.system_user.user)
         lv_ac_db = lv_db_access.LiveAction.get_by_id(str(lv_ac_db.id))
         self.assertEqual(lv_ac_db.status, ac_const.LIVEACTION_STATUS_PAUSING)
+        self.assertEqual(lv_ac_db.context["paused_by"], cfg.CONF.system_user.user)
 
     @mock.patch.object(ac_svc, "is_children_active", mock.MagicMock(return_value=True))
     def test_pause_with_active_children(self):
@@ -525,6 +526,7 @@ class OrquestaRunnerPauseResumeTest(st2tests.ExecutionDbTestCase):
             workflow_execution=str(wf_ex_dbs[0].id)
         )
         self.assertEqual(len(tk_ex_dbs), 2)
+        self.assertEqual(lv_ac_db.context["resumed_by"], cfg.CONF.system_user.user)
 
     def test_resume_cascade_to_subworkflow(self):
         wf_meta = base.get_wf_fixture_meta_data(TEST_PACK_PATH, "subworkflow.yaml")


### PR DESCRIPTION
This is required to track who cancelled/paused/resumed any execution.

"context" : { "user" : "stanley", "pack" : "examples", "workflow_execution" : "61a0887aac2049b57fed57de", "paused_by" : "stanley", "resumed_by" : "stanley" }

e2e self-check-test failure happening as part of last PR (https://github.com/StackStorm/st2/pull/5489) is fixed in this PR.