### PR TITLE
Add Mark Mercado (@mamercad) to the StackStorm Contributors

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -57,6 +57,7 @@ They're not part of the TSC voting process, but appreciated for their contributi
 * Anand Patel ([@arms11](https://github.com/arms11)), _VMware_ - Docker, Kubernetes.
 * Harsh Nanchahal ([@hnanchahal](https://github.com/hnanchahal)), _Starbucks_ - Core, Docker, Kubernetes.
 * Hiroyasu Ohyama ([@userlocalhost](https://github.com/userlocalhost)) - Orquesta, Workflows, st2 Japan Community. [Case Study](https://stackstorm.com/case-study-dmm/).
+* Mark Mercado ([@mamercad](https://github.com/mamercad)), _DigitalOcean_ - Ansible, Docker, K8s, StackStorm Exchange. [StackStorm Adoption](https://github.com/StackStorm/st2/pull/5836).
 * Rick Kauffman ([@xod442](https://github.com/xod442)), _HPE_ - Community, HOWTOs, Blogs, Publications, Docker.
 * Sheshagiri Rao Mallipedhi ([@sheshagiri](https://github.com/sheshagiri)) - Docker, Core, StackStorm Exchange.
 * Shital Raut ([@shital-orchestral](https://github.com/shital-orchestral)), _Orchestral.ai_ - Web UI.


### PR DESCRIPTION
I'd like to highlight the open-source contributions made by Mark Mercado @mamercad.
Mark is leading the StackStorm adoption at @DigitalOcean ([Add DigitalOcean as an adopter #5836](https://github.com/StackStorm/st2/pull/5836)) and was helping a lot with fixing and improving the broken things here and there.

### Ansible-st2 overhaul:
- https://github.com/StackStorm/ansible-st2/pull/319
- https://github.com/StackStorm/ansible-st2/pull/317
- https://github.com/StackStorm/ansible-st2/pull/307
- https://github.com/StackStorm/ansible-st2/pull/323
- https://github.com/StackStorm/ansible-st2/pull/327
- https://github.com/StackStorm/ansible-st2/pull/325
- https://github.com/StackStorm/ansible-st2/pull/326

@mamercad is adding StackStorm via `ansible-st2` to [1-click droplets](https://www.digitalocean.com/community/tags/one-click-install-apps) which will allow having StackStorm deployment automated in one-click at DO, see: [Add StackStorm 1-Click Droplet app #85 ](https://github.com/digitalocean/droplet-1-clicks/pull/85).

### Docker and K8s enhancements and fixes:
- https://github.com/StackStorm/st2/pull/5851
- https://github.com/StackStorm/stackstorm-k8s/pull/339
- https://github.com/StackStorm/stackstorm-k8s/pull/338 - fixing the CI :green_circle: 
- https://github.com/StackStorm/stackstorm-k8s/pull/340
- https://github.com/StackStorm/stackstorm-k8s/pull/341 
- https://github.com/StackStorm/st2-docker/pull/250
- https://github.com/StackStorm/st2-docker/pull/252
- https://github.com/StackStorm/st2docs/pull/1132

### StackStorm-Exchange CI/CD improvements and fixes:
- https://github.com/StackStorm-Exchange/index/pull/27 https://github.com/StackStorm-Exchange/ci/pull/137
- https://github.com/StackStorm-Exchange/ci/pull/138
- https://github.com/StackStorm-Exchange/stackstorm-jira/pull/49

The Exchange CI work ^^ will help to re-enable expired by github after `60d` CI workflows for all the exchange packs, solving one of the pain points we were having.

### And more
https://twitter.com/StackStorm/status/1578031022952026112
![Screenshot 2022-12-19 at 14-52-26 StackStorm on Twitter_DO](https://user-images.githubusercontent.com/1533818/208453568-4da5447b-569a-4310-82e0-051b57c3040a.png)

----

I'd like to thank Mark for his improvements and fixes to StackStorm.
We'd be happy to see more @mamercad presence around the [TSC](https://github.com/StackStorm/st2/blob/master/GOVERNANCE.md) activities in the future and wishing a smooth sailing at @DigitalOcean with @StackStorm!