### PR TITLE
Adjust .gitignore to work better with pantsbuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,5 +67,7 @@ benchmark_histograms/
 # Editor Saves
 *~
 \#*\#
-[._]*.sw[a-p]
-[._]sw[a-p]
+[._]*.sw[a-px]
+[._]sw[a-px]
+[._]*.sw[a-p]x
+[._]sw[a-p]x

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@
 *.egg
 *.egg-info
 dist
-build
 .venv
 eggs
 parts

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,7 +53,7 @@ Added
 
 * Begin introducing `pants <https://www.pantsbuild.org/docs>`_ to improve DX (Developer Experience)
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
-  to pants' use of PEX lockfiles. This is not a user-facing addition. #5713 #5724
+  to pants' use of PEX lockfiles. This is not a user-facing addition. #5713 #5724 #5726
   Contributed by @cognifloyd
 
 Changed


### PR DESCRIPTION
### Background

This is another part of introducing [`pants`](https://www.pantsbuild.org/docs), as discussed in the TSC Meetings on [12 July 2022](https://github.com/StackStorm/community/issues/105), [02 Aug 2022](https://github.com/StackStorm/community/issues/107) and [06 Sept 2022](https://github.com/StackStorm/community/issues/108). Pants has fine-grained per-file caching of results for lint, fmt (like black), test, etc. It also has lockfiles that work well for monorepos that have multiple python packages. With these lockfiles CI should not break when any of our dependencies or our transitive dependencies release new versions, because CI will continue to use the locked version until we explicitly relock with updates.

To keep PRs as manageable/reviewable as possible, introducing pants will take a series of PRs. I do not know yet how many PRs; I will break this up into logical steps with these goals:
- introduce `pants` to the st2 repo, and
- teach some (but not all) TSC members about `pants` step-by-step.

Other pants PRs include:
- https://github.com/StackStorm/st2/pull/5713
- https://github.com/StackStorm/st2/pull/5724
- https://github.com/StackStorm/st2/pull/5725
- https://github.com/StackStorm/st2/pull/5727

### Overview of this PR

This PR makes two adjustments to our `.gitignore` file.
1. Remove `build` from .gitignore
2. Add more vim temp file patterns

pants requires `BUILD` files to describe metadata about our code (this directory has python and it has these dependencies that can't be inferred from the imports, etc). `.gitignore` is not case sensitive, so `build` prevents adding `BUILD` files. This is required to use pants.

For more about BUILD files, see: https://www.pantsbuild.org/docs/targets#build-files

The vim temp file patterns is not required for pants but it makes it nicer to work with it. If files change while pants is running a process, it can pause and re-run. When I use `vi` to look at a file while pants is running tests, or formatters, or whatever, then the tmp files keep triggering an inspection of the filesystem (pants needs to make sure it is including all required files in the given operation). But, pants ignores all files in `.gitignore`, so, adding the `vim` temp files there prevents pants from getting false-positive filesystem changes. We might end up adding other temp files for people that use other editors to make their experience with pants nicer as well.