### PR TITLE
pants: register assets (like conf files) and dependencies on them

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Added
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #5778 #5789 #5817 #5795 #5830 #5833 #5834 #5841 #5840 #5838 #5842 #5837 #5849 #5850
+  #5846
   Contributed by @cognifloyd
 
 * Added a joint index to solve the problem of slow mongo queries for scheduled executions. #5805

--- a/conf/BUILD
+++ b/conf/BUILD
@@ -1,0 +1,56 @@
+file(
+    name="st2client_sample_config",
+    source="st2rc.sample.ini",
+)
+
+file(
+    name="st2.conf.sample",
+    source="st2.conf.sample",
+)
+
+file(
+    name="logrotate",
+    source="logrotate.conf",
+)
+
+file(
+    name="nginx_sample_config",
+    source="nginx/st2.conf",
+)
+
+file(
+    name="st2_kvstore_demo_crypto_key",
+    source="st2_kvstore_demo.crypto.key.json",
+)
+
+files(
+    name="st2_tests_conf",
+    sources=[
+        "st2.tests*.conf",
+    ],
+    dependencies=[
+        "st2auth/conf:htpasswd",
+        "st2actions/conf:logging",
+        "st2reactor/conf:logging",
+        "st2tests/conf:other-logging-conf",
+    ],
+)
+
+file(
+    name="st2_dev_conf",
+    source="st2.dev.conf",
+    dependencies=[
+        ":st2_kvstore_demo_crypto_key",
+        "st2auth/conf:htpasswd",
+        "st2actions/conf:logging",
+        "st2api/conf:logging",
+        "st2auth/conf:logging",
+        "st2reactor/conf:logging",
+        "st2stream/conf:logging",
+    ],
+)
+
+file(
+    name="st2_package_conf",
+    source="st2.package.conf",
+)

--- a/conf/BUILD
+++ b/conf/BUILD
@@ -32,7 +32,7 @@ files(
         "st2auth/conf:htpasswd",
         "st2actions/conf:logging",
         "st2reactor/conf:logging",
-        "st2tests/conf:other-logging-conf",
+        "st2tests/conf:other_logging_conf",
     ],
 )
 

--- a/contrib/chatops/tests/BUILD
+++ b/contrib/chatops/tests/BUILD
@@ -1,3 +1,10 @@
+files(
+    name="fixtures",
+    sources=["fixtures/*.json"],
+)
+
 python_tests(
+    name="tests",
+    dependencies=[":fixtures"],
     skip_pylint=True,
 )

--- a/contrib/runners/action_chain_runner/action_chain_runner/BUILD
+++ b/contrib/runners/action_chain_runner/action_chain_runner/BUILD
@@ -1,1 +1,8 @@
-python_sources()
+resource(
+    name="runner_metadata",
+    source="runner.yaml",
+)
+
+python_sources(
+    dependencies=[":runner_metadata"],
+)

--- a/contrib/runners/announcement_runner/announcement_runner/BUILD
+++ b/contrib/runners/announcement_runner/announcement_runner/BUILD
@@ -1,1 +1,8 @@
-python_sources()
+resource(
+    name="runner_metadata",
+    source="runner.yaml",
+)
+
+python_sources(
+    dependencies=[":runner_metadata"],
+)

--- a/contrib/runners/http_runner/http_runner/BUILD
+++ b/contrib/runners/http_runner/http_runner/BUILD
@@ -1,1 +1,8 @@
-python_sources()
+resource(
+    name="runner_metadata",
+    source="runner.yaml",
+)
+
+python_sources(
+    dependencies=[":runner_metadata"],
+)

--- a/contrib/runners/inquirer_runner/inquirer_runner/BUILD
+++ b/contrib/runners/inquirer_runner/inquirer_runner/BUILD
@@ -1,1 +1,8 @@
-python_sources()
+resource(
+    name="runner_metadata",
+    source="runner.yaml",
+)
+
+python_sources(
+    dependencies=[":runner_metadata"],
+)

