### PR TITLE
Add a new cron function

### DIFF
--- a/st2common/st2common/constants/triggers.py
+++ b/st2common/st2common/constants/triggers.py
@@ -245,6 +245,8 @@ CRON_PARAMETERS_SCHEMA = {
     "type": "object",
     "properties": {
         "timezone": {"type": "string"},
+        "start_date": {"type": "string"},
+        "end_date": {"type": "string"},
         "year": {
             "anyOf": [{"type": "string"}, {"type": "integer"}],
         },


### PR DESCRIPTION
## Problem description
![image](https://user-images.githubusercontent.com/30886624/196026877-30f0c718-559b-411f-a175-1a4750e98aee.png)
When I used core.st2.CronTimer to create a scheduled task, I found that I could not specify the start time and end time

## Solution

As can be seen from the source code, the scheduled task is implemented by aspscheduler and the parameters of the scheduled task are transparently transmitted. aspscheduler has this function. In use, parameters can be specified as start_date and end_date. You only need to change CRON_PARAMETERS_SCHEMA to add these two parameters
