### PR TITLE
pin GHA runners to ubuntu-20.04

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -12,7 +12,7 @@ jobs:
   # See: https://keepachangelog.com/en/1.0.0/
   changelog-checker:
     name: Add CHANGELOG.rst
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - name: Changelog check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
   # same file set which has already passed, etc.
   pre_job:
     name: Skip Duplicate Jobs Pre Job
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
@@ -45,7 +45,7 @@ jobs:
     # coverage, etc)
     # if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/master' }}
     name: '${{ matrix.name }} - Python ${{ matrix.python-version-short }}'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -143,7 +143,7 @@ jobs:
     # NB: disabled. See TODO above pre_job
     # if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/master' }}
     name: '${{ matrix.name }} - Python ${{ matrix.python-version-short }}'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -314,7 +314,7 @@ jobs:
     # coverage, etc)
     # if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/master' }}
     name: '${{ matrix.name }} - Python ${{ matrix.python-version-short }}'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -548,7 +548,7 @@ jobs:
       - lint-checks
       - unit-tests
       - integration-tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Workflow conclusion
         # this step creates an environment variable WORKFLOW_CONCLUSION and is the most reliable way to check the status of previous jobs

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,7 +26,7 @@ jobs:
   # Lint checks which don't depend on any service containes, etc. to be running.
   lint-checks:
     name: 'Lint Checks (pants runs: shellcheck, bandit, black, flake8)'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     env:
       COLUMNS: '120'

--- a/.github/workflows/microbenchmarks.yaml
+++ b/.github/workflows/microbenchmarks.yaml
@@ -11,7 +11,7 @@ jobs:
   # same file set which has already passed, etc.
   pre_job:
     name: Skip Duplicate Jobs Pre Job
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
@@ -27,7 +27,7 @@ jobs:
     # coverage, etc)
     if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/master' }}
     name: '${{ matrix.name }} - Python ${{ matrix.python-version-short }}'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -131,7 +131,7 @@ jobs:
     if: always()
     needs:
       - micro-benchmarks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Workflow conclusion
         # this step creates an environment variable WORKFLOW_CONCLUSION and is the most reliable way to check the status of previous jobs

--- a/.github/workflows/orquesta-integration-tests.yaml
+++ b/.github/workflows/orquesta-integration-tests.yaml
@@ -32,7 +32,7 @@ jobs:
   # same file set which has already passed, etc.
   pre_job:
     name: Skip Duplicate Jobs Pre Job
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
@@ -48,7 +48,7 @@ jobs:
     # coverage, etc)
     # if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref == 'refs/heads/master' }}
     name: '${{ matrix.name }} - Python ${{ matrix.python-version-short }}'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -243,7 +243,7 @@ jobs:
     if: always()
     needs:
       - integration-tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Workflow conclusion
         # this step creates an environment variable WORKFLOW_CONCLUSION and is the most reliable way to check the status of previous jobs

--- a/.github/workflows/pants.yaml
+++ b/.github/workflows/pants.yaml
@@ -21,7 +21,7 @@ on:
 jobs:
   pants-tailor:
     name: Make sure pants BUILD files are up-to-date
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
GHA just updated the ubuntu VM so that ubuntu-latest now points to 22.04.1 instead of 20.04.5

https://github.blog/changelog/2022-12-01-github-actions-larger-runners-using-ubuntu-latest-label-will-now-use-ubuntu-22-04/
 https://github.com/actions/runner-images/issues/6399

We have pinned python 3.6.13 and 3.8.10 in our workflows. There are NO 3.6.* versions available on ubuntu 22.04 in GHA. The oldest 3.8 version available is 3.8.12 on ubuntu 22.04 in GHA. So, we need to use `ubuntu-20.04` instead of `ubuntu-latest` for our workflows at least until we can drop python 3.6 support in CI.