### PR TITLE
pin typing-extensions<4.2 to fix st2client install

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -202,6 +202,9 @@ Changed
 
 * Bump black to v22.3.0 - This is  used internally to reformat our python code. #5606
 
+* Pin ``typing-extensions<4.2`` (used indirectly by st2client) to maintain python 3.6 support. #5638
+
+
 3.6.0 - October 29, 2021
 ------------------------
 

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -60,6 +60,8 @@ argparse==1.12.2
 argcomplete==1.12.2
 prettytable==2.1.0
 importlib-metadata==3.10.1
+# importlib-metadata requires typing-extensions but v4.2.0 requires py3.7+
+typing-extensions<4.2
 # NOTE: sseclient has various issues which sometimes hang the connection for a long time, etc.
 sseclient-py==1.7
 stevedore==1.30.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,6 +72,7 @@ sseclient-py==1.7
 stevedore==1.30.1
 tenacity>=3.2.1,<7.0.0
 tooz==2.8.0
+typing-extensions<4.2
 udatetime==0.0.16
 unittest2
 webob==1.8.7

--- a/st2client/in-requirements.txt
+++ b/st2client/in-requirements.txt
@@ -1,5 +1,7 @@
 # Remember to list implicit packages here, otherwise version won't be fixated!
 importlib-metadata
+# importlib-metadata requires typing-extensions
+typing-extensions
 argcomplete
 prettytable
 pytz

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -24,3 +24,4 @@ pyyaml==5.4.1
 requests[security]==2.25.1
 six==1.13.0
 sseclient-py==1.7
+typing-extensions<4.2


### PR DESCRIPTION
st2client requires importlib-metadata which requires typing-extensions.
But typing-extensions v4.2.0 dropped support for python3.6, so pin it.

Our CI has been broken on st2 master since April 17: https://github.com/StackStorm/st2/actions/workflows/ci.yaml?page=2
Turns out it’s because of typing-extensions which dropped support for python 3.6 on April 17 with their 4.2.0 release: https://github.com/python/typing/blob/master/typing_extensions/CHANGELOG.md