### PR TITLE
Inform pants about 3rd party dependencies and constraints

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2,7 +2,6 @@ python_requirements(
     name="reqs",
     source="requirements-pants.txt",
     module_mapping={
-        "gitpython": ["git"],
         "python-editor": ["editor"],
         "python-json-logger": ["pythonjsonlogger"],
         "python-statsd": ["statsd"],

--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,42 @@
 python_requirements(
-    name="root",
+    name="reqs",
+    source="requirements-pants.txt",
+    module_mapping={
+        "gitpython": ["git"],
+        "python-editor": ["editor"],
+        "python-json-logger": ["pythonjsonlogger"],
+        "python-statsd": ["statsd"],
+        "sseclient-py": ["sseclient"],
+        "oslo.config": ["oslo_config"],
+        "RandomWords": ["random_words"],
+    },
+    overrides={
+        # flex uses pkg_resources w/o declaring the dep
+        "flex": {
+            "dependencies": [
+                "//:reqs#setuptools",
+            ]
+        },
+        # do not use the prance[flex] extra as that pulls in an old version of flex
+        "prance": {
+            "dependencies": [
+                "//:reqs#flex",
+            ]
+        },
+        # stevedore uses pkg_resources w/o declaring the dep
+        "stevedore": {
+            "dependencies": [
+                "//:reqs#setuptools",
+            ]
+        },
+        # tooz needs one or more backends (tooz is used by the st2 coordination backend)
+        "tooz": {
+            "dependencies": [
+                "//:reqs#redis",
+                "//:reqs#zake",
+            ]
+        },
+    },
 )
 
 python_test_utils(

--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,8 @@
 python_requirements(
     name="reqs",
     source="requirements-pants.txt",
+    # module_mapping can be removed once pants is released with
+    # https://github.com/pantsbuild/pants/pull/17390
     module_mapping={
         "python-editor": ["editor"],
         "python-json-logger": ["pythonjsonlogger"],

--- a/BUILD
+++ b/BUILD
@@ -11,8 +11,8 @@ python_requirements(
         "RandomWords": ["random_words"],
     },
     overrides={
-        # flex uses pkg_resources w/o declaring the dep
-        "flex": {
+        # flex and stevedore uses pkg_resources w/o declaring the dep
+        ("flex", "stevedore"): {
             "dependencies": [
                 "//:reqs#setuptools",
             ]
@@ -21,12 +21,6 @@ python_requirements(
         "prance": {
             "dependencies": [
                 "//:reqs#flex",
-            ]
-        },
-        # stevedore uses pkg_resources w/o declaring the dep
-        "stevedore": {
-            "dependencies": [
-                "//:reqs#setuptools",
             ]
         },
         # tooz needs one or more backends (tooz is used by the st2 coordination backend)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Added
 * Continue introducing `pants <https://www.pantsbuild.org/docs>`_ to improve DX (Developer Experience)
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
-  #5778
+  #5778 #5789
   Contributed by @cognifloyd
 
 

--- a/contrib/core/BUILD
+++ b/contrib/core/BUILD
@@ -3,5 +3,7 @@ python_sources()
 python_requirements(
     name="reqs",
     source="requirements-tests.txt",
+    # module_mapping can be removed once pants is released with
+    # https://github.com/pantsbuild/pants/pull/17390
     module_mapping={"mail-parser": ["mailparser"]},
 )

--- a/contrib/core/BUILD
+++ b/contrib/core/BUILD
@@ -3,4 +3,5 @@ python_sources()
 python_requirements(
     name="reqs",
     source="requirements-tests.txt",
+    module_mapping={"mail-parser": ["mailparser"]},
 )

--- a/contrib/runners/winrm_runner/BUILD
+++ b/contrib/runners/winrm_runner/BUILD
@@ -1,0 +1,5 @@
+python_requirement(
+    name="winrm",
+    requirements=["pywinrm"],
+    modules=["winrm"],
+)

--- a/contrib/runners/winrm_runner/BUILD
+++ b/contrib/runners/winrm_runner/BUILD
@@ -1,5 +1,7 @@
 python_requirement(
     name="winrm",
     requirements=["pywinrm"],
+    # modules can be removed once pants is released with
+    # https://github.com/pantsbuild/pants/pull/17390
     modules=["winrm"],
 )

--- a/lockfiles/st2-constraints.txt
+++ b/lockfiles/st2-constraints.txt
@@ -3,78 +3,111 @@
 #
 # Direct dependencies should be recorded in `requirements-pants.txt`, not here.
 
+# please document each version constraint as follows:
+#
+# REQUIRED BY: <package>, <package>, ...
+# REASON: <why do we need to constrain this transitive dep?>
+# NOTE: <status of this constraint / when can we remove it?>
+# DROPS RESOLVED VERSION: <which version pip resolved without this constraint>
+#<package><version constraint>
+
 # ############################################ #
 # pinned transitive deps from requirements.txt #
 # ############################################ #
-#
-# required by jinja2:
-# fixed-requirements.txt:
-#     Fix MarkupSafe to < 2.1.0 as 2.1.0 removes soft_unicode
-#     >=0.23 was from jinja2
+
+# REQUIRED BY: jinja2
+# REASON: Fix MarkupSafe to < 2.1.0 as 2.1.0 removes soft_unicode >=0.23 was from jinja2
+# NOTE: try to remove constraint later.
+# DROPS RESOLVED VERSION: unknown
 MarkupSafe<2.1.0,>=0.23
 
-# required by kombu:
-# lockfile had 5.1.1 without this
+# REQUIRED BY: kombu
+# REASON: unknown -- this looks like a lockfile-style pin
+# NOTE: try to remove constraint later.
+# DROPS RESOLVED VERSION: 5.1.1
 amqp==5.0.6
 
-# required by cryptography, paramiko, passlib:
-# lockfile had 4.0.1 without this
+# REQUIRED BY: cryptography, paramiko, passlib
+# REASON: unknown -- this looks like a lockfile-style pin
+# NOTE: try to remove constraint later.
+# DROPS RESOLVED VERSION: 4.0.1
 bcrypt==3.2.0
 
-# required by bcrypt, cryptography, pynacl, zstandard:
-# lockfile had 1.15.1 without this
+# REQUIRED BY: bcrypt, cryptography, pynacl, zstandard
+# REASON: unknown
+# NOTE: try to remove constraint later.
+# DROPS RESOLVED VERSION: 1.15.1
 cffi<1.15.0
 
-# required by orquesta, prance, requests:
-# fixed-requirements.txt:
-#     requests 2.23 requires chardet < 3.1.0
-# lockfile had 3.0.4 without this
-# left commented since orquesta already constrains the version.
+# REQUIRED BY: orquesta, prance, requests
+# REASON: requests 2.23 requires chardet < 3.1.0
+# NOTE: orquesta already constrains this, so this is just documentation.
+# DROPS RESOLVED VERSION: 3.0.4
 #chardet<3.1.0
 
-# required by jsonpath-rw, networkx:
-# fixed-requireements.txt:
+# REQUIRED BY: jsonpath-rw, networkx
+# REASON:
 #     networkx requires decorator>=4.3,<5 which should resolve to version 4.4.2
 #     but the wheel on pypi does not say it supports python3.8, so pip gets
 #     confused. For now, pin decorator to work around pip's confusion.
-# lockfile had 4.4.2 without this (so this is just a pin)
+# NOTE: Since pants/pex use a newer version of pip, this is not an issue.
+# DROPS RESOLVED VERSION: 4.4.2
 #decorator==4.4.2
 
-# required by eventlet, pymongo:
-# fixed-requireements.txt:
-#     NOTE: 2.0 version breaks pymongo work with hosts
-# lockfile had 1.16 without this
+# REQUIRED BY: eventlet, pymongo
+# REASON: 2.0 version breaks pymongo work with hosts
+# NOTE: try to remove this later
+# DROPS RESOLVED VERSION: 1.16
 dnspython>=1.16.0,<2.0.0
 
-# required by eventlet:
-# lockfile had 1.1.3.post0 without this (so this is just a pin)
+# REQUIRED BY: eventlet
+# REASON: unknown -- this looks like a lockfile-style pin
+# NOTE: We are having a hard time upgrading eventlet, so this pin is commented
+#       out to see if that will help. If any tests fail, uncomment this.
+# DROPS RESOLVED VERSION: 1.1.3.post0
 #greenlet==1.0.0
 
-# required by argcomplete, click, debtcollector, kombu, pluggy, prettytable,
-# pytest, virtualenv:
-# lockfile had 4.8.3 without this (this pin actually causes conflicts)
+# REQUIRED BY: argcomplete, click, debtcollector, kombu, pluggy, prettytable,
+#             pytest, virtualenv
+# REASON: unknown
+# NOTE: This pinned version (3.10.1) actually conflicts with other requirements.
+#       So, it is commented out. If there are issues with newer versions,
+#       update this with a range of valid versions.
+# DROPS RESOLVED VERSION: 4.8.3
 #importlib-metadata==3.10.1
 
-# required by tooz:
-# lockfile had 4.13 without this
+# REQUIRED BY: tooz
+# REASON: unknown
+# NOTE: try to remove constraint later.
+# DROPS RESOLVED VERSION: 4.13
 oslo.utils<5.0,>=4.0.0
-# lockfile had 8.1 without this
+
+# REQUIRED BY: tooz
+# REASON: unknown
+# NOTE: try to remove constraint later.
+# DROPS RESOLVED VERSION: 8.1
 tenacity>=3.2.1,<7.0.0
 
-# required by st2-auth-backend-flat-file:
-# lockfile had 1.7.4 without this (so this is just a pin)
+# REQUIRED BY: st2-auth-backend-flat-file
+# REASON: unknown -- this looks like a lockfile-style pin
+# NOTE: st2-auth-backend-flat-file has a version range >=1.7.1,<1.8.0
+#       If we need to narrow that range, we should do so in:
+#       https://github.com/StackStorm/st2-auth-backend-flat-file/blob/master/requirements.txt
+# DROPS RESOLVED VERSION: 1.7.4
 #passlib==1.7.4
 
-# pyOpenSSL required by pymongo[ocsp], redis[ocsp], urllib3[secure]
+# pyOpenSSL required by: pymongo[ocsp], redis[ocsp], urllib3[secure]
 # but we don't use any of those, so skip copying from fixed-requirements.txt
 
-# required by httplib2, oslo.utils, packaging:
-# It looks like <3 was only needed for python2 compatibility.
-# lockfile had 3.0.7 without this.
+# REQUIRED BY: httplib2, oslo.utils, packaging
+# REASON: unknown -- It looks like <3 was only needed for python2 compatibility.
+# NOTE: this is still here, commented, until we can validate that all test are
+#       passing without it.
+# DROPS RESOLVED VERSION: 3.0.7
 #pyparsing<3
 
-# required by async-timeout, gitpython, importlib-metadata, redis:
-# fixed-requireements.txt:
-#     importlib-metadata requires typing-extensions but v4.2.0 requires py3.7+
-# lockfile had 4.1.1 without this.
+# REQUIRED BY: async-timeout, gitpython, importlib-metadata, redis
+# REASON: importlib-metadata requires typing-extensions but v4.2.0 requires py3.7+
+# NOTE: try to remove constraint later.
+# DROPS RESOLVED VERSION: 4.1.1
 typing-extensions<4.2

--- a/lockfiles/st2-constraints.txt
+++ b/lockfiles/st2-constraints.txt
@@ -12,56 +12,69 @@
 #     Fix MarkupSafe to < 2.1.0 as 2.1.0 removes soft_unicode
 #     >=0.23 was from jinja2
 MarkupSafe<2.1.0,>=0.23
-#
+
 # required by kombu:
-#amqp==5.0.6
-#
+# lockfile had 5.1.1 without this
+amqp==5.0.6
+
 # required by cryptography, paramiko, passlib:
-#bcrypt==3.2.0
-#
+# lockfile had 4.0.1 without this
+bcrypt==3.2.0
+
 # required by bcrypt, cryptography, pynacl, zstandard:
-#cffi<1.15.0
-#
+# lockfile had 1.15.1 without this
+cffi<1.15.0
+
 # required by orquesta, prance, requests:
 # fixed-requirements.txt:
 #     requests 2.23 requires chardet < 3.1.0
+# lockfile had 3.0.4 without this
+# left commented since orquesta already constrains the version.
 #chardet<3.1.0
-#
+
 # required by jsonpath-rw, networkx:
 # fixed-requireements.txt:
 #     networkx requires decorator>=4.3,<5 which should resolve to version 4.4.2
 #     but the wheel on pypi does not say it supports python3.8, so pip gets
 #     confused. For now, pin decorator to work around pip's confusion.
+# lockfile had 4.4.2 without this (so this is just a pin)
 #decorator==4.4.2
-#
+
 # required by eventlet, pymongo:
 # fixed-requireements.txt:
 #     NOTE: 2.0 version breaks pymongo work with hosts
-#dnspython>=1.16.0,<2.0.0
-#
+# lockfile had 1.16 without this
+dnspython>=1.16.0,<2.0.0
+
 # required by eventlet:
+# lockfile had 1.1.3.post0 without this (so this is just a pin)
 #greenlet==1.0.0
-#
+
 # required by argcomplete, click, debtcollector, kombu, pluggy, prettytable,
 # pytest, virtualenv:
+# lockfile had 4.8.3 without this (this pin actually causes conflicts)
 #importlib-metadata==3.10.1
-#
+
 # required by tooz:
-#oslo.utils<5.0,>=4.0.0
-#tenacity>=3.2.1,<7.0.0
-#
+# lockfile had 4.13 without this
+oslo.utils<5.0,>=4.0.0
+# lockfile had 8.1 without this
+tenacity>=3.2.1,<7.0.0
+
 # required by st2-auth-backend-flat-file:
+# lockfile had 1.7.4 without this (so this is just a pin)
 #passlib==1.7.4
-#
-# required by pymongo, urllib3:
-# fixed-requireements.txt:
-#     pyOpenSSL 22.0.0 requires cryptography>=35.0
-#pyOpenSSL<=21.0.0
-#
-# required by oslo.utils, packaging:
+
+# pyOpenSSL required by pymongo[ocsp], redis[ocsp], urllib3[secure]
+# but we don't use any of those, so skip copying from fixed-requirements.txt
+
+# required by httplib2, oslo.utils, packaging:
+# It looks like <3 was only needed for python2 compatibility.
+# lockfile had 3.0.7 without this.
 #pyparsing<3
-#
-# required by gitpython, importlib-metadata:
+
+# required by async-timeout, gitpython, importlib-metadata, redis:
 # fixed-requireements.txt:
 #     importlib-metadata requires typing-extensions but v4.2.0 requires py3.7+
-#typing-extensions<4.2
+# lockfile had 4.1.1 without this.
+typing-extensions<4.2

--- a/lockfiles/st2-constraints.txt
+++ b/lockfiles/st2-constraints.txt
@@ -1,6 +1,5 @@
 # Add/remove version constraints for transitive dependencies in this file
 # (transitive dependencies are dependencies of our direct dependencies).
-# Then run `./pants generate-lockfiles --resolve=st2` to regenerate the lockfile.
 #
 # Direct dependencies should be recorded in `requirements-pants.txt`, not here.
 

--- a/lockfiles/st2-constraints.txt
+++ b/lockfiles/st2-constraints.txt
@@ -1,0 +1,68 @@
+# Add/remove version constraints for transitive dependencies in this file
+# (transitive dependencies are dependencies of our direct dependencies).
+# Then run `./pants generate-lockfiles --resolve=st2` to regenerate the lockfile.
+#
+# Direct dependencies should be recorded in `requirements-pants.txt`, not here.
+
+# ############################################ #
+# pinned transitive deps from requirements.txt #
+# ############################################ #
+#
+# required by jinja2:
+# fixed-requirements.txt:
+#     Fix MarkupSafe to < 2.1.0 as 2.1.0 removes soft_unicode
+#     >=0.23 was from jinja2
+MarkupSafe<2.1.0,>=0.23
+#
+# required by kombu:
+#amqp==5.0.6
+#
+# required by cryptography, paramiko, passlib:
+#bcrypt==3.2.0
+#
+# required by bcrypt, cryptography, pynacl, zstandard:
+#cffi<1.15.0
+#
+# required by orquesta, prance, requests:
+# fixed-requirements.txt:
+#     requests 2.23 requires chardet < 3.1.0
+#chardet<3.1.0
+#
+# required by jsonpath-rw, networkx:
+# fixed-requireements.txt:
+#     networkx requires decorator>=4.3,<5 which should resolve to version 4.4.2
+#     but the wheel on pypi does not say it supports python3.8, so pip gets
+#     confused. For now, pin decorator to work around pip's confusion.
+#decorator==4.4.2
+#
+# required by eventlet, pymongo:
+# fixed-requireements.txt:
+#     NOTE: 2.0 version breaks pymongo work with hosts
+#dnspython>=1.16.0,<2.0.0
+#
+# required by eventlet:
+#greenlet==1.0.0
+#
+# required by argcomplete, click, debtcollector, kombu, pluggy, prettytable,
+# pytest, virtualenv:
+#importlib-metadata==3.10.1
+#
+# required by tooz:
+#oslo.utils<5.0,>=4.0.0
+#tenacity>=3.2.1,<7.0.0
+#
+# required by st2-auth-backend-flat-file:
+#passlib==1.7.4
+#
+# required by pymongo, urllib3:
+# fixed-requireements.txt:
+#     pyOpenSSL 22.0.0 requires cryptography>=35.0
+#pyOpenSSL<=21.0.0
+#
+# required by oslo.utils, packaging:
+#pyparsing<3
+#
+# required by gitpython, importlib-metadata:
+# fixed-requireements.txt:
+#     importlib-metadata requires typing-extensions but v4.2.0 requires py3.7+
+#typing-extensions<4.2

--- a/pants.toml
+++ b/pants.toml
@@ -35,7 +35,7 @@ pants_ignore.add = [
   "st2common/tests/fixtures/requirements-used-for-tests.txt",
   "/fixed-requirements.txt",
   "/test-requirements.txt",
-  # ignore requirements.txt for now, preferring interrim files that are decoupled from
+  # ignore requirements.txt for now, preferring interim files that are decoupled from
   # legacy requirements files generation: requirements-pants.txt & lockfiles/st2-constraints.txt
   "/requirements.txt",
 ]

--- a/pants.toml
+++ b/pants.toml
@@ -35,9 +35,9 @@ pants_ignore.add = [
   "st2common/tests/fixtures/requirements-used-for-tests.txt",
   "/fixed-requirements.txt",
   "/test-requirements.txt",
-  # keep requirements.txt for now. We might ignore it if we need an alternate interrim
-  # file that is decoupled from our legacy requirements files generation.
-  # "/requirements.txt",
+  # ignore requirements.txt for now, preferring interrim files that are decoupled from
+  # legacy requirements files generation: requirements-pants.txt & lockfiles/st2-constraints.txt
+  "/requirements.txt",
 ]
 
 [source]

--- a/requirements-pants.txt
+++ b/requirements-pants.txt
@@ -16,6 +16,8 @@ flex
 # gitpython & gitdb are used for pack management
 gitdb
 gitpython
+# st2common/tests/integration/test_util_green.py requires greenlet (as does eventlet)
+greenlet
 gunicorn
 jinja2
 jsonpath-rw

--- a/requirements-pants.txt
+++ b/requirements-pants.txt
@@ -1,0 +1,100 @@
+# Add/remove direct 3rd party dependencies here, with version constraints if necessary.
+# Then run `./pants generate-lockfiles --resolve=st2` to regenerate the lockfile.
+#
+# Please do not add transitive dependencies in this file (ie dependencies of our dependencies).
+# Use `lockfiles/st2-constraints.txt` to constrain the version of these transitive dependencies.
+#
+# Please keep this list alphabetical, with tooz backends in a separate list.
+
+apscheduler
+argcomplete
+ciso8601
+cryptography
+# eventlet 0.31+ and gunicorn 20.1.0 are not compatible
+eventlet<0.31
+# flex parses the openapi 2 spec in our router
+flex
+# gitpython & gitdb are used for pack management
+gitdb
+gitpython
+gunicorn
+jinja2
+jsonpath-rw
+jsonschema
+kombu
+lockfile
+mock
+mongoengine
+# Note: networkx v2.6 dropped support for Python3.6
+# networkx version is constrained in orquesta.
+networkx
+orjson
+orquesta @ git+https://github.com/StackStorm/orquesta.git@v1.5.0
+# NOTE: Recent version substantially affect the performance and add big import time overhead
+# See https://github.com/StackStorm/st2/issues/4160#issuecomment-394386433 for details
+oslo.config>=1.12.1,<1.13
+paramiko
+# prance is used by st2-validate-api-spec to validate the openapi spec
+# prance needs flex, but do not use the extra as that gets an old version.
+prance
+prettytable
+# For st2client: prompt-toolkit v2+ does not have prompt_toolkit.token.Token
+prompt-toolkit<2
+psutil
+pymongo
+# pyrabbit used in an integration test
+pyrabbit
+pytest
+python-dateutil
+python-editor
+# pythonjsonlogger referenced in st2actions/conf/logging.conf
+python-json-logger
+python-statsd
+pytz
+PyYAML
+# RandomWords used in some tests
+RandomWords
+requests[security]
+retrying
+routes
+semver
+# setuptools provides pkg_resources
+setuptools
+simplejson
+six
+# NOTE: we use sseclient-py instead of sseclient because sseclient
+# has various issues which sometimes hang the connection for a long time, etc.
+sseclient-py
+# bandit doesn't work w/ stevedore 3+
+stevedore<3
+# For backward compatibility reasons, flat file backend is installed by default
+st2-auth-backend-flat-file @ git+https://github.com/StackStorm/st2-auth-backend-flat-file.git@master
+st2-auth-ldap @ git+https://github.com/StackStorm/st2-auth-ldap.git@master
+st2-rbac-backend @ git+https://github.com/StackStorm/st2-rbac-backend.git@master
+# tabulate used by tools/log_watcher.py
+tabulate
+tooz
+udatetime
+ujson
+unittest2
+virtualenv
+webob
+webtest
+# zstandard is used for micro benchmarks
+zstandard
+
+# tooz backends
+redis
+zake
+
+# was in fixed-requirements.txt, but not in requirements-pants.txt
+# keyczar is used by a python2-only test.
+#python-keyczar
+
+###########
+
+# not needed with switch to pytest
+#nose
+#nose-timer
+#nose-parallel
+#rednose

--- a/requirements-pants.txt
+++ b/requirements-pants.txt
@@ -1,5 +1,4 @@
 # Add/remove direct 3rd party dependencies here, with version constraints if necessary.
-# Then run `./pants generate-lockfiles --resolve=st2` to regenerate the lockfile.
 #
 # Please do not add transitive dependencies in this file (ie dependencies of our dependencies).
 # Use `lockfiles/st2-constraints.txt` to constrain the version of these transitive dependencies.


### PR DESCRIPTION
### Background

This is another part of introducing [pants](https://www.pantsbuild.org/docs), as discussed in various TSC meetings.

Related PRs can be found in:
- [pantsbuild](https://github.com/StackStorm/st2/milestone/47) milestone (which includes PRs since #5713)
- https://github.com/StackStorm/st2/labels/pantsbuild label (which also includes preparatory PRs that came before adding pantsbuild)

### Overview of this PR

Our 3rd party dependencies will be in a lockfile that looks like [`lockfiles/st2.lock`](https://github.com/st2sandbox/st2/blob/pants/lockfiles/st2.lock). But, before pants can generate that, we need to add several pieces of metadata including dependencies and python version constraints.

This PR focuses on registering all of our dependencies. Future PRs will add the python version constraints (aka interpreter constraints) and other metadata so that we can actually generate the lockfile.

The [Third-party dependencies](https://www.pantsbuild.org/docs/python-third-party-dependencies) document (in pantsbuild docs) is especially helpful in understanding the contents of this PR.

#### Relevant Pants documentation

- [Third party dependencies](https://www.pantsbuild.org/docs/python-third-party-dependencies)
    - [Teaching Pants your "universe"(s) of dependencies](https://www.pantsbuild.org/docs/python-third-party-dependencies#teaching-pants-your-universes-of-dependencies)
    - [Use `modules` and `module_mapping` when the module name is not standard](https://www.pantsbuild.org/docs/python-third-party-dependencies#use-modules-and-module_mapping-when-the-module-name-is-not-standard)
    - [Lockfiles](https://www.pantsbuild.org/docs/python-third-party-dependencies#lockfiles)
    - [Requirements with undeclared dependencies](https://www.pantsbuild.org/docs/python-third-party-dependencies#requirements-with-undeclared-dependencies)
- targets and fields:
    - [`python_requirements`](https://www.pantsbuild.org/v2.14/docs/reference-python_requirements) target
        - [`module_mapping`](https://www.pantsbuild.org/v2.14/docs/reference-python_requirements#codemodule_mappingcode) field
        - [`overrides`](https://www.pantsbuild.org/v2.14/docs/reference-python_requirements#codeoverridescode) field
    - [`python_requirement`](https://www.pantsbuild.org/v2.14/docs/reference-python_requirement) target
        - [`modules`](https://www.pantsbuild.org/v2.14/docs/reference-python_requirement#codemodulescode) field
        - [`dependencies`](https://www.pantsbuild.org/docs/reference-python_requirement#codedependenciescode) field

#### The purposes of `*requirements.txt`

Today, `*requirements.txt` conflates several purposes:

1. record direct dependencies;
2. constrain problematic transitive (indirect) dependencies; and
3. lock everything to make CI and releases more reliable.

With pants, I think we should manage each of these purposes with separate files, leaving `requirements.txt` to only record our direct dependencies (purpose 1). These files are:

| purpose                   | today               | with pants                      | introduced in              |
|---------------------------|---------------------|---------------------------------|----------------------------|
| record direct deps        | `*requirements.txt` | `requirements-pants.txt`        | :heavy_check_mark: this PR |
| constrain transitive deps | `*requirements.txt` | `lockfiles/st2-constraints.txt` | :heavy_check_mark: this PR |
| lockfile                  | `requirements.txt`  | `lockfiles/st2.lock`            | future PR                  |

_Today, the first two purposes are actually spread out across multiple files. In this chart, `*requirements.txt` includes: [`requirements.txt`](https://github.com/StackStorm/st2/blob/2b4e3590f1e6867c91b3968f2264a18710b52314/requirements.txt), [`fixed-requirements.txt`](https://github.com/StackStorm/st2/blob/2b4e3590f1e6867c91b3968f2264a18710b52314/fixed-requirements.txt), and `**/in-requirements.txt`._

The many `requirements.txt` files and the scripts that compile them to generate the "locked" version of the file are heavily interdependent. To avoid introducing another relationship on all of that infrastructure, I opted to create new files instead: `requirements-pants.txt`, `st2-constraints.txt`, and `st2.lock` (the lockfile has to be added in a follow-up PR).

### `requirements-pants.txt`

`requirements-pants.txt` does not need to constrain any transitive dependencies or handle locking or pinning any dependencies, so the requirements in it should be broad as possible. If there are known code incompatibilities in our direct dependencies, then we should add a version range to that requirement. Otherwise, we let the tooling (pants+pex+pip) pick the best version given all the other constraints we through at it.

### `st2-constraints.txt`

I put `st2-constraints.txt` under `lockfiles/` since it's primary purpose is to narrow the range of valid versions that pex can choose from when creating the lockfile.

I went through all of our requirements to determine if they are direct or transient dependencies. I put the transient deps in `st2-constraints.txt` and included comments about:
- which dependencies require the transient dependency
- explanatory comments from `fixed-requirements.txt` (if any)

Everything in `st2-constraints.txt` is, ideally, temporary. Eventually, we should be able to remove the version constraints on the transient dependencies (deps of our direct deps). With the current `*requirements.txt` infra, that is very difficult to do, because it is not clear what is a direct dependency and what ended up in there to fix a build. Many of these issues get resolved upstream. Isolating these "exceptional" constraints makes it easier to comment them out and validate whether or not they are still needed.

So, I looked through the git history to determine how much has changed since each one was introduced. The `MarkupSafe` constraint was added fairly recently in #5581. Most of the other constraints seem to be either (a) no longer necessary, or (b) the only reason to include them is to "lock" or pin that dependency. Locking will be handled by `lockfiles/st2.lock`, so I left everything except `MarkupSafe` commented out. They are not needed to create a valid lockfile. Once we have pants running more of our infrastructure, we'll be able to uncomment/update any constraints that are actually still needed.

### `lockfiles/st2.lock`

Again, pants needs more metadata before we can generate this, so it will be added in a follow-up PR. Plus, the lockfile is 4544 lines long, so I want to isolate introducing it in a PR that has basically nothing else in it.

### `BUILD`

Pants needs additional metadata about some of our direct dependencies. Others, like `pywinrm`, should really only be used in one specific module of our code base (the `winrm_runner` in this case). Still others are really only needed for tests of a specific pack. These oddities are difficult to express in a simple `requirements.txt` file, but we can express them cleanly in `BUILD` files.

Many packages do not declare that they use `setuptools` because they assume that all virtualenvs will just have it. Pants only includes the bare minimum it needs to run each linter or test. If `setuptools` is not an explicit dep, then it is not included. For `stevedore` I told pants about this implicit dependency like this (I did the same for `flex` as well):
https://github.com/StackStorm/st2/blob/e9df91d24fb53d537af7b3b61592087e09fa7a4a/BUILD#L26-L31

Other packages, like `tooz` have runtime dependencies that pants can't easily discover. This block makes sure our default `tooz` backends are included in the relevant venv whenever we use `tooz`:
https://github.com/StackStorm/st2/blob/e9df91d24fb53d537af7b3b61592087e09fa7a4a/BUILD#L32-L38

Still other packages are installed with one name, but imported with another. pants uses a `module_mapping` to figure out which imports come from which 3rd party dependencies.

We use `modules` to tell pants that the `pywinrm` package provides the `winrm` module:
https://github.com/StackStorm/st2/blob/e9df91d24fb53d537af7b3b61592087e09fa7a4a/contrib/runners/winrm_runner/BUILD#L1-L4

And we use `module_mapping` to do the same for requirements defined in `requirements-pants.txt` (but only if they aren't in the [default `module_mapping` defined in pants](https://github.com/pantsbuild/pants/blob/main/src/python/pants/backend/python/dependency_inference/default_module_mapping.py):
https://github.com/StackStorm/st2/blob/e9df91d24fb53d537af7b3b61592087e09fa7a4a/BUILD#L4-L12

### planned changes to `pants.toml`

We can't adjust config in `pants.toml` until a future PR as some of that config is interdependent. Briefly, these are the settings that will be needed:
- [`[python].enable_resolves = true`](https://www.pantsbuild.org/docs/reference-python#enable_resolves)
- [`[python].default_resolve = "st2"`](https://www.pantsbuild.org/docs/reference-python#default_resolve)
- [`[python.resolves].st2 = "lockfiles/st2.lock"`](https://www.pantsbuild.org/docs/reference-python#resolves)
- [`[python.resolves_to_constraints_file].st2 = "lockfiles/st2.lock"`](https://www.pantsbuild.org/docs/reference-python#resolves_to_constraints_file)