### PR TITLE
GHA workflow to run (some) tests via pantsbuild

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -57,7 +57,7 @@ jobs:
           ./scripts/github/install-apt-packages-use-cache.sh
 
       - name: Initialize Pants and its GHA caches
-        uses: pantsbuild/actions/init-pants@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
+        uses: pantsbuild/actions/init-pants@v2
         # This action adds an env var to make pants use both pants.ci.toml & pants.toml.
         # This action also creates 3 GHA caches (1 is optional).
         # - `pants-setup` has the bootsrapped pants install

--- a/.github/workflows/pants.yaml
+++ b/.github/workflows/pants.yaml
@@ -30,7 +30,7 @@ jobs:
           submodules: 'true'
 
       - name: Initialize Pants and its GHA caches
-        uses: pantsbuild/actions/init-pants@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
+        uses: pantsbuild/actions/init-pants@v2
         # This action adds an env var to make pants use both pants.ci.toml & pants.toml.
         # This action also creates 3 GHA caches (1 is optional).
         # - `pants-setup` has the bootsrapped pants install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,7 +57,7 @@ jobs:
           ./scripts/github/install-apt-packages-use-cache.sh
 
       - name: Initialize Pants and its GHA caches
-        uses: pantsbuild/actions/init-pants@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
+        uses: pantsbuild/actions/init-pants@v2
         # This action adds an env var to make pants use both pants.ci.toml & pants.toml.
         # This action also creates 3 GHA caches (1 is optional).
         # - `pants-setup` has the bootsrapped pants install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,6 @@
 ---
-# This Lint workflow uses pants
-name: Lint
+# This Test workflow uses pants
+name: Test
 
 on:
   push:
@@ -23,10 +23,21 @@ on:
   #  - cron:  '0 0 * * *'
 
 jobs:
-  # Lint checks which don't depend on any service containes, etc. to be running.
-  lint-checks:
-    name: 'Tests: (pants runs: pytest)'
+  test:
+    name: '${{ matrix.name }} - Python ${{ matrix.python-version-short }}'
     runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        # NOTE: We need to use full Python version as part of Python deps cache key otherwise
+        # setup virtualenv step will fail.
+        include:
+          - name: 'Test (pants runs: pytest)'
+            python-version-short: '3.6'
+            python-version: '3.6.13'
+          - name: 'Test (pants runs: pytest)'
+            python-version-short: '3.8'
+            python-version: '3.8.10'
 
     env:
       COLUMNS: '120'
@@ -37,6 +48,12 @@ jobs:
         with:
           # a test uses a submodule, and pants needs access to it to calculate deps.
           submodules: 'true'
+
+      - name: 'Set up Python (${{ matrix.python-version }})'
+        uses: actions/setup-python@v2
+        with:
+          python-version: '${{ matrix.python-version }}'
+
 
       #- name: Cache APT Dependencies
       #  id: cache-apt-deps
@@ -69,7 +86,7 @@ jobs:
         with:
           base-branch: master
           # To ignore a bad cache, bump the cache* integer.
-          gha-cache-key: cache0
+          gha-cache-key: cache0-py${{ matrix.python-version }}
           # This hash should include all of our lockfiles so that the pip/pex caches
           # get invalidated on any transitive dependency update.
           named-caches-hash: ${{ hashFiles('requirements.txt') }}
@@ -78,7 +95,7 @@ jobs:
 
       - name: Test
         # We do not support running pytest everywhere yet. When we do it will be simply:
