### PR TITLE
[RFC] TSC Governance Proposal: Document the TSC Meetings host rotation

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -11,13 +11,13 @@ This group is responsible for all technical oversight of StackStorm as Open Sour
 
 ### TSC Meetings
 Because of the different schedules and time zones, TSC is keen to prioritize asynchronous collaboration and work.
-However, every `1st Tuesday` of the month `09:30 AM US Pacific`, [@StackStorm/tsc](OWNERS.md) members are gathering for `1 hour` to discuss the project problems, roadmap, priorities to help the StackStorm as a project evolve and succeed.
+However, every month, [@StackStorm/tsc](OWNERS.md) members are gathering for `1 hour` to discuss the project problems, roadmap, priorities to help the StackStorm as a project evolve and succeed.
 The meetings are open, and we invite community to join them to be up-to-date with the latest project developments and progress.
 
 * TSC Meetings Host responsibility is rotated between the TSC maintainers.
 * Priority to host is given based on activity: Current Release Owners > Maintainers who weren't in rotation > Other Maintainer Volunteers.
 * Maintainers are free to decide collectively who would run the next TSC meeting: they can run in pairs, swap.
-See [StackStorm TSC Meetings](https://github.com/StackStorm/community/issues/33) for more info about the meeting schedule, calendar, meeting host responsibilities and procedure.
+See [StackStorm TSC Meetings](https://github.com/StackStorm/community/issues/33) for more info about the meeting schedule, how to join, calendar, meeting host responsibilities and procedure.
 
 ### Maintainer Roles
 The current list of maintainers is published and updated in [OWNERS.md](OWNERS.md).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -9,6 +9,16 @@ It extends [Technical Charter](https://stackstorm.com/wp/wp-content/uploads/2020
 The Technical Steering Committee is a group of Maintainers (Committers) who have earned the ability to modify (“commit”) sourcecode, documentation or other artifacts.
 This group is responsible for all technical oversight of StackStorm as Open Source Project.
 
+### TSC Meetings
+Because of the different schedules and time zones, TSC is keen to prioritize asynchronous collaboration and work.
+However every first Tuesday of the month [@StackStorm/tsc](OWNERS.md) members are gathering for 1 hour to discuss the project problems, roadmap, priorities to help the StackStorm as a project evolve and succeed.
+These meetings are open and we invite community to join them to be up to date with the latest project developments and progress.
+
+* TSC Meetings Host responsibility is rotated between the TSC maintainers.
+* Priority is given based on activity: Current Release Managers > Senior Maintainers > Maintainers.
+* Maintainers are free to decide collectively who would run the next TSC meeting. They can run in pairs, repeat, however no Maintainer can be a host for more than one in three consecutive meetings.
+See [StackStorm TSC Meetings](https://github.com/StackStorm/community/issues/33) for more info about the meeting schedule, meeting host responsibilities and procedure.
+
 ### Maintainer Roles
 The current list of maintainers is published and updated in [OWNERS.md](OWNERS.md).
 StackStorm uses a three-tiered system of Maintainer roles:

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -11,13 +11,13 @@ This group is responsible for all technical oversight of StackStorm as Open Sour
 
 ### TSC Meetings
 Because of the different schedules and time zones, TSC is keen to prioritize asynchronous collaboration and work.
-However every first Tuesday of the month [@StackStorm/tsc](OWNERS.md) members are gathering for 1 hour to discuss the project problems, roadmap, priorities to help the StackStorm as a project evolve and succeed.
-These meetings are open and we invite community to join them to be up to date with the latest project developments and progress.
+However, every `1st Tuesday` of the month `09:30 AM US Pacific`, [@StackStorm/tsc](OWNERS.md) members are gathering for `1 hour` to discuss the project problems, roadmap, priorities to help the StackStorm as a project evolve and succeed.
+The meetings are open, and we invite community to join them to be up-to-date with the latest project developments and progress.
 
 * TSC Meetings Host responsibility is rotated between the TSC maintainers.
-* Priority is given based on activity: Current Release Managers > Senior Maintainers > Maintainers.
-* Maintainers are free to decide collectively who would run the next TSC meeting. They can run in pairs, repeat, however no Maintainer can be a host for more than one in three consecutive meetings.
-See [StackStorm TSC Meetings](https://github.com/StackStorm/community/issues/33) for more info about the meeting schedule, meeting host responsibilities and procedure.
+* Priority to host is given based on activity: Current Release Owners > Maintainers who weren't in rotation > Other Maintainer Volunteers.
+* Maintainers are free to decide collectively who would run the next TSC meeting. They can run in pairs, swap, however for diversification reasons no Maintainer can be a host for more than one in three consecutive meetings.
+See [StackStorm TSC Meetings](https://github.com/StackStorm/community/issues/33) for more info about the meeting schedule, calendar, meeting host responsibilities and procedure.
 
 ### Maintainer Roles
 The current list of maintainers is published and updated in [OWNERS.md](OWNERS.md).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -16,7 +16,7 @@ The meetings are open, and we invite community to join them to be up-to-date wit
 
 * TSC Meetings Host responsibility is rotated between the TSC maintainers.
 * Priority to host is given based on activity: Current Release Owners > Maintainers who weren't in rotation > Other Maintainer Volunteers.
-* Maintainers are free to decide collectively who would run the next TSC meeting. They can run in pairs, swap, however for diversification reasons no Maintainer can be a host for more than one in three consecutive meetings.
+* Maintainers are free to decide collectively who would run the next TSC meeting: they can run in pairs, swap.
 See [StackStorm TSC Meetings](https://github.com/StackStorm/community/issues/33) for more info about the meeting schedule, calendar, meeting host responsibilities and procedure.
 
 ### Maintainer Roles

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -11,7 +11,7 @@ This group is responsible for all technical oversight of StackStorm as Open Sour
 
 ### TSC Meetings
 Because of the different schedules and time zones, TSC is keen to prioritize asynchronous collaboration and work.
-However, every month, [@StackStorm/tsc](OWNERS.md) members are gathering for `1 hour` to discuss the project problems, roadmap, priorities to help the StackStorm as a project evolve and succeed.
+However, every month, [@StackStorm/tsc](OWNERS.md) members gather for `1 hour` to discuss the project problems, roadmap, priorities to help the StackStorm as a project evolve and succeed.
 The meetings are open, and we invite community to join them to be up-to-date with the latest project developments and progress.
 
 * TSC Meetings Host responsibility is rotated between the TSC maintainers.


### PR DESCRIPTION
Proposal to the Governance describing the TSC Meeting Host rotation.
This would document the processes we already had for the past several months when the meeting host responsibility was rotated between the TSC members.

Closes https://github.com/StackStorm/st2/pull/5135, Closes https://github.com/StackStorm/st2/pull/5071

### Other discussions
Previous discussions: [Rotation for the Monthly TSC Meeting Manager/Coordinator #4](https://github.com/StackStorm/community/issues/4)
TSC Meeting procedure & host responsibilities: [StackStorm TSC Meetings #33](https://github.com/StackStorm/community/issues/33)

### Current status
In consultation, waiting for review/feedback from @StackStorm/tsc