### PR TITLE
drop unused imports in contrib/debug/actions

### DIFF
--- a/contrib/debug/actions/print_ctx.py
+++ b/contrib/debug/actions/print_ctx.py
@@ -14,9 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
-
 try:
     from st2common.runners.base_action import Action
 except ImportError:

--- a/contrib/debug/actions/python_version.py
+++ b/contrib/debug/actions/python_version.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import sys
 
 try:


### PR DESCRIPTION
This is very minor and should be quick to review.

Some files are currently not getting linted/checked with our Makefile. I discovered this issue when running linters with pants.