### PR TITLE
Add GHA workflow to lint with pantsbuild

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,88 @@
+---
+# This Lint workflow uses pants
+name: Lint
+
+on:
+  push:
+    branches:
+      # only on merges to master branch
+      - master
+      # and version branches, which only include minor versions (eg: v3.4)
+      - v[0-9]+.[0-9]+
+    tags:
+      # also version tags, which include bugfix releases (eg: v3.4.0)
+      - v[0-9]+.[0-9]+.[0-9]+
+  pull_request:
+    type: [opened, reopened, edited]
+    branches:
+      # Only for PRs targeting those branches
+      - master
+      - v[0-9]+.[0-9]+
+  schedule:
+    # run every night at midnight
+    - cron:  '0 0 * * *'
+
+jobs:
+  # Lint checks which don't depend on any service containes, etc. to be running.
+  lint-checks:
+    name: 'Lint Checks (pants runs: shellcheck)'
+    runs-on: ubuntu-latest
+
+    env:
+      COLUMNS: '120'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          # a test uses a submodule, and pants needs access to it to calculate deps.
+          submodules: 'true'
+
+      #- name: Cache APT Dependencies
+      #  id: cache-apt-deps
+      #  uses: actions/cache@v2
+      #  with:
+      #    path: |
+      #      ~/apt_cache
+      #    key: ${{ runner.os }}-apt-v7-${{ hashFiles('scripts/github/apt-packages.txt') }}
+      #    restore-keys: |
+      #      ${{ runner.os }}-apt-v7-
+      - name: Install APT Depedencies
+        env:
+          CACHE_HIT: 'false' # cache doesn't work
+          #CACHE_HIT: ${{steps.cache-apt-deps.outputs.cache-hit}}
+        run: |
+          # install dev dependencies for Python YAML and LDAP packages
+          # https://github.com/StackStorm/st2-auth-ldap
+          ./scripts/github/install-apt-packages-use-cache.sh
+
+      - name: Initialize Pants and its GHA caches
+        uses: pantsbuild/actions/init-pants@c0ce05ee4ba288bb2a729a2b77294e9cb6ab66f7
+        # This action adds an env var to make pants use both pants.ci.toml & pants.toml.
+        # This action also creates 3 GHA caches (1 is optional).
+        # - `pants-setup` has the bootsrapped pants install
+        # - `pants-named-caches` has pip/wheel and PEX caches
+        # - `pants-lmdb-store` has the fine-grained process cache.
+        #   If we ever use a remote cache, then we can drop this.
+        #   Otherwise, we may need an additional workflow or job to delete old caches
+        #   if they are not expiring fast enough, and we hit the GHA 10GB per repo max.
+        with:
+          base-branch: master
+          # To ignore a bad cache, bump the cache* integer.
+          gha-cache-key: cache0
+          # This hash should include all of our lockfiles so that the pip/pex caches
+          # get invalidated on any transitive dependency update.
+          named-caches-hash: ${{ hashFiles('requirements.txt') }}
+          # enable the optional lmdb_store cache since we're not using remote caching.
+          cache-lmdb-store: 'true'
+
+      - name: Lint
+        run: |
+          ./pants lint ::
+
+      - name: Upload pants log
+        uses: actions/upload-artifact@v2
+        with:
+          name: pants-log-py${{ matrix.python-version }}
+          path: .pants.d/pants.log
+        if: always()  # We want the log even on failures.

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,9 +18,9 @@ on:
       # Only for PRs targeting those branches
       - master
       - v[0-9]+.[0-9]+
-  schedule:
-    # run every night at midnight
-    - cron:  '0 0 * * *'
+  #schedule:
+  #  # run every night at midnight
+  #  - cron:  '0 0 * * *'
 
 jobs:
   # Lint checks which don't depend on any service containes, etc. to be running.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,7 +53,7 @@ Added
 
 * Begin introducing `pants <https://www.pantsbuild.org/docs>`_ to improve DX (Developer Experience)
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
-  to pants' use of PEX lockfiles. This is not a user-facing addition. #5713 #5724 #5726 #5725 #5732 #5733 #5737 #5738
+  to pants' use of PEX lockfiles. This is not a user-facing addition. #5713 #5724 #5726 #5725 #5732 #5733 #5737 #5738 #5758
   Contributed by @cognifloyd
 
 Changed


### PR DESCRIPTION
### Background

This is another part of introducing [`pants`](https://www.pantsbuild.org/docs), as discussed in the TSC Meetings on [12 July 2022](https://github.com/StackStorm/community/issues/105), [02 Aug 2022](https://github.com/StackStorm/community/issues/107), [06 Sept 2022](https://github.com/StackStorm/community/issues/108), and [04 Oct 2022](https://github.com/StackStorm/community/issues/111). Pants has fine-grained per-file caching of results for lint, fmt (like black), test, etc. It also has lockfiles that work well for monorepos that have multiple python packages. With these lockfiles CI should not break when any of our dependencies or our transitive dependencies release new versions, because CI will continue to use the locked version until we explicitly relock with updates.

To keep PRs as manageable/reviewable as possible, introducing pants will take a series of PRs. I do not know yet how many PRs; I will break this up into logical steps with these goals:
- introduce `pants` to the st2 repo, and
- teach some (but not all) TSC members about `pants` step-by-step.

Other pants PRs include:
- https://github.com/StackStorm/st2/pull/5713
- https://github.com/StackStorm/st2/pull/5724
- https://github.com/StackStorm/st2/pull/5725
- https://github.com/StackStorm/st2/pull/5726
- https://github.com/StackStorm/st2/pull/5732
- https://github.com/StackStorm/st2/pull/5733
- https://github.com/StackStorm/st2/pull/5737
- https://github.com/StackStorm/st2/pull/5738
- https://github.com/StackStorm/st2/pull/5751

### Overview of this PR

We begin to add linters in #5751. This adds a GHA workflow to automatically run the linters. This workflow copies a few pants tasks from the pants validation workflow added in #5732 and the apt tasks from our current CI workflow.

Until one of the linter backends is registered, `./pants lint ::` will just return with success because there is nothing to do.

When we add python linters (black, flake8, etc) we will need to expand this workflow to handle a matrix of the various python versions. For now, this is sufficient for running shellcheck (in #5751) and a few other linters.

#### Relevant Pants documentation

- [`./pants lint` goal](https://www.pantsbuild.org/v2.14/docs/reference-lint)

### Things you can do with pantsbuild

You can run `./pants lint ::` but it doesn't do anything yet. So, output looks like this:

```
$ ./pants lint ::
13:00:22.28 [INFO] Initializing scheduler...
13:00:22.57 [INFO] Scheduler initialized.

$ echo $?
0
$ ./pants lint ::

$ echo $?
0
```