### PR TITLE
pants: use `__defaults__` to propogate unit,integration,benchmarks tags on tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Added
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #5778 #5789 #5817 #5795 #5830 #5833 #5834 #5841 #5840 #5838 #5842 #5837 #5849 #5850
-  #5846
+  #5846 #5853
   Contributed by @cognifloyd
 
 * Added a joint index to solve the problem of slow mongo queries for scheduled executions. #5805

--- a/contrib/runners/action_chain_runner/tests/integration/BUILD
+++ b/contrib/runners/action_chain_runner/tests/integration/BUILD
@@ -1,4 +1,4 @@
 __defaults__(
-    {python_tests: dict(tags=["integration"])},
+    {(python_test, python_tests): dict(tags=["integration"])},
     extend=True,
 )

--- a/contrib/runners/action_chain_runner/tests/integration/BUILD
+++ b/contrib/runners/action_chain_runner/tests/integration/BUILD
@@ -2,7 +2,3 @@ __defaults__(
     {python_tests: dict(tags=["integration"])},
     extend=True,
 )
-
-python_tests(
-    name="tests",
-)

--- a/contrib/runners/action_chain_runner/tests/unit/BUILD
+++ b/contrib/runners/action_chain_runner/tests/unit/BUILD
@@ -1,5 +1,5 @@
 __defaults__(
-    {python_tests: dict(tags=["unit"])},
+    {(python_test, python_tests): dict(tags=["unit"])},
     extend=True,
 )
 

--- a/contrib/runners/action_chain_runner/tests/unit/BUILD
+++ b/contrib/runners/action_chain_runner/tests/unit/BUILD
@@ -1,3 +1,8 @@
+__defaults__(
+    {python_tests: dict(tags=["unit"])},
+    extend=True,
+)
+
 python_tests(
     name="tests",
 )

--- a/contrib/runners/announcement_runner/tests/integration/BUILD
+++ b/contrib/runners/announcement_runner/tests/integration/BUILD
@@ -1,4 +1,4 @@
 __defaults__(
-    {python_tests: dict(tags=["integration"])},
+    {(python_test, python_tests): dict(tags=["integration"])},
     extend=True,
 )

--- a/contrib/runners/announcement_runner/tests/integration/BUILD
+++ b/contrib/runners/announcement_runner/tests/integration/BUILD
@@ -2,7 +2,3 @@ __defaults__(
     {python_tests: dict(tags=["integration"])},
     extend=True,
 )
-
-python_tests(
-    name="tests",
-)

--- a/contrib/runners/announcement_runner/tests/unit/BUILD
+++ b/contrib/runners/announcement_runner/tests/unit/BUILD
@@ -1,5 +1,5 @@
 __defaults__(
-    {python_tests: dict(tags=["unit"])},
+    {(python_test, python_tests): dict(tags=["unit"])},
     extend=True,
 )
 

--- a/contrib/runners/announcement_runner/tests/unit/BUILD
+++ b/contrib/runners/announcement_runner/tests/unit/BUILD
@@ -1,3 +1,8 @@
+__defaults__(
+    {python_tests: dict(tags=["unit"])},
+    extend=True,
+)
+
 python_tests(
     name="tests",
 )

--- a/contrib/runners/http_runner/tests/integration/BUILD
+++ b/contrib/runners/http_runner/tests/integration/BUILD
@@ -1,4 +1,4 @@
 __defaults__(
-    {python_tests: dict(tags=["integration"])},
+    {(python_test, python_tests): dict(tags=["integration"])},
     extend=True,
 )

--- a/contrib/runners/http_runner/tests/integration/BUILD
+++ b/contrib/runners/http_runner/tests/integration/BUILD
@@ -2,7 +2,3 @@ __defaults__(
     {python_tests: dict(tags=["integration"])},
     extend=True,
 )
-
-python_tests(
-    name="tests",
-)

--- a/contrib/runners/http_runner/tests/unit/BUILD
+++ b/contrib/runners/http_runner/tests/unit/BUILD
@@ -1,5 +1,5 @@
 __defaults__(
-    {python_tests: dict(tags=["unit"])},
+    {(python_test, python_tests): dict(tags=["unit"])},
     extend=True,
 )
 

