### PR TITLE
Proposal: Promote Jacob Floyd (@cognifloyd) to Senior TSC Maintainers

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -21,6 +21,8 @@ Have deep platform knowledge & experience and demonstrate technical leadership a
   - Ansible, Core, deb/rpm packages, CI/CD, Deployments, Release Engineering, Infrastructure, Documentation.
 * Eugen Cusmaunsa ([@armab](https://github.com/armab)) <<armab@stackstorm.com>>
   - Systems, Deployments, Docker, K8s, HA, Ansible, Chef, Vagrant, deb/rpm, CI/CD, Infrastructure, Release Engineering, Community.
+* Jacob Floyd ([@cognifloyd](https://github.com/cognifloyd/)), _Copart_ <<cognifloyd@gmail.com>>
+  - StackStorm Exchange, Kubernetes, ChatOps, Core, Discussions.
 * Nick Maludy ([@nmaludy](https://github.com/nmaludy)) <<nmaludy@gmail.com>>
   - Community, Core, Systems, Infrastructure, StackStorm Exchange, Puppet deployment. [Case Study](https://stackstorm.com/case-study-encore/).
 * Tomaz Muraus ([@kami](https://github.com/kami)) <<tomaz@stackstorm.com>>
@@ -37,8 +39,6 @@ Being part of Technical Steering Committee (TSC) [@StackStorm/maintainers](https
   - Community, Puppet, Workflows, HA.
 * Carlos ([@nzlosh](https://github.com/nzlosh)) <<nzlosh@yahoo.com>>
   - Packaging, Systems, Chatops, Errbot, Community, Discussions, StackStorm Exchange.
-* Jacob Floyd ([@cognifloyd](https://github.com/cognifloyd/)), _Copart_ <<cognifloyd@gmail.com>>
-  - StackStorm Exchange, Kubernetes, ChatOps, Core, Ansible, Discussions.
 * JP Bourget ([@punkrokk](https://github.com/punkrokk)) <<jp.bourget@gmail.com>>
   - Systems, deb/rpm, Deployments, Community, StackStorm Exchange, SecOps, CircleCI.
 * Khushboo Bhatia ([@khushboobhatia01](https://github.com/khushboobhatia01)), _VMware_ <<khushb99@gmail.com>>


### PR DESCRIPTION
@cognifloyd was an active StackStorm community member for many years with lots of contributions and proposals around st2 core, ansible, packs, and discussions.

Once joining the StackStorm TSC, he organized massive work to improve the entire StackStorm-Exchange:
1) CI/CD refactoring migrating CircleCI to GH Actions and improving the pack index update model to a more secure and stable. https://github.com/StackStorm/community/issues/63
2) New pack bootstrap, - creating automation for maintainers to set up a new pack with a single command. This now helps onboarding new packs really fast which was a pain point for many years. https://github.com/StackStorm-Exchange/exchange-incubator/pull/167

All this makes StackStorm-Exchange maintenance a breeze!

Jacob drove major contributions in the K8s project https://github.com/StackStorm/stackstorm-k8s/pulls?q=is%3Apr+author%3Acognifloyd+is%3Aclosed taking the ownership and shipping the features and improvements that would make that deployment method stable.

With conducting `v3.7.0` as a Release Manager (https://stackstorm.com/2022/05/10/stackstorm-3-7-0-released/), @cognifloyd is also a top StackStorm contributor, based on the aggregated useful activity. 
![](https://user-images.githubusercontent.com/1533818/173401788-a952000d-2d9e-4a20-a67c-0d670a99bd51.png)
See [LFX Analytics stats](https://insights.lfx.linuxfoundation.org/projects/stackstorm/active-contributor?time=%7B%22from%22:%22now-6M%22,%22type%22:%22datemath%22,%22to%22:%22now%22%7D), - that's a lot of hard work!

https://github.com/StackStorm/st2/blob/master/GOVERNANCE.md#how-to-become-a-senior-maintainer ticks all the boxes and the TSC Senior Maintainer group based on their in-depth StackStorm expertise and major work is promoting high standards besides [holding the poject's keys](https://github.com/StackStorm/st2/blob/master/GOVERNANCE.md#maintainer-roles).

His strong belief and effort to improve the PR review reaction and time to merge the contributions faster is a real help in building a more healthy community ecosystem :+1: 
And so with a big pleasure, I'd like to propose @StackStorm/tsc vote to promote Jacob Floyd @cognifloyd to Senior Maintainers! :100: 