### PR TITLE
Add a Changelog Checker

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,0 +1,25 @@
+name: Checks
+
+on:
+  pull_request:
+    types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - master
+      - v[0-9]+.[0-9]+
+
+jobs:
+  # Changelog checker will verify if CHANGELOG.rst was updated for every PR
+  # See: https://keepachangelog.com/en/1.0.0/
+  changelog-checker:
+    name: Add CHANGELOG.rst
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Changelog check
+        # https://github.com/marketplace/actions/changelog-checker
+        uses: Zomzog/changelog-checker@v1.2.0
+        with:
+          fileName: CHANGELOG.rst
+          checkNotification: Simple
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The Changelog is important so the community can track what changes they might expect in the upcoming releases or developers could pinpoint the changes to a particular PR and diff.

We could naturally forget or new contributors might not know about updating Changelog. Additionally, we don't want to go to every PR and ask for a Changelog addition.

This GH Action (https://github.com/marketplace/actions/changelog-checker) will verify if `CHANGELOG.rst` was updated for every PR:
![image](https://user-images.githubusercontent.com/1533818/152174543-2471c3d7-0e6e-4954-b969-4c7107677671.png)

<details>
  <summary>GH Actions view</summary>
  
  ![image](https://user-images.githubusercontent.com/1533818/152174502-ac2f5642-26b1-4930-8f45-a7293be033d8.png)
</details>



For rare cases when it's needed to skip the check, assign `no changelog` label for the PR.