### PR TITLE
fix use correct os environ to check HTTPS_PROXY

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,11 @@ Fixed
 
   Contributed by @S-T-A-R-L-O-R-D
 
+
+* Fixed ``st2client/st2client/base.py`` file to use ``https_proxy``(not ``http_proxy``) to check HTTPS_PROXY environment variables.
+
+  Contributed by @wfgydbu
+
 Added
 ~~~~~
 

--- a/st2client/st2client/base.py
+++ b/st2client/st2client/base.py
@@ -453,6 +453,6 @@ class BaseCLIApp(object):
         )
         print(
             "HTTPS_PROXY: %s"
-            % (os.environ.get("http_proxy", os.environ.get("HTTPS_PROXY", "")))
+            % (os.environ.get("https_proxy", os.environ.get("HTTPS_PROXY", "")))
         )
         print("")


### PR DESCRIPTION
Currently, st2client uses ``http_proxy`` to check os environment variable ``HTTPS_PROXY``, which is not correct.

This PR fixes this by using the correct variable ``https_proxy``.