--- a/contrib/runners/http_runner/tests/unit/BUILD
+++ b/contrib/runners/http_runner/tests/unit/BUILD
@@ -1,3 +1,8 @@
+__defaults__(
+    {python_tests: dict(tags=["unit"])},
+    extend=True,
+)
+
 python_tests(
     name="tests",
 )

--- a/contrib/runners/inquirer_runner/tests/integration/BUILD
+++ b/contrib/runners/inquirer_runner/tests/integration/BUILD
@@ -1,4 +1,4 @@
 __defaults__(
-    {python_tests: dict(tags=["integration"])},
+    {(python_test, python_tests): dict(tags=["integration"])},
     extend=True,
 )

--- a/contrib/runners/inquirer_runner/tests/integration/BUILD
+++ b/contrib/runners/inquirer_runner/tests/integration/BUILD
@@ -2,7 +2,3 @@ __defaults__(
     {python_tests: dict(tags=["integration"])},
     extend=True,
 )
-
-python_tests(
-    name="tests",
-)

--- a/contrib/runners/inquirer_runner/tests/unit/BUILD
+++ b/contrib/runners/inquirer_runner/tests/unit/BUILD
@@ -1,5 +1,5 @@
 __defaults__(
-    {python_tests: dict(tags=["unit"])},
+    {(python_test, python_tests): dict(tags=["unit"])},
     extend=True,
 )
 

--- a/contrib/runners/inquirer_runner/tests/unit/BUILD
+++ b/contrib/runners/inquirer_runner/tests/unit/BUILD
@@ -1,3 +1,8 @@
+__defaults__(
+    {python_tests: dict(tags=["unit"])},
+    extend=True,
+)
+
 python_tests(
     name="tests",
 )

--- a/contrib/runners/local_runner/tests/integration/BUILD
+++ b/contrib/runners/local_runner/tests/integration/BUILD
@@ -1,5 +1,5 @@
 __defaults__(
-    {python_tests: dict(tags=["integration"])},
+    {(python_test, python_tests): dict(tags=["integration"])},
     extend=True,
 )
 

--- a/contrib/runners/local_runner/tests/integration/BUILD
+++ b/contrib/runners/local_runner/tests/integration/BUILD
@@ -1,3 +1,8 @@
+__defaults__(
+    {python_tests: dict(tags=["integration"])},
+    extend=True,
+)
+
 python_tests(
     name="tests",
 )

--- a/contrib/runners/local_runner/tests/unit/BUILD
+++ b/contrib/runners/local_runner/tests/unit/BUILD
@@ -1,4 +1,4 @@
 __defaults__(
-    {python_tests: dict(tags=["unit"])},
+    {(python_test, python_tests): dict(tags=["unit"])},
     extend=True,
 )

--- a/contrib/runners/local_runner/tests/unit/BUILD
+++ b/contrib/runners/local_runner/tests/unit/BUILD
@@ -2,7 +2,3 @@ __defaults__(
     {python_tests: dict(tags=["unit"])},
     extend=True,
 )
-
-python_tests(
-    name="tests",
-)

--- a/contrib/runners/noop_runner/tests/integration/BUILD
+++ b/contrib/runners/noop_runner/tests/integration/BUILD
@@ -1,4 +1,4 @@
 __defaults__(
-    {python_tests: dict(tags=["integration"])},
+    {(python_test, python_tests): dict(tags=["integration"])},
     extend=True,
 )

--- a/contrib/runners/noop_runner/tests/integration/BUILD
+++ b/contrib/runners/noop_runner/tests/integration/BUILD
@@ -2,7 +2,3 @@ __defaults__(
     {python_tests: dict(tags=["integration"])},
     extend=True,
 )
-
-python_tests(
-    name="tests",
-)

--- a/contrib/runners/noop_runner/tests/unit/BUILD
+++ b/contrib/runners/noop_runner/tests/unit/BUILD
@@ -1,5 +1,5 @@
 __defaults__(
-    {python_tests: dict(tags=["unit"])},
+    {(python_test, python_tests): dict(tags=["unit"])},
     extend=True,
 )
 

