### PR TITLE
Update to pants 2.14 (final)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Added
 * Continue introducing `pants <https://www.pantsbuild.org/docs>`_ to improve DX (Developer Experience)
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
-  #5778 #5789
+  #5778 #5789 #5817
   Contributed by @cognifloyd
 
 

--- a/pants.toml
+++ b/pants.toml
@@ -6,7 +6,7 @@ enabled = false
 repo_id = "de0dea7a-9f6a-4c6e-aa20-6ba5ad969b8a"
 
 [GLOBAL]
-pants_version = "2.14.0rc3"
+pants_version = "2.14.0"
 backend_packages = [
   # python
   "pants.backend.python",

--- a/pants.toml
+++ b/pants.toml
@@ -84,6 +84,16 @@ root_patterns = [
   "/st2common/benchmarks/micro",
 ]
 
+[python-infer]
+# https://www.pantsbuild.org/docs/reference-python-infer#unowned_dependency_behavior
+# The default changed from "ignore" to "warning" in pants 2.14.
+# Many of the new warnings however have been adressed via explicit deps,
+# so the warnings are not helpful. In pants 2.16, a "visibility" feature might help
+# us to disambiguate deps between files without those explicit BUILD dependencies,
+# and without adding "# pants: no-infer-dep" comments all over the codebase.
+# Revisit this in pants 2.16 to see if it is feasible to use the default "warning".
+unowned_dependency_behavior = "ignore"
+
 [bandit]
 lockfile = "lockfiles/bandit.lock"
 version = "bandit==1.7.0"


### PR DESCRIPTION
This updates to pants 2.14. We were on release candidates before.

pants 2.14 changed a default setting from `ignore` to `warning`, but most of the warnings are not actionable for us. Eventually, we should be able to address the warnings cleanly. For now, let's just ignore the warnings.

Alternatively, we could add `# pants: no-infer-dep` comments all over the place, which is not ideal.

We can revisit this setting in pants 2.16. A new feature under development for 2.16 should make cleaning up these warnings much easier, and therefore worth the effort.