### PR TITLE
Fix and reenable prance-based openapi spec validation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,9 @@ Fixed
 
 * Fixed eventlet monkey patching so more of the unit tests work under pytest. #5689
 
+* Fix and reenable prance-based openapi spec validation, but make our custom ``x-api-model`` validation optional as the spec is out-of-date. #5709
+  Contributed by @cognifloyd
+
 Added
 ~~~~~
 

--- a/st2common/st2common/cmd/validate_api_spec.py
+++ b/st2common/st2common/cmd/validate_api_spec.py
@@ -22,8 +22,8 @@ in st2common/models/api/.
 from __future__ import absolute_import
 import os
 
+import prance
 from oslo_config import cfg
-from prance import ResolvingParser
 
 from st2common import config
 from st2common import log as logging
@@ -100,7 +100,7 @@ def validate_spec():
             f.write(spec_string)
             f.flush()
 
-    parser = ResolvingParser(spec_file)
+    parser = prance.ResolvingParser(spec_file)
     spec = parser.specification
 
     return _validate_definitions(spec)
@@ -118,7 +118,8 @@ def main():
         # The spec loader do not allow duplicate keys.
         spec_loader.load_spec("st2common", "openapi.yaml.j2")
 
-        ret = 0
+        # run the schema through prance to validate openapi spec.
+        ret = validate_spec()
     except Exception:
         LOG.error("Failed to validate openapi.yaml file", exc_info=True)
         ret = 1

--- a/st2common/st2common/models/api/pack.py
+++ b/st2common/st2common/models/api/pack.py
@@ -383,10 +383,15 @@ class PackInstallRequestAPI(BaseAPI):
     schema = {
         "type": "object",
         "properties": {
-            "packs": {"type": "array"},
+            "packs": {"type": "array"},  # TODO: add enum
             "force": {
                 "type": "boolean",
                 "description": "Force pack installation",
+                "default": False,
+            },
+            "skip_dependencies": {
+                "type": "boolean",
+                "description": "Set to True to skip pack dependency installations.",
                 "default": False,
             },
         },

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -1998,7 +1998,7 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/PackView'
+              $ref: '#/definitions/DataFilesSubSchema'
           examples:
             application/json:
               ref: 'core.local'
@@ -2391,7 +2391,7 @@ paths:
           description: User performing the operation.
       responses:
         '200':
-          description: Policy created successfully.
+          description: Policy list
           schema:
             type: array
             items:
@@ -3074,7 +3074,7 @@ paths:
           description: User performing the operation.
       responses:
         '200':
-          description: List of rules
+          description: List of runner types
           schema:
             type: array
             items:
@@ -4883,7 +4883,7 @@ definitions:
         type: object
         description: Execution result
         properties:
-          $ref: '#/definitions/Execution'
+          $ref: '#/definitions/Execution/properties'
       message:
         type: string
   AliasMatchAndExecuteInputAPI:
@@ -5172,8 +5172,9 @@ definitions:
       skip_dependencies:
         type: boolean
         description: Set to True to skip pack dependency installations.
-        required: false
         default: false
+    required:
+      - packs
   PacksUninstall:
     type: object
     properties:
@@ -5198,6 +5199,10 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/PacksContentRegisterType'
+      fail_on_failure:
+        type: boolean
+        description: True to fail on failure
+        default: true
   PacksContentRegisterType:
           type: string
           enum: ['all',

--- a/st2common/st2common/openapi.yaml.j2
+++ b/st2common/st2common/openapi.yaml.j2
@@ -1994,7 +1994,7 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/PackView'
+              $ref: '#/definitions/DataFilesSubSchema'
           examples:
             application/json:
               ref: 'core.local'
@@ -2387,7 +2387,7 @@ paths:
           description: User performing the operation.
       responses:
         '200':
-          description: Policy created successfully.
+          description: Policy list
           schema:
             type: array
             items:
@@ -3070,7 +3070,7 @@ paths:
           description: User performing the operation.
       responses:
         '200':
-          description: List of rules
+          description: List of runner types
           schema:
             type: array
             items:
@@ -4879,7 +4879,7 @@ definitions:
         type: object
         description: Execution result
         properties:
-          $ref: '#/definitions/Execution'
+          $ref: '#/definitions/Execution/properties'
       message:
         type: string
   AliasMatchAndExecuteInputAPI:
@@ -5168,8 +5168,9 @@ definitions:
       skip_dependencies:
         type: boolean
         description: Set to True to skip pack dependency installations.
-        required: false
         default: false
+    required:
+      - packs
   PacksUninstall:
     type: object
     properties:
@@ -5194,6 +5195,10 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/PacksContentRegisterType'
+      fail_on_failure:
+        type: boolean
+        description: True to fail on failure
+        default: true
   PacksContentRegisterType:
           type: string
           enum: ['all',


### PR DESCRIPTION
### Background

I'm working towards introducing [`pants`](https://www.pantsbuild.org/docs). One of the first things we will use it for is linting / reformatting (it will run black, flake8, etc). Validation of our openapi schema should happen more regularly, so we'll hook that up so pants runs it when it runs lint tools

While hooking that up, I noticed parts of the validation commented out. So, I searched through the git history to figure out when and why.
Basically, it's just tech debt that no one had time to address. So, this is a step in that direction.

### Overview

Fix and reenable prance-based openapi spec validation, but make our custom `x-api-model` validation optional as the spec is out-of-date.

This also fixes issues identified by the now-enabled spec validation.

Related: #3575 #3788
