### PR TITLE
use a fixture for pylint_plugins test

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Added
 * Continue introducing `pants <https://www.pantsbuild.org/docs>`_ to improve DX (Developer Experience)
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
-  #5778 #5789 #5817 #5795 #5830 #5833 #5834 #5841 #5840 #5838 #5842 #5837
+  #5778 #5789 #5817 #5795 #5830 #5833 #5834 #5841 #5840 #5838 #5842 #5837 #5849
   Contributed by @cognifloyd
 
 

--- a/pylint_plugins/BUILD
+++ b/pylint_plugins/BUILD
@@ -9,6 +9,7 @@ python_sources()
 python_tests(
     name="tests",
     dependencies=[
+        "./fixtures",
         "!//conftest.py:test_utils",
     ],
 )

--- a/pylint_plugins/api_models_test.py
+++ b/pylint_plugins/api_models_test.py
@@ -25,9 +25,15 @@ import pylint.testutils
 try:
     # TODO: remove this once we remove the Makefile
     from . import api_models
+
+    FIXTURE_MODULE_ACTION = "pylint_plugins.fixtures.api_models"
+    FIXTURE_MODULE_TRIGGER = "pylint_plugins.fixtures.api_models"
 except ImportError:
     # pylint_plugins is on PYTHONPATH
     import api_models
+
+    FIXTURE_MODULE_ACTION = "fixtures.api_models"
+    FIXTURE_MODULE_TRIGGER = "fixtures.api_models"
 
 
 def test_skiplist_class_gets_skipped():
@@ -135,12 +141,13 @@ def test_copied_schema():
 def test_copied_imported_schema():
     code = """
     import copy
-    from st2common.models.api.action import ActionAPI
+    from %s import ActionAPI
 
     class ActionCreateAPI(object):
         schema = copy.deepcopy(ActionAPI.schema)
         schema["properties"]["default_files"] = {}
     """
+    code = code % FIXTURE_MODULE_ACTION
 
     res = parse(code)
 
@@ -163,13 +170,14 @@ def test_copied_imported_schema():
 def test_indirect_copied_schema():
     code = """
     import copy
-    from st2common.models.api.action import ActionAPI
+    from %s import ActionAPI
 
     REQUIRED_ATTR_SCHEMAS = {"action": copy.deepcopy(ActionAPI.schema)}
 
     class ExecutionAPI(object):
         schema = {"properties": {"action": REQUIRED_ATTR_SCHEMAS["action"]}}
     """
+    code = code % FIXTURE_MODULE_ACTION
 
     res = parse(code)
 
@@ -187,11 +195,12 @@ def test_indirect_copied_schema():
 
 def test_inlined_schema():
     code = """
-    from st2common.models.api.trigger import TriggerAPI
+    from %s import TriggerAPI
 
     class ActionExecutionAPI(object):
         schema = {"properties": {"trigger": TriggerAPI.schema}}
     """
+    code = code % FIXTURE_MODULE_TRIGGER
 
     res = parse(code)
 

--- a/pylint_plugins/fixtures/BUILD
+++ b/pylint_plugins/fixtures/BUILD
@@ -1,0 +1,4 @@
+python_test_utils(
+    sources=["*.py"],
+    skip_pylint=True,
+)

--- a/pylint_plugins/fixtures/api_models.py
+++ b/pylint_plugins/fixtures/api_models.py
@@ -18,6 +18,7 @@ import abc
 DEFAULT_PACK_NAME = "default"
 
 
