### PR TITLE
Move to ciso8601 for datetime

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,7 +36,7 @@ Added
 * Add ``ST2_USE_DEBUGGER`` env var as alternative to the ``--use-debugger`` cli flag. #5675
   Contributed by @cognifloyd
 
-* Added purging of old tokens. #56791
+* Added purging of old tokens. #5679
   Contributed by Amanda McGuinness (@amanda11 intive)
 
 Changed
@@ -86,6 +86,10 @@ Changed
   ``package-name@ git+https://url@version ; markers`` instead of ``git+https://url@version#egg=package-name ; markers``. #5673
 
   Contributed by @cognifloyd
+
+* Move from udatetime to ciso8601 for date functionality ahead of supporting python3.9 #??
+  Contributed by Amanda McGuinness (@amanda11 intive)
+
 
 Removed
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -87,7 +87,7 @@ Changed
 
   Contributed by @cognifloyd
 
-* Move from udatetime to ciso8601 for date functionality ahead of supporting python3.9 #??
+* Move from udatetime to ciso8601 for date functionality ahead of supporting python3.9 #5692
   Contributed by Amanda McGuinness (@amanda11 intive)
 
 

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -82,4 +82,3 @@ psutil==5.8.0
 python-dateutil==2.8.1
 python-statsd==2.1.0
 orjson==3.5.2
-udatetime==0.0.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ argcomplete==1.12.2
 bcrypt==3.2.0
 cffi<1.15.0
 chardet<3.1.0
+ciso8601
 cryptography==3.4.7
 decorator==4.4.2
 dnspython>=1.16.0,<2.0.0
@@ -73,7 +74,6 @@ stevedore==1.30.1
 tenacity>=3.2.1,<7.0.0
 tooz==2.8.0
 typing-extensions<4.2
-udatetime==0.0.16
 unittest2
 webob==1.8.7
 webtest

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -42,7 +42,7 @@ webob
 jsonpath-rw
 pyOpenSSL
 python-statsd
-udatetime
+ciso8601
 orjson
 # Note: amqp is used by kombu, this needs to be added here to be picked up by
 # requirements fixate script.

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -10,6 +10,7 @@ amqp==5.0.6
 apscheduler==3.7.0
 cffi<1.15.0
 chardet<3.1.0
+ciso8601
 cryptography==3.4.7
 decorator==4.4.2
 dnspython>=1.16.0,<2.0.0
@@ -43,7 +44,6 @@ six==1.13.0
 st2-rbac-backend@ git+https://github.com/StackStorm/st2-rbac-backend.git@master
 tenacity>=3.2.1,<7.0.0
 tooz==2.8.0
-udatetime==0.0.16
 webob==1.8.7
 zake==0.2.2
 zstandard==0.15.2

--- a/st2common/st2common/util/date.py
+++ b/st2common/st2common/util/date.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import
 
 import datetime
 
-import udatetime
+import ciso8601
 
 import dateutil.tz
 import dateutil.parser
@@ -83,17 +83,14 @@ def parse(value, preserve_original_tz=False):
 
     :rtype: ``datetime.datetime``
     """
-    # We use udatetime since it's much faster than non-C alternatives
+    # We use ciso8601 since it's much faster than non-C alternatives
     # For compatibility reasons we still fall back to datetutil, but this should rarely happen
     # rfc3339 covers 90% of the iso8601 (it's a subset of it)
     original_value = value
 
     try:
-        if " " in value:
-            # udatetime doesn't support notation with whitespace so we replace it with T
-            value = value.replace(" ", "T")
-        dt = udatetime.from_string(str(value))
-    except Exception:
+        dt = ciso8601.parse_datetime(str(value))
+    except Exception as err:
         dt = dateutil.parser.parse(str(original_value))
 
     if not dt.tzinfo:

--- a/st2common/st2common/util/date.py
+++ b/st2common/st2common/util/date.py
@@ -90,7 +90,7 @@ def parse(value, preserve_original_tz=False):
 
     try:
         dt = ciso8601.parse_datetime(str(value))
-    except Exception as err:
+    except Exception:
         dt = dateutil.parser.parse(str(original_value))
 
     if not dt.tzinfo:


### PR DESCRIPTION
Problems using udatetime on python3.9 and it isn't supported.
It was proposed that ciso8601 is used instead.

Relates to https://github.com/StackStorm/st2/issues/5346