### PR TITLE
pants: disambiguate test file dependencies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Added
 * Continue introducing `pants <https://www.pantsbuild.org/docs>`_ to improve DX (Developer Experience)
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
-  #5778 #5789 #5817 #5795 #5830
+  #5778 #5789 #5817 #5795 #5830 #5833
   Contributed by @cognifloyd
 
 

--- a/contrib/core/tests/BUILD
+++ b/contrib/core/tests/BUILD
@@ -1,1 +1,12 @@
-python_tests()
+python_tests(
+    overrides={
+        "test_action_sendmail.py": {
+            "dependencies": [
+                # contrib/core is symlinked to st2tests/st2tests/fixtures/packs/core
+                # so pants thinks "mail-parser" is defined twice, making it ambiguous.
+                # Use contrib/core as the canonical copy.
+                "contrib/core:reqs#mail-parser",
+            ],
+        }
+    },
+)

--- a/contrib/packs/tests/BUILD
+++ b/contrib/packs/tests/BUILD
@@ -1,1 +1,10 @@
-python_tests()
+python_tests(
+    overrides={
+        "test_action_download.py": {
+            "dependencies": [
+                # imports tests.fixtures which is ambiguous. Tell pants which one to use.
+                "contrib/packs/tests/fixtures",
+            ],
+        }
+    },
+)

--- a/contrib/runners/orquesta_runner/tests/unit/BUILD
+++ b/contrib/runners/orquesta_runner/tests/unit/BUILD
@@ -1,5 +1,9 @@
 python_tests(
     name="tests",
+    dependencies=[
+        # most files import tests.unit.base which is ambiguous. Tell pants which one to use.
+        "contrib/runners/orquesta_runner/tests/unit/base.py",
+    ],
 )
 
 python_sources()

--- a/st2auth/tests/unit/BUILD
+++ b/st2auth/tests/unit/BUILD
@@ -1,3 +1,7 @@
 python_tests(
     name="tests",
+    dependencies=[
+        # most files import tests.base which is ambiguous. Tell pants which one to use.
+        "st2auth/tests/base.py",
+    ],
 )

--- a/st2auth/tests/unit/controllers/v1/BUILD
+++ b/st2auth/tests/unit/controllers/v1/BUILD
@@ -1,3 +1,7 @@
 python_tests(
     name="tests",
+    dependencies=[
+        # most files import tests.base which is ambiguous. Tell pants which one to use.
+        "st2auth/tests/base.py",
+    ],
 )

--- a/st2client/tests/unit/BUILD
+++ b/st2client/tests/unit/BUILD
@@ -1,3 +1,7 @@
 python_tests(
     name="tests",
+    dependencies=[
+        # most files import tests.base which is ambiguous. Tell pants which one to use.
+        "st2client/tests/base.py",
+    ],
 )

--- a/st2common/tests/unit/BUILD
+++ b/st2common/tests/unit/BUILD
@@ -1,5 +1,9 @@
 python_tests(
     name="tests",
+    dependencies=[
+        # several files import tests.unit.base which is ambiguous. Tell pants which one to use.
+        "st2common/tests/unit/base.py",
+    ],
 )
 
 python_sources()


### PR DESCRIPTION
### Background

This is another part of introducing [pants](https://www.pantsbuild.org/docs), as discussed in various TSC meetings.

Related PRs can be found in:
- [pantsbuild](https://github.com/StackStorm/st2/milestone/47) milestone (which includes PRs since #5713)
- https://github.com/StackStorm/st2/labels/pantsbuild label (which also includes preparatory PRs that came before adding pantsbuild)

### Overview of this PR

Pants uses dependency inference, which the [docs](https://www.pantsbuild.org/docs/how-does-pants-work#dependency-inference) describe as:

> Pants analyzes your code's import statements to determine files' dependencies automatically. Dependency information is required for precise change detection and cache invalidation, but inference means that you don't need to declare dependencies manually (and hermetic execution guarantees that they are always accurate)!

However, sometimes that inference gets confused. For example, in several places our test files import `tests.base`, but we have multiple `**/tests/base.py` files, so pants doesn't know which one we're talking about, even though python itself understands exactly what we're talking about.

So, this PR resolves that ambiguity by explicitly defining dependencies in the BUILD files. In a few cases, we can add that dependency to the one file that needs it. But in other cases, lots of test files have the "ambiguous" import on `tests.base` or `tests.unit.base`. Adding the dep to each of those files would be painful to maintain, so I added it to all of the test files in the affected directories.

_Aside: In each case, I left a comment about why the dep was "ambiguous". I hope that a future version of pants will give us some knobs to tell the inference system how to resolve dependencies it thinks are ambiguous instead of adding it explicitly to more files than necessary. Including "ambiguous" in the BUILD file comment will make it easier to grep and figure out where we can adjust things once pants includes a feature like that._

#### Relevant Pants documentation

- [How Does Pants Work? | Dependency inference](https://www.pantsbuild.org/docs/how-does-pants-work#dependency-inference)
- [Troubleshooting | Import errors and missing dependencies](https://www.pantsbuild.org/docs/troubleshooting#import-errors-and-missing-dependencies)
- [Dependency Inference (blog article)](https://blog.pantsbuild.org/dependency-inference/)