### PR TITLE
Downgraded tenacity as tooz dependency on tenacity has always been < 7.0.0

### DIFF
--- a/.github/workflows/microbenchmarks.yaml
+++ b/.github/workflows/microbenchmarks.yaml
@@ -87,8 +87,10 @@ jobs:
             virtualenv
             ~/virtualenv
           key: ${{ runner.os }}-v4-python-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'test-requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-v4-python-${{ matrix.python }}-
+          # Don't use alternative key as if requirements.txt has altered we
+          # don't want to retrieve previous cache
+          #restore-keys: |
+          #  ${{ runner.os }}-v4-python-${{ matrix.python }}-
       - name: Cache APT Dependencies
         id: cache-apt-deps
         uses: actions/cache@v2

--- a/.github/workflows/orquesta-integration-tests.yaml
+++ b/.github/workflows/orquesta-integration-tests.yaml
@@ -143,8 +143,10 @@ jobs:
           # !virtualenv/lib/python*/site-packages/st2*
           # !virtualenv/bin/st2*
           key: ${{ runner.os }}-v4-python-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'test-requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-v4-python-${{ matrix.python }}-
+          # Don't use alternative key as if requirements.txt has altered we
+          # don't want to retrieve previous cache
+          #restore-keys: |
+          #  ${{ runner.os }}-v4-python-${{ matrix.python }}-
       - name: Cache APT Dependencies
         id: cache-apt-deps
         uses: actions/cache@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,10 @@ Fixed
 
   Contributed by Amanda McGuinness (@amanda11 intive) #5581
 
+* Downgrade tenacity as tooz dependency on tenacity has always been < 7.0.0 #5607
+
+  Contributed by @khushboobhatia01
+
 Added
 ~~~~~
 

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -63,6 +63,7 @@ importlib-metadata==3.10.1
 # NOTE: sseclient has various issues which sometimes hang the connection for a long time, etc.
 sseclient-py==1.7
 stevedore==1.30.1
+tenacity>=3.2.1,<7.0.0
 tooz==2.8.0
 # Note: virtualenv embeds wheels for pip, wheel, and setuptools. So pinning virtualenv pins those as well.
 # virtualenv==20.4.0 (<21) has pip==20.3.3 wheel==0.36.2 setuptools==51.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,6 +70,7 @@ simplejson
 six==1.13.0
 sseclient-py==1.7
 stevedore==1.30.1
+tenacity>=3.2.1,<7.0.0
 tooz==2.8.0
 udatetime==0.0.16
 unittest2

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -29,6 +29,7 @@ requests
 retrying
 semver
 six
+tenacity
 tooz
 # Required by tooz - on new versions of tooz, all the backend dependencies need
 # to be installed manually

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -41,6 +41,7 @@ retrying==1.3.3
 routes==2.4.1
 semver==2.13.0
 six==1.13.0
+tenacity>=3.2.1,<7.0.0
 tooz==2.8.0
 udatetime==0.0.16
 webob==1.8.7


### PR DESCRIPTION
https://github.com/openstack/tooz/blob/174065f8750ff374e140fae956758b0b5ec2c473/requirements.txt#L9