--- a/contrib/runners/local_runner/local_runner/BUILD
+++ b/contrib/runners/local_runner/local_runner/BUILD
@@ -1,1 +1,8 @@
-python_sources()
+resource(
+    name="runner_metadata",
+    source="runner.yaml",
+)
+
+python_sources(
+    dependencies=[":runner_metadata"],
+)

--- a/contrib/runners/noop_runner/noop_runner/BUILD
+++ b/contrib/runners/noop_runner/noop_runner/BUILD
@@ -1,1 +1,8 @@
-python_sources()
+resource(
+    name="runner_metadata",
+    source="runner.yaml",
+)
+
+python_sources(
+    dependencies=[":runner_metadata"],
+)

--- a/contrib/runners/orquesta_runner/orquesta_runner/BUILD
+++ b/contrib/runners/orquesta_runner/orquesta_runner/BUILD
@@ -1,1 +1,8 @@
-python_sources()
+resource(
+    name="runner_metadata",
+    source="runner.yaml",
+)
+
+python_sources(
+    dependencies=[":runner_metadata"],
+)

--- a/contrib/runners/python_runner/python_runner/BUILD
+++ b/contrib/runners/python_runner/python_runner/BUILD
@@ -1,1 +1,8 @@
-python_sources()
+resource(
+    name="runner_metadata",
+    source="runner.yaml",
+)
+
+python_sources(
+    dependencies=[":runner_metadata"],
+)

--- a/contrib/runners/remote_runner/remote_runner/BUILD
+++ b/contrib/runners/remote_runner/remote_runner/BUILD
@@ -1,1 +1,8 @@
-python_sources()
+resource(
+    name="runner_metadata",
+    source="runner.yaml",
+)
+
+python_sources(
+    dependencies=[":runner_metadata"],
+)

--- a/contrib/runners/winrm_runner/tests/unit/fixtures/BUILD
+++ b/contrib/runners/winrm_runner/tests/unit/fixtures/BUILD
@@ -1,1 +1,8 @@
-python_sources()
+files(
+    name="powershell",
+    sources=["*.ps1"],
+)
+
+python_sources(
+    dependencies=[":powershell"],
+)

--- a/contrib/runners/winrm_runner/winrm_runner/BUILD
+++ b/contrib/runners/winrm_runner/winrm_runner/BUILD
@@ -1,1 +1,8 @@
-python_sources()
+resource(
+    name="runner_metadata",
+    source="runner.yaml",
+)
+
+python_sources(
+    dependencies=[":runner_metadata"],
+)

