### PR TITLE
Create pantsbuild `BUILD` files with `./pants tailor ::`

### DIFF
--- a/.github/workflows/pants.yaml
+++ b/.github/workflows/pants.yaml
@@ -2,23 +2,21 @@
 name: Validate Pants Metadata
 
 on:
-  # temporarily only allow manual runs until we have BUILD files and lockfiles
-  workflow_dispatch:
-  #push:
-  #  branches:
-  #    # only on merges to master branch
-  #    - master
-  #    # and version branches, which only include minor versions (eg: v3.4)
-  #    - v[0-9]+.[0-9]+
-  #  tags:
-  #    # also version tags, which include bugfix releases (eg: v3.4.0)
-  #    - v[0-9]+.[0-9]+.[0-9]+
-  #pull_request:
-  #  type: [opened, reopened, edited]
-  #  branches:
-  #    # Only for PRs targeting those branches
-  #    - master
-  #    - v[0-9]+.[0-9]+
+  push:
+    branches:
+      # only on merges to master branch
+      - master
+      # and version branches, which only include minor versions (eg: v3.4)
+      - v[0-9]+.[0-9]+
+    tags:
+      # also version tags, which include bugfix releases (eg: v3.4.0)
+      - v[0-9]+.[0-9]+.[0-9]+
+  pull_request:
+    type: [opened, reopened, edited]
+    branches:
+      # Only for PRs targeting those branches
+      - master
+      - v[0-9]+.[0-9]+
 
 jobs:
   pants-tailor:
@@ -42,11 +40,12 @@ jobs:
         #   Otherwise, we may need an additional workflow or job to delete old caches
         #   if they are not expiring fast enough, and we hit the GHA 10GB per repo max.
         with:
+          base-branch: master
           # To ignore a bad cache, bump the cache* integer.
           gha-cache-key: cache0-BUILD
           # This hash should include all of our lockfiles so that the pip/pex caches
           # get invalidated on any transitive dependency update.
