### PR TITLE
Enable pantsbuild language backends

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,7 +53,7 @@ Added
 
 * Begin introducing `pants <https://www.pantsbuild.org/docs>`_ to improve DX (Developer Experience)
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
-  to pants' use of PEX lockfiles. This is not a user-facing addition. #5713 #5724 #5726
+  to pants' use of PEX lockfiles. This is not a user-facing addition. #5713 #5724 #5726 #5725
   Contributed by @cognifloyd
 
 Changed

--- a/pants.toml
+++ b/pants.toml
@@ -1,5 +1,14 @@
 [GLOBAL]
 pants_version = "2.13.0rc2"
+backend_packages = [
+  # python
+  "pants.backend.python",
+  "pants.backend.experimental.python", # activates twine `publish` support
+  "pants.backend.python.mixed_interpreter_constraints",
+
+  # shell
+  "pants.backend.shell",
+]
 
 [source]
 # recording each pack individually under root patterns is not great, but resolves these issues:


### PR DESCRIPTION
### Background

This is part 3 of introducing [`pants`](https://www.pantsbuild.org/docs), as discussed in the TSC Meetings on [12 July 2022](https://github.com/StackStorm/community/issues/105), [02 Aug 2022](https://github.com/StackStorm/community/issues/107) and [06 Sept 2022](https://github.com/StackStorm/community/issues/108). Pants has fine-grained per-file caching of results for lint, fmt (like black), test, etc. It also has lockfiles that work well for monorepos that have multiple python packages. With these lockfiles CI should not break when any of our dependencies or our transitive dependencies release new versions, because CI will continue to use the locked version until we explicitly relock with updates.

To keep PRs as manageable/reviewable as possible, introducing pants will take a series of PRs. I do not know yet how many PRs; I will break this up into logical steps with these goals:
- introduce `pants` to the st2 repo, and
- teach some (but not all) TSC members about `pants` step-by-step.

Other pants PRs include:
- https://github.com/StackStorm/st2/pull/5713
- https://github.com/StackStorm/st2/pull/5724
- https://github.com/StackStorm/st2/pull/5726
- https://github.com/StackStorm/st2/pull/5727

### Overview of this PR

This PR enables language-specific backends for pants. This is step 3 in the initial configuration document:
https://www.pantsbuild.org/docs/initial-configuration#enable-backends

The next PR will do [step 5](https://www.pantsbuild.org/docs/initial-configuration#generate-build-files) in the initial configuration document. It will be generated by running some automation to add metadata across the repo. This PR is the manual configuration that has to be done before we can run that process.

This does not add any lint/fmt/etc backends, just the language-specific ones. That will happen in PRs after we have added metadata across the repo.

#### `pants.toml` config file

> Pants configuration lives in a file called `pants.toml` in the root of the repo.

https://www.pantsbuild.org/docs/initial-configuration#create-pantstoml

Many important things get configured in the `pants.toml` config file, but this PR only configures `[GLOBAL].backend_packages`.

##### `[GLOBAL].backend_packages`

The pants docs describe `[GLOBLA].backend_packages` as follows:

> Most Pants functionality is opt-in by adding the relevant backend to the [GLOBAL].backend_packages option in pants.toml.

https://www.pantsbuild.org/docs/enabling-backends

So, this is how we opt-in to different funcitonality. In this PR, we tell pants that we have python and shell files in this repo. We'll add other backends (like flake8 and black) in follow-up PRs.

### Things you can do with pantsbuild

This PR does not wire up any lockfiles, formatters, linters, etc, yet.

After this PR pants has more targets (metadata about a subset of code) and goals (like `count-loc` or `roots` from the previous PRs).

To explore this, use the `./pants help` system (which is extremely helpful!).

#### Before this PR

[![asciicast](https://asciinema.org/a/519743.svg)](https://asciinema.org/a/519743?autoplay=1)

#### After this PR

[![asciicast](https://asciinema.org/a/519748.svg)](https://asciinema.org/a/519748?autoplay=1)