### PR TITLE
Use regex-lint to provide circular dependency checking in pants

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,15 @@ Changelog
 in development
 --------------
 
+Added
+~~~~~
+
+* Continue introducing `pants <https://www.pantsbuild.org/docs>`_ to improve DX (Developer Experience)
+  working on StackStorm, improve our security posture, and improve CI reliability thanks in part
+  to pants' use of PEX lockfiles. This is not a user-facing addition.
+  #5778
+  Contributed by @cognifloyd
+
 
 3.8.0 - November 18, 2022
 -------------------------

--- a/lint-configs/regex-lint.yaml
+++ b/lint-configs/regex-lint.yaml
@@ -1,0 +1,101 @@
+# Note that for values that are regexes, how YAML interprets backslashes and other
+# special characters matters. For example, an unquoted string is interpreted as a raw
+# string with no escape characters (so it's particularly useful for expressing regexes).
+# Adding quotes around these may change their meaning, so don't do so without thought.
+
+required_matches:
+  # If we decide to enable this, remove the st2flake8
+  #python_source:
+  #  - python_header
+  #build_files:
+  #  - python_header
+
+  # TODO: In the future pants should get `visibility` and possibly other
+  #       features to restrict imports for dependees or dependencies.
+  #       - https://github.com/pantsbuild/pants/issues/13393
+  #       - https://github.com/pantsbuild/pants/pull/15803
+  #       - https://github.com/pantsbuild/pants/pull/15836
+  #       When that happens, we can add that target metadata,
+  #       and remove these regex based dependency checks.
+
+  # st2client-dependencies-check
+  st2client:
+    - must_not_import_st2common
+
+  # st2common-circular-dependencies-check
+  st2common:
+    - must_not_import_st2reactor
+    - must_not_import_st2api
+    - must_not_import_st2auth
+    #- must_not_import_st2actions
+    #- must_not_import_st2stream
+  st2common_except_services_inquiry:
+    # The makefile excluded: runnersregistrar.py, compat.py, inquiry.py
+    # runnersregistrar does not have an st2actions ref since 2016.
+    # compat.py st2actions function was added and removed in 2017.
+    # services/inquiry.py still imports st2actions.
+    - must_not_import_st2actions
+  st2common_except_router:
+    # The makefile excluded router.py from st2stream check.
+    # In router.py, "st2stream" is a string, not an import.
+    - must_not_import_st2stream
+
+path_patterns:
+  #- name: python_source
+  #  pattern: (?<!__init__)\.py$
+  #- name: build_files
+  #  pattern: /BUILD$
+
+  - name: st2client
+    pattern: st2client/st2client/.*\.py$
+  - name: st2common
+    pattern: st2common/st2common/.*\.py$
+
+  - name: st2common_except_services_inquiry
+    pattern: st2common/st2common/(?!services/inquiry\.py).*\.py$
+
+  - name: st2common_except_router
+    pattern: st2common/st2common/(?!router\.py).*\.py$
+
+content_patterns:
+  #- name: python_header
+  #  pattern: |+
+  #    ^(?:#\!\/usr\/bin\/env python3
+  #    )?# Copyright 20\d\d The StackStorm Authors.
+  #    (?:# Copyright 20\d\d .*
+  #    )*#
+  #    # Licensed under the Apache License, Version 2.0 (the "License");
+  #    # you may not use this file except in compliance with the License.
+  #    # You may obtain a copy of the License at
+  #    #
+  #    #     http://www.apache.org/licenses/LICENSE-2.0
+  #    #
+  #    # Unless required by applicable law or agreed to in writing, software
+  #    # distributed under the License is distributed on an "AS IS" BASIS,
+  #    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  #    # See the License for the specific language governing permissions and
+  #    # limitations under the License.
+
+  - name: must_not_import_st2common
+    pattern: st2common
+    inverted: true
+
+  - name: must_not_import_st2reactor
+    pattern: st2reactor
+    inverted: true
+
+  - name: must_not_import_st2actions
+    pattern: st2actions
+    inverted: true
+
+  - name: must_not_import_st2api
+    pattern: st2api
+    inverted: true
+
+  - name: must_not_import_st2auth
+    pattern: st2auth
+    inverted: true
+
+  - name: must_not_import_st2stream
+    pattern: st2stream
+    inverted: true

