### PR TITLE
Add `pants-plugins/schemas` to streamline regenerating `contrib/schemas`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Added
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #5778 #5789 #5817 #5795 #5830 #5833 #5834 #5841 #5840 #5838 #5842 #5837 #5849 #5850
-  #5846 #5853 #5848
+  #5846 #5853 #5848 #5847
   Contributed by @cognifloyd
 
 * Added a joint index to solve the problem of slow mongo queries for scheduled executions. #5805

--- a/contrib/schemas/BUILD
+++ b/contrib/schemas/BUILD
@@ -1,0 +1,5 @@
+schemas(
+    dependencies=[
+        "st2common/bin/st2-generate-schemas",
+    ],
+)

--- a/pants-plugins/README.md
+++ b/pants-plugins/README.md
@@ -7,3 +7,15 @@ This replaces the Makefile and related scripts such that they are more discovera
 The plugins here add custom goals or other logic into pants.
 
 To see available goals, do "./pants help goals" and "./pants help $goal".
+
+These StackStorm-specific plugins are probably only useful for the st2 repo.
+- `schemas`
+
+### `schemas` plugin
+
+This plugin wires up pants to make sure `contrib/schemas/*.json` gets
+regenerated whenever the source files change. Now, whenever someone runs
+the `fmt` goal (eg `./pants fmt contrib/schemas::`), the schemas will
+be regenerated if any of the files used to generate them have changed.
+Also, running the `lint` goal will fail if the schemas need to be
+regenerated.

--- a/pants-plugins/schemas/BUILD
+++ b/pants-plugins/schemas/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/pants-plugins/schemas/BUILD
+++ b/pants-plugins/schemas/BUILD
@@ -1,1 +1,5 @@
 python_sources()
+
+python_tests(
+    name="tests",
+)

--- a/pants-plugins/schemas/register.py
+++ b/pants-plugins/schemas/register.py
@@ -1,0 +1,24 @@
+# Copyright 2022 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from schemas.rules import rules as schemas_rules
+from schemas.target_types import Schemas
+
+
+def rules():
+    return [*schemas_rules()]
+
+
+def target_types():
+    return [Schemas]

--- a/pants-plugins/schemas/register.py
+++ b/pants-plugins/schemas/register.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The StackStorm Authors.
+# Copyright 2023 The StackStorm Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pants-plugins/schemas/rules.py
+++ b/pants-plugins/schemas/rules.py
@@ -19,7 +19,7 @@ from pants.backend.python.util_rules.pex import (
     VenvPexProcess,
 )
 from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
-from pants.core.goals.fmt import FmtResult, FmtRequest
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import (
     Digest,
@@ -44,7 +44,7 @@ class GenerateSchemasFieldSet(FieldSet):
     sources: SchemasSourcesField
 
 
-class GenerateSchemasViaFmtRequest(FmtRequest):
+class GenerateSchemasViaFmtTargetsRequest(FmtTargetsRequest):
     field_set_type = GenerateSchemasFieldSet
     name = CMD
 
@@ -54,7 +54,7 @@ class GenerateSchemasViaFmtRequest(FmtRequest):
     level=LogLevel.DEBUG,
 )
 async def generate_schemas_via_fmt(
-    request: GenerateSchemasViaFmtRequest,
+    request: GenerateSchemasViaFmtTargetsRequest,
 ) -> FmtResult:
     # There will only be one target+field_set, but we iterate
     # to satisfy how fmt expects that there could be more than one.
