### PR TITLE
Add pytest config section to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,7 @@ exclude = '''
   )/
 )
 '''
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+#addopts = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,4 +15,4 @@ exclude = '''
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-#addopts = ""
+addopts = "-l"


### PR DESCRIPTION
I'm working towards introducing [`pants`](https://www.pantsbuild.org/docs). Eventually I would like to use pants to run tests to take advantage of the fine-grained per-file caching of results that accounts for dependencies by python files (pants infers the deps by reading the python files). But, pants uses `pytest` to run tests not `nosetest`.

So, this is the first of several PRs that improves our compatibility with pytest. It adds a pytest config section to `pyproject.toml`. I also included `-l` (display local vars on test failure) because that is extremely helpful when I encounter a test failure via pytest.

Note: I do not have pytest support completely ironed out, but this is a step in that direction. Don't expect running all our tests with pytest to work yet.
