### PR TITLE
Add support for PyCharm Pro's Remote Debug Server

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,19 @@ Added
 * Added graceful shutdown for workflow engine. #5463
   Contributed by @khushboobhatia01
 
+* Allow debugging st2 services in PyCharm Pro's Remote Debug Server.
+  To enable debugging, before starting the st2 process(es), you need to:
+
+    - install pydevd-pycharm (use the version specific to your pycharm install) in StackStorm's virtualenv.
+    - set the ``ST2_PYCHARM_DEBUG`` environment var to something non-empty like "true".
+    - (optional) set environment vars ``ST2_PYCHARM_DEBUG_HOST`` and
+      ``ST2_PYCHARM_DEBUG_PORT`` if pycharm is listening somewhere other than
+      ``localhost:5000``.
+
+  see: https://www.jetbrains.com/help/pycharm/remote-debugging-with-product.html#remote-debug-config
+
+  #5674 Contributed by @cognifloyd.
+
 3.7.0 - May 05, 2022
 --------------------
 

--- a/lint-configs/python/.pylintrc
+++ b/lint-configs/python/.pylintrc
@@ -27,7 +27,7 @@ property-classes=abc.abstractproperty
 # Note: This modules are manipulated during the runtime so we can't detect all the properties during
 # static analysis
 # orjson has type stubs, but pylint doesn't support __init__.pyi yet: https://github.com/PyCQA/pylint/issues/2873
-ignored-modules=distutils,eventlet.green.subprocess,six,six.moves,orjson
+ignored-modules=distutils,eventlet.green.subprocess,six,six.moves,orjson,pydevd_pycharm
 
 [FORMAT]
 max-line-length=100

--- a/st2common/st2common/util/monkey_patch.py
+++ b/st2common/st2common/util/monkey_patch.py
@@ -58,7 +58,7 @@ def monkey_patch(patch_thread=None):
             port=os.environ.get("ST2_PYCHARM_DEBUG_PORT", 5000),
             stdoutToServer=True,
             stderrToServer=True,
-            patch_multiprocessing=True
+            patch_multiprocessing=True,
         )
 
     # Eventlet when patched doesn't throw the standard ssl error on timeout, which can break


### PR DESCRIPTION
Allow debugging st2 services in PyCharm Pro's Remote Debug Server.

To enable debugging, before starting the st2 process(es), you need to:

  - install pydevd-pycharm (use the version specific to your pycharm install) in StackStorm's virtualenv.
  - set the ``ST2_PYCHARM_DEBUG`` environment var to something non-empty like "true".
  - (optional) set environment vars ``ST2_PYCHARM_DEBUG_HOST`` and ``ST2_PYCHARM_DEBUG_PORT`` if pycharm is listening somewhere other than ``localhost:5000``.

see: https://www.jetbrains.com/help/pycharm/remote-debugging-with-product.html#remote-debug-config