-        #   ./pants lint ::
+        #   ./pants test ::
         # Until then, we need to manually adjust this command line to test what we can.
         run: |
           ./pants test pylint_plugins/:: pants-plugins/::

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,91 @@
+---
+# This Lint workflow uses pants
+name: Lint
+
+on:
+  push:
+    branches:
+      # only on merges to master branch
+      - master
+      # and version branches, which only include minor versions (eg: v3.4)
+      - v[0-9]+.[0-9]+
+    tags:
+      # also version tags, which include bugfix releases (eg: v3.4.0)
+      - v[0-9]+.[0-9]+.[0-9]+
+  pull_request:
+    type: [opened, reopened, edited]
+    branches:
+      # Only for PRs targeting those branches
+      - master
+      - v[0-9]+.[0-9]+
+  #schedule:
+  #  # run every night at midnight
+  #  - cron:  '0 0 * * *'
+
+jobs:
+  # Lint checks which don't depend on any service containes, etc. to be running.
+  lint-checks:
+    name: 'Tests: (pants runs: pytest)'
+    runs-on: ubuntu-20.04
+
+    env:
+      COLUMNS: '120'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          # a test uses a submodule, and pants needs access to it to calculate deps.
+          submodules: 'true'
+
+      #- name: Cache APT Dependencies
+      #  id: cache-apt-deps
+      #  uses: actions/cache@v2
+      #  with:
+      #    path: |
+      #      ~/apt_cache
+      #    key: ${{ runner.os }}-apt-v7-${{ hashFiles('scripts/github/apt-packages.txt') }}
+      #    restore-keys: |
+      #      ${{ runner.os }}-apt-v7-
+      - name: Install APT Depedencies
+        env:
+          CACHE_HIT: 'false' # cache doesn't work
+          #CACHE_HIT: ${{steps.cache-apt-deps.outputs.cache-hit}}
+        run: |
+          # install dev dependencies for Python YAML and LDAP packages
+          # https://github.com/StackStorm/st2-auth-ldap
+          ./scripts/github/install-apt-packages-use-cache.sh
+
+      - name: Initialize Pants and its GHA caches
+        uses: pantsbuild/actions/init-pants@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
+        # This action adds an env var to make pants use both pants.ci.toml & pants.toml.
+        # This action also creates 3 GHA caches (1 is optional).
+        # - `pants-setup` has the bootsrapped pants install
+        # - `pants-named-caches` has pip/wheel and PEX caches
+        # - `pants-lmdb-store` has the fine-grained process cache.
+        #   If we ever use a remote cache, then we can drop this.
+        #   Otherwise, we may need an additional workflow or job to delete old caches
+        #   if they are not expiring fast enough, and we hit the GHA 10GB per repo max.
+        with:
+          base-branch: master
+          # To ignore a bad cache, bump the cache* integer.
+          gha-cache-key: cache0
+          # This hash should include all of our lockfiles so that the pip/pex caches
+          # get invalidated on any transitive dependency update.
+          named-caches-hash: ${{ hashFiles('requirements.txt') }}
+          # enable the optional lmdb_store cache since we're not using remote caching.
+          cache-lmdb-store: 'true'
+
+      - name: Test
+        # We do not support running pytest everywhere yet. When we do it will be simply:
+        #   ./pants lint ::
+        # Until then, we need to manually adjust this command line to test what we can.
+        run: |
+          ./pants test pylint_plugins/:: pants-plugins/::
+
+      - name: Upload pants log
+        uses: actions/upload-artifact@v2
+        with:
+          name: pants-log-py${{ matrix.python-version }}
+          path: .pants.d/pants.log
+        if: always()  # We want the log even on failures.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Added
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #5778 #5789 #5817 #5795 #5830 #5833 #5834 #5841 #5840 #5838 #5842 #5837 #5849 #5850
-  #5846 #5853
+  #5846 #5853 #5848
   Contributed by @cognifloyd
 
 * Added a joint index to solve the problem of slow mongo queries for scheduled executions. #5805


### PR DESCRIPTION
### Background

This is another part of introducing [pants](https://www.pantsbuild.org/docs), as discussed in various TSC meetings.

Related PRs can be found in:
- [pantsbuild](https://github.com/StackStorm/st2/milestone/47) milestone (which includes PRs since #5713)
- https://github.com/StackStorm/st2/labels/pantsbuild label (which also includes preparatory PRs that came before adding pantsbuild)

### Overview of this PR

This adds a `Test` GHA workflow that uses pants to run tests. Our test suite does not support running via pytest (which is what pants uses), so this workflow only runs tests on `pylint_plugins/` and `pants-plugins/`. We can slowly expand this as we get more of our tests runnable under pytest.

The reason I'm doing this now: I want to add tests for plugins that will go in `pants-plugins/`, and I want to use pants to run those tests. `pylint_plugins/` serves as a starting point to show that testing is doing something before we add those pants plugins and related tests.

#5849 was split off of this PR to make review easier. #5849 is required before this PR can be rebased and then merged.