### PR TITLE
Make DBTestCase compatible with pytest

### DIFF
--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -16,6 +16,8 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+from unittest.result import TestResult
+
 # NOTE: We need to perform monkeypatch before importing ssl module otherwise tests will fail.
 # See https://github.com/StackStorm/st2/pull/4834 for details
 from st2common.util.monkey_patch import monkey_patch
@@ -316,7 +318,8 @@ class DbTestCase(BaseDbTestCase):
     def tearDownClass(cls):
         drop_db = True
 
-        if cls.current_result.errors or cls.current_result.failures:
+        # TODO: alternate method for pytest?
+        if cls.current_result and (cls.current_result.errors or cls.current_result.failures):
             # Don't drop DB on test failure
             drop_db = False
 
@@ -325,8 +328,11 @@ class DbTestCase(BaseDbTestCase):
 
     def run(self, result=None):
         # Remember result for use in tearDown and tearDownClass
-        self.current_result = result
-        self.__class__.current_result = result
+        # pytest sets result to _pytest.unittest.TestCaseFunction
+        # which does not have attributes: errors, failures
+        if isinstance(result, TestResult):
+            self.current_result = result
+            self.__class__.current_result = result
         super(DbTestCase, self).run(result=result)
 
 

--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -325,7 +325,9 @@ class DbTestCase(BaseDbTestCase):
         #       When someone does decide to tackle this, we will probably need to rename the db
         #       for later inspection so subsequent tests still have a clean starting point as
         #       pytest will not necessarily stop on failure like nosetest did.
-        if cls.current_result and (cls.current_result.errors or cls.current_result.failures):
+        if cls.current_result and (
+            cls.current_result.errors or cls.current_result.failures
+        ):
             # Don't drop DB on test failure
             drop_db = False
 

--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -318,7 +318,13 @@ class DbTestCase(BaseDbTestCase):
     def tearDownClass(cls):
         drop_db = True
 
-        # TODO: alternate method for pytest?
+        # TODO: pytst does not make results available to fixtures by default.
+        #       we might be able to add a hook+class fixture to help with this, but
+        #       that adds quite a bit of complexity. For now, pytest will always drop the db.
+        #       https://docs.pytest.org/en/stable/example/simple.html#making-test-result-information-available-in-fixtures
+        #       When someone does decide to tackle this, we will probably need to rename the db
+        #       for later inspection so subsequent tests still have a clean starting point as
+        #       pytest will not necessarily stop on failure like nosetest did.
         if cls.current_result and (cls.current_result.errors or cls.current_result.failures):
             # Don't drop DB on test failure
             drop_db = False


### PR DESCRIPTION
### Background

I'm working towards introducing [`pants`](https://www.pantsbuild.org/docs). Eventually I would like to use pants to run tests to take advantage of the fine-grained per-file caching of results that accounts for dependencies by python files (pants infers the deps by reading the python files). But, pants uses `pytest` to run tests not `nosetest`.

This is another of several PRs that improves our compatibility with pytest. Others include: #5686, #5689, #5690

Note: I do not have pytest support completely ironed out, but this is a step in that direction. Don't expect running all our tests with pytest to work yet.

### Overview

DBTestCase was relying on some unittest/nosetest implmentation details that are not available when running under pytest.

The purpose of those adjustments was: Keep the DB after a test failure (do not drop it) to facilitate debugging.

However, pytest does not make results availble to fixtures. There are some complex workarounds, but there are issues with blindly copying the previous logic. For example, pytest can continue running tests after a failure or error unlike nosetest which we have configured to stop on failures. In order to safely skip dropping the DB, we need to make the DB available in a clean state after the test(s) using it. So, re-implementing this test feature requires something that renames a DB to preserve data for debugging, so that subsequent tests have a clean DB to work with.

I left a `TODO` note about this for whoever ends up trying to implement this. For now, this just avoids accessing attributes on an TestResult object that pytest does not provide.
