### PR TITLE
add secret to runner overridable parameters list

### DIFF
--- a/st2common/st2common/util/schema/__init__.py
+++ b/st2common/st2common/util/schema/__init__.py
@@ -76,6 +76,7 @@ RUNNER_PARAM_OVERRIDABLE_ATTRS = [
     "enum",
     "immutable",
     "required",
+    "secret",
 ]
 
 


### PR DESCRIPTION
Add secret to the list of overridable parameters to avoid the error -  attribute “secret” for the runner parameter “cmd” in action “core.local” cannot be overridden.

Why is this required -

We want to create action core.winrm_ps_cmd_secure which is same as core.winrm_ps_cmd where the input parameter cmd is hidden. We have a use case where we need to supply credentials inside the cmd section so it's not visible in stack storm UI after execution.