--- a/contrib/runners/noop_runner/tests/unit/BUILD
+++ b/contrib/runners/noop_runner/tests/unit/BUILD
@@ -1,3 +1,8 @@
+__defaults__(
+    {python_tests: dict(tags=["unit"])},
+    extend=True,
+)
+
 python_tests(
     name="tests",
 )

--- a/contrib/runners/orquesta_runner/tests/integration/BUILD
+++ b/contrib/runners/orquesta_runner/tests/integration/BUILD
@@ -1,5 +1,5 @@
 __defaults__(
-    {python_tests: dict(tags=["integration"])},
+    {(python_test, python_tests): dict(tags=["integration"])},
     extend=True,
 )
 

--- a/contrib/runners/orquesta_runner/tests/integration/BUILD
+++ b/contrib/runners/orquesta_runner/tests/integration/BUILD
@@ -1,3 +1,8 @@
+__defaults__(
+    {python_tests: dict(tags=["integration"])},
+    extend=True,
+)
+
 python_tests(
     name="tests",
 )

--- a/contrib/runners/orquesta_runner/tests/unit/BUILD
+++ b/contrib/runners/orquesta_runner/tests/unit/BUILD
@@ -1,5 +1,5 @@
 __defaults__(
-    {python_tests: dict(tags=["unit"])},
+    {(python_test, python_tests): dict(tags=["unit"])},
     extend=True,
 )
 