@@ -98,5 +98,5 @@ async def generate_schemas_via_fmt(
 def rules():
     return [
         *collect_rules(),
-        UnionRule(FmtRequest, GenerateSchemasViaFmtRequest),
+        UnionRule(FmtTargetsRequest, GenerateSchemasViaFmtTargetsRequest),
     ]

--- a/pants-plugins/schemas/rules.py
+++ b/pants-plugins/schemas/rules.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The StackStorm Authors.
+# Copyright 2023 The StackStorm Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pants-plugins/schemas/rules.py
+++ b/pants-plugins/schemas/rules.py
@@ -1,0 +1,102 @@
+# Copyright 2021 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from dataclasses import dataclass
+
+from pants.backend.python.target_types import EntryPoint
+from pants.backend.python.util_rules.pex import (
+    VenvPex,
+    VenvPexProcess,
+)
+from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
+from pants.core.goals.fmt import FmtResult, FmtRequest
+from pants.engine.addresses import Address
+from pants.engine.fs import (
+    Digest,
+    Snapshot,
+)
+from pants.engine.process import FallibleProcessResult
+from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.target import FieldSet
+from pants.engine.unions import UnionRule
+from pants.util.logging import LogLevel
+
+from schemas.target_types import SchemasSourcesField
+
+
+CMD = "generate_schemas"
+
+
+@dataclass(frozen=True)
+class GenerateSchemasFieldSet(FieldSet):
+    required_fields = (SchemasSourcesField,)
+
+    sources: SchemasSourcesField
+
+
+class GenerateSchemasViaFmtRequest(FmtRequest):
+    field_set_type = GenerateSchemasFieldSet
+    name = CMD
+
+
+@rule(
+    desc="Update contrib/schemas/*.json with st2-generate-schemas",
+    level=LogLevel.DEBUG,
+)
+async def generate_schemas_via_fmt(
+    request: GenerateSchemasViaFmtRequest,
+) -> FmtResult:
+    # There will only be one target+field_set, but we iterate
+    # to satisfy how fmt expects that there could be more than one.
+
+    # actually generate it with an external script.
+    # Generation cannot be inlined here because it needs to import the st2 code.
+    pex = await Get(
+        VenvPex,
+        PexFromTargetsRequest(
+            [
+                Address(
+                    "st2common/st2common/cmd",
+                    target_name="cmd",
+                    relative_file_path=f"{CMD}.py",
+                )
+            ],
+            output_filename=f"{CMD}.pex",
+            internal_only=True,
+            main=EntryPoint.parse("st2common.cmd.{CMD}:main"),
+        ),
+    )
+
+    output_directory = "contrib/schemas"
+
+    result = await Get(
+        FallibleProcessResult,
+        VenvPexProcess(
+            pex,
+            argv=(output_directory,),
+            input_digest=request.snapshot.digest,
+            output_directories=[output_directory],
+            description="Regenerating st2 metadata schemas in contrib/schemas",
+            level=LogLevel.DEBUG,
+        ),
+    )
+
+    output_snapshot = await Get(Snapshot, Digest, result.output_digest)
+    return FmtResult.create(request, result, output_snapshot, strip_chroot_path=True)
+
+
+def rules():
+    return [
+        *collect_rules(),
+        UnionRule(FmtRequest, GenerateSchemasViaFmtRequest),
+    ]

--- a/pants-plugins/schemas/rules.py
+++ b/pants-plugins/schemas/rules.py
@@ -22,11 +22,7 @@ from pants.backend.python.util_rules.pex import (
 from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
 from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.engine.addresses import Address
-from pants.engine.fs import (
-    Digest,
-    MergeDigests,
-    Snapshot,
-)
+from pants.engine.fs import MergeDigests, Snapshot
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSet
@@ -36,8 +32,10 @@ from pants.util.logging import LogLevel
 from schemas.target_types import SchemasSourcesField
 
 
+# these constants are also used in the tests.
 CMD_SOURCE_ROOT = "st2common"
 CMD_DIR = "st2common/st2common/cmd"
+CMD_MODULE = "st2common.cmd"
 CMD = "generate_schemas"
 
 
@@ -77,7 +75,7 @@ async def generate_schemas_via_fmt(
             ],
             output_filename=f"{CMD}.pex",
             internal_only=True,
-            main=EntryPoint.parse(f"st2common.cmd.{CMD}:main"),
+            main=EntryPoint.parse(f"{CMD_MODULE}.{CMD}:main"),
         ),
     )
 

--- a/pants-plugins/schemas/rules.py
+++ b/pants-plugins/schemas/rules.py
@@ -14,7 +14,7 @@
 from dataclasses import dataclass
 
 from pants.backend.python.target_types import EntryPoint
-from pants.backend.python.util_rules import pex
+from pants.backend.python.util_rules import pex, pex_from_targets
 from pants.backend.python.util_rules.pex import (
     VenvPex,
     VenvPexProcess,
@@ -101,4 +101,5 @@ def rules():
         *collect_rules(),
         UnionRule(FmtTargetsRequest, GenerateSchemasViaFmtTargetsRequest),
         *pex.rules(),
+        *pex_from_targets.rules(),
     ]

--- a/pants-plugins/schemas/rules.py
+++ b/pants-plugins/schemas/rules.py
@@ -14,6 +14,7 @@
 from dataclasses import dataclass
 
 from pants.backend.python.target_types import EntryPoint
