### PR TITLE
Add GHA workflow to validate pants BUILD files

### DIFF
--- a/.github/workflows/pants.yaml
+++ b/.github/workflows/pants.yaml
@@ -1,0 +1,62 @@
+---
+name: Validate Pants Metadata
+
+on:
+  # temporarily only allow manual runs until we have BUILD files and lockfiles
+  workflow_dispatch:
+  #push:
+  #  branches:
+  #    # only on merges to master branch
+  #    - master
+  #    # and version branches, which only include minor versions (eg: v3.4)
+  #    - v[0-9]+.[0-9]+
+  #  tags:
+  #    # also version tags, which include bugfix releases (eg: v3.4.0)
+  #    - v[0-9]+.[0-9]+.[0-9]+
+  #pull_request:
+  #  type: [opened, reopened, edited]
+  #  branches:
+  #    # Only for PRs targeting those branches
+  #    - master
+  #    - v[0-9]+.[0-9]+
+
+jobs:
+  pants-tailor:
+    name: Make sure pants BUILD files are up-to-date
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          # a test uses a submodule, and pants needs access to it to calculate deps.
+          submodules: 'true'
+
+      - name: Initialize Pants and its GHA caches
+        uses: pantsbuild/actions/init-pants@c0ce05ee4ba288bb2a729a2b77294e9cb6ab66f7
+        # This action adds an env var to make pants use both pants.ci.toml & pants.toml.
+        # This action also creates 3 GHA caches (1 is optional).
+        # - `pants-setup` has the bootsrapped pants install
+        # - `pants-named-caches` has pip/wheel and PEX caches
+        # - `pants-lmdb-store` has the fine-grained process cache.
+        #   If we ever use a remote cache, then we can drop this.
+        #   Otherwise, we may need an additional workflow or job to delete old caches
+        #   if they are not expiring fast enough, and we hit the GHA 10GB per repo max.
+        with:
+          # To ignore a bad cache, bump the cache* integer.
+          gha-cache-key: cache0-BUILD
+          # This hash should include all of our lockfiles so that the pip/pex caches
+          # get invalidated on any transitive dependency update.
+          named-caches-hash: ${{ hashFiles('requirements.txt' }}
+          # enable the optional lmdb_store cache since we're not using remote caching.
+          cache-lmdb-store: 'true'
+
+      - name: Check BUILD files
+        run: |
+          ./pants tailor --check update-build-files --check ::
+
+      - name: Upload pants log
+        uses: actions/upload-artifact@v2
+        with:
+          name: pants-log-py${{ matrix.python-version }}
+          path: .pants.d/pants.log
+        if: always()  # We want the log even on failures.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,7 +53,7 @@ Added
 
 * Begin introducing `pants <https://www.pantsbuild.org/docs>`_ to improve DX (Developer Experience)
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
-  to pants' use of PEX lockfiles. This is not a user-facing addition. #5713 #5724 #5726 #5725
+  to pants' use of PEX lockfiles. This is not a user-facing addition. #5713 #5724 #5726 #5725 #5732
   Contributed by @cognifloyd
 
 Changed

--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -1,0 +1,13 @@
+# This config is for CI. It extends the config in pants.toml.
+# See https://www.pantsbuild.org/docs/using-pants-in-ci
+
+[GLOBAL]
+# Colors often work in CI, but the shell is usually not a TTY so Pants
+# doesn't attempt to use them by default.
+colors = true
+
+[stats]
+# "print metrics of your cache's performance at the end of the run,
+# including the number of cache hits and the total time saved thanks
+# to caching"
+log = true


### PR DESCRIPTION
### Background

This is another part of introducing [`pants`](https://www.pantsbuild.org/docs), as discussed in the TSC Meetings on [12 July 2022](https://github.com/StackStorm/community/issues/105), [02 Aug 2022](https://github.com/StackStorm/community/issues/107) and [06 Sept 2022](https://github.com/StackStorm/community/issues/108). Pants has fine-grained per-file caching of results for lint, fmt (like black), test, etc. It also has lockfiles that work well for monorepos that have multiple python packages. With these lockfiles CI should not break when any of our dependencies or our transitive dependencies release new versions, because CI will continue to use the locked version until we explicitly relock with updates.

To keep PRs as manageable/reviewable as possible, introducing pants will take a series of PRs. I do not know yet how many PRs; I will break this up into logical steps with these goals:
- introduce `pants` to the st2 repo, and
- teach some (but not all) TSC members about `pants` step-by-step.

Other pants PRs include:
- https://github.com/StackStorm/st2/pull/5713
- https://github.com/StackStorm/st2/pull/5724
- https://github.com/StackStorm/st2/pull/5725
- https://github.com/StackStorm/st2/pull/5726
- https://github.com/StackStorm/st2/pull/5732

Due to scope change, this PR replaces #5727

### Overview of this PR

It's helpful to review this PR one commit at a time.

This PR prepares us to run pants in GitHub Actions (GHA). There are 2 parts to this:
1. Add a CI-specific pants config file: `pants.ci.toml` (used in addition to `pants.toml`)
2. Prepare to add BUILD files to the repo: Add GHA workflow that makes sure BUILD files are up-to-date.

#### CI-specific pants config

The pants docs recommend adding a CI-specific pants config file called `pants.ci.toml`:
https://www.pantsbuild.org/docs/using-pants-in-ci#configuring-pants-for-ci-pantscitoml-optional

Please note this quote from the docs:
> set the environment variable `PANTS_CONFIG_FILES=pants.ci.toml` to use this new config file, in addition to `pants.toml`.

So, `pants.ci.toml` does NOT replace `pants.toml`, it extends it. So, pants will still use the `pants.toml`, but we can tune settings specifically for GHA, and possibly CircleCI (if we need to use pants there).

We don't have to remember to add the `PANTS_CONFIG_FILES` env var, however, because that is covered by the reusable `pants-init` action, which injects the env var for us.

#### Pants GHA workflow

`BUILD` files are an important part of helping pants understand our codebase. As [the docs](https://www.pantsbuild.org/docs/initial-configuration#generate-build-files) say:

> [BUILD](https://www.pantsbuild.org/docs/targets) files provide metadata about your code (the timeout of a test, any dependencies which cannot be inferred, etc). BUILD files are typically located in the same directory as the code they describe. Unlike many other systems, Pants BUILD files are usually very succinct, as most metadata is either inferred from static analysis, assumed from sensible defaults, or generated for you.

In one of the next PRs, we will be adding BUILD files with metadata for pants across the repo. That PR will run `./pants tailor ::` as described [in initial config docs](https://www.pantsbuild.org/docs/initial-configuration#generate-build-files).

pants has some great tooling to ensure those BUILD files are up-to-date, so we will need a GHA workflow that validates those files. I want to enable a workflow as soon as we add the BUILD files, but--to simplify reviewing--I don't want to add the workflow in the same PR that we add the BUILD files. So, I'm adding the workflow in this PR without enabling it.

This is the key part of the workflow:

https://github.com/StackStorm/st2/blob/acfffceffab66f1b7aa731b8ae6c6778fbaeeffd/.github/workflows/pants.yaml#L53-L55

Here, we run two pants [goals](https://www.pantsbuild.org/docs/goals) in check mode:
- [`tailor`](https://www.pantsbuild.org/docs/reference-tailor): "Auto-generate BUILD file targets for new source files."
- [`update-build-files`](https://www.pantsbuild.org/docs/reference-update-build-files): "Format and fix safe deprecations in BUILD files."

`tailor` example: If we add a shell script in a directory that didn't have any shell scripts before, then `tailor` would add a `shell_sources` target in a BUILD file in that directory. Same for python, and many other things. I expect to discuss more about the contents of BUILD files in the PRs where we add, and then modify them.

`update-build-files` example: BUILD files use python syntax, so this runs `black` over them to reformat them. `update-build-files` also vastly simplifies upgrading between pants versions, because it can adjust the BUILD files to use the latest-and-greatest targets/fields/etc. As the docs say, it can: "Automatically fix deprecations, such as target type renames, that are safe because they do not change semantics."