### PR TITLE
Use python imports to identify fixtures (part 1)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -86,12 +86,13 @@ Changed
 
 * Use PEP 440 direct reference requirements instead of legacy PIP VCS requirements. Now, our ``*.requirements.txt`` files use
   ``package-name@ git+https://url@version ; markers`` instead of ``git+https://url@version#egg=package-name ; markers``. #5673
-
   Contributed by @cognifloyd
 
 * Move from udatetime to ciso8601 for date functionality ahead of supporting python3.9 #5692
   Contributed by Amanda McGuinness (@amanda11 intive)
 
+* Refactor tests to use python imports to identify test fixtures. #5699
+  Contributed by @cognifloyd
 
 Removed
 ~~~~~~~

--- a/contrib/packs/tests/test_action_unload.py
+++ b/contrib/packs/tests/test_action_unload.py
@@ -36,15 +36,14 @@ from st2common.persistence.trigger import TriggerType
 
 from st2tests.base import BaseActionTestCase
 from st2tests.base import CleanDbTestCase
-from st2tests import fixturesloader
+from st2tests.fixtures.packs.dummy_pack_1.fixture import (
+    PACK_NAME as DUMMY_PACK_1,
+    PACK_PATH as PACK_PATH_1,
+)
 
 from pack_mgmt.unload import UnregisterPackAction
 
 __all__ = ["UnloadActionTestCase"]
-
-PACK_PATH_1 = os.path.join(
-    fixturesloader.get_fixtures_packs_base_path(), "dummy_pack_1"
-)
 
 
 class UnloadActionTestCase(BaseActionTestCase, CleanDbTestCase):
@@ -73,7 +72,7 @@ class UnloadActionTestCase(BaseActionTestCase, CleanDbTestCase):
         register_content()
 
     def test_run(self):
-        pack = "dummy_pack_1"
+        pack = DUMMY_PACK_1
         # Verify all the resources are there
 
         pack_dbs = Pack.query(ref=pack)

--- a/contrib/packs/tests/test_action_unload.py
+++ b/contrib/packs/tests/test_action_unload.py
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 from oslo_config import cfg
 
 from st2common.util.monkey_patch import use_select_poll_workaround

--- a/st2actions/tests/unit/test_output_schema.py
+++ b/st2actions/tests/unit/test_output_schema.py
@@ -37,9 +37,11 @@ from st2common.transport import liveaction as lv_ac_xport
 from st2common.transport import publishers
 from st2tests.mocks import liveaction as mock_lv_ac_xport
 
+from st2tests.fixtures.packs.dummy_pack_1.fixture import PACK_PATH as DUMMY_PACK_1_PATH
+
 
 PACKS = [
-    st2tests.fixturesloader.get_fixtures_packs_base_path() + "/dummy_pack_1",
+    DUMMY_PACK_1_PATH,
     st2tests.fixturesloader.get_fixtures_packs_base_path() + "/orquesta_tests",
 ]
 

--- a/st2api/tests/unit/controllers/v1/test_actions.py
+++ b/st2api/tests/unit/controllers/v1/test_actions.py
@@ -34,7 +34,10 @@ import st2common.validators.api.action as action_validator
 from st2common.constants.pack import SYSTEM_PACK_NAME
 from st2common.persistence.pack import Pack
 from st2api.controllers.v1.actions import ActionsController
-from st2tests.fixturesloader import get_fixtures_packs_base_path
+from st2tests.fixtures.packs.dummy_pack_1.fixture import (
+    PACK_NAME as DUMMY_PACK_1,
+    PACK_PATH as DUMMY_PACK_1_PATH,
+)
 from st2tests.base import CleanFilesTestCase
 
 from st2tests.api import FunctionalTest
