### PR TITLE
Prepare Release Notes for v3.7.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,7 +39,7 @@ Added
 
   Contributed by @m4dcoder and @ashwini-orchestral
 
-* Added service degerestration on shutdown of a service. #5396
+* Added service deregestration on shutdown of a service. #5396
 
   Contributed by @khushboobhatia01
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -195,11 +195,6 @@ Fixed
 
   Contributed by @khushboobhatia01
 
-Removed
-~~~~~~~
-
-* Nothing removed
-
 3.6.0 - October 29, 2021
 ------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,48 +4,6 @@ Changelog
 in development
 --------------
 
-Fixed
-~~~~~
-
-* Fix deserialization bug in st2 API for url encoded payloads. #5536
-
-  Contributed by @sravs-dev
-
-* Fix issue of WinRM parameter passing fails for larger scripts.#5538
-
-  Contributed by @ashwini-orchestral
-
-* Fix Type error for ``time_diff`` critera comparison. convert the timediff value as float to match
-  ``timedelta.total_seconds()`` return. #5462
-
-  Contributed by @blackstrip
-
-* Fix issue with pack option not working when running policy list cli #5534
-
-  Contributed by @momokuri-3
-
-* Fix exception thrown if action parameter contains {{ or {% and no closing jinja characters. #5556
-
-  contributed by @guzzijones12
-
-* Link shutdown routine and sigterm handler to main thread #5555
-
-  Contributed by @khushboobhatia01
-
-* Change compound index for ActionExecutionDB to improve query performance #5568
-
-  Contributed by @khushboobhatia01
-
-* Fix build issue due to MarkUpSafe 2.1.0 removing soft_unicode
-
-  Contributed by Amanda McGuinness (@amanda11 intive) #5581
-
-* Downgrade tenacity as tooz dependency on tenacity has always been < 7.0.0 #5607
-
-  Contributed by @khushboobhatia01
-
-* Updated paramiko version to 2.10.3 to add support for more key verification algorithms. #5600
-
 Added
 ~~~~~
 
@@ -163,9 +121,48 @@ Added
 * Added garbage collection for workflow execution and task execution objects #4924
   Contributed by @srimandaleeka01 and @amanda11
 
+Changed
+~~~~~~~
+
+* Bump black to v22.3.0 - This is  used internally to reformat our python code. #5606
+
+* Updated paramiko version to 2.10.3 to add support for more key verification algorithms. #5600
 
 Fixed
 ~~~~~
+
+* Fix deserialization bug in st2 API for url encoded payloads. #5536
+
+  Contributed by @sravs-dev
+
+* Fix issue of WinRM parameter passing fails for larger scripts.#5538
+
+  Contributed by @ashwini-orchestral
+
+* Fix Type error for ``time_diff`` critera comparison. convert the timediff value as float to match
+  ``timedelta.total_seconds()`` return. #5462
+
+  Contributed by @blackstrip
+
+* Fix issue with pack option not working when running policy list cli #5534
+
+  Contributed by @momokuri-3
+
+* Fix exception thrown if action parameter contains {{ or {% and no closing jinja characters. #5556
+
+  contributed by @guzzijones12
+
+* Link shutdown routine and sigterm handler to main thread #5555
+
+  Contributed by @khushboobhatia01
+
+* Change compound index for ActionExecutionDB to improve query performance #5568
+
+  Contributed by @khushboobhatia01
+
+* Fix build issue due to MarkUpSafe 2.1.0 removing soft_unicode
+
+  Contributed by Amanda McGuinness (@amanda11 intive) #5581
 
 * Fixed regression caused by #5358. Use string lock name instead of object ID. #5484
 
@@ -193,10 +190,14 @@ Fixed
 
   Contributed by @nzlosh
 
-Changed
+* Downgrade tenacity as tooz dependency on tenacity has always been < 7.0.0 #5607
+
+  Contributed by @khushboobhatia01
+
+Removed
 ~~~~~~~
 
-* Bump black to v22.3.0 - This is  used internally to reformat our python code. #5606
+* Nothing removed
 
 3.6.0 - October 29, 2021
 ------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,9 +7,6 @@ in development
 Added
 ~~~~~
 
-* Minor updates for RockyLinux. #5552
-  Contributed by Amanda McGuinness (@amanda11 intive)
-
 * Added st2 API get action parameters by ref. #5509
 
   API endpoint ``/api/v1/actions/views/parameters/{action_id}`` accepts ``ref_or_id``.
@@ -24,12 +21,12 @@ Added
 
   API endpoint ``/api/v1/actions/{ref_or_id}/clone`` takes ``ref_or_id`` of source action.
   Request method body takes destination pack and action name. Request method body also takes
-  optional paramater ``overwrite``. ``overwrite = true`` in case of destination action already exists and to be
+  optional parameter ``overwrite``. ``overwrite = true`` in case of destination action already exists and to be
   overwritten.
 
   CLI command ``st2 action clone <ref_or_id> <dest_pack> <dest_action>`` takes source ``ref_or_id``, destination
   pack name and destination action name as mandatory arguments.
-  In case destionation already exists then command takes optional arugument ``-f`` or ``--force`` to overwrite
+  In case destination already exists then command takes optional argument ``-f`` or ``--force`` to overwrite
   destination action. #5345
 
   Contributed by @mahesh-orch.
@@ -39,7 +36,7 @@ Added
 
   Contributed by @m4dcoder and @ashwini-orchestral
 
-* Added service deregestration on shutdown of a service. #5396
+* Added service deregistration on shutdown of a service. #5396
 
   Contributed by @khushboobhatia01
 
@@ -123,6 +120,10 @@ Added
 
 Changed
 ~~~~~~~
+
+* Minor updates for RockyLinux. #5552
+
+  Contributed by Amanda McGuinness (@amanda11 intive)
 
 * Bump black to v22.3.0 - This is  used internally to reformat our python code. #5606
 


### PR DESCRIPTION
There are two different/duplicate `Fixed` Changelog sections, so reorder and combine them.

Prepare changelog for next release

This PR will hold any final changelog adjustments. It will be merged just before cutting the final 3.7.0 release.