--- a/scripts/github/BUILD
+++ b/scripts/github/BUILD
@@ -1,5 +1,5 @@
 files(
-    name="artifacts",
+    name="assets",
     sources=[
         "*.txt",
         "*.conf",
@@ -7,5 +7,5 @@ files(
 )
 
 shell_sources(
-    dependencies=[":artifacts"],
+    dependencies=[":assets"],
 )

--- a/scripts/github/BUILD
+++ b/scripts/github/BUILD
@@ -1,1 +1,11 @@
-shell_sources()
+files(
+    name="artifacts",
+    sources=[
+        "*.txt",
+        "*.conf",
+    ],
+)
+
+shell_sources(
+    dependencies=[":artifacts"],
+)

--- a/st2actions/conf/BUILD
+++ b/st2actions/conf/BUILD
@@ -1,0 +1,14 @@
+file(
+    name="logging_console",
+    source="console.conf",
+)
+
+files(
+    name="logging",
+    sources=["logging*.conf"],
+)
+
+files(
+    name="logging_syslog",
+    sources=["syslog*.conf"],
+)

--- a/st2api/conf/BUILD
+++ b/st2api/conf/BUILD
@@ -1,0 +1,19 @@
+file(
+    name="logging_console",
+    source="console.conf",
+)
+
+file(
+    name="logging",
+    source="logging.conf",
+)
+
+file(
+    name="logging_gunicorn",
+    source="logging.gunicorn.conf",
+)
+
+file(
+    name="logging_syslog",
+    source="syslog.conf",
+)

--- a/st2api/st2api/public/BUILD
+++ b/st2api/st2api/public/BUILD
@@ -1,0 +1,5 @@
+files(
+    sources=[
+        "images/*.png",
+    ],
+)

--- a/st2api/st2api/templates/BUILD
+++ b/st2api/st2api/templates/BUILD
@@ -1,0 +1,1 @@
+file(source="index.html")

--- a/st2api/tests/integration/BUILD
+++ b/st2api/tests/integration/BUILD
@@ -1,3 +1,6 @@
 python_tests(
     name="tests",
+    dependencies=[
+        "conf/st2.tests.conf:st2_tests_conf",
+    ],
 )

--- a/st2auth/conf/BUILD
+++ b/st2auth/conf/BUILD
@@ -1,0 +1,29 @@
+file(
+    name="apache_sample_conf",
+    source="apache.sample.conf",
+)
+
+file(
+    name="htpasswd",
+    source="htpasswd_dev",
+)
+
+file(
+    name="logging_console",
+    source="console.conf",
+)
+
+file(
+    name="logging",
+    source="logging.conf",
+)
+
+file(
+    name="logging_gunicorn",
+    source="logging.gunicorn.conf",
+)
+
+file(
+    name="logging_syslog",
+    source="syslog.conf",
+)

--- a/st2client/tests/fixtures/BUILD
+++ b/st2client/tests/fixtures/BUILD
@@ -4,7 +4,7 @@ resources(
 )
 
 resources(
-    name="st2client-ini",
+    name="st2client_ini",
     sources=["*.ini"],
 )
 

--- a/st2client/tests/fixtures/BUILD
+++ b/st2client/tests/fixtures/BUILD
@@ -1,1 +1,13 @@
-python_sources()
+resources(
+    name="execution_fixtures",
+    sources=["execution*.json", "execution*.txt"],
+)
+
+resources(
+    name="st2client-ini",
+    sources=["*.ini"],
+)
+
+python_sources(
+    dependencies=[":execution_fixtures"],
+)

--- a/st2client/tests/unit/BUILD
+++ b/st2client/tests/unit/BUILD
@@ -1,7 +1,7 @@
 python_tests(
     name="tests",
     dependencies=[
-        "st2client/tests/fixtures:st2client-ini",
+        "st2client/tests/fixtures:st2client_ini",
         # most files import tests.base which is ambiguous. Tell pants which one to use.
         "st2client/tests/base.py",
     ],

--- a/st2client/tests/unit/BUILD
+++ b/st2client/tests/unit/BUILD
@@ -1,6 +1,7 @@
 python_tests(
     name="tests",
     dependencies=[
+        "st2client/tests/fixtures:st2client-ini",
         # most files import tests.base which is ambiguous. Tell pants which one to use.
         "st2client/tests/base.py",
     ],

--- a/st2common/benchmarks/fixtures/json/BUILD
+++ b/st2common/benchmarks/fixtures/json/BUILD
@@ -1,0 +1,3 @@
+files(
+    sources=["*.json"],
+)

--- a/st2common/benchmarks/micro/BUILD
+++ b/st2common/benchmarks/micro/BUILD
@@ -1,4 +1,5 @@
 python_sources(
+    dependencies=["st2common/benchmarks/fixtures/json"],
     skip_pylint=True,
 )
 

--- a/st2common/st2common/BUILD
+++ b/st2common/st2common/BUILD
@@ -1,1 +1,11 @@
-python_sources()
+python_sources(
+    dependencies=[
+        ":openapi_spec",
+    ]
+)
+
+# These may be loaded with st2common.util.spec_loader
+resources(
+    name="openapi_spec",
+    sources=["openapi.yaml", "openapi.yaml.j2"],
+)

--- a/st2common/st2common/bootstrap/BUILD
+++ b/st2common/st2common/bootstrap/BUILD
@@ -1,1 +1,5 @@
-python_sources()
+python_sources(
+    dependencies=[
+        "st2common/st2common/policies/meta:policies_meta",
+    ]
+)

--- a/st2common/st2common/bootstrap/BUILD
+++ b/st2common/st2common/bootstrap/BUILD
@@ -1,5 +1,9 @@
 python_sources(
-    dependencies=[
-        "st2common/st2common/policies/meta:policies_meta",
-    ]
+    overrides={
+        "policiesregistrar.py": {
+            "dependencies": [
+                "st2common/st2common/policies/meta:policies_meta",
+            ],
+        },
+    },
 )

--- a/st2common/st2common/conf/BUILD
+++ b/st2common/st2common/conf/BUILD
@@ -1,0 +1,5 @@
+# used in st2common.constants.logging.DEFAULT_LOGGING_CONF_PATH
+resource(
+    name="base.logging.conf",
+    source="base.logging.conf",
+)

--- a/st2common/st2common/constants/BUILD
+++ b/st2common/st2common/constants/BUILD
@@ -1,1 +1,5 @@
-python_sources()
+python_sources(
+    dependencies=[
+        "st2common/st2common/conf:base.logging.conf",
+    ]
+)

--- a/st2common/st2common/policies/meta/BUILD
+++ b/st2common/st2common/policies/meta/BUILD
@@ -1,0 +1,5 @@
+# These are loaded by st2common.bootstrap.policiesregistrar
+resources(
+    name="policies_meta",
+    sources=["*.yaml"],
+)

--- a/st2common/st2common/util/schema/BUILD
+++ b/st2common/st2common/util/schema/BUILD
@@ -1,1 +1,10 @@
-python_sources()
+python_sources(
+    dependencies=[
+        ":jsonschema",
+    ]
+)
+
+resources(
+    name="jsonschema",
+    sources=["*.json"],
+)

--- a/st2common/tests/integration/BUILD
+++ b/st2common/tests/integration/BUILD
@@ -2,4 +2,9 @@ python_sources()
 
 python_tests(
     name="tests",
+    dependencies=[
+        # used by test_register_content_script
+        "conf/st2.tests.conf:st2_tests_conf",
+        "conf/st2.tests1.conf:st2_tests_conf",
+    ],
 )

--- a/st2common/tests/unit/test_util_file_system.py
+++ b/st2common/tests/unit/test_util_file_system.py
@@ -34,6 +34,7 @@ class FileSystemUtilsTestCase(unittest2.TestCase):
             "mock_exception.py",
             "concurrency.py",
             "__init__.py",
+            "meta/BUILD",
             "meta/mock_exception.yaml",
             "meta/concurrency.yaml",
             "meta/__init__.py",
@@ -49,6 +50,6 @@ class FileSystemUtilsTestCase(unittest2.TestCase):
             "meta/__init__.py",
         ]
         result = get_file_list(
-            directory=directory, exclude_patterns=["*.pyc", "*.yaml", "BUILD"]
+            directory=directory, exclude_patterns=["*.pyc", "*.yaml", "*BUILD"]
         )
         self.assertItemsEqual(expected, result)

--- a/st2reactor/conf/BUILD
+++ b/st2reactor/conf/BUILD
@@ -1,0 +1,14 @@
+file(
+    name="logging_console",
+    source="console.conf",
+)
+
+files(
+    name="logging",
+    sources=["logging*.conf"],
+)
+
+files(
+    name="logging_syslog",
+    sources=["syslog*.conf"],
+)

--- a/st2reactor/tests/fixtures/BUILD
+++ b/st2reactor/tests/fixtures/BUILD
@@ -1,0 +1,4 @@
+resources(
+    name="metadata",
+    sources=["*.yaml"],
+)

--- a/st2reactor/tests/fixtures/fixture/BUILD
+++ b/st2reactor/tests/fixtures/fixture/BUILD
@@ -1,1 +1,3 @@
-python_sources()
+python_sources(
+    dependencies=["st2reactor/tests/fixtures:metadata"],
+)

--- a/st2reactor/tests/integration/BUILD
+++ b/st2reactor/tests/integration/BUILD
@@ -1,3 +1,7 @@
 python_tests(
     name="tests",
+    dependencies=[
+        "conf/st2.tests.conf:st2_tests_conf",
+        "conf/st2.tests2.conf:st2_tests_conf",
+    ],
 )

--- a/st2stream/conf/BUILD
+++ b/st2stream/conf/BUILD
@@ -1,0 +1,19 @@
+file(
+    name="logging_console",
+    source="console.conf",
+)
+
+file(
+    name="logging",
+    source="logging.conf",
+)
+
+file(
+    name="logging_gunicorn",
+    source="logging.gunicorn.conf",
+)
+
+file(
+    name="logging_syslog",
+    source="syslog.conf",
+)

--- a/st2tests/conf/BUILD
+++ b/st2tests/conf/BUILD
@@ -1,0 +1,19 @@
+files(
+    name="st2.conf",
+    sources=["st2.conf"],
+)
+
+files(
+    name="st2_kvstore_tests.crypto.key.json",
+    sources=["st2_kvstore_tests.crypto.key.json"],
+)
+
+files(
+    name="logging.conf",
+    sources=["logging.conf"],
+)
+
+files(
+    name="other-logging-conf",
+    sources=["logging.*.conf"],
+)

--- a/st2tests/conf/BUILD
+++ b/st2tests/conf/BUILD
@@ -1,19 +1,24 @@
-files(
+file(
     name="st2.conf",
-    sources=["st2.conf"],
+    source="st2.conf",
 )
 
-files(
+file(
     name="st2_kvstore_tests.crypto.key.json",
-    sources=["st2_kvstore_tests.crypto.key.json"],
+    source="st2_kvstore_tests.crypto.key.json",
 )
 
-files(
+file(
     name="logging.conf",
-    sources=["logging.conf"],
+    source="logging.conf",
 )
 
 files(
     name="other-logging-conf",
     sources=["logging.*.conf"],
+)
+
+file(
+    name="vagrant_ssh_key",
+    source="vagrant.privkey.insecure",
 )

--- a/st2tests/conf/BUILD
+++ b/st2tests/conf/BUILD
@@ -14,7 +14,7 @@ file(
 )
 
 files(
-    name="other-logging-conf",
+    name="other_logging_conf",
     sources=["logging.*.conf"],
 )
 

--- a/st2tests/integration/BUILD
+++ b/st2tests/integration/BUILD
@@ -8,6 +8,7 @@ shell_sources(
     name="shell",
     dependencies=[
         "st2tests/conf:st2.conf",
+        "st2tests/conf:vagrant_ssh_key",
     ],
     skip_shellcheck=True,
 )

--- a/st2tests/integration/BUILD
+++ b/st2tests/integration/BUILD
@@ -6,5 +6,8 @@ __defaults__(
 
 shell_sources(
     name="shell",
+    dependencies=[
+        "st2tests/conf:st2.conf",
+    ],
     skip_shellcheck=True,
 )

--- a/st2tests/st2tests/BUILD
+++ b/st2tests/st2tests/BUILD
@@ -1,1 +1,7 @@
-python_sources()
+python_sources(
+    dependencies=[
+        "st2tests/conf:st2.conf",
+        "st2tests/conf:st2_kvstore_tests.crypto.key.json",
+        "st2tests/conf:logging.conf",
+    ],
+)

--- a/st2tests/st2tests/BUILD
+++ b/st2tests/st2tests/BUILD
@@ -3,5 +3,7 @@ python_sources(
         "st2tests/conf:st2.conf",
         "st2tests/conf:st2_kvstore_tests.crypto.key.json",
         "st2tests/conf:logging.conf",
+        "./resources:ssh",
+        "./resources:packs",
     ],
 )

--- a/st2tests/st2tests/fixtures/BUILD
+++ b/st2tests/st2tests/fixtures/BUILD
@@ -1,0 +1,8 @@
+resources(
+    # used by tests in st2-rbac-backend
+    name="rbac_fixtures",
+    sources=[
+        "./rbac/**/*.yaml",
+        "./rbac_invalid/**/*.yaml",
+    ],
+)

--- a/st2tests/st2tests/fixtures/conf/BUILD
+++ b/st2tests/st2tests/fixtures/conf/BUILD
@@ -5,7 +5,7 @@ resources(
         "logging.*.conf",  # used by st2.tests*.conf
     ],
     dependencies=[
-        "st2tests/conf:other-logging-conf",
+        "st2tests/conf:other_logging_conf",
         # depending on st2auth from st2tests is not nice.
         "st2auth/conf:htpasswd",
     ],

--- a/st2tests/st2tests/fixtures/conf/BUILD
+++ b/st2tests/st2tests/fixtures/conf/BUILD
@@ -1,12 +1,14 @@
 resources(
     name="st2.tests.conf",
-    sources=["st2.tests*.conf"],
-    dependencies=["st2tests/conf:other-logging-conf"],
-)
-
-files(
-    name="logging-conf",
-    sources=["logging.*.conf"],
+    sources=[
+        "st2.tests*.conf",
+        "logging.*.conf",  # used by st2.tests*.conf
+    ],
+    dependencies=[
+        "st2tests/conf:other-logging-conf",
+        # depending on st2auth from st2tests is not nice.
+        "st2auth/conf:htpasswd",
+    ],
 )
 
 python_sources(

--- a/st2tests/st2tests/fixtures/conf/BUILD
+++ b/st2tests/st2tests/fixtures/conf/BUILD
@@ -1,1 +1,12 @@
 python_sources()
+
+resources(
+    name="st2.tests.conf",
+    sources=["st2.tests*.conf"],
+    dependencies=["st2tests/conf:other-logging-conf"],
+)
+
+files(
+    name="logging-conf",
+    sources=["logging.*.conf"],
+)

--- a/st2tests/st2tests/fixtures/conf/BUILD
+++ b/st2tests/st2tests/fixtures/conf/BUILD
@@ -1,5 +1,3 @@
-python_sources()
-
 resources(
     name="st2.tests.conf",
     sources=["st2.tests*.conf"],
@@ -9,4 +7,10 @@ resources(
 files(
     name="logging-conf",
     sources=["logging.*.conf"],
+)
+
+python_sources(
+    dependencies=[
+        ":st2.tests.conf",
+    ],
 )

--- a/st2tests/st2tests/fixtures/history_views/BUILD
+++ b/st2tests/st2tests/fixtures/history_views/BUILD
@@ -1,8 +1,8 @@
 resources(
-    name="artifacts",
+    name="assets",
     sources=["*.yaml"],
 )
 
 python_sources(
-    dependencies=[":artifacts"],
+    dependencies=[":assets"],
 )

--- a/st2tests/st2tests/fixtures/history_views/BUILD
+++ b/st2tests/st2tests/fixtures/history_views/BUILD
@@ -1,1 +1,8 @@
-python_sources()
+resources(
+    name="artifacts",
+    sources=["*.yaml"],
+)
+
+python_sources(
+    dependencies=[":artifacts"],
+)

--- a/st2tests/st2tests/fixtures/keyczar_keys/BUILD
+++ b/st2tests/st2tests/fixtures/keyczar_keys/BUILD
@@ -1,8 +1,8 @@
 resources(
-    name="artifacts",
+    name="assets",
     sources=["*.json"],
 )
 
 python_sources(
-    dependencies=[":artifacts"],
+    dependencies=[":assets"],
 )

--- a/st2tests/st2tests/fixtures/keyczar_keys/BUILD
+++ b/st2tests/st2tests/fixtures/keyczar_keys/BUILD
@@ -1,1 +1,8 @@
-python_sources()
+resources(
+    name="artifacts",
+    sources=["*.json"],
+)
+
+python_sources(
+    dependencies=[":artifacts"],
+)

--- a/st2tests/st2tests/fixtures/packs/configs/BUILD
+++ b/st2tests/st2tests/fixtures/packs/configs/BUILD
@@ -1,0 +1,3 @@
+resources(
+    sources=["*.yaml"],
+)

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_1/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_1/BUILD
@@ -1,1 +1,5 @@
-python_sources()
+python_sources(
+    dependencies=[
+        "st2tests/st2tests/fixtures/packs/configs/dummy_pack_1.yaml",
+    ],
+)

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_11/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_11/BUILD
@@ -1,1 +1,5 @@
-python_sources()
+python_sources(
+    dependencies=[
+        "st2tests/st2tests/fixtures/packs/configs/dummy_pack_11.yaml",
+    ],
+)

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_19/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_19/BUILD
@@ -1,1 +1,5 @@
-python_sources()
+python_sources(
+    dependencies=[
+        "st2tests/st2tests/fixtures/packs/configs/dummy_pack_19.yaml",
+    ],
+)

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_22/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_22/BUILD
@@ -1,1 +1,5 @@
-python_sources()
+python_sources(
+    dependencies=[
+        "st2tests/st2tests/fixtures/packs/configs/dummy_pack_22.yaml",
+    ],
+)

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_5/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_5/BUILD
@@ -1,1 +1,5 @@
-python_sources()
+python_sources(
+    dependencies=[
+        "st2tests/st2tests/fixtures/packs/configs/dummy_pack_5.yaml",
+    ],
+)

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_6/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_6/BUILD
@@ -1,1 +1,5 @@
-python_sources()
+python_sources(
+    dependencies=[
+        "st2tests/st2tests/fixtures/packs/configs/dummy_pack_6.yaml",
+    ],
+)

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_7/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_7/BUILD
@@ -1,1 +1,5 @@
-python_sources()
+python_sources(
+    dependencies=[
+        "st2tests/st2tests/fixtures/packs/configs/dummy_pack_7.yaml",
+    ],
+)

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_nested_object_1/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_nested_object_1/BUILD
@@ -1,1 +1,5 @@
-python_sources()
+python_sources(
+    dependencies=[
+        "st2tests/st2tests/fixtures/packs/configs/dummy_pack_schema_with_nested_object_1.yaml",
+    ],
+)

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_nested_object_2/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_nested_object_2/BUILD
@@ -1,1 +1,5 @@
-python_sources()
+python_sources(
+    dependencies=[
+        "st2tests/st2tests/fixtures/packs/configs/dummy_pack_schema_with_nested_object_2.yaml",
+    ],
+)

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_nested_object_3/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_nested_object_3/BUILD
@@ -1,1 +1,5 @@
-python_sources()
+python_sources(
+    dependencies=[
+        "st2tests/st2tests/fixtures/packs/configs/dummy_pack_schema_with_nested_object_3.yaml",
+    ],
+)

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_nested_object_4/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_schema_with_nested_object_4/BUILD
@@ -1,1 +1,5 @@
-python_sources()
+python_sources(
+    dependencies=[
+        "st2tests/st2tests/fixtures/packs/configs/dummy_pack_schema_with_nested_object_4.yaml",
+    ],
+)

--- a/st2tests/st2tests/fixtures/packs/executions/BUILD
+++ b/st2tests/st2tests/fixtures/packs/executions/BUILD
@@ -1,1 +1,8 @@
-python_sources()
+resources(
+    name="artifacts",
+    sources=["*.yaml"],
+)
+
+python_sources(
+    dependencies=[":artifacts"],
+)

--- a/st2tests/st2tests/fixtures/specs/BUILD
+++ b/st2tests/st2tests/fixtures/specs/BUILD
@@ -1,0 +1,4 @@
+resource(
+    name="openapi_specs",
+    source="openapi.yaml.j2",
+)

--- a/st2tests/st2tests/fixtures/ssl_certs/BUILD
+++ b/st2tests/st2tests/fixtures/ssl_certs/BUILD
@@ -1,5 +1,5 @@
 resources(
-    name="artifacts",
+    name="assets",
     sources=[
         "**/*.cer",
         "**/*.cnf",
@@ -11,5 +11,5 @@ resources(
 )
 
 python_sources(
-    dependencies=[":artifacts"],
+    dependencies=[":assets"],
 )

--- a/st2tests/st2tests/fixtures/ssl_certs/BUILD
+++ b/st2tests/st2tests/fixtures/ssl_certs/BUILD
@@ -1,1 +1,15 @@
-python_sources()
+resources(
+    name="artifacts",
+    sources=[
+        "**/*.cer",
+        "**/*.cnf",
+        "**/*.p12",
+        "**/*.pem",
+        "ca/index.txt*",
+        "ca/serial*",
+    ],
+)
+
+python_sources(
+    dependencies=[":artifacts"],
+)

--- a/st2tests/st2tests/policies/meta/BUILD
+++ b/st2tests/st2tests/policies/meta/BUILD
@@ -1,4 +1,4 @@
 resources(
-    name="policies-meta",
+    name="policies_meta",
     sources=["*.yaml"],
 )

--- a/st2tests/st2tests/policies/meta/BUILD
+++ b/st2tests/st2tests/policies/meta/BUILD
@@ -1,0 +1,4 @@
+resources(
+    name="policies-meta",
+    sources=["*.yaml"],
+)

--- a/st2tests/st2tests/resources/BUILD
+++ b/st2tests/st2tests/resources/BUILD
@@ -1,0 +1,9 @@
+resources(
+    name="ssh",
+    sources=["ssh/*"],
+)
+
+resources(
+    name="packs",
+    sources=["packs/**", "!packs/**/BUILD"],
+)

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -7,4 +7,7 @@ shell_sources(
         "st2-setup-*",
     ],
     skip_shellcheck=True,
+    dependencies=[
+        "conf:st2_dev_conf",
+    ],
 )


### PR DESCRIPTION
### Background

This is another part of introducing [pants](https://www.pantsbuild.org/docs), as discussed in various TSC meetings.

Related PRs can be found in:
- [pantsbuild](https://github.com/StackStorm/st2/milestone/47) milestone (which includes PRs since #5713)
- https://github.com/StackStorm/st2/labels/pantsbuild label (which also includes preparatory PRs that came before adding pantsbuild)

### Overview of this PR

So far, we have told pants about our python and our shell sources. `./pants tailor ::` made that much easier. But we have more than just `*.py` and `*.sh` files; we have conf, ini, yaml, json, and many other kinds of files. In pants, these miscellaneous files are all ["assets"](https://www.pantsbuild.org/docs/assets), and `tailor` does not know what to do with them. So, we need to register the assets manually.

This PR registers most of our assets with one of these targets: `file`, `files`, `resource`, or `resources`.

This PR also registers dependencies on these assets. I think I captured all the dependencies, but we may have to tweak them if I missed something.

I recommend stepping through the commits so that you can quickly see what depends on the assets added in that commit.

#### Relevant Pants documentation

- [Assets and archives](https://www.pantsbuild.org/docs/assets)
    - [When to use each asset target type](https://www.pantsbuild.org/docs/assets#when-to-use-each-asset-target-type)
- individual source targets:
    - [`file`](https://www.pantsbuild.org/docs/reference-file)
    - [`resource`](https://www.pantsbuild.org/docs/reference-resource)
- multiple sources targets (aka target generators):
    - [`files`](https://www.pantsbuild.org/docs/reference-files)
    - [`resources`](https://www.pantsbuild.org/docs/reference-resources)

### Files vs Resources

It can be confusing to figure out whether we need to register the assets as files or resources. In my PoC branch, I started with files and then gradually switched things over to resources when needed (like for building wheels). We will probably have to tweak `file`/`resource` on some of these in the future.

_aside: There have been some discussions in the pantsbuild community about how `file` and `resource` could be combined into an `asset` target. Whether or not that happens, registering assets in pants will hopefully improve with time. For now, just think of "assets" as a helpful term to refer to both "files" and "resources"._

### Future PRs

- Follow-up PRs will introduce some plugins that add specific handling to some of the resources/files in this PR. This way, pants will be able to auto-generate or lint things like the api spec. I will make those once this PR is merged.

- I will register the `LICENSE` file in conjunction with the metadata that we need to build wheels.

- There is also a large set of assets that I have intentionally skipped in this PR: pack metadata (including yaml files for packs, actions, workflows, rules, etc, and a few other misc files that get included in packs). I wrote a pants plugin to handle registering these assets because there are a lot of them. The plugin teaches `./pants tailor ::` how to handle those files, automatically adding a custom `pack_metadata` target.