### PR TITLE
clone packs into user_home/.st2packs directory

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ in development
 
 Added
 ~~~~~
+* Move `git clone` to `user_home/.st2packs` #5845
 
 * Error on `st2ctl status` when running in Kubernetes. #5851
   Contributed by @mamercad

--- a/st2common/st2common/util/pack_management.py
+++ b/st2common/st2common/util/pack_management.py
@@ -129,7 +129,7 @@ def download_pack(
     with lock_file:
         try:
             user_home = os.path.expanduser("~")
-            abs_local_path = os.path.join(user_home, temp_dir_name)
+            abs_local_path = os.path.join(user_home, ".st2packs", temp_dir_name)
 
             if pack_url.startswith("file://"):
                 # Local pack


### PR DESCRIPTION
Openshift does not allow packs to be cloned to home directory as they are mounted at `/`. Proposing to use a directory `.st2packs` in home directory.