### PR TITLE
Pin pyOpenSSL to <= 21.0.0

### DIFF
--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -40,6 +40,8 @@ pyinotify==0.9.6; platform_system=="Linux"
 pymongo==3.11.3
 pyparsing<3
 zstandard==0.15.2
+# pyOpenSSL 22.0.0 requires cryptography>=35.0
+pyOpenSSL<=21.0.0
 python-editor==1.0.4
 python-keyczar==0.716
 pytz==2021.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,7 @@ passlib==1.7.4
 prettytable==2.1.0
 prompt-toolkit==1.0.15
 psutil==5.8.0
+pyOpenSSL<=21.0.0
 pyinotify==0.9.6; platform_system=="Linux"
 pymongo==3.11.3
 pyparsing<3

--- a/st2client/in-requirements.txt
+++ b/st2client/in-requirements.txt
@@ -19,4 +19,5 @@ orjson
 # needed by requests
 chardet
 # required for SOCKS proxy support (HTTP_PROXY, HTTPS_PROXY, NO_PROXY)
+pyOpenSSL
 pysocks

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -15,6 +15,7 @@ jsonschema==2.6.0
 orjson==3.5.2
 prettytable==2.1.0
 prompt-toolkit==1.0.15
+pyOpenSSL<=21.0.0
 pysocks
 python-dateutil==2.8.1
 python-editor==1.0.4

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -37,6 +37,7 @@ routes
 flex
 webob
 jsonpath-rw
+pyOpenSSL
 python-statsd
 udatetime
 orjson

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -29,6 +29,7 @@ networkx>=2.5.1,<2.6
 orjson==3.5.2
 oslo.config>=1.12.1,<1.13
 paramiko==2.7.2
+pyOpenSSL<=21.0.0
 pymongo==3.11.3
 python-dateutil==2.8.1
 python-statsd==2.1.0


### PR DESCRIPTION
pyOpenSSL 22.0.0 requires cryptography>=35.0 causing dependancy conflicts https://app.circleci.com/pipelines/github/StackStorm/st2/2631/workflows/9226c6bb-50c4-46fc-a71e-f707d7ce01bf/jobs/14228