### PR TITLE
Add backward compatibility to secret masking for output schema

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,7 +41,7 @@ Fixed
 
 * A new output schema using full JSON schema was introduced and secrets previously masked using
   the legacy output schema are now being displayed as plain text. To prevent security relative
-  issues, add backward compatibility to secret masking. Full output schema validattion will need
+  issues, add backward compatibility to secret masking. Full output schema validation will need
   to be migrated to the new schema.
 
   Contributed by @m4dcoder

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,6 @@ Fixed
 
   Contributed by @bharath-orchestral
 
-
 * Fixed ``st2client/st2client/base.py`` file to use ``https_proxy``(not ``http_proxy``) to check HTTPS_PROXY environment variables.
 
   Contributed by @wfgydbu
@@ -39,16 +38,15 @@ Fixed
 * Fixed generation of `st2.conf.sample` to show correct syntax for `[sensorcontainer].partition_provider` (space separated `key:value` pairs). #5710
   Contributed by @cognifloyd
 
-* A new output schema using full JSON schema was introduced and secrets previously masked using
-  the legacy output schema are now being displayed as plain text. To prevent security relative
-  issues, add backward compatibility to secret masking. Full output schema validation will need
-  to be migrated to the new schema.
+* Fix access to key-value pairs in workflow and action execution where RBAC rules did not get applied #5764
 
   Contributed by @m4dcoder
 
-* Fix access to key-value pairs in workflow and action execution where RBAC rules did not get applied
+* Add backward compatibility to secret masking introduced in #5319 to prevent security-relative issues.
+  Migration to the new schema is required to take advantage of the full output schema validation. #5783
 
   Contributed by @m4dcoder
+
 
 Added
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,6 +39,13 @@ Fixed
 * Fixed generation of `st2.conf.sample` to show correct syntax for `[sensorcontainer].partition_provider` (space separated `key:value` pairs). #5710
   Contributed by @cognifloyd
 
+* A new output schema using full JSON schema was introduced and secrets previously masked using
+  the legacy output schema are now being displayed as plain text. To prevent security relative
+  issues, add backward compatibility to secret masking. Full output schema validattion will need
+  to be migrated to the new schema.
+
+  Contributed by @m4dcoder
+
 Added
 ~~~~~
 

--- a/st2common/tests/unit/test_util_output_schema.py
+++ b/st2common/tests/unit/test_util_output_schema.py
@@ -399,8 +399,15 @@ class OutputSchemaTestCase(unittest2.TestCase):
                 "output_schema": RUNNER_OUTPUT_SCHEMA,
             },
         }
-        ac_ex_result = {"output_1": "foobar"}
-        expected_masked_output = {"output_1": "foobar"}
+
+        ac_ex_result = {OUTPUT_KEY: {"output_1": "foobar", "output_3": "fubar"}}
+
+        expected_masked_output = {
+            OUTPUT_KEY: {
+                "output_1": "foobar",
+                "output_3": MASKED_ATTRIBUTE_VALUE,
+            }
+        }
 
         # Legacy schemas should be ignored since they aren't full json schemas.
         masked_output = output_schema.mask_secret_output(ac_ex, ac_ex_result)

--- a/st2common/tests/unit/test_util_output_schema.py
+++ b/st2common/tests/unit/test_util_output_schema.py
@@ -389,7 +389,7 @@ class OutputSchemaTestCase(unittest2.TestCase):
         masked_output = output_schema.mask_secret_output(ac_ex, ac_ex_result)
         self.assertDictEqual(masked_output, expected_masked_output)
 
-    def test_mask_secret_output_noop_legacy_schema(self):
+    def test_mask_secret_output_with_legacy_schema(self):
         ac_ex = {
             "action": {
                 "output_schema": LEGACY_ACTION_OUTPUT_SCHEMA,
@@ -409,7 +409,7 @@ class OutputSchemaTestCase(unittest2.TestCase):
             }
         }
 
-        # Legacy schemas should be ignored since they aren't full json schemas.
+        # Legacy schemas are not full json schemas, but they should still mask secrets.
         masked_output = output_schema.mask_secret_output(ac_ex, ac_ex_result)
         self.assertDictEqual(masked_output, expected_masked_output)
 


### PR DESCRIPTION
Add backward compatibility to secret masking introduced in #5319 to prevent security-relative issues. Migration to the new schema is required to take advantage of the full output schema validation.