-          named-caches-hash: ${{ hashFiles('requirements.txt' }}
+          named-caches-hash: ${{ hashFiles('requirements.txt') }}
           # enable the optional lmdb_store cache since we're not using remote caching.
           cache-lmdb-store: 'true'
 

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,7 @@
+python_requirements(
+    name="root",
+)
+
+python_test_utils(
+    name="test_utils0",
+)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,7 +53,7 @@ Added
 
 * Begin introducing `pants <https://www.pantsbuild.org/docs>`_ to improve DX (Developer Experience)
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
-  to pants' use of PEX lockfiles. This is not a user-facing addition. #5713 #5724 #5726 #5725 #5732 #5733 #5737
+  to pants' use of PEX lockfiles. This is not a user-facing addition. #5713 #5724 #5726 #5725 #5732 #5733 #5737 #5738
   Contributed by @cognifloyd
 
 Changed

--- a/contrib/chatops/actions/BUILD
+++ b/contrib/chatops/actions/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/contrib/chatops/tests/BUILD
+++ b/contrib/chatops/tests/BUILD
@@ -1,0 +1,1 @@
+python_tests()

--- a/contrib/core/BUILD
+++ b/contrib/core/BUILD
@@ -1,0 +1,6 @@
+python_sources()
+
+python_requirements(
+    name="reqs",
+    source="requirements-tests.txt",
+)

--- a/contrib/core/actions/BUILD
+++ b/contrib/core/actions/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/contrib/core/tests/BUILD
+++ b/contrib/core/tests/BUILD
@@ -1,0 +1,1 @@
+python_tests()

--- a/contrib/debug/actions/BUILD
+++ b/contrib/debug/actions/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/contrib/examples/actions/BUILD
+++ b/contrib/examples/actions/BUILD
@@ -1,0 +1,5 @@
+python_sources()
+
+shell_sources(
+    name="actions0",
+)

--- a/contrib/examples/actions/bash_exit_code/BUILD
+++ b/contrib/examples/actions/bash_exit_code/BUILD
@@ -1,0 +1,1 @@
+shell_sources()

--- a/contrib/examples/actions/bash_ping/BUILD
+++ b/contrib/examples/actions/bash_ping/BUILD
@@ -1,0 +1,1 @@
+shell_sources()

--- a/contrib/examples/actions/bash_random/BUILD
+++ b/contrib/examples/actions/bash_random/BUILD
@@ -1,0 +1,1 @@
+shell_sources()

--- a/contrib/examples/actions/pythonactions/BUILD
+++ b/contrib/examples/actions/pythonactions/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/contrib/examples/actions/ubuntu_pkg_info/BUILD
+++ b/contrib/examples/actions/ubuntu_pkg_info/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/contrib/examples/actions/ubuntu_pkg_info/lib/BUILD
+++ b/contrib/examples/actions/ubuntu_pkg_info/lib/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/contrib/examples/lib/BUILD
+++ b/contrib/examples/lib/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/contrib/examples/sensors/BUILD
+++ b/contrib/examples/sensors/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/contrib/examples/tests/BUILD
+++ b/contrib/examples/tests/BUILD
@@ -1,0 +1,1 @@
+python_tests()

--- a/contrib/hello_st2/actions/BUILD
+++ b/contrib/hello_st2/actions/BUILD
@@ -1,0 +1,1 @@
+shell_sources()

--- a/contrib/hello_st2/sensors/BUILD
+++ b/contrib/hello_st2/sensors/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/contrib/linux/BUILD
+++ b/contrib/linux/BUILD
@@ -1,0 +1,3 @@
+python_requirements(
+    name="reqs",
+)

--- a/contrib/linux/actions/BUILD
+++ b/contrib/linux/actions/BUILD
@@ -1,0 +1,5 @@
+python_sources()
+
+shell_sources(
+    name="actions0",
+)

--- a/contrib/linux/actions/checks/BUILD
+++ b/contrib/linux/actions/checks/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/contrib/linux/sensors/BUILD
+++ b/contrib/linux/sensors/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/contrib/linux/tests/BUILD
+++ b/contrib/linux/tests/BUILD
@@ -1,0 +1,1 @@
+python_tests()

--- a/contrib/packs/actions/BUILD
+++ b/contrib/packs/actions/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/contrib/packs/actions/pack_mgmt/BUILD
+++ b/contrib/packs/actions/pack_mgmt/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/contrib/packs/tests/BUILD
+++ b/contrib/packs/tests/BUILD
@@ -1,0 +1,1 @@
+python_tests()

--- a/contrib/packs/tests/fixtures/BUILD
+++ b/contrib/packs/tests/fixtures/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/contrib/runners/action_chain_runner/action_chain_runner/BUILD
+++ b/contrib/runners/action_chain_runner/action_chain_runner/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/contrib/runners/action_chain_runner/tests/unit/BUILD
+++ b/contrib/runners/action_chain_runner/tests/unit/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/contrib/runners/announcement_runner/announcement_runner/BUILD
+++ b/contrib/runners/announcement_runner/announcement_runner/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/contrib/runners/announcement_runner/tests/unit/BUILD
+++ b/contrib/runners/announcement_runner/tests/unit/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/contrib/runners/http_runner/http_runner/BUILD
+++ b/contrib/runners/http_runner/http_runner/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/contrib/runners/http_runner/tests/unit/BUILD
+++ b/contrib/runners/http_runner/tests/unit/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/contrib/runners/inquirer_runner/inquirer_runner/BUILD
+++ b/contrib/runners/inquirer_runner/inquirer_runner/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/contrib/runners/inquirer_runner/tests/unit/BUILD
+++ b/contrib/runners/inquirer_runner/tests/unit/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/contrib/runners/local_runner/local_runner/BUILD
+++ b/contrib/runners/local_runner/local_runner/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/contrib/runners/local_runner/tests/integration/BUILD
+++ b/contrib/runners/local_runner/tests/integration/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/contrib/runners/noop_runner/noop_runner/BUILD
+++ b/contrib/runners/noop_runner/noop_runner/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/contrib/runners/noop_runner/tests/unit/BUILD
+++ b/contrib/runners/noop_runner/tests/unit/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/contrib/runners/orquesta_runner/orquesta_functions/BUILD
+++ b/contrib/runners/orquesta_runner/orquesta_functions/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/contrib/runners/orquesta_runner/orquesta_runner/BUILD
+++ b/contrib/runners/orquesta_runner/orquesta_runner/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/contrib/runners/orquesta_runner/tests/integration/BUILD
+++ b/contrib/runners/orquesta_runner/tests/integration/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/contrib/runners/orquesta_runner/tests/unit/BUILD
+++ b/contrib/runners/orquesta_runner/tests/unit/BUILD
@@ -1,0 +1,5 @@
+python_tests(
+    name="tests",
+)
+
+python_sources()

--- a/contrib/runners/python_runner/python_runner/BUILD
+++ b/contrib/runners/python_runner/python_runner/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/contrib/runners/python_runner/tests/integration/BUILD
+++ b/contrib/runners/python_runner/tests/integration/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/contrib/runners/python_runner/tests/unit/BUILD
+++ b/contrib/runners/python_runner/tests/unit/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/contrib/runners/remote_runner/remote_runner/BUILD
+++ b/contrib/runners/remote_runner/remote_runner/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/contrib/runners/winrm_runner/tests/unit/BUILD
+++ b/contrib/runners/winrm_runner/tests/unit/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/contrib/runners/winrm_runner/tests/unit/fixtures/BUILD
+++ b/contrib/runners/winrm_runner/tests/unit/fixtures/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/contrib/runners/winrm_runner/winrm_runner/BUILD
+++ b/contrib/runners/winrm_runner/winrm_runner/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/pylint_plugins/BUILD
+++ b/pylint_plugins/BUILD
@@ -1,0 +1,5 @@
+python_sources()
+
+python_tests(
+    name="tests",
+)

--- a/scripts/BUILD
+++ b/scripts/BUILD
@@ -1,0 +1,5 @@
+python_sources()
+
+shell_sources(
+    name="scripts0",
+)

--- a/scripts/ci/BUILD
+++ b/scripts/ci/BUILD
@@ -1,0 +1,1 @@
+shell_sources()

--- a/scripts/github/BUILD
+++ b/scripts/github/BUILD
@@ -1,0 +1,1 @@
+shell_sources()

--- a/st2actions/bin/BUILD
+++ b/st2actions/bin/BUILD
@@ -1,0 +1,1 @@
+shell_sources()

--- a/st2actions/st2actions/BUILD
+++ b/st2actions/st2actions/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2actions/st2actions/cmd/BUILD
+++ b/st2actions/st2actions/cmd/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2actions/st2actions/container/BUILD
+++ b/st2actions/st2actions/container/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2actions/st2actions/notifier/BUILD
+++ b/st2actions/st2actions/notifier/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2actions/st2actions/policies/BUILD
+++ b/st2actions/st2actions/policies/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2actions/st2actions/runners/BUILD
+++ b/st2actions/st2actions/runners/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2actions/st2actions/scheduler/BUILD
+++ b/st2actions/st2actions/scheduler/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2actions/st2actions/workflows/BUILD
+++ b/st2actions/st2actions/workflows/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2actions/tests/integration/BUILD
+++ b/st2actions/tests/integration/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/st2actions/tests/unit/BUILD
+++ b/st2actions/tests/unit/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/st2actions/tests/unit/policies/BUILD
+++ b/st2actions/tests/unit/policies/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/st2api/st2api/BUILD
+++ b/st2api/st2api/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2api/st2api/cmd/BUILD
+++ b/st2api/st2api/cmd/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2api/st2api/controllers/BUILD
+++ b/st2api/st2api/controllers/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2api/st2api/controllers/v1/BUILD
+++ b/st2api/st2api/controllers/v1/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2api/tests/integration/BUILD
+++ b/st2api/tests/integration/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/st2api/tests/unit/BUILD
+++ b/st2api/tests/unit/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/st2api/tests/unit/controllers/BUILD
+++ b/st2api/tests/unit/controllers/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/st2api/tests/unit/controllers/v1/BUILD
+++ b/st2api/tests/unit/controllers/v1/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/st2api/tests/unit/controllers/v1/test_packs_views.py
+++ b/st2api/tests/unit/controllers/v1/test_packs_views.py
@@ -133,7 +133,7 @@ class PacksViewsControllerTestCase(FunctionalTest):
         # Ref is not equal to the name, controller should still work
         resp = self.app.get("/v1/packs/views/files/dummy_pack_16")
         self.assertEqual(resp.status_int, http_client.OK)
-        self.assertEqual(len(resp.json), 3)
+        self.assertEqual(len(resp.json), 4)
         self.assertIn("pack.yaml", [f["file_path"] for f in resp.json])
 
         resp = self.app.get("/v1/packs/views/file/dummy_pack_16/pack.yaml")

--- a/st2auth/st2auth/BUILD
+++ b/st2auth/st2auth/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2auth/st2auth/backends/BUILD
+++ b/st2auth/st2auth/backends/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2auth/st2auth/cmd/BUILD
+++ b/st2auth/st2auth/cmd/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2auth/st2auth/controllers/v1/BUILD
+++ b/st2auth/st2auth/controllers/v1/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2auth/st2auth/sso/BUILD
+++ b/st2auth/st2auth/sso/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2auth/tests/BUILD
+++ b/st2auth/tests/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2auth/tests/unit/BUILD
+++ b/st2auth/tests/unit/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/st2auth/tests/unit/controllers/v1/BUILD
+++ b/st2auth/tests/unit/controllers/v1/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/st2client/conf/BUILD
+++ b/st2client/conf/BUILD
@@ -1,0 +1,1 @@
+shell_sources()

--- a/st2client/st2client/BUILD
+++ b/st2client/st2client/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2client/st2client/commands/BUILD
+++ b/st2client/st2client/commands/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2client/st2client/exceptions/BUILD
+++ b/st2client/st2client/exceptions/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2client/st2client/formatters/BUILD
+++ b/st2client/st2client/formatters/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2client/st2client/models/BUILD
+++ b/st2client/st2client/models/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2client/st2client/utils/BUILD
+++ b/st2client/st2client/utils/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2client/tests/BUILD
+++ b/st2client/tests/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2client/tests/fixtures/BUILD
+++ b/st2client/tests/fixtures/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2client/tests/unit/BUILD
+++ b/st2client/tests/unit/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/st2common/benchmarks/micro/BUILD
+++ b/st2common/benchmarks/micro/BUILD
@@ -1,0 +1,5 @@
+python_sources()
+
+python_tests(
+    name="tests",
+)

--- a/st2common/bin/BUILD
+++ b/st2common/bin/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/bin/migrations/v1.5/BUILD
+++ b/st2common/bin/migrations/v1.5/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/bin/migrations/v2.1/BUILD
+++ b/st2common/bin/migrations/v2.1/BUILD
@@ -1,0 +1,5 @@
+python_sources()
+
+shell_sources(
+    name="v2.10",
+)

--- a/st2common/bin/migrations/v3.1/BUILD
+++ b/st2common/bin/migrations/v3.1/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/bin/migrations/v3.5/BUILD
+++ b/st2common/bin/migrations/v3.5/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/BUILD
+++ b/st2common/st2common/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/bootstrap/BUILD
+++ b/st2common/st2common/bootstrap/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/callback/BUILD
+++ b/st2common/st2common/callback/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/cmd/BUILD
+++ b/st2common/st2common/cmd/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/constants/BUILD
+++ b/st2common/st2common/constants/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/content/BUILD
+++ b/st2common/st2common/content/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/exceptions/BUILD
+++ b/st2common/st2common/exceptions/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/expressions/functions/BUILD
+++ b/st2common/st2common/expressions/functions/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/garbage_collection/BUILD
+++ b/st2common/st2common/garbage_collection/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/logging/BUILD
+++ b/st2common/st2common/logging/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/metrics/BUILD
+++ b/st2common/st2common/metrics/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/metrics/drivers/BUILD
+++ b/st2common/st2common/metrics/drivers/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/middleware/BUILD
+++ b/st2common/st2common/middleware/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/models/BUILD
+++ b/st2common/st2common/models/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/models/api/BUILD
+++ b/st2common/st2common/models/api/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/models/db/BUILD
+++ b/st2common/st2common/models/db/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/models/system/BUILD
+++ b/st2common/st2common/models/system/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/models/utils/BUILD
+++ b/st2common/st2common/models/utils/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/persistence/BUILD
+++ b/st2common/st2common/persistence/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/policies/BUILD
+++ b/st2common/st2common/policies/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/rbac/BUILD
+++ b/st2common/st2common/rbac/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/rbac/backends/BUILD
+++ b/st2common/st2common/rbac/backends/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/runners/BUILD
+++ b/st2common/st2common/runners/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/services/BUILD
+++ b/st2common/st2common/services/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/stream/BUILD
+++ b/st2common/st2common/stream/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/transport/BUILD
+++ b/st2common/st2common/transport/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/util/BUILD
+++ b/st2common/st2common/util/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/util/green/BUILD
+++ b/st2common/st2common/util/green/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/util/schema/BUILD
+++ b/st2common/st2common/util/schema/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/validators/api/BUILD
+++ b/st2common/st2common/validators/api/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/st2common/validators/workflow/BUILD
+++ b/st2common/st2common/validators/workflow/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/tests/fixtures/BUILD
+++ b/st2common/tests/fixtures/BUILD
@@ -1,0 +1,5 @@
+python_sources()
+
+shell_sources(
+    name="fixtures0",
+)

--- a/st2common/tests/fixtures/local_runner/BUILD
+++ b/st2common/tests/fixtures/local_runner/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/tests/integration/BUILD
+++ b/st2common/tests/integration/BUILD
@@ -1,0 +1,5 @@
+python_sources()
+
+python_tests(
+    name="tests",
+)

--- a/st2common/tests/resources/loadableplugin/plugin/BUILD
+++ b/st2common/tests/resources/loadableplugin/plugin/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/tests/resources/loadableplugin/plugin/util/BUILD
+++ b/st2common/tests/resources/loadableplugin/plugin/util/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2common/tests/unit/BUILD
+++ b/st2common/tests/unit/BUILD
@@ -1,0 +1,5 @@
+python_tests(
+    name="tests",
+)
+
+python_sources()

--- a/st2common/tests/unit/migrations/BUILD
+++ b/st2common/tests/unit/migrations/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/st2common/tests/unit/services/BUILD
+++ b/st2common/tests/unit/services/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/st2common/tests/unit/test_util_file_system.py
+++ b/st2common/tests/unit/test_util_file_system.py
@@ -30,6 +30,7 @@ class FileSystemUtilsTestCase(unittest2.TestCase):
         # Standard exclude pattern
         directory = os.path.join(ST2TESTS_DIR, "policies")
         expected = [
+            "BUILD",
             "mock_exception.py",
             "concurrency.py",
             "__init__.py",
@@ -48,6 +49,6 @@ class FileSystemUtilsTestCase(unittest2.TestCase):
             "meta/__init__.py",
         ]
         result = get_file_list(
-            directory=directory, exclude_patterns=["*.pyc", "*.yaml"]
+            directory=directory, exclude_patterns=["*.pyc", "*.yaml", "BUILD"]
         )
         self.assertItemsEqual(expected, result)

--- a/st2reactor/st2reactor/BUILD
+++ b/st2reactor/st2reactor/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2reactor/st2reactor/cmd/BUILD
+++ b/st2reactor/st2reactor/cmd/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2reactor/st2reactor/container/BUILD
+++ b/st2reactor/st2reactor/container/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2reactor/st2reactor/garbage_collector/BUILD
+++ b/st2reactor/st2reactor/garbage_collector/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2reactor/st2reactor/rules/BUILD
+++ b/st2reactor/st2reactor/rules/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2reactor/st2reactor/sensor/BUILD
+++ b/st2reactor/st2reactor/sensor/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2reactor/st2reactor/timer/BUILD
+++ b/st2reactor/st2reactor/timer/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2reactor/tests/fixtures/fixture/BUILD
+++ b/st2reactor/tests/fixtures/fixture/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2reactor/tests/fixtures/packs/BUILD
+++ b/st2reactor/tests/fixtures/packs/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2reactor/tests/fixtures/packs/pack_with_rules/BUILD
+++ b/st2reactor/tests/fixtures/packs/pack_with_rules/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2reactor/tests/fixtures/packs/pack_with_sensor/BUILD
+++ b/st2reactor/tests/fixtures/packs/pack_with_sensor/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2reactor/tests/integration/BUILD
+++ b/st2reactor/tests/integration/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/st2reactor/tests/resources/BUILD
+++ b/st2reactor/tests/resources/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/st2reactor/tests/unit/BUILD
+++ b/st2reactor/tests/unit/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/st2stream/st2stream/BUILD
+++ b/st2stream/st2stream/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2stream/st2stream/cmd/BUILD
+++ b/st2stream/st2stream/cmd/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2stream/st2stream/controllers/v1/BUILD
+++ b/st2stream/st2stream/controllers/v1/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2stream/tests/unit/controllers/v1/BUILD
+++ b/st2stream/tests/unit/controllers/v1/BUILD
@@ -1,0 +1,5 @@
+python_tests(
+    name="tests",
+)
+
+python_sources()

--- a/st2tests/integration/BUILD
+++ b/st2tests/integration/BUILD
@@ -1,0 +1,1 @@
+shell_sources()

--- a/st2tests/integration/orquesta/BUILD
+++ b/st2tests/integration/orquesta/BUILD
@@ -1,0 +1,5 @@
+python_sources()
+
+python_tests(
+    name="tests",
+)

--- a/st2tests/st2tests/BUILD
+++ b/st2tests/st2tests/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/aliases/BUILD
+++ b/st2tests/st2tests/fixtures/aliases/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/backstop/BUILD
+++ b/st2tests/st2tests/fixtures/backstop/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/conf/BUILD
+++ b/st2tests/st2tests/fixtures/conf/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/descendants/BUILD
+++ b/st2tests/st2tests/fixtures/descendants/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/generic/BUILD
+++ b/st2tests/st2tests/fixtures/generic/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/generic/actions/BUILD
+++ b/st2tests/st2tests/fixtures/generic/actions/BUILD
@@ -1,0 +1,1 @@
+shell_sources()

--- a/st2tests/st2tests/fixtures/history_views/BUILD
+++ b/st2tests/st2tests/fixtures/history_views/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/keyczar_keys/BUILD
+++ b/st2tests/st2tests/fixtures/keyczar_keys/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/localrunner_pack/BUILD
+++ b/st2tests/st2tests/fixtures/localrunner_pack/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/localrunner_pack/actions/BUILD
+++ b/st2tests/st2tests/fixtures/localrunner_pack/actions/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/BUILD
+++ b/st2tests/st2tests/fixtures/packs/BUILD
@@ -1,0 +1,30 @@
+# The files in test_content_version* targets are in ./test_content_version
+# which is a git submodule.
+# The test_content_version* targets are dependencies of ./test_content_version_fixture
+
+resources(
+    name="test_content_version_metadata",
+    sources=[
+        "test_content_version/pack.yaml",
+        "test_content_version/**/*.yaml",
+        "test_content_version/icon.png",
+    ],
+)
+
+shell_sources(
+    name="test_content_version_shell",
+    sources=[
+        "test_content_version/**/*.sh",
+    ],
+)
+
+python_sources(
+    name="test_content_version",
+    dependencies=[
+        ":test_content_version_metadata",
+        ":test_content_version_shell",
+    ],
+    sources=[
+        "test_content_version/**/*.py",
+    ],
+)

--- a/st2tests/st2tests/fixtures/packs/BUILD
+++ b/st2tests/st2tests/fixtures/packs/BUILD
@@ -8,6 +8,7 @@ resources(
         "test_content_version/pack.yaml",
         "test_content_version/**/*.yaml",
         "test_content_version/icon.png",
+        "test_content_version/requirements.txt",
     ],
 )
 

