### PR TITLE
make mongo tests safer to run in parallel

### DIFF
--- a/st2common/tests/unit/test_db.py
+++ b/st2common/tests/unit/test_db.py
@@ -126,6 +126,7 @@ class DbConnectionTestCase(DbTestCase):
     def test_network_level_compression(self):
         disconnect()
 
+        # db is not modified in this test, so this is safe to run in parallel.
         db_name = "st2"
         db_host = "localhost"
         db_port = 27017
@@ -521,6 +522,7 @@ class DbConnectionTestCase(DbTestCase):
         # and propagating the error
         disconnect()
 
+        # db is not modified in this test, so this is safe to run in parallel.
         db_name = "st2"
         db_host = "localhost"
         db_port = 27017

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -85,7 +85,9 @@ def _register_config_opts():
 
 
 def _override_db_opts():
-    CONF.set_override(name="db_name", override="st2-test", group="database")
+    # use separate dbs for safer parallel test runs
+    db_name = f"st2-test{os.environ.get('ST2TESTS_PARALLEL_SLOT', '')}"
+    CONF.set_override(name="db_name", override=db_name, group="database")
     CONF.set_override(name="host", override="127.0.0.1", group="database")
 
 


### PR DESCRIPTION
### Background

I'm working towards introducing [`pants`](https://www.pantsbuild.org/docs). Eventually I would like to use pants to run tests to take advantage of the fine-grained per-file caching of results that accounts for dependencies by python files (pants infers the deps by reading the python files).

pants runs each test file separately in pytest. So, if two files try to modify the same database at the same time, we'll get strange results.


### Overview

So, modify the db name for each parallel test to ensure that they can run safely in parallel.

Once we integrate pants, we will configure (in pants.toml) `[pytest].execution_slot_var = "ST2TESTS_PARALLEL_SLOT"` to take advantage of the env var introduced here.
https://www.pantsbuild.org/docs/reference-pytest#section-execution-slot-var