### PR TITLE
Add misc pylint ignores for false positives

### DIFF
--- a/contrib/runners/winrm_runner/winrm_runner/winrm_base.py
+++ b/contrib/runners/winrm_runner/winrm_runner/winrm_base.py
@@ -99,6 +99,7 @@ class WinRmRunnerTimoutError(Exception):
 
 class WinRmBaseRunner(ActionRunner):
     def pre_run(self):
+        # pylint: disable=unsubscriptable-object
         super(WinRmBaseRunner, self).pre_run()
 
         # common connection parameters

--- a/contrib/runners/winrm_runner/winrm_runner/winrm_command_runner.py
+++ b/contrib/runners/winrm_runner/winrm_runner/winrm_command_runner.py
@@ -29,6 +29,7 @@ RUNNER_COMMAND = "cmd"
 
 class WinRmCommandRunner(WinRmBaseRunner):
     def run(self, action_parameters):
+        # pylint: disable=unsubscriptable-object
         cmd_command = self.runner_parameters[RUNNER_COMMAND]
 
         # execute

--- a/contrib/runners/winrm_runner/winrm_runner/winrm_ps_command_runner.py
+++ b/contrib/runners/winrm_runner/winrm_runner/winrm_ps_command_runner.py
@@ -29,6 +29,7 @@ RUNNER_COMMAND = "cmd"
 
 class WinRmPsCommandRunner(WinRmBaseRunner):
     def run(self, action_parameters):
+        # pylint: disable=unsubscriptable-object
         powershell_command = self.runner_parameters[RUNNER_COMMAND]
 
         # execute

--- a/lint-configs/python/.pylintrc
+++ b/lint-configs/python/.pylintrc
@@ -26,7 +26,8 @@ property-classes=abc.abstractproperty
 [TYPECHECK]
 # Note: This modules are manipulated during the runtime so we can't detect all the properties during
 # static analysis
-ignored-modules=distutils,eventlet.green.subprocess,six,six.moves
+# orjson has type stubs, but pylint doesn't support __init__.pyi yet: https://github.com/PyCQA/pylint/issues/2873
+ignored-modules=distutils,eventlet.green.subprocess,six,six.moves,orjson
 
 [FORMAT]
 max-line-length=100

--- a/st2common/benchmarks/micro/test_mongo_field_types.py
+++ b/st2common/benchmarks/micro/test_mongo_field_types.py
@@ -59,7 +59,7 @@ from common import PYTEST_FIXTURE_FILE_PARAM_NO_8MB_DECORATOR
 
 
 # Needed so we can subclass it
-LiveActionDB._meta["allow_inheritance"] = True
+LiveActionDB._meta["allow_inheritance"] = True  # pylint: disable=no-member
 
 
 # 1. Current approach aka using EscapedDynamicField

--- a/st2common/bin/migrations/v3.1/st2-cleanup-policy-delayed.py
+++ b/st2common/bin/migrations/v3.1/st2-cleanup-policy-delayed.py
@@ -46,7 +46,7 @@ def main():
     except Exception as e:
         LOG.error(
             "ABORTED: Clean up of executions with deprecated policy-delayed status aborted on "
-            "first failure. %s" % e.message
+            "first failure. %s" % e.message  # pylint: disable=no-member
         )
         exit_code = 1
 


### PR DESCRIPTION
With `pants`, I'm running pylint on more of our codebase. So, I hit a few false positives that can just be ignored.

Also, orjson confuses pylint sometimes because pylint doesn't support type stubs (`.pyi`) like orjson provides. So, ignore that too.