+# copied from st2common.models.api.notification
 NotificationSubSchemaAPI = {
     "type": "object",
     "properties": {
@@ -43,13 +44,13 @@ def get_schema(**kwargs):
     return {}
 
 
-# copied from st2common.models.api.base
+# copied (in part) from st2common.models.api.base
 class BaseAPI(abc.ABC):
     schema = abc.abstractproperty
     name = None
 
 
-# copied from st2common.models.api.action
+# copied (in part) from st2common.models.api.action
 class ActionAPI(BaseAPI):
     """
     The system entity that represents a Stack Action/Automation in the system.
@@ -132,6 +133,7 @@ class ActionAPI(BaseAPI):
     }
 
 
+# copied (in part) from st2common.models.api.trigger
 class TriggerTypeAPI(BaseAPI):
     schema = {
         "type": "object",

--- a/pylint_plugins/fixtures/api_models.py
+++ b/pylint_plugins/fixtures/api_models.py
@@ -1,0 +1,159 @@
+# Copyright 2022 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import abc
+
+DEFAULT_PACK_NAME = "default"
+
+
+NotificationSubSchemaAPI = {
+    "type": "object",
+    "properties": {
+        "message": {"type": "string", "description": "Message to use for notification"},
+        "data": {
+            "type": "object",
+            "description": "Data to be sent as part of notification",
+        },
+        "routes": {
+            "type": "array",
+            "description": "Channels to post notifications to.",
+        },
+        "channels": {  # Deprecated. Only here for backward compatibility.
+            "type": "array",
+            "description": "Channels to post notifications to.",
+        },
+    },
+    "additionalProperties": False,
+}
+
+
+def get_schema(**kwargs):
+    return {}
+
+
+# copied from st2common.models.api.base
+class BaseAPI(abc.ABC):
+    schema = abc.abstractproperty
+    name = None
+
+
+# copied from st2common.models.api.action
+class ActionAPI(BaseAPI):
+    """
+    The system entity that represents a Stack Action/Automation in the system.
+    """
+
+    schema = {
+        "title": "Action",
+        "description": "An activity that happens as a response to the external event.",
+        "type": "object",
+        "properties": {
+            "id": {
+                "description": "The unique identifier for the action.",
+                "type": "string",
+            },
+            "ref": {
+                "description": "System computed user friendly reference for the action. \
+                                Provided value will be overridden by computed value.",
+                "type": "string",
+            },
+            "uid": {"type": "string"},
+            "name": {  # used in test
+                "description": "The name of the action.",
+                "type": "string",
+                "required": True,
+            },
+            "description": {  # used in test
+                "description": "The description of the action.",
+                "type": "string",
+            },
+            "enabled": {
+                "description": "Enable or disable the action from invocation.",
+                "type": "boolean",
+                "default": True,
+            },
+            "runner_type": {  # used in test
+                "description": "The type of runner that executes the action.",
+                "type": "string",
+                "required": True,
+            },
+            "entry_point": {
+                "description": "The entry point for the action.",
+                "type": "string",
+                "default": "",
+            },
+            "pack": {
+                "description": "The content pack this action belongs to.",
+                "type": "string",
+                "default": DEFAULT_PACK_NAME,
+            },
+            "parameters": {
+                "description": "Input parameters for the action.",
+                "type": "object",
+                "patternProperties": {r"^\w+$": get_schema()},
+                "additionalProperties": False,
+                "default": {},
+            },
+            "output_schema": get_schema(description="Action Output Schema"),
+            "tags": {
+                "description": "User associated metadata assigned to this object.",
+                "type": "array",
+                "items": {"type": "object"},
+            },
+            "notify": {
+                "description": "Notification settings for action.",
+                "type": "object",
+                "properties": {
+                    "on-complete": NotificationSubSchemaAPI,
+                    "on-failure": NotificationSubSchemaAPI,
+                    "on-success": NotificationSubSchemaAPI,
+                },
+                "additionalProperties": False,
+            },
+            "metadata_file": {
+                "description": "Path to the metadata file relative to the pack directory.",
+                "type": "string",
+                "default": "",
+            },
+        },
+        "additionalProperties": False,
+    }
+
+
+class TriggerTypeAPI(BaseAPI):
+    schema = {
+        "type": "object",
+        "properties": {
+            "id": {"type": "string", "default": None},
+            "ref": {"type": "string"},
+            "uid": {"type": "string"},
+            "name": {"type": "string", "required": True},
+            "pack": {"type": "string"},
+            "description": {"type": "string"},
+            "payload_schema": {"type": "object", "default": {}},
+            "parameters_schema": {"type": "object", "default": {}},
+            "tags": {
+                "description": "User associated metadata assigned to this object.",
+                "type": "array",
+                "items": {"type": "object"},
+            },
+            "metadata_file": {
+                "description": "Path to the metadata file relative to the pack directory.",
+                "type": "string",
+                "default": "",
+            },
+        },
+        "additionalProperties": False,
+    }

--- a/st2common/st2common/models/api/action.py
+++ b/st2common/st2common/models/api/action.py
@@ -165,6 +165,7 @@ class RunnerTypeAPI(BaseAPI):
         return model
 
 
+# NOTE: Update pylint_plugins/fixtures/api_models.py if this changes significantly
 class ActionAPI(BaseAPI, APIUIDMixin):
     """
     The system entity that represents a Stack Action/Automation in the system.

--- a/st2common/st2common/models/api/base.py
+++ b/st2common/st2common/models/api/base.py
@@ -29,6 +29,7 @@ __all__ = ["BaseAPI", "APIUIDMixin"]
 LOG = logging.getLogger(__name__)
 
 
+# NOTE: Update pylint_plugins/fixtures/api_models.py if this changes significantly
 @six.add_metaclass(abc.ABCMeta)
 class BaseAPI(object):
     schema = abc.abstractproperty

--- a/st2common/st2common/models/api/notification.py
+++ b/st2common/st2common/models/api/notification.py
@@ -16,6 +16,8 @@
 from __future__ import absolute_import
 from st2common.models.db.notification import NotificationSchema, NotificationSubSchema
 
+
+# NOTE: Update pylint_plugins/fixtures/api_models.py if this changes significantly
 NotificationSubSchemaAPI = {
     "type": "object",
     "properties": {

--- a/st2common/st2common/models/api/trigger.py
+++ b/st2common/st2common/models/api/trigger.py
@@ -26,6 +26,7 @@ from st2common.models.system.common import ResourceReference
 DATE_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
 
 
+# NOTE: Update pylint_plugins/fixtures/api_models.py if this changes significantly
 class TriggerTypeAPI(BaseAPI):
     model = TriggerTypeDB
     schema = {


### PR DESCRIPTION
### Background

This is another part of introducing [pants](https://www.pantsbuild.org/docs), as discussed in various TSC meetings.

Related PRs can be found in:
- [pantsbuild](https://github.com/StackStorm/st2/milestone/47) milestone (which includes PRs since #5713)
- https://github.com/StackStorm/st2/labels/pantsbuild label (which also includes preparatory PRs that came before adding pantsbuild)

### Overview of this PR

In #5848, I will add a GHA workflow to run some tests via pants, starting with tests in `pylint_plugins/`. But, the current tests in pylint_plugins import from `st2common` because that was a quick way to throw together the tests. This is a problem because `pylint_plugins/` and `st2*` each use different resolves (and therefore separate lockfiles). That means that pants puts together the sandbox for running the pylint_plugins tests, it will not include the st2* modules.

Note that running pylint ON our source code works just fine. In that case, pants knows we need pylint + any source plugins for pylint + the source code that pylint needs to inspect. For tests, however, everything is based on dependencies between targets. I could use a pants feature that puts our code in both the `st2` and the `pylint_plugins` resolve, but that makes the lockfile and BUILD file management more complex.

So, I copied a few bits from `st2common` into a test fixture for the pylint_plugins tests. The Makefile runs the pylint_plugins tests just before it runs pylint, so look in the "CI / Compile" jobs to see the test results (which pass). I've also tested with pants in #5848 to make sure this change works for both ways to test this.