### PR TITLE
Use shellcheck (via pantsbuild)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,7 +53,7 @@ Added
 
 * Begin introducing `pants <https://www.pantsbuild.org/docs>`_ to improve DX (Developer Experience)
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
-  to pants' use of PEX lockfiles. This is not a user-facing addition. #5713 #5724 #5726 #5725 #5732 #5733 #5737 #5738 #5758
+  to pants' use of PEX lockfiles. This is not a user-facing addition. #5713 #5724 #5726 #5725 #5732 #5733 #5737 #5738 #5758 #5751
   Contributed by @cognifloyd
 
 Changed

--- a/contrib/core/actions/send_mail/BUILD
+++ b/contrib/core/actions/send_mail/BUILD
@@ -1,0 +1,3 @@
+shell_source(
+    source="send_mail",
+)

--- a/contrib/core/actions/send_mail/BUILD
+++ b/contrib/core/actions/send_mail/BUILD
@@ -1,3 +1,4 @@
 shell_source(
     source="send_mail",
+    skip_shellcheck=True,
 )

--- a/contrib/examples/actions/BUILD
+++ b/contrib/examples/actions/BUILD
@@ -2,4 +2,5 @@ python_sources()
 
 shell_sources(
     name="shell",
+    skip_shellcheck=True,
 )

--- a/contrib/examples/actions/BUILD
+++ b/contrib/examples/actions/BUILD
@@ -1,5 +1,5 @@
 python_sources()
 
 shell_sources(
-    name="actions0",
+    name="shell",
 )

--- a/contrib/examples/actions/bash_ping/BUILD
+++ b/contrib/examples/actions/bash_ping/BUILD
@@ -1,1 +1,1 @@
-shell_sources()
+shell_sources(skip_shellcheck=True)

--- a/contrib/examples/actions/bash_random/BUILD
+++ b/contrib/examples/actions/bash_random/BUILD
@@ -1,1 +1,5 @@
-shell_sources()
+shell_sources(
+    overrides={
+        "random2.sh": {"skip_shellcheck": True},
+    },
+)

--- a/contrib/linux/actions/BUILD
+++ b/contrib/linux/actions/BUILD
@@ -2,4 +2,5 @@ python_sources()
 
 shell_sources(
     name="shell",
+    skip_shellcheck=True,
 )

--- a/contrib/linux/actions/BUILD
+++ b/contrib/linux/actions/BUILD
@@ -1,5 +1,5 @@
 python_sources()
 
 shell_sources(
-    name="actions0",
+    name="shell",
 )

