### PR TITLE
Explicitly disable pantsbuild opt-in anonymous telemetry

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,7 +53,7 @@ Added
 
 * Begin introducing `pants <https://www.pantsbuild.org/docs>`_ to improve DX (Developer Experience)
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
-  to pants' use of PEX lockfiles. This is not a user-facing addition. #5713 #5724 #5726 #5725 #5732 #5733
+  to pants' use of PEX lockfiles. This is not a user-facing addition. #5713 #5724 #5726 #5725 #5732 #5733 #5737
   Contributed by @cognifloyd
 
 Changed

--- a/pants.toml
+++ b/pants.toml
@@ -1,3 +1,10 @@
+[anonymous-telemetry]
+# This is opt-in by default, but we explicitly disable here as well.
+enabled = false
+# repo_id here allows individuals to opt-in on their machine
+# To opt-in, use ~/.pants.rc or envrc to set [anonymous-telemetry].enabled=true
+repo_id = "de0dea7a-9f6a-4c6e-aa20-6ba5ad969b8a"
+
 [GLOBAL]
 pants_version = "2.14.0rc1"
 backend_packages = [


### PR DESCRIPTION
### Background

This is another part of introducing [`pants`](https://www.pantsbuild.org/docs), as discussed in the TSC Meetings on [12 July 2022](https://github.com/StackStorm/community/issues/105), [02 Aug 2022](https://github.com/StackStorm/community/issues/107) and [06 Sept 2022](https://github.com/StackStorm/community/issues/108). Pants has fine-grained per-file caching of results for lint, fmt (like black), test, etc. It also has lockfiles that work well for monorepos that have multiple python packages. With these lockfiles CI should not break when any of our dependencies or our transitive dependencies release new versions, because CI will continue to use the locked version until we explicitly relock with updates.

To keep PRs as manageable/reviewable as possible, introducing pants will take a series of PRs. I do not know yet how many PRs; I will break this up into logical steps with these goals:
- introduce `pants` to the st2 repo, and
- teach some (but not all) TSC members about `pants` step-by-step.

Other pants PRs include:
- https://github.com/StackStorm/st2/pull/5713
- https://github.com/StackStorm/st2/pull/5724
- https://github.com/StackStorm/st2/pull/5725
- https://github.com/StackStorm/st2/pull/5726
- https://github.com/StackStorm/st2/pull/5732
- https://github.com/StackStorm/st2/pull/5733
- https://github.com/StackStorm/st2/pull/5738

### Overview of this PR

This PR is independent of other pantsbuild PRs.

This PR configures pants' anonymous telemetry so that it is explicitly disabled (it is already opt-in by default, but we explicitly disable it). It is also configured so that individual developers can enable it if they wish, but--again--it requires an explicit opt-in.

Documentation about anonymous telemetry is available here:
https://www.pantsbuild.org/docs/anonymous-telemetry

We need to either set the `repo_id` or explicitly disable telemetry to get rid of a non-fatal error pants prints on startup (shown below). I opted to set both so that I can still provide telemetry on my machine, but make the default state (opt-in) explicit to avoid any concerns in our community about telemetry.

```
$ ./pants --version
Bootstrapping Pants using /opt/local/bin/python3.9
Installing pantsbuild.pants==2.14.0rc1 into a virtual environment at /.../.cache/pants/setup/bootstrap-.../2.14.0rc1_py39
New virtual environment successfully created at /.../.cache/pants/setup/bootstrap-.../2.14.0rc1_py39.
13:56:52.14 [INFO] Initializing scheduler...
13:56:52.41 [INFO] Scheduler initialized.
13:56:52.46 [ERROR] Please set `repo_id = "<uuid>"` in the [anonymous-telemetry] section of pants.toml, where `<uuid>` is some fixed random identifier, such as one generated by uuidgen.

Example (using a randomly generated UUID):

    [anonymous-telemetry]
    repo_id = "6e658bee-a933-4c1b-bba2-1fee8254e653"

No telemetry will be sent for this run. See https://www.pantsbuild.org/v2.14/docs/anonymous-telemetry for details.
2.14.0rc1
```

If, like me, someone wants to enable anonymous telemetry on their machine, they can add a `~/.pants.rc` file:
```toml
[anonymous-telemetry]
enabled = true
```