### PR TITLE
Promote Ankur Singh (@rush-skills) from Contributor to TSC Maintainer

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -33,6 +33,8 @@ Have deep platform knowledge & experience and demonstrate technical leadership a
 Being part of Technical Steering Committee (TSC) [@StackStorm/maintainers](https://github.com/orgs/StackStorm/teams/maintainers) provide significant and reliable value to the project helping it grow and improve through development and maintenance. See [Maintainer Responsibilities](https://github.com/StackStorm/st2/blob/master/GOVERNANCE.md#maintainer-responsibilities) for more info.
 * AJ Jonen ([@guzzijones](https://github.com/guzzijones)), _Cypherint_ <<aaron.jonen@cypherint.com>>
   - Workflows, st2 Core Performance, Releases.
+* Ankur Singh ([@rush-skills](https://github.com/rush-skills)), _CERN_ <<ankur.singh@cern.ch>>
+  - Community, Puppet, Workflows, HA.
 * Carlos ([@nzlosh](https://github.com/nzlosh)) <<nzlosh@yahoo.com>>
   - Packaging, Systems, Chatops, Errbot, Community, Discussions, StackStorm Exchange.
 * Jacob Floyd ([@cognifloyd](https://github.com/cognifloyd/)), _Copart_ <<cognifloyd@gmail.com>>
@@ -51,7 +53,6 @@ Contributors are using and occasionally contributing back to the project, might 
 They're not part of the TSC voting process, but appreciated for their contribution, involvement and may become Maintainers in the future depending on their effort and involvement. See [How to become a Maintainer?](https://github.com/StackStorm/st2/blob/master/GOVERNANCE.md#how-to-become-a-maintainer)
 [@StackStorm/contributors](https://github.com/orgs/StackStorm/teams/contributors) are invited to StackStorm Github organization and have permissions to help triage the Issues and review PRs.
 * Anand Patel ([@arms11](https://github.com/arms11)), _VMware_ - Docker, Kubernetes.
-* Ankur Singh ([@rush-skills](https://github.com/rush-skills)), _CERN_ - Puppet, Core, Docker, K8s.
 * Harsh Nanchahal ([@hnanchahal](https://github.com/hnanchahal)), _Starbucks_ - Core, Docker, Kubernetes.
 * Hiroyasu Ohyama ([@userlocalhost](https://github.com/userlocalhost)) - Orquesta, Workflows, st2 Japan Community. [Case Study](https://stackstorm.com/case-study-dmm/).
 * Khushboo Bhatia ([@khushboobhatia01](https://github.com/khushboobhatia01)), _VMware_ - Core, Orquesta.


### PR DESCRIPTION
I'd like to thank Ankur Singh (@rush-skills) for participating in the TSC meetings for the last year as a **Contributor**, providing his help and assistance in the project maintenance, and would like to propose @StackStorm/tsc promoting him to @StackStorm/maintainers.

A few highlights: Ankur participated in the maintenance tasks helping to keep the Puppet deployment up-to-date with the major st2 release initiatives and changes, helping maintaining the feature parity between the deployment methods:
* v3.7.0 - https://github.com/StackStorm/puppet-st2/issues/345
* v3.6.0 - https://github.com/StackStorm/puppet-st2/pull/341 closing the https://github.com/StackStorm/puppet-st2/issues/340 which is part of the bigger project plan https://github.com/StackStorm/community/issues/91
* v3.6.0 - https://github.com/StackStorm/puppet-st2/pull/335 that adds U20 and MongoDB v4.4, coming with the plan of migrating U16 as part of the TSC plan.

Other PRs:
* Starting significant work implementing the HA deployment for `Puppet-st2`: https://github.com/StackStorm/puppet-st2/pull/344
* https://github.com/StackStorm/puppet-st2/pull/339, implementing https://github.com/StackStorm/puppet-st2/issues/338 and https://github.com/StackStorm/puppet-st2/issues/334 
* https://github.com/StackStorm/puppet-st2/pull/337

Overall being part of the community, technical discussions, Github Issues, and code reviews related to deployments: Puppet-st2 and Ansible.

Between the initiatives, @rush-skills shared his interest in developing the `ARM` compatible packaging/installation and I'm looking forward to seeing those projects in the future as well as production contributions and fixes during his StackStorm adoption at CERN.
