### PR TITLE
Bump black to v22.3.0 and update format

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -187,6 +187,11 @@ Fixed
 
   Contributed by @nzlosh
 
+Changed
+~~~~~~~
+
+* Bump black to v22.3.0 - This is  used internally to reformat our python code. #5606
+
 3.6.0 - October 29, 2021
 ------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -381,7 +381,9 @@ black: requirements .black-check
 		echo "Running black on" $$component; \
 		echo "==========================================================="; \
 		. $(VIRTUALENV_DIR)/bin/activate ; black --check --config pyproject.toml $$component/ || exit 1; \
-		. $(VIRTUALENV_DIR)/bin/activate ; black $$(grep -rl '^#!/.*python' $$component/bin) || exit 1; \
+		if [ -d "$$component/bin" ]; then \
+			. $(VIRTUALENV_DIR)/bin/activate ; black $$(grep -rl '^#!/.*python' $$component/bin) || exit 1; \
+		fi \
 	done
 	# runner modules and packages
 	@for component in $(COMPONENTS_RUNNERS); do\
@@ -389,7 +391,9 @@ black: requirements .black-check
 		echo "Running black on" $$component; \
 		echo "==========================================================="; \
 		. $(VIRTUALENV_DIR)/bin/activate ; black --check --config pyproject.toml $$component/ || exit 1; \