+from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import (
     VenvPex,
     VenvPexProcess,
@@ -99,4 +100,5 @@ def rules():
     return [
         *collect_rules(),
         UnionRule(FmtTargetsRequest, GenerateSchemasViaFmtTargetsRequest),
+        *pex.rules(),
     ]

--- a/pants-plugins/schemas/rules.py
+++ b/pants-plugins/schemas/rules.py
@@ -35,6 +35,7 @@ from pants.util.logging import LogLevel
 from schemas.target_types import SchemasSourcesField
 
 
+CMD_DIR = "st2common/st2common/cmd"
 CMD = "generate_schemas"
 
 
@@ -67,7 +68,7 @@ async def generate_schemas_via_fmt(
         PexFromTargetsRequest(
             [
                 Address(
-                    "st2common/st2common/cmd",
+                    CMD_DIR,
                     target_name="cmd",
                     relative_file_path=f"{CMD}.py",
                 )

--- a/pants-plugins/schemas/rules_test.py
+++ b/pants-plugins/schemas/rules_test.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The StackStorm Authors.
+# Copyright 2023 The StackStorm Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pants-plugins/schemas/rules_test.py
+++ b/pants-plugins/schemas/rules_test.py
@@ -11,17 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 import pytest
 
-from pants.backend.python import target_types_rules
-from pants.backend.python.target_types import PythonSourcesGeneratorTarget
-from pants.core.util_rules import config_files, source_files
+from pants.core.util_rules import source_files
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.target import Target
 from pants.core.goals.fmt import FmtResult
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 from .rules import GenerateSchemasFieldSet, GenerateSchemasViaFmtTargetsRequest, rules as schemas_rules
+from .target_types import Schemas
 
 
 @pytest.fixture
@@ -29,13 +30,11 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *schemas_rules(),
-            *bandit_subsystem_rules(),
             *source_files.rules(),
-            *config_files.rules(),
-            *target_types_rules.rules(),
             QueryRule(FmtResult, (GenerateSchemasViaFmtTargetsRequest,)),
+            QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
-        target_types=[PythonSourcesGeneratorTarget],
+        target_types=[Schemas],
     )
 
 

--- a/pants-plugins/schemas/rules_test.py
+++ b/pants-plugins/schemas/rules_test.py
@@ -15,12 +15,8 @@ from __future__ import annotations
 
 import pytest
 
-from pants.backend.python import target_types_rules
-from pants.core.util_rules import source_files
-from pants.core.util_rules.archive import rules as archive_rules
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.core.util_rules import system_binaries
-from pants.engine.fs import rules as fs_rules
+from pants.engine.addresses import Address
 from pants.engine.target import Target
 from pants.core.goals.fmt import FmtResult
 from pants.testutil.rule_runner import QueryRule, RuleRunner
@@ -34,11 +30,6 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *schemas_rules(),
-            *source_files.rules(),
-            *archive_rules(),
-            *fs_rules(),
-            *system_binaries.rules(),
-            *target_types_rules.rules(),
             QueryRule(FmtResult, (GenerateSchemasViaFmtTargetsRequest,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
@@ -60,7 +51,7 @@ def run_st2_generate_schemas(
     input_sources = rule_runner.request(
         SourceFiles,
         [
-            SourceFilesRequest(field_set.source for field_set in field_sets),
+            SourceFilesRequest(field_set.sources for field_set in field_sets),
         ],
     )
     fmt_result = rule_runner.request(

--- a/pants-plugins/schemas/rules_test.py
+++ b/pants-plugins/schemas/rules_test.py
@@ -1,0 +1,79 @@
+# Copyright 2022 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from pants.backend.python import target_types_rules
+from pants.backend.python.target_types import PythonSourcesGeneratorTarget
+from pants.core.util_rules import config_files, source_files
+from pants.engine.target import Target
+from pants.core.goals.fmt import FmtResult
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+from .rules import GenerateSchemasFieldSet, GenerateSchemasViaFmtTargetsRequest, rules as schemas_rules
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *schemas_rules(),
+            *bandit_subsystem_rules(),
+            *source_files.rules(),
+            *config_files.rules(),
+            *target_types_rules.rules(),
+            QueryRule(FmtResult, (GenerateSchemasViaFmtTargetsRequest,)),
+        ],
+        target_types=[PythonSourcesGeneratorTarget],
+    )
+
+
+def run_st2_generate_schemas(
+    rule_runner: RuleRunner, targets: list[Target], *, extra_args: list[str] | None = None
+) -> FmtResult:
+    rule_runner.set_options(
+        [
+            "--backend-packages=schemas",
+            *(extra_args or ()),
+        ],
+        env_inherit={"PATH", "PYENV_ROOT", "HOME"},
+    )
+    field_sets = [GenerateSchemasFieldSet.create(tgt) for tgt in targets]
+    input_sources = rule_runner.request(
+        SourceFiles,
+        [
+            SourceFilesRequest(field_set.source for field_set in field_sets),
+        ],
+    )
+    fmt_result = rule_runner.request(
+        FmtResult,
+        [
+            GenerateSchemasViaFmtTargetsRequest(field_sets, snapshot=input_sources.snapshot),
+        ],
+    )
+    return results.results
+
+
+# copied from pantsbuild/pants.git/src/python/pants/backend/python/lint/black/rules_integration_test.py
+def get_snapshot(rule_runner: RuleRunner, source_files: dict[str, str]) -> Snapshot:
+    files = [FileContent(path, content.encode()) for path, content in source_files.items()]
+    digest = rule_runner.request(Digest, [CreateDigest(files)])
+    return rule_runner.request(Snapshot, [digest])
+
+
+def test_something(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files({"action.json": "{}", "BUILD": "schemas(name='t')"})
+    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="action.json"))
+    fmt_result = run_st2_generate_schemas(rule_runner, [tgt])
+    # TODO: add asserts

--- a/pants-plugins/schemas/rules_test.py
+++ b/pants-plugins/schemas/rules_test.py
@@ -15,8 +15,12 @@ from __future__ import annotations
 
 import pytest
 
+from pants.backend.python import target_types_rules
 from pants.core.util_rules import source_files
+from pants.core.util_rules.archive import rules as archive_rules
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.core.util_rules import system_binaries
+from pants.engine.fs import rules as fs_rules
 from pants.engine.target import Target
 from pants.core.goals.fmt import FmtResult
 from pants.testutil.rule_runner import QueryRule, RuleRunner
@@ -31,6 +35,10 @@ def rule_runner() -> RuleRunner:
         rules=[
             *schemas_rules(),
             *source_files.rules(),
+            *archive_rules(),
+            *fs_rules(),
+            *system_binaries.rules(),
+            *target_types_rules.rules(),
             QueryRule(FmtResult, (GenerateSchemasViaFmtTargetsRequest,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],

--- a/pants-plugins/schemas/target_types.py
+++ b/pants-plugins/schemas/target_types.py
@@ -1,0 +1,37 @@
+# Copyright 2022 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pants.engine.fs import GlobMatchErrorBehavior
+from pants.engine.target import (
+    COMMON_TARGET_FIELDS,
+    Dependencies,
+    MultipleSourcesField,
+    Target,
+)
+
+
+class SchemasSourcesField(MultipleSourcesField):
+    expected_file_extensions = (".json",)
+    default = ("*.json",)
+    uses_source_roots = False
+
+    # make sure at least one schema is present or fmt will be skipped.
+    default_glob_match_error_behavior = GlobMatchErrorBehavior.error
+
+
+class Schemas(Target):
+    alias = "schemas"
+    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, SchemasSourcesField)
+    help = (
+        "Generate st2 metadata (pack, action, rule, ...) schemas from python sources."
+    )

--- a/pants-plugins/schemas/target_types.py
+++ b/pants-plugins/schemas/target_types.py
@@ -17,6 +17,7 @@ from pants.engine.target import (
     Dependencies,
     MultipleSourcesField,
     Target,
+    generate_multiple_sources_field_help_message,
 )
 
 
@@ -27,6 +28,10 @@ class SchemasSourcesField(MultipleSourcesField):
 
     # make sure at least one schema is present or fmt will be skipped.
     default_glob_match_error_behavior = GlobMatchErrorBehavior.error
+
+    help = generate_multiple_sources_field_help_message(
+        "Example: `sources=['*.json', '!ignore.json']`"
+    )
 
 
 class Schemas(Target):

--- a/pants-plugins/schemas/target_types.py
+++ b/pants-plugins/schemas/target_types.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The StackStorm Authors.
+# Copyright 2023 The StackStorm Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pants.toml
+++ b/pants.toml
@@ -24,6 +24,7 @@ backend_packages = [
 
   # internal plugins in pants-plugins/
   "pants.backend.plugin_development",
+  "schemas",
 ]
 # pants ignores files in .gitignore, .*/ directories, /dist/ directory, and __pycache__.
 pants_ignore.add = [


### PR DESCRIPTION
### Background

This is another part of introducing [pants](https://www.pantsbuild.org/docs), as discussed in various TSC meetings.

Related PRs can be found in:
- [pantsbuild](https://github.com/StackStorm/st2/milestone/47) milestone (which includes PRs since #5713)
- https://github.com/StackStorm/st2/labels/pantsbuild label (which also includes preparatory PRs that came before adding pantsbuild)

### Overview of this PR

This PR improves the DX (developer experience) by wiring up the `fmt` and `lint` goals to generate `contrib/schemas/*.json` if needed (or for lint, warn that it needs to be done).

This includes creating a `schemas` plugin for pants that adds a `schemas` target.

### Developer Experience

Today, if someone changes one of the files used to generate the schemas in `contrib/schemas`, they will probably forget to run the Makefile target the regenerates them: `make schemasgen`.

I've missed running that several times. If I'm lucky, CI complains with an error telling me to run that. I've seen CI logs print an error without actually failing the build. I believe that particular Makefile bug is fixed, but that anecdote highlights a usability issue: friction around generated files.

With this PR, we add schema generation into the `fmt` goal. This also adds it to the `lint` goal which will tell people if `fmt` needs to run to update any code (or in this case, regenerate the schema). Then, we only need simple instructions that say something like:

> Please run `./pants fmt lint ::` before submitting your PR. This will reformat code, if needed, and warn you about any other errors.

### Fine grained results cache

After someone runs `./pants fmt ::` once, they will benefit from the pants' results cache. For the schemas plugin, here's what that means:

First, the `schemas` target in `contrib/schemas` depends on `st2common/bin/st2-generate-schemas`:

https://github.com/StackStorm/st2/blob/d4fba5621e50aa3ba57404f72b8e6748158d063c/contrib/schemas/BUILD#L1-L5

If the `st2-generate-schemas` script changes, then pants now knows that the schemas need to be regenerated. Or, in other words, the `st2-generate-schemas` file is part of the cache key for `contrib/schemas/*.json`. If that file changes, then pants will re-run the generator.

`st2-generate-schemas` is a python script, and we use pants' python dependency inference. So pants (effectively) also adds the python files imported by `st2-generate-schemas` to the cache key. Stepping through the code, we can see what pants would infer:

https://github.com/StackStorm/st2/blob/d4fba5621e50aa3ba57404f72b8e6748158d063c/st2common/bin/st2-generate-schemas#L32
https://github.com/StackStorm/st2/blob/d4fba5621e50aa3ba57404f72b8e6748158d063c/st2common/st2common/cmd/generate_schemas.py#L26-L30

Here we reach the primary definition for the schemas that end up in `contrib/schemas`: the definition comes from the `st2common.model.api.*` modules. Now, if anyone changes any of these files, or any of the python bits that get imported to help define things in them, then the next time someone runs the `lint` goal (or in CI) they will find out that they need to run the `fmt` goal.

This PR actually only wires up the `fmt` goal and took advantage of the fact that pants also runs formatters whenever it runs linters, which are side-effect free. And because pants runs the formatters in a sandbox, it doesn't have to materialize any changes during lint.

Continuing the example, since pants cached the results when running the `lint` goal, running `fmt` will be very fast. Pants will just materialize the already-generated schemas from its cache.

### Developing pants plugins

Pants has extensive documentation on the plugin API, including how to create targets, how to write rules, and there's even a mini tutorial about how to add a formatter (adding formatters is a very common thing for plugins to do).

- [Plugins overview](https://www.pantsbuild.org/docs/plugins-overview)
- [The Target API](https://www.pantsbuild.org/docs/target-api)
- [The Rules API](https://www.pantsbuild.org/docs/rules-api)
- [Processes](https://www.pantsbuild.org/docs/rules-api-process) (running subprocesses in pants plugins)
- [Add a formatter](https://www.pantsbuild.org/docs/plugins-fmt-goal)
- [Testing Plugins](https://www.pantsbuild.org/docs/rules-api-testing)

### Why not `codegen`?

Pants has something called `codegen`. But it is for code that gets generated without getting checked into the repo. You can export those changes, but they are always exported in a directory under `dist/`, so we would have to add some custom logic somewhere that copies from `dist/` to the `contrib/schemas` directory. 

These schemas are only available in this repo; if someone wants to use them, they have to clone the repo or grab the raw file from github. So, they have to be checked into the repo. We might be able to do something different in the future, but I'm trying not to change more than I have to to introduce pants.