### PR TITLE
Adjust monkey_patching to work under pytest

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,8 @@ Fixed
 * Fixed schema utils to more reliably handle schemas that define nested arrays (object-array-object-array-string) as discovered in some
   of the ansible installer RBAC tests (see #5684). This includes a test that reproduced the error so we don't hit this again. #5685
 
+* Fixed eventlet monkey patching so more of the unit tests work under pytest. #5689
+
 Added
 ~~~~~
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,25 @@
+# Copyright 2022 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def pytest_configure(config):
+    import sys
+
+    sys._called_from_test = True
+
+
+def pytest_unconfigure(config):
+    import sys
+
+    del sys._called_from_test

--- a/st2api/tests/unit/controllers/v1/test_action_views.py
+++ b/st2api/tests/unit/controllers/v1/test_action_views.py
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pytest: make sure monkey_patching happens before importing mongoengine
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()
+
 import mock
 
 from st2common.content import utils as content_utils

--- a/st2api/tests/unit/controllers/v1/test_executions_auth.py
+++ b/st2api/tests/unit/controllers/v1/test_executions_auth.py
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pytest: make sure monkey_patching happens before importing mongoengine
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()
+
 import bson
 import copy
 import datetime

--- a/st2api/tests/unit/controllers/v1/test_rule_views.py
+++ b/st2api/tests/unit/controllers/v1/test_rule_views.py
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pytest: make sure monkey_patching happens before importing mongoengine
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()
+
 import six
 
 from st2common.models.system.common import ResourceReference

--- a/st2api/tests/unit/controllers/v1/test_runnertypes.py
+++ b/st2api/tests/unit/controllers/v1/test_runnertypes.py
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pytest: make sure monkey_patching happens before importing mongoengine
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()
+
 from st2api.controllers.v1.runnertypes import RunnerTypesController
 
 from st2tests.api import FunctionalTest

--- a/st2api/tests/unit/controllers/v1/test_traces.py
+++ b/st2api/tests/unit/controllers/v1/test_traces.py
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pytest: make sure monkey_patching happens before importing mongoengine
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()
+
 from st2api.controllers.v1.traces import TracesController
 from st2tests.fixturesloader import FixturesLoader
 

--- a/st2api/tests/unit/controllers/v1/test_triggertypes.py
+++ b/st2api/tests/unit/controllers/v1/test_triggertypes.py
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pytest: make sure monkey_patching happens before importing mongoengine
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()
+
 import six
 
 from st2api.controllers.v1.triggers import TriggerTypeController

--- a/st2auth/tests/unit/controllers/v1/test_token.py
+++ b/st2auth/tests/unit/controllers/v1/test_token.py
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pytest: make sure monkey_patching happens before importing mongoengine
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()
+
 import uuid
 import datetime
 import random

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -36,7 +36,8 @@ import sys
 # For now, we go with option 2) since it seems to be good enough of a compromise. We detect if we
 # are running inside tests by checking if "nose" module is present - the same logic we already use
 # in a couple of other places (and something which would need to be changed if we switch to pytest).
-if "nose" in sys.modules.keys():
+# For pytest, we set sys._called_from_test in conftest.py
+if "nose" in sys.modules.keys() or hasattr(sys, "_called_from_test"):
     from st2common.util.monkey_patch import monkey_patch
 
     monkey_patch()

--- a/st2common/st2common/models/db/__init__.py
+++ b/st2common/st2common/models/db/__init__.py
@@ -38,6 +38,9 @@ import sys
 # in a couple of other places (and something which would need to be changed if we switch to pytest).
 # For pytest, we set sys._called_from_test in conftest.py
 if "nose" in sys.modules.keys() or hasattr(sys, "_called_from_test"):
+    # pytest can load any test file first, which randomizes where the monkey_patch is needed.
+    # thus mongoengine might already be loaded at this point under pytest!
+    # In that case, we just add the monkey_patch to the top of that test file.
     from st2common.util.monkey_patch import monkey_patch
 
     monkey_patch()

--- a/st2common/st2common/util/monkey_patch.py
+++ b/st2common/st2common/util/monkey_patch.py
@@ -91,7 +91,11 @@ def use_select_poll_workaround(nose_only=True):
     import eventlet
 
     # Work around to get tests to pass with eventlet >= 0.20.0
-    if not nose_only or (nose_only and "nose" in sys.modules.keys()):
+    if not nose_only or (
+        nose_only
+        # sys._called_from_test set in conftest.py for pytest runs
+        and ("nose" in sys.modules.keys() or hasattr(sys, "_called_from_test"))
+    ):
         # Add back blocking poll() to eventlet monkeypatched select
         original_poll = eventlet.patcher.original("select").poll
         select.poll = original_poll

--- a/st2common/tests/unit/test_action_param_utils.py
+++ b/st2common/tests/unit/test_action_param_utils.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
+# pytest: make sure monkey_patching happens before importing mongoengine
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()
+
 import copy
 import six
 

--- a/st2common/tests/unit/test_db_base.py
+++ b/st2common/tests/unit/test_db_base.py
@@ -14,6 +14,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
+# pytest: make sure monkey_patching happens before importing mongoengine
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()
+
 import mongoengine
 
 from st2common.models.db import stormbase

--- a/st2common/tests/unit/test_db_fields.py
+++ b/st2common/tests/unit/test_db_fields.py
@@ -23,6 +23,12 @@ import mock
 import unittest2
 import orjson
 import zstandard
+
+# pytest: make sure monkey_patching happens before importing mongoengine
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()
+
 import mongoengine as me
 
 from st2common.fields import ComplexDateTimeField

--- a/st2common/tests/unit/test_param_utils.py
+++ b/st2common/tests/unit/test_param_utils.py
@@ -16,6 +16,11 @@
 
 from __future__ import absolute_import
 
+# pytest: make sure monkey_patching happens before importing mongoengine
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()
+
 import six
 import mock
 

--- a/st2common/tests/unit/test_purge_executions.py
+++ b/st2common/tests/unit/test_purge_executions.py
@@ -14,6 +14,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
+# pytest: make sure monkey_patching happens before importing mongoengine
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()
+
 import copy
 from datetime import timedelta
 

--- a/st2common/tests/unit/test_purge_trigger_instances.py
+++ b/st2common/tests/unit/test_purge_trigger_instances.py
@@ -14,6 +14,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
+# pytest: make sure monkey_patching happens before importing mongoengine
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()
+
 from datetime import timedelta
 
 from st2common import log as logging

--- a/st2common/tests/unit/test_reference.py
+++ b/st2common/tests/unit/test_reference.py
@@ -14,6 +14,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
+# pytest: make sure monkey_patching happens before importing mongoengine
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()
+
 import copy
 import mock
 import mongoengine

--- a/st2common/tests/unit/test_runners_utils.py
+++ b/st2common/tests/unit/test_runners_utils.py
@@ -14,6 +14,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
+# pytest: make sure monkey_patching happens before importing mongoengine
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()
+
 import mock
 
 from st2common.runners import utils

--- a/st2common/tests/unit/test_tags.py
+++ b/st2common/tests/unit/test_tags.py
@@ -14,6 +14,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
+# pytest: make sure monkey_patching happens before importing mongoengine
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()
+
 import random
 import string
 

--- a/st2reactor/tests/unit/test_enforce.py
+++ b/st2reactor/tests/unit/test_enforce.py
@@ -15,6 +15,11 @@
 
 from __future__ import absolute_import
 
+# pytest: make sure monkey_patching happens before importing mongoengine
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()
+
 import mock
 
 from st2common.constants import action as action_constants

--- a/st2reactor/tests/unit/test_rule_engine.py
+++ b/st2reactor/tests/unit/test_rule_engine.py
@@ -14,6 +14,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
+# pytest: make sure monkey_patching happens before importing mongoengine
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()
+
 import mock
 from mongoengine import NotUniqueError
 


### PR DESCRIPTION
### Background

I'm working towards introducing [`pants`](https://www.pantsbuild.org/docs). Eventually I would like to use pants to run tests to take advantage of the fine-grained per-file caching of results that accounts for dependencies by python files (pants infers the deps by reading the python files). But, pants uses `pytest` to run tests not `nosetest`.

This is another of several PRs that improves our compatibility with pytest. Others include: #5686, #5690, #5691

Note: I do not have pytest support completely ironed out, but this is a step in that direction. Don't expect running all our tests with pytest to work yet.

### Overview

Tests hang (with endless cycles between green threads that can't figure out what to do) when mongoengine gets imported before the monkey patching. So, this adjusts our monkey_patching code and the tests that use mongoengine to make our tests work better under pytest.

We need this because pytest can load test files in any order, or even load only a single test file. Since eventlet monkey_patching is very sensitive to when the monkey_patching happens, we need to make these adjustments or the tests won't work under pytest.