-		. $(VIRTUALENV_DIR)/bin/activate ; black $$(grep -rl '^#!/.*python' $$component/bin) || exit 1; \
+		if [ -d "$$component/bin" ]; then \
+			. $(VIRTUALENV_DIR)/bin/activate ; black $$(grep -rl '^#!/.*python' $$component/bin) || exit 1; \
+		fi \
 	done
 	. $(VIRTUALENV_DIR)/bin/activate; black --check --config pyproject.toml contrib/ || exit 1;
 	. $(VIRTUALENV_DIR)/bin/activate; black --check --config pyproject.toml scripts/*.py || exit 1;
@@ -411,7 +415,9 @@ black: requirements .black-format
 		echo "Running black on" $$component; \
 		echo "==========================================================="; \
 		. $(VIRTUALENV_DIR)/bin/activate ; black --config pyproject.toml $$component/ || exit 1; \
-		. $(VIRTUALENV_DIR)/bin/activate ; black --config pyproject.toml $$(grep -rl '^#!/.*python' $$component/bin) || exit 1; \
+		if [ -d "$$component/bin" ]; then \
+			. $(VIRTUALENV_DIR)/bin/activate ; black --config pyproject.toml $$(grep -rl '^#!/.*python' $$component/bin) || exit 1; \
+		fi \
 	done
 	# runner modules and packages
 	@for component in $(COMPONENTS_RUNNERS); do\
@@ -419,7 +425,9 @@ black: requirements .black-format
 		echo "Running black on" $$component; \
 		echo "==========================================================="; \
 		. $(VIRTUALENV_DIR)/bin/activate ; black --config pyproject.toml  $$component/ || exit 1; \
-		. $(VIRTUALENV_DIR)/bin/activate ; black --config pyproject.toml $$(grep -rl '^#!/.*python' $$component/bin) || exit 1; \
+		if [ -d "$$component/bin" ]; then \
+			. $(VIRTUALENV_DIR)/bin/activate ; black --config pyproject.toml $$(grep -rl '^#!/.*python' $$component/bin) || exit 1; \
+		fi \
 	done
 	. $(VIRTUALENV_DIR)/bin/activate; black --config pyproject.toml contrib/ || exit 1;
 	. $(VIRTUALENV_DIR)/bin/activate; black --config pyproject.toml scripts/*.py || exit 1;

--- a/contrib/packs/actions/pack_mgmt/get_installed.py
+++ b/contrib/packs/actions/pack_mgmt/get_installed.py
@@ -27,7 +27,7 @@ from st2common.constants.pack import MANIFEST_FILE_NAME
 
 
 class GetInstalled(Action):
-    """"Get information about installed pack."""
+    """Get information about installed pack."""
 
     def run(self, pack):
         """

--- a/contrib/runners/local_runner/tests/integration/test_localrunner.py
+++ b/contrib/runners/local_runner/tests/integration/test_localrunner.py
@@ -629,7 +629,7 @@ class LocalShellScriptRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         )
         runner = self._get_runner(action_db, entry_point=entry_point)
         runner.pre_run()
-        char_count = 10 ** 6  # Note 10^7 succeeds but ends up being slow.
+        char_count = 10**6  # Note 10^7 succeeds but ends up being slow.
         status, result, _ = runner.run({"chars": char_count})
         runner.post_run(status, result)
         self.assertEqual(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)

--- a/st2actions/st2actions/scheduler/handler.py
+++ b/st2actions/st2actions/scheduler/handler.py
@@ -173,9 +173,12 @@ class ActionExecutionSchedulingQueueHandler(object):
                         )
                     )
                 except db_exc.StackStormDBObjectWriteConflictError:
-                    msg = '[%s] Item "%s" is currently being processed by another scheduler.' % (
-                        execution_queue_item_db.action_execution_id,
-                        str(execution_queue_item_db.id),
+                    msg = (
+                        '[%s] Item "%s" is currently being processed by another scheduler.'
+                        % (
+                            execution_queue_item_db.action_execution_id,
+                            str(execution_queue_item_db.id),
+                        )
                     )
                     LOG.error(msg)
                     raise Exception(msg)

--- a/st2api/st2api/controllers/resource.py
+++ b/st2api/st2api/controllers/resource.py
@@ -188,7 +188,7 @@ class ResourceController(object):
 
         # TODO: To protect us from DoS, we need to make max_limit mandatory
         offset = int(offset)
-        if offset >= 2 ** 31:
+        if offset >= 2**31:
             raise ValueError('Offset "%s" specified is more than 32-bit int' % (offset))
 
         limit = validate_limit_query_param(limit=limit, requester_user=requester_user)

--- a/st2api/tests/unit/controllers/v1/test_executions.py
+++ b/st2api/tests/unit/controllers/v1/test_executions.py
@@ -871,7 +871,7 @@ class ActionExecutionControllerTestCase(
         self.assertEqual(post_resp.status_int, 201)
         execution_id = self._get_actionexecution_id(post_resp)
 
-        delay_time = 10 ** 10
+        delay_time = 10**10
         data = {"delay": delay_time}
         re_run_resp = self.app.post_json(
             "/v1/executions/%s/re_run" % (execution_id), data

--- a/st2common/bin/st2-purge-task-executions
+++ b/st2common/bin/st2-purge-task-executions
@@ -18,5 +18,5 @@ import sys
 
 from st2common.cmd.purge_task_executions import main
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/st2common/bin/st2-purge-workflows
+++ b/st2common/bin/st2-purge-workflows
@@ -18,5 +18,5 @@ import sys
 
 from st2common.cmd.purge_workflows import main
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/st2common/st2common/middleware/logging.py
+++ b/st2common/st2common/middleware/logging.py
@@ -111,7 +111,7 @@ class LoggingMiddleware(object):
             "path": request.path,
             "remote_addr": request.remote_addr,
             "status": status_code[0],
-            "runtime": float("{0:.3f}".format((clock() - start_time) * 10 ** 3)),
+            "runtime": float("{0:.3f}".format((clock() - start_time) * 10**3)),
             "content_length": content_length[0]
             if content_length
             else len(b"".join(retval)),

--- a/st2reactor/st2reactor/container/hash_partitioner.py
+++ b/st2reactor/st2reactor/container/hash_partitioner.py
@@ -35,7 +35,7 @@ class Range(object):
     RANGE_MIN_VALUE = 0
 
     RANGE_MAX_ENUM = "max"
-    RANGE_MAX_VALUE = 2 ** 32
+    RANGE_MAX_VALUE = 2**32
 
     def __init__(self, range_repr):
         self.range_start, self.range_end = self._get_range_boundaries(range_repr)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,7 +5,7 @@ st2flake8==0.1.0
 astroid==2.5.6
 pylint==2.8.2
 pylint-plugin-utils>=0.4
-black==20.8b1
+black==22.3.0
 pre-commit==2.1.0
 bandit==1.7.0
 ipython<6.0.0


### PR DESCRIPTION
black v22.3.0 fixes an incompatibility with click, which is a transitive dep.
see: https://github.com/psf/black/issues/2964

I've had to update other projects recently for the same issue.

I just saw an error in CI that hit this issue, so let's update before anything else bites us.
see: https://github.com/StackStorm/st2/runs/5796530459?check_suite_focus=true

Also includes a minor fixture update (test_content_pack submodule) because I'm tired of Make complaining. There is no functional difference with the update. The test pack has newer commits because of CI updates on the exchange.