--- a/contrib/runners/orquesta_runner/tests/unit/BUILD
+++ b/contrib/runners/orquesta_runner/tests/unit/BUILD
@@ -1,3 +1,8 @@
+__defaults__(
+    {python_tests: dict(tags=["unit"])},
+    extend=True,
+)
+
 python_tests(
     name="tests",
     dependencies=[

--- a/contrib/runners/python_runner/tests/integration/BUILD
+++ b/contrib/runners/python_runner/tests/integration/BUILD
@@ -1,5 +1,5 @@
 __defaults__(
-    {python_tests: dict(tags=["integration"])},
+    {(python_test, python_tests): dict(tags=["integration"])},
     extend=True,
 )
 

--- a/contrib/runners/python_runner/tests/integration/BUILD
+++ b/contrib/runners/python_runner/tests/integration/BUILD
@@ -1,3 +1,8 @@
+__defaults__(
+    {python_tests: dict(tags=["integration"])},
+    extend=True,
+)
+
 python_tests(
     name="tests",
 )

--- a/contrib/runners/python_runner/tests/unit/BUILD
+++ b/contrib/runners/python_runner/tests/unit/BUILD
@@ -1,5 +1,5 @@
 __defaults__(
-    {python_tests: dict(tags=["unit"])},
+    {(python_test, python_tests): dict(tags=["unit"])},
     extend=True,
 )
 

--- a/contrib/runners/python_runner/tests/unit/BUILD
+++ b/contrib/runners/python_runner/tests/unit/BUILD
@@ -1,3 +1,8 @@
+__defaults__(
+    {python_tests: dict(tags=["unit"])},
+    extend=True,
+)
+
 python_tests(
     name="tests",
 )

--- a/contrib/runners/remote_runner/tests/integration/BUILD
+++ b/contrib/runners/remote_runner/tests/integration/BUILD
@@ -1,4 +1,4 @@
 __defaults__(
-    {python_tests: dict(tags=["integration"])},
+    {(python_test, python_tests): dict(tags=["integration"])},
     extend=True,
 )

--- a/contrib/runners/remote_runner/tests/integration/BUILD
+++ b/contrib/runners/remote_runner/tests/integration/BUILD
@@ -2,7 +2,3 @@ __defaults__(
     {python_tests: dict(tags=["integration"])},
     extend=True,
 )
-
-python_tests(
-    name="tests",
-)

--- a/contrib/runners/remote_runner/tests/unit/BUILD
+++ b/contrib/runners/remote_runner/tests/unit/BUILD
@@ -1,4 +1,4 @@
 __defaults__(
-    {python_tests: dict(tags=["unit"])},
+    {(python_test, python_tests): dict(tags=["unit"])},
     extend=True,
 )

--- a/contrib/runners/remote_runner/tests/unit/BUILD
+++ b/contrib/runners/remote_runner/tests/unit/BUILD
@@ -2,7 +2,3 @@ __defaults__(
     {python_tests: dict(tags=["unit"])},
     extend=True,
 )
-
-python_tests(
-    name="tests",
-)

--- a/contrib/runners/winrm_runner/tests/integration/BUILD
+++ b/contrib/runners/winrm_runner/tests/integration/BUILD
@@ -1,4 +1,4 @@
 __defaults__(
-    {python_tests: dict(tags=["integration"])},
+    {(python_test, python_tests): dict(tags=["integration"])},
     extend=True,
 )

--- a/contrib/runners/winrm_runner/tests/integration/BUILD
+++ b/contrib/runners/winrm_runner/tests/integration/BUILD
@@ -2,7 +2,3 @@ __defaults__(
     {python_tests: dict(tags=["integration"])},
     extend=True,
 )
-
-python_tests(
-    name="tests",
-)

--- a/contrib/runners/winrm_runner/tests/unit/BUILD
+++ b/contrib/runners/winrm_runner/tests/unit/BUILD
@@ -1,5 +1,5 @@
 __defaults__(
-    {python_tests: dict(tags=["unit"])},
+    {(python_test, python_tests): dict(tags=["unit"])},
     extend=True,
 )
 

--- a/contrib/runners/winrm_runner/tests/unit/BUILD
+++ b/contrib/runners/winrm_runner/tests/unit/BUILD
@@ -1,3 +1,8 @@
+__defaults__(
+    {python_tests: dict(tags=["unit"])},
+    extend=True,
+)
+
 python_tests(
     name="tests",
 )

--- a/st2actions/tests/integration/BUILD
+++ b/st2actions/tests/integration/BUILD
@@ -1,5 +1,5 @@
 __defaults__(
-    {python_tests: dict(tags=["integration"])},
+    {(python_test, python_tests): dict(tags=["integration"])},
     extend=True,
 )
 

--- a/st2actions/tests/unit/BUILD
+++ b/st2actions/tests/unit/BUILD
@@ -1,5 +1,5 @@
 __defaults__(
-    {python_tests: dict(tags=["unit"])},
+    {(python_test, python_tests): dict(tags=["unit"])},
     extend=True,
 )
 

--- a/st2api/tests/integration/BUILD
+++ b/st2api/tests/integration/BUILD
@@ -1,5 +1,5 @@
 __defaults__(
-    {python_tests: dict(tags=["integration"])},
+    {(python_test, python_tests): dict(tags=["integration"])},
     extend=True,
 )
 

--- a/st2api/tests/integration/BUILD
+++ b/st2api/tests/integration/BUILD
@@ -1,3 +1,8 @@
+__defaults__(
+    {python_tests: dict(tags=["integration"])},
+    extend=True,
+)
+
 python_tests(
     name="tests",
     dependencies=[

--- a/st2api/tests/unit/BUILD
+++ b/st2api/tests/unit/BUILD
@@ -1,5 +1,5 @@
 __defaults__(
-    {python_tests: dict(tags=["unit"])},
+    {(python_test, python_tests): dict(tags=["unit"])},
     extend=True,
 )
 

--- a/st2api/tests/unit/BUILD
+++ b/st2api/tests/unit/BUILD
@@ -1,3 +1,8 @@
+__defaults__(
+    {python_tests: dict(tags=["unit"])},
+    extend=True,
+)
+
 python_tests(
     name="tests",
 )

--- a/st2auth/tests/integration/BUILD
+++ b/st2auth/tests/integration/BUILD
@@ -1,4 +1,4 @@
 __defaults__(
-    {python_tests: dict(tags=["integration"])},
+    {(python_test, python_tests): dict(tags=["integration"])},
     extend=True,
 )

--- a/st2auth/tests/integration/BUILD
+++ b/st2auth/tests/integration/BUILD
@@ -2,7 +2,3 @@ __defaults__(
     {python_tests: dict(tags=["integration"])},
     extend=True,
 )
-
-python_tests(
-    name="tests",
-)

--- a/st2auth/tests/unit/BUILD
+++ b/st2auth/tests/unit/BUILD
@@ -1,5 +1,5 @@
 __defaults__(
-    {python_tests: dict(tags=["unit"])},
+    {(python_test, python_tests): dict(tags=["unit"])},
     extend=True,
 )
 

--- a/st2auth/tests/unit/BUILD
+++ b/st2auth/tests/unit/BUILD
@@ -1,3 +1,8 @@
+__defaults__(
+    {python_tests: dict(tags=["unit"])},
+    extend=True,
+)
+
 python_tests(
     name="tests",
     dependencies=[

--- a/st2client/tests/integration/BUILD
+++ b/st2client/tests/integration/BUILD
@@ -1,4 +1,4 @@
 __defaults__(
-    {python_tests: dict(tags=["integration"])},
+    {(python_test, python_tests): dict(tags=["integration"])},
     extend=True,
 )

--- a/st2client/tests/integration/BUILD
+++ b/st2client/tests/integration/BUILD
@@ -2,7 +2,3 @@ __defaults__(
     {python_tests: dict(tags=["integration"])},
     extend=True,
 )
-
-python_tests(
-    name="tests",
-)

--- a/st2client/tests/unit/BUILD
+++ b/st2client/tests/unit/BUILD
@@ -1,5 +1,5 @@
 __defaults__(
-    {python_tests: dict(tags=["unit"])},
+    {(python_test, python_tests): dict(tags=["unit"])},
     extend=True,
 )
 

--- a/st2client/tests/unit/BUILD
+++ b/st2client/tests/unit/BUILD
@@ -1,3 +1,8 @@
+__defaults__(
+    {python_tests: dict(tags=["unit"])},
+    extend=True,
+)
+
 python_tests(
     name="tests",
     dependencies=[

--- a/st2common/benchmarks/BUILD
+++ b/st2common/benchmarks/BUILD
@@ -1,3 +1,3 @@
 __defaults__(
-    {python_tests: dict(tags=["benchmarks"])},
+    {(python_test, python_tests): dict(tags=["benchmarks"])},
 )

--- a/st2common/benchmarks/BUILD
+++ b/st2common/benchmarks/BUILD
@@ -1,0 +1,3 @@
+__defaults__(
+    {python_tests: dict(tags=["benchmarks"])},
+)

--- a/st2common/tests/integration/BUILD
+++ b/st2common/tests/integration/BUILD
@@ -1,5 +1,5 @@
 __defaults__(
-    {python_tests: dict(tags=["integration"])},
+    {(python_test, python_tests): dict(tags=["integration"])},
     extend=True,
 )
 

--- a/st2common/tests/integration/BUILD
+++ b/st2common/tests/integration/BUILD
@@ -1,3 +1,8 @@
+__defaults__(
+    {python_tests: dict(tags=["integration"])},
+    extend=True,
+)
+
 python_sources()
 
 python_tests(

--- a/st2common/tests/unit/BUILD
+++ b/st2common/tests/unit/BUILD
@@ -1,5 +1,5 @@
 __defaults__(
-    {python_tests: dict(tags=["unit"])},
+    {(python_test, python_tests): dict(tags=["unit"])},
     extend=True,
 )
 

--- a/st2common/tests/unit/BUILD
+++ b/st2common/tests/unit/BUILD
@@ -1,3 +1,8 @@
+__defaults__(
+    {python_tests: dict(tags=["unit"])},
+    extend=True,
+)
+
 python_tests(
     name="tests",
     dependencies=[

--- a/st2reactor/tests/integration/BUILD
+++ b/st2reactor/tests/integration/BUILD
@@ -1,5 +1,5 @@
 __defaults__(
-    {python_tests: dict(tags=["integration"])},
+    {(python_test, python_tests): dict(tags=["integration"])},
     extend=True,
 )
 

--- a/st2reactor/tests/integration/BUILD
+++ b/st2reactor/tests/integration/BUILD
@@ -1,3 +1,8 @@
+__defaults__(
+    {python_tests: dict(tags=["integration"])},
+    extend=True,
+)
+
 python_tests(
     name="tests",
     dependencies=[

--- a/st2reactor/tests/unit/BUILD
+++ b/st2reactor/tests/unit/BUILD
@@ -1,5 +1,5 @@
 __defaults__(
-    {python_tests: dict(tags=["unit"])},
+    {(python_test, python_tests): dict(tags=["unit"])},
     extend=True,
 )
 

--- a/st2reactor/tests/unit/BUILD
+++ b/st2reactor/tests/unit/BUILD
@@ -1,3 +1,8 @@
+__defaults__(
+    {python_tests: dict(tags=["unit"])},
+    extend=True,
+)
+
 python_tests(
     name="tests",
 )

--- a/st2stream/tests/integration/BUILD
+++ b/st2stream/tests/integration/BUILD
@@ -1,4 +1,4 @@
 __defaults__(
-    {python_tests: dict(tags=["integration"])},
+    {(python_test, python_tests): dict(tags=["integration"])},
     extend=True,
 )

--- a/st2stream/tests/integration/BUILD
+++ b/st2stream/tests/integration/BUILD
@@ -2,7 +2,3 @@ __defaults__(
     {python_tests: dict(tags=["integration"])},
     extend=True,
 )
-
-python_tests(
-    name="tests",
-)

--- a/st2stream/tests/unit/BUILD
+++ b/st2stream/tests/unit/BUILD
@@ -1,4 +1,4 @@
 __defaults__(
-    {python_tests: dict(tags=["unit"])},
+    {(python_test, python_tests): dict(tags=["unit"])},
     extend=True,
 )

--- a/st2stream/tests/unit/BUILD
+++ b/st2stream/tests/unit/BUILD
@@ -2,7 +2,3 @@ __defaults__(
     {python_tests: dict(tags=["unit"])},
     extend=True,
 )
-
-python_tests(
-    name="tests",
-)

--- a/st2tests/integration/BUILD
+++ b/st2tests/integration/BUILD
@@ -1,5 +1,5 @@
 __defaults__(
-    {python_tests: dict(tags=["integration"])},
+    {(python_test, python_tests): dict(tags=["integration"])},
     all=dict(
         skip_pylint=True,
     ),

--- a/st2tests/integration/BUILD
+++ b/st2tests/integration/BUILD
@@ -1,4 +1,5 @@
 __defaults__(
+    {python_tests: dict(tags=["integration"])},
     all=dict(
         skip_pylint=True,
     ),

--- a/st2tests/tests/unit/BUILD
+++ b/st2tests/tests/unit/BUILD
@@ -1,4 +1,4 @@
 __defaults__(
-    {python_tests: dict(tags=["unit"])},
+    {(python_test, python_tests): dict(tags=["unit"])},
     extend=True,
 )

--- a/st2tests/tests/unit/BUILD
+++ b/st2tests/tests/unit/BUILD
@@ -2,7 +2,3 @@ __defaults__(
     {python_tests: dict(tags=["unit"])},
     extend=True,
 )
-
-python_tests(
-    name="tests",
-)


### PR DESCRIPTION
### Background

This is another part of introducing [pants](https://www.pantsbuild.org/docs), as discussed in various TSC meetings.

Related PRs can be found in:
- [pantsbuild](https://github.com/StackStorm/st2/milestone/47) milestone (which includes PRs since #5713)
- https://github.com/StackStorm/st2/labels/pantsbuild label (which also includes preparatory PRs that came before adding pantsbuild)

### Overview of this PR

This adjusts the BUILD metadata for all of our `python_tests` targets so that they are tagged with `unit`, `integration`, or `benchmarks`. We can add other tags when/if we find something that will be generally useful.

Once we are able to run tests via pants, pants can use this to select a subset of tests to run. For example:

```
./pants --tag=benchmarks test
```

Check out the docs for more powerful examples of how to use tags on the command line.

#### Relevant pants docs

- [Tags: annotating targets](https://www.pantsbuild.org/docs/advanced-target-selection#tags-annotating-targets)