--- a/pants.toml
+++ b/pants.toml
@@ -112,3 +112,6 @@ extra_requirements = [
   "st2flake8==0.1.0",  # TODO: remove in favor of regex-lint
 ]
 config = "lint-configs/python/.flake8"
+
+[regex-lint]
+config = "@lint-configs/regex-lint.yaml"


### PR DESCRIPTION
### Background

This is another part of introducing [`pants`](https://www.pantsbuild.org/docs), as discussed in the TSC Meetings on [12 July 2022](https://github.com/StackStorm/community/issues/105), [02 Aug 2022](https://github.com/StackStorm/community/issues/107), [06 Sept 2022](https://github.com/StackStorm/community/issues/108), and [04 Oct 2022](https://github.com/StackStorm/community/issues/111). Pants has fine-grained per-file caching of results for lint, fmt (like black), test, etc. It also has lockfiles that work well for monorepos that have multiple python packages. With these lockfiles CI should not break when any of our dependencies or our transitive dependencies release new versions, because CI will continue to use the locked version until we explicitly relock with updates.

To keep PRs as manageable/reviewable as possible, introducing pants will take a series of PRs. I do not know yet how many PRs; I will break this up into logical steps with these goals:
- introduce `pants` to the st2 repo, and
- teach some (but not all) TSC members about `pants` step-by-step.

Other pants PRs include:
- https://github.com/StackStorm/st2/pull/5713
- https://github.com/StackStorm/st2/pull/5724
- https://github.com/StackStorm/st2/pull/5725
- https://github.com/StackStorm/st2/pull/5726
- https://github.com/StackStorm/st2/pull/5732
- https://github.com/StackStorm/st2/pull/5733
- https://github.com/StackStorm/st2/pull/5737
- https://github.com/StackStorm/st2/pull/5738
- https://github.com/StackStorm/st2/pull/5758
- https://github.com/StackStorm/st2/pull/5751
- https://github.com/StackStorm/st2/pull/5774
- https://github.com/StackStorm/st2/pull/5776
- https://github.com/StackStorm/st2/pull/5777

### Overview of this PR

The Makefile has some checks for circular dependencies. Pants has a builtin `regex-lint` subsystem that lets us do basically the same thing via pants.

These are the relevant targets in the Makefile:
https://github.com/StackStorm/st2/blob/94d07986a695b918b8ca2e2036025be1ca3e6685/Makefile#L578-L591

It turns out that the Makefile targets are somewhat out-of-date: For example, some of the listed exceptions to the rules no longer apply and we removed st2exporter in #5676. I documented each of my updates in comments of the lint config file.

In #5776, I had to add our `st2flake8` plugin for `flake8` which handles checking for the copyright. We can replace that plugin with `regex-lint`. I noted how we can do that in the regex-lint config file, but I left it commented out for now. We can enable it later when we're ready to retire the `st2flake8` custom plugin, which we can probably do once we're ready to remove the Makefile and related files.

#### Relevant Pants documentation

- [`./pants generate-lockfiles` goal](https://www.pantsbuild.org/v2.14/docs/reference-generate-lockfiles)
- [`./pants lint` goal](https://www.pantsbuild.org/v2.14/docs/reference-lint)
- [regex-lint backend](https://www.pantsbuild.org/v2.14/docs/reference-regex-lint)\

### Things you can do with pantsbuild

You can run `./pants lint ::` to see if regex-lint finds any issues (the GHA Lint workflow runs this as well). You can run only one of the linters with the helpful `--only` arg like this:

```
$ ./pants lint --only=regex-lint ::
13:21:52.61 [INFO] Initializing scheduler...
13:21:52.93 [INFO] Scheduler initialized.
13:21:54.27 [INFO] Completed: Lint with regex patterns - regex-lint succeeded.
385 files matched all required patterns.
0 files failed to match at least one required pattern.



✓ regex-lint succeeded.
```

The `--only` flag is "scoped" to the lint goal. So, these are equivalent if you wanted to specify that flag in a different order:
`./pants lint --only=regex-lint ::`
`./pants --lint-only=regex-lint lint ::`
`./pants lint :: --lint-only=regex-lint`

_note: that I had to add `lint` in the arg name to use a different order_