### PR TITLE
Fix build failures due to newer  MarkUpSafe

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -240,8 +240,10 @@ jobs:
           # !virtualenv/lib/python*/site-packages/st2*
           # !virtualenv/bin/st2*
           key: ${{ runner.os }}-v4-python-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'test-requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-v4-python-${{ matrix.python }}-
+          # Don't use alternative key as if requirements.txt has altered we
+          # don't want to retrieve previous cache
+          #restore-keys: |
+          #  ${{ runner.os }}-v4-python-${{ matrix.python }}-
       - name: Cache APT Dependencies
         id: cache-apt-deps
         uses: actions/cache@v2
@@ -456,8 +458,10 @@ jobs:
           # !virtualenv/lib/python*/site-packages/st2*
           # !virtualenv/bin/st2*
           key: ${{ runner.os }}-v4-python-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'test-requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-v4-python-${{ matrix.python }}-
+          # Don't use alternative key as if requirements.txt has altered we
+          # don't want to retrieve previous cache
+          #restore-keys: |
+          #  ${{ runner.os }}-v4-python-${{ matrix.python }}-
       - name: Cache APT Dependencies
         id: cache-apt-deps
         uses: actions/cache@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,8 +96,10 @@ jobs:
           # !virtualenv/lib/python*/site-packages/st2*
           # !virtualenv/bin/st2*
           key: ${{ runner.os }}-v4-python-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'test-requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-v4-python-${{ matrix.python }}-
+          # Don't use alternative key as if requirements.txt has altered we
+          # don't want to retrieve previous cache
+          #restore-keys: |
+          #  ${{ runner.os }}-v4-python-${{ matrix.python }}-
       - name: Cache APT Dependencies
         id: cache-apt-deps
         uses: actions/cache@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,11 @@ Fixed
 
   Contributed by @blackstrip
 
+* Fix build issue due to MarkUpSafe 2.1.0 removing soft_unicode
+
+  Contributed by Amanda McGuinness (@amanda11 intive) #5581
+
+
 Added
 ~~~~~
 

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -22,9 +22,9 @@ jsonpath-rw==1.4.0
 jsonschema==2.6.0
 kombu==5.0.2
 lockfile==0.12.2
-# Fix MarkUpSafe to < 2.1.0 as 2.1.0 removes soft_unicode
-# Use >=0.23 as that is required by jinja
-MarkUpSafe<2.1.0,>=0.23
+# Fix MarkupSafe to < 2.1.0 as 2.1.0 removes soft_unicode
+# >=0.23 was from jinja2
+MarkupSafe<2.1.0,>=0.23
 mongoengine==0.23.0
 # networkx v2.6 does not support Python3.6.  Update networkx to match orquesta
 networkx>=2.5.1,<2.6

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -22,6 +22,9 @@ jsonpath-rw==1.4.0
 jsonschema==2.6.0
 kombu==5.0.2
 lockfile==0.12.2
+# Fix MarkUpSafe to < 2.1.0 as 2.1.0 removes soft_unicode
+# Use >=0.23 as that is required by jinja
+MarkUpSafe<2.1.0,>=0.23
 mongoengine==0.23.0
 # networkx v2.6 does not support Python3.6.  Update networkx to match orquesta
 networkx>=2.5.1,<2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 # If you want to update depdencies for a single component, modify the
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
-MarkUpSafe<2.1.0,>=0.23
+MarkupSafe<2.1.0,>=0.23
 RandomWords
 amqp==5.0.6
 apscheduler==3.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@
 # If you want to update depdencies for a single component, modify the
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
+MarkUpSafe<2.1.0,>=0.23
 RandomWords
 amqp==5.0.6
 apscheduler==3.7.0

--- a/st2actions/in-requirements.txt
+++ b/st2actions/in-requirements.txt
@@ -5,7 +5,7 @@ eventlet
 jinja2
 kombu
 #Used by jinja2
-MarkUpSafe
+MarkupSafe
 oslo.config
 oslo.utils
 pyparsing

--- a/st2actions/in-requirements.txt
+++ b/st2actions/in-requirements.txt
@@ -4,6 +4,8 @@ python-dateutil
 eventlet
 jinja2
 kombu
+#Used by jinja2
+MarkUpSafe
 oslo.config
 oslo.utils
 pyparsing

--- a/st2actions/requirements.txt
+++ b/st2actions/requirements.txt
@@ -5,7 +5,7 @@
 # If you want to update depdencies for a single component, modify the
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
-MarkUpSafe<2.1.0,>=0.23
+MarkupSafe<2.1.0,>=0.23
 apscheduler==3.7.0
 chardet<3.1.0
 eventlet==0.30.2

--- a/st2actions/requirements.txt
+++ b/st2actions/requirements.txt
@@ -5,6 +5,7 @@
 # If you want to update depdencies for a single component, modify the
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
+MarkUpSafe<2.1.0,>=0.23
 apscheduler==3.7.0
 chardet<3.1.0
 eventlet==0.30.2

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -8,6 +8,8 @@ greenlet
 jinja2
 jsonschema
 kombu
+#Used by jinja2
+MarkUpSafe
 mongoengine
 networkx
 # used by networkx

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -9,7 +9,7 @@ jinja2
 jsonschema
 kombu
 #Used by jinja2
-MarkUpSafe
+MarkupSafe
 mongoengine
 networkx
 # used by networkx

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -5,6 +5,7 @@
 # If you want to update depdencies for a single component, modify the
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
+MarkUpSafe<2.1.0,>=0.23
 amqp==5.0.6
 apscheduler==3.7.0
 cffi<1.15.0

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -5,7 +5,7 @@
 # If you want to update depdencies for a single component, modify the
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
-MarkUpSafe<2.1.0,>=0.23
+MarkupSafe<2.1.0,>=0.23
 amqp==5.0.6
 apscheduler==3.7.0
 cffi<1.15.0


### PR DESCRIPTION
Fix build errors due to markupsafe 2.1.0 removing soft_unicode, which were breaking the ST2 package tests.

Also, updated the GHA workflow as problems found after requirements.txt was altered. Altered so that it only looks for a cache on exact match of key instead of partial, so that doesn't try and pick up cache from previous version of requirements.txt.