--- a/pants.toml
+++ b/pants.toml
@@ -15,6 +15,7 @@ backend_packages = [
 
   # shell
   "pants.backend.shell",
+  "pants.backend.shell.lint.shellcheck",
 ]
 # pants ignores files in .gitignore, .*/ directories, /dist/ directory, and __pycache__.
 pants_ignore.add = [

--- a/scripts/BUILD
+++ b/scripts/BUILD
@@ -1,5 +1,5 @@
 python_sources()
 
 shell_sources(
-    name="scripts0",
+    name="shell",
 )

--- a/st2actions/bin/BUILD
+++ b/st2actions/bin/BUILD
@@ -4,4 +4,5 @@ python_sources(
 
 shell_sources(
     name="shell",
+    skip_shellcheck=True,
 )

--- a/st2actions/bin/BUILD
+++ b/st2actions/bin/BUILD
@@ -1,1 +1,3 @@
-shell_sources()
+shell_sources(
+    name="shell",
+)

--- a/st2api/bin/BUILD
+++ b/st2api/bin/BUILD
@@ -1,7 +1,3 @@
 python_sources(
     sources=["st2*"],
 )
-
-shell_sources(
-    name="shell",
-)

--- a/st2auth/bin/BUILD
+++ b/st2auth/bin/BUILD
@@ -1,7 +1,3 @@
 python_sources(
     sources=["st2*"],
 )
-
-shell_sources(
-    name="shell",
-)

--- a/st2common/bin/BUILD
+++ b/st2common/bin/BUILD
@@ -5,4 +5,5 @@ python_sources(
 shell_sources(
     name="shell",
     sources=["st2ctl", "st2-self-check", "st2-run-pack-tests"],
+    skip_shellcheck=True,
 )

--- a/st2common/bin/BUILD
+++ b/st2common/bin/BUILD
@@ -1,1 +1,8 @@
-python_sources()
+python_sources(
+    sources=["*.py", "st2*", "!st2ctl", "!st2-self-check", "!st2-run-pack-tests"],
+)
+
+shell_sources(
+    name="shell",
+    sources=["st2ctl", "st2-self-check", "st2-run-pack-tests"],
+)

--- a/st2common/bin/migrations/v2.1/BUILD
+++ b/st2common/bin/migrations/v2.1/BUILD
@@ -2,4 +2,5 @@ python_sources()
 
 shell_sources(
     name="shell",
+    skip_shellcheck=True,
 )

--- a/st2common/bin/migrations/v2.1/BUILD
+++ b/st2common/bin/migrations/v2.1/BUILD
@@ -1,5 +1,5 @@
 python_sources()
 
 shell_sources(
-    name="v2.10",
+    name="shell",
 )

--- a/st2common/bin/migrations/v3.5/BUILD
+++ b/st2common/bin/migrations/v3.5/BUILD
@@ -1,1 +1,3 @@
+# TODO: what to do about st2-migrate-db-dict-field-values ?
+# st2_migrate_db_dict_field_values.py is a symlink to st2-migrate-db-dict-field-values
 python_sources()

--- a/st2common/tests/fixtures/BUILD
+++ b/st2common/tests/fixtures/BUILD
@@ -1,5 +1,5 @@
 python_sources()
 
 shell_sources(
-    name="fixtures0",
+    name="shell",
 )

--- a/st2reactor/bin/BUILD
+++ b/st2reactor/bin/BUILD
@@ -1,7 +1,3 @@
 python_sources(
     sources=["st2*"],
 )
-
-shell_sources(
-    name="shell",
-)

--- a/st2stream/bin/BUILD
+++ b/st2stream/bin/BUILD
@@ -1,7 +1,3 @@
 python_sources(
     sources=["st2*"],
 )
-
-shell_sources(
-    name="shell",
-)

--- a/st2tests/integration/BUILD
+++ b/st2tests/integration/BUILD
@@ -1,1 +1,3 @@
-shell_sources()
+shell_sources(
+    name="shell",
+)

--- a/st2tests/integration/BUILD
+++ b/st2tests/integration/BUILD
@@ -1,3 +1,4 @@
 shell_sources(
     name="shell",
+    skip_shellcheck=True,
 )

--- a/st2tests/st2tests/fixtures/packs/BUILD
+++ b/st2tests/st2tests/fixtures/packs/BUILD
@@ -14,6 +14,7 @@ resources(
 
 shell_sources(
     name="test_content_version_shell",
+    skip_shellcheck=True,
     sources=[
         "test_content_version/**/*.sh",
     ],

--- a/st2tests/testpacks/errorcheck/actions/BUILD
+++ b/st2tests/testpacks/errorcheck/actions/BUILD
@@ -1,1 +1,1 @@
-shell_sources()
+shell_sources(skip_shellcheck=True)

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -2,4 +2,8 @@ python_sources()
 
 shell_sources(
     name="shell",
+    sources=[
+        "*.sh",
+        "st2-setup-*",
+    ],
 )

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,5 +1,5 @@
 python_sources()
 
 shell_sources(
-    name="tools0",
+    name="shell",
 )

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -6,4 +6,5 @@ shell_sources(
         "*.sh",
         "st2-setup-*",
     ],
+    skip_shellcheck=True,
 )


### PR DESCRIPTION
### Background

This is another part of introducing [`pants`](https://www.pantsbuild.org/docs), as discussed in the TSC Meetings on [12 July 2022](https://github.com/StackStorm/community/issues/105), [02 Aug 2022](https://github.com/StackStorm/community/issues/107), [06 Sept 2022](https://github.com/StackStorm/community/issues/108), and [04 Oct 2022](https://github.com/StackStorm/community/issues/111). Pants has fine-grained per-file caching of results for lint, fmt (like black), test, etc. It also has lockfiles that work well for monorepos that have multiple python packages. With these lockfiles CI should not break when any of our dependencies or our transitive dependencies release new versions, because CI will continue to use the locked version until we explicitly relock with updates.

To keep PRs as manageable/reviewable as possible, introducing pants will take a series of PRs. I do not know yet how many PRs; I will break this up into logical steps with these goals:
- introduce `pants` to the st2 repo, and
- teach some (but not all) TSC members about `pants` step-by-step.

Other pants PRs include:
- https://github.com/StackStorm/st2/pull/5713
- https://github.com/StackStorm/st2/pull/5724
- https://github.com/StackStorm/st2/pull/5725
- https://github.com/StackStorm/st2/pull/5726
- https://github.com/StackStorm/st2/pull/5732
- https://github.com/StackStorm/st2/pull/5733
- https://github.com/StackStorm/st2/pull/5737
- https://github.com/StackStorm/st2/pull/5738
- https://github.com/StackStorm/st2/pull/5758


### Overview of this PR

It is helpful to review each commit in this PR individually.

- 6b2f9932dea938c71385f448f08086b3cb3bdae1 Rename shell targets to be a bit more consistent.
- d442fd5ae66875411487ac7a6e0cd54440f8cebe Add/adjust targets for executable files/scripts
    - In #5738, tailor added a lot of metadata, but it could not identify some of our extension-less scripts as shell or python.
    - So, we add metadata for all of those scripts (basically anything in the `bin/` directories).
    - This way, pants can run shellcheck on all of our shell files, not just `*.sh`.
- 854873c558f6f5ff39a6aa49731ba2a3e6b3b58b Add shellcheck (_skipping anything that does not pass_)
    - Enable the shellcheck backend in pants (pants.toml: `[GLOBAL].backend_packages`).
        - We enabled language backends in #5725 which included the `shell_sources` and `shell_source` targets.
        - Now, with the shellcheck backend, `./pants lint ::` will run shellcheck on all files in those `shell_source`/`s` targets.
    - The Makefile only runs shellcheck on `scripts/ci/*.sh`, `scripts/github/*.sh`, and `scripts/*.sh`.
    - So, tell pants to skip running shellcheck any of the shell files that don't currently pass.
    - This still increases our shellcheck coverage; Someone can fix other files in follow-up PRs (maybe hacktoberfest or other first-time contributors could do it).
    - Also demonstrates `overrides`: a fairly new--and awesome--feature in pants.
    - It allows you to add very specific metadata about individual files without adding extra, possibly-overlapping, targets to the BUILD files. It also avoids adding that metadata to more files than is required.

#### Relevant Pants documentation

- [`./pants lint` goal](https://www.pantsbuild.org/v2.14/docs/reference-lint)
- [Shell Overview](https://www.pantsbuild.org/v2.14/docs/shell)
- [shellcheck backend](https://www.pantsbuild.org/v2.14/docs/reference-shellcheck)
- individual source targets:
    - [`python_source`](https://www.pantsbuild.org/v2.14/docs/reference-python_source)
    - [`shell_source`](https://www.pantsbuild.org/v2.14/docs/reference-shell_source)
- multiple sources targets (aka target generators):
    - [`python_sources`](https://www.pantsbuild.org/v2.14/docs/reference-python_sources)
        - [`overrides` field](https://www.pantsbuild.org/v2.14/docs/reference-python_sources#codeoverridescode)
    - [`shell_sources`](https://www.pantsbuild.org/v2.14/docs/reference-shell_sources)
        - [`overrides` field](https://www.pantsbuild.org/v2.14/docs/reference-shell_sources#codeoverridescode)
- An example that uses the `overrides` field in the [linters/formatters docs](https://www.pantsbuild.org/v2.14/docs/python-linters-and-formatters#running-only-certain-formatters-or-linters)
- Video about how pants facilitates ["Incrementally Adopting New Tools"](https://www.youtube.com/watch?v=BOhcdRsmv0s)

### Things you can do with pantsbuild

This is the first PR that adds a `lint` backend. So, now you can run `./pants lint ::` (the same command that the new GHA Lint workflow runs).

You could do something like `./pants lint scripts/*.sh` if you only want to lint some of our scripts.

That looks like this:
```
./pants lint scripts/*.sh   
22:38:01.83 [INFO] Completed: Lint with Shellcheck - shellcheck succeeded.

✓ shellcheck succeeded.
```
```
$ ./pants lint ::
22:39:34.11 [INFO] Completed: Lint with Shellcheck - shellcheck succeeded.

✓ shellcheck succeeded.
```

To see the shellcheck errors for a skipped file--I'll use `st2common/bin/st2ctl` for example--I commented out the `skip_shellcheck=True,` line in the BUILD file. That shows what output looks like for failures:

```
$ ./pants lint st2common/bin/st2ctl            
22:45:53.16 [ERROR] Completed: Lint with Shellcheck - shellcheck failed (exit code 1).

In st2common/bin/st2ctl line 23:
[ -r /etc/environment ] && source /etc/environment
                                  ^--------------^ SC1091 (info): Not following: /etc/environment was not specified as input (see shellcheck -x).


In st2common/bin/st2ctl line 27:
[ -r /etc/default/st2ctl ] && source /etc/default/st2ctl
                                     ^-----------------^ SC1091 (info): Not following: /etc/default/st2ctl was not specified as input (see shellcheck -x).


In st2common/bin/st2ctl line 29:
[ -r /etc/sysconfig/st2ctl ] && source /etc/sysconfig/st2ctl
                                       ^-------------------^ SC1091 (info): Not following: /etc/sysconfig/st2ctl was not specified as input (see shellcheck -x).


In st2common/bin/st2ctl line 66:
    if [ $(id -u) -ne 0 ]; then
         ^------^ SC2046 (warning): Quote this to prevent word splitting.


In st2common/bin/st2ctl line 75:
  if [ -z ${COM} ]; then
          ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
  if [ -z "${COM}" ]; then


In st2common/bin/st2ctl line 97:
    service_manager ${COM} start
                    ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    service_manager "${COM}" start


In st2common/bin/st2ctl line 104:
    service_manager ${COM} stop
                    ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    service_manager "${COM}" stop


In st2common/bin/st2ctl line 112:
    if [ -z $SYSTEMD_RELOADED ]; then
            ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    if [ -z "$SYSTEMD_RELOADED" ]; then


In st2common/bin/st2ctl line 117:
    systemctl $action $svcname
              ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.
                      ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    systemctl "$action" "$svcname"


In st2common/bin/st2ctl line 118:
  elif [ $(cat /proc/1/comm) = init ] && (/sbin/initctl version 2>/dev/null | grep -q upstart) &&
         ^-----------------^ SC2046 (warning): Quote this to prevent word splitting.


In st2common/bin/st2ctl line 119:
          [ -f /etc/init/${svcname}.conf ]; then
                         ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
          [ -f /etc/init/"${svcname}".conf ]; then


In st2common/bin/st2ctl line 123:
    /sbin/initctl $action $svcname
                  ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.
                          ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    /sbin/initctl "$action" "$svcname"


In st2common/bin/st2ctl line 125:
    service $svcname $action
            ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                     ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    service "$svcname" "$action"


In st2common/bin/st2ctl line 137:
  PID=`ps ax | grep -v grep | grep -v st2ctl | grep -E "(${COM}\.wsgi)|(bin/${COM})|(hubot .*${COM})" | awk '{print $1}'`
      ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
       ^-- SC2009 (info): Consider using pgrep instead of grepping ps output.

Did you mean: 
  PID=$(ps ax | grep -v grep | grep -v st2ctl | grep -E "(${COM}\.wsgi)|(bin/${COM})|(hubot .*${COM})" | awk '{print $1}')


In st2common/bin/st2ctl line 138:
  if [[ ! -z ${PID} ]]; then
        ^-- SC2236 (style): Use -n instead of ! -z.


In st2common/bin/st2ctl line 141:
      kill -USR1 ${p}
                 ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
      kill -USR1 "${p}"


In st2common/bin/st2ctl line 154:
  flags="${@}"
        ^----^ SC2124 (warning): Assigning an array to a string! Assign as array, or use * instead of @ to concatenate.


In st2common/bin/st2ctl line 156:
  if [ ! -z ${1} ]; then
       ^-- SC2236 (style): Use -n instead of ! -z.
            ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
  if [ ! -z "${1}" ]; then


In st2common/bin/st2ctl line 170:
  if [ -z ${1} ]; then
          ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
  if [ -z "${1}" ]; then


In st2common/bin/st2ctl line 172:
  elif [ ${1} == '--verbose' ] && [ -z ${2} ]; then
         ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                       ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
  elif [ "${1}" == '--verbose' ] && [ -z "${2}" ]; then


In st2common/bin/st2ctl line 179:
  st2-register-content --config-file ${ST2_CONF} ${REGISTER_FLAGS}
                                                 ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
  st2-register-content --config-file ${ST2_CONF} "${REGISTER_FLAGS}"


In st2common/bin/st2ctl line 194:
  COMPONENTS=${COMPONENTS}
  ^--------^ SC2269 (info): This variable is assigned to itself, so the assignment does nothing.


In st2common/bin/st2ctl line 197:
    PID=`ps ax | grep -v grep | grep -v st2ctl | grep -E "(${COM}\.wsgi)|(bin/${COM})|(hubot .*${COM})" | awk '{print $1}'`
        ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
         ^-- SC2009 (info): Consider using pgrep instead of grepping ps output.

Did you mean: 
    PID=$(ps ax | grep -v grep | grep -v st2ctl | grep -E "(${COM}\.wsgi)|(bin/${COM})|(hubot .*${COM})" | awk '{print $1}')


In st2common/bin/st2ctl line 199:
    if [[ ! -z ${PID} ]]; then
          ^-- SC2236 (style): Use -n instead of ! -z.


In st2common/bin/st2ctl line 229:
    validate_in_components ${2}
                           ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    validate_in_components "${2}"


In st2common/bin/st2ctl line 230:
    service_manager ${2} restart
                    ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    service_manager "${2}" restart


In st2common/bin/st2ctl line 235:
    validate_in_components ${2}
                           ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    validate_in_components "${2}"


In st2common/bin/st2ctl line 236:
    if reopen_component_log_files ${2}; then
                                  ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    if reopen_component_log_files "${2}"; then


In st2common/bin/st2ctl line 242:
    register_content ${@:2}
                     ^----^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In st2common/bin/st2ctl line 253:
    read verify
    ^--^ SC2162 (info): read without -r will mangle backslashes.


In st2common/bin/st2ctl line 258:
      register_content ${@:2}
                       ^----^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.

For more information:
  https://www.shellcheck.net/wiki/SC2068 -- Double quote array expansions to ...
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
  https://www.shellcheck.net/wiki/SC2124 -- Assigning an array to a string! A...



✕ shellcheck failed.
```