### PR TITLE
Fix problems connecting to redis sentinel with SSL

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 in development
 --------------
 
+Fixed
+~~~~~
+
+* Fix redis SSL problems with sentinel #5660
+
 
 3.7.0 - May 05, 2022
 --------------------

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -50,7 +50,7 @@ python-keyczar==0.716
 pytz==2021.1
 pywinrm==0.4.1
 pyyaml==5.4.1
-redis==3.5.3
+redis==4.1.4
 requests[security]==2.25.1
 retrying==1.3.3
 routes==2.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ python-statsd==2.1.0
 pytz==2021.1
 pywinrm==0.4.1
 pyyaml==5.4.1
-redis==3.5.3
+redis==4.1.4
 rednose
 requests[security]==2.25.1
 retrying==1.3.3

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -35,7 +35,7 @@ pymongo==3.11.3
 python-dateutil==2.8.1
 python-statsd==2.1.0
 pyyaml==5.4.1
-redis==3.5.3
+redis==4.1.4
 requests[security]==2.25.1
 retrying==1.3.3
 routes==2.4.1

--- a/st2common/st2common/util/monkey_patch.py
+++ b/st2common/st2common/util/monkey_patch.py
@@ -43,7 +43,13 @@ def monkey_patch(patch_thread=None):
                          patched unless debugger is used.
     :type patch_thread: ``bool``
     """
+    # Eventlet when patched doesn't throw the standard ssl error on timeout, which can break
+    # some third-party libraries including redis SSL.
+    # See: https://github.com/eventlet/eventlet/issues/692
+    # Therefore set the patched ssl module to use the standard socket.timeout exception
+    from eventlet.green import ssl
     import eventlet
+    from socket import timeout
 
     if patch_thread is None:
         patch_thread = not is_use_debugger_flag_provided()
@@ -51,6 +57,7 @@ def monkey_patch(patch_thread=None):
     eventlet.monkey_patch(
         os=True, select=True, socket=True, thread=patch_thread, time=True
     )
+    ssl.timeout_exc = timeout
 
 
 def use_select_poll_workaround(nose_only=True):


### PR DESCRIPTION
When connecting to redis SSL via sentinel then 2 problems are encountered:

1. redis 3.5.3 did not support ssl parameters for sentinel, see https://github.com/redis/redis-py/pull/1419. So upping the version of redis library
2. When using eventlet and redis SSL then there are connection problems, due to the fact the redis library has expected timeouts, but monkey patched SSL library is throwing different exception. See https://github.com/eventlet/eventlet/issues/692. This causes problems on connecting to redis SSL via sentinel. It also is likely to be the cause of error: https://github.com/StackStorm/st2/issues/5337 as the stack trace encountered is the same.
Therefore when monkey patching SSL library, keep the exception raised on timeout to be socket.timeout.