--- a/st2tests/st2tests/fixtures/packs/action_chain_tests/BUILD
+++ b/st2tests/st2tests/fixtures/packs/action_chain_tests/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_1/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_1/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_1/actions/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_1/actions/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_1/sensors/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_1/sensors/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_10/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_10/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_11/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_11/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_12/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_12/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_13/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_13/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_14/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_14/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_15/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_15/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_16/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_16/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_17/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_17/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_18/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_18/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_19/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_19/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_2/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_2/BUILD
@@ -1,0 +1,5 @@
+python_sources()
+
+python_requirements(
+    name="reqs",
+)

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_2/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_2/BUILD
@@ -1,5 +1,6 @@
-python_sources()
-
-python_requirements(
-    name="reqs",
+resource(
+    name="pack_requirements",
+    source="requirements.txt",
 )
+
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_2/actions/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_2/actions/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_2/sensors/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_2/sensors/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_20/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_20/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_21/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_21/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_22/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_22/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_23/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_23/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_3/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_3/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_3/actions/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_3/actions/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_3/sensors/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_3/sensors/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_4/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_4/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_5/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_5/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_6/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_6/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_7/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_7/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_7/actions/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_7/actions/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_8/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_8/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_9/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_9/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_9/actions/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_9/actions/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_additional_items_1/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_additional_items_1/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_additional_properties_1/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_additional_properties_1/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_nested_object_1/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_nested_object_1/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_nested_object_2/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_nested_object_2/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_nested_object_3/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_nested_object_3/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_nested_object_4/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_nested_object_4/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_nested_object_5/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_nested_object_5/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_pattern_and_additional_properties_1/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_pattern_and_additional_properties_1/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_pattern_properties_1/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_pattern_properties_1/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/executions/BUILD
+++ b/st2tests/st2tests/fixtures/packs/executions/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/orquesta_tests/BUILD
+++ b/st2tests/st2tests/fixtures/packs/orquesta_tests/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/BUILD
+++ b/st2tests/st2tests/fixtures/packs/orquesta_tests/actions/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/pack_dir_name_doesnt_match_ref/BUILD
+++ b/st2tests/st2tests/fixtures/packs/pack_dir_name_doesnt_match_ref/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/pack_invalid_requirements/BUILD
+++ b/st2tests/st2tests/fixtures/packs/pack_invalid_requirements/BUILD
@@ -1,0 +1,5 @@
+python_sources()
+
+python_requirements(
+    name="reqs",
+)

--- a/st2tests/st2tests/fixtures/packs/pack_invalid_requirements/BUILD
+++ b/st2tests/st2tests/fixtures/packs/pack_invalid_requirements/BUILD
@@ -1,5 +1,6 @@
-python_sources()
-
-python_requirements(
-    name="reqs",
+resource(
+    name="pack_requirements",
+    source="requirements.txt",
 )
+
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/runners/BUILD
+++ b/st2tests/st2tests/fixtures/packs/runners/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/runners/test_async_runner/BUILD
+++ b/st2tests/st2tests/fixtures/packs/runners/test_async_runner/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/st2tests/st2tests/fixtures/packs/runners/test_polling_async_runner/BUILD
+++ b/st2tests/st2tests/fixtures/packs/runners/test_polling_async_runner/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/st2tests/st2tests/fixtures/packs/test_content_version_fixture/BUILD
+++ b/st2tests/st2tests/fixtures/packs/test_content_version_fixture/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/test_content_version_fixture/BUILD
+++ b/st2tests/st2tests/fixtures/packs/test_content_version_fixture/BUILD
@@ -1,1 +1,3 @@
-python_sources()
+python_sources(
+    dependencies=["st2tests/st2tests/fixtures/packs:test_content_version"],
+)

--- a/st2tests/st2tests/fixtures/packs/test_library_dependencies/BUILD
+++ b/st2tests/st2tests/fixtures/packs/test_library_dependencies/BUILD
@@ -1,0 +1,5 @@
+python_requirements(
+    name="reqs",
+)
+
+python_sources()

--- a/st2tests/st2tests/fixtures/packs/test_library_dependencies/BUILD
+++ b/st2tests/st2tests/fixtures/packs/test_library_dependencies/BUILD
@@ -1,5 +1,6 @@
-python_requirements(
-    name="reqs",
+resource(
+    name="pack_requirements",
+    source="requirements.txt",
 )
 
 python_sources()

--- a/st2tests/st2tests/fixtures/packs/test_library_dependencies/actions/BUILD
+++ b/st2tests/st2tests/fixtures/packs/test_library_dependencies/actions/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs_1/dummy_pack_4/BUILD
+++ b/st2tests/st2tests/fixtures/packs_1/dummy_pack_4/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs_invalid/dummy_pack_17/BUILD
+++ b/st2tests/st2tests/fixtures/packs_invalid/dummy_pack_17/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/packs_invalid/dummy_pack_18/BUILD
+++ b/st2tests/st2tests/fixtures/packs_invalid/dummy_pack_18/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/rule_enforcements/BUILD
+++ b/st2tests/st2tests/fixtures/rule_enforcements/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/ssl_certs/BUILD
+++ b/st2tests/st2tests/fixtures/ssl_certs/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/timers/BUILD
+++ b/st2tests/st2tests/fixtures/timers/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/fixtures/traces/BUILD
+++ b/st2tests/st2tests/fixtures/traces/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/mocks/BUILD
+++ b/st2tests/st2tests/mocks/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/mocks/runners/BUILD
+++ b/st2tests/st2tests/mocks/runners/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/policies/BUILD
+++ b/st2tests/st2tests/policies/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/st2tests/resources/packs/pythonactions/actions/BUILD
+++ b/st2tests/st2tests/resources/packs/pythonactions/actions/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/testpacks/checks/actions/checks/BUILD
+++ b/st2tests/testpacks/checks/actions/checks/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/st2tests/testpacks/errorcheck/actions/BUILD
+++ b/st2tests/testpacks/errorcheck/actions/BUILD
@@ -1,0 +1,1 @@
+shell_sources()

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,0 +1,5 @@
+python_sources()
+
+shell_sources(
+    name="tools0",
+)


### PR DESCRIPTION
### Background

This is another part of introducing [`pants`](https://www.pantsbuild.org/docs), as discussed in the TSC Meetings on [12 July 2022](https://github.com/StackStorm/community/issues/105), [02 Aug 2022](https://github.com/StackStorm/community/issues/107) and [06 Sept 2022](https://github.com/StackStorm/community/issues/108). Pants has fine-grained per-file caching of results for lint, fmt (like black), test, etc. It also has lockfiles that work well for monorepos that have multiple python packages. With these lockfiles CI should not break when any of our dependencies or our transitive dependencies release new versions, because CI will continue to use the locked version until we explicitly relock with updates.

To keep PRs as manageable/reviewable as possible, introducing pants will take a series of PRs. I do not know yet how many PRs; I will break this up into logical steps with these goals:
- introduce `pants` to the st2 repo, and
- teach some (but not all) TSC members about `pants` step-by-step.

Other pants PRs include:
- https://github.com/StackStorm/st2/pull/5713
- https://github.com/StackStorm/st2/pull/5724
- https://github.com/StackStorm/st2/pull/5725
- https://github.com/StackStorm/st2/pull/5726
- https://github.com/StackStorm/st2/pull/5732
- https://github.com/StackStorm/st2/pull/5733
- https://github.com/StackStorm/st2/pull/5737

### Overview of this PR

This PR does 3 things:
- Run `./pants tailor ::` ([step 5 of the initial config docs](https://www.pantsbuild.org/docs/initial-configuration#generate-build-files))
- Enable the workflow added in #5732
- Fix an edge case with our `BUILD` metadata to work around our use of git submodules (the `test_content_version` fixture pack)

_I will describe the generated BUILD file contents after I have briefly discussed each of them (the 3 things this PR does)._

#### `./pants tailor ::`

All but one of the `BUILD` files in this PR were created by running `./pants tailor ::` which is step 5 of the [initial config docs](https://www.pantsbuild.org/docs/initial-configuration#generate-build-files).

As described in #5732, BUILD files are an important part of helping pants understand our codebase. As [the docs](https://www.pantsbuild.org/docs/initial-configuration#generate-build-files) say:

> [BUILD](https://www.pantsbuild.org/docs/targets) files provide metadata about your code (the timeout of a test, any dependencies which cannot be inferred, etc). BUILD files are typically located in the same directory as the code they describe. Unlike many other systems, Pants BUILD files are usually very succinct, as most metadata is either inferred from static analysis, assumed from sensible defaults, or generated for you.

In follow-up PRs, we will customize the BUILD metadata further.

#### GHA workflow

This PR also enables the GHA workflow added in #5732 (it also fixes a typo in the workflow. oops). This workflow will ensure that we have all the BUILD files that pants needs. This is very quick, and serves as an indicator on PRs that people might need to run `./pants tailor ::`.

#### git submodule: `test_content_version` fixture pack

`./pants tailor` tried to add BUILD files in the git submodule. But, we cannot guarantee that git submodule is checked out when we run `./pants`. So, I added some targets in the parent directory's BUILD file that covers everything in the git submodule. This way, even if the submodule is not checked out, the complete set of metadata is available for pants.

_I wrote a plugin for pants that makes the developer UX even better. It checks to make sure the git submodule is checked out, and if not, it provides an error message with instructions on how to fix it. I will submit that in a later PR._

### `BUILD` file metadata

BUILD files contain metadata that guide pants through our source code. That metadata consists of "targets" with "fields".

From the docs: https://www.pantsbuild.org/docs/targets

> _Targets_ are an _addressable_ set of metadata describing your code.

> Each target type has different _fields_, or individual metadata values.

One of the nice things about `BUILD` files, is that they are essentially just python files. In fact, `./pants update-build-files ::` actually uses `black` to reformat them!

So, when looking at BUILD files, defining a target looks like a function call, and the fields are args and/or kwargs in that function call.

There are some restrictions on what python we can use in BUILD files. For example: there are no imports (Pants actually adds all of the required symbols based on which `backends` are enabled in `pants.toml`). When we need to add custom targets, we can do that with macros and pants plugins, both of which are also written in python. I have written both macros and pants plugins to add in follow-up PRs.

#### Targets

These are the targets that `./pants tailor ::` added in this PR (linked to the relevant docs page):

- [python_requirements](https://www.pantsbuild.org/docs/reference-python_requirements) (see also: [python_requirement](https://www.pantsbuild.org/docs/reference-python_requirement))
- [python_sources](https://www.pantsbuild.org/docs/reference-python_sources) (see also: [python_source](https://www.pantsbuild.org/docs/reference-python_source))
- [python_test_utils](https://www.pantsbuild.org/docs/reference-python_test_utils)
- [python_tests](https://www.pantsbuild.org/docs/reference-python_tests) (see also: [python_test](https://www.pantsbuild.org/docs/reference-python_tests))
- [shell_sources](https://www.pantsbuild.org/docs/reference-shell_sources) (see also: [shell_source](https://www.pantsbuild.org/docs/reference-shell_sources))

I also added some of these:
- [resources](https://www.pantsbuild.org/docs/reference-resources) (see also: [shell_source](https://www.pantsbuild.org/docs/reference-resource))

Tailor cannot add `resources` or [`files`](https://www.pantsbuild.org/docs/reference-files) targets, so those will be added manually in follow-up PRs.