@@ -207,7 +210,7 @@ ACTION_12 = {
     "name": "st2.dummy.action1",
     "description": "test description",
     "enabled": True,
-    "pack": "dummy_pack_1",
+    "pack": DUMMY_PACK_1,
     "entry_point": "/tmp/test/action1.sh",
     "runner_type": "local-shell-script",
     "parameters": {
@@ -225,7 +228,7 @@ ACTION_13 = {
     "name": "st2.dummy.action2",
     "description": "test description",
     "enabled": True,
-    "pack": "dummy_pack_1",
+    "pack": DUMMY_PACK_1,
     "entry_point": "/tmp/test/action1.sh",
     "runner_type": "local-shell-script",
     "parameters": {
@@ -238,7 +241,7 @@ ACTION_14 = {
     "name": "st2.dummy.action14",
     "description": "test description",
     "enabled": True,
-    "pack": "dummy_pack_1",
+    "pack": DUMMY_PACK_1,
     "entry_point": "/tmp/test/action1.sh",
     "runner_type": "local-shell-script",
     "parameters": {
@@ -252,7 +255,7 @@ ACTION_15 = {
     "name": "st2.dummy.action15",
     "description": "test description",
     "enabled": True,
-    "pack": "dummy_pack_1",
+    "pack": DUMMY_PACK_1,
     "entry_point": "/tmp/test/action1.sh",
     "runner_type": "local-shell-script",
     "parameters": {
@@ -295,7 +298,7 @@ ACTION_WITH_NOTIFY = {
     "name": "st2.dummy.action_notify_test",
     "description": "test description",
     "enabled": True,
-    "pack": "dummy_pack_1",
+    "pack": DUMMY_PACK_1,
     "entry_point": "/tmp/test/action1.sh",
     "runner_type": "local-shell-script",
     "parameters": {
@@ -311,7 +314,7 @@ ACTION_WITH_UNICODE_NAME = {
     "name": "st2.dummy.action_unicode_我爱狗",
     "description": "test description",
     "enabled": True,
-    "pack": "dummy_pack_1",
+    "pack": DUMMY_PACK_1,
     "entry_point": "/tmp/test/action1.sh",
     "runner_type": "local-shell-script",
     "parameters": {
@@ -333,9 +336,7 @@ class ActionsControllerTestCase(
 
     register_packs = True
 
-    to_delete_files = [
-        os.path.join(get_fixtures_packs_base_path(), "dummy_pack_1/actions/filea.txt")
-    ]
+    to_delete_files = [os.path.join(DUMMY_PACK_1_PATH, "actions/filea.txt")]
 
     @mock.patch.object(
         action_validator, "validate_action", mock.MagicMock(return_value=True)

--- a/st2api/tests/unit/controllers/v1/test_packs.py
+++ b/st2api/tests/unit/controllers/v1/test_packs.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 import requests
 import mock
 import sys
@@ -32,7 +30,14 @@ from st2api.controllers.v1.packs import ENTITIES
 from st2tests.api import FunctionalTest
 from st2tests.api import APIControllerWithIncludeAndExcludeFilterTestCase
 
-from st2tests.fixturesloader import get_fixtures_base_path
+from st2tests.fixtures.packs.dummy_pack_1.fixture import (
+    PACK_NAME as DUMMY_PACK_1,
+    PACK_PATH as DUMMY_PACK_1_PATH,
+)
+from st2tests.fixtures.packs.dummy_pack_10.fixture import (
+    PACK_NAME as DUMMY_PACK_10,
+    PACK_PATH as DUMMY_PACK_10_PATH,
+)
 
 __all__ = ["PacksControllerTestCase"]
 
@@ -498,15 +503,10 @@ class PacksControllerTestCase(
 
         # Note: We only register a couple of packs and not all on disk to speed
         # things up. Registering all the packs takes a long time.
-        fixtures_base_path = get_fixtures_base_path()
-        packs_base_path = os.path.join(fixtures_base_path, "packs")
-        pack_names = [
-            "dummy_pack_1",
-            "dummy_pack_10",
-        ]
-        mock_return_value = {}
-        for pack_name in pack_names:
-            mock_return_value[pack_name] = os.path.join(packs_base_path, pack_name)
+        mock_return_value = {
+            DUMMY_PACK_1: DUMMY_PACK_1_PATH,
+            DUMMY_PACK_10: DUMMY_PACK_10_PATH,
+        }
 
         mock_get_packs.return_value = mock_return_value
 
@@ -529,7 +529,8 @@ class PacksControllerTestCase(
 
         # Register resources from a specific pack
         resp = self.app.post_json(
-            "/v1/packs/register", {"packs": ["dummy_pack_1"], "fail_on_failure": False}
+            "/v1/packs/register",
+            {"packs": [DUMMY_PACK_1], "fail_on_failure": False},
         )
 
         self.assertEqual(resp.status_int, 200)
@@ -538,13 +539,13 @@ class PacksControllerTestCase(
         self.assertTrue(resp.json["configs"] >= 1)
 
         # Verify metadata_file attribute is set
-        action_dbs = Action.query(pack="dummy_pack_1")
+        action_dbs = Action.query(pack=DUMMY_PACK_1)
         self.assertEqual(action_dbs[0].metadata_file, "actions/my_action.yaml")
 
         # Register 'all' resource types should try include any possible content for the pack
         resp = self.app.post_json(
             "/v1/packs/register",
-            {"packs": ["dummy_pack_1"], "fail_on_failure": False, "types": ["all"]},
+            {"packs": [DUMMY_PACK_1], "fail_on_failure": False, "types": ["all"]},
         )
 
         self.assertEqual(resp.status_int, 200)
@@ -566,7 +567,7 @@ class PacksControllerTestCase(
         # * policies -> policy types
         resp = self.app.post_json(
             "/v1/packs/register",
-            {"packs": ["dummy_pack_1"], "fail_on_failure": False, "types": ["actions"]},
+            {"packs": [DUMMY_PACK_1], "fail_on_failure": False, "types": ["actions"]},
         )
 
         self.assertEqual(resp.status_int, 200)
@@ -575,7 +576,7 @@ class PacksControllerTestCase(
 
         resp = self.app.post_json(
             "/v1/packs/register",
-            {"packs": ["dummy_pack_1"], "fail_on_failure": False, "types": ["rules"]},
+            {"packs": [DUMMY_PACK_1], "fail_on_failure": False, "types": ["rules"]},
         )
 
         self.assertEqual(resp.status_int, 200)
@@ -611,7 +612,7 @@ class PacksControllerTestCase(
 
         # Register specific type for a single packs
         resp = self.app.post_json(
-            "/v1/packs/register", {"packs": ["dummy_pack_1"], "types": ["action"]}
+            "/v1/packs/register", {"packs": [DUMMY_PACK_1], "types": ["action"]}
         )
 
         self.assertEqual(resp.status_int, 200)
@@ -620,7 +621,7 @@ class PacksControllerTestCase(
 
         # Verify that plural name form also works
         resp = self.app.post_json(
-            "/v1/packs/register", {"packs": ["dummy_pack_1"], "types": ["actions"]}
+            "/v1/packs/register", {"packs": [DUMMY_PACK_1], "types": ["actions"]}
         )
 
         self.assertEqual(resp.status_int, 200)
@@ -632,7 +633,7 @@ class PacksControllerTestCase(
         resp = self.app.post_json(
             "/v1/packs/register",
             {
-                "packs": ["dummy_pack_1", "dummy_pack_1", "dummy_pack_1"],
+                "packs": [DUMMY_PACK_1, DUMMY_PACK_1, DUMMY_PACK_1],
                 "types": ["actions"],
                 "fail_on_failure": False,
             },
@@ -653,13 +654,13 @@ class PacksControllerTestCase(
         # Fail on failure is enabled by default
         resp = self.app.post_json("/v1/packs/register", expect_errors=True)
 
-        expected_msg = 'Failed to register pack "dummy_pack_10":'
+        expected_msg = f'Failed to register pack "{DUMMY_PACK_10}":'
         self.assertEqual(resp.status_int, 400)
         self.assertIn(expected_msg, resp.json["faultstring"])
 
         # Fail on failure (broken pack metadata)
         resp = self.app.post_json(
-            "/v1/packs/register", {"packs": ["dummy_pack_1"]}, expect_errors=True
+            "/v1/packs/register", {"packs": [DUMMY_PACK_1]}, expect_errors=True
         )
 
         expected_msg = 'Referenced policy_type "action.mock_policy_error" doesnt exist'

--- a/st2common/tests/integration/test_register_content_script.py
+++ b/st2common/tests/integration/test_register_content_script.py
@@ -23,6 +23,7 @@ from st2tests.base import IntegrationTestCase
 from st2common.util.shell import run_command
 from st2tests import config as test_config
 from st2tests.fixturesloader import get_fixtures_packs_base_path
+from st2tests.fixtures.packs.dummy_pack_1.fixture import PACK_PATH as DUMMY_PACK_1_PATH
 
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -43,7 +44,7 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
         test_config.parse_args()
 
     def test_register_from_pack_success(self):
-        pack_dir = os.path.join(get_fixtures_packs_base_path(), "dummy_pack_1")
+        pack_dir = DUMMY_PACK_1_PATH
         runner_dirs = os.path.join(get_fixtures_packs_base_path(), "runners")
 
         opts = [
@@ -142,7 +143,7 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
     def test_register_all_and_register_setup_virtualenvs(self):
         # Verify that --register-all works in combinations with --register-setup-virtualenvs
         # Single pack
-        pack_dir = os.path.join(get_fixtures_packs_base_path(), "dummy_pack_1")
+        pack_dir = DUMMY_PACK_1_PATH
         cmd = BASE_CMD_ARGS + [
             "--register-pack=%s" % (pack_dir),
             "--register-all",
@@ -157,7 +158,7 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
 
     def test_register_setup_virtualenvs(self):
         # Single pack
-        pack_dir = os.path.join(get_fixtures_packs_base_path(), "dummy_pack_1")
+        pack_dir = DUMMY_PACK_1_PATH
 
         cmd = BASE_CMD_ARGS + [
             "--register-pack=%s" % (pack_dir),
@@ -173,7 +174,7 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
     def test_register_recreate_virtualenvs(self):
         # 1. Register the pack and ensure it exists and doesn't rely on state from previous
         # test methods
-        pack_dir = os.path.join(get_fixtures_packs_base_path(), "dummy_pack_1")
+        pack_dir = DUMMY_PACK_1_PATH
 
         cmd = BASE_CMD_ARGS + [
             "--register-pack=%s" % (pack_dir),
@@ -187,7 +188,7 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
         self.assertEqual(exit_code, 0)
 
         # 2. Run it again with --register-recreate-virtualenvs flag
-        pack_dir = os.path.join(get_fixtures_packs_base_path(), "dummy_pack_1")
+        pack_dir = DUMMY_PACK_1_PATH
 
         cmd = BASE_CMD_ARGS + [
             "--register-pack=%s" % (pack_dir),

--- a/st2common/tests/unit/test_aliasesregistrar.py
+++ b/st2common/tests/unit/test_aliasesregistrar.py
@@ -20,14 +20,12 @@ from st2common.bootstrap import aliasesregistrar
 from st2common.persistence.action import ActionAlias
 
 from st2tests import DbTestCase
-from st2tests import fixturesloader
+from st2tests.fixtures.packs.dummy_pack_1.fixture import (
+    PACK_PATH as ALIASES_FIXTURE_PACK_PATH,
+)
 
 __all__ = ["TestAliasRegistrar"]
 
-
-ALIASES_FIXTURE_PACK_PATH = os.path.join(
-    fixturesloader.get_fixtures_packs_base_path(), "dummy_pack_1"
-)
 ALIASES_FIXTURE_PATH = os.path.join(ALIASES_FIXTURE_PACK_PATH, "aliases")
 
 

--- a/st2common/tests/unit/test_configs_registrar.py
+++ b/st2common/tests/unit/test_configs_registrar.py
@@ -28,13 +28,14 @@ from st2tests.api import SUPER_SECRET_PARAMETER
 
 from st2tests.base import CleanDbTestCase
 from st2tests import fixturesloader
+from st2tests.fixtures.packs.dummy_pack_1.fixture import (
+    PACK_NAME as DUMMY_PACK_1,
+    PACK_PATH as PACK_1_PATH,
+)
 
 
 __all__ = ["ConfigsRegistrarTestCase"]
 
-PACK_1_PATH = os.path.join(
-    fixturesloader.get_fixtures_packs_base_path(), "dummy_pack_1"
-)
 PACK_6_PATH = os.path.join(
     fixturesloader.get_fixtures_packs_base_path(), "dummy_pack_6"
 )
@@ -60,7 +61,7 @@ class ConfigsRegistrarTestCase(CleanDbTestCase):
 
         registrar = ConfigsRegistrar(use_pack_cache=False)
         registrar._pack_loader.get_packs = mock.Mock()
-        registrar._pack_loader.get_packs.return_value = {"dummy_pack_1": PACK_1_PATH}
+        registrar._pack_loader.get_packs.return_value = {DUMMY_PACK_1: PACK_1_PATH}
         packs_base_paths = content_utils.get_packs_base_paths()
         registrar.register_from_packs(base_dirs=packs_base_paths)
 

--- a/st2common/tests/unit/test_content_utils.py
+++ b/st2common/tests/unit/test_content_utils.py
@@ -31,6 +31,10 @@ from st2common.content.utils import get_action_libs_abs_path
 from st2common.content.utils import get_relative_path_to_pack_file
 from st2tests import config as tests_config
 from st2tests.fixturesloader import get_fixtures_packs_base_path
+from st2tests.fixtures.packs.dummy_pack_1.fixture import (
+    PACK_NAME as DUMMY_PACK_1,
+    PACK_PATH as DUMMY_PACK_1_PATH,
+)
 
 
 class ContentUtilsTestCase(unittest2.TestCase):
@@ -112,7 +116,7 @@ class ContentUtilsTestCase(unittest2.TestCase):
             ValueError,
             expected_msg,
             get_pack_resource_file_abs_path,
-            pack_ref="dummy_pack_1",
+            pack_ref=DUMMY_PACK_1,
             resource_type="fooo",
             file_path="test.py",
         )
@@ -137,7 +141,7 @@ class ContentUtilsTestCase(unittest2.TestCase):
                 ValueError,
                 expected_msg,
                 get_pack_resource_file_abs_path,
-                pack_ref="dummy_pack_1",
+                pack_ref=DUMMY_PACK_1,
                 resource_type="action",
                 file_path=file_path,
             )
@@ -152,7 +156,7 @@ class ContentUtilsTestCase(unittest2.TestCase):
                 ValueError,
                 expected_msg,
                 get_pack_resource_file_abs_path,
-                pack_ref="dummy_pack_1",
+                pack_ref=DUMMY_PACK_1,
                 resource_type="sensor",
                 file_path=file_path,
             )
@@ -166,18 +170,16 @@ class ContentUtilsTestCase(unittest2.TestCase):
                 ValueError,
                 expected_msg,
                 get_pack_file_abs_path,
-                pack_ref="dummy_pack_1",
+                pack_ref=DUMMY_PACK_1,
                 file_path=file_path,
             )
 
         # Valid paths
         file_paths = ["foo.py", "a/foo.py", "a/b/foo.py"]
         for file_path in file_paths:
-            expected = os.path.join(
-                get_fixtures_packs_base_path(), "dummy_pack_1/actions", file_path
-            )
+            expected = os.path.join(DUMMY_PACK_1_PATH, "actions", file_path)
             result = get_pack_resource_file_abs_path(
-                pack_ref="dummy_pack_1", resource_type="action", file_path=file_path
+                pack_ref=DUMMY_PACK_1, resource_type="action", file_path=file_path
             )
             self.assertEqual(result, expected)
 
@@ -236,20 +238,18 @@ class ContentUtilsTestCase(unittest2.TestCase):
     def test_get_relative_path_to_pack_file(self):
         packs_base_paths = get_fixtures_packs_base_path()
 
-        pack_ref = "dummy_pack_1"
+        pack_ref = DUMMY_PACK_1
 
         # 1. Valid paths
-        file_path = os.path.join(packs_base_paths, "dummy_pack_1/pack.yaml")
+        file_path = os.path.join(DUMMY_PACK_1_PATH, "pack.yaml")
         result = get_relative_path_to_pack_file(pack_ref=pack_ref, file_path=file_path)
         self.assertEqual(result, "pack.yaml")
 
-        file_path = os.path.join(
-            packs_base_paths, "dummy_pack_1/actions/action.meta.yaml"
-        )
+        file_path = os.path.join(DUMMY_PACK_1_PATH, "actions/action.meta.yaml")
         result = get_relative_path_to_pack_file(pack_ref=pack_ref, file_path=file_path)
         self.assertEqual(result, "actions/action.meta.yaml")
 
-        file_path = os.path.join(packs_base_paths, "dummy_pack_1/actions/lib/foo.py")
+        file_path = os.path.join(DUMMY_PACK_1_PATH, "actions/lib/foo.py")
         result = get_relative_path_to_pack_file(pack_ref=pack_ref, file_path=file_path)
         self.assertEqual(result, "actions/lib/foo.py")
 

--- a/st2common/tests/unit/test_policies_registrar.py
+++ b/st2common/tests/unit/test_policies_registrar.py
@@ -28,6 +28,10 @@ from st2common.persistence.policy import Policy
 from st2common.persistence.policy import PolicyType
 from st2tests.base import CleanDbTestCase
 from st2tests.fixturesloader import get_fixtures_packs_base_path
+from st2tests.fixtures.packs.dummy_pack_1.fixture import (
+    PACK_NAME as DUMMY_PACK_1,
+    PACK_PATH as DUMMY_PACK_1_PATH,
+)
 
 __all__ = ["PoliciesRegistrarTestCase"]
 
@@ -71,12 +75,12 @@ class PoliciesRegistrarTestCase(CleanDbTestCase):
 
         expected_policies = {
             "test_policy_1": {
-                "pack": "dummy_pack_1",
+                "pack": DUMMY_PACK_1,
                 "type": "action.concurrency",
                 "parameters": {"action": "delay", "threshold": 3},
             },
             "test_policy_3": {
-                "pack": "dummy_pack_1",
+                "pack": DUMMY_PACK_1,
                 "type": "action.retry",
                 "parameters": {"retry_on": "timeout", "max_retry_count": 5},
             },
@@ -92,12 +96,12 @@ class PoliciesRegistrarTestCase(CleanDbTestCase):
         self.assertDictEqual(expected_policies, policies)
 
     def test_register_policies_from_pack(self):
-        pack_dir = os.path.join(get_fixtures_packs_base_path(), "dummy_pack_1")
+        pack_dir = DUMMY_PACK_1_PATH
         self.assertEqual(register_policies(pack_dir=pack_dir), 2)
 
         p1 = Policy.get_by_ref("dummy_pack_1.test_policy_1")
         self.assertEqual(p1.name, "test_policy_1")
-        self.assertEqual(p1.pack, "dummy_pack_1")
+        self.assertEqual(p1.pack, DUMMY_PACK_1)
         self.assertEqual(p1.resource_ref, "dummy_pack_1.local")
         self.assertEqual(p1.policy_type, "action.concurrency")
         # Verify that a default value for parameter "action" which isn't provided in the file is set
@@ -110,16 +114,14 @@ class PoliciesRegistrarTestCase(CleanDbTestCase):
     def test_register_policy_invalid_policy_type_references(self):
         # Policy references an invalid (inexistent) policy type
         registrar = PolicyRegistrar()
-        policy_path = os.path.join(
-            get_fixtures_packs_base_path(), "dummy_pack_1/policies/policy_2.yaml"
-        )
+        policy_path = os.path.join(DUMMY_PACK_1_PATH, "policies/policy_2.yaml")
 
         expected_msg = 'Referenced policy_type "action.mock_policy_error" doesnt exist'
         self.assertRaisesRegexp(
             ValueError,
             expected_msg,
             registrar._register_policy,
-            pack="dummy_pack_1",
+            pack=DUMMY_PACK_1,
             policy=policy_path,
         )
 

--- a/st2common/tests/unit/test_resource_registrar.py
+++ b/st2common/tests/unit/test_resource_registrar.py
@@ -28,16 +28,19 @@ from st2common.persistence.pack import ConfigSchema
 
 from st2tests.base import CleanDbTestCase
 from st2tests.fixturesloader import get_fixtures_base_path
+from st2tests.fixtures.packs.dummy_pack_1.fixture import (
+    PACK_NAME as DUMMY_PACK_1,
+    PACK_PATH as PACK_PATH_1,
+)
+from st2tests.fixtures.packs.dummy_pack_10.fixture import PACK_PATH as PACK_PATH_10
 
 
 __all__ = ["ResourceRegistrarTestCase"]
 
-PACK_PATH_1 = os.path.join(get_fixtures_base_path(), "packs/dummy_pack_1")
 PACK_PATH_6 = os.path.join(get_fixtures_base_path(), "packs/dummy_pack_6")
 PACK_PATH_7 = os.path.join(get_fixtures_base_path(), "packs/dummy_pack_7")
 PACK_PATH_8 = os.path.join(get_fixtures_base_path(), "packs/dummy_pack_8")
 PACK_PATH_9 = os.path.join(get_fixtures_base_path(), "packs/dummy_pack_9")
-PACK_PATH_10 = os.path.join(get_fixtures_base_path(), "packs/dummy_pack_10")
 PACK_PATH_12 = os.path.join(get_fixtures_base_path(), "packs/dummy_pack_12")
 PACK_PATH_13 = os.path.join(get_fixtures_base_path(), "packs/dummy_pack_13")
 PACK_PATH_14 = os.path.join(get_fixtures_base_path(), "packs/dummy_pack_14")
@@ -58,7 +61,7 @@ class ResourceRegistrarTestCase(CleanDbTestCase):
 
         registrar = ResourceRegistrar(use_pack_cache=False)
         registrar._pack_loader.get_packs = mock.Mock()
-        registrar._pack_loader.get_packs.return_value = {"dummy_pack_1": PACK_PATH_1}
+        registrar._pack_loader.get_packs.return_value = {DUMMY_PACK_1: PACK_PATH_1}
         packs_base_paths = content_utils.get_packs_base_paths()
         registrar.register_packs(base_dirs=packs_base_paths)
 
@@ -72,7 +75,7 @@ class ResourceRegistrarTestCase(CleanDbTestCase):
         pack_db = pack_dbs[0]
         config_schema_db = config_schema_dbs[0]
 
-        self.assertEqual(pack_db.name, "dummy_pack_1")
+        self.assertEqual(pack_db.name, DUMMY_PACK_1)
         self.assertEqual(len(pack_db.contributors), 2)
         self.assertEqual(pack_db.contributors[0], "John Doe1 <john.doe1@gmail.com>")
         self.assertEqual(pack_db.contributors[1], "John Doe2 <john.doe2@gmail.com>")
@@ -117,7 +120,7 @@ class ResourceRegistrarTestCase(CleanDbTestCase):
         registrar = ResourceRegistrar(use_pack_cache=False)
         registrar._pack_loader.get_packs = mock.Mock()
         registrar._pack_loader.get_packs.return_value = {
-            "dummy_pack_1": PACK_PATH_1,
+            DUMMY_PACK_1: PACK_PATH_1,
             "dummy_pack_6": PACK_PATH_6,
         }
         packs_base_paths = content_utils.get_packs_base_paths()
@@ -129,8 +132,8 @@ class ResourceRegistrarTestCase(CleanDbTestCase):
         self.assertEqual(len(pack_db.contributors), 0)
 
         # Ref is not provided, directory name should be used
-        pack_db = Pack.get_by_name("dummy_pack_1")
-        self.assertEqual(pack_db.ref, "dummy_pack_1")
+        pack_db = Pack.get_by_name(DUMMY_PACK_1)
+        self.assertEqual(pack_db.ref, DUMMY_PACK_1)
 
         # "ref" is not provided, but "name" is
         registrar._register_pack_db(pack_name=None, pack_dir=PACK_PATH_7)

--- a/st2common/tests/unit/test_triggers_registrar.py
+++ b/st2common/tests/unit/test_triggers_registrar.py
@@ -21,6 +21,10 @@ from st2common.persistence.trigger import Trigger
 from st2common.persistence.trigger import TriggerType
 from st2tests.base import CleanDbTestCase
 from st2tests.fixturesloader import get_fixtures_packs_base_path
+from st2tests.fixtures.packs.dummy_pack_1.fixture import (
+    PACK_NAME as DUMMY_PACK_1,
+    PACK_PATH as DUMMY_PACK_1_PATH,
+)
 
 __all__ = ["TriggersRegistrarTestCase"]
 
@@ -41,8 +45,7 @@ class TriggersRegistrarTestCase(CleanDbTestCase):
         self.assertEqual(len(trigger_dbs), 2)
 
     def test_register_triggers_from_pack(self):
-        base_path = get_fixtures_packs_base_path()
-        pack_dir = os.path.join(base_path, "dummy_pack_1")
+        pack_dir = DUMMY_PACK_1_PATH
 
         trigger_type_dbs = TriggerType.get_all()
         self.assertEqual(len(trigger_type_dbs), 0)
@@ -57,11 +60,11 @@ class TriggersRegistrarTestCase(CleanDbTestCase):
         self.assertEqual(len(trigger_dbs), 2)
 
         self.assertEqual(trigger_type_dbs[0].name, "event_handler")
-        self.assertEqual(trigger_type_dbs[0].pack, "dummy_pack_1")
+        self.assertEqual(trigger_type_dbs[0].pack, DUMMY_PACK_1)
         self.assertEqual(trigger_dbs[0].name, "event_handler")
-        self.assertEqual(trigger_dbs[0].pack, "dummy_pack_1")
+        self.assertEqual(trigger_dbs[0].pack, DUMMY_PACK_1)
         self.assertEqual(trigger_dbs[0].type, "dummy_pack_1.event_handler")
 
         self.assertEqual(trigger_type_dbs[1].name, "head_sha_monitor")
-        self.assertEqual(trigger_type_dbs[1].pack, "dummy_pack_1")
+        self.assertEqual(trigger_type_dbs[1].pack, DUMMY_PACK_1)
         self.assertEqual(trigger_type_dbs[1].payload_schema["type"], "object")

--- a/st2common/tests/unit/test_triggers_registrar.py
+++ b/st2common/tests/unit/test_triggers_registrar.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import os
 
 import st2common.bootstrap.triggersregistrar as triggers_registrar
 from st2common.persistence.trigger import Trigger

--- a/st2common/tests/unit/test_virtualenvs.py
+++ b/st2common/tests/unit/test_virtualenvs.py
@@ -28,6 +28,7 @@ import st2common.util.virtualenvs as virtualenvs
 from st2common.util.virtualenvs import install_requirement
 from st2common.util.virtualenvs import install_requirements
 from st2common.util.virtualenvs import setup_pack_virtualenv
+from st2tests.fixtures.packs.dummy_pack_1.fixture import PACK_NAME as DUMMY_PACK_1
 
 
 __all__ = ["VirtualenvUtilsTestCase"]
@@ -51,7 +52,7 @@ class VirtualenvUtilsTestCase(CleanFilesTestCase):
 
     def test_setup_pack_virtualenv_doesnt_exist_yet(self):
         # Test a fresh virtualenv creation
-        pack_name = "dummy_pack_1"
+        pack_name = DUMMY_PACK_1
         pack_virtualenv_dir = os.path.join(self.virtualenvs_path, pack_name)
 
         # Verify virtualenv directory doesn't exist
@@ -72,7 +73,7 @@ class VirtualenvUtilsTestCase(CleanFilesTestCase):
 
     def test_setup_pack_virtualenv_already_exists(self):
         # Test a scenario where virtualenv already exists
-        pack_name = "dummy_pack_1"
+        pack_name = DUMMY_PACK_1
         pack_virtualenv_dir = os.path.join(self.virtualenvs_path, pack_name)
 
         # Verify virtualenv directory doesn't exist

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_1/fixture.py
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_1/fixture.py
@@ -1,0 +1,9 @@
+import os
+
+from st2tests import fixturesloader
+
+__all__ = ["PACK_NAME", "PACK_PATH"]
+
+
+PACK_NAME = os.path.basename(os.path.dirname(__file__))
+PACK_PATH = os.path.join(fixturesloader.get_fixtures_packs_base_path(), PACK_NAME)

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_1/fixture.py
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_1/fixture.py
@@ -1,9 +1,3 @@
-import os
-
 from st2tests import fixturesloader
 
-__all__ = ["PACK_NAME", "PACK_PATH"]
-
-
-PACK_NAME = os.path.basename(os.path.dirname(__file__))
-PACK_PATH = os.path.join(fixturesloader.get_fixtures_packs_base_path(), PACK_NAME)
+PACK_NAME, PACK_PATH = fixturesloader.get_pack_fixture_name_and_path_from(__file__)

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_1/fixture.py
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_1/fixture.py
@@ -1,3 +1,3 @@
 from st2tests import fixturesloader
 
-PACK_NAME, PACK_PATH = fixturesloader.get_pack_fixture_name_and_path_from(__file__)
+PACK_NAME, PACK_PATH = fixturesloader.get_fixture_name_and_path(__file__)

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_1/fixture.py
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_1/fixture.py
@@ -1,3 +1,16 @@
+# Copyright 2022 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from st2tests import fixturesloader
 
 PACK_NAME, PACK_PATH = fixturesloader.get_fixture_name_and_path(__file__)

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_10/fixture.py
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_10/fixture.py
@@ -1,0 +1,9 @@
+import os
+
+from st2tests import fixturesloader
+
+__all__ = ["PACK_NAME", "PACK_PATH"]
+
+
+PACK_NAME = os.path.basename(os.path.dirname(__file__))
+PACK_PATH = os.path.join(fixturesloader.get_fixtures_packs_base_path(), PACK_NAME)

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_10/fixture.py
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_10/fixture.py
@@ -1,9 +1,3 @@
-import os
-
 from st2tests import fixturesloader
 
-__all__ = ["PACK_NAME", "PACK_PATH"]
-
-
-PACK_NAME = os.path.basename(os.path.dirname(__file__))
-PACK_PATH = os.path.join(fixturesloader.get_fixtures_packs_base_path(), PACK_NAME)
+PACK_NAME, PACK_PATH = fixturesloader.get_pack_fixture_name_and_path_from(__file__)

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_10/fixture.py
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_10/fixture.py
@@ -1,3 +1,3 @@
 from st2tests import fixturesloader
 
-PACK_NAME, PACK_PATH = fixturesloader.get_pack_fixture_name_and_path_from(__file__)
+PACK_NAME, PACK_PATH = fixturesloader.get_fixture_name_and_path(__file__)

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_10/fixture.py
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_10/fixture.py
@@ -1,3 +1,16 @@
+# Copyright 2022 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from st2tests import fixturesloader
 
 PACK_NAME, PACK_PATH = fixturesloader.get_fixture_name_and_path(__file__)

--- a/st2tests/st2tests/fixturesloader.py
+++ b/st2tests/st2tests/fixturesloader.py
@@ -169,6 +169,12 @@ def get_resources_base_path():
     return os.path.abspath(os.path.join(os.path.dirname(__file__), "resources"))
 
 
+def get_pack_fixture_name_and_path_from(fixture_file):
+    pack_name = os.path.basename(os.path.dirname(fixture_file))
+    pack_path = os.path.join(get_fixtures_packs_base_path(), pack_name)
+    return pack_name, pack_path
+
+
 class FixturesLoader(object):
     def __init__(self):
         self.meta_loader = MetaLoader()

--- a/st2tests/st2tests/fixturesloader.py
+++ b/st2tests/st2tests/fixturesloader.py
@@ -158,15 +158,15 @@ submodules.
 
 
 def get_fixtures_base_path():
-    return os.path.join(os.path.dirname(__file__), "fixtures")
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), "fixtures"))
 
 
 def get_fixtures_packs_base_path():
-    return os.path.join(os.path.dirname(__file__), "fixtures/packs")
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), "fixtures/packs"))
 
 
 def get_resources_base_path():
-    return os.path.join(os.path.dirname(__file__), "resources")
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), "resources"))
 
 
 class FixturesLoader(object):

--- a/st2tests/st2tests/fixturesloader.py
+++ b/st2tests/st2tests/fixturesloader.py
@@ -169,7 +169,7 @@ def get_resources_base_path():
     return os.path.abspath(os.path.join(os.path.dirname(__file__), "resources"))
 
 
-def get_pack_fixture_name_and_path_from(fixture_file):
+def get_fixture_name_and_path(fixture_file):
     pack_name = os.path.basename(os.path.dirname(fixture_file))
     pack_path = os.path.join(get_fixtures_packs_base_path(), pack_name)
     return pack_name, pack_path


### PR DESCRIPTION
### Background

I'm working towards introducing [`pants`](https://www.pantsbuild.org/docs). Eventually I would like to use pants to run tests to take advantage of the fine-grained per-file caching of results that accounts for dependencies by python files (pants infers the deps by reading the python files).

In order to use the fine-grained caching, Pants needs to know which tests rely on which fixtures. We could add **extra** metadata to tie the tests to the fixtures, but that would be an additional maintenance burden that will become out-of-date. We can also include all fixtures for all tests, but then we don't benefit from the fine-grained per-file caching. However, pants can already infer dependencies based on python imports, so that is what this PR (and several follow-up PRs) takes advantage of.

### Overview

This PR does the following:
- adjust utils in `st2tests/st2tests/fixturesloader.py` so that we can use those utilities to identify every fixture.
- turn every fixture into an importable python module with an `__init__.py`.
- add a `fixture.py` file in each fixture that uses the fixturesloader utils (where helpful) to identify itself with `PATH` and `NAME` vars.
- in every test that uses a given fixture, import `PATH` and/or `NAME` vars from that fixture.

This PR focuses on only 2 fixture packs: `dummy_pack_1` and `dummy_pack_10`.
Follow-up PRs will address other fixture packs and other sets of fixtures. I will submit those PRs after this one is merged.

I'm leaving a comment on one of the `fixturesloader.py` utils, as we could simplify the interface by using `inspect`. I'd like feedback on preferences about how much magic we're okay with here.

### Commits

- Ensure that pack fixture paths are absolute
- Import PATH/NAME for each fixture pack
- Minimize pack fixture boilerplate code
- Rename fixtureloader func to be more generic
