### PR TITLE
add ST2_USE_DEBUGGER env var to mirror --use-debugger arg

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,9 @@ Added
 * Added graceful shutdown for workflow engine. #5463
   Contributed by @khushboobhatia01
 
+* Add ``ST2_USE_DEBUGGER`` env var as alternative to the ``--use-debugger`` cli flag. #5675
+  Contributed by @cognifloyd
+
 Changed
 ~~~~~~~
 

--- a/st2common/st2common/util/monkey_patch.py
+++ b/st2common/st2common/util/monkey_patch.py
@@ -19,6 +19,7 @@ Module for performing eventlet and other monkey patching.
 
 from __future__ import absolute_import
 
+import os
 import sys
 
 __all__ = [
@@ -29,6 +30,7 @@ __all__ = [
 
 USE_DEBUGGER_FLAG = "--use-debugger"
 PARENT_ARGS_FLAG = "--parent-args="
+USE_DEBUGGER_ENV_VAR = "ST2_USE_DEBUGGER"
 
 
 def monkey_patch(patch_thread=None):
@@ -116,5 +118,9 @@ def is_use_debugger_flag_provided():
     for arg in sys.argv:
         if arg.startswith(PARENT_ARGS_FLAG) and USE_DEBUGGER_FLAG in arg:
             return True
+
+    # 3. Check for ST2_USE_DEBUGGER env var
+    if os.environ.get(USE_DEBUGGER_ENV_VAR, False):
+        return True
 
     return False


### PR DESCRIPTION
Extracted the st2-specific bits from #5674.

This allows setting `ST2_USE_DEBUGGER` as an env var instead of passing `--use-debugger` as a command line arg. An env var is more convenient in some cases, such as when using containerized/docker st2.
