### PR TITLE
Error on n`st2ctl status` when running in k8s

### DIFF
--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -69,6 +69,13 @@ function must_be_root() {
     fi
 }
 
+function not_running_in_k8s() {
+    if [ -n "$KUBERNETES_SERVICE_HOST" ]; then
+        echo -e "\e[31mError: \"st2ctl status\" is not supported under Kubernetes \e[0m\n"
+        exit 1
+    fi
+}
+
 function validate_in_components() {
   COM=${1}
 
@@ -263,6 +270,7 @@ case ${1} in
     fi
     ;;
   status)
+    not_running_in_k8s
     getpids
     ;;
   *)


### PR DESCRIPTION
Error on `st2ctl status` when running in k8s; fixes [this](https://github.com/StackStorm/stackstorm-k8s/issues/314).