### PR TITLE
Configure pantsbuild source roots

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,7 +53,7 @@ Added
 
 * Begin introducing `pants <https://www.pantsbuild.org/docs>`_ to improve DX (Developer Experience)
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
-  to pants' use of PEX lockfiles. This is not a user-facing addition. #5713
+  to pants' use of PEX lockfiles. This is not a user-facing addition. #5713 #5724
   Contributed by @cognifloyd
 
 Changed

--- a/pants.toml
+++ b/pants.toml
@@ -1,2 +1,46 @@
 [GLOBAL]
 pants_version = "2.13.0rc2"
+
+[source]
+# recording each pack individually under root patterns is not great, but resolves these issues:
+# - Using a /contrib/* or other glob in root_patterns is dodgy as runners & schemas are in the same dir.
+#   In particular, with /contrib/* in root_patterns, *_runner imports become ambiguous
+#   (eg `import noop_runner` should use runners/noop_runner/noop_runner not runners/noop_runner).
+# - Using pack.yaml in marker_filenames prevents pants from inferring which fixture packs are
+#   used by which tests. We import a PACK_NAME and PACK_PATH from fixture.py in each of these
+#   fixture packs to enable this dependency inferrence. Having fine grained inferrence in-turn
+#   reduces the number of tests that need to be re-run when we change a fixture.
+# - Using another marker_file, like PACK_ROOT, is also problematic because of the core pack.
+#   /contrib/core is symlinked to /st2tests/st2tests/fixtures/packs/core for use as a fixture.
+#   It is used in quite a few tests, so it needs to continue living in both places.
+#   But, overlapping source roots (for st2tests and the pack) make importing from the fixture
+#   as we do with the other fixtures impossible.
+# Thus, we really do need to register each pack in contrib (but never under st2tests) separately.
+# We might also need to register packs in st2tests/testpacks.
+root_patterns = [
+  # root conftest.py
+  "/",
+  # core libs
+  "/st2*",
+  # runners
+  "/contrib/runners/*_runner",
+  # packs (list /contrib/* packs individually; see note above)
+  "/contrib/chatops",
+  "/contrib/core", # WARNING: also symlinked to st2tests/st2tests/fixtures/packs/core
+  "/contrib/default",
+  "/contrib/examples",
+  "/contrib/hello_st2",
+  "/contrib/linux",
+  "/contrib/packs",
+  "/st2tests/testpacks/checks",
+  "/st2tests/testpacks/errorcheck",
+  # odd import in examples.isprime
+  "/contrib/examples/lib",
+  # lint plugins
+  "/pylint_plugins",
+  # misc
+  "/scripts",
+  "/tools",
+  # benchmarks
+  "/st2common/benchmarks/micro",
+]


### PR DESCRIPTION
### Background

This is part 2 of introducing [`pants`](https://www.pantsbuild.org/docs), as discussed in the TSC Meetings on [12 July 2022](https://github.com/StackStorm/community/issues/105), [02 Aug 2022](https://github.com/StackStorm/community/issues/107) and [06 Sept 2022](https://github.com/StackStorm/community/issues/108). Pants has fine-grained per-file caching of results for lint, fmt (like black), test, etc. It also has lockfiles that work well for monorepos that have multiple python packages. With these lockfiles CI should not break when any of our dependencies or our transitive dependencies release new versions, because CI will continue to use the locked version until we explicitly relock with updates.

To keep PRs as manageable/reviewable as possible, introducing pants will take a series of PRs. I do not know yet how many PRs; I will break this up into logical steps with these goals:
- introduce `pants` to the st2 repo, and
- teach some (but not all) TSC members about `pants` step-by-step.

Previous pants PRs include:
- https://github.com/StackStorm/st2/pull/5713

### Overview of this PR

This PR configures pants source roots.
https://www.pantsbuild.org/docs/initial-configuration#configure-source-roots

This is based on a lot of work in a PoC pants branch where I experimented with a several approaches to define source roots. This was the most robust, and includes a comment to document why.

_We can probably simplify this config by moving the packs in `contrib/` into a separate directory like `contrib/packs/`. But that is out-of-scope until after we remove the Makefile and other CI infrastructure that expects those packs to be directly under `contrib/`._

#### `pants.toml` config file

> Pants configuration lives in a file called `pants.toml` in the root of the repo.

https://www.pantsbuild.org/docs/initial-configuration#create-pantstoml

Many important things get configured in the `pants.toml` config file, but this PR only configures `[source].root_patterns`. I also tried using `[source].marker_filenames` but that didn't work very well in our repo with how we symlink the `core` pack into st2tests' fixture packs.

##### `[source].root_patterns`

Essentially, `[source].root_patterns` tells pants where to find python modules (eg to infer dependencies between them) and how to configure `PYTHONPATH`/`sys.path`.

> Some project layouts use top-level folders for namespace purposes, but have the code live underneath. However, the code's imports will ignore these top-level folders, thanks to mechanisms like the `$PYTHONPATH` and the JVM classpath. Source roots are a generic equivalent of these concepts.
> Run `./pants roots` to see what Pants is using

Detailed docs on pants source roots are available here:
- https://www.pantsbuild.org/docs/source-roots
- https://www.pantsbuild.org/docs/reference-source

For StackStorm, we need a root for each python module (each core lib and each runner) and each pack. Plus there are some tool/util directories that we also needed to add to source roots.

### Things you can do with pantsbuild after this PR

This PR does not wire up any lockfiles, formatters, linters, etc, yet. But you can test that pants resolves the source roots correctly with `./pants roots`.

```shell
$ ./pants roots
.
contrib/chatops
contrib/core
contrib/default
contrib/examples
contrib/examples/lib
contrib/hello_st2
contrib/linux
contrib/packs
contrib/runners/action_chain_runner
contrib/runners/announcement_runner
contrib/runners/http_runner
contrib/runners/inquirer_runner
contrib/runners/local_runner
contrib/runners/noop_runner
contrib/runners/orquesta_runner
contrib/runners/python_runner
contrib/runners/remote_runner
contrib/runners/winrm_runner
pylint_plugins
scripts
st2actions
st2api
st2auth
st2client
st2common
st2common/benchmarks/micro
st2reactor
st2stream
st2tests
st2tests/testpacks/checks
st2tests/testpacks/errorcheck
tools
```